### PR TITLE
thomasgauvin: support automatic updates of wrangler.jsonc when creating a new resource in a worker project

### DIFF
--- a/packages/wrangler/src/__tests__/config/auto-update.test.ts
+++ b/packages/wrangler/src/__tests__/config/auto-update.test.ts
@@ -1,0 +1,340 @@
+import fs from "node:fs";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { autoUpdateWranglerConfig } from "../../config/auto-update";
+import { findWranglerConfig } from "../../config/config-helpers";
+import { configFormat } from "../../config/index";
+import { parseJSONC, readFileSync } from "../../parse";
+
+// Mock the logger to avoid console output during tests
+vi.mock("../../logger", () => ({
+	logger: {
+		log: vi.fn(),
+		debug: vi.fn(),
+	},
+}));
+
+// Mock dialogs to avoid interactive prompts during tests
+vi.mock("../../dialogs", () => ({
+	confirm: vi.fn().mockResolvedValue(true),
+}));
+
+// Mock findWranglerConfig
+vi.mock("../../config/config-helpers", () => ({
+	findWranglerConfig: vi.fn(),
+}));
+
+// Mock parse functions
+vi.mock("../../parse", () => ({
+	readFileSync: vi.fn(),
+	parseJSONC: vi.fn(),
+}));
+
+// Mock config format
+vi.mock("../../config/index", () => ({
+	configFormat: vi.fn(),
+	formatConfigSnippet: vi.fn((snippet: any) =>
+		JSON.stringify(snippet, null, 2)
+	),
+}));
+
+// Mock getValidBindingName
+vi.mock("../../utils/getValidBindingName", () => ({
+	getValidBindingName: vi.fn((name: string, fallback: string) => {
+		// Simple mock implementation for testing
+		return name.toUpperCase().replace(/[^A-Z0-9_]/g, "_") || fallback;
+	}),
+}));
+
+describe("autoUpdateWranglerConfig", () => {
+	const mockFindWranglerConfig = vi.mocked(findWranglerConfig);
+	const mockConfigFormat = vi.mocked(configFormat);
+	const mockReadFileSync = vi.mocked(readFileSync);
+	const mockParseJSONC = vi.mocked(parseJSONC);
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test("should return false when no config file is found", async () => {
+		mockFindWranglerConfig.mockReturnValue({
+			configPath: undefined,
+			userConfigPath: undefined,
+		});
+
+		const result = await autoUpdateWranglerConfig({
+			type: "d1_databases",
+			id: "test-id",
+			name: "test-db",
+		});
+
+		expect(result).toBe(false);
+	});
+
+	test("should return false for unsupported config format (TOML)", async () => {
+		mockFindWranglerConfig.mockReturnValue({
+			configPath: "/path/to/wrangler.toml",
+			userConfigPath: "/path/to/wrangler.toml",
+		});
+		mockConfigFormat.mockReturnValue("toml");
+
+		const result = await autoUpdateWranglerConfig({
+			type: "d1_databases",
+			id: "test-id",
+			name: "test-db",
+		});
+
+		expect(result).toBe(false);
+	});
+
+	test("should create proper D1 binding configuration with auto-update", async () => {
+		const configPath = "/tmp/test-wrangler.json";
+		const initialConfig = {
+			name: "my-worker",
+			compatibility_date: "2023-01-01",
+		};
+
+		// Mock file system operations
+		mockReadFileSync.mockReturnValue(JSON.stringify(initialConfig));
+		mockParseJSONC.mockReturnValue(initialConfig);
+		mockConfigFormat.mockReturnValue("jsonc");
+		vi.spyOn(fs, "writeFileSync").mockImplementation(() => {});
+
+		mockFindWranglerConfig.mockReturnValue({
+			configPath,
+			userConfigPath: configPath,
+		});
+
+		const result = await autoUpdateWranglerConfig(
+			{
+				type: "d1_databases",
+				id: "test-db-id",
+				name: "test-db",
+			},
+			true
+		); // auto-update enabled
+
+		expect(result).toBe(true);
+		expect(fs.writeFileSync).toHaveBeenCalledWith(
+			configPath,
+			expect.stringContaining('"d1_databases"')
+		);
+	});
+
+	test("should create proper R2 binding configuration with auto-update", async () => {
+		const configPath = "/tmp/test-wrangler.json";
+		const initialConfig = {
+			name: "my-worker",
+		};
+
+		mockReadFileSync.mockReturnValue(JSON.stringify(initialConfig));
+		mockParseJSONC.mockReturnValue(initialConfig);
+		mockConfigFormat.mockReturnValue("jsonc");
+		vi.spyOn(fs, "writeFileSync").mockImplementation(() => {});
+
+		mockFindWranglerConfig.mockReturnValue({
+			configPath,
+			userConfigPath: configPath,
+		});
+
+		const result = await autoUpdateWranglerConfig(
+			{
+				type: "r2_buckets",
+				id: "test-bucket",
+				name: "test-bucket",
+			},
+			true
+		); // auto-update enabled
+
+		expect(result).toBe(true);
+		expect(fs.writeFileSync).toHaveBeenCalledWith(
+			configPath,
+			expect.stringContaining('"r2_buckets"')
+		);
+	});
+
+	test("should not add duplicate bindings", async () => {
+		const configPath = "/tmp/test-wrangler.json";
+		const initialConfig = {
+			name: "my-worker",
+			d1_databases: [
+				{
+					binding: "DB",
+					database_name: "test-db",
+					database_id: "test-db-id",
+				},
+			],
+		};
+
+		mockReadFileSync.mockReturnValue(JSON.stringify(initialConfig));
+		mockParseJSONC.mockReturnValue(initialConfig);
+		mockConfigFormat.mockReturnValue("jsonc");
+		vi.spyOn(fs, "writeFileSync").mockImplementation(() => {});
+
+		mockFindWranglerConfig.mockReturnValue({
+			configPath,
+			userConfigPath: configPath,
+		});
+
+		const result = await autoUpdateWranglerConfig(
+			{
+				type: "d1_databases",
+				id: "test-db-id",
+				name: "test-db",
+			},
+			true
+		); // auto-update enabled
+
+		expect(result).toBe(false);
+		// Should not call writeFileSync since binding already exists
+		expect(fs.writeFileSync).not.toHaveBeenCalled();
+	});
+
+	test("should generate unique binding name when conflicts exist", async () => {
+		const configPath = "/tmp/test-wrangler.json";
+		const initialConfig = {
+			name: "my-worker",
+			d1_databases: [
+				{
+					binding: "DB",
+					database_name: "existing-db",
+					database_id: "existing-db-id",
+				},
+			],
+			r2_buckets: [
+				{
+					binding: "DB_1",
+					bucket_name: "existing-bucket",
+				},
+			],
+		};
+
+		mockReadFileSync.mockReturnValue(JSON.stringify(initialConfig));
+		mockParseJSONC.mockReturnValue(initialConfig);
+		mockConfigFormat.mockReturnValue("jsonc");
+		const writeFileSyncSpy = vi
+			.spyOn(fs, "writeFileSync")
+			.mockImplementation(() => {});
+
+		mockFindWranglerConfig.mockReturnValue({
+			configPath,
+			userConfigPath: configPath,
+		});
+
+		const result = await autoUpdateWranglerConfig(
+			{
+				type: "d1_databases",
+				id: "new-test-db-id",
+				name: "test-db", // Will use generic name "DB"
+			},
+			true
+		); // auto-update enabled
+
+		expect(result).toBe(true);
+		expect(writeFileSyncSpy).toHaveBeenCalledWith(
+			configPath,
+			expect.stringContaining('"DB_2"') // Should generate DB_2 to avoid conflicts with DB and DB_1
+		);
+	});
+
+	test("should handle case-insensitive binding name conflicts", async () => {
+		const configPath = "/tmp/test-wrangler.json";
+		const initialConfig = {
+			name: "my-worker",
+			d1_databases: [
+				{
+					binding: "bucket", // lowercase to conflict with R2's "BUCKET"
+					database_name: "existing-db",
+					database_id: "existing-db-id",
+				},
+			],
+		};
+
+		mockReadFileSync.mockReturnValue(JSON.stringify(initialConfig));
+		mockParseJSONC.mockReturnValue(initialConfig);
+		mockConfigFormat.mockReturnValue("jsonc");
+		const writeFileSyncSpy = vi
+			.spyOn(fs, "writeFileSync")
+			.mockImplementation(() => {});
+
+		mockFindWranglerConfig.mockReturnValue({
+			configPath,
+			userConfigPath: configPath,
+		});
+
+		const result = await autoUpdateWranglerConfig(
+			{
+				type: "r2_buckets",
+				id: "new-bucket-id",
+				name: "test-bucket", // Will use generic name "BUCKET" but conflicts with "bucket"
+			},
+			true
+		); // auto-update enabled
+
+		expect(result).toBe(true);
+		expect(writeFileSyncSpy).toHaveBeenCalledWith(
+			configPath,
+			expect.stringContaining('"BUCKET_1"') // Should generate BUCKET_1 due to case-insensitive conflict
+		);
+	});
+
+	test("should not auto-update for KV preview namespaces", async () => {
+		// This test documents that KV preview namespaces should be handled
+		// differently in the KV create command, not in the auto-update module
+
+		// Mock no config file found
+		mockFindWranglerConfig.mockReturnValue({
+			configPath: undefined,
+			userConfigPath: undefined,
+		});
+
+		const result = await autoUpdateWranglerConfig(
+			{
+				type: "kv_namespaces",
+				id: "preview-kv-id",
+				name: "preview-namespace",
+				additionalConfig: { preview_id: "preview-kv-id" },
+			},
+			true
+		);
+
+		// The auto-update module itself doesn't distinguish preview vs regular
+		// The KV command should skip calling auto-update for preview namespaces
+		expect(result).toBe(false); // No config file found, so returns false
+	});
+
+	test("should respect user decline when prompting for update", async () => {
+		const { confirm } = await import("../../dialogs");
+		vi.mocked(confirm).mockResolvedValueOnce(false);
+
+		const configPath = "/tmp/test-wrangler.json";
+		const initialConfig = { name: "my-worker" };
+
+		mockReadFileSync.mockReturnValue(JSON.stringify(initialConfig));
+		mockParseJSONC.mockReturnValue(initialConfig);
+		mockConfigFormat.mockReturnValue("jsonc");
+		vi.spyOn(fs, "writeFileSync").mockImplementation(() => {});
+
+		mockFindWranglerConfig.mockReturnValue({
+			configPath,
+			userConfigPath: configPath,
+		});
+
+		const result = await autoUpdateWranglerConfig(
+			{
+				type: "d1_databases",
+				id: "test-db-id",
+				name: "test-db",
+			},
+			false
+		); // auto-update disabled, should prompt
+
+		expect(result).toBe(false);
+		expect(fs.writeFileSync).not.toHaveBeenCalled();
+		expect(confirm).toHaveBeenCalledWith(
+			expect.stringContaining(
+				"Would you like to update the wrangler.jsonc file"
+			),
+			{ defaultValue: true, fallbackValue: false }
+		);
+	});
+});

--- a/packages/wrangler/src/__tests__/d1/create.test.ts
+++ b/packages/wrangler/src/__tests__/d1/create.test.ts
@@ -64,6 +64,8 @@ describe("create", () => {
 			"✅ Successfully created DB 'test' in region OC
 			Created your new D1 database.
 
+			Add the following to your configuration file:
+
 			{
 			  \\"d1_databases\\": [
 			    {

--- a/packages/wrangler/src/config/auto-update-helpers.ts
+++ b/packages/wrangler/src/config/auto-update-helpers.ts
@@ -1,0 +1,243 @@
+import { confirm, prompt } from "../dialogs";
+import { logger } from "../logger";
+import { isValidIdentifier } from "../type-generation";
+import { formatConfigSnippet } from "./index";
+import type { ResourceBinding } from "./auto-update";
+import type { RawConfig } from "./config";
+
+// Registry of resource configuration patterns for better maintainability
+export const RESOURCE_CONFIG_REGISTRY = {
+	d1_databases: {
+		displayName: "D1 Database",
+		genericBindingName: "DB",
+		identifierField: "database_id" as const,
+		createConfig: (resource: ResourceBinding, bindingName: string) => ({
+			binding: bindingName,
+			database_name: resource.name,
+			database_id: resource.id,
+		}),
+	},
+	r2_buckets: {
+		displayName: "R2 Bucket",
+		genericBindingName: "BUCKET",
+		identifierField: "bucket_name" as const,
+		createConfig: (resource: ResourceBinding, bindingName: string) => ({
+			binding: bindingName,
+			bucket_name: resource.name,
+		}),
+	},
+	kv_namespaces: {
+		displayName: "KV Namespace",
+		genericBindingName: "KV",
+		identifierField: "id" as const,
+		createConfig: (resource: ResourceBinding, bindingName: string) => ({
+			binding: bindingName,
+			id: resource.id,
+		}),
+	},
+	vectorize: {
+		displayName: "Vectorize Index",
+		genericBindingName: "VECTORIZE",
+		identifierField: "index_name" as const,
+		createConfig: (resource: ResourceBinding, bindingName: string) => ({
+			binding: bindingName,
+			index_name: resource.name,
+		}),
+	},
+	hyperdrive: {
+		displayName: "Hyperdrive Configuration",
+		genericBindingName: "HYPERDRIVE",
+		identifierField: "id" as const,
+		createConfig: (resource: ResourceBinding, bindingName: string) => ({
+			binding: bindingName,
+			id: resource.id,
+		}),
+	},
+} as const;
+
+export function createBindingConfig(
+	resource: ResourceBinding,
+	bindingName: string
+): Record<string, unknown> {
+	const configTemplate = RESOURCE_CONFIG_REGISTRY[resource.type];
+	if (!configTemplate) {
+		throw new Error(`Unsupported resource type: ${resource.type}`);
+	}
+	return configTemplate.createConfig(resource, bindingName);
+}
+
+export function getBindingIdentifier(
+	binding: Record<string, unknown>,
+	type: ResourceBinding["type"]
+): string | undefined {
+	const configTemplate = RESOURCE_CONFIG_REGISTRY[type];
+	if (!configTemplate) {
+		return undefined;
+	}
+
+	const field = configTemplate.identifierField;
+	return binding[field] as string;
+}
+
+/**
+ * Checks if a binding name conflicts with existing bindings across all resource types.
+ * Binding names are case-insensitive in JavaScript.
+ */
+export function hasBindingNameConflict(
+	config: RawConfig,
+	bindingName: string
+): boolean {
+	const normalizedName = bindingName.toUpperCase();
+
+	// Check all resource types for existing bindings
+	for (const resourceType of Object.keys(RESOURCE_CONFIG_REGISTRY)) {
+		const bindings = config[
+			resourceType as keyof typeof RESOURCE_CONFIG_REGISTRY
+		] as Array<Record<string, unknown>> | undefined;
+		if (bindings) {
+			for (const binding of bindings) {
+				if (binding.binding && typeof binding.binding === "string") {
+					if (binding.binding.toUpperCase() === normalizedName) {
+						return true;
+					}
+				}
+			}
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Gets the display name for a resource type from the registry.
+ */
+export function getResourceDisplayName(
+	resourceType: ResourceBinding["type"]
+): string {
+	const config = RESOURCE_CONFIG_REGISTRY[resourceType];
+	return config?.displayName || resourceType.replace(/_/g, " ");
+}
+
+/**
+ * Gets the generic binding name for a resource type from the registry.
+ */
+export function getGenericBindingName(
+	resourceType: ResourceBinding["type"]
+): string {
+	const config = RESOURCE_CONFIG_REGISTRY[resourceType];
+	return config?.genericBindingName || resourceType.toUpperCase();
+}
+
+/**
+ * Display a configuration snippet for a resource binding.
+ * This is used to show users how to manually add the binding if auto-update fails.
+ */
+export function displayConfigSnippet(
+	resource: ResourceBinding,
+	configPath: string | undefined,
+	bindingName?: string
+) {
+	const actualBindingName =
+		bindingName || resource.binding || getGenericBindingName(resource.type);
+	const newBinding = createBindingConfig(resource, actualBindingName);
+	const snippet = { [resource.type]: [newBinding] };
+
+	logger.log("\n" + formatConfigSnippet(snippet, configPath));
+}
+
+/**
+ * Validates that a binding name is a valid JavaScript identifier and doesn't conflict with existing bindings.
+ */
+export function validateBindingName(
+	config: RawConfig,
+	bindingName: string
+): { valid: boolean; error?: string } {
+	// Check if it's a valid JavaScript identifier
+	if (!isValidIdentifier(bindingName)) {
+		return {
+			valid: false,
+			error: `"${bindingName}" is not a valid JavaScript identifier. Binding names must start with a letter, underscore, or $ and contain only letters, numbers, underscores, and $.`,
+		};
+	}
+
+	// Check for conflicts with existing bindings
+	if (hasBindingNameConflict(config, bindingName)) {
+		return {
+			valid: false,
+			error: `Binding name "${bindingName}" already exists. Please choose a different name.`,
+		};
+	}
+
+	return { valid: true };
+}
+
+/**
+ * Asks if the user wants to add the resource to their wrangler config.
+ */
+export async function promptForConfigUpdate(
+	resourceType: ResourceBinding["type"]
+): Promise<boolean> {
+	return await confirm(
+		`Would you like to add this ${getResourceDisplayName(resourceType)} to your wrangler.jsonc?`,
+		{ defaultValue: true, fallbackValue: false }
+	);
+}
+
+/**
+ * Prompts the user for a binding name with conflict resolution.
+ * Shows a placeholder based on the resource type and handles conflicts by re-prompting.
+ */
+export async function promptForValidBindingName(
+	config: RawConfig,
+	resourceType: ResourceBinding["type"],
+	conflictingName?: string
+): Promise<string> {
+	const placeholder = getGenericBindingName(resourceType);
+
+	// If there's a conflicting name, ask if they want to enter a new one
+	if (conflictingName) {
+		const shouldTryAgain = await confirm(
+			`That binding name is not available. Would you like to enter a new binding name?`,
+			{ defaultValue: true, fallbackValue: false }
+		);
+
+		if (!shouldTryAgain) {
+			throw new Error(
+				"Binding name conflict - user chose not to provide alternative"
+			);
+		}
+	}
+
+	let bindingName: string = "";
+	let isValid = false;
+	let currentDefault: string | undefined = placeholder;
+
+	while (!isValid) {
+		const promptOptions = currentDefault 
+			? { defaultValue: currentDefault }
+			: {};
+		
+		bindingName = await prompt(`What binding name would you like to use?`, promptOptions);
+
+		// Use currentDefault if user just pressed enter and we have a default
+		if (!bindingName || bindingName.trim() === "") {
+			if (currentDefault) {
+				bindingName = currentDefault;
+			} else {
+				// If no default and user pressed enter, continue the loop
+				continue;
+			}
+		}
+
+		const validation = validateBindingName(config, bindingName);
+		if (validation.valid) {
+			isValid = true;
+		} else {
+			logger.error(validation.error || "Invalid binding name");
+			// Don't show the failed binding name as default on next attempt
+			currentDefault = undefined;
+		}
+	}
+
+	return bindingName;
+}

--- a/packages/wrangler/src/config/auto-update.ts
+++ b/packages/wrangler/src/config/auto-update.ts
@@ -1,0 +1,316 @@
+import fs from "node:fs";
+import path from "node:path";
+import { applyEdits, modify } from "jsonc-parser";
+import { confirm } from "../dialogs";
+import { logger } from "../logger";
+import { parseJSONC, readFileSync } from "../parse";
+import { findWranglerConfig } from "./config-helpers";
+import { configFormat, formatConfigSnippet } from "./index";
+import type { RawConfig } from "./config";
+
+export interface ResourceBinding {
+	type:
+		| "d1_databases"
+		| "r2_buckets"
+		| "kv_namespaces"
+		| "vectorize"
+		| "hyperdrive";
+	id: string;
+	name: string;
+	binding?: string;
+	additionalConfig?: Record<string, unknown>;
+}
+
+// Generic binding names for each resource type
+const GENERIC_BINDING_NAMES: Record<string, string> = {
+	d1_databases: "DB",
+	kv_namespaces: "KV",
+	r2_buckets: "BUCKET",
+	vectorize: "VECTORIZE",
+	hyperdrive: "HYPERDRIVE",
+};
+
+// Registry of resource configuration patterns for better maintainability
+const RESOURCE_CONFIG_REGISTRY = {
+	d1_databases: {
+		identifierField: "database_id" as const,
+		createConfig: (resource: ResourceBinding, bindingName: string) => ({
+			binding: bindingName,
+			database_name: resource.name,
+			database_id: resource.id,
+			...resource.additionalConfig,
+		}),
+	},
+	r2_buckets: {
+		identifierField: "bucket_name" as const,
+		createConfig: (resource: ResourceBinding, bindingName: string) => ({
+			binding: bindingName,
+			bucket_name: resource.name,
+			...resource.additionalConfig,
+		}),
+	},
+	kv_namespaces: {
+		identifierField: "id" as const,
+		createConfig: (resource: ResourceBinding, bindingName: string) => ({
+			binding: bindingName,
+			...resource.additionalConfig, // This allows passing id or preview_id
+		}),
+	},
+	vectorize: {
+		identifierField: "index_name" as const,
+		createConfig: (resource: ResourceBinding, bindingName: string) => ({
+			binding: bindingName,
+			index_name: resource.name,
+			...resource.additionalConfig,
+		}),
+	},
+	hyperdrive: {
+		identifierField: "id" as const,
+		createConfig: (resource: ResourceBinding, bindingName: string) => ({
+			binding: bindingName,
+			id: resource.id,
+			...resource.additionalConfig,
+		}),
+	},
+} as const;
+
+/**
+ * Automatically updates the wrangler.jsonc config file with a new resource binding.
+ * Only supports JSON/JSONC files. Prompts user for confirmation unless autoUpdate is true.
+ */
+export async function autoUpdateWranglerConfig(
+	resource: ResourceBinding,
+	autoUpdate: boolean = false,
+	cwd: string = process.cwd()
+): Promise<boolean> {
+	const { configPath } = findWranglerConfig(cwd);
+
+	if (!configPath) {
+		logger.debug("No wrangler config file found, skipping auto-update");
+		return false;
+	}
+
+	const format = configFormat(configPath);
+	if (format !== "jsonc") {
+		logger.debug(
+			`Only JSON/JSONC config files are supported for auto-update, found: ${format}`
+		);
+		return false;
+	}
+
+	try {
+		// Check if resource already exists
+		const content = readFileSync(configPath);
+		const config = parseJSONC(content, configPath) as RawConfig;
+
+		if (resourceAlreadyExists(config, resource)) {
+			logger.debug(
+				`Binding for ${resource.type} ${resource.id} already exists`
+			);
+			return false;
+		}
+
+		// Prompt user for confirmation unless auto-update is enabled
+		if (!autoUpdate) {
+			const shouldUpdate = await confirm(
+				`Would you like to update the wrangler.jsonc file with the new ${capitalizeResourceType(resource.type)} binding?`,
+				{ defaultValue: true, fallbackValue: false }
+			);
+
+			if (!shouldUpdate) {
+				return false;
+			}
+		}
+
+		updateJsonConfig(configPath, resource, config);
+		return true;
+	} catch (error) {
+		logger.debug(`Failed to auto-update wrangler config: ${error}`);
+		return false;
+	}
+}
+
+function updateJsonConfig(
+	configPath: string,
+	resource: ResourceBinding,
+	config: RawConfig
+) {
+	// Read the original file content to preserve formatting and comments
+	const originalContent = readFileSync(configPath);
+	let edits: any[] = [];
+
+	// Generate a unique binding name that doesn't conflict
+	const bindingName = generateUniqueBindingName(config, resource);
+
+	// Create new binding configuration
+	const newBinding = createBindingConfig(resource, bindingName);
+
+	// Check if the resource type array exists
+	if (!config[resource.type]) {
+		// Create the entire array with the new binding
+		edits = modify(originalContent, [resource.type], [newBinding], {
+			formattingOptions: { tabSize: 2, insertSpaces: true },
+		});
+	} else {
+		// Add to existing array (using -1 to append to end)
+		edits = modify(originalContent, [resource.type, -1], newBinding, {
+			formattingOptions: { tabSize: 2, insertSpaces: true },
+		});
+	}
+
+	// Apply the edits to preserve formatting and comments
+	const updatedContent = applyEdits(originalContent, edits);
+
+	// Write back to file
+	fs.writeFileSync(configPath, updatedContent);
+
+	// Log success with capitalized resource type
+	const resourceTypeName = capitalizeResourceType(resource.type);
+	logger.log(
+		`✅ Updated ${path.relative(process.cwd(), configPath)} with new ${resourceTypeName} binding: ${bindingName} (${resource.name}, ID: ${resource.id})`
+	);
+}
+
+function createBindingConfig(
+	resource: ResourceBinding,
+	bindingName: string
+): Record<string, unknown> {
+	const configTemplate = RESOURCE_CONFIG_REGISTRY[resource.type];
+	if (!configTemplate) {
+		throw new Error(`Unsupported resource type: ${resource.type}`);
+	}
+	return configTemplate.createConfig(resource, bindingName);
+}
+
+function getBindingIdentifier(
+	binding: Record<string, unknown>,
+	type: ResourceBinding["type"]
+): string | undefined {
+	const configTemplate = RESOURCE_CONFIG_REGISTRY[type];
+	if (!configTemplate) {
+		return undefined;
+	}
+
+	const field = configTemplate.identifierField;
+	return binding[field] as string;
+}
+
+/**
+ * Simplified helper function for integrating auto-update into create commands.
+ * Attempts auto-update and falls back to displaying config snippet if it fails.
+ */
+export async function updateWranglerConfigOrDisplaySnippet(
+	resource: ResourceBinding,
+	configPath: string | undefined,
+	autoUpdate: boolean = false,
+	fallbackMessage = "Add the following to your wrangler configuration file:"
+): Promise<void> {
+	const updated = await autoUpdateWranglerConfig(resource, autoUpdate);
+
+	if (!updated) {
+		logger.log(fallbackMessage);
+		displayConfigSnippet(resource, configPath);
+	}
+}
+
+/**
+ * Display a configuration snippet for a resource binding.
+ * This is used to show users how to manually add the binding if auto-update fails.
+ */
+export function displayConfigSnippet(
+	resource: ResourceBinding,
+	configPath: string | undefined,
+	bindingName?: string
+) {
+	const actualBindingName =
+		bindingName ||
+		GENERIC_BINDING_NAMES[resource.type] ||
+		resource.type.toUpperCase();
+	const newBinding = createBindingConfig(resource, actualBindingName);
+	const snippet = { [resource.type]: [newBinding] };
+
+	logger.log("\n" + formatConfigSnippet(snippet, configPath));
+}
+
+/**
+ * Checks if a resource binding already exists in the config.
+ */
+function resourceAlreadyExists(
+	config: RawConfig,
+	resource: ResourceBinding
+): boolean {
+	const bindings = config[resource.type] as
+		| Array<Record<string, unknown>>
+		| undefined;
+	if (!bindings) {
+		return false;
+	}
+	return bindings.some(
+		(binding: any) =>
+			getBindingIdentifier(binding, resource.type) === resource.id
+	);
+}
+
+/**
+ * Generates a unique binding name that doesn't conflict with existing bindings in the config.
+ */
+function generateUniqueBindingName(
+	config: RawConfig,
+	resource: ResourceBinding
+): string {
+	const baseBindingName =
+		resource.binding ||
+		GENERIC_BINDING_NAMES[resource.type] ||
+		resource.type.toUpperCase();
+	const existingBindings = getAllExistingBindingNames(config);
+
+	let bindingName = baseBindingName;
+	let counter = 1;
+
+	// Keep trying with incrementing numbers until we find a unique name
+	while (existingBindings.has(bindingName.toUpperCase())) {
+		bindingName = `${baseBindingName}_${counter}`;
+		counter++;
+	}
+
+	return bindingName;
+}
+
+/**
+ * Collects all existing binding names from the config to check for conflicts.
+ * Binding names are case-insensitive in JavaScript, so we normalize to uppercase.
+ */
+function getAllExistingBindingNames(config: RawConfig): Set<string> {
+	const bindingNames = new Set<string>();
+
+	// Check all resource types for existing bindings
+	for (const resourceType of Object.keys(RESOURCE_CONFIG_REGISTRY)) {
+		const bindings = config[
+			resourceType as keyof typeof RESOURCE_CONFIG_REGISTRY
+		] as Array<Record<string, unknown>> | undefined;
+		if (bindings) {
+			for (const binding of bindings) {
+				if (binding.binding && typeof binding.binding === "string") {
+					bindingNames.add(binding.binding.toUpperCase());
+				}
+			}
+		}
+	}
+
+	return bindingNames;
+}
+
+/**
+ * Capitalizes resource type names for user-facing messages.
+ */
+function capitalizeResourceType(resourceType: string): string {
+	const typeMap: Record<string, string> = {
+		d1_databases: "D1 Database",
+		r2_buckets: "R2 Bucket",
+		kv_namespaces: "KV Namespace",
+		vectorize: "Vectorize Index",
+		hyperdrive: "Hyperdrive Configuration",
+	};
+
+	return typeMap[resourceType] || resourceType.replace(/_/g, " ");
+}

--- a/packages/wrangler/src/config/auto-update.ts
+++ b/packages/wrangler/src/config/auto-update.ts
@@ -1,11 +1,18 @@
 import fs from "node:fs";
 import path from "node:path";
-import { applyEdits, modify } from "jsonc-parser";
-import { confirm } from "../dialogs";
+import { applyEdits, Edit, modify } from "jsonc-parser";
 import { logger } from "../logger";
-import { parseJSONC, readFileSync } from "../parse";
-import { findWranglerConfig } from "./config-helpers";
-import { configFormat, formatConfigSnippet } from "./index";
+import { readFileSync } from "../parse";
+import {
+	createBindingConfig,
+	displayConfigSnippet,
+	getGenericBindingName,
+	getResourceDisplayName,
+	promptForConfigUpdate,
+	promptForValidBindingName,
+	validateBindingName,
+} from "./auto-update-helpers";
+import { configFormat } from "./index";
 import type { RawConfig } from "./config";
 
 export interface ResourceBinding {
@@ -18,129 +25,82 @@ export interface ResourceBinding {
 	id: string;
 	name: string;
 	binding?: string;
-	additionalConfig?: Record<string, unknown>;
 }
-
-// Generic binding names for each resource type
-const GENERIC_BINDING_NAMES: Record<string, string> = {
-	d1_databases: "DB",
-	kv_namespaces: "KV",
-	r2_buckets: "BUCKET",
-	vectorize: "VECTORIZE",
-	hyperdrive: "HYPERDRIVE",
-};
-
-// Registry of resource configuration patterns for better maintainability
-const RESOURCE_CONFIG_REGISTRY = {
-	d1_databases: {
-		identifierField: "database_id" as const,
-		createConfig: (resource: ResourceBinding, bindingName: string) => ({
-			binding: bindingName,
-			database_name: resource.name,
-			database_id: resource.id,
-			...resource.additionalConfig,
-		}),
-	},
-	r2_buckets: {
-		identifierField: "bucket_name" as const,
-		createConfig: (resource: ResourceBinding, bindingName: string) => ({
-			binding: bindingName,
-			bucket_name: resource.name,
-			...resource.additionalConfig,
-		}),
-	},
-	kv_namespaces: {
-		identifierField: "id" as const,
-		createConfig: (resource: ResourceBinding, bindingName: string) => ({
-			binding: bindingName,
-			...resource.additionalConfig, // This allows passing id or preview_id
-		}),
-	},
-	vectorize: {
-		identifierField: "index_name" as const,
-		createConfig: (resource: ResourceBinding, bindingName: string) => ({
-			binding: bindingName,
-			index_name: resource.name,
-			...resource.additionalConfig,
-		}),
-	},
-	hyperdrive: {
-		identifierField: "id" as const,
-		createConfig: (resource: ResourceBinding, bindingName: string) => ({
-			binding: bindingName,
-			id: resource.id,
-			...resource.additionalConfig,
-		}),
-	},
-} as const;
 
 /**
- * Automatically updates the wrangler.jsonc config file with a new resource binding.
- * Only supports JSON/JSONC files. Prompts user for confirmation unless autoUpdate is true.
+ * Unified function to handle binding name validation, prompting, and config updates
+ * for all resource creation commands. This eliminates code duplication across
+ * KV, D1, R2, Vectorize, and Hyperdrive commands.
+ *
+ * This function handles early binding name validation when provided,
+ * prompts for binding names when needed, and manages config updates.
  */
-export async function autoUpdateWranglerConfig(
-	resource: ResourceBinding,
-	autoUpdate: boolean = false,
-	cwd: string = process.cwd()
-): Promise<boolean> {
-	const { configPath } = findWranglerConfig(cwd);
-
-	if (!configPath) {
-		logger.debug("No wrangler config file found, skipping auto-update");
-		return false;
-	}
-
-	const format = configFormat(configPath);
+export async function handleResourceBindingAndConfigUpdate(
+	args: { configBindingName?: string; env?: string },
+	config: RawConfig & { configPath?: string },
+	resource: ResourceBinding
+): Promise<void> {
+	// If the file is not wrangler.jsonc, display the snippet
+	const format = configFormat(config.configPath);
 	if (format !== "jsonc") {
 		logger.debug(
-			`Only JSON/JSONC config files are supported for auto-update, found: ${format}`
+			`Only JSON/JSONC config files are supported for auto-update, found: ${format}. Falling back to snippet display.`
 		);
-		return false;
+
+		logger.log(`Add the following to your configuration file:`);
+		displayConfigSnippet(resource, config.configPath);
+		return;
 	}
 
-	try {
-		// Check if resource already exists
-		const content = readFileSync(configPath);
-		const config = parseJSONC(content, configPath) as RawConfig;
+	const { type: resourceType, id: resourceId, name: resourceName } = resource;
+	let shouldUpdate = true;
 
-		if (resourceAlreadyExists(config, resource)) {
-			logger.debug(
-				`Binding for ${resource.type} ${resource.id} already exists`
-			);
-			return false;
+	// Validate binding name (passed via arguments). If invalid, notify and give them the opportunity to add the config binding name interactive.
+	if (args.configBindingName) {
+		const bindingNameIsValid = validateBindingName(
+			config,
+			args.configBindingName
+		);
+		if (bindingNameIsValid.valid) {
+			resource.binding = args.configBindingName;
+		} else {
+			logger.log(`⚠️ You entered an invalid binding name.`);
 		}
+	}
 
-		// Prompt user for confirmation unless auto-update is enabled
-		if (!autoUpdate) {
-			const shouldUpdate = await confirm(
-				`Would you like to update the wrangler.jsonc file with the new ${capitalizeResourceType(resource.type)} binding?`,
-				{ defaultValue: true, fallbackValue: false }
-			);
+	// If there is no binding name in args, prompt to know if user wants to create binding in wrangler.jsonc
+	if (!resource.binding) {
+		shouldUpdate = await promptForConfigUpdate(resourceType);
 
-			if (!shouldUpdate) {
-				return false;
-			}
+		// If the user does want to update wrangler.jsonc, get a valid binding name
+		if (shouldUpdate) {
+			resource.binding = await promptForValidBindingName(config, resourceType);
 		}
+	}
 
-		updateJsonConfig(configPath, resource, config);
-		return true;
-	} catch (error) {
-		logger.debug(`Failed to auto-update wrangler config: ${error}`);
-		return false;
+	// We now have a valid binding name. We can use it to update the wrangler.jsonc config.
+	if (resource.binding) {
+		updateJsonConfig(config.configPath!, resource, config);
+	} else {
+		// Show snippet only
+		const envString = args.env ? ` under [env.${args.env}]` : "";
+		logger.log(`Add the following to your configuration file:`);
+
+		displayConfigSnippet(resource, config.configPath);
 	}
 }
 
-function updateJsonConfig(
+export function updateJsonConfig(
 	configPath: string,
 	resource: ResourceBinding,
 	config: RawConfig
 ) {
 	// Read the original file content to preserve formatting and comments
 	const originalContent = readFileSync(configPath);
-	let edits: any[] = [];
+	let edits: Edit[] = [];
 
-	// Generate a unique binding name that doesn't conflict
-	const bindingName = generateUniqueBindingName(config, resource);
+	// Use the provided binding name (should be validated before calling this function)
+	const bindingName = resource.binding || getGenericBindingName(resource.type);
 
 	// Create new binding configuration
 	const newBinding = createBindingConfig(resource, bindingName);
@@ -164,153 +124,9 @@ function updateJsonConfig(
 	// Write back to file
 	fs.writeFileSync(configPath, updatedContent);
 
-	// Log success with capitalized resource type
-	const resourceTypeName = capitalizeResourceType(resource.type);
+	// Log success with display name
+	const resourceTypeName = getResourceDisplayName(resource.type);
 	logger.log(
 		`✅ Updated ${path.relative(process.cwd(), configPath)} with new ${resourceTypeName} binding: ${bindingName} (${resource.name}, ID: ${resource.id})`
 	);
-}
-
-function createBindingConfig(
-	resource: ResourceBinding,
-	bindingName: string
-): Record<string, unknown> {
-	const configTemplate = RESOURCE_CONFIG_REGISTRY[resource.type];
-	if (!configTemplate) {
-		throw new Error(`Unsupported resource type: ${resource.type}`);
-	}
-	return configTemplate.createConfig(resource, bindingName);
-}
-
-function getBindingIdentifier(
-	binding: Record<string, unknown>,
-	type: ResourceBinding["type"]
-): string | undefined {
-	const configTemplate = RESOURCE_CONFIG_REGISTRY[type];
-	if (!configTemplate) {
-		return undefined;
-	}
-
-	const field = configTemplate.identifierField;
-	return binding[field] as string;
-}
-
-/**
- * Simplified helper function for integrating auto-update into create commands.
- * Attempts auto-update and falls back to displaying config snippet if it fails.
- */
-export async function updateWranglerConfigOrDisplaySnippet(
-	resource: ResourceBinding,
-	configPath: string | undefined,
-	autoUpdate: boolean = false,
-	fallbackMessage = "Add the following to your wrangler configuration file:"
-): Promise<void> {
-	const updated = await autoUpdateWranglerConfig(resource, autoUpdate);
-
-	if (!updated) {
-		logger.log(fallbackMessage);
-		displayConfigSnippet(resource, configPath);
-	}
-}
-
-/**
- * Display a configuration snippet for a resource binding.
- * This is used to show users how to manually add the binding if auto-update fails.
- */
-export function displayConfigSnippet(
-	resource: ResourceBinding,
-	configPath: string | undefined,
-	bindingName?: string
-) {
-	const actualBindingName =
-		bindingName ||
-		GENERIC_BINDING_NAMES[resource.type] ||
-		resource.type.toUpperCase();
-	const newBinding = createBindingConfig(resource, actualBindingName);
-	const snippet = { [resource.type]: [newBinding] };
-
-	logger.log("\n" + formatConfigSnippet(snippet, configPath));
-}
-
-/**
- * Checks if a resource binding already exists in the config.
- */
-function resourceAlreadyExists(
-	config: RawConfig,
-	resource: ResourceBinding
-): boolean {
-	const bindings = config[resource.type] as
-		| Array<Record<string, unknown>>
-		| undefined;
-	if (!bindings) {
-		return false;
-	}
-	return bindings.some(
-		(binding: any) =>
-			getBindingIdentifier(binding, resource.type) === resource.id
-	);
-}
-
-/**
- * Generates a unique binding name that doesn't conflict with existing bindings in the config.
- */
-function generateUniqueBindingName(
-	config: RawConfig,
-	resource: ResourceBinding
-): string {
-	const baseBindingName =
-		resource.binding ||
-		GENERIC_BINDING_NAMES[resource.type] ||
-		resource.type.toUpperCase();
-	const existingBindings = getAllExistingBindingNames(config);
-
-	let bindingName = baseBindingName;
-	let counter = 1;
-
-	// Keep trying with incrementing numbers until we find a unique name
-	while (existingBindings.has(bindingName.toUpperCase())) {
-		bindingName = `${baseBindingName}_${counter}`;
-		counter++;
-	}
-
-	return bindingName;
-}
-
-/**
- * Collects all existing binding names from the config to check for conflicts.
- * Binding names are case-insensitive in JavaScript, so we normalize to uppercase.
- */
-function getAllExistingBindingNames(config: RawConfig): Set<string> {
-	const bindingNames = new Set<string>();
-
-	// Check all resource types for existing bindings
-	for (const resourceType of Object.keys(RESOURCE_CONFIG_REGISTRY)) {
-		const bindings = config[
-			resourceType as keyof typeof RESOURCE_CONFIG_REGISTRY
-		] as Array<Record<string, unknown>> | undefined;
-		if (bindings) {
-			for (const binding of bindings) {
-				if (binding.binding && typeof binding.binding === "string") {
-					bindingNames.add(binding.binding.toUpperCase());
-				}
-			}
-		}
-	}
-
-	return bindingNames;
-}
-
-/**
- * Capitalizes resource type names for user-facing messages.
- */
-function capitalizeResourceType(resourceType: string): string {
-	const typeMap: Record<string, string> = {
-		d1_databases: "D1 Database",
-		r2_buckets: "R2 Bucket",
-		kv_namespaces: "KV Namespace",
-		vectorize: "Vectorize Index",
-		hyperdrive: "Hyperdrive Configuration",
-	};
-
-	return typeMap[resourceType] || resourceType.replace(/_/g, " ");
 }

--- a/packages/wrangler/src/d1/create.ts
+++ b/packages/wrangler/src/d1/create.ts
@@ -1,6 +1,6 @@
 import dedent from "ts-dedent";
 import { fetchResult } from "../cfetch";
-import { updateWranglerConfigOrDisplaySnippet } from "../config/auto-update";
+import { handleResourceBindingAndConfigUpdate } from "../config/auto-update";
 import { createCommand } from "../core/create-command";
 import { UserError } from "../errors";
 import { logger } from "../logger";
@@ -65,16 +65,15 @@ export const d1CreateCommand = createCommand({
 
 					`,
 		},
-		"update-config": {
-			type: "boolean",
-			default: false,
-			description: "Automatically update wrangler.jsonc with the new database binding without prompting",
+		"config-binding-name": {
+			type: "string",
+			description: "The binding name to use when updating wrangler.jsonc",
 		},
 	},
 	positionalArgs: ["name"],
 	async handler(args, { config }) {
 		const { name, location } = args;
-		const autoUpdate = args.updateConfig;
+
 		const accountId = await requireAuth(config);
 
 		const db = await createD1Database(config, accountId, name, location);
@@ -90,15 +89,15 @@ export const d1CreateCommand = createCommand({
 		);
 		logger.log("Created your new D1 database.\n");
 
-		// Auto-update wrangler config or show snippet
-		await updateWranglerConfigOrDisplaySnippet(
+		// Handle binding name and config update using unified utility
+		await handleResourceBindingAndConfigUpdate(
+			args,
+			{ ...config, configPath: config.configPath },
 			{
 				type: "d1_databases",
 				id: db.uuid,
 				name: db.name,
-			},
-			config.configPath,
-			autoUpdate
+			}
 		);
 	},
 });

--- a/packages/wrangler/src/hyperdrive/create.ts
+++ b/packages/wrangler/src/hyperdrive/create.ts
@@ -1,4 +1,5 @@
-import { configFileName, formatConfigSnippet } from "../config";
+import { configFileName } from "../config";
+import { updateWranglerConfigOrDisplaySnippet } from "../config/auto-update";
 import { createCommand } from "../core/create-command";
 import { logger } from "../logger";
 import { createConfig } from "./client";
@@ -22,6 +23,11 @@ export const hyperdriveCreateCommand = createCommand({
 			demandOption: true,
 			description: "The name of the Hyperdrive config",
 		},
+		"update-config": {
+			type: "boolean",
+			default: false,
+			description: "Automatically update wrangler.jsonc with the new hyperdrive binding without prompting",
+		},
 		...upsertOptions("postgresql"),
 	},
 	positionalArgs: ["name"],
@@ -38,16 +44,18 @@ export const hyperdriveCreateCommand = createCommand({
 		logger.log(
 			`✅ Created new Hyperdrive ${capitalizeScheme(database.origin.scheme)} config: ${database.id}`
 		);
-		logger.log(
+
+		// Auto-update wrangler config or show snippet
+		await updateWranglerConfigOrDisplaySnippet(
+			{
+				type: "hyperdrive",
+				id: database.id,
+				name: database.name,
+				binding: "HYPERDRIVE",
+			},
+			config.configPath,
+			args.updateConfig,
 			`📋 To start using your config from a Worker, add the following binding configuration to your ${configFileName(config.configPath)} file:\n`
-		);
-		logger.log(
-			formatConfigSnippet(
-				{
-					hyperdrive: [{ binding: "HYPERDRIVE", id: database.id }],
-				},
-				config.configPath
-			)
 		);
 	},
 });

--- a/packages/wrangler/src/hyperdrive/create.ts
+++ b/packages/wrangler/src/hyperdrive/create.ts
@@ -1,5 +1,4 @@
-import { configFileName } from "../config";
-import { updateWranglerConfigOrDisplaySnippet } from "../config/auto-update";
+import { handleResourceBindingAndConfigUpdate } from "../config/auto-update";
 import { createCommand } from "../core/create-command";
 import { logger } from "../logger";
 import { createConfig } from "./client";
@@ -23,10 +22,9 @@ export const hyperdriveCreateCommand = createCommand({
 			demandOption: true,
 			description: "The name of the Hyperdrive config",
 		},
-		"update-config": {
-			type: "boolean",
-			default: false,
-			description: "Automatically update wrangler.jsonc with the new hyperdrive binding without prompting",
+		"config-binding-name": {
+			type: "string",
+			description: "The binding name to use when updating wrangler.jsonc",
 		},
 		...upsertOptions("postgresql"),
 	},
@@ -45,17 +43,15 @@ export const hyperdriveCreateCommand = createCommand({
 			`✅ Created new Hyperdrive ${capitalizeScheme(database.origin.scheme)} config: ${database.id}`
 		);
 
-		// Auto-update wrangler config or show snippet
-		await updateWranglerConfigOrDisplaySnippet(
+		// Handle binding name and config update using unified utility
+		await handleResourceBindingAndConfigUpdate(
+			args,
+			{ ...config, configPath: config.configPath },
 			{
 				type: "hyperdrive",
 				id: database.id,
 				name: database.name,
-				binding: "HYPERDRIVE",
-			},
-			config.configPath,
-			args.updateConfig,
-			`📋 To start using your config from a Worker, add the following binding configuration to your ${configFileName(config.configPath)} file:\n`
+			}
 		);
 	},
 });

--- a/packages/wrangler/src/vectorize/create.ts
+++ b/packages/wrangler/src/vectorize/create.ts
@@ -1,4 +1,5 @@
-import { configFileName, formatConfigSnippet } from "../config";
+import { configFileName } from "../config";
+import { updateWranglerConfigOrDisplaySnippet } from "../config/auto-update";
 import { createCommand } from "../core/create-command";
 import { UserError } from "../errors";
 import { logger } from "../logger";
@@ -60,6 +61,11 @@ export const vectorizeCreateCommand = createCommand({
 			description:
 				"Create a deprecated Vectorize V1 index. This is not recommended and indexes created with this option need all other Vectorize operations to have this option enabled.",
 		},
+		"update-config": {
+			type: "boolean",
+			default: false,
+			description: "Automatically update wrangler.jsonc with the new vectorize binding without prompting",
+		},
 	},
 	positionalArgs: ["name"],
 	async handler(args, { config }) {
@@ -112,21 +118,18 @@ export const vectorizeCreateCommand = createCommand({
 		logger.log(
 			`✅ Successfully created a new Vectorize index: '${indexResult.name}'`
 		);
-		logger.log(
+
+		// Auto-update wrangler config or show snippet
+		await updateWranglerConfigOrDisplaySnippet(
+			{
+				type: "vectorize",
+				id: indexResult.name,
+				name: indexResult.name,
+				binding: bindingName,
+			},
+			config.configPath,
+			args.updateConfig,
 			`📋 To start querying from a Worker, add the following binding configuration to your ${configFileName(config.configPath)} file:\n`
-		);
-		logger.log(
-			formatConfigSnippet(
-				{
-					vectorize: [
-						{
-							binding: bindingName,
-							index_name: indexResult.name,
-						},
-					],
-				},
-				config.configPath
-			)
 		);
 	},
 });


### PR DESCRIPTION
addresses https://github.com/cloudflare/workers-sdk/issues/9730

1. Only support wrangler.jsonc. Supports KV, R2, D1, Hyperdrive, Vectorize
3. Make updating wrangler.jsonc optional, interactive, logs to console otherwise
4. Provide a flag to permit updating wrangler.jsonc from initial command line (--update-config)
5. Try to add binding and add _2, _3... to binding variable in event of conflict
6. Don't support auto-adding preview KV namespaces
7. Preserves comments and structure of wrangler.jsonc