### PR TITLE
Add `x-cf-pages-analytics` header when Web Analytics token is injected

### DIFF
--- a/.changeset/deep-mirrors-help.md
+++ b/.changeset/deep-mirrors-help.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/pages-shared": patch
+---
+
+Add `x-cf-pages-analytics` header when Web Analytics token is injected
+
+- Emit `x-cf-pages-analytics: 1` header when analytics script is added to HTML responses
+- Add comprehensive tests covering HTML with/without body, non-HTML responses, and missing analytics config
+- Header indicates when analytics injection is attempted regardless of HTMLRewriter success

--- a/packages/pages-shared/asset-server/handler.ts
+++ b/packages/pages-shared/asset-server/handler.ts
@@ -114,6 +114,7 @@ type FullHandlerContext<AssetEntry, ContentNegotiation, Asset> = {
 	metadata: Metadata;
 	xServerEnvHeader?: string;
 	xDeploymentIdHeader?: boolean;
+	xWebAnalyticsHeader?: boolean;
 	logError: (err: Error) => void;
 	setMetrics?: (metrics: HandlerMetrics) => void;
 	findAssetEntryForPath: FindAssetEntryForPath<AssetEntry>;
@@ -162,6 +163,7 @@ export async function generateHandler<
 	metadata,
 	xServerEnvHeader,
 	xDeploymentIdHeader,
+	xWebAnalyticsHeader,
 	logError,
 	setMetrics,
 	findAssetEntryForPath,
@@ -642,6 +644,9 @@ export async function generateHandler<
 				isHTMLContentType(asset.contentType) &&
 				metadata.analytics?.version === ANALYTICS_VERSION
 			) {
+				if (xWebAnalyticsHeader) {
+					response.headers.set("x-cf-pages-analytics", "1");
+				}
 				return new HTMLRewriter()
 					.on("body", {
 						element(e) {

--- a/packages/wrangler/src/miniflare-cli/assets.ts
+++ b/packages/wrangler/src/miniflare-cli/assets.ts
@@ -206,6 +206,7 @@ async function generateAssetsFetch(
 			request: request as unknown as WorkersRequest,
 			metadata: metadata as Metadata,
 			xServerEnvHeader: "dev",
+			xWebAnalyticsHeader: false,
 			logError: console.error,
 			findAssetEntryForPath: async (path) => {
 				const filepath = resolve(join(directory, path));


### PR DESCRIPTION
Fixes WC-3619.

- Emit `x-cf-pages-analytics: 1` header when analytics script is added to HTML responses
- Add comprehensive tests covering HTML with/without body, non-HTML responses, and missing analytics config
- Header indicates when analytics injection is attempted regardless of HTMLRewriter success

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not wrangler

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
