### PR TITLE
Allow "plain text" images when blocking vulnerable non-image responses

### DIFF
--- a/.changeset/fluffy-comics-study.md
+++ b/.changeset/fluffy-comics-study.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+Allow "plain text" images when blocking vulnerable non-image responses

--- a/packages/workers-shared/router-worker/src/worker.ts
+++ b/packages/workers-shared/router-worker/src/worker.ts
@@ -132,10 +132,12 @@ export default {
 
 					if (shouldBlockNonImageResponse) {
 						const resp = await env.USER_WORKER.fetch(maybeSecondRequest);
-						if (
-							!resp.headers.get("content-type")?.startsWith("image/") &&
-							resp.status !== 304
-						) {
+						const isImage = resp.headers
+							.get("content-type")
+							?.startsWith("image/");
+						const isPlainText =
+							resp.headers.get("content-type") === "text/plain";
+						if (!isImage && !isPlainText && resp.status !== 304) {
 							analytics.setData({ abuseMitigationBlocked: true });
 							return new Response("Blocked", { status: 403 });
 						}

--- a/packages/workers-shared/router-worker/tests/index.test.ts
+++ b/packages/workers-shared/router-worker/tests/index.test.ts
@@ -247,123 +247,143 @@ describe("unit tests", async () => {
 		expect(await response.text()).toEqual("hello from user worker");
 	});
 
-	it.each([
-		{
-			description:
-				"blocks /_next/image requests with remote URLs when not fetched as image",
-			url: "https://example.com/_next/image?url=https://evil.com/ssrf",
-		},
-		{
-			description:
-				"blocks /_next/image requests with remote URLs when not fetched as image for next apps host not at the root",
-			url: "https://example.com/some/subpath/_next/image?url=https://evil.com/ssrf",
-		},
-	])("$description", async ({ url }) => {
-		const request = new Request(url);
-		const ctx = createExecutionContext();
+	describe.each(["/some/subpath/", "/"])(
+		"blocking /_next/image requests hosted at %s with remote URLs",
+		(subpath) => {
+			it("blocks /_next/image requests with remote URLs when not fetched as image", async () => {
+				const request = new Request(
+					`https://example.com${subpath}_next/image?url=https://evil.com/ssrf`
+				);
+				const ctx = createExecutionContext();
 
-		const env = {
-			CONFIG: {
-				has_user_worker: true,
-				invoke_user_worker_ahead_of_assets: true,
-			},
-			USER_WORKER: {
-				async fetch(_: Request): Promise<Response> {
-					return new Response("<!DOCTYPE html><html></html>", {
-						headers: { "content-type": "text/html" },
-					});
-				},
-			},
-		} as Env;
-
-		const response = await worker.fetch(request, env, ctx);
-		expect(response.status).toBe(403);
-		expect(await response.text()).toBe("Blocked");
-	});
-
-	it.each([
-		{
-			description:
-				"allows /_next/image requests with remote URLs when fetched as image",
-			url: "https://example.com/_next/image?url=https://example.com/image.jpg",
-			headers: { "sec-fetch-dest": "image" } as HeadersInit,
-			userWorkerResponse: {
-				body: "fake image data",
-				headers: { "content-type": "image/jpeg" },
-				status: 200,
-			},
-			expectedStatus: 200,
-			expectedBody: "fake image data",
-		},
-		{
-			description:
-				"allows /_next/image with remote URL and image header regardless of response content",
-			url: "https://example.com/_next/image?url=https://example.com/image.jpg",
-			headers: { "sec-fetch-dest": "image" } as HeadersInit,
-			userWorkerResponse: {
-				body: "<!DOCTYPE html><html></html>",
-				headers: { "content-type": "text/html" },
-				status: 200,
-			},
-			expectedStatus: 200,
-			expectedBody: "<!DOCTYPE html><html></html>",
-		},
-		{
-			description: "allows /_next/image requests with local URLs",
-			url: "https://example.com/_next/image?url=/local/image.jpg",
-			headers: {} as HeadersInit,
-			userWorkerResponse: {
-				body: "local image data",
-				headers: { "content-type": "image/jpeg" },
-				status: 200,
-			},
-			expectedStatus: 200,
-			expectedBody: "local image data",
-		},
-		{
-			description: "allows /_next/image requests with 304 status",
-			url: "https://example.com/_next/image?url=https://example.com/image.jpg",
-			headers: {} as HeadersInit,
-			userWorkerResponse: {
-				body: null,
-				headers: { "content-type": "text/html" },
-				status: 304,
-			},
-			expectedStatus: 304,
-			expectedBody: null,
-		},
-	])(
-		"$description",
-		async ({
-			url,
-			headers,
-			userWorkerResponse,
-			expectedStatus,
-			expectedBody,
-		}) => {
-			const request = new Request(url, { headers });
-			const ctx = createExecutionContext();
-
-			const env = {
-				CONFIG: {
-					has_user_worker: true,
-					invoke_user_worker_ahead_of_assets: true,
-				},
-				USER_WORKER: {
-					async fetch(_: Request): Promise<Response> {
-						return new Response(userWorkerResponse.body, {
-							status: userWorkerResponse.status,
-							headers: userWorkerResponse.headers,
-						});
+				const env = {
+					CONFIG: {
+						has_user_worker: true,
+						invoke_user_worker_ahead_of_assets: true,
 					},
-				},
-			} as Env;
+					USER_WORKER: {
+						async fetch(_: Request): Promise<Response> {
+							return new Response("<!DOCTYPE html><html></html>", {
+								headers: { "content-type": "text/html" },
+							});
+						},
+					},
+				} as Env;
 
-			const response = await worker.fetch(request, env, ctx);
-			expect(response.status).toBe(expectedStatus);
-			if (expectedBody !== null) {
-				expect(await response.text()).toBe(expectedBody);
-			}
+				const response = await worker.fetch(request, env, ctx);
+				expect(response.status).toBe(403);
+				expect(await response.text()).toBe("Blocked");
+			});
+
+			it.each([
+				{
+					description:
+						"allows /_next/image requests with remote URLs when fetched as image",
+					url: `https://example.com${subpath}_next/image?url=https://example.com/image.jpg`,
+					headers: { "sec-fetch-dest": "image" } as HeadersInit,
+					userWorkerResponse: {
+						body: "fake image data",
+						headers: { "content-type": "image/jpeg" },
+						status: 200,
+					},
+					expectedStatus: 200,
+					expectedBody: "fake image data",
+				},
+				{
+					description:
+						"allows /_next/image requests with remote URLs that have content type starting with image/...",
+					url: `https://example.com${subpath}_next/image?url=https://example.com/image.jpg`,
+					userWorkerResponse: {
+						body: "fake image data",
+						headers: { "content-type": "image/jpeg" },
+						status: 200,
+					},
+					expectedStatus: 200,
+					expectedBody: "fake image data",
+				},
+				{
+					description:
+						"allows /_next/image requests with remote URLs that have content type text/plain",
+					url: `https://example.com${subpath}_next/image?url=https://example.com/image.jpg`,
+					userWorkerResponse: {
+						body: "fake image data",
+						headers: { "content-type": "text/plain" },
+						status: 200,
+					},
+					expectedStatus: 200,
+					expectedBody: "fake image data",
+				},
+				{
+					description:
+						"allows /_next/image with remote URL and image header regardless of response content",
+					url: `https://example.com${subpath}_next/image?url=https://example.com/image.jpg`,
+					headers: { "sec-fetch-dest": "image" } as HeadersInit,
+					userWorkerResponse: {
+						body: "<!DOCTYPE html><html></html>",
+						headers: { "content-type": "text/html" },
+						status: 200,
+					},
+					expectedStatus: 200,
+					expectedBody: "<!DOCTYPE html><html></html>",
+				},
+				{
+					description: "allows /_next/image requests with local URLs",
+					url: `https://example.com${subpath}_next/image?url=/local/image.jpg`,
+					headers: {} as HeadersInit,
+					userWorkerResponse: {
+						body: "local image data",
+						headers: { "content-type": "image/jpeg" },
+						status: 200,
+					},
+					expectedStatus: 200,
+					expectedBody: "local image data",
+				},
+				{
+					description: "allows /_next/image requests with 304 status",
+					url: `https://example.com${subpath}_next/image?url=https://example.com/image.jpg`,
+					headers: {} as HeadersInit,
+					userWorkerResponse: {
+						body: null,
+						headers: { "content-type": "text/html" },
+						status: 304,
+					},
+					expectedStatus: 304,
+					expectedBody: null,
+				},
+			])(
+				"$description",
+				async ({
+					url,
+					headers,
+					userWorkerResponse,
+					expectedStatus,
+					expectedBody,
+				}) => {
+					const request = new Request(url, { headers });
+					const ctx = createExecutionContext();
+
+					const env = {
+						CONFIG: {
+							has_user_worker: true,
+							invoke_user_worker_ahead_of_assets: true,
+						},
+						USER_WORKER: {
+							async fetch(_: Request): Promise<Response> {
+								return new Response(userWorkerResponse.body, {
+									status: userWorkerResponse.status,
+									headers: userWorkerResponse.headers,
+								});
+							},
+						},
+					} as Env;
+
+					const response = await worker.fetch(request, env, ctx);
+					expect(response.status).toBe(expectedStatus);
+					if (expectedBody !== null) {
+						expect(await response.text()).toBe(expectedBody);
+					}
+				}
+			);
 		}
 	);
 


### PR DESCRIPTION

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> assets stuff not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
