### PR TITLE
Skip remote E2E tests when no auth available

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,13 +31,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo
-        if: github.event.pull_request.head.repo.owner.login == 'cloudflare' || github.event_name == 'merge_group'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Install Dependencies
-        if: github.event.pull_request.head.repo.owner.login == 'cloudflare' || github.event_name == 'merge_group'
         uses: ./.github/actions/install-dependencies
         with:
           node-version: ${{ matrix.node }}
@@ -47,13 +45,11 @@ jobs:
           turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
 
       - name: Bump package versions
-        if: github.event.pull_request.head.repo.owner.login == 'cloudflare' || github.event_name == 'merge_group'
         run: node .github/changeset-version.js
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run Wrangler E2E tests
-        if: github.event.pull_request.head.repo.owner.login == 'cloudflare' || github.event_name == 'merge_group'
         run: pnpm run test:e2e:wrangler
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -59,9 +59,6 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
           HYPERDRIVE_DATABASE_URL: ${{ secrets.TEST_HYPERDRIVE_DATABASE_URL}}
-          WRANGLER: node --no-warnings ${{ github.workspace}}/packages/wrangler/bin/wrangler.js
-          WRANGLER_IMPORT: ${{ github.workspace}}/packages/wrangler/wrangler-dist/cli.js
-          MINIFLARE_IMPORT: ${{ github.workspace}}/packages/miniflare/dist/src/index.js
           NODE_OPTIONS: "--max_old_space_size=8192"
           WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-debug-logs/
           TEST_REPORT_PATH: ${{ runner.temp }}/test-report/index.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -330,42 +330,51 @@ export default mergeConfig(
 
 If you need to test the interaction of Wrangler with a real Cloudflare account, you can add an E2E test within the `packages/wrangler/e2e` folder. This lets you add a test for functionality that requires real credentials (i.e. testing whether a worker deployed from Wrangler can be accessed over the internet).
 
-When you open a PR to the `workers-sdk` repo, you should expect several checks to run in CI. For most PRs (except for those which trigger the **C3 E2E (Quarantine)** Action), every check should pass (although some will be skipped).
+A summary of this repositories actions can be found [in the `.github/workflows` folder](.github/workflows/README.md)
 
-A summary of this repositories actions can be found [here](.github/workflows/README.md)
+## Running E2E tests locally
 
-## Running e2e tests locally
+A large number of Wrangler & Vite's E2E tests don't require any authentication, and can be run with no Cloudflare account credentials. These can be run as follows:
 
-To run the e2e tests locally, you'll need a Cloudflare API Token and run:
+- **Vite:** `pnpm test:e2e -F @cloudflare/vite-plugin`, optionally providing [`CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` environment variables.](#creating-an-api-token)
 
-```sh
-WRANGLER="node ~/path/to/workers-sdk/packages/wrangler/wrangler-dist/cli.js" CLOUDFLARE_ACCOUNT_ID=$CLOUDFLARE_TESTING_ACCOUNT_ID CLOUDFLARE_API_TOKEN=$CLOUDFLARE_TESTING_API_TOKEN pnpm run test:e2e
-```
+- **Wrangler:** `pnpm test:e2e:wrangler`, optionally providing [`CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` environment variables.](#creating-an-api-token)
 
 You may optionally want to append a filename pattern to limit which e2e tests are run. Also you may want to set `--bail=n` to limit the number of fails tests to show the error before the rest of the tests finish running and to limit the noise in that output:
 
 ```sh
-WRANGLER="node ~/path/to/workers-sdk/packages/wrangler/wrangler-dist/cli.js" CLOUDFLARE_ACCOUNT_ID=$CLOUDFLARE_TESTING_ACCOUNT_ID CLOUDFLARE_API_TOKEN=$CLOUDFLARE_TESTING_API_TOKEN pnpm run test:e2e [file-pattern] --bail=1
+# Vite
+pnpm test:e2e -F @cloudflare/vite-plugin [file-pattern] --bail=1
+
+# Wrangler
+pnpm test:e2e:wrangler [file-pattern] --bail=1
 ```
 
 ### Creating an API Token
+
+If you want to run the E2E tests that access the Cloudflare API (e.g. for testing Worker deployment and interaction with bindings), you can create an API token for running the tests:
 
 1. Go to ["My Profile" > "User API Tokens"](https://dash.cloudflare.com/profile/api-tokens)
 1. Click "Create Token"
 1. Use the "Edit Cloudflare Workers" template
 1. Set "Account Resources" to "Include" the account you want to use for running the test
-   (Note for the internal wrangler team, here we use the "DevProd Testing" account)
-1. Set "Zone Resources" to "All zones from an account" and the same account as above
+   (for internal and CI use, this needs to be the "DevProd Testing" account)
+1. No "Zone Resources" are required for general use (for internal and CI use, this needs to be set to "All Zones")
 1. Click "Continue to summary"
 1. Verify your token works by running the curl command provided
-1. Set the environment variables in your terminal or in your profile file (e.g. ~/.zshrc, ~/.bashrc, ~/.profile, etc):
+
+Once you've created the token, you can use it when running E2E tests to test against the API:
 
 ```sh
-export CLOUDFLARE_TESTING_ACCOUNT_ID="<Account ID for the token you just created>"
-export CLOUDFLARE_TESTING_API_TOKEN="<Token you just created>"
+# Vite
+CLOUDFLARE_ACCOUNT_ID="<Account ID for the token you just created>" CLOUDFLARE_API_TOKEN="<Token you just created>" pnpm test:e2e -F @cloudflare/vite-plugin [file-pattern] --bail=1
+
+# Wrangler
+CLOUDFLARE_ACCOUNT_ID="<Account ID for the token you just created>" CLOUDFLARE_API_TOKEN="<Token you just created>" pnpm test:e2e:wrangler [file-pattern] --bail=1
 ```
 
-Note: Workers created in the e2e tests that fail might not always be cleaned up (deleted). Internal users with access to the "DevProd Testing" account can rely on an automated job to clean up the Workers based on the format of the name. If you use another account, please be aware you may want to manually delete the Workers yourself.
+> [!NOTE]
+> Workers and other resources created in the E2E tests might not always be cleaned up. Internal users with access to the "DevProd Testing" account can rely on an automated job to clean up the Workers and other resources, but if you use another account, please be aware you may want to manually delete the Workers and other resources yourself.
 
 ## Changesets
 

--- a/packages/wrangler/e2e/cert.test.ts
+++ b/packages/wrangler/e2e/cert.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
 import {
 	generateCaCertName,
 	generateLeafCertificate,
@@ -9,7 +10,7 @@ import {
 import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { normalizeOutput } from "./helpers/normalize";
 
-describe("cert", () => {
+describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("cert", () => {
 	const normalize = (str: string) =>
 		normalizeOutput(str, {
 			[process.env.CLOUDFLARE_ACCOUNT_ID as string]: "CLOUDFLARE_ACCOUNT_ID",

--- a/packages/wrangler/e2e/dev-env.test.ts
+++ b/packages/wrangler/e2e/dev-env.test.ts
@@ -5,7 +5,7 @@ import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
 import { makeRoot, seed } from "./helpers/setup";
 import { WRANGLER_IMPORT } from "./helpers/wrangler";
 
-describe("switching runtimes", () => {
+describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("switching runtimes", () => {
 	let root: string;
 	beforeEach(async () => {
 		root = await makeRoot();

--- a/packages/wrangler/e2e/dev-remote-bindings.test.ts
+++ b/packages/wrangler/e2e/dev-remote-bindings.test.ts
@@ -4,271 +4,64 @@ import { setTimeout } from "node:timers/promises";
 import getPort from "get-port";
 import dedent from "ts-dedent";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
 import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { fetchText } from "./helpers/fetch-text";
 import { generateResourceName } from "./helpers/generate-resource-name";
 import { normalizeOutput } from "./helpers/normalize";
 import { makeRoot, seed } from "./helpers/setup";
 
-describe("wrangler dev - remote bindings", () => {
-	const remoteWorkerName = generateResourceName();
-	const alternativeRemoteWorkerName = generateResourceName();
-	const helper = new WranglerE2ETestHelper();
+describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
+	"wrangler dev - remote bindings",
+	() => {
+		const remoteWorkerName = generateResourceName();
+		const alternativeRemoteWorkerName = generateResourceName();
+		const helper = new WranglerE2ETestHelper();
 
-	beforeAll(async () => {
-		await helper.seed(
-			resolve(__dirname, "./seed-files/remote-binding-workers")
-		);
+		beforeAll(async () => {
+			await helper.seed(
+				resolve(__dirname, "./seed-files/remote-binding-workers")
+			);
 
-		await helper.seed({
-			"remote-worker.js": dedent/* javascript */ `
+			await helper.seed({
+				"remote-worker.js": dedent/* javascript */ `
 					export default {
 						fetch() {
 							return new Response('Hello from a remote worker (wrangler dev mixed-mode)');
 						}
 					};
 			`,
-		});
-		await helper.run(
-			`wrangler deploy remote-worker.js --name ${remoteWorkerName} --compatibility-date 2025-01-01`
-		);
-		await helper.seed({
-			"alt-remote-worker.js": dedent/* javascript */ `
+			});
+			await helper.run(
+				`wrangler deploy remote-worker.js --name ${remoteWorkerName} --compatibility-date 2025-01-01`
+			);
+			await helper.seed({
+				"alt-remote-worker.js": dedent/* javascript */ `
 				export default {
 					fetch() {
 						return new Response('Hello from an alternative remote worker (wrangler dev mixed-mode)');
 					}
 				};`,
-		});
-		await helper.run(
-			`wrangler deploy alt-remote-worker.js --name ${alternativeRemoteWorkerName} --compatibility-date 2025-01-01`
-		);
-	}, 35_000);
+			});
+			await helper.run(
+				`wrangler deploy alt-remote-worker.js --name ${alternativeRemoteWorkerName} --compatibility-date 2025-01-01`
+			);
+		}, 35_000);
 
-	afterAll(async () => {
-		await helper.run(`wrangler delete --name ${remoteWorkerName}`);
-		await helper.run(`wrangler delete --name ${alternativeRemoteWorkerName}`);
-	});
-
-	it("handles both remote and local service bindings at the same time", async () => {
-		await spawnLocalWorker(helper);
-		await helper.seed({
-			"wrangler.json": JSON.stringify({
-				name: "mixed-mode-mixed-bindings-test",
-				main: "local-and-remote-service-bindings.js",
-				compatibility_date: "2025-05-07",
-				services: [
-					{ binding: "LOCAL_WORKER", service: "local-worker", remote: false },
-					{
-						binding: "REMOTE_WORKER",
-						service: remoteWorkerName,
-						experimental_remote: true,
-					},
-				],
-			}),
+		afterAll(async () => {
+			await helper.run(`wrangler delete --name ${remoteWorkerName}`);
+			await helper.run(`wrangler delete --name ${alternativeRemoteWorkerName}`);
 		});
 
-		const worker = helper.runLongLived("wrangler dev --x-remote-bindings");
-
-		const { url } = await worker.waitForReady();
-
-		await expect(fetchText(url)).resolves.toMatchInlineSnapshot(`
-			"LOCAL<WORKER>: Hello from a local worker!
-			REMOTE<WORKER>: Hello from a remote worker (wrangler dev mixed-mode)
-			"
-		`);
-	});
-
-	it("allows code changes during development", async () => {
-		await spawnLocalWorker(helper);
-		await helper.seed({
-			"wrangler.json": JSON.stringify({
-				name: "mixed-mode-mixed-bindings-test",
-				main: "simple-service-binding.js",
-				compatibility_date: "2025-05-07",
-				services: [
-					{
-						binding: "REMOTE_WORKER",
-						service: remoteWorkerName,
-						experimental_remote: true,
-					},
-				],
-			}),
-		});
-
-		const worker = helper.runLongLived("wrangler dev --x-remote-bindings");
-
-		const { url } = await worker.waitForReady();
-
-		await expect(fetchText(url)).resolves.toMatchInlineSnapshot(
-			`"REMOTE<WORKER>: Hello from a remote worker (wrangler dev mixed-mode)"`
-		);
-
-		const indexContent = await readFile(
-			`${helper.tmpPath}/simple-service-binding.js`,
-			"utf8"
-		);
-		await writeFile(
-			`${helper.tmpPath}/simple-service-binding.js`,
-			indexContent.replace(
-				"REMOTE<WORKER>:",
-				"The remote worker responded with:"
-			),
-			"utf8"
-		);
-
-		await setTimeout(500);
-
-		await expect(fetchText(url)).resolves.toMatchInlineSnapshot(
-			`"The remote worker responded with: Hello from a remote worker (wrangler dev mixed-mode)"`
-		);
-
-		await writeFile(
-			`${helper.tmpPath}/simple-service-binding.js`,
-			indexContent,
-			"utf8"
-		);
-
-		await setTimeout(500);
-
-		await expect(fetchText(url)).resolves.toMatchInlineSnapshot(
-			`"REMOTE<WORKER>: Hello from a remote worker (wrangler dev mixed-mode)"`
-		);
-	});
-
-	it("handles workers AI alongside a local service binding", async () => {
-		await spawnLocalWorker(helper);
-		await helper.seed({
-			"wrangler.json": JSON.stringify({
-				name: "mixed-mode-mixed-bindings-test",
-				main: "local-service-binding-and-remote-ai.js",
-				compatibility_date: "2025-05-07",
-				ai: {
-					binding: "AI",
-				},
-				services: [
-					{ binding: "LOCAL_WORKER", service: "local-worker", remote: false },
-				],
-			}),
-		});
-
-		const worker = helper.runLongLived("wrangler dev --x-remote-bindings");
-
-		const { url } = await worker.waitForReady();
-
-		await expect(fetchText(url)).resolves.toMatchInlineSnapshot(`
-			"LOCAL<WORKER>: Hello from a local worker!
-			REMOTE<AI>: "This is a response from Workers AI."
-			"
-		`);
-	});
-
-	it("doesn't show any logs from startMixedModeSession()", async () => {
-		await spawnLocalWorker(helper);
-		await helper.seed({
-			"wrangler.json": JSON.stringify({
-				name: "mixed-mode-mixed-bindings-test",
-				main: "ai.js",
-				compatibility_date: "2025-05-07",
-				ai: {
-					binding: "AI",
-				},
-			}),
-		});
-
-		const worker = helper.runLongLived("wrangler dev --x-remote-bindings");
-
-		const { url } = await worker.waitForReady();
-
-		await expect(fetchText(url)).resolves.toMatchInlineSnapshot(
-			`""This is a response from Workers AI.""`
-		);
-
-		// This should only include logs from the user Wrangler session (i.e. a single list of attached bindings, and only one ready message)
-		expect(normalizeOutput(worker.currentOutput)).toMatchInlineSnapshot(`
-			"Your Worker has access to the following bindings:
-			Binding        Resource      Mode
-			env.AI         AI            remote
-			[wrangler:info] Ready on http://<HOST>:<PORT>
-			▲ [WARNING] AI bindings always access remote resources, and so may incur usage charges even in local dev. To suppress this warning, set \`experimental_remote: true\` for the binding definition in your configuration file.
-			⎔ Starting local server...
-			[wrangler:info] GET / 200 OK (TIMINGS)"
-		`);
-	});
-
-	describe("shows helpful error logs", () => {
-		it("when a remote service binding is not properly configured", async () => {
+		it("handles both remote and local service bindings at the same time", async () => {
+			await spawnLocalWorker(helper);
 			await helper.seed({
 				"wrangler.json": JSON.stringify({
 					name: "mixed-mode-mixed-bindings-test",
-					main: "simple-service-binding.js",
-					compatibility_date: "2025-05-07",
-					services: [
-						{
-							binding: "REMOTE_WORKER",
-							service: "non-existent-service-binding",
-							experimental_remote: true,
-						},
-					],
-				}),
-			});
-
-			const worker = helper.runLongLived("wrangler dev --x-remote-bindings");
-
-			await worker.waitForReady();
-
-			await vi.waitFor(
-				() =>
-					expect(worker.currentOutput).toContain(
-						"Could not resolve service binding 'REMOTE_WORKER'. Target script 'non-existent-service-binding' not found."
-					),
-				5_000
-			);
-		});
-
-		it("when a remote KV binding is not properly configured", async () => {
-			await helper.seed({
-				"wrangler.json": JSON.stringify({
-					name: "mixed-mode-mixed-bindings-test",
-					main: "kv.js",
-					compatibility_date: "2025-05-07",
-					kv_namespaces: [
-						{
-							binding: "KV_BINDING",
-							id: "non-existent-kv",
-							experimental_remote: true,
-						},
-					],
-				}),
-			});
-
-			const worker = helper.runLongLived("wrangler dev --x-remote-bindings");
-
-			await worker.waitForReady();
-
-			await vi.waitFor(
-				() =>
-					expect(worker.currentOutput).toContain(
-						"KV namespace 'non-existent-kv' is not valid."
-					),
-				5_000
-			);
-		});
-	});
-
-	describe("multi-worker", () => {
-		it("handles both remote and local service bindings at the same time in all workers", async () => {
-			await helper.seed({
-				"wrangler.json": JSON.stringify({
-					name: "mixed-mode-mixed-bindings-multi-worker-test",
 					main: "local-and-remote-service-bindings.js",
 					compatibility_date: "2025-05-07",
 					services: [
-						{
-							binding: "LOCAL_WORKER",
-							service: "local-test-worker",
-							remote: false,
-						},
+						{ binding: "LOCAL_WORKER", service: "local-worker", remote: false },
 						{
 							binding: "REMOTE_WORKER",
 							service: remoteWorkerName,
@@ -277,44 +70,255 @@ describe("wrangler dev - remote bindings", () => {
 					],
 				}),
 			});
-			const localTest = makeRoot();
-			await seed(localTest, {
+
+			const worker = helper.runLongLived("wrangler dev --x-remote-bindings");
+
+			const { url } = await worker.waitForReady();
+
+			await expect(fetchText(url)).resolves.toMatchInlineSnapshot(`
+			"LOCAL<WORKER>: Hello from a local worker!
+			REMOTE<WORKER>: Hello from a remote worker (wrangler dev mixed-mode)
+			"
+		`);
+		});
+
+		it("allows code changes during development", async () => {
+			await spawnLocalWorker(helper);
+			await helper.seed({
 				"wrangler.json": JSON.stringify({
-					name: "local-test-worker",
-					main: "index.js",
+					name: "mixed-mode-mixed-bindings-test",
+					main: "simple-service-binding.js",
 					compatibility_date: "2025-05-07",
 					services: [
 						{
-							// Note: we use the same binding name but bound to a difference service
 							binding: "REMOTE_WORKER",
-							service: alternativeRemoteWorkerName,
+							service: remoteWorkerName,
 							experimental_remote: true,
 						},
 					],
 				}),
-				"index.js": dedent`
+			});
+
+			const worker = helper.runLongLived("wrangler dev --x-remote-bindings");
+
+			const { url } = await worker.waitForReady();
+
+			await expect(fetchText(url)).resolves.toMatchInlineSnapshot(
+				`"REMOTE<WORKER>: Hello from a remote worker (wrangler dev mixed-mode)"`
+			);
+
+			const indexContent = await readFile(
+				`${helper.tmpPath}/simple-service-binding.js`,
+				"utf8"
+			);
+			await writeFile(
+				`${helper.tmpPath}/simple-service-binding.js`,
+				indexContent.replace(
+					"REMOTE<WORKER>:",
+					"The remote worker responded with:"
+				),
+				"utf8"
+			);
+
+			await setTimeout(500);
+
+			await expect(fetchText(url)).resolves.toMatchInlineSnapshot(
+				`"The remote worker responded with: Hello from a remote worker (wrangler dev mixed-mode)"`
+			);
+
+			await writeFile(
+				`${helper.tmpPath}/simple-service-binding.js`,
+				indexContent,
+				"utf8"
+			);
+
+			await setTimeout(500);
+
+			await expect(fetchText(url)).resolves.toMatchInlineSnapshot(
+				`"REMOTE<WORKER>: Hello from a remote worker (wrangler dev mixed-mode)"`
+			);
+		});
+
+		it("handles workers AI alongside a local service binding", async () => {
+			await spawnLocalWorker(helper);
+			await helper.seed({
+				"wrangler.json": JSON.stringify({
+					name: "mixed-mode-mixed-bindings-test",
+					main: "local-service-binding-and-remote-ai.js",
+					compatibility_date: "2025-05-07",
+					ai: {
+						binding: "AI",
+					},
+					services: [
+						{ binding: "LOCAL_WORKER", service: "local-worker", remote: false },
+					],
+				}),
+			});
+
+			const worker = helper.runLongLived("wrangler dev --x-remote-bindings");
+
+			const { url } = await worker.waitForReady();
+
+			await expect(fetchText(url)).resolves.toMatchInlineSnapshot(`
+			"LOCAL<WORKER>: Hello from a local worker!
+			REMOTE<AI>: "This is a response from Workers AI."
+			"
+		`);
+		});
+
+		it("doesn't show any logs from startMixedModeSession()", async () => {
+			await spawnLocalWorker(helper);
+			await helper.seed({
+				"wrangler.json": JSON.stringify({
+					name: "mixed-mode-mixed-bindings-test",
+					main: "ai.js",
+					compatibility_date: "2025-05-07",
+					ai: {
+						binding: "AI",
+					},
+				}),
+			});
+
+			const worker = helper.runLongLived("wrangler dev --x-remote-bindings");
+
+			const { url } = await worker.waitForReady();
+
+			await expect(fetchText(url)).resolves.toMatchInlineSnapshot(
+				`""This is a response from Workers AI.""`
+			);
+
+			// This should only include logs from the user Wrangler session (i.e. a single list of attached bindings, and only one ready message)
+			expect(normalizeOutput(worker.currentOutput)).toMatchInlineSnapshot(`
+			"Your Worker has access to the following bindings:
+			Binding        Resource      Mode
+			env.AI         AI            remote
+			[wrangler:info] Ready on http://<HOST>:<PORT>
+			▲ [WARNING] AI bindings always access remote resources, and so may incur usage charges even in local dev. To suppress this warning, set \`experimental_remote: true\` for the binding definition in your configuration file.
+			⎔ Starting local server...
+			[wrangler:info] GET / 200 OK (TIMINGS)"
+		`);
+		});
+
+		describe("shows helpful error logs", () => {
+			it("when a remote service binding is not properly configured", async () => {
+				await helper.seed({
+					"wrangler.json": JSON.stringify({
+						name: "mixed-mode-mixed-bindings-test",
+						main: "simple-service-binding.js",
+						compatibility_date: "2025-05-07",
+						services: [
+							{
+								binding: "REMOTE_WORKER",
+								service: "non-existent-service-binding",
+								experimental_remote: true,
+							},
+						],
+					}),
+				});
+
+				const worker = helper.runLongLived("wrangler dev --x-remote-bindings");
+
+				await worker.waitForReady();
+
+				await vi.waitFor(
+					() =>
+						expect(worker.currentOutput).toContain(
+							"Could not resolve service binding 'REMOTE_WORKER'. Target script 'non-existent-service-binding' not found."
+						),
+					5_000
+				);
+			});
+
+			it("when a remote KV binding is not properly configured", async () => {
+				await helper.seed({
+					"wrangler.json": JSON.stringify({
+						name: "mixed-mode-mixed-bindings-test",
+						main: "kv.js",
+						compatibility_date: "2025-05-07",
+						kv_namespaces: [
+							{
+								binding: "KV_BINDING",
+								id: "non-existent-kv",
+								experimental_remote: true,
+							},
+						],
+					}),
+				});
+
+				const worker = helper.runLongLived("wrangler dev --x-remote-bindings");
+
+				await worker.waitForReady();
+
+				await vi.waitFor(
+					() =>
+						expect(worker.currentOutput).toContain(
+							"KV namespace 'non-existent-kv' is not valid."
+						),
+					5_000
+				);
+			});
+		});
+
+		describe("multi-worker", () => {
+			it("handles both remote and local service bindings at the same time in all workers", async () => {
+				await helper.seed({
+					"wrangler.json": JSON.stringify({
+						name: "mixed-mode-mixed-bindings-multi-worker-test",
+						main: "local-and-remote-service-bindings.js",
+						compatibility_date: "2025-05-07",
+						services: [
+							{
+								binding: "LOCAL_WORKER",
+								service: "local-test-worker",
+								remote: false,
+							},
+							{
+								binding: "REMOTE_WORKER",
+								service: remoteWorkerName,
+								experimental_remote: true,
+							},
+						],
+					}),
+				});
+				const localTest = makeRoot();
+				await seed(localTest, {
+					"wrangler.json": JSON.stringify({
+						name: "local-test-worker",
+						main: "index.js",
+						compatibility_date: "2025-05-07",
+						services: [
+							{
+								// Note: we use the same binding name but bound to a difference service
+								binding: "REMOTE_WORKER",
+								service: alternativeRemoteWorkerName,
+								experimental_remote: true,
+							},
+						],
+					}),
+					"index.js": dedent`
 								export default {
 									async fetch(request, env) {
 										const remoteWorkerText = await (await env.REMOTE_WORKER.fetch(request)).text();
 										return new Response(\`[local-test-worker]REMOTE<WORKER>: \${remoteWorkerText}\`);
 									}
 								}`,
-			});
+				});
 
-			const worker = helper.runLongLived(
-				`wrangler dev --x-remote-bindings -c wrangler.json -c ${localTest}/wrangler.json`
-			);
+				const worker = helper.runLongLived(
+					`wrangler dev --x-remote-bindings -c wrangler.json -c ${localTest}/wrangler.json`
+				);
 
-			const { url } = await worker.waitForReady();
+				const { url } = await worker.waitForReady();
 
-			await expect(fetchText(url)).resolves.toMatchInlineSnapshot(`
+				await expect(fetchText(url)).resolves.toMatchInlineSnapshot(`
 				"LOCAL<WORKER>: [local-test-worker]REMOTE<WORKER>: Hello from an alternative remote worker (wrangler dev mixed-mode)
 				REMOTE<WORKER>: Hello from a remote worker (wrangler dev mixed-mode)
 				"
 			`);
+			});
 		});
-	});
-});
+	}
+);
 
 async function spawnLocalWorker(helper: WranglerE2ETestHelper): Promise<void> {
 	const local = makeRoot();

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -6,6 +6,7 @@ import { scheduler, setTimeout } from "node:timers/promises";
 import dedent from "ts-dedent";
 import { fetch } from "undici";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
 import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { fetchText } from "./helpers/fetch-text";
 import { fetchWithETag } from "./helpers/fetch-with-etag";
@@ -23,13 +24,15 @@ import { getStartedWorkerdProcesses } from "./helpers/workerd-processes";
  */
 const workerName = generateResourceName();
 
-describe.each([{ cmd: "wrangler dev" }, { cmd: "wrangler dev --remote" }])(
-	"basic js dev: $cmd",
-	({ cmd }) => {
-		it(`can modify Worker during ${cmd}`, async () => {
-			const helper = new WranglerE2ETestHelper();
-			await helper.seed({
-				"wrangler.toml": dedent`
+describe.each(
+	CLOUDFLARE_ACCOUNT_ID
+		? [{ cmd: "wrangler dev" }, { cmd: "wrangler dev --remote" }]
+		: [{ cmd: "wrangler dev" }]
+)("basic js dev: $cmd", ({ cmd }) => {
+	it(`can modify Worker during ${cmd}`, async () => {
+		const helper = new WranglerE2ETestHelper();
+		await helper.seed({
+			"wrangler.toml": dedent`
 							name = "${workerName}"
 							main = "src/index.ts"
 							compatibility_date = "2023-01-01"
@@ -38,19 +41,178 @@ describe.each([{ cmd: "wrangler dev" }, { cmd: "wrangler dev --remote" }])(
 							[vars]
 							KEY = "value"
 					`,
-				"src/index.ts": dedent`
+			"src/index.ts": dedent`
 							export default {
 								fetch(request) {
 									return new Response("Hello World!")
 								}
 							}`,
-				"package.json": dedent`
+			"package.json": dedent`
 							{
 								"name": "worker",
 								"version": "0.0.0",
 								"private": true
 							}
 							`,
+		});
+		const worker = helper.runLongLived(cmd);
+
+		const { url } = await worker.waitForReady();
+
+		await expect(fetch(url).then((r) => r.text())).resolves.toMatchSnapshot();
+
+		await helper.seed({
+			"src/index.ts": dedent`
+						export default {
+							fetch(request, env) {
+								return new Response("Updated Worker! " + env.KEY)
+							}
+						}`,
+		});
+
+		await worker.waitForReload();
+
+		// Regression test for issue where multiple request logs were being logged per request
+		expect([...worker.currentOutput.matchAll(/GET /g)].length).toBe(1);
+
+		await expect(fetchText(url)).resolves.toMatchSnapshot();
+	});
+
+	it(`hotkeys can be disabled with ${cmd}`, async () => {
+		const helper = new WranglerE2ETestHelper();
+		await helper.seed({
+			"wrangler.toml": dedent`
+							name = "${workerName}"
+							main = "src/index.ts"
+							compatibility_date = "2023-01-01"
+							compatibility_flags = ["nodejs_compat"]
+
+							[vars]
+							KEY = "value"
+					`,
+			"src/index.ts": dedent`
+							export default {
+								fetch(request) {
+									return new Response("Hello World!")
+								}
+							}`,
+			"package.json": dedent`
+							{
+								"name": "worker",
+								"version": "0.0.0",
+								"private": true
+							}
+							`,
+		});
+		const worker = helper.runLongLived(
+			`${cmd} --show-interactive-dev-session=false`
+		);
+
+		const { url } = await worker.waitForReady();
+
+		await expect(fetch(url).then((r) => r.text())).resolves.toMatchSnapshot();
+
+		await expect(worker.currentOutput).not.toContain("[b] open a browser");
+	});
+
+	describe(`--test-scheduled works with ${cmd}`, async () => {
+		it("custom build", async () => {
+			const helper = new WranglerE2ETestHelper();
+			await helper.seed({
+				"wrangler.toml": dedent`
+								name = "${workerName}"
+								main = "src/index.ts"
+								compatibility_date = "2023-01-01"
+								[build]
+								command = "true"
+						`,
+				"src/index.ts": dedent`
+								export default {
+									scheduled(event) {
+										console.log("Event triggered")
+									}
+								}`,
+				"package.json": dedent`
+								{
+									"name": "worker",
+									"version": "0.0.0",
+									"private": true
+								}
+								`,
+			});
+			const worker = helper.runLongLived(`${cmd} --test-scheduled`);
+
+			const { url } = await worker.waitForReady();
+
+			await expect(
+				fetch(`${url}/__scheduled`).then((r) => r.text())
+			).resolves.toMatchSnapshot();
+
+			await worker.readUntil(/Event triggered/);
+		});
+
+		it("no custom build", async () => {
+			const helper = new WranglerE2ETestHelper();
+			await helper.seed({
+				"wrangler.toml": dedent`
+								name = "${workerName}"
+								main = "src/index.ts"
+								compatibility_date = "2023-01-01"
+						`,
+				"src/index.ts": dedent`
+								export default {
+									scheduled(event) {
+										console.log("Event triggered")
+									}
+								}`,
+				"package.json": dedent`
+								{
+									"name": "worker",
+									"version": "0.0.0",
+									"private": true
+								}
+								`,
+			});
+			const worker = helper.runLongLived(`${cmd} --test-scheduled`);
+
+			const { url } = await worker.waitForReady();
+
+			await expect(
+				fetch(`${url}/__scheduled`).then((r) => r.text())
+			).resolves.toMatchSnapshot();
+
+			await worker.readUntil(/Event triggered/);
+		});
+	});
+
+	describe("Workers + Assets", () => {
+		it(`can modify User Worker during ${cmd}`, async () => {
+			const helper = new WranglerE2ETestHelper();
+			await helper.seed({
+				"wrangler.toml": dedent`
+								name = "${workerName}"
+								main = "src/index.ts"
+								compatibility_date = "2023-01-01"
+								compatibility_flags = ["nodejs_compat"]
+
+								[assets]
+								directory = "public"
+						`,
+				"src/index.ts": dedent`
+								export default {
+									fetch(request) {
+										return new Response("Hello World!")
+									}
+								}`,
+				"public/readme.md": dedent`
+								Welcome to Workers + Assets readme!`,
+				"package.json": dedent`
+								{
+									"name": "worker",
+									"version": "0.0.0",
+									"private": true
+								}
+								`,
 			});
 			const worker = helper.runLongLived(cmd);
 
@@ -60,183 +222,22 @@ describe.each([{ cmd: "wrangler dev" }, { cmd: "wrangler dev --remote" }])(
 
 			await helper.seed({
 				"src/index.ts": dedent`
-						export default {
-							fetch(request, env) {
-								return new Response("Updated Worker! " + env.KEY)
-							}
-						}`,
-			});
-
-			await worker.waitForReload();
-
-			// Regression test for issue where multiple request logs were being logged per request
-			expect([...worker.currentOutput.matchAll(/GET /g)].length).toBe(1);
-
-			await expect(fetchText(url)).resolves.toMatchSnapshot();
-		});
-
-		it(`hotkeys can be disabled with ${cmd}`, async () => {
-			const helper = new WranglerE2ETestHelper();
-			await helper.seed({
-				"wrangler.toml": dedent`
-							name = "${workerName}"
-							main = "src/index.ts"
-							compatibility_date = "2023-01-01"
-							compatibility_flags = ["nodejs_compat"]
-
-							[vars]
-							KEY = "value"
-					`,
-				"src/index.ts": dedent`
-							export default {
-								fetch(request) {
-									return new Response("Hello World!")
-								}
-							}`,
-				"package.json": dedent`
-							{
-								"name": "worker",
-								"version": "0.0.0",
-								"private": true
-							}
-							`,
-			});
-			const worker = helper.runLongLived(
-				`${cmd} --show-interactive-dev-session=false`
-			);
-
-			const { url } = await worker.waitForReady();
-
-			await expect(fetch(url).then((r) => r.text())).resolves.toMatchSnapshot();
-
-			await expect(worker.currentOutput).not.toContain("[b] open a browser");
-		});
-
-		describe(`--test-scheduled works with ${cmd}`, async () => {
-			it("custom build", async () => {
-				const helper = new WranglerE2ETestHelper();
-				await helper.seed({
-					"wrangler.toml": dedent`
-								name = "${workerName}"
-								main = "src/index.ts"
-								compatibility_date = "2023-01-01"
-								[build]
-								command = "true"
-						`,
-					"src/index.ts": dedent`
-								export default {
-									scheduled(event) {
-										console.log("Event triggered")
-									}
-								}`,
-					"package.json": dedent`
-								{
-									"name": "worker",
-									"version": "0.0.0",
-									"private": true
-								}
-								`,
-				});
-				const worker = helper.runLongLived(`${cmd} --test-scheduled`);
-
-				const { url } = await worker.waitForReady();
-
-				await expect(
-					fetch(`${url}/__scheduled`).then((r) => r.text())
-				).resolves.toMatchSnapshot();
-
-				await worker.readUntil(/Event triggered/);
-			});
-
-			it("no custom build", async () => {
-				const helper = new WranglerE2ETestHelper();
-				await helper.seed({
-					"wrangler.toml": dedent`
-								name = "${workerName}"
-								main = "src/index.ts"
-								compatibility_date = "2023-01-01"
-						`,
-					"src/index.ts": dedent`
-								export default {
-									scheduled(event) {
-										console.log("Event triggered")
-									}
-								}`,
-					"package.json": dedent`
-								{
-									"name": "worker",
-									"version": "0.0.0",
-									"private": true
-								}
-								`,
-				});
-				const worker = helper.runLongLived(`${cmd} --test-scheduled`);
-
-				const { url } = await worker.waitForReady();
-
-				await expect(
-					fetch(`${url}/__scheduled`).then((r) => r.text())
-				).resolves.toMatchSnapshot();
-
-				await worker.readUntil(/Event triggered/);
-			});
-		});
-
-		describe("Workers + Assets", () => {
-			it(`can modify User Worker during ${cmd}`, async () => {
-				const helper = new WranglerE2ETestHelper();
-				await helper.seed({
-					"wrangler.toml": dedent`
-								name = "${workerName}"
-								main = "src/index.ts"
-								compatibility_date = "2023-01-01"
-								compatibility_flags = ["nodejs_compat"]
-
-								[assets]
-								directory = "public"
-						`,
-					"src/index.ts": dedent`
-								export default {
-									fetch(request) {
-										return new Response("Hello World!")
-									}
-								}`,
-					"public/readme.md": dedent`
-								Welcome to Workers + Assets readme!`,
-					"package.json": dedent`
-								{
-									"name": "worker",
-									"version": "0.0.0",
-									"private": true
-								}
-								`,
-				});
-				const worker = helper.runLongLived(cmd);
-
-				const { url } = await worker.waitForReady();
-
-				await expect(
-					fetch(url).then((r) => r.text())
-				).resolves.toMatchSnapshot();
-
-				await helper.seed({
-					"src/index.ts": dedent`
 							export default {
 								fetch(request, env) {
 									return new Response("Updated Worker!")
 								}
 							}`,
-				});
-
-				await worker.waitForReload();
-
-				await expect(fetchText(url)).resolves.toMatchSnapshot();
 			});
 
-			it(`can modify assets during ${cmd}`, async () => {
-				const helper = new WranglerE2ETestHelper();
-				await helper.seed({
-					"wrangler.toml": dedent`
+			await worker.waitForReload();
+
+			await expect(fetchText(url)).resolves.toMatchSnapshot();
+		});
+
+		it(`can modify assets during ${cmd}`, async () => {
+			const helper = new WranglerE2ETestHelper();
+			await helper.seed({
+				"wrangler.toml": dedent`
 								name = "${workerName}"
 								main = "src/index.ts"
 								compatibility_date = "2023-01-01"
@@ -245,42 +246,39 @@ describe.each([{ cmd: "wrangler dev" }, { cmd: "wrangler dev --remote" }])(
 								[assets]
 								directory = "public"
 						`,
-					"src/index.ts": dedent`
+				"src/index.ts": dedent`
 								export default {
 									fetch(request) {
 										return new Response("Hello World!")
 									}
 								}`,
-					"public/readme.md": dedent`
+				"public/readme.md": dedent`
 								Welcome to Workers + Assets readme!`,
-					"package.json": dedent`
+				"package.json": dedent`
 								{
 									"name": "worker",
 									"version": "0.0.0",
 									"private": true
 								}
 								`,
-				});
-				const worker = helper.runLongLived(cmd);
-
-				const { url } = await worker.waitForReady();
-
-				await expect(
-					fetch(url).then((r) => r.text())
-				).resolves.toMatchSnapshot();
-
-				await helper.seed({
-					"public/readme.md": dedent`
-								Welcome to updated Workers + Assets readme!`,
-				});
-
-				await worker.waitForReload();
-
-				await expect(fetchText(url)).resolves.toMatchSnapshot();
 			});
+			const worker = helper.runLongLived(cmd);
+
+			const { url } = await worker.waitForReady();
+
+			await expect(fetch(url).then((r) => r.text())).resolves.toMatchSnapshot();
+
+			await helper.seed({
+				"public/readme.md": dedent`
+								Welcome to updated Workers + Assets readme!`,
+			});
+
+			await worker.waitForReload();
+
+			await expect(fetchText(url)).resolves.toMatchSnapshot();
 		});
-	}
-);
+	});
+});
 
 // This fails on Windows because of https://github.com/cloudflare/workerd/issues/1664
 it.runIf(process.platform !== "win32")(
@@ -705,12 +703,14 @@ describe("hyperdrive dev tests", () => {
 		await socketMsgPromise;
 	});
 
-	it("does not require local connection string when running `wrangler dev --remote`", async () => {
-		const helper = new WranglerE2ETestHelper();
-		const { id } = await helper.hyperdrive(false);
+	it.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
+		"does not require local connection string when running `wrangler dev --remote`",
+		async () => {
+			const helper = new WranglerE2ETestHelper();
+			const { id } = await helper.hyperdrive(false);
 
-		await helper.seed({
-			"wrangler.toml": dedent`
+			await helper.seed({
+				"wrangler.toml": dedent`
 					name = "${workerName}"
 					main = "src/index.ts"
 					compatibility_date = "2023-10-25"
@@ -719,7 +719,7 @@ describe("hyperdrive dev tests", () => {
 					binding = "HYPERDRIVE"
 					id = "${id}"
 			`,
-			"src/index.ts": dedent`
+				"src/index.ts": dedent`
 					export default {
 						async fetch(request, env) {
 							if (request.url.includes("connect")) {
@@ -728,20 +728,21 @@ describe("hyperdrive dev tests", () => {
 							return new Response(env.HYPERDRIVE?.connectionString ?? "no")
 						}
 					}`,
-			"package.json": dedent`
+				"package.json": dedent`
 					{
 						"name": "worker",
 						"version": "0.0.0",
 						"private": true
 					}
 					`,
-		});
+			});
 
-		const worker = helper.runLongLived("wrangler dev --remote");
+			const worker = helper.runLongLived("wrangler dev --remote");
 
-		const { url } = await worker.waitForReady();
-		await fetch(`${url}/connect`);
-	});
+			const { url } = await worker.waitForReady();
+			await fetch(`${url}/connect`);
+		}
+	);
 
 	afterEach(() => {
 		if (server.listening) {
@@ -950,42 +951,44 @@ describe("analytics engine", () => {
 	);
 });
 
-describe("zone selection", () => {
-	it("defaults to a workers.dev preview", async () => {
-		const helper = new WranglerE2ETestHelper();
-		await helper.seed({
-			"wrangler.toml": dedent`
+describe.skipIf(CLOUDFLARE_ACCOUNT_ID !== "8d783f274e1f82dc46744c297b015a2f")(
+	"zone selection",
+	() => {
+		it("defaults to a workers.dev preview", async () => {
+			const helper = new WranglerE2ETestHelper();
+			await helper.seed({
+				"wrangler.toml": dedent`
 				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
 				compatibility_flags = ["nodejs_compat"]`,
-			"src/index.ts": dedent`
+				"src/index.ts": dedent`
 				export default {
 					fetch(request) {
 						return new Response(request.url)
 					}
 				}`,
-			"package.json": dedent`
+				"package.json": dedent`
 				{
 					"name": "worker",
 					"version": "0.0.0",
 					"private": true
 				}
 				`,
+			});
+			const worker = helper.runLongLived("wrangler dev --remote");
+
+			const { url } = await worker.waitForReady();
+
+			const text = await fetchText(url);
+
+			expect(text).toContain(`devprod-testing7928.workers.dev`);
 		});
-		const worker = helper.runLongLived("wrangler dev --remote");
 
-		const { url } = await worker.waitForReady();
-
-		const text = await fetchText(url);
-
-		expect(text).toContain(`devprod-testing7928.workers.dev`);
-	});
-
-	it("respects dev.host setting", async () => {
-		const helper = new WranglerE2ETestHelper();
-		await helper.seed({
-			"wrangler.toml": dedent`
+		it("respects dev.host setting", async () => {
+			const helper = new WranglerE2ETestHelper();
+			await helper.seed({
+				"wrangler.toml": dedent`
 				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
@@ -993,35 +996,35 @@ describe("zone selection", () => {
 
 				[dev]
 				host = "wrangler-testing.testing.devprod.cloudflare.dev"`,
-			"src/index.ts": dedent`
+				"src/index.ts": dedent`
 				export default {
 					fetch(request) {
 						return new Response(request.url)
 					}
 				}`,
-			"package.json": dedent`
+				"package.json": dedent`
 				{
 					"name": "worker",
 					"version": "0.0.0",
 					"private": true
 				}
 				`,
+			});
+			const worker = helper.runLongLived("wrangler dev --remote");
+
+			const { url } = await worker.waitForReady();
+
+			const text = await fetchText(url);
+
+			expect(text).toMatchInlineSnapshot(
+				`"https://wrangler-testing.testing.devprod.cloudflare.dev/"`
+			);
 		});
-		const worker = helper.runLongLived("wrangler dev --remote");
 
-		const { url } = await worker.waitForReady();
-
-		const text = await fetchText(url);
-
-		expect(text).toMatchInlineSnapshot(
-			`"https://wrangler-testing.testing.devprod.cloudflare.dev/"`
-		);
-	});
-
-	it("infers host from first route", async () => {
-		const helper = new WranglerE2ETestHelper();
-		await helper.seed({
-			"wrangler.toml": dedent`
+		it("infers host from first route", async () => {
+			const helper = new WranglerE2ETestHelper();
+			await helper.seed({
+				"wrangler.toml": dedent`
 				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
@@ -1031,35 +1034,35 @@ describe("zone selection", () => {
 				pattern = "wrangler-testing.testing.devprod.cloudflare.dev/*"
 				zone_name = "testing.devprod.cloudflare.dev"
 			`,
-			"src/index.ts": dedent`
+				"src/index.ts": dedent`
 				export default {
 					fetch(request) {
 						return new Response(request.url)
 					}
 				}`,
-			"package.json": dedent`
+				"package.json": dedent`
 				{
 					"name": "worker",
 					"version": "0.0.0",
 					"private": true
 				}
 				`,
+			});
+			const worker = helper.runLongLived("wrangler dev --remote");
+
+			const { url } = await worker.waitForReady();
+
+			const text = await fetchText(url);
+
+			expect(text).toMatchInlineSnapshot(
+				`"https://wrangler-testing.testing.devprod.cloudflare.dev/"`
+			);
 		});
-		const worker = helper.runLongLived("wrangler dev --remote");
 
-		const { url } = await worker.waitForReady();
-
-		const text = await fetchText(url);
-
-		expect(text).toMatchInlineSnapshot(
-			`"https://wrangler-testing.testing.devprod.cloudflare.dev/"`
-		);
-	});
-
-	it("fails with useful error message if host is not routable", async () => {
-		const helper = new WranglerE2ETestHelper();
-		await helper.seed({
-			"wrangler.toml": dedent`
+		it("fails with useful error message if host is not routable", async () => {
+			const helper = new WranglerE2ETestHelper();
+			await helper.seed({
+				"wrangler.toml": dedent`
 				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
@@ -1069,27 +1072,28 @@ describe("zone selection", () => {
 				pattern = "not-a-domain.testing.devprod.cloudflare.dev/*"
 				zone_name = "testing.devprod.cloudflare.dev"
 			`,
-			"src/index.ts": dedent`
+				"src/index.ts": dedent`
 				export default {
 					fetch(request) {
 						return new Response(request.url)
 					}
 				}`,
-			"package.json": dedent`
+				"package.json": dedent`
 				{
 					"name": "worker",
 					"version": "0.0.0",
 					"private": true
 				}
 				`,
-		});
-		const worker = helper.runLongLived("wrangler dev --remote");
+			});
+			const worker = helper.runLongLived("wrangler dev --remote");
 
-		await worker.readUntil(
-			/Could not access `not-a-domain.testing.devprod.cloudflare.dev`. Make sure the domain is set up to be proxied by Cloudflare/
-		);
-	});
-});
+			await worker.readUntil(
+				/Could not access `not-a-domain.testing.devprod.cloudflare.dev`. Make sure the domain is set up to be proxied by Cloudflare/
+			);
+		});
+	}
+);
 
 describe("custom builds", () => {
 	it("does not hang when custom build does not cause esbuild to run", async () => {

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -24,11 +24,10 @@ import { getStartedWorkerdProcesses } from "./helpers/workerd-processes";
  */
 const workerName = generateResourceName();
 
-describe.each(
-	CLOUDFLARE_ACCOUNT_ID
-		? [{ cmd: "wrangler dev" }, { cmd: "wrangler dev --remote" }]
-		: [{ cmd: "wrangler dev" }]
-)("basic js dev: $cmd", ({ cmd }) => {
+describe.each([
+	{ cmd: "wrangler dev" },
+	...(CLOUDFLARE_ACCOUNT_ID ? [{ cmd: "wrangler dev --remote" }] : []),
+])("basic js dev: $cmd", ({ cmd }) => {
 	it(`can modify Worker during ${cmd}`, async () => {
 		const helper = new WranglerE2ETestHelper();
 		await helper.seed({

--- a/packages/wrangler/e2e/get-platform-proxy.test.ts
+++ b/packages/wrangler/e2e/get-platform-proxy.test.ts
@@ -9,7 +9,7 @@ import { makeRoot, seed } from "./helpers/setup";
 import { WRANGLER_IMPORT } from "./helpers/wrangler";
 
 describe("getPlatformProxy()", () => {
-	describe("Workers AI", () => {
+	describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("Workers AI", () => {
 		let root: string;
 		beforeEach(async () => {
 			root = makeRoot();

--- a/packages/wrangler/e2e/helpers/wrangler.ts
+++ b/packages/wrangler/e2e/helpers/wrangler.ts
@@ -60,7 +60,19 @@ function getWranglerCommand(command: string) {
 		"Commands must start with `wrangler` (e.g. `wrangler dev`) but got " +
 			command
 	);
-	return `${WRANGLER} ${command.slice("wrangler ".length)}`;
+
+	// If the user hasn't specifically set an inspector port, set it to 0 to reduce port conflicts
+	const inspectorPort =
+		command.includes(`--inspector-port`) || !command.startsWith("wrangler dev")
+			? ""
+			: " --inspector-port 0";
+
+	// If the user hasn't specifically set a Worker port, set it to 0 to reduce port conflicts
+	const workerPort =
+		command.includes(`--port`) || !command.startsWith("wrangler dev")
+			? ""
+			: " --port 0";
+	return `${WRANGLER} ${command.slice("wrangler ".length)}${inspectorPort}${workerPort}`;
 }
 
 function getOptions({

--- a/packages/wrangler/e2e/miniflare-remote-resources.test.ts
+++ b/packages/wrangler/e2e/miniflare-remote-resources.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert";
 import path from "node:path";
 import dedent from "ts-dedent";
 import { beforeEach, describe, expect, it, onTestFinished } from "vitest";
+import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
 import {
 	generateLeafCertificate,
 	generateMtlsCertName,
@@ -403,26 +404,29 @@ const mtlsTest: TestCase<{ certificateId: string; workerName: string }> = {
 	],
 };
 
-describe.each([...testCases, mtlsTest])("Mixed Mode for $name", (testCase) => {
-	let helper: WranglerE2ETestHelper;
-	beforeEach(() => {
-		helper = new WranglerE2ETestHelper();
-	});
-	it("enabled", async () => {
-		await runTestCase(testCase as TestCase<unknown>, helper);
-	});
-	// Ensure the test case _relies_ on Mixed Mode, and fails in regular local dev
-	it(
-		"fails when disabled",
-		// Turn off retries because this test is expected to fail
-		{ retry: 0, fails: true },
-		async () => {
-			await runTestCase(testCase as TestCase<unknown>, helper, {
-				disableRemoteBindings: true,
-			});
-		}
-	);
-});
+describe.skipIf(!CLOUDFLARE_ACCOUNT_ID).each([...testCases, mtlsTest])(
+	"Mixed Mode for $name",
+	(testCase) => {
+		let helper: WranglerE2ETestHelper;
+		beforeEach(() => {
+			helper = new WranglerE2ETestHelper();
+		});
+		it("enabled", async () => {
+			await runTestCase(testCase as TestCase<unknown>, helper);
+		});
+		// Ensure the test case _relies_ on Mixed Mode, and fails in regular local dev
+		it(
+			"fails when disabled",
+			// Turn off retries because this test is expected to fail
+			{ retry: 0, fails: true },
+			async () => {
+				await runTestCase(testCase as TestCase<unknown>, helper, {
+					disableRemoteBindings: true,
+				});
+			}
+		);
+	}
+);
 
 async function runTestCase<T>(
 	testCase: TestCase<T>,

--- a/packages/wrangler/e2e/pages-deploy.test.ts
+++ b/packages/wrangler/e2e/pages-deploy.test.ts
@@ -1,9 +1,10 @@
 import dedent from "ts-dedent";
 import { describe, test } from "vitest";
+import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
 import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { generateResourceName } from "./helpers/generate-resource-name";
 
-describe("pages deploy", () => {
+describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("pages deploy", () => {
 	const helper = new WranglerE2ETestHelper();
 	const projectName = generateResourceName("pages");
 

--- a/packages/wrangler/e2e/provision.test.ts
+++ b/packages/wrangler/e2e/provision.test.ts
@@ -17,27 +17,30 @@ const normalize = (str: string) => {
 };
 const workerName = generateResourceName();
 
-describe("provisioning", { timeout: TIMEOUT }, () => {
-	let deployedUrl: string;
-	let kvId: string;
-	let kvId2: string;
-	let d1Id: string;
-	const helper = new WranglerE2ETestHelper();
+describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
+	"provisioning",
+	{ timeout: TIMEOUT },
+	() => {
+		let deployedUrl: string;
+		let kvId: string;
+		let kvId2: string;
+		let d1Id: string;
+		const helper = new WranglerE2ETestHelper();
 
-	it("can run dev without resource ids", async () => {
-		const worker = helper.runLongLived("wrangler dev --x-provision");
+		it("can run dev without resource ids", async () => {
+			const worker = helper.runLongLived("wrangler dev --x-provision");
 
-		const { url } = await worker.waitForReady();
-		await fetch(url);
+			const { url } = await worker.waitForReady();
+			await fetch(url);
 
-		const text = await fetchText(url);
+			const text = await fetchText(url);
 
-		expect(text).toMatchInlineSnapshot(`"Hello World!"`);
-	});
+			expect(text).toMatchInlineSnapshot(`"Hello World!"`);
+		});
 
-	beforeAll(async () => {
-		await helper.seed({
-			"wrangler.toml": dedent`
+		beforeAll(async () => {
+			await helper.seed({
+				"wrangler.toml": dedent`
 						name = "${workerName}"
 						main = "src/index.ts"
 						compatibility_date = "2023-01-01"
@@ -51,27 +54,27 @@ describe("provisioning", { timeout: TIMEOUT }, () => {
 						[[d1_databases]]
 						binding = "D1"
 						`,
-			"src/index.ts": dedent`
+				"src/index.ts": dedent`
 						export default {
 							fetch(request) {
 								return new Response("Hello World!")
 							}
 						}`,
-			"package.json": dedent`
+				"package.json": dedent`
 						{
 							"name": "${workerName}",
 							"version": "0.0.0",
 							"private": true
 						}
 						`,
+			});
 		});
-	});
 
-	it("can provision resources and deploy worker", async () => {
-		const worker = helper.runLongLived(`wrangler deploy --x-provision`);
-		await worker.exitCode;
-		const output = await worker.output;
-		expect(normalize(output)).toMatchInlineSnapshot(`
+		it("can provision resources and deploy worker", async () => {
+			const worker = helper.runLongLived(`wrangler deploy --x-provision`);
+			await worker.exitCode;
+			const output = await worker.output;
+			expect(normalize(output)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			The following bindings need to be provisioned:
 			Binding        Resource
@@ -98,37 +101,37 @@ describe("provisioning", { timeout: TIMEOUT }, () => {
 			  https://tmp-e2e-worker-00000000-0000-0000-0000-000000000000.SUBDOMAIN.workers.dev
 			Current Version ID: 00000000-0000-0000-0000-000000000000"
 		`);
-		const urlMatch = output.match(
-			/(?<url>https:\/\/tmp-e2e-.+?\..+?\.workers\.dev)/
-		);
-		assert(urlMatch?.groups);
-		deployedUrl = urlMatch.groups.url;
+			const urlMatch = output.match(
+				/(?<url>https:\/\/tmp-e2e-.+?\..+?\.workers\.dev)/
+			);
+			assert(urlMatch?.groups);
+			deployedUrl = urlMatch.groups.url;
 
-		const kvMatch = output.match(/env.KV \((?<kv>[0-9a-f]{32})/);
-		assert(kvMatch?.groups);
-		kvId = kvMatch.groups.kv;
+			const kvMatch = output.match(/env.KV \((?<kv>[0-9a-f]{32})/);
+			assert(kvMatch?.groups);
+			kvId = kvMatch.groups.kv;
 
-		const d1Match = output.match(
-			/env.D1 \((?<d1>\w{8}-\w{4}-\w{4}-\w{4}-\w{12})/
-		);
-		assert(d1Match?.groups);
-		d1Id = d1Match.groups.d1;
+			const d1Match = output.match(
+				/env.D1 \((?<d1>\w{8}-\w{4}-\w{4}-\w{4}-\w{12})/
+			);
+			assert(d1Match?.groups);
+			d1Id = d1Match.groups.d1;
 
-		const { text } = await retry(
-			(s) => s.status !== 200,
-			async () => {
-				const r = await fetch(deployedUrl);
-				return { text: await r.text(), status: r.status };
-			}
-		);
-		expect(text).toMatchInlineSnapshot('"Hello World!"');
-	});
+			const { text } = await retry(
+				(s) => s.status !== 200,
+				async () => {
+					const r = await fetch(deployedUrl);
+					return { text: await r.text(), status: r.status };
+				}
+			);
+			expect(text).toMatchInlineSnapshot('"Hello World!"');
+		});
 
-	it("can inherit bindings on re-deploy and won't re-provision", async () => {
-		const worker = helper.runLongLived(`wrangler deploy --x-provision`);
-		await worker.exitCode;
-		const output = await worker.output;
-		expect(normalize(output)).toMatchInlineSnapshot(`
+		it("can inherit bindings on re-deploy and won't re-provision", async () => {
+			const worker = helper.runLongLived(`wrangler deploy --x-provision`);
+			await worker.exitCode;
+			const output = await worker.output;
+			expect(normalize(output)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Your Worker has access to the following bindings:
 			Binding                 Resource
@@ -141,19 +144,19 @@ describe("provisioning", { timeout: TIMEOUT }, () => {
 			Current Version ID: 00000000-0000-0000-0000-000000000000"
 		`);
 
-		const { text } = await retry(
-			(s) => s.status !== 200,
-			async () => {
-				const r = await fetch(deployedUrl);
-				return { text: await r.text(), status: r.status };
-			}
-		);
-		expect(text).toMatchInlineSnapshot('"Hello World!"');
-	});
+			const { text } = await retry(
+				(s) => s.status !== 200,
+				async () => {
+					const r = await fetch(deployedUrl);
+					return { text: await r.text(), status: r.status };
+				}
+			);
+			expect(text).toMatchInlineSnapshot('"Hello World!"');
+		});
 
-	it("can inherit and provision resources on version upload", async () => {
-		await helper.seed({
-			"wrangler.toml": dedent`
+		it("can inherit and provision resources on version upload", async () => {
+			await helper.seed({
+				"wrangler.toml": dedent`
 						name = "${workerName}"
 						main = "src/index.ts"
 						compatibility_date = "2023-01-01"
@@ -164,13 +167,13 @@ describe("provisioning", { timeout: TIMEOUT }, () => {
 						[[kv_namespaces]]
 						binding = "KV2"
 						`,
-		});
-		const worker = helper.runLongLived(
-			`wrangler versions upload --x-provision`
-		);
-		await worker.exitCode;
-		const output = await worker.output;
-		expect(normalize(output)).toMatchInlineSnapshot(`
+			});
+			const worker = helper.runLongLived(
+				`wrangler versions upload --x-provision`
+			);
+			await worker.exitCode;
+			const output = await worker.output;
+			expect(normalize(output)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			The following bindings need to be provisioned:
 			Binding         Resource
@@ -191,17 +194,17 @@ describe("provisioning", { timeout: TIMEOUT }, () => {
 			Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment using the command wrangler versions deploy
 			Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy"
 		`);
-		const kvMatch = output.match(/env.KV2 \((?<kv>[0-9a-f]{32})/);
-		assert(kvMatch?.groups);
-		kvId2 = kvMatch.groups.kv;
-	});
+			const kvMatch = output.match(/env.KV2 \((?<kv>[0-9a-f]{32})/);
+			assert(kvMatch?.groups);
+			kvId2 = kvMatch.groups.kv;
+		});
 
-	afterAll(async () => {
-		// we need to add d1 back into the config because otherwise wrangler will
-		// call the api for all 5000 or so db's the e2e test account has
-		// :(
-		await helper.seed({
-			"wrangler.toml": dedent`
+		afterAll(async () => {
+			// we need to add d1 back into the config because otherwise wrangler will
+			// call the api for all 5000 or so db's the e2e test account has
+			// :(
+			await helper.seed({
+				"wrangler.toml": dedent`
 						name = "${workerName}"
 						main = "src/index.ts"
 						compatibility_date = "2023-01-01"
@@ -211,28 +214,33 @@ describe("provisioning", { timeout: TIMEOUT }, () => {
 						database_name = "${workerName}-d1"
 						database_id = "${d1Id}"
 						`,
-		});
-		let output = await helper.run(`wrangler r2 bucket delete ${workerName}-r2`);
-		expect(output.stdout).toContain(`Deleted bucket`);
-		output = await helper.run(`wrangler d1 delete ${workerName}-d1 -y`);
-		expect(output.stdout).toContain(`Deleted '${workerName}-d1' successfully.`);
-		output = await helper.run(`wrangler delete`);
-		expect(output.stdout).toContain("Successfully deleted");
+			});
+			let output = await helper.run(
+				`wrangler r2 bucket delete ${workerName}-r2`
+			);
+			expect(output.stdout).toContain(`Deleted bucket`);
+			output = await helper.run(`wrangler d1 delete ${workerName}-d1 -y`);
+			expect(output.stdout).toContain(
+				`Deleted '${workerName}-d1' successfully.`
+			);
+			output = await helper.run(`wrangler delete`);
+			expect(output.stdout).toContain("Successfully deleted");
 
-		await vi.waitFor(
-			async () => {
-				const res = await fetch(deployedUrl);
-				await expect(res.status).not.toBe(200);
-			},
-			{ interval: 1_000, timeout: 20_000 }
-		);
+			await vi.waitFor(
+				async () => {
+					const res = await fetch(deployedUrl);
+					await expect(res.status).not.toBe(200);
+				},
+				{ interval: 1_000, timeout: 20_000 }
+			);
 
-		output = await helper.run(
-			`wrangler kv namespace delete --namespace-id ${kvId}`
-		);
-		output = await helper.run(
-			`wrangler kv namespace delete --namespace-id ${kvId2}`
-		);
-		expect(output.stdout).toContain(`Deleted KV namespace`);
-	}, TIMEOUT);
-});
+			output = await helper.run(
+				`wrangler kv namespace delete --namespace-id ${kvId}`
+			);
+			output = await helper.run(
+				`wrangler kv namespace delete --namespace-id ${kvId2}`
+			);
+			expect(output.stdout).toContain(`Deleted KV namespace`);
+		}, TIMEOUT);
+	}
+);

--- a/packages/wrangler/e2e/r2.test.ts
+++ b/packages/wrangler/e2e/r2.test.ts
@@ -2,11 +2,12 @@ import crypto from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
 import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { generateResourceName } from "./helpers/generate-resource-name";
 import { normalizeOutput } from "./helpers/normalize";
 
-describe("r2", () => {
+describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("r2", () => {
 	const bucketName = generateResourceName("r2");
 	const fileContents = crypto.randomBytes(64).toString("hex");
 	const normalize = (str: string) =>

--- a/packages/wrangler/e2e/secrets-store.test.ts
+++ b/packages/wrangler/e2e/secrets-store.test.ts
@@ -1,12 +1,15 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
 import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { generateResourceName } from "./helpers/generate-resource-name";
 import { normalizeOutput } from "./helpers/normalize";
 
-const RUNTIMES = [
-	{ flags: "--remote", runtime: "remote" },
-	{ flags: "", runtime: "local" },
-] as const;
+const RUNTIMES = CLOUDFLARE_ACCOUNT_ID
+	? [
+			{ flags: "--remote", runtime: "remote" },
+			{ flags: "", runtime: "local" },
+		]
+	: [{ flags: "", runtime: "local" }];
 
 describe.each(RUNTIMES)(
 	"secrets-store $runtime",

--- a/packages/wrangler/e2e/secrets-store.test.ts
+++ b/packages/wrangler/e2e/secrets-store.test.ts
@@ -4,12 +4,10 @@ import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { generateResourceName } from "./helpers/generate-resource-name";
 import { normalizeOutput } from "./helpers/normalize";
 
-const RUNTIMES = CLOUDFLARE_ACCOUNT_ID
-	? [
-			{ flags: "--remote", runtime: "remote" },
-			{ flags: "", runtime: "local" },
-		]
-	: [{ flags: "", runtime: "local" }];
+const RUNTIMES = [
+	...(CLOUDFLARE_ACCOUNT_ID ? [{ flags: "--remote", runtime: "remote" }] : []),
+	{ flags: "", runtime: "local" },
+];
 
 describe.each(RUNTIMES)(
 	"secrets-store $runtime",

--- a/packages/wrangler/e2e/start-worker-remote-bindings.test.ts
+++ b/packages/wrangler/e2e/start-worker-remote-bindings.test.ts
@@ -3,10 +3,11 @@ import { resolve } from "node:path";
 import { setTimeout } from "node:timers/promises";
 import dedent from "ts-dedent";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
 import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { generateResourceName } from "./helpers/generate-resource-name";
 
-describe("startWorker - remote bindings", () => {
+describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("startWorker - remote bindings", () => {
 	const remoteWorkerName = generateResourceName();
 	const helper = new WranglerE2ETestHelper();
 

--- a/packages/wrangler/e2e/startWorker.test.ts
+++ b/packages/wrangler/e2e/startWorker.test.ts
@@ -11,9 +11,10 @@ import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
 import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import type { DevToolsEvent } from "../src/api";
 
-const OPTIONS = CLOUDFLARE_ACCOUNT_ID
-	? [{ remote: false }, { remote: true }]
-	: [{ remote: false }];
+const OPTIONS = [
+	{ remote: false },
+	...(CLOUDFLARE_ACCOUNT_ID ? [{ remote: true }] : []),
+];
 
 type Wrangler = Awaited<ReturnType<WranglerE2ETestHelper["importWrangler"]>>;
 

--- a/packages/wrangler/e2e/startWorker.test.ts
+++ b/packages/wrangler/e2e/startWorker.test.ts
@@ -7,10 +7,13 @@ import dedent from "ts-dedent";
 import undici from "undici";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import WebSocket from "ws";
+import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
 import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import type { DevToolsEvent } from "../src/api";
 
-const OPTIONS = [{ remote: false }, { remote: true }] as const;
+const OPTIONS = CLOUDFLARE_ACCOUNT_ID
+	? [{ remote: false }, { remote: true }]
+	: [{ remote: false }];
 
 type Wrangler = Awaited<ReturnType<WranglerE2ETestHelper["importWrangler"]>>;
 

--- a/packages/wrangler/e2e/validate-environment.ts
+++ b/packages/wrangler/e2e/validate-environment.ts
@@ -5,14 +5,14 @@ assert(
 	'You must provide a way to run Wrangler (WRANGLER="pnpm --silent dlx wrangler@beta" will run the latest beta)'
 );
 
-assert(
-	process.env.CLOUDFLARE_ACCOUNT_ID,
-	"You must provide a CLOUDFLARE_ACCOUNT_ID as an environment variable"
-);
+if (!process.env.CLOUDFLARE_ACCOUNT_ID) {
+	console.warn(
+		"No CLOUDFLARE_ACCOUNT_ID variable provided, skipping API tests"
+	);
+}
 
-assert(
-	process.env.CLOUDFLARE_API_TOKEN,
-	"You must provide a CLOUDFLARE_API_TOKEN as an environment variable"
-);
+if (!process.env.CLOUDFLARE_API_TOKEN) {
+	console.warn("No CLOUDFLARE_API_TOKEN variable provided, skipping API tests");
+}
 
 export const setup = () => {};

--- a/packages/wrangler/e2e/versions.test.ts
+++ b/packages/wrangler/e2e/versions.test.ts
@@ -21,47 +21,50 @@ const normalize = (str: string) =>
 		[CLOUDFLARE_ACCOUNT_ID]: "CLOUDFLARE_ACCOUNT_ID",
 	}).replaceAll(/^Author:.*$/gm, "Author:      person@example.com");
 
-describe("versions deploy", { timeout: TIMEOUT }, () => {
-	let versionId0: string;
-	let versionId1: string;
-	let versionId2: string;
-	let helper: WranglerE2ETestHelper;
+describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
+	"versions deploy",
+	{ timeout: TIMEOUT },
+	() => {
+		let versionId0: string;
+		let versionId1: string;
+		let versionId2: string;
+		let helper: WranglerE2ETestHelper;
 
-	beforeAll(async () => {
-		helper = new WranglerE2ETestHelper();
-		await helper.seed({
-			"wrangler.toml": dedent`
+		beforeAll(async () => {
+			helper = new WranglerE2ETestHelper();
+			await helper.seed({
+				"wrangler.toml": dedent`
 							name = "${workerName}"
 							main = "src/index.ts"
 							compatibility_date = "2023-01-01"
 					`,
-			"src/index.ts": dedent`
+				"src/index.ts": dedent`
 							export default {
 								fetch(request) {
 									return new Response("Hello World!")
 								}
 							}`,
-			"package.json": dedent`
+				"package.json": dedent`
 							{
 								"name": "${workerName}",
 								"version": "0.0.0",
 								"private": true
 							}
 							`,
+			});
+			// TEMP: regular deploy needed for the first time to *create* the worker (will create 1 extra version + deployment in snapshots below)
+			const deploy = await helper.run("wrangler deploy");
+			versionId0 = matchVersionId(deploy.stdout);
 		});
-		// TEMP: regular deploy needed for the first time to *create* the worker (will create 1 extra version + deployment in snapshots below)
-		const deploy = await helper.run("wrangler deploy");
-		versionId0 = matchVersionId(deploy.stdout);
-	});
 
-	it("should upload 1st Worker version", async () => {
-		const upload = await helper.run(
-			`wrangler versions upload --message "Upload via e2e test" --tag "e2e-upload"`
-		);
+		it("should upload 1st Worker version", async () => {
+			const upload = await helper.run(
+				`wrangler versions upload --message "Upload via e2e test" --tag "e2e-upload"`
+			);
 
-		versionId1 = matchVersionId(upload.stdout);
+			versionId1 = matchVersionId(upload.stdout);
 
-		expect(normalize(upload.stdout)).toMatchInlineSnapshot(`
+			expect(normalize(upload.stdout)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: (TIMINGS)
 			Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
@@ -71,12 +74,12 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment using the command wrangler versions deploy
 			Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy"
 		`);
-	});
+		});
 
-	it("should list 1 version", async () => {
-		const list = await helper.run(`wrangler versions list`);
+		it("should list 1 version", async () => {
+			const list = await helper.run(`wrangler versions list`);
 
-		expect(normalize(list.stdout)).toMatchInlineSnapshot(`
+			expect(normalize(list.stdout)).toMatchInlineSnapshot(`
 			"Version ID:  00000000-0000-0000-0000-000000000000
 			Created:     TIMESTAMP
 			Author:      person@example.com
@@ -91,16 +94,16 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			Message:     Upload via e2e test"
 		`);
 
-		expect(list.stdout).toMatch(/Message:\s+Upload via e2e test/);
-		expect(list.stdout).toMatch(/Tag:\s+e2e-upload/);
-	});
+			expect(list.stdout).toMatch(/Message:\s+Upload via e2e test/);
+			expect(list.stdout).toMatch(/Tag:\s+e2e-upload/);
+		});
 
-	it("should deploy 1st Worker version", async () => {
-		const deploy = await helper.run(
-			`wrangler versions deploy ${versionId1}@100% --message "Deploy via e2e test" --yes`
-		);
+		it("should deploy 1st Worker version", async () => {
+			const deploy = await helper.run(
+				`wrangler versions deploy ${versionId1}@100% --message "Deploy via e2e test" --yes`
+			);
 
-		expect(normalize(deploy.stdout)).toMatchInlineSnapshot(`
+			expect(normalize(deploy.stdout)).toMatchInlineSnapshot(`
 			"╭ Deploy Worker Versions by splitting traffic between multiple versions
 			│
 			├ Fetching latest deployment
@@ -134,12 +137,12 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			│
 			╰  SUCCESS  Deployed tmp-e2e-worker-00000000-0000-0000-0000-000000000000 version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
 		`);
-	});
+		});
 
-	it("should list 1 deployment", async () => {
-		const list = await helper.run(`wrangler deployments list`);
+		it("should list 1 deployment", async () => {
+			const list = await helper.run(`wrangler deployments list`);
 
-		expect(normalize(list.stdout)).toMatchInlineSnapshot(`
+			expect(normalize(list.stdout)).toMatchInlineSnapshot(`
 			"Created:     TIMESTAMP
 			Author:      person@example.com
 			Source:      Upload
@@ -158,26 +161,26 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			                 Message:  Upload via e2e test"
 		`);
 
-		expect(list.stdout).toContain(versionId1);
-	});
+			expect(list.stdout).toContain(versionId1);
+		});
 
-	it("should modify & upload 2nd Worker version", async () => {
-		await helper.seed({
-			"src/index.ts": dedent`
+		it("should modify & upload 2nd Worker version", async () => {
+			await helper.seed({
+				"src/index.ts": dedent`
 				export default {
 					fetch(request) {
 						return new Response("Hello World AGAIN!")
 					}
 				}`,
-		});
+			});
 
-		const upload = await helper.run(
-			`wrangler versions upload --message "Upload AGAIN via e2e test" --tag "e2e-upload-AGAIN"`
-		);
+			const upload = await helper.run(
+				`wrangler versions upload --message "Upload AGAIN via e2e test" --tag "e2e-upload-AGAIN"`
+			);
 
-		versionId2 = matchVersionId(upload.stdout);
+			versionId2 = matchVersionId(upload.stdout);
 
-		expect(normalize(upload.stdout)).toMatchInlineSnapshot(`
+			expect(normalize(upload.stdout)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: (TIMINGS)
 			Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
@@ -188,9 +191,9 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy"
 		`);
 
-		const versionsList = await helper.run(`wrangler versions list`);
+			const versionsList = await helper.run(`wrangler versions list`);
 
-		expect(normalize(versionsList.stdout)).toMatchInlineSnapshot(`
+			expect(normalize(versionsList.stdout)).toMatchInlineSnapshot(`
 			"Version ID:  00000000-0000-0000-0000-000000000000
 			Created:     TIMESTAMP
 			Author:      person@example.com
@@ -211,18 +214,20 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			Message:     Upload AGAIN via e2e test"
 		`);
 
-		expect(versionsList.stdout).toMatch(/Message:\s+Upload AGAIN via e2e test/);
-		expect(versionsList.stdout).toMatch(/Tag:\s+e2e-upload-AGAIN/);
-	});
+			expect(versionsList.stdout).toMatch(
+				/Message:\s+Upload AGAIN via e2e test/
+			);
+			expect(versionsList.stdout).toMatch(/Tag:\s+e2e-upload-AGAIN/);
+		});
 
-	it("should deploy 2nd Worker version", async () => {
-		const deploy = await helper.run(
-			`wrangler versions deploy ${versionId2}@100% --message "Deploy AGAIN via e2e test" --yes`
-		);
+		it("should deploy 2nd Worker version", async () => {
+			const deploy = await helper.run(
+				`wrangler versions deploy ${versionId2}@100% --message "Deploy AGAIN via e2e test" --yes`
+			);
 
-		const deploymentsList = await helper.run(`wrangler deployments list`);
+			const deploymentsList = await helper.run(`wrangler deployments list`);
 
-		expect(normalize(deploy.stdout)).toMatchInlineSnapshot(`
+			expect(normalize(deploy.stdout)).toMatchInlineSnapshot(`
 			"╭ Deploy Worker Versions by splitting traffic between multiple versions
 			│
 			├ Fetching latest deployment
@@ -257,8 +262,8 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			╰  SUCCESS  Deployed tmp-e2e-worker-00000000-0000-0000-0000-000000000000 version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
 		`);
 
-		// list 2 deployments (+ old deployment)
-		expect(normalize(deploymentsList.stdout)).toMatchInlineSnapshot(`
+			// list 2 deployments (+ old deployment)
+			expect(normalize(deploymentsList.stdout)).toMatchInlineSnapshot(`
 			"Created:     TIMESTAMP
 			Author:      person@example.com
 			Source:      Upload
@@ -285,21 +290,21 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			                 Message:  Upload AGAIN via e2e test"
 		`);
 
-		expect(countOccurrences(deploymentsList.stdout, versionId0)).toBe(1); // once for regular deploy, only
-		expect(countOccurrences(deploymentsList.stdout, versionId1)).toBe(1); // once for versions deploy, only
-		expect(countOccurrences(deploymentsList.stdout, versionId2)).toBe(1); // once for versions deploy, only
-	});
+			expect(countOccurrences(deploymentsList.stdout, versionId0)).toBe(1); // once for regular deploy, only
+			expect(countOccurrences(deploymentsList.stdout, versionId1)).toBe(1); // once for versions deploy, only
+			expect(countOccurrences(deploymentsList.stdout, versionId2)).toBe(1); // once for versions deploy, only
+		});
 
-	it("should rollback to implicit Worker version (1st version)", async () => {
-		const rollback = await helper.run(
-			`wrangler rollback --message "Rollback via e2e test" --yes`
-		);
+		it("should rollback to implicit Worker version (1st version)", async () => {
+			const rollback = await helper.run(
+				`wrangler rollback --message "Rollback via e2e test" --yes`
+			);
 
-		const versionsList = await helper.run(`wrangler versions list`);
+			const versionsList = await helper.run(`wrangler versions list`);
 
-		const deploymentsList = await helper.run(`wrangler deployments list`);
+			const deploymentsList = await helper.run(`wrangler deployments list`);
 
-		expect(normalize(rollback.stdout)).toMatchInlineSnapshot(`
+			expect(normalize(rollback.stdout)).toMatchInlineSnapshot(`
 			"├ Fetching latest deployment
 			│
 			├ Your current deployment has 1 version(s):
@@ -333,12 +338,12 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			Current Version ID: 00000000-0000-0000-0000-000000000000"
 		`);
 
-		expect(rollback.stdout).toContain(
-			`Worker Version ${versionId1} has been deployed to 100% of traffic`
-		);
+			expect(rollback.stdout).toContain(
+				`Worker Version ${versionId1} has been deployed to 100% of traffic`
+			);
 
-		// list same versions as before (no new versions created)
-		expect(normalize(versionsList.stdout)).toMatchInlineSnapshot(`
+			// list same versions as before (no new versions created)
+			expect(normalize(versionsList.stdout)).toMatchInlineSnapshot(`
 			"Version ID:  00000000-0000-0000-0000-000000000000
 			Created:     TIMESTAMP
 			Author:      person@example.com
@@ -359,8 +364,8 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			Message:     Upload AGAIN via e2e test"
 		`);
 
-		// list deployments with new rollback deployment of 1st version (1 new deployment created)
-		expect(normalize(deploymentsList.stdout)).toMatchInlineSnapshot(`
+			// list deployments with new rollback deployment of 1st version (1 new deployment created)
+			expect(normalize(deploymentsList.stdout)).toMatchInlineSnapshot(`
 			"Created:     TIMESTAMP
 			Author:      person@example.com
 			Source:      Upload
@@ -395,21 +400,21 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			                 Message:  Upload via e2e test"
 		`);
 
-		expect(countOccurrences(deploymentsList.stdout, versionId0)).toBe(1); // once for regular deploy, only
-		expect(countOccurrences(deploymentsList.stdout, versionId1)).toBe(2); // once for versions deploy, once for rollback
-		expect(countOccurrences(deploymentsList.stdout, versionId2)).toBe(1); // once for versions deploy, only
-	});
+			expect(countOccurrences(deploymentsList.stdout, versionId0)).toBe(1); // once for regular deploy, only
+			expect(countOccurrences(deploymentsList.stdout, versionId1)).toBe(2); // once for versions deploy, once for rollback
+			expect(countOccurrences(deploymentsList.stdout, versionId2)).toBe(1); // once for versions deploy, only
+		});
 
-	it("should rollback to specific Worker version (0th version)", async () => {
-		const rollback = await helper.run(
-			`wrangler rollback ${versionId0} --message "Rollback to old version" --yes`
-		);
+		it("should rollback to specific Worker version (0th version)", async () => {
+			const rollback = await helper.run(
+				`wrangler rollback ${versionId0} --message "Rollback to old version" --yes`
+			);
 
-		const versionsList = await helper.run(`wrangler versions list`);
+			const versionsList = await helper.run(`wrangler versions list`);
 
-		const deploymentsList = await helper.run(`wrangler deployments list`);
+			const deploymentsList = await helper.run(`wrangler deployments list`);
 
-		expect(normalize(rollback.stdout)).toMatchInlineSnapshot(`
+			expect(normalize(rollback.stdout)).toMatchInlineSnapshot(`
 			"├ Fetching latest deployment
 			│
 			├ Your current deployment has 1 version(s):
@@ -440,12 +445,12 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			Current Version ID: 00000000-0000-0000-0000-000000000000"
 		`);
 
-		expect(rollback.stdout).toContain(
-			`Worker Version ${versionId0} has been deployed to 100% of traffic`
-		);
+			expect(rollback.stdout).toContain(
+				`Worker Version ${versionId0} has been deployed to 100% of traffic`
+			);
 
-		// list same versions as before (no new versions created)
-		expect(normalize(versionsList.stdout)).toMatchInlineSnapshot(`
+			// list same versions as before (no new versions created)
+			expect(normalize(versionsList.stdout)).toMatchInlineSnapshot(`
 			"Version ID:  00000000-0000-0000-0000-000000000000
 			Created:     TIMESTAMP
 			Author:      person@example.com
@@ -466,8 +471,8 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			Message:     Upload AGAIN via e2e test"
 		`);
 
-		// list deployments with new rollback deployment of 0th version (1 new deployment created)
-		expect(normalize(deploymentsList.stdout)).toMatchInlineSnapshot(`
+			// list deployments with new rollback deployment of 0th version (1 new deployment created)
+			expect(normalize(deploymentsList.stdout)).toMatchInlineSnapshot(`
 			"Created:     TIMESTAMP
 			Author:      person@example.com
 			Source:      Upload
@@ -510,14 +515,14 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			                 Message:  -"
 		`);
 
-		expect(countOccurrences(deploymentsList.stdout, versionId0)).toBe(2); // once for regular deploy, once for rollback
-		expect(countOccurrences(deploymentsList.stdout, versionId1)).toBe(2); // once for versions deploy, once for rollback
-		expect(countOccurrences(deploymentsList.stdout, versionId2)).toBe(1); // once for versions deploy, only
-	});
+			expect(countOccurrences(deploymentsList.stdout, versionId0)).toBe(2); // once for regular deploy, once for rollback
+			expect(countOccurrences(deploymentsList.stdout, versionId1)).toBe(2); // once for versions deploy, once for rollback
+			expect(countOccurrences(deploymentsList.stdout, versionId2)).toBe(1); // once for versions deploy, only
+		});
 
-	it("fails to upload if using Workers Sites", async () => {
-		await helper.seed({
-			"wrangler.toml": dedent`
+		it("fails to upload if using Workers Sites", async () => {
+			await helper.seed({
+				"wrangler.toml": dedent`
                 name = "${workerName}"
                 main = "src/index.ts"
                 compatibility_date = "2023-01-01"
@@ -525,54 +530,54 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
                 [site]
                 bucket = "./public"
             `,
-			"src/index.ts": dedent`
+				"src/index.ts": dedent`
                 export default {
                     fetch(request) {
                         return new Response("Hello World!")
                     }
                 }
             `,
-			"package.json": dedent`
+				"package.json": dedent`
                 {
                     "name": "${workerName}",
                     "version": "0.0.0",
                     "private": true
                 }
             `,
-		});
+			});
 
-		const upload = await helper.run(`wrangler versions upload`);
+			const upload = await helper.run(`wrangler versions upload`);
 
-		expect(normalize(upload.output)).toMatchInlineSnapshot(`
+			expect(normalize(upload.output)).toMatchInlineSnapshot(`
 			"X [ERROR] Workers Sites does not support uploading versions through \`wrangler versions upload\`. You must use \`wrangler deploy\` instead.
 			🪵  Logs were written to "<LOG>""
 		`);
-	});
+		});
 
-	it("should upload version of Worker with assets", async () => {
-		await helper.seed({
-			"wrangler.toml": dedent`
+		it("should upload version of Worker with assets", async () => {
+			await helper.seed({
+				"wrangler.toml": dedent`
 	            name = "${workerName}"
 	            compatibility_date = "2023-01-01"
 
 	            [assets]
 	            directory = "./public"
 	        `,
-			"public/asset.txt": `beep boop`,
-			"package.json": dedent`
+				"public/asset.txt": `beep boop`,
+				"package.json": dedent`
 	            {
 	                "name": "${workerName}",
 	                "version": "0.0.0",
 	                "private": true
 	            }
 	        `,
-		});
+			});
 
-		const upload = await helper.run(
-			`wrangler versions upload --message "Upload via e2e test" --tag "e2e-upload-assets"`
-		);
+			const upload = await helper.run(
+				`wrangler versions upload --message "Upload via e2e test" --tag "e2e-upload-assets"`
+			);
 
-		expect(normalize(upload.stdout)).toMatchInlineSnapshot(`
+			expect(normalize(upload.stdout)).toMatchInlineSnapshot(`
 			"🌀 Building list of assets...
 			✨ Read 1 file from the assets directory /tmpdir
 			🌀 Starting asset upload...
@@ -589,36 +594,37 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment using the command wrangler versions deploy
 			Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy"
 		`);
-	});
-
-	it("should include version preview url in output file", async () => {
-		const outputFile = path.join(helper.tmpPath, "output.jsonnd");
-		const upload = await helper.run(
-			`wrangler versions upload --message "Upload via e2e test" --tag "e2e-upload"`,
-			{
-				env: {
-					...process.env,
-					WRANGLER_OUTPUT_FILE_PATH: outputFile,
-				},
-			}
-		);
-
-		versionId1 = matchVersionId(upload.stdout);
-
-		const output = await readFile(outputFile, "utf8");
-
-		expect(JSON.parse(normalizeOutput(output.split("\n")[1]))).toMatchObject({
-			preview_url: "https://tmp-e2e-worker-PREVIEW-URL.SUBDOMAIN.workers.dev",
 		});
-	});
 
-	it("should delete Worker", async () => {
-		const { stdout } = await helper.run(`wrangler delete`);
+		it("should include version preview url in output file", async () => {
+			const outputFile = path.join(helper.tmpPath, "output.jsonnd");
+			const upload = await helper.run(
+				`wrangler versions upload --message "Upload via e2e test" --tag "e2e-upload"`,
+				{
+					env: {
+						...process.env,
+						WRANGLER_OUTPUT_FILE_PATH: outputFile,
+					},
+				}
+			);
 
-		expect(normalize(stdout)).toMatchInlineSnapshot(`
+			versionId1 = matchVersionId(upload.stdout);
+
+			const output = await readFile(outputFile, "utf8");
+
+			expect(JSON.parse(normalizeOutput(output.split("\n")[1]))).toMatchObject({
+				preview_url: "https://tmp-e2e-worker-PREVIEW-URL.SUBDOMAIN.workers.dev",
+			});
+		});
+
+		it("should delete Worker", async () => {
+			const { stdout } = await helper.run(`wrangler delete`);
+
+			expect(normalize(stdout)).toMatchInlineSnapshot(`
 			"? Are you sure you want to delete tmp-e2e-worker-00000000-0000-0000-0000-000000000000? This action cannot be undone.
 			🤖 Using fallback value in non-interactive context: yes
 			Successfully deleted tmp-e2e-worker-00000000-0000-0000-0000-000000000000"
 		`);
-	});
-});
+		});
+	}
+);

--- a/packages/wrangler/e2e/wrangler-remote-resources.test.ts
+++ b/packages/wrangler/e2e/wrangler-remote-resources.test.ts
@@ -11,6 +11,7 @@ import {
 	onTestFinished,
 	vi,
 } from "vitest";
+import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
 import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { fetchText } from "./helpers/fetch-text";
 import { generateResourceName } from "./helpers/generate-resource-name";
@@ -287,7 +288,7 @@ const testCases: TestCase<Record<string, string>>[] = [
 	},
 ];
 
-describe("Wrangler Mixed Mode E2E Tests", () => {
+describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("Wrangler Mixed Mode E2E Tests", () => {
 	describe.each(testCases)("$name", (testCase) => {
 		let helper: WranglerE2ETestHelper;
 

--- a/tools/e2e/runIndividualE2EFiles.ts
+++ b/tools/e2e/runIndividualE2EFiles.ts
@@ -1,3 +1,7 @@
+// Turbo's env var linting isn't very sophisticated.
+// This file adds environment variables that are declared in Wrangler's turbo.json
+/* eslint-disable turbo/no-undeclared-env-vars */
+
 /**
  * Turbo only supports caching on the individual task level, but for Wrangler's
  * e2e tests we want to support caching on a more granular basis—at the file level.
@@ -26,6 +30,13 @@ for (const file of e2eTests) {
 const failed: string[] = [];
 
 const command = `pnpm test:e2e --log-order=stream --output-logs=new-only --summarize --filter wrangler`;
+
+// Add the default environment configuration for E2E tests.
+// Most of these rely on Turbo being set up correctly to build Wrangler & C3:
+// https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler/turbo.json#L61-L62
+process.env.WRANGLER ??= `node --no-warnings ${process.cwd()}/packages/wrangler/bin/wrangler.js`;
+process.env.WRANGLER_IMPORT ??= `${process.cwd()}/packages/wrangler/wrangler-dist/cli.js`;
+process.env.MINIFLARE_IMPORT ??= `${process.cwd()}/packages/miniflare/dist/src/index.js`;
 
 for (const file of tasks) {
 	console.log("::group::Testing: " + file);


### PR DESCRIPTION
A large number of Wrangler's "E2E" tests actually require no Cloudflare auth tokens. This PR changes our E2E setup to enable running `pnpm test:e2e:wrangler` with no other arguments, which will run all non-API-requiring E2E tests, _including on forks in CI_.

Additionally, you can pass arguments to `pnpm test:e2e:wrangler` in order to configure Vitest. e.g. `pnpm test:e2e:wrangler -u` to update snapshots.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal repo change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
