### PR TITLE
update wrangler's `pnpm dev` to also watch the containers-shared src directory

### DIFF
--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -55,7 +55,7 @@
 		"check:lint": "eslint . --max-warnings=0",
 		"check:type": "tsc -p ./tsconfig.json && tsc -p ./templates/tsconfig.json",
 		"clean": "rimraf wrangler-dist miniflare-dist emitted-types",
-		"dev": "pnpm run clean && concurrently -c black,blue --kill-others-on-fail false \"pnpm tsup --watch\" \"pnpm run check:type --watch --preserveWatchOutput\"",
+		"dev": "pnpm run clean && concurrently -c black,blue --kill-others-on-fail false \"pnpm tsup --watch src --watch ../containers-shared/src\" \"pnpm run check:type --watch --preserveWatchOutput\"",
 		"generate-json-schema": "node -r esbuild-register scripts/generate-json-schema.ts",
 		"start": "pnpm run bundle && cross-env NODE_OPTIONS=--enable-source-maps ./bin/wrangler.js",
 		"test": "dotenv -- pnpm run assert-git-version && dotenv -- vitest",


### PR DESCRIPTION
wrangler imports files from the containers-shared package (which does not have a build/dev command itself), so the wrangler dev command needs to also watch the containers-shared directory to make sure that changes to files in such directory trigger appropriate wrangler rebuilds

___

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: infra change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: infra change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: unrelated to wrangler v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
