### PR TITLE
remove extraneous double spaces from help output

### DIFF
--- a/.changeset/cool-toes-repair.md
+++ b/.changeset/cool-toes-repair.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+remove extraneous double spaces from Wrangler help output

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -58,7 +58,7 @@ describe("wrangler", () => {
 				  wrangler hyperdrive             🚀 Manage Hyperdrive databases
 				  wrangler cert                   🪪 Manage client mTLS certificates and CA certificate chains used for secured connections [open-beta]
 				  wrangler pages                  ⚡️ Configure Cloudflare Pages
-				  wrangler mtls-certificate       🪪  Manage certificates used for mTLS connections
+				  wrangler mtls-certificate       🪪 Manage certificates used for mTLS connections
 				  wrangler pubsub                 📮 Manage Pub/Sub brokers [private beta]
 				  wrangler dispatch-namespace     🏗️  Manage dispatch namespaces
 				  wrangler ai                     🤖 Manage AI models
@@ -118,7 +118,7 @@ describe("wrangler", () => {
 				  wrangler hyperdrive             🚀 Manage Hyperdrive databases
 				  wrangler cert                   🪪 Manage client mTLS certificates and CA certificate chains used for secured connections [open-beta]
 				  wrangler pages                  ⚡️ Configure Cloudflare Pages
-				  wrangler mtls-certificate       🪪  Manage certificates used for mTLS connections
+				  wrangler mtls-certificate       🪪 Manage certificates used for mTLS connections
 				  wrangler pubsub                 📮 Manage Pub/Sub brokers [private beta]
 				  wrangler dispatch-namespace     🏗️  Manage dispatch namespaces
 				  wrangler ai                     🤖 Manage AI models

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -43,7 +43,7 @@ describe("wrangler", () => {
 				  wrangler deploy [script]        🆙 Deploy a Worker to Cloudflare
 				  wrangler deployments            🚢 List and view the current and past deployments for your Worker
 				  wrangler rollback [version-id]  🔙 Rollback a deployment for a Worker
-				  wrangler versions               🫧  List, view, upload and deploy Versions of your Worker to Cloudflare
+				  wrangler versions               🫧 List, view, upload and deploy Versions of your Worker to Cloudflare
 				  wrangler triggers               🎯 Updates the triggers of your current deployment [experimental]
 				  wrangler delete [script]        🗑  Delete a Worker from Cloudflare
 				  wrangler tail [worker]          🦚 Start a log tailing session for a Worker
@@ -103,7 +103,7 @@ describe("wrangler", () => {
 				  wrangler deploy [script]        🆙 Deploy a Worker to Cloudflare
 				  wrangler deployments            🚢 List and view the current and past deployments for your Worker
 				  wrangler rollback [version-id]  🔙 Rollback a deployment for a Worker
-				  wrangler versions               🫧  List, view, upload and deploy Versions of your Worker to Cloudflare
+				  wrangler versions               🫧 List, view, upload and deploy Versions of your Worker to Cloudflare
 				  wrangler triggers               🎯 Updates the triggers of your current deployment [experimental]
 				  wrangler delete [script]        🗑  Delete a Worker from Cloudflare
 				  wrangler tail [worker]          🦚 Start a log tailing session for a Worker

--- a/packages/wrangler/src/__tests__/mtls-certificates.test.ts
+++ b/packages/wrangler/src/__tests__/mtls-certificates.test.ts
@@ -394,7 +394,7 @@ describe("wrangler", () => {
 					expect(std.out).toMatchInlineSnapshot(`
 						"wrangler mtls-certificate
 
-						🪪  Manage certificates used for mTLS connections
+						🪪 Manage certificates used for mTLS connections
 
 						COMMANDS
 						  wrangler mtls-certificate upload  Upload an mTLS certificate

--- a/packages/wrangler/src/__tests__/versions/versions.help.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.help.test.ts
@@ -13,7 +13,7 @@ describe("versions --help", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"wrangler versions
 
-			🫧  List, view, upload and deploy Versions of your Worker to Cloudflare
+			🫧 List, view, upload and deploy Versions of your Worker to Cloudflare
 
 			COMMANDS
 			  wrangler versions view <version-id>         View the details of a specific version of your Worker
@@ -44,7 +44,7 @@ describe("versions subhelp", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"wrangler versions
 
-			🫧  List, view, upload and deploy Versions of your Worker to Cloudflare
+			🫧 List, view, upload and deploy Versions of your Worker to Cloudflare
 
 			COMMANDS
 			  wrangler versions view <version-id>         View the details of a specific version of your Worker

--- a/packages/wrangler/src/mtls-certificate/cli.ts
+++ b/packages/wrangler/src/mtls-certificate/cli.ts
@@ -141,7 +141,7 @@ export const mTlsCertificateDeleteCommand = createCommand({
 
 export const mTlsCertificateNamespace = createNamespace({
 	metadata: {
-		description: "🪪  Manage certificates used for mTLS connections",
+		description: "🪪 Manage certificates used for mTLS connections",
 		owner: "Product: SSL",
 		status: "stable",
 	},

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -3,7 +3,7 @@ import { createNamespace } from "../core/create-command";
 export const versionsNamespace = createNamespace({
 	metadata: {
 		description:
-			"🫧  List, view, upload and deploy Versions of your Worker to Cloudflare",
+			"🫧 List, view, upload and deploy Versions of your Worker to Cloudflare",
 		status: "stable",
 		owner: "Workers: Authoring and Testing",
 	},


### PR DESCRIPTION
Two Wrangler subcommands (`versions` and `mtls-certificate`) had an extra space between their emoji and description, unlike all of the other subcommands, making them misaligned in the terminal:
![20250703195845](https://github.com/user-attachments/assets/4b0fc79d-609c-43fa-9083-c662b2c400d8)

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: only a cosmetic change
- Wrangler V3 Backport
  - [ ] Wrangler PR:
  - [x] Not necessary because: only a cosmetic change
