### PR TITLE
fix: use logger (and log level) from miniflare for asset metadata parsing/loading logs

### DIFF
--- a/.changeset/fast-webs-know.md
+++ b/.changeset/fast-webs-know.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+use logger (and log level) from miniflare for asset metadata parsing/loading logs

--- a/fixtures/workers-with-assets/tests/index.test.ts
+++ b/fixtures/workers-with-assets/tests/index.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fetch } from "undici";
-import { afterAll, beforeAll, describe, it } from "vitest";
+import { afterAll, beforeAll, describe, it, onTestFinished } from "vitest";
 import { runWranglerDev } from "../../shared/src/run-wrangler-long-lived";
 
 describe("[Workers + Assets] dynamic site", () => {
@@ -279,7 +279,7 @@ describe("[Workers + Assets] logging", () => {
 		expect(getOutput()).toContain(
 			`[wrangler:info] ✨ Parsed 1 valid header rule.`
 		);
-		await stop();
+		onTestFinished(() => stop());
 	});
 
 	it("should not log _headers and _redirects parsing when log level set to none", async ({
@@ -290,6 +290,6 @@ describe("[Workers + Assets] logging", () => {
 			["--port=0", "--inspector-port=0", "--log-level=none"]
 		);
 		expect(getOutput()).toMatchInlineSnapshot(`""`);
-		await stop();
+		onTestFinished(() => stop());
 	});
 });

--- a/fixtures/workers-with-assets/tests/index.test.ts
+++ b/fixtures/workers-with-assets/tests/index.test.ts
@@ -266,3 +266,30 @@ describe("[Workers + Assets] dynamic site", () => {
 		`);
 	});
 });
+
+describe("[Workers + Assets] logging", () => {
+	it("should log _headers and _redirects parsing", async ({ expect }) => {
+		const { ip, port, stop, getOutput } = await runWranglerDev(
+			resolve(__dirname, ".."),
+			["--port=0", "--inspector-port=0"]
+		);
+		expect(getOutput()).toContain(
+			`[wrangler:info] ✨ Parsed 2 valid redirect rules.`
+		);
+		expect(getOutput()).toContain(
+			`[wrangler:info] ✨ Parsed 1 valid header rule.`
+		);
+		await stop();
+	});
+
+	it("should not log _headers and _redirects parsing when log level set to none", async ({
+		expect,
+	}) => {
+		const { ip, port, stop, getOutput } = await runWranglerDev(
+			resolve(__dirname, ".."),
+			["--port=0", "--inspector-port=0", "--log-level=none"]
+		);
+		expect(getOutput()).toMatchInlineSnapshot(`""`);
+		await stop();
+	});
+});

--- a/packages/miniflare/src/plugins/assets/index.ts
+++ b/packages/miniflare/src/plugins/assets/index.ts
@@ -6,6 +6,7 @@ import {
 	ENTRY_SIZE,
 	getContentType,
 	HEADER_SIZE,
+	Logger,
 	MAX_ASSET_COUNT,
 	MAX_ASSET_SIZE,
 	normalizeFilePath,
@@ -38,7 +39,6 @@ import SCRIPT_ROUTER from "worker:assets/router";
 import SCRIPT_RPC_PROXY from "worker:assets/rpc-proxy";
 import { z } from "zod";
 import { Service } from "../../runtime";
-import { Log } from "../../shared";
 import { SharedBindings } from "../../workers";
 import { getUserServiceName } from "../core";
 import { Plugin, ProxyNodeBinding } from "../shared";
@@ -77,7 +77,7 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 		};
 	},
 
-	async getServices({ options }) {
+	async getServices({ options, log }) {
 		if (!options.assets) {
 			return [];
 		}
@@ -102,14 +102,13 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 		const redirectsContents = maybeGetFile(redirectsFile);
 		const headersContents = maybeGetFile(headersFile);
 
-		const logger = new Log();
 		const assetParserLogger = {
-			debug: (message: string) => logger.debug(message),
-			log: (message: string) => logger.info(message),
-			info: (message: string) => logger.info(message),
-			warn: (message: string) => logger.warn(message),
-			error: (error: Error) => logger.error(error),
-		};
+			debug: (message) => log.debug(message),
+			log: (message) => log.info(message),
+			info: (message) => log.info(message),
+			warn: (message) => log.warn(message),
+			error: (error) => log.error(error),
+		} satisfies Logger;
 
 		let parsedRedirects: AssetConfig["redirects"] | undefined;
 		if (redirectsContents !== undefined) {


### PR DESCRIPTION
Fixes #9809


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> Workers assets are not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
