### PR TITLE
Set the Wrangler peer dependency to the same version as the direct dependency

### DIFF
--- a/.changeset/brown-ends-wink.md
+++ b/.changeset/brown-ends-wink.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Set the Wrangler peer dependency to the same version as the direct dependency. This fixes as issue where older versions of Wrangler could override the version used by the plugin.

--- a/.changeset/brown-ends-wink.md
+++ b/.changeset/brown-ends-wink.md
@@ -2,4 +2,4 @@
 "@cloudflare/vite-plugin": patch
 ---
 
-Set the Wrangler peer dependency to the same version as the direct dependency. This fixes as issue where older versions of Wrangler could override the version used by the plugin.
+Set the Wrangler peer dependency to the same version as the direct dependency. This fixes an issue where older versions of Wrangler could override the version used by the plugin.

--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -69,7 +69,7 @@
 	},
 	"peerDependencies": {
 		"vite": "^6.1.0 || ^7.0.0",
-		"wrangler": "^3.101.0 || ^4.0.0"
+		"wrangler": "workspace:*"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
Fixes #000.

Set the Wrangler peer dependency to the same version as the direct dependency. This fixes as issue where older versions of Wrangler could override the version used by the plugin.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: covered by existing tests
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: N/A
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
