### PR TITLE
WC-3725 Add time-to-dispatch analytics to the router worker

### DIFF
--- a/.changeset/little-lands-read.md
+++ b/.changeset/little-lands-read.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+Adds metrics for time-to-dispatch to Router Worker

--- a/packages/workers-shared/router-worker/src/analytics.ts
+++ b/packages/workers-shared/router-worker/src/analytics.ts
@@ -37,6 +37,8 @@ type Data = {
 	abuseMitigationBlocked?: boolean;
 	// double8 - User worker invocation denied due to free tier limiting
 	userWorkerFreeTierLimiting?: boolean;
+	// double9 - The time it takes for the request to be handed off the Asset Worker or user Worker in milliseconds
+	timeToDispatch?: number;
 
 	// -- Blobs --
 	// blob1 - Hostname of the request
@@ -96,6 +98,7 @@ export class Analytics {
 				this.data.staticRoutingDecision ?? STATIC_ROUTING_DECISION.NOT_PROVIDED, // double6
 				this.data.abuseMitigationBlocked ? 1 : 0, // double7
 				this.data.userWorkerFreeTierLimiting ? 1 : 0, // double8
+				this.data.timeToDispatch ?? -1, // double9
 			],
 			blobs: [
 				this.data.hostname?.substring(0, 256), // blob1 - trim to 256 bytes

--- a/packages/workers-shared/router-worker/src/worker.ts
+++ b/packages/workers-shared/router-worker/src/worker.ts
@@ -130,6 +130,10 @@ export default {
 						}
 					}
 
+					analytics.setData({
+						timeToDispatch: performance.now() - startTimeMs,
+					});
+
 					if (shouldBlockNonImageResponse) {
 						const resp = await env.USER_WORKER.fetch(maybeSecondRequest);
 						const isImage = resp.headers
@@ -160,6 +164,9 @@ export default {
 						dispatchType: DISPATCH_TYPE.ASSETS,
 					});
 
+					analytics.setData({
+						timeToDispatch: performance.now() - startTimeMs,
+					});
 					return env.ASSET_WORKER.fetch(maybeSecondRequest);
 				});
 			};


### PR DESCRIPTION
Measures the time the Router Worker takes until we dispatch to either the user or Asset Worker, effectively the cost of routing.

For WC-3725

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: analytics only change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal only changes
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> not a wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
