### PR TITLE
Containers-shared: Remove undici dependency

### DIFF
--- a/.changeset/green-stars-fold.md
+++ b/.changeset/green-stars-fold.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/containers-shared": patch
+---
+
+Remove undici dependency from @cloudflare/containers-shared

--- a/packages/containers-shared/package.json
+++ b/packages/containers-shared/package.json
@@ -28,7 +28,6 @@
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@types/node": "catalog:default",
 		"typescript": "catalog:default",
-		"undici": "catalog:default",
 		"vitest": "catalog:default"
 	},
 	"engines": {

--- a/packages/containers-shared/src/client/core/OpenAPI.ts
+++ b/packages/containers-shared/src/client/core/OpenAPI.ts
@@ -1,6 +1,5 @@
 /* istanbul ignore file */
 /* tslint:disable */
-import { Agent } from "undici";
 import type { ApiRequestOptions } from "./ApiRequestOptions";
 
 type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
@@ -16,7 +15,6 @@ export type OpenAPIConfig = {
 	PASSWORD?: string | Resolver<string>;
 	HEADERS?: Headers | Resolver<Headers>;
 	ENCODE_PATH?: (path: string) => string;
-	AGENT?: Agent;
 };
 
 export const OpenAPI: OpenAPIConfig = {

--- a/packages/containers-shared/src/client/core/request.ts
+++ b/packages/containers-shared/src/client/core/request.ts
@@ -1,7 +1,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import { fetch, FormData, Headers, RequestInit, Response } from "undici";
 import { ApiError } from "./ApiError";
 import { CancelablePromise } from "./CancelablePromise";
 import { type OpenAPIConfig } from "./OpenAPI";
@@ -261,7 +260,6 @@ export const sendRequest = async (
 		body: body ?? formData,
 		method: options.method,
 		signal: controller.signal,
-		dispatcher: config.AGENT ?? undefined,
 	};
 
 	if (config.WITH_CREDENTIALS) {

--- a/packages/containers-shared/tsconfig.json
+++ b/packages/containers-shared/tsconfig.json
@@ -7,7 +7,8 @@
 		"allowSyntheticDefaultImports": true,
 		"experimentalDecorators": true,
 		"skipLibCheck": true,
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"types": ["node"]
 	},
 	"include": ["src/**/*", "index.ts"],
 	"exclude": ["dist", "node_modules"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1452,9 +1452,6 @@ importers:
       typescript:
         specifier: catalog:default
         version: 5.8.2
-      undici:
-        specifier: catalog:default
-        version: 5.28.5
       vitest:
         specifier: catalog:default
         version: 3.2.3(@types/node@20.17.32)(@vitest/ui@3.2.3)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.2))(supports-color@9.2.2)


### PR DESCRIPTION
As far as I can tell undici is un-used anywhere by containers or cloudchamber so is safe to just remove.

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: Removing unused depdency
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Not externally visible behavior changes
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> packages doesn't exist in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
