### PR TITLE
fix(vite-plugin): set `rollupOptions.platform: "neutral"` on rolldown-vite

### DIFF
--- a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
+++ b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
@@ -160,6 +160,8 @@ export function createCloudflareEnvironmentOptions(
 			ssr: true,
 			rollupOptions: {
 				input: workerConfig.main,
+				// rolldown-only option
+				...("rolldownVersion" in vite ? ({ platform: "neutral" } as any) : {}),
 			},
 		},
 		optimizeDeps: {


### PR DESCRIPTION
Fixes https://github.com/vitejs/rolldown-vite/issues/248

The issue is reported on rolldown-vite repository https://github.com/vitejs/rolldown-vite/issues/248. Rolldown has esbuild-like `platform` option to control the default behavior such as `require` polyfill. Rolldown-vite server build uses `platform: "node"` by default and it causes an issue with cloudflare plugin due to `node:module` appearing in `resolveId`, which gets externalized and not being tree-shaken (cf. https://github.com/cloudflare/workers-sdk/issues/9609).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
