### PR TITLE
perf: increase binary search experiment sample rate to 50%

### DIFF
--- a/.changeset/fine-candies-do.md
+++ b/.changeset/fine-candies-do.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+perf: increase binary search experiment sample rate to 50%

--- a/packages/workers-shared/asset-worker/src/worker.ts
+++ b/packages/workers-shared/asset-worker/src/worker.ts
@@ -232,7 +232,7 @@ export default class<TEnv extends Env = Env> extends WorkerEntrypoint<TEnv> {
 		pathname: string,
 		_request?: Request
 	): Promise<string | null> {
-		const BINARY_SEARCH_EXPERIMENT_SAMPLE_RATE = 0.05;
+		const BINARY_SEARCH_EXPERIMENT_SAMPLE_RATE = 0.5;
 		const binarySearchVersion =
 			Math.random() < BINARY_SEARCH_EXPERIMENT_SAMPLE_RATE
 				? "current"


### PR DESCRIPTION
Related to #9852 which introduced the original binary search experiment.

Increase the binary search experiment sample rate from 5% to 50% to gather more performance data on the optimized implementation.

This change will allow us to collect more comprehensive performance metrics on the optimized binary search implementation.

/cc @vicb

---

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: configuration change only
- Public documentation
  - [ ] Cloudflare docs PR(s): <\!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal experiment configuration
- Wrangler V3 Backport
  - [ ] Wrangler PR: <\!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change
 

🤖 Generated with [Claude Code](https://claude.ai/code)