### PR TITLE
clean up the vite e2e remote mode tests to avoid flakes

### DIFF
--- a/packages/vite-plugin-cloudflare/e2e/fixtures/remote-bindings/auxiliary-worker/wrangler.jsonc
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/remote-bindings/auxiliary-worker/wrangler.jsonc
@@ -6,7 +6,7 @@
 	"services": [
 		{
 			"binding": "REMOTE_WORKER",
-			"service": "tmp-e2e-vite-plugin-mixed-mode-remote-worker-alt",
+			"service": "<<REMOTE_WORKER_PLACEHOLDER_ALT>>",
 			"experimental_remote": true,
 		},
 	],

--- a/packages/vite-plugin-cloudflare/e2e/fixtures/remote-bindings/entry-worker/wrangler.jsonc
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/remote-bindings/entry-worker/wrangler.jsonc
@@ -11,7 +11,7 @@
 		},
 		{
 			"binding": "REMOTE_WORKER",
-			"service": "tmp-e2e-vite-plugin-mixed-mode-remote-worker",
+			"service": "<<REMOTE_WORKER_PLACEHOLDER>>",
 			"experimental_remote": true,
 		},
 	],

--- a/packages/vite-plugin-cloudflare/e2e/fixtures/remote-bindings/remote-worker-alt/index.js
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/remote-bindings/remote-worker-alt/index.js
@@ -1,0 +1,5 @@
+export default {
+	fetch() {
+		return new Response("Hello from an alternative remote worker");
+	},
+};

--- a/packages/vite-plugin-cloudflare/e2e/fixtures/remote-bindings/remote-worker-alt/wrangler.jsonc
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/remote-bindings/remote-worker-alt/wrangler.jsonc
@@ -1,0 +1,5 @@
+{
+	"compatibility_date": "2025-04-03",
+	"name": "<<REMOTE_WORKER_PLACEHOLDER_ALT>>",
+	"main": "./index.js",
+}

--- a/packages/vite-plugin-cloudflare/e2e/fixtures/remote-bindings/remote-worker/index.js
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/remote-bindings/remote-worker/index.js
@@ -1,0 +1,5 @@
+export default {
+	fetch() {
+		return new Response("Hello from a remote worker");
+	},
+};

--- a/packages/vite-plugin-cloudflare/e2e/fixtures/remote-bindings/remote-worker/wrangler.jsonc
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/remote-bindings/remote-worker/wrangler.jsonc
@@ -1,0 +1,5 @@
+{
+	"compatibility_date": "2025-04-03",
+	"name": "<<REMOTE_WORKER_PLACEHOLDER>>",
+	"main": "./index.js",
+}

--- a/packages/vite-plugin-cloudflare/e2e/remote-bindings.test.ts
+++ b/packages/vite-plugin-cloudflare/e2e/remote-bindings.test.ts
@@ -1,64 +1,76 @@
 import { execSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import { setTimeout } from "node:timers/promises";
 import { afterAll, beforeAll, describe, test, vi } from "vitest";
-import { fetchJson, runLongLived, seed, waitForReady } from "./helpers.js";
+import {
+	fetchJson,
+	runCommand,
+	runLongLived,
+	seed,
+	waitForReady,
+} from "./helpers.js";
 
 const isWindows = os.platform() === "win32";
 const commands = ["dev", "buildAndPreview"] as const;
 
-// These tests focus on remote bindings which require an authed connection to the CF API
-// They are skipped if you have not provided the necessary account id and api token.
-describe
-	.skipIf(
-		isWindows ||
-			!process.env.CLOUDFLARE_ACCOUNT_ID ||
-			!process.env.CLOUDFLARE_API_TOKEN
-	)
-	// Note: the reload test applies changes to the fixture files, so we do want the
-	//       tests to run sequentially in order to avoid race conditions
-	.sequential("remote bindings tests", () => {
-		const remoteWorkerName = "tmp-e2e-vite-plugin-mixed-mode-remote-worker";
-		const alternativeRemoteWorkerName =
-			"tmp-e2e-vite-plugin-mixed-mode-remote-worker-alt";
+if (
+	isWindows ||
+	!process.env.CLOUDFLARE_ACCOUNT_ID ||
+	!process.env.CLOUDFLARE_API_TOKEN
+) {
+	describe.skip(
+		"Skipping remote bindings tests on Windows or without account credentials."
+	);
+} else {
+	describe
+		// Note: the reload test applies changes to the fixture files, so we do want the
+		//       tests to run sequentially in order to avoid race conditions
+		.sequential("remote bindings tests", () => {
+			const replacements = {
+				"<<REMOTE_WORKER_PLACEHOLDER>>": `tmp-e2e-vite-remote-${randomUUID().split("-")[0]}`,
+				"<<REMOTE_WORKER_PLACEHOLDER_ALT>>": `tmp-e2e-vite-remote-alt-${randomUUID().split("-")[0]}`,
+			};
 
-		const projectPath = seed("remote-bindings", "pnpm");
+			const projectPath = seed("remote-bindings", "pnpm", replacements);
 
-		beforeAll(() => {
-			const tmp = fs.mkdtempSync(`${os.tmpdir()}/vite-plugin-e2e-tmp`);
-			[
-				{
-					name: remoteWorkerName,
-					content:
-						"export default { fetch() { return new Response('Hello from a remote worker'); } };",
-				},
-				{
-					name: alternativeRemoteWorkerName,
-					content:
-						"export default { fetch() { return new Response('Hello from an alternative remote worker'); } };",
-				},
-			].forEach((worker) => {
-				fs.writeFileSync(`${tmp}/index.js`, worker.content);
-				execSync(
-					`npx wrangler deploy index.js --name ${worker.name} --compatibility-date 2025-01-01`,
-					{ cwd: tmp }
+			beforeAll(() => {
+				runCommand(`npx wrangler deploy`, `${projectPath}/remote-worker`);
+				runCommand(`npx wrangler deploy`, `${projectPath}/remote-worker-alt`);
+			}, 35_000);
+
+			afterAll(() => {
+				runCommand(
+					`npx wrangler delete --force`,
+					`${projectPath}/remote-worker`,
+					{ canFail: true }
+				);
+				runCommand(
+					`npx wrangler delete --force`,
+					`${projectPath}/remote-worker-alt`,
+					{ canFail: true }
 				);
 			});
-		}, 35_000);
 
-		afterAll(() => {
-			[remoteWorkerName, alternativeRemoteWorkerName].forEach((worker) => {
-				execSync(`npx wrangler delete --name ${worker}`);
+			describe.each(commands)('with "%s" command', (command) => {
+				test("can fetch from both local (/auxiliary) and remote workers", async ({
+					expect,
+				}) => {
+					const proc = await runLongLived("pnpm", command, projectPath);
+					const url = await waitForReady(proc);
+					expect(await fetchJson(url)).toEqual({
+						localWorkerResponse: {
+							remoteWorkerResponse: "Hello from an alternative remote worker",
+						},
+						remoteWorkerResponse: "Hello from a remote worker",
+					});
+				});
 			});
-		});
 
-		describe.each(commands)('with "%s" command', (command) => {
-			test("can fetch from both local (/auxiliary) and remote workers", async ({
-				expect,
-			}) => {
-				const proc = await runLongLived("pnpm", command, projectPath);
+			test("reflects changes applied during dev", async ({ expect }) => {
+				const proc = await runLongLived("pnpm", "dev", projectPath);
 				const url = await waitForReady(proc);
 				expect(await fetchJson(url)).toEqual({
 					localWorkerResponse: {
@@ -66,62 +78,51 @@ describe
 					},
 					remoteWorkerResponse: "Hello from a remote worker",
 				});
+
+				const entryWorkerPath = `${projectPath}/entry-worker/src/index.ts`;
+				const entryWorkerContent = await readFile(entryWorkerPath, "utf8");
+
+				await writeFile(
+					entryWorkerPath,
+					entryWorkerContent
+						.replace(
+							"localWorkerResponse: await",
+							"localWorkerResponseJson: await"
+						)
+						.replace(
+							"remoteWorkerResponse: await",
+							"remoteWorkerResponseText: await"
+						),
+					"utf8"
+				);
+
+				await setTimeout(500);
+
+				await vi.waitFor(
+					async () => {
+						expect(await fetchJson(url)).toEqual({
+							localWorkerResponseJson: {
+								remoteWorkerResponse: "Hello from an alternative remote worker",
+							},
+							remoteWorkerResponseText: "Hello from a remote worker",
+						});
+					},
+					{ timeout: 5_000, interval: 250 }
+				);
+
+				await writeFile(entryWorkerPath, entryWorkerContent, "utf8");
+
+				await vi.waitFor(
+					async () => {
+						expect(await fetchJson(url)).toEqual({
+							localWorkerResponse: {
+								remoteWorkerResponse: "Hello from an alternative remote worker",
+							},
+							remoteWorkerResponse: "Hello from a remote worker",
+						});
+					},
+					{ timeout: 5_000, interval: 250 }
+				);
 			});
 		});
-
-		test("reflects changes applied during dev", async ({ expect }) => {
-			const proc = await runLongLived("pnpm", "dev", projectPath);
-			const url = await waitForReady(proc);
-			expect(await fetchJson(url)).toEqual({
-				localWorkerResponse: {
-					remoteWorkerResponse: "Hello from an alternative remote worker",
-				},
-				remoteWorkerResponse: "Hello from a remote worker",
-			});
-
-			const entryWorkerPath = `${projectPath}/entry-worker/src/index.ts`;
-			const entryWorkerContent = await readFile(entryWorkerPath, "utf8");
-
-			await writeFile(
-				entryWorkerPath,
-				entryWorkerContent
-					.replace(
-						"localWorkerResponse: await",
-						"localWorkerResponseJson: await"
-					)
-					.replace(
-						"remoteWorkerResponse: await",
-						"remoteWorkerResponseText: await"
-					),
-				"utf8"
-			);
-
-			await setTimeout(500);
-
-			await vi.waitFor(
-				async () => {
-					expect(await fetchJson(url)).toEqual({
-						localWorkerResponseJson: {
-							remoteWorkerResponse: "Hello from an alternative remote worker",
-						},
-						remoteWorkerResponseText: "Hello from a remote worker",
-					});
-				},
-				{ timeout: 5_000, interval: 250 }
-			);
-
-			await writeFile(entryWorkerPath, entryWorkerContent, "utf8");
-
-			await vi.waitFor(
-				async () => {
-					expect(await fetchJson(url)).toEqual({
-						localWorkerResponse: {
-							remoteWorkerResponse: "Hello from an alternative remote worker",
-						},
-						remoteWorkerResponse: "Hello from a remote worker",
-					});
-				},
-				{ timeout: 5_000, interval: 250 }
-			);
-		});
-	});
+}


### PR DESCRIPTION
The `afterAll()` hooks are run even if `describe.skipIf()` is true, so on forks these tests would likely always fail.

But even on non-forks, the tests were deploying and then deleting Workers with a fixed name, which was shared across the Cloudflare test account.
This could cause flakes if two CI jobs collided with each other.