### PR TITLE
chore: remove deprecated dependabot reviewers field

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,6 @@ updates:
     # makes it so that also the PR title gets such prefix
     commit-message:
       prefix: "[C3] "
-    reviewers:
-      - "@cloudflare/c3"
     labels:
       - "c3"
       - "dependencies"
@@ -36,8 +34,6 @@ updates:
       interval: "daily"
       time: "06:00" # the workerd release starts at 00:30 UTC each day
     versioning-strategy: increase
-    reviewers:
-      - "@cloudflare/wrangler"
     labels:
       - "miniflare"
       - "dependencies"


### PR DESCRIPTION
Fixes n/a.

As suggested in https://github.com/cloudflare/workers-sdk/pull/9912#issuecomment-3055752395:

> The reviewers field in the dependabot.yml file will be removed soon. Please use the code owners file to specify reviewers for Dependabot PRs. For more information, see [this blog post](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/).

We have proper codeowner in place, so it should be safe to just remove the reviewers field.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
