### PR TITLE
refactor: move compare to the tests

### DIFF
--- a/packages/workers-shared/asset-worker/src/assets-manifest.ts
+++ b/packages/workers-shared/asset-worker/src/assets-manifest.ts
@@ -121,30 +121,3 @@ function comparePathHashWithEntry(
 const Uint8ToHexString = (array: Uint8Array) => {
 	return [...array].map((b) => b.toString(16).padStart(2, "0")).join("");
 };
-
-/**
- * Compare two Uint8Array values
- * @param a First array
- * @param b Second array
- * @returns -1 if a < b, 1 if a > b, 0 if equal
- */
-export const compare = (a: Uint8Array, b: Uint8Array) => {
-	if (a.byteLength < b.byteLength) {
-		return -1;
-	}
-	if (a.byteLength > b.byteLength) {
-		return 1;
-	}
-
-	for (const [i, v] of a.entries()) {
-		const bVal = b[i] as number;
-		if (v < bVal) {
-			return -1;
-		}
-		if (v > bVal) {
-			return 1;
-		}
-	}
-
-	return 0;
-};

--- a/packages/workers-shared/asset-worker/tests/assets-manifest.test.ts
+++ b/packages/workers-shared/asset-worker/tests/assets-manifest.test.ts
@@ -6,7 +6,7 @@ import {
 	PATH_HASH_SIZE,
 } from "../../utils/constants";
 import AssetManifestFixture from "../fixtures/AssetManifest.bin";
-import { binarySearch, compare, hashPath } from "../src/assets-manifest";
+import { binarySearch, hashPath } from "../src/assets-manifest";
 
 const encoder = new TextEncoder();
 
@@ -214,3 +214,30 @@ describe("search methods", async () => {
 		});
 	});
 });
+
+/**
+ * Compare two Uint8Array values
+ * @param a First array
+ * @param b Second array
+ * @returns -1 if a < b, 1 if a > b, 0 if equal
+ */
+function compare(a: Uint8Array, b: Uint8Array) {
+	if (a.byteLength < b.byteLength) {
+		return -1;
+	}
+	if (a.byteLength > b.byteLength) {
+		return 1;
+	}
+
+	for (const [i, v] of a.entries()) {
+		const bVal = b[i] as number;
+		if (v < bVal) {
+			return -1;
+		}
+		if (v > bVal) {
+			return 1;
+		}
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Moving `compare` to the tests where it is used.

We do not need `compare` in production code as it is only used in the tests.

@GregBrimble I had that change in my initial PR but didn't pay attention that it was re-introduced in https://github.com/cloudflare/workers-sdk/pull/9908. I don't think it belongs there and we need to embed that code in the worker but feel free to close the PR if you did that on purpose.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: refactor
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: refactor
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not wrangler
<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
