### PR TITLE
allow plain text with charset

### DIFF
--- a/.changeset/plain-baths-leave.md
+++ b/.changeset/plain-baths-leave.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+allow plain text with charset


### PR DESCRIPTION
(Open)Next can send 400 plain text responses when they are errors on the `_next/image` endpoint - for example when the image is blocked by a remote pattern

The content type is then `text/plain;charset=UTF-8` which was blocked by the router worker.

This masks the underlying error by overriding with a "Blocked" response.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not documented
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a wrangler change
<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
