### PR TITLE
remove call to close the playwright browser in fixture tests as this can cause tests to hang

### DIFF
--- a/fixtures/workers-with-assets-static-routing/test/index.test.ts
+++ b/fixtures/workers-with-assets-static-routing/test/index.test.ts
@@ -86,10 +86,6 @@ describe("[Workers + Assets] static routing", () => {
 				});
 			}, 40_000);
 
-			afterAll(async () => {
-				await browser?.close();
-			});
-
 			it("renders the root with index.html", async ({ expect }) => {
 				if (!browser) {
 					throw new Error("Browser couldn't be initialized");


### PR DESCRIPTION
I tried lots of ways to get this statement not to hang locally for me, but to no avail.
Removing it doesn't apprear to have any impact, everything just closes down fine.