### PR TITLE
Add the nodejs_als flag for the svelte template

### DIFF
--- a/.changeset/bright-snails-knock.md
+++ b/.changeset/bright-snails-knock.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Enable the nodejs_als in the svelte template to work out of the box

--- a/packages/create-cloudflare/templates/svelte/pages/templates/wrangler.jsonc
+++ b/packages/create-cloudflare/templates/svelte/pages/templates/wrangler.jsonc
@@ -1,5 +1,6 @@
 {
   "name": "<TBD>",
   "compatibility_date": "<TBD>",
+  "compatibility_flags": ["nodejs_als"],
   "pages_build_output_dir": ".svelte-kit/cloudflare"
 }

--- a/packages/create-cloudflare/templates/svelte/workers/templates/wrangler.jsonc
+++ b/packages/create-cloudflare/templates/svelte/workers/templates/wrangler.jsonc
@@ -2,6 +2,7 @@
   "name": "<TBD>",
   "main": ".svelte-kit/cloudflare/_worker.js",
   "compatibility_date": "<TBD>",
+  "compatibility_flags": ["nodejs_als"],
   "assets": {
     "binding": "ASSETS",
     "directory": ".svelte-kit/cloudflare"


### PR DESCRIPTION
Recent sveltekit versions rely on `node:async_hooks` to access `AsyncLocalStorage`

See https://github.com/sveltejs/kit/issues/13668 for the report.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: it only changes a template for create-cloudflare, which is not something covered by tests.
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is improving the existing template for svelte to work out of the box
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a wrangler change. It changes `create-cloudflare`

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
