### PR TITLE
Pass worker name & compliance region through correctly

### DIFF
--- a/.changeset/wicked-beans-nail.md
+++ b/.changeset/wicked-beans-nail.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Pass worker name & compliance region through correctly when starting a remote bindings session

--- a/fixtures/get-platform-proxy-remote-bindings/tests/index.test.ts
+++ b/fixtures/get-platform-proxy-remote-bindings/tests/index.test.ts
@@ -19,7 +19,7 @@ if (auth) {
 		let remoteKvId: string;
 		beforeAll(async () => {
 			const deployOut = execSync(
-				`pnpm dlx wrangler deploy remote-worker.js --name ${remoteWorkerName} --compatibility-date 2025-06-19`,
+				`pnpm wrangler deploy remote-worker.js --name ${remoteWorkerName} --compatibility-date 2025-06-19`,
 				execOptions
 			);
 
@@ -28,7 +28,7 @@ if (auth) {
 			}
 
 			const kvAddOut = execSync(
-				`pnpm dlx wrangler kv namespace create ${remoteKvName}`,
+				`pnpm wrangler kv namespace create ${remoteKvName}`,
 				execOptions
 			);
 
@@ -38,7 +38,7 @@ if (auth) {
 			remoteKvId = maybeRemoteKvId;
 
 			execSync(
-				`pnpm dlx wrangler kv key put test-key remote-kv-value --namespace-id=${remoteKvId} --remote`,
+				`pnpm wrangler kv key put test-key remote-kv-value --namespace-id=${remoteKvId} --remote`,
 				execOptions
 			);
 
@@ -75,12 +75,9 @@ if (auth) {
 		}, 25_000);
 
 		afterAll(() => {
+			execSync(`pnpm wrangler delete --name ${remoteWorkerName}`, execOptions);
 			execSync(
-				`pnpm dlx wrangler delete --name ${remoteWorkerName}`,
-				execOptions
-			);
-			execSync(
-				`pnpm dlx wrangler kv namespace delete --namespace-id=${remoteKvId}`,
+				`pnpm wrangler kv namespace delete --namespace-id=${remoteKvId}`,
 				execOptions
 			);
 			rmSync("./.tmp", { recursive: true, force: true });

--- a/fixtures/vitest-pool-workers-remote-bindings/run-tests.mjs
+++ b/fixtures/vitest-pool-workers-remote-bindings/run-tests.mjs
@@ -48,7 +48,7 @@ writeFileSync(
 	"utf8"
 );
 
-const deployOut = execSync("pnpm dlx wrangler deploy -c remote-wrangler.json", {
+const deployOut = execSync("pnpm wrangler deploy -c remote-wrangler.json", {
 	stdio: "pipe",
 	cwd: "./.tmp",
 	env,
@@ -62,7 +62,7 @@ try {
 		env,
 	});
 } finally {
-	execSync(`pnpm dlx wrangler delete --name ${remoteWorkerName}`, { env });
+	execSync(`pnpm wrangler delete --name ${remoteWorkerName}`, { env });
 	rmSync("./.tmp", { recursive: true, force: true });
 }
 

--- a/fixtures/vitest-pool-workers-remote-bindings/run-tests.mjs
+++ b/fixtures/vitest-pool-workers-remote-bindings/run-tests.mjs
@@ -48,11 +48,14 @@ writeFileSync(
 	"utf8"
 );
 
-const deployOut = execSync("pnpm wrangler deploy -c remote-wrangler.json", {
-	stdio: "pipe",
-	cwd: "./.tmp",
-	env,
-});
+const deployOut = execSync(
+	"pnpm wrangler deploy -c .tmp/remote-wrangler.json",
+	{
+		stdio: "pipe",
+		cwd: "./.tmp",
+		env,
+	}
+);
 if (!new RegExp(`Deployed\\s+${remoteWorkerName}\\b`).test(`${deployOut}`)) {
 	throw new Error(`Failed to deploy ${remoteWorkerName}`);
 }

--- a/packages/wrangler/e2e/wrangler-remote-resources.test.ts
+++ b/packages/wrangler/e2e/wrangler-remote-resources.test.ts
@@ -13,6 +13,11 @@ import {
 	vi,
 } from "vitest";
 import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
+import {
+	generateLeafCertificate,
+	generateMtlsCertName,
+	generateRootCertificate,
+} from "./helpers/cert";
 import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { fetchText } from "./helpers/fetch-text";
 import { generateResourceName } from "./helpers/generate-resource-name";
@@ -22,8 +27,8 @@ import type { WranglerLongLivedCommand } from "./helpers/wrangler";
 type TestCase<T = void> = {
 	name: string;
 	scriptPath: string;
-	setup?: (helper: WranglerE2ETestHelper) => Promise<T> | T;
-	generateWranglerConfig: (setupResult: T) => RawConfig;
+	setup?: (helper: WranglerE2ETestHelper, workerName: string) => Promise<T> | T;
+	generateWranglerConfig: (setupResult: T) => Omit<RawConfig, "name">;
 	expectedResponseMatch: string | RegExp;
 	// Flag for resources that can work without remote bindings opt-in
 	worksWithoutRemoteBindings?: boolean;
@@ -73,7 +78,6 @@ const testCases: TestCase<Record<string, string>>[] = [
 			return { worker: targetWorkerName };
 		},
 		generateWranglerConfig: ({ worker: targetWorkerName }) => ({
-			name: "mixed-mode-service-binding-test",
 			main: "service-binding.js",
 			compatibility_date: "2025-01-01",
 			services: [
@@ -99,7 +103,6 @@ const testCases: TestCase<Record<string, string>>[] = [
 		name: "AI",
 		scriptPath: "ai.js",
 		generateWranglerConfig: () => ({
-			name: "mixed-mode-ai-test",
 			main: "ai.js",
 			compatibility_date: "2025-01-01",
 			ai: {
@@ -115,7 +118,6 @@ const testCases: TestCase<Record<string, string>>[] = [
 		name: "Browser",
 		scriptPath: "browser.js",
 		generateWranglerConfig: () => ({
-			name: "mixed-mode-browser-test",
 			main: "browser.js",
 			compatibility_date: "2025-01-01",
 			browser: {
@@ -130,7 +132,6 @@ const testCases: TestCase<Record<string, string>>[] = [
 		name: "Images",
 		scriptPath: "images.js",
 		generateWranglerConfig: () => ({
-			name: "mixed-mode-images-test",
 			main: "images.js",
 			compatibility_date: "2025-01-01",
 			images: {
@@ -154,7 +155,6 @@ const testCases: TestCase<Record<string, string>>[] = [
 			return { name };
 		},
 		generateWranglerConfig: ({ name }) => ({
-			name: "mixed-mode-vectorize-test",
 			main: "vectorize.js",
 			compatibility_date: "2025-01-01",
 			vectorize: [
@@ -190,7 +190,6 @@ const testCases: TestCase<Record<string, string>>[] = [
 			return { namespace };
 		},
 		generateWranglerConfig: ({ namespace }) => ({
-			name: "mixed-mode-dispatch-namespace-test",
 			main: "dispatch-namespace.js",
 			compatibility_date: "2025-01-01",
 			dispatch_namespaces: [
@@ -214,7 +213,6 @@ const testCases: TestCase<Record<string, string>>[] = [
 			return { id: ns };
 		},
 		generateWranglerConfig: ({ id: namespaceId }) => ({
-			name: "mixed-mode-kv-test",
 			main: "kv.js",
 			compatibility_date: "2025-01-01",
 			kv_namespaces: [
@@ -244,7 +242,6 @@ const testCases: TestCase<Record<string, string>>[] = [
 			return { name };
 		},
 		generateWranglerConfig: ({ name: bucketName }) => ({
-			name: "mixed-mode-r2-test",
 			main: "r2.js",
 			compatibility_date: "2025-01-01",
 			r2_buckets: [
@@ -274,7 +271,6 @@ const testCases: TestCase<Record<string, string>>[] = [
 			return { id, name };
 		},
 		generateWranglerConfig: ({ id, name }) => ({
-			name: "mixed-mode-d1-test",
 			main: "d1.js",
 			compatibility_date: "2025-01-01",
 			d1_databases: [
@@ -288,14 +284,86 @@ const testCases: TestCase<Record<string, string>>[] = [
 		}),
 		expectedResponseMatch: "existing-value",
 	},
+	{
+		name: "mTLS",
+		scriptPath: "mtls.js",
+		setup: async (helper, workerName) => {
+			// Generate root and leaf certificates
+			const { certificate: rootCert, privateKey: rootKey } =
+				generateRootCertificate();
+			const { certificate: leafCert, privateKey: leafKey } =
+				generateLeafCertificate(rootCert, rootKey);
+
+			// Generate filenames for concurrent e2e test environment
+			const mtlsCertName = generateMtlsCertName();
+			// const caCertName = generateCaCertName();
+
+			// locally generated certs/key
+			await helper.seed({ "mtls_client_cert_file.pem": leafCert });
+			await helper.seed({ "mtls_client_private_key_file.pem": leafKey });
+
+			const output = await helper.run(
+				`wrangler cert upload mtls-certificate --name ${mtlsCertName} --cert mtls_client_cert_file.pem --key mtls_client_private_key_file.pem`
+			);
+
+			const match = output.stdout.match(/ID:\s+(?<certId>.*)$/m);
+			const certificateId = match?.groups?.certId;
+			assert(certificateId);
+
+			await helper.seed({
+				"worker.js": dedent/* javascript */ `
+								export default {
+									fetch(request) { return new Response("Hello"); }
+								}
+							`,
+			});
+
+			const wranglerConfig: RawConfig = {
+				name: workerName,
+				mtls_certificates: [
+					{
+						certificate_id: certificateId,
+						binding: "MTLS",
+					},
+				],
+			};
+			await helper.seed({
+				"pre-deployment-wrangler.json": JSON.stringify(wranglerConfig, null, 2),
+			});
+
+			await helper.run(
+				`wrangler deploy worker.js --name ${workerName} -c pre-deployment-wrangler.json --compatibility-date 2025-01-01`
+			);
+			onTestFinished(async () => {
+				await helper.run(`wrangler delete --name ${workerName}`);
+			});
+
+			return { certificateId };
+		},
+		generateWranglerConfig: ({ certificateId }) => ({
+			main: "mtls.js",
+			compatibility_date: "2025-01-01",
+			mtls_certificates: [
+				{
+					binding: "MTLS",
+					certificate_id: certificateId,
+					experimental_remote: true,
+				},
+			],
+		}),
+		// Note: in this test we are making sure that TLS negotiation does work by checking that we get an SSL certificate error
+		expectedResponseMatch: /The SSL certificate error/,
+	},
 ];
 
 describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("Wrangler Mixed Mode E2E Tests", () => {
 	describe.each(testCases)("$name", (testCase) => {
 		let helper: WranglerE2ETestHelper;
+		let workerName: string;
 
 		beforeEach(() => {
 			helper = new WranglerE2ETestHelper();
+			workerName = generateResourceName();
 		});
 
 		it("works with remote bindings enabled", async () => {
@@ -303,7 +371,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("Wrangler Mixed Mode E2E Tests", () => {
 				path.resolve(__dirname, "./seed-files/remote-binding-workers")
 			);
 
-			await writeWranglerConfig(testCase, helper);
+			await writeWranglerConfig(testCase, helper, workerName);
 
 			const worker = helper.runLongLived("wrangler dev --x-remote-bindings");
 
@@ -322,7 +390,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("Wrangler Mixed Mode E2E Tests", () => {
 					path.resolve(__dirname, "./seed-files/remote-binding-workers")
 				);
 
-				await writeWranglerConfig(testCase, helper);
+				await writeWranglerConfig(testCase, helper, workerName);
 
 				const worker = helper.runLongLived("wrangler dev");
 
@@ -339,11 +407,13 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("Wrangler Mixed Mode E2E Tests", () => {
 		() => {
 			let worker: WranglerLongLivedCommand;
 			let helper: WranglerE2ETestHelper;
+			let workerName: string;
 
 			let url: string;
 
 			beforeAll(async () => {
 				helper = new WranglerE2ETestHelper();
+				workerName = generateResourceName();
 				await helper.seed(
 					path.resolve(__dirname, "./seed-files/remote-binding-workers")
 				);
@@ -374,7 +444,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("Wrangler Mixed Mode E2E Tests", () => {
 			});
 
 			it.each(testCases)("$name with worker reload", async (testCase) => {
-				await writeWranglerConfig(testCase, helper);
+				await writeWranglerConfig(testCase, helper, workerName);
 
 				await worker.waitForReload();
 
@@ -449,12 +519,17 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 
 async function writeWranglerConfig(
 	testCase: TestCase<Record<string, string>>,
-	helper: WranglerE2ETestHelper
+	helper: WranglerE2ETestHelper,
+	workerName: string
 ) {
-	const setupResult = (await testCase.setup?.(helper)) ?? {};
+	const setupResult = (await testCase.setup?.(helper, workerName)) ?? {};
 
 	const wranglerConfig = testCase.generateWranglerConfig(setupResult);
 	await helper.seed({
-		"wrangler.json": JSON.stringify(wranglerConfig, null, 2),
+		"wrangler.json": JSON.stringify(
+			{ name: workerName, ...wranglerConfig },
+			null,
+			2
+		),
 	});
 }

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -210,6 +210,7 @@ export class LocalRuntimeController extends RuntimeController {
 					await maybeStartOrUpdateRemoteProxySession(
 						{
 							name: configBundle.name,
+							complianceRegion: configBundle.complianceRegion,
 							bindings:
 								convertCfWorkerInitBindingsToBindings(configBundle.bindings) ??
 								{},

--- a/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
@@ -117,6 +117,7 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 				const remoteProxySession = await maybeStartOrUpdateRemoteProxySession(
 					{
 						name: configBundle.name,
+						complianceRegion: configBundle.complianceRegion,
 						bindings:
 							convertCfWorkerInitBindingsToBindings(configBundle.bindings) ??
 							{},


### PR DESCRIPTION
This was inadvertently changed in https://github.com/cloudflare/workers-sdk/commit/fae8c02bcfb51cb87a01a5185b249f6c5889d0a6

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because: 
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: v4-only feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
