### PR TITLE
avoid a major bump to vite-plugin when its peer dependency (wrangler) gets a minor bump

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,6 +10,9 @@
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
 	"bumpVersionsWithWorkspaceProtocolOnly": true,
+	"___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+		"onlyUpdatePeerDependentsWhenOutOfRange": true
+	},
 	"ignore": [],
 	"privatePackages": {
 		"tag": true,

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
 			"pg@8.11.3": "patches/pg@8.11.3.patch",
 			"toucan-js@3.3.1": "patches/toucan-js@3.3.1.patch",
 			"toucan-js@4.0.0": "patches/toucan-js@4.0.0.patch",
-			"postal-mime": "patches/postal-mime.patch"
+			"postal-mime": "patches/postal-mime.patch",
+			"@changesets/assemble-release-plan": "patches/@changesets__assemble-release-plan.patch"
 		}
 	}
 }

--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -69,7 +69,7 @@
 	},
 	"peerDependencies": {
 		"vite": "^6.1.0 || ^7.0.0",
-		"wrangler": "workspace:*"
+		"wrangler": "workspace:^"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/patches/@changesets__assemble-release-plan.patch
+++ b/patches/@changesets__assemble-release-plan.patch
@@ -1,0 +1,17 @@
+diff --git a/dist/changesets-assemble-release-plan.cjs.js b/dist/changesets-assemble-release-plan.cjs.js
+index e32a5e5d39c3bd920201b5694632d2b44c92d486..a7cf97e5aa5b39ed73e8a6c352fc66fb39fff4c2 100644
+--- a/dist/changesets-assemble-release-plan.cjs.js
++++ b/dist/changesets-assemble-release-plan.cjs.js
+@@ -322,7 +322,11 @@ function getDependencyVersionRanges(dependentPkgJSON, dependencyRelease) {
+         versionRange: // intentionally keep other workspace ranges untouched
+         // this has to be fixed but this should only be done when adding appropriate tests
+         versionRange === "workspace:*" ? // workspace:* actually means the current exact version, and not a wildcard similar to a reguler * range
+-        dependencyRelease.oldVersion : versionRange.replace(/^workspace:/, "")
++        dependencyRelease.oldVersion :
++				versionRange === "workspace:^" ? // workspace:^ means at least as new as the current version but less than then next major
++				`^${dependencyRelease.oldVersion}`
++				:
++				versionRange.replace(/^workspace:/, "")
+       });
+     } else {
+       dependencyVersionRanges.push({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ overrides:
   vitest>vite: ^5.0.0
 
 patchedDependencies:
+  '@changesets/assemble-release-plan':
+    hash: 73sl4mz7ouobzahao6qys7m2em
+    path: patches/@changesets__assemble-release-plan.patch
   '@cloudflare/component-listbox@1.10.6':
     hash: r2d7tqjujhdts7e7zxsa3stjki
     path: patches/@cloudflare__component-listbox@1.10.6.patch
@@ -14211,7 +14214,7 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.7.2
 
-  '@changesets/assemble-release-plan@6.0.6':
+  '@changesets/assemble-release-plan@6.0.6(patch_hash=73sl4mz7ouobzahao6qys7m2em)':
     dependencies:
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.3
@@ -14235,7 +14238,7 @@ snapshots:
   '@changesets/cli@2.28.0':
     dependencies:
       '@changesets/apply-release-plan': 7.0.9
-      '@changesets/assemble-release-plan': 6.0.6
+      '@changesets/assemble-release-plan': 6.0.6(patch_hash=73sl4mz7ouobzahao6qys7m2em)
       '@changesets/changelog-git': 0.2.1
       '@changesets/config': 3.1.0
       '@changesets/errors': 0.2.0
@@ -14293,7 +14296,7 @@ snapshots:
 
   '@changesets/get-release-plan@4.0.7':
     dependencies:
-      '@changesets/assemble-release-plan': 6.0.6
+      '@changesets/assemble-release-plan': 6.0.6(patch_hash=73sl4mz7ouobzahao6qys7m2em)
       '@changesets/config': 3.1.0
       '@changesets/pre': 2.0.2
       '@changesets/read': 0.6.3


### PR DESCRIPTION
The `workspace:*` peer dependency of vite-plugin on wrangler meant that every time wrangler had a minor bump, the vite-plugin would get a major bump.

This PR fixes that by moving from `workspace:*` (which corresponds to the exact current version of the dependency) to `workspace:^` which means that it will work with newer versions (up to the next major bump).

It required a small patch to the changesets tool to support this, which we could upstream via PR to their project.
Looks like there is already a PR: https://github.com/changesets/changesets/pull/1291

You can test this locally by checking out this PR and then running:

```
GITHUB_TOKEN=ghp_xxxx node .github/changeset-version.js
```

replacing the GITHUB_TOKEN value with one you have created.

> It is possible we could achieve the same result by setting the peer dependency to `workspace:^4` without the patch to the tool but I think this is cleaner.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: CI job
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: CI job
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> vite-plugin is not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
