### PR TITLE
fix: polls miniflare to check browser process

### DIFF
--- a/.changeset/poor-days-add.md
+++ b/.changeset/poor-days-add.md
@@ -1,0 +1,5 @@
+---
+"miniflare": minor
+---
+
+Add @cloudflare/plywright support for Browser Rendering local mode

--- a/fixtures/browser-rendering/package.json
+++ b/fixtures/browser-rendering/package.json
@@ -10,6 +10,7 @@
 		"test:ci": "vitest run"
 	},
 	"devDependencies": {
+		"@cloudflare/playwright": "^0.0.10",
 		"@cloudflare/puppeteer": "^1.0.2",
 		"@cloudflare/vitest-pool-workers": "workspace:*",
 		"@types/node": "catalog:default",

--- a/fixtures/browser-rendering/src/index.ts
+++ b/fixtures/browser-rendering/src/index.ts
@@ -1,57 +1,15 @@
-import puppeteer from "@cloudflare/puppeteer";
+import playwrightWorker from "./playwright";
+import puppeteerWorker from "./puppeteer";
 
 export default {
 	async fetch(request, env): Promise<Response> {
 		const { searchParams } = new URL(request.url);
-		let url = searchParams.get("url");
-		let action = searchParams.get("action");
-		if (url) {
-			url = new URL(url).toString(); // normalize
-			switch (action) {
-				case "select": {
-					const browser = await puppeteer.launch(env.MYBROWSER);
-					const page = await browser.newPage();
-					await page.goto(url);
-					const h1Text = await page.$eval("h1", (el) => el.textContent.trim());
-					return new Response(h1Text);
-				}
+		let lib = searchParams.get("lib");
 
-				case "alter": {
-					const browser = await puppeteer.launch(env.MYBROWSER);
-					const page = await browser.newPage();
-
-					await page.goto(url); // change to your target URL
-
-					await page.evaluate(() => {
-						const paragraph = document.querySelector("p");
-						if (paragraph) {
-							paragraph.textContent = "New paragraph text set by Puppeteer!";
-						}
-					});
-
-					const pText = await page.$eval("p", (el) => el.textContent.trim());
-					return new Response(pText);
-				}
-			}
-
-			let img = await env.BROWSER_KV_DEMO.get(url, { type: "arrayBuffer" });
-			if (img === null) {
-				const browser = await puppeteer.launch(env.MYBROWSER);
-				const page = await browser.newPage();
-				await page.goto(url);
-				img = (await page.screenshot()) as Buffer;
-				await env.BROWSER_KV_DEMO.put(url, img, {
-					expirationTtl: 60 * 60 * 24,
-				});
-				await browser.close();
-			}
-			return new Response(img, {
-				headers: {
-					"content-type": "image/jpeg",
-				},
-			});
+		if (lib === "playwright") {
+			return playwrightWorker.fetch(request, env);
 		} else {
-			return new Response("Please add an ?url=https://example.com/ parameter");
+			return puppeteerWorker.fetch(request, env);
 		}
 	},
 } satisfies ExportedHandler<Env>;

--- a/fixtures/browser-rendering/src/playwright.ts
+++ b/fixtures/browser-rendering/src/playwright.ts
@@ -1,0 +1,56 @@
+import playwright from "@cloudflare/playwright";
+
+export default {
+	async fetch(request, env): Promise<Response> {
+		const { searchParams } = new URL(request.url);
+		let url = searchParams.get("url");
+		let action = searchParams.get("action");
+		if (url) {
+			url = new URL(url).toString(); // normalize
+			switch (action) {
+				case "select": {
+					await using browser = await playwright.launch(env.MYBROWSER);
+					const page = await browser.newPage();
+					await page.goto(url);
+					const h1Text = await page.locator("h1").textContent();
+					return new Response(h1Text);
+				}
+
+				case "alter": {
+					await using browser = await playwright.launch(env.MYBROWSER);
+					const page = await browser.newPage();
+
+					await page.goto(url); // change to your target URL
+
+					await page
+						.locator("p")
+						.first()
+						.evaluate((paragraph) => {
+							paragraph.textContent = "New paragraph text set by Playwright!";
+						});
+
+					const pText = await page.locator("p").first().textContent();
+					return new Response(pText);
+				}
+			}
+
+			let img = await env.BROWSER_KV_DEMO.get(url, { type: "arrayBuffer" });
+			if (img === null) {
+				await using browser = await playwright.launch(env.MYBROWSER);
+				const page = await browser.newPage();
+				await page.goto(url);
+				img = (await page.screenshot()) as Buffer;
+				await env.BROWSER_KV_DEMO.put(url, img, {
+					expirationTtl: 60 * 60 * 24,
+				});
+			}
+			return new Response(img, {
+				headers: {
+					"content-type": "image/jpeg",
+				},
+			});
+		} else {
+			return new Response("Please add an ?url=https://example.com/ parameter");
+		}
+	},
+} satisfies ExportedHandler<Env>;

--- a/fixtures/browser-rendering/src/puppeteer.ts
+++ b/fixtures/browser-rendering/src/puppeteer.ts
@@ -1,0 +1,57 @@
+import puppeteer from "@cloudflare/puppeteer";
+
+export default {
+	async fetch(request, env): Promise<Response> {
+		const { searchParams } = new URL(request.url);
+		let url = searchParams.get("url");
+		let action = searchParams.get("action");
+		if (url) {
+			url = new URL(url).toString(); // normalize
+			switch (action) {
+				case "select": {
+					const browser = await puppeteer.launch(env.MYBROWSER);
+					const page = await browser.newPage();
+					await page.goto(url);
+					const h1Text = await page.$eval("h1", (el) => el.textContent.trim());
+					return new Response(h1Text);
+				}
+
+				case "alter": {
+					const browser = await puppeteer.launch(env.MYBROWSER);
+					const page = await browser.newPage();
+
+					await page.goto(url); // change to your target URL
+
+					await page.evaluate(() => {
+						const paragraph = document.querySelector("p");
+						if (paragraph) {
+							paragraph.textContent = "New paragraph text set by Puppeteer!";
+						}
+					});
+
+					const pText = await page.$eval("p", (el) => el.textContent.trim());
+					return new Response(pText);
+				}
+			}
+
+			let img = await env.BROWSER_KV_DEMO.get(url, { type: "arrayBuffer" });
+			if (img === null) {
+				const browser = await puppeteer.launch(env.MYBROWSER);
+				const page = await browser.newPage();
+				await page.goto(url);
+				img = (await page.screenshot()) as Buffer;
+				await env.BROWSER_KV_DEMO.put(url, img, {
+					expirationTtl: 60 * 60 * 24,
+				});
+				await browser.close();
+			}
+			return new Response(img, {
+				headers: {
+					"content-type": "image/jpeg",
+				},
+			});
+		} else {
+			return new Response("Please add an ?url=https://example.com/ parameter");
+		}
+	},
+} satisfies ExportedHandler<Env>;

--- a/fixtures/browser-rendering/test/index.spec.ts
+++ b/fixtures/browser-rendering/test/index.spec.ts
@@ -37,21 +37,31 @@ describe("Local Browser", () => {
 		return text;
 	}
 
-	it("Doesn't run a browser, just testing that the worker is running!", async () => {
-		await expect(fetchText(`http://${ip}:${port}/`)).resolves.toEqual(
-			"Please add an ?url=https://example.com/ parameter"
-		);
-	});
+	for (const lib of ["puppeteer", "playwright"]) {
+		describe(`using @cloudflare/${lib}`, () => {
+			it("Doesn't run a browser, just testing that the worker is running!", async () => {
+				await expect(
+					fetchText(`http://${ip}:${port}/?lib=${lib}`)
+				).resolves.toEqual("Please add an ?url=https://example.com/ parameter");
+			});
 
-	it("Run a browser, and check h1 text content", async () => {
-		await expect(
-			fetchText(`http://${ip}:${port}/?url=https://example.com&action=select`)
-		).resolves.toEqual("Example Domain");
-	});
+			it("Run a browser, and check h1 text content", async () => {
+				await expect(
+					fetchText(
+						`http://${ip}:${port}/?lib=${lib}&url=https://example.com&action=select`
+					)
+				).resolves.toEqual("Example Domain");
+			});
 
-	it("Run a browser, and check p text content", async () => {
-		await expect(
-			fetchText(`http://${ip}:${port}/?url=https://example.com&action=alter`)
-		).resolves.toEqual("New paragraph text set by Puppeteer!");
-	});
+			it("Run a browser, and check p text content", async () => {
+				await expect(
+					fetchText(
+						`http://${ip}:${port}/?lib=${lib}&url=https://example.com&action=alter`
+					)
+				).resolves.toEqual(
+					`New paragraph text set by ${lib === "playwright" ? "Playwright" : "Puppeteer"}!`
+				);
+			});
+		});
+	}
 });

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -900,6 +900,7 @@ export class Miniflare {
 	#workerOpts: PluginWorkerOptions[];
 	#log: Log;
 
+	// key is the browser wsEndpoint, value is the browser process
 	#browserProcesses: Map<string, ChildProcess> = new Map();
 
 	readonly #runtime?: Runtime;
@@ -1310,12 +1311,10 @@ export class Miniflare {
 				response = new Response(wsEndpoint);
 			} else if (url.pathname === "/browser/status") {
 				const wsEndpoint = url.searchParams.get("wsEndpoint");
-				assert(wsEndpoint !== null);
+				assert(wsEndpoint !== null, "Missing wsEndpoint query parameter");
 				const process = this.#browserProcesses.get(wsEndpoint);
-				assert(process);
-
 				const status = {
-					stopped: process.exitCode !== null,
+					stopped: !process || process.exitCode !== null,
 				};
 				response = new Response(JSON.stringify(status), {
 					headers: { "Content-Type": "application/json" },
@@ -1970,9 +1969,10 @@ export class Miniflare {
 	}
 
 	async #assembleAndUpdateConfig() {
-		for (const process of this.#browserProcesses.values()) {
+		for (const [wsEndpoint, process] of this.#browserProcesses.entries()) {
 			// .close() isn't enough
 			process.kill("SIGKILL");
+			this.#browserProcesses.delete(wsEndpoint);
 		}
 		// This function must be run with `#runtimeMutex` held
 		const initial = !this.#runtimeEntryURL;
@@ -2674,9 +2674,10 @@ export class Miniflare {
 		try {
 			await this.#waitForReady(/* disposing */ true);
 		} finally {
-			for (const process of this.#browserProcesses.values()) {
+			for (const [wsEndpoint, process] of this.#browserProcesses.entries()) {
 				// .close() isn't enough
 				process.kill("SIGKILL");
+				this.#browserProcesses.delete(wsEndpoint);
 			}
 
 			// Remove exit hook, we're cleaning up what they would've cleaned up now

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1301,7 +1301,10 @@ export class Miniflare {
 				);
 
 				// @ts-expect-error Puppeteer is dynamically installed, and so doesn't have types available
-				const browser = await puppeteer.launch({ headless: "old" });
+				const browser = await puppeteer.launch({
+					headless: "old",
+					args: process.env.CI ? ["--no-sandbox"] : [],
+				});
 				const wsEndpoint = browser.wsEndpoint();
 				this.#browserProcesses.set(wsEndpoint, browser.process());
 				response = new Response(wsEndpoint);

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1304,6 +1304,7 @@ export class Miniflare {
 				// @ts-expect-error Puppeteer is dynamically installed, and so doesn't have types available
 				const browser = await puppeteer.launch({
 					headless: "old",
+					// workaround for CI environments, to avoid sandboxing issues
 					args: process.env.CI ? ["--no-sandbox"] : [],
 				});
 				const wsEndpoint = browser.wsEndpoint();

--- a/packages/miniflare/test/plugins/browser/index.spec.ts
+++ b/packages/miniflare/test/plugins/browser/index.spec.ts
@@ -12,7 +12,8 @@ export default {
 };
 `;
 
-test("it creates a browser session", async (t) => {
+// we need to run browser rendering tests in a serial manner to avoid a race condition installing the browser
+test.serial("it creates a browser session", async (t) => {
 	const opts: MiniflareOptions = {
 		name: "worker",
 		compatibilityDate: "2024-11-20",
@@ -25,4 +26,64 @@ test("it creates a browser session", async (t) => {
 
 	const res = await mf.dispatchFetch("https://localhost/session");
 	t.assert((await res.text()).includes("sessionId"));
+});
+
+const BROWSER_WORKER_CLOSE_SCRIPT = `
+const HEADER_SIZE = 4; // Uint32
+
+function messageToChunk(data) {
+	const encoder = new TextEncoder();
+	const encodedUint8Array = encoder.encode(data);
+
+	const chunk = new Uint8Array(HEADER_SIZE + encodedUint8Array.length);
+	const view = new DataView(chunk.buffer);
+	view.setUint32(0, encodedUint8Array.length, true);
+	chunk.set(encodedUint8Array, HEADER_SIZE);
+	return chunk;
+};
+
+export default {
+	async fetch(request, env) {
+		const acquireResponse = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
+		const { sessionId } = await acquireResponse.json();
+		const response = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
+			headers: { "Upgrade": "websocket" },
+		});
+		const ws = response.webSocket;
+		ws.accept();
+		const closePromise = new Promise(resolve => ws.addEventListener("close", resolve));
+		// send a close message to the browser
+		const message = JSON.stringify({
+			method: "Browser.close",
+			id: -1,
+			params: {}
+		});
+		// we need to send the message in chunks
+		ws.send(messageToChunk(message));
+
+		const timeoutId = setInterval(() => {
+			// local dev browser rendering relies on a ping message to check browser process status
+			ws.send("ping");
+		}, 1000);
+		await closePromise;
+		// clear the interval, no longer need to ping
+		clearInterval(timeoutId);
+		return new Response("Browser closed");
+	}
+};
+`;
+
+test.serial("it closes a browser session", async (t) => {
+	const opts: MiniflareOptions = {
+		name: "worker",
+		compatibilityDate: "2024-11-20",
+		modules: true,
+		script: BROWSER_WORKER_CLOSE_SCRIPT,
+		browserRendering: { binding: "MYBROWSER" },
+	};
+	const mf = new Miniflare(opts);
+	t.teardown(() => mf.dispose());
+
+	const res = await mf.dispatchFetch("https://localhost/close");
+	t.is(await res.text(), "Browser closed");
 });

--- a/packages/miniflare/test/plugins/browser/index.spec.ts
+++ b/packages/miniflare/test/plugins/browser/index.spec.ts
@@ -1,5 +1,44 @@
 import test from "ava";
 import { Miniflare, MiniflareOptions } from "miniflare";
+import type { WebSocket } from "undici";
+
+async function sendMessage(ws: WebSocket, message: any) {
+	// adapted from https://github.com/cloudflare/puppeteer/blob/b4984452165437e26dd1c8e516581cec2a02b4cd/packages/puppeteer-core/src/cloudflare/chunking.ts#L6-L30
+	const messageToChunks = (data: string): Uint8Array[] => {
+		const HEADER_SIZE = 4; // Uint32
+		const MAX_MESSAGE_SIZE = 1048575; // Workers size is < 1MB
+		const FIRST_CHUNK_DATA_SIZE = MAX_MESSAGE_SIZE - HEADER_SIZE;
+
+		const encoder = new TextEncoder();
+		const encodedUint8Array = encoder.encode(data);
+
+		// We only include the header into the first chunk
+		const firstChunk = new Uint8Array(
+			Math.min(MAX_MESSAGE_SIZE, HEADER_SIZE + encodedUint8Array.length)
+		);
+		const view = new DataView(firstChunk.buffer);
+		view.setUint32(0, encodedUint8Array.length, true);
+		firstChunk.set(
+			encodedUint8Array.slice(0, FIRST_CHUNK_DATA_SIZE),
+			HEADER_SIZE
+		);
+
+		const chunks: Uint8Array[] = [firstChunk];
+		for (
+			let i = FIRST_CHUNK_DATA_SIZE;
+			i < data.length;
+			i += MAX_MESSAGE_SIZE
+		) {
+			chunks.push(encodedUint8Array.slice(i, i + MAX_MESSAGE_SIZE));
+		}
+		return chunks;
+	};
+
+	// we need to send the message in chunks
+	for (const chunk of messageToChunks(JSON.stringify(message))) {
+		ws.send(chunk);
+	}
+}
 
 const BROWSER_WORKER_SCRIPT = () => `
 export default {
@@ -29,37 +68,20 @@ test.serial("it creates a browser session", async (t) => {
 });
 
 const BROWSER_WORKER_CLOSE_SCRIPT = `
-const HEADER_SIZE = 4; // Uint32
-
-function messageToChunk(data) {
-	const encoder = new TextEncoder();
-	const encodedUint8Array = encoder.encode(data);
-
-	const chunk = new Uint8Array(HEADER_SIZE + encodedUint8Array.length);
-	const view = new DataView(chunk.buffer);
-	view.setUint32(0, encodedUint8Array.length, true);
-	chunk.set(encodedUint8Array, HEADER_SIZE);
-	return chunk;
-};
+${sendMessage.toString()}
 
 export default {
 	async fetch(request, env) {
 		const acquireResponse = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
 		const { sessionId } = await acquireResponse.json();
-		const response = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
+		const { webSocket: ws } = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
 			headers: { "Upgrade": "websocket" },
 		});
-		const ws = response.webSocket;
 		ws.accept();
+
 		const closePromise = new Promise(resolve => ws.addEventListener("close", resolve));
 		// send a close message to the browser
-		const message = JSON.stringify({
-			method: "Browser.close",
-			id: -1,
-			params: {}
-		});
-		// we need to send the message in chunks
-		ws.send(messageToChunk(message));
+		sendMessage(ws, { method: "Browser.close", id: -1 });
 
 		const timeoutId = setInterval(() => {
 			// local dev browser rendering relies on a ping message to check browser process status
@@ -86,4 +108,89 @@ test.serial("it closes a browser session", async (t) => {
 
 	const res = await mf.dispatchFetch("https://localhost/close");
 	t.is(await res.text(), "Browser closed");
+});
+
+const BROWSER_WORKER_REUSE_SCRIPT = `
+${sendMessage.toString()}
+
+export default {
+	async fetch(request, env) {
+		const acquireResponse = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
+		const { sessionId } = await acquireResponse.json();
+		const { webSocket: ws } = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
+			headers: { "Upgrade": "websocket" },
+		});
+		ws.accept();
+		ws.close();
+
+		// wait a bit to ensure webSocket readyState is updated on BrowserSession
+		await new Promise(resolve => setTimeout(resolve, 100));
+
+		// Reuse the same session by connecting to it again
+		const { webSocket: ws2 } = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
+			headers: { "Upgrade": "websocket" },
+		});
+		ws2.accept();
+		ws2.close();
+
+		return new Response("Browser session reused");
+	}
+};
+`;
+
+test.serial("it reuses a browser session", async (t) => {
+	const opts: MiniflareOptions = {
+		name: "worker",
+		compatibilityDate: "2024-11-20",
+		modules: true,
+		script: BROWSER_WORKER_REUSE_SCRIPT,
+		browserRendering: { binding: "MYBROWSER" },
+	};
+	const mf = new Miniflare(opts);
+	t.teardown(() => mf.dispose());
+
+	const res = await mf.dispatchFetch("https://localhost");
+	t.is(await res.text(), "Browser session reused");
+});
+
+const BROWSER_WORKER_ALREADY_USED_SCRIPT = `
+export default {
+	async fetch(request, env) {
+		const acquireResponse = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
+		const { sessionId } = await acquireResponse.json();
+		const { webSocket: ws } = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
+			headers: { "Upgrade": "websocket" },
+		});
+		ws.accept();
+
+		await new Promise(resolve => setTimeout(resolve, 100));
+
+
+		try {
+			// try to open new connection for the same session
+			const { webSocket: ws2 } = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
+				headers: { "Upgrade": "websocket" },
+			});
+		} catch (error) {
+			return new Response("Failed to connect to browser session");
+		}
+
+		return new Response("Should not reach here");
+	}
+};
+`;
+
+test.serial("fails if browser session already in use", async (t) => {
+	const opts: MiniflareOptions = {
+		name: "worker",
+		compatibilityDate: "2024-11-20",
+		modules: true,
+		script: BROWSER_WORKER_ALREADY_USED_SCRIPT,
+		browserRendering: { binding: "MYBROWSER" },
+	};
+	const mf = new Miniflare(opts);
+	t.teardown(() => mf.dispose());
+
+	const res = await mf.dispatchFetch("https://localhost");
+	t.is(await res.text(), "Failed to connect to browser session");
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
 
   fixtures/browser-rendering:
     devDependencies:
+      '@cloudflare/playwright':
+        specifier: ^0.0.10
+        version: 0.0.10
       '@cloudflare/puppeteer':
         specifier: ^1.0.2
         version: 1.0.3
@@ -4196,6 +4199,9 @@ packages:
   '@cloudflare/kv-asset-handler@0.4.0':
     resolution: {integrity: sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA==}
     engines: {node: '>=18.0.0'}
+
+  '@cloudflare/playwright@0.0.10':
+    resolution: {integrity: sha512-phlOzpO5FLgXFbx20C2GyQonffpe+qdL/MSMOf7ryc3+WjEsRrr6zqVLVJJq9ZW4CEypee1e/wcUQ473srC2dA==}
 
   '@cloudflare/puppeteer@1.0.3':
     resolution: {integrity: sha512-55LDVaxSv9hl99QkoLftJWvemKqfxK2+frKx2ylErV50pswGU7ILpEG0VzpN5pPqKqPXl/ajsIxuaJyp+A4kDw==}
@@ -14290,6 +14296,8 @@ snapshots:
   '@cloudflare/kv-asset-handler@0.4.0':
     dependencies:
       mime: 3.0.0
+
+  '@cloudflare/playwright@0.0.10': {}
 
   '@cloudflare/puppeteer@1.0.3':
     dependencies:


### PR DESCRIPTION
Playwright relies on a WebSocket close event that is never triggered in local dev. As a workaround, we poll miniflare to check if the browser is still up and running, otherwise we close the websocket explictly.

Fixes: #9945


- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> New feature
