### PR TITLE
V3 Backport [#9990]: Fix startup profiling with sourcemaps enabled

### DIFF
--- a/.changeset/yummy-parents-remain.md
+++ b/.changeset/yummy-parents-remain.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix startup profiling when sourcemaps are enabled

--- a/packages/wrangler/src/__tests__/startup-profiling.test.ts
+++ b/packages/wrangler/src/__tests__/startup-profiling.test.ts
@@ -30,6 +30,20 @@ describe("wrangler check startup", () => {
 			readFile("worker-startup.cpuprofile", "utf8")
 		).resolves.toContain("callFrame");
 	});
+	test("generates profile for basic worker w/ sourcemaps", async () => {
+		writeWranglerConfig({ main: "index.js", upload_source_maps: true });
+		writeWorkerSource();
+
+		await runWrangler("check startup");
+
+		expect(std.out).toContain(
+			`CPU Profile written to worker-startup.cpuprofile`
+		);
+
+		await expect(
+			readFile("worker-startup.cpuprofile", "utf8")
+		).resolves.toContain("callFrame");
+	});
 	test("--outfile works", async () => {
 		writeWranglerConfig({ main: "index.js" });
 		writeWorkerSource();

--- a/packages/wrangler/src/check/commands.ts
+++ b/packages/wrangler/src/check/commands.ts
@@ -166,14 +166,19 @@ async function convertWorkerBundleToModules(
 	workerBundle: FormData
 ): Promise<ModuleDefinition[]> {
 	return await Promise.all(
-		[...workerBundle.entries()].map(
-			async (m) =>
-				({
-					type: getModuleType(m[1]),
-					path: m[0],
-					contents: await getEntryValue(m[1]),
-				}) as ModuleDefinition
-		)
+		[...workerBundle.entries()]
+			// Sourcemaps aren't "real" modules in the application and won't be imported by user code, so lets not load them when analyzing the bundle
+			.filter(
+				(m) => m[1] instanceof Blob && m[1].type !== "application/source-map"
+			)
+			.map(
+				async (m) =>
+					({
+						type: getModuleType(m[1]),
+						path: m[0],
+						contents: await getEntryValue(m[1]),
+					}) as ModuleDefinition
+			)
 	);
 }
 


### PR DESCRIPTION
This is an automatically opened PR to backport patch changes from #9990 to Wrangler v3