### PR TITLE
Inject HMR code in Worker entry file

### DIFF
--- a/.changeset/orange-donkeys-check.md
+++ b/.changeset/orange-donkeys-check.md
@@ -11,4 +11,3 @@ if (import.meta.hot) {
 ```
 
 This prevents file changes from invalidating the full module graph and improves HMR performance in development.
-It also resolves issues that users were facing with HMR in larger applications.

--- a/.changeset/orange-donkeys-check.md
+++ b/.changeset/orange-donkeys-check.md
@@ -1,0 +1,14 @@
+---
+"@cloudflare/vite-plugin": minor
+---
+
+We now automatically inject the following HMR code into your Worker entry file:
+
+```ts
+if (import.meta.hot) {
+	import.meta.hot.accept();
+}
+```
+
+This prevents file changes from invalidating the full module graph and improves HMR performance in development.
+It also resolves issues that users were facing with HMR in larger applications.

--- a/packages/vite-plugin-cloudflare/playground/worker/__tests__/worker.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/worker/__tests__/worker.spec.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { expect, test, vi } from "vitest";
 import {
 	getTextResponse,
+	isBuild,
 	rootDir,
 	serverLogs,
 	viteTestUrl,
@@ -28,12 +29,15 @@ test("does not cause unhandled rejection", async () => {
 	expect(serverLogs.errors.join()).not.toContain("__unhandled rejection__");
 });
 
-test("updates using HMR code in Worker entry file", async () => {
-	const workerEntryPath = path.join(rootDir, "src", "index.ts");
-	const originalContent = fs.readFileSync(workerEntryPath, "utf-8");
-	fs.writeFileSync(workerEntryPath, originalContent);
+test.runIf(!isBuild)(
+	"updates using HMR code in Worker entry file",
+	async () => {
+		const workerEntryPath = path.join(rootDir, "src", "index.ts");
+		const originalContent = fs.readFileSync(workerEntryPath, "utf-8");
+		fs.writeFileSync(workerEntryPath, originalContent);
 
-	await vi.waitFor(() => {
-		expect(serverLogs.info.join()).toContain("[vite] hot updated");
-	});
-});
+		await vi.waitFor(() => {
+			expect(serverLogs.info.join()).toContain("[vite] hot updated");
+		});
+	}
+);

--- a/packages/vite-plugin-cloudflare/playground/worker/__tests__/worker.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/worker/__tests__/worker.spec.ts
@@ -1,5 +1,12 @@
-import { expect, test } from "vitest";
-import { getTextResponse, serverLogs, viteTestUrl } from "../../__test-utils__";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { expect, test, vi } from "vitest";
+import {
+	getTextResponse,
+	rootDir,
+	serverLogs,
+	viteTestUrl,
+} from "../../__test-utils__";
 
 test("basic hello-world functionality", async () => {
 	expect(await getTextResponse()).toEqual("Hello World!");
@@ -19,4 +26,14 @@ test("receives the original host as the `X-Forwarded-Host` header", async () => 
 
 test("does not cause unhandled rejection", async () => {
 	expect(serverLogs.errors.join()).not.toContain("__unhandled rejection__");
+});
+
+test("updates using HMR code in Worker entry file", async () => {
+	const workerEntryPath = path.join(rootDir, "src", "index.ts");
+	const originalContent = fs.readFileSync(workerEntryPath, "utf-8");
+	fs.writeFileSync(workerEntryPath, originalContent);
+
+	await vi.waitFor(() => {
+		expect(serverLogs.info.join()).toContain("[vite] hot updated");
+	});
 });


### PR DESCRIPTION
Fixes #000.

This transforms the Worker entry file to inject an HMR boundary. By providing an HMR boundary at the root, we ensure that the full module graph is not invalidated on code changes. Ideally, frameworks should be adding server HMR code at route boundaries but React Router does not currently do this. This follows discussion with the Vite team and they have also merged a PR to update the docs (https://github.com/vitejs/vite/pull/20401).

From feedback gathered from users, it appears this change fixes the issues experienced in https://github.com/cloudflare/workers-sdk/issues/9518. I believe this may be because HMR updates are queued (https://github.com/vitejs/vite/blob/3e81af38a80c7617aba6bf3300d8b4267570f9cf/packages/vite/src/module-runner/hmrHandler.ts#L25) whereas full reloads are not (https://github.com/vitejs/vite/blob/3e81af38a80c7617aba6bf3300d8b4267570f9cf/packages/vite/src/module-runner/hmrHandler.ts#L54). If this turns out not to be the case then we can reopen the issue.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because: not testable
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: N/A
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
