### PR TITLE
fix: Durable Object type generation to use proper TypeScript generics

### DIFF
--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -412,10 +412,8 @@ export async function generateEnvTypes(
 
 			if (importPath && exportExists) {
 				typeName = `DurableObjectNamespace<import("${importPath}").${durableObject.class_name}>`;
-			} else if (durableObject.script_name) {
-				typeName = `DurableObjectNamespace /* ${durableObject.class_name} from ${durableObject.script_name} */`;
 			} else {
-				typeName = `DurableObjectNamespace /* ${durableObject.class_name} */`;
+				typeName = `DurableObjectNamespace<${durableObject.class_name}>`;
 			}
 
 			envTypeStructure.push([constructTypeKey(durableObject.name), typeName]);


### PR DESCRIPTION
Description:

#9999 

> Fixes issue where wrangler types generated Durable Object types using comments instead of proper TypeScript generics. Now generates DurableObjectNamespace<MyDurableObject> instead of DurableObjectNamespace /* MyDurableObject */ for better type safety.

> Checkboxes:

- Tests: [ ] Tests not necessary because: Simple logic change with clear behavior
- Public documentation: [ ] Documentation not necessary because: No API changes
- Wrangler V3 Backport: [ ] Not necessary because: This is a Wrangler change