### PR TITLE
feat: interactively handle wonky asset deploy commands

### DIFF
--- a/.changeset/deep-onions-move.md
+++ b/.changeset/deep-onions-move.md
@@ -6,8 +6,8 @@ Interactively handle `wrangler deploy`s that are probably assets-only, where the
 
 For example:
 
-`npx wrangler deploy ./public` will now ask if you meant to deploy an folder of assets only, ask for a name, set the compat date and then ask to write your choices out to `wrangler.json` for subsequent deployments.
+`npx wrangler deploy ./public` will now ask if you meant to deploy a folder of assets only, ask for a name, set the compat date and then ask whether to write your choices out to `wrangler.json` for subsequent deployments.
 
-`npx wrangler deploy --assets=./public` will now ask for a name, set the compat date and then ask to write your choices out to `wrangler.json` for subsequent deployments.
+`npx wrangler deploy --assets=./public` will now ask for a name, set the compat date and then ask whether to write your choices out to `wrangler.json` for subsequent deployments.
 
-In non-interactive contexts, we will error as we currently do.
+In non-interactive contexts, Wrangler will error as it currently does.

--- a/.changeset/deep-onions-move.md
+++ b/.changeset/deep-onions-move.md
@@ -1,0 +1,13 @@
+---
+"wrangler": minor
+---
+
+Interactively handle `wrangler deploy`s that are probably assets-only, where there is no config file and flags are incorrect or missing.
+
+For example:
+
+`npx wrangler deploy ./public` will now ask if you meant to deploy an folder of assets only, ask for a name, set the compat date and then ask to write your choices out to `wrangler.json` for subsequent deployments.
+
+`npx wrangler deploy --assets=./public` will now ask for a name, set the compat date and then ask to write your choices out to `wrangler.json` for subsequent deployments.
+
+In non-interactive contexts, we will error as we currently do.

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -10,6 +10,7 @@ import * as esbuild from "esbuild";
 import { http, HttpResponse } from "msw";
 import dedent from "ts-dedent";
 import { vi } from "vitest";
+import { findWranglerConfig } from "../config/config-helpers";
 import {
 	printBundleSize,
 	printOffendingDependencies,
@@ -20,7 +21,7 @@ import { writeAuthConfigFile } from "../user";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockAuthDomain } from "./helpers/mock-auth-domain";
 import { mockConsoleMethods } from "./helpers/mock-console";
-import { clearDialogs, mockConfirm } from "./helpers/mock-dialogs";
+import { clearDialogs, mockConfirm, mockPrompt } from "./helpers/mock-dialogs";
 import { mockGetZoneFromHostRequest } from "./helpers/mock-get-zone-from-host";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { mockCollectKnownRoutesRequest } from "./helpers/mock-known-routes";
@@ -2720,6 +2721,157 @@ addEventListener('fetch', event => {});`
 				});
 			});
 		});
+
+		describe("should interactively handle misconfigured asset-only deployments", () => {
+			beforeEach(() => {
+				setIsTTY(true);
+
+				// Mock the date to ensure consistent compatibility_date
+				vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
+
+				fs.mkdirSync("my-site");
+				process.chdir("my-site");
+				const assets = [
+					{ filePath: "index.html", content: "<html>test</html>" },
+				];
+				writeAssets(assets);
+				expect(findWranglerConfig().configPath).toBe(undefined);
+				mockSubDomainRequest();
+				mockUploadWorkerRequest({
+					expectedAssets: {
+						jwt: "<<aus-completion-token>>",
+						config: {},
+					},
+					expectedType: "none",
+				});
+			});
+			afterEach(() => {
+				setIsTTY(false);
+			});
+
+			it("should handle `wrangler deploy <directory>`", async () => {
+				mockConfirm({
+					text: "It looks like you are trying to deploy a directory of static assets only. Is this correct?",
+					result: true,
+				});
+				mockPrompt({
+					text: "What do you want to name your project?",
+					options: { defaultValue: "my-site" },
+					result: "test-name",
+				});
+				mockConfirm({
+					text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
+					result: true,
+				});
+
+				const bodies: AssetManifest[] = [];
+				await mockAUSRequest(bodies);
+
+				await runWrangler("deploy ./assets");
+				expect(bodies.length).toBe(1);
+				expect(bodies[0]).toEqual({
+					manifest: {
+						"/index.html": {
+							hash: "8308ce789f3d08668ce87176838d59d0",
+							size: 17,
+						},
+					},
+				});
+				expect(fs.readFileSync("wrangler.json", "utf-8"))
+					.toMatchInlineSnapshot(`
+					"{
+					  \\"name\\": \\"test-name\\",
+					  \\"compatibility_date\\": \\"2024-01-01\\",
+					  \\"assets\\": {
+					    \\"directory\\": \\"./assets\\"
+					  }
+					}"
+				`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"
+
+
+					No compatibility date found Defaulting to today: 2024-01-01
+
+					Wrote
+					{
+					  \\"name\\": \\"test-name\\",
+					  \\"compatibility_date\\": \\"2024-01-01\\",
+					  \\"assets\\": {
+					    \\"directory\\": \\"./assets\\"
+					  }
+					}
+					 to <cwd>/wrangler.json.
+					Please run wrangler deploy instead of wrangler deploy ./assets next time. Wrangler will automatically use the configuration saved to wrangler.json.
+
+					Total Upload: xx KiB / gzip: xx KiB
+					Worker Startup Time: 100 ms
+					Uploaded test-name (TIMINGS)
+					Deployed test-name triggers (TIMINGS)
+					  https://test-name.test-sub-domain.workers.dev
+					Current Version ID: Galaxy-Class"
+				`);
+			});
+			it("should handle `wrangler deploy --assets` without name or compat date", async () => {
+				// if the user has used --assets flag and args.script is not set, we just need to prompt for the name and add compat date
+				mockPrompt({
+					text: "What do you want to name your project?",
+					options: { defaultValue: "my-site" },
+					result: "test-name",
+				});
+				mockConfirm({
+					text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
+					result: true,
+				});
+
+				const bodies: AssetManifest[] = [];
+				await mockAUSRequest(bodies);
+
+				await runWrangler("deploy --assets ./assets");
+				expect(bodies.length).toBe(1);
+				expect(bodies[0]).toEqual({
+					manifest: {
+						"/index.html": {
+							hash: "8308ce789f3d08668ce87176838d59d0",
+							size: 17,
+						},
+					},
+				});
+				expect(fs.readFileSync("wrangler.json", "utf-8"))
+					.toMatchInlineSnapshot(`
+					"{
+					  \\"name\\": \\"test-name\\",
+					  \\"compatibility_date\\": \\"2024-01-01\\",
+					  \\"assets\\": {
+					    \\"directory\\": \\"./assets\\"
+					  }
+					}"
+				`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"
+
+					No compatibility date found Defaulting to today: 2024-01-01
+
+					Wrote
+					{
+					  \\"name\\": \\"test-name\\",
+					  \\"compatibility_date\\": \\"2024-01-01\\",
+					  \\"assets\\": {
+					    \\"directory\\": \\"./assets\\"
+					  }
+					}
+					 to <cwd>/wrangler.json.
+					Please run wrangler deploy instead of wrangler deploy ./assets next time. Wrangler will automatically use the configuration saved to wrangler.json.
+
+					Total Upload: xx KiB / gzip: xx KiB
+					Worker Startup Time: 100 ms
+					Uploaded test-name (TIMINGS)
+					Deployed test-name triggers (TIMINGS)
+					  https://test-name.test-sub-domain.workers.dev
+					Current Version ID: Galaxy-Class"
+				`);
+			});
+		});
 	});
 
 	describe("(legacy) asset upload", () => {
@@ -4346,7 +4498,8 @@ addEventListener('fetch', event => {});`
 			);
 		});
 
-		it("should error if directory specified by flag --assets does not exist", async () => {
+		it("should error if directory specified by flag --assets does not exist in non-interactive mode", async () => {
+			setIsTTY(false);
 			await expect(runWrangler("deploy --assets abc")).rejects.toThrow(
 				new RegExp(
 					'^The directory specified by the "--assets" command line argument does not exist:[Ss]*'

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -1,11 +1,15 @@
 import assert from "node:assert";
+import { statSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import chalk from "chalk";
 import { getAssetsOptions, validateAssetsArgsAndConfig } from "../assets";
 import { configFileName } from "../config";
 import { createCommand } from "../core/create-command";
 import { getEntry } from "../deployment-bundle/entry";
+import { confirm, prompt } from "../dialogs";
 import { getCIOverrideName } from "../environment-variables/misc-variables";
 import { UserError } from "../errors";
+import { isNonInteractiveOrCI } from "../is-interactive";
 import { logger } from "../logger";
 import { verifyWorkerMatchesCITag } from "../match-tag";
 import * as metrics from "../metrics";
@@ -246,8 +250,29 @@ export const deployCommand = createCommand({
 		const projectRoot =
 			config.userConfigPath && path.dirname(config.userConfigPath);
 
-		const entry = await getEntry(args, config, "deploy");
+		if (!config.configPath) {
+			// Attempt to interactively handle `wrangler deploy <directory>`
+			if (args.script) {
+				try {
+					const stats = statSync(args.script);
+					if (stats.isDirectory()) {
+						args = await handleMaybeAssetsDeployment(args);
+					}
+				} catch (error) {
+					// If this is our UserError, re-throw it
+					if (error instanceof UserError) {
+						throw error;
+					}
+					// If stat fails, let the original flow handle the error
+				}
+			}
+			// atttempt to interactively handle `wrangler deploy --assets <directory>` missing compat date or name
+			else if (args.assets && (!args.compatibilityDate || !args.name)) {
+				args = await handleMaybeAssetsDeployment(args);
+			}
+		}
 
+		const entry = await getEntry(args, config, "deploy");
 		validateAssetsArgsAndConfig(args, config);
 
 		const assetsOptions = getAssetsOptions(args, config);
@@ -364,3 +389,91 @@ export const deployCommand = createCommand({
 });
 
 export type DeployArgs = (typeof deployCommand)["args"];
+
+/**
+ * Handles the case where a user provides a directory as a positional argument,
+ * probably intending to deploy static assets. e.g. wrangler deploy ./public
+ * We then interactively take the user through deployment (missing name, compatibility date, etc.)
+ * and try and output this as a wrangler.json for future deployments.
+ */
+export async function handleMaybeAssetsDeployment(
+	args: DeployArgs
+): Promise<DeployArgs> {
+	if (isNonInteractiveOrCI()) {
+		return args;
+	}
+
+	// Ask if user intended to deploy assets only
+	logger.log("");
+	if (!args.assets) {
+		const deployAssets = await confirm(
+			"It looks like you are trying to deploy a directory of static assets only. Is this correct?",
+			{ defaultValue: true }
+		);
+		logger.log("");
+		if (deployAssets) {
+			args.assets = args.script;
+			args.script = undefined;
+		} else {
+			// let the usual error handling path kick in
+			return args;
+		}
+	}
+
+	// Check if name is provided, if not ask for it
+	if (!args.name) {
+		const projectName = await prompt("What do you want to name your project?", {
+			defaultValue: process.cwd().split(path.sep).pop(),
+		});
+		args.name = projectName;
+		logger.log("");
+	}
+
+	// Set compatibility date if not provided
+	if (!args.compatibilityDate) {
+		const today = new Date();
+		const compatibilityDate = [
+			today.getFullYear(),
+			(today.getMonth() + 1).toString().padStart(2, "0"),
+			today.getDate().toString().padStart(2, "0"),
+		].join("-");
+		args.compatibilityDate = compatibilityDate;
+		logger.log(
+			`${chalk.bold("No compatibility date found")} Defaulting to today:`,
+			compatibilityDate
+		);
+		logger.log("");
+	}
+
+	// Ask if user wants to write config file
+	const writeConfig = await confirm(
+		`Do you want Wrangler to write a wrangler.json config file to store this configuration?\n${chalk.dim("This will allow you to simply run `wrangler deploy` on future deployments.")}`
+	);
+
+	if (writeConfig) {
+		const configPath = path.join(process.cwd(), "wrangler.json");
+		const jsonString = JSON.stringify(
+			{
+				name: args.name,
+				compatibility_date: args.compatibilityDate,
+				assets: { directory: args.assets },
+			},
+			null,
+			2
+		);
+		writeFileSync(configPath, jsonString);
+		logger.log(`Wrote \n${jsonString}\n to ${chalk.bold(configPath)}.`);
+		logger.log(
+			`Please run ${chalk.bold("wrangler deploy")} instead of ${chalk.bold(`wrangler deploy ${args.assets}`)} next time. Wrangler will automatically use the configuration saved to wrangler.json.`
+		);
+	} else {
+		logger.log("Proceeding with deployment...");
+		logger.log(
+			`You should run ${chalk.bold(
+				`wrangler deploy --name ${args.name} --compatibility-date ${args.compatibilityDate} --assets ${args.assets}`
+			)} next time to deploy this Worker without going through this flow again.`
+		);
+	}
+	logger.log("");
+	return args;
+}

--- a/packages/wrangler/src/deployment-bundle/run-custom-build.ts
+++ b/packages/wrangler/src/deployment-bundle/run-custom-build.ts
@@ -136,6 +136,10 @@ function getMissingEntryPointMessage(
 				"```\n" +
 				possiblePaths.map((filePath) => `main = "./${filePath}"\n`).join("") +
 				"```";
+		} else {
+			message +=
+				`\n If you want to deploy a directory of static assets, you can do so by using the \`--assets\` flag. For example:\n\n` +
+				`wrangler deploy --assets=./${relativeEntryPointPath}\n`;
 		}
 	}
 	return message;


### PR DESCRIPTION
Interactively handle `wrangler deploy`s that are probably assets-only, where there is **no config file found** and flags are incorrect or missing.

For example:

`npx wrangler deploy ./public` will now ask if you meant to deploy an folder of assets only, ask for a name, set the compat date and then ask to write your choices out to `wrangler.json` for subsequent deployments.

`npx wrangler deploy --assets=./public` will now ask for a name, set the compat date and then ask to write your choices out to `wrangler.json` for subsequent deployments.

In non-interactive contexts, we will error as we currently do.

Out of scope (for this PR) are worker or worker and asset deploys.

<img width="755" height="412" alt="Screenshot 2025-07-18 at 14 31 26" src="https://github.com/user-attachments/assets/cc0f1738-51a7-468c-85bf-ff90e452302e" />


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: self-documenting?
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: new

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
