### PR TITLE
add support for containers in wrangler multiworker dev

### DIFF
--- a/.changeset/late-taxis-switch.md
+++ b/.changeset/late-taxis-switch.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+add support for containers in wrangler multiworker dev
+
+currently when running `wrangler dev` with different workers (meaning that the `-c|--config` flag is used multiple times) containers are not being included, meaning that trying to interact with them at runtime would not work and cause errors instead. The changes here address the above making wrangler correctly detect and wire up the containers.

--- a/fixtures/interactive-dev-tests/multi-workers-containers-app/tsconfig.json
+++ b/fixtures/interactive-dev-tests/multi-workers-containers-app/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "ESNext",
+		"lib": ["ES2020"],
+		"types": ["@cloudflare/workers-types"],
+		"moduleResolution": "node",
+		"noEmit": true,
+		"skipLibCheck": true
+	},
+	"include": ["**/*.ts"],
+	"exclude": ["tests"]
+}

--- a/fixtures/interactive-dev-tests/multi-workers-containers-app/workerA/Dockerfile
+++ b/fixtures/interactive-dev-tests/multi-workers-containers-app/workerA/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:22-alpine
+
+WORKDIR /usr/src/app
+RUN echo '{"name": "simple-node-app", "version": "1.0.0"}' > package.json
+RUN npm install
+
+RUN echo 'const { createServer } = require("http");\
+\
+const server = createServer(function (req, res) {\
+	res.writeHead(200, { "Content-Type": "text/plain" });\
+	res.write("Hello from Container A");\
+	res.end();\
+});\
+\
+server.listen(8080);\
+' > app.js
+
+EXPOSE 8080

--- a/fixtures/interactive-dev-tests/multi-workers-containers-app/workerA/index.ts
+++ b/fixtures/interactive-dev-tests/multi-workers-containers-app/workerA/index.ts
@@ -1,6 +1,6 @@
 import { DurableObject } from "cloudflare:workers";
 
-class FixtureTestContainerBase extends DurableObject<Env> {
+export class FixtureTestContainer extends DurableObject<Env> {
 	container: globalThis.Container;
 
 	constructor(ctx: DurableObjectState, env: Env) {
@@ -26,24 +26,13 @@ class FixtureTestContainerBase extends DurableObject<Env> {
 	}
 }
 
-export class FixtureTestContainerA extends FixtureTestContainerBase {}
-export class FixtureTestContainerB extends FixtureTestContainerBase {}
-
 export default {
 	async fetch(request, env): Promise<Response> {
-		const getContainerText = async (
-			container: "CONTAINER_A" | "CONTAINER_B"
-		) => {
-			const id = env[container].idFromName("container");
-			const stub = env[container].get(id);
-			return await (await stub.fetch(request)).text();
-		};
-		const containerAText = await getContainerText("CONTAINER_A");
-		const containerBText = await getContainerText("CONTAINER_B");
-		return new Response(
-			`Response from A: "${containerAText}"` +
-				" " +
-				`Response from B: "${containerBText}"`
-		);
+		const id = env.CONTAINER.idFromName("container");
+		const stub = env.CONTAINER.get(id);
+		return Response.json({
+			containerAText: await (await stub.fetch(request)).text(),
+			containerBText: await (await env.WORKER_B.fetch(request)).text(),
+		});
 	},
 } satisfies ExportedHandler<Env>;

--- a/fixtures/interactive-dev-tests/multi-workers-containers-app/workerA/index.ts
+++ b/fixtures/interactive-dev-tests/multi-workers-containers-app/workerA/index.ts
@@ -1,6 +1,6 @@
 import { DurableObject } from "cloudflare:workers";
 
-export class FixtureTestContainer extends DurableObject<Env> {
+export class FixtureTestContainerA extends DurableObject<Env> {
 	container: globalThis.Container;
 
 	constructor(ctx: DurableObjectState, env: Env) {
@@ -28,8 +28,8 @@ export class FixtureTestContainer extends DurableObject<Env> {
 
 export default {
 	async fetch(request, env): Promise<Response> {
-		const id = env.CONTAINER.idFromName("container");
-		const stub = env.CONTAINER.get(id);
+		const id = env.CONTAINER_A.idFromName("container");
+		const stub = env.CONTAINER_A.get(id);
 		return Response.json({
 			containerAText: await (await stub.fetch(request)).text(),
 			containerBText: await (await env.WORKER_B.fetch(request)).text(),

--- a/fixtures/interactive-dev-tests/multi-workers-containers-app/workerA/worker-configuration.d.ts
+++ b/fixtures/interactive-dev-tests/multi-workers-containers-app/workerA/worker-configuration.d.ts
@@ -1,0 +1,7 @@
+declare namespace Cloudflare {
+	interface Env {
+		CONTAINER: DurableObjectNamespace<import(".").FixtureTestContainer>;
+		WORKER_B: Fetcher;
+	}
+}
+interface Env extends Cloudflare.Env {}

--- a/fixtures/interactive-dev-tests/multi-workers-containers-app/workerA/worker-configuration.d.ts
+++ b/fixtures/interactive-dev-tests/multi-workers-containers-app/workerA/worker-configuration.d.ts
@@ -1,6 +1,6 @@
 declare namespace Cloudflare {
 	interface Env {
-		CONTAINER: DurableObjectNamespace<import(".").FixtureTestContainer>;
+		CONTAINER_A: DurableObjectNamespace<import(".").FixtureTestContainerA>;
 		WORKER_B: Fetcher;
 	}
 }

--- a/fixtures/interactive-dev-tests/multi-workers-containers-app/workerA/wrangler.jsonc
+++ b/fixtures/interactive-dev-tests/multi-workers-containers-app/workerA/wrangler.jsonc
@@ -1,0 +1,28 @@
+{
+	"name": "worker-a",
+	"main": "index.ts",
+	"compatibility_date": "2025-04-03",
+	"services": [{ "binding": "WORKER_B", "service": "worker-b" }],
+	"containers": [
+		{
+			"image": "./Dockerfile",
+			"class_name": "FixtureTestContainer",
+			"name": "container",
+			"max_instances": 2,
+		},
+	],
+	"durable_objects": {
+		"bindings": [
+			{
+				"class_name": "FixtureTestContainer",
+				"name": "CONTAINER",
+			},
+		],
+	},
+	"migrations": [
+		{
+			"tag": "v1",
+			"new_classes": ["FixtureTestContainer"],
+		},
+	],
+}

--- a/fixtures/interactive-dev-tests/multi-workers-containers-app/workerA/wrangler.jsonc
+++ b/fixtures/interactive-dev-tests/multi-workers-containers-app/workerA/wrangler.jsonc
@@ -22,7 +22,7 @@
 	"migrations": [
 		{
 			"tag": "v1",
-			"new_classes": ["FixtureTestContainer"],
+			"new_sqlite_classes": ["FixtureTestContainer"],
 		},
 	],
 }

--- a/fixtures/interactive-dev-tests/multi-workers-containers-app/workerA/wrangler.jsonc
+++ b/fixtures/interactive-dev-tests/multi-workers-containers-app/workerA/wrangler.jsonc
@@ -6,7 +6,7 @@
 	"containers": [
 		{
 			"image": "./Dockerfile",
-			"class_name": "FixtureTestContainer",
+			"class_name": "FixtureTestContainerA",
 			"name": "container",
 			"max_instances": 2,
 		},
@@ -14,15 +14,15 @@
 	"durable_objects": {
 		"bindings": [
 			{
-				"class_name": "FixtureTestContainer",
-				"name": "CONTAINER",
+				"class_name": "FixtureTestContainerA",
+				"name": "CONTAINER_A",
 			},
 		],
 	},
 	"migrations": [
 		{
 			"tag": "v1",
-			"new_sqlite_classes": ["FixtureTestContainer"],
+			"new_sqlite_classes": ["FixtureTestContainerA"],
 		},
 	],
 }

--- a/fixtures/interactive-dev-tests/multi-workers-containers-app/workerB/Dockerfile
+++ b/fixtures/interactive-dev-tests/multi-workers-containers-app/workerB/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:22-alpine
+
+WORKDIR /usr/src/app
+RUN echo '{"name": "simple-node-app", "version": "1.0.0"}' > package.json
+RUN npm install
+
+RUN echo 'const { createServer } = require("http");\
+\
+const server = createServer(function (req, res) {\
+	res.writeHead(200, { "Content-Type": "text/plain" });\
+	res.write("Hello from Container B");\
+	res.end();\
+});\
+\
+server.listen(8080);\
+' > app.js
+
+EXPOSE 8080

--- a/fixtures/interactive-dev-tests/multi-workers-containers-app/workerB/index.ts
+++ b/fixtures/interactive-dev-tests/multi-workers-containers-app/workerB/index.ts
@@ -1,6 +1,6 @@
 import { DurableObject } from "cloudflare:workers";
 
-class FixtureTestContainerBase extends DurableObject<Env> {
+export class FixtureTestContainer extends DurableObject<Env> {
 	container: globalThis.Container;
 
 	constructor(ctx: DurableObjectState, env: Env) {
@@ -26,24 +26,10 @@ class FixtureTestContainerBase extends DurableObject<Env> {
 	}
 }
 
-export class FixtureTestContainerA extends FixtureTestContainerBase {}
-export class FixtureTestContainerB extends FixtureTestContainerBase {}
-
 export default {
 	async fetch(request, env): Promise<Response> {
-		const getContainerText = async (
-			container: "CONTAINER_A" | "CONTAINER_B"
-		) => {
-			const id = env[container].idFromName("container");
-			const stub = env[container].get(id);
-			return await (await stub.fetch(request)).text();
-		};
-		const containerAText = await getContainerText("CONTAINER_A");
-		const containerBText = await getContainerText("CONTAINER_B");
-		return new Response(
-			`Response from A: "${containerAText}"` +
-				" " +
-				`Response from B: "${containerBText}"`
-		);
+		const id = env.CONTAINER.idFromName("container");
+		const stub = env.CONTAINER.get(id);
+		return stub.fetch(request);
 	},
 } satisfies ExportedHandler<Env>;

--- a/fixtures/interactive-dev-tests/multi-workers-containers-app/workerB/index.ts
+++ b/fixtures/interactive-dev-tests/multi-workers-containers-app/workerB/index.ts
@@ -1,6 +1,6 @@
 import { DurableObject } from "cloudflare:workers";
 
-export class FixtureTestContainer extends DurableObject<Env> {
+export class FixtureTestContainerB extends DurableObject<Env> {
 	container: globalThis.Container;
 
 	constructor(ctx: DurableObjectState, env: Env) {
@@ -28,8 +28,8 @@ export class FixtureTestContainer extends DurableObject<Env> {
 
 export default {
 	async fetch(request, env): Promise<Response> {
-		const id = env.CONTAINER.idFromName("container");
-		const stub = env.CONTAINER.get(id);
+		const id = env.CONTAINER_B.idFromName("container");
+		const stub = env.CONTAINER_B.get(id);
 		return stub.fetch(request);
 	},
 } satisfies ExportedHandler<Env>;

--- a/fixtures/interactive-dev-tests/multi-workers-containers-app/workerB/worker-configuration.d.ts
+++ b/fixtures/interactive-dev-tests/multi-workers-containers-app/workerB/worker-configuration.d.ts
@@ -1,0 +1,6 @@
+declare namespace Cloudflare {
+	interface Env {
+		CONTAINER: DurableObjectNamespace<import(".").FixtureTestContainer>;
+	}
+}
+interface Env extends Cloudflare.Env {}

--- a/fixtures/interactive-dev-tests/multi-workers-containers-app/workerB/worker-configuration.d.ts
+++ b/fixtures/interactive-dev-tests/multi-workers-containers-app/workerB/worker-configuration.d.ts
@@ -1,6 +1,6 @@
 declare namespace Cloudflare {
 	interface Env {
-		CONTAINER: DurableObjectNamespace<import(".").FixtureTestContainer>;
+		CONTAINER_B: DurableObjectNamespace<import(".").FixtureTestContainerB>;
 	}
 }
 interface Env extends Cloudflare.Env {}

--- a/fixtures/interactive-dev-tests/multi-workers-containers-app/workerB/wrangler.jsonc
+++ b/fixtures/interactive-dev-tests/multi-workers-containers-app/workerB/wrangler.jsonc
@@ -5,7 +5,7 @@
 	"containers": [
 		{
 			"image": "./Dockerfile",
-			"class_name": "FixtureTestContainer",
+			"class_name": "FixtureTestContainerB",
 			"name": "container",
 			"max_instances": 2,
 		},
@@ -13,15 +13,15 @@
 	"durable_objects": {
 		"bindings": [
 			{
-				"class_name": "FixtureTestContainer",
-				"name": "CONTAINER",
+				"class_name": "FixtureTestContainerB",
+				"name": "CONTAINER_B",
 			},
 		],
 	},
 	"migrations": [
 		{
 			"tag": "v1",
-			"new_classes": ["FixtureTestContainer"],
+			"new_classes": ["FixtureTestContainerB"],
 		},
 	],
 }

--- a/fixtures/interactive-dev-tests/multi-workers-containers-app/workerB/wrangler.jsonc
+++ b/fixtures/interactive-dev-tests/multi-workers-containers-app/workerB/wrangler.jsonc
@@ -1,0 +1,27 @@
+{
+	"name": "worker-b",
+	"main": "index.ts",
+	"compatibility_date": "2025-04-03",
+	"containers": [
+		{
+			"image": "./Dockerfile",
+			"class_name": "FixtureTestContainer",
+			"name": "container",
+			"max_instances": 2,
+		},
+	],
+	"durable_objects": {
+		"bindings": [
+			{
+				"class_name": "FixtureTestContainer",
+				"name": "CONTAINER",
+			},
+		],
+	},
+	"migrations": [
+		{
+			"tag": "v1",
+			"new_classes": ["FixtureTestContainer"],
+		},
+	],
+}

--- a/fixtures/interactive-dev-tests/tests/index.test.ts
+++ b/fixtures/interactive-dev-tests/tests/index.test.ts
@@ -729,6 +729,124 @@ baseDescribe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
 	}
 );
 
+baseDescribe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
+	"multi-workers containers dev",
+	{ retry: 0, timeout: 50000 },
+	() => {
+		let tmpDir: string;
+		beforeAll(async () => {
+			tmpDir = fs.mkdtempSync(
+				path.join(tmpdir(), "wrangler-multi-workers-containers-")
+			);
+			fs.cpSync(
+				path.resolve(__dirname, "../", "multi-workers-containers-app"),
+				path.join(tmpDir),
+				{
+					recursive: true,
+				}
+			);
+
+			const ids = getContainerIds();
+			if (ids.length > 0) {
+				execSync("docker rm -f " + ids.join(" "), {
+					encoding: "utf8",
+				});
+			}
+		});
+
+		afterEach(async () => {
+			const ids = getContainerIds();
+
+			if (ids.length > 0) {
+				execSync("docker rm -f " + ids.join(" "), {
+					encoding: "utf8",
+				});
+			}
+		});
+		afterAll(async () => {
+			try {
+				fs.rmSync(tmpDir, { recursive: true, force: true });
+			} catch (e) {
+				// It seems that Windows doesn't let us delete this, with errors like:
+				//
+				// Error: EBUSY: resource busy or locked, rmdir 'C:\Users\RUNNER~1\AppData\Local\Temp\wrangler-modules-pKJ7OQ'
+				// ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+				// Serialized Error: {
+				// 	"code": "EBUSY",
+				// 	"errno": -4082,
+				// 	"path": "C:\Users\RUNNER~1\AppData\Local\Temp\wrangler-modules-pKJ7OQ",
+				// 	"syscall": "rmdir",
+				// }
+				console.error(e);
+			}
+		});
+
+		it("should be interact with both workers, rebuild the containers with the hotkey and all containers should be cleaned up at the end", async () => {
+			const wrangler = await startWranglerDev([
+				"dev",
+				"-c",
+				path.join(tmpDir, "workerA/wrangler.jsonc"),
+				"-c",
+				path.join(tmpDir, "workerB/wrangler.jsonc"),
+			]);
+
+			await vi.waitFor(
+				async () => {
+					const json = await (
+						await fetch(wrangler.url, { signal: AbortSignal.timeout(5_000) })
+					).json();
+					expect(json).toEqual({
+						containerAText: "Hello from Container A",
+						containerBText: "Hello from Container B",
+					});
+				},
+				{ timeout: 10_000, interval: 1000 }
+			);
+
+			const tmpDockerfileAPath = path.join(tmpDir, "workerA/Dockerfile");
+			const dockerFileAContent = fs.readFileSync(tmpDockerfileAPath, "utf8");
+			fs.writeFileSync(
+				tmpDockerfileAPath,
+				dockerFileAContent
+					.replace('"Hello from Container A"', '"Hello World from Container A"')
+					.replace("RUN sleep 2", "RUN sleep 2.1"),
+				"utf-8"
+			);
+
+			const tmpDockerfileBPath = path.join(tmpDir, "workerB/Dockerfile");
+			const dockerFileBContent = fs.readFileSync(tmpDockerfileBPath, "utf8");
+			fs.writeFileSync(
+				tmpDockerfileBPath,
+				dockerFileBContent.replace(
+					'"Hello from Container B"',
+					'"Hello from the B Container"'
+				),
+				"utf-8"
+			);
+
+			wrangler.pty.write("r");
+
+			await vi.waitFor(
+				async () => {
+					const json = await (
+						await fetch(wrangler.url, { signal: AbortSignal.timeout(5_000) })
+					).json();
+					expect(json).toEqual({
+						containerAText: "Hello World from Container A",
+						containerBText: "Hello from the B Container",
+					});
+				},
+				{ timeout: 30_000, interval: 1000 }
+			);
+
+			fs.writeFileSync(tmpDockerfileAPath, dockerFileAContent, "utf-8");
+			fs.writeFileSync(tmpDockerfileBPath, dockerFileBContent, "utf-8");
+
+			wrangler.pty.kill("SIGINT");
+		});
+	}
+);
+
 /** gets any containers that were created by running this fixture */
 const getContainerIds = () => {
 	// note the -a to include stopped containers

--- a/fixtures/interactive-dev-tests/tests/index.test.ts
+++ b/fixtures/interactive-dev-tests/tests/index.test.ts
@@ -807,9 +807,10 @@ baseDescribe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
 			const dockerFileAContent = fs.readFileSync(tmpDockerfileAPath, "utf8");
 			fs.writeFileSync(
 				tmpDockerfileAPath,
-				dockerFileAContent
-					.replace('"Hello from Container A"', '"Hello World from Container A"')
-					.replace("RUN sleep 2", "RUN sleep 2.1"),
+				dockerFileAContent.replace(
+					'"Hello from Container A"',
+					'"Hello World from Container A"'
+				),
 				"utf-8"
 			);
 

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -173,9 +173,9 @@ export class LocalRuntimeController extends RuntimeController {
 
 	// Set of container images that have been seen in the current dev session.
 	// This is used to clean up containers at the end of the dev session.
-	#containerImageTagsSeen: Set<string> = new Set();
+	containerImageTagsSeen: Set<string> = new Set();
 	// Stored here, so it can be used in `cleanupContainers()`
-	#dockerPath: string | undefined;
+	dockerPath: string | undefined;
 	// If this doesn't match what is in config, trigger a rebuild.
 	// Used for the rebuild hotkey
 	#currentContainerBuildId: string | undefined;
@@ -221,10 +221,10 @@ export class LocalRuntimeController extends RuntimeController {
 
 			// Assemble container options and build if necessary
 			const containerOptions = await getContainerOptions(data.config);
-			this.#dockerPath = data.config.dev?.dockerPath ?? getDockerPath();
+			this.dockerPath = data.config.dev?.dockerPath ?? getDockerPath();
 			// keep track of them so we can clean up later
 			for (const container of containerOptions ?? []) {
-				this.#containerImageTagsSeen.add(container.imageTag);
+				this.containerImageTagsSeen.add(container.imageTag);
 			}
 			if (
 				containerOptions &&
@@ -232,7 +232,7 @@ export class LocalRuntimeController extends RuntimeController {
 			) {
 				logger.log(chalk.dim("⎔ Preparing container image(s)..."));
 				await prepareContainerImagesForDev({
-					dockerPath: this.#dockerPath,
+					dockerPath: this.dockerPath,
 					configPath: data.config.config,
 					containerOptions: containerOptions,
 					onContainerImagePreparationStart: (buildStartEvent) => {
@@ -373,10 +373,10 @@ export class LocalRuntimeController extends RuntimeController {
 
 	cleanupContainers = async () => {
 		assert(
-			this.#dockerPath,
+			this.dockerPath,
 			"Docker path should have been set if containers are enabled"
 		);
-		await cleanupContainers(this.#dockerPath, this.#containerImageTagsSeen);
+		await cleanupContainers(this.dockerPath, this.containerImageTagsSeen);
 	};
 
 	#teardown = async (): Promise<void> => {
@@ -389,7 +389,7 @@ export class LocalRuntimeController extends RuntimeController {
 		await this.#mf?.dispose();
 		this.#mf = undefined;
 
-		if (this.#containerImageTagsSeen.size > 0) {
+		if (this.containerImageTagsSeen.size > 0) {
 			try {
 				await this.cleanupContainers();
 			} catch {

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -624,7 +624,7 @@ export async function startDev(args: StartDevOptions) {
 				if (hotkeysDisplayed) {
 					assert(devEnv !== undefined);
 					unregisterHotKeys = registerDevHotKeys(
-						Array.isArray(devEnv) ? devEnv[0] : devEnv,
+						Array.isArray(devEnv) ? devEnv : [devEnv],
 						args
 					);
 				}
@@ -681,7 +681,7 @@ export async function startDev(args: StartDevOptions) {
 				))
 			);
 			if (isInteractive() && args.showInteractiveDevSession !== false) {
-				unregisterHotKeys = registerDevHotKeys(primaryDevEnv, args);
+				unregisterHotKeys = registerDevHotKeys(devEnv, args);
 			}
 		} else {
 			devEnv = new DevEnv();
@@ -736,7 +736,7 @@ export async function startDev(args: StartDevOptions) {
 			await setupDevEnv(devEnv, args.config, authHook, args);
 
 			if (isInteractive() && args.showInteractiveDevSession !== false) {
-				unregisterHotKeys = registerDevHotKeys(devEnv, args);
+				unregisterHotKeys = registerDevHotKeys([devEnv], args);
 			}
 		}
 

--- a/packages/wrangler/src/dev/hotkeys.ts
+++ b/packages/wrangler/src/dev/hotkeys.ts
@@ -8,15 +8,16 @@ import { openInspector } from "./inspect";
 import type { DevEnv } from "../api";
 
 export default function registerDevHotKeys(
-	devEnv: DevEnv,
+	devEnvs: DevEnv[],
 	args: { forceLocal?: boolean }
 ) {
+	const primaryDevEnv = devEnvs[0];
 	const unregisterHotKeys = registerHotKeys([
 		{
 			keys: ["b"],
 			label: "open a browser",
 			handler: async () => {
-				const { url } = await devEnv.proxy.ready.promise;
+				const { url } = await primaryDevEnv.proxy.ready.promise;
 				await openInBrowser(url.href);
 			},
 		},
@@ -26,7 +27,7 @@ export default function registerDevHotKeys(
 			// Don't display this hotkey if we're in a VSCode debug session
 			disabled: !!process.env.VSCODE_INSPECTOR_OPTIONS,
 			handler: async () => {
-				const { inspectorUrl } = await devEnv.proxy.ready.promise;
+				const { inspectorUrl } = await primaryDevEnv.proxy.ready.promise;
 
 				if (!inspectorUrl) {
 					logger.warn("DevTools is not available while in a debug terminal");
@@ -34,7 +35,7 @@ export default function registerDevHotKeys(
 					// TODO: refactor this function to accept a whole URL (not just .port and assuming .hostname)
 					await openInspector(
 						parseInt(inspectorUrl.port),
-						devEnv.config.latestConfig?.name
+						primaryDevEnv.config.latestConfig?.name
 					);
 				}
 			},
@@ -44,48 +45,52 @@ export default function registerDevHotKeys(
 			label: "rebuild container(s)",
 			disabled: () => {
 				return (
-					!devEnv.config.latestConfig?.dev?.enableContainers ||
-					!devEnv.config.latestConfig?.containers?.length
+					// TODO: update this
+					!primaryDevEnv.config.latestConfig?.dev?.enableContainers ||
+					!primaryDevEnv.config.latestConfig?.containers?.length
 				);
 			},
 			handler: debounce(async () => {
-				devEnv.runtimes.forEach((runtime) => {
-					if (runtime instanceof LocalRuntimeController) {
-						if (runtime.containerBeingBuilt) {
-							// Let's abort the image built so that we
-							// can restart the build process
-							runtime.containerBeingBuilt.abort();
-							runtime.containerBeingBuilt.abortRequested = true;
-						}
-					}
-				});
-				const newContainerBuildId = randomUUID().slice(0, 8);
-				// cleanup any existing containers
-				await Promise.all(
-					devEnv.runtimes.map(async (runtime) => {
+				for (const devEnv of devEnvs) {
+					devEnv.runtimes.forEach((runtime) => {
 						if (runtime instanceof LocalRuntimeController) {
-							await runtime.cleanupContainers();
+							if (runtime.containerBeingBuilt) {
+								// Let's abort the image built so that we
+								// can restart the build process
+								runtime.containerBeingBuilt.abort();
+								runtime.containerBeingBuilt.abortRequested = true;
+							}
 						}
-					})
-				);
+					});
+					// cleanup any existing containers
+					await Promise.all(
+						devEnv.runtimes.map(async (runtime) => {
+							if (runtime instanceof LocalRuntimeController) {
+								await runtime.cleanupContainers();
+							}
+						})
+					);
 
-				// updating the build ID will trigger a rebuild of the containers
-				await devEnv.config.patch({
-					dev: {
-						...devEnv.config.latestConfig?.dev,
-						containerBuildId: newContainerBuildId,
-					},
-				});
+					const newContainerBuildId = randomUUID().slice(0, 8);
+
+					// updating the build ID will trigger a rebuild of the containers
+					await devEnv.config.patch({
+						dev: {
+							...devEnv.config.latestConfig?.dev,
+							containerBuildId: newContainerBuildId,
+						},
+					});
+				}
 			}, 250),
 		},
 		{
 			keys: ["l"],
 			disabled: () => args.forceLocal ?? false,
 			handler: async () => {
-				await devEnv.config.patch({
+				await primaryDevEnv.config.patch({
 					dev: {
-						...devEnv.config.latestConfig?.dev,
-						remote: !devEnv.config.latestConfig?.dev?.remote,
+						...primaryDevEnv.config.latestConfig?.dev,
+						remote: !primaryDevEnv.config.latestConfig?.dev?.remote,
 					},
 				});
 			},
@@ -94,7 +99,7 @@ export default function registerDevHotKeys(
 			keys: ["c"],
 			label: "clear console",
 			handler: async () => {
-				const someContainerIsBeingBuilt = devEnv.runtimes.some(
+				const someContainerIsBeingBuilt = primaryDevEnv.runtimes.some(
 					(runtime) =>
 						runtime instanceof LocalRuntimeController &&
 						runtime.containerBeingBuilt
@@ -111,7 +116,7 @@ export default function registerDevHotKeys(
 			keys: ["x", "q", "ctrl+c"],
 			label: "to exit",
 			handler: async () => {
-				devEnv.runtimes.forEach((runtime) => {
+				primaryDevEnv.runtimes.forEach((runtime) => {
 					if (runtime instanceof LocalRuntimeController) {
 						if (runtime.containerBeingBuilt) {
 							// Let's abort the image built so that we
@@ -121,7 +126,7 @@ export default function registerDevHotKeys(
 						}
 					}
 				});
-				await devEnv.teardown();
+				await primaryDevEnv.teardown();
 			},
 		},
 	]);

--- a/packages/wrangler/src/dev/hotkeys.ts
+++ b/packages/wrangler/src/dev/hotkeys.ts
@@ -44,10 +44,10 @@ export default function registerDevHotKeys(
 			keys: ["r"],
 			label: "rebuild container(s)",
 			disabled: () => {
-				return (
-					// TODO: update this
-					!primaryDevEnv.config.latestConfig?.dev?.enableContainers ||
-					!primaryDevEnv.config.latestConfig?.containers?.length
+				return devEnvs.every(
+					(devEnv) =>
+						!devEnv.config.latestConfig?.dev?.enableContainers ||
+						!devEnv.config.latestConfig?.containers?.length
 				);
 			},
 			handler: debounce(async () => {


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/9933
Fixes https://jira.cfdata.org/browse/DEVX-2088

currently when running `wrangler dev` with different workers (meaning that the `-c|--config` flag is used multiple times) containers are not being included, meaning that trying to interact with them at runtime would not work and cause errors instead. The changes here address the above making wrangler correctly detect and wire up the containers.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is expected behavior
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: containers are not a v3 feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
