### PR TITLE
[vitest-pool-workers] Fix Workflow binding's script_name when it matches its own Worker name

### DIFF
--- a/.changeset/spotty-pants-jog.md
+++ b/.changeset/spotty-pants-jog.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Make vitest-pool-workers not break when a Workflow binding script_name matches its Worker name

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -347,7 +347,7 @@ function updateWorkflowsScriptNames(
 	testWorkerName: string
 ): void {
 	const workflows = runnerWorker.workflows;
-	if (!workflows || !wranglerWorkerName) {
+	if (!workflows || wranglerWorkerName === undefined) {
 		return;
 	}
 	for (const workflow of Object.values(workflows)) {
@@ -680,7 +680,7 @@ function buildProjectMiniflareOptions(
 
 		// Set Workflows scriptName to the runner worker name if it matches the Wrangler worker name
 		const wranglerWorkerName = getWranglerWorkerName(
-			"project.options.wrangler?.configPath"
+			project.options.wrangler?.configPath
 		);
 		updateWorkflowsScriptNames(
 			runnerWorker,

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -343,8 +343,7 @@ function getWranglerWorkerName(
 
 function updateWorkflowsScriptNames(
 	runnerWorker: WorkerOptions,
-	wranglerWorkerName: string | undefined,
-	testWorkerName: string
+	wranglerWorkerName: string | undefined
 ): void {
 	const workflows = runnerWorker.workflows;
 	if (!workflows || wranglerWorkerName === undefined) {
@@ -352,7 +351,7 @@ function updateWorkflowsScriptNames(
 	}
 	for (const workflow of Object.values(workflows)) {
 		if (workflow.scriptName === wranglerWorkerName) {
-			workflow.scriptName = testWorkerName;
+			delete workflow.scriptName;
 		}
 	}
 }
@@ -682,11 +681,7 @@ function buildProjectMiniflareOptions(
 		const wranglerWorkerName = getWranglerWorkerName(
 			project.options.wrangler?.configPath
 		);
-		updateWorkflowsScriptNames(
-			runnerWorker,
-			wranglerWorkerName,
-			runnerWorker.name
-		);
+		updateWorkflowsScriptNames(runnerWorker, wranglerWorkerName);
 
 		return {
 			...SHARED_MINIFLARE_OPTIONS,
@@ -711,11 +706,7 @@ function buildProjectMiniflareOptions(
 			const wranglerWorkerName = getWranglerWorkerName(
 				project.options.wrangler?.configPath
 			);
-			updateWorkflowsScriptNames(
-				testWorker,
-				wranglerWorkerName,
-				testWorker.name
-			);
+			updateWorkflowsScriptNames(testWorker, wranglerWorkerName);
 
 			testWorkers.push(testWorker);
 		}

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -23,6 +23,7 @@ import {
 } from "miniflare";
 import semverSatisfies from "semver/functions/satisfies.js";
 import { createMethodsRPC } from "vitest/node";
+import { experimental_readRawConfig } from "wrangler";
 import { workerdBuiltinModules } from "../shared/builtin-modules";
 import { createChunkingSocket } from "../shared/chunking-socket";
 import { CompatibilityFlagAssertions } from "./compatibility-flag-assertions";
@@ -328,8 +329,37 @@ function fixupDurableObjectBindingsToSelf(
 	return result;
 }
 
+function getWranglerWorkerName(
+	relativeWranglerConfigPath?: string
+): string | undefined {
+	if (!relativeWranglerConfigPath) {
+		return undefined;
+	}
+	const wranglerConfigObject = experimental_readRawConfig({
+		config: relativeWranglerConfigPath,
+	});
+	return wranglerConfigObject.rawConfig.name;
+}
+
+function updateWorkflowsScriptNames(
+	runnerWorker: WorkerOptions,
+	wranglerWorkerName: string | undefined,
+	testWorkerName: string
+): void {
+	const workflows = runnerWorker.workflows;
+	if (!workflows || !wranglerWorkerName) {
+		return;
+	}
+	for (const workflow of Object.values(workflows)) {
+		if (workflow.scriptName === wranglerWorkerName) {
+			workflow.scriptName = testWorkerName;
+		}
+	}
+}
+
 function fixupWorkflowBindingsToSelf(
-	worker: SourcelessWorkerOptions
+	worker: SourcelessWorkerOptions,
+	relativeWranglerConfigPath: string | undefined
 ): Set<string> {
 	// TODO(someday): may need to extend this to take into account other workers
 	//  if doing multi-worker tests across workspace projects
@@ -340,8 +370,21 @@ function fixupWorkflowBindingsToSelf(
 	}
 	for (const key of Object.keys(worker.workflows)) {
 		const designator = worker.workflows[key];
+
+		let workerName: string | undefined;
+		// If the designator's scriptName matches its own Worker name,
+		// use that as the worker name, otherwise use the vitest worker's name
+		const wranglerWorkerName = getWranglerWorkerName(
+			relativeWranglerConfigPath
+		);
+		if (wranglerWorkerName && designator.scriptName === wranglerWorkerName) {
+			workerName = wranglerWorkerName;
+		} else {
+			workerName = worker.name;
+		}
+
 		// `designator` hasn't been validated at this point
-		if (isWorkflowDesignatorToSelf(designator, worker.name)) {
+		if (isWorkflowDesignatorToSelf(designator, workerName)) {
 			result.add(designator.className);
 			// Shallow clone to avoid mutating config
 			worker.workflows[key] = {
@@ -448,7 +491,7 @@ function buildProjectWorkerOptions(
 		fixupDurableObjectBindingsToSelf(runnerWorker)
 	).sort();
 	const workflowClassNames = Array.from(
-		fixupWorkflowBindingsToSelf(runnerWorker)
+		fixupWorkflowBindingsToSelf(runnerWorker, relativeWranglerConfigPath)
 	).sort();
 
 	if (
@@ -634,6 +677,17 @@ function buildProjectMiniflareOptions(
 		//  --> single instance with single runner worker
 		// Multiple Workers, Isolated Storage:
 		//  --> multiple instances each with single runner worker
+
+		// Set Workflows scriptName to the runner worker name if it matches the Wrangler worker name
+		const wranglerWorkerName = getWranglerWorkerName(
+			"project.options.wrangler?.configPath"
+		);
+		updateWorkflowsScriptNames(
+			runnerWorker,
+			wranglerWorkerName,
+			runnerWorker.name
+		);
+
 		return {
 			...SHARED_MINIFLARE_OPTIONS,
 			inspectorPort,
@@ -652,6 +706,16 @@ function buildProjectMiniflareOptions(
 			assert(testWorker.bindings !== undefined);
 			testWorker.bindings = { ...testWorker.bindings };
 			testWorker.bindings[SELF_NAME_BINDING] = testWorker.name;
+
+			// Set Workflows scriptName to the test worker name if it matches the Wrangler worker name
+			const wranglerWorkerName = getWranglerWorkerName(
+				project.options.wrangler?.configPath
+			);
+			updateWorkflowsScriptNames(
+				testWorker,
+				wranglerWorkerName,
+				testWorker.name
+			);
 
 			testWorkers.push(testWorker);
 		}


### PR DESCRIPTION
Fixes WOR-760.

A user can define a Workflow binding where the `script_name` is the same as the name of the Worker on which the binding is defined. Although redundant, it should be supported.

`vitest-pool-workers` breaks because it does not use the user's Worker as the test entrypoint. It uses its own runner worker, which has a different name generated before execution. This leads to a mismatch between the `script_name` in the binding and the Worker that will run.

To fix this, the code now checks it a workflow binding's  `script_name` matches its own Worker's name. When it does, `script_name` is removed, making it default to the current worker.

---

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: bug not reproduced in fixtures for some unknown reason
- Public documentation
  - [ ] Cloudflare docs PR(s): 
  - [x] Documentation not necessary because: only makes vitest-pool-workers not break in a specific case for Workflows
- Wrangler V3 Backport
  - [ ] Wrangler PR:
  - [x] Not necessary because: does not affect wrangler
