### PR TITLE
BACKPORT #9866: fix: escape column names and handle mismatched data types in D1 SQL dump

### DIFF
--- a/.changeset/mean-schools-see.md
+++ b/.changeset/mean-schools-see.md
@@ -1,0 +1,8 @@
+---
+"miniflare": patch
+---
+
+Fix D1 SQL dump generation: escape identifiers and handle SQLite's dynamic typing
+
+Escape column and table names to prevent SQL syntax errors.
+Escape values based on their runtime type to support SQLite's flexible typing.

--- a/packages/wrangler/src/__tests__/d1/export.test.ts
+++ b/packages/wrangler/src/__tests__/d1/export.test.ts
@@ -59,14 +59,14 @@ describe("export", () => {
 		const create_foo = "CREATE TABLE foo(id INTEGER PRIMARY KEY, value TEXT);";
 		const create_bar = "CREATE TABLE bar(id INTEGER PRIMARY KEY, value TEXT);";
 		const insert_foo = [
-			"INSERT INTO foo VALUES(1,'xxx');",
-			"INSERT INTO foo VALUES(2,'yyy');",
-			"INSERT INTO foo VALUES(3,'zzz');",
+			`INSERT INTO "foo" VALUES(1,'xxx');`,
+			`INSERT INTO "foo" VALUES(2,'yyy');`,
+			`INSERT INTO "foo" VALUES(3,'zzz');`,
 		];
 		const insert_bar = [
-			"INSERT INTO bar VALUES(1,'aaa');",
-			"INSERT INTO bar VALUES(2,'bbb');",
-			"INSERT INTO bar VALUES(3,'ccc');",
+			`INSERT INTO "bar" VALUES(1,'aaa');`,
+			`INSERT INTO "bar" VALUES(2,'bbb');`,
+			`INSERT INTO "bar" VALUES(3,'ccc');`,
 		];
 
 		// Full export


### PR DESCRIPTION

* fix: escape column names and handle mismatched data types in D1 SQL dump

* fix(d1): allow exporting blob in tests and importing without errors

* fix(d1): correct test case by quoting table names with double quotes in SQL INSERT

* fix(d1): Add patch note for escape identifiers and handle dynamic typing

---------
