### PR TITLE
Quarantine next on pages c3 tests

### DIFF
--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -372,7 +372,7 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			flags: ["--typescript", "--no-install", "--no-git-init"],
 		},
 		{
-			quarantine:true,
+			quarantine: true,
 			name: "next:pages",
 			argv: ["--platform", "pages"],
 			timeout: LONG_TIMEOUT,

--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -372,6 +372,7 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			flags: ["--typescript", "--no-install", "--no-git-init"],
 		},
 		{
+			quarantine:true,
 			name: "next:pages",
 			argv: ["--platform", "pages"],
 			timeout: LONG_TIMEOUT,


### PR DESCRIPTION
A recent bump to`vercel` (44.5.4) has broken next-on-pages, where we don't pin the version of `vercel` and `next`, just the version of`create-next-app`. A fix is incoming, but in the meantime, let's skip these tests.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: test skip
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: n/a
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: n/a

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
