### PR TITLE
unquarantine the C3 next-on-pages e2e

### DIFF
--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -372,7 +372,6 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			flags: ["--typescript", "--no-install", "--no-git-init"],
 		},
 		{
-			quarantine: true,
 			name: "next:pages",
 			argv: ["--platform", "pages"],
 			timeout: LONG_TIMEOUT,


### PR DESCRIPTION
Reverting https://github.com/cloudflare/workers-sdk/pull/10056 since the issue causing C3 to create non-functioning next-on-pages applications has been fixed upstream

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: this is already tested
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no functional changes needed documenting
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
