### PR TITLE
move config update handling to a devServer watcher rather than hotUpdate

### DIFF
--- a/.changeset/itchy-doodles-add.md
+++ b/.changeset/itchy-doodles-add.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+fix: ensure that Vite restarts atomically when config files change

--- a/packages/vite-plugin-cloudflare/playground/__test-utils__/responses.ts
+++ b/packages/vite-plugin-cloudflare/playground/__test-utils__/responses.ts
@@ -1,3 +1,4 @@
+import { vi } from "vitest";
 import { page, viteTestUrl } from "./index";
 
 export async function getTextResponse(path = "/"): Promise<string> {
@@ -21,6 +22,6 @@ export async function getResponse(path = "/") {
 	const url = `${viteTestUrl}${path}`;
 
 	const response = page.waitForResponse(url);
-	await page.goto(url);
+	await vi.waitFor(() => page.goto(url));
 	return response;
 }

--- a/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/config-changes.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/config-changes.spec.ts
@@ -11,14 +11,6 @@ test.runIf(!isBuild)(
 
 		onTestFinished(async () => {
 			fs.writeFileSync(workerConfigPath, originalWorkerConfig);
-			// We need to ensure that the original config is restored before the next test runs
-			await vi.waitFor(
-				async () => {
-					const revertedResponse = await getTextResponse();
-					expect(revertedResponse).toContain('The value of MY_VAR is "one"');
-				},
-				{ timeout: 5000 }
-			);
 		});
 
 		const originalResponse = await getTextResponse();
@@ -49,14 +41,6 @@ test.runIf(!isBuild)(
 
 		onTestFinished(async () => {
 			fs.writeFileSync(workerConfigPath, originalWorkerConfig);
-			// We need to ensure that the original config is restored before the next test runs
-			await vi.waitFor(
-				async () => {
-					const revertedResponse = await getTextResponse();
-					expect(revertedResponse).toContain('The value of MY_VAR is "one"');
-				},
-				{ timeout: 5000 }
-			);
 		});
 
 		const originalResponse = await getTextResponse();

--- a/packages/vite-plugin-cloudflare/playground/dev-vars/__tests__/vars-changes.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/dev-vars/__tests__/vars-changes.spec.ts
@@ -14,19 +14,6 @@ test.runIf(!isBuild)(
 
 		onTestFinished(async () => {
 			fs.writeFileSync(dotDevDotVarsFilePath, originalDotDevDotVars);
-			// We need to ensure that the original config is restored before the next test runs
-			await vi.waitFor(
-				async () => {
-					expect(await getJsonResponse()).toEqual({
-						"variables present in .dev.vars": {
-							MY_DEV_VAR_A: "my .dev.vars variable A",
-							MY_DEV_VAR_B: "my .dev.vars variable B",
-							MY_DEV_VAR_C: "my .dev.vars variable C",
-						},
-					});
-				},
-				{ timeout: 5000 }
-			);
 		});
 
 		const originalResponse = await getJsonResponse();

--- a/packages/vite-plugin-cloudflare/playground/dev-vars/__tests__/with-specified-env/vars-changes.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/dev-vars/__tests__/with-specified-env/vars-changes.spec.ts
@@ -17,18 +17,6 @@ test.runIf(!isBuild)(
 
 		onTestFinished(async () => {
 			fs.writeFileSync(dotDevDotVarsFilePath, originalDotDevDotVars);
-			// We need to ensure that the original config is restored before the next test runs
-			await vi.waitFor(
-				async () => {
-					expect(await getJsonResponse()).toEqual({
-						"variables present in .dev.vars.staging": {
-							MY_DEV_VAR_A: "my .dev.vars staging variable A",
-							MY_DEV_VAR_B: "my .dev.vars staging variable B",
-						},
-					});
-				},
-				{ timeout: 5000 }
-			);
 		});
 
 		const originalResponse = await getJsonResponse();


### PR DESCRIPTION
Fixes flakes in Vite config change tests; but also should make general real-world usage less error prone when config files are changing rapidly.

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: covered by current tests
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix / refactor
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> vite is not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
