### PR TITLE
feat(vite-plugin): Add Containers-related info logs

### DIFF
--- a/.changeset/afraid-experts-take.md
+++ b/.changeset/afraid-experts-take.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+feat(vite-plugin): Add Containers-related info logs
+
+Add logs, when a Worker has Containers configured, providing information about container build status, and how to rebuild containers during local development.

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -449,6 +449,9 @@ if (import.meta.hot) {
 					}
 
 					if (hasDevContainers) {
+						viteDevServer.config.logger.info(
+							"Building container images for local development..."
+						);
 						containerImageTagsSeen = await prepareContainerImages({
 							containersConfig: entryWorkerConfig.containers,
 							containerBuildId,
@@ -456,6 +459,9 @@ if (import.meta.hot) {
 							dockerPath,
 							configPath: entryWorkerConfig.configPath,
 						});
+						viteDevServer.config.logger.info(
+							"Containers successfully built. To rebuild your containers during development, restart the Vite dev server (r + enter)."
+						);
 
 						// poll Docker every two seconds and update the list of ids of all
 						// running containers

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -10,6 +10,7 @@ import { generateStaticRoutingRuleMatcher } from "@cloudflare/workers-shared/ass
 import replace from "@rollup/plugin-replace";
 import MagicString from "magic-string";
 import { Miniflare } from "miniflare";
+import colors from "picocolors";
 import * as vite from "vite";
 import {
 	createModuleReference,
@@ -450,7 +451,11 @@ if (import.meta.hot) {
 
 					if (hasDevContainers) {
 						viteDevServer.config.logger.info(
-							"Building container images for local development..."
+							colors.dim(
+								colors.yellow(
+									"∷ Building container images for local development...\n"
+								)
+							)
 						);
 						containerImageTagsSeen = await prepareContainerImages({
 							containersConfig: entryWorkerConfig.containers,
@@ -460,7 +465,11 @@ if (import.meta.hot) {
 							configPath: entryWorkerConfig.configPath,
 						});
 						viteDevServer.config.logger.info(
-							"Containers successfully built. To rebuild your containers during development, restart the Vite dev server (r + enter)."
+							colors.dim(
+								colors.yellow(
+									"\n⚡️ Containers successfully built. To rebuild your containers during development, restart the Vite dev server (r + enter)."
+								)
+							)
 						);
 
 						// poll Docker every two seconds and update the list of ids of all
@@ -581,6 +590,13 @@ if (import.meta.hot) {
 				if (hasDevContainers) {
 					const dockerPath = getDockerPath();
 
+					vitePreviewServer.config.logger.info(
+						colors.dim(
+							colors.yellow(
+								"∷ Building container images for local preview...\n"
+							)
+						)
+					);
 					containerImageTagsSeen = await prepareContainerImages({
 						containersConfig: entryWorkerConfig.containers,
 						containerBuildId,
@@ -588,6 +604,9 @@ if (import.meta.hot) {
 						dockerPath,
 						configPath: entryWorkerConfig.configPath,
 					});
+					vitePreviewServer.config.logger.info(
+						colors.dim(colors.yellow("\n⚡️ Containers successfully built.\n"))
+					);
 
 					const dockerPollIntervalId = setInterval(async () => {
 						if (containerImageTagsSeen?.size) {

--- a/packages/wrangler/src/dev/hotkeys.ts
+++ b/packages/wrangler/src/dev/hotkeys.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "crypto";
+import { generateContainerBuildId } from "@cloudflare/containers-shared";
 import { LocalRuntimeController } from "../api/startDevWorker/LocalRuntimeController";
 import registerHotKeys from "../cli-hotkeys";
 import { logger } from "../logger";
@@ -71,7 +71,7 @@ export default function registerDevHotKeys(
 						})
 					);
 
-					const newContainerBuildId = randomUUID().slice(0, 8);
+					const newContainerBuildId = generateContainerBuildId();
 
 					// updating the build ID will trigger a rebuild of the containers
 					await devEnv.config.patch({


### PR DESCRIPTION
Fixes DEVX-2052

Adds logs, when a Worker has Containers configured, providing information about container build status, and how to rebuild containers during local development.

`dev`

<img width="986" height="426" alt="Screenshot 2025-07-29 at 14 26 59" src="https://github.com/user-attachments/assets/3ac3ad7e-5888-42e1-8a3b-31d7909d32b9" />

`preview`

<img width="1045" height="425" alt="Screenshot 2025-07-29 at 14 30 56" src="https://github.com/user-attachments/assets/f5dfc46b-b71f-44da-ade1-61aa0f163df2" />

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: just a log change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: we're keeping docs lite on this sort of details
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: containers is a beta feat that only exists in v4

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
