### PR TITLE
respect environment of services when searching them in local running wranglers

### DIFF
--- a/packages/wrangler/src/api/integrations/platform/services.ts
+++ b/packages/wrangler/src/api/integrations/platform/services.ts
@@ -30,11 +30,14 @@ export async function getServiceBindings(
 
 	const foundServices: AvailableBindingInfo[] = [];
 	for (const { binding: bindingName, service: serviceName } of services) {
-		const worker = registeredWorkers[serviceName];
+		const serviceNameWithEnvironment = environment == null
+			? serviceName
+			: `${serviceName}-${environment}`;
+		const worker = registeredWorkers[serviceNameWithEnvironment];
 		if (worker) {
 			foundServices.push({
 				bindingName,
-				serviceName,
+		        serviceName: serviceNameWithEnvironment,
 				workerDefinition: worker,
 			});
 		}

--- a/packages/wrangler/src/dev-registry/index.ts
+++ b/packages/wrangler/src/dev-registry/index.ts
@@ -71,7 +71,9 @@ export async function getBoundRegisteredWorkers(
 	existingWorkerDefinitions?: WorkerRegistry | undefined
 ): Promise<WorkerRegistry | undefined> {
 	const serviceNames = [...(services || []), ...(tailConsumers ?? [])].map(
-		(serviceBinding) => serviceBinding.service
+	    (serviceBinding) => serviceBinding.environment == null
+			? serviceBinding.name
+			: `${serviceBinding.service}-${serviceBinding.environment}`
 	);
 	const durableObjectServices = (
 		durableObjects || { bindings: [] }

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -592,7 +592,9 @@ export function buildMiniflareBindingOptions(
 			continue;
 		}
 
-		const target = config.workerDefinitions?.[service.service];
+		const target = config.workerDefinitions?.[service.environment == null
+			? service.service
+			: `${service.service}-${service.environment}`];
 
 		if (target?.host === undefined || target.port === undefined) {
 			// If the target isn't in the registry, always return an error response


### PR DESCRIPTION
Shouldn't it be like this? When I write:
```json
        {
          "environment": "development",
          "binding": "some_binding",
          "service": "x",
        },
```
it should look for "x-development" not "x", right?
---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
