### PR TITLE
[preset] add support for the native http modules

### DIFF
--- a/.changeset/quick-cycles-send.md
+++ b/.changeset/quick-cycles-send.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/unenv-preset": patch
+---
+
+add support for the native http modules

--- a/.changeset/quick-cycles-send.md
+++ b/.changeset/quick-cycles-send.md
@@ -1,5 +1,5 @@
 ---
-"@cloudflare/unenv-preset": patch
+"@cloudflare/unenv-preset": minor
 ---
 
 add support for the native http modules

--- a/packages/unenv-preset/package.json
+++ b/packages/unenv-preset/package.json
@@ -51,7 +51,7 @@
 	},
 	"peerDependencies": {
 		"unenv": "2.0.0-rc.17",
-		"workerd": "^1.20250521.0"
+		"workerd": "^1.20250722.0"
 	},
 	"peerDependenciesMeta": {
 		"workerd": {

--- a/packages/unenv-preset/src/index.ts
+++ b/packages/unenv-preset/src/index.ts
@@ -2,4 +2,7 @@ import { getCloudflarePreset } from "./preset";
 
 export { getCloudflarePreset } from "./preset";
 
+/**
+ * @deprecated Use getCloudflarePreset instead.
+ */
 export const cloudflare = getCloudflarePreset({});

--- a/packages/unenv-preset/src/preset.ts
+++ b/packages/unenv-preset/src/preset.ts
@@ -146,6 +146,7 @@ function getHttpAliases({
 
 	const aliases: Record<string, string> = {};
 
+	// Override the unenv base aliases to use the native modules
 	const nativeModules = [
 		"_http_common",
 		"_http_outgoing",
@@ -159,6 +160,7 @@ function getHttpAliases({
 		aliases[`node:${nativeModule}`] = `node:${nativeModule}`;
 	}
 
+	// Override the unenv base aliases to use the hybrid polyfills
 	const hybridModules = ["http", "https"];
 
 	for (const hybridModule of hybridModules) {

--- a/packages/unenv-preset/src/preset.ts
+++ b/packages/unenv-preset/src/preset.ts
@@ -120,7 +120,7 @@ export function getCloudflarePreset({
  * The native implementation:
  * - is enabled after 2025-08-15
  * - can be enabled with the "enable_nodejs_http_modules" flag
- * - cab be disabled with the "disable_nodejs_http_modules" flag
+ * - can be disabled with the "disable_nodejs_http_modules" flag
  */
 function getHttpAliases({
 	compatibilityDate,

--- a/packages/unenv-preset/src/runtime/node/http.ts
+++ b/packages/unenv-preset/src/runtime/node/http.ts
@@ -1,0 +1,71 @@
+// TODO: use the workerd server implementation when available
+// See https://github.com/cloudflare/workerd/pull/4591
+import {
+	_connectionListener,
+	CloseEvent,
+	createServer,
+	maxHeaderSize,
+	MessageEvent,
+	Server,
+	ServerResponse,
+	setMaxIdleHTTPParsers,
+	WebSocket,
+} from "unenv/node/http";
+import type nodeHttp from "node:http";
+
+export {
+	_connectionListener,
+	CloseEvent,
+	createServer,
+	maxHeaderSize,
+	MessageEvent,
+	Server,
+	ServerResponse,
+	setMaxIdleHTTPParsers,
+	WebSocket,
+} from "unenv/node/http";
+
+const workerdHttp = process.getBuiltinModule("node:http");
+
+export const {
+	Agent,
+	ClientRequest,
+	globalAgent,
+	IncomingMessage,
+	METHODS,
+	OutgoingMessage,
+	STATUS_CODES,
+	validateHeaderName,
+	validateHeaderValue,
+	request,
+	get,
+} = workerdHttp;
+
+export default {
+	_connectionListener,
+	Agent,
+	ClientRequest,
+	// @ts-expect-error Node types do not match unenv
+	CloseEvent,
+	// @ts-expect-error Node types do not match unenv
+	createServer,
+	get,
+	globalAgent,
+	IncomingMessage,
+	maxHeaderSize,
+	// @ts-expect-error Node types do not match unenv
+	MessageEvent,
+	METHODS,
+	OutgoingMessage,
+	request,
+	Server,
+	// @ts-expect-error Node types do not match unenv
+	ServerResponse,
+	// @ts-expect-error Node types do not match unenv
+	setMaxIdleHTTPParsers,
+	STATUS_CODES,
+	validateHeaderName,
+	validateHeaderValue,
+	// @ts-expect-error Node types do not match unenv
+	WebSocket,
+} satisfies typeof nodeHttp;

--- a/packages/unenv-preset/src/runtime/node/https.ts
+++ b/packages/unenv-preset/src/runtime/node/https.ts
@@ -1,0 +1,20 @@
+import { createServer, Server } from "unenv/node/https";
+import type nodeHttps from "node:https";
+
+// TODO: use the workerd implementation when available
+// See https://github.com/cloudflare/workerd/pull/4591
+export { Server, createServer } from "unenv/node/https";
+
+const workerdHttps = process.getBuiltinModule("node:https");
+
+export const { Agent, globalAgent, request, get } = workerdHttps;
+
+export default {
+	Agent,
+	// @ts-expect-error Node types do not match unenv
+	createServer,
+	get,
+	globalAgent,
+	request,
+	Server,
+} satisfies typeof nodeHttps;

--- a/packages/unenv-preset/src/runtime/polyfill/performance.ts
+++ b/packages/unenv-preset/src/runtime/polyfill/performance.ts
@@ -12,19 +12,19 @@ import {
 } from "node:perf_hooks";
 
 // `performance` augments the existing workerd implementation
-// @ts-expect-error  Node types do not match unenv
+// @ts-expect-error Node types do not match unenv
 globalThis.performance = performance;
 
 // Classes not exposes by workerd
 globalThis.Performance = Performance;
-// @ts-expect-error  Node types do not match unenv
+// @ts-expect-error Node types do not match unenv
 globalThis.PerformanceEntry = PerformanceEntry;
-// @ts-expect-error  Node types do not match unenv
+// @ts-expect-error Node types do not match unenv
 globalThis.PerformanceMark = PerformanceMark;
-// @ts-expect-error  Node types do not match unenv
+// @ts-expect-error Node types do not match unenv
 globalThis.PerformanceMeasure = PerformanceMeasure;
-// @ts-expect-error  Node types do not match unenv
+// @ts-expect-error Node types do not match unenv
 globalThis.PerformanceObserver = PerformanceObserver;
 globalThis.PerformanceObserverEntryList = PerformanceObserverEntryList;
-// @ts-expect-error  Node types do not match unenv
+// @ts-expect-error Node types do not match unenv
 globalThis.PerformanceResourceTiming = PerformanceResourceTiming;

--- a/packages/wrangler/e2e/unenv-preset/preset.test.ts
+++ b/packages/wrangler/e2e/unenv-preset/preset.test.ts
@@ -1,70 +1,129 @@
 import { join } from "node:path";
 import { fetch } from "undici";
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
-import { formatCompatibilityDate } from "../../src/utils/compatibility-date";
 import { WranglerE2ETestHelper } from "../helpers/e2e-wrangler-test";
 import { generateResourceName } from "../helpers/generate-resource-name";
 import { retry } from "../helpers/retry";
 import { TESTS } from "./worker/index";
 import type { WranglerLongLivedCommand } from "../helpers/wrangler";
 
-describe(`@cloudflare/unenv-preset tests`, () => {
-	let helper: WranglerE2ETestHelper;
+type TestConfig = {
+	name: string;
+	compatibilityDate: string;
+	// "nodejs_compat" is included by default
+	compatibilityFlags?: string[];
+	// Assert runtime compatibility flag values
+	expectRuntimeFlags?: {
+		// Whether the http modules are enabled
+		enable_nodejs_http_modules: boolean;
+	};
+};
 
-	beforeAll(async () => {
-		helper = new WranglerE2ETestHelper();
-		await helper.seed({
-			"wrangler.jsonc": JSON.stringify({
-				name: generateResourceName(),
-				main: join(__dirname, "/worker/index.ts"),
-				compatibility_date: formatCompatibilityDate(new Date()),
-				compatibility_flags: ["nodejs_compat"],
-				vars: {
-					DEBUG: "example",
-				},
-			}),
-		});
-	});
+const testConfigs: TestConfig[] = [
+	{
+		name: "Oldest supported compatibility date for nodejs_compat",
+		compatibilityDate: "2024-09-23",
+		expectRuntimeFlags: {
+			enable_nodejs_http_modules: false,
+		},
+	},
+	// http
+	[
+		{
+			name: "http disabled by date",
+			compatibilityDate: "2025-07-26",
+			expectRuntimeFlags: {
+				enable_nodejs_http_modules: false,
+			},
+		},
+		{
+			name: "http disabled by flag",
+			// TODO: use a date when http is enabled by default (> 2025-08-15)
+			compatibilityDate: "2025-07-26",
+			compatibilityFlags: ["disable_nodejs_http_modules"],
+			expectRuntimeFlags: {
+				enable_nodejs_http_modules: false,
+			},
+		},
+		// TODO: add a config when http is enabled by default (> 2025-08-15)
+		{
+			name: "http enabled by flag",
+			compatibilityDate: "2025-07-26",
+			compatibilityFlags: ["enable_nodejs_http_modules"],
+			expectRuntimeFlags: {
+				enable_nodejs_http_modules: true,
+			},
+		},
+	],
+].flat();
 
-	// Run the tests on:
-	// - the "local" runtime installed in miniflare
-	// - the "remote" runtime available in Cloudflare prod
-	//
-	// The "local" and "remote" runtimes do not necessarily use the exact same version
-	// of workerd and we want to make sure the preset works for both.
-	describe.for(["local", "remote"])("%s tests", (localOrRemote) => {
-		let url: string;
-		let wrangler: WranglerLongLivedCommand;
+describe.each(testConfigs)(
+	`Preset test: $name`,
+	({ compatibilityDate, compatibilityFlags = [], expectRuntimeFlags = {} }) => {
+		let helper: WranglerE2ETestHelper;
+
 		beforeAll(async () => {
-			wrangler = helper.runLongLived(`wrangler dev --${localOrRemote}`, {
-				stopOnTestFinished: false,
+			helper = new WranglerE2ETestHelper();
+			await helper.seed({
+				"wrangler.jsonc": JSON.stringify({
+					name: generateResourceName(),
+					main: join(__dirname, "/worker/index.ts"),
+					compatibility_date: compatibilityDate,
+					compatibility_flags: ["nodejs_compat", ...compatibilityFlags],
+					vars: {
+						DEBUG: "example",
+					},
+				}),
 			});
-			url = (await wrangler.waitForReady()).url;
-
-			// Wait for the Worker to be actually responding.
-			const response = await retry(
-				(resp) => !resp.ok,
-				async () => await fetch(`${url}/ping`)
-			);
-			await expect(response.text()).resolves.toEqual("pong");
 		});
 
-		afterAll(async () => {
-			await wrangler.stop();
-		});
-
-		test.for(Object.keys(TESTS))(
-			"%s",
-			{ timeout: 20_000 },
-			async (testName) => {
-				// Retries the callback until it succeeds or times out.
-				// Useful for the i.e. DNS tests where underlying requests might error/timeout.
-				await vi.waitFor(async () => {
-					const response = await fetch(`${url}/${testName}`);
-					const body = await response.text();
-					expect(body).toMatch("OK!");
+		// Run the tests on:
+		// - the "local" runtime installed in miniflare
+		// - the "remote" runtime available in Cloudflare prod
+		//
+		// The "local" and "remote" runtimes do not necessarily use the exact same version
+		// of workerd and we want to make sure the preset works for both.
+		describe.for(["local", "remote"])("%s tests", (localOrRemote) => {
+			let url: string;
+			let wrangler: WranglerLongLivedCommand;
+			beforeAll(async () => {
+				wrangler = helper.runLongLived(`wrangler dev --${localOrRemote}`, {
+					stopOnTestFinished: false,
 				});
-			}
-		);
-	});
-});
+				url = (await wrangler.waitForReady()).url;
+
+				// Wait for the Worker to be actually responding.
+				const readyResp = await retry(
+					(resp) => !resp.ok,
+					async () => await fetch(`${url}/ping`)
+				);
+				await expect(readyResp.text()).resolves.toEqual("pong");
+
+				// Assert runtime flag values
+				for await (const [flag, value] of Object.entries(expectRuntimeFlags)) {
+					const flagResp = await fetch(`${url}/flag?name=${flag}`);
+					expect(flagResp.ok).toEqual(true);
+					await expect(flagResp.json()).resolves.toEqual(value);
+				}
+			}, 20_000);
+
+			afterAll(async () => {
+				await wrangler.stop();
+			});
+
+			test.for(Object.keys(TESTS))(
+				"%s",
+				{ timeout: 20_000 },
+				async (testName) => {
+					// Retries the callback until it succeeds or times out.
+					// Useful for the i.e. DNS tests where underlying requests might error/timeout.
+					await vi.waitFor(async () => {
+						const response = await fetch(`${url}/${testName}`);
+						const body = await response.text();
+						expect(body).toMatch("passed");
+					});
+				}
+			);
+		});
+	}
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2031,8 +2031,8 @@ importers:
         specifier: 2.0.0-rc.17
         version: 2.0.0-rc.17
       workerd:
-        specifier: ^1.20250521.0
-        version: 1.20250612.0
+        specifier: ^1.20250722.0
+        version: 1.20250726.0
     devDependencies:
       '@types/debug':
         specifier: 4.1.12
@@ -4284,8 +4284,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-64@1.20250612.0':
-    resolution: {integrity: sha512-IpL/tOvNY04n2hvp/XGdOGjeMDycEjbwJL8gJ0kenBFBa13EE82I61ceA56kuCiEdb1vBv3O+xiD9zN6AuQlmQ==}
+  '@cloudflare/workerd-darwin-64@1.20250712.0':
+    resolution: {integrity: sha512-M6S6a/LQ0Jb0R+g0XhlYi1adGifvYmxA5mD/i9TuZZgjs2bIm5ELuka/n3SCnI98ltvlx3HahRaHagAtOilsFg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
@@ -4308,8 +4308,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20250612.0':
-    resolution: {integrity: sha512-Hb9GWzLT4ydBYfGE29jxZFkx58NEA+oRMuGP358A6PUZ9UEDYWTDhskVQovhjELZMgOppUYXN2v/Je3sO1anpg==}
+  '@cloudflare/workerd-darwin-arm64@1.20250712.0':
+    resolution: {integrity: sha512-7sFzn6rvAcnLy7MktFL42dYtzL0Idw/kiUmNf2P3TvsBRoShhLK5ZKhbw+NAhvU8e4pXWm5lkE0XmpieA0zNjw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -4332,8 +4332,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-64@1.20250612.0':
-    resolution: {integrity: sha512-7kOA1sCfl9m2osolplDM9XqyBPf5KupvDs4UbD2kQq0zfd+u6acLz/YB9Q5tsVQIyhQoP32Oe+kr6IZJBImq9A==}
+  '@cloudflare/workerd-linux-64@1.20250712.0':
+    resolution: {integrity: sha512-EFRrGe/bqK7NHtht7vNlbrDpfvH3eRvtJOgsTpEQEysDjVmlK6pVJxSnLy9Hg1zlLY15IfhfGC+K2qisseHGJQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
@@ -4356,8 +4356,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20250612.0':
-    resolution: {integrity: sha512-x2UsZhfacZftD/kpDE2mtAlrLZPmkwRInFHJc7uIl8mvovQqVKMBkexH7dkfrgvBV98S2hOjxqFKP9mETuQQAQ==}
+  '@cloudflare/workerd-linux-arm64@1.20250712.0':
+    resolution: {integrity: sha512-rG8JUleddhUHQVwpXOYv0VbL0S9kOtR9PNKecgVhFpxEhC8aTeg2HNBBjo8st7IfcUvY8WaW3pD3qdAMZ05UwQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
@@ -4380,8 +4380,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workerd-windows-64@1.20250612.0':
-    resolution: {integrity: sha512-CeYe4OM5doIVGsOtrmDTrIBV2/wa/SPREEXH/N7ZCEs7mRhsTNFOwmctC0CYe3ZiutJ02dJmmyh/CIij2mkOLQ==}
+  '@cloudflare/workerd-windows-64@1.20250712.0':
+    resolution: {integrity: sha512-qS8H5RCYwE21Om9wo5/F807ClBJIfknhuLBj16eYxvJcj9JqgAKWi12BGgjyGxHuJJjeoQ63lr4wHAdbFntDDg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -12986,8 +12986,8 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  workerd@1.20250612.0:
-    resolution: {integrity: sha512-YWCjj4uZf3eH32epQy/c7tKWOInAswgFRAJoH6I/EY08OJKDfoJtKvRZj5f675KoJlKTPAoJ1ig/oE+RUKP3uw==}
+  workerd@1.20250712.0:
+    resolution: {integrity: sha512-7h+k1OxREpiZW0849g0uQNexRWMcs5i5gUGhJzCY8nIx6Tv4D/ndlXJ47lEFj7/LQdp165IL9dM2D5uDiedZrg==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -14410,7 +14410,7 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20250417.0':
     optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20250612.0':
+  '@cloudflare/workerd-darwin-64@1.20250712.0':
     optional: true
 
   '@cloudflare/workerd-darwin-64@1.20250726.0':
@@ -14422,7 +14422,7 @@ snapshots:
   '@cloudflare/workerd-darwin-arm64@1.20250417.0':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20250612.0':
+  '@cloudflare/workerd-darwin-arm64@1.20250712.0':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20250726.0':
@@ -14434,7 +14434,7 @@ snapshots:
   '@cloudflare/workerd-linux-64@1.20250417.0':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20250612.0':
+  '@cloudflare/workerd-linux-64@1.20250712.0':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20250726.0':
@@ -14446,7 +14446,7 @@ snapshots:
   '@cloudflare/workerd-linux-arm64@1.20250417.0':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20250612.0':
+  '@cloudflare/workerd-linux-arm64@1.20250712.0':
     optional: true
 
   '@cloudflare/workerd-linux-arm64@1.20250726.0':
@@ -14458,7 +14458,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20250417.0':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20250612.0':
+  '@cloudflare/workerd-windows-64@1.20250712.0':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20250726.0':


### PR DESCRIPTION
The preset now returns a different polyfill whether or not http modules are enabled.

Notes:
- `workerd` peer dep is bumped to `^1.20250722.0` where clients side http feature are enable
- the [server http APIs](https://github.com/cloudflare/workerd/pull/4591) are not available yet, so the PR still uses `unenv`

/cc @anonrig @jamesopstad @petebacondarwin 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user facing changes
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
