### PR TITLE
import debug instead of the alias

### DIFF
--- a/packages/wrangler/e2e/unenv-preset/worker/index.ts
+++ b/packages/wrangler/e2e/unenv-preset/worker/index.ts
@@ -184,15 +184,15 @@ export async function testTls() {
 }
 
 export async function testDebug() {
-	// @ts-expect-error "@cloudflare/unenv-preset/npm/debug" is an unenv alias, it does not exist as a module.
-	const debug = await import("@cloudflare/unenv-preset/npm/debug");
+	// @ts-expect-error "debug" is an unenv alias, not installed locally
+	const debug = (await import("debug")).default;
 	const logs: string[] = [];
 
 	// Append all logs to the array instead of logging to console
-	debug.default.log = (...args: string[]) =>
+	debug.log = (...args: string[]) =>
 		logs.push(args.map((arg) => arg.toString()).join(" "));
 
-	const exampleLog = debug.default("example");
+	const exampleLog = debug("example");
 	const testLog = exampleLog.extend("test");
 
 	exampleLog("This is an example log");


### PR DESCRIPTION
The test used to `import("@cloudflare/unenv-preset/npm/debug")`, it now just `import("debug")`

This also test that `debug` is actually aliased to `@cloudflare/unenv-preset/npm/debug` (i.e. the package polyfill is in place).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
