### PR TITLE
Clean up containers started by local dev during process exit hook instead

### DIFF
--- a/.changeset/great-terms-roll.md
+++ b/.changeset/great-terms-roll.md
@@ -3,4 +3,4 @@
 "wrangler": patch
 ---
 
-fix: move local dev container cleanup to process exit hook. this should hopefully clean up containers in more scenarios.
+fix: move local dev container cleanup to process exit hook. This should ensure containers are cleaned up even when Wrangler is shut down programatically.

--- a/.changeset/great-terms-roll.md
+++ b/.changeset/great-terms-roll.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/vite-plugin": patch
+"wrangler": patch
+---
+
+fix: move local dev container cleanup to process exit hook. this should hopefully clean up containers in more scenarios.

--- a/fixtures/interactive-dev-tests/tests/index.test.ts
+++ b/fixtures/interactive-dev-tests/tests/index.test.ts
@@ -395,8 +395,7 @@ baseDescribe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
 			);
 
 			wrangler.pty.write("r");
-			await setTimeout(2000); // wait for the rebuild to start
-			// wait for build to finish
+
 			await vi.waitFor(async () => {
 				const status = await fetch(wrangler.url + "/status");
 				expect(await status.json()).toBe(false);

--- a/fixtures/interactive-dev-tests/tests/index.test.ts
+++ b/fixtures/interactive-dev-tests/tests/index.test.ts
@@ -395,7 +395,7 @@ baseDescribe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
 			);
 
 			wrangler.pty.write("r");
-
+			await setTimeout(2000); // wait for the rebuild to start
 			// wait for build to finish
 			await vi.waitFor(async () => {
 				const status = await fetch(wrangler.url + "/status");
@@ -435,7 +435,7 @@ baseDescribe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
 			await new Promise<void>((resolve) => {
 				wrangler.pty.onExit(() => resolve());
 			});
-			vi.waitFor(() => {
+			await vi.waitFor(() => {
 				const remainingIds = getContainerIds();
 				expect(remainingIds.length).toBe(0);
 			});
@@ -719,7 +719,7 @@ baseDescribe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
 			await new Promise<void>((resolve) => {
 				wrangler.pty.onExit(() => resolve());
 			});
-			vi.waitFor(() => {
+			await vi.waitFor(() => {
 				const remainingIds = getContainerIds();
 				expect(remainingIds.length).toBe(0);
 			});
@@ -779,7 +779,7 @@ baseDescribe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
 			}
 		});
 
-		it("should be interact with both workers, rebuild the containers with the hotkey and all containers should be cleaned up at the end", async () => {
+		it("should be able to interact with both workers, rebuild the containers with the hotkey and all containers should be cleaned up at the end", async () => {
 			const wrangler = await startWranglerDev([
 				"dev",
 				"-c",

--- a/packages/containers-shared/src/utils.ts
+++ b/packages/containers-shared/src/utils.ts
@@ -141,11 +141,6 @@ export const isDockerfile = (
 
 /**
  * Kills and removes any containers which come from the given image tag
- *
- * Please note that this function has an almost identical counterpart
- * in the `vite-plugin-cloudflare` package (see `removeContainersByIds`).
- * If you make any changes to this fn, please make sure you persist those
- * changes in `removeContainersByIds` if necessary.
  */
 export const cleanupContainers = (
 	dockerPath: string,

--- a/packages/vite-plugin-cloudflare/playground/containers/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/containers/src/index.ts
@@ -1,6 +1,6 @@
 import { DurableObject } from "cloudflare:workers";
 
-export class Container extends DurableObject<Env> {
+export class VitePluginContainer extends DurableObject<Env> {
 	container: globalThis.Container;
 	monitor?: Promise<unknown>;
 

--- a/packages/vite-plugin-cloudflare/playground/containers/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/containers/src/index.ts
@@ -1,6 +1,6 @@
 import { DurableObject } from "cloudflare:workers";
 
-export class VitePluginContainer extends DurableObject<Env> {
+export class Container extends DurableObject<Env> {
 	container: globalThis.Container;
 	monitor?: Promise<unknown>;
 

--- a/packages/vite-plugin-cloudflare/src/containers.ts
+++ b/packages/vite-plugin-cloudflare/src/containers.ts
@@ -2,10 +2,7 @@ import assert from "node:assert";
 import path from "node:path";
 import { prepareContainerImagesForDev } from "@cloudflare/containers-shared/src/images";
 import { getDevContainerImageName } from "@cloudflare/containers-shared/src/knobs";
-import {
-	isDockerfile,
-	runDockerCmd,
-} from "@cloudflare/containers-shared/src/utils";
+import { isDockerfile } from "@cloudflare/containers-shared/src/utils";
 import type { WorkerConfig } from "./plugin-config";
 
 /**
@@ -18,40 +15,6 @@ export function getDockerPath(): string {
 	const dockerPathEnvVar = "WRANGLER_DOCKER_BIN";
 
 	return process.env[dockerPathEnvVar] || defaultDockerPath;
-}
-
-/**
- * Performs the forced removal of running Docker containers, given their ids.
- *
- * Please note that this function is almost identical to `cleanupContainers`
- * defined in `containers-shared`, with the exception that the current fn
- * expects the list of ids of all containers that are to be removed, as a
- * parameter. This is because extracting these ids is an async operation, and
- * we are currently restricted from performing async cleanup work upon
- * closing/exiting the vite dev process (see vite-plugin-cloudflare/src/index.ts
- * for more details).
- *
- * @param dockerPath The path to the Docker executable
- * @param containerIds The ids of the containers that should be removed
- */
-export async function removeContainersByIds(
-	dockerPath: string,
-	containerIds: string[]
-) {
-	try {
-		if (containerIds.length === 0) {
-			return;
-		}
-
-		await runDockerCmd(
-			dockerPath,
-			["rm", "--force", ...containerIds],
-			["inherit", "pipe", "pipe"]
-		);
-	} catch (error) {
-		// fail silently
-		return;
-	}
 }
 
 /**

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -483,13 +483,7 @@ if (import.meta.hot) {
 						 */
 						process.on("exit", async () => {
 							if (containerImageTagsSeen.size) {
-								try {
-									cleanupContainers(dockerPath, containerImageTagsSeen);
-								} catch (error) {
-									viteDevServer.config.logger.warnOnce(
-										"Failed to clean up containers. You may have to stop and remove them up manually"
-									);
-								}
+								cleanupContainers(dockerPath, containerImageTagsSeen);
 							}
 						});
 					}
@@ -590,13 +584,7 @@ if (import.meta.hot) {
 
 					process.on("exit", () => {
 						if (containerImageTagsSeen.size) {
-							try {
-								cleanupContainers(dockerPath, containerImageTagsSeen);
-							} catch (error) {
-								vitePreviewServer.config.logger.warnOnce(
-									"Failed to clean up containers. You may have to stop and remove them up manually"
-								);
-							}
+							cleanupContainers(dockerPath, containerImageTagsSeen);
 						}
 					});
 				}

--- a/packages/wrangler/e2e/containers.dev.test.ts
+++ b/packages/wrangler/e2e/containers.dev.test.ts
@@ -158,9 +158,11 @@ for (const source of imageSource) {
 				await helper.seed({
 					"wrangler.json": JSON.stringify(wranglerConfig),
 				});
-				// wait a bit in case any cleanup is already happening
+				/// wait a bit in case the expected cleanup from shutting down wrangler dev is already happening
 				await new Promise((resolve) => setTimeout(resolve, 500));
-				// cleanup any running containers
+				// cleanup any running containers. this does happen automatically when we shut down wrangler,
+				// but treekill is being uncooperative. this is also tested in interactive-dev-fixture
+				// where it is working as expected
 				const ids = getContainerIds("e2econtainer");
 				if (ids.length > 0) {
 					execSync(`${getDockerPath()} rm -f ${ids.join(" ")}`, {
@@ -169,8 +171,10 @@ for (const source of imageSource) {
 				}
 			});
 			afterAll(async () => {
-				// wait a bit in case any cleanup is already happening
+				// wait a bit in case the expected cleanup from shutting down wrangler dev is already happening
 				await new Promise((resolve) => setTimeout(resolve, 500));
+				// again this should happen automatically when we shut down wrangler, but treekill is being uncooperative.
+				// this is tested in interactive-dev-fixture where it is working as expected.
 				const ids = getContainerIds("e2econtainer");
 				if (ids.length > 0) {
 					execSync(`${getDockerPath()} rm -f ${ids.join(" ")}`, {
@@ -228,7 +232,7 @@ for (const source of imageSource) {
 						text = await response.text();
 						expect(text).toBe("Hello World! Have an env var! I'm an env var!");
 					},
-					{ timeout: 30_000 }
+					{ timeout: 5_000 }
 				);
 
 				// Check that a container is running using `docker ps`

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -191,7 +191,9 @@ export class LocalRuntimeController extends RuntimeController {
 	};
 
 	onBundleStart(_: BundleStartEvent) {
-		// Ignored in local runtime
+		process.on("exit", () => {
+			this.cleanupContainers();
+		});
 	}
 
 	async #onBundleComplete(data: BundleCompleteEvent, id: number) {
@@ -381,12 +383,22 @@ export class LocalRuntimeController extends RuntimeController {
 		// Ignored in local runtime
 	}
 
-	cleanupContainers = async () => {
+	cleanupContainers = () => {
+		if (!this.containerImageTagsSeen.size) {
+			return;
+		}
+
 		assert(
 			this.dockerPath,
 			"Docker path should have been set if containers are enabled"
 		);
-		await cleanupContainers(this.dockerPath, this.containerImageTagsSeen);
+		try {
+			cleanupContainers(this.dockerPath, this.containerImageTagsSeen);
+		} catch {
+			logger.warn(
+				`Failed to clean up containers. You may have to stop and remove them up manually.`
+			);
+		}
 	};
 
 	#teardown = async (): Promise<void> => {
@@ -399,15 +411,6 @@ export class LocalRuntimeController extends RuntimeController {
 		await this.#mf?.dispose();
 		this.#mf = undefined;
 
-		if (this.containerImageTagsSeen.size > 0) {
-			try {
-				await this.cleanupContainers();
-			} catch {
-				logger.warn(
-					`Failed to clean up containers. You may have to stop and remove them up manually.`
-				);
-			}
-		}
 		if (this.#remoteProxySessionData) {
 			logger.log(chalk.dim("⎔ Shutting down remote connection..."));
 		}

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -392,13 +392,7 @@ export class LocalRuntimeController extends RuntimeController {
 			this.dockerPath,
 			"Docker path should have been set if containers are enabled"
 		);
-		try {
-			cleanupContainers(this.dockerPath, this.containerImageTagsSeen);
-		} catch {
-			logger.warn(
-				`Failed to clean up containers. You may have to stop and remove them up manually.`
-			);
-		}
+		cleanupContainers(this.dockerPath, this.containerImageTagsSeen);
 	};
 
 	#teardown = async (): Promise<void> => {

--- a/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
@@ -297,16 +297,6 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 		await this.#mf?.dispose();
 		this.#mf = undefined;
 
-		if (this.containerImageTagsSeen.size > 0) {
-			try {
-				await this.cleanupContainers();
-			} catch {
-				logger.warn(
-					`Failed to clean up containers. You may have to stop and remove them up manually.`
-				);
-			}
-		}
-
 		if (this.#remoteProxySessionsData.size > 0) {
 			logger.log(chalk.dim("⎔ Shutting down remote connections..."));
 		}

--- a/packages/wrangler/src/dev/hotkeys.ts
+++ b/packages/wrangler/src/dev/hotkeys.ts
@@ -63,13 +63,12 @@ export default function registerDevHotKeys(
 						}
 					});
 					// cleanup any existing containers
-					await Promise.all(
-						devEnv.runtimes.map(async (runtime) => {
-							if (runtime instanceof LocalRuntimeController) {
-								await runtime.cleanupContainers();
-							}
-						})
-					);
+
+					devEnv.runtimes.map((runtime) => {
+						if (runtime instanceof LocalRuntimeController) {
+							runtime.cleanupContainers();
+						}
+					});
 
 					const newContainerBuildId = generateContainerBuildId();
 


### PR DESCRIPTION
previously these methods were async so we could not call them from `process.on('exit')`. by using synchronous apis instead to run docker commands, we can actually do cleanup from that hook, which simplifies a lot of the vite plugin cleanup code and also ensures proper cleanup if you run and stop wrangler programmatically (e.g. using something like `concurrently`). 

Vite manual testing:
I don't think we can test this with the vite plugin because we start and stop the vite server in vitest's global setup hook, which runs after test hooks like `afterAll`.
You can manually test this by:
1. running vite dev in `container-app` in the vite playground
2. hit `/start` 
3. verify a container is running with `docker ps`
4. stop the vite dev session
5. run `docker ps` again to verify no containers are still running

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: these should just pass existing tests in fixtures/interactive-dev-tests that check that containers are cleaned up after a dev session. fine. 
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: new to v4

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
