### PR TITLE
Fix container build ID generation in vitest-pool-workers

### DIFF
--- a/.changeset/fix-vitest-container-build-id.md
+++ b/.changeset/fix-vitest-container-build-id.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Fix container build ID generation when containers are present
+
+Generate container build ID when containers are defined in wrangler config, resolving "Build ID should be set if containers are defined and enabled" assertion error during testing.

--- a/packages/vitest-pool-workers/src/pool/config.ts
+++ b/packages/vitest-pool-workers/src/pool/config.ts
@@ -9,6 +9,7 @@ import {
 	PLUGINS,
 } from "miniflare";
 import { z } from "zod";
+import { generateContainerBuildId } from "@cloudflare/containers-shared";
 import { getProjectPath, getRelativeProjectPath } from "./helpers";
 import type { ModuleRule, WorkerOptions } from "miniflare";
 import type { ProvidedContext } from "vitest";
@@ -253,6 +254,12 @@ async function parseCustomPoolOptions(
 		// Lazily import `wrangler` if and when we need it
 		const wrangler = await import("wrangler");
 
+		// Read the config to check for containers
+		const config = wrangler.readConfig({ config: configPath, env: options.wrangler.environment });
+		
+		// Generate container build ID if containers are present
+		const containerBuildId = config.containers?.length ? generateContainerBuildId() : undefined;
+
 		const preExistingRemoteProxySessionData = options.wrangler?.configPath
 			? remoteProxySessionsDataMap.get(options.wrangler.configPath)
 			: undefined;
@@ -281,6 +288,7 @@ async function parseCustomPoolOptions(
 					remoteBindingsEnabled: options.experimental_remoteBindings,
 					remoteProxyConnectionString:
 						remoteProxySessionData?.session?.remoteProxyConnectionString,
+					containerBuildId,
 				}
 			);
 


### PR DESCRIPTION
## Problem

When using `@cloudflare/vitest-pool-workers` with container-enabled Durable Objects, tests fail with:

```
AssertionError: Build ID should be set if containers are defined and enabled
```

This occurs because the vitest integration doesn't pass the required `containerBuildId` parameter to `unstable_getMiniflareWorkerOptions()`, while regular `wrangler dev` generates this ID automatically.

## Solution

Read the wrangler config to detect containers and generate a container build ID when present, matching the behavior of regular `wrangler dev`.

## Changes

- Import `generateContainerBuildId` from `@cloudflare/containers-shared`
- Read config to detect container presence
- Generate and pass `containerBuildId` to `unstable_getMiniflareWorkerOptions()`

Resolves assertion error at `miniflare.ts:1420` and enables container testing with vitest-pool-workers.