### PR TITLE
Fix container build ID generation in vitest-pool-workers

### DIFF
--- a/.changeset/shy-pots-cheer.md
+++ b/.changeset/shy-pots-cheer.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Fix container build ID generation when containers are present
+
+Generate container build ID when containers are defined in wrangler config, resolving "Build ID should be set if containers are defined and enabled" assertion error during testing.

--- a/packages/vitest-pool-workers/src/pool/config.ts
+++ b/packages/vitest-pool-workers/src/pool/config.ts
@@ -65,7 +65,11 @@ const WorkersPoolOptionsSchema = z.object({
 		.passthrough()
 		.optional(),
 	wrangler: z
-		.object({ configPath: z.ostring(), environment: z.ostring() })
+		.object({
+			configPath: z.ostring(),
+			environment: z.ostring(),
+			containerBuildId: z.ostring(),
+		})
 		.optional(),
 });
 export type SourcelessWorkerOptions = Omit<
@@ -259,10 +263,33 @@ async function parseCustomPoolOptions(
 			env: options.wrangler.environment,
 		});
 
-		// Generate container build ID if containers are present
-		const containerBuildId = config.containers?.length
-			? crypto.randomUUID().slice(0, 8)
-			: undefined;
+		// Require explicit container build ID when containers are present
+		if (config.containers?.length && !options.wrangler.containerBuildId) {
+			throw new Error(
+				`
+Container-enabled Durable Objects detected but no container build ID provided.
+
+To use containers in tests:
+1. Build your containers: docker build -t cloudflare-dev/sandbox:my-test-id .
+2. Configure the build ID in vitest.config.ts:
+   {
+     test: {
+       poolOptions: {
+         workers: {
+           wrangler: {
+             containerBuildId: "my-test-id"
+           }
+         }
+       }
+     }
+   }
+
+For more details, see: https://developers.cloudflare.com/durable-objects/platform/testing/
+			`.trim()
+			);
+		}
+
+		const containerBuildId = options.wrangler.containerBuildId;
 
 		const preExistingRemoteProxySessionData = options.wrangler?.configPath
 			? remoteProxySessionsDataMap.get(options.wrangler.configPath)

--- a/packages/vitest-pool-workers/src/pool/config.ts
+++ b/packages/vitest-pool-workers/src/pool/config.ts
@@ -253,6 +253,12 @@ async function parseCustomPoolOptions(
 		// Lazily import `wrangler` if and when we need it
 		const wrangler = await import("wrangler");
 
+		// Read the config to check for containers
+		const config = wrangler.unstable_readConfig({ config: configPath, env: options.wrangler.environment });
+		
+		// Generate container build ID if containers are present
+		const containerBuildId = config.containers?.length ? crypto.randomUUID().slice(0, 8) : undefined;
+
 		const preExistingRemoteProxySessionData = options.wrangler?.configPath
 			? remoteProxySessionsDataMap.get(options.wrangler.configPath)
 			: undefined;
@@ -281,6 +287,7 @@ async function parseCustomPoolOptions(
 					remoteBindingsEnabled: options.experimental_remoteBindings,
 					remoteProxyConnectionString:
 						remoteProxySessionData?.session?.remoteProxyConnectionString,
+					containerBuildId,
 				}
 			);
 

--- a/packages/vitest-pool-workers/src/pool/config.ts
+++ b/packages/vitest-pool-workers/src/pool/config.ts
@@ -254,10 +254,15 @@ async function parseCustomPoolOptions(
 		const wrangler = await import("wrangler");
 
 		// Read the config to check for containers
-		const config = wrangler.unstable_readConfig({ config: configPath, env: options.wrangler.environment });
-		
+		const config = wrangler.unstable_readConfig({
+			config: configPath,
+			env: options.wrangler.environment,
+		});
+
 		// Generate container build ID if containers are present
-		const containerBuildId = config.containers?.length ? crypto.randomUUID().slice(0, 8) : undefined;
+		const containerBuildId = config.containers?.length
+			? crypto.randomUUID().slice(0, 8)
+			: undefined;
 
 		const preExistingRemoteProxySessionData = options.wrangler?.configPath
 			? remoteProxySessionsDataMap.get(options.wrangler.configPath)


### PR DESCRIPTION
When using `@cloudflare/vitest-pool-workers` with container-enabled Durable Objects, tests fail with:

```
AssertionError: Build ID should be set if containers are defined and enabled
```

This occurs because the vitest integration doesn't pass the required `containerBuildId` parameter to `unstable_getMiniflareWorkerOptions()`.

This PR fixes the issue by adding a `containerBuildId` configuration option to vitest-pool-workers, allowing users to specify the build ID that matches their pre-built Docker images.

## Usage

```typescript
// vitest.config.ts
export default defineWorkersConfig({
  test: {
    poolOptions: {
      workers: {
        wrangler: {
          configPath: "./wrangler.jsonc",
          containerBuildId: "my-test-id" // Must match docker build tag
        }
      }
    }
  }
});
```

```bash
# Build container with matching tag
docker build -t cloudflare-dev/myclass:my-test-id .
```

This approach ensures proper synchronization between test configuration and available container images, preventing build ID mismatches.

---

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: This is a configuration fix that resolves an assertion error during test execution. The fix enables existing container tests to run rather than adding new functionality that needs testing.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This fixes a bug in the testing infrastructure. While it adds a new configuration option, it's for fixing broken functionality rather than new features.
- Wrangler V3 Backport
  - [ ] Wrangler PR:
  - [x] Not necessary because: This is a patch to vitest-pool-workers testing infrastructure, not a change to wrangler itself, so no v3 back-port is required.