### PR TITLE
Add containerBuildId configuration to vitest-pool-workers

### DIFF
--- a/.changeset/shy-pots-cheer.md
+++ b/.changeset/shy-pots-cheer.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Fix container build ID generation when containers are present
+
+Generate container build ID when containers are defined in wrangler config, resolving "Build ID should be set if containers are defined and enabled" assertion error during testing.


### PR DESCRIPTION
Fixes "Build ID should be set if containers are defined and enabled" assertion error when testing container-enabled Durable Objects with vitest-pool-workers.

## Problem

When using `@cloudflare/vitest-pool-workers` with container-enabled Durable Objects, tests fail with:

```
AssertionError: Build ID should be set if containers are defined and enabled
```

This occurs because the vitest integration doesn't pass the required `containerBuildId` parameter to `unstable_getMiniflareWorkerOptions()`.

## Solution

This PR adds a `containerBuildId` configuration option to vitest-pool-workers, allowing users to specify the build ID that matches their pre-built Docker images.

## Usage

```typescript
// vitest.config.ts
export default defineWorkersConfig({
  test: {
    poolOptions: {
      workers: {
        wrangler: {
          configPath: "./wrangler.jsonc",
          containerBuildId: "my-test-id" // Must match docker build tag
        }
      }
    }
  }
});
```

```bash
# Build container with matching tag
docker build -t cloudflare-dev/myclass:my-test-id .
```

This approach ensures proper synchronization between test configuration and available container images, preventing build ID mismatches.

---

- Tests
  - [x] Tests not necessary because: This is a configuration fix that resolves an assertion error during test execution. The fix enables existing container tests to run rather than adding new functionality that needs testing.
- Public documentation
  - [x] Documentation not necessary because: This fixes a bug in the testing infrastructure. While it adds a new configuration option, it's for fixing broken functionality rather than new features.
- Wrangler V3 Backport
  - [x] Not necessary because: This is a patch to vitest-pool-workers testing infrastructure, not a change to wrangler itself, so no v3 back-port is required.