### PR TITLE
fix `startWorker` not respecting `auth` options for remote bindings

### DIFF
--- a/.changeset/sdw-auth.md
+++ b/.changeset/sdw-auth.md
@@ -1,0 +1,41 @@
+---
+"wrangler": patch
+---
+
+fix `startWorker` not respecting `auth` options for remote bindings
+
+fix `startWorker` currently not taking into account the `auth` field
+that can be provided as part of the `dev` options when used in conjunction
+with remote bindings
+
+example:
+
+Given the following
+
+```js
+import { unstable_startWorker } from "wrangler";
+
+const worker = await unstable_startWorker({
+	entrypoint: "./worker.js",
+	bindings: {
+		AI: {
+			type: "ai",
+			experimental_remote: true,
+		},
+	},
+	dev: {
+		experimentalRemoteBindings: true,
+		auth: {
+			accountId: "<ACCOUNT_ID>",
+			apiToken: {
+				apiToken: "<API_TOKEN>",
+			},
+		},
+	},
+});
+
+await worker.ready;
+```
+
+`wrangler` will now use the provided `<ACCOUNT_ID>` and `<API_TOKEN>` to integrate with
+the remote AI binding instead of requiring the user to authenticate.

--- a/.changeset/whole-masks-sniff.md
+++ b/.changeset/whole-masks-sniff.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix incorrect TypeScript type for AI binding in the `startWorker` API

--- a/packages/wrangler/e2e/dev-env.test.ts
+++ b/packages/wrangler/e2e/dev-env.test.ts
@@ -52,7 +52,9 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("switching runtimes", () => {
                             remote: firstRemote,
                             auth: {
                                 accountId: process.env.CLOUDFLARE_ACCOUNT_ID,
-                                apiToken: process.env.CLOUDFLARE_API_TOKEN,
+                                apiToken: {
+                                    apiToken: process.env.CLOUDFLARE_API_TOKEN,
+                                }
                             },
                         },
                     });

--- a/packages/wrangler/e2e/start-worker-auth-opts.test.ts
+++ b/packages/wrangler/e2e/start-worker-auth-opts.test.ts
@@ -1,0 +1,196 @@
+import assert from "node:assert";
+import path from "node:path";
+import dedent from "ts-dedent";
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
+import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
+import type { Worker } from "../src/api/startDevWorker";
+import type { MockInstance } from "vitest";
+
+type Wrangler = Awaited<ReturnType<WranglerE2ETestHelper["importWrangler"]>>;
+
+describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("startWorker - auth options", () => {
+	let helper: WranglerE2ETestHelper;
+	let wrangler: Wrangler;
+	let startWorker: Wrangler["unstable_startWorker"];
+	let consoleErrorMock: MockInstance<typeof console.error>;
+
+	beforeAll(() => {
+		consoleErrorMock = vi.spyOn(console, "error").mockImplementation(() => {});
+	});
+
+	beforeEach(async () => {
+		helper = new WranglerE2ETestHelper();
+		const aiWorkerScript = dedent`
+			export default {
+				async fetch(_request, env) {
+					const messages = [
+						{
+							role: "user",
+							content:
+								"Respond with the exact text 'This is a response from Workers AI.'. Do not include any other text",
+						},
+					];
+
+					const content = await env.AI.run("@hf/thebloke/zephyr-7b-beta-awq", {
+						messages,
+					});
+
+					return new Response(content.response);
+				},
+			}
+		`;
+		await helper.seed({
+			"src/index.js": aiWorkerScript,
+		});
+		wrangler = await helper.importWrangler();
+		startWorker = wrangler.unstable_startWorker;
+	});
+
+	test("starting startWorker with the valid auth information and updating it with invalid information", async (t) => {
+		t.onTestFinished(async () => await worker?.dispose());
+
+		assert(process.env.CLOUDFLARE_API_TOKEN);
+
+		const worker = await startWorker({
+			entrypoint: path.resolve(helper.tmpPath, "src/index.js"),
+			bindings: {
+				AI: {
+					type: "ai",
+					experimental_remote: true,
+				},
+			},
+			dev: {
+				experimentalRemoteBindings: true,
+				auth: {
+					accountId: CLOUDFLARE_ACCOUNT_ID,
+					apiToken: {
+						apiToken: process.env.CLOUDFLARE_API_TOKEN,
+					},
+				},
+			},
+		});
+
+		await assertValidWorkerAiResponse(worker);
+
+		consoleErrorMock.mockReset();
+
+		await worker.patchConfig({
+			dev: {
+				experimentalRemoteBindings: true,
+				auth: {
+					accountId: CLOUDFLARE_ACCOUNT_ID,
+					apiToken: {
+						apiToken: "This is an incorrect API TOKEN!",
+					},
+				},
+			},
+		});
+
+		await assertInvalidWorkerAiResponse(worker);
+	});
+
+	test("starting startWorker with invalid auth information and updating it with valid auth information", async (t) => {
+		t.onTestFinished(async () => await worker?.dispose());
+
+		assert(process.env.CLOUDFLARE_API_TOKEN);
+
+		const worker = await startWorker({
+			entrypoint: path.resolve(helper.tmpPath, "src/index.js"),
+			bindings: {
+				AI: {
+					type: "ai",
+					experimental_remote: true,
+				},
+			},
+			dev: {
+				experimentalRemoteBindings: true,
+				auth: {
+					accountId: CLOUDFLARE_ACCOUNT_ID,
+					apiToken: {
+						apiToken: "This is an incorrect API TOKEN!",
+					},
+				},
+			},
+		});
+
+		await assertInvalidWorkerAiResponse(worker);
+
+		consoleErrorMock.mockReset();
+
+		await worker.patchConfig({
+			dev: {
+				experimentalRemoteBindings: true,
+				auth: {
+					accountId: CLOUDFLARE_ACCOUNT_ID,
+					apiToken: {
+						apiToken: process.env.CLOUDFLARE_API_TOKEN,
+					},
+				},
+			},
+		});
+
+		await assertValidWorkerAiResponse(worker);
+	});
+
+	async function assertValidWorkerAiResponse(worker: Worker) {
+		const responseText = await fetchTimedTextFromWorker(worker);
+
+		// We've fixed the auth information so now we can indeed get
+		// a valid response from the worker
+		expect(responseText).toBeTruthy();
+		expect(responseText).toContain("This is a response from Workers AI.");
+
+		// And there should be no error regarding the Cloudflare API in the console
+		expect(consoleErrorMock).not.toHaveBeenCalledWith(
+			expect.stringMatching(
+				/A request to the Cloudflare API \([^)]*\) failed\./
+			)
+		);
+	}
+
+	async function assertInvalidWorkerAiResponse(worker: Worker) {
+		const responseText = await fetchTimedTextFromWorker(worker);
+
+		// The remote connection is not established so we can't successfully
+		// get a response from the worker
+		expect(responseText).toBe(null);
+
+		// And in the console an appropriate error was logged
+		expect(consoleErrorMock).toHaveBeenCalledWith(
+			expect.stringMatching(
+				/A request to the Cloudflare API \([^)]*\) failed\./
+			)
+		);
+	}
+});
+
+/**
+ * Tries to fetch some text from a target worker, as part of this it also polls from the worker
+ * trying multiple times to fetch from it.
+ *
+ * @param worker The worker in question
+ * @returns The text from the worker's response, or null if not response could be obtained.
+ */
+async function fetchTimedTextFromWorker(
+	worker: Worker
+): Promise<string | null> {
+	let responseText: string | null = null;
+
+	try {
+		await vi.waitFor(
+			async () => {
+				responseText = await (
+					await worker.fetch("http://example.com", {
+						signal: AbortSignal.timeout(500),
+					})
+				).text();
+			},
+			{ timeout: 10_000, interval: 700 }
+		);
+	} catch {
+		return null;
+	}
+
+	return responseText;
+}

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -11,7 +11,6 @@ import { Miniflare, Mutex } from "miniflare";
 import * as MF from "../../dev/miniflare";
 import { getDockerPath } from "../../environment-variables/misc-variables";
 import { logger } from "../../logger";
-import { pickRemoteBindings } from "../remoteBindings";
 import { RuntimeController } from "./BaseController";
 import { castErrorCause } from "./events";
 import {
@@ -209,9 +208,8 @@ export class LocalRuntimeController extends RuntimeController {
 			if (experimentalRemoteBindings && !data.config.dev?.remote) {
 				// note: remote bindings use (transitively) LocalRuntimeController, so we need to import
 				// from the module lazily in order to avoid circular dependency issues
-				const { maybeStartOrUpdateRemoteProxySession } = await import(
-					"../remoteBindings"
-				);
+				const { maybeStartOrUpdateRemoteProxySession, pickRemoteBindings } =
+					await import("../remoteBindings");
 
 				const remoteBindings = pickRemoteBindings(
 					convertCfWorkerInitBindingsToBindings(configBundle.bindings) ?? {}

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -16,6 +16,7 @@ import { castErrorCause } from "./events";
 import {
 	convertBindingsToCfWorkerInitBindings,
 	convertCfWorkerInitBindingsToBindings,
+	unwrapHook,
 } from "./utils";
 import type { WorkerEntrypointsDefinition } from "../../dev-registry";
 import type { RemoteProxySession } from "../remoteBindings";
@@ -211,6 +212,8 @@ export class LocalRuntimeController extends RuntimeController {
 					"../remoteBindings"
 				);
 
+				const auth = await unwrapHook(data.config.dev.auth);
+
 				this.#remoteProxySessionData =
 					await maybeStartOrUpdateRemoteProxySession(
 						{
@@ -220,7 +223,8 @@ export class LocalRuntimeController extends RuntimeController {
 								convertCfWorkerInitBindingsToBindings(configBundle.bindings) ??
 								{},
 						},
-						this.#remoteProxySessionData ?? null
+						this.#remoteProxySessionData ?? null,
+						auth
 					);
 			}
 

--- a/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
@@ -199,6 +199,7 @@ export class RemoteRuntimeController extends RuntimeController {
 			this.#session ??= await this.#previewSession({
 				complianceConfig: { compliance_region: config.complianceRegion },
 				accountId: auth.accountId,
+				apiToken: auth.apiToken,
 				env: config.env, // deprecated service environments -- just pass it through for now
 				legacyEnv: !config.legacy?.enableServiceEnvironments, // wrangler environment -- just pass it through for now
 				host: config.dev.origin?.hostname,

--- a/packages/wrangler/src/api/startDevWorker/types.ts
+++ b/packages/wrangler/src/api/startDevWorker/types.ts
@@ -10,6 +10,7 @@ import type {
 	ZoneNameRoute,
 } from "../../config/environment";
 import type {
+	CfAIBinding,
 	CfAnalyticsEngineDataset,
 	CfD1Database,
 	CfDispatchNamespace,
@@ -282,7 +283,7 @@ export type Binding =
 	| { type: "wasm_module"; source: BinaryFile }
 	| { type: "text_blob"; source: File }
 	| { type: "browser" }
-	| { type: "ai" }
+	| ({ type: "ai" } & BindingOmit<CfAIBinding>)
 	| { type: "images" }
 	| { type: "version_metadata" }
 	| { type: "data_blob"; source: BinaryFile }

--- a/packages/wrangler/src/cfetch/index.ts
+++ b/packages/wrangler/src/cfetch/index.ts
@@ -3,6 +3,7 @@ import { APIError } from "../parse";
 import { maybeThrowFriendlyError } from "./errors";
 import { fetchInternal } from "./internal";
 import type { ComplianceConfig } from "../environment-variables/misc-variables";
+import type { ApiCredentials } from "../user";
 import type { FetchError } from "./errors";
 import type { RequestInit } from "undici";
 
@@ -26,14 +27,16 @@ export async function fetchResult<ResponseType>(
 	resource: string,
 	init: RequestInit = {},
 	queryParams?: URLSearchParams,
-	abortSignal?: AbortSignal
+	abortSignal?: AbortSignal,
+	apiToken?: ApiCredentials
 ): Promise<ResponseType> {
 	const json = await fetchInternal<FetchResult<ResponseType>>(
 		complianceConfig,
 		resource,
 		init,
 		queryParams,
-		abortSignal
+		abortSignal,
+		apiToken
 	);
 	if (json.success) {
 		return json.result;

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -21,7 +21,8 @@ export async function performApiFetch(
 	resource: string,
 	init: RequestInit = {},
 	queryParams?: URLSearchParams,
-	abortSignal?: AbortSignal
+	abortSignal?: AbortSignal,
+	apiToken?: ApiCredentials
 ) {
 	const method = init.method ?? "GET";
 	assert(
@@ -29,7 +30,7 @@ export async function performApiFetch(
 		`CF API fetch - resource path must start with a "/" but got "${resource}"`
 	);
 	await requireLoggedIn(complianceConfig);
-	const apiToken = requireApiToken();
+	apiToken ??= requireApiToken();
 	const headers = cloneHeaders(new Headers(init.headers));
 	addAuthorizationHeaderIfUnspecified(headers, apiToken);
 	addUserAgent(headers);
@@ -78,7 +79,8 @@ export async function fetchInternal<ResponseType>(
 	resource: string,
 	init: RequestInit = {},
 	queryParams?: URLSearchParams,
-	abortSignal?: AbortSignal
+	abortSignal?: AbortSignal,
+	apiToken?: ApiCredentials
 ): Promise<ResponseType> {
 	const method = init.method ?? "GET";
 	const response = await performApiFetch(
@@ -86,7 +88,8 @@ export async function fetchInternal<ResponseType>(
 		resource,
 		init,
 		queryParams,
-		abortSignal
+		abortSignal,
+		apiToken
 	);
 	const jsonText = await response.text();
 	logger.debug(

--- a/packages/wrangler/src/dev/create-worker-preview.ts
+++ b/packages/wrangler/src/dev/create-worker-preview.ts
@@ -158,7 +158,7 @@ export async function createPreviewSession(
 	ctx: CfWorkerContext,
 	abortSignal: AbortSignal
 ): Promise<CfPreviewSession> {
-	const { accountId } = account;
+	const { accountId, apiToken } = account;
 	const initUrl = ctx.zone
 		? `/zones/${ctx.zone}/workers/edge-preview`
 		: `/accounts/${accountId}/workers/subdomain/edge-preview`;
@@ -168,7 +168,8 @@ export async function createPreviewSession(
 		initUrl,
 		undefined,
 		undefined,
-		abortSignal
+		abortSignal,
+		apiToken
 	);
 
 	const switchedExchangeUrl = switchHost(

--- a/packages/wrangler/src/dev/remote.ts
+++ b/packages/wrangler/src/dev/remote.ts
@@ -22,6 +22,7 @@ import type {
 import type { ComplianceConfig } from "../environment-variables/misc-variables";
 import type { ParseError } from "../parse";
 import type { LegacyAssetPaths } from "../sites";
+import type { ApiCredentials } from "../user";
 import type { CfAccount } from "./create-worker-preview";
 import type { EsbuildBundle } from "./use-esbuild";
 
@@ -203,6 +204,7 @@ export async function createRemoteWorkerInit(props: {
 export async function getWorkerAccountAndContext(props: {
 	complianceConfig: ComplianceConfig;
 	accountId: string;
+	apiToken?: ApiCredentials | undefined;
 	env: string | undefined;
 	legacyEnv: boolean | undefined;
 	host: string | undefined;
@@ -212,7 +214,7 @@ export async function getWorkerAccountAndContext(props: {
 }): Promise<{ workerAccount: CfAccount; workerContext: CfWorkerContext }> {
 	const workerAccount: CfAccount = {
 		accountId: props.accountId,
-		apiToken: requireApiToken(),
+		apiToken: props.apiToken ?? requireApiToken(),
 	};
 
 	// What zone should the realish preview for this Worker run on?


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-1857



---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is fixing expected behavior
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: related to remote bindings which are not a v3 feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
