### PR TITLE
feat: update getMigrationNames() to sort

### DIFF
--- a/packages/wrangler/src/d1/migrations/helpers.ts
+++ b/packages/wrangler/src/d1/migrations/helpers.ts
@@ -143,7 +143,7 @@ function getMigrationNames(migrationsPath: string): Array<string> {
 
 	dir.closeSync();
 
-	return migrations;
+	return migrations.sort();
 }
 
 /**


### PR DESCRIPTION
Fixes #[insert GH or internal issue link(s)].  
  
Fix D1 migration files ordering by sorting migration names alphabetically  
  
This change addresses the issue where `wrangler d1 migrations list` displays migration files in random order instead of chronological order. The fix ensures migration files are always displayed and executed in the correct chronological order by sorting them alphabetically by filename.  
  
**Changes:**  
- Modified `getMigrationNames()` function in `packages/wrangler/src/d1/migrations/helpers.ts` to sort migration filenames before returning  
- Since migration files follow the naming convention `migration_YYYYMMDDHHMMSS.sql`, alphabetical sorting ensures chronological order  
  
---  
  
- Tests  
  - [x] Tests included  
  - [ ] Tests not necessary because:  
- Public documentation  
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->  
  - [x] Documentation not necessary because: This is an internal bug fix that doesn't change user-facing API or behavior expectations  
- Wrangler V3 Backport  
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->  
  - [x] Not necessary because: This is a minor bug fix that doesn't affect core functionality