### PR TITLE
Remove mention of cf-requirements when Python Worker is enabled

### DIFF
--- a/.changeset/brown-knives-sort.md
+++ b/.changeset/brown-knives-sort.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Removes mention of cf-requirements when Python Workers are enabled

--- a/packages/wrangler/src/deployment-bundle/guess-worker-format.ts
+++ b/packages/wrangler/src/deployment-bundle/guess-worker-format.ts
@@ -24,7 +24,7 @@ export default async function guessWorkerFormat(
 			`The entrypoint ${path.relative(
 				process.cwd(),
 				entryFile
-			)} defines a Python worker, support for Python workers is currently experimental. Python workers with a cf-requirements.txt file can only be run locally and cannot be deployed.`
+			)} defines a Python worker, support for Python workers is currently experimental.`
 		);
 		return { format: "modules", exports: [] };
 	}


### PR DESCRIPTION
Simple change that modifies a warning output by wrangler slightly.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: minor change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: minor change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
