### PR TITLE
refactor: add `page.goto()` back into beforeEach

### DIFF
--- a/packages/vite-plugin-cloudflare/playground/hot-channel/__tests__/hot-channel.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/hot-channel/__tests__/hot-channel.spec.ts
@@ -1,12 +1,10 @@
 import { expect, test } from "vitest";
-import { isBuild, page, serverLogs, viteTestUrl } from "../../__test-utils__";
+import { isBuild, serverLogs } from "../../__test-utils__";
 
 test.runIf(!isBuild)("client receives custom events", async () => {
-	await page.goto(viteTestUrl);
 	expect(serverLogs.info.join()).toContain("__server-event-data-received__");
 });
 
 test.runIf(!isBuild)("server receives custom events", async () => {
-	await page.goto(viteTestUrl);
 	expect(serverLogs.info.join()).toContain("__client-event-data-received__");
 });

--- a/packages/vite-plugin-cloudflare/playground/vitest-setup.ts
+++ b/packages/vite-plugin-cloudflare/playground/vitest-setup.ts
@@ -9,7 +9,7 @@ import {
 	preview,
 	Rollup,
 } from "vite";
-import { beforeAll, inject } from "vitest";
+import { beforeAll, beforeEach, inject } from "vitest";
 import type * as http from "node:http";
 import type { Browser, Page } from "playwright-chromium";
 import type {
@@ -183,6 +183,9 @@ beforeAll(async (s) => {
 		await browser?.close();
 	};
 }, 15_000);
+
+// Ensure that each test starts with the same page URL
+beforeEach(() => page.goto(viteTestUrl));
 
 export async function loadConfig(configEnv: ConfigEnv) {
 	let config: UserConfig | null = null;

--- a/packages/vite-plugin-cloudflare/playground/websockets/__tests__/websockets.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/websockets/__tests__/websockets.spec.ts
@@ -1,8 +1,7 @@
 import { expect, test, vi } from "vitest";
-import { page, viteTestUrl } from "../../__test-utils__";
+import { page } from "../../__test-utils__";
 
 async function openWebSocket() {
-	await page.goto(viteTestUrl);
 	const openButton = page.getByRole("button", { name: "Open WebSocket" });
 	const statusTextBefore = await page.textContent("h2");
 	expect(statusTextBefore).toBe("WebSocket closed");
@@ -16,7 +15,6 @@ async function openWebSocket() {
 test("opens WebSocket connection", openWebSocket);
 
 test("closes WebSocket connection", async () => {
-	await page.goto(viteTestUrl);
 	await openWebSocket();
 	const closeButton = page.getByRole("button", { name: "Close WebSocket" });
 	const statusTextBefore = await page.textContent("h2");
@@ -29,7 +27,6 @@ test("closes WebSocket connection", async () => {
 });
 
 test("sends and receives WebSocket string messages", async () => {
-	await page.goto(viteTestUrl);
 	await openWebSocket();
 	const sendButton = page.getByRole("button", { name: "Send string" });
 	const messageTextBefore = await page.textContent("p");
@@ -44,7 +41,6 @@ test("sends and receives WebSocket string messages", async () => {
 });
 
 test("sends and receives WebSocket ArrayBuffer messages", async () => {
-	await page.goto(viteTestUrl);
 	await openWebSocket();
 	const sendButton = page.getByRole("button", { name: "Send ArrayBuffer" });
 	const messageTextBefore = await page.textContent("p");


### PR DESCRIPTION
Will remove gotos from individual tests if this doesn't fail CI.