### PR TITLE
feat(miniflare): support node bindings over dev registry

### DIFF
--- a/.changeset/nine-moose-decide.md
+++ b/.changeset/nine-moose-decide.md
@@ -1,0 +1,5 @@
+---
+"miniflare": minor
+---
+
+feat: support node bindings over dev registry

--- a/.changeset/nine-moose-decide.md
+++ b/.changeset/nine-moose-decide.md
@@ -1,5 +1,9 @@
 ---
-"miniflare": minor
+"miniflare": patch
 ---
 
-feat: support node bindings over dev registry
+fix: support `mf.getBindings()` when dev registry is enabled
+
+Fixes a deadlock when using bindings from `mf.getBindings()` with the dev registry enabled. The deadlock happened because the runtime attempted to resolve a worker address via the loopback server, which was blocked by the Node.js thread waiting on the same runtime.
+
+Address lookup has been moved to a proxy running in a worker thread to avoid blocking the main thread.

--- a/packages/miniflare/scripts/build.mjs
+++ b/packages/miniflare/scripts/build.mjs
@@ -153,6 +153,14 @@ async function buildPackage() {
 	const pkg = getPackage(pkgRoot);
 
 	const indexPath = path.join(pkgRoot, "src", "index.ts");
+	// The dev registry proxy will be run in a separate worker thread, so we
+	// will define a separate entry point for it
+	const devRegistryProxyPath = path.join(
+		pkgRoot,
+		"src",
+		"shared",
+		"dev-registry.worker.ts"
+	);
 	// Look for test files ending with .spec.ts in the test directory, default to
 	// empty array if not found
 	let testPaths = [];
@@ -190,7 +198,7 @@ async function buildPackage() {
 		logLevel: watch ? "info" : "warning",
 		outdir: outPath,
 		outbase: pkgRoot,
-		entryPoints: [indexPath, ...testPaths],
+		entryPoints: [indexPath, devRegistryProxyPath, ...testPaths],
 	};
 	if (watch) {
 		const ctx = await esbuild.context(buildOptions);

--- a/packages/miniflare/scripts/build.mjs
+++ b/packages/miniflare/scripts/build.mjs
@@ -153,8 +153,8 @@ async function buildPackage() {
 	const pkg = getPackage(pkgRoot);
 
 	const indexPath = path.join(pkgRoot, "src", "index.ts");
-	// The dev registry proxy will be run in a separate worker thread, so we
-	// will define a separate entry point for it
+	// The dev registry proxy runs in a Node.js worker thread (instead of workerd) and
+	// requires a separate entry file
 	const devRegistryProxyPath = path.join(
 		pkgRoot,
 		"src",

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -2103,15 +2103,12 @@ export class Miniflare {
 		);
 	}
 
-	#updateProxyServer(url: URL): void {
-		assert(this.#socketPorts !== undefined);
-		this.#devRegistry.configureProxyWorker(url.toString(), this.#socketPorts);
-	}
-
 	get ready(): Promise<URL> {
 		return this.#waitForReady().then(async (url) => {
+			assert(this.#socketPorts !== undefined);
+
 			// Update proxy server with the addresses of the fallback services
-			this.#updateProxyServer(url);
+			this.#devRegistry.configureProxyWorker(url.toString(), this.#socketPorts);
 			// Register all workers with the dev registry
 			await this.#registerWorkers(url);
 

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -110,8 +110,6 @@ import {
 	createInboundDoProxyService,
 	createOutboundDoProxyService,
 	createProxyFallbackService,
-	extractDoFetchProxyTarget,
-	extractServiceFetchProxyTarget,
 	getHttpProxyOptions,
 	getOutboundDoProxyClassName,
 	getProtocol,
@@ -396,13 +394,12 @@ function getDurableObjectClassNames(
 
 /**
  * This collects all external service bindings from all workers and overrides
- * it to point to a proxy in the loopback server. A fallback service will be created
+ * it to point to the dev registry proxy. A fallback service will be created
  * for each of the external service in case the external service is not available.
  */
 function getExternalServiceEntrypoints(
 	allWorkerOpts: PluginWorkerOptions[],
-	loopbackHost: string,
-	loopbackPort: number
+	proxyAddress: string
 ) {
 	const externalServices = new Map<
 		string,
@@ -446,7 +443,7 @@ function getExternalServiceEntrypoints(
 					// Override it to connect to the dev registry proxy
 					workerOpts.core.serviceBindings[name] = {
 						external: {
-							address: `${loopbackHost}:${loopbackPort}`,
+							address: proxyAddress,
 							http: getHttpProxyOptions(serviceName, entrypoint),
 						},
 					};
@@ -515,7 +512,7 @@ function getExternalServiceEntrypoints(
 					// Override it to connect to the dev registry proxy
 					workerOpts.core.tails[i] = {
 						external: {
-							address: `${loopbackHost}:${loopbackPort}`,
+							address: proxyAddress,
 							http: getHttpProxyOptions(serviceName, entrypoint),
 						},
 					};
@@ -1092,81 +1089,10 @@ export class Miniflare {
 		return this.#workerOpts.map<NameSourceOptions>(({ core }) => core);
 	}
 
-	#getFallbackServiceAddress(
-		service: string,
-		entrypoint: string
-	): {
-		httpStyle: "host" | "proxy";
-		protocol: "http" | "https";
-		host: string;
-		port: number;
-	} {
-		assert(
-			this.#socketPorts !== undefined && this.#runtimeEntryURL !== undefined,
-			"Cannot resolve address for fallback service before runtime is initialised"
-		);
-
-		const port = this.#socketPorts.get(
-			getProxyFallbackServiceSocketName(service, entrypoint)
-		);
-
-		if (!port) {
-			throw new Error(
-				`There is no socket opened for "${service}" with the "${entrypoint}" entrypoint`
-			);
-		}
-
-		return {
-			httpStyle: "proxy",
-			protocol: getProtocol(this.#runtimeEntryURL),
-			host: this.#runtimeEntryURL.hostname,
-			port,
-		};
-	}
-
 	#handleLoopback = async (
 		req: http.IncomingMessage,
 		res?: http.ServerResponse
 	): Promise<Response | undefined> => {
-		const serviceProxyTarget = extractServiceFetchProxyTarget(req);
-
-		if (serviceProxyTarget) {
-			assert(res !== undefined, "No response object provided");
-
-			const address =
-				this.#devRegistry.getExternalServiceAddress(
-					serviceProxyTarget.service,
-					serviceProxyTarget.entrypoint
-				) ??
-				this.#getFallbackServiceAddress(
-					serviceProxyTarget.service,
-					serviceProxyTarget.entrypoint
-				);
-
-			this.#handleProxy(req, res, address);
-			return;
-		}
-
-		const doProxyTarget = extractDoFetchProxyTarget(req);
-
-		if (doProxyTarget) {
-			assert(res !== undefined, "No response object provided");
-
-			const address = this.#devRegistry.getExternalDurableObjectAddress(
-				doProxyTarget.scriptName,
-				doProxyTarget.className
-			);
-
-			if (!address) {
-				res.writeHead(503);
-				res.end("Service Unavailable");
-				return;
-			}
-
-			this.#handleProxy(req, res, address);
-			return;
-		}
-
 		const customNodeService =
 			req.headers[CoreHeaders.CUSTOM_NODE_SERVICE.toLowerCase()];
 		if (typeof customNodeService === "string") {
@@ -1359,109 +1285,6 @@ export class Miniflare {
 		await this.#writeResponse(response, res);
 	};
 
-	#handleLoopbackConnect = async (
-		req: http.IncomingMessage,
-		clientSocket: Duplex,
-		head: Buffer
-	) => {
-		try {
-			const connectHost = req.url;
-			const [serviceName, entrypoint] = connectHost?.split(":") ?? [];
-			const address =
-				this.#devRegistry.getExternalServiceAddress(serviceName, entrypoint) ??
-				this.#getFallbackServiceAddress(serviceName, entrypoint);
-
-			const serverSocket = net.connect(address.port, address.host, () => {
-				serverSocket.write(`CONNECT ${HOST_CAPNP_CONNECT} HTTP/1.1\r\n\r\n`);
-
-				// Push along any buffered bytes
-				if (head && head.length) {
-					serverSocket.write(head);
-				}
-
-				serverSocket.pipe(clientSocket);
-				clientSocket.pipe(serverSocket);
-			});
-
-			// Errors on either side
-			serverSocket.on("error", (err) => {
-				this.#log.error(err);
-				clientSocket.end();
-			});
-			clientSocket.on("error", () => serverSocket.end());
-
-			// Close the tunnel if the service is updated
-			// This make sure workerd will re-connect to the latest address
-			this.#devRegistry.subscribe(serviceName, () => {
-				this.#log.debug(
-					`Closing tunnel as service "${serviceName}" was updated`
-				);
-				clientSocket.end();
-			});
-		} catch (ex: any) {
-			this.#log.error(ex);
-			clientSocket.end();
-		}
-	};
-
-	#handleProxy = (
-		req: http.IncomingMessage,
-		res: http.ServerResponse,
-		target: {
-			protocol: "http" | "https";
-			host: string;
-			port: number;
-			httpStyle?: "host" | "proxy";
-			path?: string;
-		}
-	) => {
-		const headers = { ...req.headers };
-		let path = target.path;
-
-		if (!path) {
-			switch (target.httpStyle) {
-				case "host": {
-					const url = new URL(req.url ?? `http://${req.headers.host}`);
-					// If the target is a host, use the path from the request URL
-					path = url.pathname + url.search + url.hash;
-					headers.host = url.host;
-					break;
-				}
-				case "proxy": {
-					// If the target is a proxy, use the full request URL
-					path = req.url;
-					break;
-				}
-			}
-		}
-
-		const options: http.RequestOptions = {
-			host: target.host,
-			port: target.port,
-			method: req.method,
-			path,
-			headers,
-		};
-
-		// Res is optional only on websocket upgrade requests
-		assert(res !== undefined, "No response object provided");
-		const upstream = http.request(options, (upRes) => {
-			// Relay status and headers back to the original client
-			res.writeHead(upRes.statusCode ?? 500, upRes.headers);
-			// Pipe the response body
-			upRes.pipe(res);
-		});
-
-		// Pipe the client request body to the upstream
-		req.pipe(upstream);
-
-		upstream.on("error", (err) => {
-			this.#log.error(err);
-			if (!res.headersSent) res.writeHead(502);
-			res.end("Bad Gateway");
-		});
-	};
-
 	async #writeResponse(response: Response, res: http.ServerResponse) {
 		// Convert headers into Node-friendly format
 		const headers: http.OutgoingHttpHeaders = {};
@@ -1547,17 +1370,9 @@ export class Miniflare {
 
 		return new Promise((resolve) => {
 			const server = stoppable(
-				http.createServer(
-					{
-						// There might be no HOST header when proxying a fetch request made over service binding
-						//  e.g. env.MY_WORKER.fetch("https://example.com")
-						requireHostHeader: false,
-					},
-					this.#handleLoopback
-				),
+				http.createServer(this.#handleLoopback),
 				/* grace */ 0
 			);
-			server.on("connect", this.#handleLoopbackConnect);
 			server.on("upgrade", this.#handleLoopbackUpgrade);
 			server.listen(0, hostname, () => resolve(server));
 		});
@@ -1586,8 +1401,8 @@ export class Miniflare {
 	}
 
 	async #assembleConfig(
-		loopbackHost: string,
-		loopbackPort: number
+		loopbackPort: number,
+		proxyAddress: string | null
 	): Promise<Config> {
 		const allPreviousWorkerOpts = this.#previousWorkerOpts;
 		const allWorkerOpts = this.#workerOpts;
@@ -1596,9 +1411,10 @@ export class Miniflare {
 		sharedOpts.core.cf = await setupCf(this.#log, sharedOpts.core.cf);
 		this.#cfObject = sharedOpts.core.cf;
 
-		const externalServices = this.#devRegistry.isEnabled()
-			? getExternalServiceEntrypoints(allWorkerOpts, loopbackHost, loopbackPort)
-			: null;
+		const externalServices =
+			proxyAddress !== null
+				? getExternalServiceEntrypoints(allWorkerOpts, proxyAddress)
+				: null;
 		const durableObjectClassNames = getDurableObjectClassNames(allWorkerOpts);
 		const wrappedBindingNames = getWrappedBindingNames(
 			allWorkerOpts,
@@ -1887,9 +1703,6 @@ export class Miniflare {
 						},
 					});
 				}
-
-				// Ask the dev registry to watch for this service
-				this.#devRegistry.subscribe(serviceName);
 			}
 
 			const externalObjects = Array.from(externalServices).flatMap(
@@ -1901,12 +1714,15 @@ export class Miniflare {
 			);
 			const outboundDoProxyService = createOutboundDoProxyService(
 				externalObjects,
-				`http://${loopbackHost}:${loopbackPort}`,
+				`http://${proxyAddress}`,
 				this.#devRegistry.isDurableObjectProxyEnabled()
 			);
 
 			assert(outboundDoProxyService.name !== undefined);
 			services.set(outboundDoProxyService.name, outboundDoProxyService);
+
+			// Watch the dev registry for changes
+			await this.#devRegistry.watch(externalServices);
 		}
 
 		// Expose all internal durable object with a proxy service
@@ -2010,7 +1826,8 @@ export class Miniflare {
 			maybeGetLocallyAccessibleHost(configuredHost) ??
 			getURLSafeHost(configuredHost);
 		const loopbackPort = await this.#getLoopbackPort();
-		const config = await this.#assembleConfig(loopbackHost, loopbackPort);
+		const proxyAddress = await this.#devRegistry.initializeProxyWorker();
+		const config = await this.#assembleConfig(loopbackPort, proxyAddress);
 		const configBuffer = serializeConfig(config);
 
 		// Get all socket names we expect to get ports for
@@ -2286,12 +2103,17 @@ export class Miniflare {
 		);
 	}
 
+	#updateProxyServer(url: URL): void {
+		assert(this.#socketPorts !== undefined);
+		this.#devRegistry.configureProxyWorker(url.toString(), this.#socketPorts);
+	}
+
 	get ready(): Promise<URL> {
 		return this.#waitForReady().then(async (url) => {
+			// Update proxy server with the addresses of the fallback services
+			this.#updateProxyServer(url);
 			// Register all workers with the dev registry
 			await this.#registerWorkers(url);
-			// Watch for changes to the dev registry
-			await this.#devRegistry.watch();
 
 			return url;
 		});

--- a/packages/miniflare/src/shared/dev-registry.ts
+++ b/packages/miniflare/src/shared/dev-registry.ts
@@ -34,7 +34,7 @@ export type WorkerDefinition = {
 export class DevRegistry {
 	private heartbeats = new Map<string, NodeJS.Timeout>();
 	private registry: WorkerRegistry = {};
-	private registeredWorkers = new Set<string>();
+	private registeredWorkers: Set<string> = new Set();
 	private externalServices: Map<
 		string,
 		{
@@ -68,6 +68,8 @@ export class DevRegistry {
 			return;
 		}
 
+		// Keep track of external services we are depending on
+		// To pre-populate the proxy server with the fallback service addresses
 		this.externalServices = new Map(services);
 
 		if (!this.watcher) {

--- a/packages/miniflare/src/shared/dev-registry.ts
+++ b/packages/miniflare/src/shared/dev-registry.ts
@@ -124,14 +124,17 @@ export class DevRegistry {
 		this.registry = {};
 
 		// Only this step is async and could be awaited
-		return Promise.all([
-			this.watcher?.close(),
-			this.proxyWorker?.terminate(),
-		]).then(() => {
-			this.watcher = undefined;
-			this.proxyWorker = undefined;
-			this.proxyAddress = undefined;
-		});
+		return Promise.all([this.watcher?.close(), this.proxyWorker?.terminate()])
+			.then(() => {
+				// Typescript complains that the return type is
+				// not compatible with `Promise<void>` without this.
+				return;
+			})
+			.finally(() => {
+				this.watcher = undefined;
+				this.proxyWorker = undefined;
+				this.proxyAddress = undefined;
+			});
 	}
 
 	private unregisterWorkers() {

--- a/packages/miniflare/src/shared/dev-registry.ts
+++ b/packages/miniflare/src/shared/dev-registry.ts
@@ -9,8 +9,10 @@ import {
 	writeFileSync,
 } from "node:fs";
 import path from "node:path";
+import { Worker } from "node:worker_threads";
 import { FSWatcher, watch } from "chokidar";
-import { INBOUND_DO_PROXY_SERVICE_PATH } from "./external-service";
+import { SocketPorts } from "../runtime";
+import { getProxyFallbackServiceSocketName } from "./external-service";
 import { Log } from "./log";
 import { getGlobalWranglerConfigPath } from "./wrangler";
 
@@ -32,9 +34,17 @@ export type WorkerDefinition = {
 export class DevRegistry {
 	private heartbeats = new Map<string, NodeJS.Timeout>();
 	private registry: WorkerRegistry = {};
-	private registeredWorkers: Set<string> = new Set();
-	private subscribers: Map<string, Array<() => void>> = new Map();
+	private registeredWorkers = new Set<string>();
+	private externalServices: Map<
+		string,
+		{
+			classNames: Set<string>;
+			entrypoints: Set<string | undefined>;
+		}
+	> = new Map();
 	private watcher: FSWatcher | undefined;
+	private proxyWorker: Worker | undefined;
+	private proxyAddress: string | undefined;
 
 	constructor(
 		private registryPath: string | undefined,
@@ -45,13 +55,61 @@ export class DevRegistry {
 	/**
 	 * Watch files inside the registry directory for changes.
 	 */
-	public watch(): void {
-		if (this.subscribers.size === 0 || !this.registryPath || this.watcher) {
+	public watch(
+		services: Map<
+			string,
+			{
+				classNames: Set<string>;
+				entrypoints: Set<string | undefined>;
+			}
+		>
+	): void {
+		if (services.size === 0 || !this.registryPath) {
 			return;
 		}
 
-		this.watcher = watch(this.registryPath).on("all", () => this.refresh());
-		this.refresh();
+		this.externalServices = new Map(services);
+
+		if (!this.watcher) {
+			this.watcher = watch(this.registryPath).on("all", () => this.refresh());
+			this.refresh();
+		}
+	}
+
+	/**
+	 * Initialize the worker thread proxy server
+	 */
+	public async initializeProxyWorker(): Promise<string | null> {
+		if (!this.isEnabled()) {
+			return null;
+		}
+
+		if (this.proxyAddress !== undefined) {
+			this.log.debug("Dev registry proxy is already running");
+			return this.proxyAddress;
+		}
+
+		const worker = new Worker(
+			path.join(__dirname, "shared", "dev-registry.worker.js")
+		);
+
+		// Wait for the worker to signal it's ready and provide the port
+		const address = await new Promise<string>((resolve, reject) => {
+			worker.once("message", (message) => {
+				if (message.type === "ready") {
+					resolve(message.address);
+				} else if (message.type === "error") {
+					reject(new Error(message.error));
+				}
+			});
+			worker.once("error", reject);
+		});
+
+		this.proxyWorker = worker;
+		this.proxyAddress = address;
+		this.log.debug(`Dev registry proxy started on http://${address}`);
+
+		return address;
 	}
 
 	/**
@@ -60,15 +118,26 @@ export class DevRegistry {
 	 * to ensure all workers are unregistered within the exit hook
 	 */
 	public dispose(): Promise<void> | undefined {
-		for (const worker of this.registeredWorkers) {
-			this.unregister(worker);
-		}
-		this.registeredWorkers.clear();
-		this.subscribers.clear();
+		this.unregisterWorkers();
 		this.registry = {};
 
 		// Only this step is async and could be awaited
-		return this.watcher?.close();
+		return Promise.all([
+			this.watcher?.close(),
+			this.proxyWorker?.terminate(),
+		]).then(() => {
+			this.watcher = undefined;
+			this.proxyWorker = undefined;
+			this.proxyAddress = undefined;
+		});
+	}
+
+	private unregisterWorkers() {
+		for (const worker of this.registeredWorkers) {
+			this.unregister(worker);
+		}
+
+		this.registeredWorkers.clear();
 	}
 
 	/**
@@ -87,8 +156,6 @@ export class DevRegistry {
 			if (this.registryPath) {
 				unlinkSync(path.join(this.registryPath, name));
 			}
-
-			this.notifySubscribers(name);
 		} catch (e) {
 			this.log?.debug(`Failed to unregister worker "${name}": ${e}`);
 		}
@@ -106,9 +173,53 @@ export class DevRegistry {
 		registryPath: string | undefined,
 		enableDurableObjectProxy: boolean
 	): Promise<void> {
-		await this.dispose();
-		this.registryPath = registryPath;
+		// Unregister all registered workers
+		this.unregisterWorkers();
 		this.enableDurableObjectProxy = enableDurableObjectProxy;
+
+		if (registryPath !== this.registryPath) {
+			// Close the existing watcher if it exists.
+			// It will watch the new path if there is any dependent services in a later step
+			await this.watcher?.close();
+
+			this.watcher = undefined;
+			this.registryPath = registryPath;
+		}
+	}
+
+	public configureProxyWorker(
+		runtimeEntryURL: string,
+		socketPorts: SocketPorts
+	) {
+		if (!this.proxyWorker) {
+			return;
+		}
+
+		const fallbackServicePorts: Record<string, Record<string, number>> = {};
+
+		for (const [service, { entrypoints }] of this.externalServices) {
+			for (const entrypoint of entrypoints) {
+				const port = socketPorts.get(
+					getProxyFallbackServiceSocketName(service, entrypoint)
+				);
+
+				if (!port) {
+					throw new Error(
+						`There is no socket opened for "${service}" with the "${entrypoint ?? "default"}" entrypoint`
+					);
+				}
+
+				fallbackServicePorts[service] ??= {};
+				fallbackServicePorts[service][entrypoint ?? "default"] = port;
+			}
+		}
+
+		// Send updated config to the proxy worker
+		this.proxyWorker.postMessage({
+			type: "setup",
+			runtimeEntryURL,
+			fallbackServicePorts,
+		});
 	}
 
 	public register(workers: Record<string, WorkerDefinition>) {
@@ -116,13 +227,15 @@ export class DevRegistry {
 			return;
 		}
 
+		// Make sure the registry path exists
+		mkdirSync(this.registryPath, { recursive: true });
+
 		for (const [name, definition] of Object.entries(workers)) {
 			const definitionPath = path.join(this.registryPath, name);
 			const existingHeartbeat = this.heartbeats.get(name);
 			if (existingHeartbeat) {
 				clearInterval(existingHeartbeat);
 			}
-			mkdirSync(this.registryPath, { recursive: true });
 
 			// Skip the durable objects in the definition if the proxy is not enabled
 			if (!this.enableDurableObjectProxy) {
@@ -142,143 +255,54 @@ export class DevRegistry {
 		}
 	}
 
-	public getExternalServiceAddress(
-		service: string,
-		entrypoint: string
-	): {
-		httpStyle?: "host" | "proxy";
-		protocol: "http" | "https";
-		host: string;
-		port: number;
-	} | null {
-		if (!this.isEnabled()) {
-			return null;
-		}
-
-		const target = this.registry?.[service];
-		const entrypointAddress = target?.entrypointAddresses[entrypoint];
-
-		if (entrypointAddress !== undefined) {
-			return {
-				httpStyle: "proxy",
-				protocol: target.protocol,
-				host: entrypointAddress.host,
-				port: entrypointAddress.port,
-			};
-		}
-
-		if (target && target.protocol !== "https" && entrypoint === "default") {
-			// Fallback to sending requests directly to the entry worker
-			return {
-				httpStyle: "host",
-				protocol: target.protocol,
-				host: target.host,
-				port: target.port,
-			};
-		}
-
-		return null;
-	}
-
-	public getExternalDurableObjectAddress(
-		scriptName: string,
-		className: string
-	): {
-		httpStyle?: "host" | "proxy";
-		protocol: "http" | "https";
-		host: string;
-		port: number;
-		path: string;
-	} | null {
-		if (!this.isDurableObjectProxyEnabled()) {
-			return null;
-		}
-
-		const target = this.registry?.[scriptName];
-
-		if (
-			target?.durableObjects.some(
-				(durableObject) => durableObject.className === className
-			)
-		) {
-			return {
-				...target,
-				path: `/${INBOUND_DO_PROXY_SERVICE_PATH}`,
-			};
-		}
-
-		return null;
-	}
-
-	public subscribe(workerName: string, callback?: () => void): void {
-		let callbacks = this.subscribers.get(workerName);
-
-		if (!callbacks) {
-			callbacks = [];
-			this.subscribers.set(workerName, callbacks);
-		}
-
-		if (callback !== undefined) {
-			callbacks.push(callback);
-		}
-	}
-
-	private notifySubscribers(workerName: string): void {
-		const callbacks = this.subscribers.get(workerName);
-		if (callbacks) {
-			for (const callback of callbacks) {
-				callback();
-			}
-		}
-	}
-
 	private refresh(): void {
 		if (!this.registryPath) {
 			return;
 		}
 
-		// Make sure the registry path exists
-		mkdirSync(this.registryPath, { recursive: true });
+		this.registry = getWorkerRegistry(this.registryPath, (workerName) => {
+			this.unregister(workerName);
+		});
 
-		const workerNames = readdirSync(this.registryPath);
-
-		// Cleanup existing definition that are not in the registry anymore
-		for (const existingWorkerName of Object.keys(this.registry)) {
-			if (!workerNames.includes(existingWorkerName)) {
-				delete this.registry[existingWorkerName];
-				this.notifySubscribers(existingWorkerName);
-			}
-		}
-
-		for (const workerName of workerNames) {
-			try {
-				const definitionPath = path.join(this.registryPath, workerName);
-				const file = readFileSync(definitionPath, "utf8");
-				const stats = statSync(definitionPath);
-
-				// Cleanup existing workers older than 5 minutes
-				if (stats.mtime.getTime() < Date.now() - 300_000) {
-					this.unregister(workerName);
-					continue;
-				}
-
-				if (
-					// If the worker is not registered before, or
-					!this.registry[workerName] ||
-					// If the file content is different from the registry
-					file !== JSON.stringify(this.registry[workerName], null, 2)
-				) {
-					this.registry[workerName] = JSON.parse(file);
-					this.notifySubscribers(workerName);
-				}
-			} catch (e) {
-				// This can safely be ignored. It generally indicates the worker was too old and was removed by a parallel process
-				this.log?.debug(
-					`Error while loading worker definition from the registry: ${e}`
-				);
-			}
+		// Send updated workers to the proxy worker
+		if (this.proxyWorker) {
+			this.proxyWorker.postMessage({
+				type: "update",
+				workers: this.registry,
+			});
 		}
 	}
+}
+
+export function getWorkerRegistry(
+	registryPath: string,
+	unregisterStaleWorker?: (workerName: string) => void
+): WorkerRegistry {
+	const registry: WorkerRegistry = {};
+
+	if (!existsSync(registryPath)) {
+		return registry;
+	}
+
+	for (const workerName of readdirSync(registryPath)) {
+		try {
+			const definitionPath = path.join(registryPath, workerName);
+			const file = readFileSync(definitionPath, "utf8");
+			const stats = statSync(definitionPath);
+
+			// Cleanup existing workers older than 5 minutes
+			if (stats.mtime.getTime() < Date.now() - 300_000) {
+				unregisterStaleWorker?.(workerName);
+				continue;
+			}
+
+			registry[workerName] = JSON.parse(file);
+		} catch {
+			// This can safely be ignored. It generally indicates the worker was too old and was removed by a parallel process
+		}
+	}
+
+	return registry;
 }
 
 export function getDefaultDevRegistryPath() {

--- a/packages/miniflare/src/shared/dev-registry.ts
+++ b/packages/miniflare/src/shared/dev-registry.ts
@@ -305,6 +305,10 @@ export function getWorkerRegistry(
 	return registry;
 }
 
+/**
+ * Get the default path for the dev registry.
+ * This is used by both Wrangler and the Vite plugin to ensure they use the same path.
+ */
 export function getDefaultDevRegistryPath() {
 	return (
 		process.env.MINIFLARE_REGISTRY_PATH ??

--- a/packages/miniflare/src/shared/dev-registry.ts
+++ b/packages/miniflare/src/shared/dev-registry.ts
@@ -295,7 +295,7 @@ export function getWorkerRegistry(
 			const file = readFileSync(definitionPath, "utf8");
 			const stats = statSync(definitionPath);
 
-			// Cleanup existing workers older than 5 minutes
+			// Cleanup old workers that have not sent a heartbeat in over 5 minutes
 			if (stats.mtime.getTime() < Date.now() - 300_000) {
 				unregisterStaleWorker?.(workerName);
 				continue;

--- a/packages/miniflare/src/shared/dev-registry.worker.ts
+++ b/packages/miniflare/src/shared/dev-registry.worker.ts
@@ -1,0 +1,349 @@
+import http from "node:http";
+import net from "node:net";
+import { Duplex } from "node:stream";
+import { parentPort } from "node:worker_threads";
+import { HOST_CAPNP_CONNECT } from "../plugins/shared/constants";
+import {
+	extractDoFetchProxyTarget,
+	extractServiceFetchProxyTarget,
+	getProtocol,
+	INBOUND_DO_PROXY_SERVICE_PATH,
+} from "../shared/external-service";
+import { Log } from "./log";
+import type { WorkerDefinition } from "../shared/dev-registry";
+import type { MessagePort } from "node:worker_threads";
+
+interface ProxyAddress {
+	protocol: "http" | "https";
+	host: string;
+	port: number;
+	httpStyle?: "host" | "proxy";
+	path?: string;
+}
+
+const log = new Log();
+
+/**
+ * Worker thread implementation for dev registry with HTTP proxy server.
+ * This runs both the file watching and HTTP proxy in a separate thread
+ * to prevent blocking the main thread.
+ */
+class ProxyServer {
+	private registry: Record<string, WorkerDefinition> = {};
+	private runtimeEntryURL: string | null = null;
+	private fallbackServicePorts: Record<string, Record<string, number>> = {};
+	private subscribers: Map<string, Array<() => void>> = new Map();
+
+	constructor(private messagePort: MessagePort) {
+		this.setupMessageHandlers();
+	}
+
+	private setupMessageHandlers() {
+		this.messagePort.on("message", (message) => {
+			switch (message.type) {
+				case "update":
+					this.updateRegistry(message.workers);
+					break;
+				case "setup":
+					this.runtimeEntryURL = message.runtimeEntryURL;
+					this.fallbackServicePorts = message.fallbackServicePorts;
+					break;
+				default:
+					// Ignore unknown message types
+					break;
+			}
+		});
+	}
+
+	public async start() {
+		try {
+			// Listen on a random port
+			await new Promise<void>((resolve, reject) => {
+				const server = http.createServer({
+					// There might be no HOST header when proxying a fetch request made over service binding
+					//  e.g. env.MY_WORKER.fetch("https://example.com")
+					requireHostHeader: false,
+				});
+
+				server.on("request", this.handleRequest.bind(this));
+				server.on("connect", this.handleConnect.bind(this));
+				server.listen(0, "127.0.0.1", () => {
+					const address = server.address();
+
+					if (!address || typeof address === "string") {
+						reject(new Error("Failed to get server address"));
+						return;
+					}
+
+					// Notify parent that server is ready with the port
+					this.messagePort.postMessage({
+						type: "ready",
+						address: `${address.address}:${address.port}`,
+					});
+
+					resolve();
+				});
+				server.on("error", reject);
+			});
+		} catch (error) {
+			this.messagePort.postMessage({
+				type: "error",
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+
+	private handleRequest(
+		req: http.IncomingMessage,
+		res: http.ServerResponse
+	): void {
+		const serviceProxyTarget = extractServiceFetchProxyTarget(req);
+		if (serviceProxyTarget) {
+			const address = this.getServiceAddress(
+				serviceProxyTarget.service,
+				serviceProxyTarget.entrypoint
+			);
+
+			this.handleProxy(req, res, address);
+			return;
+		}
+
+		const doProxyTarget = extractDoFetchProxyTarget(req);
+		if (doProxyTarget) {
+			const address = this.getDurableObjectAddress(
+				doProxyTarget.scriptName,
+				doProxyTarget.className
+			);
+
+			if (!address) {
+				res.writeHead(503);
+				res.end("Service Unavailable");
+				return;
+			}
+
+			this.handleProxy(req, res, address);
+			return;
+		}
+
+		// If no valid target found, return 404
+		res.writeHead(404);
+		res.end("Not Found");
+	}
+
+	private async handleConnect(
+		req: http.IncomingMessage,
+		clientSocket: Duplex,
+		head: Buffer
+	) {
+		try {
+			const connectHost = req.url;
+			const [serviceName, entrypoint] = connectHost?.split(":") ?? [];
+			const address = this.getServiceAddress(serviceName, entrypoint);
+			const serverSocket = net.connect(address.port, address.host, () => {
+				serverSocket.write(`CONNECT ${HOST_CAPNP_CONNECT} HTTP/1.1\r\n\r\n`);
+
+				// Push along any buffered bytes
+				if (head && head.length) {
+					serverSocket.write(head);
+				}
+
+				serverSocket.pipe(clientSocket);
+				clientSocket.pipe(serverSocket);
+			});
+
+			// Errors on either side
+			serverSocket.on("error", (error) => {
+				log.error(error);
+				clientSocket.end();
+			});
+			clientSocket.on("error", () => serverSocket.end());
+			// Close the tunnel if the service is updated
+			// This make sure workerd will re-connect to the latest address
+			this.subscribe(serviceName, () => {
+				log.debug(`Closing tunnel as service "${serviceName}" was updated`);
+				clientSocket.end();
+			});
+		} catch (e) {
+			log.error(e instanceof Error ? e : new Error(`${e}`));
+			clientSocket.end();
+		}
+	}
+
+	private getServiceAddress(service: string, entrypoint: string): ProxyAddress {
+		const target = this.registry?.[service];
+		const entrypointAddress = target?.entrypointAddresses[entrypoint];
+
+		if (entrypointAddress !== undefined) {
+			return {
+				httpStyle: "proxy",
+				protocol: target.protocol,
+				host: entrypointAddress.host,
+				port: entrypointAddress.port,
+			};
+		}
+
+		if (target && target.protocol !== "https" && entrypoint === "default") {
+			// Fallback to sending requests directly to the entry worker
+			return {
+				httpStyle: "host",
+				protocol: target.protocol,
+				host: target.host,
+				port: target.port,
+			};
+		}
+
+		return this.getFallbackServiceAddress(service, entrypoint);
+	}
+
+	private getFallbackServiceAddress(
+		service: string,
+		entrypoint: string
+	): ProxyAddress {
+		if (!this.runtimeEntryURL) {
+			throw new Error("No runtime entry URL set");
+		}
+
+		const url = new URL(this.runtimeEntryURL);
+		const port = this.fallbackServicePorts[service]?.[entrypoint];
+
+		if (!port) {
+			throw new Error(
+				`There is no socket opened for "${service}" with the "${entrypoint}" entrypoint`
+			);
+		}
+
+		return {
+			httpStyle: "proxy",
+			protocol: getProtocol(url),
+			host: url.hostname,
+			port,
+		};
+	}
+
+	private getDurableObjectAddress(
+		scriptName: string,
+		className: string
+	): ProxyAddress | null {
+		const target = this.registry?.[scriptName];
+
+		if (
+			target?.durableObjects.some(
+				(durableObject) => durableObject.className === className
+			)
+		) {
+			return {
+				...target,
+				path: `/${INBOUND_DO_PROXY_SERVICE_PATH}`,
+			};
+		}
+
+		return null;
+	}
+
+	private handleProxy(
+		req: http.IncomingMessage,
+		res: http.ServerResponse,
+		target: ProxyAddress
+	) {
+		const headers = { ...req.headers };
+		let path = target.path;
+
+		if (!path) {
+			switch (target.httpStyle) {
+				case "host": {
+					const url = new URL(req.url ?? `http://${req.headers.host}`);
+					// If the target is a host, use the path from the request URL
+					path = url.pathname + url.search + url.hash;
+					headers.host = url.host;
+					break;
+				}
+				case "proxy": {
+					// If the target is a proxy, use the full request URL
+					path = req.url;
+					break;
+				}
+			}
+		}
+
+		const options: http.RequestOptions = {
+			host: target.host,
+			port: target.port,
+			method: req.method,
+			path,
+			headers,
+		};
+
+		const upstream = http.request(options, (upRes) => {
+			// Relay status and headers back to the original client
+			res.writeHead(upRes.statusCode ?? 500, upRes.headers);
+			// Pipe the response body
+			upRes.pipe(res);
+		});
+
+		// Pipe the client request body to the upstream
+		req.pipe(upstream);
+
+		upstream.on("error", () => {
+			if (!res.headersSent) res.writeHead(502);
+			res.end("Bad Gateway");
+		});
+	}
+
+	private subscribe(workerName: string, callback: () => void): void {
+		let callbacks = this.subscribers.get(workerName);
+
+		if (!callbacks) {
+			callbacks = [];
+			this.subscribers.set(workerName, callbacks);
+		}
+
+		callbacks.push(callback);
+	}
+
+	private notifySubscribers(workerName: string): void {
+		const callbacks = this.subscribers.get(workerName);
+		if (callbacks) {
+			for (const callback of callbacks) {
+				callback();
+			}
+		}
+	}
+
+	private updateRegistry(workers: Record<string, WorkerDefinition>) {
+		const workerNames = Object.keys(workers);
+
+		// Cleanup existing definition that are not in the registry anymore
+		for (const existingWorkerName of Object.keys(this.registry)) {
+			if (!workerNames.includes(existingWorkerName)) {
+				delete this.registry[existingWorkerName];
+				this.notifySubscribers(existingWorkerName);
+			}
+		}
+
+		for (const workerName of workerNames) {
+			if (
+				JSON.stringify(workers[workerName]) ===
+				JSON.stringify(this.registry[workerName])
+			) {
+				continue; // No change, skip
+			}
+
+			this.registry[workerName] = workers[workerName];
+			this.notifySubscribers(workerName);
+		}
+	}
+}
+
+function runProxyServer() {
+	if (!parentPort) {
+		throw new Error("This script must be run in a worker thread");
+	}
+
+	const server = new ProxyServer(parentPort);
+
+	// Start the server
+	server.start();
+}
+
+// Initialize the proxy server
+runProxyServer();

--- a/packages/miniflare/src/shared/dev-registry.worker.ts
+++ b/packages/miniflare/src/shared/dev-registry.worker.ts
@@ -289,6 +289,10 @@ class ProxyServer {
 		});
 	}
 
+	/**
+	 * To subscribe to updates for a specific worker.
+	 * This is currently used to close HTTP tunnels when a service is updated.
+	 */
 	private subscribe(workerName: string, callback: () => void): void {
 		let callbacks = this.subscribers.get(workerName);
 
@@ -300,6 +304,9 @@ class ProxyServer {
 		callbacks.push(callback);
 	}
 
+	/**
+	 * Notify all subscribers of a worker that has been updated.
+	 */
 	private notifySubscribers(workerName: string): void {
 		const callbacks = this.subscribers.get(workerName);
 		if (callbacks) {
@@ -309,6 +316,9 @@ class ProxyServer {
 		}
 	}
 
+	/**
+	 * Find out which workers have been updated and notify subscribers.
+	 */
 	private updateRegistry(workers: Record<string, WorkerDefinition>) {
 		const workerNames = Object.keys(workers);
 


### PR DESCRIPTION
Fixes n/a.

This PR moves the address lookup logic from the loopback server to a new proxy server running in a worker thread to workaround a deadlock situation with the node bindings locking the main thread when waiting for a response from the runtime while the runtime is also waiting for a response from the loopback server on the address of the other workerd process. 😅 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not a new feature
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: v4 feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
