### PR TITLE
fix `require("debug")` in nodejs_compat mode

### DIFF
--- a/.changeset/nasty-foxes-find.md
+++ b/.changeset/nasty-foxes-find.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix `require("debug")` in nodejs_compat mode

--- a/packages/wrangler/e2e/unenv-preset/preset.test.ts
+++ b/packages/wrangler/e2e/unenv-preset/preset.test.ts
@@ -70,8 +70,9 @@ describe.each(testConfigs)(
 					main: join(__dirname, "/worker/index.ts"),
 					compatibility_date: compatibilityDate,
 					compatibility_flags: ["nodejs_compat", ...compatibilityFlags],
+					// Enable `enabled` logs for the `debug` package
 					vars: {
-						DEBUG: "example",
+						DEBUG: "enabled",
 					},
 				}),
 			});

--- a/packages/wrangler/e2e/unenv-preset/worker/index.ts
+++ b/packages/wrangler/e2e/unenv-preset/worker/index.ts
@@ -12,7 +12,8 @@ export const TESTS: Record<string, () => void> = {
 	testTimers,
 	testNet,
 	testTls,
-	testDebug,
+	testDebugImport,
+	testDebugRequire,
 	testHttp,
 	testHttps,
 };
@@ -212,7 +213,7 @@ export async function testTls() {
 	assert.strictEqual(typeof tls.convertALPNProtocols, "function");
 }
 
-export async function testDebug() {
+export async function testDebugImport() {
 	// @ts-expect-error "debug" is an unenv alias, not installed locally
 	const debug = (await import("debug")).default;
 	const logs: string[] = [];
@@ -221,13 +222,39 @@ export async function testDebug() {
 	debug.log = (...args: string[]) =>
 		logs.push(args.map((arg) => arg.toString()).join(" "));
 
-	const exampleLog = debug("example");
-	const testLog = exampleLog.extend("test");
+	// Append all logs to the array instead of logging to console
+	debug.log = (...args: string[]) =>
+		logs.push(args.map((arg) => arg.toString()).join(" "));
 
-	exampleLog("This is an example log");
-	testLog("This is a test log");
+	// This should log because as `DEBUG` is set to "enabled".
+	const enabledLog = debug("enabled");
+	enabledLog("This should be logged");
 
-	assert.deepEqual(logs, ["example This is an example log +0ms"]);
+	// This should not log as `DEBUG` does not contain "enabled:disabled"
+	const disabledLog = enabledLog.extend("disabled");
+	disabledLog("This should not be logged");
+
+	assert.deepEqual(logs, ["enabled This should be logged +0ms"]);
+}
+
+export async function testDebugRequire() {
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	const debug = require("debug");
+	const logs: string[] = [];
+
+	// Append all logs to the array instead of logging to console
+	debug.log = (...args: string[]) =>
+		logs.push(args.map((arg) => arg.toString()).join(" "));
+
+	// This should log because as `DEBUG` is set to "enabled".
+	const enabledLog = debug("enabled");
+	enabledLog("This should be logged");
+
+	// This should not log as `DEBUG` does not contain "enabled:disabled"
+	const disabledLog = enabledLog.extend("disabled");
+	disabledLog("This should not be logged");
+
+	assert.deepEqual(logs, ["enabled This should be logged +0ms"]);
 }
 
 export async function testHttp() {

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
@@ -143,6 +143,7 @@ function handleUnenvAliasedPackages(
 		if (
 			args.kind === "require-call" &&
 			(unresolvedAlias.startsWith("unenv/npm/") ||
+				unresolvedAlias.startsWith("@cloudflare/unenv-preset/npm/") ||
 				unresolvedAlias.startsWith("unenv/mock/"))
 		) {
 			return {


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/10146

The esbuild plugin was fixed to handle npm shim in `@cloudflare/unenv-preset` - previously it would only support importing npm shims from the base `unenv` preset.

Note: the bag was introduced by https://github.com/cloudflare/workers-sdk/pull/10014, do we want to deprecate the affected releases?

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: unenv not updated in v3 (does not contain #10014)

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
