### PR TITLE
V3 Backport [#10160]: fix: switch teardown helper to use vitest.onTestFinished()

### DIFF
--- a/.changeset/fix-teardown-helper.md
+++ b/.changeset/fix-teardown-helper.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Switch teardown helper from afterEach to onTestFinished to improve console log handling
+
+Resolves the TODO comment in teardown.ts by switching from `afterEach()` to `vitest.onTestFinished()` while avoiding the timing issue where console spies get restored before teardown callbacks run.

--- a/packages/wrangler/src/__tests__/helpers/teardown.ts
+++ b/packages/wrangler/src/__tests__/helpers/teardown.ts
@@ -1,31 +1,33 @@
-import { afterEach } from "vitest";
+import { onTestFinished } from "vitest";
 
 export function useTeardown(): typeof teardown {
 	const teardownCallbacks: (() => void | Promise<void>)[] = [];
-	// TODO: Switch to vitest.onTestFinished()
-	// We can't really use `onTestFinished()` because it always runs the callback after all the `afterEach()` blocks have run.
-	// And so, for example, all the spies have been removed by the time it is called.
-	// This leads to unwanted console logs in tests for example.
+	let cleanupRegistered = false;
+
 	function teardown(callback: () => void | Promise<void>) {
 		// `unshift()` so teardown callbacks executed in reverse
 		teardownCallbacks.unshift(callback);
+
+		if (!cleanupRegistered) {
+			cleanupRegistered = true;
+			onTestFinished(async () => {
+				const errors: unknown[] = [];
+				for (const teardownCallback of teardownCallbacks.splice(0)) {
+					try {
+						await teardownCallback();
+					} catch (error) {
+						errors.push(error);
+					}
+				}
+				if (errors.length > 0) {
+					throw new AggregateError(
+						errors,
+						["Unable to teardown:", ...errors.map(String)].join("\n")
+					);
+				}
+			});
+		}
 	}
 
-	afterEach(async () => {
-		const errors: unknown[] = [];
-		for (const callback of teardownCallbacks.splice(0)) {
-			try {
-				await callback();
-			} catch (error) {
-				errors.push(error);
-			}
-		}
-		if (errors.length > 0) {
-			throw new AggregateError(
-				errors,
-				["Unable to teardown:", ...errors.map(String)].join("\n")
-			);
-		}
-	});
 	return teardown;
 }


### PR DESCRIPTION
This is an automatically opened PR to backport patch changes from #10160 to Wrangler v3