### PR TITLE
stop vitest pool workers breaking when containers are present 

### DIFF
--- a/.changeset/evil-loops-eat.md
+++ b/.changeset/evil-loops-eat.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+fix: stop containers breaking vitest-pool-workers
+
+Testing interactions with containers is still currently unsupported.

--- a/fixtures/vitest-pool-workers-examples/container-app/Dockerfile
+++ b/fixtures/vitest-pool-workers-examples/container-app/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:22-alpine
+
+WORKDIR /usr/src/app
+RUN echo '{"name": "simple-node-app", "version": "1.0.0", "dependencies": {"ws": "^8.0.0"}}' > package.json
+RUN npm install
+
+COPY ./container/simple-node-app.js app.js
+EXPOSE 8787
+CMD ["node", "app.js"]

--- a/fixtures/vitest-pool-workers-examples/container-app/README.md
+++ b/fixtures/vitest-pool-workers-examples/container-app/README.md
@@ -1,0 +1,3 @@
+# Apps with no-op containers
+
+Currently, `vitest-pool-workers` does not support testing containers yet. It should still let you test your application as long as you do not test with any code paths that interact with containers.

--- a/fixtures/vitest-pool-workers-examples/container-app/container/simple-node-app.js
+++ b/fixtures/vitest-pool-workers-examples/container-app/container/simple-node-app.js
@@ -1,0 +1,12 @@
+const { createServer } = require("http");
+
+// Create HTTP server
+const server = createServer(function (req, res) {
+	res.writeHead(200, { "Content-Type": "text/plain" });
+	res.write("Hello World! Have an env var! " + process.env.MESSAGE);
+	res.end();
+});
+
+server.listen(8787, function () {
+	console.log("Server listening on port 8080");
+});

--- a/fixtures/vitest-pool-workers-examples/container-app/src/index.ts
+++ b/fixtures/vitest-pool-workers-examples/container-app/src/index.ts
@@ -1,0 +1,57 @@
+import { Container, getContainer, getRandom } from "@cloudflare/containers"; // in a real Worker
+
+export class MyContainer extends Container {
+	defaultPort = 8787; // The default port for the container to listen on
+	sleepAfter = "3m"; // Sleep the container if no requests are made in this timeframe
+
+	envVars = {
+		MESSAGE: "I was passed in via the container class!",
+	};
+
+	override onStart() {
+		console.log("Container successfully started");
+	}
+
+	override onStop() {
+		console.log("Container successfully shut down");
+	}
+
+	override onError(error: unknown) {
+		console.log("Container error:", error);
+	}
+}
+
+export default {
+	async fetch(
+		request: Request,
+		env: { MY_CONTAINER: DurableObjectNamespace<MyContainer> }
+	): Promise<Response> {
+		const pathname = new URL(request.url).pathname;
+		// If you want to route requests to a specific container,
+		// pass a unique container identifier to .get()
+
+		if (pathname.startsWith("/container")) {
+			const containerInstance = getContainer(env.MY_CONTAINER, pathname);
+			return containerInstance.fetch(request);
+		}
+
+		if (pathname.startsWith("/error")) {
+			const containerInstance = getContainer(env.MY_CONTAINER, "error-test");
+			return containerInstance.fetch(request);
+		}
+
+		if (pathname.startsWith("/lb")) {
+			const containerInstance = await getRandom(env.MY_CONTAINER, 3);
+			return containerInstance.fetch(request);
+		}
+
+		if (pathname.startsWith("/singleton")) {
+			// getContainer will return a specific instance if no second argument is provided
+			return getContainer(env.MY_CONTAINER).fetch(request);
+		}
+
+		return new Response(
+			"Call /container to start a container with a 10s timeout.\nCall /error to start a container that errors\nCall /lb to test load balancing"
+		);
+	},
+};

--- a/fixtures/vitest-pool-workers-examples/container-app/src/tsconfig.json
+++ b/fixtures/vitest-pool-workers-examples/container-app/src/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.workerd.json",
+	"include": ["./**/*.ts"]
+}

--- a/fixtures/vitest-pool-workers-examples/container-app/test/container.test.ts
+++ b/fixtures/vitest-pool-workers-examples/container-app/test/container.test.ts
@@ -1,0 +1,16 @@
+import { env, runDurableObjectAlarm, SELF } from "cloudflare:test";
+import { expect, it, vi } from "vitest";
+
+it("dispatches fetch event", { timeout: 10_000 }, async () => {
+	// requests to code paths that do not interact with a container should work fine
+	const res = await SELF.fetch("http://example.com/");
+	expect(await res.text()).toMatchInlineSnapshot(`
+		"Call /container to start a container with a 10s timeout.
+		Call /error to start a container that errors
+		Call /lb to test load balancing"
+	`);
+	// however if you attempt to start a container, you should expect an error
+	await expect(() =>
+		SELF.fetch("http://example.com/container/hello")
+	).rejects.toThrow();
+});

--- a/fixtures/vitest-pool-workers-examples/container-app/test/container.unit.test.ts
+++ b/fixtures/vitest-pool-workers-examples/container-app/test/container.unit.test.ts
@@ -1,0 +1,9 @@
+import { env } from "cloudflare:test";
+import { expect, it } from "vitest";
+
+it("dispatches fetch event", { timeout: 10000 }, async () => {
+	const id = env.MY_CONTAINER.idFromName("helloagain");
+	const stub = env.MY_CONTAINER.get(id);
+	// the DO constructor will now throw
+	await expect(() => stub.fetch("http://example.com/")).rejects.toThrow();
+});

--- a/fixtures/vitest-pool-workers-examples/container-app/test/env.d.ts
+++ b/fixtures/vitest-pool-workers-examples/container-app/test/env.d.ts
@@ -1,0 +1,6 @@
+declare module "cloudflare:test" {
+	// Controls the type of `import("cloudflare:test").env`
+	interface ProvidedEnv extends Env {
+		MY_CONTAINER: DurableObjectNamespace<MyContainer>;
+	}
+}

--- a/fixtures/vitest-pool-workers-examples/container-app/test/tsconfig.json
+++ b/fixtures/vitest-pool-workers-examples/container-app/test/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.workerd-test.json",
+	"include": ["./**/*.ts"]
+}

--- a/fixtures/vitest-pool-workers-examples/container-app/tsconfig.json
+++ b/fixtures/vitest-pool-workers-examples/container-app/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../tsconfig.node.json",
+	"include": ["./*.ts"]
+}

--- a/fixtures/vitest-pool-workers-examples/container-app/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/container-app/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineWorkersProject } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersProject({
+	test: {
+		poolOptions: {
+			workers: {
+				singleWorker: true,
+				wrangler: { configPath: "./wrangler.jsonc" },
+			},
+		},
+	},
+});

--- a/fixtures/vitest-pool-workers-examples/container-app/wrangler.jsonc
+++ b/fixtures/vitest-pool-workers-examples/container-app/wrangler.jsonc
@@ -1,0 +1,27 @@
+{
+	"name": "container-app",
+	"main": "src/index.ts",
+	"compatibility_date": "2025-04-03",
+	"containers": [
+		{
+			"image": "./Dockerfile",
+			"class_name": "MyContainer",
+			"name": "container",
+			"max_instances": 2,
+		},
+	],
+	"durable_objects": {
+		"bindings": [
+			{
+				"class_name": "MyContainer",
+				"name": "MY_CONTAINER",
+			},
+		],
+	},
+	"migrations": [
+		{
+			"tag": "v1",
+			"new_sqlite_classes": ["MyContainer"],
+		},
+	],
+}

--- a/fixtures/vitest-pool-workers-examples/package.json
+++ b/fixtures/vitest-pool-workers-examples/package.json
@@ -11,6 +11,7 @@
 		"test:ci:win32": "vitest run --config vitest.workers.config.ts --exclude test/sqlite-in-do.test.ts"
 	},
 	"devDependencies": {
+		"@cloudflare/containers": "^0.0.25",
 		"@cloudflare/vitest-pool-workers": "workspace:*",
 		"@cloudflare/workers-types": "^4.20250730.0",
 		"@microlabs/otel-cf-workers": "1.0.0-rc.45",

--- a/packages/vitest-pool-workers/src/pool/config.ts
+++ b/packages/vitest-pool-workers/src/pool/config.ts
@@ -277,7 +277,11 @@ async function parseCustomPoolOptions(
 				options.wrangler.environment,
 				{
 					imagesLocalMode: true,
-					overrides: { assets: options.miniflare.assets },
+					overrides: {
+						assets: options.miniflare.assets,
+						// doesn't work with containers yet so let's just disable it
+						enableContainers: false,
+					},
 					remoteBindingsEnabled: options.experimental_remoteBindings,
 					remoteProxyConnectionString:
 						remoteProxySessionData?.session?.remoteProxyConnectionString,

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -243,6 +243,7 @@ async function getMiniflareOptionsFromConfig(args: {
 				config.containers?.map((c) => c.class_name)
 			),
 			containerBuildId: undefined,
+			enableContainers: config.dev.enable_containers,
 		},
 		remoteProxyConnectionString,
 		remoteBindingsEnabled
@@ -348,6 +349,7 @@ export function unstable_getMiniflareWorkerOptions(
 		remoteBindingsEnabled?: boolean;
 		overrides?: {
 			assets?: Partial<AssetsOptions>;
+			enableContainers?: boolean;
 		};
 		containerBuildId?: string;
 	}
@@ -361,6 +363,7 @@ export function unstable_getMiniflareWorkerOptions(
 		remoteBindingsEnabled?: boolean;
 		overrides?: {
 			assets?: Partial<AssetsOptions>;
+			enableContainers?: boolean;
 		};
 		containerBuildId?: string;
 	}
@@ -375,6 +378,7 @@ export function unstable_getMiniflareWorkerOptions(
 		remoteBindingsEnabled?: boolean;
 		overrides?: {
 			assets?: Partial<AssetsOptions>;
+			enableContainers?: boolean;
 		};
 		containerBuildId?: string;
 	}
@@ -396,6 +400,12 @@ export function unstable_getMiniflareWorkerOptions(
 		config.containers?.map((c) => c.class_name)
 	);
 	const bindings = getBindings(config, env, options?.envFiles, true, {}, true);
+
+	const enableContainers =
+		options?.overrides?.enableContainers !== undefined
+			? options?.overrides?.enableContainers
+			: config.dev.enable_containers;
+
 	const { bindingOptions, externalWorkers } = buildMiniflareBindingOptions(
 		{
 			name: config.name,
@@ -410,6 +420,7 @@ export function unstable_getMiniflareWorkerOptions(
 			tails: config.tail_consumers,
 			containerDOClassNames,
 			containerBuildId: options?.containerBuildId,
+			enableContainers,
 		},
 		options?.remoteProxyConnectionString,
 		options?.remoteBindingsEnabled ?? false
@@ -459,11 +470,14 @@ export function unstable_getMiniflareWorkerOptions(
 						className: binding.class_name,
 						scriptName: binding.script_name,
 						useSQLite,
-						container: getImageNameFromDOClassName({
-							doClassName: binding.class_name,
-							containerDOClassNames,
-							containerBuildId: options?.containerBuildId,
-						}),
+						container:
+							enableContainers && config.containers?.length
+								? getImageNameFromDOClassName({
+										doClassName: binding.class_name,
+										containerDOClassNames,
+										containerBuildId: options?.containerBuildId,
+									})
+								: undefined,
 					} satisfies DurableObjectDefinition,
 				];
 			})

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -146,6 +146,7 @@ export async function convertToConfigBundle(
 		),
 		containerBuildId: event.config.dev?.containerBuildId,
 		containerEngine: event.config.dev.containerEngine,
+		enableContainers: event.config.dev.enableContainers ?? true,
 	};
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1056,6 +1056,9 @@ importers:
 
   fixtures/vitest-pool-workers-examples:
     devDependencies:
+      '@cloudflare/containers':
+        specifier: ^0.0.25
+        version: 0.0.25
       '@cloudflare/vitest-pool-workers':
         specifier: workspace:*
         version: link:../../packages/vitest-pool-workers
@@ -4199,6 +4202,9 @@ packages:
       '@cloudflare/style-const': ^5.7.2
       '@cloudflare/style-container': ^7.10.0
       react: ^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0
+
+  '@cloudflare/containers@0.0.25':
+    resolution: {integrity: sha512-41sCUwGPhMMQI/kwksEZXNWe/GZdQoIy8QlgO4NAF68M4y4NN41IXeQ4n2jn4iJ7tHaV4noe7RI75b7T6h2JGg==}
 
   '@cloudflare/elements@3.0.3':
     resolution: {integrity: sha512-s6Sjh+IWJD0xn+4iy6hk/FYwY1gAFLWvpiWUmfDZWrQ09ZOTto8aRwpoEN7jUV6dZCPlCkUqMj4xKwRzDQ72FQ==}
@@ -14275,6 +14281,8 @@ snapshots:
       react: 18.3.1
     transitivePeerDependencies:
       - regenerator-runtime
+
+  '@cloudflare/containers@0.0.25': {}
 
   '@cloudflare/elements@3.0.3(@cloudflare/style-const@5.7.3(react@18.3.1))(@cloudflare/style-container@7.12.2(@cloudflare/style-const@5.7.3(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
This doesn't actually enable testing, but it stops vitest breaking entirely at least. also fixes enable_containers with the vite plugin.

todo: document enable_containers

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: new

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
