### PR TITLE
Add headers from `server.headers` to HTML asset responses

### DIFF
--- a/.changeset/shaky-experts-beg.md
+++ b/.changeset/shaky-experts-beg.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Ensure that headers set via `server.headers` in the Vite config are added to HTML asset responses in development.

--- a/packages/vite-plugin-cloudflare/playground/react-spa/__tests__/server-headers/react-spa.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/react-spa/__tests__/server-headers/react-spa.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "vitest";
+import { getResponse, isBuild } from "../../../__test-utils__";
+
+describe.runIf(!isBuild)(
+	"adds headers included in `server.headers` to asset responses",
+	() => {
+		test("adds headers to HTML responses", async () => {
+			const response = await getResponse();
+			const customHeader = await response.headerValue("custom-header");
+			expect(customHeader).toBe("custom-value");
+		});
+
+		test("adds headers to non-HTML responses", async () => {
+			const response = await getResponse("/vite.svg");
+			const customHeader = await response.headerValue("custom-header");
+			expect(customHeader).toBe("custom-value");
+		});
+	}
+);

--- a/packages/vite-plugin-cloudflare/playground/react-spa/__tests__/server-headers/react-spa.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/react-spa/__tests__/server-headers/react-spa.spec.ts
@@ -2,18 +2,26 @@ import { describe, expect, test } from "vitest";
 import { getResponse, isBuild } from "../../../__test-utils__";
 
 describe.runIf(!isBuild)(
-	"adds headers included in `server.headers` to asset responses",
+	"adds headers included in Vite's `server.headers` to asset responses in dev",
 	() => {
 		test("adds headers to HTML responses", async () => {
 			const response = await getResponse();
-			const customHeader = await response.headerValue("custom-header");
-			expect(customHeader).toBe("custom-value");
+			const headers = await response.allHeaders();
+			expect(headers).toMatchObject({
+				"custom-string": "string-value",
+				"custom-string-array": "one, two, three",
+				"custom-number": "123",
+			});
 		});
 
 		test("adds headers to non-HTML responses", async () => {
 			const response = await getResponse("/vite.svg");
-			const customHeader = await response.headerValue("custom-header");
-			expect(customHeader).toBe("custom-value");
+			const headers = await response.allHeaders();
+			expect(headers).toMatchObject({
+				"custom-string": "string-value",
+				"custom-string-array": "one, two, three",
+				"custom-number": "123",
+			});
 		});
 	}
 );

--- a/packages/vite-plugin-cloudflare/playground/react-spa/package.json
+++ b/packages/vite-plugin-cloudflare/playground/react-spa/package.json
@@ -6,6 +6,7 @@
 		"build": "vite build --app",
 		"check:types": "tsc --build",
 		"dev": "vite dev",
+		"dev:server-headers": "vite dev -c ./vite.config.server-headers.ts",
 		"preview": "vite preview"
 	},
 	"dependencies": {

--- a/packages/vite-plugin-cloudflare/playground/react-spa/vite.config.server-headers.ts
+++ b/packages/vite-plugin-cloudflare/playground/react-spa/vite.config.server-headers.ts
@@ -1,0 +1,12 @@
+import { cloudflare } from "@cloudflare/vite-plugin";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+	server: {
+		headers: {
+			"custom-header": "custom-value",
+		},
+	},
+	plugins: [react(), cloudflare({ inspectorPort: false, persistState: false })],
+});

--- a/packages/vite-plugin-cloudflare/playground/react-spa/vite.config.server-headers.ts
+++ b/packages/vite-plugin-cloudflare/playground/react-spa/vite.config.server-headers.ts
@@ -5,7 +5,9 @@ import { defineConfig } from "vite";
 export default defineConfig({
 	server: {
 		headers: {
-			"custom-header": "custom-value",
+			"custom-string": "string-value",
+			"custom-string-array": ["one", "two", "three"],
+			"custom-number": 123,
 		},
 	},
 	plugins: [react(), cloudflare({ inspectorPort: false, persistState: false })],

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -292,6 +292,7 @@ export async function getDevMiniflareOptions(config: {
 			],
 			bindings: {
 				CONFIG: assetsConfig,
+				__VITE_HEADERS__: JSON.stringify(viteDevServer.config.server.headers),
 			},
 			serviceBindings: {
 				__VITE_HTML_EXISTS__: async (request) => {


### PR DESCRIPTION
Fixes #10104.

Ensure that headers set via `server.headers` in the Vite config are added to HTML asset responses in development.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): TODO
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
