### PR TITLE
make sure we run wrangler e2e tests in nested folders

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1109,7 +1109,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ~3.0.7
-        version: 3.0.9(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/ui@3.2.3)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 3.0.9(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/ui@3.2.3(vitest@3.2.3))(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -3688,6 +3688,9 @@ importers:
       find-up:
         specifier: ^6.3.0
         version: 6.3.0
+      glob:
+        specifier: ^11.0.3
+        version: 11.0.3
       ts-dedent:
         specifier: ^2.2.0
         version: 2.2.0
@@ -5653,6 +5656,14 @@ packages:
   '@inquirer/type@2.0.0':
     resolution: {integrity: sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==}
     engines: {node: '>=18'}
+
+  '@isaacs/balanced-match@4.0.1':
+    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/brace-expansion@5.0.0':
+    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+    engines: {node: 20 || >=22}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -9207,6 +9218,10 @@ packages:
     resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
     engines: {node: '>=14'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
 
@@ -9358,6 +9373,11 @@ packages:
 
   glob@11.0.1:
     resolution: {integrity: sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+
+  glob@11.0.3:
+    resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
     hasBin: true
 
@@ -9871,6 +9891,10 @@ packages:
 
   jackspeak@4.1.0:
     resolution: {integrity: sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==}
+    engines: {node: 20 || >=22}
+
+  jackspeak@4.1.1:
+    resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
     engines: {node: 20 || >=22}
 
   javascript-time-ago@2.5.7:
@@ -10397,6 +10421,10 @@ packages:
 
   minimatch@10.0.1:
     resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
+    engines: {node: 20 || >=22}
+
+  minimatch@10.0.3:
+    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
     engines: {node: 20 || >=22}
 
   minimatch@3.0.8:
@@ -15240,6 +15268,12 @@ snapshots:
     dependencies:
       mute-stream: 1.0.0
 
+  '@isaacs/balanced-match@4.0.1': {}
+
+  '@isaacs/brace-expansion@5.0.0':
+    dependencies:
+      '@isaacs/balanced-match': 4.0.1
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -19629,6 +19663,11 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   forever-agent@0.6.1: {}
 
   form-data@4.0.0:
@@ -19803,6 +19842,15 @@ snapshots:
       foreground-child: 3.1.1
       jackspeak: 4.1.0
       minimatch: 10.0.1
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.0
+      path-scurry: 2.0.0
+
+  glob@11.0.3:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.1.1
+      minimatch: 10.0.3
       minipass: 7.1.2
       package-json-from-dist: 1.0.0
       path-scurry: 2.0.0
@@ -20276,6 +20324,10 @@ snapshots:
       '@pkgjs/parseargs': 0.11.0
 
   jackspeak@4.1.0:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+
+  jackspeak@4.1.1:
     dependencies:
       '@isaacs/cliui': 8.0.2
 
@@ -20765,6 +20817,10 @@ snapshots:
   minimatch@10.0.1:
     dependencies:
       brace-expansion: 2.0.1
+
+  minimatch@10.0.3:
+    dependencies:
+      '@isaacs/brace-expansion': 5.0.0
 
   minimatch@3.0.8:
     dependencies:
@@ -23449,7 +23505,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@3.0.9(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/ui@3.2.3)(jiti@2.4.2)(lightningcss@1.29.2):
+  vitest@3.0.9(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/ui@3.2.3(vitest@3.2.3))(jiti@2.4.2)(lightningcss@1.29.2):
     dependencies:
       '@vitest/expect': 3.0.9
       '@vitest/mocker': 3.0.9(vite@5.4.14(@types/node@20.19.9)(lightningcss@1.29.2))

--- a/tools/e2e/runIndividualE2EFiles.ts
+++ b/tools/e2e/runIndividualE2EFiles.ts
@@ -1,5 +1,8 @@
+import assert from "assert";
 import { execSync } from "child_process";
-import { readdirSync } from "fs";
+import { statSync } from "fs";
+import path from "path";
+import { globIterateSync } from "glob";
 import type { ExecSyncOptionsWithBufferEncoding } from "child_process";
 
 // Turbo only supports caching on the individual task level, but for Wrangler's
@@ -27,19 +30,20 @@ const command =
 	extraParams.join(" ");
 
 const failed: string[] = [];
-for (const file of readdirSync("packages/wrangler/e2e")) {
-	if (!file.endsWith(".test.ts")) {
-		// Ignore other files in the e2e directory (the README, for instance)
-		continue;
-	}
 
-	const WRANGLER_E2E_TEST_FILE = `e2e/${file}`;
+const wranglerPath = path.join(__dirname, "../../packages/wrangler");
+assert(statSync(wranglerPath).isDirectory());
+
+for (const testFile of globIterateSync("e2e/**/*.test.ts", {
+	cwd: wranglerPath,
+})) {
 	const options: ExecSyncOptionsWithBufferEncoding = {
 		stdio: "inherit",
-		env: { ...process.env, WRANGLER_E2E_TEST_FILE },
+		env: { ...process.env, WRANGLER_E2E_TEST_FILE: testFile },
 	};
 
-	console.log("::group::Testing: " + WRANGLER_E2E_TEST_FILE);
+	console.log(`::group::Testing: ${testFile}`);
+
 	try {
 		execSync(command, options);
 	} catch {
@@ -48,7 +52,7 @@ for (const file of readdirSync("packages/wrangler/e2e")) {
 			execSync(command, options);
 		} catch {
 			console.error("Still failed, moving on");
-			failed.push(file);
+			failed.push(testFile);
 		}
 	}
 	console.log("::endgroup::");

--- a/tools/e2e/runIndividualE2EFiles.ts
+++ b/tools/e2e/runIndividualE2EFiles.ts
@@ -36,6 +36,8 @@ assert(statSync(wranglerPath).isDirectory());
 
 for (const testFile of globIterateSync("e2e/**/*.test.ts", {
 	cwd: wranglerPath,
+	// Return `/` delimited paths, even on Windows.
+	posix: true,
 })) {
 	const options: ExecSyncOptionsWithBufferEncoding = {
 		stdio: "inherit",

--- a/tools/package.json
+++ b/tools/package.json
@@ -14,6 +14,7 @@
 		"@typescript-eslint/eslint-plugin": "catalog:default",
 		"@typescript-eslint/parser": "catalog:default",
 		"find-up": "^6.3.0",
+		"glob": "^11.0.3",
 		"ts-dedent": "^2.2.0",
 		"undici": "catalog:default",
 		"wrangler": "workspace:*"


### PR DESCRIPTION
`tools/e2e/runIndividualE2EFiles.ts` was missing test files in nested directories.

That before the PR the top level `test:e2e:wrangler` was not testing the same as `test:e2e` from the wrangler package (the former would miss nested folders).

I also updated the file so that it can be executed from anywhere by using `__dirname` rather than relying on the cwd.

Do we want to update wrangler's `test:e2e` to also use `runIndividualE2EFiles`? (that's how I originally miss that the behavior was not correct on CI)

Nested tests are now executed:

<img width="1054" height="194" alt="image" src="https://github.com/user-attachments/assets/61b22a98-e1b6-4d13-b123-8cd84f4f9e66" />


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: will make sure the test logs are as expected
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test runner changer
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a wrangler changer

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
