### PR TITLE
[wrangler] fix: prevent multiple workflows definition with same name

### DIFF
--- a/.changeset/moody-rings-ask.md
+++ b/.changeset/moody-rings-ask.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Prevent defining multiple workflows with the same "name" property in the same wrangler file

--- a/packages/wrangler/src/__tests__/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/workflows.test.ts
@@ -780,5 +780,30 @@ describe("wrangler workflows", () => {
 			await expect(runWrangler("deploy --dry-run")).rejects.toThrow();
 			expect(std.err).toContain('"workflows" bindings should be objects');
 		});
+
+		it("should reject workflows binding with same name", async () => {
+			writeWorkerSource({ format: "ts" });
+			writeWranglerConfig({
+				main: "index.ts",
+				workflows: [
+					{
+						binding: "MY_WORKFLOW",
+						name: "valid-workflow-name",
+						class_name: "MyWorkflow",
+						script_name: "external-script",
+					},
+					{
+						binding: "MY_WORKFLOW_2",
+						name: "valid-workflow-name",
+						class_name: "MyWorkflow2",
+						script_name: "external-script-2",
+					},
+				],
+			});
+			await expect(runWrangler("deploy --dry-run")).rejects.toThrow();
+			expect(std.err).toContain(
+				'"workflows" bindings must have unique "name" values'
+			);
+		});
 	});
 });

--- a/packages/wrangler/src/__tests__/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/workflows.test.ts
@@ -788,22 +788,46 @@ describe("wrangler workflows", () => {
 				workflows: [
 					{
 						binding: "MY_WORKFLOW",
-						name: "valid-workflow-name",
+						name: "duplicate-workflow-name",
 						class_name: "MyWorkflow",
 						script_name: "external-script",
 					},
 					{
 						binding: "MY_WORKFLOW_2",
-						name: "valid-workflow-name",
+						name: "duplicate-workflow-name",
 						class_name: "MyWorkflow2",
 						script_name: "external-script-2",
+					},
+					{
+						binding: "MY_WORKFLOW_3",
+						name: "valid-workflow-name",
+						class_name: "MyWorkflow3",
+						script_name: "external-script-3",
+					},
+					{
+						binding: "MY_WORKFLOW_4",
+						name: "duplicate-workflow-name-2",
+						class_name: "MyWorkflow4",
+						script_name: "external-script-4",
+					},
+					{
+						binding: "MY_WORKFLOW_5",
+						name: "duplicate-workflow-name-2",
+						class_name: "MyWorkflow5",
+						script_name: "external-script-5",
 					},
 				],
 			});
 			await expect(runWrangler("deploy --dry-run")).rejects.toThrow();
-			expect(std.err).toContain(
-				'"workflows" bindings must have unique "name" values'
-			);
+
+			expect(std.err).toMatchInlineSnapshot(`
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mProcessing wrangler.toml configuration:[0m
+
+				    - \\"workflows\\" bindings must have unique \\"name\\" values; duplicate(s) found:
+				  \\"duplicate-workflow-name\\", \\"duplicate-workflow-name-2\\"
+
+				"
+			`);
 		});
 	});
 });

--- a/packages/wrangler/src/config/validation-helpers.ts
+++ b/packages/wrangler/src/config/validation-helpers.ts
@@ -682,10 +682,18 @@ export const validateUniqueNameProperty: ValidatorFn = (
 	value
 ) => {
 	if (Array.isArray(value)) {
-		const names = value.map((entry) => entry.name);
-		const duplicates = names.filter((name, i) => names.indexOf(name) !== i);
+		const nameCount = new Map<string, number>();
+
+		Object.entries(value).forEach(([_, entry]) => {
+			nameCount.set(entry.name, (nameCount.get(entry.name) ?? 0) + 1);
+		});
+
+		const duplicates = Array.from(nameCount.entries())
+			.filter(([_, count]) => count > 1)
+			.map(([name]) => name);
+
 		if (duplicates.length > 0) {
-			const list = Array.from(new Set(duplicates)).join('", "');
+			const list = duplicates.join('", "');
 			diagnostics.errors.push(
 				`"${field}" bindings must have unique "name" values; duplicate(s) found: "${list}"`
 			);

--- a/packages/wrangler/src/config/validation-helpers.ts
+++ b/packages/wrangler/src/config/validation-helpers.ts
@@ -674,6 +674,29 @@ const isRecord = (
 	typeof value === "object" && value !== null && !Array.isArray(value);
 
 /**
+ * Ensure that all bindings in an array have unique `name` properties.
+ */
+export const validateUniqueNameProperty: ValidatorFn = (
+	diagnostics,
+	field,
+	value
+) => {
+	if (Array.isArray(value)) {
+		const names = value.map((entry) => entry.name);
+		const duplicates = names.filter((name, i) => names.indexOf(name) !== i);
+		if (duplicates.length > 0) {
+			const list = Array.from(new Set(duplicates)).join('", "');
+			diagnostics.errors.push(
+				`"${field}" bindings must have unique "name" values; duplicate(s) found: "${list}"`
+			);
+			return false;
+		}
+	}
+
+	return true;
+};
+
+/**
  * JavaScript `typeof` operator return values.
  */
 export type TypeofType =

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -32,6 +32,7 @@ import {
 	validateOptionalTypedArray,
 	validateRequiredProperty,
 	validateTypedArray,
+	validateUniqueNameProperty,
 } from "./validation-helpers";
 import { configFileName, formatConfigSnippet } from ".";
 import type { CfWorkerInit } from "../deployment-bundle/worker";
@@ -1207,7 +1208,10 @@ function normalizeAndValidateEnvironment(
 			rawEnv,
 			envName,
 			"workflows",
-			validateBindingArray(envName, validateWorkflowBinding),
+			all(
+				validateBindingArray(envName, validateWorkflowBinding),
+				validateUniqueNameProperty
+			),
 			[]
 		),
 		migrations: inheritable(


### PR DESCRIPTION
Fixes WOR-795

Users should not be allowed to define multiple workflows with the same "name" property within a single Wrangler jsonc/toml file. If duplicate names are allowed, only the last-defined workflow would be active, as it would overwrite any earlier workflows with the same name.

To fix this, the code now includes a check for duplicate "name" properties within the workflows array.

---

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because: 
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: only makes a specific scenario not work as intended
- Wrangler V3 Backport
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/10180
  - [ ] Not necessary because: 
