### PR TITLE
WC-3776 Require confirm for delete when Pages project binds to worker

### DIFF
--- a/.changeset/hip-sites-camp.md
+++ b/.changeset/hip-sites-camp.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Deleting when Pages project binds to worker requires confirmation


### PR DESCRIPTION
EWC changes add the new "pages_function" boolean field to the service reference API when a pages function has a service binding to this worker, and requires "force=true" when deleting

WC-3776

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/10187
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
