### PR TITLE
[wip] add worker to notify internal teams of relevant github issues

### DIFF
--- a/packages/devprod-status-bot/worker-configuration.d.ts
+++ b/packages/devprod-status-bot/worker-configuration.d.ts
@@ -10,6 +10,7 @@ interface Env {
 	TEST_WEBHOOK: string;
 	AI: Ai;
 	PRESHARED_SECRET: string;
+	LABEL_TO_CHAT_CHANNEL_MAPPING: KVNamespace;
 }
 declare module "*.png" {
 	const value: ArrayBuffer;

--- a/packages/devprod-status-bot/wrangler.jsonc
+++ b/packages/devprod-status-bot/wrangler.jsonc
@@ -16,6 +16,15 @@
 	"ai": {
 		"binding": "AI",
 	},
+	"kv_namespaces": [
+		{
+			// Title: devprod-status-bot/label-to-chat-channel-mapping
+			// This KV namespace is used to map labels to chat channels integration webhook URLs (see Apps and Integrations settings).
+			// Update the mappings via the Cloudflare dashboard.
+			"binding": "LABEL_TO_CHAT_CHANNEL_MAPPING",
+			"id": "feda603505f44753bd10610e8b52bb4b",
+		},
+	],
 	"observability": {
 		"enabled": true,
 	},


### PR DESCRIPTION
this is all generated by claude, and needs a proper, thorough, human review. just pushing this WIP up in case i do not get a chance to finish up this PR and it falls to whoever is on call next.

This adds to `devprod-status-bot` the ability to send messages to certain internal channels when github issues with a certain label are created or have new activity. 

i also added a new github webhook for issue creation and updates.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
