### PR TITLE
[Preset] Add support for http and https server APIs

### DIFF
--- a/.changeset/strong-dryers-stand.md
+++ b/.changeset/strong-dryers-stand.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/unenv-preset": minor
+---
+
+Add support for http and https server APIs

--- a/packages/unenv-preset/package.json
+++ b/packages/unenv-preset/package.json
@@ -51,7 +51,7 @@
 	},
 	"peerDependencies": {
 		"unenv": "2.0.0-rc.19",
-		"workerd": "^1.20250722.0"
+		"workerd": "^1.20250730.0"
 	},
 	"peerDependenciesMeta": {
 		"workerd": {

--- a/packages/unenv-preset/src/preset.ts
+++ b/packages/unenv-preset/src/preset.ts
@@ -162,8 +162,21 @@ function getHttpOverrides({
 		return { nativeModules: [], hybridModules: [] };
 	}
 
+	const httpServerEnabledByFlags = compatibilityFlags.includes(
+		"enable_nodejs_http_server_modules"
+	);
+
+	const httpServerDisabledByFlags = compatibilityFlags.includes(
+		"disable_nodejs_http_server_modules"
+	);
+
+	// Note that `httpServerEnabled` requires `httpEnabled`
+	// TODO: add `httpServerEnabledByDate` when a default date is set
+	const httpServerEnabled =
+		httpServerEnabledByFlags && !httpServerDisabledByFlags;
+
 	// Override unenv base aliases with native and hybrid modules
-	// `node:https` is fully implemented by workerd
+	// `node:https` is fully implemented by workerd if both flags are enabled
 	return {
 		nativeModules: [
 			"_http_agent",
@@ -171,7 +184,8 @@ function getHttpOverrides({
 			"_http_common",
 			"_http_incoming",
 			"_http_outgoing",
+			...(httpServerEnabled ? ["_http_server", "https"] : []),
 		],
-		hybridModules: ["http", "https"],
+		hybridModules: httpServerEnabled ? ["http"] : ["http", "https"],
 	};
 }

--- a/packages/unenv-preset/src/runtime/node/http.ts
+++ b/packages/unenv-preset/src/runtime/node/http.ts
@@ -1,14 +1,12 @@
-// TODO: use the workerd server implementation when available
-// See https://github.com/cloudflare/workerd/pull/4591
 import {
 	_connectionListener,
 	CloseEvent,
-	createServer,
 	maxHeaderSize,
 	MessageEvent,
-	Server,
-	ServerResponse,
 	setMaxIdleHTTPParsers,
+	createServer as unenvCreateServer,
+	Server as unenvServer,
+	ServerResponse as unenvServerResponse,
 	WebSocket,
 } from "unenv/node/http";
 import type nodeHttp from "node:http";
@@ -16,11 +14,8 @@ import type nodeHttp from "node:http";
 export {
 	_connectionListener,
 	CloseEvent,
-	createServer,
 	maxHeaderSize,
 	MessageEvent,
-	Server,
-	ServerResponse,
 	setMaxIdleHTTPParsers,
 	WebSocket,
 } from "unenv/node/http";
@@ -40,6 +35,20 @@ export const {
 	request,
 	get,
 } = workerdHttp;
+
+// Use the workerd implementation of server APIs when the
+// `enable_nodejs_http_server_modules` flag is on.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isWorkerdServerEnabled = (globalThis as any).Cloudflare.compatibilityFlags
+	.enable_nodejs_http_server_modules;
+
+export const createServer = isWorkerdServerEnabled
+	? workerdHttp.createServer
+	: unenvCreateServer;
+export const Server = isWorkerdServerEnabled ? workerdHttp.Server : unenvServer;
+export const ServerResponse = isWorkerdServerEnabled
+	? workerdHttp.ServerResponse
+	: unenvServerResponse;
 
 export default {
 	_connectionListener,

--- a/packages/unenv-preset/src/runtime/node/https.ts
+++ b/packages/unenv-preset/src/runtime/node/https.ts
@@ -1,8 +1,9 @@
+// This hybrid polyfill is used only when the native implementation is not available
+// See `src/preset.ts` for details
+
 import { createServer, Server } from "unenv/node/https";
 import type nodeHttps from "node:https";
 
-// TODO: use the workerd implementation when available
-// See https://github.com/cloudflare/workerd/pull/4591
 export { Server, createServer } from "unenv/node/https";
 
 const workerdHttps = process.getBuiltinModule("node:https");

--- a/packages/wrangler/e2e/unenv-preset/preset.test.ts
+++ b/packages/wrangler/e2e/unenv-preset/preset.test.ts
@@ -28,7 +28,7 @@ const testConfigs: TestConfig[] = [
 			enable_nodejs_http_modules: false,
 		},
 	},
-	// http modules
+	// http client only modules (no server)
 	[
 		{
 			name: "http disabled by date",
@@ -53,6 +53,45 @@ const testConfigs: TestConfig[] = [
 			compatibilityFlags: ["enable_nodejs_http_modules"],
 			expectRuntimeFlags: {
 				enable_nodejs_http_modules: true,
+			},
+		},
+	],
+	// http client and server modules
+	[
+		{
+			name: "http server disabled by date",
+			compatibilityDate: "2025-07-26",
+			compatibilityFlags: ["experimental"],
+			expectRuntimeFlags: {
+				enable_nodejs_http_modules: false,
+			},
+		},
+		// TODO: add a config when http server is enabled by default (date no set yet)
+		{
+			name: "http server enabled by flag",
+			compatibilityDate: "2025-07-26",
+			compatibilityFlags: [
+				"enable_nodejs_http_modules",
+				"enable_nodejs_http_server_modules",
+				"experimental",
+			],
+			expectRuntimeFlags: {
+				enable_nodejs_http_modules: true,
+				enable_nodejs_http_server_modules: true,
+			},
+		},
+		// TODO: change the date pass the default enabled date (date not set yet)
+		{
+			name: "http server disabled by flag",
+			compatibilityDate: "2025-07-26",
+			compatibilityFlags: [
+				"enable_nodejs_http_modules",
+				"disable_nodejs_http_server_modules",
+				"experimental",
+			],
+			expectRuntimeFlags: {
+				enable_nodejs_http_modules: true,
+				enable_nodejs_http_server_modules: false,
 			},
 		},
 	],

--- a/packages/wrangler/e2e/unenv-preset/worker/index.ts
+++ b/packages/wrangler/e2e/unenv-preset/worker/index.ts
@@ -277,4 +277,52 @@ export const WorkerdTests: Record<string, () => void> = {
 		assert.strictEqual(typeof https.globalAgent, "object");
 		assert.strictEqual(typeof https.request, "function");
 	},
+
+	async testHttpServer() {
+		const http = await import("http");
+
+		const useNativeHttp = getRuntimeFlagValue(
+			"enable_nodejs_http_server_modules"
+		);
+
+		if (useNativeHttp) {
+			// Test the workerd implementation only
+			let server: unknown;
+			assert.doesNotThrow(
+				() =>
+					(server = http.createServer((_req, res) => {
+						res.end();
+					}))
+			);
+			assert.deepEqual(server instanceof http.Server, true);
+		} else {
+			// Test the unenv polyfill only
+			assert.throws(() => http.createServer(), /not implemented/);
+			assert.throws(() => new http.Server(), /not implemented/);
+		}
+	},
+
+	async testHttpsServer() {
+		const https = await import("https");
+
+		const useNativeHttp = getRuntimeFlagValue(
+			"enable_nodejs_http_server_modules"
+		);
+
+		if (useNativeHttp) {
+			// Test the workerd implementation only
+			let server: unknown;
+			assert.doesNotThrow(
+				() =>
+					(server = https.createServer((_req, res) => {
+						res.end();
+					}))
+			);
+			assert.deepEqual(server instanceof https.Server, true);
+		} else {
+			// Test the unenv polyfill only
+			assert.throws(() => https.createServer(), /not implemented/);
+			assert.throws(() => new https.Server(), /not implemented/);
+		}
+	},
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2049,7 +2049,7 @@ importers:
         specifier: 2.0.0-rc.19
         version: 2.0.0-rc.19
       workerd:
-        specifier: ^1.20250722.0
+        specifier: ^1.20250730.0
         version: 1.20250801.0
     devDependencies:
       '@types/debug':


### PR DESCRIPTION
Use the native http/https server APIs when available.

They are behind the `enable_nodejs_http_server_modules` and `experimental` flags - they also require the `enable_nodejs_http_modules` flag.

Bump the compat of the preset to 1.20250730.0.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: will be documented by the runtime team
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: unenv not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
