### PR TITLE
add support for native `node:os`

### DIFF
--- a/.changeset/cold-hands-reply.md
+++ b/.changeset/cold-hands-reply.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/unenv-preset": minor
+---
+
+add support for native `node:os`

--- a/packages/unenv-preset/package.json
+++ b/packages/unenv-preset/package.json
@@ -51,7 +51,7 @@
 	},
 	"peerDependencies": {
 		"unenv": "2.0.0-rc.19",
-		"workerd": "^1.20250730.0"
+		"workerd": "^1.20250802.0"
 	},
 	"peerDependenciesMeta": {
 		"workerd": {

--- a/packages/unenv-preset/src/preset.ts
+++ b/packages/unenv-preset/src/preset.ts
@@ -71,16 +71,23 @@ export function getCloudflarePreset({
 		compatibilityFlags,
 	});
 
+	const osOverrides = getOsOverrides({
+		compatibilityDate,
+		compatibilityFlags,
+	});
+
 	// "dynamic" as they depend on the compatibility date and flags
 	const dynamicNativeModules = [
 		...nativeModules,
 		...httpOverrides.nativeModules,
+		...osOverrides.nativeModules,
 	];
 
 	// "dynamic" as they depend on the compatibility date and flags
 	const dynamicHybridModules = [
 		...hybridModules,
 		...httpOverrides.hybridModules,
+		...osOverrides.hybridModules,
 	];
 
 	return {
@@ -138,6 +145,7 @@ export function getCloudflarePreset({
  *
  * The native http server APIS implementation:
  * - can be enabled with the "enable_nodejs_http_server_modules" flag
+ * - can be enabled with the "disable_nodejs_http_server_modules" flag
  */
 function getHttpOverrides({
 	compatibilityDate,
@@ -149,31 +157,31 @@ function getHttpOverrides({
 	const httpDisabledByFlag = compatibilityFlags.includes(
 		"disable_nodejs_http_modules"
 	);
-	const httpEnabledByFlags = compatibilityFlags.includes(
+	const httpEnabledByFlag = compatibilityFlags.includes(
 		"enable_nodejs_http_modules"
 	);
 	const httpEnabledByDate = compatibilityDate >= "2025-08-15";
 
 	const httpEnabled =
-		(httpEnabledByFlags || httpEnabledByDate) && !httpDisabledByFlag;
+		(httpEnabledByFlag || httpEnabledByDate) && !httpDisabledByFlag;
 
 	if (!httpEnabled) {
 		// use the unenv polyfill
 		return { nativeModules: [], hybridModules: [] };
 	}
 
-	const httpServerEnabledByFlags = compatibilityFlags.includes(
-		"enable_nodejs_http_server_modules"
-	);
+	const httpServerEnabledByFlag =
+		compatibilityFlags.includes("enable_nodejs_http_server_modules") &&
+		compatibilityFlags.includes("experimental");
 
-	const httpServerDisabledByFlags = compatibilityFlags.includes(
-		"disable_nodejs_http_server_modules"
-	);
+	const httpServerDisabledByFlag =
+		compatibilityFlags.includes("disable_nodejs_http_server_modules") &&
+		compatibilityFlags.includes("experimental");
 
 	// Note that `httpServerEnabled` requires `httpEnabled`
 	// TODO: add `httpServerEnabledByDate` when a default date is set
 	const httpServerEnabled =
-		httpServerEnabledByFlags && !httpServerDisabledByFlags;
+		httpServerEnabledByFlag && !httpServerDisabledByFlag;
 
 	// Override unenv base aliases with native and hybrid modules
 	// `node:https` is fully implemented by workerd if both flags are enabled
@@ -188,4 +196,43 @@ function getHttpOverrides({
 		],
 		hybridModules: httpServerEnabled ? ["http"] : ["http", "https"],
 	};
+}
+
+/**
+ * Returns the overrides for `node:os` (unenv or workerd)
+ *
+ * The native http implementation:
+ * - can be enabled with the "enable_nodejs_os_module" flag
+ * - can be disabled with the "disable_nodejs_os_module" flag
+ */
+function getOsOverrides({
+	// eslint-disable-next-line unused-imports/no-unused-vars
+	compatibilityDate,
+	compatibilityFlags,
+}: {
+	compatibilityDate: string;
+	compatibilityFlags: string[];
+}): { nativeModules: string[]; hybridModules: string[] } {
+	const disabledByFlag =
+		compatibilityFlags.includes("disable_nodejs_os_module") &&
+		compatibilityFlags.includes("experimental");
+
+	const enabledByFlag =
+		compatibilityFlags.includes("enable_nodejs_os_module") &&
+		compatibilityFlags.includes("experimental");
+
+	// TODO: add `enabledByDate` when a default date is set
+	const enabled = enabledByFlag && !disabledByFlag;
+
+	// The native os module implements all the APIs.
+	// It can then be used as a native module.
+	return enabled
+		? {
+				nativeModules: ["os"],
+				hybridModules: [],
+			}
+		: {
+				nativeModules: [],
+				hybridModules: [],
+			};
 }

--- a/packages/wrangler/e2e/unenv-preset/preset.test.ts
+++ b/packages/wrangler/e2e/unenv-preset/preset.test.ts
@@ -15,8 +15,9 @@ type TestConfig = {
 	compatibilityFlags?: string[];
 	// Assert runtime compatibility flag values
 	expectRuntimeFlags?: {
-		// Whether the http modules are enabled
-		enable_nodejs_http_modules: boolean;
+		enable_nodejs_http_modules?: boolean;
+		enable_nodejs_http_server_modules?: boolean;
+		enable_nodejs_os_module?: boolean;
 	};
 };
 
@@ -92,6 +93,35 @@ const testConfigs: TestConfig[] = [
 			expectRuntimeFlags: {
 				enable_nodejs_http_modules: true,
 				enable_nodejs_http_server_modules: false,
+			},
+		},
+	],
+	// node:os
+	[
+		{
+			name: "os disabled by date",
+			compatibilityDate: "2025-07-26",
+			compatibilityFlags: ["experimental"],
+			expectRuntimeFlags: {
+				enable_nodejs_os_module: false,
+			},
+		},
+		// TODO: add a config when os is enabled by default (date no set yet)
+		{
+			name: "os enabled by flag",
+			compatibilityDate: "2025-07-26",
+			compatibilityFlags: ["enable_nodejs_os_module", "experimental"],
+			expectRuntimeFlags: {
+				enable_nodejs_os_module: true,
+			},
+		},
+		// TODO: change the date pass the default enabled date (date not set yet)
+		{
+			name: "os disabled by flag",
+			compatibilityDate: "2025-07-26",
+			compatibilityFlags: ["disable_nodejs_os_module", "experimental"],
+			expectRuntimeFlags: {
+				enable_nodejs_os_module: false,
 			},
 		},
 	],

--- a/packages/wrangler/e2e/unenv-preset/worker/index.ts
+++ b/packages/wrangler/e2e/unenv-preset/worker/index.ts
@@ -243,7 +243,7 @@ export const WorkerdTests: Record<string, () => void> = {
 	},
 
 	async testHttp() {
-		const http = await import("http");
+		const http = await import("node:http");
 
 		const useNativeHttp = getRuntimeFlagValue("enable_nodejs_http_modules");
 
@@ -270,7 +270,7 @@ export const WorkerdTests: Record<string, () => void> = {
 	},
 
 	async testHttps() {
-		const https = await import("https");
+		const https = await import("node:https");
 
 		assert.strictEqual(typeof https.Agent, "function");
 		assert.strictEqual(typeof https.get, "function");
@@ -279,7 +279,7 @@ export const WorkerdTests: Record<string, () => void> = {
 	},
 
 	async testHttpServer() {
-		const http = await import("http");
+		const http = await import("node:http");
 
 		const useNativeHttp = getRuntimeFlagValue(
 			"enable_nodejs_http_server_modules"
@@ -303,7 +303,7 @@ export const WorkerdTests: Record<string, () => void> = {
 	},
 
 	async testHttpsServer() {
-		const https = await import("https");
+		const https = await import("node:https");
 
 		const useNativeHttp = getRuntimeFlagValue(
 			"enable_nodejs_http_server_modules"
@@ -324,5 +324,13 @@ export const WorkerdTests: Record<string, () => void> = {
 			assert.throws(() => https.createServer(), /not implemented/);
 			assert.throws(() => new https.Server(), /not implemented/);
 		}
+	},
+
+	async testOs() {
+		const os = await import("node:os");
+
+		assert.strictEqual(typeof os.arch(), "string");
+		assert.strictEqual(typeof os.freemem(), "number");
+		assert.strictEqual(typeof os.availableParallelism(), "number");
 	},
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2049,8 +2049,8 @@ importers:
         specifier: 2.0.0-rc.19
         version: 2.0.0-rc.19
       workerd:
-        specifier: ^1.20250730.0
-        version: 1.20250801.0
+        specifier: ^1.20250802.0
+        version: 1.20250803.0
     devDependencies:
       '@types/debug':
         specifier: 4.1.12
@@ -4329,12 +4329,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-64@1.20250801.0':
-    resolution: {integrity: sha512-2wv3J3UUOmFvGZ/EsQRyCJwe6SDUVzaleTIySjCXdZN+4Zzm8gquLUHUBvbPXQGDX4e1wAv+FOYEUctl2OCwKg==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [darwin]
-
   '@cloudflare/workerd-darwin-64@1.20250803.0':
     resolution: {integrity: sha512-6QciMnJp1p3F1qUiN0LaLfmw7SuZA/gfUBOe8Ft81pw16JYZ3CyiqIKPJvc1SV8jgDx8r+gz/PRi1NwOMt329A==}
     engines: {node: '>=16'}
@@ -4349,12 +4343,6 @@ packages:
 
   '@cloudflare/workerd-darwin-arm64@1.20250417.0':
     resolution: {integrity: sha512-dSlk18F4i3T1OTzFBxx3pKpXRMP6w2xZ26+oIV32BFWrCi/HxGzUd6gVA0q37oLGqITRt8xU693J4Gl1CwC/Ag==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@cloudflare/workerd-darwin-arm64@1.20250801.0':
-    resolution: {integrity: sha512-93Sy13+xl30M0RztFNOL9ViBQgEMqgq9ChlvCdN6n+xXqOnztOAcdNxQxx1XDt5PjXaTZ9nLfjmyyTdVWUuhsw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -4377,12 +4365,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-64@1.20250801.0':
-    resolution: {integrity: sha512-S50L0W/hrbMlsn96XI0tCxSPCEMAZMtfIqYg/FReDbqKO5L9BZZjsR5P6a2GtMg44gvmycpW/0M9Drvsbtg61g==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [linux]
-
   '@cloudflare/workerd-linux-64@1.20250803.0':
     resolution: {integrity: sha512-mYdz4vNWX3+PoqRjssepVQqgh42IBiSrl+wb7vbh7VVWUVzBnQKtW3G+UFiBF62hohCLexGIEi7L0cFfRlcKSQ==}
     engines: {node: '>=16'}
@@ -4401,12 +4383,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20250801.0':
-    resolution: {integrity: sha512-VciKoz80ETfJx0j4E313K8VA7TF69WT3jG1fl2n0RDAYOtl0e/+C0lvVBzGub/TrBVjZ/5S1Q62w98/+Mzd2Cw==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [linux]
-
   '@cloudflare/workerd-linux-arm64@1.20250803.0':
     resolution: {integrity: sha512-RmrtUYLRUg6djKU7Z6yebS6YGJVnaDVY6bbXca+2s26vw4ibJDOTPLuBHFQF62Grw3fAfsNbjQh5i14vG2mqUg==}
     engines: {node: '>=16'}
@@ -4421,12 +4397,6 @@ packages:
 
   '@cloudflare/workerd-windows-64@1.20250417.0':
     resolution: {integrity: sha512-PDwATFioff+geVHfgTzSWsxgwjgotrdXStb0EL0lMyMT5zNmHArAnOx83CbDtud63Uv9rVX1BAfPP4tyD1O+5A==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [win32]
-
-  '@cloudflare/workerd-windows-64@1.20250801.0':
-    resolution: {integrity: sha512-2Drz6PY7SqJH+4Qj5Ba2RIXpnMu+iYdS26+MbtHTvdPHfawpzQRT2FbTCinzkVqUz8RKEu2W0+hbPJ7nukV7Gw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -13052,11 +13022,6 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  workerd@1.20250801.0:
-    resolution: {integrity: sha512-TokpRQB9i8ZswnaHN+IUwWqjRtO1Wci/KQi2QpquBUehFRm5U5EA8+Dda4aFSxAxsnlk5SoxmQwf4XMsVtZ15A==}
-    engines: {node: '>=16'}
-    hasBin: true
-
   workerd@1.20250803.0:
     resolution: {integrity: sha512-oYH29mE/wNolPc32NHHQbySaNorj6+KASUtOvQHySxB5mO1NWdGuNv49woxNCF5971UYceGQndY+OLT+24C3wQ==}
     engines: {node: '>=16'}
@@ -14476,9 +14441,6 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20250417.0':
     optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20250801.0':
-    optional: true
-
   '@cloudflare/workerd-darwin-64@1.20250803.0':
     optional: true
 
@@ -14486,9 +14448,6 @@ snapshots:
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20250417.0':
-    optional: true
-
-  '@cloudflare/workerd-darwin-arm64@1.20250801.0':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20250803.0':
@@ -14500,9 +14459,6 @@ snapshots:
   '@cloudflare/workerd-linux-64@1.20250417.0':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20250801.0':
-    optional: true
-
   '@cloudflare/workerd-linux-64@1.20250803.0':
     optional: true
 
@@ -14512,9 +14468,6 @@ snapshots:
   '@cloudflare/workerd-linux-arm64@1.20250417.0':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20250801.0':
-    optional: true
-
   '@cloudflare/workerd-linux-arm64@1.20250803.0':
     optional: true
 
@@ -14522,9 +14475,6 @@ snapshots:
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20250417.0':
-    optional: true
-
-  '@cloudflare/workerd-windows-64@1.20250801.0':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20250803.0':
@@ -23668,14 +23618,6 @@ snapshots:
       '@cloudflare/workerd-linux-64': 1.20250417.0
       '@cloudflare/workerd-linux-arm64': 1.20250417.0
       '@cloudflare/workerd-windows-64': 1.20250417.0
-
-  workerd@1.20250801.0:
-    optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20250801.0
-      '@cloudflare/workerd-darwin-arm64': 1.20250801.0
-      '@cloudflare/workerd-linux-64': 1.20250801.0
-      '@cloudflare/workerd-linux-arm64': 1.20250801.0
-      '@cloudflare/workerd-windows-64': 1.20250801.0
 
   workerd@1.20250803.0:
     optionalDependencies:


### PR DESCRIPTION
Add support for the native `node:os` when enabled by flag.

Bump workerd to [1.20250802.0](https://github.com/cloudflare/workerd/releases/tag/v1.20250802.0) where this has been implemented

/cc @anonrig @jasnell 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: will be documented by the runtime team
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: unenv changes are not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
