### PR TITLE
validate id in `wrangler containers delete` and also include container API calls in WRANGLER_LOG=debug

### DIFF
--- a/.changeset/blue-seas-visit.md
+++ b/.changeset/blue-seas-visit.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: validate `wrangler containers delete ID` to ensure a valid ID has been provided. Previously if you provided the container name (or any non-ID shaped string) you would get an auth error instead of a 404.

--- a/.changeset/pink-heads-help.md
+++ b/.changeset/pink-heads-help.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/containers-shared": patch
+"wrangler": patch
+---
+
+include containers API calls in output of WRANGLER_LOG=debug

--- a/packages/containers-shared/src/client/core/OpenAPI.ts
+++ b/packages/containers-shared/src/client/core/OpenAPI.ts
@@ -1,5 +1,6 @@
 /* istanbul ignore file */
 /* tslint:disable */
+import type { Logger } from "../../types";
 import type { ApiRequestOptions } from "./ApiRequestOptions";
 
 type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
@@ -15,6 +16,7 @@ export type OpenAPIConfig = {
 	PASSWORD?: string | Resolver<string>;
 	HEADERS?: Headers | Resolver<Headers>;
 	ENCODE_PATH?: (path: string) => string;
+	LOGGER?: Logger | undefined;
 };
 
 export const OpenAPI: OpenAPIConfig = {
@@ -27,4 +29,5 @@ export const OpenAPI: OpenAPIConfig = {
 	PASSWORD: undefined,
 	HEADERS: undefined,
 	ENCODE_PATH: undefined,
+	LOGGER: undefined,
 };

--- a/packages/containers-shared/src/client/core/request.ts
+++ b/packages/containers-shared/src/client/core/request.ts
@@ -402,7 +402,7 @@ const debugLogRequest = async (
 	config: OpenAPIConfig,
 	url: string,
 	headers: Headers,
-	body: any
+	body: FormData | unknown
 ) => {
 	config.LOGGER?.debug(`-- START CF API REQUEST: ${url}`);
 	const logHeaders = new Headers(headers);

--- a/packages/containers-shared/src/client/core/request.ts
+++ b/packages/containers-shared/src/client/core/request.ts
@@ -352,6 +352,7 @@ export const request = <T>(
 			const formData = getFormData(options);
 			const body = getRequestBody(options);
 			const headers = await getHeaders(config, options);
+			debugLogRequest(config, url, headers, formData ?? body ?? {});
 
 			if (!onCancel.isCancelled) {
 				const response = await sendRequest(
@@ -387,7 +388,7 @@ export const request = <T>(
 						body: responseHeader ?? responseBody,
 					};
 				}
-
+				debugLogResponse(config, result);
 				catchErrorCodes(options, result);
 				resolve(result.body);
 			}
@@ -395,4 +396,39 @@ export const request = <T>(
 			reject(error);
 		}
 	});
+};
+
+const debugLogRequest = async (
+	config: OpenAPIConfig,
+	url: string,
+	headers: Headers,
+	body: any
+) => {
+	config.LOGGER?.debug(`-- START CF API REQUEST: ${url}`);
+	const logHeaders = new Headers(headers);
+	logHeaders.delete("Authorization");
+	config.LOGGER?.debugWithSanitization(
+		"HEADERS:",
+		JSON.stringify(logHeaders, null, 2)
+	);
+	config.LOGGER?.debugWithSanitization(
+		"BODY:",
+		JSON.stringify(
+			body instanceof FormData ? await new Response(body).text() : body,
+			null,
+			2
+		)
+	);
+	config.LOGGER?.debug("-- END CF API REQUEST");
+};
+
+const debugLogResponse = (config: OpenAPIConfig, response: ApiResult) => {
+	config.LOGGER?.debug(
+		"-- START CF API RESPONSE:",
+		response.statusText,
+		response.status
+	);
+
+	config.LOGGER?.debugWithSanitization("RESPONSE:", response.body);
+	config.LOGGER?.debug("-- END CF API RESPONSE");
 };

--- a/packages/containers-shared/src/types.ts
+++ b/packages/containers-shared/src/types.ts
@@ -1,11 +1,12 @@
 import type { InstanceType, SchedulingPolicy } from "./client";
 
 export interface Logger {
-	debug: (message: string) => void;
-	log: (message: string) => void;
-	info: (message: string) => void;
-	warn: (message: string) => void;
-	error: (error: Error) => void;
+	debug: (...args: unknown[]) => void;
+	debugWithSanitization: (label: string, ...args: unknown[]) => void;
+	log: (...args: unknown[]) => void;
+	info: (...args: unknown[]) => void;
+	warn: (...args: unknown[]) => void;
+	error: (...args: unknown[]) => void;
 }
 
 export type BuildArgs = {

--- a/packages/wrangler/src/__tests__/containers/delete.test.ts
+++ b/packages/wrangler/src/__tests__/containers/delete.test.ts
@@ -48,7 +48,7 @@ describe("containers delete", () => {
 		await expect(
 			runWrangler("containers delete invalid-id")
 		).rejects.toMatchInlineSnapshot(
-			`[Error: You must provide the container ID. Use \`wrangler containers list\` to view your containers and corresponding IDs.]`
+			`[Error: Expected a container ID but got invalid-id. Use \`wrangler containers list\` to view your containers and corresponding IDs.]`
 		);
 	});
 

--- a/packages/wrangler/src/__tests__/containers/delete.test.ts
+++ b/packages/wrangler/src/__tests__/containers/delete.test.ts
@@ -46,9 +46,7 @@ describe("containers delete", () => {
 	it("should reject invalid container ID format", async () => {
 		setWranglerConfig({});
 		await expect(runWrangler("containers delete invalid-id")).rejects
-			.toMatchInlineSnapshot(`
-			[Error: You must provide the container ID. Use 'wrangler containers list\` to view your containers and corresponding IDs.]
-		`);
+			.toMatchInlineSnapshot(`[Error: You must provide the container ID. Use \`wrangler containers list\` to view your containers and corresponding IDs.]`);
 	});
 
 	async function testStatusCode(code: number) {

--- a/packages/wrangler/src/__tests__/containers/delete.test.ts
+++ b/packages/wrangler/src/__tests__/containers/delete.test.ts
@@ -45,8 +45,11 @@ describe("containers delete", () => {
 
 	it("should reject invalid container ID format", async () => {
 		setWranglerConfig({});
-		await expect(runWrangler("containers delete invalid-id")).rejects
-			.toMatchInlineSnapshot(`[Error: You must provide the container ID. Use \`wrangler containers list\` to view your containers and corresponding IDs.]`);
+		await expect(
+			runWrangler("containers delete invalid-id")
+		).rejects.toMatchInlineSnapshot(
+			`[Error: You must provide the container ID. Use \`wrangler containers list\` to view your containers and corresponding IDs.]`
+		);
 	});
 
 	async function testStatusCode(code: number) {

--- a/packages/wrangler/src/__tests__/containers/delete.test.ts
+++ b/packages/wrangler/src/__tests__/containers/delete.test.ts
@@ -43,6 +43,14 @@ describe("containers delete", () => {
 		`);
 	});
 
+	it("should reject invalid container ID format", async () => {
+		setWranglerConfig({});
+		await expect(runWrangler("containers delete invalid-id")).rejects
+			.toMatchInlineSnapshot(`
+			[Error: You must provide the container ID. Use 'wrangler containers list\` to view your containers and corresponding IDs.]
+		`);
+	});
+
 	async function testStatusCode(code: number) {
 		setWranglerConfig({});
 		msw.use(

--- a/packages/wrangler/src/cloudchamber/common.ts
+++ b/packages/wrangler/src/cloudchamber/common.ts
@@ -194,6 +194,7 @@ export async function fillOpenAPIConfiguration(
 		...(OpenAPI.HEADERS ?? {}),
 		...Object.fromEntries(headers.entries()),
 	};
+	OpenAPI.LOGGER = logger;
 }
 
 type NonObject = undefined | null | boolean | string | number;

--- a/packages/wrangler/src/containers/containers.ts
+++ b/packages/wrangler/src/containers/containers.ts
@@ -39,8 +39,8 @@ export async function deleteCommand(
 	const uuidRegex =
 		/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 	if (!uuidRegex.test(deleteArgs.ID)) {
-		throw new Error(
-			"You must provide the container ID. Use `wrangler containers list` to view your containers and corresponding IDs."
+		throw new UserError(
+			`Expected a container ID but got ${deleteArgs.ID}. Use \`wrangler containers list\` to view your containers and corresponding IDs.`
 		);
 	}
 

--- a/packages/wrangler/src/containers/containers.ts
+++ b/packages/wrangler/src/containers/containers.ts
@@ -40,7 +40,7 @@ export async function deleteCommand(
 		/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 	if (!uuidRegex.test(deleteArgs.ID)) {
 		throw new Error(
-			"You must provide the container ID. Use 'wrangler containers list` to view your containers and corresponding IDs."
+			"You must provide the container ID. Use `wrangler containers list` to view your containers and corresponding IDs."
 		);
 	}
 

--- a/packages/wrangler/src/containers/containers.ts
+++ b/packages/wrangler/src/containers/containers.ts
@@ -27,6 +27,7 @@ export function deleteYargs(args: CommonYargsArgv) {
 	return args.positional("ID", {
 		describe: "id of the containers to delete",
 		type: "string",
+		demandOption: true,
 	});
 }
 
@@ -34,9 +35,12 @@ export async function deleteCommand(
 	deleteArgs: StrictYargsOptionsToInterface<typeof deleteYargs>,
 	_config: Config
 ) {
-	if (!deleteArgs.ID) {
+	// API gateway has path restrictions so if someone provides a string that isn't ID shaped, we get a weird error instead of a 404
+	const uuidRegex =
+		/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+	if (!uuidRegex.test(deleteArgs.ID)) {
 		throw new Error(
-			"You must provide an ID. Use 'wrangler containers list` to view your containers."
+			"You must provide the container ID. Use 'wrangler containers list` to view your containers and corresponding IDs."
 		);
 	}
 


### PR DESCRIPTION
Fixes CC-5810.

Previously we'd see `DELETE method not allowed for the oauth_token authentication scheme` when you try and do something like `wrangler containers images delete <container-name>`, because `<container-name>` didn't look like an ID to API gateway and it would get confused.

Also, added container API calls to the output of `WRANGLER_LOG=debug`, since I wanted to see that when i was debugging.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: new

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
