### PR TITLE
containers: add option to allow all tiers

### DIFF
--- a/.changeset/famous-coats-chew.md
+++ b/.changeset/famous-coats-chew.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/containers-shared": patch
+"wrangler": patch
+---
+
+Add the option to allow all tiers when creating a container

--- a/packages/containers-shared/src/types.ts
+++ b/packages/containers-shared/src/types.ts
@@ -67,7 +67,7 @@ export type SharedContainerConfig = {
 	constraints: {
 		regions?: string[];
 		cities?: string[];
-		tier?: number;
+		tier: number | undefined;
 	};
 	observability: { logs_enabled: boolean };
 } & InstanceTypeOrLimits;

--- a/packages/containers-shared/src/types.ts
+++ b/packages/containers-shared/src/types.ts
@@ -67,7 +67,7 @@ export type SharedContainerConfig = {
 	constraints: {
 		regions?: string[];
 		cities?: string[];
-		tier: number;
+		tier?: number;
 	};
 	observability: { logs_enabled: boolean };
 } & InstanceTypeOrLimits;

--- a/packages/wrangler/src/__tests__/containers/config.test.ts
+++ b/packages/wrangler/src/__tests__/containers/config.test.ts
@@ -542,4 +542,33 @@ describe("getNormalizedContainerOptions", () => {
 		expect(result[0]).toHaveProperty("image_build_context");
 		expect(result[0]).not.toHaveProperty("image_uri");
 	});
+
+	it("should be able to specify all tiers", async () => {
+		writeFileSync("Dockerfile", "FROM scratch");
+		const config: Config = {
+			name: "test-worker",
+			containers: [
+				{
+					class_name: "TestContainer",
+					image: `${getCloudflareContainerRegistry()}/test:latest`,
+					name: "test-container",
+					constraints: {
+						tier: -1,
+					},
+				},
+			],
+			durable_objects: {
+				bindings: [
+					{
+						name: "TEST_DO",
+						class_name: "TestContainer",
+					},
+				],
+			},
+		} as Partial<Config> as Config;
+
+		const result = await getNormalizedContainerOptions(config);
+		expect(result).toHaveLength(1);
+		expect(result[0].constraints.tier).toBeUndefined();
+	});
 });

--- a/packages/wrangler/src/containers/config.ts
+++ b/packages/wrangler/src/containers/config.ts
@@ -59,6 +59,8 @@ export const getNormalizedContainerOptions = async (
 				SchedulingPolicy.DEFAULT) as SchedulingPolicy,
 			constraints: {
 				// if the tier is -1, then we allow all tiers
+				// Wrangler will default an input value to 1. The API, however, will
+				// treat an undefined value to mean no constraints on tier (i.e. "all tiers")
 				tier:
 					container.constraints?.tier === -1
 						? undefined

--- a/packages/wrangler/src/containers/config.ts
+++ b/packages/wrangler/src/containers/config.ts
@@ -58,7 +58,11 @@ export const getNormalizedContainerOptions = async (
 			scheduling_policy: (container.scheduling_policy ??
 				SchedulingPolicy.DEFAULT) as SchedulingPolicy,
 			constraints: {
-				tier: container.constraints?.tier ?? 1,
+				// if the tier is -1, then we allow all tiers
+				tier:
+					container.constraints?.tier === -1
+						? undefined
+						: container.constraints?.tier ?? 1,
 				regions: container.constraints?.regions?.map((region) =>
 					region.toUpperCase()
 				),

--- a/packages/wrangler/src/containers/deploy.ts
+++ b/packages/wrangler/src/containers/deploy.ts
@@ -183,7 +183,7 @@ function containerConfigToCreateRequest(
 		// deprecated in favour of max_instances
 		instances: 0,
 		max_instances: containerApp.max_instances,
-		constraints: stripUndefined(containerApp.constraints),
+		constraints: containerApp.constraints,
 		durable_objects: {
 			namespace_id: durableObjectNamespaceId,
 		},

--- a/packages/wrangler/src/containers/deploy.ts
+++ b/packages/wrangler/src/containers/deploy.ts
@@ -183,7 +183,7 @@ function containerConfigToCreateRequest(
 		// deprecated in favour of max_instances
 		instances: 0,
 		max_instances: containerApp.max_instances,
-		constraints: containerApp.constraints,
+		constraints: stripUndefined(containerApp.constraints),
 		durable_objects: {
 			namespace_id: durableObjectNamespaceId,
 		},


### PR DESCRIPTION
Fixes CC-5818

Adds the option to allow all tiers when creating a container application.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [X] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: not a documented feature
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [X] Not necessary because: not in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
