### PR TITLE
ensure that `maybeStartOrUpdateRemoteProxySession` considers the potential account_id from the users' wrangler config

### DIFF
--- a/.changeset/calm-gifts-hear.md
+++ b/.changeset/calm-gifts-hear.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+ensure that `maybeStartOrUpdateRemoteProxySession` considers the potential account_id from the user's wrangler config
+
+currently if the user has an `account_id` in their wrangler config file, such id won't be taken into consideration for the remote proxy session, the changes here make sure that it is (note that the `auth` option of `maybeStartOrUpdateRemoteProxySession`, if provided, takes precedence over this id value).
+
+the changes here also fix the same issue for `wrangler dev` and `getPlatformProxy` (since they use `maybeStartOrUpdateRemoteProxySession` under the hook).

--- a/.changeset/calm-gifts-hear.md
+++ b/.changeset/calm-gifts-hear.md
@@ -2,8 +2,8 @@
 "wrangler": patch
 ---
 
-ensure that `maybeStartOrUpdateRemoteProxySession` considers the potential account_id from the user's wrangler config
+Ensure that `maybeStartOrUpdateRemoteProxySession` considers the potential account_id from the user's wrangler config
 
-currently if the user has an `account_id` in their wrangler config file, such id won't be taken into consideration for the remote proxy session, the changes here make sure that it is (note that the `auth` option of `maybeStartOrUpdateRemoteProxySession`, if provided, takes precedence over this id value).
+Currently if the user has an `account_id` in their wrangler config file, such id won't be taken into consideration for the remote proxy session, the changes here make sure that it is (note that the `auth` option of `maybeStartOrUpdateRemoteProxySession`, if provided, takes precedence over this id value).
 
-the changes here also fix the same issue for `wrangler dev` and `getPlatformProxy` (since they use `maybeStartOrUpdateRemoteProxySession` under the hook).
+The changes here also fix the same issue for `wrangler dev` and `getPlatformProxy` (since they use `maybeStartOrUpdateRemoteProxySession` under the hook).

--- a/fixtures/get-platform-proxy-remote-bindings/tests/index.test.ts
+++ b/fixtures/get-platform-proxy-remote-bindings/tests/index.test.ts
@@ -19,54 +19,71 @@ const remoteStagingWorkerName = `tmp-e2e-staging-worker-test-remote-bindings-${r
 const remoteKvName = `tmp-e2e-remote-kv-test-remote-bindings-${randomUUID().split("-")[0]}`;
 
 if (auth) {
-	describe(
-		"getPlatformProxy - remote bindings",
-		() => {
-			let remoteKvId: string;
+	describe("getPlatformProxy - remote bindings", { timeout: 50_000 }, () => {
+		let remoteKvId: string;
+
+		beforeAll(async () => {
+			const deployOut = execSync(
+				`pnpm wrangler deploy remote-worker.js --name ${remoteWorkerName} --compatibility-date 2025-06-19`,
+				execOptions
+			);
+
+			if (!new RegExp(`Deployed\\s+${remoteWorkerName}\\b`).test(deployOut)) {
+				throw new Error(`Failed to deploy ${remoteWorkerName}`);
+			}
+
+			const stagingDeployOut = execSync(
+				`pnpm wrangler deploy remote-worker.staging.js --name ${remoteStagingWorkerName} --compatibility-date 2025-06-19`,
+				execOptions
+			);
+
+			if (
+				!new RegExp(`Deployed\\s+${remoteStagingWorkerName}\\b`).test(
+					stagingDeployOut
+				)
+			) {
+				throw new Error(`Failed to deploy ${remoteStagingWorkerName}`);
+			}
+
+			const kvAddOut = execSync(
+				`pnpm wrangler kv namespace create ${remoteKvName}`,
+				execOptions
+			);
+
+			const createdKvRegexMatch = kvAddOut.match(/"id": "(?<id>[^"]*?)"/);
+			const maybeRemoteKvId = createdKvRegexMatch?.groups?.["id"];
+			assert(maybeRemoteKvId, `Failed to create remote kv ${remoteKvName}`);
+			remoteKvId = maybeRemoteKvId;
+
+			execSync(
+				`pnpm wrangler kv key put test-key remote-kv-value --namespace-id=${remoteKvId} --remote`,
+				execOptions
+			);
+
+			rmSync("./.tmp", { recursive: true, force: true });
+			mkdirSync("./.tmp");
+		}, 35_000);
+
+		afterAll(() => {
+			execSync(`pnpm wrangler delete --name ${remoteWorkerName}`, execOptions);
+			execSync(
+				`pnpm wrangler delete --name ${remoteStagingWorkerName}`,
+				execOptions
+			);
+			execSync(
+				`pnpm wrangler kv namespace delete --namespace-id=${remoteKvId}`,
+				execOptions
+			);
+
+			rmSync("./.tmp", { recursive: true, force: true });
+		}, 35_000);
+
+		describe("normal usage", () => {
 			beforeAll(async () => {
-				const deployOut = execSync(
-					`pnpm wrangler deploy remote-worker.js --name ${remoteWorkerName} --compatibility-date 2025-06-19`,
-					execOptions
-				);
-
-				if (!new RegExp(`Deployed\\s+${remoteWorkerName}\\b`).test(deployOut)) {
-					throw new Error(`Failed to deploy ${remoteWorkerName}`);
-				}
-
-				const stagingDeployOut = execSync(
-					`pnpm wrangler deploy remote-worker.staging.js --name ${remoteStagingWorkerName} --compatibility-date 2025-06-19`,
-					execOptions
-				);
-
-				if (
-					!new RegExp(`Deployed\\s+${remoteStagingWorkerName}\\b`).test(
-						stagingDeployOut
-					)
-				) {
-					throw new Error(`Failed to deploy ${remoteStagingWorkerName}`);
-				}
-
-				const kvAddOut = execSync(
-					`pnpm wrangler kv namespace create ${remoteKvName}`,
-					execOptions
-				);
-
-				const createdKvRegexMatch = kvAddOut.match(/"id": "(?<id>[^"]*?)"/);
-				const maybeRemoteKvId = createdKvRegexMatch?.groups?.["id"];
-				assert(maybeRemoteKvId, `Failed to create remote kv ${remoteKvName}`);
-				remoteKvId = maybeRemoteKvId;
-
-				execSync(
-					`pnpm wrangler kv key put test-key remote-kv-value --namespace-id=${remoteKvId} --remote`,
-					execOptions
-				);
-
-				rmSync("./.tmp", { recursive: true, force: true });
-
-				mkdirSync("./.tmp");
+				mkdirSync("./.tmp/normal-usage");
 
 				writeFileSync(
-					"./.tmp/wrangler.json",
+					"./.tmp/normal-usage/wrangler.json",
 					JSON.stringify(
 						{
 							name: "get-platform-proxy-fixture-test",
@@ -109,23 +126,7 @@ if (auth) {
 					),
 					"utf8"
 				);
-			}, 25_000);
-
-			afterAll(() => {
-				execSync(
-					`pnpm wrangler delete --name ${remoteWorkerName}`,
-					execOptions
-				);
-				execSync(
-					`pnpm wrangler delete --name ${remoteStagingWorkerName}`,
-					execOptions
-				);
-				execSync(
-					`pnpm wrangler kv namespace delete --namespace-id=${remoteKvId}`,
-					execOptions
-				);
-				rmSync("./.tmp", { recursive: true, force: true });
-			}, 25_000);
+			});
 
 			test("getPlatformProxy works with remote bindings", async () => {
 				vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", auth.CLOUDFLARE_ACCOUNT_ID);
@@ -135,7 +136,7 @@ if (auth) {
 					MY_WORKER: Fetcher;
 					MY_KV: KVNamespace;
 				}>({
-					configPath: "./.tmp/wrangler.json",
+					configPath: "./.tmp/normal-usage/wrangler.json",
 					experimental: { remoteBindings: true },
 				});
 
@@ -158,7 +159,7 @@ if (auth) {
 					MY_WORKER: Fetcher;
 					MY_KV: KVNamespace;
 				}>({
-					configPath: "./.tmp/wrangler.json",
+					configPath: "./.tmp/normal-usage/wrangler.json",
 					experimental: { remoteBindings: true },
 					environment: "staging",
 				});
@@ -181,7 +182,7 @@ if (auth) {
 					MY_WORKER: Fetcher;
 					MY_KV: KVNamespace;
 				}>({
-					configPath: "./.tmp/wrangler.json",
+					configPath: "./.tmp/normal-usage/wrangler.json",
 				});
 
 				const response = await fetchFromWorker(
@@ -198,9 +199,91 @@ if (auth) {
 
 				await dispose();
 			});
-		},
-		{ timeout: 50_000 }
-	);
+		});
+
+		describe("account id taken from the wrangler config", () => {
+			vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", undefined);
+			vi.stubEnv("CLOUDFLARE_API_TOKEN", auth.CLOUDFLARE_API_TOKEN);
+
+			test("usage with a wrangler config file with an invalid account id", async () => {
+				mkdirSync("./.tmp/config-with-invalid-account-id");
+
+				writeFileSync(
+					"./.tmp/config-with-invalid-account-id/wrangler.json",
+					JSON.stringify(
+						{
+							name: "get-platform-proxy-fixture-test",
+							account_id: "NOT a valid account id",
+							compatibility_date: "2025-06-01",
+							services: [
+								{
+									binding: "MY_WORKER",
+									service: remoteWorkerName,
+									experimental_remote: true,
+								},
+							],
+						},
+						undefined,
+						2
+					),
+					"utf8"
+				);
+
+				const { env, dispose } = await getPlatformProxy<{
+					MY_WORKER: Fetcher;
+				}>({
+					configPath: "./.tmp/config-with-invalid-account-id/wrangler.json",
+					experimental: { remoteBindings: true },
+				});
+
+				const response = await fetchFromWorker(env.MY_WORKER, "OK", 10_000);
+				// The worker does not return a response
+				expect(response).toBe(undefined);
+
+				await dispose();
+			});
+
+			test("usage with a wrangler config file with a valid account id", async () => {
+				mkdirSync("./.tmp/config-with-no-account-id");
+
+				writeFileSync(
+					"./.tmp/config-with-no-account-id/wrangler.json",
+					JSON.stringify(
+						{
+							name: "get-platform-proxy-fixture-test",
+							account_id: auth.CLOUDFLARE_ACCOUNT_ID,
+							compatibility_date: "2025-06-01",
+							services: [
+								{
+									binding: "MY_WORKER",
+									service: remoteWorkerName,
+									experimental_remote: true,
+								},
+							],
+						},
+						undefined,
+						2
+					),
+					"utf8"
+				);
+
+				const { env, dispose } = await getPlatformProxy<{
+					MY_WORKER: Fetcher;
+				}>({
+					configPath: "./.tmp/config-with-no-account-id/wrangler.json",
+					experimental: { remoteBindings: true },
+				});
+
+				const response = await fetchFromWorker(env.MY_WORKER, "OK");
+				const workerText = await response?.text();
+				expect(workerText).toEqual(
+					"Hello from a remote Worker part of the getPlatformProxy remote bindings fixture!"
+				);
+
+				await dispose();
+			});
+		});
+	});
 } else {
 	test.skip("getPlatformProxy - remote bindings (no auth credentials)");
 }
@@ -217,17 +300,20 @@ if (auth) {
  */
 async function fetchFromWorker(
 	worker: Fetcher,
-	expectedStatusText: string
-): Promise<Response> {
+	expectedStatusText: string,
+	timeout = 30_000
+): Promise<Response | undefined> {
 	return vi.waitFor(
 		async () => {
-			const response = await worker.fetch("http://example.com", {
-				signal: AbortSignal.timeout(5_000),
-			});
-			expect(response.statusText).toEqual(expectedStatusText);
-			return response;
+			try {
+				const response = await worker.fetch("http://example.com", {
+					signal: AbortSignal.timeout(5_000),
+				});
+				expect(response.statusText).toEqual(expectedStatusText);
+				return response;
+			} catch {}
 		},
-		{ timeout: 30_000, interval: 500 }
+		{ timeout, interval: 500 }
 	);
 }
 

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -584,6 +584,7 @@ describe("hyperdrive dev tests", () => {
 
 		const text = await fetchText(url);
 
+		assert(text);
 		const hyperdrive = new URL(text);
 		expect(hyperdrive.pathname).toBe("/some_db");
 		expect(hyperdrive.username).toBe("user");

--- a/packages/wrangler/e2e/helpers/fetch-text.ts
+++ b/packages/wrangler/e2e/helpers/fetch-text.ts
@@ -1,7 +1,15 @@
 import { fetch } from "undici";
 
-export function fetchText(url: string) {
+export function fetchText(
+	url: string,
+	timeout?: number
+): Promise<string | null> {
+	const signal =
+		timeout !== undefined ? AbortSignal.timeout(timeout) : undefined;
 	return fetch(url, {
 		headers: { "MF-Disable-Pretty-Error": "true" },
-	}).then((r) => r.text());
+		signal,
+	})
+		.then((r) => r.text())
+		.catch(() => null);
 }

--- a/packages/wrangler/e2e/remote-binding/wrangler-remote-resources.test.ts
+++ b/packages/wrangler/e2e/remote-binding/wrangler-remote-resources.test.ts
@@ -512,6 +512,69 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 	}
 );
 
+describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
+	"Wrangler dev uses a provided account_id from the wrangler config file",
+	() => {
+		const remoteWorkerName = generateResourceName();
+		const helper = new WranglerE2ETestHelper();
+
+		beforeAll(async () => {
+			await helper.seed(path.resolve(__dirname, "./workers"));
+			await helper.run(
+				`wrangler deploy remote-worker.js --name ${remoteWorkerName} --compatibility-date 2025-01-01`
+			);
+		}, 35_000);
+
+		afterAll(async () => {
+			await helper.run(`wrangler delete --name ${remoteWorkerName}`);
+		});
+
+		test.each(["valid", "invalid"] as const)(
+			"usage with a wrangler config file with an %s account id",
+			async (accountIdValidity) => {
+				await helper.seed({
+					"wrangler.json": JSON.stringify({
+						name: "remote-bindings-test",
+						main: "simple-service-binding.js",
+						account_id:
+							accountIdValidity === "valid"
+								? CLOUDFLARE_ACCOUNT_ID
+								: "invalid account id",
+						compatibility_date: "2025-05-07",
+						services: [
+							{
+								binding: "REMOTE_WORKER",
+								service: remoteWorkerName,
+								experimental_remote: true,
+							},
+						],
+					}),
+				});
+
+				const worker = helper.runLongLived("wrangler dev --x-remote-bindings", {
+					env: {
+						...process.env,
+						CLOUDFLARE_ACCOUNT_ID: undefined,
+					},
+				});
+
+				const { url } = await worker.waitForReady();
+
+				const response = await fetchText(url, 5_000);
+				if (accountIdValidity === "valid") {
+					expect(response).toEqual(
+						"REMOTE<WORKER>: Hello from a remote worker"
+					);
+				} else {
+					expect(response).toBeNull();
+				}
+
+				await worker.stop();
+			}
+		);
+	}
+);
+
 async function writeWranglerConfig(
 	testCase: TestCase<Record<string, string>>,
 	helper: WranglerE2ETestHelper,

--- a/packages/wrangler/e2e/remote-binding/wrangler-remote-resources.test.ts
+++ b/packages/wrangler/e2e/remote-binding/wrangler-remote-resources.test.ts
@@ -561,15 +561,22 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 				const { url } = await worker.waitForReady();
 
 				const response = await fetchText(url, 5_000);
+
+				await worker.stop();
+
 				if (accountIdValidity === "valid") {
 					expect(response).toEqual(
 						"REMOTE<WORKER>: Hello from a remote worker"
 					);
+					expect(await worker.output).not.toMatch(
+						/A request to the Cloudflare API \(.*?\) failed\./
+					);
 				} else {
 					expect(response).toBeNull();
+					expect(await worker.output).toMatch(
+						/A request to the Cloudflare API \(\/accounts\/invalid account id\/workers\/subdomain\/edge-preview\) failed\./
+					);
 				}
-
-				await worker.stop();
 			}
 		);
 	}

--- a/packages/wrangler/src/api/remoteBindings/index.ts
+++ b/packages/wrangler/src/api/remoteBindings/index.ts
@@ -4,6 +4,7 @@ import getPort from "get-port";
 import { readConfig } from "../../config";
 import { getCloudflareComplianceRegion } from "../../environment-variables/misc-variables";
 import { getBasePath } from "../../paths";
+import { requireApiToken } from "../../user";
 import {
 	convertConfigBindingsToStartWorkerBindings,
 	startWorker,
@@ -11,6 +12,7 @@ import {
 import type { Config } from "../../config";
 import type { CfAccount } from "../../dev/create-worker-preview";
 import type {
+	AsyncHook,
 	Binding,
 	StartDevWorkerInput,
 	Worker,
@@ -142,6 +144,7 @@ export async function maybeStartOrUpdateRemoteProxySession(
 	session: RemoteProxySession;
 	remoteBindings: Record<string, Binding>;
 } | null> {
+	let configAccountId: string | undefined;
 	if ("path" in wranglerOrWorkerConfigObject) {
 		const wranglerConfigObject = wranglerOrWorkerConfigObject;
 		const config = readConfig({
@@ -150,6 +153,8 @@ export async function maybeStartOrUpdateRemoteProxySession(
 		});
 
 		assert(config.name);
+
+		configAccountId = config.account_id;
 
 		wranglerOrWorkerConfigObject = {
 			name: config.name,
@@ -175,10 +180,11 @@ export async function maybeStartOrUpdateRemoteProxySession(
 		if (preExistingRemoteProxySessionData?.session) {
 			await preExistingRemoteProxySessionData.session.dispose();
 		}
+
 		remoteProxySession = await startRemoteProxySession(remoteBindings, {
 			workerName: workerConfigObject.name,
 			complianceRegion: workerConfigObject.complianceRegion,
-			auth,
+			auth: getAuthHook(auth, configAccountId),
 		});
 	} else {
 		// The auth values haven't changed so we can reuse the pre-existing session
@@ -195,7 +201,7 @@ export async function maybeStartOrUpdateRemoteProxySession(
 					remoteProxySession = await startRemoteProxySession(remoteBindings, {
 						workerName: workerConfigObject.name,
 						complianceRegion: workerConfigObject.complianceRegion,
-						auth,
+						auth: getAuthHook(auth, configAccountId),
 					});
 				}
 			} else {
@@ -215,6 +221,35 @@ export async function maybeStartOrUpdateRemoteProxySession(
 		session: remoteProxySession,
 		remoteBindings,
 	};
+}
+
+/**
+ * Gets the auth hook to use for the remote proxy session, this is either the user provided auth
+ * hook if there is one, or an ad-hoc hook created using the account_id from the user's wrangler
+ * config file otherwise.
+ *
+ * @param auth the auth hook provided by the user if any
+ * @param configAccountId the account_id taken from the user's wrangler config if any
+ * @returns the auth hook to pass to the startRemoteProxy session function if any
+ */
+function getAuthHook(
+	auth: CfAccount | undefined,
+	configAccountId: string | undefined
+): AsyncHook<CfAccount, [Pick<Config, "account_id">]> | undefined {
+	if (auth) {
+		return auth;
+	}
+
+	if (configAccountId) {
+		return async () => {
+			return {
+				accountId: configAccountId ?? "",
+				apiToken: requireApiToken(),
+			};
+		};
+	}
+
+	return undefined;
 }
 
 function deepStrictEqual(source: unknown, target: unknown): boolean {

--- a/packages/wrangler/src/api/remoteBindings/index.ts
+++ b/packages/wrangler/src/api/remoteBindings/index.ts
@@ -243,7 +243,7 @@ function getAuthHook(
 	if (configAccountId) {
 		return async () => {
 			return {
-				accountId: configAccountId ?? "",
+				accountId: configAccountId,
 				apiToken: requireApiToken(),
 			};
 		};


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-2152
Fixes https://github.com/cloudflare/workers-sdk/issues/9568

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: remote bindings are not a v3 feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
