### PR TITLE
fix security alerts to avoid being in the same notification thread

### DIFF
--- a/.changeset/crazy-experts-wonder.md
+++ b/.changeset/crazy-experts-wonder.md
@@ -1,0 +1,5 @@
+---
+"devprod-status-bot": patch
+---
+
+fix security alerts to avoid being in the same notification thread


### PR DESCRIPTION
- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: devprod-status-bot has no tests
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: devprod-status-bot has no docs
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: devprod-status-bot is not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
