### PR TITLE
test: reduce flakes on pages-dev e2e tests

### DIFF
--- a/packages/wrangler/e2e/pages-dev.test.ts
+++ b/packages/wrangler/e2e/pages-dev.test.ts
@@ -117,18 +117,20 @@ describe.sequential("wrangler pages dev", () => {
 			`${cmd} --inspector-port ${inspectorPort} . --port ${port} --service TEST_SERVICE=test-worker --kv TEST_KV --do TEST_DO=TestDurableObject@a --d1 TEST_D1 --r2 TEST_R2 --compatibility-date=2025-05-21`
 		);
 		await worker.waitForReady();
-		expect(normalizeOutput(worker.currentOutput)).toMatchInlineSnapshot(`
-			"✨ Compiled Worker successfully
-			Your Worker has access to the following bindings:
-			Binding                                                 Resource            Mode
-			env.TEST_DO (TestDurableObject, defined in a)           Durable Object      local [not connected]
-			env.TEST_KV (TEST_KV)                                   KV Namespace        local
-			env.TEST_D1 (local-TEST_D1)                             D1 Database         local
-			env.TEST_R2 (TEST_R2)                                   R2 Bucket           local
-			env.TEST_SERVICE (test-worker)                          Worker              local [not connected]
-			Service bindings, Durable Object bindings, and Tail consumers connect to other \`wrangler dev\` processes running locally, with their connection status indicated by [connected] or [not connected]. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development
-			⎔ Starting local server...
-			[wrangler:info] Ready on http://<HOST>:<PORT>"
+		const bindingMessages = worker.currentOutput.split(
+			"Your Worker has access to the following bindings:"
+		);
+		const bindings = Array.from(
+			(bindingMessages[1] ?? "").matchAll(/env\.[^\n]+/g)
+		).flat();
+		expect(bindings).toMatchInlineSnapshot(`
+			[
+			  "env.TEST_DO (TestDurableObject, defined in a)           Durable Object      local [not connected]",
+			  "env.TEST_KV (TEST_KV)                                   KV Namespace        local",
+			  "env.TEST_D1 (local-TEST_D1)                             D1 Database         local",
+			  "env.TEST_R2 (TEST_R2)                                   R2 Bucket           local",
+			  "env.TEST_SERVICE (test-worker)                          Worker              local [not connected]",
+			]
 		`);
 	});
 


### PR DESCRIPTION
Occasionally this test flaked because the dev process output the bindings twice. I believe this is a timings issue around watching for file changes, triggering a second update and printing of the bindings

So now we only extract the first bindings list and clean it up to make it resilient to flaking

Fixes #[insert GH or internal issue link(s)].

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test change
- Wrangler V3 Backport
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/10284
  - [ ] Not necessary because: 

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
