### PR TITLE
feat(wrangler): support long branch names in preview alias generation

### DIFF
--- a/.changeset/lucky-hornets-listen.md
+++ b/.changeset/lucky-hornets-listen.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Support long branch names in generation of branch aliases in WCI.


### PR DESCRIPTION
Updates generatePreviewAlias to truncate long branch names with hash suffixes when they exceed DNS label constraints, instead of returning undefined. This allows preview deployments for branches with longer descriptive names.

Fixes #WC-3840

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: alias generation is a function of WCI, and is best-effort.
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: v4 feature only
