### PR TITLE
Backport of 10280 - test: reduce flakes on pages-dev e2e tests

### DIFF
--- a/packages/wrangler/e2e/pages-dev.test.ts
+++ b/packages/wrangler/e2e/pages-dev.test.ts
@@ -118,20 +118,19 @@ describe.sequential.each([{ cmd: "wrangler pages dev" }])(
 				`${cmd} --inspector-port ${inspectorPort} . --port ${port} --service TEST_SERVICE=test-worker --kv TEST_KV --do TEST_DO=TestDurableObject@a --d1 TEST_D1 --r2 TEST_R2`
 			);
 			await worker.waitForReady();
-			expect(normalizeOutput(worker.currentOutput)).toContain(
-				dedent`Your worker has access to the following bindings:
-					- Durable Objects:
-					  - TEST_DO: TestDurableObject (defined in a [not connected])
-					- KV Namespaces:
-					  - TEST_KV: TEST_KV [simulated locally]
-					- D1 Databases:
-					  - TEST_D1: local-TEST_D1 (TEST_D1) [simulated locally]
-					- R2 Buckets:
-					  - TEST_R2: TEST_R2 [simulated locally]
-					- Services:
-					  - TEST_SERVICE: test-worker [not connected]
-		`
+			const bindingMessages = worker.currentOutput.split(
+				"Your worker has access to the following bindings:"
 			);
+			const bindings = Array.from(
+				(bindingMessages[1] ?? "").matchAll(/ {2}- [A-Z_0-9]+:[^\n]+/g)
+			).flat();
+			expect(bindings).toEqual([
+				"  - TEST_DO: TestDurableObject (defined in a [not connected])",
+				"  - TEST_KV: TEST_KV [simulated locally]",
+				"  - TEST_D1: local-TEST_D1 (TEST_D1) [simulated locally]",
+				"  - TEST_R2: TEST_R2 [simulated locally]",
+				"  - TEST_SERVICE: test-worker [not connected]",
+			]);
 		});
 
 		it("should support wrangler.toml", async () => {


### PR DESCRIPTION
Backport of #10280 

Occasionally this test flaked because the dev process output the bindings twice. I believe this is a timings issue around watching for file changes, triggering a second update and printing of the bindings

So now we only extract the first bindings list and clean it up to make it resilient to flaking

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> test change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
