### PR TITLE
fix(wrangler) remove putQueue call when deploying a worker with queue producer binding

### DIFF
--- a/.changeset/chatty-pens-sniff.md
+++ b/.changeset/chatty-pens-sniff.md
@@ -2,4 +2,6 @@
 "wrangler": patch
 ---
 
-Remove putQueue call when setting queue producer binding in a worker
+Do not attempt to update queue producer settings when deploying a Worker with a queue binding
+
+Previously, each deployed Worker would update a subset of the queue producer's settings for each queue binding, which could result in broken queue producers or at least conflicts where different Workers tried to set different producer settings on a shared queue.

--- a/.changeset/chatty-pens-sniff.md
+++ b/.changeset/chatty-pens-sniff.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Remove putQueue call when setting queue producer binding in a worker

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -14,7 +14,6 @@ jobs:
   deploy-test-workers:
     name: Deploy Test Workers
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.owner.login == 'cloudflare' || github.event_name == 'merge_group'
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -39,7 +38,7 @@ jobs:
           turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
 
       - name: Deploy test workers
-        if: steps.changes.outputs.everything_but_markdown == 'true'
+        if: github.event.pull_request.head.repo.owner.login == 'cloudflare' && steps.changes.outputs.everything_but_markdown == 'true'
         shell: bash
         run: node -r esbuild-register tools/test-workers/deploy-all.ts
         env:

--- a/packages/miniflare/test/plugins/email/index.spec.ts
+++ b/packages/miniflare/test/plugins/email/index.spec.ts
@@ -75,13 +75,15 @@ test("Unbound send_email binding works", async (t) => {
 	);
 	t.is(await res.text(), "ok");
 	t.is(res.status, 200);
-	t.true(
-		log.logs.some(
-			([type, message]) =>
-				type === LogLevel.INFO &&
-				message.includes(
-					"send_email binding called with the following message:"
-				)
+	waitFor(async () =>
+		t.true(
+			log.logs.some(
+				([type, message]) =>
+					type === LogLevel.INFO &&
+					message.includes(
+						"send_email binding called with the following message:"
+					)
+			)
 		)
 	);
 

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -58,11 +58,7 @@ import { writeWranglerConfig } from "./helpers/write-wrangler-config";
 import type { AssetManifest } from "../assets";
 import type { Config } from "../config";
 import type { CustomDomain, CustomDomainChangeset } from "../deploy/deploy";
-import type {
-	PostQueueBody,
-	PostTypedConsumerBody,
-	QueueResponse,
-} from "../queues/client";
+import type { PostTypedConsumerBody, QueueResponse } from "../queues/client";
 import type { FormData } from "undici";
 import type { Mock } from "vitest";
 
@@ -11443,10 +11439,6 @@ export default{
 				modified_on: "",
 			};
 			mockGetQueueByName(queueName, existingQueue);
-			mockPutQueueById(queueId, {
-				queue_name: queueName,
-				settings: {},
-			});
 
 			await runWrangler("deploy index.js");
 			expect(std.out).toMatchInlineSnapshot(`
@@ -11490,12 +11482,7 @@ export default{
 				modified_on: "",
 			};
 			mockGetQueueByName(queueName, existingQueue);
-			mockPutQueueById(queueId, {
-				queue_name: queueName,
-				settings: {
-					delivery_delay: 10,
-				},
-			});
+
 			await runWrangler("deploy index.js");
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
@@ -13646,37 +13633,6 @@ function mockPostConsumerById(
 				});
 			},
 			{ once: true }
-		)
-	);
-	return requests;
-}
-
-function mockPutQueueById(
-	expectedQueueId: string,
-	expectedBody: PostQueueBody
-) {
-	const requests = { count: 0 };
-	msw.use(
-		http.put(
-			`*/accounts/:accountId/queues/:queueId`,
-			async ({ request, params }) => {
-				const body = await request.json();
-				expect(params.queueId).toEqual(expectedQueueId);
-				expect(params.accountId).toEqual("some-account-id");
-				expect(body).toEqual(expectedBody);
-				requests.count += 1;
-				return HttpResponse.json({
-					success: true,
-					errors: [],
-					messages: [],
-					result: {
-						queue: expectedBody.queue_name,
-						settings: {
-							delivery_delay: expectedBody.settings?.delivery_delay,
-						},
-					},
-				});
-			}
 		)
 	);
 	return requests;

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -39,7 +39,6 @@ import {
 	postConsumer,
 	putConsumer,
 	putConsumerById,
-	putQueue,
 } from "../queues/client";
 import { syncWorkersSite } from "../sites";
 import {
@@ -72,7 +71,7 @@ import type {
 	CfWorkerInit,
 } from "../deployment-bundle/worker";
 import type { ComplianceConfig } from "../environment-variables/misc-variables";
-import type { PostQueueBody, PostTypedConsumerBody } from "../queues/client";
+import type { PostTypedConsumerBody } from "../queues/client";
 import type { LegacyAssetPaths } from "../sites";
 import type { RetrieveSourceMapFunction } from "../sourcemap";
 import type { ApiVersion, Percentage, VersionId } from "../versions/types";
@@ -1258,29 +1257,6 @@ async function publishRoutesFallback(
 export function isAuthenticationError(e: unknown): e is ParseError {
 	// TODO: don't want to report these
 	return e instanceof ParseError && (e as { code?: number }).code === 10000;
-}
-
-export async function updateQueueProducers(
-	config: Config
-): Promise<Promise<string[]>[]> {
-	const producers = config.queues.producers || [];
-	const updateProducers: Promise<string[]>[] = [];
-	for (const producer of producers) {
-		const body: PostQueueBody = {
-			queue_name: producer.queue,
-			settings: {
-				delivery_delay: producer.delivery_delay,
-			},
-		};
-
-		updateProducers.push(
-			putQueue(config, producer.queue, body).then(() => [
-				`Producer for ${producer.queue}`,
-			])
-		);
-	}
-
-	return updateProducers;
 }
 
 export async function updateQueueConsumers(

--- a/packages/wrangler/src/triggers/deploy.ts
+++ b/packages/wrangler/src/triggers/deploy.ts
@@ -7,7 +7,6 @@ import {
 	publishRoutes,
 	renderRoute,
 	updateQueueConsumers,
-	updateQueueProducers,
 	validateRoutes,
 } from "../deploy/deploy";
 import { UserError } from "../errors";
@@ -279,8 +278,11 @@ export default async function triggersDeploy(
 	}
 
 	if (config.queues.producers && config.queues.producers.length) {
-		const updateProducers = await updateQueueProducers(config);
-		deployments.push(...updateProducers);
+		deployments.push(
+			...config.queues.producers.map((producer) =>
+				Promise.resolve([`Producer for ${producer.queue}`])
+			)
+		);
 	}
 
 	if (config.queues.consumers && config.queues.consumers.length) {


### PR DESCRIPTION
Fixes #[MQ-861](https://jira.cfdata.org/browse/MQ-861)


Removed a call to putQueue when deploying a worker with a queue producer binding. 
This is needed because a worker should not be able to affect queue level settings. Additionally, when having multiple producers, the settings will be determined by the last deployed producer which also leads to issues.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included (changed tests are updated)
  - [ ] Tests not necessary because: 
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: change does not reflect externally. (optionally start deprecating "delivery_delay" as now, setting it will not do anything
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: @petebacondarwin will create the backport once this is merged.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
