### PR TITLE
chore: increase miniflare waitUntil helper default timeout time

### DIFF
--- a/packages/miniflare/test/test-shared/asserts.ts
+++ b/packages/miniflare/test/test-shared/asserts.ts
@@ -66,7 +66,7 @@ export async function waitFor<T>(
 export async function waitUntil(
 	t: ExecutionContext,
 	impl: (t: ExecutionContext) => Awaitable<void>,
-	timeout: number = 5000
+	timeout: number = 10000
 ): Promise<void> {
 	const start = Date.now();
 


### PR DESCRIPTION
Fixes n/a.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
