### PR TITLE
skip flaky browser render test on Windows

### DIFF
--- a/packages/miniflare/test/plugins/browser/index.spec.ts
+++ b/packages/miniflare/test/plugins/browser/index.spec.ts
@@ -180,17 +180,21 @@ export default {
 };
 `;
 
-test.serial("fails if browser session already in use", async (t) => {
-	const opts: MiniflareOptions = {
-		name: "worker",
-		compatibilityDate: "2024-11-20",
-		modules: true,
-		script: BROWSER_WORKER_ALREADY_USED_SCRIPT,
-		browserRendering: { binding: "MYBROWSER" },
-	};
-	const mf = new Miniflare(opts);
-	t.teardown(() => mf.dispose());
+const isWindows = process.platform === "win32";
+(isWindows ? test.skip : test.serial)(
+	"fails if browser session already in use",
+	async (t) => {
+		const opts: MiniflareOptions = {
+			name: "worker",
+			compatibilityDate: "2024-11-20",
+			modules: true,
+			script: BROWSER_WORKER_ALREADY_USED_SCRIPT,
+			browserRendering: { binding: "MYBROWSER" },
+		};
+		const mf = new Miniflare(opts);
+		t.teardown(() => mf.dispose());
 
-	const res = await mf.dispatchFetch("https://localhost");
-	t.is(await res.text(), "Failed to connect to browser session");
-});
+		const res = await mf.dispatchFetch("https://localhost");
+		t.is(await res.text(), "Failed to connect to browser session");
+	}
+);


### PR DESCRIPTION
This test is constantly flaking on Windows, so we will skip it for now.
@ruifigueira - can you look into re-enabling this as part of your other work on Browser rendering?