### PR TITLE
chore: dummy quick-edit release  due to changeset job failure

### DIFF
--- a/.changeset/empty-chefs-tan.md
+++ b/.changeset/empty-chefs-tan.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/quick-edit": patch
+---
+
+Dummy changeset


### PR DESCRIPTION
https://github.com/cloudflare/workers-sdk/actions/runs/16915588716/job/47928545181 job failed to release `quick-edit`. https://github.com/cloudflare/workers-sdk/pull/10336 is meant to fix the root cause of why the job failed. This PR adds a dummy changeset so that we can run another release of `quick-edit`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: changeset
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: changeset
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: changeset
<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
