### PR TITLE
[Vectorize] Add Wrangler command for Vectorize list-vectors operation

### DIFF
--- a/.changeset/bumpy-wolves-tell.md
+++ b/.changeset/bumpy-wolves-tell.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feat: Add Wrangler command for Vectorize list-vectors operation

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -299,6 +299,7 @@ import { vectorizeInfoCommand } from "./vectorize/info";
 import { vectorizeInsertCommand } from "./vectorize/insert";
 import { vectorizeListCommand } from "./vectorize/list";
 import { vectorizeListMetadataIndexCommand } from "./vectorize/listMetadataIndex";
+import { vectorizeListVectorsCommand } from "./vectorize/listVectors";
 import { vectorizeQueryCommand } from "./vectorize/query";
 import { vectorizeUpsertCommand } from "./vectorize/upsert";
 import { versionsNamespace } from "./versions";
@@ -1030,6 +1031,10 @@ export function createCLIParser(argv: string[]) {
 		},
 		{ command: "wrangler vectorize get", definition: vectorizeGetCommand },
 		{ command: "wrangler vectorize list", definition: vectorizeListCommand },
+		{
+			command: "wrangler vectorize list-vectors",
+			definition: vectorizeListVectorsCommand,
+		},
 		{ command: "wrangler vectorize query", definition: vectorizeQueryCommand },
 		{
 			command: "wrangler vectorize insert",

--- a/packages/wrangler/src/vectorize/client.ts
+++ b/packages/wrangler/src/vectorize/client.ts
@@ -6,6 +6,7 @@ import type {
 	VectorizeAsyncMutation,
 	VectorizeIndex,
 	VectorizeIndexDetails,
+	VectorizeListVectorsResponse,
 	VectorizeMatches,
 	VectorizeMetadataIndexList,
 	VectorizeMetadataIndexProperty,
@@ -292,4 +293,32 @@ export async function deleteMetadataIndex(
 			body: JSON.stringify(payload),
 		}
 	);
+}
+
+export async function listVectors(
+	config: Config,
+	indexName: string,
+	options?: {
+		count?: number;
+		cursor?: string;
+	}
+): Promise<VectorizeListVectorsResponse> {
+	const accountId = await requireAuth(config);
+
+	const searchParams = new URLSearchParams();
+	if (options?.count !== undefined) {
+		searchParams.set("count", options.count.toString());
+	}
+	if (options?.cursor !== undefined) {
+		searchParams.set("cursor", options.cursor);
+	}
+
+	const queryString = searchParams.toString();
+	const url = `/accounts/${accountId}/vectorize/v2/indexes/${indexName}/list${
+		queryString ? `?${queryString}` : ""
+	}`;
+
+	return await fetchResult(config, url, {
+		method: "GET",
+	});
 }

--- a/packages/wrangler/src/vectorize/listVectors.ts
+++ b/packages/wrangler/src/vectorize/listVectors.ts
@@ -1,0 +1,90 @@
+import { createCommand } from "../core/create-command";
+import { logger } from "../logger";
+import { listVectors } from "./client";
+
+export const vectorizeListVectorsCommand = createCommand({
+	metadata: {
+		description: "List vector identifiers in a Vectorize index",
+		status: "stable",
+		owner: "Product: Vectorize",
+		examples: [
+			{
+				command: "wrangler vectorize list-vectors my-index",
+				description: "List vector identifiers in the index 'my-index'",
+			},
+			{
+				command: "wrangler vectorize list-vectors my-index --count 50",
+				description: "List up to 50 vector identifiers",
+			},
+			{
+				command: "wrangler vectorize list-vectors my-index --cursor abc123",
+				description: "Continue listing from a specific cursor position",
+			},
+		],
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		name: {
+			type: "string",
+			demandOption: true,
+			description: "The name of the Vectorize index",
+		},
+		count: {
+			type: "number",
+			description: "Maximum number of vectors to return (1-1000)",
+		},
+		cursor: {
+			type: "string",
+			description: "Cursor for pagination to get the next page of results",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as clean JSON",
+		},
+	},
+	positionalArgs: ["name"],
+	async handler(args, { config }) {
+		logger.log(`📋 Listing vectors in index '${args.name}'...`);
+
+		const options: Parameters<typeof listVectors>[2] = {};
+		if (args.count !== undefined) {
+			options.count = args.count;
+		}
+		if (args.cursor) {
+			options.cursor = args.cursor;
+		}
+
+		const result = await listVectors(config, args.name, options);
+
+		if (result.vectors.length === 0) {
+			logger.warn("No vectors found in this index.");
+			return;
+		}
+
+		if (args.json) {
+			logger.log(JSON.stringify(result, null, 2));
+			return;
+		}
+
+		logger.table(
+			result.vectors.map((vector, index) => ({
+				"#": (index + 1).toString(),
+				"Vector ID": vector.id,
+			}))
+		);
+
+		logger.log(
+			`\nShowing ${result.count} of ${result.totalCount} total vectors`
+		);
+
+		if (result.isTruncated && result.nextCursor) {
+			logger.log(`\n💡 To get the next page, run:`);
+			logger.log(
+				`   wrangler vectorize list-vectors ${args.name} --cursor ${result.nextCursor}`
+			);
+		}
+	},
+});

--- a/packages/wrangler/src/vectorize/types.ts
+++ b/packages/wrangler/src/vectorize/types.ts
@@ -188,3 +188,29 @@ export interface VectorizeMetadataIndexPropertyName {
 	/** Indexed metadata property. */
 	propertyName: string;
 }
+
+/**
+ * Represents a single vector item in a list response.
+ */
+export interface VectorizeListVectorItem {
+	/** The ID of the vector. */
+	id: string;
+}
+
+/**
+ * Response from listing vectors in an index.
+ */
+export interface VectorizeListVectorsResponse {
+	/** Number of vectors returned in this response */
+	count: number;
+	/** Total number of vectors in the index */
+	totalCount: number;
+	/** Whether there are more vectors available beyond this response */
+	isTruncated: boolean;
+	/** Cursor for the next page of results */
+	nextCursor?: string;
+	/** When the cursor expires as an ISO8601 string */
+	cursorExpirationTimestamp?: string;
+	/** Array of vector items */
+	vectors: VectorizeListVectorItem[];
+}


### PR DESCRIPTION
Fixes VS-446.

_Describe your change..._
Vectorize now supports the "list-vectors" operation that allows users to iterate through all the vectors in an index via a paginated response. 

This change adds the Wrangler operation to list vectors in a Vectorize index.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/issues/24375
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: New feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
