### PR TITLE
Bugfix: Update regex for valid branch names

### DIFF
--- a/.changeset/giant-ghosts-flow.md
+++ b/.changeset/giant-ghosts-flow.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Update regex for valid branch name to remove 61 char length requirement, allowing for longer branch names to be specified for preview aliases.

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -484,21 +484,16 @@ describe("generatePreviewAlias", () => {
 		expect(result).toBeUndefined();
 	});
 
-	it("handles complex branch names with truncation", () => {
-		const scriptName = "myworker";
-		const complexBranch =
-			"feat/JIRA-12345/implement-awesome-new-feature-with-detail";
+	it("handles long branch names with truncation", () => {
+		const scriptName = "longer-branch-name-worker";
+		const longBranch = "a".repeat(100);
 		mockExecSync
 			.mockImplementationOnce(() => {}) // is-inside-work-tree
-			.mockImplementationOnce(() => Buffer.from(complexBranch));
+			.mockImplementationOnce(() => Buffer.from(longBranch));
 
 		const result = generatePreviewAlias(scriptName);
 
 		expect(result).toBeDefined();
-		expect(result).toMatch(
-			/^feat-jira-12345-implement-awesome-new-feature-wit-[a-f0-9]{4}$/
-		);
-		expect(result?.length).toBe(54);
 		expect(result).not.toBeUndefined();
 		expect((scriptName + "-" + result).length).toBeLessThanOrEqual(63);
 	});

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -905,7 +905,7 @@ function formatTime(duration: number) {
 // Constants for DNS label constraints and hash configuration
 const MAX_DNS_LABEL_LENGTH = 63;
 const HASH_LENGTH = 4;
-const ALIAS_VALIDATION_REGEX = /^[a-z](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+const ALIAS_VALIDATION_REGEX = /^[a-z](?:[a-z0-9-]*[a-z0-9])?$/i;
 
 /**
  * Sanitizes a branch name to create a valid DNS label alias.


### PR DESCRIPTION
Bugfix: updates regex to allow for longer branch names. This was previously failing the regex check, even though we later truncate the branch name if it's too long.

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: n/a
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: V4 only

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
