### PR TITLE
Use pnpm catalog for workerd & workers-types

### DIFF
--- a/fixtures/additional-modules/package.json
+++ b/fixtures/additional-modules/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"undici": "catalog:default",
 		"vitest": "catalog:default",

--- a/fixtures/container-app/package.json
+++ b/fixtures/container-app/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"ts-dedent": "^2.2.0",
 		"typescript": "catalog:default",
 		"wrangler": "workspace:*"

--- a/fixtures/d1-read-replication-app/package.json
+++ b/fixtures/d1-read-replication-app/package.json
@@ -10,7 +10,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"undici": "catalog:default",
 		"vitest": "catalog:default",

--- a/fixtures/d1-worker-app/package.json
+++ b/fixtures/d1-worker-app/package.json
@@ -13,7 +13,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"undici": "catalog:default",
 		"vitest": "catalog:default",

--- a/fixtures/dev-registry/package.json
+++ b/fixtures/dev-registry/package.json
@@ -12,7 +12,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"vitest": "catalog:default",

--- a/fixtures/email-worker/package.json
+++ b/fixtures/email-worker/package.json
@@ -6,7 +6,7 @@
 		"start": "wrangler dev"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@types/mimetext": "^2.0.4",
 		"mimetext": "^3.0.27",
 		"wrangler": "workspace:*"

--- a/fixtures/get-platform-proxy-remote-bindings/package.json
+++ b/fixtures/get-platform-proxy-remote-bindings/package.json
@@ -8,7 +8,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"miniflare": "workspace:*",
 		"typescript": "catalog:default",
 		"vitest": "catalog:default",

--- a/fixtures/get-platform-proxy/package.json
+++ b/fixtures/get-platform-proxy/package.json
@@ -9,7 +9,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@types/jest-image-snapshot": "^6.4.0",
 		"jest-image-snapshot": "^6.4.0",
 		"typescript": "catalog:default",

--- a/fixtures/local-mode-tests/package.json
+++ b/fixtures/local-mode-tests/package.json
@@ -14,7 +14,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@types/node": "catalog:default",
 		"buffer": "^6.0.3",
 		"typescript": "catalog:default",

--- a/fixtures/miniflare-node-test/package.json
+++ b/fixtures/miniflare-node-test/package.json
@@ -10,7 +10,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@types/is-even": "^1.0.2",
 		"is-even": "^1.0.0",
 		"miniflare": "workspace:*",

--- a/fixtures/node-app-pages/package.json
+++ b/fixtures/node-app-pages/package.json
@@ -15,7 +15,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"undici": "catalog:default",
 		"vitest": "catalog:default",

--- a/fixtures/nodejs-als-app/package.json
+++ b/fixtures/nodejs-als-app/package.json
@@ -9,7 +9,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"

--- a/fixtures/nodejs-hybrid-app/package.json
+++ b/fixtures/nodejs-hybrid-app/package.json
@@ -9,7 +9,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@types/pg": "^8.11.2",
 		"pg": "8.11.3",
 		"pg-cloudflare": "^1.1.1",

--- a/fixtures/pages-dev-proxy-with-script/package.json
+++ b/fixtures/pages-dev-proxy-with-script/package.json
@@ -10,7 +10,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"undici": "catalog:default",
 		"vitest": "catalog:default",

--- a/fixtures/pages-functions-app/package.json
+++ b/fixtures/pages-functions-app/package.json
@@ -15,7 +15,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@fixture/pages-plugin": "workspace:*",
 		"typescript": "catalog:default",
 		"undici": "catalog:default",

--- a/fixtures/pages-functions-with-routes-app/package.json
+++ b/fixtures/pages-functions-with-routes-app/package.json
@@ -11,7 +11,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"undici": "catalog:default",
 		"vitest": "catalog:default",

--- a/fixtures/pages-plugin-mounted-on-root-app/package.json
+++ b/fixtures/pages-plugin-mounted-on-root-app/package.json
@@ -15,7 +15,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@fixture/pages-plugin": "workspace:*",
 		"typescript": "catalog:default",
 		"undici": "catalog:default",

--- a/fixtures/pages-simple-assets/package.json
+++ b/fixtures/pages-simple-assets/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"undici": "catalog:default",
 		"vitest": "catalog:default",

--- a/fixtures/secrets-store/package.json
+++ b/fixtures/secrets-store/package.json
@@ -6,7 +6,7 @@
 		"start": "wrangler dev"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"volta": {

--- a/fixtures/start-worker-node-test/package.json
+++ b/fixtures/start-worker-node-test/package.json
@@ -10,7 +10,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@types/is-even": "^1.0.2",
 		"get-port": "^7.1.0",
 		"is-even": "^1.0.0",

--- a/fixtures/vitest-pool-workers-examples/package.json
+++ b/fixtures/vitest-pool-workers-examples/package.json
@@ -13,7 +13,7 @@
 	"devDependencies": {
 		"@cloudflare/containers": "^0.0.25",
 		"@cloudflare/vitest-pool-workers": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@microlabs/otel-cf-workers": "1.0.0-rc.45",
 		"@types/node": "catalog:default",
 		"discord-api-types": "0.37.98",

--- a/fixtures/wildcard-modules/package.json
+++ b/fixtures/wildcard-modules/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"undici": "catalog:default",
 		"wrangler": "workspace:*"
 	},

--- a/fixtures/worker-ts/package.json
+++ b/fixtures/worker-ts/package.json
@@ -6,7 +6,7 @@
 		"start": "wrangler dev"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"volta": {

--- a/fixtures/workers-shared-asset-config/package.json
+++ b/fixtures/workers-shared-asset-config/package.json
@@ -13,7 +13,7 @@
 		"@cloudflare/vitest-pool-workers": "workspace:*",
 		"@cloudflare/workers-shared": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"run-script-os": "^1.1.6",
 		"typescript": "catalog:default",
 		"undici": "catalog:default",

--- a/fixtures/workers-with-assets-and-service-bindings/package.json
+++ b/fixtures/workers-with-assets-and-service-bindings/package.json
@@ -9,7 +9,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"undici": "catalog:default",
 		"vitest": "catalog:default",

--- a/fixtures/workers-with-assets-only/package.json
+++ b/fixtures/workers-with-assets-only/package.json
@@ -9,7 +9,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"undici": "catalog:default",
 		"vitest": "catalog:default",

--- a/fixtures/workers-with-assets-run-worker-first/package.json
+++ b/fixtures/workers-with-assets-run-worker-first/package.json
@@ -10,7 +10,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"undici": "catalog:default",
 		"vitest": "catalog:default",

--- a/fixtures/workers-with-assets-spa/package.json
+++ b/fixtures/workers-with-assets-spa/package.json
@@ -11,7 +11,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@types/jest-image-snapshot": "^6.4.0",
 		"@types/node": "catalog:default",
 		"jest-image-snapshot": "^6.4.0",

--- a/fixtures/workers-with-assets-static-routing/package.json
+++ b/fixtures/workers-with-assets-static-routing/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"playwright-chromium": "catalog:default",
 		"typescript": "catalog:default",
 		"undici": "catalog:default",

--- a/fixtures/workers-with-assets/package.json
+++ b/fixtures/workers-with-assets/package.json
@@ -10,7 +10,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"undici": "catalog:default",
 		"vitest": "catalog:default",

--- a/fixtures/workflow-multiple/package.json
+++ b/fixtures/workflow-multiple/package.json
@@ -7,7 +7,7 @@
 		"test:ci": "vitest run"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"undici": "catalog:default",
 		"vitest": "catalog:default",

--- a/fixtures/workflow/package.json
+++ b/fixtures/workflow/package.json
@@ -8,7 +8,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"undici": "catalog:default",
 		"vitest": "catalog:default",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"@changesets/changelog-github": "^0.5.0",
 		"@changesets/cli": "^2.28.0",
 		"@changesets/parse": "^0.4.0",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@ianvs/prettier-plugin-sort-imports": "4.2.1",
 		"@manypkg/cli": "^0.23.0",
 		"@types/node": "catalog:default",

--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -46,7 +46,7 @@
 		"@cloudflare/mock-npm-registry": "workspace:*",
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@iarna/toml": "^3.0.0",
 		"@types/command-exists": "^1.2.0",
 		"@types/cross-spawn": "^6.0.2",

--- a/packages/edge-preview-authenticated-proxy/package.json
+++ b/packages/edge-preview-authenticated-proxy/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@types/cookie": "^0.6.0",
 		"cookie": "^0.7.2",
 		"promjs": "^0.4.2",

--- a/packages/format-errors/package.json
+++ b/packages/format-errors/package.json
@@ -11,7 +11,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"mustache": "^4.2.0",
 		"promjs": "^0.4.2",
 		"toucan-js": "^3.3.1",

--- a/packages/kv-asset-handler/package.json
+++ b/packages/kv-asset-handler/package.json
@@ -42,7 +42,7 @@
 	},
 	"devDependencies": {
 		"@ava/typescript": "^4.1.0",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@types/mime": "^3.0.4",
 		"@types/node": "catalog:default",
 		"@types/service-worker-mock": "^2.0.1",

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -51,7 +51,7 @@
 		"sharp": "^0.33.5",
 		"stoppable": "1.1.0",
 		"undici": "catalog:default",
-		"workerd": "1.20250813.0",
+		"workerd": "catalog:default",
 		"ws": "catalog:default",
 		"youch": "4.1.0-beta.10",
 		"zod": "3.22.3"
@@ -62,7 +62,7 @@
 		"@cloudflare/containers-shared": "workspace:*",
 		"@cloudflare/kv-asset-handler": "workspace:*",
 		"@cloudflare/workers-shared": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@cloudflare/workflows-shared": "workspace:*",
 		"@microsoft/api-extractor": "^7.52.8",
 		"@puppeteer/browsers": "^2.10.6",

--- a/packages/pages-shared/package.json
+++ b/packages/pages-shared/package.json
@@ -25,7 +25,7 @@
 		"@cloudflare/vitest-pool-workers": "^0.8.19",
 		"@cloudflare/workers-shared": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"concurrently": "^8.2.2",
 		"glob": "^10.4.5",
 		"html-rewriter-wasm": "^0.4.1",

--- a/packages/playground-preview-worker/package.json
+++ b/packages/playground-preview-worker/package.json
@@ -19,7 +19,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@types/cookie": "^0.6.0",
 		"cookie": "^0.7.2",
 		"itty-router": "^4.0.13",

--- a/packages/quick-edit-extension/package.json
+++ b/packages/quick-edit-extension/package.json
@@ -43,7 +43,7 @@
 	],
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:^",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"esbuild": "catalog:default",
 		"esbuild-register": "^3.5.0"
 	},

--- a/packages/quick-edit/package.json
+++ b/packages/quick-edit/package.json
@@ -22,7 +22,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@types/node": "catalog:default",
 		"concurrently": "^8.2.2",
 		"esbuild": "catalog:default",

--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -58,7 +58,7 @@
 		"@cloudflare/mock-npm-registry": "workspace:*",
 		"@cloudflare/workers-shared": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@types/node": "catalog:vite-plugin",
 		"@types/ws": "^8.5.13",
 		"magic-string": "^0.30.12",

--- a/packages/vite-plugin-cloudflare/playground/additional-modules/package.json
+++ b/packages/vite-plugin-cloudflare/playground/additional-modules/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/assets/package.json
+++ b/packages/vite-plugin-cloudflare/playground/assets/package.json
@@ -15,7 +15,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/bindings/package.json
+++ b/packages/vite-plugin-cloudflare/playground/bindings/package.json
@@ -12,7 +12,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/block-concurrency-while/package.json
+++ b/packages/vite-plugin-cloudflare/playground/block-concurrency-while/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/cloudflare-env/package.json
+++ b/packages/vite-plugin-cloudflare/playground/cloudflare-env/package.json
@@ -14,7 +14,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/config-changes/package.json
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/containers/package.json
+++ b/packages/vite-plugin-cloudflare/playground/containers/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/custom-build-app/package.json
+++ b/packages/vite-plugin-cloudflare/playground/custom-build-app/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/deps-assets-importing/package.json
+++ b/packages/vite-plugin-cloudflare/playground/deps-assets-importing/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/dev-vars/package.json
+++ b/packages/vite-plugin-cloudflare/playground/dev-vars/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/dot-env/package.json
+++ b/packages/vite-plugin-cloudflare/playground/dot-env/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/durable-objects/package.json
+++ b/packages/vite-plugin-cloudflare/playground/durable-objects/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/dynamic-import-paths/package.json
+++ b/packages/vite-plugin-cloudflare/playground/dynamic-import-paths/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/external-durable-objects/package.json
+++ b/packages/vite-plugin-cloudflare/playground/external-durable-objects/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/external-workers/package.json
+++ b/packages/vite-plugin-cloudflare/playground/external-workers/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/external-workflows/package.json
+++ b/packages/vite-plugin-cloudflare/playground/external-workflows/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/hot-channel/package.json
+++ b/packages/vite-plugin-cloudflare/playground/hot-channel/package.json
@@ -10,7 +10,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/importable-env/package.json
+++ b/packages/vite-plugin-cloudflare/playground/importable-env/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/middleware-mode/package.json
+++ b/packages/vite-plugin-cloudflare/playground/middleware-mode/package.json
@@ -8,7 +8,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@types/express": "^5.0.1",
 		"express": "^5.1.0",
 		"typescript": "catalog:default",

--- a/packages/vite-plugin-cloudflare/playground/module-resolution/package.json
+++ b/packages/vite-plugin-cloudflare/playground/module-resolution/package.json
@@ -14,7 +14,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@playground/module-resolution-excludes": "file:./packages/excludes",
 		"@playground/module-resolution-imports": "file:./packages/imports",
 		"@playground/module-resolution-requires": "file:./packages/requires",

--- a/packages/vite-plugin-cloudflare/playground/multi-worker/package.json
+++ b/packages/vite-plugin-cloudflare/playground/multi-worker/package.json
@@ -18,7 +18,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/node-compat/package.json
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/package.json
@@ -45,7 +45,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@types/node": "catalog:vite-plugin",
 		"@types/pg": "^8.15.4",
 		"cross-fetch": "^4.0.0",

--- a/packages/vite-plugin-cloudflare/playground/partyserver/package.json
+++ b/packages/vite-plugin-cloudflare/playground/partyserver/package.json
@@ -17,7 +17,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@tailwindcss/vite": "^4.0.15",
 		"@types/react": "^19.0.0",
 		"@types/react-dom": "^19.0.0",

--- a/packages/vite-plugin-cloudflare/playground/prisma/package.json
+++ b/packages/vite-plugin-cloudflare/playground/prisma/package.json
@@ -16,7 +16,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@prisma/adapter-d1": "^6.3.0",
 		"@prisma/client": "^6.3.0",
 		"prisma": "^6.3.0",

--- a/packages/vite-plugin-cloudflare/playground/react-dom-server/package.json
+++ b/packages/vite-plugin-cloudflare/playground/react-dom-server/package.json
@@ -15,7 +15,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@types/react": "^19.1.0",
 		"@types/react-dom": "^19.1.1",
 		"typescript": "catalog:default",

--- a/packages/vite-plugin-cloudflare/playground/react-spa/package.json
+++ b/packages/vite-plugin-cloudflare/playground/react-spa/package.json
@@ -16,7 +16,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@types/react": "^19.0.0",
 		"@types/react-dom": "^19.0.0",
 		"@vitejs/plugin-react": "^4.3.4",

--- a/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/package.json
+++ b/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/sensitive-files/package.json
+++ b/packages/vite-plugin-cloudflare/playground/sensitive-files/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/spa-with-api/package.json
+++ b/packages/vite-plugin-cloudflare/playground/spa-with-api/package.json
@@ -22,7 +22,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@types/react": "^19.0.0",
 		"@types/react-dom": "^19.0.0",
 		"@vitejs/plugin-basic-ssl": "^2.0.0",

--- a/packages/vite-plugin-cloudflare/playground/static-mpa/package.json
+++ b/packages/vite-plugin-cloudflare/playground/static-mpa/package.json
@@ -14,7 +14,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/static/package.json
+++ b/packages/vite-plugin-cloudflare/playground/static/package.json
@@ -14,7 +14,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/streaming/package.json
+++ b/packages/vite-plugin-cloudflare/playground/streaming/package.json
@@ -14,7 +14,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@vitejs/plugin-basic-ssl": "^2.0.0",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",

--- a/packages/vite-plugin-cloudflare/playground/virtual-modules/package.json
+++ b/packages/vite-plugin-cloudflare/playground/virtual-modules/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/websockets/package.json
+++ b/packages/vite-plugin-cloudflare/playground/websockets/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/worker/package.json
+++ b/packages/vite-plugin-cloudflare/playground/worker/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/workflows/package.json
+++ b/packages/vite-plugin-cloudflare/playground/workflows/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vitest-pool-workers/package.json
+++ b/packages/vitest-pool-workers/package.json
@@ -65,7 +65,7 @@
 		"@cloudflare/eslint-config-worker": "workspace:*",
 		"@cloudflare/mock-npm-registry": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@types/node": "catalog:default",
 		"@types/semver": "^7.5.1",
 		"@vitest/runner": "catalog:default",

--- a/packages/workers-shared/package.json
+++ b/packages/workers-shared/package.json
@@ -45,7 +45,7 @@
 		"@cloudflare/eslint-config-worker": "workspace:*",
 		"@cloudflare/vitest-pool-workers": "^0.7.0",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@sentry/cli": "^2.37.0",
 		"@types/mime": "^3.0.4",
 		"concurrently": "^8.2.2",

--- a/packages/workers.new/package.json
+++ b/packages/workers.new/package.json
@@ -11,7 +11,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@types/node": "catalog:default",
 		"miniflare": "workspace:*",
 		"typescript": "catalog:default",

--- a/packages/workflows-shared/package.json
+++ b/packages/workflows-shared/package.json
@@ -43,7 +43,7 @@
 		"@cloudflare/eslint-config-worker": "workspace:*",
 		"@cloudflare/vitest-pool-workers": "^0.8.19",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@types/mime": "^3.0.4",
 		"esbuild": "catalog:default",
 		"rimraf": "catalog:default",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -73,7 +73,7 @@
 		"miniflare": "workspace:*",
 		"path-to-regexp": "6.3.0",
 		"unenv": "2.0.0-rc.19",
-		"workerd": "1.20250813.0"
+		"workerd": "catalog:default"
 	},
 	"devDependencies": {
 		"@aws-sdk/client-s3": "^3.721.0",
@@ -84,7 +84,7 @@
 		"@cloudflare/types": "6.18.4",
 		"@cloudflare/workers-shared": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250813.0",
+		"@cloudflare/workers-types": "catalog:default",
 		"@cspotcode/source-map-support": "0.8.1",
 		"@iarna/toml": "^3.0.0",
 		"@sentry/node": "^7.86.0",
@@ -160,7 +160,7 @@
 		"yargs": "^17.7.2"
 	},
 	"peerDependencies": {
-		"@cloudflare/workers-types": "^4.20250813.0"
+		"@cloudflare/workers-types": "catalog:default"
 	},
 	"peerDependenciesMeta": {
 		"@cloudflare/workers-types": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@cloudflare/workers-types':
+      specifier: ^4.20250813.0
+      version: 4.20250813.0
     '@typescript-eslint/eslint-plugin':
       specifier: ^8.35.1
       version: 8.35.1
@@ -42,6 +45,9 @@ catalogs:
     vitest:
       specifier: ~3.2.0
       version: 3.2.3
+    workerd:
+      specifier: 1.20250813.0
+      version: 1.20250813.0
     ws:
       specifier: 8.18.0
       version: 8.18.0
@@ -104,7 +110,7 @@ importers:
         specifier: ^0.4.0
         version: 0.4.0
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@ianvs/prettier-plugin-sort-imports':
         specifier: 4.2.1
@@ -161,7 +167,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -224,7 +230,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       ts-dedent:
         specifier: ^2.2.0
@@ -242,7 +248,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -263,7 +269,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -287,7 +293,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -320,7 +326,7 @@ importers:
   fixtures/email-worker:
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@types/mimetext':
         specifier: ^2.0.4
@@ -356,7 +362,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@types/jest-image-snapshot':
         specifier: ^6.4.0
@@ -383,7 +389,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       miniflare:
         specifier: workspace:*
@@ -453,7 +459,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@types/node':
         specifier: ^20.19.9
@@ -477,7 +483,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@types/is-even':
         specifier: ^1.0.2
@@ -514,7 +520,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -535,7 +541,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       undici:
         specifier: catalog:default
@@ -553,7 +559,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@types/pg':
         specifier: ^8.11.2
@@ -598,7 +604,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -623,7 +629,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@fixture/pages-plugin':
         specifier: workspace:*
@@ -701,7 +707,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -753,7 +759,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@fixture/pages-plugin':
         specifier: workspace:*
@@ -813,7 +819,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -1012,7 +1018,7 @@ importers:
   fixtures/secrets-store:
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       wrangler:
         specifier: workspace:*
@@ -1036,7 +1042,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@types/is-even':
         specifier: ^1.0.2
@@ -1069,7 +1075,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vitest-pool-workers
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@microlabs/otel-cf-workers':
         specifier: 1.0.0-rc.45
@@ -1118,7 +1124,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ~3.0.7
-        version: 3.0.9(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/ui@3.2.3(vitest@3.2.3))(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 3.0.9(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/ui@3.2.3)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -1131,7 +1137,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       undici:
         specifier: catalog:default
@@ -1183,7 +1189,7 @@ importers:
   fixtures/worker-ts:
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       wrangler:
         specifier: workspace:*
@@ -1201,7 +1207,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       run-script-os:
         specifier: ^1.1.6
@@ -1225,7 +1231,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -1246,7 +1252,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -1267,7 +1273,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -1288,7 +1294,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -1309,7 +1315,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@types/jest-image-snapshot':
         specifier: ^6.4.0
@@ -1342,7 +1348,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       playwright-chromium:
         specifier: catalog:default
@@ -1366,7 +1372,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -1384,7 +1390,7 @@ importers:
   fixtures/workflow-multiple:
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -1483,7 +1489,7 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@iarna/toml':
         specifier: ^3.0.0
@@ -1630,7 +1636,7 @@ importers:
         specifier: workspace:*
         version: link:../eslint-config-worker
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@types/cookie':
         specifier: ^0.6.0
@@ -1684,7 +1690,7 @@ importers:
         specifier: workspace:*
         version: link:../eslint-config-worker
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       mustache:
         specifier: ^4.2.0
@@ -1715,7 +1721,7 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@types/mime':
         specifier: ^3.0.4
@@ -1760,7 +1766,7 @@ importers:
         specifier: catalog:default
         version: 7.11.0
       workerd:
-        specifier: 1.20250813.0
+        specifier: catalog:default
         version: 1.20250813.0
       ws:
         specifier: catalog:default
@@ -1788,7 +1794,7 @@ importers:
         specifier: workspace:*
         version: link:../workers-shared
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@cloudflare/workflows-shared':
         specifier: workspace:*
@@ -1945,7 +1951,7 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       concurrently:
         specifier: ^8.2.2
@@ -1973,7 +1979,7 @@ importers:
         specifier: workspace:*
         version: link:../eslint-config-worker
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@types/cookie':
         specifier: ^0.6.0
@@ -2007,7 +2013,7 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@types/node':
         specifier: ^20.19.9
@@ -2031,7 +2037,7 @@ importers:
         specifier: workspace:^
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       esbuild:
         specifier: catalog:default
@@ -2132,7 +2138,7 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@types/node':
         specifier: ^20.19.9
@@ -2186,7 +2192,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2207,7 +2213,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2228,7 +2234,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2249,7 +2255,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2270,7 +2276,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2291,7 +2297,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2312,7 +2318,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2333,7 +2339,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2354,7 +2360,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2375,7 +2381,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2396,7 +2402,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2417,7 +2423,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2438,7 +2444,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2459,7 +2465,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2480,7 +2486,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2501,7 +2507,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2522,7 +2528,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2543,7 +2549,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2564,7 +2570,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@types/express':
         specifier: ^5.0.1
@@ -2591,7 +2597,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@playground/module-resolution-excludes':
         specifier: file:./packages/excludes
@@ -2636,7 +2642,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2657,7 +2663,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@types/node':
         specifier: ^20.19.9
@@ -2706,7 +2712,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@tailwindcss/vite':
         specifier: ^4.0.15
@@ -2742,7 +2748,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@prisma/adapter-d1':
         specifier: ^6.3.0
@@ -2779,7 +2785,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@types/react':
         specifier: ^19.1.0
@@ -2813,7 +2819,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@types/react':
         specifier: ^19.0.0
@@ -2843,7 +2849,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2864,7 +2870,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2892,7 +2898,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@types/react':
         specifier: ^19.0.0
@@ -2925,7 +2931,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2946,7 +2952,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -2967,7 +2973,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@vitejs/plugin-basic-ssl':
         specifier: ^2.0.0
@@ -2991,7 +2997,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -3012,7 +3018,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -3033,7 +3039,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -3054,7 +3060,7 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       typescript:
         specifier: catalog:default
@@ -3100,7 +3106,7 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@types/node':
         specifier: ^20.19.9
@@ -3309,7 +3315,7 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@sentry/cli':
         specifier: ^2.37.0
@@ -3353,7 +3359,7 @@ importers:
         specifier: workspace:*
         version: link:../vitest-pool-workers
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@types/node':
         specifier: ^20.19.9
@@ -3396,7 +3402,7 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@types/mime':
         specifier: ^3.0.4
@@ -3438,7 +3444,7 @@ importers:
         specifier: 2.0.0-rc.19
         version: 2.0.0-rc.19
       workerd:
-        specifier: 1.20250813.0
+        specifier: catalog:default
         version: 1.20250813.0
     optionalDependencies:
       fsevents:
@@ -3470,7 +3476,7 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250813.0
+        specifier: catalog:default
         version: 4.20250813.0
       '@cspotcode/source-map-support':
         specifier: 0.8.1
@@ -23550,7 +23556,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@3.0.9(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/ui@3.2.3(vitest@3.2.3))(jiti@2.4.2)(lightningcss@1.29.2):
+  vitest@3.0.9(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/ui@3.2.3)(jiti@2.4.2)(lightningcss@1.29.2):
     dependencies:
       '@vitest/expect': 3.0.9
       '@vitest/mocker': 3.0.9(vite@5.4.14(@types/node@20.19.9)(lightningcss@1.29.2))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,8 @@ catalog:
   "ws": "8.18.0"
   esbuild: "0.25.4"
   playwright-chromium: "^1.49.1"
+  "@cloudflare/workers-types": "^4.20250813.0"
+  workerd: "1.20250813.0"
 
 catalogs:
   vite-plugin:


### PR DESCRIPTION
Centralise the dependencies rather than duplicating them in every package.json. This has no functional effect (because they were updated in lockstep by dependabot anyway), but it's a bit cleaner.