### PR TITLE
[wrangler] test: use current process.env for .env local e2e test

### DIFF
--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -2379,7 +2379,7 @@ describe(".env support in local dev", () => {
 		});
 
 		const worker = helper.runLongLived("wrangler dev", {
-			env: { CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV: "false" },
+			env: { ...process.env, CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV: "false" },
 		});
 		const { url } = await worker.waitForReady();
 		expect(await (await fetch(url)).text()).toMatchInlineSnapshot(`


### PR DESCRIPTION
### Overview

Currently, the `"should not load dev variables from .env files if CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV is set to false"` wrangler dev e2e test uses  `env: {CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV=false}` for the `helper.runLongLived("wrangler dev", ...)` call, meaning that there's only one env var set during that command's execution.

This change simply passes the current `process.env` so `CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV` isn't the only env var during that test's `wrangler dev` execution.

[Similar to how the `"should load environment variables from process.env if CLOUDFLARE_INCLUDE_PROCESS_ENV is true"` test currently passes process.env](https://github.com/cloudflare/workers-sdk/blob/d54d8b73a2771cde9645937ff241675dddf0e8d2/packages/wrangler/e2e/dev.test.ts#L2554)

#### Current behavior - `wrangler/e2e/dev.test.ts` output

```
wrangler:test:e2e:  ❯ e2e/dev.test.ts (56 tests | 1 failed | 5 skipped) 71020ms
wrangler:test:e2e:    ✓ basic js dev: 'wrangler dev' (6)
wrangler:test:e2e:      ✓ can modify Worker during wrangler dev  491ms
wrangler:test:e2e:      ✓ hotkeys can be disabled with wrangler dev  421ms
wrangler:test:e2e:      ✓ --test-scheduled works with wrangler dev (2)
wrangler:test:e2e:        ✓ custom build  416ms
wrangler:test:e2e:        ✓ no custom build  413ms
wrangler:test:e2e:      ✓ Workers + Assets (2)
wrangler:test:e2e:        ✓ can modify User Worker during wrangler dev  520ms
wrangler:test:e2e:        ✓ can modify assets during wrangler dev  543ms
wrangler:test:e2e:    ✓ leaves no orphaned workerd processes with port conflict  1096ms
wrangler:test:e2e:    ✓ basic python dev: 'wrangler dev' (4)
wrangler:test:e2e:      ✓ can modify entrypoint during wrangler dev  11240ms
wrangler:test:e2e:      ✓ can modify imports during wrangler dev  10456ms
wrangler:test:e2e:      ✓ can print during wrangler dev  5414ms
wrangler:test:e2e:      ✓ prints additional modules when vendored modules are present during wrangler dev  6890ms
wrangler:test:e2e:    ✓ hyperdrive dev tests (4)
wrangler:test:e2e:      ✓ matches expected configuration parameters  384ms
wrangler:test:e2e:      ✓ connects to a socket  378ms
wrangler:test:e2e:      ✓ uses HYPERDRIVE_LOCAL_CONNECTION_STRING for the localConnectionString variable in the binding  385ms
wrangler:test:e2e:      ↓ does not require local connection string when running `wrangler dev --remote`
wrangler:test:e2e:    ✓ queue dev tests (1)
wrangler:test:e2e:      ✓ matches expected configuration parameters  390ms
wrangler:test:e2e:    ✓ writes debug logs to hidden file (2)
wrangler:test:e2e:      ✓ writes to file when --log-level = debug  1321ms
wrangler:test:e2e:      ✓ does NOT write to file when --log-level != debug  369ms
wrangler:test:e2e:    ✓ analytics engine (2)
wrangler:test:e2e:      ✓ mock analytics engine datasets: 'wrangler dev' (2)
wrangler:test:e2e:        ✓ module worker (1)
wrangler:test:e2e:          ✓ analytics engine datasets are mocked in dev  373ms
wrangler:test:e2e:        ✓ service worker (1)
wrangler:test:e2e:          ✓ using analytics engine datasets logs a warning in dev  341ms
wrangler:test:e2e:    ↓ zone selection (4)
wrangler:test:e2e:      ↓ defaults to a workers.dev preview
wrangler:test:e2e:      ↓ respects dev.host setting
wrangler:test:e2e:      ↓ infers host from first route
wrangler:test:e2e:      ↓ fails with useful error message if host is not routable
wrangler:test:e2e:    ✓ custom builds (2)
wrangler:test:e2e:      ✓ does not hang when custom build does not cause esbuild to run  458ms
wrangler:test:e2e:      ✓ does not infinite-loop custom build with assets  5444ms
wrangler:test:e2e:    ✓ watch mode (16)
wrangler:test:e2e:      ✓ Workers watch mode: 'wrangler dev' (1)
wrangler:test:e2e:        ✓ supports modifying the Worker script during dev session  502ms
wrangler:test:e2e:      ✓ Workers + Assets watch mode: 'wrangler dev' (11)
wrangler:test:e2e:        ✓ supports modifying existing assets during dev session  603ms
wrangler:test:e2e:        ✓ supports adding new assets during dev session  2572ms
wrangler:test:e2e:        ✓ supports removing existing assets during dev session  707ms
wrangler:test:e2e:        ✓ supports adding new metafiles during dev session  2571ms
wrangler:test:e2e:        ✓ supports modifying the assets directory in wrangler.toml during dev session  506ms
wrangler:test:e2e:        ✓ supports switching from Workers without assets to assets-only Workers during the current dev session  515ms
wrangler:test:e2e:        ✓ supports switching from Workers without assets to Workers with assets during the current dev session  546ms
wrangler:test:e2e:        ✓ supports switching from assets-only Workers to Workers with assets during the current dev session  504ms
wrangler:test:e2e:        ✓ supports switching from Workers with assets to assets-only Workers during the current dev session  518ms
wrangler:test:e2e:        ✓ debounces runtime restarts when assets are modified  5562ms
wrangler:test:e2e:        ✓ warns on mounted paths when routes are configured in the configuration file  439ms
wrangler:test:e2e:      ✓ Workers + Assets watch mode: 'wrangler dev --assets=dist' (4)
wrangler:test:e2e:        ✓ supports modifying assets during dev session  2872ms
wrangler:test:e2e:        ✓ supports switching from assets-only Workers to Workers with assets during the current dev session  502ms
wrangler:test:e2e:        ✓ supports switching from Workers with assets to assets-only Workers during the current dev session  505ms
wrangler:test:e2e:        ✓ warns on mounted paths when routes are configured in the configuration file  456ms
wrangler:test:e2e:    ✓ email local dev (4)
wrangler:test:e2e:      ✓ should save file on reply  389ms
wrangler:test:e2e:      ✓ should print reject with reason  376ms
wrangler:test:e2e:      ✓ should print forward email  405ms
wrangler:test:e2e:      ✓ should save file on send_email  1419ms
wrangler:test:e2e:    ❯ .env support in local dev (10)
wrangler:test:e2e:      ✓ should load environment variables from .env file  378ms
wrangler:test:e2e:      ✓ should not load local dev variables from .env files if there is a .dev.vars file  401ms
wrangler:test:e2e:      × should not load dev variables from .env files if CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV is set to false 26ms
wrangler:test:e2e:      · should load environment variables from .env.staging if it exists and --env=staging
wrangler:test:e2e:      · should prefer to load environment variables from .env.staging over .env, if --env=staging
wrangler:test:e2e:      · should load environment variables from .env file if --env=xxx and .env.xxx does not exist
wrangler:test:e2e:      · should prefer to load environment variables from .env.local over .env
wrangler:test:e2e:      · should prefer to load environment variables from .env.staging.local over .env.staging, etc
wrangler:test:e2e:      · should load environment variables from process.env if CLOUDFLARE_INCLUDE_PROCESS_ENV is true
wrangler:test:e2e:      · should load environment variables from the .env files pointed to by `--env-file`
wrangler:test:e2e:
wrangler:test:e2e: ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
wrangler:test:e2e:
wrangler:test:e2e:  FAIL  e2e/dev.test.ts > .env support in local dev > should not load dev variables from .env files if CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV is set to false
wrangler:test:e2e: Error: readUntil() reached the end of the stream without matching /Ready on (?<url>https?:\/\/.*)/ in output:
wrangler:test:e2e: /bin/sh: node: command not found
```

#### After change - `wrangler/e2e/dev.test.ts` output

```
wrangler:test:e2e:  ✓ e2e/dev.test.ts (56 tests | 5 skipped) 87881ms
wrangler:test:e2e:    ✓ basic js dev: 'wrangler dev' (6)
wrangler:test:e2e:      ✓ can modify Worker during wrangler dev  4489ms
wrangler:test:e2e:      ✓ hotkeys can be disabled with wrangler dev  394ms
wrangler:test:e2e:      ✓ --test-scheduled works with wrangler dev (2)
wrangler:test:e2e:        ✓ custom build  391ms
wrangler:test:e2e:        ✓ no custom build  399ms
wrangler:test:e2e:      ✓ Workers + Assets (2)
wrangler:test:e2e:        ✓ can modify User Worker during wrangler dev  503ms
wrangler:test:e2e:        ✓ can modify assets during wrangler dev  578ms
wrangler:test:e2e:    ✓ leaves no orphaned workerd processes with port conflict  1144ms
wrangler:test:e2e:    ✓ basic python dev: 'wrangler dev' (4)
wrangler:test:e2e:      ✓ can modify entrypoint during wrangler dev  13203ms
wrangler:test:e2e:      ✓ can modify imports during wrangler dev  18191ms
wrangler:test:e2e:      ✓ can print during wrangler dev  9098ms
wrangler:test:e2e:      ✓ prints additional modules when vendored modules are present during wrangler dev  9078ms
wrangler:test:e2e:    ✓ hyperdrive dev tests (4)
wrangler:test:e2e:      ✓ matches expected configuration parameters  386ms
wrangler:test:e2e:      ✓ connects to a socket  378ms
wrangler:test:e2e:      ✓ uses HYPERDRIVE_LOCAL_CONNECTION_STRING for the localConnectionString variable in the binding  380ms
wrangler:test:e2e:      ↓ does not require local connection string when running `wrangler dev --remote`
wrangler:test:e2e:    ✓ queue dev tests (1)
wrangler:test:e2e:      ✓ matches expected configuration parameters  380ms
wrangler:test:e2e:    ✓ writes debug logs to hidden file (2)
wrangler:test:e2e:      ✓ writes to file when --log-level = debug  1326ms
wrangler:test:e2e:      ✓ does NOT write to file when --log-level != debug  379ms
wrangler:test:e2e:    ✓ analytics engine (2)
wrangler:test:e2e:      ✓ mock analytics engine datasets: 'wrangler dev' (2)
wrangler:test:e2e:        ✓ module worker (1)
wrangler:test:e2e:          ✓ analytics engine datasets are mocked in dev  386ms
wrangler:test:e2e:        ✓ service worker (1)
wrangler:test:e2e:          ✓ using analytics engine datasets logs a warning in dev  340ms
wrangler:test:e2e:    ↓ zone selection (4)
wrangler:test:e2e:      ↓ defaults to a workers.dev preview
wrangler:test:e2e:      ↓ respects dev.host setting
wrangler:test:e2e:      ↓ infers host from first route
wrangler:test:e2e:      ↓ fails with useful error message if host is not routable
wrangler:test:e2e:    ✓ custom builds (2)
wrangler:test:e2e:      ✓ does not hang when custom build does not cause esbuild to run  457ms
wrangler:test:e2e:      ✓ does not infinite-loop custom build with assets  5448ms
wrangler:test:e2e:    ✓ watch mode (16)
wrangler:test:e2e:      ✓ Workers watch mode: 'wrangler dev' (1)
wrangler:test:e2e:        ✓ supports modifying the Worker script during dev session  480ms
wrangler:test:e2e:      ✓ Workers + Assets watch mode: 'wrangler dev' (11)
wrangler:test:e2e:        ✓ supports modifying existing assets during dev session  562ms
wrangler:test:e2e:        ✓ supports adding new assets during dev session  599ms
wrangler:test:e2e:        ✓ supports removing existing assets during dev session  699ms
wrangler:test:e2e:        ✓ supports adding new metafiles during dev session  635ms
wrangler:test:e2e:        ✓ supports modifying the assets directory in wrangler.toml during dev session  502ms
wrangler:test:e2e:        ✓ supports switching from Workers without assets to assets-only Workers during the current dev session  503ms
wrangler:test:e2e:        ✓ supports switching from Workers without assets to Workers with assets during the current dev session  577ms
wrangler:test:e2e:        ✓ supports switching from assets-only Workers to Workers with assets during the current dev session  501ms
wrangler:test:e2e:        ✓ supports switching from Workers with assets to assets-only Workers during the current dev session  511ms
wrangler:test:e2e:        ✓ debounces runtime restarts when assets are modified  5612ms
wrangler:test:e2e:        ✓ warns on mounted paths when routes are configured in the configuration file  450ms
wrangler:test:e2e:      ✓ Workers + Assets watch mode: 'wrangler dev --assets=dist' (4)
wrangler:test:e2e:        ✓ supports modifying assets during dev session  899ms
wrangler:test:e2e:        ✓ supports switching from assets-only Workers to Workers with assets during the current dev session  500ms
wrangler:test:e2e:        ✓ supports switching from Workers with assets to assets-only Workers during the current dev session  505ms
wrangler:test:e2e:        ✓ warns on mounted paths when routes are configured in the configuration file  450ms
wrangler:test:e2e:    ✓ email local dev (4)
wrangler:test:e2e:      ✓ should save file on reply  394ms
wrangler:test:e2e:      ✓ should print reject with reason  385ms
wrangler:test:e2e:      ✓ should print forward email  386ms
wrangler:test:e2e:      ✓ should save file on send_email  1405ms
wrangler:test:e2e:    ✓ .env support in local dev (10)
wrangler:test:e2e:      ✓ should load environment variables from .env file  388ms
wrangler:test:e2e:      ✓ should not load local dev variables from .env files if there is a .dev.vars file  391ms
wrangler:test:e2e:      ✓ should not load dev variables from .env files if CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV is set to false  394ms
wrangler:test:e2e:      ✓ should load environment variables from .env.staging if it exists and --env=staging  408ms
wrangler:test:e2e:      ✓ should prefer to load environment variables from .env.staging over .env, if --env=staging  408ms
wrangler:test:e2e:      ✓ should load environment variables from .env file if --env=xxx and .env.xxx does not exist  414ms
wrangler:test:e2e:      ✓ should prefer to load environment variables from .env.local over .env  389ms
wrangler:test:e2e:      ✓ should prefer to load environment variables from .env.staging.local over .env.staging, etc  410ms
wrangler:test:e2e:      ✓ should load environment variables from process.env if CLOUDFLARE_INCLUDE_PROCESS_ENV is true  397ms
wrangler:test:e2e:      ✓ should load environment variables from the .env files pointed to by `--env-file`  395ms
wrangler:test:e2e: 
wrangler:test:e2e:  Test Files  1 passed (1)
wrangler:test:e2e:       Tests  51 passed | 5 skipped (56)
wrangler:test:e2e:    Start at  21:36:18
wrangler:test:e2e:    Duration  88.19s (transform 74ms, setup 6ms, collect 112ms, tests 87.88s, environment 0ms, prepare 37ms)
```

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Only changing internal e2e test
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a patch change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
