### PR TITLE
hide and mark `service.environments` as deprecated

### DIFF
--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -840,7 +840,11 @@ export interface EnvironmentNonInheritable {
 		| {
 				/** The binding name used to refer to the bound service. */
 				binding: string;
-				/** The name of the service. */
+				/**
+				 * The name of the service.
+				 * To bind to a worker in a specific environment,
+				 * you should use the format `<worker_name>-<environment_name>`.
+				 */
 				service: string;
 				/**
 				 * @hidden

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -842,7 +842,12 @@ export interface EnvironmentNonInheritable {
 				binding: string;
 				/** The name of the service. */
 				service: string;
-				/** The environment of the service (e.g. production, staging, etc). */
+				/**
+				 * @hidden
+				 * @deprecated you should use `service: <worker_name>-<environment_name>` instead.
+				 * This refers to the deprecated concept of 'service environments'.
+				 * The environment of the service (e.g. production, staging, etc).
+				 */
 				environment?: string;
 				/** Optionally, the entrypoint (named export) of the service to bind to. */
 				entrypoint?: string;


### PR DESCRIPTION
Fixes #10168

This refers to the deprecated service environments, not wrangler environments, so hiding it to reduce confusion. 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: docs change 
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: already documented correctly
- Wrangler V3 Backport
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/10398
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
