### PR TITLE
improve diff lines ordering in remote deploy config diffing logic

### DIFF
--- a/.changeset/loud-insects-drive.md
+++ b/.changeset/loud-insects-drive.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+improve diff lines ordering in remote deploy config diffing logic

--- a/packages/wrangler/src/__tests__/deploy/config-diffs.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/config-diffs.test.ts
@@ -164,8 +164,8 @@ describe("getRemoteConfigsDiff", () => {
 			      }
 			    },
 			    \\"account_id\\": \\"account-id-123\\",
-			-   \\"workers_dev\\": true,
 			+   \\"workers_dev\\": true
+			-   \\"workers_dev\\": true,
 			-   \\"kv_namespaces\\": [
 			-     {
 			-       \\"binding\\": \\"MY_KV\\",


### PR DESCRIPTION
Fixes #10362

Example diff log when the current config removed a variable set in the dashboard:

| Before | After |
|--------|--------|
| <img width="503" height="174" alt="Screenshot 2025-08-18 at 16 58 16" src="https://github.com/user-attachments/assets/ca1a5903-da59-440e-9fca-ed3aee5e7f43" /> | <img width="444" height="173" alt="Screenshot 2025-08-18 at 16 54 42" src="https://github.com/user-attachments/assets/ecc04bc6-fe29-4d58-ba51-e96ed95c1a44" /> 
Notice how the `+` line is weirdly positioned, making the diff much less readable | All the `-` lines are now together making the diff much cleaner and more readable |

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: updates to a non-v3 feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
