### PR TITLE
fix: sanitize double-slashes in asset-worker redirects

### DIFF
--- a/.changeset/social-rockets-shine.md
+++ b/.changeset/social-rockets-shine.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/workers-shared": minor
+---
+
+Sanitize double-slashes in asset-worker relative redirects.
+
+Without sanitizing, some relative redirect patterns were being treated as external redirects.

--- a/packages/workers-shared/asset-worker/src/utils/rules-engine.ts
+++ b/packages/workers-shared/asset-worker/src/utils/rules-engine.ts
@@ -140,10 +140,23 @@ export const generateRedirectsMatcher = (
 		configuration.redirects.version === REDIRECTS_VERSION
 			? configuration.redirects.rules
 			: {},
-		({ status, to }, replacements) => ({
-			status,
-			to: replacer(to, replacements),
-		})
+		({ status, to }, replacements) => {
+			const target = replacer(to, replacements).trim();
+			const protoPattern = /^(\w+:\/\/)/;
+			if (protoPattern.test(target)) {
+				// External redirects are not modified.
+				return {
+					status,
+					to: target,
+				};
+			} else {
+				// Relative redirects are modified to remove multiple slashes.
+				return {
+					status,
+					to: target.replace(/\/+/g, "/"),
+				};
+			}
+		}
 	);
 
 export const generateStaticRoutingRuleMatcher =


### PR DESCRIPTION
A redirect rule such as:

```
/foo/* /:splat
```

And a request such as:

```
https://example.com/foo//google.com
```

Would result in a redirect target:

```
//google.com
```

Which would incorrectly resolve to:

```
https://google.com
```

When constructing a URL.

Problem was already patched in the live service.

_Describe your change..._

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
