### PR TITLE
Update config after creation commands

### DIFF
--- a/.changeset/ten-yaks-teach.md
+++ b/.changeset/ten-yaks-teach.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Support automatically updating the user's config file with newly created resources

--- a/packages/wrangler/e2e/r2.test.ts
+++ b/packages/wrangler/e2e/r2.test.ts
@@ -27,7 +27,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("r2", () => {
 		expect(normalize(output.stdout)).toMatchInlineSnapshot(`
 			"Creating bucket 'tmp-e2e-r2-00000000-0000-0000-0000-000000000000'...
 			✅ Created bucket 'tmp-e2e-r2-00000000-0000-0000-0000-000000000000' with default storage class of Standard.
-			Configure your Worker to write objects to this bucket:
+			To access your new R2 Bucket in your Worker, add the following snippet to your configuration file:
 			{
 			  "r2_buckets": [
 			    {

--- a/packages/wrangler/src/__tests__/__snapshots__/kv.test.ts.snap
+++ b/packages/wrangler/src/__tests__/__snapshots__/kv.test.ts.snap
@@ -1,5 +1,122 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`wrangler > kv namespace > create > wrangler.json > should create a namespace 1`] = `
+"Resource location: remote
+🌀 Creating namespace with title \\"UnitTestNamespace\\"
+✨ Success!
+To access your new KV Namespace in your Worker, add the following snippet to your configuration file:
+{
+  \\"kv_namespaces\\": [
+    {
+      \\"binding\\": \\"UnitTestNamespace\\",
+      \\"id\\": \\"some-namespace-id\\"
+    }
+  ]
+}"
+`;
+
+exports[`wrangler > kv namespace > create > wrangler.json > should create a namespace 2`] = `
+"{
+	\\"compatibility_date\\": \\"2022-01-12\\",
+	\\"name\\": \\"worker\\",
+	\\"kv_namespaces\\": [
+		{
+			\\"binding\\": \\"UnitTestNamespace\\",
+			\\"id\\": \\"some-namespace-id\\"
+		}
+	]
+}"
+`;
+
+exports[`wrangler > kv namespace > create > wrangler.json > should create a namespace in an environment if configured to do so 1`] = `
+"Resource location: remote
+🌀 Creating namespace with title \\"customEnv-UnitTestNamespace\\"
+✨ Success!
+To access your new KV Namespace in your Worker, add the following snippet to your configuration file in the \\"customEnv\\" environment:
+{
+  \\"kv_namespaces\\": [
+    {
+      \\"binding\\": \\"UnitTestNamespace\\",
+      \\"id\\": \\"some-namespace-id\\"
+    }
+  ]
+}"
+`;
+
+exports[`wrangler > kv namespace > create > wrangler.json > should create a namespace in an environment if configured to do so 2`] = `
+"{
+	\\"compatibility_date\\": \\"2022-01-12\\",
+	\\"name\\": \\"worker\\",
+	\\"env\\": {
+		\\"customEnv\\": {
+			\\"name\\": \\"worker\\",
+			\\"kv_namespaces\\": [
+				{
+					\\"binding\\": \\"UnitTestNamespace\\",
+					\\"id\\": \\"some-namespace-id\\"
+				}
+			]
+		}
+	}
+}"
+`;
+
+exports[`wrangler > kv namespace > create > wrangler.json > should create a namespace using configured worker name 1`] = `
+"Resource location: remote
+🌀 Creating namespace with title \\"UnitTestNamespace\\"
+✨ Success!
+To access your new KV Namespace in your Worker, add the following snippet to your configuration file:
+{
+  \\"kv_namespaces\\": [
+    {
+      \\"binding\\": \\"UnitTestNamespace\\",
+      \\"id\\": \\"some-namespace-id\\"
+    }
+  ]
+}"
+`;
+
+exports[`wrangler > kv namespace > create > wrangler.json > should create a namespace using configured worker name 2`] = `
+"{
+	\\"compatibility_date\\": \\"2022-01-12\\",
+	\\"name\\": \\"other-worker\\",
+	\\"kv_namespaces\\": [
+		{
+			\\"binding\\": \\"UnitTestNamespace\\",
+			\\"id\\": \\"some-namespace-id\\"
+		}
+	]
+}"
+`;
+
+exports[`wrangler > kv namespace > create > wrangler.json > should create a namespace with custom binding name 1`] = `
+"Resource location: remote
+🌀 Creating namespace with title \\"UnitTestNamespace\\"
+✨ Success!
+To access your new KV Namespace in your Worker, add the following snippet to your configuration file:
+{
+  \\"kv_namespaces\\": [
+    {
+      \\"binding\\": \\"UnitTestNamespace\\",
+      \\"id\\": \\"some-namespace-id\\"
+    }
+  ]
+}"
+`;
+
+exports[`wrangler > kv namespace > create > wrangler.json > should create a namespace with custom binding name 2`] = `
+"{
+	\\"compatibility_date\\": \\"2022-01-12\\",
+	\\"name\\": \\"worker\\",
+	\\"kv_namespaces\\": [
+		{
+			\\"binding\\": \\"HELLO\\",
+			\\"id\\": \\"some-namespace-id\\"
+		}
+	]
+}"
+`;
+
 exports[`wrangler > kv namespace > create > wrangler.json > should create a preview namespace if configured to do so 1`] = `
 "Resource location: remote
 🌀 Creating namespace with title \\"UnitTestNamespace_preview\\"
@@ -26,6 +143,12 @@ id = \\"some-namespace-id\\"
 "
 `;
 
+exports[`wrangler > kv namespace > create > wrangler.toml > should create a namespace 2`] = `
+"compatibility_date = \\"2022-01-12\\"
+name = \\"worker\\"
+"
+`;
+
 exports[`wrangler > kv namespace > create > wrangler.toml > should create a namespace in an environment if configured to do so 1`] = `
 "Resource location: remote
 🌀 Creating namespace with title \\"customEnv-UnitTestNamespace\\"
@@ -37,6 +160,15 @@ id = \\"some-namespace-id\\"
 "
 `;
 
+exports[`wrangler > kv namespace > create > wrangler.toml > should create a namespace in an environment if configured to do so 2`] = `
+"compatibility_date = \\"2022-01-12\\"
+name = \\"worker\\"
+
+[env.customEnv]
+name = \\"worker\\"
+"
+`;
+
 exports[`wrangler > kv namespace > create > wrangler.toml > should create a namespace using configured worker name 1`] = `
 "Resource location: remote
 🌀 Creating namespace with title \\"UnitTestNamespace\\"
@@ -45,6 +177,29 @@ To access your new KV Namespace in your Worker, add the following snippet to you
 [[kv_namespaces]]
 binding = \\"UnitTestNamespace\\"
 id = \\"some-namespace-id\\"
+"
+`;
+
+exports[`wrangler > kv namespace > create > wrangler.toml > should create a namespace using configured worker name 2`] = `
+"compatibility_date = \\"2022-01-12\\"
+name = \\"other-worker\\"
+"
+`;
+
+exports[`wrangler > kv namespace > create > wrangler.toml > should create a namespace with custom binding name 1`] = `
+"Resource location: remote
+🌀 Creating namespace with title \\"UnitTestNamespace\\"
+✨ Success!
+To access your new KV Namespace in your Worker, add the following snippet to your configuration file:
+[[kv_namespaces]]
+binding = \\"UnitTestNamespace\\"
+id = \\"some-namespace-id\\"
+"
+`;
+
+exports[`wrangler > kv namespace > create > wrangler.toml > should create a namespace with custom binding name 2`] = `
+"compatibility_date = \\"2022-01-12\\"
+name = \\"worker\\"
 "
 `;
 

--- a/packages/wrangler/src/__tests__/__snapshots__/kv.test.ts.snap
+++ b/packages/wrangler/src/__tests__/__snapshots__/kv.test.ts.snap
@@ -1,55 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`wrangler > kv namespace > create > wrangler.json > should create a namespace 1`] = `
-"Resource location: remote
-🌀 Creating namespace with title \\"UnitTestNamespace\\"
-✨ Success!
-Add the following to your configuration file in your kv_namespaces array:
-{
-  \\"kv_namespaces\\": [
-    {
-      \\"binding\\": \\"UnitTestNamespace\\",
-      \\"id\\": \\"some-namespace-id\\"
-    }
-  ]
-}"
-`;
-
-exports[`wrangler > kv namespace > create > wrangler.json > should create a namespace in an environment if configured to do so 1`] = `
-"Resource location: remote
-🌀 Creating namespace with title \\"customEnv-UnitTestNamespace\\"
-✨ Success!
-Add the following to your configuration file in your kv_namespaces array under [env.customEnv]:
-{
-  \\"kv_namespaces\\": [
-    {
-      \\"binding\\": \\"UnitTestNamespace\\",
-      \\"id\\": \\"some-namespace-id\\"
-    }
-  ]
-}"
-`;
-
-exports[`wrangler > kv namespace > create > wrangler.json > should create a namespace using configured worker name 1`] = `
-"Resource location: remote
-🌀 Creating namespace with title \\"UnitTestNamespace\\"
-✨ Success!
-Add the following to your configuration file in your kv_namespaces array:
-{
-  \\"kv_namespaces\\": [
-    {
-      \\"binding\\": \\"UnitTestNamespace\\",
-      \\"id\\": \\"some-namespace-id\\"
-    }
-  ]
-}"
-`;
-
 exports[`wrangler > kv namespace > create > wrangler.json > should create a preview namespace if configured to do so 1`] = `
 "Resource location: remote
 🌀 Creating namespace with title \\"UnitTestNamespace_preview\\"
 ✨ Success!
-Add the following to your configuration file in your kv_namespaces array:
+To access your new KV Namespace in your Worker, add the following snippet to your configuration file:
 {
   \\"kv_namespaces\\": [
     {
@@ -64,7 +19,7 @@ exports[`wrangler > kv namespace > create > wrangler.toml > should create a name
 "Resource location: remote
 🌀 Creating namespace with title \\"UnitTestNamespace\\"
 ✨ Success!
-Add the following to your configuration file in your kv_namespaces array:
+To access your new KV Namespace in your Worker, add the following snippet to your configuration file:
 [[kv_namespaces]]
 binding = \\"UnitTestNamespace\\"
 id = \\"some-namespace-id\\"
@@ -75,7 +30,7 @@ exports[`wrangler > kv namespace > create > wrangler.toml > should create a name
 "Resource location: remote
 🌀 Creating namespace with title \\"customEnv-UnitTestNamespace\\"
 ✨ Success!
-Add the following to your configuration file in your kv_namespaces array under [env.customEnv]:
+To access your new KV Namespace in your Worker, add the following snippet to your configuration file in the \\"customEnv\\" environment:
 [[kv_namespaces]]
 binding = \\"UnitTestNamespace\\"
 id = \\"some-namespace-id\\"
@@ -86,7 +41,7 @@ exports[`wrangler > kv namespace > create > wrangler.toml > should create a name
 "Resource location: remote
 🌀 Creating namespace with title \\"UnitTestNamespace\\"
 ✨ Success!
-Add the following to your configuration file in your kv_namespaces array:
+To access your new KV Namespace in your Worker, add the following snippet to your configuration file:
 [[kv_namespaces]]
 binding = \\"UnitTestNamespace\\"
 id = \\"some-namespace-id\\"
@@ -97,7 +52,7 @@ exports[`wrangler > kv namespace > create > wrangler.toml > should create a prev
 "Resource location: remote
 🌀 Creating namespace with title \\"UnitTestNamespace_preview\\"
 ✨ Success!
-Add the following to your configuration file in your kv_namespaces array:
+To access your new KV Namespace in your Worker, add the following snippet to your configuration file:
 [[kv_namespaces]]
 binding = \\"UnitTestNamespace\\"
 preview_id = \\"some-namespace-id\\"

--- a/packages/wrangler/src/__tests__/__snapshots__/r2.test.ts.snap
+++ b/packages/wrangler/src/__tests__/__snapshots__/r2.test.ts.snap
@@ -13,7 +13,7 @@ To access your new R2 Bucket in your Worker, add the following snippet to your c
   ]
 }
 ? Would you like Wrangler to add it on your behalf?
-🤖 Using fallback value in non-interactive context: no"
+🤖 Using fallback value in non-interactive context: No"
 `;
 
 exports[`r2 > bucket > create > wrangler.json > should create a bucket with the expected default storage class 1`] = `
@@ -29,7 +29,7 @@ To access your new R2 Bucket in your Worker, add the following snippet to your c
   ]
 }
 ? Would you like Wrangler to add it on your behalf?
-🤖 Using fallback value in non-interactive context: no"
+🤖 Using fallback value in non-interactive context: No"
 `;
 
 exports[`r2 > bucket > create > wrangler.json > should create a bucket with the expected jurisdiction 1`] = `
@@ -45,7 +45,7 @@ To access your new R2 Bucket in your Worker, add the following snippet to your c
   ]
 }
 ? Would you like Wrangler to add it on your behalf?
-🤖 Using fallback value in non-interactive context: no"
+🤖 Using fallback value in non-interactive context: No"
 `;
 
 exports[`r2 > bucket > create > wrangler.json > should create a bucket with the expected location hint 1`] = `
@@ -61,7 +61,7 @@ To access your new R2 Bucket in your Worker, add the following snippet to your c
   ]
 }
 ? Would you like Wrangler to add it on your behalf?
-🤖 Using fallback value in non-interactive context: no"
+🤖 Using fallback value in non-interactive context: No"
 `;
 
 exports[`r2 > bucket > create > wrangler.toml > should create a bucket & check request inputs 1`] = `

--- a/packages/wrangler/src/__tests__/__snapshots__/r2.test.ts.snap
+++ b/packages/wrangler/src/__tests__/__snapshots__/r2.test.ts.snap
@@ -3,9 +3,7 @@
 exports[`r2 > bucket > create > wrangler.json > should create a bucket & check request inputs 1`] = `
 "Creating bucket 'test-bucket'...
 ✅ Created bucket 'test-bucket' with default storage class of Standard.
-
-Configure your Worker to write objects to this bucket:
-
+To access your new R2 Bucket in your Worker, add the following snippet to your configuration file:
 {
   \\"r2_buckets\\": [
     {
@@ -13,15 +11,15 @@ Configure your Worker to write objects to this bucket:
       \\"binding\\": \\"test_bucket\\"
     }
   ]
-}"
+}
+? Would you like Wrangler to add it on your behalf?
+🤖 Using fallback value in non-interactive context: no"
 `;
 
 exports[`r2 > bucket > create > wrangler.json > should create a bucket with the expected default storage class 1`] = `
 "Creating bucket 'test-bucket'...
 ✅ Created bucket 'test-bucket' with default storage class of InfrequentAccess.
-
-Configure your Worker to write objects to this bucket:
-
+To access your new R2 Bucket in your Worker, add the following snippet to your configuration file:
 {
   \\"r2_buckets\\": [
     {
@@ -29,15 +27,15 @@ Configure your Worker to write objects to this bucket:
       \\"binding\\": \\"test_bucket\\"
     }
   ]
-}"
+}
+? Would you like Wrangler to add it on your behalf?
+🤖 Using fallback value in non-interactive context: no"
 `;
 
 exports[`r2 > bucket > create > wrangler.json > should create a bucket with the expected jurisdiction 1`] = `
 "Creating bucket 'test-bucket (eu)'...
 ✅ Created bucket 'test-bucket (eu)' with default storage class of Standard.
-
-Configure your Worker to write objects to this bucket:
-
+To access your new R2 Bucket in your Worker, add the following snippet to your configuration file:
 {
   \\"r2_buckets\\": [
     {
@@ -45,15 +43,15 @@ Configure your Worker to write objects to this bucket:
       \\"binding\\": \\"test_bucket\\"
     }
   ]
-}"
+}
+? Would you like Wrangler to add it on your behalf?
+🤖 Using fallback value in non-interactive context: no"
 `;
 
 exports[`r2 > bucket > create > wrangler.json > should create a bucket with the expected location hint 1`] = `
 "Creating bucket 'test-bucket'...
 ✅ Created bucket 'test-bucket' with location hint weur and default storage class of Standard.
-
-Configure your Worker to write objects to this bucket:
-
+To access your new R2 Bucket in your Worker, add the following snippet to your configuration file:
 {
   \\"r2_buckets\\": [
     {
@@ -61,15 +59,15 @@ Configure your Worker to write objects to this bucket:
       \\"binding\\": \\"test_bucket\\"
     }
   ]
-}"
+}
+? Would you like Wrangler to add it on your behalf?
+🤖 Using fallback value in non-interactive context: no"
 `;
 
 exports[`r2 > bucket > create > wrangler.toml > should create a bucket & check request inputs 1`] = `
 "Creating bucket 'test-bucket'...
 ✅ Created bucket 'test-bucket' with default storage class of Standard.
-
-Configure your Worker to write objects to this bucket:
-
+To access your new R2 Bucket in your Worker, add the following snippet to your configuration file:
 [[r2_buckets]]
 bucket_name = \\"test-bucket\\"
 binding = \\"test_bucket\\"
@@ -79,9 +77,7 @@ binding = \\"test_bucket\\"
 exports[`r2 > bucket > create > wrangler.toml > should create a bucket with the expected default storage class 1`] = `
 "Creating bucket 'test-bucket'...
 ✅ Created bucket 'test-bucket' with default storage class of InfrequentAccess.
-
-Configure your Worker to write objects to this bucket:
-
+To access your new R2 Bucket in your Worker, add the following snippet to your configuration file:
 [[r2_buckets]]
 bucket_name = \\"test-bucket\\"
 binding = \\"test_bucket\\"
@@ -91,9 +87,7 @@ binding = \\"test_bucket\\"
 exports[`r2 > bucket > create > wrangler.toml > should create a bucket with the expected jurisdiction 1`] = `
 "Creating bucket 'test-bucket (eu)'...
 ✅ Created bucket 'test-bucket (eu)' with default storage class of Standard.
-
-Configure your Worker to write objects to this bucket:
-
+To access your new R2 Bucket in your Worker, add the following snippet to your configuration file:
 [[r2_buckets]]
 bucket_name = \\"test-bucket\\"
 binding = \\"test_bucket\\"
@@ -103,9 +97,7 @@ binding = \\"test_bucket\\"
 exports[`r2 > bucket > create > wrangler.toml > should create a bucket with the expected location hint 1`] = `
 "Creating bucket 'test-bucket'...
 ✅ Created bucket 'test-bucket' with location hint weur and default storage class of Standard.
-
-Configure your Worker to write objects to this bucket:
-
+To access your new R2 Bucket in your Worker, add the following snippet to your configuration file:
 [[r2_buckets]]
 bucket_name = \\"test-bucket\\"
 binding = \\"test_bucket\\"

--- a/packages/wrangler/src/__tests__/d1/create.test.ts
+++ b/packages/wrangler/src/__tests__/d1/create.test.ts
@@ -64,6 +64,7 @@ describe("create", () => {
 			"✅ Successfully created DB 'test' in region OC
 			Created your new D1 database.
 
+			To access your new D1 Database in your Worker, add the following snippet to your configuration file:
 			{
 			  \\"d1_databases\\": [
 			    {

--- a/packages/wrangler/src/__tests__/d1/create.test.ts
+++ b/packages/wrangler/src/__tests__/d1/create.test.ts
@@ -6,6 +6,7 @@ import { mockGetMemberships } from "../helpers/mock-oauth-flow";
 import { msw } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
+import { writeWranglerConfig } from "../helpers/write-wrangler-config";
 
 describe("create", () => {
 	mockAccountId({ accountId: null });
@@ -40,6 +41,8 @@ describe("create", () => {
 	});
 
 	it("should try send a request to the API for a valid input", async () => {
+		writeWranglerConfig({ name: "worker" }, "wrangler.json");
+
 		setIsTTY(false);
 		mockGetMemberships([
 			{ id: "IG-88", account: { id: "1701", name: "enterprise" } },
@@ -68,12 +71,14 @@ describe("create", () => {
 			{
 			  \\"d1_databases\\": [
 			    {
-			      \\"binding\\": \\"DB\\",
+			      \\"binding\\": \\"test\\",
 			      \\"database_name\\": \\"test\\",
 			      \\"database_id\\": \\"51e7c314-456e-4167-b6c3-869ad188fc23\\"
 			    }
 			  ]
-			}"
+			}
+			? Would you like Wrangler to add it on your behalf?
+			🤖 Using fallback value in non-interactive context: No"
 		`);
 	});
 });

--- a/packages/wrangler/src/__tests__/hyperdrive.test.ts
+++ b/packages/wrangler/src/__tests__/hyperdrive.test.ts
@@ -123,8 +123,7 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive PostgreSQL config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
-
+			To access your new Hyperdrive Config in your Worker, add the following snippet to your configuration file:
 			{
 			  \\"hyperdrive\\": [
 			    {
@@ -160,8 +159,7 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive PostgreSQL config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-			📋 To start using your config from a Worker, add the following binding configuration to your wrangler.toml file:
-
+			To access your new Hyperdrive Config in your Worker, add the following snippet to your configuration file:
 			[[hyperdrive]]
 			binding = \\"HYPERDRIVE\\"
 			id = \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
@@ -191,8 +189,7 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive PostgreSQL config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
-
+			To access your new Hyperdrive Config in your Worker, add the following snippet to your configuration file:
 			{
 			  \\"hyperdrive\\": [
 			    {
@@ -226,8 +223,7 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive MySQL config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
-
+			To access your new Hyperdrive Config in your Worker, add the following snippet to your configuration file:
 			{
 			  \\"hyperdrive\\": [
 			    {
@@ -265,8 +261,7 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive PostgreSQL config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
-
+			To access your new Hyperdrive Config in your Worker, add the following snippet to your configuration file:
 			{
 			  \\"hyperdrive\\": [
 			    {
@@ -301,8 +296,7 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive PostgreSQL config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
-
+			To access your new Hyperdrive Config in your Worker, add the following snippet to your configuration file:
 			{
 			  \\"hyperdrive\\": [
 			    {
@@ -336,8 +330,7 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive PostgreSQL config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
-
+			To access your new Hyperdrive Config in your Worker, add the following snippet to your configuration file:
 			{
 			  \\"hyperdrive\\": [
 			    {
@@ -371,8 +364,7 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive PostgreSQL config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
-
+			To access your new Hyperdrive Config in your Worker, add the following snippet to your configuration file:
 			{
 			  \\"hyperdrive\\": [
 			    {
@@ -406,8 +398,7 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive PostgreSQL config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
-
+			To access your new Hyperdrive Config in your Worker, add the following snippet to your configuration file:
 			{
 			  \\"hyperdrive\\": [
 			    {
@@ -441,8 +432,7 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive PostgreSQL config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
-
+			To access your new Hyperdrive Config in your Worker, add the following snippet to your configuration file:
 			{
 			  \\"hyperdrive\\": [
 			    {
@@ -476,8 +466,7 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive PostgreSQL config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
-
+			To access your new Hyperdrive Config in your Worker, add the following snippet to your configuration file:
 			{
 			  \\"hyperdrive\\": [
 			    {
@@ -511,8 +500,7 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive MySQL config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
-
+			To access your new Hyperdrive Config in your Worker, add the following snippet to your configuration file:
 			{
 			  \\"hyperdrive\\": [
 			    {
@@ -587,8 +575,7 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive PostgreSQL config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
-
+			To access your new Hyperdrive Config in your Worker, add the following snippet to your configuration file:
 			{
 			  \\"hyperdrive\\": [
 			    {
@@ -622,8 +609,7 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive PostgreSQL config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
-
+			To access your new Hyperdrive Config in your Worker, add the following snippet to your configuration file:
 			{
 			  \\"hyperdrive\\": [
 			    {
@@ -689,8 +675,7 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive PostgreSQL config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
-
+			To access your new Hyperdrive Config in your Worker, add the following snippet to your configuration file:
 			{
 			  \\"hyperdrive\\": [
 			    {
@@ -727,8 +712,7 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive PostgreSQL config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
-
+			To access your new Hyperdrive Config in your Worker, add the following snippet to your configuration file:
 			{
 			  \\"hyperdrive\\": [
 			    {

--- a/packages/wrangler/src/__tests__/pipelines.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines.test.ts
@@ -367,9 +367,7 @@ describe("pipelines", () => {
 				    Max records:   10,000,000
 
 				🎉 You can now send data to your pipeline!
-
-				To send data to your pipeline from a Worker, add the following to your wrangler config file:
-
+				To access your new Pipeline in your Worker, add the following snippet to your configuration file:
 				{
 				  \\"pipelines\\": [
 				    {

--- a/packages/wrangler/src/__tests__/update-config-file.test.ts
+++ b/packages/wrangler/src/__tests__/update-config-file.test.ts
@@ -242,10 +242,8 @@ describe("updateConfigFile()", () => {
 			  }
 			}"
 		`);
-		await expect(
-			readFile("wrangler.json", "utf8")
-		).rejects.toThrowErrorMatchingInlineSnapshot(
-			`[Error: ENOENT: no such file or directory, open 'wrangler.json']`
+		await expect(readFile("wrangler.json", "utf8")).rejects.toThrowError(
+			"ENOENT"
 		);
 	});
 

--- a/packages/wrangler/src/__tests__/update-config-file.test.ts
+++ b/packages/wrangler/src/__tests__/update-config-file.test.ts
@@ -21,14 +21,6 @@ describe("updateConfigFile()", () => {
 	afterEach(() => {
 		clearDialogs();
 	});
-	// mockSelect({
-	// 	text: "Would you like Wrangler to add it on your behalf?",
-	// 	result: "yes-but",
-	// });
-	// mockPrompt({
-	// 	text: "What binding name would you like to use?",
-	// 	result: "HELLO",
-	// });
 
 	it("non interactive: no prompts and no file update", async () => {
 		writeWranglerConfig({ name: "worker" }, "wrangler.json");

--- a/packages/wrangler/src/__tests__/update-config-file.test.ts
+++ b/packages/wrangler/src/__tests__/update-config-file.test.ts
@@ -1,0 +1,282 @@
+import { readFile } from "node:fs/promises";
+import { updateConfigFile } from "../config";
+import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import { clearDialogs, mockPrompt, mockSelect } from "./helpers/mock-dialogs";
+import { useMockIsTTY } from "./helpers/mock-istty";
+import { runInTempDir } from "./helpers/run-in-tmp";
+import { writeWranglerConfig } from "./helpers/write-wrangler-config";
+
+describe("updateConfigFile()", () => {
+	mockAccountId();
+	mockApiToken();
+	runInTempDir();
+
+	const std = mockConsoleMethods();
+
+	const { setIsTTY } = useMockIsTTY();
+	beforeEach(() => {
+		setIsTTY(false);
+	});
+	afterEach(() => {
+		clearDialogs();
+	});
+	// mockSelect({
+	// 	text: "Would you like Wrangler to add it on your behalf?",
+	// 	result: "yes-but",
+	// });
+	// mockPrompt({
+	// 	text: "What binding name would you like to use?",
+	// 	result: "HELLO",
+	// });
+
+	it("non interactive: no prompts and no file update", async () => {
+		writeWranglerConfig({ name: "worker" }, "wrangler.json");
+
+		await updateConfigFile(
+			(name) => ({ ai: { binding: name ?? "AI" } }),
+			"wrangler.json",
+			undefined,
+			true
+		);
+		expect(std.out).toMatchInlineSnapshot(`
+			"To access your new AI in your Worker, add the following snippet to your configuration file:
+			{
+			  \\"ai\\": {
+			    \\"binding\\": \\"AI\\"
+			  }
+			}
+			? Would you like Wrangler to add it on your behalf?
+			🤖 Using fallback value in non-interactive context: No"
+		`);
+		expect(await readFile("wrangler.json", "utf8")).toMatchInlineSnapshot(
+			`"{\\"compatibility_date\\":\\"2022-01-12\\",\\"name\\":\\"worker\\"}"`
+		);
+	});
+
+	it("interactive: no file update after answering no", async () => {
+		writeWranglerConfig({ name: "worker" }, "wrangler.json");
+
+		setIsTTY(true);
+		mockSelect({
+			text: "Would you like Wrangler to add it on your behalf?",
+			result: "no",
+		});
+
+		await updateConfigFile(
+			(name) => ({ ai: { binding: name ?? "AI" } }),
+			"wrangler.json",
+			undefined,
+			true
+		);
+		expect(std.out).toMatchInlineSnapshot(`
+			"To access your new AI in your Worker, add the following snippet to your configuration file:
+			{
+			  \\"ai\\": {
+			    \\"binding\\": \\"AI\\"
+			  }
+			}"
+		`);
+		expect(await readFile("wrangler.json", "utf8")).toMatchInlineSnapshot(
+			`"{\\"compatibility_date\\":\\"2022-01-12\\",\\"name\\":\\"worker\\"}"`
+		);
+	});
+
+	it("interactive: file update after answering yes", async () => {
+		writeWranglerConfig({ name: "worker" }, "wrangler.json");
+
+		setIsTTY(true);
+		mockSelect({
+			text: "Would you like Wrangler to add it on your behalf?",
+			result: "yes",
+		});
+
+		await updateConfigFile(
+			(name) => ({ ai: { binding: name ?? "AI" } }),
+			"wrangler.json",
+			undefined,
+			true
+		);
+		expect(std.out).toMatchInlineSnapshot(`
+			"To access your new AI in your Worker, add the following snippet to your configuration file:
+			{
+			  \\"ai\\": {
+			    \\"binding\\": \\"AI\\"
+			  }
+			}"
+		`);
+		expect(await readFile("wrangler.json", "utf8")).toMatchInlineSnapshot(
+			`
+			"{
+				\\"compatibility_date\\": \\"2022-01-12\\",
+				\\"name\\": \\"worker\\",
+				\\"ai\\": {
+					\\"binding\\": \\"AI\\"
+				}
+			}"
+		`
+		);
+	});
+
+	it("interactive: file update in env after answering yes", async () => {
+		writeWranglerConfig({ name: "worker" }, "wrangler.json");
+
+		setIsTTY(true);
+		mockSelect({
+			text: "Would you like Wrangler to add it on your behalf?",
+			result: "yes",
+		});
+
+		await updateConfigFile(
+			(name) => ({ ai: { binding: name ?? "AI" } }),
+			"wrangler.json",
+			"testEnv",
+			true
+		);
+		expect(std.out).toMatchInlineSnapshot(`
+			"To access your new AI in your Worker, add the following snippet to your configuration file in the \\"testEnv\\" environment:
+			{
+			  \\"ai\\": {
+			    \\"binding\\": \\"AI\\"
+			  }
+			}"
+		`);
+		expect(await readFile("wrangler.json", "utf8")).toMatchInlineSnapshot(
+			`
+			"{
+				\\"compatibility_date\\": \\"2022-01-12\\",
+				\\"name\\": \\"worker\\",
+				\\"env\\": {
+					\\"testEnv\\": {
+						\\"ai\\": {
+							\\"binding\\": \\"AI\\"
+						}
+					}
+				}
+			}"
+		`
+		);
+	});
+
+	it("interactive: file update after answering yes-but", async () => {
+		writeWranglerConfig({ name: "worker" }, "wrangler.json");
+
+		setIsTTY(true);
+		mockSelect({
+			text: "Would you like Wrangler to add it on your behalf?",
+			result: "yes-but",
+		});
+
+		mockPrompt({
+			text: "What binding name would you like to use?",
+			result: "HELLO",
+		});
+
+		await updateConfigFile(
+			(name) => ({ ai: { binding: name ?? "AI" } }),
+			"wrangler.json",
+			undefined,
+			true
+		);
+		expect(std.out).toMatchInlineSnapshot(`
+			"To access your new AI in your Worker, add the following snippet to your configuration file:
+			{
+			  \\"ai\\": {
+			    \\"binding\\": \\"AI\\"
+			  }
+			}"
+		`);
+		expect(await readFile("wrangler.json", "utf8")).toMatchInlineSnapshot(
+			`
+			"{
+				\\"compatibility_date\\": \\"2022-01-12\\",
+				\\"name\\": \\"worker\\",
+				\\"ai\\": {
+					\\"binding\\": \\"HELLO\\"
+				}
+			}"
+		`
+		);
+	});
+
+	it("interactive: no prompts & no file update for toml", async () => {
+		writeWranglerConfig({ name: "worker" }, "wrangler.toml");
+
+		setIsTTY(true);
+
+		await updateConfigFile(
+			(name) => ({ ai: { binding: name ?? "AI" } }),
+			"wrangler.toml",
+			undefined,
+			true
+		);
+		expect(std.out).toMatchInlineSnapshot(`
+			"To access your new AI in your Worker, add the following snippet to your configuration file:
+			[ai]
+			binding = \\"AI\\"
+			"
+		`);
+		expect(await readFile("wrangler.toml", "utf8")).toMatchInlineSnapshot(
+			`
+			"compatibility_date = \\"2022-01-12\\"
+			name = \\"worker\\"
+			"
+		`
+		);
+	});
+
+	it("interactive: no prompts & no file update for no config file", async () => {
+		setIsTTY(true);
+
+		await updateConfigFile(
+			(name) => ({ ai: { binding: name ?? "AI" } }),
+			undefined,
+			undefined,
+			true
+		);
+		expect(std.out).toMatchInlineSnapshot(`
+			"To access your new AI in your Worker, add the following snippet to your configuration file:
+			{
+			  \\"ai\\": {
+			    \\"binding\\": \\"AI\\"
+			  }
+			}"
+		`);
+		await expect(
+			readFile("wrangler.json", "utf8")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: ENOENT: no such file or directory, open 'wrangler.json']`
+		);
+	});
+
+	it("logs correct binding type", async () => {
+		writeWranglerConfig({ name: "worker" }, "wrangler.json");
+
+		await updateConfigFile(
+			() => ({
+				kv_namespaces: [
+					{
+						binding: "KV",
+						id: "id",
+					},
+				],
+			}),
+			"wrangler.json",
+			undefined,
+			true
+		);
+		expect(std.out).toMatchInlineSnapshot(`
+			"To access your new KV Namespace in your Worker, add the following snippet to your configuration file:
+			{
+			  \\"kv_namespaces\\": [
+			    {
+			      \\"binding\\": \\"KV\\",
+			      \\"id\\": \\"id\\"
+			    }
+			  ]
+			}
+			? Would you like Wrangler to add it on your behalf?
+			🤖 Using fallback value in non-interactive context: No"
+		`);
+	});
+});

--- a/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
+++ b/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
@@ -201,8 +201,7 @@ describe("vectorize commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating index: 'some-index'
 			✅ Successfully created a new Vectorize index: 'test-index'
-			📋 To start querying from a Worker, add the following binding configuration to your Wrangler configuration file:
-
+			To access your new Vectorize Index in your Worker, add the following snippet to your configuration file:
 			{
 			  \\"vectorize\\": [
 			    {
@@ -222,8 +221,7 @@ describe("vectorize commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating index: 'test-index'
 			✅ Successfully created a new Vectorize index: 'test-index'
-			📋 To start querying from a Worker, add the following binding configuration to your Wrangler configuration file:
-
+			To access your new Vectorize Index in your Worker, add the following snippet to your configuration file:
 			{
 			  \\"vectorize\\": [
 			    {
@@ -244,8 +242,7 @@ describe("vectorize commands", () => {
 			"Configuring index based for the embedding model openai/text-embedding-ada-002.
 			🚧 Creating index: 'test-index'
 			✅ Successfully created a new Vectorize index: 'test-index'
-			📋 To start querying from a Worker, add the following binding configuration to your Wrangler configuration file:
-
+			To access your new Vectorize Index in your Worker, add the following snippet to your configuration file:
 			{
 			  \\"vectorize\\": [
 			    {

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -1,5 +1,4 @@
 import TOML from "@iarna/toml";
-import type { CfWorkerInit } from "../deployment-bundle/worker";
 import { prompt, select } from "../dialogs";
 import { FatalError, UserError } from "../errors";
 import { logger } from "../logger";
@@ -10,6 +9,7 @@ import { resolveWranglerConfigPath } from "./config-helpers";
 import { experimental_patchConfig } from "./patch-config";
 import { isPagesConfig, normalizeAndValidateConfig } from "./validation";
 import { validatePagesConfig } from "./validation-pages";
+import type { CfWorkerInit } from "../deployment-bundle/worker";
 import type { CommonYargsOptions } from "../yargs-types";
 import type { Config, OnlyCamelCase, RawConfig } from "./config";
 import type { ResolveConfigPathOptions } from "./config-helpers";

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -1,6 +1,6 @@
 import TOML from "@iarna/toml";
-import { CfWorkerInit } from "../deployment-bundle/worker";
-import { confirm, prompt, select } from "../dialogs";
+import type { CfWorkerInit } from "../deployment-bundle/worker";
+import { prompt, select } from "../dialogs";
 import { FatalError, UserError } from "../errors";
 import { logger } from "../logger";
 import { EXIT_CODE_INVALID_PAGES_CONFIG } from "../pages/errors";

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -79,7 +79,7 @@ export async function updateConfigFile(
 
 	logger.log(formatConfigSnippet(snippet, configPath));
 
-	if (configPath && offerToUpdate) {
+	if (configPath && offerToUpdate && configFormat(configPath) === "jsonc") {
 		const autoAdd = await confirm(
 			"Would you like Wrangler to add it on your behalf?",
 			{

--- a/packages/wrangler/src/d1/create.ts
+++ b/packages/wrangler/src/d1/create.ts
@@ -6,6 +6,7 @@ import { getD1ExtraLocationChoices } from "../environment-variables/misc-variabl
 import { UserError } from "../errors";
 import { logger } from "../logger";
 import { requireAuth } from "../user";
+import { getValidBindingName } from "../utils/getValidBindingName";
 import { LOCATION_CHOICES } from "./constants";
 import type { ComplianceConfig } from "../environment-variables/misc-variables";
 import type { DatabaseCreationResult } from "./types";
@@ -88,11 +89,15 @@ export const d1CreateCommand = createCommand({
 		logger.log("Created your new D1 database.\n");
 
 		await updateConfigFile(
-			{
+			(name) => ({
 				d1_databases: [
-					{ binding: "DB", database_name: db.name, database_id: db.uuid },
+					{
+						binding: getValidBindingName(name ?? db.name, "DB"),
+						database_name: db.name,
+						database_id: db.uuid,
+					},
 				],
-			},
+			}),
 			config.configPath,
 			env
 		);

--- a/packages/wrangler/src/d1/create.ts
+++ b/packages/wrangler/src/d1/create.ts
@@ -1,6 +1,6 @@
 import dedent from "ts-dedent";
 import { fetchResult } from "../cfetch";
-import { formatConfigSnippet, updateConfigFile } from "../config";
+import { updateConfigFile } from "../config";
 import { createCommand } from "../core/create-command";
 import { getD1ExtraLocationChoices } from "../environment-variables/misc-variables";
 import { UserError } from "../errors";
@@ -89,10 +89,10 @@ export const d1CreateCommand = createCommand({
 		logger.log("Created your new D1 database.\n");
 
 		await updateConfigFile(
-			(name) => ({
+			(bindingName) => ({
 				d1_databases: [
 					{
-						binding: getValidBindingName(name ?? db.name, "DB"),
+						binding: getValidBindingName(bindingName ?? db.name, "DB"),
 						database_name: db.name,
 						database_id: db.uuid,
 					},

--- a/packages/wrangler/src/d1/create.ts
+++ b/packages/wrangler/src/d1/create.ts
@@ -1,6 +1,6 @@
 import dedent from "ts-dedent";
 import { fetchResult } from "../cfetch";
-import { formatConfigSnippet } from "../config";
+import { formatConfigSnippet, updateConfigFile } from "../config";
 import { createCommand } from "../core/create-command";
 import { getD1ExtraLocationChoices } from "../environment-variables/misc-variables";
 import { UserError } from "../errors";
@@ -71,7 +71,7 @@ export const d1CreateCommand = createCommand({
 		},
 	},
 	positionalArgs: ["name"],
-	async handler({ name, location }, { config }) {
+	async handler({ name, location, env }, { config }) {
 		const accountId = await requireAuth(config);
 
 		const db = await createD1Database(config, accountId, name, location);
@@ -86,15 +86,15 @@ export const d1CreateCommand = createCommand({
 			}`
 		);
 		logger.log("Created your new D1 database.\n");
-		logger.log(
-			formatConfigSnippet(
-				{
-					d1_databases: [
-						{ binding: "DB", database_name: db.name, database_id: db.uuid },
-					],
-				},
-				config.configPath
-			)
+
+		await updateConfigFile(
+			{
+				d1_databases: [
+					{ binding: "DB", database_name: db.name, database_id: db.uuid },
+				],
+			},
+			config.configPath,
+			env
 		);
 	},
 });

--- a/packages/wrangler/src/deployment-bundle/bindings.ts
+++ b/packages/wrangler/src/deployment-bundle/bindings.ts
@@ -547,6 +547,7 @@ async function runProvisioningFlow(
 						{ title: "Create new", value: NEW_OPTION_VALUE },
 					]),
 					defaultOption: options.length,
+					fallbackOption: options.length,
 				}
 			);
 		}

--- a/packages/wrangler/src/dialogs.ts
+++ b/packages/wrangler/src/dialogs.ts
@@ -91,6 +91,7 @@ export async function prompt(
 interface SelectOptions<Values> {
 	choices: SelectOption<Values>[];
 	defaultOption?: number;
+	fallbackOption?: number;
 }
 
 interface SelectOption<Values> {
@@ -104,16 +105,17 @@ export async function select<Values extends string>(
 	options: SelectOptions<Values>
 ): Promise<Values> {
 	if (isNonInteractiveOrCI()) {
-		if (options?.defaultOption === undefined) {
+		const fallback = options.fallbackOption ?? options.defaultOption;
+		if (fallback === undefined) {
 			throw new NoDefaultValueProvided();
 		}
 		logger.log(`? ${text}`);
 		logger.log(
 			`🤖 ${chalk.dim(
-				"Using default value in non-interactive context:"
-			)} ${chalk.white.bold(options.choices[options.defaultOption].title)}`
+				"Using fallback value in non-interactive context:"
+			)} ${chalk.white.bold(options.choices[fallback].title)}`
 		);
-		return options.choices[options.defaultOption].value;
+		return options.choices[fallback].value;
 	}
 
 	const { value } = await prompts({

--- a/packages/wrangler/src/dialogs.ts
+++ b/packages/wrangler/src/dialogs.ts
@@ -105,17 +105,16 @@ export async function select<Values extends string>(
 	options: SelectOptions<Values>
 ): Promise<Values> {
 	if (isNonInteractiveOrCI()) {
-		const fallback = options.fallbackOption ?? options.defaultOption;
-		if (fallback === undefined) {
+		if (options.fallbackOption === undefined) {
 			throw new NoDefaultValueProvided();
 		}
 		logger.log(`? ${text}`);
 		logger.log(
 			`🤖 ${chalk.dim(
 				"Using fallback value in non-interactive context:"
-			)} ${chalk.white.bold(options.choices[fallback].title)}`
+			)} ${chalk.white.bold(options.choices[options.fallbackOption].title)}`
 		);
-		return options.choices[fallback].value;
+		return options.choices[options.fallbackOption].value;
 	}
 
 	const { value } = await prompts({

--- a/packages/wrangler/src/hyperdrive/create.ts
+++ b/packages/wrangler/src/hyperdrive/create.ts
@@ -5,6 +5,7 @@ import {
 } from "../config";
 import { createCommand } from "../core/create-command";
 import { logger } from "../logger";
+import { getValidBindingName } from "../utils/getValidBindingName";
 import { createConfig } from "./client";
 import { capitalizeScheme } from "./shared";
 import {
@@ -46,9 +47,14 @@ export const hyperdriveCreateCommand = createCommand({
 		);
 
 		await updateConfigFile(
-			{
-				hyperdrive: [{ binding: "HYPERDRIVE", id: database.id }],
-			},
+			(name) => ({
+				hyperdrive: [
+					{
+						binding: getValidBindingName(name ?? "HYPERDRIVE", "HYPERDRIVE"),
+						id: database.id,
+					},
+				],
+			}),
 			config.configPath,
 			args.env
 		);

--- a/packages/wrangler/src/hyperdrive/create.ts
+++ b/packages/wrangler/src/hyperdrive/create.ts
@@ -1,4 +1,8 @@
-import { configFileName, formatConfigSnippet } from "../config";
+import {
+	configFileName,
+	formatConfigSnippet,
+	updateConfigFile,
+} from "../config";
 import { createCommand } from "../core/create-command";
 import { logger } from "../logger";
 import { createConfig } from "./client";
@@ -40,16 +44,13 @@ export const hyperdriveCreateCommand = createCommand({
 		logger.log(
 			`✅ Created new Hyperdrive ${capitalizeScheme(database.origin.scheme)} config: ${database.id}`
 		);
-		logger.log(
-			`📋 To start using your config from a Worker, add the following binding configuration to your ${configFileName(config.configPath)} file:\n`
-		);
-		logger.log(
-			formatConfigSnippet(
-				{
-					hyperdrive: [{ binding: "HYPERDRIVE", id: database.id }],
-				},
-				config.configPath
-			)
+
+		await updateConfigFile(
+			{
+				hyperdrive: [{ binding: "HYPERDRIVE", id: database.id }],
+			},
+			config.configPath,
+			args.env
 		);
 	},
 });

--- a/packages/wrangler/src/hyperdrive/create.ts
+++ b/packages/wrangler/src/hyperdrive/create.ts
@@ -1,6 +1,4 @@
 import {
-	configFileName,
-	formatConfigSnippet,
 	updateConfigFile,
 } from "../config";
 import { createCommand } from "../core/create-command";

--- a/packages/wrangler/src/hyperdrive/create.ts
+++ b/packages/wrangler/src/hyperdrive/create.ts
@@ -1,6 +1,4 @@
-import {
-	updateConfigFile,
-} from "../config";
+import { updateConfigFile } from "../config";
 import { createCommand } from "../core/create-command";
 import { logger } from "../logger";
 import { getValidBindingName } from "../utils/getValidBindingName";

--- a/packages/wrangler/src/kv/index.ts
+++ b/packages/wrangler/src/kv/index.ts
@@ -105,14 +105,14 @@ export const kvNamespaceCreateCommand = createCommand({
 		const previewString = args.preview ? "preview_" : "";
 
 		await updateConfigFile(
-			{
+			(name) => ({
 				kv_namespaces: [
 					{
-						binding: getValidBindingName(args.namespace, "KV"),
+						binding: getValidBindingName(name ?? args.namespace, "KV"),
 						[`${previewString}id`]: namespaceId,
 					},
 				],
-			},
+			}),
 			config.configPath,
 			args.env,
 			!args.preview

--- a/packages/wrangler/src/kv/index.ts
+++ b/packages/wrangler/src/kv/index.ts
@@ -2,7 +2,7 @@ import { strict as assert } from "node:assert";
 import { Blob } from "node:buffer";
 import { arrayBuffer } from "node:stream/consumers";
 import { StringDecoder } from "node:string_decoder";
-import { formatConfigSnippet, readConfig } from "../config";
+import { readConfig, updateConfigFile } from "../config";
 import { demandOneOfOption } from "../core";
 import { createCommand, createNamespace } from "../core/create-command";
 import { confirm } from "../dialogs";
@@ -102,24 +102,20 @@ export const kvNamespaceCreateCommand = createCommand({
 		});
 
 		logger.log("✨ Success!");
-		const envString = args.env ? ` under [env.${args.env}]` : "";
 		const previewString = args.preview ? "preview_" : "";
-		logger.log(
-			`Add the following to your configuration file in your kv_namespaces array${envString}:`
-		);
 
-		logger.log(
-			formatConfigSnippet(
-				{
-					kv_namespaces: [
-						{
-							binding: getValidBindingName(args.namespace, "KV"),
-							[`${previewString}id`]: namespaceId,
-						},
-					],
-				},
-				config.configPath
-			)
+		await updateConfigFile(
+			{
+				kv_namespaces: [
+					{
+						binding: getValidBindingName(args.namespace, "KV"),
+						[`${previewString}id`]: namespaceId,
+					},
+				],
+			},
+			config.configPath,
+			args.env,
+			!args.preview
 		);
 	},
 });

--- a/packages/wrangler/src/pipelines/cli/create.ts
+++ b/packages/wrangler/src/pipelines/cli/create.ts
@@ -1,4 +1,4 @@
-import { formatConfigSnippet } from "../../config";
+import { formatConfigSnippet, updateConfigFile } from "../../config";
 import { createCommand } from "../../core/create-command";
 import { FatalError, UserError } from "../../errors";
 import { logger } from "../../logger";
@@ -277,21 +277,17 @@ export const pipelinesCreateCommand = createCommand({
 		logger.log("🎉 You can now send data to your pipeline!");
 
 		if (args.source.includes("worker")) {
-			logger.log(
-				`\nTo send data to your pipeline from a Worker, add the following to your wrangler config file:\n`
-			);
-			logger.log(
-				formatConfigSnippet(
-					{
-						pipelines: [
-							{
-								pipeline: pipeline.name,
-								binding: getValidBindingName("PIPELINE", "PIPELINE"),
-							},
-						],
-					},
-					config.configPath
-				)
+			await updateConfigFile(
+				{
+					pipelines: [
+						{
+							pipeline: pipeline.name,
+							binding: getValidBindingName("PIPELINE", "PIPELINE"),
+						},
+					],
+				},
+				config.configPath,
+				args.env
 			);
 		}
 

--- a/packages/wrangler/src/pipelines/cli/create.ts
+++ b/packages/wrangler/src/pipelines/cli/create.ts
@@ -1,4 +1,4 @@
-import { formatConfigSnippet, updateConfigFile } from "../../config";
+import { updateConfigFile } from "../../config";
 import { createCommand } from "../../core/create-command";
 import { FatalError, UserError } from "../../errors";
 import { logger } from "../../logger";
@@ -278,11 +278,14 @@ export const pipelinesCreateCommand = createCommand({
 
 		if (args.source.includes("worker")) {
 			await updateConfigFile(
-				(name) => ({
+				(bindingName) => ({
 					pipelines: [
 						{
 							pipeline: pipeline.name,
-							binding: getValidBindingName(name ?? "PIPELINE", "PIPELINE"),
+							binding: getValidBindingName(
+								bindingName ?? "PIPELINE",
+								"PIPELINE"
+							),
 						},
 					],
 				}),

--- a/packages/wrangler/src/pipelines/cli/create.ts
+++ b/packages/wrangler/src/pipelines/cli/create.ts
@@ -278,14 +278,14 @@ export const pipelinesCreateCommand = createCommand({
 
 		if (args.source.includes("worker")) {
 			await updateConfigFile(
-				{
+				(name) => ({
 					pipelines: [
 						{
 							pipeline: pipeline.name,
-							binding: getValidBindingName("PIPELINE", "PIPELINE"),
+							binding: getValidBindingName(name ?? "PIPELINE", "PIPELINE"),
 						},
 					],
-				},
+				}),
 				config.configPath,
 				args.env
 			);

--- a/packages/wrangler/src/r2/bucket.ts
+++ b/packages/wrangler/src/r2/bucket.ts
@@ -97,14 +97,14 @@ export const r2BucketCreateCommand = createCommand({
 			} default storage class of ${storageClass ? storageClass : `Standard`}.`);
 
 		await updateConfigFile(
-			{
+			(name) => ({
 				r2_buckets: [
 					{
 						bucket_name: args.name,
-						binding: getValidBindingName(args.name, "r2"),
+						binding: getValidBindingName(name ?? args.name, "r2"),
 					},
 				],
-			},
+			}),
 			config.configPath,
 			args.env
 		);

--- a/packages/wrangler/src/r2/bucket.ts
+++ b/packages/wrangler/src/r2/bucket.ts
@@ -1,5 +1,5 @@
 import dedent from "ts-dedent";
-import { formatConfigSnippet } from "../config";
+import { formatConfigSnippet, updateConfigFile } from "../config";
 import { createCommand, createNamespace } from "../core/create-command";
 import { UserError } from "../errors";
 import { logger } from "../logger";
@@ -94,11 +94,20 @@ export const r2BucketCreateCommand = createCommand({
 		logger.log(dedent`
 			✅ Created bucket '${fullBucketName}' with${
 				location ? ` location hint ${location} and` : ``
-			} default storage class of ${storageClass ? storageClass : `Standard`}.
+			} default storage class of ${storageClass ? storageClass : `Standard`}.`);
 
-			Configure your Worker to write objects to this bucket:
-
-			${formatConfigSnippet({ r2_buckets: [{ bucket_name: args.name, binding: getValidBindingName(args.name, "r2") }] }, config.configPath)}`);
+		await updateConfigFile(
+			{
+				r2_buckets: [
+					{
+						bucket_name: args.name,
+						binding: getValidBindingName(args.name, "r2"),
+					},
+				],
+			},
+			config.configPath,
+			args.env
+		);
 
 		metrics.sendMetricsEvent("create r2 bucket", {
 			sendMetrics: config.send_metrics,

--- a/packages/wrangler/src/r2/bucket.ts
+++ b/packages/wrangler/src/r2/bucket.ts
@@ -1,5 +1,5 @@
 import dedent from "ts-dedent";
-import { formatConfigSnippet, updateConfigFile } from "../config";
+import { updateConfigFile } from "../config";
 import { createCommand, createNamespace } from "../core/create-command";
 import { UserError } from "../errors";
 import { logger } from "../logger";
@@ -97,11 +97,11 @@ export const r2BucketCreateCommand = createCommand({
 			} default storage class of ${storageClass ? storageClass : `Standard`}.`);
 
 		await updateConfigFile(
-			(name) => ({
+			(bindingName) => ({
 				r2_buckets: [
 					{
 						bucket_name: args.name,
-						binding: getValidBindingName(name ?? args.name, "r2"),
+						binding: getValidBindingName(bindingName ?? args.name, "r2"),
 					},
 				],
 			}),

--- a/packages/wrangler/src/vectorize/create.ts
+++ b/packages/wrangler/src/vectorize/create.ts
@@ -1,4 +1,8 @@
-import { configFileName, formatConfigSnippet } from "../config";
+import {
+	configFileName,
+	formatConfigSnippet,
+	updateConfigFile,
+} from "../config";
 import { createCommand } from "../core/create-command";
 import { UserError } from "../errors";
 import { logger } from "../logger";
@@ -112,21 +116,18 @@ export const vectorizeCreateCommand = createCommand({
 		logger.log(
 			`✅ Successfully created a new Vectorize index: '${indexResult.name}'`
 		);
-		logger.log(
-			`📋 To start querying from a Worker, add the following binding configuration to your ${configFileName(config.configPath)} file:\n`
-		);
-		logger.log(
-			formatConfigSnippet(
-				{
-					vectorize: [
-						{
-							binding: bindingName,
-							index_name: indexResult.name,
-						},
-					],
-				},
-				config.configPath
-			)
+
+		await updateConfigFile(
+			{
+				vectorize: [
+					{
+						binding: bindingName,
+						index_name: indexResult.name,
+					},
+				],
+			},
+			config.configPath,
+			args.env
 		);
 	},
 });

--- a/packages/wrangler/src/vectorize/create.ts
+++ b/packages/wrangler/src/vectorize/create.ts
@@ -6,6 +6,7 @@ import {
 import { createCommand } from "../core/create-command";
 import { UserError } from "../errors";
 import { logger } from "../logger";
+import { getValidBindingName } from "../utils/getValidBindingName";
 import { createIndex } from "./client";
 import { deprecatedV1DefaultFlag } from "./common";
 import type { VectorizeDistanceMetric } from "./types";
@@ -118,14 +119,14 @@ export const vectorizeCreateCommand = createCommand({
 		);
 
 		await updateConfigFile(
-			{
+			(name) => ({
 				vectorize: [
 					{
-						binding: bindingName,
+						binding: getValidBindingName(name ?? bindingName, bindingName),
 						index_name: indexResult.name,
 					},
 				],
-			},
+			}),
 			config.configPath,
 			args.env
 		);

--- a/packages/wrangler/src/vectorize/create.ts
+++ b/packages/wrangler/src/vectorize/create.ts
@@ -1,6 +1,4 @@
-import {
-	updateConfigFile,
-} from "../config";
+import { updateConfigFile } from "../config";
 import { createCommand } from "../core/create-command";
 import { UserError } from "../errors";
 import { logger } from "../logger";

--- a/packages/wrangler/src/vectorize/create.ts
+++ b/packages/wrangler/src/vectorize/create.ts
@@ -1,6 +1,4 @@
 import {
-	configFileName,
-	formatConfigSnippet,
 	updateConfigFile,
 } from "../config";
 import { createCommand } from "../core/create-command";


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/9730

When running a resource creation command (like `wrangler kv namespace create NAME`), Wrangler will now offer to update your config file for you. Some notes:
- This does not work for preview KV namespaces, as we don't know the right main KV ID to use
- This _does_ work for environments, and will update the relevant resource field in the given environment (i.e. `--env test`)
- Wrangler will prompt with 3 options: Yes, Yes but change the binding name (which will then present a second dialog to choose the binding name), or No
- This will not work in non-interactive contexts like CI
- This will not work when running Wrangler in a context that can't find a config file
- Updating the config file only works for jsonc format

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this doesn't need additional documentation
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: new feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
