### PR TITLE
Exclude Cloudflare built-ins from client dependency optimization

### DIFF
--- a/.changeset/thick-breads-jam.md
+++ b/.changeset/thick-breads-jam.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Exclude Cloudflare built-ins from client dependency optimization.
+Some frameworks allow users to mix client and server code in the same file and then extract the server code.
+As the dependency optimization may happen before the server code is extracted, we now exclude Cloudflare built-ins from client optimization.

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -20,6 +20,7 @@ import {
 import { hasAssetsConfigChanged } from "./asset-config";
 import { createBuildApp } from "./build";
 import {
+	cloudflareBuiltInModules,
 	createCloudflareEnvironmentOptions,
 	initRunners,
 } from "./cloudflare-environment";
@@ -172,6 +173,11 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 									client: {
 										build: {
 											outDir: getOutputDirectory(userConfig, "client"),
+										},
+										optimizeDeps: {
+											// Some frameworks allow users to mix client and server code in the same file and then extract the server code.
+											// As the dependency optimization may happen before the server code is extracted, we should exclude Cloudflare built-ins from client optimization.
+											exclude: [...cloudflareBuiltInModules],
 										},
 									},
 								}


### PR DESCRIPTION
Fixes #000.

Some frameworks allow users to mix client and server code in the same file and then extract the server code.
As the dependency optimization may happen before the server code is extracted, we now exclude Cloudflare built-ins from client optimization.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: not failing existing tests is enough
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
