### PR TITLE
Update C3 templates to use Durable Object getByName

### DIFF
--- a/.changeset/curvy-feet-swim.md
+++ b/.changeset/curvy-feet-swim.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": minor
+---
+
+Update create-cloudflare hello-world Durable Objects templates to use `getByName()`

--- a/packages/create-cloudflare/templates/hello-world-durable-object-with-assets/js/src/index.js
+++ b/packages/create-cloudflare/templates/hello-world-durable-object-with-assets/js/src/index.js
@@ -52,17 +52,15 @@ export default {
 	 * @returns {Promise<Response>} The response to be sent back to the client
 	 */
 	async fetch(request, env, ctx) {
-		// Create a `DurableObjectId` for an instance of the `MyDurableObject`
-		// class named "foo". Requests from all Workers to the instance named
-		// "foo" will go to a single globally unique Durable Object instance.
-		const id = env.MY_DURABLE_OBJECT.idFromName("foo");
-
-		// Create a stub to open a communication channel with the Durable
-		// Object instance.
-		const stub = env.MY_DURABLE_OBJECT.get(id);
+		// Create a stub to open a communication channel with the Durable Object
+		// instance named "foo".
+		//
+		// Requests from all Workers to the Durable Object instance named "foo"
+		// will go to a single remote Durable Object instance.
+		const stub = env.MY_DURABLE_OBJECT.getByName("foo");
 
 		// Call the `sayHello()` RPC method on the stub to invoke the method on
-		// the remote Durable Object instance
+		// the remote Durable Object instance.
 		const greeting = await stub.sayHello("world");
 
 		return new Response(greeting);

--- a/packages/create-cloudflare/templates/hello-world-durable-object-with-assets/py/src/entry.py
+++ b/packages/create-cloudflare/templates/hello-world-durable-object-with-assets/py/src/entry.py
@@ -50,17 +50,15 @@ class MyDurableObject(DurableObject):
 """
 class Default(WorkerEntrypoint):
     async def fetch(self, request):
-        # Create a `DurableObjectId` for an instance of the `MyDurableObject`
-        # class named "foo". Requests from all Workers to the instance named
-        # "foo" will go to a single globally unique Durable Object instance.
-        id = self.env.MY_DURABLE_OBJECT.idFromName("foo")
+		# Create a stub to open a communication channel with the Durable Object
+		# instance named "foo".
+		#
+		# Requests from all Workers to the Durable Object instance named "foo"
+		# will go to a single remote Durable Object instance.
+        stub = self.env.MY_DURABLE_OBJECT.getByName("foo")
 
-        # Create a stub to open a communication channel with the Durable
-        # Object instance.
-        stub = self.env.MY_DURABLE_OBJECT.get(id)
-
-        # Call the `say_hello()` RPC method on the stub to invoke the method on
-        # the remote Durable Object instance
+		# Call the `say_hello()` RPC method on the stub to invoke the method on
+		# the remote Durable Object instance.
         greeting = await stub.say_hello("world")
 
         return Response(greeting)

--- a/packages/create-cloudflare/templates/hello-world-durable-object-with-assets/ts/src/index.ts
+++ b/packages/create-cloudflare/templates/hello-world-durable-object-with-assets/ts/src/index.ts
@@ -49,17 +49,15 @@ export default {
 	 * @returns The response to be sent back to the client
 	 */
 	async fetch(request, env, ctx): Promise<Response> {
-		// Create a `DurableObjectId` for an instance of the `MyDurableObject`
-		// class named "foo". Requests from all Workers to the instance named
-		// "foo" will go to a single globally unique Durable Object instance.
-		const id: DurableObjectId = env.MY_DURABLE_OBJECT.idFromName("foo");
-
-		// Create a stub to open a communication channel with the Durable
-		// Object instance.
-		const stub = env.MY_DURABLE_OBJECT.get(id);
+		// Create a stub to open a communication channel with the Durable Object
+		// instance named "foo".
+		//
+		// Requests from all Workers to the Durable Object instance named "foo"
+		// will go to a single remote Durable Object instance.
+		const stub = env.MY_DURABLE_OBJECT.getByName("foo");
 
 		// Call the `sayHello()` RPC method on the stub to invoke the method on
-		// the remote Durable Object instance
+		// the remote Durable Object instance.
 		const greeting = await stub.sayHello("world");
 
 		return new Response(greeting);

--- a/packages/create-cloudflare/templates/hello-world-durable-object/js/src/index.js
+++ b/packages/create-cloudflare/templates/hello-world-durable-object/js/src/index.js
@@ -52,17 +52,15 @@ export default {
 	 * @returns {Promise<Response>} The response to be sent back to the client
 	 */
 	async fetch(request, env, ctx) {
-		// Create a `DurableObjectId` for an instance of the `MyDurableObject`
-		// class named "foo". Requests from all Workers to the instance named
-		// "foo" will go to a single globally unique Durable Object instance.
-		const id = env.MY_DURABLE_OBJECT.idFromName("foo");
-
-		// Create a stub to open a communication channel with the Durable
-		// Object instance.
-		const stub = env.MY_DURABLE_OBJECT.get(id);
+		// Create a stub to open a communication channel with the Durable Object
+		// instance named "foo".
+		//
+		// Requests from all Workers to the Durable Object instance named "foo"
+		// will go to a single remote Durable Object instance.
+		const stub = env.MY_DURABLE_OBJECT.getByName("foo");
 
 		// Call the `sayHello()` RPC method on the stub to invoke the method on
-		// the remote Durable Object instance
+		// the remote Durable Object instance.
 		const greeting = await stub.sayHello("world");
 
 		return new Response(greeting);

--- a/packages/create-cloudflare/templates/hello-world-durable-object/py/src/entry.py
+++ b/packages/create-cloudflare/templates/hello-world-durable-object/py/src/entry.py
@@ -50,17 +50,15 @@ class Default(WorkerEntrypoint):
     * @returns {Promise<Response>} The response to be sent back to the client
     """
     async def fetch(self, request):
-        # Create a `DurableObjectId` for an instance of the `MyDurableObject`
-        # class named "foo". Requests from all Workers to the instance named
-        # "foo" will go to a single globally unique Durable Object instance.
-        id = self.env.MY_DURABLE_OBJECT.idFromName("foo")
+		# Create a stub to open a communication channel with the Durable Object
+		# instance named "foo".
+		#
+		# Requests from all Workers to the Durable Object instance named "foo"
+		# will go to a single remote Durable Object instance.
+        stub = self.env.MY_DURABLE_OBJECT.getByName("foo")
 
-        # Create a stub to open a communication channel with the Durable
-        # Object instance.
-        stub = self.env.MY_DURABLE_OBJECT.get(id)
-
-        # Call the `say_hello()` RPC method on the stub to invoke the method on
-        # the remote Durable Object instance
+		# Call the `say_hello()` RPC method on the stub to invoke the method on
+		# the remote Durable Object instance.
         greeting = await stub.say_hello("world")
 
         return Response(greeting)

--- a/packages/create-cloudflare/templates/hello-world-durable-object/ts/src/index.ts
+++ b/packages/create-cloudflare/templates/hello-world-durable-object/ts/src/index.ts
@@ -48,17 +48,15 @@ export default {
 	 * @returns The response to be sent back to the client
 	 */
 	async fetch(request, env, ctx): Promise<Response> {
-		// Create a `DurableObjectId` for an instance of the `MyDurableObject`
-		// class named "foo". Requests from all Workers to the instance named
-		// "foo" will go to a single globally unique Durable Object instance.
-		const id: DurableObjectId = env.MY_DURABLE_OBJECT.idFromName("foo");
-
-		// Create a stub to open a communication channel with the Durable
-		// Object instance.
-		const stub = env.MY_DURABLE_OBJECT.get(id);
+		// Create a stub to open a communication channel with the Durable Object
+		// instance named "foo".
+		//
+		// Requests from all Workers to the Durable Object instance named "foo"
+		// will go to a single remote Durable Object instance.
+		const stub = env.MY_DURABLE_OBJECT.getByName("foo");
 
 		// Call the `sayHello()` RPC method on the stub to invoke the method on
-		// the remote Durable Object instance
+		// the remote Durable Object instance.
 		const greeting = await stub.sayHello("world");
 
 		return new Response(greeting);


### PR DESCRIPTION
Fixes #[insert GH or internal issue link(s)].

Update C3 templates to use Durable Object getByName

- Tests
  - [ ] Tests included
  - [X] Tests not necessary because: I assume we already have tests that C3 templates render
- Public documentation
  - [X] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/24586
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [X] Not necessary because: The only templates work just fine.

