### PR TITLE
Simplify ENOENT debug logs for `.env` files

### DIFF
--- a/.changeset/green-bugs-shout.md
+++ b/.changeset/green-bugs-shout.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Simplify ENOENT debug logs for `.env` files

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1118,6 +1118,17 @@ describe.sequential("wrangler dev", () => {
 					__DOT_ENV_TEST_CUSTOM_BUILD_VAR_LOCAL=other-local"
 				`);
 			});
+
+			it("should show reasonable debug output if `.env` does not exist", async () => {
+				fs.rmSync(".env");
+				writeWranglerConfig({
+					main: "index.js",
+				});
+				await runWranglerUntilConfig("dev --log-level debug");
+				expect(std.debug).toContain(
+					'.env file not found at "<cwd>/.env". Continuing... For more details, refer to https://developers.cloudflare.com/workers/wrangler/system-environment-variables/'
+				);
+			});
 		});
 	});
 

--- a/packages/wrangler/src/config/dot-env.ts
+++ b/packages/wrangler/src/config/dot-env.ts
@@ -49,7 +49,7 @@ export function loadDotEnv(
 			override: true,
 		});
 		if (error) {
-			if ('code' in error && error.code === "ENOENT") {
+			if ("code" in error && error.code === "ENOENT") {
 				logger.debug(
 					`.env file not found at "${envPath}". Continuing... For more details, refer to https://developers.cloudflare.com/workers/wrangler/system-environment-variables/`
 				);

--- a/packages/wrangler/src/config/dot-env.ts
+++ b/packages/wrangler/src/config/dot-env.ts
@@ -49,7 +49,7 @@ export function loadDotEnv(
 			override: true,
 		});
 		if (error) {
-			if ((error as unknown as { code: string }).code === "ENOENT") {
+			if ('code' in error && error.code === "ENOENT") {
 				logger.debug(
 					`.env file not found at "${envPath}". Continuing... For more details, refer to https://developers.cloudflare.com/workers/wrangler/system-environment-variables/`
 				);

--- a/packages/wrangler/src/config/dot-env.ts
+++ b/packages/wrangler/src/config/dot-env.ts
@@ -49,7 +49,13 @@ export function loadDotEnv(
 			override: true,
 		});
 		if (error) {
-			logger.debug(`Failed to load .env file "${envPath}":`, error);
+			if ((error as unknown as { code: string }).code === "ENOENT") {
+				logger.debug(
+					`.env file not found at "${envPath}". Continuing... For more details, refer to https://developers.cloudflare.com/workers/wrangler/system-environment-variables/`
+				);
+			} else {
+				logger.debug(`Failed to load .env file "${envPath}":`, error);
+			}
 		} else if (parsed && !silent) {
 			const relativePath = path.relative(process.cwd(), envPath);
 			logger.log(`Using vars defined in ${relativePath}`);


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/7042

This PR reintroduces the changes made in https://github.com/cloudflare/workers-sdk/pull/7272 that were incorrectly removed in https://github.com/cloudflare/workers-sdk/pull/9914

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: simple UX improvement
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: The `.env` change that caused this regression is not in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
