### PR TITLE
fix(vite-plugin): Run type check for all playground projects

### DIFF
--- a/packages/vite-plugin-cloudflare/playground/additional-modules/package.json
+++ b/packages/vite-plugin-cloudflare/playground/additional-modules/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"preview": "vite preview"
 	},

--- a/packages/vite-plugin-cloudflare/playground/assets/package.json
+++ b/packages/vite-plugin-cloudflare/playground/assets/package.json
@@ -6,7 +6,7 @@
 		"build": "vite build",
 		"build:no-client-entry": "vite build -c vite.config.no-client-entry.ts",
 		"build:public-dir-only": "vite build -c vite.config.public-dir-only.ts",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"dev:no-client-entry": "vite dev -c vite.config.no-client-entry.ts",
 		"dev:public-dir-only": "vite dev -c vite.config.public-dir-only.ts",

--- a/packages/vite-plugin-cloudflare/playground/bindings/package.json
+++ b/packages/vite-plugin-cloudflare/playground/bindings/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"build": "vite build --app",
 		"cf-typegen": "wrangler types --include-runtime=false",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"preview": "vite preview"
 	},

--- a/packages/vite-plugin-cloudflare/playground/block-concurrency-while/package.json
+++ b/packages/vite-plugin-cloudflare/playground/block-concurrency-while/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"preview": "vite preview"
 	},

--- a/packages/vite-plugin-cloudflare/playground/cloudflare-env/package.json
+++ b/packages/vite-plugin-cloudflare/playground/cloudflare-env/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"build": "vite build --app",
 		"build:custom-mode": "vite build --app -c vite.config.custom-mode.ts",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"dev:custom-mode": "vite dev -c vite.config.custom-mode.ts",
 		"preview": "vite preview",

--- a/packages/vite-plugin-cloudflare/playground/cloudflare-env/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/cloudflare-env/src/index.ts
@@ -3,7 +3,7 @@ interface Env {
 }
 
 export default {
-	async fetch(request, env) {
+	async fetch(_request, env) {
 		return new Response(env.MY_VAR);
 	},
 } satisfies ExportedHandler<Env>;

--- a/packages/vite-plugin-cloudflare/playground/config-changes/package.json
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"preview": "vite preview"
 	},

--- a/packages/vite-plugin-cloudflare/playground/containers/package.json
+++ b/packages/vite-plugin-cloudflare/playground/containers/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"preview": "vite preview"
 	},

--- a/packages/vite-plugin-cloudflare/playground/containers/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/containers/src/index.ts
@@ -1,5 +1,9 @@
 import { DurableObject } from "cloudflare:workers";
 
+interface Env {
+	CONTAINER: DurableObjectNamespace<import(".").Container>
+}
+
 export class Container extends DurableObject<Env> {
 	container: globalThis.Container;
 	monitor?: Promise<unknown>;
@@ -9,7 +13,7 @@ export class Container extends DurableObject<Env> {
 		this.container = ctx.container!;
 	}
 
-	async fetch(req: Request) {
+	override async fetch(req: Request) {
 		const path = new URL(req.url).pathname;
 		switch (path) {
 			case "/status":

--- a/packages/vite-plugin-cloudflare/playground/custom-build-app/package.json
+++ b/packages/vite-plugin-cloudflare/playground/custom-build-app/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"preview": "vite preview"
 	},

--- a/packages/vite-plugin-cloudflare/playground/deps-assets-importing/package.json
+++ b/packages/vite-plugin-cloudflare/playground/deps-assets-importing/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"preview": "vite preview"
 	},

--- a/packages/vite-plugin-cloudflare/playground/dev-vars/package.json
+++ b/packages/vite-plugin-cloudflare/playground/dev-vars/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"preview": "vite preview"
 	},

--- a/packages/vite-plugin-cloudflare/playground/dot-env/package.json
+++ b/packages/vite-plugin-cloudflare/playground/dot-env/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"preview": "vite preview"
 	},

--- a/packages/vite-plugin-cloudflare/playground/durable-objects/package.json
+++ b/packages/vite-plugin-cloudflare/playground/durable-objects/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"preview": "vite preview"
 	},

--- a/packages/vite-plugin-cloudflare/playground/dynamic-import-paths/package.json
+++ b/packages/vite-plugin-cloudflare/playground/dynamic-import-paths/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"preview": "vite preview"
 	},

--- a/packages/vite-plugin-cloudflare/playground/external-durable-objects/package.json
+++ b/packages/vite-plugin-cloudflare/playground/external-durable-objects/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"preview": "vite preview"
 	},

--- a/packages/vite-plugin-cloudflare/playground/external-workers/package.json
+++ b/packages/vite-plugin-cloudflare/playground/external-workers/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"preview": "vite preview"
 	},

--- a/packages/vite-plugin-cloudflare/playground/external-workflows/package.json
+++ b/packages/vite-plugin-cloudflare/playground/external-workflows/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"preview": "vite preview"
 	},

--- a/packages/vite-plugin-cloudflare/playground/external-workflows/worker-b/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/external-workflows/worker-b/index.ts
@@ -2,7 +2,7 @@ import { WorkflowEntrypoint } from "cloudflare:workers";
 import type { WorkflowEvent, WorkflowStep } from "cloudflare:workers";
 
 export class MyWorkflow extends WorkflowEntrypoint {
-	override async run(event: WorkflowEvent<Params>, step: WorkflowStep) {
+	override async run(_event: WorkflowEvent<Params>, step: WorkflowStep) {
 		await step.do("first step", async () => {
 			return {
 				output: "First step result",

--- a/packages/vite-plugin-cloudflare/playground/hot-channel/package.json
+++ b/packages/vite-plugin-cloudflare/playground/hot-channel/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev"
 	},
 	"devDependencies": {

--- a/packages/vite-plugin-cloudflare/playground/importable-env/package.json
+++ b/packages/vite-plugin-cloudflare/playground/importable-env/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"preview": "vite preview"
 	},

--- a/packages/vite-plugin-cloudflare/playground/module-resolution/package.json
+++ b/packages/vite-plugin-cloudflare/playground/module-resolution/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"build": "vite build --app",
 		"build:nodejs-compat": "vite build --app -c ./vite.config.nodejs-compat.ts",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"dev:nodejs-compat": "vite dev -c ./vite.config.nodejs-compat.ts",
 		"preview": "vite preview",

--- a/packages/vite-plugin-cloudflare/playground/multi-worker/package.json
+++ b/packages/vite-plugin-cloudflare/playground/multi-worker/package.json
@@ -6,7 +6,7 @@
 		"build": "vite build --app",
 		"build:custom-output-directories": "vite build --app -c ./vite.config.custom-output-directories.ts",
 		"build:with-worker-configs-warning": "vite build --app -c vite.config.with-worker-configs-warning.ts",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"deploy-a": "wrangler deploy -c ./dist/worker_a/wrangler.json",
 		"deploy-b": "wrangler deploy -c ./dist/worker_b/wrangler.json",
 		"dev": "vite dev",

--- a/packages/vite-plugin-cloudflare/playground/node-compat/package.json
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/package.json
@@ -9,7 +9,7 @@
 		"basic:preview": "vite preview -c vite.config.worker-basic.ts",
 		"basic:test": "vitest run -c ../vitest.config.e2e.ts worker-basic",
 		"build": "pnpm run basic:build && pnpm run cross-env:build && pnpm run crypto:build && pnpm run postgres:build && pnpm run process:build && pnpm run random:build",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"cross-env:build": "vite build --app -c vite.config.worker-cross-env.ts",
 		"cross-env:dev": "vite dev -c vite.config.worker-cross-env.ts",
 		"cross-env:preview": "vite preview -c vite.config.worker-cross-env.ts",

--- a/packages/vite-plugin-cloudflare/playground/node-env/package.json
+++ b/packages/vite-plugin-cloudflare/playground/node-env/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"build": "vite build",
 		"build:nodejs-compat": "vite build -c vite.config.nodejs-compat.ts",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"dev:nodejs-compat": "vite dev -c vite.config.nodejs-compat.ts",
 		"preview": "vite preview"

--- a/packages/vite-plugin-cloudflare/playground/package.json
+++ b/packages/vite-plugin-cloudflare/playground/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"playwright:install": "pnpm playwright install chromium",
 		"pretest:ci": "pnpm playwright:install",
 		"test:ci": "pnpm test:ci:serve && pnpm test:ci:build",

--- a/packages/vite-plugin-cloudflare/playground/partyserver/package.json
+++ b/packages/vite-plugin-cloudflare/playground/partyserver/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"preview": "vite preview"
 	},

--- a/packages/vite-plugin-cloudflare/playground/prisma/package.json
+++ b/packages/vite-plugin-cloudflare/playground/prisma/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"prebuild": "pnpm generate",
 		"build": "vite build --app",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"predev": "pnpm generate",
 		"dev": "vite dev",
 		"generate": "pnpm prisma generate",

--- a/packages/vite-plugin-cloudflare/playground/prisma/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/prisma/src/index.ts
@@ -6,7 +6,7 @@ interface Env {
 }
 
 export default {
-	async fetch(request, env) {
+	async fetch(_request, env) {
 		const adapter = new PrismaD1(env.DB);
 		const prisma = new PrismaClient({ adapter });
 		const users = await prisma.user.findMany();

--- a/packages/vite-plugin-cloudflare/playground/react-spa/package.json
+++ b/packages/vite-plugin-cloudflare/playground/react-spa/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"dev:server-headers": "vite dev -c ./vite.config.server-headers.ts",
 		"preview": "vite preview"

--- a/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/package.json
+++ b/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"preview": "vite preview"
 	},

--- a/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/src/index.ts
@@ -11,7 +11,7 @@ export class NamedEntrypoint extends WorkerEntrypoint {
 }
 
 export default {
-	async fetch(request, env) {
+	async fetch(_request, env) {
 		const result = await env.NAMED_ENTRYPOINT.multiply(4, 5);
 		return Response.json({ result });
 	},

--- a/packages/vite-plugin-cloudflare/playground/sensitive-files/package.json
+++ b/packages/vite-plugin-cloudflare/playground/sensitive-files/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"preview": "vite preview"
 	},

--- a/packages/vite-plugin-cloudflare/playground/spa-with-api/package.json
+++ b/packages/vite-plugin-cloudflare/playground/spa-with-api/package.json
@@ -8,7 +8,7 @@
 		"build:https": "vite build -c ./vite.config.https.ts",
 		"build:run-worker-first": "vite build -c ./vite.config.run-worker-first.ts",
 		"build:static-routing": "vite build -c ./vite.config.static-routing.ts",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"dev:https": "vite dev -c ./vite.config.https.ts",
 		"dev:run-worker-first": "vite dev -c ./vite.config.run-worker-first.ts",

--- a/packages/vite-plugin-cloudflare/playground/static-mpa/package.json
+++ b/packages/vite-plugin-cloudflare/playground/static-mpa/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"build": "vite build --app",
 		"build:with-worker-configs-warning": "vite build --app -c vite.config.with-worker-configs-warning.ts",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"dev:with-worker-configs-warning": "vite dev -c vite.config.with-worker-configs-warning.ts",
 		"preview": "vite preview",

--- a/packages/vite-plugin-cloudflare/playground/static/api/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/static/api/index.ts
@@ -1,5 +1,5 @@
 export default {
-	fetch(request, env) {
+	fetch(request) {
 		const url = new URL(request.url);
 
 		if (url.pathname.startsWith("/api/")) {

--- a/packages/vite-plugin-cloudflare/playground/static/package.json
+++ b/packages/vite-plugin-cloudflare/playground/static/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"build": "vite build --app",
 		"build:with-api": "vite build --app -c vite.config.with-api.ts",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"dev:with-api": "vite dev -c vite.config.with-api.ts",
 		"preview": "vite preview",

--- a/packages/vite-plugin-cloudflare/playground/streaming/package.json
+++ b/packages/vite-plugin-cloudflare/playground/streaming/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"build": "vite build",
 		"build:https": "vite build -c ./vite.config.https.ts",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"dev:https": "vite dev -c ./vite.config.https.ts",
 		"preview": "vite preview",

--- a/packages/vite-plugin-cloudflare/playground/streaming/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/streaming/src/index.ts
@@ -32,7 +32,7 @@ async function streamResponse(writable: WritableStream) {
 }
 
 export default {
-	async fetch(request, env) {
+	async fetch(request) {
 		const url = new URL(request.url);
 
 		if (url.pathname === "/") {

--- a/packages/vite-plugin-cloudflare/playground/virtual-modules/package.json
+++ b/packages/vite-plugin-cloudflare/playground/virtual-modules/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"preview": "vite preview"
 	},

--- a/packages/vite-plugin-cloudflare/playground/websockets/package.json
+++ b/packages/vite-plugin-cloudflare/playground/websockets/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"preview": "vite preview"
 	},

--- a/packages/vite-plugin-cloudflare/playground/worker/package.json
+++ b/packages/vite-plugin-cloudflare/playground/worker/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"preview": "vite preview"
 	},

--- a/packages/vite-plugin-cloudflare/playground/worker/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/worker/src/index.ts
@@ -14,6 +14,6 @@ export default {
 	},
 } satisfies ExportedHandler;
 
-addEventListener("unhandledrejection", (event) => {
+addEventListener("unhandledrejection", () => {
 	console.error("__unhandled rejection__");
 });

--- a/packages/vite-plugin-cloudflare/playground/workflows/package.json
+++ b/packages/vite-plugin-cloudflare/playground/workflows/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
-		"check:types": "tsc --build",
+		"check:type": "tsc --build",
 		"dev": "vite dev",
 		"preview": "vite preview"
 	},

--- a/packages/vite-plugin-cloudflare/playground/workflows/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/workflows/src/index.ts
@@ -6,7 +6,7 @@ interface Env {
 }
 
 export class MyWorkflow extends WorkflowEntrypoint<Env> {
-	override async run(event: WorkflowEvent<Params>, step: WorkflowStep) {
+	override async run(_event: WorkflowEvent<Params>, step: WorkflowStep) {
 		await step.do("first step", async () => {
 			return {
 				output: "First step result",


### PR DESCRIPTION
Fixes n/a

All playground projects in `vite-plugin` were incorrectly set with the incorrect `check:types` (see extra `s`) type check script. This resulted in type checking never running on these projects when running `pnpm run type:check` in the root of the repo, or in CI. 

This PR changes the type check script to the correct one: `check:type`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [ ] Tests not necessary because: npm script change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because: internal change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: we are not porting vite-plugin changes

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
