### PR TITLE
make dns test more robust

### DIFF
--- a/packages/wrangler/e2e/unenv-preset/worker/index.ts
+++ b/packages/wrangler/e2e/unenv-preset/worker/index.ts
@@ -157,9 +157,17 @@ export const WorkerdTests: Record<string, () => void> = {
 					reject(error);
 					return;
 				}
-				assert.ok(Array.isArray(results[0]));
-				assert.strictEqual(results.length, 1);
-				assert.ok(results[0][0].startsWith("v=spf1"));
+				assert.ok(Array.isArray(results));
+				assert.ok(results.length >= 1);
+				let foundSpf = false;
+				for (const result of results) {
+					assert.ok(Array.isArray(result));
+					if (result.length >= 1) {
+						assert.strictEqual(typeof result[0], "string");
+						foundSpf ||= result[0].startsWith("v=spf1");
+					}
+				}
+				assert.ok(foundSpf);
 				resolve(null);
 			});
 		});


### PR DESCRIPTION
It looks like `nodejs.org` added a DNS record which break the e2e tests.

Records are now:
- `google-site-verification=v0MKccGKHVIlJbu0s9K45qnPGB7EBWnKzjpsd010r4E` (added)
- `v=spf1 include:aspmx.googlemail.com -all`

This PR updates the test to expect one or more record and at least one starting with `v=spf1`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test update
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
