### PR TITLE
enable_nodejs_http_server_modules is no more experimental

### DIFF
--- a/.changeset/bumpy-mice-follow.md
+++ b/.changeset/bumpy-mice-follow.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/unenv-preset": patch
+---
+
+Remove experimental from the enable_nodejs_http_server_modules flag

--- a/packages/unenv-preset/src/preset.ts
+++ b/packages/unenv-preset/src/preset.ts
@@ -161,18 +161,20 @@ function getHttpOverrides({
 		return { nativeModules: [], hybridModules: [] };
 	}
 
-	const httpServerEnabledByFlag =
-		compatibilityFlags.includes("enable_nodejs_http_server_modules") &&
-		compatibilityFlags.includes("experimental");
+	const httpServerEnabledByFlag = compatibilityFlags.includes(
+		"enable_nodejs_http_server_modules"
+	);
 
 	const httpServerDisabledByFlag = compatibilityFlags.includes(
 		"disable_nodejs_http_server_modules"
 	);
 
+	const httpServerEnabledByDate = compatibilityDate >= "2025-09-01";
+
 	// Note that `httpServerEnabled` requires `httpEnabled`
-	// TODO: add `httpServerEnabledByDate` when a default date is set
 	const httpServerEnabled =
-		httpServerEnabledByFlag && !httpServerDisabledByFlag;
+		(httpServerEnabledByFlag || httpServerEnabledByDate) &&
+		!httpServerDisabledByFlag;
 
 	// Override unenv base aliases with native and hybrid modules
 	// `node:https` is fully implemented by workerd if both flags are enabled

--- a/packages/wrangler/e2e/unenv-preset/preset.test.ts
+++ b/packages/wrangler/e2e/unenv-preset/preset.test.ts
@@ -33,25 +33,30 @@ const testConfigs: TestConfig[] = [
 	[
 		{
 			name: "http disabled by date",
-			compatibilityDate: "2025-07-26",
+			compatibilityDate: "2024-09-23",
 			expectRuntimeFlags: {
 				enable_nodejs_http_modules: false,
 			},
 		},
 		{
 			name: "http disabled by flag",
-			// TODO: use a date when http is enabled by default (> 2025-08-15)
-			compatibilityDate: "2025-07-26",
+			compatibilityDate: "2025-08-15",
 			compatibilityFlags: ["disable_nodejs_http_modules"],
 			expectRuntimeFlags: {
 				enable_nodejs_http_modules: false,
 			},
 		},
-		// TODO: add a config when http is enabled by default (> 2025-08-15)
 		{
 			name: "http enabled by flag",
-			compatibilityDate: "2025-07-26",
+			compatibilityDate: "2024-09-23",
 			compatibilityFlags: ["enable_nodejs_http_modules"],
+			expectRuntimeFlags: {
+				enable_nodejs_http_modules: true,
+			},
+		},
+		{
+			name: "http enabled by date",
+			compatibilityDate: "2025-08-15",
 			expectRuntimeFlags: {
 				enable_nodejs_http_modules: true,
 			},
@@ -61,34 +66,31 @@ const testConfigs: TestConfig[] = [
 	[
 		{
 			name: "http server disabled by date",
-			compatibilityDate: "2025-07-26",
-			compatibilityFlags: ["experimental"],
+			compatibilityDate: "2024-09-23",
 			expectRuntimeFlags: {
 				enable_nodejs_http_modules: false,
 			},
 		},
-		// TODO: add a config when http server is enabled by default (date no set yet)
+		// TODO: add a config when http server is enabled by default (>= 2025-09-01)
 		{
 			name: "http server enabled by flag",
-			compatibilityDate: "2025-07-26",
+			compatibilityDate: "2024-09-23",
 			compatibilityFlags: [
 				"enable_nodejs_http_modules",
 				"enable_nodejs_http_server_modules",
-				"experimental",
 			],
 			expectRuntimeFlags: {
 				enable_nodejs_http_modules: true,
 				enable_nodejs_http_server_modules: true,
 			},
 		},
-		// TODO: change the date pass the default enabled date (date not set yet)
+		// TODO: change the date pass the default enabled date (>= 2025-09-01)
 		{
 			name: "http server disabled by flag",
-			compatibilityDate: "2025-07-26",
+			compatibilityDate: "2024-09-23",
 			compatibilityFlags: [
 				"enable_nodejs_http_modules",
 				"disable_nodejs_http_server_modules",
-				"experimental",
 			],
 			expectRuntimeFlags: {
 				enable_nodejs_http_modules: true,


### PR DESCRIPTION
`enable_nodejs_http_server_modules` is no more experimental and implicitly enabled on 2025-09-01

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: documented by the runtime team
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
