### PR TITLE
chore: bump devalue to 5.3.2

### DIFF
--- a/.changeset/small-things-poke.md
+++ b/.changeset/small-things-poke.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+"miniflare": patch
+---
+
+chore: bump `devalue` version to 5.3.2

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -82,7 +82,7 @@
 		"capnp-es": "^0.0.11",
 		"chokidar": "^4.0.1",
 		"concurrently": "^8.2.2",
-		"devalue": "^4.3.0",
+		"devalue": "^5.3.2",
 		"devtools-protocol": "^0.0.1182435",
 		"esbuild": "catalog:default",
 		"eslint": "^8.57.1",

--- a/packages/vitest-pool-workers/package.json
+++ b/packages/vitest-pool-workers/package.json
@@ -55,7 +55,7 @@
 	"dependencies": {
 		"birpc": "0.2.14",
 		"cjs-module-lexer": "^1.2.3",
-		"devalue": "^4.3.0",
+		"devalue": "^5.3.2",
 		"miniflare": "workspace:*",
 		"semver": "^7.7.1",
 		"wrangler": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1875,7 +1875,7 @@ importers:
         specifier: ^8.2.2
         version: 8.2.2
       devalue:
-        specifier: ^4.3.0
+        specifier: ^5.3.2
         version: 5.3.2
       devtools-protocol:
         specifier: ^0.0.1182435
@@ -3156,7 +3156,7 @@ importers:
         specifier: ^1.2.3
         version: 1.2.3
       devalue:
-        specifier: ^4.3.0
+        specifier: ^5.3.2
         version: 5.3.2
       miniflare:
         specifier: workspace:*
@@ -8637,6 +8637,9 @@ packages:
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
+
+  devalue@4.3.3:
+    resolution: {integrity: sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg==}
 
   devalue@5.3.2:
     resolution: {integrity: sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw==}
@@ -14533,7 +14536,7 @@ snapshots:
       '@vitest/snapshot': 3.2.3
       birpc: 0.2.14
       cjs-module-lexer: 1.2.3
-      devalue: 5.3.2
+      devalue: 4.3.3
       esbuild: 0.17.19
       miniflare: 3.20250310.0
       semver: 7.7.1
@@ -14551,7 +14554,7 @@ snapshots:
       '@vitest/snapshot': 3.2.3
       birpc: 0.2.14
       cjs-module-lexer: 1.2.3
-      devalue: 5.3.2
+      devalue: 4.3.3
       miniflare: 4.20250417.0
       semver: 7.7.2
       vitest: 3.2.3(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/ui@3.2.3)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.3))(supports-color@9.2.2)
@@ -18727,6 +18730,8 @@ snapshots:
   detect-libc@2.0.3: {}
 
   detect-newline@3.1.0: {}
+
+  devalue@4.3.3: {}
 
   devalue@5.3.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1876,7 +1876,7 @@ importers:
         version: 8.2.2
       devalue:
         specifier: ^4.3.0
-        version: 4.3.2
+        version: 5.3.2
       devtools-protocol:
         specifier: ^0.0.1182435
         version: 0.0.1182435
@@ -3157,7 +3157,7 @@ importers:
         version: 1.2.3
       devalue:
         specifier: ^4.3.0
-        version: 4.3.2
+        version: 5.3.2
       miniflare:
         specifier: workspace:*
         version: link:../miniflare
@@ -8638,8 +8638,8 @@ packages:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
 
-  devalue@4.3.2:
-    resolution: {integrity: sha512-KqFl6pOgOW+Y6wJgu80rHpo2/3H07vr8ntR9rkkFIRETewbf5GaYYcakYfiKz89K+sLsuPkQIZaXDMjUObZwWg==}
+  devalue@5.3.2:
+    resolution: {integrity: sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw==}
 
   devtools-protocol@0.0.1182435:
     resolution: {integrity: sha512-EmlkWb62wSbQNE1gRZZsi4KZYRaF5Skpp183LhRU7+sadKR06O1dHCjZmFSEG6Kv7P6S/UYLxcY3NlYwqKM99w==}
@@ -14533,7 +14533,7 @@ snapshots:
       '@vitest/snapshot': 3.2.3
       birpc: 0.2.14
       cjs-module-lexer: 1.2.3
-      devalue: 4.3.2
+      devalue: 5.3.2
       esbuild: 0.17.19
       miniflare: 3.20250310.0
       semver: 7.7.1
@@ -14551,7 +14551,7 @@ snapshots:
       '@vitest/snapshot': 3.2.3
       birpc: 0.2.14
       cjs-module-lexer: 1.2.3
-      devalue: 4.3.2
+      devalue: 5.3.2
       miniflare: 4.20250417.0
       semver: 7.7.2
       vitest: 3.2.3(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/ui@3.2.3)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.8.3))(supports-color@9.2.2)
@@ -18728,7 +18728,7 @@ snapshots:
 
   detect-newline@3.1.0: {}
 
-  devalue@4.3.2: {}
+  devalue@5.3.2: {}
 
   devtools-protocol@0.0.1182435: {}
 


### PR DESCRIPTION
Fixes n/a.

Updated devalue version to address https://github.com/sveltejs/devalue/security/advisories/GHSA-vj54-72f3-p5jv

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: covered by existing tests
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: version bump
- Wrangler V3 Backport
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/10484
  - [ ] Not necessary because: 

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
