### PR TITLE
Update devalue

### DIFF
--- a/.changeset/five-loops-lose.md
+++ b/.changeset/five-loops-lose.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+"miniflare": patch
+---
+
+fix: Update devalue dependency to fix https://github.com/advisories/GHSA-vj54-72f3-p5jv

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -82,7 +82,7 @@
 		"capnp-es": "^0.0.11",
 		"chokidar": "^4.0.1",
 		"concurrently": "^8.2.2",
-		"devalue": "^4.3.0",
+		"devalue": "^5.3.2",
 		"devtools-protocol": "^0.0.1182435",
 		"esbuild": "catalog:default",
 		"eslint": "^8.57.1",

--- a/packages/vitest-pool-workers/package.json
+++ b/packages/vitest-pool-workers/package.json
@@ -55,7 +55,7 @@
 	"dependencies": {
 		"birpc": "0.2.14",
 		"cjs-module-lexer": "^1.2.3",
-		"devalue": "^4.3.0",
+		"devalue": "^5.3.2",
 		"miniflare": "workspace:*",
 		"semver": "^7.7.1",
 		"wrangler": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1875,8 +1875,8 @@ importers:
         specifier: ^8.2.2
         version: 8.2.2
       devalue:
-        specifier: ^4.3.0
-        version: 4.3.2
+        specifier: ^5.3.2
+        version: 5.3.2
       devtools-protocol:
         specifier: ^0.0.1182435
         version: 0.0.1182435
@@ -3156,8 +3156,8 @@ importers:
         specifier: ^1.2.3
         version: 1.2.3
       devalue:
-        specifier: ^4.3.0
-        version: 4.3.2
+        specifier: ^5.3.2
+        version: 5.3.2
       miniflare:
         specifier: workspace:*
         version: link:../miniflare
@@ -8640,6 +8640,9 @@ packages:
 
   devalue@4.3.2:
     resolution: {integrity: sha512-KqFl6pOgOW+Y6wJgu80rHpo2/3H07vr8ntR9rkkFIRETewbf5GaYYcakYfiKz89K+sLsuPkQIZaXDMjUObZwWg==}
+
+  devalue@5.3.2:
+    resolution: {integrity: sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw==}
 
   devtools-protocol@0.0.1182435:
     resolution: {integrity: sha512-EmlkWb62wSbQNE1gRZZsi4KZYRaF5Skpp183LhRU7+sadKR06O1dHCjZmFSEG6Kv7P6S/UYLxcY3NlYwqKM99w==}
@@ -18729,6 +18732,8 @@ snapshots:
   detect-newline@3.1.0: {}
 
   devalue@4.3.2: {}
+
+  devalue@5.3.2: {}
 
   devtools-protocol@0.0.1182435: {}
 


### PR DESCRIPTION
Fixes #[insert GH or internal issue link(s)].

_Describe your change..._
Following https://github.com/advisories/GHSA-vj54-72f3-p5jv, I checked if devalue has had any significant changes, unfortunately the version used by vpw was 4.3.2, but looks like 5.0.0 didn't have anything requiring code changes.

Changelog: https://github.com/sveltejs/devalue/blob/main/CHANGELOG.md
Code diff: https://npmdiff.dev/devalue/5.3.2/4.3.0/

As usual, running tests locally exploded, but looking through the diff and running a manual test worked.
---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
