### PR TITLE
fix outdated Remix template url being used

### DIFF
--- a/.changeset/shiny-maps-type.md
+++ b/.changeset/shiny-maps-type.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix outdated Remix template url being used

--- a/packages/create-cloudflare/templates/remix/pages/c3.ts
+++ b/packages/create-cloudflare/templates/remix/pages/c3.ts
@@ -13,7 +13,7 @@ const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, [
 		ctx.project.name,
 		"--template",
-		"https://github.com/remix-run/remix/tree/main/templates/cloudflare",
+		"https://github.com/remix-run/remix/tree/main-prev/templates/cloudflare",
 	]);
 
 	logRaw(""); // newline

--- a/packages/create-cloudflare/templates/remix/workers/c3.ts
+++ b/packages/create-cloudflare/templates/remix/workers/c3.ts
@@ -12,7 +12,7 @@ const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, [
 		ctx.project.name,
 		"--template",
-		"https://github.com/remix-run/remix/tree/main/templates/cloudflare-workers",
+		"https://github.com/remix-run/remix/tree/main-prev/templates/cloudflare-workers",
 	]);
 
 	logRaw(""); // newline


### PR DESCRIPTION
It looks like the Remix team has updated their main branch for the new Remix v3 ([`main`](https://github.com/remix-run/remix/tree/main)). This causes C3, which fetches the workers/pages template, to fail when trying to create new Remix applications. Thankfully the Remix team also kept the pre-existing templates in the [`main-prev` branch](https://github.com/remix-run/remix/tree/main-prev), so here I am updating C3 to use that instead.

> [!Note]
> Long term we should discuss and see if we should just not support Remix in C3 anymore, and if that would necessarily constitute a breaking change

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: this functionality is already tested
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
