### PR TITLE
[R2 Data Catalog] Add wrangler commands for the R2 Data Catalog compaction

### DIFF
--- a/.changeset/flat-mice-prove.md
+++ b/.changeset/flat-mice-prove.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feat: Add wrangler commands for the R2 Data Catalog compaction feature

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -967,6 +967,7 @@ describe("r2", () => {
 					  wrangler r2 bucket catalog enable <bucket>   Enable the data catalog on an R2 bucket [open-beta]
 					  wrangler r2 bucket catalog disable <bucket>  Disable the data catalog for an R2 bucket [open-beta]
 					  wrangler r2 bucket catalog get <bucket>      Get the status of the data catalog for an R2 bucket [open-beta]
+					  wrangler r2 bucket catalog compaction        Manage compaction maintenance for tables in your R2 data catalog [private-beta]
 
 					GLOBAL FLAGS
 					  -c, --config    Path to Wrangler configuration file  [string]
@@ -1227,6 +1228,220 @@ For more details, refer to: https://developers.cloudflare.com/r2/api/s3/tokens/"
 
 					Data catalog is not enabled for bucket 'test-bucket'. Please use 'wrangler r2 bucket catalog enable test-bucket' to first enable the data catalog on this bucket."
 				`);
+				});
+			});
+
+			describe("compaction", () => {
+				it("should show the correct help when an invalid command is passed", async () => {
+					await expect(() =>
+						runWrangler("r2 bucket catalog compaction foo")
+					).rejects.toThrowErrorMatchingInlineSnapshot(
+						`[Error: Unknown argument: foo]`
+					);
+					expect(std.err).toMatchInlineSnapshot(`
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown argument: foo[0m
+
+				"
+			`);
+					expect(std.out).toMatchInlineSnapshot(`
+						"
+						wrangler r2 bucket catalog compaction
+
+						Manage compaction maintenance for tables in your R2 data catalog [private-beta]
+
+						COMMANDS
+						  wrangler r2 bucket catalog compaction enable <bucket>   Enable compaction maintenance for a table in the R2 data catalog [private-beta]
+						  wrangler r2 bucket catalog compaction disable <bucket>  Disable compaction maintenance for a table in the R2 data catalog [private-beta]
+
+						GLOBAL FLAGS
+						  -c, --config    Path to Wrangler configuration file  [string]
+						      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+						  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+						      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+						  -h, --help      Show help  [boolean]
+						  -v, --version   Show version number  [boolean]"
+					`);
+				});
+
+				describe("enable", () => {
+					it("should enable compaction for the given table", async () => {
+						msw.use(
+							http.post(
+								"*/accounts/some-account-id/r2-catalog/testBucket/namespaces/testNamespace/tables/testTable/maintenance-configs",
+								async ({ request }) => {
+									const body = await request.json();
+									expect(body).toEqual({
+										configuration_type: "compaction",
+										configuration: {},
+										state: "enabled",
+									});
+									return HttpResponse.json(
+										createFetchResult({ success: true }, true)
+									);
+								},
+								{ once: true }
+							)
+						);
+						await runWrangler(
+							"r2 bucket catalog compaction enable testBucket --table testTable --namespace testNamespace"
+						);
+						expect(std.out).toMatchInlineSnapshot(
+							`"✨ Successfully enabled compaction maintenance for table 'testTable' in namespace 'testNamespace' of bucket 'testBucket'."`
+						);
+					});
+
+					it("should error if no bucket name is given", async () => {
+						await expect(
+							runWrangler("r2 bucket catalog compaction enable")
+						).rejects.toThrowErrorMatchingInlineSnapshot(
+							`[Error: Not enough non-option arguments: got 0, need at least 1]`
+						);
+						expect(std.out).toMatchInlineSnapshot(`
+							"
+							wrangler r2 bucket catalog compaction enable <bucket>
+
+							Enable compaction maintenance for a table in the R2 data catalog [private-beta]
+
+							POSITIONALS
+							  bucket  The name of the bucket  [string] [required]
+
+							GLOBAL FLAGS
+							  -c, --config    Path to Wrangler configuration file  [string]
+							      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+							  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+							      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+							  -h, --help      Show help  [boolean]
+							  -v, --version   Show version number  [boolean]
+
+							OPTIONS
+							      --table      The name of the table to enable compaction for  [string] [required]
+							      --namespace  The namespace containing the table  [string] [required]"
+						`);
+						expect(std.err).toMatchInlineSnapshot(`
+					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
+
+					"
+				`);
+					});
+
+					it("should error if --table is not provided", async () => {
+						await expect(
+							runWrangler(
+								"r2 bucket catalog compaction enable testBucket --namespace testNamespace"
+							)
+						).rejects.toThrowErrorMatchingInlineSnapshot(
+							`[Error: Missing required argument: table]`
+						);
+					});
+
+					it("should error if --namespace is not provided", async () => {
+						await expect(
+							runWrangler(
+								"r2 bucket catalog compaction enable testBucket --table testTable"
+							)
+						).rejects.toThrowErrorMatchingInlineSnapshot(
+							`[Error: Missing required argument: namespace]`
+						);
+					});
+				});
+
+				describe("disable", () => {
+					const { setIsTTY } = useMockIsTTY();
+
+					it("should error if no bucket name is given", async () => {
+						await expect(
+							runWrangler("r2 bucket catalog compaction disable")
+						).rejects.toThrowErrorMatchingInlineSnapshot(
+							`[Error: Not enough non-option arguments: got 0, need at least 1]`
+						);
+						expect(std.out).toMatchInlineSnapshot(`
+							"
+							wrangler r2 bucket catalog compaction disable <bucket>
+
+							Disable compaction maintenance for a table in the R2 data catalog [private-beta]
+
+							POSITIONALS
+							  bucket  The name of the bucket  [string] [required]
+
+							GLOBAL FLAGS
+							  -c, --config    Path to Wrangler configuration file  [string]
+							      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+							  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+							      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+							  -h, --help      Show help  [boolean]
+							  -v, --version   Show version number  [boolean]
+
+							OPTIONS
+							      --table      The name of the table to disable compaction for  [string] [required]
+							      --namespace  The namespace containing the table  [string] [required]"
+						`);
+						expect(std.err).toMatchInlineSnapshot(`
+					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
+
+					"
+				`);
+					});
+
+					it("should disable compaction for the given table with confirmation", async () => {
+						setIsTTY(true);
+						mockConfirm({
+							text: "Are you sure you want to disable compaction maintenance for table 'testTable' in namespace 'testNamespace' of bucket 'testBucket'?",
+							result: true,
+						});
+						msw.use(
+							http.put(
+								"*/accounts/some-account-id/r2-catalog/testBucket/namespaces/testNamespace/tables/testTable/maintenance-configs/compaction",
+								async ({ request }) => {
+									const body = await request.json();
+									expect(body).toEqual({
+										state: "disabled",
+									});
+									return HttpResponse.json(
+										createFetchResult({ success: true }, true)
+									);
+								},
+								{ once: true }
+							)
+						);
+						await runWrangler(
+							"r2 bucket catalog compaction disable testBucket --table testTable --namespace testNamespace"
+						);
+						expect(std.out).toMatchInlineSnapshot(
+							`"Successfully disabled compaction maintenance for table 'testTable' in namespace 'testNamespace' of bucket 'testBucket'."`
+						);
+					});
+
+					it("should cancel disable when confirmation is rejected", async () => {
+						setIsTTY(true);
+						mockConfirm({
+							text: "Are you sure you want to disable compaction maintenance for table 'testTable' in namespace 'testNamespace' of bucket 'testBucket'?",
+							result: false,
+						});
+						await runWrangler(
+							"r2 bucket catalog compaction disable testBucket --table testTable --namespace testNamespace"
+						);
+						expect(std.out).toMatchInlineSnapshot(`"Disable cancelled."`);
+					});
+
+					it("should error if --table is not provided", async () => {
+						await expect(
+							runWrangler(
+								"r2 bucket catalog compaction disable testBucket --namespace testNamespace"
+							)
+						).rejects.toThrowErrorMatchingInlineSnapshot(
+							`[Error: Missing required argument: table]`
+						);
+					});
+
+					it("should error if --namespace is not provided", async () => {
+						await expect(
+							runWrangler(
+								"r2 bucket catalog compaction disable testBucket --table testTable"
+							)
+						).rejects.toThrowErrorMatchingInlineSnapshot(
+							`[Error: Missing required argument: namespace]`
+						);
+					});
 				});
 			});
 		});

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -188,6 +188,9 @@ import {
 	r2BucketUpdateStorageClassCommand,
 } from "./r2/bucket";
 import {
+	r2BucketCatalogCompactionDisableCommand,
+	r2BucketCatalogCompactionEnableCommand,
+	r2BucketCatalogCompactionNamespace,
 	r2BucketCatalogDisableCommand,
 	r2BucketCatalogEnableCommand,
 	r2BucketCatalogGetCommand,
@@ -838,6 +841,18 @@ export function createCLIParser(argv: string[]) {
 		{
 			command: "wrangler r2 bucket catalog get",
 			definition: r2BucketCatalogGetCommand,
+		},
+		{
+			command: "wrangler r2 bucket catalog compaction",
+			definition: r2BucketCatalogCompactionNamespace,
+		},
+		{
+			command: "wrangler r2 bucket catalog compaction enable",
+			definition: r2BucketCatalogCompactionEnableCommand,
+		},
+		{
+			command: "wrangler r2 bucket catalog compaction disable",
+			definition: r2BucketCatalogCompactionDisableCommand,
 		},
 		{
 			command: "wrangler r2 bucket notification",

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -588,6 +588,62 @@ export async function disableR2Catalog(
 	);
 }
 
+type R2CatalogCompactionResponse = {
+	success: boolean;
+};
+
+/**
+ * Enable compaction maintenance configuration for a table in the R2 catalog
+ */
+export async function enableR2CatalogCompaction(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	bucketName: string,
+	namespace: string,
+	tableName: string
+): Promise<R2CatalogCompactionResponse> {
+	return await fetchResult(
+		complianceConfig,
+		`/accounts/${accountId}/r2-catalog/${bucketName}/namespaces/${namespace}/tables/${tableName}/maintenance-configs`,
+		{
+			method: "POST",
+			body: JSON.stringify({
+				configuration_type: "compaction",
+				configuration: {},
+				state: "enabled",
+			}),
+			headers: {
+				"Content-Type": "application/json",
+			},
+		}
+	);
+}
+
+/**
+ * Disable compaction maintenance configuration for a table in the R2 catalog
+ */
+export async function disableR2CatalogCompaction(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	bucketName: string,
+	namespace: string,
+	tableName: string
+): Promise<R2CatalogCompactionResponse> {
+	return await fetchResult(
+		complianceConfig,
+		`/accounts/${accountId}/r2-catalog/${bucketName}/namespaces/${namespace}/tables/${tableName}/maintenance-configs/compaction`,
+		{
+			method: "PUT",
+			body: JSON.stringify({
+				state: "disabled",
+			}),
+			headers: {
+				"Content-Type": "application/json",
+			},
+		}
+	);
+}
+
 export type R2EventableOperation =
 	| "PutObject"
 	| "DeleteObject"


### PR DESCRIPTION
Closes internal jira IGLOO-102.


This change adds two new Wrangler sub-commands within R2 Data Catalog to enable/disable automatic compaction for an Iceberg Table in their catalog. Compaction optimizes the size of data files to improve read performance.

The feature is still in private-beta.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): 
  - [x] Documentation not necessary because: This is forthcoming
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: new feature.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
