### PR TITLE
Update the changeset for the enable_nodejs_http_server_modules flag

### DIFF
--- a/.changeset/bumpy-mice-follow.md
+++ b/.changeset/bumpy-mice-follow.md
@@ -2,4 +2,6 @@
 "@cloudflare/unenv-preset": patch
 ---
 
-Remove experimental from the enable_nodejs_http_server_modules flag
+Remove experimental from the `enable_nodejs_http_server_modules` flag
+
+See [`node:http`](https://developers.cloudflare.com/workers/runtime-apis/nodejs/http/) and [`node:https`](https://developers.cloudflare.com/workers/runtime-apis/nodejs/https/) for details.

--- a/.changeset/ripe-doodles-retire.md
+++ b/.changeset/ripe-doodles-retire.md
@@ -2,4 +2,4 @@
 "@cloudflare/unenv-preset": minor
 ---
 
-add support for native `node:fs` and `node:fs/promises`
+add support for native `node:fs` and `node:fs/promises`.


### PR DESCRIPTION
Add a link to the docs.

Note that there is no existing docs for the `node:fs` module.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: doc update
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is a doc (changelog) update
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not applicable to v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
