### PR TITLE
V3 Backport [#10471]: chore: bump devalue to 5.3.2

### DIFF
--- a/.changeset/small-things-poke.md
+++ b/.changeset/small-things-poke.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+chore: bump `devalue` version to 5.3.2

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -76,7 +76,7 @@
 		"ava": "^6.0.1",
 		"capnp-es": "^0.0.7",
 		"concurrently": "^8.2.2",
-		"devalue": "^4.3.0",
+		"devalue": "^5.3.2",
 		"devtools-protocol": "^0.0.1182435",
 		"esbuild": "0.17.19",
 		"eslint": "^8.57.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1236,8 +1236,8 @@ importers:
         specifier: ^8.2.2
         version: 8.2.2
       devalue:
-        specifier: ^4.3.0
-        version: 4.3.2
+        specifier: ^5.3.2
+        version: 5.3.2
       devtools-protocol:
         specifier: ^0.0.1182435
         version: 0.0.1182435
@@ -4620,6 +4620,9 @@ packages:
 
   devalue@4.3.2:
     resolution: {integrity: sha512-KqFl6pOgOW+Y6wJgu80rHpo2/3H07vr8ntR9rkkFIRETewbf5GaYYcakYfiKz89K+sLsuPkQIZaXDMjUObZwWg==}
+
+  devalue@5.3.2:
+    resolution: {integrity: sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw==}
 
   devtools-protocol@0.0.1182435:
     resolution: {integrity: sha512-EmlkWb62wSbQNE1gRZZsi4KZYRaF5Skpp183LhRU7+sadKR06O1dHCjZmFSEG6Kv7P6S/UYLxcY3NlYwqKM99w==}
@@ -11499,6 +11502,8 @@ snapshots:
   detect-newline@3.1.0: {}
 
   devalue@4.3.2: {}
+
+  devalue@5.3.2: {}
 
   devtools-protocol@0.0.1182435: {}
 


### PR DESCRIPTION
Fixes n/a.

Backport of #10471

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: covered by existing tests
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no new feature
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: This is a backport

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
