### PR TITLE
Up max asset count to 100k

### DIFF
--- a/.changeset/clear-views-scream.md
+++ b/.changeset/clear-views-scream.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Allow Wrangler to upload 100,000 assets inline with the newly increased Workers Paid limit.

--- a/packages/workers-editor-shared/package.json
+++ b/packages/workers-editor-shared/package.json
@@ -42,6 +42,7 @@
 		"eslint": "^8.57.1",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
+		"typescript": "catalog:default",
 		"vite": "catalog:default",
 		"vite-plugin-dts": "^4.0.1"
 	},

--- a/packages/workers-shared/utils/constants.ts
+++ b/packages/workers-shared/utils/constants.ts
@@ -23,9 +23,12 @@ export const ENTRY_SIZE = PATH_HASH_SIZE + CONTENT_HASH_SIZE + TAIL_SIZE;
 
 // -- Manifest creation constants --
 // used in wrangler dev and deploy
-/** Maximum number of assets that can be deployed with a worker */
-export const MAX_ASSET_COUNT = 20_000;
-/** Maximum size per asset that can be deployed with a worker */
+/**
+ * Maximum number of assets that can be deployed with a Worker; this is a global
+ * ceiling, and may vary by the user's subscription.
+ */
+export const MAX_ASSET_COUNT = 100_000;
+/** Maximum size per asset that can be deployed with a Worker */
 export const MAX_ASSET_SIZE = 25 * 1024 * 1024;
 
 export const CF_ASSETS_IGNORE_FILENAME = ".assetsignore";

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -6,7 +6,6 @@ import { parseStaticRouting } from "@cloudflare/workers-shared/utils/configurati
 import {
 	CF_ASSETS_IGNORE_FILENAME,
 	HEADERS_FILENAME,
-	MAX_ASSET_COUNT,
 	MAX_ASSET_SIZE,
 	REDIRECTS_FILENAME,
 } from "@cloudflare/workers-shared/utils/constants";
@@ -263,7 +262,6 @@ const buildAssetManifest = async (dir: string) => {
 	logReadFilesFromDirectory(dir, files);
 
 	const manifest: AssetManifest = {};
-	let counter = 0;
 
 	const { assetsIgnoreFunction, assetsIgnoreFilePresent } =
 		await createAssetsIgnoreFunction(dir);
@@ -287,15 +285,6 @@ const buildAssetManifest = async (dir: string) => {
 					assetsIgnoreFilePresent
 				);
 
-				if (counter >= MAX_ASSET_COUNT) {
-					throw new UserError(
-						`Maximum number of assets exceeded.\n` +
-							`Cloudflare Workers supports up to ${MAX_ASSET_COUNT.toLocaleString()} assets in a version. We found ${counter.toLocaleString()} files in the specified assets directory "${dir}".\n` +
-							`Ensure your assets directory contains a maximum of ${MAX_ASSET_COUNT.toLocaleString()} files, and that you have specified your assets directory correctly.`,
-						{ telemetryMessage: "Maximum number of assets exceeded" }
-					);
-				}
-
 				if (filestat.size > MAX_ASSET_SIZE) {
 					throw new UserError(
 						`Asset too large.\n` +
@@ -318,7 +307,6 @@ const buildAssetManifest = async (dir: string) => {
 					hash: hashFile(filepath),
 					size: filestat.size,
 				};
-				counter++;
 			}
 		})
 	);
@@ -340,7 +328,7 @@ function logAssetUpload(line: string, diffCount: number) {
 			"   (truncating changed assets log, set `WRANGLER_LOG=debug` environment variable to see full diff)";
 		logger.info(chalk.dim(msg));
 	}
-	return diffCount++;
+	return ++diffCount;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3276,6 +3276,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      typescript:
+        specifier: catalog:default
+        version: 5.8.3
       vite:
         specifier: catalog:default
         version: 5.4.14(@types/node@20.19.9)(lightningcss@1.29.2)


### PR DESCRIPTION
Fixes N/A

Allows up to 100k static assets for Workers Assets. Further work needed in the future to pull the limit from the API and use that instead of having a hardcoded limit.
We could remove the limit totally in Wrangler but having it for dev is nice so this is the best current path currently.

---

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/24842
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: assets wasn't GA till v4
