### PR TITLE
Include cursor in text prompts

### DIFF
--- a/.changeset/orange-signs-lose.md
+++ b/.changeset/orange-signs-lose.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/cli": patch
+---
+
+Include cursor in text prompts

--- a/packages/cli/interactive.ts
+++ b/packages/cli/interactive.ts
@@ -301,11 +301,14 @@ const getTextRenderers = (config: TextPromptConfig) => {
 	const helpText = config.helpText ?? "";
 	const format = config.format ?? ((val: Arg) => String(val));
 	const defaultValue = config.defaultValue?.toString() ?? "";
-	const activeRenderer = ({ value }: { value: Arg }) => [
-		`${blCorner} ${bold(question)} ${dim(helpText)}`,
-		`${space(2)}${format(value || dim(defaultValue))}`,
-		``, // extra line for readability
-	];
+	const activeRenderer = (props: RenderProps) => {
+		const { valueWithCursor } = props as TextPrompt;
+		return [
+			`${blCorner} ${bold(question)} ${dim(helpText)}`,
+			`${space(2)}${format(valueWithCursor || dim(defaultValue))}`,
+			``, // extra line for readability
+		];
+	};
 
 	return {
 		initial: () => [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,6 +19,7 @@
 	"scripts": {
 		"check:lint": "eslint . --max-warnings=0",
 		"check:type": "tsc",
+		"deploy": "echo 'no deploy'",
 		"test:ci": "vitest run"
 	},
 	"devDependencies": {

--- a/tools/deployments/__tests__/validate-changesets.test.ts
+++ b/tools/deployments/__tests__/validate-changesets.test.ts
@@ -22,6 +22,7 @@ describe("findPackageNames()", () => {
 		expect(findPackageNames()).toEqual(
 			new Set([
 				"@cloudflare/chrome-devtools-patches",
+				"@cloudflare/cli",
 				"@cloudflare/kv-asset-handler",
 				"@cloudflare/pages-shared",
 				"@cloudflare/quick-edit",


### PR DESCRIPTION
Fixes CC-5962.

Include the cursor in text prompts.

**Before:**

<img width="265" height="138" alt="Screenshot from 2025-08-28 09-48-22" src="https://github.com/user-attachments/assets/d8cf5489-9fdf-4121-8ad1-d945ae9ffa99" />

**After:**

<img width="247" height="111" alt="Screenshot from 2025-08-28 09-47-27" src="https://github.com/user-attachments/assets/eb48026c-96e0-4463-8a34-11903f79d6ae" />


<!--


Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: Minor UI change, not tested
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no public facing behavior
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not wrangler

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
