### PR TITLE
native `node:fs` and `node:os` are no more experimental

### DIFF
--- a/.changeset/spicy-sloths-divide.md
+++ b/.changeset/spicy-sloths-divide.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/unenv-preset": patch
+---
+
+native `node:fs` and `node:os` are no more experimental

--- a/packages/unenv-preset/package.json
+++ b/packages/unenv-preset/package.json
@@ -49,7 +49,7 @@
 	},
 	"peerDependencies": {
 		"unenv": "2.0.0-rc.19",
-		"workerd": "^1.20250823.0"
+		"workerd": "^1.20250827.0"
 	},
 	"peerDependenciesMeta": {
 		"workerd": {

--- a/packages/unenv-preset/src/preset.ts
+++ b/packages/unenv-preset/src/preset.ts
@@ -132,11 +132,12 @@ export function getCloudflarePreset({
  * Returns the overrides for node http modules (unenv or workerd)
  *
  * The native http implementation (excluding server APIs):
- * - is enabled after 2025-08-15
+ * - is enabled starting from 2025-08-15
  * - can be enabled with the "enable_nodejs_http_modules" flag
  * - can be disabled with the "disable_nodejs_http_modules" flag
  *
  * The native http server APIS implementation:
+ * - is enabled starting from 2025-09-15
  * - can be enabled with the "enable_nodejs_http_server_modules" flag
  * - can be disabled with the "disable_nodejs_http_server_modules" flag
  */
@@ -196,12 +197,12 @@ function getHttpOverrides({
 /**
  * Returns the overrides for `node:os` (unenv or workerd)
  *
- * The native http implementation:
+ * The native os implementation:
+ * - is enabled starting from 2025-09-15
  * - can be enabled with the "enable_nodejs_os_module" flag
  * - can be disabled with the "disable_nodejs_os_module" flag
  */
 function getOsOverrides({
-	// eslint-disable-next-line unused-imports/no-unused-vars
 	compatibilityDate,
 	compatibilityFlags,
 }: {
@@ -212,12 +213,10 @@ function getOsOverrides({
 		"disable_nodejs_os_module"
 	);
 
-	const enabledByFlag =
-		compatibilityFlags.includes("enable_nodejs_os_module") &&
-		compatibilityFlags.includes("experimental");
+	const enabledByFlag = compatibilityFlags.includes("enable_nodejs_os_module");
+	const enabledByDate = compatibilityDate >= "2025-09-15";
 
-	// TODO: add `enabledByDate` when a default date is set
-	const enabled = enabledByFlag && !disabledByFlag;
+	const enabled = (enabledByFlag || enabledByDate) && !disabledByFlag;
 
 	// The native os module implements all the APIs.
 	// It can then be used as a native module.
@@ -236,11 +235,11 @@ function getOsOverrides({
  * Returns the overrides for `node:fs` and `node:fs/promises` (unenv or workerd)
  *
  * The native fs implementation:
+ * - is enabled starting from 2025-09-15
  * - can be enabled with the "enable_nodejs_fs_module" flag
  * - can be disabled with the "disable_nodejs_fs_module" flag
  */
 function getFsOverrides({
-	// eslint-disable-next-line unused-imports/no-unused-vars
 	compatibilityDate,
 	compatibilityFlags,
 }: {
@@ -251,12 +250,10 @@ function getFsOverrides({
 		"disable_nodejs_fs_module"
 	);
 
-	const enabledByFlag =
-		compatibilityFlags.includes("enable_nodejs_fs_module") &&
-		compatibilityFlags.includes("experimental");
+	const enabledByFlag = compatibilityFlags.includes("enable_nodejs_fs_module");
+	const enabledByDate = compatibilityDate >= "2025-09-15";
 
-	// TODO: add `enabledByDate` when a default date is set
-	const enabled = enabledByFlag && !disabledByFlag;
+	const enabled = (enabledByFlag || enabledByDate) && !disabledByFlag;
 
 	// The native `fs` and `fs/promises` modules implement all the node APIs so we can use them directly
 	return enabled

--- a/packages/wrangler/e2e/unenv-preset/preset.test.ts
+++ b/packages/wrangler/e2e/unenv-preset/preset.test.ts
@@ -98,26 +98,25 @@ const testConfigs: TestConfig[] = [
 	[
 		{
 			name: "os disabled by date",
-			compatibilityDate: "2025-07-26",
-			compatibilityFlags: ["experimental"],
+			compatibilityDate: "2024-09-23",
 			expectRuntimeFlags: {
 				enable_nodejs_os_module: false,
 			},
 		},
-		// TODO: add a config when os is enabled by default (date no set yet)
+		// TODO: add a config when os is enabled by default (>= 2025-09-15)
 		{
 			name: "os enabled by flag",
-			compatibilityDate: "2025-07-26",
-			compatibilityFlags: ["enable_nodejs_os_module", "experimental"],
+			compatibilityDate: "2024-09-23",
+			compatibilityFlags: ["enable_nodejs_os_module"],
 			expectRuntimeFlags: {
 				enable_nodejs_os_module: true,
 			},
 		},
-		// TODO: change the date pass the default enabled date (date not set yet)
+		// TODO: change the date pass the default enabled date (>= 2025-09-15)
 		{
 			name: "os disabled by flag",
 			compatibilityDate: "2025-07-26",
-			compatibilityFlags: ["disable_nodejs_os_module", "experimental"],
+			compatibilityFlags: ["disable_nodejs_os_module"],
 			expectRuntimeFlags: {
 				enable_nodejs_os_module: false,
 			},
@@ -127,26 +126,25 @@ const testConfigs: TestConfig[] = [
 	[
 		{
 			name: "fs disabled by date",
-			compatibilityDate: "2025-07-26",
-			compatibilityFlags: ["experimental"],
+			compatibilityDate: "2024-09-23",
 			expectRuntimeFlags: {
 				enable_nodejs_fs_module: false,
 			},
 		},
-		// TODO: add a config when fs is enabled by default (date no set yet)
+		// TODO: add a config when fs is enabled by default (>= 2025-09-15)
 		{
 			name: "fs enabled by flag",
-			compatibilityDate: "2025-07-26",
-			compatibilityFlags: ["enable_nodejs_fs_module", "experimental"],
+			compatibilityDate: "2024-09-23",
+			compatibilityFlags: ["enable_nodejs_fs_module"],
 			expectRuntimeFlags: {
 				enable_nodejs_fs_module: true,
 			},
 		},
-		// TODO: change the date pass the default enabled date (date not set yet)
+		// TODO: change the date pass the default enabled date (>= 2025-09-15)
 		{
 			name: "fs disabled by flag",
 			compatibilityDate: "2025-07-26",
-			compatibilityFlags: ["disable_nodejs_fs_module", "experimental"],
+			compatibilityFlags: ["disable_nodejs_fs_module"],
 			expectRuntimeFlags: {
 				enable_nodejs_fs_module: false,
 			},


### PR DESCRIPTION
The experimental flag for `node:fs` and `node:os` was removed in https://github.com/cloudflare/workerd/releases/tag/v1.20250827.0

Note: this PR is expected to fail until wrangler/miniflare have been updated to use workerd >= 20250827

[Flag definition](https://github.com/cloudflare/workerd/blob/94fa1595fb86b8989242005be59c505cf6f29b8e/src/workerd/io/compatibility-date.capnp#L913-L925):

```
  enableNodeJsFsModule @105 :Bool
    $compatEnableFlag("enable_nodejs_fs_module")
    $compatDisableFlag("disable_nodejs_fs_module")
    $impliedByAfterDate(name = "nodeJsCompat", date = "2025-09-15");
  # Enables the Node.js fs module. It is required to use this flag with
  # nodejs_compat (or nodejs_compat_v2).

  enableNodeJsOsModule @106 :Bool
    $compatEnableFlag("enable_nodejs_os_module")
    $compatDisableFlag("disable_nodejs_os_module")
    $impliedByAfterDate(name = "nodeJsCompat", date = "2025-09-15");
  # Enables the Node.js os module. It is required to use this flag with
  # nodejs_compat (or nodejs_compat_v2).
```

/cc @anonrig @danlapid @jasnell 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: it will be documented by the runtime team (docs are not published yet)
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
