### PR TITLE
chore(vitest): remove deprecated vitest types

### DIFF
--- a/packages/vitest-pool-workers/src/pool/config.ts
+++ b/packages/vitest-pool-workers/src/pool/config.ts
@@ -12,7 +12,7 @@ import { z } from "zod";
 import { getProjectPath, getRelativeProjectPath } from "./helpers";
 import type { ModuleRule, WorkerOptions } from "miniflare";
 import type { ProvidedContext } from "vitest";
-import type { WorkspaceProject } from "vitest/node";
+import type { TestProject } from "vitest/node";
 import type {
 	Experimental_RemoteProxySession,
 	Unstable_Binding,
@@ -344,7 +344,7 @@ async function parseCustomPoolOptions(
 }
 
 export async function parseProjectOptions(
-	project: WorkspaceProject
+	project: TestProject
 ): Promise<WorkersPoolOptionsWithDefines> {
 	// Make sure the user hasn't specified a custom environment. This was how
 	// users enabled Miniflare 2's Vitest environment, so it's likely users will

--- a/packages/vitest-pool-workers/src/pool/helpers.ts
+++ b/packages/vitest-pool-workers/src/pool/helpers.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import type { WorkspaceProject } from "vitest/node";
+import type { TestProject } from "vitest/node";
 
 // User worker names must not start with this
 export const WORKER_NAME_PREFIX = "vitest-pool-workers-";
@@ -10,13 +10,11 @@ export function isFileNotFoundError(e: unknown): boolean {
 	);
 }
 
-export function getProjectPath(project: WorkspaceProject): string | number {
+export function getProjectPath(project: TestProject): string | number {
 	return project.config.config ?? project.path;
 }
 
-export function getRelativeProjectPath(
-	project: WorkspaceProject
-): string | number {
+export function getRelativeProjectPath(project: TestProject): string | number {
 	const projectPath = getProjectPath(project);
 	if (typeof projectPath === "number") {
 		return projectPath;


### PR DESCRIPTION
This PR removes deprecated Vitest types. They are removed in Vitest 4 completely. There are more changes needed to be compatible with Vitest 4 that I will try to address in a follow-up.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: types are not tested
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal types
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
