### PR TITLE
Add strict mode for the `wrangler deploy` command

### DIFF
--- a/.changeset/calm-camels-return.md
+++ b/.changeset/calm-camels-return.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add strict mode for the `wrangler deploy` command
+
+Add a new flag: `--strict` that makes the `wrangler deploy` command be more strict/prudent and not deploy workers when such deployments can be potentially problematic. This "strict mode" currently only effects non-interactive sessions where conflicts with the remote settings for the worker (for example when the worker has been re-deployed via the dashboard) will cause the deployment to fail instead of automatically overriding the remote settings.

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -232,10 +232,23 @@ export const deployCommand = createCommand({
 			choices: ["immediate", "gradual"] as const,
 		},
 		"experimental-deploy-remote-diff-check": {
-			describe: `Experimental: Enable The Deployment Remote Diff check`,
+			describe: "Experimental: Enable The Deployment Remote Diff check",
 			type: "boolean",
 			hidden: true,
 			alias: ["x-remote-diff-check"],
+		},
+		strict: {
+			describe:
+				"Enables strict mode for the deploy command, this prevents deployments to occur when there are even small potential risks.",
+			type: "boolean",
+			default: false,
+		},
+		// TODO: check, if `--force` really necessary? users can just provide or not `--strict`, no?
+		force: {
+			describe:
+				"This flag can be used to disable strict mode (if set via `--strict`).",
+			type: "boolean",
+			default: false,
 		},
 	},
 	behaviour: {
@@ -251,7 +264,7 @@ export const deployCommand = createCommand({
 	validateArgs(args) {
 		if (args.nodeCompat) {
 			throw new UserError(
-				`The --node-compat flag is no longer supported as of Wrangler v4. Instead, use the \`nodejs_compat\` compatibility flag. This includes the functionality from legacy \`node_compat\` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information.`,
+				"The --node-compat flag is no longer supported as of Wrangler v4. Instead, use the `nodejs_compat` compatibility flag. This includes the functionality from legacy `node_compat` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information.",
 				{ telemetryMessage: true }
 			);
 		}
@@ -382,6 +395,8 @@ export const deployCommand = createCommand({
 			dispatchNamespace: args.dispatchNamespace,
 			experimentalAutoCreate: args.experimentalAutoCreate,
 			containersRollout: args.containersRollout,
+			strict: args.strict,
+			force: args.force,
 		});
 
 		writeOutput({


### PR DESCRIPTION
Addresses the third point of #10235

This PR adds a new "strict mode" for the `wrangler deploy` command, for more details please check the changelog in the file changes

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: this is a new feature, so not something needing backporting

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
