### PR TITLE
Use the native `node:constants` module

### DIFF
--- a/.changeset/brave-wings-behave.md
+++ b/.changeset/brave-wings-behave.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/unenv-preset": patch
+---
+
+Use the native `node:constants` module
+
+The native `node:constants` module was implemented in [this PR](https://github.com/cloudflare/workerd/pull/4759)
+It was released as part of workerd [1.20250813.0](https://github.com/cloudflare/workerd/releases/tag/v1.20250813.0)

--- a/packages/unenv-preset/src/preset.ts
+++ b/packages/unenv-preset/src/preset.ts
@@ -6,8 +6,6 @@ import type { Preset } from "unenv";
 // https://developers.cloudflare.com/workers/runtime-apis/nodejs/
 // https://github.com/cloudflare/workerd/tree/main/src/node
 //
-// Last checked: 2025-01-24
-//
 // NOTE: Please sync any changes to `testNodeCompatModules`.
 const nativeModules = [
 	"_stream_duplex",
@@ -21,6 +19,7 @@ const nativeModules = [
 	"assert/strict",
 	"async_hooks",
 	"buffer",
+	"constants",
 	"diagnostics_channel",
 	"dns",
 	"dns/promises",

--- a/packages/wrangler/e2e/unenv-preset/worker/index.ts
+++ b/packages/wrangler/e2e/unenv-preset/worker/index.ts
@@ -107,6 +107,7 @@ export const WorkerdTests: Record<string, () => void> = {
 			"assert/strict",
 			"async_hooks",
 			"buffer",
+			"constants",
 			"diagnostics_channel",
 			"dns",
 			"dns/promises",
@@ -434,5 +435,13 @@ export const WorkerdTests: Record<string, () => void> = {
 		assert.strictEqual(typeof module._extensions, "object");
 		// @ts-expect-error TS2339 Invalid node/types.
 		assert.strictEqual(typeof module._pathCache, "object");
+	},
+
+	async testConstants() {
+		const constants = await import("node:constants");
+
+		assert.deepStrictEqual(constants.O_RDONLY, 0);
+		assert.deepStrictEqual(constants.O_WRONLY, 1);
+		assert.deepStrictEqual(constants.O_RDWR, 2);
 	},
 };


### PR DESCRIPTION
The native `node:constants` module was implemented in [this PR](https://github.com/cloudflare/workerd/pull/4759)
It was released as part of workerd [1.20250813.0](https://github.com/cloudflare/workerd/releases/tag/v1.20250813.0)

unenv already requires a version of workerd enabling the native module:

https://github.com/cloudflare/workers-sdk/blob/4851955c2b87763004b4eb0353a2b65e590993e4/packages/unenv-preset/package.json#L52

/cc @jasnell @anonrig @danlapid 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
