### PR TITLE
add no op deploy script to @cloudflare/cli to appease changeset validation

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,6 +19,7 @@
 	"scripts": {
 		"check:lint": "eslint . --max-warnings=0",
 		"check:type": "tsc",
+		"deploy": "echo 'no deploy'",
 		"test:ci": "vitest run"
 	},
 	"devDependencies": {


### PR DESCRIPTION
validate-changesets.ts does not consider a package a valid name unless it is published to npm or has a deploy script :/

this is the same thing as what workflows-shared and containers-shared do.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: trivial tooling change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not wrangler

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
