### PR TITLE
Bump `unenv` to 2.0.0-rc.20

### DIFF
--- a/.changeset/lemon-boxes-flow.md
+++ b/.changeset/lemon-boxes-flow.md
@@ -1,0 +1,10 @@
+---
+"@cloudflare/vite-plugin": patch
+"@cloudflare/unenv-preset": patch
+"wrangler": patch
+---
+
+Bump `unenv` to 2.0.0-rc.20
+
+The latest release include [a fix for `node:tty` default export](https://github.com/unjs/unenv/pull/513).
+See [the changelog](https://github.com/unjs/unenv/releases/tag/v2.0.0-rc.20) for full details.

--- a/packages/unenv-preset/package.json
+++ b/packages/unenv-preset/package.json
@@ -48,7 +48,7 @@
 		"unbuild": "^3.2.0"
 	},
 	"peerDependencies": {
-		"unenv": "2.0.0-rc.19",
+		"unenv": "2.0.0-rc.20",
 		"workerd": "^1.20250828.1"
 	},
 	"peerDependenciesMeta": {

--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -48,7 +48,7 @@
 		"miniflare": "workspace:*",
 		"picocolors": "^1.1.1",
 		"tinyglobby": "^0.2.12",
-		"unenv": "2.0.0-rc.19",
+		"unenv": "2.0.0-rc.20",
 		"wrangler": "workspace:*",
 		"ws": "catalog:default"
 	},

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -72,7 +72,7 @@
 		"esbuild": "catalog:default",
 		"miniflare": "workspace:*",
 		"path-to-regexp": "6.3.0",
-		"unenv": "2.0.0-rc.19",
+		"unenv": "2.0.0-rc.20",
 		"workerd": "1.20250829.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2120,8 +2120,8 @@ importers:
   packages/unenv-preset:
     dependencies:
       unenv:
-        specifier: 2.0.0-rc.19
-        version: 2.0.0-rc.19
+        specifier: 2.0.0-rc.20
+        version: 2.0.0-rc.20
       workerd:
         specifier: ^1.20250828.1
         version: 1.20250829.0
@@ -2157,8 +2157,8 @@ importers:
         specifier: ^0.2.12
         version: 0.2.12
       unenv:
-        specifier: 2.0.0-rc.19
-        version: 2.0.0-rc.19
+        specifier: 2.0.0-rc.20
+        version: 2.0.0-rc.20
       wrangler:
         specifier: workspace:*
         version: link:../wrangler
@@ -3539,8 +3539,8 @@ importers:
         specifier: 6.3.0
         version: 6.3.0
       unenv:
-        specifier: 2.0.0-rc.19
-        version: 2.0.0-rc.19
+        specifier: 2.0.0-rc.20
+        version: 2.0.0-rc.20
       workerd:
         specifier: 1.20250829.0
         version: 1.20250829.0
@@ -12751,8 +12751,8 @@ packages:
   unenv@2.0.0-rc.15:
     resolution: {integrity: sha512-J/rEIZU8w6FOfLNz/hNKsnY+fFHWnu9MH4yRbSZF3xbbGHovcetXPs7sD+9p8L6CeNC//I9bhRYAOsBt2u7/OA==}
 
-  unenv@2.0.0-rc.19:
-    resolution: {integrity: sha512-t/OMHBNAkknVCI7bVB9OWjUUAwhVv9vsPIAGnNUxnu3FxPQN11rjh0sksLMzc3g7IlTgvHmOTl4JM7JHpcv5wA==}
+  unenv@2.0.0-rc.20:
+    resolution: {integrity: sha512-8tn4tAl9vD5nWoggAAPz28vf0FY8+pQAayhU94qD+ZkIbVKCBAH/E1MWEEmhb9Whn5EgouYVfBJB20RsTLRDdg==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -23275,7 +23275,7 @@ snapshots:
       pathe: 2.0.3
       ufo: 1.6.1
 
-  unenv@2.0.0-rc.19:
+  unenv@2.0.0-rc.20:
     dependencies:
       defu: 6.1.4
       exsolve: 1.0.7


### PR DESCRIPTION
Pulls [a fix for `node:tty` default export](https://github.com/unjs/unenv/pull/513)

Thanks @pi0 for the `unenv` release

/cc @jasnell 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: not affected
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no functional change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: unenv updates are not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
