### PR TITLE
default containers.max_instances to 1

### DIFF
--- a/.changeset/moody-terms-drive.md
+++ b/.changeset/moody-terms-drive.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+If unset, containers.max_instances should default to 1 instead of 0.

--- a/packages/wrangler/src/__tests__/containers/config.test.ts
+++ b/packages/wrangler/src/__tests__/containers/config.test.ts
@@ -197,6 +197,41 @@ describe("getNormalizedContainerOptions", () => {
 		});
 	});
 
+	it("should default max_instances and rollout_step_percentage accordingly", async () => {
+		writeFileSync("Dockerfile", "FROM scratch");
+
+		const config: Config = {
+			name: "test-worker",
+			configPath: "./wrangler.toml",
+			topLevelName: "test-worker",
+			containers: [
+				{
+					class_name: "TestContainer",
+					image: path.resolve("./Dockerfile"),
+					name: "test-container",
+				},
+			],
+			durable_objects: {
+				bindings: [
+					{
+						name: "TEST_DO",
+						class_name: "TestContainer",
+					},
+				],
+			},
+		} as Partial<Config> as Config;
+
+		const result = await getNormalizedContainerOptions(config, {});
+
+		expect(result).toHaveLength(1);
+		expect(result[0]).toMatchObject({
+			name: "test-container",
+			class_name: "TestContainer",
+			max_instances: 1,
+			rollout_step_percentage: 100,
+		});
+	});
+
 	it("should handle custom limit configuration", async () => {
 		// deprecated path for setting custom limits
 		const config: Config = {

--- a/packages/wrangler/src/containers/config.ts
+++ b/packages/wrangler/src/containers/config.ts
@@ -62,7 +62,7 @@ export const getNormalizedContainerOptions = async (
 		const shared: Omit<SharedContainerConfig, "disk_size" | "instance_type"> = {
 			name: container.name,
 			class_name: container.class_name,
-			max_instances: container.max_instances ?? 0,
+			max_instances: container.max_instances ?? 1,
 			scheduling_policy: (container.scheduling_policy ??
 				SchedulingPolicy.DEFAULT) as SchedulingPolicy,
 			constraints: {


### PR DESCRIPTION
Fixes CC-5970

previously this defaulted to 0, which meant that users would run `wrangler deploy` with a container, then not have any container instances available. setting the default to a 'broken' state is very confusing, so lets just default to 1.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: containers

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
