### PR TITLE
Fix preview config values not being correctly used with remote bindings in the vite plugin

### DIFF
--- a/.changeset/fine-days-mix.md
+++ b/.changeset/fine-days-mix.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Ensure that preview config values are used for remote bindings
+
+Ensure that if in some remote binding configuration provides a preview value (e.g. `preview_database_id` for D1 bindings) such value gets used instead of the standard ones

--- a/.changeset/many-carrots-boil.md
+++ b/.changeset/many-carrots-boil.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+update `unstable_convertConfigBindingsToStartWorkerBindings` to prioritize preview config values
+
+Ensure that if some bindings include preview values (e.g. `preview_database_id` for D1 bindings) those get used instead of the standard ones (since these are the ones that start worker should be using)

--- a/packages/wrangler/src/__tests__/api/startDevWorker/utils.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/utils.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert";
+import { describe, it } from "vitest";
+import { convertConfigBindingsToStartWorkerBindings } from "../../../api/startDevWorker/utils";
+
+describe("convertConfigBindingsToStartWorkerBindings", () => {
+	it("converts config bindings into startWorker bindings", async () => {
+		const result = convertConfigBindingsToStartWorkerBindings({
+			kv_namespaces: [
+				{
+					id: "<kv_id>",
+					binding: "MY_KV",
+				},
+			],
+			ai: { binding: "AI" },
+			browser: { binding: "BROWSER" },
+			d1_databases: [
+				{
+					database_id: "<database_id>",
+					database_name: "my-database",
+					binding: "MY_DB",
+				},
+			],
+			dispatch_namespaces: [
+				{
+					binding: "MY_DISPATCH_NAMESPACE",
+					namespace: "namespace",
+				},
+			],
+			durable_objects: {
+				bindings: [
+					{
+						class_name: "MyDo",
+						name: "MY_DO",
+					},
+				],
+			},
+			queues: {
+				producers: [
+					{
+						binding: "MY_QUEUE_PRODUCER",
+						queue: "my-queue",
+					},
+				],
+				consumers: undefined,
+			},
+			r2_buckets: [
+				{
+					binding: "MY_R2",
+					bucket_name: "my-bucket",
+				},
+			],
+			services: [
+				{
+					binding: "MY_SERVICE",
+					service: "my-service",
+				},
+			],
+			mtls_certificates: [
+				{
+					binding: "MTLS",
+					certificate_id: "123",
+				},
+			],
+			vectorize: [
+				{
+					binding: "MY_VECTORIZE",
+					index_name: "idx",
+				},
+			],
+			workflows: [
+				{
+					binding: "MY_WORKFLOW",
+					name: "workflow",
+					class_name: "MyWorkflow",
+				},
+			],
+		});
+		expect(result).toEqual({
+			AI: {
+				type: "ai",
+			},
+			BROWSER: {
+				type: "browser",
+			},
+			MTLS: {
+				certificate_id: "123",
+				type: "mtls_certificate",
+			},
+			MY_DB: {
+				database_id: "<database_id>",
+				database_name: "my-database",
+				type: "d1",
+			},
+			MY_DISPATCH_NAMESPACE: {
+				namespace: "namespace",
+				type: "dispatch_namespace",
+			},
+			MY_DO: {
+				class_name: "MyDo",
+				type: "durable_object_namespace",
+			},
+			MY_KV: {
+				id: "<kv_id>",
+				type: "kv_namespace",
+			},
+			MY_QUEUE_PRODUCER: {
+				queue: "my-queue",
+				queue_name: "my-queue",
+				type: "queue",
+			},
+			MY_R2: {
+				bucket_name: "my-bucket",
+				type: "r2_bucket",
+			},
+			MY_SERVICE: {
+				service: "my-service",
+				type: "service",
+			},
+			MY_VECTORIZE: {
+				index_name: "idx",
+				type: "vectorize",
+			},
+			MY_WORKFLOW: {
+				class_name: "MyWorkflow",
+				name: "workflow",
+				type: "workflow",
+			},
+		});
+	});
+
+	it("prioritizes preview values compared to their standard counterparts", async () => {
+		const result = convertConfigBindingsToStartWorkerBindings({
+			ai: undefined,
+			browser: undefined,
+			vectorize: [],
+			d1_databases: [
+				{
+					binding: "MY_DB",
+					database_id: "production-db-id",
+					preview_database_id: "staging-db-id",
+				},
+			],
+			dispatch_namespaces: [],
+			durable_objects: {
+				bindings: [],
+			},
+			queues: {
+				producers: undefined,
+				consumers: undefined,
+			},
+			r2_buckets: [
+				{
+					binding: "MY_R2",
+					bucket_name: "production-bucket-name",
+					preview_bucket_name: "staging-bucket-name",
+				},
+			],
+			services: undefined,
+			kv_namespaces: [
+				{
+					binding: "MY_KV",
+					id: "production-kv-id",
+					preview_id: "staging-kv-id",
+				},
+			],
+			mtls_certificates: [],
+			workflows: [],
+		});
+
+		assert(result);
+		assert(result.MY_KV.type === "kv_namespace");
+		expect(result.MY_KV.id).toBe("staging-kv-id");
+
+		assert(result);
+		assert(result.MY_R2.type === "r2_bucket");
+		expect(result.MY_R2.bucket_name).toBe("staging-bucket-name");
+
+		assert(result);
+		assert(result.MY_DB.type === "d1");
+		expect(result.MY_DB.database_id).toBe("staging-db-id");
+	});
+});

--- a/packages/wrangler/src/api/startDevWorker/utils.ts
+++ b/packages/wrangler/src/api/startDevWorker/utils.ts
@@ -82,6 +82,18 @@ export function convertConfigBindingsToStartWorkerBindings(
 
 	return convertCfWorkerInitBindingsToBindings({
 		...bindings,
+		kv_namespaces: bindings.kv_namespaces.map((kv) => ({
+			...kv,
+			id: kv.preview_id ?? kv.id,
+		})),
+		d1_databases: bindings.d1_databases.map((d1) => ({
+			...d1,
+			database_id: d1.preview_database_id ?? d1.database_id,
+		})),
+		r2_buckets: bindings.r2_buckets.map((r2) => ({
+			...r2,
+			bucket_name: r2.preview_bucket_name ?? r2.bucket_name,
+		})),
 		queues: queues.producers?.map((q) => ({ ...q, queue_name: q.queue })),
 	});
 }


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/10460

If the user provides some preview value for some remote binding in their config, like `preview_database_id` in a D1 binding, those values should be used instead of the standard values.

This behavior is correctly applied by wrangler but it is not by the vite-plugin, this function addresses that by updating the `unstable_convertConfigBindingsToStartWorkerBindings` utility (used by the vite-plugin)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix of expected behavior
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: bugfix to a non-v3 feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
