### PR TITLE
use the native `node:http2` when available

### DIFF
--- a/.changeset/tiny-hotels-win.md
+++ b/.changeset/tiny-hotels-win.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/unenv-preset": patch
+---
+
+Use the native `node:http2` when available.
+
+It is enabled starting on 2025-09-01 or when the `enable_nodejs_http2_module` compatibility flag is set.

--- a/packages/wrangler/e2e/unenv-preset/preset.test.ts
+++ b/packages/wrangler/e2e/unenv-preset/preset.test.ts
@@ -94,6 +94,39 @@ const testConfigs: TestConfig[] = [
 			},
 		},
 	],
+	// node:http2
+	[
+		{
+			name: "http2 disabled by date",
+			compatibilityDate: "2024-09-23",
+			expectRuntimeFlags: {
+				enable_nodejs_http2_module: false,
+			},
+		},
+		{
+			name: "http2 disabled by flag",
+			compatibilityDate: "2025-09-01",
+			compatibilityFlags: ["disable_nodejs_http2_module"],
+			expectRuntimeFlags: {
+				enable_nodejs_http2_module: false,
+			},
+		},
+		{
+			name: "http2 enabled by flag",
+			compatibilityDate: "2024-09-23",
+			compatibilityFlags: ["enable_nodejs_http2_module"],
+			expectRuntimeFlags: {
+				enable_nodejs_http2_module: true,
+			},
+		},
+		{
+			name: "http2 enabled by date",
+			compatibilityDate: "2025-09-01",
+			expectRuntimeFlags: {
+				enable_nodejs_http2_module: true,
+			},
+		},
+	],
 	// node:os
 	[
 		{

--- a/packages/wrangler/e2e/unenv-preset/worker/index.ts
+++ b/packages/wrangler/e2e/unenv-preset/worker/index.ts
@@ -497,4 +497,12 @@ export const WorkerdTests: Record<string, () => void> = {
 		assert.deepStrictEqual(constants.O_WRONLY, 1);
 		assert.deepStrictEqual(constants.O_RDWR, 2);
 	},
+
+	async testHttp2() {
+		const http2 = await import("node:http2");
+
+		assert.strictEqual(typeof http2.createSecureServer, "function");
+		assert.strictEqual(typeof http2.connect, "function");
+		assert.strictEqual(http2.constants.HTTP2_HEADER_STATUS, ":status");
+	},
 };


### PR DESCRIPTION
`node:http2` was implemented in https://github.com/cloudflare/workerd/pull/4765, released in https://github.com/cloudflare/workerd/releases/tag/v1.20250814.0

unenv has a peer dep on workerd ^1.20250828.1 which includes this change.

Notes: 
- it is a deliberate choice not to fold `getHttp2Overrides` into `getHttpOverrides` in order to keep the preset code simple. The later already handle http modules and server modules and the dependency on server module to the base module
- ~tests are expected to fail until workerd is >= 20250901 in wrangler and vite - needed to test the default enabled date.~ workerd was updated to 2050902 in #10535 

/cc @anonrig @jasnell 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: will be documented by the runtime team
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: unenv updates are not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
