### PR TITLE
refactor unenv e2e tests now that workerd >= 20250901

### DIFF
--- a/packages/wrangler/e2e/unenv-preset/preset.test.ts
+++ b/packages/wrangler/e2e/unenv-preset/preset.test.ts
@@ -67,7 +67,13 @@ const testConfigs: TestConfig[] = [
 				enable_nodejs_http_modules: false,
 			},
 		},
-		// TODO: add a config when http server is enabled by default (>= 2025-09-01)
+		{
+			name: "http server enabled by date",
+			compatibilityDate: "2025-09-01",
+			expectRuntimeFlags: {
+				enable_nodejs_http_modules: true,
+			},
+		},
 		{
 			name: "http server enabled by flag",
 			compatibilityDate: "2024-09-23",
@@ -80,10 +86,9 @@ const testConfigs: TestConfig[] = [
 				enable_nodejs_http_server_modules: true,
 			},
 		},
-		// TODO: change the date pass the default enabled date (>= 2025-09-01)
 		{
 			name: "http server disabled by flag",
-			compatibilityDate: "2024-09-23",
+			compatibilityDate: "2025-09-01",
 			compatibilityFlags: [
 				"enable_nodejs_http_modules",
 				"disable_nodejs_http_server_modules",


### PR DESCRIPTION
workerd >= 20250901 was required to test a compatibility date of 20250901 locally.

workerd was updated in https://github.com/cloudflare/workers-sdk/pull/10535

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test update
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: the updated code is not in v3 (unenv)

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
