### PR TITLE
 Set `preserveEntrySignatures: "strict"` for Worker environments

### DIFF
--- a/.changeset/bumpy-garlics-call.md
+++ b/.changeset/bumpy-garlics-call.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Set `preserveEntrySignatures: "strict"` for Worker environments. This ensures that no additional exports are added to the entry module.

--- a/packages/vite-plugin-cloudflare/playground/worker/__tests__/worker.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/worker/__tests__/worker.spec.ts
@@ -17,6 +17,10 @@ test("basic hello-world functionality", async () => {
 	);
 });
 
+test("preserves entry signatures", async () => {
+	expect(serverLogs.info.join()).toContain("__preserves-entry-signatures__");
+});
+
 test("basic dev logging", async () => {
 	expect(serverLogs.info.join()).toContain("__console log__");
 	expect(serverLogs.errors.join()).toContain("__console error__");

--- a/packages/vite-plugin-cloudflare/playground/worker/src/a.ts
+++ b/packages/vite-plugin-cloudflare/playground/worker/src/a.ts
@@ -1,0 +1,1 @@
+export const a = "__preserves-entry-signatures__";

--- a/packages/vite-plugin-cloudflare/playground/worker/src/b.ts
+++ b/packages/vite-plugin-cloudflare/playground/worker/src/b.ts
@@ -1,0 +1,5 @@
+import { a } from "./a";
+
+export function fn() {
+	console.log(a);
+}

--- a/packages/vite-plugin-cloudflare/playground/worker/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/worker/src/index.ts
@@ -1,3 +1,5 @@
+import { a } from "./a";
+
 export default {
 	async fetch(request) {
 		const url = new URL(request.url);
@@ -5,6 +7,10 @@ export default {
 		if (url.pathname === "/x-forwarded-host") {
 			return new Response(request.headers.get("X-Forwarded-Host"));
 		}
+
+		console.log(a);
+		const { fn } = await import("./b");
+		fn();
 
 		console.log("__console log__");
 		console.warn("__console warn__");

--- a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
+++ b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
@@ -168,6 +168,8 @@ export function createCloudflareEnvironmentOptions({
 			ssr: true,
 			rollupOptions: {
 				input: workerConfig.main,
+				// workerd checks the types of the exports so we need to ensure that additional exports are not added to the entry module
+				preserveEntrySignatures: "strict",
 				// rolldown-only option
 				...("rolldownVersion" in vite ? ({ platform: "neutral" } as any) : {}),
 			},


### PR DESCRIPTION
Fixes #10213.

Sets `preserveEntrySignatures: "strict"` for Worker environments. This ensures that no additional exports are added to the entry module.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
