### PR TITLE
Adds dummy workflow entrypoint field

### DIFF
--- a/packages/workflows-shared/src/binding.ts
+++ b/packages/workflows-shared/src/binding.ts
@@ -14,6 +14,7 @@ type Env = {
 
 // this.env.WORKFLOW is WorkflowBinding
 export class WorkflowBinding extends WorkerEntrypoint<Env> implements Workflow {
+	public readonly __workflow_entrypoint = true;
 	public async create({
 		id = crypto.randomUUID(),
 		params = {},


### PR DESCRIPTION
Fixes WOR-865.

Local dev for Python Workflows stopped working with the default entrypoint class. The reason for this is that named entrypoints wrap the `env` parameter to perform type conversions. Consequently the workflow binding was not considered convertible.

For example: 
```python
class Default(WorkerEntrypoint):
    async def fetch(self, request):
        await self.env.MY_WORKFLOW.create() # this would throw
```

We need to preserve the workflow as a `JsProxy`. For that we need to know that the object itself is a workflow binding. This PR accomplishes that.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [ ] Tests not necessary because: no need in asserting the added field
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because: this is merely for internal purposes
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: not a wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
