### PR TITLE
fix version upload e2e test

### DIFF
--- a/packages/wrangler/e2e/provision.test.ts
+++ b/packages/wrangler/e2e/provision.test.ts
@@ -44,6 +44,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 						name = "${workerName}"
 						main = "src/index.ts"
 						compatibility_date = "2023-01-01"
+						workers_dev = true
 
 						[[kv_namespaces]]
 						binding = "KV"
@@ -183,7 +184,6 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 			env.R2 (inherited)                              R2 Bucket
 			Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
 			Worker Version ID: 00000000-0000-0000-0000-000000000000
-			Version Preview URL: https://tmp-e2e-worker-PREVIEW-URL.SUBDOMAIN.workers.dev
 			To deploy this version to production traffic use the command wrangler versions deploy
 			Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment using the command wrangler versions deploy
 			Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy"

--- a/packages/wrangler/e2e/versions.test.ts
+++ b/packages/wrangler/e2e/versions.test.ts
@@ -37,6 +37,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 							name = "${workerName}"
 							main = "src/index.ts"
 							compatibility_date = "2023-01-01"
+							preview_urls = true
 					`,
 				"src/index.ts": dedent`
 							export default {


### PR DESCRIPTION
Fixes #10478.

Wrangler preview urls now default to disabled and a few wrangler e2e tests should be updated.
need to be updated.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: update test
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: v4 only

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
