### PR TITLE
Adds the `--force-subdomain-deploy` flag to the `wrangler triggers deploy` command

### DIFF
--- a/.changeset/moody-goats-cry.md
+++ b/.changeset/moody-goats-cry.md
@@ -1,0 +1,9 @@
+---
+"wrangler": minor
+---
+
+Adds the `--force-subdomain-deploy` flag to the `wrangler triggers deploy` command.
+
+Wrangler will sometimes skip the API call if the config file matches
+the remote state. The flag lets us skip this behavior, and force the
+subdomain deployment.

--- a/packages/wrangler/src/triggers/deploy.ts
+++ b/packages/wrangler/src/triggers/deploy.ts
@@ -30,6 +30,7 @@ type Props = {
 	legacyEnv: boolean | undefined;
 	dryRun: boolean | undefined;
 	assetsOptions: AssetsOptions | undefined;
+	forceSubdomainDeploy?: boolean;
 };
 
 export default async function triggersDeploy(
@@ -90,7 +91,8 @@ export default async function triggersDeploy(
 		envName,
 		workerUrl,
 		routes,
-		deployments
+		deployments,
+		props.forceSubdomainDeploy ?? false
 	);
 
 	if (!wantWorkersDev && workersDevInSync && routes.length !== 0) {
@@ -315,7 +317,8 @@ async function subdomainDeploy(
 	envName: string,
 	workerUrl: string,
 	routes: Route[],
-	deployments: Array<Promise<string[]>>
+	deployments: Array<Promise<string[]>>,
+	forceSubdomainDeploy: boolean
 ) {
 	const { config } = props;
 
@@ -375,7 +378,7 @@ async function subdomainDeploy(
 
 	// Update subdomain enablement status if needed.
 
-	if (!allInSync) {
+	if (!allInSync || forceSubdomainDeploy) {
 		await fetchResult(config, `${workerUrl}/subdomain`, {
 			method: "POST",
 			body: JSON.stringify({

--- a/packages/wrangler/src/triggers/index.ts
+++ b/packages/wrangler/src/triggers/index.ts
@@ -48,6 +48,11 @@ export const triggersDeployCommand = createCommand({
 			describe: "Use legacy environments",
 			hidden: true,
 		},
+		"force-subdomain-deploy": {
+			type: "boolean",
+			describe:
+				"Force deployment of subdomain triggers, even if the they are in sync.",
+		},
 	},
 	behaviour: {
 		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
@@ -74,6 +79,7 @@ export const triggersDeployCommand = createCommand({
 			legacyEnv: isLegacyEnv(config),
 			dryRun: args.dryRun,
 			assetsOptions,
+			forceSubdomainDeploy: args.forceSubdomainDeploy,
 		});
 	},
 });


### PR DESCRIPTION
Wrangler will sometimes skip the API call if the config file matches the remote state. The flag lets us skip this behavior, and force the subdomain deployment.

Follow up of: https://github.com/cloudflare/workers-sdk/pull/10478

_Describe your change..._

Adds `--force-subdomain-deploy` flag to `wrangler triggers deploy`.

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: experimental command.
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: experimental command.
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: experimental command.
<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
