### PR TITLE
Pin the `vercel` and `next` dependencies to their latest supported for C3 next-on-pages applications

### DIFF
--- a/.changeset/hungry-chairs-invite.md
+++ b/.changeset/hungry-chairs-invite.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Pin the `vercel` and `next` dependencies to their latest supported for next-on-pages applications

--- a/packages/create-cloudflare/templates/next/pages/c3.ts
+++ b/packages/create-cloudflare/templates/next/pages/c3.ts
@@ -137,7 +137,8 @@ export const writeEslintrc = async (ctx: C3Context): Promise<void> => {
 const addDevDependencies = async (installEslintPlugin: boolean) => {
 	const packages = [
 		"@cloudflare/next-on-pages@1",
-		"vercel",
+		"vercel@47.0.4",
+		"next@15.4.6",
 		...(installEslintPlugin ? ["eslint-plugin-next-on-pages"] : []),
 	];
 	await installPackages(packages, {


### PR DESCRIPTION
We've deprecated next-on-pages in https://github.com/cloudflare/next-on-pages/pull/986 and pinned the `vercel` and `next` dependencies to their current latest stable releases

As a result we also need to update C3 not to use any newer version of `vercel` and `next`, which is what this PR is doing

Additionally there's the question whether we should then remove next-on-pages as a C3 option, that will be discussed with the team and addressed separately

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: this functionality is already all tested
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not something needing documentation
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a wrangler feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
