### PR TITLE
fix(wrangler): remove workers dev mismatch warning

### DIFF
--- a/.changeset/chilly-snails-carry.md
+++ b/.changeset/chilly-snails-carry.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: remove workers dev mismatch warning

--- a/packages/wrangler/src/triggers/deploy.ts
+++ b/packages/wrangler/src/triggers/deploy.ts
@@ -338,16 +338,6 @@ async function subdomainDeploy(
 
 	// Warn about mismatching config and current values.
 
-	if (config.workers_dev == undefined && !workersDevInSync) {
-		const currWorkersDevStatus = currWorkersDev ? "enabled" : "disabled";
-		logger.warn(
-			[
-				`Worker has workers.dev ${currWorkersDevStatus}, but 'workers_dev' is not in the config.`,
-				`Using fallback value 'workers_dev = ${wantWorkersDev}'.`,
-			].join("\n")
-		);
-	}
-
 	if (config.preview_urls == undefined && !previewsInSync) {
 		const currPreviewsStatus = currPreviews ? "enabled" : "disabled";
 		logger.warn(


### PR DESCRIPTION
Fixes #10478.

This PR removes the following warning as it is currently unable to distinguish whether it is a new worker or not and logged a confusing message:

```sh
▲ [WARNING] Worker has workers.dev disabled, but 'workers_dev' is not in the config.

  Using fallback value 'workers_dev = true'.
```

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
