### PR TITLE
[wrangler/d1] Support migrations in a directory (multi-file migrations)

### DIFF
--- a/.changeset/support-migrations.md
+++ b/.changeset/support-migrations.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Support migration directories (multi-file migrations) for D1 migrations.
+
+Allows a migration to be either a top-level `.sql` file or a directory whose name is the migration name and which contains one or more `.sql` files executed in deterministic order. Backwards compatible with single-file migrations.


### PR DESCRIPTION
#### Summary

Allow a migration to be either:
- a top-level **.sql** file (unchanged), or
- a directory whose name is the migration name and which contains one or more **.sql** files (executed in deterministic order).

<br>

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal behavior change; README/docs follow-up can be added separately.
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: change is contained to D1 migration logic and tests in this repo.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
