### PR TITLE
V3 Backport [#10571]: add missing type for 's  field

### DIFF
--- a/.changeset/four-news-read.md
+++ b/.changeset/four-news-read.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+add missing type for `send_email`'s `experimental_remote` field

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -543,6 +543,8 @@ export interface EnvironmentNonInheritable {
 		destination_address?: string;
 		/** If this binding should be restricted to a set of verified addresses */
 		allowed_destination_addresses?: string[];
+		/** Whether the binding should be remote or not (only available under `--x-remote-bindings`) */
+		experimental_remote?: boolean;
 	}[];
 
 	/**


### PR DESCRIPTION
This is an automatically opened PR to backport patch changes from #10571 to Wrangler v3