### PR TITLE
Use workerd `node:process` v2 when available

### DIFF
--- a/.changeset/red-wasps-kick.md
+++ b/.changeset/red-wasps-kick.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/unenv-preset": patch
+---
+
+Use workerd `node:process` v2 when available

--- a/fixtures/worker-logs/tests/index.test.ts
+++ b/fixtures/worker-logs/tests/index.test.ts
@@ -306,4 +306,23 @@ describe("'wrangler dev' correctly displays logs", () => {
 			expect(output).toMatchInlineSnapshot(`[]`);
 		});
 	});
+
+	describe("nodejs compat process v2", () => {
+		test("default behavior", async ({ expect }) => {
+			const output = await getWranglerDevOutput("module", [
+				"--compatibility-flags=enable_nodejs_process_v2",
+				"--compatibility-flags=nodejs_compat",
+			]);
+			expect(output).toMatchInlineSnapshot(`
+				[
+				  "<<<<< console.info() message >>>>>",
+				  "<<<<< console.log() message >>>>>",
+				  "X [ERROR] <<<<< console.error() message >>>>>",
+				  "stderr: <<<<< stderr.write() message >>>>>",
+				  "stdout: <<<<< stdout.write() message >>>>>",
+				  "▲ [WARNING] <<<<< console.warning() message >>>>>",
+				]
+			`);
+		});
+	});
 });

--- a/packages/unenv-preset/package.json
+++ b/packages/unenv-preset/package.json
@@ -49,7 +49,7 @@
 	},
 	"peerDependencies": {
 		"unenv": "2.0.0-rc.21",
-		"workerd": "^1.20250828.1"
+		"workerd": "^1.20250912.0"
 	},
 	"peerDependenciesMeta": {
 		"workerd": {

--- a/packages/unenv-preset/src/runtime/node/process.ts
+++ b/packages/unenv-preset/src/runtime/node/process.ts
@@ -38,7 +38,7 @@ const unenvProcess = new UnenvProcess({
 // Note that `env`, `hrtime` and `nextTick` are always retrieved from `unenv`
 export const { exit, features, platform } = workerdProcess;
 
-// APIs that can be implemented by either by `unenv` or `workerd`.
+// APIs that can be implemented by either `unenv` or `workerd`.
 // They are always retrieved from `unenv` which might use their `workerd` implementation.
 export const {
 	// Always implemented by workerd
@@ -53,102 +53,111 @@ export const {
 // They are retrieved from `unenv`.
 export const {
 	_channel,
-	_debugEnd,
-	_debugProcess,
 	_disconnect,
 	_events,
 	_eventsCount,
-	_exiting,
-	_fatalException,
-	_getActiveHandles,
-	_getActiveRequests,
 	_handleQueue,
-	_kill,
-	_linkedBinding,
 	_maxListeners,
 	_pendingMessage,
-	_preload_modules,
-	_rawDebug,
 	_send,
-	_startProfilerIdleNotifier,
-	_stopProfilerIdleNotifier,
-	_tickCallback,
 	assert,
-	availableMemory,
-	constrainedMemory,
-	cpuUsage,
 	disconnect,
-	domain,
-	emit, // not exported from workerd but used internally
-	execPath,
 	mainModule,
-	moduleLoadList,
-	openStdin,
-	reallyExit,
-} = unenvProcess;
-
-// APIs that are not implemented in `workerd` v1 and `undefined` in v2.
-// They are retrieved from `unenv`.
-export const {
-	binding,
-	channel,
-	connected,
-	debugPort,
-	dlopen,
-	exitCode,
-	finalization,
-	getActiveResourcesInfo,
-	hasUncaughtExceptionCaptureCallback,
-	kill,
-	memoryUsage,
-	permission,
-	ref,
-	release,
-	report,
-	resourceUsage,
-	send,
-	setUncaughtExceptionCaptureCallback,
-	sourceMapsEnabled,
-	throwDeprecation,
-	traceDeprecation,
-	unref,
 } = unenvProcess;
 
 // API that are only implemented starting from v2 of workerd process
+// They are retrieved from unenv when process v1 is used
 export const {
+	// @ts-expect-error `domain` is missing typings
+	_debugEnd,
+	// @ts-expect-error `domain` is missing typings
+	_debugProcess,
+	// @ts-expect-error `domain` is missing typings
+	_exiting,
+	// @ts-expect-error `domain` is missing typings
+	_fatalException,
+	// @ts-expect-error `domain` is missing typings
+	_getActiveHandles,
+	// @ts-expect-error `domain` is missing typings
+	_getActiveRequests,
+	// @ts-expect-error `domain` is missing typings
+	_kill,
+	// @ts-expect-error `domain` is missing typings
+	_linkedBinding,
+	// @ts-expect-error `domain` is missing typings
+	_preload_modules,
+	// @ts-expect-error `domain` is missing typings
+	_rawDebug,
+	// @ts-expect-error `domain` is missing typings
+	_startProfilerIdleNotifier,
+	// @ts-expect-error `domain` is missing typings
+	_stopProfilerIdleNotifier,
+	// @ts-expect-error `domain` is missing typings
+	_tickCallback,
 	abort,
 	addListener,
 	allowedNodeEnvironmentFlags,
 	arch,
 	argv,
 	argv0,
+	availableMemory,
+	// @ts-expect-error `domain` is missing typings
+	binding,
+	channel,
 	chdir,
 	config,
+	connected,
+	constrainedMemory,
+	cpuUsage,
 	cwd,
+	debugPort,
+	dlopen,
+	// @ts-expect-error `domain` is missing typings
+	domain,
+	emit,
 	emitWarning,
 	eventNames,
 	execArgv,
+	execPath,
+	exitCode,
+	finalization,
+	getActiveResourcesInfo,
 	getegid,
 	geteuid,
 	getgid,
 	getgroups,
 	getMaxListeners,
 	getuid,
+	hasUncaughtExceptionCaptureCallback,
 	// @ts-expect-error `initgroups` is missing typings
 	initgroups,
+	kill,
 	listenerCount,
 	listeners,
 	loadEnvFile,
+	memoryUsage,
+	// @ts-expect-error `moduleLoadList` is missing typings
+	moduleLoadList,
 	off,
 	on,
 	once,
+	// @ts-expect-error `openStdin` is missing typings
+	openStdin,
+	permission,
 	pid,
 	ppid,
 	prependListener,
 	prependOnceListener,
 	rawListeners,
+	// @ts-expect-error `reallyExit` is missing typings
+	reallyExit,
+	ref,
+	release,
 	removeAllListeners,
 	removeListener,
+	report,
+	resourceUsage,
+	send,
 	setegid,
 	seteuid,
 	setgid,
@@ -156,11 +165,16 @@ export const {
 	setMaxListeners,
 	setSourceMapsEnabled,
 	setuid,
+	setUncaughtExceptionCaptureCallback,
+	sourceMapsEnabled,
 	stderr,
 	stdin,
 	stdout,
+	throwDeprecation,
 	title,
+	traceDeprecation,
 	umask,
+	unref,
 	uptime,
 	version,
 	versions,

--- a/packages/unenv-preset/src/runtime/node/process.ts
+++ b/packages/unenv-preset/src/runtime/node/process.ts
@@ -68,31 +68,31 @@ export const {
 // API that are only implemented starting from v2 of workerd process
 // They are retrieved from unenv when process v1 is used
 export const {
-	// @ts-expect-error `domain` is missing typings
+	// @ts-expect-error `_debugEnd` is missing typings
 	_debugEnd,
-	// @ts-expect-error `domain` is missing typings
+	// @ts-expect-error `_debugProcess` is missing typings
 	_debugProcess,
-	// @ts-expect-error `domain` is missing typings
+	// @ts-expect-error `_exiting` is missing typings
 	_exiting,
-	// @ts-expect-error `domain` is missing typings
+	// @ts-expect-error `_fatalException` is missing typings
 	_fatalException,
-	// @ts-expect-error `domain` is missing typings
+	// @ts-expect-error `_getActiveHandles` is missing typings
 	_getActiveHandles,
-	// @ts-expect-error `domain` is missing typings
+	// @ts-expect-error `_getActiveRequests` is missing typings
 	_getActiveRequests,
-	// @ts-expect-error `domain` is missing typings
+	// @ts-expect-error `_kill` is missing typings
 	_kill,
-	// @ts-expect-error `domain` is missing typings
+	// @ts-expect-error `_linkedBinding` is missing typings
 	_linkedBinding,
-	// @ts-expect-error `domain` is missing typings
+	// @ts-expect-error `_preload_modules` is missing typings
 	_preload_modules,
-	// @ts-expect-error `domain` is missing typings
+	// @ts-expect-error `_rawDebug` is missing typings
 	_rawDebug,
-	// @ts-expect-error `domain` is missing typings
+	// @ts-expect-error `_startProfilerIdleNotifier` is missing typings
 	_startProfilerIdleNotifier,
-	// @ts-expect-error `domain` is missing typings
+	// @ts-expect-error `_stopProfilerIdleNotifier` is missing typings
 	_stopProfilerIdleNotifier,
-	// @ts-expect-error `domain` is missing typings
+	// @ts-expect-error `_tickCallback` is missing typings
 	_tickCallback,
 	abort,
 	addListener,
@@ -101,7 +101,7 @@ export const {
 	argv,
 	argv0,
 	availableMemory,
-	// @ts-expect-error `domain` is missing typings
+	// @ts-expect-error `binding` is missing typings
 	binding,
 	channel,
 	chdir,

--- a/packages/unenv-preset/src/runtime/node/process.ts
+++ b/packages/unenv-preset/src/runtime/node/process.ts
@@ -14,121 +14,157 @@ const globalProcess: NodeJS.Process = (globalThis as any)["pro" + "cess"];
 export const getBuiltinModule: NodeJS.Process["getBuiltinModule"] =
 	globalProcess.getBuiltinModule;
 
-export const { exit, platform, nextTick } = getBuiltinModule(
-	"node:process"
-) as NodeJS.Process;
+const workerdProcess = getBuiltinModule("node:process");
+
+// Workerd has 2 different implementation for `node:process`
+//
+// See:
+// - [workerd `process` v1](https://github.com/cloudflare/workerd/blob/main/src/node/internal/legacy_process.ts)
+// - [workerd `process` v2](https://github.com/cloudflare/workerd/blob/main/src/node/internal/public_process.ts)
+// - [`enable_nodejs_process_v2` flag](https://github.com/cloudflare/workerd/blob/main/src/workerd/io/compatibility-date.capnp)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isWorkerdProcessV2 = (globalThis as any).Cloudflare.compatibilityFlags
+	.enable_nodejs_process_v2;
 
 const unenvProcess = new UnenvProcess({
 	env: globalProcess.env,
-	hrtime: UnenvHrTime,
-	nextTick,
+	// `hrtime` is only available from workerd process v2
+	hrtime: isWorkerdProcessV2 ? workerdProcess.hrtime : UnenvHrTime,
+	// `nextTick` is available from workerd process v1
+	nextTick: workerdProcess.nextTick,
 });
 
+// APIs implemented by workerd module in both v1 and v2
+// Note that `env`, `hrtime` and `nextTick` are always retrieved from `unenv`
+export const { exit, features, platform } = workerdProcess;
+
+// APIs that can be implemented by either by `unenv` or `workerd`.
+// They are always retrieved from `unenv` which might use their `workerd` implementation.
+export const {
+	// Always implemented by workerd
+	env,
+	// Only implemented in workerd v2
+	hrtime,
+	// Always implemented by workerd
+	nextTick,
+} = unenvProcess;
+
+// APIs that are not implemented by `workerd` (whether v1 or v2)
+// They are retrieved from `unenv`.
+export const {
+	_channel,
+	_debugEnd,
+	_debugProcess,
+	_disconnect,
+	_events,
+	_eventsCount,
+	_exiting,
+	_fatalException,
+	_getActiveHandles,
+	_getActiveRequests,
+	_handleQueue,
+	_kill,
+	_linkedBinding,
+	_maxListeners,
+	_pendingMessage,
+	_preload_modules,
+	_rawDebug,
+	_send,
+	_startProfilerIdleNotifier,
+	_stopProfilerIdleNotifier,
+	_tickCallback,
+	assert,
+	availableMemory,
+	constrainedMemory,
+	cpuUsage,
+	disconnect,
+	domain,
+	emit, // not exported from workerd but used internally
+	execPath,
+	mainModule,
+	moduleLoadList,
+	openStdin,
+	reallyExit,
+} = unenvProcess;
+
+// APIs that are not implemented in `workerd` v1 and `undefined` in v2.
+// They are retrieved from `unenv`.
+export const {
+	binding,
+	channel,
+	connected,
+	debugPort,
+	dlopen,
+	exitCode,
+	finalization,
+	getActiveResourcesInfo,
+	hasUncaughtExceptionCaptureCallback,
+	kill,
+	memoryUsage,
+	permission,
+	ref,
+	release,
+	report,
+	resourceUsage,
+	send,
+	setUncaughtExceptionCaptureCallback,
+	sourceMapsEnabled,
+	throwDeprecation,
+	traceDeprecation,
+	unref,
+} = unenvProcess;
+
+// API that are only implemented starting from v2 of workerd process
 export const {
 	abort,
 	addListener,
 	allowedNodeEnvironmentFlags,
-	hasUncaughtExceptionCaptureCallback,
-	setUncaughtExceptionCaptureCallback,
-	loadEnvFile,
-	sourceMapsEnabled,
 	arch,
 	argv,
 	argv0,
 	chdir,
 	config,
-	connected,
-	constrainedMemory,
-	availableMemory,
-	cpuUsage,
 	cwd,
-	debugPort,
-	dlopen,
-	disconnect,
-	emit,
 	emitWarning,
-	env,
 	eventNames,
 	execArgv,
-	execPath,
-	finalization,
-	features,
-	getActiveResourcesInfo,
+	getegid,
+	geteuid,
+	getgid,
+	getgroups,
 	getMaxListeners,
-	hrtime,
-	kill,
-	listeners,
+	getuid,
+	// @ts-expect-error `initgroups` is missing typings
+	initgroups,
 	listenerCount,
-	memoryUsage,
-	on,
+	listeners,
+	loadEnvFile,
 	off,
+	on,
 	once,
 	pid,
 	ppid,
 	prependListener,
 	prependOnceListener,
 	rawListeners,
-	release,
 	removeAllListeners,
 	removeListener,
-	report,
-	resourceUsage,
-	setMaxListeners,
-	setSourceMapsEnabled,
-	stderr,
-	stdin,
-	stdout,
-	title,
-	throwDeprecation,
-	traceDeprecation,
-	umask,
-	uptime,
-	version,
-	versions,
-	domain,
-	initgroups,
-	moduleLoadList,
-	reallyExit,
-	openStdin,
-	assert,
-	binding,
-	send,
-	exitCode,
-	channel,
-	getegid,
-	geteuid,
-	getgid,
-	getgroups,
-	getuid,
 	setegid,
 	seteuid,
 	setgid,
 	setgroups,
+	setMaxListeners,
+	setSourceMapsEnabled,
 	setuid,
-	permission,
-	mainModule,
-	_events,
-	_eventsCount,
-	_exiting,
-	_maxListeners,
-	_debugEnd,
-	_debugProcess,
-	_fatalException,
-	_getActiveHandles,
-	_getActiveRequests,
-	_kill,
-	_preload_modules,
-	_rawDebug,
-	_startProfilerIdleNotifier,
-	_stopProfilerIdleNotifier,
-	_tickCallback,
-	_disconnect,
-	_handleQueue,
-	_pendingMessage,
-	_channel,
-	_send,
-	_linkedBinding,
-} = unenvProcess;
+	stderr,
+	stdin,
+	stdout,
+	title,
+	umask,
+	uptime,
+	version,
+	versions,
+} = isWorkerdProcessV2 ? workerdProcess : unenvProcess;
 
 const _process = {
 	abort,

--- a/packages/wrangler/e2e/unenv-preset/preset.test.ts
+++ b/packages/wrangler/e2e/unenv-preset/preset.test.ts
@@ -188,6 +188,34 @@ const testConfigs: TestConfig[] = [
 			},
 		},
 	],
+	// node:process v2
+	[
+		{
+			name: "process v1  by date",
+			compatibilityDate: "2024-09-23",
+			expectRuntimeFlags: {
+				enable_nodejs_process_v2: false,
+			},
+		},
+		// TODO: add a config when v2 is enabled by default (>= 2025-09-15)
+		{
+			name: "process v2 by flag",
+			compatibilityDate: "2024-09-23",
+			compatibilityFlags: ["enable_nodejs_process_v2"],
+			expectRuntimeFlags: {
+				enable_nodejs_process_v2: true,
+			},
+		},
+		// TODO: change the date pass the default enabled date (>= 2025-09-15)
+		{
+			name: "process v1 by flag",
+			compatibilityDate: "2024-09-23",
+			compatibilityFlags: ["disable_nodejs_process_v2"],
+			expectRuntimeFlags: {
+				enable_nodejs_process_v2: false,
+			},
+		},
+	],
 ].flat() as TestConfig[];
 
 describe.each(testConfigs)(

--- a/packages/wrangler/e2e/unenv-preset/worker/index.ts
+++ b/packages/wrangler/e2e/unenv-preset/worker/index.ts
@@ -505,4 +505,41 @@ export const WorkerdTests: Record<string, () => void> = {
 		assert.strictEqual(typeof http2.connect, "function");
 		assert.strictEqual(http2.constants.HTTP2_HEADER_STATUS, ":status");
 	},
+
+	async testProcess() {
+		const mProcess = await import("node:process");
+		const gProcess = globalThis.process;
+
+		const useV2 = getRuntimeFlagValue("enable_nodejs_process_v2");
+
+		for (const p of [mProcess, gProcess]) {
+			if (useV2) {
+				// workerd implementation only
+				assert.equal(p.arch, "x64");
+				assert.equal(p.title, "workerd");
+			} else {
+				// unenv implementation only
+				assert.equal(p.arch, "");
+				assert.equal(p.title, "");
+			}
+
+			assert.doesNotThrow(() => p.chdir("/tmp"));
+			assert.equal(typeof p.cwd(), "string");
+
+			assert.equal(typeof p.addListener, "function");
+			assert.equal(typeof p.eventNames, "function");
+			assert.equal(typeof p.getMaxListeners, "function");
+			assert.equal(typeof p.listenerCount, "function");
+			assert.equal(typeof p.listeners, "function");
+			assert.equal(typeof p.off, "function");
+			assert.equal(typeof p.on, "function");
+			assert.equal(typeof p.once, "function");
+			assert.equal(typeof p.prependListener, "function");
+			assert.equal(typeof p.prependOnceListener, "function");
+			assert.equal(typeof p.rawListeners, "function");
+			assert.equal(typeof p.removeAllListeners, "function");
+			assert.equal(typeof p.removeListener, "function");
+			assert.equal(typeof p.setMaxListeners, "function");
+		}
+	},
 };

--- a/packages/wrangler/e2e/unenv-preset/worker/index.ts
+++ b/packages/wrangler/e2e/unenv-preset/worker/index.ts
@@ -540,6 +540,8 @@ export const WorkerdTests: Record<string, () => void> = {
 			assert.equal(typeof p.removeAllListeners, "function");
 			assert.equal(typeof p.removeListener, "function");
 			assert.equal(typeof p.setMaxListeners, "function");
+			assert.equal(typeof (p as any).binding, "function");
+			assert.equal(typeof p.permission, "object");
 		}
 	},
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2175,8 +2175,8 @@ importers:
         specifier: 2.0.0-rc.21
         version: 2.0.0-rc.21
       workerd:
-        specifier: ^1.20250828.1
-        version: 1.20250829.0
+        specifier: ^1.20250912.0
+        version: 1.20250913.0
     devDependencies:
       '@types/node-unenv':
         specifier: npm:@types/node@^22.14.0
@@ -4539,12 +4539,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-64@1.20250829.0':
-    resolution: {integrity: sha512-IkB5gaLz3gzBg9hIsC/bVvOMDaRiWA5anaPK0ERDXXXJnMiBkLnA009O5Mp0x7j0fpxbw05xaiYXcFdGPdUt3A==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [darwin]
-
   '@cloudflare/workerd-darwin-64@1.20250913.0':
     resolution: {integrity: sha512-926bBGIYDsF0FraaPQV0hO9LymEN+Zdkkm1qOHxU1c58oAxr5b9Tpe4d1z1EqOD0DTFhjn7V/AxKcZBaBBhO/A==}
     engines: {node: '>=16'}
@@ -4559,12 +4553,6 @@ packages:
 
   '@cloudflare/workerd-darwin-arm64@1.20250417.0':
     resolution: {integrity: sha512-dSlk18F4i3T1OTzFBxx3pKpXRMP6w2xZ26+oIV32BFWrCi/HxGzUd6gVA0q37oLGqITRt8xU693J4Gl1CwC/Ag==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@cloudflare/workerd-darwin-arm64@1.20250829.0':
-    resolution: {integrity: sha512-gFYC+w0jznCweKmrv63inEYduGj6crOskgZrn5zHI8S7c3ynC1LSW6LR8E9A2mSOwuDWKM1hHypwctwGUKlikg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -4587,12 +4575,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-64@1.20250829.0':
-    resolution: {integrity: sha512-JS699jk+Bn7j4QF7tdF+Sqhy4EUHM2NGVLF/vOIbpPWQnBVvP6Z+vmxi5MuVUwpAH48kpqbtMx380InNvT5f1Q==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [linux]
-
   '@cloudflare/workerd-linux-64@1.20250913.0':
     resolution: {integrity: sha512-khdF7MBi8L9WIt3YyWBQxipMny0J3gG824kurZiRACZmPdQ1AOzkKybDDXC3EMcF8TmGMRqKRUGQIB/25PwJuQ==}
     engines: {node: '>=16'}
@@ -4611,12 +4593,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20250829.0':
-    resolution: {integrity: sha512-9Ic/VwcrCEQiIzynmpFQnS8N3uXm8evxUxFe37r6OC8/MGcXZTcp0/lmEk+cjjz+2aw5CfPMP82IdQyRKVZ+Og==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [linux]
-
   '@cloudflare/workerd-linux-arm64@1.20250913.0':
     resolution: {integrity: sha512-KF5nIOt5YIYGfinY0YEe63JqaAx8WSFDHTLQpytTX+N/oJWEJu3KW6evU1TfX7o8gRlRsc0j/evcZ1vMfbDy5g==}
     engines: {node: '>=16'}
@@ -4631,12 +4607,6 @@ packages:
 
   '@cloudflare/workerd-windows-64@1.20250417.0':
     resolution: {integrity: sha512-PDwATFioff+geVHfgTzSWsxgwjgotrdXStb0EL0lMyMT5zNmHArAnOx83CbDtud63Uv9rVX1BAfPP4tyD1O+5A==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [win32]
-
-  '@cloudflare/workerd-windows-64@1.20250829.0':
-    resolution: {integrity: sha512-6uETqeeMciRSA00GRGzH1nnz0egDP2bqMOJtTBWlLzFs88GbLe2RXECJxo4E3eVr8yvAMyqwd0WUR4dDBjO7Rg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -13326,11 +13296,6 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  workerd@1.20250829.0:
-    resolution: {integrity: sha512-8qoE56hf9QHS2llMM1tybjhvFEX5vnNUa1PpuyxeNC9F0dn9/qb9eDqN/z3sBPgpYK8vfQU9J8KOxczA+qo/cQ==}
-    engines: {node: '>=16'}
-    hasBin: true
-
   workerd@1.20250913.0:
     resolution: {integrity: sha512-y3J1NjCL10SAWDwgGdcNSRyOVod/dWNypu64CCdjj8VS4/k+Ofa/fHaJGC1stbdzAB1tY2P35Ckgm1PU5HKWiw==}
     engines: {node: '>=16'}
@@ -14752,9 +14717,6 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20250417.0':
     optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20250829.0':
-    optional: true
-
   '@cloudflare/workerd-darwin-64@1.20250913.0':
     optional: true
 
@@ -14762,9 +14724,6 @@ snapshots:
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20250417.0':
-    optional: true
-
-  '@cloudflare/workerd-darwin-arm64@1.20250829.0':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20250913.0':
@@ -14776,9 +14735,6 @@ snapshots:
   '@cloudflare/workerd-linux-64@1.20250417.0':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20250829.0':
-    optional: true
-
   '@cloudflare/workerd-linux-64@1.20250913.0':
     optional: true
 
@@ -14788,9 +14744,6 @@ snapshots:
   '@cloudflare/workerd-linux-arm64@1.20250417.0':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20250829.0':
-    optional: true
-
   '@cloudflare/workerd-linux-arm64@1.20250913.0':
     optional: true
 
@@ -14798,9 +14751,6 @@ snapshots:
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20250417.0':
-    optional: true
-
-  '@cloudflare/workerd-windows-64@1.20250829.0':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20250913.0':
@@ -24007,14 +23957,6 @@ snapshots:
       '@cloudflare/workerd-linux-64': 1.20250417.0
       '@cloudflare/workerd-linux-arm64': 1.20250417.0
       '@cloudflare/workerd-windows-64': 1.20250417.0
-
-  workerd@1.20250829.0:
-    optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20250829.0
-      '@cloudflare/workerd-darwin-arm64': 1.20250829.0
-      '@cloudflare/workerd-linux-64': 1.20250829.0
-      '@cloudflare/workerd-linux-arm64': 1.20250829.0
-      '@cloudflare/workerd-windows-64': 1.20250829.0
 
   workerd@1.20250913.0:
     optionalDependencies:


### PR DESCRIPTION
This PR enabled using workerd `node:process` v2 when it is enabled (by flag or date).

It depends on the implemntation being available:
- implemented in https://github.com/cloudflare/workerd/pull/4960
- releases in [workerd v1.20250904.0](https://github.com/cloudflare/workerd/releases/tag/v1.20250904.0)
- depends on https://github.com/cloudflare/workerd/pull/5040  released in https://github.com/cloudflare/workerd/releases/tag/v1.20250911.0
- depends on https://github.com/cloudflare/workerd/pull/5024 released in https://github.com/cloudflare/workerd/releases/tag/v1.20250912.0


---

Outdated comment:

<details>

A few notes:

This PR still fails the remote tests as the v2 changes have not reached production yet.

Some of [the v2 APIs are `undefined`](https://github.com/cloudflare/workerd/blob/e8aad2a03def0f5a18344c0e96b17a6dfafefdee/src/node/internal/public_process.ts#L204-L227).

For that reason we still need an hybrid polyfill pulling their implementation from `unenv`. Otherwise the following code might break:

```ts
import { process } from "node:process";

// This would break with v2 as `process.release` is `undefined.
console.log(process.release.name);
```

Because we have to use an hybrid polyfill anyway, we keep all the APIs that are implemented in `unenv` and missing from `workerd`:
- `_...` APIs (`_channel`, `_debugEnd`, ...)
- some other APIs as `addListener`, `assert`, ...

`addListener`, `assert`, ... are not all documented on nodejs.org and a few are deprecated. But they all are available for Node 22.16.0 (tested in the REPL).

Maybe we can refine and better handle deprecated APIs now that we have a dedicated workerd flag. Comments welcome.

@petebacondarwin @guybedford could you please review the PR, the API surface is quite large and having more eyes would be helpful.

<details>

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: will be documented by the runtime team
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: unenv changes are not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
