### PR TITLE
[Wrangler/D1] Add CLI flag to skip migration confirmation

### DIFF
--- a/.changeset/auto-apply-migrations.md
+++ b/.changeset/auto-apply-migrations.md
@@ -1,0 +1,13 @@
+---
+"wrangler": patch
+---
+
+Add a new `--auto-apply` flag to `d1 migrations apply` which skips the interactive
+confirmation and applies any pending migrations non-interactively. This is useful
+for CI and automation.
+
+Usage example:
+
+wrangler d1 migrations apply <db> --remote --auto-apply
+
+Fixes #5017

--- a/.changeset/auto-apply-migrations.md
+++ b/.changeset/auto-apply-migrations.md
@@ -2,12 +2,12 @@
 "wrangler": patch
 ---
 
-Add a new `--auto-apply` flag to `d1 migrations apply` which skips the interactive
+Add a new `--force-non-interactive` flag to `d1 migrations apply` which skips the interactive
 confirmation and applies any pending migrations non-interactively. This is useful
 for CI and automation.
 
 Usage example:
 
-wrangler d1 migrations apply <db> --remote --auto-apply
+wrangler d1 migrations apply <db> --remote --force-non-interactive
 
 Fixes #5017

--- a/.changeset/auto-apply-migrations.md
+++ b/.changeset/auto-apply-migrations.md
@@ -2,12 +2,12 @@
 "wrangler": patch
 ---
 
-Add a new `--force-non-interactive` flag to `d1 migrations apply` which skips the interactive
+Add a new `--force` flag to `d1 migrations apply` which skips the interactive
 confirmation and applies any pending migrations non-interactively. This is useful
 for CI and automation.
 
 Usage example:
 
-wrangler d1 migrations apply <db> --remote --force-non-interactive
+wrangler d1 migrations apply <db> --remote --force
 
 Fixes #5017

--- a/.changeset/auto-apply-migrations.md
+++ b/.changeset/auto-apply-migrations.md
@@ -1,5 +1,5 @@
 ---
-"wrangler": patch
+"wrangler": minor
 ---
 
 Add a new `--force` flag to `d1 migrations apply` which skips the interactive

--- a/.changeset/auto-apply-migrations.md
+++ b/.changeset/auto-apply-migrations.md
@@ -8,6 +8,8 @@ for CI and automation.
 
 Usage example:
 
+```
 wrangler d1 migrations apply <db> --remote --force
+```
 
 Fixes #5017

--- a/packages/wrangler/src/__tests__/d1/migrate.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrate.test.ts
@@ -1,6 +1,7 @@
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { describe, it, vi } from "vitest";
+import { logger } from "../../logger";
 import { reinitialiseAuthTokens } from "../../user";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -159,7 +160,7 @@ Your database may not be available to serve requests during the migration, conti
 			expect,
 		}) => {
 			setIsTTY(false);
-			const std = mockConsoleMethods();
+
 			msw.use(
 				http.post(
 					"*/accounts/:accountId/d1/database/:databaseId/query",
@@ -226,12 +227,13 @@ Your database may not be available to serve requests during the migration, conti
 				result: true,
 			});
 			await runWrangler("d1 migrations apply db --remote");
-			expect(std.out).toBe("");
+			expect(mockStd.out).toBe("");
 		});
 
 		it("should not prompt when --force is passed", async ({ expect }) => {
+			vi.stubEnv("WRANGLER_LOG", "debug");
+			logger.loggerLevel = "debug";
 			setIsTTY(false);
-			const std = mockConsoleMethods();
 
 			msw.use(
 				http.post(
@@ -285,21 +287,19 @@ Your database may not be available to serve requests during the migration, conti
 						migrations_dir: "migrations",
 					},
 				],
-				account_id: "nx01",
 			});
 
 			// Ensure account selection works in non-interactive mode
 			mockGetMemberships([
 				{ id: "IG-88", account: { id: "1701", name: "enterprise" } },
-				{ id: "R2-D2", account: { id: "nx01", name: "enterprise-nx" } },
 			]);
 
 			await runWrangler("d1 migrations create db test");
 
 			await runWrangler("d1 migrations apply db --remote --force");
 
-			expect(std.out).toContain(
-				"--force passed, applying 1 migration(s) without prompt"
+			expect(mockStd.out).toContain(
+				"--force passed, applying 1 migration(s) without prompt."
 			);
 		});
 	});

--- a/packages/wrangler/src/__tests__/d1/migrate.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrate.test.ts
@@ -227,6 +227,162 @@ Your database may not be available to serve requests during the migration, conti
 			await runWrangler("d1 migrations apply db --remote");
 			expect(std.out).toBe("");
 		});
+
+		it("applies migrations from a migration directory containing .sql files", async () => {
+			setIsTTY(false);
+			const commands: string[] = [];
+
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/d1/database/:databaseId/query",
+					async (req) => {
+						const { body } = req.request;
+						if (body && typeof body === "object") {
+							commands.push(JSON.stringify(body));
+						} else {
+							commands.push(String(body));
+						}
+
+						return HttpResponse.json(
+							{
+								result: [
+									{
+										results: [],
+										success: true,
+										meta: {},
+									},
+								],
+								success: true,
+								errors: [],
+								messages: [],
+							},
+							{ status: 200 }
+						);
+					}
+				)
+			);
+
+			msw.use(
+				http.get("*/accounts/:accountId/d1/database/:databaseId", async () => {
+					return HttpResponse.json(
+						{
+							result: {
+								file_size: 123,
+								name: "testdb",
+								num_tables: 0,
+								uuid: "uuid",
+								version: "production",
+							},
+							success: true,
+							errors: [],
+							messages: [],
+						},
+						{ status: 200 }
+					);
+				})
+			);
+
+			writeWranglerConfig({
+				d1_databases: [
+					{
+						binding: "DATABASE",
+						database_name: "db",
+						database_id: "xxxx",
+						migrations_dir: "migrations",
+					},
+				],
+				account_id: "nx01",
+			});
+
+			mockGetMemberships([
+				{ id: "IG-88", account: { id: "1701", name: "enterprise" } },
+				{ id: "R2-D2", account: { id: "nx01", name: "enterprise-nx" } },
+			]);
+
+			await runWrangler("d1 migrations create db test");
+
+			await runWrangler("d1 migrations apply db --remote");
+
+			expect(commands.some((c) => c.includes("CREATE TABLE users"))).toBe(true);
+			expect(commands.some((c) => c.includes("INSERT INTO users"))).toBe(true);
+			expect(commands.some((c) => c.includes("INSERT INTO migrations"))).toBe(
+				true
+			);
+		});
+
+		it("should not prompt when --auto-apply is passed", async () => {
+			setIsTTY(false);
+			const std = mockConsoleMethods();
+
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/d1/database/:databaseId/query",
+					async () => {
+						return HttpResponse.json(
+							{
+								result: [
+									{
+										results: [],
+										success: true,
+										meta: {},
+									},
+								],
+								success: true,
+								errors: [],
+								messages: [],
+							},
+							{ status: 200 }
+						);
+					}
+				)
+			);
+
+			msw.use(
+				http.get("*/accounts/:accountId/d1/database/:databaseId", async () => {
+					return HttpResponse.json(
+						{
+							result: {
+								file_size: 123,
+								name: "testdb",
+								num_tables: 0,
+								uuid: "uuid",
+								version: "production",
+							},
+							success: true,
+							errors: [],
+							messages: [],
+						},
+						{ status: 200 }
+					);
+				})
+			);
+
+			writeWranglerConfig({
+				d1_databases: [
+					{
+						binding: "DATABASE",
+						database_name: "db",
+						database_id: "xxxx",
+						migrations_dir: "migrations",
+					},
+				],
+				account_id: "nx01",
+			});
+
+			// Ensure account selection works in non-interactive mode
+			mockGetMemberships([
+				{ id: "IG-88", account: { id: "1701", name: "enterprise" } },
+				{ id: "R2-D2", account: { id: "nx01", name: "enterprise-nx" } },
+			]);
+
+			await runWrangler("d1 migrations create db test");
+
+			await runWrangler("d1 migrations apply db --remote --auto-apply");
+
+			expect(std.out).toContain(
+				"--auto-apply passed, applying 1 migration(s) without prompt"
+			);
+		});
 	});
 
 	describe("list", () => {

--- a/packages/wrangler/src/__tests__/d1/migrate.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrate.test.ts
@@ -310,7 +310,7 @@ Your database may not be available to serve requests during the migration, conti
 			);
 		});
 
-		it("should not prompt when --auto-apply is passed", async () => {
+		it("should not prompt when --force-non-interactive is passed", async () => {
 			setIsTTY(false);
 			const std = mockConsoleMethods();
 
@@ -377,10 +377,12 @@ Your database may not be available to serve requests during the migration, conti
 
 			await runWrangler("d1 migrations create db test");
 
-			await runWrangler("d1 migrations apply db --remote --auto-apply");
+			await runWrangler(
+				"d1 migrations apply db --remote --force-non-interactive"
+			);
 
 			expect(std.out).toContain(
-				"--auto-apply passed, applying 1 migration(s) without prompt"
+				"--force-non-interactive passed, applying 1 migration(s) without prompt"
 			);
 		});
 	});

--- a/packages/wrangler/src/__tests__/d1/migrate.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrate.test.ts
@@ -11,6 +11,7 @@ import { getMswSuccessMembershipHandlers, msw } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
+
 describe("migrate", () => {
 	runInTempDir();
 	const mockStd = mockConsoleMethods();
@@ -310,7 +311,7 @@ Your database may not be available to serve requests during the migration, conti
 			);
 		});
 
-		it("should not prompt when --force-non-interactive is passed", async () => {
+		it("should not prompt when --force is passed", async () => {
 			setIsTTY(false);
 			const std = mockConsoleMethods();
 
@@ -377,12 +378,10 @@ Your database may not be available to serve requests during the migration, conti
 
 			await runWrangler("d1 migrations create db test");
 
-			await runWrangler(
-				"d1 migrations apply db --remote --force-non-interactive"
-			);
+			await runWrangler("d1 migrations apply db --remote --force");
 
 			expect(std.out).toContain(
-				"--force-non-interactive passed, applying 1 migration(s) without prompt"
+				"--force passed, applying 1 migration(s) without prompt"
 			);
 		});
 	});

--- a/packages/wrangler/src/__tests__/d1/migrate.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrate.test.ts
@@ -11,7 +11,6 @@ import { getMswSuccessMembershipHandlers, msw } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
-
 describe("migrate", () => {
 	runInTempDir();
 	const mockStd = mockConsoleMethods();
@@ -229,7 +228,7 @@ Your database may not be available to serve requests during the migration, conti
 			expect(std.out).toBe("");
 		});
 
-		it("applies migrations from a migration directory containing .sql files", async () => {
+		it("applies migrations from a migration directory containing .sql files", async ( { expect }) => {
 			setIsTTY(false);
 			const commands: string[] = [];
 
@@ -311,7 +310,7 @@ Your database may not be available to serve requests during the migration, conti
 			);
 		});
 
-		it("should not prompt when --force is passed", async () => {
+		it("should not prompt when --force is passed", async ({ expect }) => {
 			setIsTTY(false);
 			const std = mockConsoleMethods();
 

--- a/packages/wrangler/src/__tests__/d1/migrate.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrate.test.ts
@@ -55,6 +55,7 @@ describe("migrate", () => {
 	describe("apply", () => {
 		mockAccountId({ accountId: null });
 		mockApiToken();
+
 		it("should not attempt to login in local mode", async ({ expect }) => {
 			setIsTTY(false);
 			writeWranglerConfig({
@@ -226,88 +227,6 @@ Your database may not be available to serve requests during the migration, conti
 			});
 			await runWrangler("d1 migrations apply db --remote");
 			expect(std.out).toBe("");
-		});
-
-		it("applies migrations from a migration directory containing .sql files", async ( { expect }) => {
-			setIsTTY(false);
-			const commands: string[] = [];
-
-			msw.use(
-				http.post(
-					"*/accounts/:accountId/d1/database/:databaseId/query",
-					async (req) => {
-						const { body } = req.request;
-						if (body && typeof body === "object") {
-							commands.push(JSON.stringify(body));
-						} else {
-							commands.push(String(body));
-						}
-
-						return HttpResponse.json(
-							{
-								result: [
-									{
-										results: [],
-										success: true,
-										meta: {},
-									},
-								],
-								success: true,
-								errors: [],
-								messages: [],
-							},
-							{ status: 200 }
-						);
-					}
-				)
-			);
-
-			msw.use(
-				http.get("*/accounts/:accountId/d1/database/:databaseId", async () => {
-					return HttpResponse.json(
-						{
-							result: {
-								file_size: 123,
-								name: "testdb",
-								num_tables: 0,
-								uuid: "uuid",
-								version: "production",
-							},
-							success: true,
-							errors: [],
-							messages: [],
-						},
-						{ status: 200 }
-					);
-				})
-			);
-
-			writeWranglerConfig({
-				d1_databases: [
-					{
-						binding: "DATABASE",
-						database_name: "db",
-						database_id: "xxxx",
-						migrations_dir: "migrations",
-					},
-				],
-				account_id: "nx01",
-			});
-
-			mockGetMemberships([
-				{ id: "IG-88", account: { id: "1701", name: "enterprise" } },
-				{ id: "R2-D2", account: { id: "nx01", name: "enterprise-nx" } },
-			]);
-
-			await runWrangler("d1 migrations create db test");
-
-			await runWrangler("d1 migrations apply db --remote");
-
-			expect(commands.some((c) => c.includes("CREATE TABLE users"))).toBe(true);
-			expect(commands.some((c) => c.includes("INSERT INTO users"))).toBe(true);
-			expect(commands.some((c) => c.includes("INSERT INTO migrations"))).toBe(
-				true
-			);
 		});
 
 		it("should not prompt when --force is passed", async ({ expect }) => {

--- a/packages/wrangler/src/d1/migrations/apply.ts
+++ b/packages/wrangler/src/d1/migrations/apply.ts
@@ -10,12 +10,9 @@ import { isLocal } from "../../utils/is-local";
 import { DEFAULT_MIGRATION_PATH, DEFAULT_MIGRATION_TABLE } from "../constants";
 import { executeSql } from "../execute";
 import { getDatabaseInfoFromConfig } from "../utils";
-import {
-	getMigrationsPath,
-	getUnappliedMigrations,
-	initMigrationsTable,
-} from "./helpers";
+import { getMigrationsPath, getUnappliedMigrations, initMigrationsTable } from "./helpers";
 import type { ParseError } from "@cloudflare/workers-utils";
+
 
 export const d1MigrationsApplyCommand = createCommand({
 	metadata: {
@@ -66,7 +63,7 @@ export const d1MigrationsApplyCommand = createCommand({
 				"Specify directory to use for local persistence (you must use --local with this flag)",
 			requiresArg: true,
 		},
-		"force-non-interactive": {
+		force: {
 			type: "boolean",
 			description: "Automatically apply all pending migrations without prompt",
 			default: false,
@@ -74,7 +71,7 @@ export const d1MigrationsApplyCommand = createCommand({
 	},
 	positionalArgs: ["database"],
 	async handler(
-		{ database, local, remote, persistTo, preview, forceNonInteractive },
+		{ database, local, remote, persistTo, preview, force },
 		{ config }
 	) {
 		if (!config.configPath) {
@@ -156,7 +153,7 @@ export const d1MigrationsApplyCommand = createCommand({
 		logger.log("Migrations to be applied:");
 		logger.table(unappliedMigrations.map((m) => ({ name: m.name })));
 
-		if (!forceNonInteractive) {
+		if (!force) {
 			const ok = await confirm(
 				`About to apply ${unappliedMigrations.length} migration(s)
 Your database may not be available to serve requests during the migration, continue?`
@@ -167,7 +164,7 @@ Your database may not be available to serve requests during the migration, conti
 			}
 		} else {
 			logger.log(
-				`--force-non-interactive passed, applying ${unappliedMigrations.length} migration(s) without prompt`
+				`--force passed, applying ${unappliedMigrations.length} migration(s) without prompt`
 			);
 		}
 

--- a/packages/wrangler/src/d1/migrations/apply.ts
+++ b/packages/wrangler/src/d1/migrations/apply.ts
@@ -13,7 +13,6 @@ import { getDatabaseInfoFromConfig } from "../utils";
 import { getMigrationsPath, getUnappliedMigrations, initMigrationsTable } from "./helpers";
 import type { ParseError } from "@cloudflare/workers-utils";
 
-
 export const d1MigrationsApplyCommand = createCommand({
 	metadata: {
 		description: "Apply any unapplied D1 migrations",
@@ -67,6 +66,7 @@ export const d1MigrationsApplyCommand = createCommand({
 			type: "boolean",
 			description: "Automatically apply all pending migrations without prompt",
 			default: false,
+			alias: "y",
 		},
 	},
 	positionalArgs: ["database"],

--- a/packages/wrangler/src/d1/migrations/apply.ts
+++ b/packages/wrangler/src/d1/migrations/apply.ts
@@ -66,7 +66,7 @@ export const d1MigrationsApplyCommand = createCommand({
 				"Specify directory to use for local persistence (you must use --local with this flag)",
 			requiresArg: true,
 		},
-		"auto-apply": {
+		"force-non-interactive": {
 			type: "boolean",
 			description: "Automatically apply all pending migrations without prompt",
 			default: false,
@@ -74,7 +74,7 @@ export const d1MigrationsApplyCommand = createCommand({
 	},
 	positionalArgs: ["database"],
 	async handler(
-		{ database, local, remote, persistTo, preview, autoApply },
+		{ database, local, remote, persistTo, preview, forceNonInteractive },
 		{ config }
 	) {
 		if (!config.configPath) {
@@ -156,7 +156,7 @@ export const d1MigrationsApplyCommand = createCommand({
 		logger.log("Migrations to be applied:");
 		logger.table(unappliedMigrations.map((m) => ({ name: m.name })));
 
-		if (!autoApply) {
+		if (!forceNonInteractive) {
 			const ok = await confirm(
 				`About to apply ${unappliedMigrations.length} migration(s)
 Your database may not be available to serve requests during the migration, continue?`
@@ -167,7 +167,7 @@ Your database may not be available to serve requests during the migration, conti
 			}
 		} else {
 			logger.log(
-				`--auto-apply passed, applying ${unappliedMigrations.length} migration(s) without prompt`
+				`--force-non-interactive passed, applying ${unappliedMigrations.length} migration(s) without prompt`
 			);
 		}
 

--- a/packages/wrangler/src/d1/migrations/apply.ts
+++ b/packages/wrangler/src/d1/migrations/apply.ts
@@ -164,7 +164,7 @@ Your database may not be available to serve requests during the migration, conti
 			}
 		} else {
 			logger.log(
-				`--force passed, applying ${unappliedMigrations.length} migration(s) without prompt`
+				`--force passed, applying ${unappliedMigrations.length} migration(s) without prompt.`
 			);
 		}
 

--- a/packages/wrangler/src/d1/migrations/apply.ts
+++ b/packages/wrangler/src/d1/migrations/apply.ts
@@ -10,7 +10,11 @@ import { isLocal } from "../../utils/is-local";
 import { DEFAULT_MIGRATION_PATH, DEFAULT_MIGRATION_TABLE } from "../constants";
 import { executeSql } from "../execute";
 import { getDatabaseInfoFromConfig } from "../utils";
-import { getMigrationsPath, getUnappliedMigrations, initMigrationsTable } from "./helpers";
+import {
+	getMigrationsPath,
+	getUnappliedMigrations,
+	initMigrationsTable,
+} from "./helpers";
 import type { ParseError } from "@cloudflare/workers-utils";
 
 export const d1MigrationsApplyCommand = createCommand({

--- a/packages/wrangler/src/d1/migrations/apply.ts
+++ b/packages/wrangler/src/d1/migrations/apply.ts
@@ -66,9 +66,17 @@ export const d1MigrationsApplyCommand = createCommand({
 				"Specify directory to use for local persistence (you must use --local with this flag)",
 			requiresArg: true,
 		},
+		"auto-apply": {
+			type: "boolean",
+			description: "Automatically apply all pending migrations without prompt",
+			default: false,
+		},
 	},
 	positionalArgs: ["database"],
-	async handler({ database, local, remote, persistTo, preview }, { config }) {
+	async handler(
+		{ database, local, remote, persistTo, preview, autoApply },
+		{ config }
+	) {
 		if (!config.configPath) {
 			throw new UserError(
 				"No configuration file found. Create a wrangler.jsonc file to define your D1 database.",
@@ -148,12 +156,19 @@ export const d1MigrationsApplyCommand = createCommand({
 		logger.log("Migrations to be applied:");
 		logger.table(unappliedMigrations.map((m) => ({ name: m.name })));
 
-		const ok = await confirm(
-			`About to apply ${unappliedMigrations.length} migration(s)
+		if (!autoApply) {
+			const ok = await confirm(
+				`About to apply ${unappliedMigrations.length} migration(s)
 Your database may not be available to serve requests during the migration, continue?`
-		);
-		if (!ok) {
-			return;
+			);
+
+			if (!ok) {
+				return;
+			}
+		} else {
+			logger.log(
+				`--auto-apply passed, applying ${unappliedMigrations.length} migration(s) without prompt`
+			);
 		}
 
 		for (const migration of unappliedMigrations) {


### PR DESCRIPTION
Fixes #5017.

Add a new --force boolean flag to `d1 migrations apply` that skips the interactive
confirmation and applies any pending migrations non-interactively. This is useful
for CI and automation where a prompt is undesirable.

Usage example:

    wrangler d1 migrations apply <db> --remote --force

Behavior:

- When `--force` is present the command will not prompt and will proceed to apply
  all pending migrations. It logs a short informational message indicating force
  was used.
- Default behavior is unchanged when the flag is not provided.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because: tests should already include this
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: The CLI usage text has been updated
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: A small patch with visible usage information

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/10598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
