### PR TITLE
fix: update Secrets Store status from alpha to open-beta

### DIFF
--- a/.changeset/bitter-banks-teach.md
+++ b/.changeset/bitter-banks-teach.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: update Secrets Store command status from alpha to open-beta

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -62,7 +62,7 @@ describe("wrangler", () => {
 				  wrangler pubsub                 📮 Manage Pub/Sub brokers [private beta]
 				  wrangler dispatch-namespace     🏗️  Manage dispatch namespaces
 				  wrangler ai                     🤖 Manage AI models
-				  wrangler secrets-store          🔐 Manage the Secrets Store [alpha]
+				  wrangler secrets-store          🔐 Manage the Secrets Store [open-beta]
 				  wrangler workflows              🔁 Manage Workflows
 				  wrangler pipelines              🚰 Manage Cloudflare Pipelines [open-beta]
 				  wrangler vpc                    🌐 Manage VPC [open-beta]
@@ -124,7 +124,7 @@ describe("wrangler", () => {
 				  wrangler pubsub                 📮 Manage Pub/Sub brokers [private beta]
 				  wrangler dispatch-namespace     🏗️  Manage dispatch namespaces
 				  wrangler ai                     🤖 Manage AI models
-				  wrangler secrets-store          🔐 Manage the Secrets Store [alpha]
+				  wrangler secrets-store          🔐 Manage the Secrets Store [open-beta]
 				  wrangler workflows              🔁 Manage Workflows
 				  wrangler pipelines              🚰 Manage Cloudflare Pipelines [open-beta]
 				  wrangler vpc                    🌐 Manage VPC [open-beta]

--- a/packages/wrangler/src/__tests__/secrets-store.test.ts
+++ b/packages/wrangler/src/__tests__/secrets-store.test.ts
@@ -27,11 +27,11 @@ describe("secrets-store help", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"wrangler secrets-store
 
-			🔐 Manage the Secrets Store [alpha]
+			🔐 Manage the Secrets Store [open-beta]
 
 			COMMANDS
-			  wrangler secrets-store store   🔐 Manage Stores within the Secrets Store [alpha]
-			  wrangler secrets-store secret  🔐 Manage Secrets within the Secrets Store [alpha]
+			  wrangler secrets-store store   🔐 Manage Stores within the Secrets Store [open-beta]
+			  wrangler secrets-store secret  🔐 Manage Secrets within the Secrets Store [open-beta]
 
 			GLOBAL FLAGS
 			  -c, --config    Path to Wrangler configuration file  [string]
@@ -57,11 +57,11 @@ describe("secrets-store help", () => {
 			"
 			wrangler secrets-store
 
-			🔐 Manage the Secrets Store [alpha]
+			🔐 Manage the Secrets Store [open-beta]
 
 			COMMANDS
-			  wrangler secrets-store store   🔐 Manage Stores within the Secrets Store [alpha]
-			  wrangler secrets-store secret  🔐 Manage Secrets within the Secrets Store [alpha]
+			  wrangler secrets-store store   🔐 Manage Stores within the Secrets Store [open-beta]
+			  wrangler secrets-store secret  🔐 Manage Secrets within the Secrets Store [open-beta]
 
 			GLOBAL FLAGS
 			  -c, --config    Path to Wrangler configuration file  [string]

--- a/packages/wrangler/src/secrets-store/commands.ts
+++ b/packages/wrangler/src/secrets-store/commands.ts
@@ -56,7 +56,7 @@ export async function usingLocalSecretsStoreSecretAPI<T>(
 export const secretsStoreStoreCreateCommand = createCommand({
 	metadata: {
 		description: "Create a store within an account",
-		status: "alpha",
+		status: "open-beta",
 		owner: "Product: SSL",
 	},
 	positionalArgs: ["name"],
@@ -92,7 +92,7 @@ export const secretsStoreStoreCreateCommand = createCommand({
 export const secretsStoreStoreDeleteCommand = createCommand({
 	metadata: {
 		description: "Delete a store within an account",
-		status: "alpha",
+		status: "open-beta",
 		owner: "Product: SSL",
 	},
 	positionalArgs: ["store-id"],
@@ -127,7 +127,7 @@ export const secretsStoreStoreDeleteCommand = createCommand({
 export const secretsStoreStoreListCommand = createCommand({
 	metadata: {
 		description: "List stores within an account",
-		status: "alpha",
+		status: "open-beta",
 		owner: "Product: SSL",
 	},
 	args: {
@@ -191,7 +191,7 @@ export const secretsStoreStoreListCommand = createCommand({
 export const secretsStoreSecretListCommand = createCommand({
 	metadata: {
 		description: "List secrets within a store",
-		status: "alpha",
+		status: "open-beta",
 		owner: "Product: SSL",
 	},
 	positionalArgs: ["store-id"],
@@ -281,7 +281,7 @@ export const secretsStoreSecretListCommand = createCommand({
 export const secretsStoreSecretGetCommand = createCommand({
 	metadata: {
 		description: "Get a secret within a store",
-		status: "alpha",
+		status: "open-beta",
 		owner: "Product: SSL",
 	},
 	positionalArgs: ["store-id"],
@@ -354,7 +354,7 @@ export const secretsStoreSecretGetCommand = createCommand({
 export const secretsStoreSecretCreateCommand = createCommand({
 	metadata: {
 		description: "Create a secret within a store",
-		status: "alpha",
+		status: "open-beta",
 		owner: "Product: SSL",
 	},
 	positionalArgs: ["store-id"],
@@ -476,7 +476,7 @@ export const secretsStoreSecretCreateCommand = createCommand({
 export const secretsStoreSecretUpdateCommand = createCommand({
 	metadata: {
 		description: "Update a secret within a store",
-		status: "alpha",
+		status: "open-beta",
 		owner: "Product: SSL",
 	},
 	positionalArgs: ["store-id"],
@@ -601,7 +601,7 @@ export const secretsStoreSecretUpdateCommand = createCommand({
 export const secretsStoreSecretDeleteCommand = createCommand({
 	metadata: {
 		description: "Delete a secret within a store",
-		status: "alpha",
+		status: "open-beta",
 		owner: "Product: SSL",
 	},
 	positionalArgs: ["store-id"],
@@ -650,7 +650,7 @@ export const secretsStoreSecretDeleteCommand = createCommand({
 export const secretsStoreSecretDuplicateCommand = createCommand({
 	metadata: {
 		description: "Duplicate a secret within a store",
-		status: "alpha",
+		status: "open-beta",
 		owner: "Product: SSL",
 	},
 	positionalArgs: ["store-id"],

--- a/packages/wrangler/src/secrets-store/index.ts
+++ b/packages/wrangler/src/secrets-store/index.ts
@@ -3,7 +3,7 @@ import { createNamespace } from "../core/create-command";
 export const secretsStoreNamespace = createNamespace({
 	metadata: {
 		description: `🔐 Manage the Secrets Store`,
-		status: "alpha",
+		status: "open-beta",
 		owner: "Product: SSL",
 	},
 });
@@ -11,7 +11,7 @@ export const secretsStoreNamespace = createNamespace({
 export const secretsStoreStoreNamespace = createNamespace({
 	metadata: {
 		description: "🔐 Manage Stores within the Secrets Store",
-		status: "alpha",
+		status: "open-beta",
 		owner: "Product: SSL",
 	},
 });
@@ -19,7 +19,7 @@ export const secretsStoreStoreNamespace = createNamespace({
 export const secretsStoreSecretNamespace = createNamespace({
 	metadata: {
 		description: "🔐 Manage Secrets within the Secrets Store",
-		status: "alpha",
+		status: "open-beta",
 		owner: "Product: SSL",
 	},
 });


### PR DESCRIPTION
Fix #10566.

The "Secrets Store" description in the CLI still shows [alpha], but the command is already [open-beta].
I've updated it accordingly and also updated the tests.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Since it has already been changed
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a GA feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
