### PR TITLE
Use native `node:vm` module when available

### DIFF
--- a/.changeset/upset-ducks-sin.md
+++ b/.changeset/upset-ducks-sin.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/unenv-preset": patch
+---
+
+Use native node:vm module when available
+
+It is enabled starting on 2025-10-01 or when the `enable_nodejs_vm_module` compatibility flag is set.

--- a/packages/wrangler/e2e/unenv-preset/preset.test.ts
+++ b/packages/wrangler/e2e/unenv-preset/preset.test.ts
@@ -377,6 +377,39 @@ const localTestConfigs: TestConfig[] = [
 			},
 		},
 	],
+	// node:vm
+	[
+		{
+			name: "vm disabled by date",
+			compatibilityDate: "2024-09-23",
+			expectRuntimeFlags: {
+				enable_nodejs_vm_module: false,
+			},
+		},
+		{
+			name: "vm enabled by date",
+			compatibilityDate: "2025-10-01",
+			expectRuntimeFlags: {
+				enable_nodejs_vm_module: true,
+			},
+		},
+		{
+			name: "vm enabled by flag",
+			compatibilityDate: "2024-09-23",
+			compatibilityFlags: ["enable_nodejs_vm_module"],
+			expectRuntimeFlags: {
+				enable_nodejs_vm_module: true,
+			},
+		},
+		{
+			name: "vm disabled by flag",
+			compatibilityDate: "2025-10-01",
+			compatibilityFlags: ["disable_nodejs_vm_module"],
+			expectRuntimeFlags: {
+				enable_nodejs_vm_module: false,
+			},
+		},
+	],
 ].flat() as TestConfig[];
 
 describe.each(localTestConfigs)(

--- a/packages/wrangler/e2e/unenv-preset/worker/index.ts
+++ b/packages/wrangler/e2e/unenv-preset/worker/index.ts
@@ -698,6 +698,36 @@ export const WorkerdTests: Record<string, () => void> = {
 			/not implemented/
 		);
 	},
+
+	async testVm() {
+		const vm = await import("node:vm");
+
+		assertTypeOfProperties(vm, {
+			Script: "function",
+			constants: "object",
+			compileFunction: "function",
+			createContext: "function",
+			createScript: "function",
+			isContext: "function",
+			measureMemory: "function",
+			runInContext: "function",
+			runInThisContext: "function",
+			runInNewContext: "function",
+		});
+
+		assertTypeOfProperties(vm.default, {
+			Script: "function",
+			compileFunction: "function",
+			constants: "object",
+			createContext: "function",
+			isContext: "function",
+			measureMemory: "function",
+			runInContext: "function",
+			runInNewContext: "function",
+			runInThisContext: "function",
+			createScript: "function",
+		});
+	},
 };
 
 /**


### PR DESCRIPTION
The native code appears in workerd as of https://github.com/cloudflare/workerd/releases/tag/v1.20250910.0.
It was turned on by default (when `nodejs_compat` is on) on 2025-10-01.

The remote mode tests would fail if we didn't have a version of workerd in prod that supports this.

| Export                  | workerd       | unenv                            | diff                                  |
| ----------------------- | ------------- | -------------------------------- | ------------------------------------- |
| new Script                  | throws         | fake script object                                 | different                                  |
| Script.runInContext     | throws        | throws                           | same                                  |
| Script.runInNewContext  | throws        | throws                           | same                                  |
| Script.runInThisContext | throws        | throws                           | same                                  |
| Script.createCachedData | throws        | throws                           | same                                  |
| constants               | object        | object                           | same                                  |
| compileFunction         | throws        | throws                           | same                                  |
| createContext           | throws        | returns fake context object         | different                             |
| createScript            | throws        | returns new Script               | different                             |
| isContext               | returns false | returns true if fake context obj | n/a since no way to create in workerd |
| measureMemory           | throws        | returns fake promise             | different                             |
| runInContext            | throws        | throws                           | same                                  |
| runInThisContext        | throws        | throws                           | same                                  |
| runInNewContext         | throws        | throws                           | same                                  |

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> unenv is not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
