### PR TITLE
Extend services bindings to support VPC Services.

### DIFF
--- a/.changeset/five-drinks-stick.md
+++ b/.changeset/five-drinks-stick.md
@@ -5,4 +5,3 @@
 stable `ratelimit` binding
 
 [Rate Limiting in Workers ](https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/) is now generally available, `ratelimit` can be removed from unsafe bindings.
-

--- a/.changeset/ready-singers-smash.md
+++ b/.changeset/ready-singers-smash.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+VPC service binding support

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -9654,6 +9654,83 @@ addEventListener('fetch', event => {});`
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
+
+			it("should support service bindings with service_id", async () => {
+				writeWranglerConfig({
+					services: [
+						{
+							binding: "FOO",
+							service_id: "123e4567-e89b-12d3-a456-426614174000",
+						},
+					],
+				});
+				writeWorkerSource();
+				mockSubDomainRequest();
+				mockUploadWorkerRequest({
+					expectedBindings: [
+						{
+							type: "connectivity_service_binding",
+							name: "FOO",
+							service_id: "123e4567-e89b-12d3-a456-426614174000",
+						},
+					],
+				});
+
+				await runWrangler("deploy index.js");
+				expect(std.out).toMatchInlineSnapshot(`
+					"Total Upload: xx KiB / gzip: xx KiB
+					Worker Startup Time: 100 ms
+					Your Worker has access to the following bindings:
+					Binding                                             Resource
+					env.FOO (123e4567-e89b-12d3-a456-426614174000)      VPC Service
+
+					Uploaded test-name (TIMINGS)
+					Deployed test-name triggers (TIMINGS)
+					  https://test-name.test-sub-domain.workers.dev
+					Current Version ID: Galaxy-Class"
+				`);
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(std.warn).toMatchInlineSnapshot(`""`);
+			});
+
+			it("should support service bindings with service_id and experimental_remote", async () => {
+				writeWranglerConfig({
+					services: [
+						{
+							binding: "FOO",
+							service_id: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+							experimental_remote: true,
+						},
+					],
+				});
+				writeWorkerSource();
+				mockSubDomainRequest();
+				mockUploadWorkerRequest({
+					expectedBindings: [
+						{
+							type: "connectivity_service_binding",
+							name: "FOO",
+							service_id: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+						},
+					],
+				});
+
+				await runWrangler("deploy index.js");
+				expect(std.out).toMatchInlineSnapshot(`
+					"Total Upload: xx KiB / gzip: xx KiB
+					Worker Startup Time: 100 ms
+					Your Worker has access to the following bindings:
+					Binding                                             Resource
+					env.FOO (f47ac10b-58cc-4372-a567-0e02b2c3d479)      VPC Service
+
+					Uploaded test-name (TIMINGS)
+					Deployed test-name triggers (TIMINGS)
+					  https://test-name.test-sub-domain.workers.dev
+					Current Version ID: Galaxy-Class"
+				`);
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(std.warn).toMatchInlineSnapshot(`""`);
+			});
 		});
 
 		describe("[analytics_engine_datasets]", () => {

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -2081,6 +2081,11 @@ describe.sequential("wrangler dev", () => {
 		const wranglerConfigWithRemoteBindings = {
 			services: [
 				{ binding: "WorkerA", service: "A", experimental_remote: true },
+				{
+					binding: "SERVICE",
+					service_id: "123e4567-e89b-12d3-a456-426614174000",
+					experimental_remote: true,
+				},
 			],
 			kv_namespaces: [
 				{
@@ -2128,13 +2133,14 @@ describe.sequential("wrangler dev", () => {
 			await runWranglerUntilConfig("dev index.js");
 			expect(std.out).toMatchInlineSnapshot(`
 				"Your Worker has access to the following bindings:
-				Binding                                          Resource          Mode
-				env.MY_WORKFLOW (myClass)                        Workflow          local
-				env.KV (xxxx-xxxx-xxxx-xxxx)                     KV Namespace      local
-				env.MY_QUEUE_PRODUCES (my-queue)                 Queue             local
-				env.MY_D1 (xxx)                                  D1 Database       local
-				env.MY_R2 (my-bucket)                            R2 Bucket         local
-				env.WorkerA (A)                                  Worker            local [not connected]
+				Binding                                                           Resource          Mode
+				env.MY_WORKFLOW (myClass)                                         Workflow          local
+				env.KV (xxxx-xxxx-xxxx-xxxx)                                      KV Namespace      local
+				env.MY_QUEUE_PRODUCES (my-queue)                                  Queue             local
+				env.MY_D1 (xxx)                                                   D1 Database       local
+				env.MY_R2 (my-bucket)                                             R2 Bucket         local
+				env.WorkerA (A)                                                   Worker            local [not connected]
+				env.SERVICE (123e4567-e89b-12d3-a456-426614174000)                VPC Service       local
 
 				"
 			`);
@@ -2146,13 +2152,14 @@ describe.sequential("wrangler dev", () => {
 			await runWranglerUntilConfig("dev --x-remote-bindings index.js");
 			expect(std.out).toMatchInlineSnapshot(`
 				"Your Worker has access to the following bindings:
-				Binding                                          Resource          Mode
-				env.MY_WORKFLOW (myClass)                        Workflow          local
-				env.KV (xxxx-xxxx-xxxx-xxxx)                     KV Namespace      remote
-				env.MY_QUEUE_PRODUCES (my-queue)                 Queue             remote
-				env.MY_D1 (xxx)                                  D1 Database       remote
-				env.MY_R2 (my-bucket)                            R2 Bucket         remote
-				env.WorkerA (A)                                  Worker            remote
+				Binding                                                           Resource          Mode
+				env.MY_WORKFLOW (myClass)                                         Workflow          local
+				env.KV (xxxx-xxxx-xxxx-xxxx)                                      KV Namespace      remote
+				env.MY_QUEUE_PRODUCES (my-queue)                                  Queue             remote
+				env.MY_D1 (xxx)                                                   D1 Database       remote
+				env.MY_R2 (my-bucket)                                             R2 Bucket         remote
+				env.WorkerA (A)                                                   Worker            remote
+				env.SERVICE (123e4567-e89b-12d3-a456-426614174000)                VPC Service       remote
 
 				"
 			`);

--- a/packages/wrangler/src/api/startDevWorker/utils.ts
+++ b/packages/wrangler/src/api/startDevWorker/utils.ts
@@ -393,7 +393,31 @@ export async function convertBindingsToCfWorkerInitBindings(
 			bindings.hyperdrive.push({ ...binding, binding: name });
 		} else if (binding.type === "service") {
 			bindings.services ??= [];
-			bindings.services.push({ ...binding, binding: name });
+			// Transform service_id bindings to use service_id as the service name
+			if (binding.service_id) {
+				bindings.services.push({
+					binding: name,
+					service: binding.service_id,
+					experimental_remote: binding.experimental_remote,
+				});
+			} else {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				const serviceBinding: any = {
+					binding: name,
+					service: binding.service,
+					experimental_remote: binding.experimental_remote,
+				};
+				if ("environment" in binding && binding.environment) {
+					serviceBinding.environment = binding.environment;
+				}
+				if ("entrypoint" in binding && binding.entrypoint) {
+					serviceBinding.entrypoint = binding.entrypoint;
+				}
+				if ("props" in binding && binding.props) {
+					serviceBinding.props = binding.props;
+				}
+				bindings.services.push(serviceBinding);
+			}
 		} else if (binding.type === "fetcher") {
 			fetchers[name] = binding.fetcher;
 		} else if (binding.type === "analytics_engine") {

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -880,7 +880,7 @@ export interface EnvironmentNonInheritable {
 	}[];
 
 	/**
-	 * Specifies service bindings (Worker-to-Worker) that are bound to this Worker environment.
+	 * Specifies service bindings (Worker-to-Worker or Worker-to-Service) that are bound to this Worker environment.
 	 *
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
@@ -891,29 +891,46 @@ export interface EnvironmentNonInheritable {
 	 * @nonInheritable
 	 */
 	services:
-		| {
-				/** The binding name used to refer to the bound service. */
-				binding: string;
-				/**
-				 * The name of the service.
-				 * To bind to a worker in a specific environment,
-				 * you should use the format `<worker_name>-<environment_name>`.
-				 */
-				service: string;
-				/**
-				 * @hidden
-				 * @deprecated you should use `service: <worker_name>-<environment_name>` instead.
-				 * This refers to the deprecated concept of 'service environments'.
-				 * The environment of the service (e.g. production, staging, etc).
-				 */
-				environment?: string;
-				/** Optionally, the entrypoint (named export) of the service to bind to. */
-				entrypoint?: string;
-				/** Optional properties that will be made available to the service via ctx.props. */
-				props?: Record<string, unknown>;
-				/** Whether the service binding should be remote or not (only available under `--x-remote-bindings`) */
-				experimental_remote?: boolean;
-		  }[]
+		| (
+				| {
+						/** The binding name used to refer to the bound service. */
+						binding: string;
+						/**
+						 * The name of the service.
+						 * To bind to a worker in a specific environment,
+						 * you should use the format `<worker_name>-<environment_name>`.
+						 */
+						service: string;
+						/** The service_id cannot be specified when using service name. */
+						service_id?: never;
+						/**
+						 * @hidden
+						 * @deprecated you should use `service: <worker_name>-<environment_name>` instead.
+						 * This refers to the deprecated concept of 'service environments'.
+						 * The environment of the service (e.g. production, staging, etc).
+						 */
+						environment?: string;
+						/** Optionally, the entrypoint (named export) of the service to bind to. */
+						entrypoint?: string;
+						/** Optional properties that will be made available to the service via ctx.props. */
+						props?: Record<string, unknown>;
+						/** Whether the service binding should be remote or not (only available under `--x-remote-bindings`) */
+						experimental_remote?: boolean;
+				  }
+				| {
+						/** The binding name used to refer to the bound service. */
+						binding: string;
+						/** The service name cannot be specified when using service_id. */
+						service?: never;
+						/**
+						 * The UUID of the WVPC connectivity service.
+						 * Use this to bind to a service created via `wrangler wvpc service create`.
+						 */
+						service_id: string;
+						/** Whether the service binding should be remote or not (only available under `--x-remote-bindings`) */
+						experimental_remote?: boolean;
+				  }
+		  )[]
 		| undefined;
 
 	/**

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -125,6 +125,11 @@ export type WorkerMetadataBinding =
 			environment?: string;
 			entrypoint?: string;
 	  }
+	| {
+			type: "connectivity_service_binding";
+			name: string;
+			service_id: string;
+	  }
 	| { type: "analytics_engine"; name: string; dataset?: string }
 	| {
 			type: "dispatch_namespace";
@@ -439,8 +444,16 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 		});
 	});
 
-	bindings.services?.forEach(
-		({ binding, service, environment, entrypoint, props }) => {
+	bindings.services?.forEach((serviceBinding) => {
+		if ("service_id" in serviceBinding && serviceBinding.service_id) {
+			metadataBindings.push({
+				name: serviceBinding.binding,
+				type: "connectivity_service_binding",
+				service_id: serviceBinding.service_id,
+			});
+		} else if ("service" in serviceBinding && serviceBinding.service) {
+			const { binding, service, environment, entrypoint, props } =
+				serviceBinding;
 			metadataBindings.push({
 				name: binding,
 				type: "service",
@@ -450,7 +463,7 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 				...(props && { props }),
 			});
 		}
-	);
+	});
 
 	bindings.analytics_engine_datasets?.forEach(({ binding, dataset }) => {
 		metadataBindings.push({

--- a/packages/wrangler/src/deployment-bundle/worker.ts
+++ b/packages/wrangler/src/deployment-bundle/worker.ts
@@ -245,14 +245,22 @@ export interface CfHyperdrive {
 	localConnectionString?: string;
 }
 
-export interface CfService {
-	binding: string;
-	service: string;
-	environment?: string;
-	entrypoint?: string;
-	props?: Record<string, unknown>;
-	experimental_remote?: boolean;
-}
+export type CfService =
+	| {
+			binding: string;
+			service: string;
+			service_id?: never;
+			environment?: string;
+			entrypoint?: string;
+			props?: Record<string, unknown>;
+			experimental_remote?: boolean;
+	  }
+	| {
+			binding: string;
+			service?: never;
+			service_id: string;
+			experimental_remote?: boolean;
+	  };
 
 export interface CfAnalyticsEngineDataset {
 	binding: string;

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -336,12 +336,20 @@ export type AdditionalDevProps = {
 		script_name?: string | undefined;
 		environment?: string | undefined;
 	}[];
-	services?: {
-		binding: string;
-		service: string;
-		environment?: string;
-		entrypoint?: string;
-	}[];
+	services?: (
+		| {
+				binding: string;
+				service: string;
+				service_id?: never;
+				environment?: string;
+				entrypoint?: string;
+		  }
+		| {
+				binding: string;
+				service?: never;
+				service_id: string;
+		  }
+	)[];
 	r2?: {
 		binding: string;
 		bucket_name?: string | typeof INHERIT_SYMBOL;

--- a/packages/wrangler/src/dev/miniflare/index.ts
+++ b/packages/wrangler/src/dev/miniflare/index.ts
@@ -482,20 +482,26 @@ export function buildMiniflareBindingOptions(
 	};
 
 	for (const service of config.services ?? []) {
+		const serviceName = service.service || service.service_id;
+		if (!serviceName) {
+			throw new Error("Service binding must have either service or service_id");
+		}
 		if (remoteProxyConnectionString && service.experimental_remote) {
 			serviceBindings[service.binding] = {
-				name: service.service,
-				props: service.props,
-				entrypoint: service.entrypoint,
+				name: serviceName,
+				...("props" in service && service.props && { props: service.props }),
+				...("entrypoint" in service &&
+					service.entrypoint && { entrypoint: service.entrypoint }),
 				remoteProxyConnectionString,
 			};
 			continue;
 		}
 
 		serviceBindings[service.binding] = {
-			name: service.service,
-			entrypoint: service.entrypoint,
-			props: service.props,
+			name: serviceName,
+			...("entrypoint" in service &&
+				service.entrypoint && { entrypoint: service.entrypoint }),
+			...("props" in service && service.props && { props: service.props }),
 		};
 	}
 

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -1312,7 +1312,11 @@ function getBindingsFromArgs(args: typeof pagesDevCommand.args): Partial<
 			})
 			.filter(Boolean) as NonNullable<AdditionalDevProps["services"]>;
 
-		if (services.find(({ environment }) => !!environment)) {
+		if (
+			services.find(
+				(service) => "environment" in service && !!service.environment
+			)
+		) {
 			// We haven't yet properly defined how environments of service bindings should
 			// work, so if the user is using an environment for any of their service
 			// bindings we warn them that they are experimental

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -463,30 +463,37 @@ export async function generateEnvTypes(
 
 	if (configToDTS.services) {
 		for (const service of configToDTS.services) {
-			const serviceEntry =
-				service.service !== entrypoint?.name
-					? serviceEntries?.get(service.service)
-					: entrypoint;
+			if ("service_id" in service) {
+				envTypeStructure.push([
+					constructTypeKey(service.binding),
+					`Fetcher /* VPC Service (${service.service_id}) */`,
+				]);
+			} else if ("service" in service) {
+				const serviceEntry =
+					service.service !== entrypoint?.name
+						? serviceEntries?.get(service.service)
+						: entrypoint;
 
-			const importPath = serviceEntry
-				? generateImportSpecifier(fullOutputPath, serviceEntry.file)
-				: undefined;
+				const importPath = serviceEntry
+					? generateImportSpecifier(fullOutputPath, serviceEntry.file)
+					: undefined;
 
-			const exportExists = serviceEntry?.exports?.some(
-				(e) => e === (service.entrypoint ?? "default")
-			);
+				const exportExists = serviceEntry?.exports?.some(
+					(e) => e === (service.entrypoint ?? "default")
+				);
 
-			let typeName: string;
+				let typeName: string;
 
-			if (importPath && exportExists) {
-				typeName = `Service<typeof import("${importPath}").${service.entrypoint ?? "default"}>`;
-			} else if (service.entrypoint) {
-				typeName = `Service /* entrypoint ${service.entrypoint} from ${service.service} */`;
-			} else {
-				typeName = `Fetcher /* ${service.service} */`;
+				if (importPath && exportExists) {
+					typeName = `Service<typeof import("${importPath}").${service.entrypoint ?? "default"}>`;
+				} else if (service.entrypoint) {
+					typeName = `Service /* entrypoint ${service.entrypoint} from ${service.service} */`;
+				} else {
+					typeName = `Fetcher /* ${service.service} */`;
+				}
+
+				envTypeStructure.push([constructTypeKey(service.binding), typeName]);
 			}
-
-			envTypeStructure.push([constructTypeKey(service.binding), typeName]);
 		}
 	}
 

--- a/packages/wrangler/src/utils/map-worker-metadata-bindings.ts
+++ b/packages/wrangler/src/utils/map-worker-metadata-bindings.ts
@@ -164,6 +164,17 @@ export async function mapWorkerMetadataBindings(
 							];
 						}
 						break;
+					case "connectivity_service_binding":
+						{
+							configObj.services = [
+								...(configObj.services ?? []),
+								{
+									binding: binding.name,
+									service_id: binding.service_id,
+								},
+							];
+						}
+						break;
 					case "analytics_engine":
 						{
 							configObj.analytics_engine_datasets = [

--- a/packages/wrangler/src/utils/print-bindings.ts
+++ b/packages/wrangler/src/utils/print-bindings.ts
@@ -367,8 +367,23 @@ export function printBindings(
 
 	if (services !== undefined && services.length > 0) {
 		output.push(
-			...services.map(
-				({ binding, service, entrypoint, experimental_remote }) => {
+			...services.map((serviceBinding) => {
+				if ("service_id" in serviceBinding) {
+					const { binding, service_id, experimental_remote } = serviceBinding;
+
+					const mode = experimental_remote
+						? getMode({ isSimulatedLocally: false })
+						: getMode({ isSimulatedLocally: true });
+					return {
+						name: binding,
+						type: "VPC Service",
+						value: service_id,
+						mode,
+					};
+				} else {
+					const { binding, service, entrypoint, experimental_remote } =
+						serviceBinding;
+
 					let value = service;
 					let mode = undefined;
 
@@ -400,7 +415,7 @@ export function printBindings(
 						mode,
 					};
 				}
-			)
+			})
 		);
 	}
 


### PR DESCRIPTION
Implements WVPC-42.

Extend services bindings to support VPC Services.

e.g. `"services": [{ "binding": "MYAPI", "service_id": "0199295b-b3ac-7760-8246-bca40877b3e9" }]`

I am pretty confident with the `deploy` and `types`, but less so with `wrangler dev` and its various modes - I will need to dig in more but wanted to get this initially reviewed. Also because `services` is now a union (either a `service` or a `service_id`) there is some added complexity here that probably needs improving.

Docs PR to follow
---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a v3 feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
