### PR TITLE
Fix up vite-plugin runner type params

### DIFF
--- a/packages/vite-plugin-cloudflare/src/runner-worker/index.ts
+++ b/packages/vite-plugin-cloudflare/src/runner-worker/index.ts
@@ -14,7 +14,7 @@ export { __VITE_RUNNER_OBJECT__ } from "./module-runner";
  * Constructor interface for `WorkerEntrypoint` class.
  * @template T - The `env` type
  */
-interface WorkerEntrypointConstructor<T = unknown> {
+interface WorkerEntrypointConstructor<T = Cloudflare.Env> {
 	new (
 		...args: ConstructorParameters<typeof WorkerEntrypoint<T>>
 	): WorkerEntrypoint<T>;
@@ -24,7 +24,7 @@ interface WorkerEntrypointConstructor<T = unknown> {
  * Constructor interface for `DurableObject` class.
  * @template T - The `env` type
  */
-interface DurableObjectConstructor<T = unknown> {
+interface DurableObjectConstructor<T = Cloudflare.Env> {
 	new (
 		...args: ConstructorParameters<typeof DurableObject<T>>
 	): DurableObject<T>;
@@ -34,7 +34,7 @@ interface DurableObjectConstructor<T = unknown> {
  * Constructor interface for `WorkflowEntrypoint` class.
  * @template T - The `env` type
  */
-interface WorkflowEntrypointConstructor<T = unknown> {
+interface WorkflowEntrypointConstructor<T = Cloudflare.Env> {
 	new (
 		...args: ConstructorParameters<typeof WorkflowEntrypoint<T>>
 	): WorkflowEntrypoint<T>;

--- a/packages/wrangler/e2e/remote-binding/start-worker-remote-bindings.test.ts
+++ b/packages/wrangler/e2e/remote-binding/start-worker-remote-bindings.test.ts
@@ -53,6 +53,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("startWorker - remote bindings", () => {
 					config: `${helper.tmpPath}/wrangler.json`,
 					dev: {
 						experimentalRemoteBindings,
+						inspector: false,
 					},
 				});
 
@@ -87,6 +88,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("startWorker - remote bindings", () => {
 					config: `${helper.tmpPath}/wrangler.json`,
 					dev: {
 						experimentalRemoteBindings,
+						inspector: false,
 					},
 				});
 

--- a/packages/wrangler/e2e/start-worker-auth-opts.test.ts
+++ b/packages/wrangler/e2e/start-worker-auth-opts.test.ts
@@ -73,6 +73,7 @@ describe("startWorker - auth options", () => {
 				},
 				dev: {
 					auth: validAuth,
+					inspector: false,
 				},
 			});
 
@@ -124,6 +125,7 @@ describe("startWorker - auth options", () => {
 				},
 				dev: {
 					auth: incorrectAuth,
+					inspector: false,
 				},
 			});
 

--- a/packages/wrangler/e2e/startWorker.test.ts
+++ b/packages/wrangler/e2e/startWorker.test.ts
@@ -73,7 +73,7 @@ describe("DevEnv", () => {
 			const worker = await startWorker({
 				entrypoint: path.resolve(helper.tmpPath, "src/index.ts"),
 
-				dev: { remote },
+				dev: { remote, inspector: false },
 			});
 
 			let res = await worker.fetch("http://dummy");
@@ -343,6 +343,7 @@ describe("DevEnv", () => {
 				dev: {
 					remote,
 					liveReload: true,
+					inspector: false,
 				},
 			});
 
@@ -436,6 +437,7 @@ describe("DevEnv", () => {
 			const worker = await startWorker({
 				name: "test-worker",
 				entrypoint: path.resolve(helper.tmpPath, "src/index.ts"),
+				dev: { inspector: false },
 			});
 
 			await expect(worker.fetch("http://dummy")).rejects.toThrowError("Boom!");
@@ -521,6 +523,7 @@ describe("DevEnv", () => {
 					origin: {
 						hostname: "www.google.com",
 					},
+					inspector: false,
 				},
 			});
 
@@ -574,6 +577,9 @@ describe("DevEnv", () => {
 			const worker = await startWorker({
 				name: "test-worker",
 				entrypoint: path.resolve(helper.tmpPath, "src/index.ts"),
+				dev: {
+					inspector: false,
+				},
 			});
 
 			let res = await worker.fetch("http://dummy/short");
@@ -641,6 +647,7 @@ describe("DevEnv", () => {
 				config: path.resolve(helper.tmpPath, "wrangler.jsonc"),
 				name: "test-worker",
 				entrypoint: path.resolve(helper.tmpPath, "src/index.ts"),
+				dev: { inspector: false },
 			});
 
 			const res = await worker.fetch("http://dummy/test/path/1");
@@ -686,6 +693,7 @@ describe("DevEnv", () => {
 				config: path.resolve(helper.tmpPath, "wrangler.jsonc"),
 				name: "test-worker",
 				entrypoint: path.resolve(helper.tmpPath, "src/index.ts"),
+				dev: { inspector: false },
 			});
 
 			const res = await worker.fetch("http://dummy/test/path/1");
@@ -743,6 +751,7 @@ describe("DevEnv", () => {
 					WRANGLER_ENV_VAR_3: { type: "plain_text", value: "inline-3" },
 					WRANGLER_ENV_VAR_4: { type: "plain_text", value: "inline-4" },
 				},
+				dev: { inspector: false },
 			});
 
 			const res = await worker.fetch("http://dummy/test/path/1");
@@ -798,6 +807,7 @@ describe("DevEnv", () => {
 				name: "test-worker",
 				entrypoint: path.resolve(helper.tmpPath, "src/index.ts"),
 				envFiles: ["other/.env", "other/.env.local"],
+				dev: { inspector: false },
 			});
 
 			const res = await worker.fetch("http://dummy/test/path/1");


### PR DESCRIPTION
Just a very simple change to the type parameters to avoid future issues when workers-types locks down its Env types