### PR TITLE
Add new attribute allowed_sender_addresses

### DIFF
--- a/.changeset/soft-flies-search.md
+++ b/.changeset/soft-flies-search.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Added new attribute "allowed_sender_addresses" to send email binding.

--- a/packages/miniflare/src/plugins/email/index.ts
+++ b/packages/miniflare/src/plugins/email/index.ts
@@ -17,6 +17,7 @@ const EmailBindingOptionsSchema = z
 		remoteProxyConnectionString: z
 			.custom<RemoteProxyConnectionString>()
 			.optional(),
+		allowed_sender_addresses: z.array(z.string()).optional(),
 	})
 	.and(
 		z.union([

--- a/packages/miniflare/src/workers/email/send_email.worker.ts
+++ b/packages/miniflare/src/workers/email/send_email.worker.ts
@@ -10,6 +10,7 @@ interface SendEmailEnv {
 	[CoreBindings.SERVICE_LOOPBACK]: Fetcher;
 	destination_address: string | undefined;
 	allowed_destination_addresses: string[] | undefined;
+	allowed_sender_addresses: string[] | undefined;
 }
 
 export class SendEmailBinding extends WorkerEntrypoint<SendEmailEnv> {
@@ -28,8 +29,17 @@ export class SendEmailBinding extends WorkerEntrypoint<SendEmailEnv> {
 			throw new Error(`email to ${to} not allowed`);
 		}
 	}
+	private checkSenderAllowed(from: string) {
+		if (
+			this.env.allowed_sender_addresses !== undefined &&
+			!this.env.allowed_sender_addresses.includes(from)
+		) {
+			throw new Error(`email from ${from} not allowed`);
+		}
+	}
 	async send(emailMessage: EmailMessage): Promise<void> {
 		this.checkDestinationAllowed(emailMessage.to);
+		this.checkSenderAllowed(emailMessage.from);
 
 		const rawEmail: ReadableStream<Uint8Array> = emailMessage[RAW_EMAIL];
 

--- a/packages/miniflare/test/plugins/email/index.spec.ts
+++ b/packages/miniflare/test/plugins/email/index.spec.ts
@@ -263,6 +263,49 @@ This is a random email body.
 	t.is(res.status, 200);
 });
 
+test("Multiple allowed senders send_email binding works", async (t) => {
+	const mf = new Miniflare({
+		modules: true,
+		script: SEND_EMAIL_WORKER,
+		email: {
+			send_email: [
+				{
+					name: "SEND_EMAIL",
+					allowed_sender_addresses: [
+						"milchick@example.com",
+						"miss-huang@example.com",
+					],
+				},
+			],
+		},
+		compatibilityDate: "2025-03-17",
+	});
+
+	t.teardown(() => mf.dispose());
+
+	const res = await mf.dispatchFetch(
+		"http://localhost/?" +
+			new URLSearchParams({
+				to: "someone@example.com",
+				from: "milchick@example.com",
+			}).toString(),
+		{
+			body: `To: someone <someone@example.com>
+From: someone else <milchick@example.com>
+Message-ID: <im-a-random-message-id@example.com>
+MIME-Version: 1.0
+Content-Type: text/plain
+
+This is a random email body.
+`,
+			method: "POST",
+		}
+	);
+
+	t.is(await res.text(), "ok");
+	t.is(res.status, 200);
+});
+
 test("Multiple allowed send_email binding throws if destination is not equal", async (t) => {
 	const mf = new Miniflare({
 		modules: true,

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -300,6 +300,7 @@ describe("init", () => {
 					name: "EMAIL_BINDING",
 					destination_address: "some@address.com",
 					allowed_destination_addresses: ["some2@address.com"],
+					allowed_sender_addresses: ["some2@address.com"],
 				},
 				{
 					type: "version_metadata",
@@ -474,6 +475,7 @@ describe("init", () => {
 			],
 			send_email: [
 				{
+					allowed_sender_addresses: ["some2@address.com"],
 					allowed_destination_addresses: ["some2@address.com"],
 					destination_address: "some@address.com",
 					name: "EMAIL_BINDING",
@@ -1004,6 +1006,7 @@ describe("init", () => {
 					name = \\"EMAIL_BINDING\\"
 					destination_address = \\"some@address.com\\"
 					allowed_destination_addresses = [ \\"some2@address.com\\" ]
+					allowed_sender_addresses = [ \\"some2@address.com\\" ]
 
 					[version_metadata]
 					binding = \\"Version_BINDING\\"

--- a/packages/wrangler/src/__tests__/versions/versions.view.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.view.test.ts
@@ -618,6 +618,7 @@ describe("versions view", () => {
 								name: "MAIL_3",
 								destination_address: "dest@example.com",
 								allowed_destination_addresses: ["1@a.com", "2@a.com"],
+								allowed_sender_addresses: ["3@a.com", "4@a.com"],
 							},
 							{ type: "service", name: "SERVICE", service: "worker" },
 							{
@@ -740,6 +741,7 @@ describe("versions view", () => {
 				name = \\"MAIL_3\\"
 				destination_address = \\"dest@example.com\\"
 				allowed_destination_addresses = [\\"1@a.com\\", \\"2@a.com\\"]
+				allowed_sender_addresses = [\\"3@a.com\\", \\"4@a.com\\"]
 
 				[[services]]
 				binding = \\"SERVICE\\"

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -723,6 +723,8 @@ export interface EnvironmentNonInheritable {
 		destination_address?: string;
 		/** If this binding should be restricted to a set of verified addresses */
 		allowed_destination_addresses?: string[];
+		/** If this binding should be restricted to a set of sender addresses */
+		allowed_sender_addresses?: string[];
 		/** Whether the binding should be remote or not */
 		remote?: boolean;
 	}[];

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -2956,6 +2956,14 @@ const validateSendEmailBinding: ValidatorFn = (diagnostics, field, value) => {
 		);
 		isValid = false;
 	}
+	if (!isOptionalProperty(value, "allowed_sender_addresses", "object")) {
+		diagnostics.errors.push(
+			`"${field}" bindings should, optionally, have a []string "allowed_sender_addresses" field but got ${JSON.stringify(
+				value
+			)}.`
+		);
+		isValid = false;
+	}
 	if (
 		"destination_address" in value &&
 		"allowed_destination_addresses" in value
@@ -2971,6 +2979,7 @@ const validateSendEmailBinding: ValidatorFn = (diagnostics, field, value) => {
 	}
 
 	validateAdditionalProperties(diagnostics, field, Object.keys(value), [
+		"allowed_sender_addresses",
 		"allowed_destination_addresses",
 		"destination_address",
 		"name",

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -72,6 +72,7 @@ export type WorkerMetadataBinding =
 			name: string;
 			destination_address?: string;
 			allowed_destination_addresses?: string[];
+			allowed_sender_addresses?: string[];
 	  }
 	| {
 			type: "durable_object_namespace";
@@ -301,11 +302,16 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 			"allowed_destination_addresses" in emailBinding
 				? emailBinding.allowed_destination_addresses
 				: undefined;
+		const allowed_sender_addresses =
+			"allowed_sender_addresses" in emailBinding
+				? emailBinding.allowed_sender_addresses
+				: undefined;
 		metadataBindings.push({
 			name: emailBinding.name,
 			type: "send_email",
 			destination_address,
 			allowed_destination_addresses,
+			allowed_sender_addresses,
 		});
 	});
 

--- a/packages/wrangler/src/deployment-bundle/worker.ts
+++ b/packages/wrangler/src/deployment-bundle/worker.ts
@@ -95,12 +95,8 @@ export type CfSendEmailBindings = {
 } & (
 	| { destination_address?: string }
 	| { allowed_destination_addresses?: string[] }
+	| { allowed_sender_addresses?: string[] }
 );
-// export interface CfSendEmailBindings {
-// 	name: string;
-// 	destination_address?: string | undefined;
-// 	allowed_destination_addresses?: string[] | undefined;
-// }
 
 /**
  * A binding to a wasm module (in service-worker format)

--- a/packages/wrangler/src/utils/map-worker-metadata-bindings.ts
+++ b/packages/wrangler/src/utils/map-worker-metadata-bindings.ts
@@ -244,6 +244,7 @@ export async function mapWorkerMetadataBindings(
 								destination_address: binding.destination_address,
 								allowed_destination_addresses:
 									binding.allowed_destination_addresses,
+								allowed_sender_addresses: binding.allowed_sender_addresses,
 							},
 						];
 						break;

--- a/packages/wrangler/src/utils/print-bindings.ts
+++ b/packages/wrangler/src/utils/print-bindings.ts
@@ -206,13 +206,22 @@ export function printBindings(
 					"allowed_destination_addresses" in emailBinding
 						? emailBinding.allowed_destination_addresses
 						: undefined;
+				const allowed_sender_addresses =
+					"allowed_sender_addresses" in emailBinding
+						? emailBinding.allowed_sender_addresses
+						: undefined;
+				let value =
+					destination_address ||
+					allowed_destination_addresses?.join(", ") ||
+					"unrestricted";
+
+				if (allowed_sender_addresses) {
+					value += ` - senders: ${allowed_sender_addresses.join(", ")}`;
+				}
 				return {
 					name: emailBinding.name,
 					type: friendlyBindingNames.send_email,
-					value:
-						destination_address ||
-						allowed_destination_addresses?.join(", ") ||
-						"unrestricted",
+					value: value,
 					mode: getMode({
 						isSimulatedLocally: getFlag("REMOTE_BINDINGS")
 							? !emailBinding.remote

--- a/packages/wrangler/src/versions/view.ts
+++ b/packages/wrangler/src/versions/view.ts
@@ -244,6 +244,9 @@ function printBindingAsToml(binding: WorkerMetadataBinding) {
 					: "") +
 				(binding.allowed_destination_addresses
 					? `\nallowed_destination_addresses = [${binding.allowed_destination_addresses.map((addr) => `"${addr}"`).join(", ")}]`
+					: "") +
+				(binding.allowed_sender_addresses
+					? `\nallowed_sender_addresses = [${binding.allowed_sender_addresses.map((addr) => `"${addr}"`).join(", ")}]`
 					: "")
 			);
 


### PR DESCRIPTION
Fixes EMAIL-1228.

_Describe your change..._

Added new attribute called "allowed_sender_addresses" to send_email binding. This allows the binding to be restricted in the possible values for the sender of emails.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [X] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/25125
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: new feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
