### PR TITLE
fix: skip service tagging when no top-level name configured

### DIFF
--- a/.changeset/bumpy-islands-slide.md
+++ b/.changeset/bumpy-islands-slide.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fixed an issue with service tags not being applied properly to Workers when the Wrangler configuration file did not include a top-level `name` property.

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -628,6 +628,35 @@ describe("versions upload", () => {
 			expect(tagsUpdateHandler.isUsed).toBeFalsy();
 		});
 
+		test("no top-level name", async ({ expect }) => {
+			mockGetScriptWithTags(["some-tag", "cf:service=undefined"]);
+
+			writeWranglerConfig({
+				name: undefined,
+				main: "./index.js",
+				env: {
+					production: {
+						name: "test-name-production",
+					},
+				},
+			});
+
+			expect.assertions(2);
+			mockPatchScriptSettings(async ({ request }) => {
+				await expect(request.json()).resolves.toEqual({
+					tags: ["some-tag"],
+				});
+			});
+
+			await runWrangler("versions upload --env production");
+
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mNo top-level \`name\` has been defined in Wrangler configuration. Add a top-level \`name\` to group this Worker together with its sibling environments in the Cloudflare dashboard.[0m
+
+				"
+			`);
+		});
+
 		test("displays warning when error updating tags", async ({ expect }) => {
 			mockGetScriptWithTags([
 				"some-tag",


### PR DESCRIPTION
Refs #10546.

This PR fixes an issue where Workers were not being tagged appropriately when a top-level name was not present in Wrangler configuration.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: Not released in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
