### PR TITLE
 Avoid mutating the Worker config during build.

### DIFF
--- a/.changeset/free-pants-jump.md
+++ b/.changeset/free-pants-jump.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Avoid mutating the Worker config during build.

--- a/packages/vite-plugin-cloudflare/playground/custom-build-app/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/custom-build-app/vite.config.ts
@@ -13,6 +13,8 @@ export default defineConfig({
 
 			builder.config.logger.info("__before-build__");
 			await builder.build(workerEnvironment);
+			// Some plugins build the Worker environment twice so we do that here to test this scenario
+			await builder.build(workerEnvironment);
 			builder.config.logger.info("__after-build__");
 
 			await builder.build(clientEnvironment);

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -330,10 +330,7 @@ if (import.meta.hot) {
 					outputConfig.unsafe &&
 					Object.keys(outputConfig.unsafe).length === 0
 				) {
-					outputConfig = {
-						...outputConfig,
-						unsafe: undefined,
-					};
+					outputConfig.unsafe = undefined;
 				}
 
 				this.emitFile({

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -57,6 +57,7 @@ import {
 	nodeJsBuiltins,
 	NodeJsCompatWarnings,
 } from "./nodejs-compat";
+import { getAssetsDirectory } from "./output-config";
 import {
 	assertIsNotPreview,
 	assertIsPreview,
@@ -244,13 +245,13 @@ if (import.meta.hot) {
 			generateBundle(_, bundle) {
 				assertIsNotPreview(resolvedPluginConfig);
 
-				let config: Unstable_RawConfig | undefined;
+				let outputConfig: Unstable_RawConfig | undefined;
 
 				if (resolvedPluginConfig.type === "workers") {
-					const workerConfig =
+					const inputConfig =
 						resolvedPluginConfig.workers[this.environment.name];
 
-					if (!workerConfig) {
+					if (!inputConfig) {
 						return;
 					}
 
@@ -266,42 +267,29 @@ if (import.meta.hot) {
 						`Expected entry chunk with name "${MAIN_ENTRY_NAME}"`
 					);
 
-					workerConfig.main = entryChunk.fileName;
-					workerConfig.no_bundle = true;
-					workerConfig.rules = [
-						{ type: "ESModule", globs: ["**/*.js", "**/*.mjs"] },
-					];
-
 					const isEntryWorker =
 						this.environment.name ===
 						resolvedPluginConfig.entryWorkerEnvironmentName;
 
-					if (isEntryWorker) {
-						const workerOutputDirectory = this.environment.config.build.outDir;
-						const clientOutputDirectory =
-							resolvedViteConfig.environments.client?.build.outDir;
+					outputConfig = {
+						...inputConfig,
+						main: entryChunk.fileName,
+						no_bundle: true,
+						rules: [{ type: "ESModule", globs: ["**/*.js", "**/*.mjs"] }],
+						assets: isEntryWorker
+							? {
+									...inputConfig.assets,
+									directory: getAssetsDirectory(
+										this.environment.config.build.outDir,
+										resolvedViteConfig
+									),
+								}
+							: undefined,
+					};
 
-						assert(
-							clientOutputDirectory,
-							"Unexpected error: client output directory is undefined"
-						);
-
-						workerConfig.assets = {
-							...workerConfig.assets,
-							directory: path.relative(
-								path.resolve(resolvedViteConfig.root, workerOutputDirectory),
-								path.resolve(resolvedViteConfig.root, clientOutputDirectory)
-							),
-						};
-					} else {
-						workerConfig.assets = undefined;
-					}
-
-					config = workerConfig;
-
-					if (workerConfig.configPath) {
+					if (inputConfig.configPath) {
 						const localDevVars = getLocalDevVarsForPreview(
-							workerConfig.configPath,
+							inputConfig.configPath,
 							resolvedPluginConfig.cloudflareEnv
 						);
 						// Save a .dev.vars file to the worker's build output directory if there are local dev vars, so that it will be then detected by `vite preview`.
@@ -314,11 +302,14 @@ if (import.meta.hot) {
 						}
 					}
 				} else if (this.environment.name === "client") {
-					const assetsOnlyConfig = resolvedPluginConfig.config;
+					const inputConfig = resolvedPluginConfig.config;
 
-					assetsOnlyConfig.assets = {
-						...assetsOnlyConfig.assets,
-						directory: ".",
+					outputConfig = {
+						...inputConfig,
+						assets: {
+							...inputConfig.assets,
+							directory: ".",
+						},
 					};
 
 					const filesToAssetsIgnore = ["wrangler.json", ".dev.vars"];
@@ -328,23 +319,27 @@ if (import.meta.hot) {
 						fileName: ".assetsignore",
 						source: `${filesToAssetsIgnore.join("\n")}\n`,
 					});
-
-					config = assetsOnlyConfig;
 				}
 
-				if (!config) {
+				if (!outputConfig) {
 					return;
 				}
 
 				// Set to `undefined` if it's an empty object so that the user doesn't see a warning about using `unsafe` fields when deploying their Worker.
-				if (config.unsafe && Object.keys(config.unsafe).length === 0) {
-					config.unsafe = undefined;
+				if (
+					outputConfig.unsafe &&
+					Object.keys(outputConfig.unsafe).length === 0
+				) {
+					outputConfig = {
+						...outputConfig,
+						unsafe: undefined,
+					};
 				}
 
 				this.emitFile({
 					type: "asset",
 					fileName: "wrangler.json",
-					source: JSON.stringify(config),
+					source: JSON.stringify(outputConfig),
 				});
 			},
 			writeBundle() {

--- a/packages/vite-plugin-cloudflare/src/output-config.ts
+++ b/packages/vite-plugin-cloudflare/src/output-config.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert";
+import * as path from "node:path";
+import * as vite from "vite";
+
+export function getAssetsDirectory(
+	workerOutputDirectory: string,
+	resolvedViteConfig: vite.ResolvedConfig
+): string {
+	const clientOutputDirectory =
+		resolvedViteConfig.environments.client?.build.outDir;
+
+	assert(
+		clientOutputDirectory,
+		"Unexpected error: client output directory is undefined"
+	);
+
+	return path.relative(
+		path.resolve(resolvedViteConfig.root, workerOutputDirectory),
+		path.resolve(resolvedViteConfig.root, clientOutputDirectory)
+	);
+}


### PR DESCRIPTION
Fixes #10650.

This fixes an issue that can occur if the same Worker environment is built twice.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
