### PR TITLE
wrangler: fix: support the deletion of secrets with complex names

### DIFF
--- a/.changeset/warm-clowns-visit.md
+++ b/.changeset/warm-clowns-visit.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Support the deletion of secrets with complex names

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -318,7 +318,14 @@ export const secretDeleteCommand = createCommand({
 					? `/accounts/${accountId}/workers/scripts/${scriptName}/secrets`
 					: `/accounts/${accountId}/workers/services/${scriptName}/environments/${args.env}/secrets`;
 
-			await fetchResult(config, `${url}/${args.key}`, { method: "DELETE" });
+			await fetchResult(
+				config,
+				`${url}/${encodeURIComponent(args.key)}`,
+				{ method: "DELETE" },
+				new URLSearchParams({
+					url_encoded: "true",
+				})
+			);
 			metrics.sendMetricsEvent("delete encrypted variable", {
 				sendMetrics: config.send_metrics,
 			});


### PR DESCRIPTION
URL encode the secret names before being sent to the API, should allow users to delete secrets with complex names. Change is still compatible with older Wrangler versions thanks to the optional query param flag `url_encoded`.

Tracking internally: https://jira.cfdata.org/browse/WC-3991

_Describe your change..._

URL encode all secret names in the `DELETE .../secrets/:secret` call, should allow the deletion of secrets with complex names.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Updating the API docs, rather than developer docs.
- Wrangler V3 Backport
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/10760
  - [ ] Not necessary because: API still supports plain secret names.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

---

Docs have new query param `url_encoded`:
https://developers.cloudflare.com/api/resources/workers/subresources/scripts/subresources/secrets/methods/delete/
<img width="726" height="570" alt="image" src="https://github.com/user-attachments/assets/73314cf4-8ab6-46fd-b7aa-6b4a38b57764" />

