### PR TITLE
Fix remote/local display

### DIFF
--- a/.changeset/giant-cherries-shake.md
+++ b/.changeset/giant-cherries-shake.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix remote/local display for KV/D1/R2 & Browser bindings

--- a/packages/wrangler/src/dev/miniflare/index.ts
+++ b/packages/wrangler/src/dev/miniflare/index.ts
@@ -533,10 +533,6 @@ export function buildMiniflareBindingOptions(
 		warnOrError("ai", bindings.ai.remote, "always-remote");
 	}
 
-	if (bindings.browser && remoteBindingsEnabled) {
-		warnOrError("browser", bindings.browser.remote, "remote");
-	}
-
 	if (bindings.mtls_certificates && remoteBindingsEnabled) {
 		for (const mtls of bindings.mtls_certificates) {
 			warnOrError("mtls_certificates", mtls.remote, "always-remote");

--- a/packages/wrangler/src/utils/print-bindings.ts
+++ b/packages/wrangler/src/utils/print-bindings.ts
@@ -188,7 +188,7 @@ export function printBindings(
 					type: friendlyBindingNames.kv_namespaces,
 					value: id,
 					mode: getMode({
-						isSimulatedLocally: !remote,
+						isSimulatedLocally: getFlag("REMOTE_BINDINGS") ? !remote : true,
 					}),
 				};
 			})
@@ -231,7 +231,7 @@ export function printBindings(
 					type: friendlyBindingNames.queues,
 					value: queue_name,
 					mode: getMode({
-						isSimulatedLocally: !remote,
+						isSimulatedLocally: getFlag("REMOTE_BINDINGS") ? !remote : true,
 					}),
 				};
 			})
@@ -257,7 +257,7 @@ export function printBindings(
 						name: binding,
 						type: friendlyBindingNames.d1_databases,
 						mode: getMode({
-							isSimulatedLocally: !remote,
+							isSimulatedLocally: getFlag("REMOTE_BINDINGS") ? !remote : true,
 						}),
 						value,
 					};
@@ -315,7 +315,7 @@ export function printBindings(
 					type: friendlyBindingNames.r2_buckets,
 					value: value,
 					mode: getMode({
-						isSimulatedLocally: !remote,
+						isSimulatedLocally: getFlag("REMOTE_BINDINGS") ? !remote : true,
 					}),
 				};
 			})
@@ -371,7 +371,7 @@ export function printBindings(
 					value += `#${entrypoint}`;
 				}
 
-				if (remote) {
+				if (remote && getFlag("REMOTE_BINDINGS")) {
 					mode = getMode({ isSimulatedLocally: false });
 				} else if (context.local && context.registry !== null) {
 					const registryDefinition = context.registry?.[service];


### PR DESCRIPTION
Fixes two minor display bugs:
- Browser bindings incorrectly showed a warning about not supporting local mode
- KV/R2/D1 bindings did not respect the REMOTE_BINDINGS flag when displaying their remote/local status

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: minor display issues
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: minor display issues
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a v3 feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
