### PR TITLE
CFSQL-1371 reconcile dumpSql changes from D1 and document how to keep them in sync

### DIFF
--- a/.changeset/plain-women-think.md
+++ b/.changeset/plain-women-think.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+Document that dumpSql is shared with d1-worker, and incorporate some D1 internal stats gathering machinery (which is currently unused by miniflare)


### PR DESCRIPTION
Fixes CFSQL-1371

_Describe your change..._

This adds a comment at the top of dumpSql.ts so we don't let them get out of sync again. It also adds the d1 stats tracking machinery (which remains unused in miniflare) so that there now only whitespace differences between the two files.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: stats tracking functionality is not used by miniflare (is extensively covered by D1's internal test suite)
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not public facing
- Wrangler V3 Backport
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/10890
  - [ ] Not necessary because: no public-facing functional change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
