### PR TITLE
increase tests timeout to 45 minutes

### DIFF
--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -80,7 +80,7 @@ jobs:
         run: node packages/wrangler/src/__tests__/test-old-node-version.js error
 
   test:
-    timeout-minutes: 30
+    timeout-minutes: 45
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.filter }}-${{ matrix.node_version }}-test
       cancel-in-progress: true


### PR DESCRIPTION
We have this PR which windows test always either errors because of flakes or times out because of the 30 minutes limit: https://github.com/cloudflare/workers-sdk/pull/10561

<img width="455" height="821" alt="Screenshot 2025-09-17 at 18 17 28" src="https://github.com/user-attachments/assets/22a18e62-3452-4af9-98b1-dc5657799fa9" />

So I am increasing the limit to 45 minutes hoping that this will enable the PR's workflow to pass

Note: 45 is the same time limit we have for the c3 e2es: https://github.com/cloudflare/workers-sdk/blob/b30263ea2d0b608640f181ba84b46c27b14bfcaf/.github/workflows/c3-e2e.yml#L51

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: infra change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: infra change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: infra change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
