### PR TITLE
rename connectivity_service_binding to vpc_service

### DIFF
--- a/packages/wrangler/src/__tests__/api/startDevWorker/utils.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/utils.test.ts
@@ -133,7 +133,7 @@ describe("convertConfigBindingsToStartWorkerBindings", () => {
 			},
 			MY_VPC_SERVICE: {
 				service_id: "0199295b-b3ac-7760-8246-bca40877b3e9",
-				type: "connectivity_service_binding",
+				type: "vpc_service",
 			},
 		});
 	});

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -12720,7 +12720,7 @@ export default{
 			mockUploadWorkerRequest({
 				expectedBindings: [
 					{
-						type: "connectivity_service_binding",
+						type: "vpc_service",
 						name: "VPC_SERVICE",
 						service_id: "0199295b-b3ac-7760-8246-bca40877b3e9",
 					},
@@ -12760,12 +12760,12 @@ export default{
 			mockUploadWorkerRequest({
 				expectedBindings: [
 					{
-						type: "connectivity_service_binding",
+						type: "vpc_service",
 						name: "VPC_API",
 						service_id: "0199295b-b3ac-7760-8246-bca40877b3e9",
 					},
 					{
-						type: "connectivity_service_binding",
+						type: "vpc_service",
 						name: "VPC_DATABASE",
 						service_id: "0299295b-b3ac-7760-8246-bca40877b3e0",
 					},

--- a/packages/wrangler/src/api/remoteBindings/index.ts
+++ b/packages/wrangler/src/api/remoteBindings/index.ts
@@ -100,7 +100,7 @@ export function pickRemoteBindings(
 				return true;
 			}
 
-			if (binding.type === "connectivity_service_binding") {
+			if (binding.type === "vpc_service") {
 				// VPC Service is always remote
 				return true;
 			}

--- a/packages/wrangler/src/api/startDevWorker/types.ts
+++ b/packages/wrangler/src/api/startDevWorker/types.ts
@@ -305,7 +305,7 @@ export type Binding =
 	| ({ type: "logfwdr" } & NameOmit<CfLogfwdrBinding>)
 	| ({ type: "unsafe_hello_world" } & BindingOmit<CfHelloWorld>)
 	| ({ type: "ratelimit" } & NameOmit<CfRateLimit>)
-	| ({ type: "connectivity_service_binding" } & BindingOmit<CfVpcService>)
+	| ({ type: "vpc_service" } & BindingOmit<CfVpcService>)
 	| { type: `unsafe_${string}` }
 	| { type: "assets" };
 

--- a/packages/wrangler/src/api/startDevWorker/utils.ts
+++ b/packages/wrangler/src/api/startDevWorker/utils.ts
@@ -289,7 +289,7 @@ export function convertCfWorkerInitBindingsToBindings(
 			}
 			case "vpc_services": {
 				for (const { binding, ...x } of info) {
-					output[binding] = { type: "connectivity_service_binding", ...x };
+					output[binding] = { type: "vpc_service", ...x };
 				}
 				break;
 			}
@@ -430,7 +430,7 @@ export async function convertBindingsToCfWorkerInitBindings(
 		} else if (binding.type === "ratelimit") {
 			bindings.ratelimits ??= [];
 			bindings.ratelimits.push({ ...binding, name: name });
-		} else if (binding.type === "connectivity_service_binding") {
+		} else if (binding.type === "vpc_service") {
 			bindings.vpc_services ??= [];
 			bindings.vpc_services.push({ ...binding, binding: name });
 		} else if (isUnsafeBindingType(binding.type)) {

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -2395,7 +2395,7 @@ const validateUnsafeBinding: ValidatorFn = (diagnostics, field, value) => {
 			"logfwdr",
 			"mtls_certificate",
 			"pipeline",
-			"connectivity_service_binding",
+			"vpc_service",
 		];
 
 		if (safeBindings.includes(value.type)) {

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -158,7 +158,7 @@ export type WorkerMetadataBinding =
 			namespace_id: string;
 			simple: { limit: number; period: 10 | 60 };
 	  }
-	| { type: "connectivity_service_binding"; name: string; service_id: string }
+	| { type: "vpc_service"; name: string; service_id: string }
 	| {
 			type: "logfwdr";
 			name: string;
@@ -449,7 +449,7 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 	bindings.vpc_services?.forEach(({ binding, service_id }) => {
 		metadataBindings.push({
 			name: binding,
-			type: "connectivity_service_binding",
+			type: "vpc_service",
 			service_id,
 		});
 	});

--- a/packages/wrangler/src/utils/map-worker-metadata-bindings.ts
+++ b/packages/wrangler/src/utils/map-worker-metadata-bindings.ts
@@ -334,7 +334,7 @@ export async function mapWorkerMetadataBindings(
 							];
 						}
 						break;
-					case "connectivity_service_binding":
+					case "vpc_service":
 						{
 							configObj.vpc_services = [
 								...(configObj.vpc_services ?? []),


### PR DESCRIPTION
Fixes WVPC-86

`connectivity_service_binding` awkwardly had `_binding` in the name which did not match other bindings. We also deciding to rename `connectivity_service` to `vpc_service`. Put it all together and you have `connectivity_service_binding` -> `vpc_service`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: to be merged into other vpc binding branch
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: feature not in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
