### PR TITLE
C3: Error when an unsupported platform is specified for a framework

### DIFF
--- a/.changeset/neat-pets-laugh.md
+++ b/.changeset/neat-pets-laugh.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Error when an unsupported platform is specified for a framework

--- a/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
+++ b/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
@@ -634,6 +634,19 @@ describe("Create Cloudflare CLI", () => {
 			}
 		});
 	});
+
+	test("E2E: Incorrect platform specified for framework", async ({
+		logStream,
+	}) => {
+		const { errors } = await runC3(
+			["--platform=pages", "--framework=solid", "my-app"],
+			[],
+			logStream,
+		);
+		expect(errors).toMatch(
+			/Error: The .*? framework doesn't support the "pages" platform/,
+		);
+	});
 });
 
 function normalizeOutput(output: string): string {

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -529,6 +529,12 @@ export const createContext = async (
 			}
 
 			frameworkConfig = frameworkConfig.platformVariants[platform];
+		} else {
+			if (frameworkConfig.platform !== args.platform) {
+				throw new Error(
+					`The ${frameworkConfig.displayName} framework doesn't support the "${args.platform}" platform`,
+				);
+			}
 		}
 
 		template = {


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-2195

Currently providing an invalid platform via the `--platform` argument for a framework causes the option to simply be ignored, this makes C3 create the application using the supported framework's platform instead, this can be surprising and confusing to users, so as a DX improvement here I am updating C3 to hard-error instead.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This is a self explanatory change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
