### PR TITLE
PIPE-374 Use new model for Pipelines bindings

### DIFF
--- a/.changeset/pipeline-streams-format.md
+++ b/.changeset/pipeline-streams-format.md
@@ -1,0 +1,39 @@
+---
+"wrangler": minor
+---
+
+**Breaking Change for compatibility_date >= "2025-10-22":** Updated pipeline bindings configuration format.
+
+For compatibility_date >= "2025-10-22", pipelines now use a new configuration format:
+
+**New format (compatibility_date >= "2025-10-22"):**
+
+```toml
+compatibility_date = "2025-10-22"
+
+[pipelines.streams]
+binding = "MY_STREAM"
+stream = "stream-id-1"
+
+[pipelines.streams]
+binding = "ANOTHER_STREAM"
+stream = "stream-id-2"
+```
+
+**Legacy format (compatibility_date < "2025-10-22"):**
+
+```toml
+compatibility_date = "2024-12-01"
+
+[[pipelines]]
+binding = "MY_PIPELINE"
+pipeline = "pipeline-id-1"
+
+[[pipelines]]
+binding = "ANOTHER_PIPELINE"
+pipeline = "pipeline-id-2"
+```
+
+Both formats produce identical runtime bindings. The new format provides better structure for future pipeline features and aligns with modern configuration patterns.
+
+This change only affects the configuration format - the runtime API and binding behavior remain unchanged, since in the new Pipelines API, streams are functionally the same as the legacy pipelines.

--- a/packages/miniflare/src/plugins/pipelines/index.ts
+++ b/packages/miniflare/src/plugins/pipelines/index.ts
@@ -16,7 +16,8 @@ export const PipelineOptionsSchema = z.object({
 			z.string().array(),
 			z.record(
 				z.object({
-					pipeline: z.string(),
+					pipeline: z.string().optional(),
+					stream: z.string().optional(),
 					remoteProxyConnectionString: z
 						.custom<RemoteProxyConnectionString>()
 						.optional(),
@@ -77,7 +78,8 @@ function bindingEntries(
 		| Record<
 				string,
 				{
-					pipeline: string;
+					pipeline?: string;
+					stream?: string;
 					remoteProxyConnectionString?: RemoteProxyConnectionString;
 				}
 		  >
@@ -88,6 +90,7 @@ function bindingEntries(
 	{ id: string; remoteProxyConnectionString?: RemoteProxyConnectionString },
 ][] {
 	if (Array.isArray(namespaces)) {
+		// old style pipeline bindings (by pipeline name)
 		return namespaces.map((bindingName) => [bindingName, { id: bindingName }]);
 	} else if (namespaces !== undefined) {
 		return (
@@ -96,7 +99,8 @@ function bindingEntries(
 				(
 					| string
 					| {
-							pipeline: string;
+							pipeline?: string;
+							stream?: string;
 							remoteProxyConnectionString?: RemoteProxyConnectionString;
 					  }
 				),
@@ -106,7 +110,7 @@ function bindingEntries(
 			typeof opts === "string"
 				? { id: opts }
 				: {
-						id: opts.pipeline,
+						id: opts.stream || opts.pipeline || "<invalid>", // last one should be impossible
 						remoteProxyConnectionString: opts.remoteProxyConnectionString,
 					},
 		]);

--- a/packages/wrangler/src/__tests__/api/startDevWorker/utils.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/utils.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert";
+import { stream } from "undici";
 import { describe, it } from "vitest";
 import { convertConfigBindingsToStartWorkerBindings } from "../../../api/startDevWorker/utils";
 
@@ -42,6 +43,14 @@ describe("convertConfigBindingsToStartWorkerBindings", () => {
 					},
 				],
 				consumers: undefined,
+			},
+			pipelines: {
+				streams: [
+					{
+						binding: "MY_PIPELINE",
+						stream: "my-stream",
+					},
+				],
 			},
 			r2_buckets: [
 				{
@@ -103,6 +112,10 @@ describe("convertConfigBindingsToStartWorkerBindings", () => {
 				id: "<kv_id>",
 				type: "kv_namespace",
 			},
+			MY_PIPELINE: {
+				stream: "my-stream",
+				type: "pipeline",
+			},
 			MY_QUEUE_PRODUCER: {
 				queue: "my-queue",
 				queue_name: "my-queue",
@@ -147,6 +160,9 @@ describe("convertConfigBindingsToStartWorkerBindings", () => {
 			queues: {
 				producers: undefined,
 				consumers: undefined,
+			},
+			pipelines: {
+				streams: [],
 			},
 			r2_buckets: [
 				{

--- a/packages/wrangler/src/api/startDevWorker/utils.ts
+++ b/packages/wrangler/src/api/startDevWorker/utils.ts
@@ -77,7 +77,7 @@ async function getBinaryFileContents(file: File<string | Uint8Array>) {
 export function convertConfigBindingsToStartWorkerBindings(
 	configBindings: ConfigBindingOptions
 ): StartDevWorkerOptions["bindings"] {
-	const { queues, ...bindings } = configBindings;
+	const { queues, pipelines, ...bindings } = configBindings;
 
 	return convertCfWorkerInitBindingsToBindings({
 		...bindings,
@@ -94,6 +94,7 @@ export function convertConfigBindingsToStartWorkerBindings(
 			bucket_name: r2.preview_bucket_name ?? r2.bucket_name,
 		})),
 		queues: queues.producers?.map((q) => ({ ...q, queue_name: q.queue })),
+		pipelines: Array.isArray(pipelines) ? pipelines : pipelines?.streams,
 	});
 }
 

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -389,5 +389,5 @@ export const defaultWranglerConfig: Config = {
 	unsafe: {},
 	mtls_certificates: [],
 	tail_consumers: undefined,
-	pipelines: [],
+	pipelines: { streams: [] },
 };

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -1104,13 +1104,24 @@ export interface EnvironmentNonInheritable {
 	 * @default []
 	 * @nonInheritable
 	 */
-	pipelines: {
-		/** The binding name used to refer to the bound service. */
-		binding: string;
+	pipelines:
+		| {
+				/** The binding name used to refer to the bound service. */
+				binding: string;
 
-		/** Name of the Pipeline to bind */
-		pipeline: string;
-	}[];
+				/** Name of the Pipeline to bind */
+				pipeline: string;
+		  }[]
+		| {
+				/** List of stream bindings */
+				streams: {
+					/** The binding name used to refer to the bound service. */
+					binding: string;
+
+					/** Name of the stream to bind */
+					stream: string;
+				}[];
+		  };
 
 	/**
 	 * Specifies Secret Store bindings that are bound to this Worker environment.

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -133,6 +133,7 @@ export type ConfigBindingOptions = Pick<
 	| "dispatch_namespaces"
 	| "durable_objects"
 	| "queues"
+	| "pipelines"
 	| "r2_buckets"
 	| "services"
 	| "kv_namespaces"

--- a/packages/wrangler/src/deployment-bundle/bindings.ts
+++ b/packages/wrangler/src/deployment-bundle/bindings.ts
@@ -60,7 +60,9 @@ export function getBindings(
 			? undefined
 			: config?.dispatch_namespaces,
 		mtls_certificates: config?.mtls_certificates,
-		pipelines: options?.pages ? undefined : config?.pipelines,
+		pipelines: Array.isArray(config?.pipelines)
+			? config?.pipelines
+			: config?.pipelines?.streams,
 		logfwdr: options?.pages ? undefined : config?.logfwdr,
 		assets: options?.pages
 			? undefined

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -139,7 +139,7 @@ export type WorkerMetadataBinding =
 			};
 	  }
 	| { type: "mtls_certificate"; name: string; certificate_id: string }
-	| { type: "pipelines"; name: string; pipeline: string }
+	| { type: "pipelines"; name: string; pipeline?: string; stream?: string }
 	| {
 			type: "secrets_store_secret";
 			name: string;
@@ -485,12 +485,20 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 		});
 	});
 
-	bindings.pipelines?.forEach(({ binding, pipeline }) => {
-		metadataBindings.push({
-			name: binding,
-			type: "pipelines",
-			pipeline: pipeline,
-		});
+	bindings.pipelines?.forEach((b) => {
+		metadataBindings.push(
+			Object.hasOwn(b, "pipeline")
+				? {
+						name: b.binding,
+						type: "pipelines",
+						pipeline: b.pipeline,
+					}
+				: {
+						name: b.binding,
+						type: "pipelines",
+						stream: b.stream,
+					}
+		);
 	});
 
 	bindings.logfwdr?.bindings.forEach(({ name, destination }) => {

--- a/packages/wrangler/src/deployment-bundle/worker.ts
+++ b/packages/wrangler/src/deployment-bundle/worker.ts
@@ -291,8 +291,9 @@ export interface CfAssetsBinding {
 
 export interface CfPipeline {
 	binding: string;
-	pipeline: string;
 	remote?: boolean;
+	pipeline?: string;
+	stream?: string;
 }
 
 export interface CfUnsafeBinding {

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -951,6 +951,11 @@ export function getBindings(
 		}),
 	];
 
+	const pipelines = configParam.pipelines;
+	const pipelineBindings = Array.isArray(pipelines)
+		? pipelines
+		: pipelines.streams;
+
 	const bindings: CfWorkerInit["bindings"] = {
 		// top-level fields
 		wasm_modules: configParam.wasm_modules,
@@ -995,7 +1000,7 @@ export function getBindings(
 			capnp: configParam.unsafe.capnp,
 		},
 		mtls_certificates: configParam.mtls_certificates,
-		pipelines: configParam.pipelines,
+		pipelines: pipelineBindings,
 		send_email: configParam.send_email,
 		assets: configParam.assets?.binding
 			? { binding: configParam.assets?.binding }

--- a/packages/wrangler/src/dev/miniflare/index.ts
+++ b/packages/wrangler/src/dev/miniflare/index.ts
@@ -289,16 +289,24 @@ function pipelineEntry(
 ): [
 	string,
 	{
-		pipeline: string;
+		pipeline?: string;
+		stream?: string;
 		remoteProxyConnectionString?: RemoteProxyConnectionString;
 	},
 ] {
 	if (!remoteProxyConnectionString || !pipeline.remote) {
-		return [pipeline.binding, { pipeline: pipeline.pipeline }];
+		return [
+			pipeline.binding,
+			{ pipeline: pipeline.pipeline, stream: pipeline.stream },
+		];
 	}
 	return [
 		pipeline.binding,
-		{ pipeline: pipeline.pipeline, remoteProxyConnectionString },
+		{
+			pipeline: pipeline.pipeline,
+			stream: pipeline.stream,
+			remoteProxyConnectionString,
+		},
 	];
 }
 function hyperdriveEntry(hyperdrive: CfHyperdrive): [string, string] {

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -617,11 +617,21 @@ export async function generateEnvTypes(
 	}
 
 	if (configToDTS.pipelines) {
-		for (const pipeline of configToDTS.pipelines) {
-			envTypeStructure.push([
-				constructTypeKey(pipeline.binding),
-				`import("cloudflare:pipelines").Pipeline<import("cloudflare:pipelines").PipelineRecord>`,
-			]);
+		if (Array.isArray(configToDTS.pipelines)) {
+			// legacy pipelines
+			for (const pipeline of configToDTS.pipelines) {
+				envTypeStructure.push([
+					constructTypeKey(pipeline.binding),
+					`import("cloudflare:pipelines").Pipeline<import("cloudflare:pipelines").PipelineRecord>`,
+				]);
+			}
+		} else {
+			for (const pipeline of configToDTS.pipelines.streams) {
+				envTypeStructure.push([
+					constructTypeKey(pipeline.binding),
+					`import("cloudflare:pipelines").Pipeline<import("cloudflare:pipelines").PipelineRecord>`,
+				]);
+			}
 		}
 	}
 

--- a/packages/wrangler/src/utils/map-worker-metadata-bindings.ts
+++ b/packages/wrangler/src/utils/map-worker-metadata-bindings.ts
@@ -287,13 +287,31 @@ export async function mapWorkerMetadataBindings(
 						];
 						break;
 					case "pipelines":
-						configObj.pipelines = [
-							...(configObj.pipelines ?? []),
-							{
-								binding: binding.name,
-								pipeline: binding.pipeline,
-							},
-						];
+						configObj.pipelines ??= { streams: [] };
+						if (binding.stream) {
+							if (Array.isArray(configObj.pipelines)) {
+								configObj.pipelines = { streams: [] };
+							}
+							configObj.pipelines.streams = [
+								...configObj.pipelines.streams,
+								{
+									binding: binding.name,
+									stream: binding.stream,
+								},
+							];
+						} else if (binding.pipeline) {
+							// Legacy Pipelines (remove once deprecated)
+							if (!Array.isArray(configObj.pipelines)) {
+								configObj.pipelines = [];
+							}
+							configObj.pipelines = [
+								...configObj.pipelines,
+								{
+									binding: binding.name,
+									pipeline: binding.pipeline,
+								},
+							];
+						}
 						break;
 					case "assets":
 						throw new FatalError(


### PR DESCRIPTION
Fixes PIPE-374

Upgrades wrangler to use the new Worker Bindings for Pipelines V1, which references Streams, instead of Pipelines.
---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): TBD, being written
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: New product.  Can discuss.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
