### PR TITLE
Wrangler crashes and exits on a custom build error issue 10646

### DIFF
--- a/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
@@ -257,7 +257,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 
 		test("custom build failures are recoverable", async ({ expect }) => {
 			await seed({
-				"build.js": dedent/* javascript */ `
+				"build.js": dedent /* javascript */ `
 					const fs = require("node:fs");
 					const input = fs.readFileSync("random_dir/index.ts", "utf8");
 					if (input.includes("FAIL_BUILD")) {
@@ -265,7 +265,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 					}
 					fs.writeFileSync("out.ts", input);
 				`,
-				"random_dir/index.ts": dedent/* javascript */ `
+				"random_dir/index.ts": dedent /* javascript */ `
 					export default {
 						fetch() {
 							return new Response("hello custom build")
@@ -288,8 +288,9 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 			const initialBundle = bus.waitFor("bundleComplete");
 			controller.onConfigUpdate({ type: "configUpdate", config });
 
-			expect(findSourceFile((await initialBundle).bundle.entrypointSource, "out.ts"))
-				.toContain(`return new Response("hello custom build")`);
+			expect(
+				findSourceFile((await initialBundle).bundle.entrypointSource, "out.ts")
+			).toContain(`return new Response("hello custom build")`);
 
 			await vi.waitFor(
 				async () => {
@@ -300,7 +301,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 							event.reason === "Custom build failed"
 					);
 					await seed({
-						"random_dir/index.ts": dedent/* javascript */ `
+						"random_dir/index.ts": dedent /* javascript */ `
 							// FAIL_BUILD
 							export default {
 								fetch() {
@@ -323,7 +324,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 				async () => {
 					const recoveryPromise = bus.waitFor("bundleComplete");
 					await seed({
-						"random_dir/index.ts": dedent/* javascript */ `
+						"random_dir/index.ts": dedent /* javascript */ `
 							export default {
 								fetch() {
 									return new Response("hello custom build again")
@@ -333,7 +334,10 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 					});
 
 					expect(
-						findSourceFile((await recoveryPromise).bundle.entrypointSource, "out.ts")
+						findSourceFile(
+							(await recoveryPromise).bundle.entrypointSource,
+							"out.ts"
+						)
 					).toContain(`return new Response("hello custom build again")`);
 				},
 				{ timeout: 5_000, interval: 500 }

--- a/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
@@ -254,6 +254,91 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 				{ timeout: 5_000, interval: 500 }
 			);
 		});
+
+		test("custom build failures are recoverable", async ({ expect }) => {
+			await seed({
+				"build.js": dedent/* javascript */ `
+					const fs = require("node:fs");
+					const input = fs.readFileSync("random_dir/index.ts", "utf8");
+					if (input.includes("FAIL_BUILD")) {
+						process.exit(1);
+					}
+					fs.writeFileSync("out.ts", input);
+				`,
+				"random_dir/index.ts": dedent/* javascript */ `
+					export default {
+						fetch() {
+							return new Response("hello custom build")
+						}
+					} satisfies ExportedHandler
+				`,
+			});
+			const config = configDefaults({
+				entrypoint: path.resolve("out.ts"),
+				projectRoot: path.resolve("."),
+				build: {
+					custom: {
+						command: "node build.js",
+						watch: "random_dir",
+					},
+					moduleRoot: path.resolve("."),
+				},
+			});
+
+			const initialBundle = bus.waitFor("bundleComplete");
+			controller.onConfigUpdate({ type: "configUpdate", config });
+
+			expect(findSourceFile((await initialBundle).bundle.entrypointSource, "out.ts"))
+				.toContain(`return new Response("hello custom build")`);
+
+			await vi.waitFor(
+				async () => {
+					const errorPromise = bus.waitFor(
+						"error",
+						(event) =>
+							event.source === "BundlerController" &&
+							event.reason === "Custom build failed"
+					);
+					await seed({
+						"random_dir/index.ts": dedent/* javascript */ `
+							// FAIL_BUILD
+							export default {
+								fetch() {
+									return new Response("broken custom build")
+								}
+							} satisfies ExportedHandler
+						`,
+					});
+
+					const error = await errorPromise;
+					expect(error.cause).toBeInstanceOf(Error);
+					expect(error.cause.message).toContain(
+						"Running custom build `node build.js` failed."
+					);
+				},
+				{ timeout: 5_000, interval: 500 }
+			);
+
+			await vi.waitFor(
+				async () => {
+					const recoveryPromise = bus.waitFor("bundleComplete");
+					await seed({
+						"random_dir/index.ts": dedent/* javascript */ `
+							export default {
+								fetch() {
+									return new Response("hello custom build again")
+								}
+							} satisfies ExportedHandler
+						`,
+					});
+
+					expect(
+						findSourceFile((await recoveryPromise).bundle.entrypointSource, "out.ts")
+					).toContain(`return new Response("hello custom build again")`);
+				},
+				{ timeout: 5_000, interval: 500 }
+			);
+		});
 	});
 
 	test("module aliasing", async ({ expect }) => {

--- a/packages/wrangler/src/__tests__/api/startDevWorker/DevEnv.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/DevEnv.test.ts
@@ -1,4 +1,6 @@
-import { describe, test } from "vitest";
+import { once } from "node:events";
+import { setImmediate as waitForImmediate } from "node:timers/promises";
+import { describe, expect, test } from "vitest";
 import { DevEnv } from "../../../api/startDevWorker/DevEnv";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 
@@ -11,7 +13,6 @@ describe("DevEnv", () => {
 		}) => {
 			const devEnv = new DevEnv();
 
-			// Create an esbuild-like BuildFailure with errors and warnings arrays
 			const buildFailure = Object.assign(new Error("Build failed"), {
 				errors: [
 					{
@@ -45,7 +46,6 @@ describe("DevEnv", () => {
 		}) => {
 			const devEnv = new DevEnv();
 
-			// Create an esbuild-like BuildFailure nested in cause
 			const innerFailure = Object.assign(new Error("Build failed"), {
 				errors: [
 					{
@@ -94,6 +94,29 @@ describe("DevEnv", () => {
 			expect(std.err).toContain("Custom build command failed");
 
 			void devEnv.teardown();
+		});
+
+		test("should keep custom build failures recoverable while waiting for teardown", async () => {
+			const devEnv = new DevEnv();
+			const teardownPromise = once(devEnv, "teardown");
+
+			devEnv.dispatch({
+				type: "error",
+				reason: "Custom build failed",
+				cause: new Error("Custom build command failed"),
+				source: "BundlerController",
+				data: { config: undefined, filePath: "src/index.ts" },
+			});
+
+			await expect(
+				Promise.race([
+					teardownPromise.then(() => "teardown"),
+					waitForImmediate().then(() => "waiting"),
+				])
+			).resolves.toBe("waiting");
+
+			void devEnv.teardown();
+			await expect(teardownPromise).resolves.toEqual([]);
 		});
 	});
 });


### PR DESCRIPTION
Fixes #10646.

Improve custom build error handling in dev mode to match non-custom build behavior:

1. **Initial Build Failures**:
   - Exit immediately with error code 1 if the initial build fails
   - Provide clear error messages explaining the build failure

2. **Development Build Failures**:
   - Continue running the dev server when builds fail during development
   - Return 500 errors for requests when the build is in a failed state
   - Show clear error messages in both console and HTTP responses

3. **Error Recovery**:
   - Automatically recover when build issues are fixed
   - Clear error state and resume normal operation

4. **Testing**:
   - Added unit tests for build failure scenarios
   - Added E2E test to verify the complete flow
   - Ensured tests clean up properly

---

- Tests
  - [x] Tests included
    - Unit tests for build failure scenarios
    - E2E test for complete flow verification
  - [ ] Tests not necessary because:

- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This is an internal behavior improvement

- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
