### PR TITLE
On version upload, check requested status instead of actual status

### DIFF
--- a/.changeset/chubby-shirts-sell.md
+++ b/.changeset/chubby-shirts-sell.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+On version upload, check Preview URLs status using requested status, not actual status.

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -880,12 +880,17 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 	let versionPreviewAliasUrl: string | undefined = undefined;
 
 	if (versionId && hasPreview) {
-		const { previews_enabled: previews_available_on_subdomain } =
-			await fetchResult<{
+		const { requested: { previews_enabled } = {} } = await fetchResult<{
+			requested: {
 				previews_enabled: boolean;
-			}>(config, `${workerUrl}/subdomain`);
-
-		if (previews_available_on_subdomain) {
+			};
+		}>(
+			config,
+			`${workerUrl}/subdomain`,
+			{},
+			new URLSearchParams({ show_requested: "true" })
+		);
+		if (previews_enabled) {
 			const userSubdomain = await getWorkersDevSubdomain(
 				config,
 				accountId,


### PR DESCRIPTION
Internally tracked: https://jira.cfdata.org/browse/WC-4022.

_Describe your change..._

Check the requested status instead of the actual status of Preview URLs. Should result in more consistent artifact generation depending on what the intent of the user was.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Public API docs will be updated and released separately.
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: Not a problem in Wrangler v3, these are just improvements in our API.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
