### PR TITLE
Improve error logging

### DIFF
--- a/.changeset/spotty-knives-roll.md
+++ b/.changeset/spotty-knives-roll.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Improve formatting of logged errors in some cases

--- a/packages/wrangler/e2e/secrets-store.test.ts
+++ b/packages/wrangler/e2e/secrets-store.test.ts
@@ -148,7 +148,7 @@ describe.each(RUNTIMES)(
 				"🔐 Getting secret... (ID: 00000000000000000000000000000000)"
 			);
 			if (runtime === "remote") {
-				expect(normalize(output.stdout)).toContain(
+				expect(normalize(output.stderr)).toContain(
 					"secret_not_found [code: 1001]"
 				);
 			} else {
@@ -180,7 +180,7 @@ describe.each(RUNTIMES)(
 			expect(normalize(output.stdout)).toContain(
 				"🔐 Getting secret... (ID: 00000000000000000000000000000000)"
 			);
-			expect(normalize(output.stdout)).toContain(
+			expect(normalize(output.stderr)).toContain(
 				"store_not_found [code: 1001]"
 			);
 		});

--- a/packages/wrangler/src/__tests__/cfetch-utils.test.ts
+++ b/packages/wrangler/src/__tests__/cfetch-utils.test.ts
@@ -147,10 +147,10 @@ describe("throwFetchError", () => {
 			`[APIError: A request to the Cloudflare API (/user) failed.]`
 		);
 
-		expect(std.out).toMatchInlineSnapshot(`
-			"Getting User settings...
-
-			[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/user) failed.[0m
+		expect(std).toMatchInlineSnapshot(`
+			Object {
+			  "debug": "",
+			  "err": "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/user) failed.[0m
 
 			  error one [code: 10001]
 			  To learn more about this error, visit: [4mhttps://example.com/1[0m
@@ -169,7 +169,12 @@ describe("throwFetchError", () => {
 			  If you think this is a bug, please open an issue at:
 			  [4mhttps://github.com/cloudflare/workers-sdk/issues/new/choose[0m
 
-			"
+			",
+			  "info": "",
+			  "out": "Getting User settings...
+			",
+			  "warn": "",
+			}
 		`);
 	});
 

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -464,13 +464,16 @@ describe("deploy", () => {
 		).rejects.toThrowErrorMatchingInlineSnapshot(
 			`[APIError: A request to the Cloudflare API (/accounts/some-account-id/workers/services/test-name) failed.]`
 		);
-		expect(std.out).toMatchInlineSnapshot(`
-			"
-			[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/workers/services/test-name) failed.[0m
+		expect(std).toMatchInlineSnapshot(`
+			Object {
+			  "debug": "",
+			  "err": "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/workers/services/test-name) failed.[0m
 
 			  Authentication error [code: 10000]
 
-
+			",
+			  "info": "",
+			  "out": "
 			📎 It looks like you are authenticating Wrangler via a custom API token set in an environment variable.
 			Please ensure it has the correct permissions for this operation.
 
@@ -486,7 +489,9 @@ describe("deploy", () => {
 			├─┼─┤
 			│ Account Three │ account-3 │
 			└─┴─┘
-			🔓 To see token permissions visit https://dash.cloudflare.com/profile/api-tokens."
+			🔓 To see token permissions visit https://dash.cloudflare.com/profile/api-tokens.",
+			  "warn": "",
+			}
 		`);
 	});
 
@@ -11381,11 +11386,7 @@ export default{
 			expect(std).toMatchInlineSnapshot(`
 				Object {
 				  "debug": "",
-				  "err": "",
-				  "info": "",
-				  "out": "Total Upload: xx KiB / gzip: xx KiB
-
-				[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/workers/scripts/test-name/versions) failed.[0m
+				  "err": "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/workers/scripts/test-name/versions) failed.[0m
 
 				  Worker Startup Timed out. This could be due to script exceeding size limits or expensive code in
 				  the global scope. [code: 11337]
@@ -11393,6 +11394,9 @@ export default{
 				  If you think this is a bug, please open an issue at:
 				  [4mhttps://github.com/cloudflare/workers-sdk/issues/new/choose[0m
 
+				",
+				  "info": "",
+				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				",
 				  "warn": "",
 				}
@@ -11469,9 +11473,6 @@ export default{
 				  If these are unnecessary, consider removing them
 
 
-				",
-				  "info": "",
-				  "out": "Total Upload: xx KiB / gzip: xx KiB
 
 				[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/workers/scripts/test-name/versions) failed.[0m
 
@@ -11480,6 +11481,9 @@ export default{
 				  If you think this is a bug, please open an issue at:
 				  [4mhttps://github.com/cloudflare/workers-sdk/issues/new/choose[0m
 
+				",
+				  "info": "",
+				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				",
 				  "warn": "",
 				}
@@ -11544,9 +11548,6 @@ export default{
 				  .wrangler/tmp/startup-profile-<HASH>/worker.cpuprofile - load it into the Chrome DevTools profiler
 				  (or directly in VSCode) to view a flamegraph.
 
-				",
-				  "info": "",
-				  "out": "Total Upload: xx KiB / gzip: xx KiB
 
 				[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/workers/scripts/test-name/versions) failed.[0m
 
@@ -11555,6 +11556,9 @@ export default{
 				  If you think this is a bug, please open an issue at:
 				  [4mhttps://github.com/cloudflare/workers-sdk/issues/new/choose[0m
 
+				",
+				  "info": "",
+				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				",
 				  "warn": "",
 				}

--- a/packages/wrangler/src/__tests__/pages/functions-build.test.ts
+++ b/packages/wrangler/src/__tests__/pages/functions-build.test.ts
@@ -1172,6 +1172,14 @@ export default {
 		expect(buildMetadataExists).toBeFalsy();
 
 		// This logs a parsing error, but continues anyway
-		expect(std.err).toContain("ParseError");
+		expect(std.err).toMatchInlineSnapshot(`
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnexpected character, expected only whitespace or comments till end of line[0m
+
+			    <cwd>/wrangler.toml:5:23:
+			[37m      5 │ limits = { cpu_ms = 50 [32m[37m}\\"
+			        ╵                        [32m^[0m
+
+			"
+		`);
 	});
 });

--- a/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
@@ -120,7 +120,15 @@ describe("pages build env", () => {
 		await runWrangler("pages functions build-env . --outfile data.json");
 
 		expect(process.exitCode).toEqual(EXIT_CODE_INVALID_PAGES_CONFIG);
-		expect(std.err).toContain("ParseError");
+		expect(std.err).toMatchInlineSnapshot(`
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mInvalid character, expected \\"=\\"[0m
+
+			    <cwd>/wrangler.toml:1:8:
+			[37m      1 │ INVALID [32m[37m\\"FILE
+			        ╵         [32m^[0m
+
+			"
+		`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"Checking for configuration in a Wrangler configuration file (BETA)
 

--- a/packages/wrangler/src/__tests__/pages/pages-download-config.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-download-config.test.ts
@@ -863,18 +863,25 @@ describe("pages download config", () => {
 		).rejects.toThrowErrorMatchingInlineSnapshot(
 			`[APIError: A request to the Cloudflare API (/accounts/MOCK_ACCOUNT_ID/pages/projects/NOT_REAL) failed.]`
 		);
-		expect(std.out).toMatchInlineSnapshot(`
-		"
-		[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/MOCK_ACCOUNT_ID/pages/projects/NOT_REAL) failed.[0m
+		expect(std).toMatchInlineSnapshot(`
+			Object {
+			  "debug": "",
+			  "err": "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/MOCK_ACCOUNT_ID/pages/projects/NOT_REAL) failed.[0m
 
-		  Project not found. The specified project name does not match any of your existing projects. [code:
-		  8000007]
+			  Project not found. The specified project name does not match any of your existing projects. [code:
+			  8000007]
 
-		  If you think this is a bug, please open an issue at:
-		  [4mhttps://github.com/cloudflare/workers-sdk/issues/new/choose[0m
+			  If you think this is a bug, please open an issue at:
+			  [4mhttps://github.com/cloudflare/workers-sdk/issues/new/choose[0m
 
-		"
-	`);
+			",
+			  "info": "",
+			  "out": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m🚧 \`wrangler pages download config\` is an experimental command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose[0m
+
+			",
+			}
+		`);
 	});
 	describe("overwrite existing file", () => {
 		it("should overwrite existing file w/ --force", async () => {

--- a/packages/wrangler/src/__tests__/pages/secret.test.ts
+++ b/packages/wrangler/src/__tests__/pages/secret.test.ts
@@ -737,19 +737,24 @@ describe("wrangler pages secret", () => {
 				`[APIError: A request to the Cloudflare API (/accounts/some-account-id/workers/scripts/script-name/settings) failed.]`
 			);
 
-			expect(std.out).toMatchInlineSnapshot(`
-				"🌀 Creating the secrets for the Worker \\"script-name\\"
-
-				🚨 Secrets failed to upload
-
-				[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/workers/scripts/script-name/settings) failed.[0m
+			expect(std).toMatchInlineSnapshot(`
+				Object {
+				  "debug": "",
+				  "err": "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/workers/scripts/script-name/settings) failed.[0m
 
 				  This is a helpful error [code: 1]
 
 				  If you think this is a bug, please open an issue at:
 				  [4mhttps://github.com/cloudflare/workers-sdk/issues/new/choose[0m
 
-				"
+				",
+				  "info": "",
+				  "out": "🌀 Creating the secrets for the Worker \\"script-name\\"
+
+				🚨 Secrets failed to upload
+				",
+				  "warn": "",
+				}
 			`);
 		});
 	});

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -448,17 +448,22 @@ describe("r2", () => {
 				).rejects.toThrowErrorMatchingInlineSnapshot(
 					`[APIError: A request to the Cloudflare API (/accounts/some-account-id/r2/buckets) failed.]`
 				);
-				expect(std.out).toMatchInlineSnapshot(`
-					"Creating bucket 'test-bucket'...
-
-					[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/r2/buckets) failed.[0m
+				expect(std).toMatchInlineSnapshot(`
+					Object {
+					  "debug": "",
+					  "err": "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/r2/buckets) failed.[0m
 
 					  The JSON you provided was not well formed. [code: 10040]
 
 					  If you think this is a bug, please open an issue at:
 					  [4mhttps://github.com/cloudflare/workers-sdk/issues/new/choose[0m
 
-					"
+					",
+					  "info": "",
+					  "out": "Creating bucket 'test-bucket'...
+					",
+					  "warn": "",
+					}
 				`);
 			});
 		});
@@ -536,17 +541,9 @@ describe("r2", () => {
 						`[APIError: A request to the Cloudflare API (/accounts/some-account-id/r2/buckets/testBucket) failed.]`
 					);
 					expect(std.out).toMatchInlineSnapshot(`
-				"Updating bucket testBucket to Foo default storage class.
-
-				[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/r2/buckets/testBucket) failed.[0m
-
-				  The storage class specified is not valid. [code: 10062]
-
-				  If you think this is a bug, please open an issue at:
-				  [4mhttps://github.com/cloudflare/workers-sdk/issues/new/choose[0m
-
-				"
-		`);
+						"Updating bucket testBucket to Foo default storage class.
+						"
+					`);
 				});
 
 				it("should update the default storage class", async () => {

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -1186,22 +1186,27 @@ describe("wrangler secret", () => {
 				`[APIError: A request to the Cloudflare API (/accounts/some-account-id/workers/scripts/script-name/settings) failed.]`
 			);
 
-			expect(std.out).toMatchInlineSnapshot(`
-				"
-				 ⛅️ wrangler x.x.x
-				──────────────────
-				🌀 Creating the secrets for the Worker \\"script-name\\"
-
-				🚨 Secrets failed to upload
-
-				[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/workers/scripts/script-name/settings) failed.[0m
+			expect(std).toMatchInlineSnapshot(`
+				Object {
+				  "debug": "",
+				  "err": "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/workers/scripts/script-name/settings) failed.[0m
 
 				  This is a helpful error [code: 1]
 
 				  If you think this is a bug, please open an issue at:
 				  [4mhttps://github.com/cloudflare/workers-sdk/issues/new/choose[0m
 
-				"
+				",
+				  "info": "",
+				  "out": "
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				🌀 Creating the secrets for the Worker \\"script-name\\"
+
+				🚨 Secrets failed to upload
+				",
+				  "warn": "",
+				}
 			`);
 		});
 

--- a/packages/wrangler/src/api/startDevWorker/DevEnv.ts
+++ b/packages/wrangler/src/api/startDevWorker/DevEnv.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import { EventEmitter } from "node:events";
 import { logger, runWithLogLevel } from "../../logger";
-import { formatMessage, ParseError } from "../../parse";
+import { ParseError } from "../../parse";
 import { BundlerController } from "./BundlerController";
 import { ConfigController } from "./ConfigController";
 import { LocalRuntimeController } from "./LocalRuntimeController";
@@ -137,7 +137,7 @@ export class DevEnv extends EventEmitter {
 			ev.source === "ConfigController" &&
 			ev.cause instanceof ParseError
 		) {
-			logger.log(formatMessage(ev.cause));
+			logger.error(ev.cause);
 		}
 		// if other knowable + recoverable errors occur, handle them here
 		else {

--- a/packages/wrangler/src/dev/remote.ts
+++ b/packages/wrangler/src/dev/remote.ts
@@ -7,6 +7,7 @@ import { withSourceURLs } from "../deployment-bundle/source-url";
 import { getInferredHost } from "../dev";
 import { UserError } from "../errors";
 import { logger } from "../logger";
+import { APIError } from "../parse";
 import { syncWorkersSite } from "../sites";
 import { requireApiToken } from "../user";
 import { isAbortError } from "../utils/isAbortError";
@@ -20,7 +21,6 @@ import type {
 	CfWorkerInit,
 } from "../deployment-bundle/worker";
 import type { ComplianceConfig } from "../environment-variables/misc-variables";
-import type { ParseError } from "../parse";
 import type { LegacyAssetPaths } from "../sites";
 import type { ApiCredentials } from "../user";
 import type { CfAccount } from "./create-worker-preview";
@@ -35,7 +35,7 @@ export function handlePreviewSessionUploadError(
 	// since it could recover after the developer fixes whatever's wrong
 	// instead of logging the raw API error to the user,
 	// give them friendly instructions
-	if (isAbortError(err)) {
+	if (!isAbortError(err)) {
 		// code 10049 happens when the preview token expires
 		if ("code" in err && err.code === 10049) {
 			logger.log("Preview token expired, fetching a new one");
@@ -44,7 +44,7 @@ export function handlePreviewSessionUploadError(
 			// lets increment the counter, and trigger a rerun of
 			// the useEffect above
 			return true;
-		} else if (!handleUserFriendlyError(err as ParseError, accountId)) {
+		} else if (!handleUserFriendlyError(err, accountId)) {
 			logger.error("Error on remote worker:", err);
 		}
 	}
@@ -78,7 +78,7 @@ export function handlePreviewSessionCreationError(
 	}
 	// we want to log the error, but not end the process
 	// since it could recover after the developer fixes whatever's wrong
-	else if (isAbortError(err)) {
+	else if (!isAbortError(err)) {
 		logger.error("Error while creating remote dev session:", err);
 	}
 }
@@ -241,49 +241,52 @@ export async function getWorkerAccountAndContext(props: {
  * messages, does not perform any logic other than logging errors.
  * @returns if the error was handled or not
  */
-function handleUserFriendlyError(error: ParseError, accountId?: string) {
-	switch ((error as unknown as { code: number }).code) {
-		// code 10021 is a validation error
-		case 10021: {
-			// if it is the following message, give a more user friendly
-			// error, otherwise do not handle this error in this function
-			if (
-				error.notes[0].text ===
-				"binding DB of type d1 must have a valid `id` specified [code: 10021]"
-			) {
-				const errorMessage =
-					"Error: You must use a real database in the preview_database_id configuration.";
-				const solutionMessage =
-					"You can find your databases using 'wrangler d1 list', or read how to develop locally with D1 here:";
-				const documentationLink = `https://developers.cloudflare.com/d1/configuration/local-development`;
+function handleUserFriendlyError(error: unknown, accountId?: string) {
+	if (error instanceof APIError) {
+		switch (error.code) {
+			// code 10021 is a validation error
+			case 10021: {
+				// if it is the following message, give a more user friendly
+				// error, otherwise do not handle this error in this function
+				if (
+					error.notes[0].text ===
+					"binding DB of type d1 must have a valid `id` specified [code: 10021]"
+				) {
+					const errorMessage =
+						"Error: You must use a real database in the preview_database_id configuration.";
+					const solutionMessage =
+						"You can find your databases using 'wrangler d1 list', or read how to develop locally with D1 here:";
+					const documentationLink = `https://developers.cloudflare.com/d1/configuration/local-development`;
 
-				logger.error(
-					`${errorMessage}\n${solutionMessage}\n${documentationLink}`
-				);
+					logger.error(
+						`${errorMessage}\n${solutionMessage}\n${documentationLink}`
+					);
+
+					return true;
+				}
+
+				return false;
+			}
+
+			// for error 10063 (workers.dev subdomain required)
+			case 10063: {
+				const errorMessage =
+					"Error: You need to register a workers.dev subdomain before running the dev command in remote mode";
+				const solutionMessage =
+					"You can either enable local mode by pressing l, or register a workers.dev subdomain here:";
+				const onboardingLink = accountId
+					? `https://dash.cloudflare.com/${accountId}/workers/onboarding`
+					: "https://dash.cloudflare.com/?to=/:account/workers/onboarding";
+
+				logger.error(`${errorMessage}\n${solutionMessage}\n${onboardingLink}`);
 
 				return true;
 			}
 
-			return false;
-		}
-
-		// for error 10063 (workers.dev subdomain required)
-		case 10063: {
-			const errorMessage =
-				"Error: You need to register a workers.dev subdomain before running the dev command in remote mode";
-			const solutionMessage =
-				"You can either enable local mode by pressing l, or register a workers.dev subdomain here:";
-			const onboardingLink = accountId
-				? `https://dash.cloudflare.com/${accountId}/workers/onboarding`
-				: "https://dash.cloudflare.com/?to=/:account/workers/onboarding";
-
-			logger.error(`${errorMessage}\n${solutionMessage}\n${onboardingLink}`);
-
-			return true;
-		}
-
-		default: {
-			return false;
+			default: {
+				logger.error(error);
+				return true;
+			}
 		}
 	}
 }

--- a/packages/wrangler/src/dev/remote.ts
+++ b/packages/wrangler/src/dev/remote.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert";
 import path from "node:path";
-import dedent from "ts-dedent";
 import { syncAssets } from "../assets";
 import { printBundleSize } from "../deployment-bundle/bundle-reporter";
 import { getBundleType } from "../deployment-bundle/bundle-type";

--- a/packages/wrangler/src/dev/remote.ts
+++ b/packages/wrangler/src/dev/remote.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
 import path from "node:path";
+import dedent from "ts-dedent";
 import { syncAssets } from "../assets";
 import { printBundleSize } from "../deployment-bundle/bundle-reporter";
 import { getBundleType } from "../deployment-bundle/bundle-type";
@@ -60,12 +61,9 @@ export function handlePreviewSessionCreationError(
 	// give them friendly instructions
 	// for error 10063 (workers.dev subdomain required)
 	if ("code" in err && err.code === 10063) {
-		const errorMessage =
-			"Error: You need to register a workers.dev subdomain before running the dev command in remote mode";
-		const solutionMessage =
-			"You can either enable local mode by pressing l, or register a workers.dev subdomain here:";
-		const onboardingLink = `https://dash.cloudflare.com/${accountId}/workers/onboarding`;
-		logger.error(`${errorMessage}\n${solutionMessage}\n${onboardingLink}`);
+		logger.error(
+			`You need to register a workers.dev subdomain before running the dev command in remote mode. You can either enable local mode by pressing l, or register a workers.dev subdomain here: https://dash.cloudflare.com/${accountId}/workers/onboarding`
+		);
 	} else if (
 		"cause" in err &&
 		(err.cause as { code: string; hostname: string })?.code === "ENOTFOUND"
@@ -252,14 +250,8 @@ function handleUserFriendlyError(error: unknown, accountId?: string) {
 					error.notes[0].text ===
 					"binding DB of type d1 must have a valid `id` specified [code: 10021]"
 				) {
-					const errorMessage =
-						"Error: You must use a real database in the preview_database_id configuration.";
-					const solutionMessage =
-						"You can find your databases using 'wrangler d1 list', or read how to develop locally with D1 here:";
-					const documentationLink = `https://developers.cloudflare.com/d1/configuration/local-development`;
-
 					logger.error(
-						`${errorMessage}\n${solutionMessage}\n${documentationLink}`
+						`You must use a real database in the preview_database_id configuration. You can find your databases using 'wrangler d1 list', or read how to develop locally with D1 here: https://developers.cloudflare.com/d1/configuration/local-development`
 					);
 
 					return true;
@@ -270,15 +262,13 @@ function handleUserFriendlyError(error: unknown, accountId?: string) {
 
 			// for error 10063 (workers.dev subdomain required)
 			case 10063: {
-				const errorMessage =
-					"Error: You need to register a workers.dev subdomain before running the dev command in remote mode";
-				const solutionMessage =
-					"You can either enable local mode by pressing l, or register a workers.dev subdomain here:";
 				const onboardingLink = accountId
 					? `https://dash.cloudflare.com/${accountId}/workers/onboarding`
 					: "https://dash.cloudflare.com/?to=/:account/workers/onboarding";
 
-				logger.error(`${errorMessage}\n${solutionMessage}\n${onboardingLink}`);
+				logger.error(
+					`You need to register a workers.dev subdomain before running the dev command in remote mode. You can either enable local mode by pressing l, or register a workers.dev subdomain here: ${onboardingLink}`
+				);
 
 				return true;
 			}

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -147,7 +147,7 @@ import {
 } from "./pages/secret";
 import { pagesProjectUploadCommand } from "./pages/upload";
 import { pagesProjectValidateCommand } from "./pages/validate";
-import { APIError, formatMessage, ParseError } from "./parse";
+import { APIError, ParseError } from "./parse";
 import { pipelinesNamespace } from "./pipelines";
 import { pipelinesCreateCommand } from "./pipelines/cli/create";
 import { pipelinesDeleteCommand } from "./pipelines/cli/delete";
@@ -1677,7 +1677,7 @@ export async function main(argv: string[]): Promise<void> {
 				logger.error(e.cause);
 			} else {
 				assert(isAuthenticationError(e));
-				logger.log(formatMessage(e));
+				logger.error(e);
 			}
 			const envAuth = getAuthFromEnv();
 			if (envAuth !== undefined && "apiToken" in envAuth) {
@@ -1700,7 +1700,7 @@ export async function main(argv: string[]): Promise<void> {
 			e.notes.push({
 				text: "\nIf you think this is a bug, please open an issue at: https://github.com/cloudflare/workers-sdk/issues/new/choose",
 			});
-			logger.log(formatMessage(e));
+			logger.error(e);
 		} else if (e instanceof JsonFriendlyFatalError) {
 			logger.log(e.message);
 		} else if (
@@ -1747,7 +1747,7 @@ export async function main(argv: string[]): Promise<void> {
 			error.notes.push({
 				text: "\nIf you think this is a bug, please open an issue at: https://github.com/cloudflare/workers-sdk/issues/new/choose",
 			});
-			logger.log(formatMessage(error));
+			logger.error(error);
 		} else {
 			if (
 				// Is this a StartDevEnv error event? If so, unwrap the cause, which is usually the user-recognisable error

--- a/packages/wrangler/src/utils/isAbortError.ts
+++ b/packages/wrangler/src/utils/isAbortError.ts
@@ -7,7 +7,7 @@
  * https://developer.mozilla.org/en-US/docs/Web/API/DOMException#aborterror
  */
 export function isAbortError(err: unknown) {
-	const legacyAbortErroCheck = (err as { code: string }).code !== "ABORT_ERR";
+	const legacyAbortErroCheck = (err as { code: string }).code == "ABORT_ERR";
 	const abortErrorCheck = err instanceof Error && err.name == "AbortError";
 
 	return legacyAbortErroCheck || abortErrorCheck;


### PR DESCRIPTION
Fixes [DEVX-2213](https://jira.cfdata.org/browse/DEVX-2213)

Previously, the `formatMessage` utility was heavily used across the Wrangler codebase to nicely format `ParseError`-style error messages. This led to nice display, but had two problems:
- It was used via `logger.log(formatMessage(...))`, which meant that a large chunk of Wrangler's error messages were shoing up in stdout rather than stderr
- It needed to be used intentionally, which meant that in various places we logged out a potentional `ParseError` without applying the formatting (leading to hard to understand stack traces being shown to users when e.g. a preview session failed)

Now, `logger.error()` will automatically apply `formatMessage()` when the first argument is a `ParseError`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal refactor
- Wrangler V3 Backport
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/10782
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
