### PR TITLE
wrangler: fix: preserve remote preview_urls status

### DIFF
--- a/.changeset/cold-rockets-rule.md
+++ b/.changeset/cold-rockets-rule.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Wrangler will preserve remote `preview_urls` status instead of disabling it.

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -6922,7 +6922,8 @@ addEventListener('fetch', event => {});`
 			`);
 		});
 
-		it("should warn the user if preview_urls default is different from remote", async () => {
+		// Skip because Preview URLs will now default to remote state.
+		it.skip("should warn the user if preview_urls default is different from remote", async () => {
 			writeWranglerConfig({}); // Default preview_urls should be false.
 			writeWorkerSource();
 			mockSubDomainRequest();
@@ -6947,6 +6948,27 @@ addEventListener('fetch', event => {});`
 
 				"
 			`);
+		});
+
+		it("should preserve preview_urls status when not in config", async () => {
+			writeWranglerConfig({});
+			writeWorkerSource();
+			mockSubDomainRequest();
+			mockUploadWorkerRequest();
+			mockGetWorkerSubdomain({ enabled: true, previews_enabled: true });
+			mockUpdateWorkerSubdomain({ enabled: true, previews_enabled: true });
+			await runWrangler("deploy ./index");
+
+			expect(std.out).toMatchInlineSnapshot(`
+				"Total Upload: xx KiB / gzip: xx KiB
+				Worker Startup Time: 100 ms
+				Uploaded test-name (TIMINGS)
+				Deployed test-name triggers (TIMINGS)
+				  https://test-name.test-sub-domain.workers.dev
+				Current Version ID: Galaxy-Class"
+			`);
+			expect(std.err).toMatchInlineSnapshot(`""`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 	});
 

--- a/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
@@ -257,8 +257,8 @@ export function mockUploadWorkerRequest(
 		envConfig = config.env?.[env] ?? {};
 	}
 	const { workers_dev, preview_urls } = getSubdomainValues(
-		envConfig.workers_dev,
-		envConfig.preview_urls,
+		envConfig,
+		{},
 		envConfig.routes ?? []
 	);
 	mockGetWorkerSubdomain({

--- a/packages/wrangler/src/deploy/config-diffs.ts
+++ b/packages/wrangler/src/deploy/config-diffs.ts
@@ -28,8 +28,10 @@ export function getRemoteConfigDiff(
 	remoteConfig: RawConfig,
 	localResolvedConfig: Config
 ): ConfigDiff {
-	const normalizedLocalConfig =
-		normalizeLocalResolvedConfigAsRemote(localResolvedConfig);
+	const normalizedLocalConfig = normalizeLocalResolvedConfigAsRemote(
+		remoteConfig,
+		localResolvedConfig
+	);
 	const normalizedRemoteConfig = normalizeRemoteConfigAsResolvedLocal(
 		remoteConfig,
 		localResolvedConfig
@@ -100,11 +102,12 @@ function configDiffOnlyHasAdditionsIfAny(diff: Diff): boolean {
  * @returns The normalized config
  */
 function normalizeLocalResolvedConfigAsRemote(
+	remoteConfig: RawConfig,
 	localResolvedConfig: Config
 ): Config {
 	const subdomainValues = getSubdomainValues(
-		localResolvedConfig.workers_dev,
-		localResolvedConfig.preview_urls,
+		localResolvedConfig,
+		remoteConfig,
 		localResolvedConfig.routes ?? []
 	);
 	const normalizedConfig: Config = {


### PR DESCRIPTION
Fixes #10722.

_Describe your change..._

Instead of defaulting to `false`, `preview_urls` will default to current remote status.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): TBD
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a patch change.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
