### PR TITLE
V3 Backport [#10735]: allow WRANGLER_SEND_ERROR_REPORTS to override whether to report Wrangler crashes to Sentry

### DIFF
--- a/.changeset/angry-apes-share.md
+++ b/.changeset/angry-apes-share.md
@@ -2,4 +2,4 @@
 "wrangler": patch
 ---
 
-allow WRANGLER_SEND_METRICS to override whether to report Wrangler crashes to Sentry
+Allow WRANGLER_SEND_ERROR_REPORTS env var to override whether to report Wrangler crashes to Sentry

--- a/packages/wrangler/src/__tests__/sentry.test.ts
+++ b/packages/wrangler/src/__tests__/sentry.test.ts
@@ -123,7 +123,7 @@ describe("sentry", () => {
 			expect(sentryRequests?.length).toEqual(0);
 		});
 
-		it("should not hit sentry (or even ask) after reportable error if WRANGLER_SEND_METRICS is explicitly false", async () => {
+		it("should not hit sentry (or even ask) after reportable error if WRANGLER_SEND_ERROR_REPORTS is explicitly false", async () => {
 			// Trigger an API error
 			msw.use(
 				http.get(
@@ -138,7 +138,7 @@ describe("sentry", () => {
 				})
 			);
 			await expect(
-				runWrangler("whoami", { WRANGLER_SEND_METRICS: "false" })
+				runWrangler("whoami", { WRANGLER_SEND_ERROR_REPORTS: "false" })
 			).rejects.toMatchInlineSnapshot(`[TypeError: Failed to fetch]`);
 			expect(std.out).toMatchInlineSnapshot(`
 			"Getting User settings...
@@ -454,7 +454,7 @@ describe("sentry", () => {
 			`);
 		});
 
-		it("should hit sentry after reportable error (without confirmation) if WRANGLER_SEND_METRICS is explicitly true", async () => {
+		it("should hit sentry after reportable error (without confirmation) if WRANGLER_SEND_ERROR_REPORTS is explicitly true", async () => {
 			// Trigger an API error
 			msw.use(
 				http.get(
@@ -469,7 +469,7 @@ describe("sentry", () => {
 				})
 			);
 			await expect(
-				runWrangler("whoami", { WRANGLER_SEND_METRICS: "true" })
+				runWrangler("whoami", { WRANGLER_SEND_ERROR_REPORTS: "true" })
 			).rejects.toMatchInlineSnapshot(`[TypeError: Failed to fetch]`);
 			expect(std.out).toMatchInlineSnapshot(`
 			"Getting User settings...

--- a/packages/wrangler/src/environment-variables/factory.ts
+++ b/packages/wrangler/src/environment-variables/factory.ts
@@ -1,3 +1,5 @@
+import { UserError } from "../errors";
+
 type VariableNames =
 	| "CLOUDFLARE_ACCOUNT_ID"
 	| "CLOUDFLARE_API_BASE_URL"
@@ -22,6 +24,7 @@ type VariableNames =
 	| "WRANGLER_TOKEN_URL"
 	| "WRANGLER_OUTPUT_FILE_DIRECTORY"
 	| "WRANGLER_OUTPUT_FILE_PATH"
+	| "WRANGLER_SEND_ERROR_REPORTS"
 	| "WRANGLER_CI_MATCH_TAG"
 	| "WRANGLER_CI_OVERRIDE_NAME"
 	| "WRANGLER_BUILD_CONDITIONS"
@@ -34,6 +37,49 @@ type DeprecatedNames =
 	| "CF_API_KEY"
 	| "CF_EMAIL"
 	| "CF_API_BASE_URL";
+
+/**
+ * Create a function used to access a boolean environment variable. It may return undefined if the variable is not set.
+ *
+ * This is not memoized to allow us to change the value at runtime, such as in testing.
+ *
+ * The environment variable must be either "true" or "false" (after lowercasing), otherwise it will throw an error.
+ */
+export function getBooleanEnvironmentVariableFactory(options: {
+	variableName: VariableNames;
+}): () => boolean | undefined;
+export function getBooleanEnvironmentVariableFactory(options: {
+	variableName: VariableNames;
+	defaultValue: boolean | (() => boolean);
+}): () => boolean;
+export function getBooleanEnvironmentVariableFactory(options: {
+	variableName: VariableNames;
+	defaultValue?: boolean | (() => boolean);
+}): () => boolean | undefined {
+	return () => {
+		if (
+			!(options.variableName in process.env) ||
+			process.env[options.variableName] === undefined
+		) {
+			return typeof options.defaultValue === "function"
+				? options.defaultValue()
+				: options.defaultValue;
+		}
+
+		switch (process.env[options.variableName]?.toLowerCase()) {
+			case "true":
+				return true;
+			case "false":
+				return false;
+			default:
+				throw new UserError(
+					`Expected ${options.variableName} to be "true" or "false", but got ${JSON.stringify(
+						process.env[options.variableName]
+					)}`
+				);
+		}
+	};
+}
 
 /**
  * Create a function used to access an environment variable.

--- a/packages/wrangler/src/environment-variables/misc-variables.ts
+++ b/packages/wrangler/src/environment-variables/misc-variables.ts
@@ -1,6 +1,9 @@
 import path from "node:path";
 import { getGlobalWranglerConfigPath } from "../global-wrangler-config-path";
-import { getEnvironmentVariableFactory } from "./factory";
+import {
+	getBooleanEnvironmentVariableFactory,
+	getEnvironmentVariableFactory,
+} from "./factory";
 
 /**
  * `WRANGLER_C3_COMMAND` can override the command used by `wrangler init` when delegating to C3.
@@ -37,6 +40,14 @@ export const getC3CommandFromEnv = getEnvironmentVariableFactory({
 export const getWranglerSendMetricsFromEnv = getEnvironmentVariableFactory({
 	variableName: "WRANGLER_SEND_METRICS",
 });
+
+/**
+ * `WRANGLER_SEND_ERROR_REPORTS` can override whether we attempt to send error reports to Sentry.
+ */
+export const getWranglerSendErrorReportsFromEnv =
+	getBooleanEnvironmentVariableFactory({
+		variableName: "WRANGLER_SEND_ERROR_REPORTS",
+	});
 
 /**
  * Set `WRANGLER_API_ENVIRONMENT` environment variable to "staging" to tell Wrangler to hit the staging APIs rather than production.

--- a/packages/wrangler/src/sentry/index.ts
+++ b/packages/wrangler/src/sentry/index.ts
@@ -3,7 +3,7 @@ import { rejectedSyncPromise } from "@sentry/utils";
 import { fetch } from "undici";
 import { version as wranglerVersion } from "../../package.json";
 import { confirm } from "../dialogs";
-import { getWranglerSendMetricsFromEnv } from "../environment-variables/misc-variables";
+import { getWranglerSendErrorReportsFromEnv } from "../environment-variables/misc-variables";
 import { logger } from "../logger";
 import type { BaseTransportOptions, TransportRequest } from "@sentry/types";
 import type { RequestInit } from "undici";
@@ -151,10 +151,10 @@ export function addBreadcrumb(
 // consent if not already granted.
 export async function captureGlobalException(e: unknown) {
 	if (typeof SENTRY_DSN !== "undefined") {
-		const sendMetricsEnvVar = getWranglerSendMetricsFromEnv();
+		const sendErrorReportsEnvVar = getWranglerSendErrorReportsFromEnv();
 		sentryReportingAllowed =
-			sendMetricsEnvVar !== undefined
-				? sendMetricsEnvVar
+			sendErrorReportsEnvVar !== undefined
+				? sendErrorReportsEnvVar
 				: await confirm(
 						"Would you like to report this error to Cloudflare? Wrangler's output and the error details will be shared with the Wrangler team to help us diagnose and fix the issue.",
 						{ fallbackValue: false }


### PR DESCRIPTION
This is an automatically opened PR to backport patch changes from #10735 to Wrangler v3