### PR TITLE
[wrangler] Notify user on local dev server reload

### DIFF
--- a/.changeset/pretty-llamas-grin.md
+++ b/.changeset/pretty-llamas-grin.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Notify user on local dev server reload.
+
+When running `wrangler dev`, the local server suppresses Miniflare's reload messages to prevent duplicate log entries from the proxy and user workers. This update adds a reload complete message so users know their changes were applied, instead of only seeing "Reloading local server...".

--- a/packages/wrangler/e2e/helpers/wrangler.ts
+++ b/packages/wrangler/e2e/helpers/wrangler.ts
@@ -43,9 +43,9 @@ export class WranglerLongLivedCommand extends LongLivedCommand {
 		return match.groups as { url: string };
 	}
 
-	async waitForReload(readTimeout = 5_000): Promise<void> {
+	async waitForReload(readTimeout = 15_000): Promise<void> {
 		await this.readUntil(
-			/Detected changes, restarted server|Reloading local server\.\.\./,
+			/Detected changes, restarted server|Local server updated and ready/,
 			readTimeout
 		);
 	}

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -306,6 +306,8 @@ export class LocalRuntimeController extends RuntimeController {
 				logger.log(chalk.dim("⎔ Reloading local server..."));
 
 				await this.#mf.setOptions(options);
+
+				logger.log(chalk.dim("⎔ Local server updated and ready"));
 			}
 			// All asynchronous `Miniflare` methods will wait for all `setOptions()`
 			// calls to complete before resolving. To ensure we get the `url` and

--- a/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
@@ -210,6 +210,8 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 					logger.log(chalk.dim("⎔ Reloading local server..."));
 
 					await this.#mf.setOptions(mergedMfOptions);
+
+					logger.log(chalk.dim("⎔ Local server updated and ready"));
 				}
 
 				// All asynchronous `Miniflare` methods will wait for all `setOptions()`


### PR DESCRIPTION
### Overview

Currently, `wrangler dev` does not notify the user that reloads have completed for local servers. Users only see "Reloading local server...", which might cause confusion for users expecting a ready message.

```txt
 ⛅️ wrangler 4.39.0
───────────────────
⎔ Starting local server...
[wrangler:info] Ready on http://localhost:8787
[wrangler:info] GET / 200 OK (3ms)
⎔ Reloading local server...
[wrangler:info] GET / 200 OK (2ms)
⎔ Shutting down local server...
```

This change adds a log message to inform users the local server is ready after reload.

```txt
 ⛅️ wrangler 4.39.1
───────────────────
⎔ Starting local server...
[wrangler:info] Ready on http://localhost:8787
[wrangler:info] GET / 200 OK (3ms)
⎔ Reloading local server...
⎔ Local server updated and ready
[wrangler:info] GET / 200 OK (2ms)
⎔ Shutting down local server...
```

### Implementation Details

Because we set `logRequests: false` in the miniflare options, [miniflare's "Updated and ready" message](https://github.com/cloudflare/workers-sdk/blob/5cb806f41cc95442b2e4f7047459b1d312da9da6/packages/miniflare/src/index.ts#L2009) is suppressed for all local server reloads.

This is done to avoid duplicate log entries from the proxy and user workers, so it seems simplest for `wrangler` to provide its own reload complete message after awaiting the miniflare options change.

This also changes the `waitForReload` e2e helper function to check for the reload success message rather than the
"Updating local server..." message for a stronger guarantee that reloads have completed.

To accommodate the stronger wait condition, we set the default timeout of `waitForReload` to 15 seconds to match the `waitForReady` timeout.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Does not affect user-facing docs
- Wrangler V3 Backport
  - [x] Wrangler PR: TBD - I think this does need to be backported but we'll have to create it manually since the CI won't automatically for PRs from forks
  - [ ] Not necessary because: 

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
