### PR TITLE
Wrangler: fix `console.debug` logs not being logged at the `info` level (as users expect)

### DIFF
--- a/.changeset/mean-parks-take.md
+++ b/.changeset/mean-parks-take.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix `console.debug` logs not being logged at the `info` level (as users expect)

--- a/fixtures/worker-logs/tests/index.test.ts
+++ b/fixtures/worker-logs/tests/index.test.ts
@@ -58,6 +58,7 @@ describe("'wrangler dev' correctly displays logs", () => {
 			const output = await getWranglerDevOutput("module");
 			expect(output).toMatchInlineSnapshot(`
 				[
+				  "<<<<< console.debug() message >>>>>",
 				  "<<<<< console.info() message >>>>>",
 				  "<<<<< console.log() message >>>>>",
 				  "<<<<< stderr.write() message >>>>>",
@@ -72,6 +73,7 @@ describe("'wrangler dev' correctly displays logs", () => {
 			const output = await getWranglerDevOutput("module", ["--log-level=log"]);
 			expect(output).toMatchInlineSnapshot(`
 				[
+				  "<<<<< console.debug() message >>>>>",
 				  "<<<<< console.info() message >>>>>",
 				  "<<<<< console.log() message >>>>>",
 				  "<<<<< stderr.write() message >>>>>",
@@ -86,6 +88,7 @@ describe("'wrangler dev' correctly displays logs", () => {
 			const output = await getWranglerDevOutput("module", ["--log-level=info"]);
 			expect(output).toMatchInlineSnapshot(`
 				[
+				  "<<<<< console.debug() message >>>>>",
 				  "<<<<< console.info() message >>>>>",
 				  "X [ERROR] <<<<< console.error() message >>>>>",
 				  "▲ [WARNING] <<<<< console.warning() message >>>>>",
@@ -315,6 +318,7 @@ describe("'wrangler dev' correctly displays logs", () => {
 			]);
 			expect(output).toMatchInlineSnapshot(`
 				[
+				  "<<<<< console.debug() message >>>>>",
 				  "<<<<< console.info() message >>>>>",
 				  "<<<<< console.log() message >>>>>",
 				  "X [ERROR] <<<<< console.error() message >>>>>",

--- a/packages/wrangler/src/dev/miniflare/stdio.ts
+++ b/packages/wrangler/src/dev/miniflare/stdio.ts
@@ -185,7 +185,15 @@ function logStructuredLog(
 	}
 
 	if (level === "debug") {
-		return logger.debug(message);
+		// note that debug logs are logged at the info level, this is like so because before structured logs
+		// were introduced developers were used to call `console.debug` and get their logs in the terminal
+		// during local development and we don't want to break such workflow in a non-major release
+		// (For more context see: https://github.com/cloudflare/workers-sdk/issues/10690)
+		//
+		// TODO: for the next major release we do want the debug logs to be logged at the debug level instead,
+		//       we should also introduce some mechanism to allows users to get their worker debug logs without
+		//       also getting all the wrangler debug logs
+		return logger.info(message);
 	}
 
 	if (level === "error") {


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/10690

The changes in https://github.com/cloudflare/workers-sdk/pull/10004 made sure that wrangler prints logs at the correct log level.

This however caused `console.debug` logs not to be printed anymore at the default info level. Users also cannot get their debug logs (via `--log-level=debug`) without also getting all the noisy Wrangler logs.

So it's been decided that for the time being wrangler should log `console.debug` logs at the info level so that users keep getting them as they are used to. Then in the next major wrangler release we should update wrangler to print those logs in the debug level instead but also introduce some mechanism for allowing users to opt-out/in to the wrangler noisy debug logs.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: DX aspect not needing docs
- Wrangler V3 Backport
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/10758
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
