### PR TITLE
BACKPORT #10668 - wrangler: fix: support the deletion of secrets with complex names

### DIFF
--- a/.changeset/warm-clowns-visit.md
+++ b/.changeset/warm-clowns-visit.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Support the deletion of secrets with complex names

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -530,16 +530,15 @@ describe("wrangler secret", () => {
 			msw.use(
 				http.delete(
 					`*/accounts/:accountId/workers/${servicesOrScripts}/:scriptName${environment}/secrets/:secretName`,
-					({ params }) => {
+					({ request, params }) => {
 						expect(params.accountId).toEqual("some-account-id");
 						expect(params.scriptName).toEqual(
 							legacyEnv && env ? `script-name-${env}` : "script-name"
 						);
-						if (!legacyEnv) {
-							if (env) {
-								expect(params.secretName).toEqual(input.secretName);
-							}
-						}
+						expect(params.secretName).toEqual(input.secretName);
+						expect(
+							new URL(request.url).searchParams.get("url_encoded")
+						).toEqual("true");
 						return HttpResponse.json(createFetchResult(null));
 					},
 					{ once: true }
@@ -580,6 +579,24 @@ describe("wrangler secret", () => {
 
 				🌀 Deleting the secret the-key on the Worker script-name
 				✨ Success! Deleted secret the-key"
+			`);
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
+		it("should delete a secret which name includes special characters", async () => {
+			mockDeleteRequest({ scriptName: "script-name", secretName: "the/key" });
+			mockConfirm({
+				text: "Are you sure you want to permanently delete the secret the/key on the Worker script-name?",
+				result: true,
+			});
+			await runWrangler("secret delete the/key --name script-name");
+			expect(std.out).toMatchInlineSnapshot(`
+				"
+				 ⛅️ wrangler x.x.x
+				------------------
+
+				🌀 Deleting the secret the/key on the Worker script-name
+				✨ Success! Deleted secret the/key"
 			`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -310,7 +310,13 @@ export const secretDeleteCommand = createCommand({
 					? `/accounts/${accountId}/workers/scripts/${scriptName}/secrets`
 					: `/accounts/${accountId}/workers/services/${scriptName}/environments/${args.env}/secrets`;
 
-			await fetchResult(`${url}/${args.key}`, { method: "DELETE" });
+			await fetchResult(
+				`${url}/${encodeURIComponent(args.key)}`,
+				{ method: "DELETE" },
+				new URLSearchParams({
+					url_encoded: "true",
+				})
+			);
 			metrics.sendMetricsEvent("delete encrypted variable", {
 				sendMetrics: config.send_metrics,
 			});


### PR DESCRIPTION
URL encode the secret names before being sent to the API, should allow users to delete secrets with complex names. Change is still compatible with older Wrangler versions thanks to the optional query param flag `url_encoded`.

Backport for https://github.com/cloudflare/workers-sdk/pull/10668

