### PR TITLE
Do not override any `.env` settings in `.gitignore` files

### DIFF
--- a/.changeset/silly-parks-fall.md
+++ b/.changeset/silly-parks-fall.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+do not override .env settings in .gitignore files

--- a/.changeset/silly-parks-fall.md
+++ b/.changeset/silly-parks-fall.md
@@ -2,4 +2,11 @@
 "create-cloudflare": patch
 ---
 
-do not override .env settings in .gitignore files
+Do not override any `.env` settings in `.gitignore` files
+
+Previously we only looked for `.env*` in the `gitignore` but now we cover more cases such as:
+
+- `.env`
+- `.env\*`
+- `.env.<local|production|staging>`
+- `/env\*.<local|production|staging>`

--- a/.changeset/silly-parks-fall.md
+++ b/.changeset/silly-parks-fall.md
@@ -8,5 +8,5 @@ Previously we only looked for `.env*` in the `gitignore` but now we cover more c
 
 - `.env`
 - `.env\*`
-- `.env.<local|production|staging>`
-- `/env\*.<local|production|staging>`
+- `.env.<local|production|staging|...>`
+- `.env\*.<local|production|staging|...>`

--- a/packages/create-cloudflare/src/__tests__/templates.test.ts
+++ b/packages/create-cloudflare/src/__tests__/templates.test.ts
@@ -320,6 +320,32 @@ describe("addWranglerToGitIgnore", () => {
 		`);
 	});
 
+	test("should not add the .env entries if some form of .env entries are already included", () => {
+		mockGitIgnore(
+			"my-project/.gitignore",
+			`
+			.env
+			.env.*
+			!.env.example
+			`,
+		);
+		addWranglerToGitIgnore({
+			project: { path: "my-project" },
+		} as unknown as C3Context);
+
+		expect(appendFileResults.file).toMatchInlineSnapshot(
+			`"my-project/.gitignore"`,
+		);
+		expect(appendFileResults.content).toMatchInlineSnapshot(`
+			"
+			# wrangler files
+			.wrangler
+			.dev.vars*
+			!.dev.vars.example
+			"
+		`);
+	});
+
 	test("should not add the .wrangler entry if a .wrangler/ is already included)", () => {
 		mockGitIgnore(
 			"my-project/.gitignore",

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -958,6 +958,22 @@ export const addWranglerToGitIgnore = (ctx: C3Context) => {
 		wranglerGitIgnoreFilesToAdd.push("!.dev.vars.example");
 	}
 
+	/**
+	 * We check for the following type of occurrences:
+	 *
+	 * ```
+	 * .env
+	 * .env*
+	 * .env.<local|production|staging>
+	 * /env*.<local|production|staging>
+	 * ```
+	 *
+	 * Any of these may alone on a line or be followed by a space and a trailing comment:
+	 *
+	 * ```
+	 * .env.<local|production|staging> # some trailing comment
+	 * ```
+	 */
 	const hasDotEnv = existingGitIgnoreContent.match(
 		/^\/?\.env\*?(\..*?)?(\s|$)/m,
 	);

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -958,7 +958,9 @@ export const addWranglerToGitIgnore = (ctx: C3Context) => {
 		wranglerGitIgnoreFilesToAdd.push("!.dev.vars.example");
 	}
 
-	const hasDotEnv = existingGitIgnoreContent.match(/^\/?\.env\*(\s|$)/m);
+	const hasDotEnv = existingGitIgnoreContent.match(
+		/^\/?\.env\*?(\..*?)?(\s|$)/m,
+	);
 	if (!hasDotEnv) {
 		wranglerGitIgnoreFilesToAdd.push(".env*");
 	}

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -964,8 +964,8 @@ export const addWranglerToGitIgnore = (ctx: C3Context) => {
 	 * ```
 	 * .env
 	 * .env*
-	 * .env.<local|production|staging>
-	 * /env*.<local|production|staging>
+	 * .env.<local|production|staging|...>
+	 * .env*.<local|production|staging|...>
 	 * ```
 	 *
 	 * Any of these may alone on a line or be followed by a space and a trailing comment:


### PR DESCRIPTION
Previously we only looked for `.env*` in the `gitignore` but now we cover more cases such as:

- `.env`
- `.env\*`
- `.env.<local|production|staging>`
- `.env\*.<local|production|staging>`


Fixes https://github.com/cloudflare/workers-sdk/issues/10749

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> create-cloudflare not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
