### PR TITLE
Mark more errors as `UserError`

### DIFF
--- a/.changeset/popular-moons-knock.md
+++ b/.changeset/popular-moons-knock.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/containers-shared": patch
+"miniflare": patch
+"wrangler": patch
+---
+
+Mark more errors as `UserError` to disable Sentry reporting

--- a/fixtures/ratelimit-app/tsconfig.json
+++ b/fixtures/ratelimit-app/tsconfig.json
@@ -1,9 +1,9 @@
 {
 	"compilerOptions": {
-		"target": "ES2020",
+		"target": "esnext",
 		"esModuleInterop": true,
 		"module": "CommonJS",
-		"lib": ["ES2020"],
+		"lib": ["esnext"],
 		"types": ["node"],
 		"skipLibCheck": true,
 		"moduleResolution": "node",

--- a/fixtures/worker-ts/wrangler.jsonc
+++ b/fixtures/worker-ts/wrangler.jsonc
@@ -1,11 +1,6 @@
 {
+	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "worker-ts",
 	"main": "src/index.ts",
 	"compatibility_date": "2023-05-04",
-	"hyperdrive": [
-		{
-			"binding": "H",
-			"id": "hello",
-		},
-	],
 }

--- a/packages/containers-shared/src/build.ts
+++ b/packages/containers-shared/src/build.ts
@@ -1,5 +1,6 @@
 import { spawn } from "child_process";
 import { readFileSync } from "fs";
+import { UserError } from "./error";
 import type {
 	BuildArgs,
 	ContainerDevOptions,
@@ -70,7 +71,7 @@ export function dockerBuild(
 			resolve();
 		} else if (!errorHandled) {
 			errorHandled = true;
-			reject(new Error(`Docker build exited with code: ${code}`));
+			reject(new UserError(`Docker build exited with code: ${code}`));
 		}
 	});
 	child.on("error", (err) => {

--- a/packages/containers-shared/src/error.ts
+++ b/packages/containers-shared/src/error.ts
@@ -17,7 +17,11 @@ export class UserError extends Error {
 	telemetryMessage: string | undefined;
 	constructor(
 		message?: string | undefined,
-		options?: (ErrorOptions & TelemetryMessage) | undefined
+		options?:
+			| ({
+					cause?: unknown;
+			  } & TelemetryMessage)
+			| undefined
 	) {
 		super(message, options);
 		// Restore prototype chain:

--- a/packages/containers-shared/src/error.ts
+++ b/packages/containers-shared/src/error.ts
@@ -1,0 +1,29 @@
+/**
+ * This is used to provide telemetry with a sanitised error
+ * message that could not have any user-identifying information.
+ * Set to `true` to duplicate `message`.
+ *  */
+type TelemetryMessage = {
+	telemetryMessage?: string | true;
+};
+
+/**
+ * Base class for errors where the user has done something wrong. These are not
+ * reported to Sentry. API errors are intentionally *not* `UserError`s, and are
+ * reported to Sentry. This will help us understand which API errors need better
+ * messaging.
+ */
+export class UserError extends Error {
+	telemetryMessage: string | undefined;
+	constructor(
+		message?: string | undefined,
+		options?: (ErrorOptions & TelemetryMessage) | undefined
+	) {
+		super(message, options);
+		// Restore prototype chain:
+		// https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#support-for-newtarget
+		Object.setPrototypeOf(this, new.target.prototype);
+		this.telemetryMessage =
+			options?.telemetryMessage === true ? message : options?.telemetryMessage;
+	}
+}

--- a/packages/containers-shared/src/images.ts
+++ b/packages/containers-shared/src/images.ts
@@ -1,4 +1,5 @@
 import { buildImage } from "./build";
+import { UserError } from "./error";
 import {
 	getCloudflareContainerRegistry,
 	isCloudflareRegistryLink,
@@ -72,7 +73,7 @@ export async function prepareContainerImagesForDev(args: {
 	} = args;
 	let aborted = false;
 	if (process.platform === "win32") {
-		throw new Error(
+		throw new UserError(
 			"Local development with containers is currently not supported on Windows. You should use WSL instead. You can also set `enable_containers` to false if you do not need to develop the container part of your application."
 		);
 	}
@@ -94,7 +95,7 @@ export async function prepareContainerImagesForDev(args: {
 			});
 		} else {
 			if (!isCloudflareRegistryLink(options.image_uri)) {
-				throw new Error(
+				throw new UserError(
 					`Image "${options.image_uri}" is a registry link but does not point to the Cloudflare container registry.\n` +
 						`To use an existing image from another repository, see https://developers.cloudflare.com/containers/image-management/#using-existing-images`
 				);

--- a/packages/containers-shared/src/inspect.ts
+++ b/packages/containers-shared/src/inspect.ts
@@ -1,4 +1,5 @@
 import { spawn } from "child_process";
+import { UserError } from "./error";
 
 export async function dockerImageInspect(
 	dockerPath: string,
@@ -22,7 +23,7 @@ export async function dockerImageInspect(
 		proc.on("close", (code) => {
 			if (code !== 0) {
 				return reject(
-					new Error(`failed inspecting image locally: ${stderr.trim()}`)
+					new UserError(`failed inspecting image locally: ${stderr.trim()}`)
 				);
 			}
 			resolve(stdout.trim());

--- a/packages/containers-shared/src/login.ts
+++ b/packages/containers-shared/src/login.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { ImageRegistriesService, ImageRegistryPermissions } from "./client";
+import { UserError } from "./error";
 import { getCloudflareContainerRegistry } from "./knobs";
 
 /**
@@ -44,7 +45,7 @@ export async function dockerLoginManagedRegistry(pathToDocker: string) {
 			if (code === 0) {
 				resolve();
 			} else {
-				reject(new Error(`Login failed with code: ${code}`));
+				reject(new UserError(`Login failed with code: ${code}`));
 			}
 		});
 	});

--- a/packages/containers-shared/tests/docker-context.test.ts
+++ b/packages/containers-shared/tests/docker-context.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "child_process";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { UserError } from "../src/error";
 import { resolveDockerHost } from "../src/utils";
 
 vi.mock("node:child_process");
@@ -41,7 +42,7 @@ describe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
 
 		it("should fall back to platform default when context fails", () => {
 			vi.mocked(execFileSync).mockImplementation(() => {
-				throw new Error("Docker command failed");
+				throw new UserError("Docker command failed");
 			});
 
 			const result = resolveDockerHost("/no/op/docker");

--- a/packages/edge-preview-authenticated-proxy/tests/tsconfig.json
+++ b/packages/edge-preview-authenticated-proxy/tests/tsconfig.json
@@ -1,8 +1,8 @@
 {
 	"compilerOptions": {
-		"target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+		"target": "esnext" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
 		"lib": [
-			"es2021"
+			"esnext"
 		] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
 		"module": "es2022" /* Specify what module code is generated. */,
 		"moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -2001,7 +2001,8 @@ export class Miniflare {
 		const maybeSocketPorts = await this.#runtime.updateConfig(
 			configBuffer,
 			runtimeOpts,
-			this.#workerOpts.flatMap((w) => w.core.name ?? [])
+			this.#workerOpts.flatMap((w) => w.core.name ?? []),
+			this.#disposeController.signal
 		);
 		if (this.#disposeController.signal.aborted) return;
 		if (maybeSocketPorts === undefined) {

--- a/packages/miniflare/src/runtime/index.ts
+++ b/packages/miniflare/src/runtime/index.ts
@@ -4,13 +4,14 @@ import { randomBytes } from "crypto";
 import { Abortable, once } from "events";
 import path from "path";
 import rl from "readline";
-import { Readable } from "stream";
+import { Readable, Transform } from "stream";
 import { $ as $colors, red } from "kleur/colors";
 import workerdPath, {
 	compatibilityDate as supportedCompatibilityDate,
 } from "workerd";
 import { z } from "zod";
 import { SERVICE_LOOPBACK, SOCKET_ENTRY } from "../plugins";
+import { MiniflareCoreError } from "../shared";
 import { Awaitable } from "../workers";
 
 const ControlMessageSchema = z.discriminatedUnion("event", [
@@ -149,6 +150,54 @@ function getInspectorOptions() {
 	}
 }
 
+class StartupLogBuffer {
+	stdoutStream: Transform;
+	stderrStream: Transform;
+	stdoutBuffer: string[] = [];
+	stderrBuffer: string[] = [];
+
+	buffering = true;
+
+	constructor() {
+		this.stdoutStream = new Transform({
+			transform: (chunk, encoding, callback) => {
+				if (this.buffering) {
+					this.stdoutBuffer.push(chunk.toString());
+				}
+				callback(null, chunk);
+			},
+		});
+		this.stderrStream = new Transform({
+			transform: (chunk, encoding, callback) => {
+				if (this.buffering) {
+					this.stderrBuffer.push(chunk.toString());
+				}
+				callback(null, chunk);
+			},
+		});
+	}
+
+	stopBuffering() {
+		this.buffering = false;
+	}
+
+	handleStartupFailure() {
+		const addressInUseLog = this.stderrBuffer.find((chunk) =>
+			chunk.includes("Address already in use; toString() = ")
+		);
+		if (addressInUseLog) {
+			const [_, host, port] = addressInUseLog.match(
+				/Address already in use; toString\(\) = (.+):(.+)/
+			) ?? ["", "unknown", "unknown"];
+
+			throw new MiniflareCoreError(
+				"ERR_ADDRESS_IN_USE",
+				`Address already in use (${host}:${port}). Please check that you are not already running a server on this address or specify a different port with --port.`
+			);
+		}
+	}
+}
+
 export class Runtime {
 	#process?: childProcess.ChildProcess;
 	#processExitPromise?: Promise<void>;
@@ -157,7 +206,7 @@ export class Runtime {
 		configBuffer: Buffer,
 		options: Abortable & RuntimeOptions,
 		workerNames: string[]
-	): Promise<SocketPorts | undefined> {
+	): Promise<SocketPorts> {
 		// 1. Stop existing process (if any) and wait for exit
 		await this.dispose();
 		// TODO: what happens if runtime crashes?
@@ -172,11 +221,16 @@ export class Runtime {
 			stdio: ["pipe", "pipe", "pipe", "pipe"],
 			env: { ...process.env, FORCE_COLOR },
 		});
+		const startupLogBuffer = new StartupLogBuffer();
 		this.#process = runtimeProcess;
 		this.#processExitPromise = waitForExit(runtimeProcess);
 
 		const handleRuntimeStdio = options.handleRuntimeStdio ?? pipeOutput;
-		handleRuntimeStdio(runtimeProcess.stdout, runtimeProcess.stderr);
+
+		handleRuntimeStdio(
+			runtimeProcess.stdout.pipe(startupLogBuffer.stdoutStream),
+			runtimeProcess.stderr.pipe(startupLogBuffer.stderrStream)
+		);
 
 		const controlPipe = runtimeProcess.stdio[3];
 		assert(controlPipe instanceof Readable);
@@ -226,6 +280,18 @@ export class Runtime {
 				p.unref();
 			}
 		}
+
+		startupLogBuffer.stopBuffering();
+
+		if (!ports) {
+			startupLogBuffer.handleStartupFailure();
+			throw new MiniflareCoreError(
+				"ERR_RUNTIME_FAILURE",
+				"The Workers runtime failed to start. " +
+					"There is likely additional logging output above."
+			);
+		}
+
 		return ports;
 	}
 

--- a/packages/miniflare/src/runtime/index.ts
+++ b/packages/miniflare/src/runtime/index.ts
@@ -205,8 +205,9 @@ export class Runtime {
 	async updateConfig(
 		configBuffer: Buffer,
 		options: Abortable & RuntimeOptions,
-		workerNames: string[]
-	): Promise<SocketPorts> {
+		workerNames: string[],
+		abortSignal: AbortSignal
+	): Promise<SocketPorts | undefined> {
 		// 1. Stop existing process (if any) and wait for exit
 		await this.dispose();
 		// TODO: what happens if runtime crashes?
@@ -283,13 +284,8 @@ export class Runtime {
 
 		startupLogBuffer.stopBuffering();
 
-		if (!ports) {
+		if (ports === undefined && !abortSignal.aborted) {
 			startupLogBuffer.handleStartupFailure();
-			throw new MiniflareCoreError(
-				"ERR_RUNTIME_FAILURE",
-				"The Workers runtime failed to start. " +
-					"There is likely additional logging output above."
-			);
 		}
 
 		return ports;

--- a/packages/miniflare/src/runtime/index.ts
+++ b/packages/miniflare/src/runtime/index.ts
@@ -186,13 +186,13 @@ class StartupLogBuffer {
 			chunk.includes("Address already in use; toString() = ")
 		);
 		if (addressInUseLog) {
-			const [_, host, port] = addressInUseLog.match(
+			const match = addressInUseLog.match(
 				/Address already in use; toString\(\) = (.+):(.+)/
 			) ?? ["", "unknown", "unknown"];
 
 			throw new MiniflareCoreError(
 				"ERR_ADDRESS_IN_USE",
-				`Address already in use (${host}:${port}). Please check that you are not already running a server on this address or specify a different port with --port.`
+				`Address already in use (${match[1]}:${match[2]}). Please check that you are not already running a server on this address or specify a different port with --port.`
 			);
 		}
 	}

--- a/packages/miniflare/src/shared/error.ts
+++ b/packages/miniflare/src/shared/error.ts
@@ -1,4 +1,4 @@
-const USER_ERROR_CODES = new Set([
+export const USER_ERROR_CODES = new Set([
 	"ERR_ADDRESS_IN_USE", // Runtime failed to start because the address was in use
 	"ERR_DISPOSED", // Attempted to use Miniflare instance after calling dispose()
 	"ERR_MODULE_PARSE", // SyntaxError when attempting to parse/locate modules
@@ -18,7 +18,7 @@ const USER_ERROR_CODES = new Set([
 	"ERR_MISSING_INSPECTOR_PROXY_PORT", // An inspector proxy has been requested but no inspector port to use has been specified
 ] as const);
 
-const SYSTEM_ERROR_CODES = new Set([
+export const SYSTEM_ERROR_CODES = new Set([
 	"ERR_RUNTIME_FAILURE", // Runtime failed to start
 	"ERR_CYCLIC", // Generate cyclic workerd config
 	"ERR_PLUGIN_LOADING_FAILED",
@@ -50,7 +50,7 @@ export class MiniflareError<Code extends string = string> extends Error {
 	}
 }
 
-type KeyTypes<T> = T extends Set<infer Keys> ? Keys : never;
+export type KeyTypes<T> = T extends Set<infer Keys> ? Keys : never;
 
 export type MiniflareCoreErrorCode =
 	| KeyTypes<typeof USER_ERROR_CODES>

--- a/packages/miniflare/src/shared/error.ts
+++ b/packages/miniflare/src/shared/error.ts
@@ -1,6 +1,30 @@
-export class MiniflareError<
-	Code extends string | number = string | number,
-> extends Error {
+const USER_ERROR_CODES = new Set([
+	"ERR_ADDRESS_IN_USE", // Runtime failed to start because the address was in use
+	"ERR_DISPOSED", // Attempted to use Miniflare instance after calling dispose()
+	"ERR_MODULE_PARSE", // SyntaxError when attempting to parse/locate modules
+	"ERR_MODULE_STRING_SCRIPT", // Attempt to resolve module within string script
+	"ERR_MODULE_DYNAMIC_SPEC", // Attempted to import/require a module without a literal spec
+	"ERR_MODULE_RULE", // No matching module rule for file
+	"ERR_PERSIST_UNSUPPORTED", // Unsupported storage persistence protocol
+	"ERR_FUTURE_COMPATIBILITY_DATE", // Compatibility date in the future
+	"ERR_NO_WORKERS", // No workers defined
+	"ERR_VALIDATION", // Options failed to parse
+	"ERR_DUPLICATE_NAME", // Multiple workers defined with same name
+	"ERR_DIFFERENT_STORAGE_BACKEND", // Multiple Durable Object bindings declared for same class with different storage backends
+	"ERR_DIFFERENT_UNIQUE_KEYS", // Multiple Durable Object bindings declared for same class with different unsafe unique keys
+	"ERR_DIFFERENT_PREVENT_EVICTION", // Multiple Durable Object bindings declared for same class with different unsafe prevent eviction values
+	"ERR_MULTIPLE_OUTBOUNDS", // Both `outboundService` and `fetchMock` specified
+	"ERR_INVALID_WRAPPED", // Worker not allowed to be used as wrapped binding
+	"ERR_MISSING_INSPECTOR_PROXY_PORT", // An inspector proxy has been requested but no inspector port to use has been specified
+] as const);
+
+const SYSTEM_ERROR_CODES = new Set([
+	"ERR_RUNTIME_FAILURE", // Runtime failed to start
+	"ERR_CYCLIC", // Generate cyclic workerd config
+	"ERR_PLUGIN_LOADING_FAILED",
+] as const);
+
+export class MiniflareError<Code extends string = string> extends Error {
 	constructor(
 		readonly code: Code,
 		message?: string,
@@ -12,28 +36,24 @@ export class MiniflareError<
 		Object.setPrototypeOf(this, new.target.prototype);
 		this.name = `${new.target.name} [${code}]`;
 	}
+
+	// Is this caused by user error in using/configuring Miniflare...
+	isUserError() {
+		return USER_ERROR_CODES.has(this.code as KeyTypes<typeof USER_ERROR_CODES>);
+	}
+
+	// ...or has something unexpected gone wrong?
+	isSystemError() {
+		return SYSTEM_ERROR_CODES.has(
+			this.code as KeyTypes<typeof SYSTEM_ERROR_CODES>
+		);
+	}
 }
 
+type KeyTypes<T> = T extends Set<infer Keys> ? Keys : never;
+
 export type MiniflareCoreErrorCode =
-	| "ERR_RUNTIME_FAILURE" // Runtime failed to start
-	| "ERR_DISPOSED" // Attempted to use Miniflare instance after calling dispose()
-	| "ERR_MODULE_PARSE" // SyntaxError when attempting to parse/locate modules
-	| "ERR_MODULE_STRING_SCRIPT" // Attempt to resolve module within string script
-	| "ERR_MODULE_DYNAMIC_SPEC" // Attempted to import/require a module without a literal spec
-	| "ERR_MODULE_RULE" // No matching module rule for file
-	| "ERR_PERSIST_UNSUPPORTED" // Unsupported storage persistence protocol
-	| "ERR_PERSIST_REMOTE_UNAUTHENTICATED" // cloudflareFetch implementation not provided
-	| "ERR_PERSIST_REMOTE_UNSUPPORTED" // Remote storage is not supported for this database
-	| "ERR_FUTURE_COMPATIBILITY_DATE" // Compatibility date in the future
-	| "ERR_NO_WORKERS" // No workers defined
-	| "ERR_VALIDATION" // Options failed to parse
-	| "ERR_DUPLICATE_NAME" // Multiple workers defined with same name
-	| "ERR_DIFFERENT_STORAGE_BACKEND" // Multiple Durable Object bindings declared for same class with different storage backends
-	| "ERR_DIFFERENT_UNIQUE_KEYS" // Multiple Durable Object bindings declared for same class with different unsafe unique keys
-	| "ERR_DIFFERENT_PREVENT_EVICTION" // Multiple Durable Object bindings declared for same class with different unsafe prevent eviction values
-	| "ERR_MULTIPLE_OUTBOUNDS" // Both `outboundService` and `fetchMock` specified
-	| "ERR_INVALID_WRAPPED" // Worker not allowed to be used as wrapped binding
-	| "ERR_CYCLIC" // Generate cyclic workerd config
-	| "ERR_MISSING_INSPECTOR_PROXY_PORT" // An inspector proxy has been requested but no inspector port to use has been specified
-	| "ERR_PLUGIN_LOADING_FAILED"; // Requested external plugins could not be loaded
+	| KeyTypes<typeof USER_ERROR_CODES>
+	| KeyTypes<typeof SYSTEM_ERROR_CODES>;
+
 export class MiniflareCoreError extends MiniflareError<MiniflareCoreErrorCode> {}

--- a/packages/wrangler/src/api/startDevWorker/DevEnv.ts
+++ b/packages/wrangler/src/api/startDevWorker/DevEnv.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert";
 import { EventEmitter } from "node:events";
+import { MiniflareCoreError } from "miniflare";
+import { UserError } from "../../errors";
 import { logger, runWithLogLevel } from "../../logger";
 import { formatMessage, ParseError } from "../../parse";
 import { BundlerController } from "./BundlerController";
@@ -123,7 +125,9 @@ export class DevEnv extends EventEmitter {
 	}
 
 	emitErrorEvent(ev: ErrorEvent) {
-		if (
+		if (ev.cause instanceof MiniflareCoreError && ev.cause.isUserError()) {
+			this.emit("error", new UserError(ev.cause.message));
+		} else if (
 			ev.source === "ProxyController" &&
 			(ev.reason.startsWith("Failed to send message to") ||
 				ev.reason.startsWith("Could not connect to InspectorProxyWorker"))

--- a/packages/wrangler/src/d1/execute.ts
+++ b/packages/wrangler/src/d1/execute.ts
@@ -533,7 +533,7 @@ async function pollUntilComplete(
 	db: Database
 ): Promise<ImportPollingResponse> {
 	if (!response.success) {
-		throw new Error(response.error);
+		throw new UserError(response.error);
 	}
 
 	response.messages.forEach((line) => {


### PR DESCRIPTION
- Wrangler uses a lot of code from `@cloudflare/containers-shared`. Sometimes, that code throws an error. Previously, it threw a plain `Error` class, which Wrangler treated as a _system_ error, allowing users to report it to Sentry. However, pretty much all of those errors should actually have been treated as _user_ errors, which don't get reported to Sentry. As such, `@cloudflare/containers-shared` now has it's own `UserError` class which Wrangler will recognise as well.
- Miniflare previously reported all startup errors as `ERR_RUNTIME_FAILED`. Now, we distinguish between user and system errors, and report the common case of "Address in use" errors as a user error
- D1 previously threw an `Error` class when something went wrong querying SQL—that's now a `UserError`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: existing test coverage is sufficient, and shouldn't break
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal detail
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not user facing

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
