### PR TITLE
Fix Worker Loader binding type

### DIFF
--- a/.changeset/modern-bobcats-tie.md
+++ b/.changeset/modern-bobcats-tie.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix Worker Loader binding type

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -2405,7 +2405,7 @@ const validateUnsafeBinding: ValidatorFn = (diagnostics, field, value) => {
 			"logfwdr",
 			"mtls_certificate",
 			"pipeline",
-			"worker-loader",
+			"worker_loader",
 			"vpc_service",
 		];
 

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -160,7 +160,7 @@ export type WorkerMetadataBinding =
 	  }
 	| { type: "vpc_service"; name: string; service_id: string }
 	| {
-			type: "worker-loader";
+			type: "worker_loader";
 			name: string;
 	  }
 	| {
@@ -515,7 +515,7 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 	bindings.worker_loaders?.forEach(({ binding }) => {
 		metadataBindings.push({
 			name: binding,
-			type: "worker-loader",
+			type: "worker_loader",
 		});
 	});
 

--- a/packages/wrangler/src/utils/map-worker-metadata-bindings.ts
+++ b/packages/wrangler/src/utils/map-worker-metadata-bindings.ts
@@ -319,7 +319,7 @@ export async function mapWorkerMetadataBindings(
 							];
 						}
 						break;
-					case "worker-loader":
+					case "worker_loader":
 						{
 							configObj.worker_loaders = [
 								...(configObj.worker_loaders ?? []),


### PR DESCRIPTION
Turns out it's `worker_loader` not `worker-loader`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: still in private beta—will follow up with tests
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: handled elsewhere
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not available in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
