### PR TITLE
Backport (#10112) - fix: allow Workflow bindings when calling getPlatformProxy()

### DIFF
--- a/.changeset/modern-flowers-care.md
+++ b/.changeset/modern-flowers-care.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+fix: allow Workflow bindings when calling getPlatformProxy()
+
+Workflow bindings are not supported in practice when using `getPlatformProxy()`.
+But their existence in a Wrangler config file should not prevent other bindings from working.
+Previously, calling `getPlatformProxy()` would crash if there were any Workflow bindings defined.
+Now, instead, you get a warning telling you that these bindings are not available.

--- a/fixtures/get-platform-proxy/tests/get-platform-proxy.env.test.ts
+++ b/fixtures/get-platform-proxy/tests/get-platform-proxy.env.test.ts
@@ -14,6 +14,7 @@ import type {
 	Fetcher,
 	Hyperdrive,
 	KVNamespace,
+	Workflow,
 } from "@cloudflare/workers-types";
 import type { Unstable_DevWorker } from "wrangler";
 
@@ -28,16 +29,21 @@ type Env = {
 	MY_D1: D1Database;
 	MY_HYPERDRIVE: Hyperdrive;
 	ASSETS: Fetcher;
+	MY_WORKFLOW_INTERNAL: Workflow;
+	MY_WORKFLOW_EXTERNAL: Workflow;
 };
 
 const wranglerConfigFilePath = path.join(__dirname, "..", "wrangler.jsonc");
 
 describe("getPlatformProxy - env", () => {
 	let devWorkers: Unstable_DevWorker[];
+	let warn = {} as MockInstance<typeof console.warn>;
 
 	beforeEach(() => {
 		// Hide stdout messages from the test logs
 		vi.spyOn(console, "log").mockImplementation(() => {});
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 	});
 
 	describe("var bindings", () => {
@@ -221,41 +227,20 @@ describe("getPlatformProxy - env", () => {
 	});
 
 	describe("DO warnings", () => {
-		let warn = {} as MockInstance<typeof console.warn>;
-		beforeEach(() => {
-			warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-		});
-		afterEach(() => {
-			warn.mockRestore();
-		});
-
 		it("warns about internal DOs and doesn't crash", async () => {
 			await getPlatformProxy<Env>({
 				configPath: path.join(__dirname, "..", "wrangler_internal_do.jsonc"),
 			});
-			expect(warn).toMatchInlineSnapshot(`
-				[MockFunction warn] {
-				  "calls": [
-				    [
-				      "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m				You have defined bindings to the following internal Durable Objects:[0m
+			expect(warn.mock.calls[0][0].replaceAll(/[\r\n]+/g, "\n"))
+				.toMatchInlineSnapshot(`
+					"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m				You have defined bindings to the following internal Durable Objects:[0m
+					  				- {"class_name":"MyDurableObject","name":"MY_DURABLE_OBJECT"}
+					  				These will not work in local development, but they should work in production.
 
-				  				- {"class_name":"MyDurableObject","name":"MY_DURABLE_OBJECT"}
-				  				These will not work in local development, but they should work in production.
-				  
-				  				If you want to develop these locally, you can define your DO in a separate Worker, with a separate configuration file.
-				  				For detailed instructions, refer to the Durable Objects section here: [4mhttps://developers.cloudflare.com/workers/wrangler/api#supported-bindings[0m
-
-				",
-				    ],
-				  ],
-				  "results": [
-				    {
-				      "type": "return",
-				      "value": undefined,
-				    },
-				  ],
-				}
-			`);
+					  				If you want to develop these locally, you can define your DO in a separate Worker, with a separate configuration file.
+					  				For detailed instructions, refer to the Durable Objects section here: [4mhttps://developers.cloudflare.com/workers/wrangler/api#supported-bindings[0m
+					"
+				`);
 		});
 
 		it("doesn't warn about external DOs and doesn't crash", async () => {
@@ -263,6 +248,20 @@ describe("getPlatformProxy - env", () => {
 				configPath: path.join(__dirname, "..", "wrangler_external_do.jsonc"),
 			});
 			expect(warn).not.toHaveBeenCalled();
+		});
+
+		it("warns about Workflows and doesn't crash", async () => {
+			await getPlatformProxy<Env>({
+				configPath: path.join(__dirname, "..", "wrangler_workflow.jsonc"),
+			});
+			expect(warn.mock.calls[0][0].replaceAll(/[\r\n]+/g, "\n"))
+				.toMatchInlineSnapshot(`
+					"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m				You have defined bindings to the following Workflows:[0m
+					  				- {"binding":"MY_WORKFLOW_INTERNAL","name":"my-workflow-internal","class_name":"MyWorkflowInternal"}
+					  - {"binding":"MY_WORKFLOW_EXTERNAL","name":"my-workflow-external","class_name":"MyWorkflowExternal","script_name":"OtherWorker"}
+					  				These are not available in local development, so you will not be able to bind to them when testing locally, but they should work in production.
+					"
+				`);
 		});
 	});
 

--- a/fixtures/get-platform-proxy/vitest.config.mts
+++ b/fixtures/get-platform-proxy/vitest.config.mts
@@ -6,5 +6,6 @@ export default defineConfig({
 		hookTimeout: 25_000,
 		teardownTimeout: 25_000,
 		useAtomics: true,
+		restoreMocks: true,
 	},
 });

--- a/fixtures/get-platform-proxy/wrangler_workflow.jsonc
+++ b/fixtures/get-platform-proxy/wrangler_workflow.jsonc
@@ -1,0 +1,22 @@
+{
+	"name": "workflow-test",
+	"main": "src/index.ts",
+	// An internal workflow is indicated by the binding not specifying a script name.
+	// This implies the workflow is exported alongside this worker in `index.ts`, which it isn't actually.
+	// However we don't care about this here because `getPlatformProxy()` will discard all user code anyway.
+	// We are simply making sure the warning shows up.
+	"compatibility_date": "2023-11-21",
+	"workflows": [
+		{
+			"binding": "MY_WORKFLOW_INTERNAL",
+			"name": "my-workflow-internal",
+			"class_name": "MyWorkflowInternal",
+		},
+		{
+			"binding": "MY_WORKFLOW_EXTERNAL",
+			"name": "my-workflow-external",
+			"class_name": "MyWorkflowExternal",
+			"script_name": "OtherWorker",
+		},
+	],
+}

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -161,6 +161,17 @@ async function getMiniflareOptionsFromConfig(
 		durableObjects: rawConfig["durable_objects"],
 	});
 
+	if (rawConfig.workflows?.length > 0) {
+		logger.warn(dedent`
+				You have defined bindings to the following Workflows:
+				${rawConfig.workflows.map((b) => `- ${JSON.stringify(b)}`).join("\n")}
+				These are not available in local development, so you will not be able to bind to them when testing locally, but they should work in production.
+				`);
+
+		// Remove workflows from bindings to prevent Miniflare from complaining
+		bindings.workflows = [];
+	}
+
 	const { bindingOptions, externalWorkers } = buildMiniflareBindingOptions({
 		name: rawConfig.name,
 		bindings,


### PR DESCRIPTION
Workflow bindings are not supported in practice when using `getPlatformProxy()`. But their existence in a Wrangler config file should not prevent other bindings from working. Previously, calling `getPlatformProxy()` would crash if there were any Workflow bindings defined. Now, instead, you get a warning telling you that these bindings are not available.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> it is a backport

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
