### PR TITLE
Add fallthrough: true to python-modules .so glob rule

### DIFF
--- a/.changeset/metal-needles-hope.md
+++ b/.changeset/metal-needles-hope.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Add fallthrough: true for python_modules data rule

--- a/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
+++ b/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
@@ -168,7 +168,7 @@ export async function findAdditionalModules(
 				entry.projectRoot
 			);
 			const vendoredRules: Rule[] = [
-				{ type: "Data", globs: ["**/*.so", "**/*.py"] },
+				{ type: "Data", globs: ["**/*"], fallthrough: true },
 			];
 			const vendoredModules = (
 				await matchFiles(


### PR DESCRIPTION
Otherwise, we can't add any other data modules.
Also, perhaps this rule should just glob for everything? I think all the files in `python_modules` should be added.

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: very minor change
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: very minor change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: beta feature