### PR TITLE
Fixes pyproject.toml/uv.lock not including quotes

### DIFF
--- a/.changeset/some-singers-sit.md
+++ b/.changeset/some-singers-sit.md
@@ -1,5 +1,5 @@
 ---
-"create-cloudflare": minor
+"create-cloudflare": patch
 ---
 
 Python templates now create valid pyproject.toml/uv.lock files

--- a/.changeset/some-singers-sit.md
+++ b/.changeset/some-singers-sit.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": minor
+---
+
+Python templates now create valid pyproject.toml/uv.lock files

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -833,10 +833,16 @@ function updatePythonPackageName(path: string, projectName: string) {
 	const s = spinner();
 	s.start("Updating name in `pyproject.toml`");
 	let pyprojectTomlContents = readFile(pyprojectTomlPath);
-	pyprojectTomlContents = pyprojectTomlContents.replace('"TBD"', projectName);
+	pyprojectTomlContents = pyprojectTomlContents.replace(
+		'"TBD"',
+		`"${projectName}"`,
+	);
 	writeFile(pyprojectTomlPath, pyprojectTomlContents);
 	let uvLockContents = readFile(uvLockPath);
-	uvLockContents = uvLockContents.replace('"tbd"', projectName.toLowerCase());
+	uvLockContents = uvLockContents.replace(
+		'"tbd"',
+		`${"projectName.toLowerCase()"}`,
+	);
 	writeFile(uvLockPath, uvLockContents);
 	s.stop(`${brandColor("updated")} ${dim("`pyproject.toml`")}`);
 }


### PR DESCRIPTION
The pyproject.toml and uv.lock files were ending up with names generated in them that had no quotes which resulted in errors.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: templates update
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: template update
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> not a wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
