### PR TITLE
Add python-specific git ignores to Python templates

### DIFF
--- a/.changeset/new-lizards-check.md
+++ b/.changeset/new-lizards-check.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": minor
+---
+
+Adds Python-specific folders to gitignore in Python templates

--- a/packages/create-cloudflare/templates/hello-world-durable-object-with-assets/py/.gitignore
+++ b/packages/create-cloudflare/templates/hello-world-durable-object-with-assets/py/.gitignore
@@ -61,3 +61,8 @@ jspm_packages/
 .env*
 !.env.example
 .wrangler/
+
+# python-specific
+python_modules/
+.venv/
+.venv-workers/

--- a/packages/create-cloudflare/templates/hello-world-durable-object/py/.gitignore
+++ b/packages/create-cloudflare/templates/hello-world-durable-object/py/.gitignore
@@ -61,3 +61,8 @@ jspm_packages/
 .env*
 !.env.example
 .wrangler/
+
+# python-specific
+python_modules/
+.venv/
+.venv-workers/

--- a/packages/create-cloudflare/templates/hello-world-with-assets/py/.gitignore
+++ b/packages/create-cloudflare/templates/hello-world-with-assets/py/.gitignore
@@ -61,3 +61,8 @@ jspm_packages/
 .env*
 !.env.example
 .wrangler/
+
+# python-specific
+python_modules/
+.venv/
+.venv-workers/

--- a/packages/create-cloudflare/templates/hello-world/py/.gitignore
+++ b/packages/create-cloudflare/templates/hello-world/py/.gitignore
@@ -61,3 +61,8 @@ jspm_packages/
 .env*
 !.env.example
 .wrangler/
+
+# python-specific
+python_modules/
+.venv/
+.venv-workers/


### PR DESCRIPTION
Just a simple change to add some folders that should be ignored in Python workers

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: templates
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: templates
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> not wrangler

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
