### PR TITLE
Fix README title text

### DIFF
--- a/fixtures/workers-with-assets-run-worker-first/README.md
+++ b/fixtures/workers-with-assets-run-worker-first/README.md
@@ -1,4 +1,4 @@
-# workers-assets-with-user-worker"
+# workers-assets-with-user-worker
 
 `workers-assets-with-user-worker-run-worker-first"` is a test fixture that showcases Workers with Assets using the run_worker_first option. This particular fixture forces a user Worker to be invoked, even if it otherwise would have matched an assets request.
 

--- a/fixtures/workers-with-assets-spa/README.md
+++ b/fixtures/workers-with-assets-spa/README.md
@@ -1,4 +1,4 @@
-# workers-assets-with-spa"
+# workers-assets-with-spa
 
 `workers-assets-with-spa` is a test fixture that showcases Workers with Assets in SPA mode. This particular fixture sets up a User Worker, assets in SPA mode, and a binding from the user Worker to the assets.
 

--- a/fixtures/workers-with-assets/README.md
+++ b/fixtures/workers-with-assets/README.md
@@ -1,4 +1,4 @@
-# workers-assets-with-user-worker"
+# workers-assets-with-user-worker
 
 `workers-assets-with-user-worker` is a test fixture that showcases Workers with Assets. This particular fixture sets up a User Worker, assets, and a binding from the user Worker to the assets.
 


### PR DESCRIPTION
Fixes #[insert GH or internal issue link(s)].

For some reason we had quotes in the README title (eg. see: https://github.com/cloudflare/workers-sdk/tree/main/fixtures/workers-with-assets-run-worker-first). Removed for 3 fixtures I saw.

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: na
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: na
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: na

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
