### PR TITLE
test: only watch config files in ConfigController when not testing

### DIFF
--- a/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
+++ b/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
@@ -527,7 +527,11 @@ describe("dev with remote bindings", { sequential: true }, () => {
 				),
 				"index.js": `export default { fetch() { return new Response("hello") } }`,
 			});
-			const wranglerStopped = runWrangler("dev --port=0 --inspector-port=0");
+			const wranglerStopped = runWrangler("dev --port=0 --inspector-port=0", {
+				// We need to turn off the WRANGLER_CI_DISABLE_CONFIG_WATCHING env var so that the ConfigController
+				// enables watching for config changes, which is required to trigger reloading.
+				WRANGLER_CI_DISABLE_CONFIG_WATCHING: "false",
+			});
 			const match = await vi.waitUntil(
 				() => std.out.match(/Ready on (?<url>http:\/\/[^:]+:\d{4}.+)/),
 

--- a/packages/wrangler/src/__tests__/vitest.setup.ts
+++ b/packages/wrangler/src/__tests__/vitest.setup.ts
@@ -9,6 +9,10 @@ import { msw } from "./helpers/msw";
 //turn off chalk for tests due to inconsistencies between operating systems
 chalk.level = 0;
 
+// In general we don't want the ConfigController to watch the config files
+// as this tends to make the tests flaky.
+vi.stubEnv("WRANGLER_CI_DISABLE_CONFIG_WATCHING", "true");
+
 /**
  * The relative path between the bundled code and the Wrangler package.
  * This is used as a reliable way to compute paths relative to the Wrangler package

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -17,7 +17,10 @@ import {
 } from "../../dev";
 import { getClassNamesWhichUseSQLite } from "../../dev/class-names-sqlite";
 import { getLocalPersistencePath } from "../../dev/get-local-persistence-path";
-import { getDockerPath } from "../../environment-variables/misc-variables";
+import {
+	getDisableConfigWatching,
+	getDockerPath,
+} from "../../environment-variables/misc-variables";
 import { UserError } from "../../errors";
 import { getFlag } from "../../experimental-flags";
 import { logger, runWithLogLevel } from "../../logger";
@@ -561,7 +564,9 @@ export class ConfigController extends Controller<ConfigControllerEventMap> {
 				{ useRedirectIfAvailable: true }
 			);
 
-			await this.#ensureWatchingConfig(fileConfig.configPath);
+			if (!getDisableConfigWatching()) {
+				await this.#ensureWatchingConfig(fileConfig.configPath);
+			}
 
 			if (this.#tearingDown || signal.aborted) {
 				return;

--- a/packages/wrangler/src/environment-variables/factory.ts
+++ b/packages/wrangler/src/environment-variables/factory.ts
@@ -96,6 +96,8 @@ type VariableNames =
 	| "WRANGLER_CI_OVERRIDE_NETWORK_MODE_HOST"
 	/** CI preview alias generation (internal use). */
 	| "WRANGLER_CI_GENERATE_PREVIEW_ALIAS"
+	/** Disable config watching in ConfigController. */
+	| "WRANGLER_CI_DISABLE_CONFIG_WATCHING"
 
 	// ## Docker Configuration
 

--- a/packages/wrangler/src/environment-variables/misc-variables.ts
+++ b/packages/wrangler/src/environment-variables/misc-variables.ts
@@ -294,3 +294,8 @@ export const getCloudflareIncludeProcessEnvFromEnv =
 export const getTraceHeader = getEnvironmentVariableFactory({
 	variableName: "WRANGLER_TRACE_ID",
 });
+
+export const getDisableConfigWatching = getBooleanEnvironmentVariableFactory({
+	variableName: "WRANGLER_CI_DISABLE_CONFIG_WATCHING",
+	defaultValue: false,
+});


### PR DESCRIPTION
Previously we blocked config watching based on the existence of the `vitest` global. But this made it difficult to override in the tests where we actually needed config file changes to trigger reloads.

Turning on config watching for all tests proved to cause a bunch of tests that don't care about config file changes to become flaky.

So now we are guarding config watching once again but now with the more configurable `process.env.VITEST`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> original test change was not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
