### PR TITLE
Add fallthrough: true to python-modules .so glob rule

### DIFF
--- a/.changeset/tender-areas-burn.md
+++ b/.changeset/tender-areas-burn.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Add fallthrough: true for python_modules data rule

--- a/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
+++ b/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
@@ -168,7 +168,7 @@ export async function findAdditionalModules(
 				entry.projectRoot
 			);
 			const vendoredRules: Rule[] = [
-				{ type: "Data", globs: ["**/*.so", "**/*.py"] },
+				{ type: "Data", globs: ["**/*.so", "**/*.py"], fallthrough: true },
 			];
 			const vendoredModules = (
 				await matchFiles(


### PR DESCRIPTION
Add fallthrough: true to python-modules .so glob rule

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
