### PR TITLE
pin the URL for the react-router template since it was deleted from their project

### DIFF
--- a/.changeset/pink-coins-switch.md
+++ b/.changeset/pink-coins-switch.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+pin the URL for the react-router template since it was deleted from the project

--- a/packages/create-cloudflare/templates/react-router/c3.ts
+++ b/packages/create-cloudflare/templates/react-router/c3.ts
@@ -10,7 +10,8 @@ const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, [
 		ctx.project.name,
 		"--template",
-		"https://github.com/remix-run/react-router-templates/tree/main/cloudflare",
+		// React-router deleted the template here
+		"https://github.com/remix-run/react-router-templates/tree/29ac272b9532fe26463a2d2693fc73ff3c1e884b/cloudflare",
 		// to prevent asking about git twice, just let c3 do it
 		"--no-git-init",
 		"--no-install",


### PR DESCRIPTION
See https://github.com/remix-run/react-router-templates/pull/161

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> C3 not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
