### PR TITLE
Exclude certain file extensions from being bundled in python_modules.

### DIFF
--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -12605,6 +12605,11 @@ export default{
 				"# Python vendor module 2\nprint('hello')"
 			);
 
+			await fs.promises.writeFile(
+				"python_modules/test.pyc",
+				"this shouldn't be deployed"
+			);
+
 			// Create a regular Python module
 			await fs.promises.writeFile(
 				"src/helper.py",
@@ -12614,12 +12619,15 @@ export default{
 			const expectedModules = {
 				"index.py": mainPython,
 				"helper.py": "# Helper module\ndef helper(): pass",
+				"python_modules/module1.so": "binary content for module 1",
+				"python_modules/module2.py": "# Python vendor module 2\nprint('hello')",
 			};
 
 			mockSubDomainRequest();
 			mockUploadWorkerRequest({
 				expectedMainModule: "index.py",
 				expectedModules,
+				excludedModules: ["python_modules/test.pyc"],
 			});
 
 			await runWrangler("deploy");

--- a/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
@@ -23,6 +23,7 @@ export function mockUploadWorkerRequest(
 		expectedType?: "esm" | "sw" | "none";
 		expectedBindings?: unknown;
 		expectedModules?: Record<string, string | null>;
+		excludedModules?: string[];
 		expectedCompatibilityDate?: string;
 		expectedCompatibilityFlags?: string[];
 		expectedMigrations?: CfWorkerInit["migrations"];
@@ -135,6 +136,9 @@ export function mockUploadWorkerRequest(
 		for (const [name, content] of Object.entries(expectedModules)) {
 			expect(await serialize(formBody.get(name))).toEqual(content);
 		}
+		for (const name of excludedModules) {
+			expect(formBody.get(name)).toBeNull();
+		}
 
 		if (useOldUploadApi) {
 			return HttpResponse.json(
@@ -173,6 +177,7 @@ export function mockUploadWorkerRequest(
 		expectedType = "esm",
 		expectedBindings,
 		expectedModules = {},
+		excludedModules = [],
 		expectedCompatibilityDate,
 		expectedCompatibilityFlags,
 		env = undefined,

--- a/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
+++ b/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
@@ -176,13 +176,30 @@ export async function findAdditionalModules(
 					pythonModulesDir,
 					parseRules(vendoredRules)
 				)
-			).map((m) => {
-				const prefixedPath = path.join("python_modules", m.name);
-				return {
-					...m,
-					name: prefixedPath,
-				};
-			});
+			)
+				.filter(
+					// Exclude certain file extensions to avoid bundling files that aren't
+					// necessary and which increase the size of the bundle considerably.
+					(m) =>
+						!m.name.endsWith(".pyc") &&
+						// Translation files
+						!m.name.endsWith(".po") &&
+						// Static files shouldn't be included
+						!m.name.endsWith(".svg") &&
+						!m.name.endsWith(".png") &&
+						!m.name.endsWith(".jpg") &&
+						!m.name.endsWith(".css") &&
+						!m.name.endsWith(".gz") &&
+						!m.name.endsWith(".txt") &&
+						!m.name.endsWith(".js")
+				)
+				.map((m) => {
+					const prefixedPath = path.join("python_modules", m.name);
+					return {
+						...m,
+						name: prefixedPath,
+					};
+				});
 
 			modules.push(...vendoredModules);
 		} else {


### PR DESCRIPTION
Certain packages, like django, install a lot of additional files into python_modules which shouldn't be bundled in the worker. Some of these files are so large in aggregate that they balloon up the size of the bundle past limits.

This PR adds certain file extensions that we shouldn't be including. We can expand this list later in the future as we find other file types that shouldn't be included.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: fixes to existing feature
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> new feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

---- 

### Test Plan

```
pnpm run test --filter wrangler -- -t "should print vendor modules correctly in table" src/__tests__/deploy.test.ts
```
