### PR TITLE
[Workflows] Fix Workflows failure with redirect after creation

### DIFF
--- a/.changeset/polite-paths-raise.md
+++ b/.changeset/polite-paths-raise.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workflows-shared": patch
+---
+
+Workflows are now created if the Request gets redirected after creation

--- a/fixtures/workflow/src/index.ts
+++ b/fixtures/workflow/src/index.ts
@@ -146,7 +146,15 @@ export default class extends WorkerEntrypoint<Env> {
 			handle = await this.env.WORKFLOW2.get(id);
 		} else if (url.pathname === "/get3") {
 			handle = await this.env.WORKFLOW3.get(id);
-		} else {
+		} else if (url.pathname === "/createWithRedirect") {
+			console.log("create with redirect called");
+			handle = await this.env.WORKFLOW.create();
+
+			return Response.redirect(
+				new URL(`/status?workflowName=${handle.id}`, url).toString(),
+				302
+			);
+		} else if (url.pathname === "/status") {
 			handle = await this.env.WORKFLOW.get(id);
 		}
 

--- a/fixtures/workflow/tests/index.test.ts
+++ b/fixtures/workflow/tests/index.test.ts
@@ -257,6 +257,23 @@ describe("Workflows", () => {
 		);
 	});
 
+	it("should create an instance after immediate redirect", async ({
+		expect,
+	}) => {
+		await expect(fetchJson(`http://${ip}:${port}/createWithRedirect`)).resolves
+			.toMatchInlineSnapshot(`
+			{
+			  "__LOCAL_DEV_STEP_OUTPUTS": [
+			    {
+			      "output": "First step result",
+			    },
+			  ],
+			  "output": null,
+			  "status": "running",
+			}
+		`);
+	});
+
 	it("should persist instances across lifetimes", async ({ expect }) => {
 		await fetchJson(`http://${ip}:${port}/create?workflowName=something`);
 

--- a/packages/workflows-shared/src/binding.ts
+++ b/packages/workflows-shared/src/binding.ts
@@ -28,7 +28,7 @@ export class WorkflowBinding extends WorkerEntrypoint<Env> implements Workflow {
 		const stubId = this.env.ENGINE.idFromName(id);
 		const stub = this.env.ENGINE.get(stubId);
 
-		void stub.init(
+		const initPromise = stub.init(
 			0, // accountId: number,
 			{} as DatabaseWorkflow, // workflow: DatabaseWorkflow,
 			{} as DatabaseVersion, // version: DatabaseVersion,
@@ -39,6 +39,8 @@ export class WorkflowBinding extends WorkerEntrypoint<Env> implements Workflow {
 				instanceId: id,
 			}
 		);
+
+		this.ctx.waitUntil(initPromise);
 
 		const handle = new WorkflowHandle(id, stub);
 		return {
@@ -55,7 +57,6 @@ export class WorkflowBinding extends WorkerEntrypoint<Env> implements Workflow {
 	public async get(id: string): Promise<WorkflowInstance> {
 		const engineStubId = this.env.ENGINE.idFromName(id);
 		const engineStub = this.env.ENGINE.get(engineStubId);
-
 		const handle = new WorkflowHandle(id, engineStub);
 
 		try {


### PR DESCRIPTION
Fixes WOR-929.

Issue: https://github.com/cloudflare/workers-sdk/issues/10806

### The problem
Creating an instance and immediately after calling a Response redirect (that will call that instance) in local dev causes the instance to not be found, because it is actually never created.

Simplified code:
```typescript
if (path === "/trigger-with-redirect") {
      const workflow = await env.TEST_WORKFLOW.create();

      return Response.redirect(
        new URL(`/status?id=${workflow.id}`, url).toString(),
        302
      );
}

if (path === "/status") {
      const id = url.searchParams.get("id"); 
      const instance = await env.TEST_WORKFLOW.get(id); // BREAKS HERE -> instance.not_found
      const status = await instance.status();
}
```

### Why? 
Because in local dev our `create()` method does not await for anything. `create()` calls the Engine DO `init()` that will create the instance. Init sets up metadata, does some other logic and then runs the Workflow instance. Since the Workflow can and probably will be long running, we don't await the `init()` call. This behavior is different from the production one, hence the issue only being found in local dev.

The response redirect makes the runtime consider everything is "done", making unresolved promises be killed, meaning that `init()` call could be aborted.

What I actually found while debugging this specific case was that the metadata was never set (even if it is the first thing being done by `init()`), which then leads to the error being thrown by `.get()`. 

### How to solve
I found a few ways of making this not break:

1. **By adding a setTimeout of 0 inside the `create()` method after calling `init()`**: This forces the runtime to do another event loop tick before finishing the request and gives the init promise another chance to run. However I don't think this is the best solution. 
2. **By changing the init() logic**: Having a initMetadata() function that is  awaited by `create()`. At the end, initMetadata() would call the remainder of the `init()` logic. This is okay but would require further changes (tests, everywhere init is called, ...)
3. **waitUntil**: By telling the runtime to keep the worker alive until the `init()` promise resolves or rejects. This is what I ended up doing.




---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: No new features were added
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: Workflows were not GA in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
