### PR TITLE
retry subdomain requests to be more resilient to flakes

### DIFF
--- a/.changeset/tangy-donuts-jog.md
+++ b/.changeset/tangy-donuts-jog.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+retry subdomain requests to be more resilient to flakes

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -6087,7 +6087,7 @@ addEventListener('fetch', event => {});`
 			mockUploadWorkerRequest();
 			mockGetWorkerSubdomain({ enabled: false });
 			mockSubDomainRequest();
-			mockUpdateWorkerSubdomain({ enabled: true, flakes: 1 });
+			mockUpdateWorkerSubdomain({ enabled: true, flakeCount: 1 });
 
 			await runWrangler("deploy ./index");
 

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -6081,6 +6081,27 @@ addEventListener('fetch', event => {});`
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
+		it("should deploy successfully if the /subdomain POST request is flaky", async () => {
+			writeWranglerConfig();
+			writeWorkerSource();
+			mockUploadWorkerRequest();
+			mockGetWorkerSubdomain({ enabled: false });
+			mockSubDomainRequest();
+			mockUpdateWorkerSubdomain({ enabled: true, flakes: 1 });
+
+			await runWrangler("deploy ./index");
+
+			expect(std.out).toMatchInlineSnapshot(`
+				"Total Upload: xx KiB / gzip: xx KiB
+				Worker Startup Time: 100 ms
+				Uploaded test-name (TIMINGS)
+				Deployed test-name triggers (TIMINGS)
+				  https://test-name.test-sub-domain.workers.dev
+				Current Version ID: Galaxy-Class"
+			`);
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
 		it("should deploy to the workers.dev domain if workers_dev is `true`", async () => {
 			writeWranglerConfig({
 				workers_dev: true,

--- a/packages/wrangler/src/__tests__/helpers/mock-workers-subdomain.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-workers-subdomain.ts
@@ -79,14 +79,14 @@ export function mockUpdateWorkerSubdomain({
 	env,
 	legacyEnv = false,
 	expectedScriptName = "test-name",
-	flakes = 0,
+	flakeCount = 0,
 }: {
 	enabled: boolean;
 	previews_enabled?: boolean;
 	env?: string | undefined;
 	legacyEnv?: boolean | undefined;
 	expectedScriptName?: string;
-	flakes?: number;
+	flakeCount?: number; // The first `flakeCount` requests will fail with a 500 error
 }) {
 	const url =
 		env && !legacyEnv
@@ -113,8 +113,8 @@ export function mockUpdateWorkerSubdomain({
 			{ once: true }
 		),
 	];
-	while (flakes > 0) {
-		flakes--;
+	while (flakeCount > 0) {
+		flakeCount--;
 		handlers.unshift(
 			http.post(
 				url,

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -250,7 +250,7 @@ describe("versions upload", () => {
 		writeWorkerSource();
 		setIsTTY(false);
 
-		const result = runWrangler("versions upload");
+		const result = runWrangler("versions upload", { WRANGLER_LOG: "debug" });
 
 		await expect(result).resolves.toBeUndefined();
 
@@ -265,7 +265,7 @@ describe("versions upload", () => {
 			Worker Version ID: 51e4886e-2db7-4900-8d38-fbfecfeab993"
 		`);
 
-		expect(std.info).toContain("Retrying API call after error...");
+		expect(std.debug).toContain("Retrying API call after error...");
 	});
 
 	test("correctly detects python workers", async () => {

--- a/packages/wrangler/src/triggers/deploy.ts
+++ b/packages/wrangler/src/triggers/deploy.ts
@@ -379,17 +379,21 @@ async function subdomainDeploy(
 	// Update subdomain enablement status if needed.
 
 	if (!allInSync) {
-		await fetchResult(config, `${workerUrl}/subdomain`, {
-			method: "POST",
-			body: JSON.stringify({
-				enabled: wantWorkersDev,
-				previews_enabled: wantPreviews,
-			}),
-			headers: {
-				"Content-Type": "application/json",
-				"Cloudflare-Workers-Script-Api-Date": "2025-08-01",
-			},
-		});
+		// Occasionally this update to the subdomain endpoint fails due to some internal API error.
+		// We retry this request a few times to mitigate that.
+		await retryOnAPIFailure(async () =>
+			fetchResult(config, `${workerUrl}/subdomain`, {
+				method: "POST",
+				body: JSON.stringify({
+					enabled: wantWorkersDev,
+					previews_enabled: wantPreviews,
+				}),
+				headers: {
+					"Content-Type": "application/json",
+					"Cloudflare-Workers-Script-Api-Date": "2025-08-01",
+				},
+			})
+		);
 	}
 
 	if (workersDevURL) {

--- a/packages/wrangler/src/utils/retry.ts
+++ b/packages/wrangler/src/utils/retry.ts
@@ -29,7 +29,7 @@ export async function retryOnAPIFailure<T>(
 			throw err;
 		}
 
-		logger.info(chalk.dim(`Retrying API call after error...`));
+		logger.debug(chalk.dim(`Retrying API call after error...`));
 		logger.debug(err);
 
 		if (attempts <= 1) {


### PR DESCRIPTION
We were seeing some flakes in CI such as https://github.com/cloudflare/workers-sdk/actions/runs/18130487486/job/51595708301?pr=10766#step:6:9893

I discussed with the D&C team and they identified that this is a problem internally but there is not a clear fix at this stage.
They confirmed that an acceptable mitigation would be to retry (a few times) the request if it fails with a 500 response.

---

Notable aspects of this PR:

- the utility function was writing messages to `console.log()` when retrying but this seems wrong, since the user shouldn't care about this - these logs have been moved to `console.debug()`.
- the utility function only retried 5xx errors but the `fetchRequest()` helper did not provide the response status to the new `APIError` so these were not being retried - this has now been threaded through,

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/10837
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
