### PR TITLE
PIPE-391: Better error messages and client-side validation

### DIFF
--- a/.changeset/some-spies-greet.md
+++ b/.changeset/some-spies-greet.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Validate entity names client-side

--- a/packages/wrangler/src/pipelines/cli/setup.ts
+++ b/packages/wrangler/src/pipelines/cli/setup.ts
@@ -16,6 +16,7 @@ import {
 } from "../client";
 import { SINK_DEFAULTS } from "../defaults";
 import { authorizeR2Bucket } from "../index";
+import { validateEntityName } from "../validate";
 import {
 	displayUsageExamples,
 	formatSchemaFieldsForTable,
@@ -91,11 +92,7 @@ async function setupPipelineNaming(
 		throw new UserError("Pipeline name is required");
 	}
 
-	if (!/^[a-zA-Z0-9_-]+$/.test(pipelineName)) {
-		throw new UserError(
-			"Pipeline name must contain only letters, numbers, hyphens, and underscores"
-		);
-	}
+	validateEntityName("pipeline", pipelineName);
 
 	const streamName = `${pipelineName}_stream`;
 	const sinkName = `${pipelineName}_sink`;

--- a/packages/wrangler/src/pipelines/cli/sinks/create.ts
+++ b/packages/wrangler/src/pipelines/cli/sinks/create.ts
@@ -6,6 +6,7 @@ import { requireAuth } from "../../../user";
 import { createSink } from "../../client";
 import { applyDefaultsToSink, SINK_DEFAULTS } from "../../defaults";
 import { authorizeR2Bucket } from "../../index";
+import { validateEntityName } from "../../validate";
 import { displaySinkConfiguration } from "./utils";
 import type { CreateSinkRequest, SinkFormat } from "../../types";
 
@@ -102,6 +103,8 @@ export const pipelinesSinksCreateCommand = createCommand({
 		},
 	},
 	validateArgs: (args) => {
+		validateEntityName("sink", args.sink);
+
 		const sinkType = parseSinkType(args.type);
 
 		if (!isValidR2BucketName(args.bucket)) {

--- a/packages/wrangler/src/pipelines/cli/streams/create.ts
+++ b/packages/wrangler/src/pipelines/cli/streams/create.ts
@@ -6,6 +6,7 @@ import { logger } from "../../../logger";
 import { parseJSON } from "../../../parse";
 import { requireAuth } from "../../../user";
 import { createStream } from "../../client";
+import { validateEntityName } from "../../validate";
 import { displayStreamConfiguration } from "./utils";
 import type { CreateStreamRequest, SchemaField } from "../../types";
 
@@ -41,6 +42,9 @@ export const pipelinesStreamsCreateCommand = createCommand({
 			type: "string",
 			array: true,
 		},
+	},
+	validateArgs: (args) => {
+		validateEntityName("stream", args.stream);
 	},
 	async handler(args, { config }) {
 		await requireAuth(config);

--- a/packages/wrangler/src/pipelines/validate.ts
+++ b/packages/wrangler/src/pipelines/validate.ts
@@ -1,5 +1,23 @@
 import { UserError } from "../errors";
 
+/**
+ * Validate entity name is used for Pipelines V1 API entities such as sources, sinks and pipelines.
+ * @param label - the name of the entity to validate
+ * @param name - the user provided name
+ */
+export function validateEntityName(label: string, name: string) {
+	if (!name.match(/^[a-zA-Z0-9_]+$/)) {
+		throw new UserError(
+			`${label} name must contain only letters, numbers, and underscores`
+		);
+	}
+}
+
+/**
+ * Validate name is used for legacy Pipelines. This validation should not be used for Pipelines V1 entities.
+ * @param label - the name of the entity to validate
+ * @param name - the user provided name
+ */
 export function validateName(label: string, name: string) {
 	if (!name.match(/^[a-zA-Z0-9-]+$/)) {
 		throw new UserError(`Must provide a valid ${label}`);


### PR DESCRIPTION
Some field validation has been moved to the client side for more immediate feedback.

```
./bin/wrangler.js pipelines setup

 ⛅️ wrangler 4.40.3
───────────────────
▲ [WARNING] 🚧 `wrangler pipelines setup` is an open-beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose

🚀 Welcome to Cloudflare Pipelines Setup!
This will guide you through creating a complete pipeline: stream → pipeline → sink

✔ What would you like to name your pipeline? … this-a-test

✘ [ERROR] Pipeline name must contain only letters, numbers, and underscores
```

Fixes PIPE-391

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [X] Tests not necessary because: validation change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: validation change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [X] Not necessary because: Only supported in v4. 

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
