### PR TITLE
Update workers containers instance types

### DIFF
--- a/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
@@ -119,7 +119,7 @@ describe("cloudchamber create", () => {
 			      --label          Deployment labels  [array]
 			      --all-ssh-keys   To add all SSH keys configured on your account to be added to this deployment, set this option to true  [boolean]
 			      --ssh-key-id     ID of the SSH key to add to the deployment  [array]
-			      --instance-type  Instance type to allocate to this deployment  [choices: \\"dev\\", \\"basic\\", \\"standard\\"]
+			      --instance-type  Instance type to allocate to this deployment  [choices: \\"dev\\", \\"standard\\", \\"lite\\", \\"basic\\", \\"standard-1\\", \\"standard-2\\", \\"standard-3\\", \\"standard-4\\"]
 			      --vcpu           Number of vCPUs to allocate to this deployment.  [number]
 			      --memory         Amount of memory (GiB, MiB...) to allocate to this deployment. Ex: 4GiB.  [string]
 			      --ipv4           Include an IPv4 in the deployment  [boolean]"
@@ -250,7 +250,7 @@ describe("cloudchamber create", () => {
 		);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 		await runWrangler(
-			"cloudchamber create --image hello:world --location sfo06 --var HELLO:WORLD --var YOU:CONQUERED --instance-type dev --ipv4 true"
+			"cloudchamber create --image hello:world --location sfo06 --var HELLO:WORLD --var YOU:CONQUERED --instance-type lite --ipv4 true"
 		);
 		expect(std.out).toMatchInlineSnapshot(`"{}"`);
 	});

--- a/packages/wrangler/src/__tests__/cloudchamber/modify.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/modify.test.ts
@@ -86,7 +86,7 @@ describe("cloudchamber modify", () => {
 			      --ssh-public-key-id  Public SSH key IDs to include in this container. You can add one to your account with \`wrangler cloudchamber ssh create  [array]
 			      --image              The new image that the deployment will have from now on  [string]
 			      --location           The new location that the deployment will have from now on  [string]
-			      --instance-type      The new instance type that the deployment will have from now on  [choices: \\"dev\\", \\"basic\\", \\"standard\\"]
+			      --instance-type      The new instance type that the deployment will have from now on  [choices: \\"dev\\", \\"standard\\", \\"lite\\", \\"basic\\", \\"standard-1\\", \\"standard-2\\", \\"standard-3\\", \\"standard-4\\"]
 			      --vcpu               The new vcpu that the deployment will have from now on  [number]
 			      --memory             The new memory that the deployment will have from now on  [string]"
 		`);

--- a/packages/wrangler/src/cloudchamber/create.ts
+++ b/packages/wrangler/src/cloudchamber/create.ts
@@ -98,7 +98,7 @@ export function createCommandOptionalYargs(yargs: CommonYargsArgv) {
 		})
 		.option("instance-type", {
 			requiresArg: true,
-			choices: ["dev", "basic", "standard"] as const,
+			choices: ["lite", "basic", "standard-1", "standard-2", "standard-3", "standard-4"] as const,
 			demandOption: false,
 			describe: "Instance type to allocate to this deployment",
 		})

--- a/packages/wrangler/src/cloudchamber/create.ts
+++ b/packages/wrangler/src/cloudchamber/create.ts
@@ -98,7 +98,7 @@ export function createCommandOptionalYargs(yargs: CommonYargsArgv) {
 		})
 		.option("instance-type", {
 			requiresArg: true,
-			choices: ["lite", "basic", "standard-1", "standard-2", "standard-3", "standard-4"] as const,
+			choices: ["dev", "standard", "lite", "basic", "standard-1", "standard-2", "standard-3", "standard-4"] as const, // suppporting "dev" and "standard" for backward compatibility
 			demandOption: false,
 			describe: "Instance type to allocate to this deployment",
 		})

--- a/packages/wrangler/src/cloudchamber/modify.ts
+++ b/packages/wrangler/src/cloudchamber/modify.ts
@@ -78,7 +78,7 @@ export function modifyCommandOptionalYargs(yargs: CommonYargsArgv) {
 		})
 		.option("instance-type", {
 			requiresArg: true,
-			choices: ["dev", "basic", "standard"] as const,
+			choices: ["lite", "basic", "standard-1", "standard-2", "standard-3", "standard-4"] as const,
 			demandOption: false,
 			describe:
 				"The new instance type that the deployment will have from now on",

--- a/packages/wrangler/src/cloudchamber/modify.ts
+++ b/packages/wrangler/src/cloudchamber/modify.ts
@@ -78,7 +78,7 @@ export function modifyCommandOptionalYargs(yargs: CommonYargsArgv) {
 		})
 		.option("instance-type", {
 			requiresArg: true,
-			choices: ["lite", "basic", "standard-1", "standard-2", "standard-3", "standard-4"] as const,
+			choices: ["dev", "standard", "lite", "basic", "standard-1", "standard-2", "standard-3", "standard-4"] as const, // suppporting "dev" and "standard" for backward compatibility
 			demandOption: false,
 			describe:
 				"The new instance type that the deployment will have from now on",

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -2796,7 +2796,7 @@ function validateContainerApp(
 					"instance_type",
 					containerAppOptional.instance_type,
 					"string",
-					["lite", "basic", "standard-1", "standard-2", "standard-3", "standard-4"]
+					["dev", "standard", "lite", "basic", "standard-1", "standard-2", "standard-3", "standard-4"], // suppporting "dev" and "standard" for backward compatibility
 				);
 			} else if (
 				validateOptionalProperty(
@@ -2871,7 +2871,7 @@ const validateCloudchamberConfig: ValidatorFn = (diagnostics, field, value) => {
 	if ("instance_type" in value && value.instance_type !== undefined) {
 		if (
 			typeof value.instance_type !== "string" ||
-			!["lite", "basic", "standard-1", "standard-2", "standard-3", "standard-4"].includes(value.instance_type)
+			!["dev", "standard", "lite", "basic", "standard-1", "standard-2", "standard-3", "standard-4"].includes(value.instance_type) // suppporting "dev" and "standard" for backward compatibility
 		) {
 			diagnostics.errors.push(
 				`"instance_type" should be one of 'dev', 'basic', or 'standard', but got ${value.instance_type}`

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -2796,7 +2796,7 @@ function validateContainerApp(
 					"instance_type",
 					containerAppOptional.instance_type,
 					"string",
-					["dev", "basic", "standard"]
+					["lite", "basic", "standard-1", "standard-2", "standard-3", "standard-4"]
 				);
 			} else if (
 				validateOptionalProperty(
@@ -2871,7 +2871,7 @@ const validateCloudchamberConfig: ValidatorFn = (diagnostics, field, value) => {
 	if ("instance_type" in value && value.instance_type !== undefined) {
 		if (
 			typeof value.instance_type !== "string" ||
-			!["dev", "basic", "standard"].includes(value.instance_type)
+			!["lite", "basic", "standard-1", "standard-2", "standard-3", "standard-4"].includes(value.instance_type)
 		) {
 			diagnostics.errors.push(
 				`"instance_type" should be one of 'dev', 'basic', or 'standard', but got ${value.instance_type}`


### PR DESCRIPTION
New [container instance types](https://developers.cloudflare.com/changelog/2025-10-01-new-container-instance-types/) recently dropped, but the CLI invalidates them as it's still comparing against the old 

- Tests
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->
