### PR TITLE
skip container tests locally docker is not running

### DIFF
--- a/fixtures/interactive-dev-tests/tests/index.test.ts
+++ b/fixtures/interactive-dev-tests/tests/index.test.ts
@@ -290,12 +290,29 @@ it.each(exitKeys)("multiworker cleanly exits with $name", async ({ key }) => {
 	}
 });
 
-// it seems like if we spam the container too often, it freezes up and crashes
-const WAITFOR_OPTIONS = { timeout: 2000, interval: 500 };
-baseDescribe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
-	"container dev",
-	{ retry: 0, timeout: 90000 },
-	() => {
+const isCINonLinux = process.platform !== "linux" && process.env.CI === "true";
+
+function isDockerRunning() {
+	try {
+		execSync("docker ps");
+		return true;
+	} catch (e) {
+		return false;
+	}
+}
+
+/** Indicates whether the test is being run locally (not in CI) AND docker is currently not running on the system */
+const isLocalWithoutDockerRunning =
+	process.env.CI !== "true" && !isDockerRunning();
+
+baseDescribe.skipIf(
+	isCINonLinux ||
+		// If the tests are being run locally and docker is not running we just skip this test
+		isLocalWithoutDockerRunning
+)("containers", () => {
+	// it seems like if we spam the container too often, it freezes up and crashes
+	const WAITFOR_OPTIONS = { timeout: 2000, interval: 500 };
+	baseDescribe("container dev", { retry: 0, timeout: 90000 }, () => {
 		let tmpDir: string;
 		beforeAll(async () => {
 			tmpDir = fs.mkdtempSync(path.join(tmpdir(), "wrangler-container-"));
@@ -397,15 +414,15 @@ baseDescribe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
 				path.join(tmpDir, "container", "simple-node-app.js"),
 				`const { createServer } = require("http");
 
-				const server = createServer(function (req, res) {
-					res.writeHead(200, { "Content-Type": "text/plain" });
-					res.write("Blah! " + process.env.MESSAGE);
-					res.end();
-				});
+					const server = createServer(function (req, res) {
+						res.writeHead(200, { "Content-Type": "text/plain" });
+						res.write("Blah! " + process.env.MESSAGE);
+						res.end();
+					});
 
-				server.listen(8080, function () {
-					console.log("Server listening on port 8080");
-				});`,
+					server.listen(8080, function () {
+						console.log("Server listening on port 8080");
+					});`,
 				"utf-8"
 			);
 
@@ -460,136 +477,134 @@ baseDescribe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
 				expect(remainingIds.length).toBe(0);
 			});
 		});
-	}
-);
+	});
 
-baseDescribe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
-	"container dev where image build takes a long time",
-	{ retry: 0, timeout: 90000 },
-	() => {
-		let tmpDir: string;
-		beforeAll(async () => {
-			tmpDir = fs.mkdtempSync(path.join(tmpdir(), "wrangler-container-sleep-"));
-			fs.cpSync(
-				path.resolve(__dirname, "../", "container-app"),
-				path.join(tmpDir),
-				{
-					recursive: true,
+	baseDescribe(
+		"container dev where image build takes a long time",
+		{ retry: 0, timeout: 90000 },
+		() => {
+			let tmpDir: string;
+			beforeAll(async () => {
+				tmpDir = fs.mkdtempSync(
+					path.join(tmpdir(), "wrangler-container-sleep-")
+				);
+				fs.cpSync(
+					path.resolve(__dirname, "../", "container-app"),
+					path.join(tmpDir),
+					{
+						recursive: true,
+					}
+				);
+				const tmpDockerFilePath = path.join(tmpDir, "Dockerfile");
+				fs.rmSync(tmpDockerFilePath);
+				fs.renameSync(
+					path.join(tmpDir, "DockerfileWithLongSleep"),
+					tmpDockerFilePath
+				);
+
+				const ids = getContainerIds();
+				if (ids.length > 0) {
+					execSync("docker rm -f " + ids.join(" "), {
+						encoding: "utf8",
+					});
 				}
-			);
-			const tmpDockerFilePath = path.join(tmpDir, "Dockerfile");
-			fs.rmSync(tmpDockerFilePath);
-			fs.renameSync(
-				path.join(tmpDir, "DockerfileWithLongSleep"),
-				tmpDockerFilePath
-			);
+			});
 
-			const ids = getContainerIds();
-			if (ids.length > 0) {
-				execSync("docker rm -f " + ids.join(" "), {
-					encoding: "utf8",
-				});
-			}
-		});
+			afterEach(async () => {
+				const ids = getContainerIds();
+				if (ids.length > 0) {
+					execSync("docker rm -f " + ids.join(" "), {
+						encoding: "utf8",
+					});
+				}
+			});
 
-		afterEach(async () => {
-			const ids = getContainerIds();
-			if (ids.length > 0) {
-				execSync("docker rm -f " + ids.join(" "), {
-					encoding: "utf8",
-				});
-			}
-		});
+			afterAll(async () => {
+				try {
+					fs.rmSync(tmpDir, { recursive: true, force: true });
+				} catch (e) {
+					// It seems that Windows doesn't let us delete this, with errors like:
+					//
+					// Error: EBUSY: resource busy or locked, rmdir 'C:\Users\RUNNER~1\AppData\Local\Temp\wrangler-modules-pKJ7OQ'
+					// ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+					// Serialized Error: {
+					// 	"code": "EBUSY",
+					// 	"errno": -4082,
+					// 	"path": "C:\Users\RUNNER~1\AppData\Local\Temp\wrangler-modules-pKJ7OQ",
+					// 	"syscall": "rmdir",
+					// }
+					console.error(e);
+				}
+			});
 
-		afterAll(async () => {
-			try {
-				fs.rmSync(tmpDir, { recursive: true, force: true });
-			} catch (e) {
-				// It seems that Windows doesn't let us delete this, with errors like:
-				//
-				// Error: EBUSY: resource busy or locked, rmdir 'C:\Users\RUNNER~1\AppData\Local\Temp\wrangler-modules-pKJ7OQ'
-				// ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
-				// Serialized Error: {
-				// 	"code": "EBUSY",
-				// 	"errno": -4082,
-				// 	"path": "C:\Users\RUNNER~1\AppData\Local\Temp\wrangler-modules-pKJ7OQ",
-				// 	"syscall": "rmdir",
-				// }
-				console.error(e);
-			}
-		});
+			it("should allow quitting while the image is building", async () => {
+				const wrangler = await startWranglerDev(
+					["dev", "-c", path.join(tmpDir, "wrangler.jsonc")],
+					true
+				);
 
-		it("should allow quitting while the image is building", async () => {
-			const wrangler = await startWranglerDev(
-				["dev", "-c", path.join(tmpDir, "wrangler.jsonc")],
-				true
-			);
+				const waitForOptions = {
+					timeout: 10_000,
+					interval: WAITFOR_OPTIONS.interval,
+				};
 
-			const waitForOptions = {
-				timeout: 10_000,
-				interval: WAITFOR_OPTIONS.interval,
-			};
+				// wait for long sleep instruction to start
+				await vi.waitFor(async () => {
+					expect(wrangler.stdout).toContain("RUN sleep 50000");
+				}, waitForOptions);
 
-			// wait for long sleep instruction to start
-			await vi.waitFor(async () => {
-				expect(wrangler.stdout).toContain("RUN sleep 50000");
-			}, waitForOptions);
+				wrangler.pty.write("q");
 
-			wrangler.pty.write("q");
+				await vi.waitFor(async () => {
+					expect(wrangler.stdout).toMatch(/CANCELED \[.*?\] RUN sleep 50000/);
+				}, waitForOptions);
+			});
 
-			await vi.waitFor(async () => {
-				expect(wrangler.stdout).toMatch(/CANCELED \[.*?\] RUN sleep 50000/);
-			}, waitForOptions);
-		});
+			it("should rebuilding while the image is building", async () => {
+				const wrangler = await startWranglerDev(
+					["dev", "-c", path.join(tmpDir, "wrangler.jsonc")],
+					true
+				);
 
-		it("should rebuilding while the image is building", async () => {
-			const wrangler = await startWranglerDev(
-				["dev", "-c", path.join(tmpDir, "wrangler.jsonc")],
-				true
-			);
+				const waitForOptions = {
+					timeout: 15_000,
+					interval: 1_500,
+				};
 
-			const waitForOptions = {
-				timeout: 15_000,
-				interval: 1_500,
-			};
+				// wait for long sleep instruction to start
+				await vi.waitFor(async () => {
+					expect(wrangler.stdout).toContain("RUN sleep 50000");
+				}, waitForOptions);
 
-			// wait for long sleep instruction to start
-			await vi.waitFor(async () => {
-				expect(wrangler.stdout).toContain("RUN sleep 50000");
-			}, waitForOptions);
-
-			let logOccurrencesBefore =
-				wrangler.stdout.match(/This \(no-op\) build takes forever.../g)
-					?.length ?? 0;
-
-			wrangler.pty.write("r");
-
-			await vi.waitFor(async () => {
-				const logOccurrences =
+				let logOccurrencesBefore =
 					wrangler.stdout.match(/This \(no-op\) build takes forever.../g)
 						?.length ?? 0;
-				expect(logOccurrences).toBeGreaterThan(1);
-				logOccurrencesBefore = logOccurrences;
-			}, waitForOptions);
 
-			await vi.waitFor(async () => {
-				await setTimeout(700);
 				wrangler.pty.write("r");
-				const logOccurrences =
-					wrangler.stdout.match(/This \(no-op\) build takes forever.../g)
-						?.length ?? 0;
-				expect(logOccurrences).toBeGreaterThan(logOccurrencesBefore);
-			}, waitForOptions);
 
-			wrangler.pty.kill();
-		});
-	}
-);
+				await vi.waitFor(async () => {
+					const logOccurrences =
+						wrangler.stdout.match(/This \(no-op\) build takes forever.../g)
+							?.length ?? 0;
+					expect(logOccurrences).toBeGreaterThan(1);
+					logOccurrencesBefore = logOccurrences;
+				}, waitForOptions);
 
-baseDescribe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
-	"multi-containers dev",
-	{ retry: 0, timeout: 50000 },
-	() => {
+				await vi.waitFor(async () => {
+					await setTimeout(700);
+					wrangler.pty.write("r");
+					const logOccurrences =
+						wrangler.stdout.match(/This \(no-op\) build takes forever.../g)
+							?.length ?? 0;
+					expect(logOccurrences).toBeGreaterThan(logOccurrencesBefore);
+				}, waitForOptions);
+
+				wrangler.pty.kill();
+			});
+		}
+	);
+
+	baseDescribe("multi-containers dev", { retry: 0, timeout: 50000 }, () => {
 		let tmpDir: string;
 		beforeAll(async () => {
 			tmpDir = fs.mkdtempSync(
@@ -744,144 +759,144 @@ baseDescribe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
 				expect(remainingIds.length).toBe(0);
 			});
 		});
-	}
-);
-
-baseDescribe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
-	"multi-workers containers dev",
-	{ retry: 0, timeout: 50000 },
-	() => {
-		let tmpDir: string;
-		beforeAll(async () => {
-			tmpDir = fs.mkdtempSync(
-				path.join(tmpdir(), "wrangler-multi-workers-containers-")
-			);
-			fs.cpSync(
-				path.resolve(__dirname, "../", "multi-workers-containers-app"),
-				path.join(tmpDir),
-				{
-					recursive: true,
-				}
-			);
-
-			const ids = getContainerIds();
-			if (ids.length > 0) {
-				execSync("docker rm -f " + ids.join(" "), {
-					encoding: "utf8",
-				});
-			}
-		});
-
-		afterEach(async () => {
-			const ids = getContainerIds();
-
-			if (ids.length > 0) {
-				execSync("docker rm -f " + ids.join(" "), {
-					encoding: "utf8",
-				});
-			}
-		});
-		afterAll(async () => {
-			try {
-				fs.rmSync(tmpDir, { recursive: true, force: true });
-			} catch (e) {
-				// It seems that Windows doesn't let us delete this, with errors like:
-				//
-				// Error: EBUSY: resource busy or locked, rmdir 'C:\Users\RUNNER~1\AppData\Local\Temp\wrangler-modules-pKJ7OQ'
-				// ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
-				// Serialized Error: {
-				// 	"code": "EBUSY",
-				// 	"errno": -4082,
-				// 	"path": "C:\Users\RUNNER~1\AppData\Local\Temp\wrangler-modules-pKJ7OQ",
-				// 	"syscall": "rmdir",
-				// }
-				console.error(e);
-			}
-		});
-
-		it("should be able to interact with both workers, rebuild the containers with the hotkey and all containers should be cleaned up at the end", async () => {
-			const wrangler = await startWranglerDev([
-				"dev",
-				"-c",
-				path.join(tmpDir, "workerA/wrangler.jsonc"),
-				"-c",
-				path.join(tmpDir, "workerB/wrangler.jsonc"),
-			]);
-
-			await vi.waitFor(
-				async () => {
-					const json = await (
-						await fetch(wrangler.url, { signal: AbortSignal.timeout(5_000) })
-					).json();
-					expect(json).toEqual({
-						containerAText: "Hello from Container A",
-						containerBText: "Hello from Container B",
-					});
-				},
-				{ timeout: 10_000, interval: 1000 }
-			);
-
-			const tmpDockerfileAPath = path.join(tmpDir, "workerA/Dockerfile");
-			const dockerFileAContent = fs.readFileSync(tmpDockerfileAPath, "utf8");
-			fs.writeFileSync(
-				tmpDockerfileAPath,
-				dockerFileAContent.replace(
-					'"Hello from Container A"',
-					'"Hello World from Container A"'
-				),
-				"utf-8"
-			);
-
-			const tmpDockerfileBPath = path.join(tmpDir, "workerB/Dockerfile");
-			const dockerFileBContent = fs.readFileSync(tmpDockerfileBPath, "utf8");
-			fs.writeFileSync(
-				tmpDockerfileBPath,
-				dockerFileBContent.replace(
-					'"Hello from Container B"',
-					'"Hello from the B Container"'
-				),
-				"utf-8"
-			);
-
-			wrangler.pty.write("r");
-
-			await vi.waitFor(
-				async () => {
-					const json = await (
-						await fetch(wrangler.url, { signal: AbortSignal.timeout(5_000) })
-					).json();
-					expect(json).toEqual({
-						containerAText: "Hello World from Container A",
-						containerBText: "Hello from the B Container",
-					});
-				},
-				{ timeout: 30_000, interval: 1000 }
-			);
-
-			fs.writeFileSync(tmpDockerfileAPath, dockerFileAContent, "utf-8");
-			fs.writeFileSync(tmpDockerfileBPath, dockerFileBContent, "utf-8");
-
-			wrangler.pty.kill("SIGINT");
-		});
-	}
-);
-
-/** gets any containers that were created by running this fixture */
-const getContainerIds = () => {
-	// note the -a to include stopped containers
-	const allContainers = execSync(`docker ps -a --format json`)
-		.toString()
-		.split("\n")
-		.filter((line) => line.trim());
-	if (allContainers.length === 0) {
-		return [];
-	}
-	const jsonOutput = allContainers.map((line) => JSON.parse(line));
-
-	const matches = jsonOutput.map((container) => {
-		if (container.Image.includes("cloudflare-dev/fixturetestcontainer")) {
-			return container.ID;
-		}
 	});
-	return matches.filter(Boolean);
-};
+
+	baseDescribe(
+		"multi-workers containers dev",
+		{ retry: 0, timeout: 50000 },
+		() => {
+			let tmpDir: string;
+			beforeAll(async () => {
+				tmpDir = fs.mkdtempSync(
+					path.join(tmpdir(), "wrangler-multi-workers-containers-")
+				);
+				fs.cpSync(
+					path.resolve(__dirname, "../", "multi-workers-containers-app"),
+					path.join(tmpDir),
+					{
+						recursive: true,
+					}
+				);
+
+				const ids = getContainerIds();
+				if (ids.length > 0) {
+					execSync("docker rm -f " + ids.join(" "), {
+						encoding: "utf8",
+					});
+				}
+			});
+
+			afterEach(async () => {
+				const ids = getContainerIds();
+
+				if (ids.length > 0) {
+					execSync("docker rm -f " + ids.join(" "), {
+						encoding: "utf8",
+					});
+				}
+			});
+			afterAll(async () => {
+				try {
+					fs.rmSync(tmpDir, { recursive: true, force: true });
+				} catch (e) {
+					// It seems that Windows doesn't let us delete this, with errors like:
+					//
+					// Error: EBUSY: resource busy or locked, rmdir 'C:\Users\RUNNER~1\AppData\Local\Temp\wrangler-modules-pKJ7OQ'
+					// ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+					// Serialized Error: {
+					// 	"code": "EBUSY",
+					// 	"errno": -4082,
+					// 	"path": "C:\Users\RUNNER~1\AppData\Local\Temp\wrangler-modules-pKJ7OQ",
+					// 	"syscall": "rmdir",
+					// }
+					console.error(e);
+				}
+			});
+
+			it("should be able to interact with both workers, rebuild the containers with the hotkey and all containers should be cleaned up at the end", async () => {
+				const wrangler = await startWranglerDev([
+					"dev",
+					"-c",
+					path.join(tmpDir, "workerA/wrangler.jsonc"),
+					"-c",
+					path.join(tmpDir, "workerB/wrangler.jsonc"),
+				]);
+
+				await vi.waitFor(
+					async () => {
+						const json = await (
+							await fetch(wrangler.url, { signal: AbortSignal.timeout(5_000) })
+						).json();
+						expect(json).toEqual({
+							containerAText: "Hello from Container A",
+							containerBText: "Hello from Container B",
+						});
+					},
+					{ timeout: 10_000, interval: 1000 }
+				);
+
+				const tmpDockerfileAPath = path.join(tmpDir, "workerA/Dockerfile");
+				const dockerFileAContent = fs.readFileSync(tmpDockerfileAPath, "utf8");
+				fs.writeFileSync(
+					tmpDockerfileAPath,
+					dockerFileAContent.replace(
+						'"Hello from Container A"',
+						'"Hello World from Container A"'
+					),
+					"utf-8"
+				);
+
+				const tmpDockerfileBPath = path.join(tmpDir, "workerB/Dockerfile");
+				const dockerFileBContent = fs.readFileSync(tmpDockerfileBPath, "utf8");
+				fs.writeFileSync(
+					tmpDockerfileBPath,
+					dockerFileBContent.replace(
+						'"Hello from Container B"',
+						'"Hello from the B Container"'
+					),
+					"utf-8"
+				);
+
+				wrangler.pty.write("r");
+
+				await vi.waitFor(
+					async () => {
+						const json = await (
+							await fetch(wrangler.url, { signal: AbortSignal.timeout(5_000) })
+						).json();
+						expect(json).toEqual({
+							containerAText: "Hello World from Container A",
+							containerBText: "Hello from the B Container",
+						});
+					},
+					{ timeout: 30_000, interval: 1000 }
+				);
+
+				fs.writeFileSync(tmpDockerfileAPath, dockerFileAContent, "utf-8");
+				fs.writeFileSync(tmpDockerfileBPath, dockerFileBContent, "utf-8");
+
+				wrangler.pty.kill("SIGINT");
+			});
+		}
+	);
+
+	/** gets any containers that were created by running this fixture */
+	const getContainerIds = () => {
+		// note the -a to include stopped containers
+		const allContainers = execSync(`docker ps -a --format json`)
+			.toString()
+			.split("\n")
+			.filter((line) => line.trim());
+		if (allContainers.length === 0) {
+			return [];
+		}
+		const jsonOutput = allContainers.map((line) => JSON.parse(line));
+
+		const matches = jsonOutput.map((container) => {
+			if (container.Image.includes("cloudflare-dev/fixturetestcontainer")) {
+				return container.ID;
+			}
+		});
+		return matches.filter(Boolean);
+	};
+});

--- a/packages/containers-shared/src/utils.ts
+++ b/packages/containers-shared/src/utils.ts
@@ -73,15 +73,23 @@ export const runDockerCmdWithOutput = (dockerPath: string, args: string[]) => {
 	}
 };
 
+/** Checks whether docker is running on the system */
+export const isDockerRunning = async (dockerPath: string) => {
+	try {
+		await runDockerCmd(dockerPath, ["info"], ["inherit", "pipe", "pipe"]);
+	} catch {
+		// We assume this command is unlikely to fail for reasons other than the Docker daemon not running, or the Docker CLI not being installed or in the PATH.
+		return false;
+	}
+	return true;
+};
+
 /** throws when docker is not installed */
 export const verifyDockerInstalled = async (
 	dockerPath: string,
 	isDev = true
 ) => {
-	try {
-		await runDockerCmd(dockerPath, ["info"], ["inherit", "pipe", "pipe"]);
-	} catch {
-		// We assume this command is unlikely to fail for reasons other than the Docker daemon not running, or the Docker CLI not being installed or in the PATH.
+	if (!isDockerRunning(dockerPath)) {
 		throw new UserError(
 			`The Docker CLI could not be launched. Please ensure that the Docker CLI is installed and the daemon is running.\n` +
 				`Other container tooling that is compatible with the Docker CLI and engine may work, but is not yet guaranteed to do so. You can specify an executable with the environment variable WRANGLER_DOCKER_BIN and a socket with DOCKER_HOST.` +

--- a/packages/vite-plugin-cloudflare/playground/containers/__tests__/containers.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/containers/__tests__/containers.spec.ts
@@ -1,13 +1,24 @@
+import { isDockerRunning } from "@cloudflare/containers-shared";
 import { expect, test, vi } from "vitest";
 import {
 	getTextResponse,
 	isCINonLinux,
 	viteTestUrl,
 } from "../../__test-utils__";
+import { getDockerPath } from "../../../src/containers";
+
+const dockerIsRunning = await isDockerRunning(getDockerPath());
+/** Indicates whether the test is being run locally (not in CI) AND docker is currently not running on the system */
+const isLocalWithoutDockerRunning =
+	process.env.CI !== "true" && !dockerIsRunning;
 
 // We can only really run these tests on Linux, because we build our images for linux/amd64,
 // and github runners don't really support container virtualization in any sane way
-test.skipIf(isCINonLinux)("starts container", async () => {
+test.skipIf(
+	isCINonLinux ||
+		// If the test is being run locally and docker is not running we just skip this test
+		isLocalWithoutDockerRunning
+)("starts container", async () => {
 	const startResponse = await getTextResponse("/start");
 	expect(startResponse).toBe("Container create request sent...");
 

--- a/packages/wrangler/e2e/containers.dev.test.ts
+++ b/packages/wrangler/e2e/containers.dev.test.ts
@@ -11,7 +11,10 @@ import {
 	vi,
 } from "vitest";
 import { buildImage } from "../../containers-shared/src/build";
-import { generateContainerBuildId } from "../../containers-shared/src/utils";
+import {
+	generateContainerBuildId,
+	isDockerRunning,
+} from "../../containers-shared/src/utils";
 import { getDockerPath } from "../src/environment-variables/misc-variables";
 import { dedent } from "../src/utils/dedent";
 import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
@@ -29,47 +32,51 @@ for (const source of imageSource) {
 	// When pulling images an account id is necessary
 	const isPullWithoutAccountId = source === "pull" && !CLOUDFLARE_ACCOUNT_ID;
 
-	describe.skipIf(isCINonLinux || isPullWithoutAccountId)(
-		`containers local dev tests: ${source}`,
-		{ timeout: 90_000 },
-		() => {
-			let helper: WranglerE2ETestHelper;
-			let workerName: string;
-			let wranglerConfig: Record<string, unknown>;
+	const dockerIsRunning = await isDockerRunning(getDockerPath());
+	/** Indicates whether the test is being run locally (not in CI) AND docker is currently not running on the system */
+	const isLocalWithoutDockerRunning =
+		process.env.CI !== "true" && !dockerIsRunning;
 
-			beforeAll(async () => {
-				workerName = generateResourceName();
+	describe.skipIf(
+		isCINonLinux || isPullWithoutAccountId || isLocalWithoutDockerRunning
+	)(`containers local dev tests: ${source}`, { timeout: 90_000 }, () => {
+		let helper: WranglerE2ETestHelper;
+		let workerName: string;
+		let wranglerConfig: Record<string, unknown>;
 
-				helper = new WranglerE2ETestHelper();
-				wranglerConfig = {
-					name: `${workerName}`,
-					main: "src/index.ts",
-					compatibility_date: "2025-04-03",
-					containers: [
-						{
-							image: "./Dockerfile",
-							class_name: `E2EContainer`,
-							name: `${workerName}-container`,
-						},
-					],
-					durable_objects: {
-						bindings: [
-							{
-								class_name: `E2EContainer`,
-								name: "CONTAINER",
-							},
-						],
+		beforeAll(async () => {
+			workerName = generateResourceName();
+
+			helper = new WranglerE2ETestHelper();
+			wranglerConfig = {
+				name: `${workerName}`,
+				main: "src/index.ts",
+				compatibility_date: "2025-04-03",
+				containers: [
+					{
+						image: "./Dockerfile",
+						class_name: `E2EContainer`,
+						name: `${workerName}-container`,
 					},
-					migrations: [
+				],
+				durable_objects: {
+					bindings: [
 						{
-							tag: "v1",
-							new_classes: [`E2EContainer`],
+							class_name: `E2EContainer`,
+							name: "CONTAINER",
 						},
 					],
-				};
-				await helper.seed({
-					"wrangler.json": JSON.stringify(wranglerConfig),
-					"src/index.ts": dedent`
+				},
+				migrations: [
+					{
+						tag: "v1",
+						new_classes: [`E2EContainer`],
+					},
+				],
+			};
+			await helper.seed({
+				"wrangler.json": JSON.stringify(wranglerConfig),
+				"src/index.ts": dedent`
 						import { DurableObject } from "cloudflare:workers";
 
 						export class E2EContainer extends DurableObject<Env> {
@@ -112,7 +119,7 @@ for (const source of imageSource) {
 								return stub.fetch(request);
 							},
 						} satisfies ExportedHandler<Env>;`,
-					Dockerfile: dedent`
+				Dockerfile: dedent`
 						FROM node:22-alpine
 
 						WORKDIR /usr/src/app
@@ -120,7 +127,7 @@ for (const source of imageSource) {
 						COPY ./container/app.js app.js
 						EXPOSE 8080
 						`,
-					"container/app.js": dedent`
+				"container/app.js": dedent`
 					const { createServer } = require("http");
 
 					const server = createServer(function (req, res) {
@@ -133,248 +140,247 @@ for (const source of imageSource) {
 						console.log("Server listening on port 8080");
 					});
 					`,
-				});
-				// if we are pulling we need to push the image first
-				if (source === "pull") {
-					// pull a container image from the registry
-					await helper.run(
-						`wrangler containers build . -t ${workerName}:tmp-e2e -p`
-					);
+			});
+			// if we are pulling we need to push the image first
+			if (source === "pull") {
+				// pull a container image from the registry
+				await helper.run(
+					`wrangler containers build . -t ${workerName}:tmp-e2e -p`
+				);
 
-					wranglerConfig = {
-						...wranglerConfig,
-						containers: [
-							{
-								image: `registry.cloudflare.com/${CLOUDFLARE_ACCOUNT_ID}/${workerName}:tmp-e2e`,
-								class_name: `E2EContainer`,
-								name: `${workerName}-container`,
-							},
-						],
-					};
-					await helper.seed({
-						"wrangler.json": JSON.stringify(wranglerConfig),
-					});
-					// wait a bit for the image to be available to pull
-					await new Promise((resolve) => setTimeout(resolve, 5_000));
-				}
-			}, 30_000);
-			beforeEach(async () => {
+				wranglerConfig = {
+					...wranglerConfig,
+					containers: [
+						{
+							image: `registry.cloudflare.com/${CLOUDFLARE_ACCOUNT_ID}/${workerName}:tmp-e2e`,
+							class_name: `E2EContainer`,
+							name: `${workerName}-container`,
+						},
+					],
+				};
 				await helper.seed({
 					"wrangler.json": JSON.stringify(wranglerConfig),
 				});
-				/// wait a bit in case the expected cleanup from shutting down wrangler dev is already happening
-				await new Promise((resolve) => setTimeout(resolve, 500));
-				// cleanup any running containers. this does happen automatically when we shut down wrangler,
-				// but treekill is being uncooperative. this is also tested in interactive-dev-fixture
-				// where it is working as expected
-				const ids = getContainerIds("e2econtainer");
-				if (ids.length > 0) {
-					execSync(`${getDockerPath()} rm -f ${ids.join(" ")}`, {
-						encoding: "utf8",
-					});
-				}
+				// wait a bit for the image to be available to pull
+				await new Promise((resolve) => setTimeout(resolve, 5_000));
+			}
+		}, 30_000);
+		beforeEach(async () => {
+			await helper.seed({
+				"wrangler.json": JSON.stringify(wranglerConfig),
 			});
-			afterAll(async () => {
-				// wait a bit in case the expected cleanup from shutting down wrangler dev is already happening
-				await new Promise((resolve) => setTimeout(resolve, 500));
-				// again this should happen automatically when we shut down wrangler, but treekill is being uncooperative.
-				// this is tested in interactive-dev-fixture where it is working as expected.
-				const ids = getContainerIds("e2econtainer");
-				if (ids.length > 0) {
-					execSync(`${getDockerPath()} rm -f ${ids.join(" ")}`, {
-						encoding: "utf8",
-					});
-				}
-				if (source === "pull") {
-					// TODO: we won't need to prefix the account id once 9811 lands
-					await helper.run(
-						`wrangler containers images delete ${workerName}:tmp-e2e`
-					);
-				}
-			});
-			it(`will build or pull containers when miniflare starts`, async () => {
-				const worker = helper.runLongLived("wrangler dev");
-				await worker.readUntil(/Preparing container/);
-				if (source === "pull") {
-					await worker.readUntil(/Status/);
-				} else {
-					await worker.readUntil(/DONE/);
-				}
-				// from miniflare output:
-				await worker.readUntil(/Container image\(s\) ready/);
-			});
-
-			it(`will be able to interact with the container`, async () => {
-				const worker = helper.runLongLived("wrangler dev");
-				const ready = await worker.waitForReady();
-
-				await vi.waitFor(async () => {
-					const response = await fetch(`${ready.url}/status`);
-					expect(response.status).toBe(200);
-					const status = await response.json();
-					expect(status).toBe(false);
+			/// wait a bit in case the expected cleanup from shutting down wrangler dev is already happening
+			await new Promise((resolve) => setTimeout(resolve, 500));
+			// cleanup any running containers. this does happen automatically when we shut down wrangler,
+			// but treekill is being uncooperative. this is also tested in interactive-dev-fixture
+			// where it is working as expected
+			const ids = getContainerIds("e2econtainer");
+			if (ids.length > 0) {
+				execSync(`${getDockerPath()} rm -f ${ids.join(" ")}`, {
+					encoding: "utf8",
 				});
+			}
+		});
+		afterAll(async () => {
+			// wait a bit in case the expected cleanup from shutting down wrangler dev is already happening
+			await new Promise((resolve) => setTimeout(resolve, 500));
+			// again this should happen automatically when we shut down wrangler, but treekill is being uncooperative.
+			// this is tested in interactive-dev-fixture where it is working as expected.
+			const ids = getContainerIds("e2econtainer");
+			if (ids.length > 0) {
+				execSync(`${getDockerPath()} rm -f ${ids.join(" ")}`, {
+					encoding: "utf8",
+				});
+			}
+			if (source === "pull") {
+				// TODO: we won't need to prefix the account id once 9811 lands
+				await helper.run(
+					`wrangler containers images delete ${workerName}:tmp-e2e`
+				);
+			}
+		});
+		it(`will build or pull containers when miniflare starts`, async () => {
+			const worker = helper.runLongLived("wrangler dev");
+			await worker.readUntil(/Preparing container/);
+			if (source === "pull") {
+				await worker.readUntil(/Status/);
+			} else {
+				await worker.readUntil(/DONE/);
+			}
+			// from miniflare output:
+			await worker.readUntil(/Container image\(s\) ready/);
+		});
 
-				let response = await fetch(`${ready.url}/start`);
-				let text = await response.text();
+		it(`will be able to interact with the container`, async () => {
+			const worker = helper.runLongLived("wrangler dev");
+			const ready = await worker.waitForReady();
+
+			await vi.waitFor(async () => {
+				const response = await fetch(`${ready.url}/status`);
 				expect(response.status).toBe(200);
-				expect(text).toBe("Container create request sent...");
-
-				await vi.waitFor(async () => {
-					response = await fetch(`${ready.url}/status`);
-					expect(response.status).toBe(200);
-					const status = await response.json();
-					expect(status).toBe(true);
-				});
-
-				await vi.waitFor(
-					async () => {
-						response = await fetch(`${ready.url}/fetch`, {
-							signal: AbortSignal.timeout(3_000),
-							headers: { "MF-Disable-Pretty-Error": "true" },
-						});
-						text = await response.text();
-						expect(text).toBe("Hello World! Have an env var! I'm an env var!");
-					},
-					{ timeout: 5_000 }
-				);
-
-				// Check that a container is running using `docker ps`
-				const ids = getContainerIds("e2econtainer");
-				expect(ids.length).toBe(1);
-				await worker.stop();
+				const status = await response.json();
+				expect(status).toBe(false);
 			});
 
-			it("should clean up duplicate image tags after build", async () => {
-				const dockerPath = getDockerPath();
-				const fakeBuildID = generateContainerBuildId();
-				const initialImageTag = `cloudflare-dev/test-cleanup:${fakeBuildID}`;
+			let response = await fetch(`${ready.url}/start`);
+			let text = await response.text();
+			expect(response.status).toBe(200);
+			expect(text).toBe("Container create request sent...");
 
-				// First, build an image directly to create a duplicate tag scenario
-				const build = await buildImage(dockerPath, {
-					dockerfile: path.resolve(helper.tmpPath, "./Dockerfile"),
-					image_tag: initialImageTag,
-					class_name: "TestContainer",
-					image_build_context: helper.tmpPath,
-					image_vars: {},
-				});
-				await build.ready;
-
-				const initialRepoTags = JSON.parse(
-					execSync(
-						`${dockerPath} image inspect ${initialImageTag} --format "{{ json .RepoTags }}"`,
-						{ encoding: "utf8" }
-					)
-				);
-				expect(initialRepoTags.length).toBeGreaterThan(0);
-
-				// wrangler dev will rebuild/pull and trigger cleanup
-				const worker = helper.runLongLived("wrangler dev");
-				const ready = await worker.waitForReady();
-
-				// check that the container can still start
-				await vi.waitFor(async () => {
-					const response = await fetch(`${ready.url}/status`);
-					expect(response.status).toBe(200);
-					const status = await response.json();
-					expect(status).toBe(false);
-				});
-
-				// expect the original tag not to be there any more
-				expect(() => {
-					execSync(`${dockerPath} image inspect ${initialImageTag}`);
-				}).toThrow();
+			await vi.waitFor(async () => {
+				response = await fetch(`${ready.url}/status`);
+				expect(response.status).toBe(200);
+				const status = await response.json();
+				expect(status).toBe(true);
 			});
 
-			it("won't start the container service if no containers are present", async () => {
-				await helper.seed({
-					"wrangler.json": JSON.stringify({
-						...wranglerConfig,
-						containers: [],
-					}),
-				});
-				const worker = helper.runLongLived("wrangler dev");
-				await worker.waitForReady();
-				await worker.stop();
-				const output = await worker.output;
-				expect(output).not.toContain("Preparing container image(s)...");
+			await vi.waitFor(
+				async () => {
+					response = await fetch(`${ready.url}/fetch`, {
+						signal: AbortSignal.timeout(3_000),
+						headers: { "MF-Disable-Pretty-Error": "true" },
+					});
+					text = await response.text();
+					expect(text).toBe("Hello World! Have an env var! I'm an env var!");
+				},
+				{ timeout: 5_000 }
+			);
+
+			// Check that a container is running using `docker ps`
+			const ids = getContainerIds("e2econtainer");
+			expect(ids.length).toBe(1);
+			await worker.stop();
+		});
+
+		it("should clean up duplicate image tags after build", async () => {
+			const dockerPath = getDockerPath();
+			const fakeBuildID = generateContainerBuildId();
+			const initialImageTag = `cloudflare-dev/test-cleanup:${fakeBuildID}`;
+
+			// First, build an image directly to create a duplicate tag scenario
+			const build = await buildImage(dockerPath, {
+				dockerfile: path.resolve(helper.tmpPath, "./Dockerfile"),
+				image_tag: initialImageTag,
+				class_name: "TestContainer",
+				image_build_context: helper.tmpPath,
+				image_vars: {},
+			});
+			await build.ready;
+
+			const initialRepoTags = JSON.parse(
+				execSync(
+					`${dockerPath} image inspect ${initialImageTag} --format "{{ json .RepoTags }}"`,
+					{ encoding: "utf8" }
+				)
+			);
+			expect(initialRepoTags.length).toBeGreaterThan(0);
+
+			// wrangler dev will rebuild/pull and trigger cleanup
+			const worker = helper.runLongLived("wrangler dev");
+			const ready = await worker.waitForReady();
+
+			// check that the container can still start
+			await vi.waitFor(async () => {
+				const response = await fetch(`${ready.url}/status`);
+				expect(response.status).toBe(200);
+				const status = await response.json();
+				expect(status).toBe(false);
 			});
 
-			it("won't start the container service if enable_containers is set to false via config", async () => {
-				await helper.seed({
-					"wrangler.json": JSON.stringify({
-						...wranglerConfig,
-						dev: { enable_containers: false },
-					}),
-				});
-				const worker = helper.runLongLived("wrangler dev");
-				await worker.waitForReady();
-				await worker.stop();
-				expect(await worker.output).not.toContain(
-					"Preparing container image(s)..."
-				);
+			// expect the original tag not to be there any more
+			expect(() => {
+				execSync(`${dockerPath} image inspect ${initialImageTag}`);
+			}).toThrow();
+		});
+
+		it("won't start the container service if no containers are present", async () => {
+			await helper.seed({
+				"wrangler.json": JSON.stringify({
+					...wranglerConfig,
+					containers: [],
+				}),
 			});
+			const worker = helper.runLongLived("wrangler dev");
+			await worker.waitForReady();
+			await worker.stop();
+			const output = await worker.output;
+			expect(output).not.toContain("Preparing container image(s)...");
+		});
 
-			it("will display the ready-on message after the container(s) have been built/pulled", async () => {
-				const worker = helper.runLongLived("wrangler dev");
-				const readyRegexp = /Ready on (http:\/\/[a-z0-9.]+:[0-9]+)/;
-				await worker.readUntil(readyRegexp);
-
-				await worker.stop();
-
-				const fullOutput = await worker.output;
-				const indexOfContainersReadyMessage = fullOutput.indexOf(
-					"Container image(s) ready"
-				);
-
-				const indexOfReadyOnMessage = fullOutput.indexOf("Ready on");
-				expect(indexOfReadyOnMessage).toBeGreaterThan(
-					indexOfContainersReadyMessage
-				);
+		it("won't start the container service if enable_containers is set to false via config", async () => {
+			await helper.seed({
+				"wrangler.json": JSON.stringify({
+					...wranglerConfig,
+					dev: { enable_containers: false },
+				}),
 			});
+			const worker = helper.runLongLived("wrangler dev");
+			await worker.waitForReady();
+			await worker.stop();
+			expect(await worker.output).not.toContain(
+				"Preparing container image(s)..."
+			);
+		});
 
-			it("won't start the container service if --enable-containers is set to false via CLI", async () => {
-				const worker = helper.runLongLived(
-					"wrangler dev --enable-containers=false"
-				);
-				await worker.waitForReady();
-				await worker.stop();
-				expect(await worker.output).not.toContain(
-					"Preparing container image(s)..."
-				);
-			});
+		it("will display the ready-on message after the container(s) have been built/pulled", async () => {
+			const worker = helper.runLongLived("wrangler dev");
+			const readyRegexp = /Ready on (http:\/\/[a-z0-9.]+:[0-9]+)/;
+			await worker.readUntil(readyRegexp);
 
-			it("errors if no ports are exposed", async () => {
-				await helper.seed({
-					Dockerfile: dedent`
+			await worker.stop();
+
+			const fullOutput = await worker.output;
+			const indexOfContainersReadyMessage = fullOutput.indexOf(
+				"Container image(s) ready"
+			);
+
+			const indexOfReadyOnMessage = fullOutput.indexOf("Ready on");
+			expect(indexOfReadyOnMessage).toBeGreaterThan(
+				indexOfContainersReadyMessage
+			);
+		});
+
+		it("won't start the container service if --enable-containers is set to false via CLI", async () => {
+			const worker = helper.runLongLived(
+				"wrangler dev --enable-containers=false"
+			);
+			await worker.waitForReady();
+			await worker.stop();
+			expect(await worker.output).not.toContain(
+				"Preparing container image(s)..."
+			);
+		});
+
+		it("errors if no ports are exposed", async () => {
+			await helper.seed({
+				Dockerfile: dedent`
 								FROM alpine:latest
 								CMD ["echo", "hello world"]
 								`,
-				});
-				if (source === "pull") {
-					await helper.run(
-						`wrangler containers build . -t ${workerName}:tmp-e2e -p`
-					);
-				}
-				const worker = helper.runLongLived("wrangler dev");
-				expect(await worker.exitCode).toBe(1);
-				expect(await worker.output).toContain("does not expose any ports");
 			});
+			if (source === "pull") {
+				await helper.run(
+					`wrangler containers build . -t ${workerName}:tmp-e2e -p`
+				);
+			}
+			const worker = helper.runLongLived("wrangler dev");
+			expect(await worker.exitCode).toBe(1);
+			expect(await worker.output).toContain("does not expose any ports");
+		});
 
-			it("errors if docker is not installed", async () => {
-				vi.stubEnv("WRANGLER_DOCKER_BIN", "not-a-real-docker-binary");
-				const worker = helper.runLongLived("wrangler dev");
-				expect(await worker.exitCode).toBe(1);
-				expect(await worker.output).toContain(
-					`The Docker CLI could not be launched. Please ensure that the Docker CLI is installed and the daemon is running.`
-				);
-				expect(await worker.output).toContain(
-					`To suppress this error if you do not intend on triggering any container instances, set dev.enable_containers to false in your Wrangler config or passing in --enable-containers=false.`
-				);
-				vi.unstubAllEnvs();
-			});
-		}
-	);
+		it("errors if docker is not installed", async () => {
+			vi.stubEnv("WRANGLER_DOCKER_BIN", "not-a-real-docker-binary");
+			const worker = helper.runLongLived("wrangler dev");
+			expect(await worker.exitCode).toBe(1);
+			expect(await worker.output).toContain(
+				`The Docker CLI could not be launched. Please ensure that the Docker CLI is installed and the daemon is running.`
+			);
+			expect(await worker.output).toContain(
+				`To suppress this error if you do not intend on triggering any container instances, set dev.enable_containers to false in your Wrangler config or passing in --enable-containers=false.`
+			);
+			vi.unstubAllEnvs();
+		});
+	});
 }
 
 /** gets any containers that were created by running this fixture */


### PR DESCRIPTION
The changes here make it so that containers tests run locally are skipped when docker is not running instead of failing, in this way we are not forcing users to have docker running when they run the tests (similarly on how we skip the API tests locally when we don't get a token)

The tests still always run in CI

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: tests-change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler v3 change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
