### PR TITLE
chore: run fork CI job by rewriting last commit

### DIFF
--- a/.github/workflows/run-ci-for-external-forks.yml
+++ b/.github/workflows/run-ci-for-external-forks.yml
@@ -55,7 +55,10 @@ jobs:
           COMMIT_SHA: ${{ inputs.commit-sha }}
 
       - name: Push Branch
-        run: git push origin HEAD --force
+        run: |
+          # Rewrite last commit so GitHub considers it new and runs the CI jobs with our secrets
+          git commit --amend --no-edit
+          git push origin HEAD --force
 
       - name: "Create Draft PR"
         run: |


### PR DESCRIPTION
Fixes n/a.

This fixes the `Run CI on behalf of External Forks` workflow by rewriting the last commit, so that GitHub consider it a new commit and will run it with the repository secret.

This means the CI run result will no longer be reflected on the original PR, which should be fine as we are using it as an additional check to verify the result of our API tests. 

This is manually tested with #10849.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
