### PR TITLE
Revert 10805 (Drop process polyfill when v2 is available)

### DIFF
--- a/.changeset/little-numbers-report.md
+++ b/.changeset/little-numbers-report.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/unenv-preset": patch
+---
+
+Revert "Drop `node:process` polyfill when v2 is available"

--- a/packages/unenv-preset/package.json
+++ b/packages/unenv-preset/package.json
@@ -49,7 +49,7 @@
 	},
 	"peerDependencies": {
 		"unenv": "2.0.0-rc.21",
-		"workerd": "^1.20250924.0"
+		"workerd": "^1.20250912.0"
 	},
 	"peerDependenciesMeta": {
 		"workerd": {

--- a/packages/unenv-preset/package.json
+++ b/packages/unenv-preset/package.json
@@ -49,7 +49,7 @@
 	},
 	"peerDependencies": {
 		"unenv": "2.0.0-rc.21",
-		"workerd": "^1.20250912.0"
+		"workerd": "^1.20250927.0"
 	},
 	"peerDependenciesMeta": {
 		"workerd": {

--- a/packages/unenv-preset/src/preset.ts
+++ b/packages/unenv-preset/src/preset.ts
@@ -47,7 +47,7 @@ const nativeModules = [
 ];
 
 // Modules implemented via a mix of workerd APIs and polyfills.
-const hybridModules = ["console"];
+const hybridModules = ["console", "process"];
 
 /**
  * Creates the Cloudflare preset for the given compatibility date and compatibility flags
@@ -72,7 +72,6 @@ export function getCloudflarePreset({
 	const http2Overrides = getHttp2Overrides(compat);
 	const osOverrides = getOsOverrides(compat);
 	const fsOverrides = getFsOverrides(compat);
-	const processOverrides = getProcessOverrides(compat);
 
 	// "dynamic" as they depend on the compatibility date and flags
 	const dynamicNativeModules = [
@@ -81,7 +80,6 @@ export function getCloudflarePreset({
 		...http2Overrides.nativeModules,
 		...osOverrides.nativeModules,
 		...fsOverrides.nativeModules,
-		...processOverrides.nativeModules,
 	];
 
 	// "dynamic" as they depend on the compatibility date and flags
@@ -91,7 +89,6 @@ export function getCloudflarePreset({
 		...http2Overrides.hybridModules,
 		...osOverrides.hybridModules,
 		...fsOverrides.hybridModules,
-		...processOverrides.hybridModules,
 	];
 
 	return {
@@ -125,7 +122,7 @@ export function getCloudflarePreset({
 			clearImmediate: false,
 			setImmediate: false,
 			console: "@cloudflare/unenv-preset/node/console",
-			...processOverrides.inject,
+			process: "@cloudflare/unenv-preset/node/process",
 		},
 		polyfill: ["@cloudflare/unenv-preset/polyfill/performance"],
 		external: dynamicNativeModules.flatMap((p) => [p, `node:${p}`]),
@@ -306,50 +303,5 @@ function getFsOverrides({
 		: {
 				nativeModules: [],
 				hybridModules: [],
-			};
-}
-
-/**
- * Returns the overrides for `node:process` and `node:fs/promises`
- *
- * The native process v2 implementation:
- * - is enabled starting from 2025-09-15
- * - can be enabled with the "enable_nodejs_process_v2" flag
- * - can be disabled with the "disable_nodejs_process_v2" flag
- */
-function getProcessOverrides({
-	compatibilityDate,
-	compatibilityFlags,
-}: {
-	compatibilityDate: string;
-	compatibilityFlags: string[];
-}): {
-	nativeModules: string[];
-	hybridModules: string[];
-	inject: { process: string | false };
-} {
-	const disabledV2ByFlag = compatibilityFlags.includes(
-		"disable_nodejs_process_v2"
-	);
-
-	const enabledV2ByFlag = compatibilityFlags.includes(
-		"enable_nodejs_process_v2"
-	);
-	const enabledV2ByDate = compatibilityDate >= "2025-09-15";
-
-	const isV2 = (enabledV2ByFlag || enabledV2ByDate) && !disabledV2ByFlag;
-
-	return isV2
-		? {
-				nativeModules: ["process"],
-				hybridModules: [],
-				// We can use the native global, return `false` to drop the unenv default
-				inject: { process: false },
-			}
-		: {
-				nativeModules: [],
-				hybridModules: ["process"],
-				// Use the module default export as the global `process`
-				inject: { process: "@cloudflare/unenv-preset/node/process" },
 			};
 }

--- a/packages/unenv-preset/src/runtime/node/process.ts
+++ b/packages/unenv-preset/src/runtime/node/process.ts
@@ -1,6 +1,3 @@
-// The polyfill is only used with the process v1 native implementation
-// process v2 implements all the APIs from workerd v1.20250924.0
-
 import { hrtime as UnenvHrTime } from "unenv/node/internal/process/hrtime";
 import { Process as UnenvProcess } from "unenv/node/internal/process/process";
 
@@ -19,38 +16,83 @@ export const getBuiltinModule: NodeJS.Process["getBuiltinModule"] =
 
 const workerdProcess = getBuiltinModule("node:process");
 
+// Workerd has 2 different implementation for `node:process`
+//
+// See:
+// - [workerd `process` v1](https://github.com/cloudflare/workerd/blob/main/src/node/internal/legacy_process.ts)
+// - [workerd `process` v2](https://github.com/cloudflare/workerd/blob/main/src/node/internal/public_process.ts)
+// - [`enable_nodejs_process_v2` flag](https://github.com/cloudflare/workerd/blob/main/src/workerd/io/compatibility-date.capnp)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isWorkerdProcessV2 = (globalThis as any).Cloudflare.compatibilityFlags
+	.enable_nodejs_process_v2;
+
 const unenvProcess = new UnenvProcess({
 	env: globalProcess.env,
-	hrtime: UnenvHrTime,
+	// `hrtime` is only available from workerd process v2
+	hrtime: isWorkerdProcessV2 ? workerdProcess.hrtime : UnenvHrTime,
 	// `nextTick` is available from workerd process v1
 	nextTick: workerdProcess.nextTick,
 });
 
-// APIs implemented by workerd process in both v1 and v2
+// APIs implemented by workerd module in both v1 and v2
 // Note that `env`, `hrtime` and `nextTick` are always retrieved from `unenv`
 export const { exit, features, platform } = workerdProcess;
 
+// APIs that can be implemented by either `unenv` or `workerd`.
+// They are always retrieved from `unenv` which might use their `workerd` implementation.
+export const {
+	// Always implemented by workerd
+	env,
+	// Only implemented in workerd v2
+	hrtime,
+	// Always implemented by workerd
+	nextTick,
+} = unenvProcess;
+
+// APIs that are not implemented by `workerd` (whether v1 or v2)
+// They are retrieved from `unenv`.
 export const {
 	_channel,
-	_debugEnd,
-	_debugProcess,
 	_disconnect,
 	_events,
 	_eventsCount,
-	_exiting,
-	_fatalException,
-	_getActiveHandles,
-	_getActiveRequests,
 	_handleQueue,
-	_kill,
-	_linkedBinding,
 	_maxListeners,
 	_pendingMessage,
-	_preload_modules,
-	_rawDebug,
 	_send,
+	assert,
+	disconnect,
+	mainModule,
+} = unenvProcess;
+
+// API that are only implemented starting from v2 of workerd process
+// They are retrieved from unenv when process v1 is used
+export const {
+	// @ts-expect-error `_debugEnd` is missing typings
+	_debugEnd,
+	// @ts-expect-error `_debugProcess` is missing typings
+	_debugProcess,
+	// @ts-expect-error `_exiting` is missing typings
+	_exiting,
+	// @ts-expect-error `_fatalException` is missing typings
+	_fatalException,
+	// @ts-expect-error `_getActiveHandles` is missing typings
+	_getActiveHandles,
+	// @ts-expect-error `_getActiveRequests` is missing typings
+	_getActiveRequests,
+	// @ts-expect-error `_kill` is missing typings
+	_kill,
+	// @ts-expect-error `_linkedBinding` is missing typings
+	_linkedBinding,
+	// @ts-expect-error `_preload_modules` is missing typings
+	_preload_modules,
+	// @ts-expect-error `_rawDebug` is missing typings
+	_rawDebug,
+	// @ts-expect-error `_startProfilerIdleNotifier` is missing typings
 	_startProfilerIdleNotifier,
+	// @ts-expect-error `_stopProfilerIdleNotifier` is missing typings
 	_stopProfilerIdleNotifier,
+	// @ts-expect-error `_tickCallback` is missing typings
 	_tickCallback,
 	abort,
 	addListener,
@@ -58,8 +100,8 @@ export const {
 	arch,
 	argv,
 	argv0,
-	assert,
 	availableMemory,
+	// @ts-expect-error `binding` is missing typings
 	binding,
 	channel,
 	chdir,
@@ -69,12 +111,11 @@ export const {
 	cpuUsage,
 	cwd,
 	debugPort,
-	disconnect,
 	dlopen,
+	// @ts-expect-error `domain` is missing typings
 	domain,
 	emit,
 	emitWarning,
-	env,
 	eventNames,
 	execArgv,
 	execPath,
@@ -88,19 +129,19 @@ export const {
 	getMaxListeners,
 	getuid,
 	hasUncaughtExceptionCaptureCallback,
-	hrtime,
+	// @ts-expect-error `initgroups` is missing typings
 	initgroups,
 	kill,
 	listenerCount,
 	listeners,
 	loadEnvFile,
-	mainModule,
 	memoryUsage,
+	// @ts-expect-error `moduleLoadList` is missing typings
 	moduleLoadList,
-	nextTick,
 	off,
 	on,
 	once,
+	// @ts-expect-error `openStdin` is missing typings
 	openStdin,
 	permission,
 	pid,
@@ -108,6 +149,7 @@ export const {
 	prependListener,
 	prependOnceListener,
 	rawListeners,
+	// @ts-expect-error `reallyExit` is missing typings
 	reallyExit,
 	ref,
 	release,
@@ -136,7 +178,7 @@ export const {
 	uptime,
 	version,
 	versions,
-} = unenvProcess;
+} = isWorkerdProcessV2 ? workerdProcess : unenvProcess;
 
 const _process = {
 	abort,

--- a/packages/wrangler/e2e/unenv-preset/worker/index.ts
+++ b/packages/wrangler/e2e/unenv-preset/worker/index.ts
@@ -513,6 +513,7 @@ export const WorkerdTests: Record<string, () => void> = {
 		const useV2 = getRuntimeFlagValue("enable_nodejs_process_v2");
 
 		for (const p of [mProcess, gProcess]) {
+			assert.equal(typeof (p as any).binding, "function");
 			if (useV2) {
 				// workerd implementation only
 				assert.equal(p.arch, "x64");
@@ -525,23 +526,22 @@ export const WorkerdTests: Record<string, () => void> = {
 
 			assert.doesNotThrow(() => p.chdir("/tmp"));
 			assert.equal(typeof p.cwd(), "string");
-
-			assert.equal(typeof p.addListener, "function");
-			assert.equal(typeof p.eventNames, "function");
-			assert.equal(typeof p.getMaxListeners, "function");
-			assert.equal(typeof p.listenerCount, "function");
-			assert.equal(typeof p.listeners, "function");
-			assert.equal(typeof p.off, "function");
-			assert.equal(typeof p.on, "function");
-			assert.equal(typeof p.once, "function");
-			assert.equal(typeof p.prependListener, "function");
-			assert.equal(typeof p.prependOnceListener, "function");
-			assert.equal(typeof p.rawListeners, "function");
-			assert.equal(typeof p.removeAllListeners, "function");
-			assert.equal(typeof p.removeListener, "function");
-			assert.equal(typeof p.setMaxListeners, "function");
-			assert.equal(typeof (p as any).binding, "function");
-			assert.equal(typeof p.permission, "object");
 		}
+
+		// Event APIs are only available on global process
+		assert.equal(typeof gProcess.addListener, "function");
+		assert.equal(typeof gProcess.eventNames, "function");
+		assert.equal(typeof gProcess.getMaxListeners, "function");
+		assert.equal(typeof gProcess.listenerCount, "function");
+		assert.equal(typeof gProcess.listeners, "function");
+		assert.equal(typeof gProcess.off, "function");
+		assert.equal(typeof gProcess.on, "function");
+		assert.equal(typeof gProcess.once, "function");
+		assert.equal(typeof gProcess.prependListener, "function");
+		assert.equal(typeof gProcess.prependOnceListener, "function");
+		assert.equal(typeof gProcess.rawListeners, "function");
+		assert.equal(typeof gProcess.removeAllListeners, "function");
+		assert.equal(typeof gProcess.removeListener, "function");
+		assert.equal(typeof gProcess.setMaxListeners, "function");
 	},
 };

--- a/packages/wrangler/e2e/unenv-preset/worker/index.ts
+++ b/packages/wrangler/e2e/unenv-preset/worker/index.ts
@@ -513,7 +513,6 @@ export const WorkerdTests: Record<string, () => void> = {
 		const useV2 = getRuntimeFlagValue("enable_nodejs_process_v2");
 
 		for (const p of [mProcess, gProcess]) {
-			assert.equal(typeof (p as any).binding, "function");
 			if (useV2) {
 				// workerd implementation only
 				assert.equal(p.arch, "x64");
@@ -526,22 +525,23 @@ export const WorkerdTests: Record<string, () => void> = {
 
 			assert.doesNotThrow(() => p.chdir("/tmp"));
 			assert.equal(typeof p.cwd(), "string");
-		}
 
-		// Event APIs are only available on global process
-		assert.equal(typeof gProcess.addListener, "function");
-		assert.equal(typeof gProcess.eventNames, "function");
-		assert.equal(typeof gProcess.getMaxListeners, "function");
-		assert.equal(typeof gProcess.listenerCount, "function");
-		assert.equal(typeof gProcess.listeners, "function");
-		assert.equal(typeof gProcess.off, "function");
-		assert.equal(typeof gProcess.on, "function");
-		assert.equal(typeof gProcess.once, "function");
-		assert.equal(typeof gProcess.prependListener, "function");
-		assert.equal(typeof gProcess.prependOnceListener, "function");
-		assert.equal(typeof gProcess.rawListeners, "function");
-		assert.equal(typeof gProcess.removeAllListeners, "function");
-		assert.equal(typeof gProcess.removeListener, "function");
-		assert.equal(typeof gProcess.setMaxListeners, "function");
+			assert.equal(typeof p.addListener, "function");
+			assert.equal(typeof p.eventNames, "function");
+			assert.equal(typeof p.getMaxListeners, "function");
+			assert.equal(typeof p.listenerCount, "function");
+			assert.equal(typeof p.listeners, "function");
+			assert.equal(typeof p.off, "function");
+			assert.equal(typeof p.on, "function");
+			assert.equal(typeof p.once, "function");
+			assert.equal(typeof p.prependListener, "function");
+			assert.equal(typeof p.prependOnceListener, "function");
+			assert.equal(typeof p.rawListeners, "function");
+			assert.equal(typeof p.removeAllListeners, "function");
+			assert.equal(typeof p.removeListener, "function");
+			assert.equal(typeof p.setMaxListeners, "function");
+			assert.equal(typeof (p as any).binding, "function");
+			assert.equal(typeof p.permission, "object");
+		}
 	},
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2172,8 +2172,8 @@ importers:
         specifier: 2.0.0-rc.21
         version: 2.0.0-rc.21
       workerd:
-        specifier: ^1.20250924.0
-        version: 1.20250927.0
+        specifier: ^1.20250912.0
+        version: 1.20250913.0
     devDependencies:
       '@types/node-unenv':
         specifier: npm:@types/node@^22.14.0
@@ -4493,6 +4493,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@cloudflare/workerd-darwin-64@1.20250913.0':
+    resolution: {integrity: sha512-926bBGIYDsF0FraaPQV0hO9LymEN+Zdkkm1qOHxU1c58oAxr5b9Tpe4d1z1EqOD0DTFhjn7V/AxKcZBaBBhO/A==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
   '@cloudflare/workerd-darwin-64@1.20250927.0':
     resolution: {integrity: sha512-rFtXu/qhZziGOltjhHUCdlqP9wLUhf/CmnjJS0hXffGRAVxsCXhJw+7Vlr+hyRSHjHRhEV+gBFc4pHzT10Stzw==}
     engines: {node: '>=16'}
@@ -4513,6 +4519,12 @@ packages:
 
   '@cloudflare/workerd-darwin-arm64@1.20250417.0':
     resolution: {integrity: sha512-dSlk18F4i3T1OTzFBxx3pKpXRMP6w2xZ26+oIV32BFWrCi/HxGzUd6gVA0q37oLGqITRt8xU693J4Gl1CwC/Ag==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20250913.0':
+    resolution: {integrity: sha512-uy5nJIt44CpICgfsKQotji31cn39i71e2KqE/zeAmmgYp/tzl2cXotVeDtynqqEsloox7hl/eBY5sU0x99N8oQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -4541,6 +4553,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-64@1.20250913.0':
+    resolution: {integrity: sha512-khdF7MBi8L9WIt3YyWBQxipMny0J3gG824kurZiRACZmPdQ1AOzkKybDDXC3EMcF8TmGMRqKRUGQIB/25PwJuQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
   '@cloudflare/workerd-linux-64@1.20250927.0':
     resolution: {integrity: sha512-3c+RuyMj3CkaFS9mmVJyX6nNUdTn2kdWgPrpPoj7VbtU2BEGkrH1a4VAgIAiUh/tYRGUeY3owrUhqCv6L7HmJQ==}
     engines: {node: '>=16'}
@@ -4565,6 +4583,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-arm64@1.20250913.0':
+    resolution: {integrity: sha512-KF5nIOt5YIYGfinY0YEe63JqaAx8WSFDHTLQpytTX+N/oJWEJu3KW6evU1TfX7o8gRlRsc0j/evcZ1vMfbDy5g==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
   '@cloudflare/workerd-linux-arm64@1.20250927.0':
     resolution: {integrity: sha512-/XtcZnIryAgLvums08r5xiSm5hYfRfUuj2iq/5Jl+Yysx1BmPjYLqjcIIXNATrzpKUrxf3AkvpSI75MBcePgpA==}
     engines: {node: '>=16'}
@@ -4585,6 +4609,12 @@ packages:
 
   '@cloudflare/workerd-windows-64@1.20250417.0':
     resolution: {integrity: sha512-PDwATFioff+geVHfgTzSWsxgwjgotrdXStb0EL0lMyMT5zNmHArAnOx83CbDtud63Uv9rVX1BAfPP4tyD1O+5A==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workerd-windows-64@1.20250913.0':
+    resolution: {integrity: sha512-m/PMnVdaUB7ymW8BvDIC5xrU16hBDCBpyf9/4y9YZSQOYTVXihxErX8kaW9H9A/I6PTX081NmxxhTbb/n+EQRg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -13168,6 +13198,11 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  workerd@1.20250913.0:
+    resolution: {integrity: sha512-y3J1NjCL10SAWDwgGdcNSRyOVod/dWNypu64CCdjj8VS4/k+Ofa/fHaJGC1stbdzAB1tY2P35Ckgm1PU5HKWiw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   workerd@1.20250927.0:
     resolution: {integrity: sha512-6kyAGPGYNvn5mbpCJJ48VebN7QGSrvU/WJXgd4EQz20PyqjJAxHcEGGAJ+0Da0u/ewrN1+6fuMKQ1ALLBPiTWg==}
     engines: {node: '>=16'}
@@ -14478,6 +14513,9 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20250417.0':
     optional: true
 
+  '@cloudflare/workerd-darwin-64@1.20250913.0':
+    optional: true
+
   '@cloudflare/workerd-darwin-64@1.20250927.0':
     optional: true
 
@@ -14488,6 +14526,9 @@ snapshots:
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20250417.0':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20250913.0':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20250927.0':
@@ -14502,6 +14543,9 @@ snapshots:
   '@cloudflare/workerd-linux-64@1.20250417.0':
     optional: true
 
+  '@cloudflare/workerd-linux-64@1.20250913.0':
+    optional: true
+
   '@cloudflare/workerd-linux-64@1.20250927.0':
     optional: true
 
@@ -14514,6 +14558,9 @@ snapshots:
   '@cloudflare/workerd-linux-arm64@1.20250417.0':
     optional: true
 
+  '@cloudflare/workerd-linux-arm64@1.20250913.0':
+    optional: true
+
   '@cloudflare/workerd-linux-arm64@1.20250927.0':
     optional: true
 
@@ -14524,6 +14571,9 @@ snapshots:
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20250417.0':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20250913.0':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20250927.0':
@@ -23591,6 +23641,14 @@ snapshots:
       '@cloudflare/workerd-linux-64': 1.20250417.0
       '@cloudflare/workerd-linux-arm64': 1.20250417.0
       '@cloudflare/workerd-windows-64': 1.20250417.0
+
+  workerd@1.20250913.0:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20250913.0
+      '@cloudflare/workerd-darwin-arm64': 1.20250913.0
+      '@cloudflare/workerd-linux-64': 1.20250913.0
+      '@cloudflare/workerd-linux-arm64': 1.20250913.0
+      '@cloudflare/workerd-windows-64': 1.20250913.0
 
   workerd@1.20250927.0:
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2172,8 +2172,8 @@ importers:
         specifier: 2.0.0-rc.21
         version: 2.0.0-rc.21
       workerd:
-        specifier: ^1.20250912.0
-        version: 1.20250913.0
+        specifier: ^1.20250927.0
+        version: 1.20251001.0
     devDependencies:
       '@types/node-unenv':
         specifier: npm:@types/node@^22.14.0
@@ -4493,18 +4493,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-64@1.20250913.0':
-    resolution: {integrity: sha512-926bBGIYDsF0FraaPQV0hO9LymEN+Zdkkm1qOHxU1c58oAxr5b9Tpe4d1z1EqOD0DTFhjn7V/AxKcZBaBBhO/A==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@cloudflare/workerd-darwin-64@1.20250927.0':
-    resolution: {integrity: sha512-rFtXu/qhZziGOltjhHUCdlqP9wLUhf/CmnjJS0hXffGRAVxsCXhJw+7Vlr+hyRSHjHRhEV+gBFc4pHzT10Stzw==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [darwin]
-
   '@cloudflare/workerd-darwin-64@1.20251001.0':
     resolution: {integrity: sha512-y1ST/cCscaRewWRnsHZdWbgiLJbki5UMGd0hMo/FLqjlztwPeDgQ5CGm5jMiCDdw/IBCpWxEukftPYR34rWNog==}
     engines: {node: '>=16'}
@@ -4519,18 +4507,6 @@ packages:
 
   '@cloudflare/workerd-darwin-arm64@1.20250417.0':
     resolution: {integrity: sha512-dSlk18F4i3T1OTzFBxx3pKpXRMP6w2xZ26+oIV32BFWrCi/HxGzUd6gVA0q37oLGqITRt8xU693J4Gl1CwC/Ag==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@cloudflare/workerd-darwin-arm64@1.20250913.0':
-    resolution: {integrity: sha512-uy5nJIt44CpICgfsKQotji31cn39i71e2KqE/zeAmmgYp/tzl2cXotVeDtynqqEsloox7hl/eBY5sU0x99N8oQ==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@cloudflare/workerd-darwin-arm64@1.20250927.0':
-    resolution: {integrity: sha512-BcNlLVfPyctLjFeIJENhK7OZFkfaysHVA6G6KT1lwum+BaVOutebweLo2zOrH7UQCMDYdpkQOeb5nLDctvs8YA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -4553,18 +4529,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-64@1.20250913.0':
-    resolution: {integrity: sha512-khdF7MBi8L9WIt3YyWBQxipMny0J3gG824kurZiRACZmPdQ1AOzkKybDDXC3EMcF8TmGMRqKRUGQIB/25PwJuQ==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [linux]
-
-  '@cloudflare/workerd-linux-64@1.20250927.0':
-    resolution: {integrity: sha512-3c+RuyMj3CkaFS9mmVJyX6nNUdTn2kdWgPrpPoj7VbtU2BEGkrH1a4VAgIAiUh/tYRGUeY3owrUhqCv6L7HmJQ==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [linux]
-
   '@cloudflare/workerd-linux-64@1.20251001.0':
     resolution: {integrity: sha512-hGS+O2V9Mm2XjJUaB9ZHMA5asDUaDjKko42e+accbew0PQR7zrAl1afdII6hMqCLV4tk4GAjvhv281pN4g48rg==}
     engines: {node: '>=16'}
@@ -4583,18 +4547,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20250913.0':
-    resolution: {integrity: sha512-KF5nIOt5YIYGfinY0YEe63JqaAx8WSFDHTLQpytTX+N/oJWEJu3KW6evU1TfX7o8gRlRsc0j/evcZ1vMfbDy5g==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@cloudflare/workerd-linux-arm64@1.20250927.0':
-    resolution: {integrity: sha512-/XtcZnIryAgLvums08r5xiSm5hYfRfUuj2iq/5Jl+Yysx1BmPjYLqjcIIXNATrzpKUrxf3AkvpSI75MBcePgpA==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [linux]
-
   '@cloudflare/workerd-linux-arm64@1.20251001.0':
     resolution: {integrity: sha512-QYaMK+pRgt28N7CX1JlJ+ToegJF9LxzqdT7MjWqPgVj9D2WTyIhBVYl3wYjJRcgOlnn+DRt42+li4T64CPEeuA==}
     engines: {node: '>=16'}
@@ -4609,18 +4561,6 @@ packages:
 
   '@cloudflare/workerd-windows-64@1.20250417.0':
     resolution: {integrity: sha512-PDwATFioff+geVHfgTzSWsxgwjgotrdXStb0EL0lMyMT5zNmHArAnOx83CbDtud63Uv9rVX1BAfPP4tyD1O+5A==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [win32]
-
-  '@cloudflare/workerd-windows-64@1.20250913.0':
-    resolution: {integrity: sha512-m/PMnVdaUB7ymW8BvDIC5xrU16hBDCBpyf9/4y9YZSQOYTVXihxErX8kaW9H9A/I6PTX081NmxxhTbb/n+EQRg==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [win32]
-
-  '@cloudflare/workerd-windows-64@1.20250927.0':
-    resolution: {integrity: sha512-+m124IiM149QvvzAOrO766uTdILqXJZqzZjqTaMTaWXegjjsJwGSL6v9d71TSFntEwxeXnpJPBkVWyKZFjqrvg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -13198,16 +13138,6 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  workerd@1.20250913.0:
-    resolution: {integrity: sha512-y3J1NjCL10SAWDwgGdcNSRyOVod/dWNypu64CCdjj8VS4/k+Ofa/fHaJGC1stbdzAB1tY2P35Ckgm1PU5HKWiw==}
-    engines: {node: '>=16'}
-    hasBin: true
-
-  workerd@1.20250927.0:
-    resolution: {integrity: sha512-6kyAGPGYNvn5mbpCJJ48VebN7QGSrvU/WJXgd4EQz20PyqjJAxHcEGGAJ+0Da0u/ewrN1+6fuMKQ1ALLBPiTWg==}
-    engines: {node: '>=16'}
-    hasBin: true
-
   workerd@1.20251001.0:
     resolution: {integrity: sha512-oT/K4YWNhmwpVmGeaHNmF7mLRfgjszlVr7lJtpS4jx5khmxmMzWZEEQRrJEpgzeHP6DOq9qWLPNT0bjMK7TchQ==}
     engines: {node: '>=16'}
@@ -14513,12 +14443,6 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20250417.0':
     optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20250913.0':
-    optional: true
-
-  '@cloudflare/workerd-darwin-64@1.20250927.0':
-    optional: true
-
   '@cloudflare/workerd-darwin-64@1.20251001.0':
     optional: true
 
@@ -14526,12 +14450,6 @@ snapshots:
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20250417.0':
-    optional: true
-
-  '@cloudflare/workerd-darwin-arm64@1.20250913.0':
-    optional: true
-
-  '@cloudflare/workerd-darwin-arm64@1.20250927.0':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20251001.0':
@@ -14543,12 +14461,6 @@ snapshots:
   '@cloudflare/workerd-linux-64@1.20250417.0':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20250913.0':
-    optional: true
-
-  '@cloudflare/workerd-linux-64@1.20250927.0':
-    optional: true
-
   '@cloudflare/workerd-linux-64@1.20251001.0':
     optional: true
 
@@ -14558,12 +14470,6 @@ snapshots:
   '@cloudflare/workerd-linux-arm64@1.20250417.0':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20250913.0':
-    optional: true
-
-  '@cloudflare/workerd-linux-arm64@1.20250927.0':
-    optional: true
-
   '@cloudflare/workerd-linux-arm64@1.20251001.0':
     optional: true
 
@@ -14571,12 +14477,6 @@ snapshots:
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20250417.0':
-    optional: true
-
-  '@cloudflare/workerd-windows-64@1.20250913.0':
-    optional: true
-
-  '@cloudflare/workerd-windows-64@1.20250927.0':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20251001.0':
@@ -23641,22 +23541,6 @@ snapshots:
       '@cloudflare/workerd-linux-64': 1.20250417.0
       '@cloudflare/workerd-linux-arm64': 1.20250417.0
       '@cloudflare/workerd-windows-64': 1.20250417.0
-
-  workerd@1.20250913.0:
-    optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20250913.0
-      '@cloudflare/workerd-darwin-arm64': 1.20250913.0
-      '@cloudflare/workerd-linux-64': 1.20250913.0
-      '@cloudflare/workerd-linux-arm64': 1.20250913.0
-      '@cloudflare/workerd-windows-64': 1.20250913.0
-
-  workerd@1.20250927.0:
-    optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20250927.0
-      '@cloudflare/workerd-darwin-arm64': 1.20250927.0
-      '@cloudflare/workerd-linux-64': 1.20250927.0
-      '@cloudflare/workerd-linux-arm64': 1.20250927.0
-      '@cloudflare/workerd-windows-64': 1.20250927.0
 
   workerd@1.20251001.0:
     optionalDependencies:


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/10855

Astro detects Node with:

```ts
const isNode = typeof process !== "undefined" && Object.prototype.toString.call(process) === "[object process]";
```

With `unenv` process would `toString` as `[object Object]` and `isNode` is `false`.
The the v2 implementation from @guybedford it `toString` as `[object process]` to match the Node implementation (this is correct) so `isNode` becomes `true`

However, when Node is detected, Astro construct a response from an `AsyncIterable`:

```ts
  if (streaming) {
    if (isNode && !isDeno) {
      const nodeBody = await renderToAsyncIterable(
        result,
        componentFactory,
        props,
        children,
        true,
        route
      );
      body = nodeBody;
    } else {
      body = await renderToReadableStream(result, componentFactory, props, children, true, route);
    }
  } else {
    body = await renderToString(result, componentFactory, props, children, true, route);
  }
```

But we know that workerd behavior does not conform to Node here, see https://github.com/cloudflare/workerd/issues/2746. Fixing that issue would solve the Astro issue (i.e. we could drop the process polyfill).

However we will revert the PR dropping the polyfill for now.

Notes: 

- It looks like sentry is also using the same `isNode` check - we should inspect commonly used packages before dropping the `process` polyfill again.

- There are a couples of additional changes on top of the revert:
  - the workerd dependency in unenv is bump to 0927 when the behavior of the builtin `process.toString` was updated
  - the latest version of the tests is used are they are more correct than the version before the PR. 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: already tests, tested Astro locally
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not behavior change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: unenv changes not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
