### PR TITLE
WC-4047 Respect keep_vars for versions upload

### DIFF
--- a/.changeset/lovely-spoons-rhyme.md
+++ b/.changeset/lovely-spoons-rhyme.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Respect keep_vars for wrangler versions upload.

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -383,7 +383,7 @@ export const versionsUploadCommand = createCommand({
 				outDir: args.outdir,
 				dryRun: args.dryRun,
 				noBundle: !(args.bundle ?? !config.no_bundle),
-				keepVars: false,
+				keepVars: config.keep_vars,
 				projectRoot: entry.projectRoot,
 				tag: args.tag,
 				message: args.message,
@@ -701,7 +701,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 				: undefined,
 			compatibility_date: compatibilityDate,
 			compatibility_flags: compatibilityFlags,
-			keepVars: false, // the wrangler.toml should be the source-of-truth for vars
+			keepVars: props.keepVars ?? false,
 			keepSecrets: true, // until wrangler.toml specifies secret bindings, we need to inherit from the previous Worker Version
 			placement,
 			tail_consumers: config.tail_consumers,


### PR DESCRIPTION
Previously, versions uploaded was hardcoded to be false, but users are confused that this behavior differs from deploy. Instead, we should inherit the value from keep_vars, defaulting to false if not provided. This aligns with the deploy behavior.

Fixes WC-4047

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: n/a
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: n/a

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
