### PR TITLE
test: fix snapshots for certificate tests

### DIFF
--- a/packages/wrangler/src/__tests__/cert.test.ts
+++ b/packages/wrangler/src/__tests__/cert.test.ts
@@ -188,7 +188,7 @@ describe("wrangler", () => {
 		return config;
 	}
 
-	const now = new Date();
+	const now = new Date(2025, 1, 1);
 	const oneYearLater = new Date(now);
 	oneYearLater.setFullYear(now.getFullYear() + 1);
 
@@ -515,7 +515,7 @@ describe("wrangler", () => {
 						Success! Uploaded mTLS Certificate
 						ID: 1234
 						Issuer: example.com...
-						Expires on 10/3/2026"
+						Expires on 2/1/2026"
 					`
 					);
 				});
@@ -540,7 +540,7 @@ describe("wrangler", () => {
 						Success! Uploaded mTLS Certificate my-cert
 						ID: 1234
 						Issuer: example.com...
-						Expires on 10/3/2026"
+						Expires on 2/1/2026"
 					`
 					);
 				});
@@ -564,7 +564,7 @@ describe("wrangler", () => {
 						Success! Uploaded CA Certificate
 						ID: 1234
 						Issuer: example.com...
-						Expires on 10/3/2026"
+						Expires on 2/1/2026"
 					`
 					);
 				});
@@ -588,7 +588,7 @@ describe("wrangler", () => {
 						Success! Uploaded CA Certificate my-caCert
 						ID: 1234
 						Issuer: example.com...
-						Expires on 10/3/2026"
+						Expires on 2/1/2026"
 					`
 					);
 				});
@@ -609,15 +609,15 @@ describe("wrangler", () => {
 						ID: 1234
 						Name: cert one
 						Issuer: example.com...
-						Created on: 10/3/2025
-						Expires on: 10/3/2026
+						Created on: 2/1/2025
+						Expires on: 2/1/2026
 
 
 						ID: 5678
 						Name: cert two
 						Issuer: example.com...
-						Created on: 10/3/2025
-						Expires on: 10/3/2026
+						Created on: 2/1/2025
+						Expires on: 2/1/2026
 
 						"
 					`

--- a/packages/wrangler/src/__tests__/mtls-certificates.test.ts
+++ b/packages/wrangler/src/__tests__/mtls-certificates.test.ts
@@ -154,7 +154,7 @@ describe("wrangler", () => {
 		return config;
 	}
 
-	const now = new Date();
+	const now = new Date(2025, 1, 1);
 	const oneYearLater = new Date(now);
 	oneYearLater.setFullYear(now.getFullYear() + 1);
 
@@ -433,7 +433,7 @@ describe("wrangler", () => {
 						Success! Uploaded mTLS Certificate
 						ID: 1234
 						Issuer: example.com...
-						Expires on 10/3/2026"
+						Expires on 2/1/2026"
 					`
 					);
 				});
@@ -458,7 +458,7 @@ describe("wrangler", () => {
 						Success! Uploaded mTLS Certificate my-cert
 						ID: 1234
 						Issuer: example.com...
-						Expires on 10/3/2026"
+						Expires on 2/1/2026"
 					`
 					);
 				});
@@ -479,15 +479,15 @@ describe("wrangler", () => {
 						ID: 1234
 						Name: cert one
 						Issuer: example.com...
-						Created on: 10/3/2025
-						Expires on: 10/3/2026
+						Created on: 2/1/2025
+						Expires on: 2/1/2026
 
 
 						ID: 5678
 						Name: cert two
 						Issuer: example.com...
-						Created on: 10/3/2025
-						Expires on: 10/3/2026
+						Created on: 2/1/2025
+						Expires on: 2/1/2026
 
 						"
 					`


### PR DESCRIPTION
The snapshots in the cert.test.ts were originally "dynamic" with the current date being inserted.
When we bumped the snapshots (as is normal) these dynamic bits got blown away and we froze the dates at the point in time we did the bump (e.g. yesterday). So now they fail today.
This fixes the problem by hard coding dates in to the tests overall so that the snapshots are stable.