### PR TITLE
use the native node:punycode when available

### DIFF
--- a/.changeset/thirty-windows-own.md
+++ b/.changeset/thirty-windows-own.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/unenv-preset": patch
+---
+
+Use the native `node:punycode` module when available.
+
+It is enabled when the `enable_nodejs_punycode_module` compatibility flag is set.

--- a/packages/wrangler/e2e/unenv-preset/preset.test.ts
+++ b/packages/wrangler/e2e/unenv-preset/preset.test.ts
@@ -231,6 +231,28 @@ const testConfigs: TestConfig[] = [
 			},
 		},
 	],
+	// node:punycode
+	[
+		// TODO: add test for disabled by date (no date defined yet)
+		// TODO: add test for enabled by date (no date defined yet)
+		{
+			name: "punycode enabled by flag",
+			compatibilityDate: "2024-09-23",
+			compatibilityFlags: ["enable_nodejs_punycode_module", "experimental"],
+			expectRuntimeFlags: {
+				enable_nodejs_punycode_module: true,
+			},
+		},
+		// TODO: update the date past the default enable date (when defined)
+		{
+			name: "punycode disabled by flag",
+			compatibilityDate: "2024-09-23",
+			compatibilityFlags: ["disable_nodejs_punycode_module", "experimental"],
+			expectRuntimeFlags: {
+				enable_nodejs_punycode_module: false,
+			},
+		},
+	],
 ].flat() as TestConfig[];
 
 describe.each(testConfigs)(

--- a/packages/wrangler/e2e/unenv-preset/worker/index.ts
+++ b/packages/wrangler/e2e/unenv-preset/worker/index.ts
@@ -544,4 +544,21 @@ export const WorkerdTests: Record<string, () => void> = {
 		assert.equal(typeof gProcess.removeListener, "function");
 		assert.equal(typeof gProcess.setMaxListeners, "function");
 	},
+
+	async testPunycode() {
+		const punycode = await import("node:punycode");
+
+		assert.strictEqual(typeof punycode.decode, "function");
+		assert.strictEqual(typeof punycode.encode, "function");
+		assert.strictEqual(typeof punycode.toASCII, "function");
+		assert.strictEqual(typeof punycode.toUnicode, "function");
+		assert.strictEqual(
+			punycode.toASCII("Bücher@日本語.com"),
+			"Bücher@xn--wgv71a119e.com"
+		);
+		assert.strictEqual(
+			punycode.toUnicode("Bücher@xn--wgv71a119e.com"),
+			"Bücher@日本語.com"
+		);
+	},
 };


### PR DESCRIPTION
punycode was natively implemented in https://github.com/cloudflare/workerd/releases/tag/v1.20250911.0

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: will be documented by the runtime team
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: unenv not backported to v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
