### PR TITLE
Preserve the original `x-forwarded-host` header if it is set.

### DIFF
--- a/.changeset/five-files-throw.md
+++ b/.changeset/five-files-throw.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Preserve the original `x-forwarded-host` header if it is set.

--- a/packages/vite-plugin-cloudflare/playground/worker-♫/__tests__/worker.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/worker-♫/__tests__/worker.spec.ts
@@ -32,7 +32,15 @@ test("basic dev logging", async () => {
 	expect(serverLogs.errors.join()).toContain("__console warn__");
 });
 
-test("receives the original host as the `X-Forwarded-Host` header", async () => {
+test("receives the original `x-forwarded-host` header if it is set", async () => {
+	const response = await fetch(`${viteTestUrl}/x-forwarded-host`, {
+		headers: { "x-forwarded-host": "example.com:8080" },
+	});
+
+	expect(await response.text()).toBe("example.com:8080");
+});
+
+test("receives the Vite server host as the `x-forwarded-host` header if the `x-forwarded-host` header is not set", async () => {
 	const testUrl = new URL(viteTestUrl);
 	await vi.waitFor(
 		async () =>


### PR DESCRIPTION
Fixes #10884.

Preserve the original `x-forwarded-host` header if it is set.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
