### PR TITLE
Revert "Use updated VSCode"

### DIFF
--- a/.changeset/blue-dancers-cry.md
+++ b/.changeset/blue-dancers-cry.md
@@ -1,5 +1,0 @@
----
-"@cloudflare/workers-playground": patch
----
-
-Use updated VSCode version

--- a/.github/workflows/deploy-pages-previews.yml
+++ b/.github/workflows/deploy-pages-previews.yml
@@ -46,9 +46,6 @@ jobs:
         with:
           node-version: 22
 
-      - name: Install grep
-        run: brew install grep
-
       - name: Build tools and libraries
         run: pnpm run build
         env:
@@ -60,7 +57,7 @@ jobs:
         run: |
           output=$(pnpm --filter @cloudflare/chrome-devtools-patches run deploy)
           echo "Extracting deployed URL from command output"
-          url=$(echo "$output" | ggrep -oP 'Take a peek over at \K\S+')
+          url=$(echo "$output" | grep -oP 'Take a peek over at \K\S+')
           echo "Extracted URL: $url"
           echo "VITE_DEVTOOLS_PREVIEW_URL=$url" >> $GITHUB_ENV
         env:
@@ -76,11 +73,10 @@ jobs:
 
       - name: Deploy Workers Playground preview
         if: contains(github.event.*.labels.*.name, 'preview:workers-playground')
-        shell: bash
         run: |
           output=$(pnpm --filter workers-playground run build:testing && pnpm --filter workers-playground run deploy)
           echo "Extracting deployed URL from command output"
-          url=$(echo "$output" | ggrep -oP 'Take a peek over at \K\S+')
+          url=$(echo "$output" | grep -oP 'Take a peek over at \K\S+')
           echo "Extracted URL: $url"
           echo "PLAYGROUND_URL=$url" >> $GITHUB_ENV
         env:

--- a/packages/workers-playground/src/QuickEditor/VSCodeEditor.tsx
+++ b/packages/workers-playground/src/QuickEditor/VSCodeEditor.tsx
@@ -15,8 +15,7 @@ function stripSlashPrefix(path: string) {
 	return path[0] === "/" ? path.slice(1) : path;
 }
 
-const quickEditHost =
-	"https://e98a7604.quick-edit-workers.devprod.cloudflare.dev";
+const quickEditHost = "https://quick-edit.devprod.cloudflare.dev";
 
 function constructVSCodeURL(serviceId: string, baseURL: string) {
 	const workerPath = `cfs:/${serviceId}`;


### PR DESCRIPTION
This is causing 522 errors, because fetching a Workers preview (on workers.dev) doesn't seem to be a cross-zone fetch in the way fetching a Pages preview is. This needs more investigation.