### PR TITLE
rename !legacyEnv to enableServiceEnvironments

### DIFF
--- a/packages/wrangler/src/__tests__/config/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.test.ts
@@ -213,7 +213,11 @@ describe("normalizeAndValidateConfig()", () => {
 			);
 
 			expect(config).toEqual(
-				expect.objectContaining({ ...expectedConfig, main: undefined })
+				expect.objectContaining({
+					...expectedConfig,
+					main: undefined,
+					legacy_env: true,
+				})
 			);
 			expect(diagnostics.hasWarnings()).toBe(false);
 			expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
@@ -4958,9 +4962,9 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 				expect(diagnostics.hasWarnings()).toBe(true);
 				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
-			          "Processing wrangler configuration:
-			            - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION."
-		        `);
+					"Processing wrangler configuration:
+					  - Service environments are deprecated, and will be removed in the future. DO NOT USE IN PRODUCTION."
+				`);
 			});
 
 			it("should error if named environment contains a `name` field, even if there is no top-level name", () => {
@@ -4984,9 +4988,9 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBe(true);
 				expect(diagnostics.hasErrors()).toBe(true);
 				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
-			          "Processing wrangler configuration:
-			            - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION."
-		        `);
+					"Processing wrangler configuration:
+					  - Service environments are deprecated, and will be removed in the future. DO NOT USE IN PRODUCTION."
+				`);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 			          "Processing wrangler configuration:
 
@@ -5018,9 +5022,9 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBe(true);
 				expect(diagnostics.hasErrors()).toBe(true);
 				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
-			          "Processing wrangler configuration:
-			            - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION."
-		        `);
+					"Processing wrangler configuration:
+					  - Service environments are deprecated, and will be removed in the future. DO NOT USE IN PRODUCTION."
+				`);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 			          "Processing wrangler configuration:
 
@@ -5051,7 +5055,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(config.account_id).toBeUndefined();
 				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
-					  - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION."
+					  - Service environments are deprecated, and will be removed in the future. DO NOT USE IN PRODUCTION."
 				`);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
@@ -5085,7 +5089,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBe(true);
 				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
-					  - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in the future. DO NOT USE IN PRODUCTION."
+					  - Service environments are deprecated, and will be removed in the future. DO NOT USE IN PRODUCTION."
 				`);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:

--- a/packages/wrangler/src/__tests__/delete.test.ts
+++ b/packages/wrangler/src/__tests__/delete.test.ts
@@ -516,11 +516,11 @@ function mockDeleteWorkerRequest(
 	options: {
 		name?: string;
 		env?: string;
-		legacyEnv?: boolean;
+		enableServiceEnvironments?: boolean;
 		force?: boolean;
 	} = {}
 ) {
-	const { env, legacyEnv, name } = options;
+	const { env, enableServiceEnvironments, name } = options;
 	msw.use(
 		http.delete(
 			"*/accounts/:accountId/workers/services/:scriptName",
@@ -529,7 +529,7 @@ function mockDeleteWorkerRequest(
 
 				expect(params.accountId).toEqual("some-account-id");
 				expect(params.scriptName).toEqual(
-					legacyEnv && env
+					!enableServiceEnvironments && env
 						? `${name ?? "test-name"}-${env}`
 						: `${name ?? "test-name"}`
 				);

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -1085,8 +1085,8 @@ describe("deploy", () => {
 				expect(std.warn).toMatchInlineSnapshot(`
 					"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
 
-					    - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in
-					  the future. DO NOT USE IN PRODUCTION.
+					    - Service environments are deprecated, and will be removed in the future. DO NOT USE IN
+					  PRODUCTION.
 
 					"
 				`);
@@ -1118,8 +1118,8 @@ describe("deploy", () => {
 				expect(std.warn).toMatchInlineSnapshot(`
 					"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
 
-					    - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in
-					  the future. DO NOT USE IN PRODUCTION.
+					    - Service environments are deprecated, and will be removed in the future. DO NOT USE IN
+					  PRODUCTION.
 
 					"
 				`);
@@ -1502,8 +1502,8 @@ describe("deploy", () => {
 				Current Version ID: Galaxy-Class",
 				  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
 
-				    - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in
-				  the future. DO NOT USE IN PRODUCTION.
+				    - Service environments are deprecated, and will be removed in the future. DO NOT USE IN
+				  PRODUCTION.
 
 				",
 				}
@@ -8178,8 +8178,8 @@ addEventListener('fetch', event => {});`
 				expect(std.warn).toMatchInlineSnapshot(`
 					"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
 
-					    - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in
-					  the future. DO NOT USE IN PRODUCTION.
+					    - Service environments are deprecated, and will be removed in the future. DO NOT USE IN
+					  PRODUCTION.
 
 					"
 				`);
@@ -8248,8 +8248,8 @@ addEventListener('fetch', event => {});`
 				expect(std.warn).toMatchInlineSnapshot(`
 					"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
 
-					    - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in
-					  the future. DO NOT USE IN PRODUCTION.
+					    - Service environments are deprecated, and will be removed in the future. DO NOT USE IN
+					  PRODUCTION.
 
 					"
 				`);
@@ -8314,8 +8314,8 @@ addEventListener('fetch', event => {});`
 					Current Version ID: Galaxy-Class",
 					  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
 
-					    - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in
-					  the future. DO NOT USE IN PRODUCTION.
+					    - Service environments are deprecated, and will be removed in the future. DO NOT USE IN
+					  PRODUCTION.
 
 					",
 					}
@@ -8391,8 +8391,8 @@ addEventListener('fetch', event => {});`
 					Current Version ID: Galaxy-Class",
 					  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
 
-					    - Experimental: Service environments are in beta, and their behaviour is guaranteed to change in
-					  the future. DO NOT USE IN PRODUCTION.
+					    - Service environments are deprecated, and will be removed in the future. DO NOT USE IN
+					  PRODUCTION.
 
 					",
 					}

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -917,7 +917,7 @@ describe("deploy", () => {
 			mockSubDomainRequest();
 			mockUploadWorkerRequest({
 				env: "some-env",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 
 			await runWrangler("deploy index.js --env some-env");
@@ -942,7 +942,7 @@ describe("deploy", () => {
 				writeWorkerSource();
 				mockSubDomainRequest();
 				mockUploadWorkerRequest({
-					legacyEnv: true,
+					enableServiceEnvironments: false,
 				});
 
 				await runWrangler("deploy index.js --legacy-env true");
@@ -967,7 +967,7 @@ describe("deploy", () => {
 				mockSubDomainRequest();
 				mockUploadWorkerRequest({
 					env: "some-env",
-					legacyEnv: true,
+					enableServiceEnvironments: false,
 				});
 
 				await runWrangler("deploy index.js --env some-env --legacy-env true");
@@ -992,7 +992,7 @@ describe("deploy", () => {
 				mockSubDomainRequest();
 				mockUploadWorkerRequest({
 					env: "some-env",
-					legacyEnv: true,
+					enableServiceEnvironments: false,
 				});
 
 				await runWrangler("deploy index.js --env some-env --legacy-env true");
@@ -1052,7 +1052,7 @@ describe("deploy", () => {
 				mockUploadWorkerRequest({
 					env: "some-env",
 					expectedScriptName: "voyager",
-					legacyEnv: true,
+					enableServiceEnvironments: false,
 				});
 				await runWrangler(
 					"deploy index.js --name voyager --env some-env --legacy-env true"
@@ -1066,7 +1066,7 @@ describe("deploy", () => {
 				writeWorkerSource();
 				mockSubDomainRequest();
 				mockUploadWorkerRequest({
-					legacyEnv: false,
+					enableServiceEnvironments: true,
 				});
 
 				await runWrangler("deploy index.js --legacy-env false");
@@ -1098,7 +1098,7 @@ describe("deploy", () => {
 				mockSubDomainRequest();
 				mockUploadWorkerRequest({
 					env: "some-env",
-					legacyEnv: false,
+					enableServiceEnvironments: true,
 					useOldUploadApi: true,
 				});
 
@@ -1422,12 +1422,12 @@ describe("deploy", () => {
 			mockUpdateWorkerSubdomain({
 				enabled: false,
 				env: "staging",
-				legacyEnv: false,
+				enableServiceEnvironments: true,
 			});
 			mockUploadWorkerRequest({
 				expectedType: "esm",
 				env: "staging",
-				legacyEnv: false,
+				enableServiceEnvironments: true,
 				useOldUploadApi: true,
 			});
 			// These run during route conflict resolution.
@@ -1479,7 +1479,7 @@ describe("deploy", () => {
 					"more-examples.com/*",
 				],
 				env: "staging",
-				legacyEnv: false,
+				enableServiceEnvironments: true,
 			});
 			await runWrangler("deploy ./index --legacy-env false --env staging");
 			expect(std).toMatchInlineSnapshot(`
@@ -1522,12 +1522,12 @@ describe("deploy", () => {
 			writeWorkerSource();
 			mockUpdateWorkerSubdomain({
 				enabled: false,
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 				env: "dev",
 			});
 			mockUploadWorkerRequest({
 				expectedType: "esm",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 				env: "dev",
 			});
 			// These run during route conflict resolution.
@@ -1549,7 +1549,7 @@ describe("deploy", () => {
 			// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 			mockPublishRoutesRequest({
 				routes: ["dev-example.com/some-route/*"],
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 				env: "dev",
 			});
 			await runWrangler("deploy ./index --env dev --legacy-env true");
@@ -3887,8 +3887,8 @@ addEventListener('fetch', event => {});`
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should make environment specific kv namespace for assets, even for legacy envs", async () => {
-			// And this is the same test as the one before this, but with legacyEnv:true
+		it("should make environment specific kv namespace for assets, even for wrangler environments", async () => {
+			// And this is the same test as the one before this, but with enableServiceEnvironments:false
 			const assets = [
 				{ filePath: "file-1.txt", content: "Content of file-1" },
 				{ filePath: "file-2.txt", content: "Content of file-2" },
@@ -3907,7 +3907,7 @@ addEventListener('fetch', event => {});`
 			writeWorkerSource();
 			writeAssets(assets);
 			mockUploadWorkerRequest({
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 				env: "some-env",
 				expectedBindings: [
 					{
@@ -6950,18 +6950,21 @@ addEventListener('fetch', event => {});`
 				},
 			});
 			writeWorkerSource();
-			mockUploadWorkerRequest({ env: "production", legacyEnv: true });
+			mockUploadWorkerRequest({
+				env: "production",
+				enableServiceEnvironments: false,
+			});
 			mockGetWorkerSubdomain({
 				enabled: false,
 				env: "production",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 			mockGetZones("production.example.com", [{ id: "example-id" }]);
 			mockGetZoneWorkerRoutes("example-id");
 			mockPublishRoutesRequest({
 				routes: ["http://production.example.com/*"],
 				env: "production",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 			await runWrangler("deploy index.js --env production");
 
@@ -6990,18 +6993,21 @@ addEventListener('fetch', event => {});`
 			});
 			writeWorkerSource();
 			mockSubDomainRequest();
-			mockUploadWorkerRequest({ env: "production", legacyEnv: true });
+			mockUploadWorkerRequest({
+				env: "production",
+				enableServiceEnvironments: false,
+			});
 			mockGetWorkerSubdomain({
 				enabled: false,
 				env: "production",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 			mockGetZones("production.example.com", [{ id: "example-id" }]);
 			mockGetZoneWorkerRoutes("example-id");
 			mockPublishRoutesRequest({
 				routes: ["http://production.example.com/*"],
 				env: "production",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 			await runWrangler("deploy index.js --env production");
 
@@ -7066,21 +7072,24 @@ addEventListener('fetch', event => {});`
 			});
 			writeWorkerSource();
 			mockSubDomainRequest();
-			mockUploadWorkerRequest({ env: "production", legacyEnv: true });
+			mockUploadWorkerRequest({
+				env: "production",
+				enableServiceEnvironments: false,
+			});
 			mockGetWorkerSubdomain({
 				enabled: false,
 				env: "production",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 			mockUpdateWorkerSubdomain({
 				enabled: true,
 				env: "production",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 			mockPublishRoutesRequest({
 				routes: ["http://production.example.com/*"],
 				env: "production",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 			await runWrangler("deploy index.js --env production");
 
@@ -7111,21 +7120,24 @@ addEventListener('fetch', event => {});`
 			});
 			writeWorkerSource();
 			mockSubDomainRequest();
-			mockUploadWorkerRequest({ env: "production", legacyEnv: true });
+			mockUploadWorkerRequest({
+				env: "production",
+				enableServiceEnvironments: false,
+			});
 			mockGetWorkerSubdomain({
 				enabled: false,
 				env: "production",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 			mockUpdateWorkerSubdomain({
 				enabled: true,
 				env: "production",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 			mockPublishRoutesRequest({
 				routes: ["http://production.example.com/*"],
 				env: "production",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 			await runWrangler("deploy index.js --env production");
 
@@ -7156,18 +7168,21 @@ addEventListener('fetch', event => {});`
 			});
 			writeWorkerSource();
 			mockSubDomainRequest();
-			mockUploadWorkerRequest({ env: "production", legacyEnv: true });
+			mockUploadWorkerRequest({
+				env: "production",
+				enableServiceEnvironments: false,
+			});
 			mockGetWorkerSubdomain({
 				enabled: false,
 				env: "production",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 			mockGetZones("production.example.com", [{ id: "example-id" }]);
 			mockGetZoneWorkerRoutes("example-id");
 			mockPublishRoutesRequest({
 				routes: ["http://production.example.com/*"],
 				env: "production",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 			await runWrangler("deploy index.js --env production");
 
@@ -7197,18 +7212,21 @@ addEventListener('fetch', event => {});`
 			});
 			writeWorkerSource();
 			mockSubDomainRequest();
-			mockUploadWorkerRequest({ env: "production", legacyEnv: true });
+			mockUploadWorkerRequest({
+				env: "production",
+				enableServiceEnvironments: false,
+			});
 			mockGetWorkerSubdomain({
 				enabled: false,
 				env: "production",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 			mockGetZones("production.example.com", [{ id: "example-id" }]);
 			mockGetZoneWorkerRoutes("example-id");
 			mockPublishRoutesRequest({
 				routes: ["http://production.example.com/*"],
 				env: "production",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 			await runWrangler("deploy index.js --env production");
 
@@ -7775,7 +7793,7 @@ addEventListener('fetch', event => {});`
 			mockUploadWorkerRequest({
 				env: "testEnv",
 				expectedType: "esm",
-				legacyEnv: false,
+				enableServiceEnvironments: true,
 				expectedEntry: `fetch(){return new Response("hello Cpt Picard")`,
 			});
 
@@ -7823,7 +7841,7 @@ addEventListener('fetch', event => {});`
 			mockUploadWorkerRequest({
 				env: "testEnv",
 				expectedType: "esm",
-				legacyEnv: false,
+				enableServiceEnvironments: true,
 				expectedEntry: (str) => {
 					expect(str).toMatch(underscoreUnderscoreNameRegex);
 				},
@@ -7863,7 +7881,7 @@ addEventListener('fetch', event => {});`
 			mockUploadWorkerRequest({
 				env: "testEnv",
 				expectedType: "esm",
-				legacyEnv: false,
+				enableServiceEnvironments: true,
 				expectedEntry: (str) => {
 					expect(str).not.toMatch(underscoreUnderscoreNameRegex);
 				},
@@ -8146,7 +8164,7 @@ addEventListener('fetch', event => {});`
 				mockSubDomainRequest();
 				mockServiceScriptData({}); // no scripts at all
 				mockUploadWorkerRequest({
-					legacyEnv: false,
+					enableServiceEnvironments: true,
 					expectedMigrations: {
 						new_tag: "v2",
 						steps: [
@@ -8215,7 +8233,7 @@ addEventListener('fetch', event => {});`
 				mockSubDomainRequest();
 				mockServiceScriptData({ env: "xyz" }); // no scripts at all
 				mockUploadWorkerRequest({
-					legacyEnv: false,
+					enableServiceEnvironments: true,
 					env: "xyz",
 					expectedMigrations: {
 						new_tag: "v2",
@@ -8277,7 +8295,7 @@ addEventListener('fetch', event => {});`
 					script: { id: "test-name", migration_tag: "v2" },
 				});
 				mockUploadWorkerRequest({
-					legacyEnv: false,
+					enableServiceEnvironments: true,
 					expectedMigrations: {
 						new_tag: "v2",
 						steps: [
@@ -8355,7 +8373,7 @@ addEventListener('fetch', event => {});`
 					env: "xyz",
 				});
 				mockUploadWorkerRequest({
-					legacyEnv: false,
+					enableServiceEnvironments: true,
 					env: "xyz",
 					expectedMigrations: {
 						old_tag: "v1",
@@ -14248,7 +14266,7 @@ export default{
 			mockGetScriptWithTags(null);
 			mockUploadWorkerRequest({
 				env: "production",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 
 			writeWranglerConfig({
@@ -14296,7 +14314,7 @@ export default{
 			mockGetScriptWithTags(["some-tag"]);
 			mockUploadWorkerRequest({
 				env: "production",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 
 			writeWranglerConfig({
@@ -14324,7 +14342,7 @@ export default{
 			mockGetScriptWithTags(["some-tag", "cf:service=test-name"]);
 			mockUploadWorkerRequest({
 				env: "production",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 
 			writeWranglerConfig({
@@ -14377,7 +14395,7 @@ export default{
 			]);
 			mockUploadWorkerRequest({
 				env: "production",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 
 			writeWranglerConfig({
@@ -14434,7 +14452,7 @@ export default{
 			]);
 			mockUploadWorkerRequest({
 				env: "production",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 
 			writeWranglerConfig({
@@ -14487,7 +14505,7 @@ export default{
 			]);
 			mockUploadWorkerRequest({
 				env: "production",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 
 			writeWranglerConfig({
@@ -14537,7 +14555,7 @@ export default{
 			mockGetScriptWithTags(["some-tag", "cf:service=undefined"]);
 			mockUploadWorkerRequest({
 				env: "production",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 
 			writeWranglerConfig({
@@ -14573,7 +14591,7 @@ export default{
 			]);
 			mockUploadWorkerRequest({
 				env: "production",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 
 			writeWranglerConfig({
@@ -14689,7 +14707,7 @@ export default{
 			mockSubDomainRequest();
 			mockUploadWorkerRequest({
 				env: "test",
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 			});
 
 			await runWrangler("deploy -e test");
@@ -14985,14 +15003,16 @@ function mockLastDeploymentRequest() {
 function mockPublishSchedulesRequest({
 	crons = [],
 	env = undefined,
-	legacyEnv = false,
+	enableServiceEnvironments = true,
 }: {
 	crons: Config["triggers"]["crons"];
 	env?: string | undefined;
-	legacyEnv?: boolean | undefined;
+	enableServiceEnvironments?: boolean | undefined;
 }) {
-	const servicesOrScripts = env && !legacyEnv ? "services" : "scripts";
-	const environment = env && !legacyEnv ? "/environments/:envName" : "";
+	const servicesOrScripts =
+		env && enableServiceEnvironments ? "services" : "scripts";
+	const environment =
+		env && enableServiceEnvironments ? "/environments/:envName" : "";
 
 	msw.use(
 		http.put(
@@ -15000,9 +15020,9 @@ function mockPublishSchedulesRequest({
 			async ({ request, params }) => {
 				expect(params.accountId).toEqual("some-account-id");
 				expect(params.scriptName).toEqual(
-					legacyEnv && env ? `test-name-${env}` : "test-name"
+					!enableServiceEnvironments && env ? `test-name-${env}` : "test-name"
 				);
-				if (!legacyEnv) {
+				if (enableServiceEnvironments) {
 					expect(params.envName).toEqual(env);
 				}
 				const body = (await request.json()) as [{ cron: string }];
@@ -15017,14 +15037,16 @@ function mockPublishSchedulesRequest({
 function mockPublishRoutesRequest({
 	routes = [],
 	env = undefined,
-	legacyEnv = false,
+	enableServiceEnvironments = true,
 }: {
 	routes: Config["routes"];
 	env?: string | undefined;
-	legacyEnv?: boolean | undefined;
+	enableServiceEnvironments?: boolean | undefined;
 }) {
-	const servicesOrScripts = env && !legacyEnv ? "services" : "scripts";
-	const environment = env && !legacyEnv ? "/environments/:envName" : "";
+	const servicesOrScripts =
+		env && enableServiceEnvironments ? "services" : "scripts";
+	const environment =
+		env && enableServiceEnvironments ? "/environments/:envName" : "";
 
 	msw.use(
 		http.put(
@@ -15032,9 +15054,9 @@ function mockPublishRoutesRequest({
 			async ({ request, params }) => {
 				expect(params.accountId).toEqual("some-account-id");
 				expect(params.scriptName).toEqual(
-					legacyEnv && env ? `test-name-${env}` : "test-name"
+					!enableServiceEnvironments && env ? `test-name-${env}` : "test-name"
 				);
-				if (!legacyEnv) {
+				if (enableServiceEnvironments) {
 					expect(params.envName).toEqual(env);
 				}
 				const body = await request.json();
@@ -15052,13 +15074,15 @@ function mockPublishRoutesRequest({
 
 function mockUnauthorizedPublishRoutesRequest({
 	env = undefined,
-	legacyEnv = false,
+	enableServiceEnvironments = true,
 }: {
 	env?: string | undefined;
-	legacyEnv?: boolean | undefined;
+	enableServiceEnvironments?: boolean | undefined;
 } = {}) {
-	const servicesOrScripts = env && !legacyEnv ? "services" : "scripts";
-	const environment = env && !legacyEnv ? "/environments/:envName" : "";
+	const servicesOrScripts =
+		env && enableServiceEnvironments ? "services" : "scripts";
+	const environment =
+		env && enableServiceEnvironments ? "/environments/:envName" : "";
 
 	msw.use(
 		http.put(
@@ -15112,24 +15136,26 @@ function mockCustomDomainsChangesetRequest({
 	originConflicts = [],
 	dnsRecordConflicts = [],
 	env = undefined,
-	legacyEnv = false,
+	enableServiceEnvironments = true,
 }: {
 	originConflicts?: Array<CustomDomain>;
 	dnsRecordConflicts?: Array<CustomDomain>;
 	env?: string | undefined;
-	legacyEnv?: boolean | undefined;
+	enableServiceEnvironments?: boolean | undefined;
 }) {
-	const servicesOrScripts = env && !legacyEnv ? "services" : "scripts";
-	const environment = env && !legacyEnv ? "/environments/:envName" : "";
+	const servicesOrScripts =
+		env && enableServiceEnvironments ? "services" : "scripts";
+	const environment =
+		env && enableServiceEnvironments ? "/environments/:envName" : "";
 	msw.use(
 		http.post<{ accountId: string; scriptName: string; envName: string }>(
 			`*/accounts/:accountId/workers/${servicesOrScripts}/:scriptName${environment}/domains/changeset`,
 			async ({ request, params }) => {
 				expect(params.accountId).toEqual("some-account-id");
 				expect(params.scriptName).toEqual(
-					legacyEnv && env ? `test-name-${env}` : "test-name"
+					!enableServiceEnvironments && env ? `test-name-${env}` : "test-name"
 				);
-				if (!legacyEnv) {
+				if (enableServiceEnvironments) {
 					expect(params.envName).toEqual(env);
 				}
 
@@ -15170,7 +15196,7 @@ function mockPublishCustomDomainsRequest({
 	publishFlags,
 	domains = [],
 	env = undefined,
-	legacyEnv = false,
+	enableServiceEnvironments = true,
 }: {
 	publishFlags: {
 		override_scope: boolean;
@@ -15181,10 +15207,12 @@ function mockPublishCustomDomainsRequest({
 		{ hostname: string } & ({ zone_id?: string } | { zone_name?: string })
 	>;
 	env?: string | undefined;
-	legacyEnv?: boolean | undefined;
+	enableServiceEnvironments?: boolean | undefined;
 }) {
-	const servicesOrScripts = env && !legacyEnv ? "services" : "scripts";
-	const environment = env && !legacyEnv ? "/environments/:envName" : "";
+	const servicesOrScripts =
+		env && enableServiceEnvironments ? "services" : "scripts";
+	const environment =
+		env && enableServiceEnvironments ? "/environments/:envName" : "";
 
 	msw.use(
 		http.put(
@@ -15192,9 +15220,9 @@ function mockPublishCustomDomainsRequest({
 			async ({ request, params }) => {
 				expect(params.accountId).toEqual("some-account-id");
 				expect(params.scriptName).toEqual(
-					legacyEnv && env ? `test-name-${env}` : "test-name"
+					!enableServiceEnvironments && env ? `test-name-${env}` : "test-name"
 				);
-				if (!legacyEnv) {
+				if (enableServiceEnvironments) {
 					expect(params.envName).toEqual(env);
 				}
 				const body = await request.json();

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -84,7 +84,7 @@ async function expectedHostAndZone(
 				}
 			}),
 		env: undefined,
-		legacyEnv: undefined,
+		useServiceEnvironments: undefined,
 		sendMetrics: undefined,
 		configPath: config.config,
 	});

--- a/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
@@ -31,7 +31,7 @@ export function mockUploadWorkerRequest(
 		expectedCapnpSchema?: string;
 		expectedLimits?: CfWorkerInit["limits"];
 		env?: string;
-		legacyEnv?: boolean;
+		enableServiceEnvironments?: boolean;
 		keepVars?: boolean;
 		keepSecrets?: boolean;
 		tag?: string;
@@ -54,7 +54,7 @@ export function mockUploadWorkerRequest(
 		);
 		expect(params.accountId).toEqual("some-account-id");
 		expect(params.scriptName).toEqual(expectedScriptName);
-		if (!legacyEnv) {
+		if (enableServiceEnvironments) {
 			expect(params.envName).toEqual(env);
 		}
 		if (useOldUploadApi) {
@@ -176,7 +176,7 @@ export function mockUploadWorkerRequest(
 		expectedCompatibilityDate,
 		expectedCompatibilityFlags,
 		env = undefined,
-		legacyEnv = false,
+		enableServiceEnvironments = true,
 		expectedMigrations,
 		expectedTailConsumers,
 		expectedUnsafeMetaData,
@@ -193,9 +193,9 @@ export function mockUploadWorkerRequest(
 
 	const expectedScriptName =
 		options.expectedScriptName ??
-		"test-name" + (legacyEnv && env ? `-${env}` : "");
+		"test-name" + (!enableServiceEnvironments && env ? `-${env}` : "");
 
-	if (env && !legacyEnv) {
+	if (env && enableServiceEnvironments) {
 		msw.use(
 			http.put(
 				"*/accounts/:accountId/workers/services/:scriptName/environments/:envName",
@@ -265,7 +265,7 @@ export function mockUploadWorkerRequest(
 		enabled: workers_dev,
 		previews_enabled: preview_urls,
 		env,
-		legacyEnv,
+		enableServiceEnvironments,
 		expectedScriptName,
 	});
 }

--- a/packages/wrangler/src/__tests__/helpers/mock-workers-subdomain.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-workers-subdomain.ts
@@ -39,17 +39,18 @@ export function mockGetWorkerSubdomain({
 	enabled,
 	previews_enabled = false,
 	env,
-	legacyEnv = false,
-	expectedScriptName = "test-name" + (legacyEnv && env ? `-${env}` : ""),
+	enableServiceEnvironments = true,
+	expectedScriptName = "test-name" +
+		(!enableServiceEnvironments && env ? `-${env}` : ""),
 }: {
 	enabled: boolean;
 	previews_enabled?: boolean;
 	env?: string | undefined;
-	legacyEnv?: boolean | undefined;
+	enableServiceEnvironments?: boolean | undefined;
 	expectedScriptName?: string | false;
 }) {
 	const url =
-		env && !legacyEnv
+		enableServiceEnvironments && env
 			? `*/accounts/:accountId/workers/services/:scriptName/environments/:envName/subdomain`
 			: `*/accounts/:accountId/workers/scripts/:scriptName/subdomain`;
 	msw.use(
@@ -60,7 +61,7 @@ export function mockGetWorkerSubdomain({
 				if (expectedScriptName !== false) {
 					expect(params.scriptName).toEqual(expectedScriptName);
 				}
-				if (!legacyEnv) {
+				if (enableServiceEnvironments) {
 					expect(params.envName).toEqual(env);
 				}
 
@@ -78,19 +79,19 @@ export function mockUpdateWorkerSubdomain({
 	enabled,
 	previews_enabled = false,
 	env,
-	legacyEnv = false,
+	enableServiceEnvironments = true,
 	expectedScriptName = "test-name",
 	flakeCount = 0,
 }: {
 	enabled: boolean;
 	previews_enabled?: boolean;
 	env?: string | undefined;
-	legacyEnv?: boolean | undefined;
+	enableServiceEnvironments?: boolean | undefined;
 	expectedScriptName?: string;
 	flakeCount?: number; // The first `flakeCount` requests will fail with a 500 error
 }) {
 	const url =
-		env && !legacyEnv
+		env && enableServiceEnvironments
 			? `*/accounts/:accountId/workers/services/:scriptName/environments/:envName/subdomain`
 			: `*/accounts/:accountId/workers/scripts/:scriptName/subdomain`;
 
@@ -100,9 +101,11 @@ export function mockUpdateWorkerSubdomain({
 			async ({ request, params }) => {
 				expect(params.accountId).toEqual("some-account-id");
 				expect(params.scriptName).toEqual(
-					legacyEnv && env ? `${expectedScriptName}-${env}` : expectedScriptName
+					!enableServiceEnvironments && env
+						? `${expectedScriptName}-${env}`
+						: expectedScriptName
 				);
-				if (!legacyEnv) {
+				if (enableServiceEnvironments) {
 					expect(params.envName).toEqual(env);
 				}
 				const body = await request.json();

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -96,22 +96,24 @@ describe("wrangler secret", () => {
 		function mockPutRequest(
 			input: { name: string; text: string },
 			env?: string,
-			legacyEnv = false,
+			enableServiceEnvironments = true,
 			expectedScriptName = "script-name"
 		) {
-			const servicesOrScripts = env && !legacyEnv ? "services" : "scripts";
-			const environment = env && !legacyEnv ? "/environments/:envName" : "";
+			const servicesOrScripts =
+				env && enableServiceEnvironments ? "services" : "scripts";
+			const environment =
+				env && enableServiceEnvironments ? "/environments/:envName" : "";
 			msw.use(
 				http.put(
 					`*/accounts/:accountId/workers/${servicesOrScripts}/:scriptName${environment}/secrets`,
 					async ({ request, params }) => {
 						expect(params.accountId).toEqual("some-account-id");
 						expect(params.scriptName).toEqual(
-							legacyEnv && env
+							!enableServiceEnvironments && env
 								? `${expectedScriptName}-${env}`
 								: expectedScriptName
 						);
-						if (!legacyEnv) {
+						if (enableServiceEnvironments) {
 							expect(params.envName).toEqual(env);
 						}
 						const { name, text, type } = (await request.json()) as Record<
@@ -172,7 +174,7 @@ describe("wrangler secret", () => {
 				`);
 			});
 
-			it("should create a secret", async () => {
+			it("should create a secret: service envs", async () => {
 				mockPrompt({
 					text: "Enter a secret value:",
 					options: { isSecret: true },
@@ -192,7 +194,7 @@ describe("wrangler secret", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should create a secret: legacy envs", async () => {
+			it("should create a secret", async () => {
 				mockPrompt({
 					text: "Enter a secret value:",
 					options: { isSecret: true },
@@ -202,7 +204,7 @@ describe("wrangler secret", () => {
 				mockPutRequest(
 					{ name: "the-key", text: "the-secret" },
 					"some-env",
-					true
+					false
 				);
 				await runWrangler(
 					"secret put the-key --name script-name --env some-env --legacy-env"
@@ -228,7 +230,7 @@ describe("wrangler secret", () => {
 				mockPutRequest(
 					{ name: "the-key", text: "the-secret" },
 					"some-env",
-					false
+					true
 				);
 				await runWrangler(
 					"secret put the-key --name script-name --env some-env --legacy-env false"
@@ -487,7 +489,11 @@ describe("wrangler secret", () => {
 						},
 					});
 					mockStdIn.send("the-secret");
-					mockPutRequest({ name: "the-key", text: "the-secret" }, "test", true);
+					mockPutRequest(
+						{ name: "the-key", text: "the-secret" },
+						"test",
+						false
+					);
 					await runWrangler("secret put the-key --name script-name -e test");
 					expect(std.warn).toMatchInlineSnapshot(`""`);
 				});
@@ -554,17 +560,21 @@ describe("wrangler secret", () => {
 				secretName: string;
 			},
 			env?: string,
-			legacyEnv = false
+			enableServiceEnvironments = true
 		) {
-			const servicesOrScripts = env && !legacyEnv ? "services" : "scripts";
-			const environment = env && !legacyEnv ? "/environments/:envName" : "";
+			const servicesOrScripts =
+				env && enableServiceEnvironments ? "services" : "scripts";
+			const environment =
+				env && enableServiceEnvironments ? "/environments/:envName" : "";
 			msw.use(
 				http.delete(
 					`*/accounts/:accountId/workers/${servicesOrScripts}/:scriptName${environment}/secrets/:secretName`,
 					({ request, params }) => {
 						expect(params.accountId).toEqual("some-account-id");
 						expect(params.scriptName).toEqual(
-							legacyEnv && env ? `script-name-${env}` : "script-name"
+							!enableServiceEnvironments && env
+								? `script-name-${env}`
+								: "script-name"
 						);
 						expect(params.secretName).toEqual(input.secretName);
 						expect(
@@ -630,11 +640,11 @@ describe("wrangler secret", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should delete a secret: legacy envs", async () => {
+		it("should delete a secret", async () => {
 			mockDeleteRequest(
 				{ scriptName: "script-name", secretName: "the-key" },
 				"some-env",
-				true
+				false
 			);
 			mockConfirm({
 				text: "Are you sure you want to permanently delete the secret the-key on the Worker script-name-some-env?",
@@ -733,7 +743,7 @@ describe("wrangler secret", () => {
 				mockDeleteRequest(
 					{ scriptName: "script-name", secretName: "the-key" },
 					"test",
-					true
+					false
 				);
 				mockConfirm({
 					text: "Are you sure you want to permanently delete the secret the-key on the Worker script-name-test?",
@@ -763,19 +773,23 @@ describe("wrangler secret", () => {
 		function mockListRequest(
 			input: { scriptName: string },
 			env?: string,
-			legacyEnv = false
+			enableServiceEnvironments = true
 		) {
-			const servicesOrScripts = env && !legacyEnv ? "services" : "scripts";
-			const environment = env && !legacyEnv ? "/environments/:envName" : "";
+			const servicesOrScripts =
+				env && enableServiceEnvironments ? "services" : "scripts";
+			const environment =
+				env && enableServiceEnvironments ? "/environments/:envName" : "";
 			msw.use(
 				http.get(
 					`*/accounts/:accountId/workers/${servicesOrScripts}/:scriptName${environment}/secrets`,
 					({ params }) => {
 						expect(params.accountId).toEqual("some-account-id");
 						expect(params.scriptName).toEqual(
-							legacyEnv && env ? `script-name-${env}` : "script-name"
+							!enableServiceEnvironments && env
+								? `script-name-${env}`
+								: "script-name"
 						);
-						if (!legacyEnv) {
+						if (enableServiceEnvironments) {
 							expect(params.envName).toEqual(env);
 						}
 
@@ -826,8 +840,8 @@ describe("wrangler secret", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should list secrets: legacy envs", async () => {
-			mockListRequest({ scriptName: "script-name" }, "some-env", true);
+		it("should list secrets: wrangler environment", async () => {
+			mockListRequest({ scriptName: "script-name" }, "some-env", false);
 			await runWrangler(
 				"secret list --name script-name --env some-env --legacy-env"
 			);

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -218,7 +218,7 @@ describe("tail", () => {
 		});
 
 		it("creates and then delete tails: legacy envs", async () => {
-			api = mockWebsocketAPIs("some-env", true);
+			api = mockWebsocketAPIs("some-env", false);
 			expect(api.requests.creation.length).toStrictEqual(0);
 
 			await runWrangler("tail test-worker --env some-env --legacy-env true");
@@ -1033,12 +1033,16 @@ type RequestCounter = {
 function mockCreateTailRequest(
 	websocketURL: string,
 	env?: string,
-	legacyEnv = false,
-	expectedScriptName = legacyEnv && env ? `test-worker-${env}` : "test-worker"
+	enableServiceEnvironments = true,
+	expectedScriptName = !enableServiceEnvironments && env
+		? `test-worker-${env}`
+		: "test-worker"
 ): RequestInit[] {
 	const requests: RequestInit[] = [];
-	const servicesOrScripts = env && !legacyEnv ? "services" : "scripts";
-	const environment = env && !legacyEnv ? "/environments/:envName" : "";
+	const servicesOrScripts =
+		env && enableServiceEnvironments ? "services" : "scripts";
+	const environment =
+		env && enableServiceEnvironments ? "/environments/:envName" : "";
 	msw.use(
 		http.post<
 			{ accountId: string; scriptName: string; envName: string },
@@ -1050,7 +1054,7 @@ function mockCreateTailRequest(
 				requests.push(r);
 				expect(params.accountId).toEqual("some-account-id");
 				expect(params.scriptName).toEqual(expectedScriptName);
-				if (!legacyEnv) {
+				if (enableServiceEnvironments) {
 					expect(params.envName).toEqual(env);
 				}
 				return HttpResponse.json(
@@ -1105,12 +1109,16 @@ const mockEmailEventSize = 45416;
  */
 function mockDeleteTailRequest(
 	env?: string,
-	legacyEnv = false,
-	expectedScriptName = legacyEnv && env ? `test-worker-${env}` : "test-worker"
+	enableServiceEnvironments = true,
+	expectedScriptName = !enableServiceEnvironments && env
+		? `test-worker-${env}`
+		: "test-worker"
 ): RequestCounter {
 	const requests = { count: 0 };
-	const servicesOrScripts = env && !legacyEnv ? "services" : "scripts";
-	const environment = env && !legacyEnv ? "/environments/:envName" : "";
+	const servicesOrScripts =
+		env && enableServiceEnvironments ? "services" : "scripts";
+	const environment =
+		env && enableServiceEnvironments ? "/environments/:envName" : "";
 	msw.use(
 		http.delete(
 			`*/accounts/:accountId/workers/${servicesOrScripts}/:scriptName${environment}/tails/:tailId`,
@@ -1118,7 +1126,7 @@ function mockDeleteTailRequest(
 				requests.count++;
 				expect(params.accountId).toEqual("some-account-id");
 				expect(params.scriptName).toEqual(expectedScriptName);
-				if (!legacyEnv) {
+				if (enableServiceEnvironments) {
 					if (env) {
 						expect(params.tailId).toEqual("tail-id");
 					}
@@ -1143,7 +1151,7 @@ let mockWebSockets: MockWebSocketServer[] = [];
  */
 function mockWebsocketAPIs(
 	env?: string,
-	legacyEnv = false,
+	enableServiceEnvironments = true,
 	expectedScriptName?: string
 ): MockAPI {
 	const websocketURL = "ws://localhost:1234";
@@ -1176,12 +1184,12 @@ function mockWebsocketAPIs(
 	api.requests.creation = mockCreateTailRequest(
 		websocketURL,
 		env,
-		legacyEnv,
+		enableServiceEnvironments,
 		expectedScriptName
 	);
 	api.requests.deletion = mockDeleteTailRequest(
 		env,
-		legacyEnv,
+		enableServiceEnvironments,
 		expectedScriptName
 	);
 	api.ws = new MockWebSocketServer(websocketURL);

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -952,7 +952,14 @@ describe("versions deploy", () => {
 					"versions deploy 10000000-0000-0000-0000-000000000000 --yes --env test"
 				);
 
-				expect(consoleStd.warn).toMatchInlineSnapshot(`""`);
+				expect(consoleStd.warn).toMatchInlineSnapshot(`
+					"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+					    - Service environments are deprecated, and will be removed in the future. DO NOT USE IN
+					  PRODUCTION.
+
+					"
+				`);
 			});
 
 			it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async () => {
@@ -962,7 +969,14 @@ describe("versions deploy", () => {
 					"versions deploy 10000000-0000-0000-0000-000000000000 --yes"
 				);
 
-				expect(consoleStd.warn).toMatchInlineSnapshot(`""`);
+				expect(consoleStd.warn).toMatchInlineSnapshot(`
+					"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+
+					    - Service environments are deprecated, and will be removed in the future. DO NOT USE IN
+					  PRODUCTION.
+
+					"
+				`);
 			});
 		});
 	});

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -952,14 +952,7 @@ describe("versions deploy", () => {
 					"versions deploy 10000000-0000-0000-0000-000000000000 --yes --env test"
 				);
 
-				expect(consoleStd.warn).toMatchInlineSnapshot(`
-					"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
-
-					    - Service environments are deprecated, and will be removed in the future. DO NOT USE IN
-					  PRODUCTION.
-
-					"
-				`);
+				expect(consoleStd.warn).toMatchInlineSnapshot(`""`);
 			});
 
 			it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async () => {
@@ -969,14 +962,7 @@ describe("versions deploy", () => {
 					"versions deploy 10000000-0000-0000-0000-000000000000 --yes"
 				);
 
-				expect(consoleStd.warn).toMatchInlineSnapshot(`
-					"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
-
-					    - Service environments are deprecated, and will be removed in the future. DO NOT USE IN
-					  PRODUCTION.
-
-					"
-				`);
+				expect(consoleStd.warn).toMatchInlineSnapshot(`""`);
 			});
 		});
 	});

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -705,7 +705,11 @@ describe("versions upload", () => {
 			mockGetScript();
 			mockUploadVersion(true);
 			mockPatchScriptSettings();
-			mockGetWorkerSubdomain({ enabled: true, previews_enabled: false });
+			mockGetWorkerSubdomain({
+				enabled: true,
+				previews_enabled: false,
+				enableServiceEnvironments: false,
+			});
 
 			// Setup
 			writeWranglerConfig({
@@ -741,7 +745,7 @@ describe("versions upload", () => {
 			mockGetWorkerSubdomain({
 				enabled: true,
 				previews_enabled: false,
-				legacyEnv: true,
+				enableServiceEnvironments: false,
 				env: "test",
 			});
 

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -35,9 +35,9 @@ import {
 	DEFAULT_INSPECTOR_PORT,
 	DEFAULT_LOCAL_PORT,
 } from "../../utils/constants";
+import { enableServiceEnvironments } from "../../utils/enableServiceEnvironments";
 import { getRules } from "../../utils/getRules";
 import { getScriptName } from "../../utils/getScriptName";
-import { isLegacyEnv } from "../../utils/isLegacyEnv";
 import { memoizeGetPort } from "../../utils/memoizeGetPort";
 import { printBindings } from "../../utils/print-bindings";
 import { getZoneIdForPreview } from "../../zones";
@@ -381,7 +381,8 @@ async function resolveConfig(
 		legacy: {
 			site: legacySite,
 			enableServiceEnvironments:
-				input.legacy?.enableServiceEnvironments ?? !isLegacyEnv(config),
+				input.legacy?.enableServiceEnvironments ??
+				enableServiceEnvironments(config),
 		},
 		unsafe: {
 			capnp: input.unsafe?.capnp ?? unsafe?.capnp,

--- a/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
@@ -96,7 +96,7 @@ export class RemoteRuntimeController extends RuntimeController {
 					complianceConfig: props.complianceConfig,
 					accountId: props.accountId,
 					env: props.env,
-					legacyEnv: props.legacyEnv,
+					useServiceEnvironments: props.useServiceEnvironments,
 					host: props.host,
 					routes: props.routes,
 					sendMetrics: props.sendMetrics,
@@ -121,7 +121,7 @@ export class RemoteRuntimeController extends RuntimeController {
 				modules: props.modules,
 				accountId: props.accountId,
 				name: scriptId,
-				legacyEnv: props.legacyEnv,
+				useServiceEnvironments: props.useServiceEnvironments,
 				env: props.env,
 				isWorkersSite: props.isWorkersSite,
 				assets: props.assets,
@@ -201,7 +201,7 @@ export class RemoteRuntimeController extends RuntimeController {
 				accountId: auth.accountId,
 				apiToken: auth.apiToken,
 				env: config.env, // deprecated service environments -- just pass it through for now
-				legacyEnv: !config.legacy?.enableServiceEnvironments, // wrangler environment -- just pass it through for now
+				useServiceEnvironments: config.legacy?.enableServiceEnvironments, // wrangler environment -- just pass it through for now
 				host: config.dev.origin?.hostname,
 				routes,
 				sendMetrics: config.sendMetrics,
@@ -224,7 +224,7 @@ export class RemoteRuntimeController extends RuntimeController {
 				accountId: auth.accountId,
 				complianceConfig: { compliance_region: config.complianceRegion },
 				name: config.name,
-				legacyEnv: !config.legacy?.enableServiceEnvironments,
+				useServiceEnvironments: config.legacy?.enableServiceEnvironments,
 				env: config.env,
 				isWorkersSite: config.legacy?.site !== undefined,
 				assets: config.assets,

--- a/packages/wrangler/src/config/validation-helpers.ts
+++ b/packages/wrangler/src/config/validation-helpers.ts
@@ -82,7 +82,7 @@ export function inheritable<K extends keyof Environment>(
 /**
  * Get an inheritable environment field, but only if we are in legacy environments
  */
-export function inheritableInLegacyEnvironments<K extends keyof Environment>(
+export function inheritableInWranglerEnvironments<K extends keyof Environment>(
 	diagnostics: Diagnostics,
 	enableServiceEnvironments: boolean | undefined,
 	topLevelEnv: Environment | undefined,

--- a/packages/wrangler/src/config/validation-helpers.ts
+++ b/packages/wrangler/src/config/validation-helpers.ts
@@ -84,7 +84,7 @@ export function inheritable<K extends keyof Environment>(
  */
 export function inheritableInLegacyEnvironments<K extends keyof Environment>(
 	diagnostics: Diagnostics,
-	isLegacyEnv: boolean | undefined,
+	enableServiceEnvironments: boolean | undefined,
 	topLevelEnv: Environment | undefined,
 	rawEnv: RawEnvironment,
 	field: K,
@@ -92,8 +92,16 @@ export function inheritableInLegacyEnvironments<K extends keyof Environment>(
 	transformFn: TransformFn<Environment[K]> = (v) => v,
 	defaultValue: Environment[K]
 ): Environment[K] {
-	return topLevelEnv === undefined || isLegacyEnv === true
-		? inheritable(
+	const usingServiceEnvironments =
+		enableServiceEnvironments && topLevelEnv !== undefined;
+	return usingServiceEnvironments
+		? notAllowedInNamedServiceEnvironment(
+				diagnostics,
+				topLevelEnv,
+				rawEnv,
+				field
+			)
+		: inheritable(
 				diagnostics,
 				topLevelEnv,
 				rawEnv,
@@ -101,12 +109,6 @@ export function inheritableInLegacyEnvironments<K extends keyof Environment>(
 				validate,
 				defaultValue,
 				transformFn
-			)
-		: notAllowedInNamedServiceEnvironment(
-				diagnostics,
-				topLevelEnv,
-				rawEnv,
-				field
 			);
 }
 

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -18,7 +18,7 @@ import {
 	getBindingNames,
 	hasProperty,
 	inheritable,
-	inheritableInLegacyEnvironments,
+	inheritableInWranglerEnvironments,
 	isBoolean,
 	isMutuallyExclusiveWith,
 	isOneOf,
@@ -1057,7 +1057,7 @@ function normalizeAndValidateEnvironment(
 
 	const route = normalizeAndValidateRoute(diagnostics, topLevelEnv, rawEnv);
 
-	const account_id = inheritableInLegacyEnvironments(
+	const account_id = inheritableInWranglerEnvironments(
 		diagnostics,
 		enableServiceEnvironments,
 		topLevelEnv,
@@ -1137,7 +1137,7 @@ function normalizeAndValidateEnvironment(
 			configPath
 		),
 		rules: validateAndNormalizeRules(diagnostics, topLevelEnv, rawEnv, envName),
-		name: inheritableInLegacyEnvironments(
+		name: inheritableInWranglerEnvironments(
 			diagnostics,
 			enableServiceEnvironments,
 			topLevelEnv,

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -102,7 +102,8 @@ type Props = {
 	triggers: string[] | undefined;
 	routes: string[] | undefined;
 	domains: string[] | undefined;
-	legacyEnv: boolean | undefined;
+	/** Deprecated service environments.*/
+	enableServiceEnvironments: boolean | undefined;
 	jsxFactory: string | undefined;
 	jsxFragment: string | undefined;
 	tsconfig: string | undefined;
@@ -518,18 +519,27 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 	const envName = props.env ?? "production";
 
 	const start = Date.now();
-	const prod = Boolean(props.legacyEnv || !props.env);
-	const notProd = !prod;
-	const workerName = notProd ? `${scriptName} (${envName})` : scriptName;
+	/** Whether to use the deprecated service environments path */
+	const useServiceEnvironments = Boolean(
+		props.enableServiceEnvironments && props.env
+	);
+	const workerName = useServiceEnvironments
+		? `${scriptName} (${envName})`
+		: scriptName;
 	const workerUrl = props.dispatchNamespace
 		? `/accounts/${accountId}/workers/dispatch/namespaces/${props.dispatchNamespace}/scripts/${scriptName}`
-		: notProd
+		: useServiceEnvironments
 			? `/accounts/${accountId}/workers/services/${scriptName}/environments/${envName}`
 			: `/accounts/${accountId}/workers/scripts/${scriptName}`;
 
 	const { format } = props.entry;
 
-	if (!props.dispatchNamespace && prod && accountId && scriptName) {
+	if (
+		!props.dispatchNamespace &&
+		!useServiceEnvironments &&
+		accountId &&
+		scriptName
+	) {
 		const yes = await confirmLatestDeploymentOverwrite(
 			config,
 			accountId,
@@ -681,7 +691,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			? await getMigrationsToUpload(scriptName, {
 					accountId,
 					config,
-					legacyEnv: props.legacyEnv,
+					enableServiceEnvironments: props.enableServiceEnvironments,
 					env: props.env,
 					dispatchNamespace: props.dispatchNamespace,
 				})
@@ -706,7 +716,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			// have added the env name on to the script name. However, we must
 			// include it in the kv namespace name regardless (since there's no
 			// concept of service environments for kv namespaces yet).
-			scriptName + (!props.legacyEnv && props.env ? `-${props.env}` : ""),
+			scriptName + (useServiceEnvironments ? `-${props.env}` : ""),
 			props.legacyAssetPaths,
 			false,
 			props.dryRun,
@@ -822,7 +832,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		const canUseNewVersionsDeploymentsApi =
 			workerExists &&
 			props.dispatchNamespace === undefined &&
-			prod &&
+			!useServiceEnvironments &&
 			format === "modules" &&
 			migrations === undefined &&
 			!config.first_party_worker &&
@@ -1171,12 +1181,12 @@ export async function publishRoutes(
 	{
 		workerUrl,
 		scriptName,
-		notProd,
+		useServiceEnvironments,
 		accountId,
 	}: {
 		workerUrl: string;
 		scriptName: string;
-		notProd: boolean;
+		useServiceEnvironments: boolean;
 		accountId: string;
 	}
 ): Promise<string[]> {
@@ -1199,7 +1209,7 @@ export async function publishRoutes(
 			// where the user is logged in via an API token that does not have "All Zones".
 			return await publishRoutesFallback(complianceConfig, routes, {
 				scriptName,
-				notProd,
+				useServiceEnvironments,
 				accountId,
 			});
 		} else {
@@ -1218,11 +1228,11 @@ async function publishRoutesFallback(
 	routes: Route[],
 	{
 		scriptName,
-		notProd,
+		useServiceEnvironments,
 		accountId,
-	}: { scriptName: string; notProd: boolean; accountId: string }
+	}: { scriptName: string; useServiceEnvironments: boolean; accountId: string }
 ) {
-	if (notProd) {
+	if (useServiceEnvironments) {
 		throw new UserError(
 			"Service environments combined with an API token that doesn't have 'All Zones' permissions is not supported.\n" +
 				"Either turn off service environments by setting `legacy_env = true`, creating an API token with 'All Zones' permissions, or logging in via OAuth",

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -18,9 +18,9 @@ import { getSiteAssetPaths } from "../sites";
 import { requireAuth } from "../user";
 import { collectKeyValues } from "../utils/collectKeyValues";
 import { formatCompatibilityDate } from "../utils/compatibility-date";
+import { enableServiceEnvironments } from "../utils/enableServiceEnvironments";
 import { getRules } from "../utils/getRules";
 import { getScriptName } from "../utils/getScriptName";
-import { isLegacyEnv } from "../utils/isLegacyEnv";
 import deploy from "./deploy";
 
 export const deployCommand = createCommand({
@@ -372,7 +372,7 @@ export const deployCommand = createCommand({
 			domains: args.domains,
 			assetsOptions,
 			legacyAssetPaths: siteAssetPaths,
-			legacyEnv: isLegacyEnv(config),
+			enableServiceEnvironments: enableServiceEnvironments(config),
 			minify: args.minify,
 			isWorkersSite: Boolean(args.site || config.site),
 			outDir: args.outdir,

--- a/packages/wrangler/src/deployment-bundle/bindings.ts
+++ b/packages/wrangler/src/deployment-bundle/bindings.ts
@@ -10,7 +10,7 @@ import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { APIError } from "../parse";
 import { createR2Bucket, getR2Bucket, listR2Buckets } from "../r2/helpers";
-import { isLegacyEnv } from "../utils/isLegacyEnv";
+import { enableServiceEnvironments } from "../utils/enableServiceEnvironments";
 import { printBindings } from "../utils/print-bindings";
 import type { Config } from "../config";
 import type { ComplianceConfig } from "../environment-variables/misc-variables";
@@ -441,7 +441,7 @@ export async function provisionBindings(
 	);
 
 	if (pendingResources.length > 0) {
-		if (!isLegacyEnv(config)) {
+		if (enableServiceEnvironments(config)) {
 			throw new UserError(
 				"Provisioning resources is not supported with a service environment"
 			);

--- a/packages/wrangler/src/deployment-bundle/worker.ts
+++ b/packages/wrangler/src/deployment-bundle/worker.ts
@@ -466,7 +466,7 @@ export interface CfWorkerInit {
 
 export interface CfWorkerContext {
 	env: string | undefined;
-	legacyEnv: boolean | undefined;
+	useServiceEnvironments: boolean | undefined;
 	zone: string | undefined;
 	host: string | undefined;
 	routes: Route[] | undefined;

--- a/packages/wrangler/src/dev/create-worker-preview.ts
+++ b/packages/wrangler/src/dev/create-worker-preview.ts
@@ -243,7 +243,7 @@ async function createPreviewToken(
 	const { value, host, inspectorUrl, prewarmUrl } = session;
 	const { accountId } = account;
 	const url =
-		ctx.env && !ctx.legacyEnv
+		ctx.env && ctx.useServiceEnvironments
 			? `/accounts/${accountId}/workers/services/${worker.name}/environments/${ctx.env}/edge-preview`
 			: `/accounts/${accountId}/workers/scripts/${worker.name}/edge-preview`;
 
@@ -294,7 +294,7 @@ async function createPreviewToken(
 						// TODO: this should also probably have the env prefix
 						// but it doesn't appear to work yet, instead giving us the
 						// "There is nothing here yet" screen
-						// ctx.env && !ctx.legacyEnv
+						// ctx.env && ctx.useServiceEnvironments
 						//   ? `${ctx.env}.${worker.name}`
 						//   : worker.name
 					}.${host.split(".").slice(1).join(".")}`

--- a/packages/wrangler/src/dev/dev.ts
+++ b/packages/wrangler/src/dev/dev.ts
@@ -49,6 +49,7 @@ export type DevProps = {
 	nodejsCompatMode: NodeJSCompatMode | undefined;
 	build: Config["build"];
 	env: string | undefined;
+	/** Legacy env is wrangler environments, and not at all legacy. LegacyEnv = false is service environments, which is deprecated. */
 	legacyEnv: boolean;
 	host: string | undefined;
 	routes: Route[] | undefined;

--- a/packages/wrangler/src/dev/remote.ts
+++ b/packages/wrangler/src/dev/remote.ts
@@ -89,7 +89,7 @@ export async function createRemoteWorkerInit(props: {
 	complianceConfig: ComplianceConfig;
 	accountId: string;
 	name: string;
-	legacyEnv: boolean | undefined;
+	useServiceEnvironments: boolean | undefined;
 	env: string | undefined;
 	isWorkersSite: boolean;
 	assets: AssetsOptions | undefined;
@@ -122,7 +122,8 @@ export async function createRemoteWorkerInit(props: {
 		// have added the env name on to the script name. However, we must
 		// include it in the kv namespace name regardless (since there's no
 		// concept of service environments for kv namespaces yet).
-		props.name + (!props.legacyEnv && props.env ? `-${props.env}` : ""),
+		props.name +
+			(props.useServiceEnvironments && props.env ? `-${props.env}` : ""),
 		props.isWorkersSite ? props.legacyAssetPaths : undefined,
 		true,
 		false,
@@ -203,7 +204,7 @@ export async function getWorkerAccountAndContext(props: {
 	accountId: string;
 	apiToken?: ApiCredentials | undefined;
 	env: string | undefined;
-	legacyEnv: boolean | undefined;
+	useServiceEnvironments: boolean | undefined;
 	host: string | undefined;
 	routes: Route[] | undefined;
 	sendMetrics: boolean | undefined;
@@ -223,7 +224,7 @@ export async function getWorkerAccountAndContext(props: {
 
 	const workerContext: CfWorkerContext = {
 		env: props.env,
-		legacyEnv: props.legacyEnv,
+		useServiceEnvironments: props.useServiceEnvironments,
 		zone: zoneId,
 		host: props.host ?? getInferredHost(props.routes, props.configPath),
 		routes: props.routes,

--- a/packages/wrangler/src/durable.ts
+++ b/packages/wrangler/src/durable.ts
@@ -14,7 +14,8 @@ export async function getMigrationsToUpload(
 	props: {
 		accountId: string | undefined;
 		config: Config;
-		legacyEnv: boolean | undefined;
+		/** Deprecated service environments. Previously known as !legacyEnv :-) */
+		enableServiceEnvironments: boolean | undefined;
 		env: string | undefined;
 		dispatchNamespace: string | undefined;
 	}
@@ -39,7 +40,7 @@ export async function getMigrationsToUpload(
 				suppressNotFoundError(err);
 			}
 		} else {
-			if (!props.legacyEnv) {
+			if (props.enableServiceEnvironments) {
 				try {
 					if (props.env) {
 						const scriptData = await fetchResult<{

--- a/packages/wrangler/src/environments/index.ts
+++ b/packages/wrangler/src/environments/index.ts
@@ -1,12 +1,15 @@
 import { logger } from "../logger";
-import { isLegacyEnv } from "../utils/isLegacyEnv";
+import { enableServiceEnvironments } from "../utils/enableServiceEnvironments";
 import type { Config } from "../config";
 
 const SERVICE_TAG_PREFIX = "cf:service=";
 const ENVIRONMENT_TAG_PREFIX = "cf:environment=";
 
 export function hasDefinedEnvironments(config: Config) {
-	return isLegacyEnv(config) && Boolean(config.definedEnvironments?.length);
+	return (
+		!enableServiceEnvironments(config) &&
+		Boolean(config.definedEnvironments?.length)
+	);
 }
 
 export function applyServiceAndEnvironmentTags(config: Config, tags: string[]) {

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -12,8 +12,8 @@ import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { APIError, parseJSON, readFileSync } from "../parse";
 import { requireAuth } from "../user";
+import { enableServiceEnvironments } from "../utils/enableServiceEnvironments";
 import { getLegacyScriptName } from "../utils/getLegacyScriptName";
-import { isLegacyEnv } from "../utils/isLegacyEnv";
 import { readFromStdin, trimTrailingWhitespace } from "../utils/std";
 import type { Config } from "../config";
 import type { WorkerMetadataBinding } from "../deployment-bundle/create-worker-upload-form";
@@ -65,7 +65,7 @@ async function createDraftWorker({
 	}
 	await fetchResult(
 		config,
-		!isLegacyEnv(config) && args.env
+		enableServiceEnvironments(config) && args.env
 			? `/accounts/${accountId}/workers/services/${scriptName}/environments/${args.env}`
 			: `/accounts/${accountId}/workers/scripts/${scriptName}`,
 		{
@@ -173,6 +173,10 @@ export const secretPutCommand = createCommand({
 			);
 		}
 
+		const useServiceEnvironments = Boolean(
+			enableServiceEnvironments(config) && args.env
+		);
+
 		const scriptName = getLegacyScriptName(args, config);
 		if (!scriptName) {
 			throw new UserError(
@@ -191,15 +195,14 @@ export const secretPutCommand = createCommand({
 
 		logger.log(
 			`🌀 Creating the secret for the Worker "${scriptName}" ${
-				args.env && !isLegacyEnv(config) ? `(${args.env})` : ""
+				useServiceEnvironments ? `(${args.env})` : ""
 			}`
 		);
 
 		async function submitSecret() {
-			const url =
-				!args.env || isLegacyEnv(config)
-					? `/accounts/${accountId}/workers/scripts/${scriptName}/secrets`
-					: `/accounts/${accountId}/workers/services/${scriptName}/environments/${args.env}/secrets`;
+			const url = useServiceEnvironments
+				? `/accounts/${accountId}/workers/services/${scriptName}/environments/${args.env}/secrets`
+				: `/accounts/${accountId}/workers/scripts/${scriptName}/secrets`;
 
 			try {
 				return await fetchResult(config, url, {
@@ -282,6 +285,8 @@ export const secretDeleteCommand = createCommand({
 		},
 	},
 	async handler(args, { config }) {
+		const useServiceEnvironments =
+			enableServiceEnvironments(config) && args.env;
 		if (config.pages_build_output_dir) {
 			throw new UserError(
 				"It looks like you've run a Workers-specific command in a Pages project.\n" +
@@ -303,20 +308,19 @@ export const secretDeleteCommand = createCommand({
 				`Are you sure you want to permanently delete the secret ${
 					args.key
 				} on the Worker ${scriptName}${
-					args.env && !isLegacyEnv(config) ? ` (${args.env})` : ""
+					useServiceEnvironments ? ` (${args.env})` : ""
 				}?`
 			)
 		) {
 			logger.log(
 				`🌀 Deleting the secret ${args.key} on the Worker ${scriptName}${
-					args.env && !isLegacyEnv(config) ? ` (${args.env})` : ""
+					useServiceEnvironments ? ` (${args.env})` : ""
 				}`
 			);
 
-			const url =
-				!args.env || isLegacyEnv(config)
-					? `/accounts/${accountId}/workers/scripts/${scriptName}/secrets`
-					: `/accounts/${accountId}/workers/services/${scriptName}/environments/${args.env}/secrets`;
+			const url = useServiceEnvironments
+				? `/accounts/${accountId}/workers/services/${scriptName}/environments/${args.env}/secrets`
+				: `/accounts/${accountId}/workers/scripts/${scriptName}/secrets`;
 
 			await fetchResult(
 				config,
@@ -361,6 +365,8 @@ export const secretListCommand = createCommand({
 		printBanner: (args) => args.format === "pretty",
 	},
 	async handler(args, { config }) {
+		const useServiceEnvironments =
+			enableServiceEnvironments(config) && args.env;
 		if (config.pages_build_output_dir) {
 			throw new UserError(
 				"It looks like you've run a Workers-specific command in a Pages project.\n" +
@@ -377,10 +383,9 @@ export const secretListCommand = createCommand({
 
 		const accountId = await requireAuth(config);
 
-		const url =
-			!args.env || isLegacyEnv(config)
-				? `/accounts/${accountId}/workers/scripts/${scriptName}/secrets`
-				: `/accounts/${accountId}/workers/services/${scriptName}/environments/${args.env}/secrets`;
+		const url = useServiceEnvironments
+			? `/accounts/${accountId}/workers/services/${scriptName}/environments/${args.env}/secrets`
+			: `/accounts/${accountId}/workers/scripts/${scriptName}/secrets`;
 
 		const secrets = await fetchResult<{ name: string; type: string }[]>(
 			config,
@@ -434,6 +439,8 @@ export const secretBulkCommand = createCommand({
 			);
 		}
 
+		const useServiceEnvironments =
+			enableServiceEnvironments(config) && args.env;
 		const scriptName = getLegacyScriptName(args, config);
 		if (!scriptName) {
 			const error = new UserError(
@@ -447,7 +454,7 @@ export const secretBulkCommand = createCommand({
 
 		logger.log(
 			`🌀 Creating the secrets for the Worker "${scriptName}" ${
-				args.env && !isLegacyEnv(config) ? `(${args.env})` : ""
+				useServiceEnvironments ? `(${args.env})` : ""
 			}`
 		);
 
@@ -458,10 +465,9 @@ export const secretBulkCommand = createCommand({
 		}
 
 		function getSettings() {
-			const url =
-				!args.env || isLegacyEnv(config)
-					? `/accounts/${accountId}/workers/scripts/${scriptName}/settings`
-					: `/accounts/${accountId}/workers/services/${scriptName}/environments/${args.env}/settings`;
+			const url = useServiceEnvironments
+				? `/accounts/${accountId}/workers/services/${scriptName}/environments/${args.env}/settings`
+				: `/accounts/${accountId}/workers/scripts/${scriptName}/settings`;
 
 			return fetchResult<{
 				bindings: Array<WorkerMetadataBinding | SecretBindingRedacted>;
@@ -471,10 +477,9 @@ export const secretBulkCommand = createCommand({
 		function putBindingsSettings(
 			bindings: Array<SecretBindingUpload | InheritBindingUpload>
 		) {
-			const url =
-				!args.env || isLegacyEnv(config)
-					? `/accounts/${accountId}/workers/scripts/${scriptName}/settings`
-					: `/accounts/${accountId}/workers/services/${scriptName}/environments/${args.env}/settings`;
+			const url = useServiceEnvironments
+				? `/accounts/${accountId}/workers/services/${scriptName}/environments/${args.env}/settings`
+				: `/accounts/${accountId}/workers/scripts/${scriptName}/settings`;
 
 			const data = new FormData();
 			data.set("settings", JSON.stringify({ bindings }));

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -6,8 +6,8 @@ import { createFatalError, UserError } from "../errors";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { requireAuth } from "../user";
+import { enableServiceEnvironments } from "../utils/enableServiceEnvironments";
 import { getLegacyScriptName } from "../utils/getLegacyScriptName";
-import { isLegacyEnv } from "../utils/isLegacyEnv";
 import { printWranglerBanner } from "../wrangler-banner";
 import { getWorkerForZone } from "../zones";
 import {
@@ -151,11 +151,11 @@ export const tailCommand = createCommand({
 			scriptName,
 			filters,
 			args.debug,
-			!isLegacyEnv(config) ? args.env : undefined
+			enableServiceEnvironments(config) ? args.env : undefined
 		);
 
 		const scriptDisplayName = `${scriptName}${
-			args.env && !isLegacyEnv(config) ? ` (${args.env})` : ""
+			enableServiceEnvironments(config) && args.env ? ` (${args.env})` : ""
 		}`;
 
 		if (args.format === "pretty") {

--- a/packages/wrangler/src/triggers/deploy.ts
+++ b/packages/wrangler/src/triggers/deploy.ts
@@ -29,7 +29,7 @@ type Props = {
 	env: string | undefined;
 	triggers: string[] | undefined;
 	routes: Route[] | undefined;
-	legacyEnv: boolean | undefined;
+	enableServiceEnvironments: boolean | undefined;
 	dryRun: boolean | undefined;
 	assetsOptions: AssetsOptions | undefined;
 	firstDeploy: boolean;
@@ -64,9 +64,13 @@ export default async function triggersDeploy(
 	const envName = props.env ?? "production";
 
 	const start = Date.now();
-	const notProd = Boolean(!props.legacyEnv && props.env);
-	const workerName = notProd ? `${scriptName} (${envName})` : scriptName;
-	const workerUrl = notProd
+	const useServiceEnvironments = Boolean(
+		props.enableServiceEnvironments && props.env
+	);
+	const workerName = useServiceEnvironments
+		? `${scriptName} (${envName})`
+		: scriptName;
+	const workerUrl = useServiceEnvironments
 		? `/accounts/${accountId}/workers/services/${scriptName}/environments/${envName}`
 		: `/accounts/${accountId}/workers/scripts/${scriptName}`;
 
@@ -195,7 +199,7 @@ export default async function triggersDeploy(
 			publishRoutes(config, routesOnly, {
 				workerUrl,
 				scriptName,
-				notProd,
+				useServiceEnvironments,
 				accountId,
 			}).then(() => {
 				if (routesOnly.length > 10) {
@@ -466,7 +470,7 @@ async function subdomainDeploy(
 			config.configPath
 		);
 		workersDevURL =
-			props.legacyEnv || !props.env
+			!props.enableServiceEnvironments || !props.env
 				? `${scriptName}.${userSubdomain}`
 				: `${envName}.${scriptName}.${userSubdomain}`;
 	}

--- a/packages/wrangler/src/triggers/index.ts
+++ b/packages/wrangler/src/triggers/index.ts
@@ -2,8 +2,8 @@ import { getAssetsOptions } from "../assets";
 import { createCommand, createNamespace } from "../core/create-command";
 import * as metrics from "../metrics";
 import { requireAuth } from "../user";
+import { enableServiceEnvironments } from "../utils/enableServiceEnvironments";
 import { getScriptName } from "../utils/getScriptName";
-import { isLegacyEnv } from "../utils/isLegacyEnv";
 import triggersDeploy from "./deploy";
 
 export const triggersNamespace = createNamespace({
@@ -71,7 +71,7 @@ export const triggersDeployCommand = createCommand({
 			env: args.env,
 			triggers: args.triggers,
 			routes: args.routes,
-			legacyEnv: isLegacyEnv(config),
+			enableServiceEnvironments: enableServiceEnvironments(config),
 			dryRun: args.dryRun,
 			assetsOptions,
 			firstDeploy: false, // at this point the Worker should already exist.

--- a/packages/wrangler/src/utils/enableServiceEnvironments.ts
+++ b/packages/wrangler/src/utils/enableServiceEnvironments.ts
@@ -1,0 +1,15 @@
+import type { Config } from "../config";
+
+/**
+ * whether deprecated service environments are enabled.
+ */
+export function enableServiceEnvironments(config: Config): boolean {
+	// legacy env refers to wrangler environments, which are not actually legacy in any way.
+	// This is opposed to service environments, which are deprecated.
+	// Unfortunately legacy-env is a public facing arg and config option, so we have to leave the name.
+	// However we can change the internal handling to be less confusing.
+	//
+	// We only read from config here, because we've already accounted for
+	// args["legacy-env"] in https://github.com/cloudflare/workers-sdk/blob/b24aeb5722370c2e04bce97a84a1fa1e55725d79/packages/wrangler/src/config/validation.ts#L94-L98
+	return !config.legacy_env;
+}

--- a/packages/wrangler/src/utils/getLegacyScriptName.ts
+++ b/packages/wrangler/src/utils/getLegacyScriptName.ts
@@ -1,4 +1,4 @@
-import { isLegacyEnv } from "./isLegacyEnv";
+import { enableServiceEnvironments } from "./enableServiceEnvironments";
 import type { Config } from "../config";
 
 /**
@@ -9,7 +9,7 @@ export function getLegacyScriptName(
 	args: { name: string | undefined; env: string | undefined },
 	config: Config
 ) {
-	return args.name && args.env && isLegacyEnv(config)
+	return args.name && args.env && !enableServiceEnvironments(config)
 		? `${args.name}-${args.env}`
 		: args.name ?? config.name;
 }

--- a/packages/wrangler/src/utils/isLegacyEnv.ts
+++ b/packages/wrangler/src/utils/isLegacyEnv.ts
@@ -1,7 +1,0 @@
-import type { Config } from "../config";
-
-export function isLegacyEnv(config: Config): boolean {
-	// We only read from config here, because we've already accounted for
-	// args["legacy-env"] in https://github.com/cloudflare/workers-sdk/blob/b24aeb5722370c2e04bce97a84a1fa1e55725d79/packages/wrangler/src/config/validation.ts#L94-L98
-	return config.legacy_env;
-}

--- a/packages/wrangler/src/versions/secrets/delete.ts
+++ b/packages/wrangler/src/versions/secrets/delete.ts
@@ -5,8 +5,8 @@ import { confirm } from "../../dialogs";
 import { UserError } from "../../errors";
 import { logger } from "../../logger";
 import { requireAuth } from "../../user";
+import { enableServiceEnvironments } from "../../utils/enableServiceEnvironments";
 import { getLegacyScriptName } from "../../utils/getLegacyScriptName";
-import { isLegacyEnv } from "../../utils/isLegacyEnv";
 import { copyWorkerVersionWithNewSecrets } from "./index";
 import type { VersionDetails, WorkerVersion } from "./index";
 
@@ -59,18 +59,21 @@ export const versionsSecretDeleteCommand = createCommand({
 
 		const accountId = await requireAuth(config);
 
+		const useServiceEnvironments =
+			args.env && enableServiceEnvironments(config);
+
 		if (
 			await confirm(
 				`Are you sure you want to permanently delete the secret ${
 					args.key
 				} on the Worker ${scriptName}${
-					args.env && !isLegacyEnv(config) ? ` (${args.env})` : ""
+					useServiceEnvironments ? ` (${args.env})` : ""
 				}?`
 			)
 		) {
 			logger.log(
 				`🌀 Deleting the secret ${args.key} on the Worker ${scriptName}${
-					args.env && !isLegacyEnv(config) ? ` (${args.env})` : ""
+					useServiceEnvironments ? ` (${args.env})` : ""
 				}`
 			);
 

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -57,10 +57,10 @@ import {
 import { requireAuth } from "../user";
 import { collectKeyValues } from "../utils/collectKeyValues";
 import { formatCompatibilityDate } from "../utils/compatibility-date";
+import { enableServiceEnvironments } from "../utils/enableServiceEnvironments";
 import { helpIfErrorIsSizeOrScriptStartup } from "../utils/friendly-validator-errors";
 import { getRules } from "../utils/getRules";
 import { getScriptName } from "../utils/getScriptName";
-import { isLegacyEnv } from "../utils/isLegacyEnv";
 import { printBindings } from "../utils/print-bindings";
 import { retryOnAPIFailure } from "../utils/retry";
 import { patchNonVersionedScriptSettings } from "./api";
@@ -77,7 +77,7 @@ type Props = {
 	entry: Entry;
 	rules: Config["rules"];
 	name: string;
-	legacyEnv: boolean | undefined;
+	enableServiceEnvironments: boolean | undefined;
 	env: string | undefined;
 	compatibilityDate: string | undefined;
 	compatibilityFlags: string[] | undefined;
@@ -364,7 +364,7 @@ export const versionsUploadCommand = createCommand({
 				name,
 				rules: getRules(config),
 				entry,
-				legacyEnv: isLegacyEnv(config),
+				enableServiceEnvironments: enableServiceEnvironments(config),
 				env: args.env,
 				compatibilityDate: args.latest
 					? formatCompatibilityDate(new Date())
@@ -655,7 +655,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			? await getMigrationsToUpload(scriptName, {
 					accountId,
 					config,
-					legacyEnv: props.legacyEnv,
+					enableServiceEnvironments: props.enableServiceEnvironments,
 					env: props.env,
 					dispatchNamespace: undefined,
 				})


### PR DESCRIPTION
There is nothing legacy about legacy env, which is extremely confusing. legacy env = true means that we are using regular wrangler environments. legacy env = false means that we are using **_deprecated_** service environments.

Unfortunately legacy_env is in our wrangler config schema and cli flags so i can't just rename it to something sensible, but we can translate this in our codebase to something that makes sense.

Thankfully we have a lot of tests for this, although concerningly a lot of tests also seem to default to service environments by default. But i'd prefer to minimise changes to tests in this PR. 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal refactor
- Wrangler V3 Backport
  - [x] Wrangler PR: todo 😭 
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
