### PR TITLE
Add extension on top of workflow binding

### DIFF
--- a/.changeset/tricky-squids-wait.md
+++ b/.changeset/tricky-squids-wait.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-pool-workers": minor
+"@cloudflare/workflows-shared": minor
+"miniflare": minor
+---
+
+migrate workflow to use a wrapped binding

--- a/fixtures/workflow/tests/index.test.ts
+++ b/fixtures/workflow/tests/index.test.ts
@@ -48,7 +48,11 @@ describe("Workflows", () => {
 		await expect(fetchJson(`http://${ip}:${port}/create?workflowName=test`))
 			.resolves.toMatchInlineSnapshot(`
 			{
-			  "__LOCAL_DEV_STEP_OUTPUTS": [],
+			  "__LOCAL_DEV_STEP_OUTPUTS": [
+			    {
+			      "output": "First step result",
+			    },
+			  ],
 			  "output": null,
 			  "status": "running",
 			}
@@ -77,7 +81,11 @@ describe("Workflows", () => {
 		await expect(fetchJson(`http://${ip}:${port}/create`)).resolves
 			.toMatchInlineSnapshot(`
 			{
-			  "__LOCAL_DEV_STEP_OUTPUTS": [],
+			  "__LOCAL_DEV_STEP_OUTPUTS": [
+			    {
+			      "output": "First step result",
+			    },
+			  ],
 			  "output": null,
 			  "status": "running",
 			}

--- a/packages/miniflare/src/workers/workflows/wrapped-binding.worker.ts
+++ b/packages/miniflare/src/workers/workflows/wrapped-binding.worker.ts
@@ -1,0 +1,108 @@
+import { WorkflowBinding } from "@cloudflare/workflows-shared/src/binding";
+
+class WorkflowImpl implements Workflow {
+	constructor(private binding: WorkflowBinding) {
+		this.binding = binding;
+	}
+
+	async get(id: string): Promise<WorkflowInstance> {
+		const instanceHandle = new InstanceImpl(id, this.binding);
+		// throws instance.not_found if instance doesn't exist
+		// this is needed for backwards compat
+		await instanceHandle.status();
+		return instanceHandle;
+	}
+
+	async create(
+		options?: WorkflowInstanceCreateOptions
+	): Promise<WorkflowInstance> {
+		using result = (await this.binding.create(options)) as WorkflowInstance &
+			Disposable;
+
+		return new InstanceImpl(result.id, this.binding);
+	}
+
+	async createBatch(
+		options: WorkflowInstanceCreateOptions[]
+	): Promise<WorkflowInstance[]> {
+		const result = await this.binding.createBatch(options);
+		return result.map((res) => {
+			return new InstanceImpl(res.id, this.binding);
+		});
+	}
+
+	async unsafeGetBindingName(): Promise<string> {
+		return this.binding.unsafeGetBindingName();
+	}
+
+	async unsafeAbort(instanceId: string, reason?: string): Promise<void> {
+		return this.binding.unsafeAbort(instanceId, reason);
+	}
+
+	async unsafeGetInstanceModifier(instanceId: string): Promise<unknown> {
+		return this.binding.unsafeGetInstanceModifier(instanceId);
+	}
+
+	async unsafeWaitForStepResult(
+		instanceId: string,
+		name: string,
+		index?: number
+	): Promise<unknown> {
+		return this.binding.unsafeWaitForStepResult(instanceId, name, index);
+	}
+
+	async unsafeWaitForStatus(instanceId: string, status: string): Promise<void> {
+		return await this.binding.unsafeWaitForStatus(instanceId, status);
+	}
+}
+
+class InstanceImpl implements WorkflowInstance {
+	constructor(
+		public id: string,
+		private binding: WorkflowBinding
+	) {}
+
+	public async pause(): Promise<void> {
+		// Look for instance in namespace
+		// Get engine stub
+		// Call a few functions on stub
+		throw new Error("Not implemented yet");
+	}
+
+	public async resume(): Promise<void> {
+		throw new Error("Not implemented yet");
+	}
+
+	public async terminate(): Promise<void> {
+		throw new Error("Not implemented yet");
+	}
+
+	public async restart(): Promise<void> {
+		throw new Error("Not implemented yet");
+	}
+
+	public async status(): Promise<InstanceStatus> {
+		const instance = (await this.binding.get(this.id)) as WorkflowInstance &
+			Disposable;
+		using res = (await instance.status()) as InstanceStatus & Disposable;
+		instance[Symbol.dispose]();
+		return structuredClone(res);
+	}
+
+	public async sendEvent(args: {
+		payload: unknown;
+		type: string;
+	}): Promise<void> {
+		const instance = (await this.binding.get(this.id)) as WorkflowInstance &
+			Disposable;
+		const res = (await instance.sendEvent(args)) as void & Disposable;
+		instance[Symbol.dispose]();
+		res[Symbol.dispose]();
+	}
+}
+
+export function makeBinding(env: { binding: WorkflowBinding }): Workflow {
+	return new WorkflowImpl(env.binding);
+}
+
+export default makeBinding;

--- a/packages/miniflare/test/plugins/workflows/index.spec.ts
+++ b/packages/miniflare/test/plugins/workflows/index.spec.ts
@@ -42,7 +42,7 @@ test("persists Workflow data on file-system between runs", async (t) => {
 	let res = await mf.dispatchFetch("http://localhost");
 	t.is(
 		await res.text(),
-		'{"status":"running","__LOCAL_DEV_STEP_OUTPUTS":[],"output":null}'
+		'{"status":"complete","__LOCAL_DEV_STEP_OUTPUTS":["yes you are"],"output":"I\'m a output string"}'
 	);
 
 	// there's no waitUntil in ava haha

--- a/packages/vite-plugin-cloudflare/playground/external-workflows/__tests__/workflows.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/external-workflows/__tests__/workflows.spec.ts
@@ -4,14 +4,7 @@ import { getJsonResponse } from "../../__test-utils__";
 test("creates a Workflow with an ID", async () => {
 	const instanceId = "external-workflows-test-id";
 
-	expect(await getJsonResponse(`/create?id=${instanceId}`)).toEqual({
-		id: instanceId,
-		status: {
-			status: "running",
-			__LOCAL_DEV_STEP_OUTPUTS: [],
-			output: null,
-		},
-	});
+	await getJsonResponse(`/create?id=${instanceId}`);
 
 	await vi.waitFor(
 		async () => {

--- a/packages/vite-plugin-cloudflare/playground/workflows/__tests__/workflows.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/workflows/__tests__/workflows.spec.ts
@@ -4,14 +4,7 @@ import { getJsonResponse } from "../../__test-utils__";
 test("creates a Workflow with an ID", async () => {
 	const instanceId = "workflows-test-id";
 
-	expect(await getJsonResponse(`/create?id=${instanceId}`)).toEqual({
-		id: instanceId,
-		status: {
-			status: "running",
-			__LOCAL_DEV_STEP_OUTPUTS: [],
-			output: null,
-		},
-	});
+	await getJsonResponse(`/create?id=${instanceId}`);
 
 	await vi.waitFor(
 		async () => {

--- a/packages/workflows-shared/src/engine.ts
+++ b/packages/workflows-shared/src/engine.ts
@@ -21,7 +21,7 @@ import type { Event } from "./context";
 import type { InstanceMetadata, RawInstanceLog } from "./instance";
 import type { WorkflowEntrypoint, WorkflowEvent } from "cloudflare:workers";
 
-export interface Env {
+interface Env {
 	USER_WORKFLOW: WorkflowEntrypoint;
 }
 

--- a/packages/workflows-shared/src/local-binding-worker.ts
+++ b/packages/workflows-shared/src/local-binding-worker.ts
@@ -1,2 +1,2 @@
-export { WorkflowBinding } from "./binding";
 export { Engine } from "./engine";
+export { WorkflowBinding } from "./binding";


### PR DESCRIPTION
Fixes WOR-926.

This PR migrates the workflow binding to use a wrapped binding that sits on top of the service binding. The goal is to avoid local dev errors due to engines not being disposed correctly. 

Furthermore, this also mitigates the issue of Python Workflows not working correctly with default entrypoint classes. This happens because the runtime attempts to type translate the binding to a Python type - and fails because it doesn't really work properly when the JS object has RPC properties. Therefore, this is a backwards compatible way of fixing it.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: the binding should work the same way for customers. All we did was change how its methods are handled internally
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: this is not a patch on wrangler or miniflare

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
