### PR TITLE
Configurable rules for exclusions in bundling of python_modules

### DIFF
--- a/.changeset/itchy-radios-drive.md
+++ b/.changeset/itchy-radios-drive.md
@@ -1,0 +1,10 @@
+---
+"wrangler": minor
+---
+
+Implements `python_modules.excludes` wrangler config field
+
+```toml
+[python_modules]
+excludes = ["**/*.pyc", "**/__pycache__"]
+```

--- a/packages/wrangler/src/__tests__/config/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.test.ts
@@ -136,6 +136,7 @@ describe("normalizeAndValidateConfig()", () => {
 			data_blobs: undefined,
 			workers_dev: undefined,
 			preview_urls: undefined,
+			python_modules: { exclude: ["**/*.pyc"] },
 			no_bundle: undefined,
 			minify: undefined,
 			first_party_worker: undefined,

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -13484,6 +13484,7 @@ export default{
 			writeWranglerConfig({
 				main: "src/index.py",
 				compatibility_flags: ["python_workers"],
+				// python_modules.exclude is set to `**/*.pyc` by default
 			});
 
 			// Create main Python file
@@ -13503,6 +13504,16 @@ export default{
 				"# Python vendor module 2\nprint('hello')"
 			);
 
+			await fs.promises.writeFile(
+				"python_modules/test.pyc",
+				"this shouldn't be deployed"
+			);
+			await fs.promises.mkdir("python_modules/other", { recursive: true });
+			await fs.promises.writeFile(
+				"python_modules/other/test.pyc",
+				"this shouldn't be deployed"
+			);
+
 			// Create a regular Python module
 			await fs.promises.writeFile(
 				"src/helper.py",
@@ -13512,12 +13523,19 @@ export default{
 			const expectedModules = {
 				"index.py": mainPython,
 				"helper.py": "# Helper module\ndef helper(): pass",
+				[`python_modules${path.sep}module1.so`]: "binary content for module 1",
+				[`python_modules${path.sep}module2.py`]:
+					"# Python vendor module 2\nprint('hello')",
 			};
 
 			mockSubDomainRequest();
 			mockUploadWorkerRequest({
 				expectedMainModule: "index.py",
 				expectedModules,
+				excludedModules: [
+					`python_modules${path.sep}test.pyc`,
+					`python_modules${path.sep}other${path.sep}test.pyc`,
+				],
 			});
 
 			await runWrangler("deploy");

--- a/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
@@ -30,6 +30,7 @@ export function mockUploadWorkerRequest(
 		expectedType?: "esm" | "sw" | "none";
 		expectedBindings?: unknown;
 		expectedModules?: Record<string, string | null>;
+		excludedModules?: string[];
 		expectedCompatibilityDate?: string;
 		expectedCompatibilityFlags?: string[];
 		expectedMigrations?: CfWorkerInit["migrations"];
@@ -142,6 +143,9 @@ export function mockUploadWorkerRequest(
 		for (const [name, content] of Object.entries(expectedModules)) {
 			expect(await serialize(formBody.get(name))).toEqual(content);
 		}
+		for (const name of excludedModules) {
+			expect(formBody.get(name)).toBeNull();
+		}
 
 		if (useOldUploadApi) {
 			return HttpResponse.json(
@@ -180,6 +184,7 @@ export function mockUploadWorkerRequest(
 		expectedType = "esm",
 		expectedBindings,
 		expectedModules = {},
+		excludedModules = [],
 		expectedCompatibilityDate,
 		expectedCompatibilityFlags,
 		env = undefined,

--- a/packages/wrangler/src/api/startDevWorker/BundlerController.ts
+++ b/packages/wrangler/src/api/startDevWorker/BundlerController.ts
@@ -106,7 +106,8 @@ export class BundlerController extends Controller<BundlerControllerEventMap> {
 				? await noBundleWorker(
 						entry,
 						config.build.moduleRules,
-						this.#tmpDir.path
+						this.#tmpDir.path,
+						config.pythonModules?.exclude ?? []
 					)
 				: await bundleWorker(entry, this.#tmpDir.path, {
 						bundle: true,
@@ -279,6 +280,7 @@ export class BundlerController extends Controller<BundlerControllerEventMap> {
 					config.compatibilityDate,
 					config.compatibilityFlags
 				),
+				pythonModulesExcludes: config.pythonModules?.exclude ?? [],
 			},
 			(cb) => {
 				const newBundle = cb(this.#currentBundle);

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -342,6 +342,9 @@ async function resolveConfig(
 		compatibilityDate: getDevCompatibilityDate(config, input.compatibilityDate),
 		compatibilityFlags: input.compatibilityFlags ?? config.compatibility_flags,
 		complianceRegion: input.complianceRegion ?? config.compliance_region,
+		pythonModules: {
+			exclude: input.pythonModules?.exclude ?? config.python_modules.exclude,
+		},
 		entrypoint: entry.file,
 		projectRoot: entry.projectRoot,
 		bindings,

--- a/packages/wrangler/src/api/startDevWorker/types.ts
+++ b/packages/wrangler/src/api/startDevWorker/types.ts
@@ -88,6 +88,12 @@ export interface StartDevWorkerInput {
 	/** Specify the compliance region mode of the Worker. */
 	complianceRegion?: Config["compliance_region"];
 
+	/** Configuration for Python modules. */
+	pythonModules?: {
+		/** A list of glob patterns to exclude files from the python_modules directory when bundling. */
+		exclude?: string[];
+	};
+
 	env?: string;
 
 	/**

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -381,6 +381,7 @@ export const defaultWranglerConfig: Config = {
 	observability: { enabled: true },
 	/** The default here is undefined so that we can delegate to the CLOUDFLARE_COMPLIANCE_REGION environment variable. */
 	compliance_region: undefined,
+	python_modules: { exclude: ["**/*.pyc"] },
 
 	/** NON-INHERITABLE ENVIRONMENT FIELDS **/
 	define: {},

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -589,6 +589,22 @@ interface EnvironmentInheritable {
 	 * it can be set to `undefined` in configuration to delegate to the CLOUDFLARE_COMPLIANCE_REGION environment variable.
 	 */
 	compliance_region: "public" | "fedramp_high" | undefined;
+
+	/**
+	 * Configuration for Python modules.
+	 *
+	 * @inheritable
+	 */
+	python_modules: {
+		/**
+		 * A list of glob patterns to exclude files from the python_modules directory when bundling.
+		 *
+		 * Patterns are relative to the python_modules directory and use glob syntax.
+		 *
+		 * @default ["**\*.pyc"]
+		 */
+		exclude: string[];
+	};
 }
 
 export type DurableObjectBindings = {

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -1591,6 +1591,14 @@ function normalizeAndValidateEnvironment(
 			isOneOf("public", "fedramp_high"),
 			undefined
 		),
+		python_modules: inheritable(
+			diagnostics,
+			topLevelEnv,
+			rawEnv,
+			"python_modules",
+			validatePythonModules,
+			{ exclude: ["**/*.pyc"] }
+		),
 	};
 
 	warnIfDurableObjectsHaveNoMigrations(
@@ -4419,6 +4427,37 @@ function warnIfDurableObjectsHaveNoMigrations(
 		}
 	}
 }
+
+const validatePythonModules: ValidatorFn = (
+	diagnostics,
+	field,
+	value,
+	topLevelEnv
+) => {
+	if (value === undefined) {
+		return true;
+	}
+
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		diagnostics.errors.push(
+			`"${field}" should be an object but got ${JSON.stringify(value)}.`
+		);
+		return false;
+	}
+
+	const val = value as { exclude?: unknown };
+	if (!("exclude" in val)) {
+		return false;
+	}
+
+	if (
+		!isStringArray(diagnostics, `${field}.exclude`, val.exclude, topLevelEnv)
+	) {
+		return false;
+	}
+
+	return true;
+};
 
 function isRemoteValid(
 	targetObject: object,

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -613,7 +613,12 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			bundleType,
 			...bundle
 		} = props.noBundle
-			? await noBundleWorker(props.entry, props.rules, props.outDir)
+			? await noBundleWorker(
+					props.entry,
+					props.rules,
+					props.outDir,
+					config.python_modules.exclude
+				)
 			: await bundleWorker(
 					props.entry,
 					typeof destination === "string" ? destination : destination.path,

--- a/packages/wrangler/src/deployment-bundle/no-bundle-worker.ts
+++ b/packages/wrangler/src/deployment-bundle/no-bundle-worker.ts
@@ -9,9 +9,15 @@ import type { Entry } from "./entry";
 export async function noBundleWorker(
 	entry: Entry,
 	rules: Rule[],
-	outDir: string | undefined
+	outDir: string | undefined,
+	pythonModulesExcludes: string[] = []
 ) {
-	const modules = await findAdditionalModules(entry, rules);
+	const modules = await findAdditionalModules(
+		entry,
+		rules,
+		false,
+		pythonModulesExcludes
+	);
 	if (outDir) {
 		await writeAdditionalModules(modules, outDir);
 	}

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -59,6 +59,7 @@ export function runBuild(
 		onStart,
 		defineNavigatorUserAgent,
 		checkFetch,
+		pythonModulesExcludes,
 	}: {
 		entry: Entry;
 		destination: string | undefined;
@@ -86,6 +87,7 @@ export function runBuild(
 		onStart: () => void;
 		defineNavigatorUserAgent: boolean;
 		checkFetch: boolean;
+		pythonModulesExcludes?: string[];
 	},
 	setBundle: (
 		cb: (previous: EsbuildBundle | undefined) => EsbuildBundle
@@ -110,7 +112,12 @@ export function runBuild(
 	async function getAdditionalModules() {
 		return noBundle
 			? dedupeModulesByName([
-					...((await doFindAdditionalModules(entry, rules)) ?? []),
+					...((await doFindAdditionalModules(
+						entry,
+						rules,
+						false,
+						pythonModulesExcludes ?? []
+					)) ?? []),
 					...additionalModules,
 				])
 			: additionalModules;

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -588,7 +588,12 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			bundleType,
 			...bundle
 		} = props.noBundle
-			? await noBundleWorker(props.entry, props.rules, props.outDir)
+			? await noBundleWorker(
+					props.entry,
+					props.rules,
+					props.outDir,
+					config.python_modules.exclude
+				)
 			: await bundleWorker(
 					props.entry,
 					typeof destination === "string" ? destination : destination.path,


### PR DESCRIPTION
Implements a new `python_modules_excludes` wrangler config field. The user can specify a list of globs in that field to exclude them from being vendored. By default every file in `python_modules` is included but for certain packages they contain so much stuff that sometimes it's good to be able to filter it out, especially since our bundle sizes are limited.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/25725
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: new feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->


---- 

### Test Plan

```
pnpm run test --filter wrangler -- -t "should print vendor modules correctly in table" src/__tests__/deploy.test.ts

cd packages/wrangler/
pnpm i
pnpm run build
pnpm test:e2e --run --testNamePattern="can exclude vendored module during"
```