### PR TITLE
Allow python workers to define custom vendor rules

### DIFF
--- a/.changeset/breezy-schools-clean.md
+++ b/.changeset/breezy-schools-clean.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Allow python workers to define custom vendor rules

--- a/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
+++ b/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
@@ -167,9 +167,36 @@ export async function findAdditionalModules(
 				pythonModulesDir,
 				entry.projectRoot
 			);
-			const vendoredRules: Rule[] = [
-				{ type: "Data", globs: ["**/*"], fallthrough: true },
-			];
+
+			const vendoredRules: Rule[] = [];
+
+			// If user defined any vendor rules, use them instead of default ones
+			for (const rule of rules.rules) {
+				if (rule.type !== "Data") {
+					continue;
+				}
+
+				const newRule: Rule = { type: "Data", globs: [], fallthrough: true };
+				for (const glob of rule.globs) {
+					if (glob.startsWith("python_modules/")) {
+						newRule.globs.push(glob.replace("python_modules/", ""));
+					}
+				}
+
+				if (newRule.globs.length > 0) {
+					vendoredRules.push(newRule);
+				}
+			}
+
+			// If there is no user defined vendor rules, enable the default one
+			if (vendoredRules.length === 0) {
+				vendoredRules.push({
+					type: "Data",
+					globs: ["**/*"],
+					fallthrough: true,
+				});
+			}
+
 			const vendoredModules = (
 				await matchFiles(
 					pythonModulesFiles,


### PR DESCRIPTION
Python workers right now bundle all files inside the python_modules folder, this pr makes this default behavour optional.
When the user defined any rules that starts with `python_modules/` then the default behaviour is disabled and user defined rules are applied.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: small change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: small change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
