### PR TITLE
Fix remote dev with Access

### DIFF
--- a/.changeset/ninety-snakes-peel.md
+++ b/.changeset/ninety-snakes-peel.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Acquire Cloudflare Access tokens for additional requests made during a `wrangler dev --remote` session

--- a/packages/wrangler/src/dev/create-worker-preview.ts
+++ b/packages/wrangler/src/dev/create-worker-preview.ts
@@ -172,20 +172,24 @@ export async function createPreviewSession(
 		apiToken
 	);
 
-	const switchedExchangeUrl = switchHost(
-		exchange_url,
-		ctx.host,
-		!!ctx.zone
-	).toString();
+	const switchedExchangeUrl = switchHost(exchange_url, ctx.host, !!ctx.zone);
+
+	const headers: HeadersInit = {};
+	const accessToken = await getAccessToken(switchedExchangeUrl.hostname);
+
+	if (accessToken) {
+		headers.cookie = `CF_Authorization=${accessToken}`;
+	}
 
 	logger.debugWithSanitization(
 		"-- START EXCHANGE API REQUEST:",
-		` GET ${switchedExchangeUrl}`
+		` GET ${switchedExchangeUrl.href}`
 	);
 
 	logger.debug("-- END EXCHANGE API REQUEST");
 	const exchangeResponse = await fetch(switchedExchangeUrl, {
 		signal: abortSignal,
+		headers,
 	});
 	const bodyText = await exchangeResponse.text();
 	logger.debug(


### PR DESCRIPTION
Too many internal details are involved to give an effective summary, but suffice to say that `wrangler dev --remote` has been broken against Cloudflare Access protected domains for a few weeks. This PR fixes that by adding Access tokens to more requests made during a `wrangler dev --remote` session.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: This involves Cloudflare Access and so needs to be manually verified. In theory we could add an E2E test for this, but given the current length and flakiness of the suite I'm hesitant to do that. @penalosa  has manually verified this fixes the issue against a test Access application.
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/10961
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
