### PR TITLE
[Workflows] Align local development behavior with production

### DIFF
--- a/.changeset/silent-mice-pay.md
+++ b/.changeset/silent-mice-pay.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workflows-shared": patch
+---
+
+Add proper validations to match production behavior.

--- a/fixtures/vitest-pool-workers-examples/workflows/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/workflows/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineWorkersProject({
 		target: "ES2022",
 	},
 	test: {
+		name: "@scoped/workflows",
 		poolOptions: {
 			workers: {
 				singleWorker: true,

--- a/packages/workflows-shared/src/lib/validators.ts
+++ b/packages/workflows-shared/src/lib/validators.ts
@@ -1,6 +1,5 @@
 import { ms } from "itty-time";
 import { z } from "zod";
-import type { WorkflowStepConfig } from "cloudflare:workers";
 
 export const MAX_INSTANCE_STEPS = 1024;
 
@@ -65,21 +64,23 @@ const STEP_CONFIG_SCHEMA = z
 	})
 	.strict();
 
-export function isValidStepConfig(stepConfig: WorkflowStepConfig): boolean {
-	if (!STEP_CONFIG_SCHEMA.safeParse(stepConfig).success) {
+export function isValidStepConfig(stepConfig: unknown): boolean {
+	const config = STEP_CONFIG_SCHEMA.safeParse(stepConfig);
+
+	if (!config.success) {
 		return false;
 	}
 
 	if (
-		stepConfig.retries !== undefined &&
-		Number.isNaN(ms(stepConfig.retries.delay))
+		config.data.retries !== undefined &&
+		Number.isNaN(ms(config.data.retries.delay))
 	) {
 		return false;
 	}
 
-	if (stepConfig.timeout !== undefined) {
-		const timeout = stepConfig.timeout;
-		if (timeout == 0 || Number.isNaN(ms(stepConfig.timeout))) {
+	if (config.data.timeout !== undefined) {
+		const timeout = config.data.timeout;
+		if (timeout == 0 || Number.isNaN(ms(config.data.timeout))) {
 			return false;
 		}
 	}

--- a/packages/workflows-shared/tests/validators.test.ts
+++ b/packages/workflows-shared/tests/validators.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	isValidStepConfig,
 	isValidStepName,
 	isValidWorkflowInstanceId,
 	isValidWorkflowName,
@@ -71,5 +72,36 @@ describe("Workflow instance step name validation", () => {
 		"valid step name",
 	])("should accept valid names", function (value) {
 		expect(isValidStepName(value as string)).toBe(true);
+	});
+});
+
+describe("Workflow step config validation", () => {
+	it.each([
+		{ timeout: "5 years", retries: { limit: 1 } },
+		{ timeout: "5 years", retries: { delay: 50 } },
+		{ timeout: "5 years", retries: { backoff: "exponential" } },
+		{
+			timeout: "5 years",
+			retries: {
+				delay: "10 minutes",
+				limit: 5,
+				"i-like-trains": "yes".repeat(100),
+			},
+		},
+	])("should reject invalid step configs", function (value) {
+		expect(isValidStepConfig(value)).toBe(false);
+	});
+
+	it.each([
+		{
+			retries: { limit: 0, delay: 100000, backoff: "exponential" },
+			timeout: "15 minutes",
+		},
+		{
+			retries: { limit: 5, delay: 0, backoff: "constant" },
+			timeout: "2 minutes",
+		},
+	])("should accept valid names", function (value) {
+		expect(isValidStepConfig(value)).toBe(true);
 	});
 });


### PR DESCRIPTION
Fixes WOR-957.

Some changes made to match production behaviors:
- Limit of 1024 steps is now enforced
- Don't free retry if the last attempt was due to internal errors
- Step errors are now being properly thrown to the user

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: no tests needed, just a simple throw fix
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no new features were added
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: Workflows were not GA in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
