### PR TITLE
Enable NPM Trusted Publishing

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -60,7 +60,6 @@ jobs:
           publish: pnpm exec changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
       - name: Deploy non-NPM Packages
         id: deploy
@@ -76,7 +75,6 @@ jobs:
           WORKERS_SHARED_SENTRY_ACCESS_ID: ${{ secrets.WORKERS_SHARED_SENTRY_ACCESS_ID }}
           WORKERS_SHARED_SENTRY_ACCESS_SECRET: ${{ secrets.WORKERS_SHARED_SENTRY_ACCESS_SECRET }}
           WORKERS_SHARED_SENTRY_AUTH_TOKEN: ${{ secrets.WORKERS_SHARED_SENTRY_AUTH_TOKEN }}
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
       - name: Send Alert
         if: always()


### PR DESCRIPTION
Enabled Trusted Publishing: https://docs.npmjs.com/trusted-publishers

The relevant NPM setting changes have already been made for all our published packages