### PR TITLE
Fixes generation of uv.lock name in Python templates.

### DIFF
--- a/.changeset/big-goats-rescue.md
+++ b/.changeset/big-goats-rescue.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": minor
+---
+
+Fixes generation of 'name' in Python uv.lock template

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -843,7 +843,7 @@ function updatePythonPackageName(path: string, projectName: string) {
 	let uvLockContents = readFile(uvLockPath);
 	uvLockContents = uvLockContents.replace(
 		'"tbd"',
-		`${"projectName.toLowerCase()"}`,
+		`"${projectName.toLowerCase()}"`,
 	);
 	writeFile(uvLockPath, uvLockContents);
 	s.stop(`${brandColor("updated")} ${dim("`pyproject.toml`")}`);


### PR DESCRIPTION
This fixes a bug where the code wasn't being interpolated correctly in uv.lock.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: template change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: new feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
