### PR TITLE
[Wrangler] Make Workflows instance list command cursor based

### DIFF
--- a/.changeset/sad-mirrors-mix.md
+++ b/.changeset/sad-mirrors-mix.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Make Workflows instances list command cursor based

--- a/packages/wrangler/src/__tests__/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/workflows.test.ts
@@ -211,7 +211,9 @@ describe("wrangler workflows", () => {
 			await mockGetWorkflows(mockWorkflows);
 
 			await runWrangler(`workflows list`);
-			expect(std.info).toMatchInlineSnapshot(`"Showing last 2 workflows:"`);
+			expect(std.info).toMatchInlineSnapshot(
+				`"Showing 2 workflows from page 1:"`
+			);
 			expect(std.out).toMatchInlineSnapshot(
 				`
 				"
@@ -280,12 +282,20 @@ describe("wrangler workflows", () => {
 				status: "terminated",
 			},
 			{
-				id: "e",
+				id: "f",
 				created_on: mockCreateDate.toISOString(),
 				modified_on: mockModifiedDate.toISOString(),
 				workflow_id: "b",
 				version_id: "c",
 				status: "waiting",
+			},
+			{
+				id: "g",
+				created_on: mockCreateDate.toISOString(),
+				modified_on: mockModifiedDate.toISOString(),
+				workflow_id: "b",
+				version_id: "c",
+				status: "waitingForPause",
 			},
 		];
 
@@ -295,7 +305,7 @@ describe("wrangler workflows", () => {
 
 			await runWrangler(`workflows instances list some-workflow`);
 			expect(std.info).toMatchInlineSnapshot(
-				`"Showing 7 instances from page 1:"`
+				`"Showing 8 instances from page 1:"`
 			);
 			expect(std.out).toMatchInlineSnapshot(
 				`
@@ -303,7 +313,7 @@ describe("wrangler workflows", () => {
 				 ⛅️ wrangler x.x.x
 				──────────────────
 				┌─┬─┬─┬─┬─┐
-				│ Id │ Version │ Created │ Modified │ Status │
+				│ Instance ID │ Version │ Created │ Modified │ Status │
 				├─┼─┼─┼─┼─┤
 				│ a │ c │ [mock-create-date] │ [mock-modified-date] │ ✅ Completed │
 				├─┼─┼─┼─┼─┤
@@ -317,7 +327,9 @@ describe("wrangler workflows", () => {
 				├─┼─┼─┼─┼─┤
 				│ e │ c │ [mock-create-date] │ [mock-modified-date] │ 🚫 Terminated │
 				├─┼─┼─┼─┼─┤
-				│ e │ c │ [mock-create-date] │ [mock-modified-date] │ ⏰ Waiting │
+				│ f │ c │ [mock-create-date] │ [mock-modified-date] │ ⏰ Waiting │
+				├─┼─┼─┼─┼─┤
+				│ g │ c │ [mock-create-date] │ [mock-modified-date] │ ⏱️ Waiting for Pause │
 				└─┴─┴─┴─┴─┘"
 			`
 			);

--- a/packages/wrangler/src/workflows/commands/list.ts
+++ b/packages/wrangler/src/workflows/commands/list.ts
@@ -40,24 +40,31 @@ export const workflowsListCommand = createCommand({
 			URLParams
 		);
 
-		if (workflows.length === 0) {
+		if (workflows.length === 0 && args.page === 1) {
 			logger.warn("There are no deployed Workflows in this account");
-		} else {
-			// TODO(lduarte): can we improve this message once pagination is deployed
-			logger.info(
-				`Showing last ${workflows.length} workflow${workflows.length > 1 ? "s" : ""}:`
-			);
-			// sort by name and make the table head prettier by changing the keys
-			const prettierWorkflows = workflows
-				.sort((a, b) => a.name.localeCompare(b.name))
-				.map((workflow) => ({
-					Name: workflow.name,
-					"Script name": workflow.script_name,
-					"Class name": workflow.class_name,
-					Created: new Date(workflow.created_on).toLocaleString(),
-					Modified: new Date(workflow.modified_on).toLocaleString(),
-				}));
-			logger.table(prettierWorkflows);
+			return;
 		}
+
+		if (workflows.length === 0 && args.page > 1) {
+			logger.warn(
+				`No Workflows found on page ${args.page}. Please try a smaller page number.`
+			);
+			return;
+		}
+
+		logger.info(
+			`Showing ${workflows.length} workflow${workflows.length > 1 ? "s" : ""} from page ${args.page}:`
+		);
+
+		const prettierWorkflows = workflows
+			.sort((a, b) => b.created_on.localeCompare(a.created_on))
+			.map((workflow) => ({
+				Name: workflow.name,
+				"Script name": workflow.script_name,
+				"Class name": workflow.class_name,
+				Created: new Date(workflow.created_on).toLocaleString(),
+				Modified: new Date(workflow.modified_on).toLocaleString(),
+			}));
+		logger.table(prettierWorkflows);
 	},
 });

--- a/packages/wrangler/src/workflows/types.ts
+++ b/packages/wrangler/src/workflows/types.ts
@@ -22,6 +22,7 @@ export type InstanceStatus =
 	| "errored"
 	| "terminated"
 	| "waiting"
+	| "waitingForPause"
 	| "complete";
 
 export type InstanceWithoutDates = {

--- a/packages/wrangler/src/workflows/utils.ts
+++ b/packages/wrangler/src/workflows/utils.ts
@@ -19,6 +19,8 @@ export const emojifyInstanceStatus = (status: InstanceStatus) => {
 			return "🚫 Terminated";
 		case "waiting":
 			return "⏰ Waiting";
+		case "waitingForPause":
+			return "⏱️ Waiting for Pause";
 		default:
 			return "❓ Unknown";
 	}
@@ -68,9 +70,13 @@ export const validateStatus = (status: string): InstanceStatus => {
 			return "running";
 		case "terminated":
 			return "terminated";
+		case "waiting":
+			return "waiting";
+		case "waitingForPause":
+			return "waitingForPause";
 		default:
 			throw new UserError(
-				`Looks like you have provided a invalid status "${status}". Valid statuses are: queued, running, paused, errored, terminated, complete`
+				`Looks like you have provided a invalid status "${status}". Valid statuses are: queued, running, paused, errored, terminated, complete, waiting, waitingForPause`
 			);
 	}
 };


### PR DESCRIPTION
Fixes WOR-962.

Since we changed our control plane, workflow instances list pagination through 'page' is only a best-effort set of instances. Consequently wrangler command `workflows instances list <WORKFLOW_NAME> [OPTIONS]` became to not be accurate anymore.

To make this command match the expected list of instances and still provide pagination the same way (through '--page'), this change makes 'cursor' based requests to the Workflows API (just like dash, thus providing accurate lists of instances) rather than 'page' based requests. 

Also added `waitingForPause` instance status.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: they already existed (just refactored them)
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no new features were added, command will work the same way
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: Workflows were not GA in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
