### PR TITLE
CC-6265: Handle Cloudchamber accounts with no allowed locations

### DIFF
--- a/.changeset/thirty-geckos-open.md
+++ b/.changeset/thirty-geckos-open.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Handle Cloudchamber accounts with no allowed locations in `wrangler cloudchamber create` command

--- a/packages/wrangler/src/cloudchamber/cli/locations.ts
+++ b/packages/wrangler/src/cloudchamber/cli/locations.ts
@@ -1,6 +1,6 @@
 import { processArgument } from "@cloudflare/cli/args";
 import { inputPrompt } from "@cloudflare/cli/interactive";
-import { getLocations, loadAccount } from "../locations";
+import { loadAccount } from "../locations";
 import type { Location, LocationID } from "@cloudflare/containers-shared";
 
 const whichLocationQuestion = "Choose where you want to deploy your container";

--- a/packages/wrangler/src/cloudchamber/cli/locations.ts
+++ b/packages/wrangler/src/cloudchamber/cli/locations.ts
@@ -1,6 +1,6 @@
 import { processArgument } from "@cloudflare/cli/args";
 import { inputPrompt } from "@cloudflare/cli/interactive";
-import { getLocations } from "../locations";
+import { getLocations, loadAccount } from "../locations";
 import type { Location, LocationID } from "@cloudflare/containers-shared";
 
 const whichLocationQuestion = "Choose where you want to deploy your container";
@@ -19,7 +19,13 @@ export async function getLocation(
 	args: { location?: string },
 	options: { skipLocation?: boolean } = {}
 ): Promise<LocationID | "Skip"> {
+	const { external_account_id } = await loadAccount();
 	const locations = await getLocations();
+
+	if (locations.length === 0) {
+		throw new Error(`No allowed locations found for account ${external_account_id}`);
+	}
+
 	if (
 		args.location !== undefined &&
 		!locations.find((location) => location.location === args.location)

--- a/packages/wrangler/src/cloudchamber/cli/locations.ts
+++ b/packages/wrangler/src/cloudchamber/cli/locations.ts
@@ -19,8 +19,7 @@ export async function getLocation(
 	args: { location?: string },
 	options: { skipLocation?: boolean } = {}
 ): Promise<LocationID | "Skip"> {
-	const { external_account_id } = await loadAccount();
-	const locations = await getLocations();
+	const { external_account_id, locations } = await loadAccount();
 
 	if (locations.length === 0) {
 		throw new Error(`No allowed locations found for account ${external_account_id}`);
@@ -30,7 +29,7 @@ export async function getLocation(
 		args.location !== undefined &&
 		!locations.find((location) => location.location === args.location)
 	) {
-		locations.push({
+		(locations as Location[]).push({
 			name: `Other (${args.location})`,
 			location: args.location,
 			region: "",

--- a/packages/wrangler/src/cloudchamber/locations.ts
+++ b/packages/wrangler/src/cloudchamber/locations.ts
@@ -20,10 +20,6 @@ export async function loadAccount(): Promise<CompleteAccountCustomer> {
 	return cachedAccount;
 }
 
-export async function getLocations(): Promise<Location[]> {
-	return (await loadAccount()).locations;
-}
-
 export function idToLocationName(locationId: string): string {
 	if (!cachedAccount) {
 		throw new Error("Needs a call to loadAccount beforehand");


### PR DESCRIPTION
Fixes CC-6265

It is possible for an account to return `locations: []` from the `/me` endpoint which would currently result in a `Cannot read properties of undefined (reading 'value')` error from the select UI.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: There is no existing harness for testing interactive experiences for non-dev commands.
    - [ ] **steps to test manually ...**
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Not a public product.
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: Not a public product.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
