### PR TITLE
if the CLOUDFLARE_ACCOUNT_ID was an empty string it caused e2e tests to fail

### DIFF
--- a/packages/wrangler/e2e/cert.test.ts
+++ b/packages/wrangler/e2e/cert.test.ts
@@ -11,15 +11,7 @@ import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { normalizeOutput } from "./helpers/normalize";
 
 describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("cert", () => {
-	const normalize = (str: string) =>
-		normalizeOutput(
-			str,
-			process.env.CLOUDFLARE_ACCOUNT_ID
-				? {
-						[process.env.CLOUDFLARE_ACCOUNT_ID]: "CLOUDFLARE_ACCOUNT_ID",
-					}
-				: {}
-		);
+	const normalize = (str: string) => normalizeOutput(str);
 	const helper = new WranglerE2ETestHelper();
 	// Generate root and leaf certificates
 	const { certificate: rootCert, privateKey: rootKey } =

--- a/packages/wrangler/e2e/helpers/normalize.ts
+++ b/packages/wrangler/e2e/helpers/normalize.ts
@@ -213,7 +213,9 @@ function normalizeAuthor(stdout: string) {
 }
 
 function normalizeAccountId(stdout: string) {
-	return stdout.replaceAll(CLOUDFLARE_ACCOUNT_ID, "CLOUDFLARE_ACCOUNT_ID");
+	return CLOUDFLARE_ACCOUNT_ID
+		? stdout.replaceAll(CLOUDFLARE_ACCOUNT_ID, "CLOUDFLARE_ACCOUNT_ID")
+		: stdout;
 }
 
 /**

--- a/packages/wrangler/e2e/r2.test.ts
+++ b/packages/wrangler/e2e/r2.test.ts
@@ -13,11 +13,6 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("r2", () => {
 	const normalize = (str: string) =>
 		normalizeOutput(str, {
 			[bucketName]: "tmp-e2e-r2",
-			...(process.env.CLOUDFLARE_ACCOUNT_ID
-				? {
-						[process.env.CLOUDFLARE_ACCOUNT_ID]: "CLOUDFLARE_ACCOUNT_ID",
-					}
-				: {}),
 		});
 	const helper = new WranglerE2ETestHelper();
 

--- a/packages/wrangler/e2e/secrets-store.test.ts
+++ b/packages/wrangler/e2e/secrets-store.test.ts
@@ -32,11 +32,6 @@ describe.each(RUNTIMES)(
 			return normalizeOutput(str, {
 				[storeName]: "tmp-e2e-secrets-store-store",
 				[secretName]: "tmp-e2e-secrets-store-secret",
-				...(process.env.CLOUDFLARE_ACCOUNT_ID
-					? {
-							[process.env.CLOUDFLARE_ACCOUNT_ID]: "CLOUDFLARE_ACCOUNT_ID",
-						}
-					: {}),
 			});
 		};
 


### PR DESCRIPTION
Notably this didn't fail locally for me because I was not setting this env var at all (meaning it was `undefined`) whereas in the CI it gets set to empty string `""`.