### PR TITLE
Improve potential errors thrown by `startRemoteProxySession` by including more information

### DIFF
--- a/.changeset/afraid-sloths-begin.md
+++ b/.changeset/afraid-sloths-begin.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Improve potential errors thrown by `startRemoteProxySession` by including more information

--- a/packages/wrangler/src/__tests__/dev/remote-bindings-errors.test.ts
+++ b/packages/wrangler/src/__tests__/dev/remote-bindings-errors.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, it } from "vitest";
+import { startRemoteProxySession } from "../../api";
+import { mockApiToken } from "../helpers/mock-account-id";
+import { msw, mswSuccessUserHandlers } from "../helpers/msw";
+import { runInTempDir } from "../helpers/run-in-tmp";
+
+describe("errors during dev with remote bindings", () => {
+	mockApiToken();
+	runInTempDir();
+
+	beforeEach(() => {
+		msw.use(...mswSuccessUserHandlers);
+	});
+
+	it("errors when starting the remote proxy session are appropriately surfaced", async () => {
+		let thrownError: Error | undefined;
+
+		try {
+			await startRemoteProxySession({
+				MY_WORKER: {
+					type: "service",
+					service: "my-worker",
+					remote: true,
+				},
+			});
+		} catch (e) {
+			assert(e instanceof Error);
+			thrownError = e;
+		}
+
+		assert(thrownError);
+
+		expect(thrownError.message).toContain(
+			"Failed to start the remote proxy session"
+		);
+
+		// The issue here is that with the test setup there is more than one account available (but we're
+		// in non-interactive mode). Here we make sure that this information is presented in the thrown error
+		expect(thrownError.message).toContain(
+			"More than one account available but unable to select one in non-interactive mode."
+		);
+	});
+});

--- a/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
+++ b/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
@@ -46,6 +46,18 @@ export async function startRemoteProxySession(
 			logLevel: "error",
 		},
 		bindings: rawBindings,
+	}).catch((startWorkerError) => {
+		let errorMessage = startWorkerError;
+		if (startWorkerError instanceof Error) {
+			if (startWorkerError.cause instanceof Error) {
+				errorMessage = startWorkerError.cause.message;
+			} else {
+				errorMessage = startWorkerError.message;
+			}
+		}
+		throw new Error(
+			`Failed to start the remote proxy session, see the error details below:\n\n${errorMessage}`
+		);
 	});
 
 	const remoteProxyConnectionString =


### PR DESCRIPTION
I noticed that when I try to run `wrangler`/`vite` dev in non-interactive mode, since I have more than one account associated to my user, starting a remote proxy session fails since wrangler doesn't know what account to use. I think that this is acceptable, that's problematic is however that this information is completely missing in the terminal:
<img width="1145" height="304" alt="Screenshot 2025-10-19 at 17 19 27" src="https://github.com/user-attachments/assets/335e3f5a-3726-42b4-a237-dbcb226ccc6d" />

So here I am improving the error thrown by `startRemoteProxySession` to also include the missing information:
<img width="1484" height="514" alt="Screenshot 2025-10-19 at 17 17 58" src="https://github.com/user-attachments/assets/90d9e7c6-8173-48e0-8d43-e6a4feab824f" />



---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: DX improvement
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a v3 feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
