### PR TITLE
Fix `observability.logs.persist` being flagged as an unexpected field during the wrangler config file validation

### DIFF
--- a/.changeset/common-beans-wink.md
+++ b/.changeset/common-beans-wink.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix `observability.logs.persist` being flagged as an unexpected field during the wrangler config file validation

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -4324,6 +4324,7 @@ const validateObservability: ValidatorFn = (diagnostics, field, value) => {
 				"head_sampling_rate",
 				"invocation_logs",
 				"destinations",
+				"persist",
 			]) && isValid;
 	}
 


### PR DESCRIPTION
`observability.logs.persist` is a valid field for the wrangler config

As you can also see from our config schema:

<img width="904" height="226" alt="Screenshot 2025-10-19 at 21 28 13" src="https://github.com/user-attachments/assets/a2cfb0e8-29d9-42be-8c48-93485d4ef00d" />

<img width="1129" height="340" alt="Screenshot 2025-10-19 at 21 28 57" src="https://github.com/user-attachments/assets/d4ffcc47-0bec-4324-8b5e-2ac3b61bbc8e" />

However including it in a wrangler config file causes wrangler to currently output the following warning:
<img width="551" height="120" alt="Screenshot 2025-10-19 at 21 24 54" src="https://github.com/user-attachments/assets/ca7cae13-0f69-499c-a0fa-6474b998d394" />

This PR makes sure that the warning is actually not presented anymore

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: as far as I know not all config fields are tested one by one
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/11020
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
