### PR TITLE
wrangler: feat: better wrangler subdomain defaults warning

### DIFF
--- a/.changeset/floppy-zoos-listen.md
+++ b/.changeset/floppy-zoos-listen.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Better Wrangler subdomain defaults warning.
+
+Improves the warnings that we show users when either `worker_dev` or `preview_urls` are missing.

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -7356,9 +7356,10 @@ addEventListener('fetch', event => {});`
 			`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`
-				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mWorker has workers.dev disabled, but 'workers_dev' is not in the config.[0m
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mBecause 'workers_dev' is not in your Wrangler file, it will be enabled for this deployment by default.[0m
 
-				  Using default config 'workers_dev = true', current status will be overwritten.
+				  To override this setting, you can disable workers.dev by explicitly setting 'workers_dev = false'
+				  in your Wrangler file.
 
 				"
 			`);
@@ -7386,9 +7387,10 @@ addEventListener('fetch', event => {});`
 			`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`
-				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mWorker has preview URLs disabled, but 'preview_urls' is not in the config.[0m
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mBecause your 'workers.dev' route is enabled and your 'preview_urls' setting is not in your Wrangler file, Preview URLs will be enabled for this deployment by default.[0m
 
-				  Using default config 'preview_urls = true', current status will be overwritten.
+				  To override this setting, you can disable Preview URLs by explicitly setting 'preview_urls =
+				  false' in your Wrangler file.
 
 				"
 			`);

--- a/packages/wrangler/src/triggers/deploy.ts
+++ b/packages/wrangler/src/triggers/deploy.ts
@@ -481,11 +481,17 @@ async function subdomainDeploy(
 		config.workers_dev == undefined &&
 		after.enabled !== before.enabled
 	) {
-		const beforeStatus = before.enabled ? "enabled" : "disabled";
+		const status = (enabled: boolean, past: boolean) => {
+			if (past) {
+				return enabled ? "enabled" : "disabled";
+			} else {
+				return enabled ? "enable" : "disable";
+			}
+		};
 		logger.warn(
 			[
-				`Worker has workers.dev ${beforeStatus}, but 'workers_dev' is not in the config.`,
-				`Using default config 'workers_dev = ${after.enabled}', current status will be overwritten.`,
+				`Because 'workers_dev' is not in your Wrangler file, it will be ${status(after.enabled, true)} for this deployment by default.`,
+				`To override this setting, you can ${status(before.enabled, false)} workers.dev by explicitly setting 'workers_dev = ${before.enabled}' in your Wrangler file.`,
 			].join("\n")
 		);
 	}
@@ -495,11 +501,17 @@ async function subdomainDeploy(
 		config.preview_urls == undefined &&
 		after.previews_enabled !== before.previews_enabled
 	) {
-		const beforeStatus = before.previews_enabled ? "enabled" : "disabled";
+		const status = (enabled: boolean, past: boolean) => {
+			if (past) {
+				return enabled ? "enabled" : "disabled";
+			} else {
+				return enabled ? "enable" : "disable";
+			}
+		};
 		logger.warn(
 			[
-				`Worker has preview URLs ${beforeStatus}, but 'preview_urls' is not in the config.`,
-				`Using default config 'preview_urls = ${after.previews_enabled}', current status will be overwritten.`,
+				`Because your 'workers.dev' route is ${status(after.enabled, true)} and your 'preview_urls' setting is not in your Wrangler file, Preview URLs will be ${status(after.previews_enabled, true)} for this deployment by default.`,
+				`To override this setting, you can ${status(before.previews_enabled, false)} Preview URLs by explicitly setting 'preview_urls = ${before.previews_enabled}' in your Wrangler file.`,
 			].join("\n")
 		);
 	}


### PR DESCRIPTION
Tracked internally here: https://jira.cfdata.org/browse/WC-4121.

_Describe your change..._

Improves the warnings that we show users when either `worker_dev` or `preview_urls` are missing.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: just a warning change.
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: warning not present in Wrangler V3.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
