### PR TITLE
move the `debug` alias from the node hybrid plugin to unenv

### DIFF
--- a/.changeset/proud-bugs-cheat-unenv.md
+++ b/.changeset/proud-bugs-cheat-unenv.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/unenv-preset": minor
+---
+
+Use the original `debug` npm package instead of the unenv shim

--- a/.changeset/proud-bugs-cheat-wrangler.md
+++ b/.changeset/proud-bugs-cheat-wrangler.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+refactor: rely on unenv to resolve the `debug` package.

--- a/packages/unenv-preset/src/preset.ts
+++ b/packages/unenv-preset/src/preset.ts
@@ -116,6 +116,10 @@ export function getCloudflarePreset({
 					[`node:${m}`, `@cloudflare/unenv-preset/node/${m}`],
 				])
 			),
+
+			// Use the actual `debug` package.
+			// The basic unenv shim has much less functionality.
+			debug: "debug",
 		},
 		inject: {
 			// Do not inject globals implemented natively by workerd. Setting the value to `false` ensures that any base preset inject is not used.

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
@@ -32,13 +32,6 @@ export function nodejsHybridPlugin({
 						compatibilityDate,
 						compatibilityFlags,
 					}),
-					{
-						alias: {
-							// Force esbuild to use the node implementation of debug instead of unenv's no-op stub.
-							// The alias is processed by handleUnenvAliasedPackages which uses require.resolve().
-							debug: "debug",
-						},
-					},
 				],
 				npmShims: true,
 			}).env;


### PR DESCRIPTION
IMO it's better to move the alias back to unenv.

Two main reasons:
- Easier to understand if aliases are not spread across unenv, the cloudfalre preset, and the hybrid plugin
- Both Vite and wrangler/esbuild are using unenv so it's better to factor things there (note that Vite is not using the npm shims at the moment).

Context: the [latest release of unenv](https://github.com/unjs/unenv/releases/tag/v2.0.0-rc.22) rewrites the shim for the debug package and I was trying to understand how that would affect us. It will not as both wrangler and Vite use the original package rather than the shim.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Additional testing not necessary because: this is a refactoring and there are already tests to cover the behaviour.
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user facing change
<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/11079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
