### PR TITLE
[vite plugin] allow resolving unenv aliases to packages

### DIFF
--- a/.changeset/petite-rules-kneel.md
+++ b/.changeset/petite-rules-kneel.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+allow resolving unenv aliases to packages

--- a/packages/vite-plugin-cloudflare/src/plugins/nodejs-compat.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/nodejs-compat.ts
@@ -403,15 +403,24 @@ export class NodeJsCompat {
 	): { unresolved: string; resolved: string } | undefined {
 		const alias = this.#env.alias[source];
 
-		// These aliases must be resolved from the context of this plugin since the alias will refer to one of the
-		// `@cloudflare/unenv-preset` or the `unenv` packages, which are direct dependencies of this package,
-		// and not the user's project.
 		// We exclude `externals` as these should be externalized rather than optimized.
 		if (alias && !this.externals.has(alias)) {
-			return {
-				unresolved: alias,
-				resolved: resolvePathSync(alias, { url: import.meta.url }),
-			};
+			try {
+				// These aliases must be resolved from the context of this plugin since the alias can refer to one of
+				// the `@cloudflare/unenv-preset` or the `unenv` packages, which are direct dependencies of this package,
+				// and not the user's project.
+				// When the alias is a package (i.e. the `debug` npm package), `resolvePathSync` will throw
+				return {
+					unresolved: alias,
+					resolved: resolvePathSync(alias, { url: import.meta.url }),
+				};
+			} catch {
+				// Returns the raw alias when it can not be resolved.
+				return {
+					unresolved: source,
+					resolved: alias,
+				};
+			}
 		}
 
 		if (this.entries.has(source)) {


### PR DESCRIPTION
Sometimes unenv aliases can point to packages.

For example the base unenv package aliases `debug` to a shim `/unenv/...`.
But we want to use the actual package instead, so we override that by creating an alias `debug` -> `debug`.


Before this PR, the plugin assumed that the alias as to be a path and it would throw when trying to resolve the `debug` path.
This PR updates the plugin so that it assumes that the alias is a package when it can not be resolved to a path.

This was tested on top of https://github.com/cloudflare/workers-sdk/pull/11079 and solves the test issues there.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: tested manuallu, merging 11079 will test that (see details above)
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: fix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: unenv changes are not backported to v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
