### PR TITLE
Workflow binding: remove dispose on void returning method

### DIFF
--- a/.changeset/seven-camels-guess.md
+++ b/.changeset/seven-camels-guess.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+remove explicit disposal on void-returning rpc method on workflow binding. This was adding extra dispose calls that were not needed, making the runtime noisy for the customers that saw internal errors unrelated to their code.

--- a/packages/miniflare/src/workers/workflows/wrapped-binding.worker.ts
+++ b/packages/miniflare/src/workers/workflows/wrapped-binding.worker.ts
@@ -95,9 +95,8 @@ class InstanceImpl implements WorkflowInstance {
 	}): Promise<void> {
 		const instance = (await this.binding.get(this.id)) as WorkflowInstance &
 			Disposable;
-		const res = (await instance.sendEvent(args)) as void & Disposable;
+		await instance.sendEvent(args);
 		instance[Symbol.dispose]();
-		res[Symbol.dispose]();
 	}
 }
 

--- a/packages/workflows-shared/tests/binding.test.ts
+++ b/packages/workflows-shared/tests/binding.test.ts
@@ -1,0 +1,92 @@
+import {
+	createExecutionContext,
+	env,
+	runInDurableObject,
+} from "cloudflare:test";
+import { describe, expect, it, vi } from "vitest";
+import { WorkflowBinding } from "../src/binding";
+import type { Engine } from "../src/engine";
+import type { ProvidedEnv } from "cloudflare:test";
+import type { WorkflowEvent, WorkflowStep } from "cloudflare:workers";
+
+async function setWorkflowEntrypoint(
+	stub: DurableObjectStub<Engine>,
+	callback: (event: unknown, step: WorkflowStep) => Promise<unknown>
+) {
+	const ctx = createExecutionContext();
+	await runInDurableObject(stub, (instance) => {
+		// @ts-expect-error this is only a stub for WorkflowEntrypoint
+		instance.env.USER_WORKFLOW = new (class {
+			constructor(
+				// eslint-disable-next-line @typescript-eslint/no-shadow
+				protected ctx: ExecutionContext,
+				// eslint-disable-next-line @typescript-eslint/no-shadow
+				protected env: ProvidedEnv
+			) {}
+			public async run(
+				event: Readonly<WorkflowEvent<unknown>>,
+				step: WorkflowStep
+			): Promise<unknown> {
+				return await callback(event, step);
+			}
+		})(ctx, env);
+	});
+}
+
+describe("WorkflowBinding", () => {
+	it("should not call dispose when sending an event to an instance", async () => {
+		const instanceId = "test-instance-with-event";
+		const ctx = createExecutionContext();
+
+		const binding = new WorkflowBinding(ctx, {
+			ENGINE: env.ENGINE,
+			BINDING_NAME: "TEST_WORKFLOW",
+		});
+
+		// Set up a workflow that waits for an event
+		const engineId = env.ENGINE.idFromName(instanceId);
+		const engineStub = env.ENGINE.get(engineId);
+
+		await setWorkflowEntrypoint(engineStub, async (event, step) => {
+			const receivedEvent = await step.waitForEvent("wait-for-test-event", {
+				type: "test-event",
+				timeout: "10 seconds",
+			});
+			return receivedEvent;
+		});
+
+		const { id } = await binding.create({ id: instanceId });
+		expect(id).toBe(instanceId);
+
+		const instance = await binding.get(instanceId);
+		expect(instance.id).toBe(instanceId);
+
+		const disposeSpy = vi.fn();
+
+		await runInDurableObject(engineStub, (engine) => {
+			const originalReceiveEvent = engine.receiveEvent.bind(engine);
+			engine.receiveEvent = (event) => {
+				const result = originalReceiveEvent(event);
+				return Object.assign(result, {
+					[Symbol.dispose]: disposeSpy,
+				});
+			};
+		});
+
+		using _ = (await instance.sendEvent({
+			type: "test-event",
+			payload: { test: "data" },
+		})) as unknown as Disposable;
+
+		// Wait a bit to ensure event processing
+		await vi.waitFor(
+			async () => {
+				const status = await instance.status();
+				expect(status.status).toBe("complete");
+			},
+			{ timeout: 1000 }
+		);
+
+		expect(disposeSpy).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Fixes WOR-926.

This fix comes in sequence of https://github.com/cloudflare/workers-sdk/pull/10919. `sendEvent` returns void and therefore doesn't need disposal.

Disposing here would make the dev output more noisy because users would see a runtime error which is a consequence of a failed disposer call.

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: `sendEvent` is already covered with existing fixture tests. The coverage wasn't enough here because the hot path will still work (i.e.: event will be sent but the disposer will throw afterwards)
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no changes were made to public APIs
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: this is a Miniflare change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
