### PR TITLE
Revert "allow resolving unenv aliases to packages (#11083)"

### DIFF
--- a/.changeset/petite-rules-kneel.md
+++ b/.changeset/petite-rules-kneel.md
@@ -1,5 +1,0 @@
----
-"@cloudflare/vite-plugin": patch
----
-
-allow resolving unenv aliases to packages

--- a/packages/vite-plugin-cloudflare/src/plugins/nodejs-compat.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/nodejs-compat.ts
@@ -403,24 +403,15 @@ export class NodeJsCompat {
 	): { unresolved: string; resolved: string } | undefined {
 		const alias = this.#env.alias[source];
 
+		// These aliases must be resolved from the context of this plugin since the alias will refer to one of the
+		// `@cloudflare/unenv-preset` or the `unenv` packages, which are direct dependencies of this package,
+		// and not the user's project.
 		// We exclude `externals` as these should be externalized rather than optimized.
 		if (alias && !this.externals.has(alias)) {
-			try {
-				// These aliases must be resolved from the context of this plugin since the alias can refer to one of
-				// the `@cloudflare/unenv-preset` or the `unenv` packages, which are direct dependencies of this package,
-				// and not the user's project.
-				// When the alias is a package (i.e. the `debug` npm package), `resolvePathSync` will throw
-				return {
-					unresolved: alias,
-					resolved: resolvePathSync(alias, { url: import.meta.url }),
-				};
-			} catch {
-				// Returns the raw alias when it can not be resolved.
-				return {
-					unresolved: source,
-					resolved: alias,
-				};
-			}
+			return {
+				unresolved: alias,
+				resolved: resolvePathSync(alias, { url: import.meta.url }),
+			};
 		}
 
 		if (this.entries.has(source)) {


### PR DESCRIPTION
#11083 broke [the tests](https://github.com/cloudflare/workers-sdk/actions/runs/18779955033/job/53583364701?pr=11079#step:7:5392).

I'll investigate more but first let's revert
