### PR TITLE
wrangler: feat: fix e2e tests for new preview_urls=workers_dev default

### DIFF
--- a/.changeset/clever-radios-cough.md
+++ b/.changeset/clever-radios-cough.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix Wrangler e2e tests for new preview_urls=workers_dev default.

--- a/packages/wrangler/e2e/deploy.test.ts
+++ b/packages/wrangler/e2e/deploy.test.ts
@@ -103,7 +103,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("deploy", { timeout: TIMEOUT }, () => {
                     main = "src/index.ts"
                     compatibility_date = "2023-01-01"
                     workers_dev = true
-                    preview_urls = true
+                    preview_urls = false
                 `,
 			});
 			await helper.run("wrangler triggers deploy");
@@ -114,7 +114,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("deploy", { timeout: TIMEOUT }, () => {
                     main = "src/index.ts"
                     compatibility_date = "2023-01-01"
                     workers_dev = true
-                    # preview_urls = false # Defaults to false.
+                    # preview_urls = workers_dev = true # Defaults to true.
                 `,
 			});
 			const deploy = await helper.run("wrangler deploy");
@@ -126,8 +126,8 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("deploy", { timeout: TIMEOUT }, () => {
 				Current Version ID: 00000000-0000-0000-0000-000000000000"
 			`);
 			expect(normalize(deploy.stderr)).toMatchInlineSnapshot(`
-				"▲ [WARNING] Because your 'workers.dev' route is enabled and your 'preview_urls' setting is not in your Wrangler file, Preview URLs will be disabled for this deployment by default.
-				  To override this setting, you can enable Preview URLs by explicitly setting 'preview_urls = true' in your Wrangler file."
+				"▲ [WARNING] Because your 'workers.dev' route is enabled and your 'preview_urls' setting is not in your Wrangler file, Preview URLs will be enabled for this deployment by default.
+				  To override this setting, you can disable Preview URLs by explicitly setting 'preview_urls = false' in your Wrangler file."
 			`);
 		});
 	});

--- a/packages/wrangler/e2e/provision.test.ts
+++ b/packages/wrangler/e2e/provision.test.ts
@@ -188,6 +188,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 						name = "${workerName}"
 						main = "src/index.ts"
 						compatibility_date = "2023-01-01"
+						preview_urls = false
 
 						[[r2_buckets]]
 						binding = "R2"

--- a/packages/wrangler/e2e/versions.test.ts
+++ b/packages/wrangler/e2e/versions.test.ts
@@ -37,6 +37,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 							name = "${workerName}"
 							main = "src/index.ts"
 							compatibility_date = "2023-01-01"
+							preview_urls = false
 					`,
 				"src/index.ts": dedent`
 							export default {


### PR DESCRIPTION
Tracked internally: https://jira.cfdata.org/browse/WC-4120.

_Describe your change..._

Fix Wrangler e2e tests for new preview_urls=workers_dev default:

https://developers.cloudflare.com/changelog/2025-10-23-preview-url-default-behavior/

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not a feature change, just test fixes.
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: warning and tests not in Wrangler V3.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
