### PR TITLE
check if there are any pending DO migrations for a worker

### DIFF
--- a/.changeset/fruity-ears-wave.md
+++ b/.changeset/fruity-ears-wave.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Adds `wrangler check do-migration` to check if there are any pending DO migrations for a worker.

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -77,7 +77,7 @@ import type { FormData } from "undici";
 import type { Mock } from "vitest";
 
 vi.mock("command-exists");
-vi.mock("../check/commands", async (importOriginal) => {
+vi.mock("../check/startup", async (importOriginal) => {
 	return {
 		...(await importOriginal()),
 		analyseBundle() {

--- a/packages/wrangler/src/__tests__/do-migration-check.test.ts
+++ b/packages/wrangler/src/__tests__/do-migration-check.test.ts
@@ -51,15 +51,23 @@ describe("wrangler check do-migrations", () => {
 		writeWranglerConfig({
 			durable_objects: {
 				bindings: [
-                    { name: "SOMESQLITENAME", class_name: "SomeSQLiteClass" },
-                    { name: "THATOTHERNAME", class_name: "ThatOtherClass"},
+					{ name: "SOMESQLITENAME", class_name: "SomeSQLiteClass" },
+					{ name: "THATOTHERNAME", class_name: "ThatOtherClass" },
 				],
 			},
 			migrations: [
 				{ tag: "v1", new_classes: ["SomeClass"] },
 				{ tag: "v2", new_classes: ["SomeOtherClass"] },
-                { tag: "v3", new_classes: ["ThisOtherClass"], new_sqlite_classes: ["SomeSQLiteClass"] },
-                { tag: "v4", deleted_classes: ["SomeClass", "SomeOtherClass"], renamed_classes: [ {from: "ThisOtherClass", to: "ThatOtherClass" }]}
+				{
+					tag: "v3",
+					new_classes: ["ThisOtherClass"],
+					new_sqlite_classes: ["SomeSQLiteClass"],
+				},
+				{
+					tag: "v4",
+					deleted_classes: ["SomeClass", "SomeOtherClass"],
+					renamed_classes: [{ from: "ThisOtherClass", to: "ThatOtherClass" }],
+				},
 			],
 		});
 		mockLegacyScriptData({
@@ -86,15 +94,23 @@ describe("wrangler check do-migrations", () => {
 		writeWranglerConfig({
 			durable_objects: {
 				bindings: [
-                    { name: "SOMESQLITENAME", class_name: "SomeSQLiteClass" },
-                    { name: "THATOTHERNAME", class_name: "ThatOtherClass"},
+					{ name: "SOMESQLITENAME", class_name: "SomeSQLiteClass" },
+					{ name: "THATOTHERNAME", class_name: "ThatOtherClass" },
 				],
 			},
 			migrations: [
 				{ tag: "v1", new_classes: ["SomeClass"] },
 				{ tag: "v2", new_classes: ["SomeOtherClass"] },
-                { tag: "v3", new_classes: ["ThisOtherClass"], new_sqlite_classes: ["SomeSQLiteClass"] },
-                { tag: "v4", deleted_classes: ["SomeClass", "SomeOtherClass"], renamed_classes: [ {from: "ThisOtherClass", to: "ThatOtherClass" }]}
+				{
+					tag: "v3",
+					new_classes: ["ThisOtherClass"],
+					new_sqlite_classes: ["SomeSQLiteClass"],
+				},
+				{
+					tag: "v4",
+					deleted_classes: ["SomeClass", "SomeOtherClass"],
+					renamed_classes: [{ from: "ThisOtherClass", to: "ThatOtherClass" }],
+				},
 			],
 		});
 		mockLegacyScriptData({
@@ -143,15 +159,23 @@ describe("wrangler check do-migrations", () => {
 		writeWranglerConfig({
 			durable_objects: {
 				bindings: [
-                    { name: "SOMESQLITENAME", class_name: "SomeSQLiteClass" },
-                    { name: "THATOTHERNAME", class_name: "ThatOtherClass"},
+					{ name: "SOMESQLITENAME", class_name: "SomeSQLiteClass" },
+					{ name: "THATOTHERNAME", class_name: "ThatOtherClass" },
 				],
 			},
 			migrations: [
 				{ tag: "v1", new_classes: ["SomeClass"] },
 				{ tag: "v2", new_classes: ["SomeOtherClass"] },
-                { tag: "v3", new_classes: ["ThisOtherClass"], new_sqlite_classes: ["SomeSQLiteClass"] },
-                { tag: "v4", deleted_classes: ["SomeClass", "SomeOtherClass"], renamed_classes: [ {from: "ThisOtherClass", to: "ThatOtherClass" }]}
+				{
+					tag: "v3",
+					new_classes: ["ThisOtherClass"],
+					new_sqlite_classes: ["SomeSQLiteClass"],
+				},
+				{
+					tag: "v4",
+					deleted_classes: ["SomeClass", "SomeOtherClass"],
+					renamed_classes: [{ from: "ThisOtherClass", to: "ThatOtherClass" }],
+				},
 			],
 		});
 		mockLegacyScriptData({
@@ -189,15 +213,23 @@ describe("wrangler check do-migrations", () => {
 		writeWranglerConfig({
 			durable_objects: {
 				bindings: [
-                    { name: "SOMESQLITENAME", class_name: "SomeSQLiteClass" },
-                    { name: "THATOTHERNAME", class_name: "ThatOtherClass"},
+					{ name: "SOMESQLITENAME", class_name: "SomeSQLiteClass" },
+					{ name: "THATOTHERNAME", class_name: "ThatOtherClass" },
 				],
 			},
 			migrations: [
 				{ tag: "v1", new_classes: ["SomeClass"] },
 				{ tag: "v2", new_classes: ["SomeOtherClass"] },
-                { tag: "v3", new_classes: ["ThisOtherClass"], new_sqlite_classes: ["SomeSQLiteClass"] },
-                { tag: "v4", deleted_classes: ["SomeClass", "SomeOtherClass"], renamed_classes: [ {from: "ThisOtherClass", to: "ThatOtherClass" }]}
+				{
+					tag: "v3",
+					new_classes: ["ThisOtherClass"],
+					new_sqlite_classes: ["SomeSQLiteClass"],
+				},
+				{
+					tag: "v4",
+					deleted_classes: ["SomeClass", "SomeOtherClass"],
+					renamed_classes: [{ from: "ThisOtherClass", to: "ThatOtherClass" }],
+				},
 			],
 		});
 		mockLegacyScriptData({

--- a/packages/wrangler/src/__tests__/do-migration-check.test.ts
+++ b/packages/wrangler/src/__tests__/do-migration-check.test.ts
@@ -1,0 +1,210 @@
+import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import { useMockIsTTY } from "./helpers/mock-istty";
+import { mockLegacyScriptData } from "./helpers/mock-legacy-script";
+import { runInTempDir } from "./helpers/run-in-tmp";
+import { runWrangler } from "./helpers/run-wrangler";
+import { writeWranglerConfig } from "./helpers/write-wrangler-config";
+
+describe("wrangler check do-migrations", () => {
+	mockAccountId();
+	mockApiToken();
+	runInTempDir();
+	const { setIsTTY } = useMockIsTTY();
+	const std = mockConsoleMethods();
+
+	beforeEach(() => {
+		setIsTTY(true);
+	});
+
+	test("it can list a pending DO migration", async () => {
+		writeWranglerConfig({
+			durable_objects: {
+				bindings: [
+					{ name: "SOMENAME", class_name: "SomeClass" },
+					{ name: "SOMEOTHERNAME", class_name: "SomeOtherClass" },
+				],
+			},
+			migrations: [
+				{ tag: "v1", new_classes: ["SomeClass"] },
+				{ tag: "v2", new_classes: ["SomeOtherClass"] },
+			],
+		});
+		mockLegacyScriptData({
+			scripts: [{ id: "test-name", migration_tag: "v1" }],
+		});
+
+		await runWrangler("check do-migrations");
+		expect(std.out).toMatchInlineSnapshot(`
+			"
+			 ⛅️ wrangler x.x.x
+			──────────────────
+			┌─┬─┬─┬─┐
+			│ New Classes │ New SQLite Classes │ Renamed Classes │ Deleted Classes │
+			├─┼─┼─┼─┤
+			│ SomeOtherClass │ │ │ │
+			└─┴─┴─┴─┘"
+		`);
+	});
+
+	test("it can list multiple pending DO migrations", async () => {
+		writeWranglerConfig({
+			durable_objects: {
+				bindings: [
+                    { name: "SOMESQLITENAME", class_name: "SomeSQLiteClass" },
+                    { name: "THATOTHERNAME", class_name: "ThatOtherClass"},
+				],
+			},
+			migrations: [
+				{ tag: "v1", new_classes: ["SomeClass"] },
+				{ tag: "v2", new_classes: ["SomeOtherClass"] },
+                { tag: "v3", new_classes: ["ThisOtherClass"], new_sqlite_classes: ["SomeSQLiteClass"] },
+                { tag: "v4", deleted_classes: ["SomeClass", "SomeOtherClass"], renamed_classes: [ {from: "ThisOtherClass", to: "ThatOtherClass" }]}
+			],
+		});
+		mockLegacyScriptData({
+			scripts: [{ id: "test-name", migration_tag: "v2" }],
+		});
+
+		await runWrangler("check do-migrations");
+		expect(std.out).toMatchInlineSnapshot(`
+			"
+			 ⛅️ wrangler x.x.x
+			──────────────────
+			┌─┬─┬─┬─┐
+			│ New Classes │ New SQLite Classes │ Renamed Classes │ Deleted Classes │
+			├─┼─┼─┼─┤
+			│ ThisOtherClass │ SomeSQLiteClass │ │ │
+			├─┼─┼─┼─┤
+			│ │ │ ThisOtherClass to ThatOtherClass │ SomeClass │
+			│ │ │ │ SomeOtherClass │
+			└─┴─┴─┴─┘"
+		`);
+	});
+
+	test("it can no pending DO migrations", async () => {
+		writeWranglerConfig({
+			durable_objects: {
+				bindings: [
+                    { name: "SOMESQLITENAME", class_name: "SomeSQLiteClass" },
+                    { name: "THATOTHERNAME", class_name: "ThatOtherClass"},
+				],
+			},
+			migrations: [
+				{ tag: "v1", new_classes: ["SomeClass"] },
+				{ tag: "v2", new_classes: ["SomeOtherClass"] },
+                { tag: "v3", new_classes: ["ThisOtherClass"], new_sqlite_classes: ["SomeSQLiteClass"] },
+                { tag: "v4", deleted_classes: ["SomeClass", "SomeOtherClass"], renamed_classes: [ {from: "ThisOtherClass", to: "ThatOtherClass" }]}
+			],
+		});
+		mockLegacyScriptData({
+			scripts: [{ id: "test-name", migration_tag: "v4" }],
+		});
+
+		await runWrangler("check do-migrations");
+		expect(std.out).toMatchInlineSnapshot(`
+			"
+			 ⛅️ wrangler x.x.x
+			──────────────────
+			No DO migrations pending for this worker"
+		`);
+	});
+
+	test("it can list a pending DO migration (json)", async () => {
+		writeWranglerConfig({
+			durable_objects: {
+				bindings: [
+					{ name: "SOMENAME", class_name: "SomeClass" },
+					{ name: "SOMEOTHERNAME", class_name: "SomeOtherClass" },
+				],
+			},
+			migrations: [
+				{ tag: "v1", new_classes: ["SomeClass"] },
+				{ tag: "v2", new_classes: ["SomeOtherClass"] },
+			],
+		});
+		mockLegacyScriptData({
+			scripts: [{ id: "test-name", migration_tag: "v1" }],
+		});
+
+		await runWrangler("check do-migrations --json");
+		expect(std.out).toMatchInlineSnapshot(`
+			"[
+			    {
+			        \\"new_classes\\": [
+			            \\"SomeOtherClass\\"
+			        ]
+			    }
+			]"
+		`);
+	});
+
+	test("it can list multiple pending DO migrations (json)", async () => {
+		writeWranglerConfig({
+			durable_objects: {
+				bindings: [
+                    { name: "SOMESQLITENAME", class_name: "SomeSQLiteClass" },
+                    { name: "THATOTHERNAME", class_name: "ThatOtherClass"},
+				],
+			},
+			migrations: [
+				{ tag: "v1", new_classes: ["SomeClass"] },
+				{ tag: "v2", new_classes: ["SomeOtherClass"] },
+                { tag: "v3", new_classes: ["ThisOtherClass"], new_sqlite_classes: ["SomeSQLiteClass"] },
+                { tag: "v4", deleted_classes: ["SomeClass", "SomeOtherClass"], renamed_classes: [ {from: "ThisOtherClass", to: "ThatOtherClass" }]}
+			],
+		});
+		mockLegacyScriptData({
+			scripts: [{ id: "test-name", migration_tag: "v2" }],
+		});
+
+		await runWrangler("check do-migrations --json");
+		expect(std.out).toMatchInlineSnapshot(`
+			"[
+			    {
+			        \\"new_classes\\": [
+			            \\"ThisOtherClass\\"
+			        ],
+			        \\"new_sqlite_classes\\": [
+			            \\"SomeSQLiteClass\\"
+			        ]
+			    },
+			    {
+			        \\"deleted_classes\\": [
+			            \\"SomeClass\\",
+			            \\"SomeOtherClass\\"
+			        ],
+			        \\"renamed_classes\\": [
+			            {
+			                \\"from\\": \\"ThisOtherClass\\",
+			                \\"to\\": \\"ThatOtherClass\\"
+			            }
+			        ]
+			    }
+			]"
+		`);
+	});
+
+	test("it can no pending DO migrations (json)", async () => {
+		writeWranglerConfig({
+			durable_objects: {
+				bindings: [
+                    { name: "SOMESQLITENAME", class_name: "SomeSQLiteClass" },
+                    { name: "THATOTHERNAME", class_name: "ThatOtherClass"},
+				],
+			},
+			migrations: [
+				{ tag: "v1", new_classes: ["SomeClass"] },
+				{ tag: "v2", new_classes: ["SomeOtherClass"] },
+                { tag: "v3", new_classes: ["ThisOtherClass"], new_sqlite_classes: ["SomeSQLiteClass"] },
+                { tag: "v4", deleted_classes: ["SomeClass", "SomeOtherClass"], renamed_classes: [ {from: "ThisOtherClass", to: "ThatOtherClass" }]}
+			],
+		});
+		mockLegacyScriptData({
+			scripts: [{ id: "test-name", migration_tag: "v4" }],
+		});
+
+		await runWrangler("check do-migrations --json");
+		expect(std.out).toMatchInlineSnapshot(`"[]"`);
+	});
+});

--- a/packages/wrangler/src/__tests__/do-migration-check.test.ts
+++ b/packages/wrangler/src/__tests__/do-migration-check.test.ts
@@ -1,8 +1,8 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { mockLegacyScriptData } from "./helpers/mock-legacy-script";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import { writeWranglerConfig } from "./helpers/write-wrangler-config";
 

--- a/packages/wrangler/src/__tests__/friendly-validator-errors.test.ts
+++ b/packages/wrangler/src/__tests__/friendly-validator-errors.test.ts
@@ -1,6 +1,6 @@
 import { FormData } from "undici";
 import { describe, expect, it, vi } from "vitest";
-import * as checkCommands from "../check/commands";
+import * as checkStartupCommand from "../check/startup";
 import { logger } from "../logger";
 import { ParseError } from "../parse";
 import { helpIfErrorIsSizeOrScriptStartup } from "../utils/friendly-validator-errors";
@@ -9,7 +9,7 @@ import { normalizeString } from "./helpers/normalize";
 import { runInTempDir } from "./helpers/run-in-tmp";
 
 vi.mock("../check/commands", () => ({ analyseBundle: vi.fn() }));
-const mockAnalyseBundle = vi.mocked(checkCommands.analyseBundle);
+const mockAnalyseBundle = vi.mocked(checkStartupCommand.analyseBundle);
 
 describe("helpIfErrorIsSizeOrScriptStartup", () => {
 	const std = mockConsoleMethods();

--- a/packages/wrangler/src/__tests__/friendly-validator-errors.test.ts
+++ b/packages/wrangler/src/__tests__/friendly-validator-errors.test.ts
@@ -8,7 +8,7 @@ import { mockConsoleMethods } from "./helpers/mock-console";
 import { normalizeString } from "./helpers/normalize";
 import { runInTempDir } from "./helpers/run-in-tmp";
 
-vi.mock("../check/commands", () => ({ analyseBundle: vi.fn() }));
+vi.mock("../check/startup", () => ({ analyseBundle: vi.fn() }));
 const mockAnalyseBundle = vi.mocked(checkStartupCommand.analyseBundle);
 
 describe("helpIfErrorIsSizeOrScriptStartup", () => {

--- a/packages/wrangler/src/check/common.ts
+++ b/packages/wrangler/src/check/common.ts
@@ -1,0 +1,10 @@
+import { createNamespace } from "../core/create-command";
+
+export const checkNamespace = createNamespace({
+	metadata: {
+		description: "☑︎ Run checks on your Worker",
+		owner: "Workers: Authoring and Testing",
+		status: "alpha",
+		hidden: true,
+	},
+});

--- a/packages/wrangler/src/check/migration.ts
+++ b/packages/wrangler/src/check/migration.ts
@@ -1,0 +1,90 @@
+import { createCommand, createNamespace } from "../core/create-command";
+import { getMigrationsToUpload } from "../durable";
+import { UserError } from "../errors";
+import { isNonInteractiveOrCI } from "../is-interactive";
+import { logger } from "../logger";
+import { requireAuth } from "../user";
+import { getScriptName } from "../utils/getScriptName";
+
+export const checkNamespace = createNamespace({
+	metadata: {
+		description: "🔍 Check pending migrations for your Worker",
+		owner: "Workers: Deploy and Config",
+		status: "alpha",
+		hidden: true,
+	},
+});
+
+export const checkDOMigrationCommand = createCommand({
+	args: {
+		name: {
+			describe: "Name of the Worker",
+			type: "string",
+			requiresArg: true,
+		},
+		json: {
+			describe: "Return output as a clean JSON object",
+			type: "boolean",
+			default: false,
+		},
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	metadata: {
+		description: "🔍 Check pending migrations for your Worker",
+		owner: "Workers: Authoring and Testing",
+		status: "alpha",
+	},
+	handler: async function doMigrationHandler(args, { config }) {
+		const accountId = await requireAuth(config);
+		const name = getScriptName(args, config);
+
+		if (!name) {
+			throw new UserError(
+				'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`',
+				{ telemetryMessage: true }
+			);
+		}
+
+		const migrations = await getMigrationsToUpload(name, {
+			accountId,
+			config,
+			// deprecated fields
+			useServiceEnvironments: undefined,
+			env: undefined,
+			dispatchNamespace: undefined,
+		});
+
+		if (args.json || isNonInteractiveOrCI()) {
+			logger.json(migrations?.steps ?? []);
+			return;
+		}
+
+		if (!migrations || migrations.steps.length === 0) {
+			logger.log("No DO migrations pending for this worker");
+		} else {
+			logger.table(
+				migrations.steps.map((migration) => {
+					const new_classes = migration.new_classes?.join("\n") ?? "";
+					const new_sqlite_classes =
+						migration.new_sqlite_classes?.join("\n") ?? "";
+					const renamed_classes =
+						migration.renamed_classes
+							?.map((renamed_class) => {
+								return `${renamed_class.from} to ${renamed_class.to}`;
+							})
+							.join("\n") ?? "";
+					const deleted_classes = migration.deleted_classes?.join("\n") ?? "";
+
+					return {
+						"New Classes": new_classes,
+						"New SQLite Classes": new_sqlite_classes,
+						"Renamed Classes": renamed_classes,
+						"Deleted Classes": deleted_classes,
+					};
+				})
+			);
+		}
+	},
+});

--- a/packages/wrangler/src/check/startup.ts
+++ b/packages/wrangler/src/check/startup.ts
@@ -9,7 +9,7 @@ import chalk from "chalk";
 import { Miniflare } from "miniflare";
 import { WebSocket } from "ws";
 import { createCLIParser } from "..";
-import { createCommand, createNamespace } from "../core/create-command";
+import { createCommand } from "../core/create-command";
 import { moduleTypeMimeType } from "../deployment-bundle/create-worker-upload-form";
 import {
 	flipObject,
@@ -23,15 +23,6 @@ import type { ModuleDefinition } from "miniflare";
 import type { FormData, FormDataEntryValue } from "undici";
 
 const mimeTypeModuleType = flipObject(moduleTypeMimeType);
-
-export const checkNamespace = createNamespace({
-	metadata: {
-		description: "☑︎ Run checks on your Worker",
-		owner: "Workers: Authoring and Testing",
-		status: "alpha",
-		hidden: true,
-	},
-});
 
 async function checkStartupHandler(
 	{

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -23,7 +23,9 @@ import {
 	certUploadNamespace,
 } from "./cert/cert";
 import { renderError } from "./cfetch";
-import { checkNamespace, checkStartupCommand } from "./check/commands";
+import { checkNamespace } from "./check/common";
+import { checkDOMigrationCommand } from "./check/migration";
+import { checkStartupCommand } from "./check/startup";
 import { cloudchamber } from "./cloudchamber";
 import { experimental_readRawConfig, readConfig } from "./config";
 import { getDefaultEnvFiles, loadDotEnv } from "./config/dot-env";
@@ -1560,6 +1562,10 @@ export function createCLIParser(argv: string[]) {
 		{
 			command: "wrangler check startup",
 			definition: checkStartupCommand,
+		},
+		{
+			command: "wrangler check do-migrations",
+			definition: checkDOMigrationCommand,
 		},
 	]);
 	registry.registerNamespace("check");

--- a/packages/wrangler/src/utils/friendly-validator-errors.ts
+++ b/packages/wrangler/src/utils/friendly-validator-errors.ts
@@ -1,7 +1,7 @@
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import dedent from "ts-dedent";
-import { analyseBundle } from "../check/commands";
+import { analyseBundle } from "../check/startup";
 import { logger } from "../logger";
 import { ParseError } from "../parse";
 import { getWranglerTmpDir } from "../paths";


### PR DESCRIPTION
Fixes CC-6312

DO migrations block version uploads. Currently, the only reliable way to check if a DO migration is to run `wrangler versions upload` and inspect the error to determine if it's a result of an unsupported DO migration. This is especially important for CI scripting to determine if changes should be deployed instead of uploading a version. Also addresses https://github.com/cloudflare/workers-sdk/issues/10965.

Design decisions made by this pr:
* Uses `wrangler check do-migrations` to avoid confusion with D1 migrations
* This information was not added to a `--dry-run` call to avoid making API calls on a dry run
  * Avoids making the assumption that version uploads will not support DO migrations in the future.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [X] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: `wrangler check` isn't documented
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [X] Not necessary because: not in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
