### PR TITLE
Backport of #11133 - Reduce the amount of arguments being passed in metrics capture.

### DIFF
--- a/.changeset/cold-tips-relate.md
+++ b/.changeset/cold-tips-relate.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+Reduce the amount of arguments being passed in metrics capture.
+
+Now the argument values that are captured come from an allow list,
+and can be marked as ALLOW (capture the real value) or REDACT (capture as "<REDACTED>").

--- a/packages/wrangler/src/__tests__/metrics.test.ts
+++ b/packages/wrangler/src/__tests__/metrics.test.ts
@@ -16,10 +16,7 @@ import {
 	readMetricsConfig,
 	writeMetricsConfig,
 } from "../metrics/metrics-config";
-import {
-	getMetricsDispatcher,
-	redactArgValues,
-} from "../metrics/metrics-dispatcher";
+import { getMetricsDispatcher } from "../metrics/metrics-dispatcher";
 import { sniffUserAgent } from "../package-manager";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { useMockIsTTY } from "./helpers/mock-istty";
@@ -196,11 +193,7 @@ describe("metrics", () => {
 				argsUsed: [],
 				argsCombination: "",
 				command: "wrangler docs",
-				args: {
-					xJsonConfig: true,
-					j: true,
-					search: ["<REDACTED>"],
-				},
+				args: {},
 			};
 			beforeEach(() => {
 				globalThis.ALGOLIA_APP_ID = "FAKE-ID";
@@ -574,40 +567,6 @@ describe("metrics", () => {
 					);
 
 					expect(requests.count).toBe(2);
-				});
-			});
-		});
-
-		describe("redactArgValues()", () => {
-			it("should redact sensitive values", () => {
-				const args = {
-					default: false,
-					array: ["beep", "boop"],
-					// Note how this is normalised
-					"secret-array": ["beep", "boop"],
-					number: 42,
-					string: "secret",
-					secretString: "secret",
-					flagOne: "default",
-					// Note how this is normalised
-					experimentalIncludeRuntime: "",
-				};
-
-				const redacted = redactArgValues(args, {
-					string: "*",
-					array: "*",
-					flagOne: ["default"],
-					xIncludeRuntime: [".wrangler/types/runtime.d.ts"],
-				});
-				expect(redacted).toEqual({
-					default: false,
-					array: ["beep", "boop"],
-					secretArray: ["<REDACTED>", "<REDACTED>"],
-					number: 42,
-					string: "secret",
-					secretString: "<REDACTED>",
-					flagOne: "default",
-					xIncludeRuntime: ".wrangler/types/runtime.d.ts",
 				});
 			});
 		});

--- a/packages/wrangler/src/__tests__/metrics/sanitization.test.ts
+++ b/packages/wrangler/src/__tests__/metrics/sanitization.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+	ALLOW,
+	getAllowedArgs,
+	REDACT,
+	sanitizeArgKeys,
+	sanitizeArgValues,
+} from "../../../src/metrics/sanitization";
+import type { AllowedArgs, AllowList } from "../../../src/metrics/sanitization";
+
+describe("sanitizeArgKeys", () => {
+	it("should sanitize arg keys based on argv", () => {
+		const args = {
+			config: "wrangler.toml",
+			env: "production",
+			unknownArg: "shouldBeRemoved",
+			"arg-one": true,
+			"arg-two": true,
+			argTwo: true,
+			"x-new-idea": true,
+			"experimental-new-idea": true,
+			$0: "wrangler",
+			_: [],
+		};
+		const argv = [
+			"node",
+			"wrangler",
+			"deploy",
+			"--config",
+			"wrangler.toml",
+			"--arg-one",
+			"--arg-two",
+			"--experimental-new-idea",
+		];
+		const sanitized = sanitizeArgKeys(args, argv);
+		expect(sanitized).toEqual({
+			config: "wrangler.toml",
+			argOne: true,
+			argTwo: true,
+			xNewIdea: true,
+		});
+	});
+});
+
+describe("sanitizeArgValues", () => {
+	it("should redact and allow arg values based on allowedArgs", () => {
+		const sanitizedArgs = {
+			config: "wrangler.toml",
+			env: "production",
+			force: true,
+			dryRun: false,
+		};
+		const allowedArgs: AllowedArgs = {
+			config: REDACT,
+			env: ["production", "staging", "development"],
+			force: ALLOW,
+		};
+		const result = sanitizeArgValues(sanitizedArgs, allowedArgs);
+		expect(result).toEqual({
+			config: "<REDACTED>",
+			env: "production",
+			force: true,
+		});
+	});
+});
+
+describe("getAllowedArgs", () => {
+	it("should return allowed args for a given command", () => {
+		const commandArgAllowList: AllowList = {
+			"wrangler deploy": {
+				config: REDACT,
+				force: ALLOW,
+			},
+			"wrangler *": {
+				env: ["production", "staging", "development"],
+			},
+			"wrangler deploy *": {
+				subArg: ALLOW,
+			},
+		};
+
+		expect(getAllowedArgs(commandArgAllowList, "wrangler dev")).toEqual({
+			env: ["production", "staging", "development"],
+		});
+
+		expect(getAllowedArgs(commandArgAllowList, "wrangler deploy")).toEqual({
+			config: REDACT,
+			force: ALLOW,
+			env: ["production", "staging", "development"],
+		});
+
+		expect(getAllowedArgs(commandArgAllowList, "wrangler deploy sub")).toEqual({
+			config: REDACT,
+			force: ALLOW,
+			env: ["production", "staging", "development"],
+			subArg: ALLOW,
+		});
+	});
+});

--- a/packages/wrangler/src/metrics/sanitization.ts
+++ b/packages/wrangler/src/metrics/sanitization.ts
@@ -1,0 +1,88 @@
+/**
+ * Sanitizes the non-positional args provided to the command for metrics reporting.
+ *
+ * Removes non-canonical args and filters out args that were not provided on the command line.
+ */
+export function sanitizeArgKeys(
+	args: Record<string, unknown>,
+	argv: string[] | undefined
+) {
+	const special = new Set(["$0", "_"]);
+	const sanitizedArgs: Record<string, unknown> = {};
+
+	for (const arg of Object.keys(args)) {
+		if (
+			!special.has(arg) &&
+			(argv === undefined ||
+				argv.includes(`--${arg}`) ||
+				argv.includes(`-${arg[0]}`))
+		) {
+			sanitizedArgs[canonicalArg(arg)] = args[arg];
+		}
+	}
+	return sanitizedArgs;
+}
+
+/** Allow this arg but redact its value. */
+export const REDACT = Symbol("REDACT");
+/** Allow all values for this arg. */
+export const ALLOW = Symbol("ALLOW");
+export type AllowedArgs = {
+	[arg: string]: unknown[] | typeof REDACT | typeof ALLOW;
+};
+export type AllowList = Record<string, AllowedArgs>;
+
+/**
+ * Returns the allowed args for a given command.
+ *
+ * This takes into account wildcard commands (e.g., "wrangler *").
+ */
+export function getAllowedArgs(
+	commandArgAllowList: AllowList,
+	command: string
+): AllowedArgs {
+	let allowedArgs: AllowedArgs = {};
+	const commandParts = command.split(" ");
+	while (commandParts.length > 0) {
+		const subCommand = commandParts.join(" ");
+		allowedArgs = { ...commandArgAllowList[subCommand], ...allowedArgs };
+		commandParts.pop();
+		if (commandParts.length > 0) {
+			const wildcardCommand = commandParts.join(" ") + " *";
+			allowedArgs = { ...commandArgAllowList[wildcardCommand], ...allowedArgs };
+		}
+	}
+	return allowedArgs;
+}
+
+/**
+ * Sanitizes the values of the non-positional args provided to the command for metrics reporting.
+ *
+ * Only returns args that are "allowed", redacting their value if necessary.
+ */
+export function sanitizeArgValues(
+	sanitizedArgs: Record<string, unknown>,
+	allowedArgs: AllowedArgs
+) {
+	const result: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(sanitizedArgs)) {
+		const allowedValuesForArg = allowedArgs[key];
+		if (allowedValuesForArg === ALLOW) {
+			result[key] = value;
+		} else if (allowedValuesForArg === REDACT) {
+			result[key] = "<REDACTED>";
+		} else if (Array.isArray(allowedValuesForArg)) {
+			result[key] = allowedValuesForArg.includes(value) ? value : "<REDACTED>";
+		}
+	}
+	return result;
+}
+
+/**
+ * Returns the canonical argument name for metrics reporting.
+ */
+export function canonicalArg(arg: string) {
+	const camelize = (str: string) =>
+		str.replace(/-./g, (x) => x[1].toUpperCase());
+	return camelize(arg.replace("experimental", "x"));
+}


### PR DESCRIPTION
Now the argument values that are captured come from an allow list, and can be marked as ALLOW (capture the real value) or REDACT (capture as "<REDACTED>").

Backport of #11133
