### PR TITLE
fix: use script_tag instead of script.tag when deploying

### DIFF
--- a/.changeset/wide-regions-dance.md
+++ b/.changeset/wide-regions-dance.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: use script_tag instead of script.tag when deploying
+
+Script is null when creating a Worker via the new [Workers beta APIs](https://developers.cloudflare.com/api/resources/workers/subresources/beta/subresources/workers/methods/create/).
+
+This change allows wrangler to create new deployments and upload versions to Workers created via `POST /accounts/{account_id}/workers/workers`

--- a/packages/wrangler/src/__tests__/helpers/msw/handlers/deployments.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/handlers/deployments.ts
@@ -87,6 +87,7 @@ export const mswSuccessDeploymentScriptMetadata = [
 			return HttpResponse.json(
 				createFetchResult({
 					default_environment: {
+						script_tag: tag,
 						script: { last_deployed_from: "wrangler", tag },
 					},
 				})
@@ -104,6 +105,7 @@ export const mswSuccessDeploymentScriptAPI = [
 			return HttpResponse.json(
 				createFetchResult({
 					default_environment: {
+						script_tag: tag,
 						script: { last_deployed_from: "api", tag },
 					},
 				})

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -40,6 +40,7 @@ describe("versions upload", () => {
 						createFetchResult(
 							result ?? {
 								default_environment: {
+									script_tag: `tag:${params.scriptName}`,
 									script: {
 										last_deployed_from: "wrangler",
 									},
@@ -56,6 +57,7 @@ describe("versions upload", () => {
 	function mockGetScriptWithTags(tags: string[] | null) {
 		mockGetScript({
 			default_environment: {
+				script_tag: "tag:test-name",
 				script: {
 					last_deployed_from: "wrangler",
 					tags,

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -386,20 +386,21 @@ export default async function deploy(props: Props): Promise<{
 			const serviceMetaData = await fetchResult<{
 				default_environment: {
 					environment: string;
+					script_tag: string;
 					script: {
 						tag: string;
 						tags: string[] | null;
 						last_deployed_from: "dash" | "wrangler" | "api";
-					};
+					} | null;
 				};
 			}>(config, `/accounts/${accountId}/workers/services/${name}`);
 			const {
-				default_environment: { script },
+				default_environment: { script_tag, script },
 			} = serviceMetaData;
-			workerTag = script.tag;
-			tags = script.tags ?? tags;
+			workerTag = script_tag;
+			tags = script?.tags ?? tags;
 
-			if (script.last_deployed_from === "dash") {
+			if (script?.last_deployed_from === "dash") {
 				let configDiff: ReturnType<typeof getRemoteConfigDiff> | undefined;
 				if (getFlag("DEPLOY_REMOTE_DIFF_CHECK")) {
 					const remoteWorkerConfig = await downloadWorkerConfig(
@@ -437,7 +438,7 @@ export default async function deploy(props: Props): Promise<{
 						return { versionId, workerTag };
 					}
 				}
-			} else if (script.last_deployed_from === "api") {
+			} else if (script?.last_deployed_from === "api") {
 				logger.warn(
 					`You are about to publish a Workers Service that was last updated via the script API.\nEdits that have been made via the script API will be overridden by your local code and config.`
 				);

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -208,9 +208,12 @@ export const versionsDeployCommand = createCommand({
 		let workerTag: string | null = null;
 		try {
 			const serviceMetaData = await fetchResult<{
-				default_environment: { script: { tag: string } };
+				default_environment: {
+					script_tag: string;
+					script: { tag: string } | null;
+				};
 			}>(config, `/accounts/${accountId}/workers/services/${workerName}`);
-			workerTag = serviceMetaData.default_environment.script.tag;
+			workerTag = serviceMetaData.default_environment.script_tag;
 		} catch {
 			// If the fetch fails then we just output a null for the workerTag.
 		}

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -427,24 +427,25 @@ export default async function versionsUpload(props: Props): Promise<{
 	if (accountId && name) {
 		try {
 			const {
-				default_environment: { script },
+				default_environment: { script_tag, script },
 			} = await fetchResult<{
 				default_environment: {
+					script_tag: string;
 					script: {
 						tag: string;
 						tags: string[] | null;
 						last_deployed_from: "dash" | "wrangler" | "api";
-					};
+					} | null;
 				};
 			}>(
 				config,
 				`/accounts/${accountId}/workers/services/${name}` // TODO(consider): should this be a /versions endpoint?
 			);
 
-			workerTag = script.tag;
-			tags = script.tags ?? tags;
+			workerTag = script_tag;
+			tags = script?.tags ?? tags;
 
-			if (script.last_deployed_from === "dash") {
+			if (script?.last_deployed_from === "dash") {
 				logger.warn(
 					`You are about to upload a Worker Version that was last published via the Cloudflare Dashboard.\nEdits that have been made via the dashboard will be overridden by your local code and config.`
 				);
@@ -454,7 +455,7 @@ export default async function versionsUpload(props: Props): Promise<{
 						workerTag,
 					};
 				}
-			} else if (script.last_deployed_from === "api") {
+			} else if (script?.last_deployed_from === "api") {
 				logger.warn(
 					`You are about to upload a Workers Version that was last updated via the API.\nEdits that have been made via the API will be overridden by your local code and config.`
 				);


### PR DESCRIPTION
Fixes BANDA-1286

Script is null when creating a Worker via the new [Workers beta APIs](https://developers.cloudflare.com/api/resources/workers/subresources/beta/subresources/workers/methods/create/).

This change allows wrangler to create new deployments and upload versions to Workers created via `POST
/accounts/{account_id}/workers/workers` instead of throwing an error.

LLM usage:
I fixed the bug myself, but Claude Code assisted in identifying the mocks that needed fixing.

It's unclear to me if there are additional mocks I should update (even though no other tests failed).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: don't think we need to support beta APIs in wrangler v3 but correct me if I'm wrong

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
