### PR TITLE
Non-existing template options now filtered out for lang in C3

### DIFF
--- a/.changeset/olive-snails-hunt.md
+++ b/.changeset/olive-snails-hunt.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": minor
+---
+
+Create-cloudflare now filters out options that don't exist for specified language

--- a/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
+++ b/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
@@ -275,6 +275,49 @@ describe("Create Cloudflare CLI", () => {
 			},
 		);
 
+		test.skipIf(isWindows)(
+			"Filtering templates when --lang=python is specified",
+			async ({ logStream, project }) => {
+				const { output } = await runC3(
+					[
+						project.path,
+						"--lang=python",
+						"--type=hello-world",
+						"--no-deploy",
+						"--git=false",
+					],
+					[],
+					logStream,
+				);
+
+				expect(project.path).toExist();
+				expect(output).toContain(`category Hello World example`);
+				expect(output).toContain(`type Worker only`);
+				expect(output).toContain(`lang Python`);
+			},
+		);
+
+		test.skipIf(isWindows)(
+			"Error when --lang=python is used with a category that has no Python templates",
+			async ({ logStream, project }) => {
+				const { errors } = await runC3(
+					[
+						project.path,
+						"--lang=python",
+						"--category=demo",
+						"--no-deploy",
+						"--git=false",
+					],
+					[],
+					logStream,
+				);
+
+				expect(errors).toContain(
+					`No templates available for language "python" in the "demo" category`,
+				);
+			},
+		);
+
 		/*
 		 * Skipping in yarn due to node version resolution conflict
 		 * The Openapi C3 template depends on `chanfana`, which has a dependency

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -180,6 +180,53 @@ const defaultSelectVariant = async (ctx: C3Context) => {
 	return ctx.args.lang;
 };
 
+/**
+ * Helper function to check if a template supports a specific language
+ */
+const templateSupportsLanguage = (
+	config: TemplateConfig,
+	lang: string,
+): boolean => {
+	const { copyFiles } = config;
+	// If the template has no copyFiles or uses a single path, it doesn't support variants.
+	// In that case we assume that this template doesn't support the language specified.
+	// Note that this isn't perfect, if a template supports only Python for example then we
+	// may miss it, but we have no way of deducing the supported language based on the path
+	// alone.
+	if (!copyFiles || isVariantInfo(copyFiles)) {
+		return false;
+	}
+	// If the template has variants, check if the specified language is supported
+	if (copyFiles.variants && !copyFiles.variants[lang]) {
+		return false;
+	}
+	return true;
+};
+
+const filterTemplatesByLanguage = <
+	T extends TemplateConfig | MultiPlatformTemplateConfig,
+>(
+	templates: Record<string, T>,
+	lang: string | undefined,
+): Record<string, T> => {
+	// If no language is specified, return all templates
+	if (!lang) {
+		return templates;
+	}
+
+	return Object.fromEntries(
+		Object.entries(templates).filter(([, config]) => {
+			if ("platformVariants" in config) {
+				return (
+					templateSupportsLanguage(config.platformVariants.pages, lang) ||
+					templateSupportsLanguage(config.platformVariants.workers, lang)
+				);
+			}
+			return templateSupportsLanguage(config, lang);
+		}),
+	) as Record<string, T>;
+};
+
 export type TemplateMap = Record<
 	string,
 	TemplateConfig | MultiPlatformTemplateConfig
@@ -332,11 +379,20 @@ export const createContext = async (
 
 	const experimental = args.experimental;
 
-	const frameworkMap = getFrameworkMap({ experimental });
-	const helloWorldTemplateMap = getHelloWorldTemplateMap({
-		experimental,
-	});
-	const otherTemplateMap = getOtherTemplateMap({ experimental });
+	const frameworkMap = filterTemplatesByLanguage(
+		getFrameworkMap({ experimental }),
+		args.lang,
+	);
+	const helloWorldTemplateMap = filterTemplatesByLanguage(
+		getHelloWorldTemplateMap({
+			experimental,
+		}),
+		args.lang,
+	);
+	const otherTemplateMap = filterTemplatesByLanguage(
+		getOtherTemplateMap({ experimental }),
+		args.lang,
+	);
 
 	let linesPrinted = 0;
 
@@ -557,6 +613,13 @@ export const createContext = async (
 				};
 			},
 		);
+
+		// If no templates are available for the specified language, throw an error
+		if (args.lang && templateOptions.length === 0) {
+			throw new Error(
+				`No templates available for language "${args.lang}" in the "${category}" category.`,
+			);
+		}
 
 		const type = await processArgument(args, "type", {
 			type: "select",


### PR DESCRIPTION
When running `create-cloudflare` with the `--lang=python` argument, all templates are shown including ones that don't support Python. This PR filters those out.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: feature improvement
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: c3 change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->


----

```
$ pnpm i
$ pnpm run test:e2e:c3
```