### PR TITLE
Remove warning for Python workers

### DIFF
--- a/.changeset/lovely-hairs-post.md
+++ b/.changeset/lovely-hairs-post.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Removed warning when deploying a Python worker

--- a/packages/wrangler/src/deployment-bundle/guess-worker-format.ts
+++ b/packages/wrangler/src/deployment-bundle/guess-worker-format.ts
@@ -20,12 +20,6 @@ export async function guessWorkerFormat(
 ): Promise<{ format: CfScriptFormat; exports: string[] }> {
 	const parsedEntryPath = path.parse(entryFile);
 	if (parsedEntryPath.ext == ".py") {
-		logger.warn(
-			`The entrypoint ${path.relative(
-				process.cwd(),
-				entryFile
-			)} defines a Python worker, support for Python workers is currently experimental.`
-		);
 		return { format: "modules", exports: [] };
 	}
 


### PR DESCRIPTION
They are mature enough at this point that we shouldn't have this warnings anymore

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: just removes warning
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: just removes warnings
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: New feature

