### PR TITLE
Add missing dash in regex for invalid worker name

### DIFF
--- a/packages/wrangler/src/autoconfig/details.ts
+++ b/packages/wrangler/src/autoconfig/details.ts
@@ -136,7 +136,7 @@ export async function getDetailsForAutoConfig({
 	};
 }
 
-const invalidWorkerNameCharsRegex = /[^a-z0-9 ]/g;
+const invalidWorkerNameCharsRegex = /[^a-z0-9- ]/g;
 const invalidWorkerNameStartEndRegex = /^(-+)|(-+)$/g;
 const workerNameLengthLimit = 63;
 


### PR DESCRIPTION
I'm not sure how but somehow I removed the dash from the regex before merging https://github.com/cloudflare/workers-sdk/pull/11187 😖 

No changeset is required here since the changes in #11187 haven't been released yet

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: this relates to the prompt validation which is something I don't think we currently test, I think we can test this aspect later on when we implement e2e tests for autoconfig
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: autoconfig is not in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
