### PR TITLE
SQC-652 Implement Hyperdrive TLS proxy in Miniflare

### DIFF
--- a/.changeset/cute-plums-relate.md
+++ b/.changeset/cute-plums-relate.md
@@ -1,0 +1,7 @@
+---
+"miniflare": minor
+"wrangler": minor
+---
+
+Implement Hyperdrive binding TLS miniflare proxy. This will allow for wrangler dev hyperdrive bindings to connect to external
+databases that require TLS.

--- a/fixtures/vitest-pool-workers-examples/hyperdrive/src/index.ts
+++ b/fixtures/vitest-pool-workers-examples/hyperdrive/src/index.ts
@@ -4,7 +4,14 @@ export default <ExportedHandler<Env>>{
 		if (request.body === null) return new Response();
 
 		const socket = env.ECHO_SERVER_HYPERDRIVE.connect();
-		await request.body.pipeTo(socket.writable);
-		return new Response(socket.readable);
+		const writer = socket.writable.getWriter();
+
+		// parse body
+		const value = await request.text();
+		await writer.write(new TextEncoder().encode(value));
+		const result = await socket.readable.getReader().read();
+
+		writer.close();
+		return new Response(result.value);
 	},
 };

--- a/packages/miniflare/src/plugins/hyperdrive/hyperdrive-proxy.ts
+++ b/packages/miniflare/src/plugins/hyperdrive/hyperdrive-proxy.ts
@@ -1,0 +1,425 @@
+import net from "node:net";
+import tls from "node:tls";
+
+export interface HyperdriveProxyConfig {
+	// Name of the Hyperdrive binding
+	name: string;
+	// The host of the target database
+	targetHost: string;
+	// The port of the target database
+	targetPort: string;
+	// The scheme of the target database
+	scheme: string;
+	// The sslmode of the target database
+	sslmode: string;
+}
+
+const schemes = {
+	postgresql: "postgresql",
+	postgres: "postgres",
+	mysql: "mysql",
+};
+
+// Initial postgres ssl request packet
+export const POSTGRES_SSL_REQUEST_PACKET = Buffer.from([
+	0x00, 0x00, 0x00, 0x08, 0x04, 0xd2, 0x16, 0x2f,
+]);
+
+/**
+ * HyperdriveProxyController establishes TLS-enabled connections between workerd
+ * and external Postgres/MySQL databases. Supports PostgreSQL sslmode options
+ * ('require', 'prefer', 'disable') by proxying each Hyperdrive binding through
+ * a randomly assigned local port.
+ */
+export class HyperdriveProxyController {
+	// Map hyperdrive binding name to proxy server
+	#servers = new Map<string, net.Server>();
+
+	/**
+	 * Creates a proxy server for a Hyperdrive binding.
+	 *
+	 * @param config - The configuration for the proxy server.
+	 * @returns A promise that resolves to the port number of the proxy server.
+	 */
+	async createProxyServer(config: HyperdriveProxyConfig): Promise<number> {
+		const { name, targetHost, targetPort, scheme, sslmode } = config;
+		const server = net.createServer((clientSocket) => {
+			this.#handleConnection(
+				clientSocket,
+				targetHost,
+				Number.parseInt(targetPort),
+				scheme,
+				sslmode
+			);
+		});
+		const port = await new Promise<number>((resolve, reject) => {
+			server.listen(0, "localhost", () => {
+				const address = server.address() as net.AddressInfo;
+				if (address && typeof address !== "string") {
+					resolve(address.port);
+				} else {
+					reject("Invalid port");
+				}
+			});
+		});
+		this.#servers.set(name, server);
+		return port;
+	}
+
+	/**
+	 * Handles a connection from workerd by hyperdrive magic hostname "randomUUID.hyperdrive.local"
+	 *
+	 * @param clientSocket - The client socket.
+	 * @param targetHost - The hostname of the target database.
+	 * @param targetPort - The port of the target database.
+	 * @param scheme - The scheme of the target database.
+	 * @param sslmode - The sslmode of the target database.
+	 */
+	async #handleConnection(
+		clientSocket: net.Socket,
+		targetHost: string,
+		targetPort: number,
+		scheme: string,
+		sslmode: string
+	) {
+		// Connect to real database
+		const dbSocket = net.connect({ host: targetHost, port: targetPort });
+		const sslmodeRequire = sslmode === "require";
+		const sslmodePrefer = sslmode === "prefer";
+		if (sslmodePrefer || sslmodeRequire) {
+			try {
+				if (scheme === schemes.postgres || scheme === schemes.postgresql) {
+					return await handlePostgresTlsConnection(
+						dbSocket,
+						clientSocket,
+						targetHost,
+						targetPort,
+						sslmodeRequire
+					);
+				} else if (scheme === schemes.mysql) {
+					return await handleMySQLTlsConnection(
+						dbSocket,
+						clientSocket,
+						targetHost,
+						targetPort,
+						sslmodeRequire
+					);
+				}
+			} catch (e) {
+				if (sslmodeRequire) {
+					// Write error to client so worker can read it
+					clientSocket.write(`${e}\n`);
+					clientSocket.end();
+					dbSocket.destroy();
+					return;
+				}
+			}
+		}
+		// Pipe plain tcp sockets
+		clientSocket.pipe(dbSocket);
+		dbSocket.pipe(clientSocket);
+	}
+
+	/** Disposes of the proxy servers when shutting down the worker.*/
+	async dispose(): Promise<void> {
+		await Promise.allSettled(
+			Array.from(this.#servers.values()).map((server) => {
+				new Promise<void>((resolve, reject) => {
+					server.close((err) => (err ? reject(err) : resolve()));
+				});
+			})
+		);
+		this.#servers.clear();
+	}
+}
+
+/** Handles Postgres TLS connection */
+async function handlePostgresTlsConnection(
+	dbSocket: net.Socket,
+	clientSocket: net.Socket,
+	targetHost: string,
+	targetPort: number,
+	sslmodeRequire: boolean
+) {
+	// Send Postgres sslrequest bytes
+	await writeAsync(dbSocket, POSTGRES_SSL_REQUEST_PACKET);
+
+	const response = await readAsync(dbSocket);
+	// Read first byte ssl flag
+	const sslResponseFlag = response.toString("utf8", 0, 1);
+	if (sslResponseFlag === "S") {
+		const tlsOptions: tls.ConnectionOptions = {
+			socket: dbSocket,
+			host: targetHost,
+			servername: targetHost,
+		};
+		try {
+			const tlsSocket = await tlsConnect(tlsOptions);
+			setupTLSConnection(clientSocket, tlsSocket);
+			return;
+		} catch (e) {
+			if (sslmodeRequire) {
+				throw e;
+			}
+			// Fallback to plain TCP connection
+		}
+	}
+	// Server doesn't support SSL but client requires it
+	if (sslmodeRequire) {
+		throw Error("Server does not support SSL, but client requires SSL.");
+	}
+	// fallback to plain TCP
+	dbSocket.destroy();
+	const newDbSocket = await createPlainTCPConnection(
+		targetHost,
+		targetPort,
+		clientSocket
+	);
+	// Pipe plain TCP sockets
+	clientSocket.pipe(newDbSocket);
+	newDbSocket.pipe(clientSocket);
+}
+
+/** Handles MySQL TLS connection */
+async function handleMySQLTlsConnection(
+	dbSocket: net.Socket,
+	clientSocket: net.Socket,
+	targetHost: string,
+	targetPort: number,
+	sslmodeRequire: boolean
+) {
+	const initPacketChunk = await readAsync(dbSocket);
+	// Little-endian parse payload header length
+	const payloadHeaderLength =
+		initPacketChunk[0] | (initPacketChunk[1] << 8) | (initPacketChunk[2] << 16);
+
+	// Handle reading bytes until correct amount payload body length
+	let fullPayloadBody: Buffer<ArrayBuffer>;
+	const payloadStart = 4;
+	const alreadyRead = initPacketChunk.length - payloadStart;
+	if (alreadyRead === payloadHeaderLength) {
+		fullPayloadBody = Buffer.from(initPacketChunk.subarray(payloadStart));
+	} else if (alreadyRead < payloadHeaderLength) {
+		const chunks = [initPacketChunk.subarray(payloadStart)];
+		let totalRead = alreadyRead;
+		while (totalRead < payloadHeaderLength) {
+			const chunk = await readAsync(dbSocket);
+			chunks.push(chunk);
+			totalRead += chunk.length;
+		}
+		fullPayloadBody = Buffer.concat(chunks);
+		// Trim if we read too much
+		if (totalRead > payloadHeaderLength) {
+			fullPayloadBody = fullPayloadBody.subarray(0, payloadHeaderLength);
+		}
+	} else {
+		throw Error("Could not parse header properly.");
+	}
+
+	if (mysqlSupportsSSL(fullPayloadBody)) {
+		// Send our own fixed SSL request to MySQL server with minimal capabilities
+		const sslRequestPacket: number[] = [
+			0x20,
+			0x00,
+			0x00,
+			0x01, // payload length = 32, sequence id = 1
+			0x00,
+			0x0a,
+			0x00,
+			0x00, // capability_flags = CLIENT_SSL | CLIENT_PROTOCOL_41
+			0x00,
+			0x00,
+			0x00,
+			0x00, // max_packet_size = 0
+			0x21, // character_set = utf8_general_ci
+			...new Array(23).fill(0x00), // reserved (23 bytes)
+		];
+		await writeAsync(dbSocket, sslRequestPacket);
+
+		// Upgrade server connection to TLS
+		const tlsOptions: tls.ConnectionOptions = {
+			socket: dbSocket,
+			host: targetHost,
+			servername: targetHost,
+			minVersion: "TLSv1.2",
+			rejectUnauthorized: true,
+		};
+
+		try {
+			const tlsSocket = await tlsConnect(tlsOptions);
+
+			// Send original init packet to client (with SSL capability)
+			const fullInitPacket = Buffer.concat([
+				initPacketChunk.subarray(0, 4),
+				fullPayloadBody,
+			]);
+			await writeAsync(clientSocket, fullInitPacket);
+			const clientAuthPayload = await readAsync(clientSocket);
+
+			// Forward client auth to server and increment sequence ID byte to keep client driver/server in sync
+			clientAuthPayload[3]++;
+			await writeAsync(tlsSocket, clientAuthPayload);
+
+			// Read and forward server's response, and fix sequence ID byte back to client
+			const authResponsePayload = await readAsync(tlsSocket);
+			authResponsePayload[3]--;
+			await writeAsync(clientSocket, authResponsePayload);
+
+			// Set up pipes with error handler
+			setupTLSConnection(clientSocket, tlsSocket);
+			return;
+		} catch (e) {
+			if (!sslmodeRequire) {
+				throw e;
+			}
+			// Attempt to fall back to plain TCP
+		}
+	}
+	if (sslmodeRequire) {
+		throw new Error("Server SSL failed, but client requires SSL.");
+	}
+	// Disconnect original socket to DB
+	dbSocket.destroy();
+
+	// Create new connection and send init packet without SSL capability
+	const newDbSocket = await createPlainTCPConnection(
+		targetHost,
+		targetPort,
+		clientSocket
+	);
+
+	// Pipe plain TCP sockets
+	clientSocket.pipe(newDbSocket);
+	newDbSocket.pipe(clientSocket);
+	return;
+}
+
+/** Create and wait for plain TCP connection */
+async function createPlainTCPConnection(
+	targetHost: string,
+	targetPort: number,
+	clientSocket: net.Socket
+): Promise<net.Socket> {
+	const dbSocket = net.connect({ host: targetHost, port: targetPort });
+
+	// Wait for connection to be established
+	await new Promise<void>((resolve, reject) => {
+		const handleConnect = () => {
+			dbSocket.off("error", handleError);
+			resolve();
+		};
+
+		const handleError = (err: Error) => {
+			dbSocket.off("data", handleConnect);
+			reject(err);
+		};
+
+		dbSocket.once("connect", handleConnect);
+		dbSocket.once("error", handleError);
+	});
+
+	// Set up error handler
+	dbSocket.on("error", () => {
+		clientSocket.destroy();
+	});
+
+	return dbSocket;
+}
+
+/** Set up TLS connection with pipes and error handlers */
+function setupTLSConnection(
+	clientSocket: net.Socket,
+	tlsSocket: tls.TLSSocket
+): void {
+	// Set up error handler for runtime TLS errors
+	tlsSocket.on("error", () => {
+		clientSocket.destroy();
+		tlsSocket.destroy();
+	});
+
+	// Pipe sockets
+	clientSocket.pipe(tlsSocket);
+	tlsSocket.pipe(clientSocket);
+}
+
+/** Write buffer to socket and return as a promise helper function  */
+function writeAsync(
+	socket: net.Socket,
+	bytes: Buffer<ArrayBuffer> | Uint8Array | number[]
+): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const buffer = Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes);
+		socket.write(buffer, (err) => (err ? reject(err) : resolve()));
+	});
+}
+
+/** Ready buffer from socket and return as a promise helper function  */
+function readAsync(socket: net.Socket): Promise<Buffer<ArrayBufferLike>> {
+	return new Promise((resolve, reject) => {
+		const handleData = (data: Buffer) => {
+			socket.off("error", handleError);
+			resolve(data);
+		};
+
+		const handleError = (err: Error) => {
+			socket.off("data", handleData);
+			reject(err);
+		};
+
+		socket.once("data", handleData);
+		socket.once("error", handleError);
+	});
+}
+
+function tlsConnect(options: tls.ConnectionOptions): Promise<tls.TLSSocket> {
+	return new Promise((resolve, reject) => {
+		const socket = tls.connect(options);
+
+		const handleSecureConnect = () => {
+			socket.off("error", handleError);
+			resolve(socket);
+		};
+
+		const handleError = (err: Error) => {
+			socket.off("secureConnect", handleSecureConnect);
+			reject(err);
+		};
+
+		socket.once("secureConnect", handleSecureConnect);
+		socket.once("error", handleError);
+	});
+}
+
+/** MySQL helper that skips through reading the init packet
+ * until we get to the ssl capability flag, only need to look at lower 16 bits
+ * docs: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_handshake_v10.html
+ */
+const MYSQL_CONNECTION_ID_LENGTH = 4;
+const MYSQL_AUTH_PLUGIN_DATA_PART_1_LENGTH = 8;
+const MYSQL_FILLER_LENGTH = 1;
+const MYSQL_CAPABILITY_FLAGS_LOWER_LENGTH = 2;
+const MYSQL_SSL_CAPABILITY_FLAG = 2048;
+function mysqlSupportsSSL(payload: Buffer<ArrayBuffer>): boolean {
+	const payloadLength = payload.length;
+	let offset = 1;
+
+	// Find end of server_version string (null terminator)
+	while (offset < payloadLength && payload[offset] != 0x00) offset++;
+
+	// Skip null terminator
+	offset++;
+
+	// Skip connection_id, auth_plugin_data_part_1, filler
+	offset += MYSQL_CONNECTION_ID_LENGTH;
+	offset += MYSQL_AUTH_PLUGIN_DATA_PART_1_LENGTH;
+	offset += MYSQL_FILLER_LENGTH;
+	// Ensure there are enough bytes left for fixed fields
+	if (offset + MYSQL_CAPABILITY_FLAGS_LOWER_LENGTH > payloadLength)
+		return false;
+
+	// Read 2-byte little-endian capability_flags_lower
+	const caps = payload[offset] | (payload[offset + 1] << 8);
+
+	// Check ssl support
+	return (caps & MYSQL_SSL_CAPABILITY_FLAG) != 0;
+}

--- a/packages/miniflare/src/plugins/hyperdrive/index.ts
+++ b/packages/miniflare/src/plugins/hyperdrive/index.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 import { z } from "zod";
-import { Service, Worker_Binding } from "../../runtime";
+import { Worker_Binding } from "../../runtime";
 import { Plugin, ProxyNodeBinding } from "../shared";
 
 export const HYPERDRIVE_PLUGIN_NAME = "hyperdrive";
@@ -115,15 +115,68 @@ export const HYPERDRIVE_PLUGIN: Plugin<typeof HyperdriveInputOptionsSchema> = {
 			})
 		);
 	},
-	async getServices({ options }) {
-		return Object.entries(options.hyperdrives ?? {}).map<Service>(
-			([name, url]) => ({
+	async getServices({ options, hyperdriveProxyController }) {
+		const services = [];
+		for (const [name, url] of Object.entries(options.hyperdrives ?? {})) {
+			const scheme = url.protocol.replace(":", "");
+
+			const proxyPort = await hyperdriveProxyController.createProxyServer({
+				name,
+				targetHost: url.hostname,
+				targetPort: getPort(url),
+				scheme,
+				sslmode: parseSslMode(url, scheme),
+			});
+			services.push({
 				name: `${HYPERDRIVE_PLUGIN_NAME}:${name}`,
 				external: {
-					address: `${url.hostname}:${getPort(url)}`,
+					address: `localhost:${proxyPort}`,
 					tcp: {},
 				},
-			})
-		);
+			});
+		}
+		return services;
 	},
 };
+
+// Postgres sslmode docs: https://www.postgresql.org/docs/current/libpq-ssl.html
+// MySQL ssl-mode docs: https://dev.mysql.com/doc/refman/8.4/en/using-encrypted-connections.html
+function parseSslMode(url: URL, scheme: string): string {
+	// Normalize keys/values to lowercase
+	const params = Object.fromEntries(
+		Array.from(url.searchParams.entries()).map(([k, v]) => [
+			k.toLowerCase(),
+			v.toLowerCase(),
+		])
+	);
+
+	if (scheme === "postgres" || scheme === "postgresql") {
+		return params["sslmode"] || "disable"; // disable is default
+	} else if (scheme === "mysql") {
+		// Parse different variations for mysql sslmode
+		const sslmode = params["ssl-mode"] || params["ssl"] || params["sslmode"];
+
+		// Normalize to postgres values
+		switch (sslmode) {
+			case "required":
+			case "true":
+			case "1":
+				return "require";
+			case "preferred":
+				return "prefer";
+			case "disabled":
+			case "false":
+			case "0":
+				return "disable";
+		}
+	}
+
+	// default to disable
+	return "disable";
+}
+
+export type {
+	HyperdriveProxyController,
+	HyperdriveProxyConfig,
+	POSTGRES_SSL_REQUEST_PACKET,
+} from "./hyperdrive-proxy";

--- a/packages/miniflare/src/plugins/shared/index.ts
+++ b/packages/miniflare/src/plugins/shared/index.ts
@@ -24,6 +24,7 @@ import {
 } from "../../workers";
 import { UnsafeUniqueKey } from "./constants";
 import type { DOContainerOptions } from "../do";
+import type { HyperdriveProxyController } from "../hyperdrive/hyperdrive-proxy";
 
 export const DEFAULT_PERSIST_ROOT = ".mf";
 
@@ -84,6 +85,7 @@ export interface PluginServicesOptions<
 	unsafeEphemeralDurableObjects: boolean;
 	queueProducers: QueueProducers;
 	queueConsumers: QueueConsumers;
+	hyperdriveProxyController: HyperdriveProxyController;
 }
 
 export interface ServicesExtensions {

--- a/packages/wrangler/e2e/helpers/postgres-echo-handler.ts
+++ b/packages/wrangler/e2e/helpers/postgres-echo-handler.ts
@@ -1,0 +1,21 @@
+import type net from "node:net";
+
+export const POSTGRES_SSL_REQUEST_PACKET = Buffer.from([
+	0x00, 0x00, 0x00, 0x08, 0x04, 0xd2, 0x16, 0x2f,
+]);
+
+/**
+ * Creates a simple echo handler for PostgreSQL test servers.
+ * Responds with 'N' to SSL request packets and echoes back all other data.
+ */
+export function createPostgresEchoHandler(
+	socket: net.Socket
+): (chunk: Buffer) => void {
+	return (chunk: Buffer) => {
+		if (POSTGRES_SSL_REQUEST_PACKET.equals(chunk)) {
+			socket.write("N");
+		} else {
+			socket.write(chunk);
+		}
+	};
+}


### PR DESCRIPTION
Fixes SQC-652.

This fixes the problem of when a user runs 
`npx wrangler dev` 
with a Hyperdrive binding and `localConnectionString` pointing to a database that requires TLS. In such cases, the command will result in the following TLS error:
```
{ "error": "connection is insecure (try using `sslmode=require`)" }
```

This change adds a proxy layer to Miniflare and introduces a proxy service for Hyperdrive bindings. The proxy layer attempts to establish a TLS connection with the appropriate database based on the specified sslmode parameter.

This allows users to simply set `sslmode=require` in their `localConnectionString`, enabling their Hyperdrive binding to automatically upgrade to TLS instead of requiring them to manually configure TLS settings in their database driver. (Note: this still will not work without additional changes to the binding service.)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [X] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [X] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/26545
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [X] Not necessary because: New feature behavior

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
