### PR TITLE
ci: bump Github Action workflows to use latest macos, windows and ubuntu

### DIFF
--- a/.github/workflows/c3-dependabot-versioning-prs.yml
+++ b/.github/workflows/c3-dependabot-versioning-prs.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   generate-changeset:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: |
       github.event.pull_request.user.login == 'dependabot[bot]'
     steps:

--- a/.github/workflows/e2e-project-cleanup.yml
+++ b/.github/workflows/e2e-project-cleanup.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
     name: "Cleanup Test Projects"
     if: ${{ github.repository_owner == 'cloudflare' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,14 +18,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-13
+          - os: macos-latest
             description: v20, macOS
             node: 20.19.1
-          - os: windows-2022
+          - os: windows-latest
             description: v20, Windows
             node: 20.19.1
             # we need to use an amd image to run the containers tests, since we build for linux/amd64
-          - os: ubuntu-24.04
+          - os: ubuntu-latest
             description: v20, Linux
             node: 20.19.1
 
@@ -96,14 +96,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-13
+          - os: macos-latest
             description: v20, macOS
             node: 20.19.1
-          - os: windows-2022
+          - os: windows-latest
             description: v20, Windows
             node: 20.19.1
             # we need to use an amd image to run the containers tests, since we build for linux/amd64
-          - os: ubuntu-24.04
+          - os: ubuntu-latest
             description: v20, Linux
             node: 20.19.1
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/miniflare-dependabot-versioning-prs.yml
+++ b/.github/workflows/miniflare-dependabot-versioning-prs.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   generate-changeset:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: |
       github.event.pull_request.user.login == 'dependabot[bot]'
     steps:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   build:
     if: ${{ github.repository_owner == 'cloudflare' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -26,7 +26,7 @@ jobs:
       cancel-in-progress: true
 
     name: "Checks"
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -95,7 +95,7 @@ jobs:
             node_version: 20.19.1
             filter: '--filter="./packages/*" --filter="./fixtures/*" --filter="./packages/vite-plugin-cloudflare/playground" --summarize'
           # needs to run on the amd runners to allow containers test to work in CI
-          - os: ubuntu-24.04
+          - os: ubuntu-latest
             description: Linux
             node_version: 20.19.1
             # ./tools _only_ runs here because they're only intended to run in CI
@@ -106,13 +106,13 @@ jobs:
             node_version: 20.19.1
             filter: '--filter="./packages/*" --filter="./fixtures/*" --filter="./packages/vite-plugin-cloudflare/playground"'
           # needs to run on the amd runners to allow containers test to work in CI
-          - os: ubuntu-24.04
+          - os: ubuntu-latest
             description: v22, Linux
             node_version: 22
             # Browser rendering is disabled here because of https://pptr.dev/troubleshooting#issues-with-apparmor-on-ubuntu
             filter: '--filter="./packages/*" --filter="./fixtures/*" --filter="./packages/vite-plugin-cloudflare/playground" --filter="!./packages/kv-asset-handler" --filter="!./fixtures/browser-rendering"'
           # Skipped until we upgrade to undici v7, because of https://github.com/nodejs/undici/issues/4285
-          # - os: ubuntu-24.04
+          # - os: ubuntu-latest
           #   label: v24, Linux
           #   node_version: 24
           #   filter: '--filter="./packages/*" --filter="./fixtures/*" --filter="./packages/vite-plugin-cloudflare/playground" --filter="!./packages/kv-asset-handler" --filter="!./fixtures/interactive-dev-tests"'

--- a/.github/workflows/validate-pr-description.yml
+++ b/.github/workflows/validate-pr-description.yml
@@ -26,7 +26,7 @@ jobs:
       cancel-in-progress: true
     timeout-minutes: 30
     name: Check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/worker-playground-preview-testing-env-deploy-and-test.yml
+++ b/.github/workflows/worker-playground-preview-testing-env-deploy-and-test.yml
@@ -26,7 +26,7 @@ jobs:
   e2e-test:
     if: github.repository_owner == 'cloudflare' && (github.event_name != 'pull_request' || contains(github.event.*.labels.*.name, 'playground-worker'))
     name: "Deploy Playground Preview Worker (testing)"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
This was prompted by brown-outs for macos-13 setups that have been deprecated.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: CI
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: CI
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> CI

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
