### PR TITLE
[miniflare] Fix WebSocket Refactor toErrorClass function for error handling

### DIFF
--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -608,7 +608,12 @@ const RawErrorToErrorClassMap: { [_: string]: typeof ErrorOAuth2 } = {
  * Translate the raw error strings returned from the server into error classes.
  */
 function toErrorClass(rawError: string): ErrorOAuth2 {
-	return new (RawErrorToErrorClassMap[rawError] || ErrorUnknown)();
+	const ErrorClass =
+		Object.prototype.hasOwnProperty.call(RawErrorToErrorClassMap, rawError) &&
+		typeof RawErrorToErrorClassMap[rawError] === "function"
+			? RawErrorToErrorClassMap[rawError]
+			: ErrorUnknown;
+	return new ErrorClass();
 }
 
 /**


### PR DESCRIPTION

Fixes https://github.com/cloudflare/workers-sdk/issues/11255 


fix this problem is to ensure that the dynamic property access for the error class is only performed on known, safe properties (not prototype-inherited properties), and that the result is a callable constructor function. The preferred fix follows the recommendation: use `Object.prototype.hasOwnProperty.call(RawErrorToErrorClassMap, rawError)` to verify the property is not inherited, and confirm the value is a function (specifically a constructor for errors). If the validation fails, default to using `ErrorUnknown`. 

The change should be made inside the `toErrorClass` function (lines 610–612) in `packages/wrangler/src/user/user.ts`. No new imports are needed since `Object.prototype.hasOwnProperty` is globally available in JS.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
