### PR TITLE
chore: ignore generated folder

### DIFF
--- a/packages/wrangler/eslint.config.mjs
+++ b/packages/wrangler/eslint.config.mjs
@@ -11,6 +11,7 @@ export default defineConfig([
 		"emitted-types",
 		"kv-asset-handler.js",
 		"**/templates/**/*.*",
+		".tmp/**",
 	]),
 	sharedConfig,
 	{


### PR DESCRIPTION
the generated `wrangler/.tmp` would error:

```
/Users/vberchet/code/work/workers-sdk/packages/wrangler/.tmp/vitest-workers/InspectorProxyWorker.js
  0:0  error  Parsing error: /Users/vberchet/code/work/workers-sdk/packages/wrangler/.tmp/vitest-workers/InspectorProxyWorker.js was not found by the project service. Consider either including it in the tsconfig.json or including it in allowDefaultProject

/Users/vberchet/code/work/workers-sdk/packages/wrangler/.tmp/vitest-workers/ProxyServerWorker.js
  0:0  error  Parsing error: /Users/vberchet/code/work/workers-sdk/packages/wrangler/.tmp/vitest-workers/ProxyServerWorker.js was not found by the project service. Consider either including it in the tsconfig.json or including it in allowDefaultProject

/Users/vberchet/code/work/workers-sdk/packages/wrangler/.tmp/vitest-workers/ProxyWorker.js
  0:0  error  Parsing error: /Users/vberchet/code/work/workers-sdk/packages/wrangler/.tmp/vitest-workers/ProxyWorker.js was not found by the project service. Consider either including it in the tsconfig.json or including it in allowDefaultProject
```

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: lint
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user facing change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: eslint changes not in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
