### PR TITLE
Try adding dependabot across the repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,3 +41,21 @@ updates:
     allow:
       - dependency-name: "workerd"
       - dependency-name: "@cloudflare/workers-types"
+  # Check for updates that are not workerd & workers-types
+  - package-ecosystem: "npm"
+    # If you restrict the update to a directory that is not the root
+    # then it will not update the package-lock.json.
+    directory: "/"
+    ignore:
+      # Don't update workerd and workers-types as they are covered above
+      - dependency-name: "workerd"
+      - dependency-name: "@cloudflare/workers-types"
+    schedule:
+      interval: "daily"
+      time: "06:00"
+    versioning-strategy: increase-if-necessary
+    cooldown:
+      default-days: 5
+    labels:
+      - "dependencies"
+      - "skip-pr-description-validation"


### PR DESCRIPTION
Currently this will not generate the changesets that we usually have for workerd, workers-types and C3 updates.
In the meantime, we could add changesets manually.
If the config looks like it is working we can look into making the tooling more general.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: CI change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: CI change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> CI change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
