### PR TITLE
Removes duplicate module warnings when vendoring Python packages

### DIFF
--- a/.changeset/sad-mirrors-kiss.md
+++ b/.changeset/sad-mirrors-kiss.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Removes duplicate module warnings when vendoring Python packages

--- a/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
+++ b/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
@@ -171,11 +171,10 @@ export async function findAdditionalModules(
 				{ type: "Data", globs: ["**/*"], fallthrough: true },
 			];
 			const vendoredModules = (
-				await matchFiles(
-					pythonModulesFiles,
-					pythonModulesDir,
-					parseRules(vendoredRules)
-				)
+				await matchFiles(pythonModulesFiles, pythonModulesDir, {
+					rules: vendoredRules,
+					removedRules: [],
+				})
 			)
 				.filter((m) => {
 					// Check if the file matches any exclusion pattern


### PR DESCRIPTION
Wrangler would output "Ignoring duplicate module" for each .txt file inside python_modules. This PR fixes this.

Turns out that this was happening because parseRules adds some default rules.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

----

### Test Plan

```
$ pnpm build -F wrangler
$ node /Users/dominik/repos/workers-sdk/packages/wrangler/wrangler-dist/cli.js dev
```

Before:
```
▲ [WARNING] Ignoring duplicate module: webtypy-0.1.7.dist-info/top_level.txt (text)
Attaching additional modules:
┌─────────────────────┬──────┬─────────────┐
│ Name                │ Type │ Size        │
├─────────────────────┼──────┼─────────────┤
│ Vendored Modules    │      │ 8941.49 KiB │
├─────────────────────┼──────┼─────────────┤
│ Total (383 modules) │      │ 8941.49 KiB │
└─────────────────────┴──────┴─────────────┘
```

After:
```
Attaching additional modules:
┌─────────────────────┬──────┬─────────────┐
│ Name                │ Type │ Size        │
├─────────────────────┼──────┼─────────────┤
│ Vendored Modules    │      │ 8941.49 KiB │
├─────────────────────┼──────┼─────────────┤
│ Total (383 modules) │      │ 8941.49 KiB │
└─────────────────────┴──────┴─────────────┘
```
