### PR TITLE
Enable c3 experimental e2es

### DIFF
--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -33,6 +33,9 @@ jobs:
           - os: { name: windows-latest, description: Windows }
             pm: { name: pnpm, version: "9.12.0" }
     runs-on: ${{ matrix.os.name }}
+    # To save resources, if we're running the experimental tests let's run them only for pnpm and on ubuntu-latest
+    # (in the future we can consider enabling them for more cases, pnpm and ubuntu haven't been chosen for any specific reason)
+    if: ${{ !matrix.experimental || (matrix.pm.name === "pnpm" && matrix.os.name === "ubuntu-latest") }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
As part of autoconfig we are re-enabling experimental framework in C3 (the C3 experimental frameworks use autoconfig under the hood), so we need to run the C3 experimental e2es as part of PRs to validate our autoconfig changes, so in this PR I am re-enabling the disabled C3 experimental e2es.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: git workflow change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal infra change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
