### PR TITLE
test: speed up worker-logs fixture tests

### DIFF
--- a/fixtures/worker-logs/tests/index.test.ts
+++ b/fixtures/worker-logs/tests/index.test.ts
@@ -3,18 +3,25 @@ import stripAnsi from "strip-ansi";
 import { describe, onTestFinished, test, vi } from "vitest";
 import { runWranglerDev } from "../../shared/src/run-wrangler-long-lived";
 
+/**
+ * Run a Worker, make a request to it, and capture the output logs.
+ *
+ * You can call the returned function repeatedly to get the currently captured logs.
+ * The Worker will be stopped automatically when the test finishes.
+ *
+ * @param type The type of worker: "module" or "service".
+ * @param extraArgs Additional command-line arguments to pass to `wrangler dev`.
+ * @param customMessage A custom message to include in the `x-custom-message` header.
+ * @param env Environment variables to set for the worker process
+ * @returns A function that returns the captured output logs when called
+ */
 async function getWranglerDevOutput(
 	type: "module" | "service",
 	extraArgs: string[] = [],
 	customMessage?: string,
 	env = {}
 ) {
-	const {
-		ip,
-		port,
-		stop,
-		getOutput: getOutputRaw,
-	} = await runWranglerDev(
+	const { ip, port, stop, getOutput } = await runWranglerDev(
 		resolve(__dirname, ".."),
 		[
 			`-c=wrangler.${type}.jsonc`,
@@ -36,7 +43,7 @@ async function getWranglerDevOutput(
 	await response.text();
 
 	return () => {
-		const output = stripAnsi(getOutputRaw())
+		const output = stripAnsi(getOutput())
 			// Windows gets a different marker for ✘, so let's normalize it here
 			// so that these tests can be platform independent
 			.replaceAll("✘", "X")


### PR DESCRIPTION
Updates the worker-logs fixture tests to use a `vi.waitFor()` rather than a 500ms sleep.
The sleep was added to avoid flakes where the console.logs didn't arrive until some time had elapsed.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Just a test change...
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> Just a test change...

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
