### PR TITLE
ci: ban major bump changesets in the repo

### DIFF
--- a/tools/deployments/__tests__/validate-changesets.test.ts
+++ b/tools/deployments/__tests__/validate-changesets.test.ts
@@ -97,57 +97,57 @@ describe("validateChangesets()", () => {
 				{
 					file: "valid-one.md",
 					contents: dedent`
-          ---
-          "package-a": patch
-          ---
+						---
+						"package-a": patch
+						---
 
-		  refactor: test`,
+						refactor: test`,
 				},
 				{
 					file: "valid-two.md",
 					contents: dedent`
-          ---
-          "package-b": minor
-          ---
+						---
+						"package-b": minor
+						---
 
-		  feature: test`,
+						feature: test`,
 				},
 				{
 					file: "valid-three.md",
 					contents: dedent`
-          ---
-          "package-c": major
-          ---
+						---
+						"package-c": minor
+						---
 
-		  chore: test`,
+						chore: test`,
 				},
 				{
 					file: "valid-three.md",
 					contents: dedent`
-          ---
-          "package-c": major
-          ---
+						---
+						"package-c": minor
+						---
 
-		  fix: test`,
+						fix: test`,
 				},
 				{ file: "invalid-frontmatter.md", contents: "" },
 				{
 					file: "invalid-package.md",
 					contents: dedent`
-          ---
-          "package-invalid": major
-          ---
+						---
+						"package-invalid": minor
+						---
 
-		  feat: test`,
+						feat: test`,
 				},
 				{
 					file: "invalid-type.md",
 					contents: dedent`
-          ---
-          "package-a": foo
-          ---
+						---
+						"package-a": foo
+						---
 
-		  docs: test`,
+						docs: test`,
 				},
 			]
 		);
@@ -156,6 +156,46 @@ describe("validateChangesets()", () => {
 			  "Error: could not parse changeset - invalid frontmatter: at file "invalid-frontmatter.md"",
 			  "Invalid package name "package-invalid" in changeset at "invalid-package.md".",
 			  "Invalid type "foo" for package "package-a" in changeset at "invalid-type.md".",
+			]
+		`);
+	});
+
+	it("should report errors for major bump changesets", ({ expect }) => {
+		const errors = validateChangesets(
+			new Set(["package-a", "package-b", "package-c"]),
+			[
+				{
+					file: "patch-one.md",
+					contents: dedent`
+						---
+						"package-a": patch
+						---
+		  				refactor: test`,
+				},
+				{
+					file: "minor-two.md",
+					contents: dedent`
+						---
+						"package-b": minor
+						---
+
+						feature: test`,
+				},
+				{
+					file: "major-three.md",
+					contents: dedent`
+						---
+						"package-c": major
+						---
+
+						breaking change!`,
+				},
+			]
+		);
+		expect(errors).toMatchInlineSnapshot(`
+			[
+			  "Major version bumps are not allowed for package "package-c" in changeset at "major-three.md".",
+			  "Invalid type "major" for package "package-c" in changeset at "major-three.md".",
 			]
 		`);
 	});

--- a/tools/deployments/validate-changesets.ts
+++ b/tools/deployments/validate-changesets.ts
@@ -29,7 +29,12 @@ export function validateChangesets(
 						`Invalid package name "${release.name}" in changeset at "${file}".`
 					);
 				}
-				if (!["major", "minor", "patch", "none"].includes(release.type)) {
+				if (release.type === "major") {
+					errors.push(
+						`Major version bumps are not allowed for package "${release.name}" in changeset at "${file}".`
+					);
+				}
+				if (!["minor", "patch", "none"].includes(release.type)) {
 					errors.push(
 						`Invalid type "${release.type}" for package "${release.name}" in changeset at "${file}".`
 					);


### PR DESCRIPTION
Unless we are doing a very carefully orchestrated roll out of a major release, we never want to accidentally land PRs that will bump a package by a major version. This simple change will fail CI if it contains a changeset that is requesting such a version bump.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: ci change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ci change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> ci change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
