### PR TITLE
Fix: mark the `r2 bulk` command as hidden and experimental

### DIFF
--- a/.changeset/green-parents-play.md
+++ b/.changeset/green-parents-play.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix: mark the `r2 bulk` command as hidden and experimental

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -301,7 +301,6 @@ describe("wrangler", () => {
 				  wrangler r2 object  Manage R2 objects
 				  wrangler r2 bucket  Manage R2 buckets
 				  wrangler r2 sql     Send queries and manage R2 SQL [open-beta]
-				  wrangler r2 bulk    Interact with multiple R2 objects at once
 
 				GLOBAL FLAGS
 				  -c, --config    Path to Wrangler configuration file  [string]

--- a/packages/wrangler/src/__tests__/r2/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/r2/bulk.test.ts
@@ -23,11 +23,6 @@ describe("r2", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"wrangler r2 bulk
 
-				Interact with multiple R2 objects at once
-
-				COMMANDS
-				  wrangler r2 bulk put <bucket>  Create objects in an R2 bucket
-
 				GLOBAL FLAGS
 				  -c, --config    Path to Wrangler configuration file  [string]
 				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]

--- a/packages/wrangler/src/__tests__/r2/help.test.ts
+++ b/packages/wrangler/src/__tests__/r2/help.test.ts
@@ -15,24 +15,23 @@ describe("r2", () => {
 			await runWrangler("r2");
 			await endEventLoop();
 			expect(std.out).toMatchInlineSnapshot(`
-			"wrangler r2
+				"wrangler r2
 
-			📦 Manage R2 buckets & objects
+				📦 Manage R2 buckets & objects
 
-			COMMANDS
-			  wrangler r2 object  Manage R2 objects
-			  wrangler r2 bucket  Manage R2 buckets
-			  wrangler r2 sql     Send queries and manage R2 SQL [open-beta]
-			  wrangler r2 bulk    Interact with multiple R2 objects at once
+				COMMANDS
+				  wrangler r2 object  Manage R2 objects
+				  wrangler r2 bucket  Manage R2 buckets
+				  wrangler r2 sql     Send queries and manage R2 SQL [open-beta]
 
-			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
-		`);
+				GLOBAL FLAGS
+				  -c, --config    Path to Wrangler configuration file  [string]
+				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help      Show help  [boolean]
+				  -v, --version   Show version number  [boolean]"
+			`);
 		});
 
 		it("should show help when an invalid argument is passed", async () => {
@@ -46,25 +45,24 @@ describe("r2", () => {
 			"
 		`);
 			expect(std.out).toMatchInlineSnapshot(`
-			"
-			wrangler r2
+				"
+				wrangler r2
 
-			📦 Manage R2 buckets & objects
+				📦 Manage R2 buckets & objects
 
-			COMMANDS
-			  wrangler r2 object  Manage R2 objects
-			  wrangler r2 bucket  Manage R2 buckets
-			  wrangler r2 sql     Send queries and manage R2 SQL [open-beta]
-			  wrangler r2 bulk    Interact with multiple R2 objects at once
+				COMMANDS
+				  wrangler r2 object  Manage R2 objects
+				  wrangler r2 bucket  Manage R2 buckets
+				  wrangler r2 sql     Send queries and manage R2 SQL [open-beta]
 
-			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
-		`);
+				GLOBAL FLAGS
+				  -c, --config    Path to Wrangler configuration file  [string]
+				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help      Show help  [boolean]
+				  -v, --version   Show version number  [boolean]"
+			`);
 		});
 	});
 });

--- a/packages/wrangler/src/r2/object.ts
+++ b/packages/wrangler/src/r2/object.ts
@@ -37,8 +37,9 @@ export const r2ObjectNamespace = createNamespace({
 export const r2BulkNamespace = createNamespace({
 	metadata: {
 		description: `Interact with multiple R2 objects at once`,
-		status: "stable",
+		status: "experimental",
 		owner: "Product: R2",
+		hidden: true,
 	},
 });
 
@@ -450,8 +451,9 @@ export const r2ObjectDeleteCommand = createCommand({
 export const r2BulkPutCommand = createCommand({
 	metadata: {
 		description: "Create objects in an R2 bucket",
-		status: "stable",
+		status: "experimental",
 		owner: "Product: R2",
+		hidden: true,
 	},
 	positionalArgs: ["bucket"],
 	args: {


### PR DESCRIPTION
This PR is marking the `r2 bulk` command (introduced in #11285) as experimental and hiding it.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because: we 
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this wasn't docu
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: the command is not in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
