### PR TITLE
test: don't render logs to the console in output.test.ts

### DIFF
--- a/packages/wrangler/src/__tests__/output.test.ts
+++ b/packages/wrangler/src/__tests__/output.test.ts
@@ -3,6 +3,7 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { FatalError } from "@cloudflare/workers-utils";
 import { clearOutputFilePath, writeOutput } from "../output";
+import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type { OutputEntry } from "../output";
@@ -10,6 +11,7 @@ import type { OutputEntry } from "../output";
 describe("writeOutput()", () => {
 	runInTempDir({ homedir: "home" });
 	afterEach(clearOutputFilePath);
+	mockConsoleMethods();
 
 	it("should do nothing with no env vars set", () => {
 		vi.stubEnv("WRANGLER_OUTPUT_FILE_DIRECTORY", "");


### PR DESCRIPTION
Previously this test was dumping the error logs into the test output, making it harder to see that it had actually passed.

Before:

<img width="923" height="320" alt="image" src="https://github.com/user-attachments/assets/17024bff-ddb0-4db4-b7be-57a5363cefb2" />


After:

<img width="941" height="257" alt="image" src="https://github.com/user-attachments/assets/a436451c-979c-4ce5-8858-fec91d97f20d" />


<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> test change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
