### PR TITLE
Improve CLI arguments for the `wrangler deploy` command by adding a new generic `--path` option and making the `--script` option explicit

### DIFF
--- a/.changeset/quick-kids-boil.md
+++ b/.changeset/quick-kids-boil.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Improve CLI arguments for the `wrangler deploy` command by adding a new generic `--path` option and making the `--script` option explicit

--- a/packages/workers-utils/src/config/config-helpers.ts
+++ b/packages/workers-utils/src/config/config-helpers.ts
@@ -32,9 +32,11 @@ export function resolveWranglerConfigPath(
 	{
 		config,
 		script,
+		path: inputPath,
 	}: {
 		config?: string;
 		script?: string;
+		path?: string;
 	},
 	options: { useRedirectIfAvailable?: boolean }
 ): ConfigPaths {
@@ -47,7 +49,10 @@ export function resolveWranglerConfigPath(
 		};
 	}
 
-	const leafPath = script !== undefined ? path.dirname(script) : process.cwd();
+	const entryPath = inputPath ?? script;
+
+	const leafPath =
+		entryPath !== undefined ? path.dirname(entryPath) : process.cwd();
 
 	return findWranglerConfig(leafPath, options);
 }

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -12330,6 +12330,43 @@ export default{
 		});
 	});
 
+	it("gives precedence to a provided positional path over a `--script` path", async () => {
+		writeWranglerConfig();
+		fs.writeFileSync("indexA.js", "export default {}");
+		fs.writeFileSync("indexB.js", "export default {}");
+		mockSubDomainRequest();
+		mockUploadWorkerRequest({
+			expectedMainModule: "indexA.js",
+		});
+		await runWrangler("deploy indexA.js --script indexB.js");
+		expect(std).toMatchInlineSnapshot(`
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "info": "",
+			  "out": "
+			 ⛅️ wrangler x.x.x
+			──────────────────
+			Total Upload: xx KiB / gzip: xx KiB
+			Worker Startup Time: 100 ms
+			Uploaded test-name (TIMINGS)
+			Deployed test-name triggers (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev
+			Current Version ID: Galaxy-Class",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mYou have passed both a positional path argument and a --script flag.[0m
+
+
+			  This is not recommended, and the --script flag will be ignored.
+
+			  If you want to deploy a script and point to an assets directory run
+			    \`wrangler deploy <PATH_TO_ENTRY_POINT> --assets <PATH_TO_ASSETS_DIR>\`
+			  instead.
+
+			",
+			}
+		`);
+	});
+
 	describe("`nodejs_compat` compatibility flag", () => {
 		it('when absent, should warn on any "external" `node:*` imports', async () => {
 			writeWranglerConfig();

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -40,7 +40,7 @@ describe("wrangler", () => {
 
 				  wrangler init [name]            📥 Initialize a basic Worker
 				  wrangler dev [script]           👂 Start a local server for developing your Worker
-				  wrangler deploy [script]        🆙 Deploy a Worker to Cloudflare
+				  wrangler deploy [path]          🆙 Deploy a Worker to Cloudflare
 				  wrangler setup                  🪄 Setup a project to work on Cloudflare [experimental]
 				  wrangler deployments            🚢 List and view the current and past deployments for your Worker
 				  wrangler rollback [version-id]  🔙 Rollback a deployment for a Worker
@@ -104,7 +104,7 @@ describe("wrangler", () => {
 
 				  wrangler init [name]            📥 Initialize a basic Worker
 				  wrangler dev [script]           👂 Start a local server for developing your Worker
-				  wrangler deploy [script]        🆙 Deploy a Worker to Cloudflare
+				  wrangler deploy [path]          🆙 Deploy a Worker to Cloudflare
 				  wrangler setup                  🪄 Setup a project to work on Cloudflare [experimental]
 				  wrangler deployments            🚢 List and view the current and past deployments for your Worker
 				  wrangler rollback [version-id]  🔙 Rollback a deployment for a Worker

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -503,13 +503,13 @@ export function validateAssetsArgsAndConfig(
 export function validateAssetsArgsAndConfig(
 	args:
 		| Pick<StartDevOptions, "site" | "assets" | "script">
-		| Pick<DeployArgs, "site" | "assets" | "script">,
+		| Pick<DeployArgs, "site" | "assets" | "path">,
 	config: Config
 ): void;
 export function validateAssetsArgsAndConfig(
 	args:
 		| Pick<StartDevOptions, "site" | "assets" | "script">
-		| Pick<DeployArgs, "site" | "assets" | "script">
+		| Pick<DeployArgs, "site" | "assets" | "path">
 		| Pick<StartDevWorkerOptions, "legacy" | "assets" | "entrypoint">,
 	config?: Config
 ): void {
@@ -533,7 +533,11 @@ export function validateAssetsArgsAndConfig(
 	if (
 		"legacy" in args
 			? args.entrypoint === noOpEntrypoint && args.assets?.binding
-			: !(args.script || config?.main) && config?.assets?.binding
+			: !(
+					("script" in args && args.script) ||
+					("path" in args && args.path) ||
+					config?.main
+				) && config?.assets?.binding
 	) {
 		throw new UserError(
 			"Cannot use assets with a binding in an assets-only Worker.\n" +

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -22,6 +22,7 @@ import type {
 export type ReadConfigCommandArgs = NormalizeAndValidateConfigArgs & {
 	config?: string;
 	script?: string;
+	path?: string;
 };
 
 export type ReadConfigOptions = ResolveConfigPathOptions & {

--- a/packages/wrangler/src/deployment-bundle/entry.ts
+++ b/packages/wrangler/src/deployment-bundle/entry.ts
@@ -53,6 +53,7 @@ export type Entry = {
 export async function getEntry(
 	args: {
 		script?: string;
+		path?: string;
 		moduleRoot?: string;
 		assets?: string | undefined;
 	},
@@ -65,8 +66,10 @@ export async function getEntry(
 		| { absolutePath: string; relativePath: string; projectRoot?: string }
 		| undefined;
 
-	if (args.script) {
-		paths = resolveEntryWithScript(args.script);
+	const entryPath = args.path ?? args.script;
+
+	if (entryPath) {
+		paths = resolveEntryWithScript(entryPath);
 	} else if (config.main !== undefined) {
 		paths = resolveEntryWithMain(config.main, config);
 	} else if (entryPoint) {


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-2333

Before:
<img width="1334" height="596" alt="Screenshot 2025-11-20 at 23 38 40" src="https://github.com/user-attachments/assets/0434297b-abd2-4dd3-9347-1f5a62e3b30b" />

After:
<img width="1283" height="611" alt="Screenshot 2025-11-20 at 23 39 40" src="https://github.com/user-attachments/assets/5a0d5f51-0625-4500-874e-9dc8534bbee8" />



_Describe your change..._

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this will be automatically(?) documented
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: Providing an assets directory to `wrangler deploy` has been added as a new v4-only functionality (see [#10016](https://github.com/cloudflare/workers-sdk/pull/10016))

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
