### PR TITLE
C3: fix step 2 saying that the will be configured using `wrangler setup` when it is not

### DIFF
--- a/.changeset/empty-pandas-exist.md
+++ b/.changeset/empty-pandas-exist.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Fix step 2 saying that the will be configured using `wrangler setup` when it is not

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -158,7 +158,7 @@ const create = async (ctx: C3Context) => {
 
 const configure = async (ctx: C3Context) => {
 	startSection(
-		"Configuring your application for Cloudflare via `wrangler setup`",
+		`Configuring your application for Cloudflare${ctx.args.experimental ? ` via \`wrangler setup\`` : ""}`,
 		"Step 2 of 3",
 	);
 


### PR DESCRIPTION
Right now if I run C3 without the `--experimental` flag, C3 says that it's going to configure the app using `wrangler setup`, which is incorrect. This PR addresses this.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: these logs are not currently being tested
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: minor change not requiring documentation
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
