### PR TITLE
Use more workerd native modules

### DIFF
--- a/.changeset/cold-parents-guess.md
+++ b/.changeset/cold-parents-guess.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/unenv-preset": patch
+"wrangler": patch
+---
+
+Use more workerd native modules
+
+Node modules `punycode`, `trace_events`, `cluster`, `wasi`, and `domains` will be used when enabled
+via a compatibility flag or by default when the compatibility date is greater or equal to 2025-12-04.

--- a/packages/unenv-preset/package.json
+++ b/packages/unenv-preset/package.json
@@ -49,7 +49,7 @@
 	},
 	"peerDependencies": {
 		"unenv": "2.0.0-rc.24",
-		"workerd": "^1.20251106.1"
+		"workerd": "^1.20251125.0"
 	},
 	"peerDependenciesMeta": {
 		"workerd": {

--- a/packages/unenv-preset/src/preset.ts
+++ b/packages/unenv-preset/src/preset.ts
@@ -325,12 +325,11 @@ function getFsOverrides({
  * Returns the overrides for `node:punycode` (unenv or workerd)
  *
  * The native punycode implementation:
- * - is experimental
+ * - is enabled starting from 2025-12-04
  * - can be enabled with the "enable_nodejs_punycode_module" flag
  * - can be disabled with the "disable_nodejs_punycode_module" flag
  */
 function getPunycodeOverrides({
-	// eslint-disable-next-line unused-imports/no-unused-vars
 	compatibilityDate,
 	compatibilityFlags,
 }: {
@@ -341,12 +340,13 @@ function getPunycodeOverrides({
 		"disable_nodejs_punycode_module"
 	);
 
-	// TODO: add `enabledByDate` when a date is defined in workerd
-	const enabledByFlag =
-		compatibilityFlags.includes("enable_nodejs_punycode_module") &&
-		compatibilityFlags.includes("experimental");
+	const enabledByFlag = compatibilityFlags.includes(
+		"enable_nodejs_punycode_module"
+	);
 
-	const enabled = enabledByFlag && !disabledByFlag;
+	const enabledByDate = compatibilityDate >= "2025-12-04";
+
+	const enabled = (enabledByFlag || enabledByDate) && !disabledByFlag;
 
 	return enabled
 		? {
@@ -363,12 +363,11 @@ function getPunycodeOverrides({
  * Returns the overrides for `node:cluster` (unenv or workerd)
  *
  * The native cluster implementation:
- * - is experimental
+ * - is enabled starting from 2025-12-04
  * - can be enabled with the "enable_nodejs_cluster_module" flag
  * - can be disabled with the "disable_nodejs_cluster_module" flag
  */
 function getClusterOverrides({
-	// eslint-disable-next-line unused-imports/no-unused-vars
 	compatibilityDate,
 	compatibilityFlags,
 }: {
@@ -379,12 +378,13 @@ function getClusterOverrides({
 		"disable_nodejs_cluster_module"
 	);
 
-	// TODO: add `enabledByDate` when a date is defined in workerd
-	const enabledByFlag =
-		compatibilityFlags.includes("enable_nodejs_cluster_module") &&
-		compatibilityFlags.includes("experimental");
+	const enabledByFlag = compatibilityFlags.includes(
+		"enable_nodejs_cluster_module"
+	);
 
-	const enabled = enabledByFlag && !disabledByFlag;
+	const enabledByDate = compatibilityDate >= "2025-12-04";
+
+	const enabled = (enabledByFlag || enabledByDate) && !disabledByFlag;
 
 	return enabled
 		? {
@@ -401,12 +401,11 @@ function getClusterOverrides({
  * Returns the overrides for `node:trace_events` (unenv or workerd)
  *
  * The native trace_events implementation:
- * - is experimental
+ * - is enabled starting from 2025-12-04
  * - can be enabled with the "enable_nodejs_trace_events_module" flag
  * - can be disabled with the "disable_nodejs_trace_events_module" flag
  */
 function getTraceEventsOverrides({
-	// eslint-disable-next-line unused-imports/no-unused-vars
 	compatibilityDate,
 	compatibilityFlags,
 }: {
@@ -417,12 +416,13 @@ function getTraceEventsOverrides({
 		"disable_nodejs_trace_events_module"
 	);
 
-	// TODO: add `enabledByDate` when a date is defined in workerd
-	const enabledByFlag =
-		compatibilityFlags.includes("enable_nodejs_trace_events_module") &&
-		compatibilityFlags.includes("experimental");
+	const enabledByFlag = compatibilityFlags.includes(
+		"enable_nodejs_trace_events_module"
+	);
 
-	const enabled = enabledByFlag && !disabledByFlag;
+	const enabledByDate = compatibilityDate >= "2025-12-04";
+
+	const enabled = (enabledByFlag || enabledByDate) && !disabledByFlag;
 
 	return enabled
 		? {
@@ -439,12 +439,11 @@ function getTraceEventsOverrides({
  * Returns the overrides for `node:domain` (unenv or workerd)
  *
  * The native domain implementation:
- * - is experimental
+ * - is enabled starting from 2025-12-04
  * - can be enabled with the "enable_nodejs_domain_module" flag
  * - can be disabled with the "disable_nodejs_domain_module" flag
  */
 function getDomainOverrides({
-	// eslint-disable-next-line unused-imports/no-unused-vars
 	compatibilityDate,
 	compatibilityFlags,
 }: {
@@ -455,12 +454,13 @@ function getDomainOverrides({
 		"disable_nodejs_domain_module"
 	);
 
-	// TODO: add `enabledByDate` when a date is defined in workerd
-	const enabledByFlag =
-		compatibilityFlags.includes("enable_nodejs_domain_module") &&
-		compatibilityFlags.includes("experimental");
+	const enabledByFlag = compatibilityFlags.includes(
+		"enable_nodejs_domain_module"
+	);
 
-	const enabled = enabledByFlag && !disabledByFlag;
+	const enabledByDate = compatibilityDate >= "2025-12-04";
+
+	const enabled = (enabledByFlag || enabledByDate) && !disabledByFlag;
 
 	return enabled
 		? {
@@ -477,12 +477,11 @@ function getDomainOverrides({
  * Returns the overrides for `node:wasi` (unenv or workerd)
  *
  * The native wasi implementation:
- * - is experimental
+ * - is enabled starting from 2025-12-04
  * - can be enabled with the "enable_nodejs_wasi_module" flag
  * - can be disabled with the "disable_nodejs_wasi_module" flag
  */
 function getWasiOverrides({
-	// eslint-disable-next-line unused-imports/no-unused-vars
 	compatibilityDate,
 	compatibilityFlags,
 }: {
@@ -493,12 +492,13 @@ function getWasiOverrides({
 		"disable_nodejs_wasi_module"
 	);
 
-	// TODO: add `enabledByDate` when a date is defined in workerd
-	const enabledByFlag =
-		compatibilityFlags.includes("enable_nodejs_wasi_module") &&
-		compatibilityFlags.includes("experimental");
+	const enabledByFlag = compatibilityFlags.includes(
+		"enable_nodejs_wasi_module"
+	);
 
-	const enabled = enabledByFlag && !disabledByFlag;
+	const enabledByDate = compatibilityDate >= "2025-12-04";
+
+	const enabled = (enabledByFlag || enabledByDate) && !disabledByFlag;
 
 	return enabled
 		? {

--- a/packages/wrangler/e2e/unenv-preset/preset.test.ts
+++ b/packages/wrangler/e2e/unenv-preset/preset.test.ts
@@ -236,21 +236,21 @@ const localTestConfigs: TestConfig[] = [
 	],
 	// node:punycode
 	[
-		// TODO: add test for disabled by date (no date defined yet)
-		// TODO: add test for enabled by date (no date defined yet)
+		// TODO: add test for disabled by date (2025-12-04)
+		// TODO: add test for enabled by date (2025-12-04)
 		{
 			name: "punycode enabled by flag",
 			compatibilityDate: "2024-09-23",
-			compatibilityFlags: ["enable_nodejs_punycode_module", "experimental"],
+			compatibilityFlags: ["enable_nodejs_punycode_module"],
 			expectRuntimeFlags: {
 				enable_nodejs_punycode_module: true,
 			},
 		},
-		// TODO: update the date past the default enable date (when defined)
+		// TODO: update the date past the default enable date (2025-12-04)
 		{
 			name: "punycode disabled by flag",
 			compatibilityDate: "2024-09-23",
-			compatibilityFlags: ["disable_nodejs_punycode_module", "experimental"],
+			compatibilityFlags: ["disable_nodejs_punycode_module"],
 			expectRuntimeFlags: {
 				enable_nodejs_punycode_module: false,
 			},
@@ -258,21 +258,21 @@ const localTestConfigs: TestConfig[] = [
 	],
 	// node:cluster
 	[
-		// TODO: add test for disabled by date (no date defined yet)
-		// TODO: add test for enabled by date (no date defined yet)
+		// TODO: add test for disabled by date (2025-12-04)
+		// TODO: add test for enabled by date (2025-12-04)
 		{
 			name: "cluster enabled by flag",
 			compatibilityDate: "2024-09-23",
-			compatibilityFlags: ["enable_nodejs_cluster_module", "experimental"],
+			compatibilityFlags: ["enable_nodejs_cluster_module"],
 			expectRuntimeFlags: {
 				enable_nodejs_cluster_module: true,
 			},
 		},
-		// TODO: update the date past the default enable date (when defined)
+		// TODO: update the date past the default enable date (2025-12-04)
 		{
 			name: "cluster disabled by flag",
 			compatibilityDate: "2024-09-23",
-			compatibilityFlags: ["disable_nodejs_cluster_module", "experimental"],
+			compatibilityFlags: ["disable_nodejs_cluster_module"],
 			expectRuntimeFlags: {
 				enable_nodejs_cluster_module: false,
 			},
@@ -280,24 +280,21 @@ const localTestConfigs: TestConfig[] = [
 	],
 	// trace_events
 	[
-		// TODO: add test for disabled by date (no date defined yet)
-		// TODO: add test for enabled by date (no date defined yet)
+		// TODO: add test for disabled by date (2025-12-04)
+		// TODO: add test for enabled by date (2025-12-04)
 		{
 			name: "trace_events enabled by flag",
 			compatibilityDate: "2024-09-23",
-			compatibilityFlags: ["enable_nodejs_trace_events_module", "experimental"],
+			compatibilityFlags: ["enable_nodejs_trace_events_module"],
 			expectRuntimeFlags: {
 				enable_nodejs_trace_events_module: true,
 			},
 		},
-		// TODO: update the date past the default enable date (when defined)
+		// TODO: update the date past the default enable date (2025-12-04)
 		{
 			name: "trace_events disabled by flag",
 			compatibilityDate: "2024-09-23",
-			compatibilityFlags: [
-				"disable_nodejs_trace_events_module",
-				"experimental",
-			],
+			compatibilityFlags: ["disable_nodejs_trace_events_module"],
 			expectRuntimeFlags: {
 				enable_nodejs_trace_events_module: false,
 			},
@@ -305,21 +302,21 @@ const localTestConfigs: TestConfig[] = [
 	],
 	// domain
 	[
-		// TODO: add test for disabled by date (no date defined yet)
-		// TODO: add test for enabled by date (no date defined yet)
+		// TODO: add test for disabled by date (2025-12-04)
+		// TODO: add test for enabled by date (2025-12-04)
 		{
 			name: "domain enabled by flag",
 			compatibilityDate: "2024-09-23",
-			compatibilityFlags: ["enable_nodejs_domain_module", "experimental"],
+			compatibilityFlags: ["enable_nodejs_domain_module"],
 			expectRuntimeFlags: {
 				enable_nodejs_domain_module: true,
 			},
 		},
-		// TODO: update the date past the default enable date (when defined)
+		// TODO: update the date past the default enable date (2025-12-04)
 		{
 			name: "domain disabled by flag",
 			compatibilityDate: "2024-09-23",
-			compatibilityFlags: ["disable_nodejs_domain_module", "experimental"],
+			compatibilityFlags: ["disable_nodejs_domain_module"],
 			expectRuntimeFlags: {
 				enable_nodejs_domain_module: false,
 			},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2281,8 +2281,8 @@ importers:
         specifier: 2.0.0-rc.24
         version: 2.0.0-rc.24
       workerd:
-        specifier: ^1.20251106.1
-        version: 1.20251106.1
+        specifier: ^1.20251125.0
+        version: 1.20251126.0
     devDependencies:
       '@types/node-unenv':
         specifier: npm:@types/node@^22.14.0
@@ -4817,8 +4817,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-64@1.20251106.1':
-    resolution: {integrity: sha512-COAzvEUZRELcHLtc7q16Zl9uMzgrYiki6BjSiScS5v+sT2qTH5bGFi2DMJs40AflCiclkhaEClEalxvmgDxwBA==}
+  '@cloudflare/workerd-darwin-64@1.20251126.0':
+    resolution: {integrity: sha512-TlZEz94vrVq0fdbabfPvfKsz/M0uzmrtdMvszlHjoNqzg3EvCUcVt7evrfmqIF3H4dQyUSDftxDGv/kIFYzFeg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
@@ -4841,8 +4841,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20251106.1':
-    resolution: {integrity: sha512-9xfuYwiZSnlY4b516GIkFtcnsR4kYzp5t/3L5wQPk7pg3fE8OuicTq4HFwTayfPdBegdYCob3C0ighrmFxOwtw==}
+  '@cloudflare/workerd-darwin-arm64@1.20251126.0':
+    resolution: {integrity: sha512-nOsSCANd+jZ/KMs24VT5caCYURcWGsOQyREuSo+J6meMaOk/3uG2gmsYT5eErM24ovithe7ucPJbNpJk5F1ioQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -4865,8 +4865,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-64@1.20251106.1':
-    resolution: {integrity: sha512-IHdku5DJmZHVcXfAxkX5AmpSuFnSGF8vyvv7tFZnHoIgnqa9GZMlqoOA/F7dRoivw9JzvccjEYxAeq9MY0aAhQ==}
+  '@cloudflare/workerd-linux-64@1.20251126.0':
+    resolution: {integrity: sha512-UqLaKUVMv+DX2HibvcBq0Wk7YvaOibotpEKFgsoYpJoQlbUkRPbTrFTgfckAPltmq2EgmHiFo84l2hnE0V1XTg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
@@ -4889,8 +4889,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20251106.1':
-    resolution: {integrity: sha512-GXIcky/w1uYLKxEfLxEoxAutw7xWHUO6aPeaAod0XkWV31E0AwDlr77Qys6zI35WicLrFa2wRNtsH5AfvT020g==}
+  '@cloudflare/workerd-linux-arm64@1.20251126.0':
+    resolution: {integrity: sha512-9gdAdIc1rF7Yh2s4MLQpARTVcy9ceHwZdssXY25BsFnQWfW2m/823YUxbenFhCMZvezBa0D+EIreb4bFQjDbtg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
@@ -4913,8 +4913,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workerd-windows-64@1.20251106.1':
-    resolution: {integrity: sha512-Br5nxQCjINrGFlpreNJPXdbfkH3L/dGHmyjLMbZdWGqnTEuOLRu3Hn2PmNw5pB14FtmW22ZOZbtZE057rJrZmA==}
+  '@cloudflare/workerd-windows-64@1.20251126.0':
+    resolution: {integrity: sha512-5lg8Ajdmo1G8RWwdH/GpPcKPr1SAd24SGUsnQMOJeMGGD3vGp/gaPh9LeMxxoLFApa8EGCVZwtOxS47ilgxBEQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -14586,8 +14586,8 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  workerd@1.20251106.1:
-    resolution: {integrity: sha512-q2/FPat1b5FhN6Y2w2jZDP3pxpvOz5/y3AvwmgiU9H+Wk1pAaqW3D6bj7ONPpsBUGlddqLSTMGi4woXgng2WzA==}
+  workerd@1.20251126.0:
+    resolution: {integrity: sha512-VMKtzD2uKWTS7g139XvkvttrmcZO/aie5jNGkpkcW742Tr8TJiyCra4kyiFBGv7PVEzMFa1JpZ6NJqxX6H5zqQ==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -16016,7 +16016,7 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20250417.0':
     optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20251106.1':
+  '@cloudflare/workerd-darwin-64@1.20251126.0':
     optional: true
 
   '@cloudflare/workerd-darwin-64@1.20251128.0':
@@ -16028,7 +16028,7 @@ snapshots:
   '@cloudflare/workerd-darwin-arm64@1.20250417.0':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20251106.1':
+  '@cloudflare/workerd-darwin-arm64@1.20251126.0':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20251128.0':
@@ -16040,7 +16040,7 @@ snapshots:
   '@cloudflare/workerd-linux-64@1.20250417.0':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20251106.1':
+  '@cloudflare/workerd-linux-64@1.20251126.0':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20251128.0':
@@ -16052,7 +16052,7 @@ snapshots:
   '@cloudflare/workerd-linux-arm64@1.20250417.0':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20251106.1':
+  '@cloudflare/workerd-linux-arm64@1.20251126.0':
     optional: true
 
   '@cloudflare/workerd-linux-arm64@1.20251128.0':
@@ -16064,7 +16064,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20250417.0':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20251106.1':
+  '@cloudflare/workerd-windows-64@1.20251126.0':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20251128.0':
@@ -26435,13 +26435,13 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20250417.0
       '@cloudflare/workerd-windows-64': 1.20250417.0
 
-  workerd@1.20251106.1:
+  workerd@1.20251126.0:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20251106.1
-      '@cloudflare/workerd-darwin-arm64': 1.20251106.1
-      '@cloudflare/workerd-linux-64': 1.20251106.1
-      '@cloudflare/workerd-linux-arm64': 1.20251106.1
-      '@cloudflare/workerd-windows-64': 1.20251106.1
+      '@cloudflare/workerd-darwin-64': 1.20251126.0
+      '@cloudflare/workerd-darwin-arm64': 1.20251126.0
+      '@cloudflare/workerd-linux-64': 1.20251126.0
+      '@cloudflare/workerd-linux-arm64': 1.20251126.0
+      '@cloudflare/workerd-windows-64': 1.20251126.0
 
   workerd@1.20251128.0:
     optionalDependencies:


### PR DESCRIPTION
Node modules `punycode`, `trace_events`, `cluster`, `wasi`, and `domains` are no more experimental since [workerd 20251122](https://github.com/cloudflare/workerd/releases/tag/v1.20251122.0).

This PR uses workerd 20251125 as 202551122 and 202551123 have not been released to npm.

~Note that remote tests are failing for now as 202551122 must not have been released to prod yet. A CI re-run should fix the error after the deployment.~ workerd was deployed

/cc @anonrig @jasnell 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: documented by the runtime team
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: unenv changes not released to v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
