### PR TITLE
ci: fix the cleanup script which stopped working for Pages projects

### DIFF
--- a/tools/e2e/__tests__/common.test.ts
+++ b/tools/e2e/__tests__/common.test.ts
@@ -46,7 +46,6 @@ describe("listTmpE2EProjects()", () => {
 			.intercept({
 				path: `/client/v4/accounts/${MOCK_CLOUDFLARE_ACCOUNT_ID}/pages/projects`,
 				query: {
-					per_page: 100,
 					page: 1,
 				},
 			})
@@ -80,7 +79,6 @@ describe("listTmpE2EProjects()", () => {
 			.intercept({
 				path: `/client/v4/accounts/${MOCK_CLOUDFLARE_ACCOUNT_ID}/pages/projects`,
 				query: {
-					per_page: 100,
 					page: 2,
 				},
 			})
@@ -136,7 +134,6 @@ describe("listTmpKVNamespaces()", () => {
 				path: `/client/v4/accounts/${MOCK_CLOUDFLARE_ACCOUNT_ID}/storage/kv/namespaces`,
 				method: "GET",
 				query: {
-					per_page: 100,
 					page: 1,
 				},
 			})
@@ -171,7 +168,6 @@ describe("listTmpKVNamespaces()", () => {
 				path: `/client/v4/accounts/${MOCK_CLOUDFLARE_ACCOUNT_ID}/storage/kv/namespaces`,
 				method: "GET",
 				query: {
-					per_page: 100,
 					page: 2,
 				},
 			})
@@ -219,7 +215,6 @@ describe("listTmpDatabases()", () => {
 				path: `/client/v4/accounts/${MOCK_CLOUDFLARE_ACCOUNT_ID}/d1/database`,
 				method: "GET",
 				query: {
-					per_page: 100,
 					page: 1,
 				},
 			})
@@ -258,7 +253,6 @@ describe("listTmpDatabases()", () => {
 				path: `/client/v4/accounts/${MOCK_CLOUDFLARE_ACCOUNT_ID}/d1/database`,
 				method: "GET",
 				query: {
-					per_page: 100,
 					page: 2,
 				},
 			})
@@ -312,7 +306,7 @@ describe("listTmpE2EWorkers()", () => {
 			.get("https://api.cloudflare.com")
 			.intercept({
 				path: `/client/v4/accounts/${MOCK_CLOUDFLARE_ACCOUNT_ID}/workers/scripts`,
-				query: { per_page: 100, page: 1 },
+				query: { page: 1 },
 				method: "GET",
 			})
 			.reply(

--- a/tools/e2e/common.ts
+++ b/tools/e2e/common.ts
@@ -86,6 +86,12 @@ async function apiFetchResponse(
 	});
 
 	if (response.status >= 400) {
+		console.error(
+			"API Fetch failed",
+			response.status,
+			response.statusText,
+			await response.text()
+		);
 		throw { url, init, response };
 	}
 
@@ -132,7 +138,6 @@ async function apiFetchList<T>(path: string, queryParams = {}): Promise<T[]> {
 				{ method: "GET" },
 				{
 					page,
-					per_page: 100,
 					...queryParams,
 				}
 			);


### PR DESCRIPTION
Something about the `per_page` parameter seems to cause the listing of Pages projects to respond with a 400 Bad Request. Removing it and going with the default seems fine.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal tooling
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> only `main` does this cleanup

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
