### PR TITLE
ci: drop pnpm-filter in install-dependencies

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -5,9 +5,6 @@ inputs:
   node-version:
     description: the version of Node.js to install
     default: 22
-  pnpm-filters:
-    description: space-separated list of pnpm filters to apply (e.g., "wrangler miniflare")
-    default: ""
   turbo-api:
     description: the api URL for connecting to the turbo remote cache
   turbo-team:
@@ -44,14 +41,4 @@ runs:
 
     - name: Install NPM Dependencies
       shell: bash
-      # Still install the root dependencies even if filters are provided.
-      # Some packages may depend on root-level packages.
-      run: |
-        FILTERS=""
-        if [ -n "${{ inputs.pnpm-filters }}" ]; then
-          FILTERS="--filter ./"
-          for filter in ${{ inputs.pnpm-filters }}; do
-            FILTERS="$FILTERS --filter $filter"
-          done
-        fi
-        pnpm install --frozen-lockfile $FILTERS
+      run: pnpm install --frozen-lockfile

--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -16,10 +16,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: ./.github/actions/install-dependencies
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: 22 # need this version for `Set` methods
-          pnpm-filters: "./tools"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+
+      - name: Install Dependencies
+        run: pnpm i -F tools --frozen-lockfile
 
       - name: Auto-assign issue
         run: node -r esbuild-register tools/github-workflow-helpers/auto-assign-issues.ts

--- a/.github/workflows/c3-dependabot-versioning-prs.yml
+++ b/.github/workflows/c3-dependabot-versioning-prs.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
-        with:
-          pnpm-filters: "./tools"
 
       - name: Configure Git
         run: |

--- a/.github/workflows/e2e-project-cleanup.yml
+++ b/.github/workflows/e2e-project-cleanup.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
-        with:
-          pnpm-filters: "./tools"
 
       - name: Cleanup E2E test projects
         run: node -r esbuild-register tools/e2e/e2eCleanup.ts

--- a/.github/workflows/miniflare-dependabot-versioning-prs.yml
+++ b/.github/workflows/miniflare-dependabot-versioning-prs.yml
@@ -25,8 +25,6 @@ jobs:
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
-        with:
-          pnpm-filters: "./tools"
 
       - name: Configure Git
         run: |

--- a/.github/workflows/open-v3-maintenance-prs.yml
+++ b/.github/workflows/open-v3-maintenance-prs.yml
@@ -33,8 +33,6 @@ jobs:
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
-        with:
-          pnpm-filters: "./tools"
 
       - uses: Ana06/get-changed-files@v2.3.0
         id: files

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
         with:
-          pnpm-filters: "./packages/*"
           turbo-api: ${{ secrets.TURBO_API }}
           turbo-team: ${{ secrets.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/validate-pr-description.yml
+++ b/.github/workflows/validate-pr-description.yml
@@ -44,7 +44,6 @@ jobs:
         if: steps.changes.outputs.everything_but_markdown == 'true'
         uses: ./.github/actions/install-dependencies
         with:
-          pnpm-filters: "./tools"
           turbo-api: ${{ secrets.TURBO_API }}
           turbo-team: ${{ secrets.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION
In #11372 I added a `pnpm-filter` input to filter the packages to install.

One problem is that it seems to break CI sometimes

<img width="1096" height="204" alt="image" src="https://github.com/user-attachments/assets/4a37aeba-568e-471e-8485-2100f88b7e77" />

Also because dependencies are cached, when the cache is generated from a filtered version, filtered out packages have to be downloaded again for the other workflows.

So I think downloading more is better because it can be cached across workflows and PRs.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: ci
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ci
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: ci

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
