### PR TITLE
test URLs rather than requests in kv-asset-handler

### DIFF
--- a/packages/kv-asset-handler/test/serveSinglePageApp.test.ts
+++ b/packages/kv-asset-handler/test/serveSinglePageApp.test.ts
@@ -22,7 +22,7 @@ test("serveSinglePageApp returns root asset path when request path ends in .html
 	const expected_request = testRequest("/index.html");
 	const actual_request = serveSinglePageApp(request);
 
-	expect(expected_request).toEqual(actual_request);
+	expect(expected_request.url).toEqual(actual_request.url);
 });
 
 test("serveSinglePageApp returns root asset path when request path does not have extension", async () => {
@@ -32,7 +32,7 @@ test("serveSinglePageApp returns root asset path when request path does not have
 	const expected_request = testRequest("/index.html");
 	const actual_request = serveSinglePageApp(request);
 
-	expect(expected_request).toEqual(actual_request);
+	expect(expected_request.url).toEqual(actual_request.url);
 });
 
 test("serveSinglePageApp returns requested asset when request path has non-html extension", async () => {
@@ -42,5 +42,5 @@ test("serveSinglePageApp returns requested asset when request path has non-html 
 	const expected_request = request;
 	const actual_request = serveSinglePageApp(request);
 
-	expect(expected_request).toEqual(actual_request);
+	expect(expected_request.url).toEqual(actual_request.url);
 });


### PR DESCRIPTION
Vitest always returns true for Request object comparisons, so we need to compare the URLs instead. See https://github.com/cloudflare/workers-sdk/pull/11348/files/2360f9166203dc12c50008a91a3cb2ce0bfa1c93#r2561982199

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> original was not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
