### PR TITLE
ci: make the release failure alert resilient to missing `DEPLOYMENT_STATUS`

### DIFF
--- a/tools/deployments/alert-on-error.ts
+++ b/tools/deployments/alert-on-error.ts
@@ -23,7 +23,7 @@ if (require.main === module) {
 		} catch (e) {
 			status.push({
 				label: "Deployment status",
-				details: `Failed to parse deployment status: ${e}`,
+				details: `Failed to parse deployment status: ${e}. Received: "${process.env.DEPLOYMENT_STATUS}"`,
 			});
 		}
 	}


### PR DESCRIPTION
If the npm release fails then the non-npm release is not even attempted. In which case the `DEPLOYMENT_STATUS` is empty, which was causing the JSON parsing to fail and no alert to be sent.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: CI fix
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Ci fix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->  v3 releases do not send alerts

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
