### PR TITLE
ci: use the correct npm version for releases

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -27,10 +27,14 @@ jobs:
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
         with:
+          node-version: 24
           turbo-api: ${{ secrets.TURBO_API }}
           turbo-team: ${{ secrets.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}
           turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+
+      - name: Check npm version
+        run: node -r esbuild-register tools/deployments/check-npm-version.ts
 
       - name: Check the changesets
         run: node -r esbuild-register tools/deployments/validate-changesets.ts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1218,7 +1218,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ~3.0.7
-        version: 3.0.9(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/ui@3.2.3)(jiti@2.6.0)(lightningcss@1.30.2)(yaml@2.8.1)
+        version: 3.0.9(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/ui@3.2.3(vitest@3.2.3))(jiti@2.6.0)(lightningcss@1.30.2)(yaml@2.8.1)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -4127,6 +4127,9 @@ importers:
       '@octokit/webhooks-types':
         specifier: ^7.6.1
         version: 7.6.1
+      '@types/semver':
+        specifier: ^7.5.1
+        version: 7.5.1
       '@typescript-eslint/eslint-plugin':
         specifier: catalog:default
         version: 8.46.3(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.0))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.0))(typescript@5.9.3)
@@ -4142,6 +4145,9 @@ importers:
       glob:
         specifier: ^11.0.3
         version: 11.0.3
+      semver:
+        specifier: ^7.7.1
+        version: 7.7.3
       ts-dedent:
         specifier: ^2.2.0
         version: 2.2.0
@@ -12936,11 +12942,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.7.2:
-    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
@@ -15221,7 +15222,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.7.1
+      semver: 7.7.3
 
   '@changesets/assemble-release-plan@6.0.9':
     dependencies:
@@ -15230,7 +15231,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.7.1
+      semver: 7.7.3
 
   '@changesets/changelog-git@0.2.1':
     dependencies:
@@ -15271,7 +15272,7 @@ snapshots:
       package-manager-detector: 0.2.9
       picocolors: 1.1.1
       resolve-from: 5.0.0
-      semver: 7.7.1
+      semver: 7.7.3
       spawndamnit: 3.0.1
       term-size: 2.2.1
     transitivePeerDependencies:
@@ -15669,7 +15670,7 @@ snapshots:
       devalue: 4.3.3
       esbuild: 0.17.19
       miniflare: 3.20250310.0
-      semver: 7.7.1
+      semver: 7.7.3
       vitest: 2.1.9(@types/node@20.19.9)(@vitest/ui@2.1.9)(lightningcss@1.30.2)
       wrangler: 3.114.1(@cloudflare/workers-types@4.20251125.0)
       zod: 3.22.3
@@ -15686,7 +15687,7 @@ snapshots:
       cjs-module-lexer: 1.2.3
       devalue: 4.3.3
       miniflare: 4.20250417.0
-      semver: 7.7.2
+      semver: 7.7.3
       vitest: 3.2.3(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/ui@3.2.3)(jiti@2.6.0)(lightningcss@1.30.2)(msw@2.4.3(typescript@5.8.3))(supports-color@9.2.2)(yaml@2.8.1)
       wrangler: 4.12.1(@cloudflare/workers-types@4.20251125.0)
       zod: 3.22.3
@@ -16410,7 +16411,7 @@ snapshots:
       '@babel/traverse': 7.25.9
       '@babel/types': 7.26.3
       prettier: 3.2.5
-      semver: 7.7.1
+      semver: 7.7.3
     optionalDependencies:
       '@vue/compiler-sfc': 3.3.4
     transitivePeerDependencies:
@@ -16606,7 +16607,7 @@ snapshots:
       parse-github-url: 1.0.2
       picocolors: 1.1.1
       sembear: 0.7.0
-      semver: 7.7.1
+      semver: 7.7.3
       tinyexec: 0.3.2
       validate-npm-package-name: 5.0.1
 
@@ -17052,7 +17053,7 @@ snapshots:
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
-      semver: 7.7.2
+      semver: 7.7.3
       tar-fs: 3.1.0
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -19793,7 +19794,7 @@ snapshots:
       js-string-escape: 1.0.1
       lodash: 4.17.21
       md5-hex: 3.0.1
-      semver: 7.7.2
+      semver: 7.7.3
       well-known-symbols: 2.0.0
 
   concurrently@8.2.2:
@@ -22228,7 +22229,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.7.2
+      semver: 7.7.3
 
   jsprim@2.0.2:
     dependencies:
@@ -22677,7 +22678,7 @@ snapshots:
       pkg-types: 1.3.1
       postcss: 8.5.6
       postcss-nested: 7.0.2(postcss@8.5.6)
-      semver: 7.7.2
+      semver: 7.7.3
       tinyglobby: 0.2.15
     optionalDependencies:
       typescript: 5.8.3
@@ -24216,8 +24217,6 @@ snapshots:
 
   semver@7.7.1: {}
 
-  semver@7.7.2: {}
-
   semver@7.7.3: {}
 
   send@0.19.0:
@@ -24310,7 +24309,7 @@ snapshots:
     dependencies:
       color: 4.2.3
       detect-libc: 2.0.3
-      semver: 7.7.2
+      semver: 7.7.3
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5
@@ -25654,7 +25653,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@3.0.9(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/ui@3.2.3)(jiti@2.6.0)(lightningcss@1.30.2)(yaml@2.8.1):
+  vitest@3.0.9(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/ui@3.2.3(vitest@3.2.3))(jiti@2.6.0)(lightningcss@1.30.2)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 3.0.9
       '@vitest/mocker': 3.0.9(vite@5.4.14(@types/node@20.19.9)(lightningcss@1.30.2))
@@ -25743,7 +25742,7 @@ snapshots:
     dependencies:
       '@volar/typescript': 2.4.0-alpha.18
       '@vue/language-core': 2.0.29(typescript@5.8.3)
-      semver: 7.7.2
+      semver: 7.7.3
       typescript: 5.8.3
 
   warning@4.0.3:

--- a/tools/deployments/check-npm-version.ts
+++ b/tools/deployments/check-npm-version.ts
@@ -1,0 +1,20 @@
+import { execSync } from "node:child_process";
+import { compare } from "semver";
+
+/**
+ * For Trusted Publishing to work, we need npm version 11.5.1 or higher.
+ */
+function checkNpmVersion() {
+	const npmVersionBuffer = execSync("npm --version");
+	const npmVersion = npmVersionBuffer.toString().trim();
+	if (compare(npmVersion, "11.5.1") === -1) {
+		console.error(
+			`Error: npm version 11.5.1 or higher is required for Trusted Publishing to work, found version ${npmVersion}`
+		);
+		process.exit(1);
+	}
+}
+
+if (require.main === module) {
+	checkNpmVersion();
+}

--- a/tools/package.json
+++ b/tools/package.json
@@ -14,11 +14,13 @@
 		"@cloudflare/eslint-config-shared": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@octokit/webhooks-types": "^7.6.1",
+		"@types/semver": "^7.5.1",
 		"@typescript-eslint/eslint-plugin": "catalog:default",
 		"@typescript-eslint/parser": "catalog:default",
 		"eslint": "catalog:default",
 		"find-up": "^6.3.0",
 		"glob": "^11.0.3",
+		"semver": "^7.7.1",
 		"ts-dedent": "^2.2.0",
 		"undici": "catalog:default",
 		"wrangler": "workspace:*"


### PR DESCRIPTION
Trusted publishing requires the installed npm to be at least 11.5.1. We get this automatically via Node 24.

See https://docs.npmjs.com/trusted-publishers

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: CI
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: CI
- Wrangler V3 Backport
  - [x] Wrangler PR: #11424
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> 

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
