### PR TITLE
ci: move the "other node versions" tests to their own workflow

### DIFF
--- a/.github/workflows/test-and-check-other-node.yml
+++ b/.github/workflows/test-and-check-other-node.yml
@@ -1,0 +1,64 @@
+name: CI (Other Node Versions)
+description: Run primary tests on other supported Node.js versions
+
+on:
+  merge_group:
+  pull_request:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  test-other-node-versions:
+    timeout-minutes: 45
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.node_version }}-test-other-node-versions
+      cancel-in-progress: true
+    name: ${{ format('Tests ({0})', matrix.description) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { node_version: 20, description: "Node 20" }
+          - { node_version: 24, description: "Node 24" }
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Filter changed paths
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            everything_but_markdown:
+              - '!**/*.md'
+
+      - name: Install Dependencies
+        if: steps.changes.outputs.everything_but_markdown == 'true'
+        uses: ./.github/actions/install-dependencies
+        with:
+          node-version: ${{ matrix.node_version }}
+          turbo-api: ${{ secrets.TURBO_API }}
+          turbo-team: ${{ secrets.TURBO_TEAM }}
+          turbo-token: ${{ secrets.TURBO_TOKEN }}
+          turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+
+      - name: Run tests (packages)
+        # We are running the package tests first be able to get early feedback on changes.
+        # There is no point in running the fixtures if a package is broken.
+        if: ${{
+          matrix.node_version != 24 ||
+          contains(github.event.pull_request.labels.*.name, 'test on node 24')
+          }}
+        run: pnpm run test:ci --log-order=stream --concurrency=1 --filter="./packages/*"
+        env:
+          NODE_OPTIONS: "--max_old_space_size=8192"
+          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-debug-logs/
+          TEST_REPORT_PATH: ${{ runner.temp }}/test-report/packages/index.html
+          CI_OS: ${{ matrix.description }}
+          NODE_DEBUG: "@cloudflare:vite-plugin"

--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   merge_group:
   pull_request:
-    types: [synchronize, opened, reopened, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -169,58 +168,3 @@ jobs:
         with:
           name: turbo-runs-${{ matrix.os }}
           path: .turbo/runs
-
-  # This job runs the main packages' tests on other supported Node.js versions to ensure compatibility.
-  test-other-node-versions:
-    timeout-minutes: 45
-    runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.node_version }}-test-other-node-versions
-      cancel-in-progress: true
-    name: ${{ format('Tests ({0})', matrix.description) }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - { node_version: 20, description: "Node 20" }
-          - { node_version: 24, description: "Node 24" }
-
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Filter changed paths
-        uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-            everything_but_markdown:
-              - '!**/*.md'
-
-      - name: Install Dependencies
-        if: steps.changes.outputs.everything_but_markdown == 'true'
-        uses: ./.github/actions/install-dependencies
-        with:
-          node-version: ${{ matrix.node_version }}
-          turbo-api: ${{ secrets.TURBO_API }}
-          turbo-team: ${{ secrets.TURBO_TEAM }}
-          turbo-token: ${{ secrets.TURBO_TOKEN }}
-          turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
-
-      - name: Run tests (packages)
-        # We are running the package tests first be able to get early feedback on changes.
-        # There is no point in running the fixtures if a package is broken.
-        if: ${{
-          steps.changes.outputs.everything_but_markdown == 'true' &&
-          matrix.node_version != 24 ||
-          contains(github.event.pull_request.labels.*.name, 'test on node 24')
-          }}
-        run: pnpm run test:ci --log-order=stream --concurrency=1 --filter="./packages/*"
-        env:
-          NODE_OPTIONS: "--max_old_space_size=8192"
-          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-debug-logs/
-          TEST_REPORT_PATH: ${{ runner.temp }}/test-report/packages/index.html
-          CI_OS: ${{ matrix.description }}
-          NODE_DEBUG: "@cloudflare:vite-plugin"


### PR DESCRIPTION
These tests depend upon the labels and so are retriggered every time a label changes. We don't want to hav to re-run the standard tests on every label change. So this PR splits these into separate workflows that have different triggers.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: CI change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: CI change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> original not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
