### PR TITLE
ci: try to fix "Opening /dev/tty failed (6): Device not configured"

### DIFF
--- a/.github/changeset-version.js
+++ b/.github/changeset-version.js
@@ -72,7 +72,9 @@ function main() {
 	// 2. Run standard `changeset version` command to apply changesets, bump
 	//    versions, and update changelogs
 	console.log("Applying changesets and updating versions...");
-	execSync("pnpm exec changeset version", { stdio: "inherit" });
+	execSync("pnpm exec changeset version", {
+		stdio: ["ignore", "inherit", "inherit"],
+	});
 
 	// 3. Force `miniflare`'s minor version to be the same as `workerd`
 	console.log("Getting miniflare and workerd versions...");


### PR DESCRIPTION
Try to fix an error in Ci "Opening /dev/tty failed (6): Device not configured"

It seems to block `.github/changeset-version.js`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: ci
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ci
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: ci error specific to main

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
