### PR TITLE
SQC-707 Fix Hyperdrive binding slow latency on Windows

### DIFF
--- a/.changeset/thick-showers-hammer.md
+++ b/.changeset/thick-showers-hammer.md
@@ -1,0 +1,5 @@
+---
+"miniflare": minor
+---
+
+Improve local Hyperdrive binding latency on Windows.

--- a/packages/miniflare/src/plugins/hyperdrive/hyperdrive-proxy.ts
+++ b/packages/miniflare/src/plugins/hyperdrive/hyperdrive-proxy.ts
@@ -53,7 +53,7 @@ export class HyperdriveProxyController {
 			);
 		});
 		const port = await new Promise<number>((resolve, reject) => {
-			server.listen(0, "localhost", () => {
+			server.listen(0, "127.0.0.1", () => {
 				const address = server.address() as net.AddressInfo;
 				if (address && typeof address !== "string") {
 					resolve(address.port);

--- a/packages/miniflare/src/plugins/hyperdrive/index.ts
+++ b/packages/miniflare/src/plugins/hyperdrive/index.ts
@@ -130,7 +130,7 @@ export const HYPERDRIVE_PLUGIN: Plugin<typeof HyperdriveInputOptionsSchema> = {
 			services.push({
 				name: `${HYPERDRIVE_PLUGIN_NAME}:${name}`,
 				external: {
-					address: `localhost:${proxyPort}`,
+					address: `127.0.0.1:${proxyPort}`,
 					tcp: {},
 				},
 			});


### PR DESCRIPTION
Fix Hyperdrive binding slow latency on Windows for `npx wrangler dev` command

- Update localhost to 127.0.0.1 address to fix issue with Windows defaulting to ipv6 lookup and timing out
- Fix skipped Windows Hyperdrive tests which were failing due to miniflare dispose() causing connection reset errors. It was causing the child process to crash but this is now fixed with calling node spawn and cleanly handling those specific connection errors by error code

Fixes #SQC-707

Customer reached out on discord reporting slow latency of 2000ms when using Hyperdrive binding and `localConnectionString` pointing at local db. Was able to reproduce on Windows 10 PC and get latency back to 8ms-15ms 

---

- Tests
  - [X] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: Bug fix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [X] Not necessary because: miniflare change
