### PR TITLE
Allow users to also provide a timestamp for workflow events mocked via `mockEvent`

### DIFF
--- a/.changeset/old-areas-spend.md
+++ b/.changeset/old-areas-spend.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/vitest-pool-workers": minor
+"@cloudflare/workflows-shared": minor
+---
+
+Allow users to also provide a timestamp for workflow events mocked via `mockEvent`

--- a/fixtures/vitest-pool-workers-examples/workflows/src/index.ts
+++ b/fixtures/vitest-pool-workers-examples/workflows/src/index.ts
@@ -5,7 +5,7 @@ import {
 } from "cloudflare:workers";
 
 export class ModeratorWorkflow extends WorkflowEntrypoint<Env> {
-	async run(_event: Readonly<WorkflowEvent<unknown>>, step: WorkflowStep) {
+	async run(event: Readonly<WorkflowEvent<unknown>>, step: WorkflowStep) {
 		await step.sleep("sleep for a while", "10 seconds");
 
 		// Get an initial analysis from an AI model
@@ -46,11 +46,16 @@ export class ModeratorWorkflow extends WorkflowEntrypoint<Env> {
 		if (eventPayload) {
 			// The moderator responded in time.
 			const decision = eventPayload.payload.moderatorAction; // e.g., "approve" or "reject"
+			const result = {
+				status: "moderated",
+				decision,
+				year: event.timestamp.getFullYear(),
+			};
 			await step.do("apply moderator decision", async () => {
 				// API call to update content status based on the decision
-				return { status: "moderated", decision: decision };
+				return result;
 			});
-			return { status: "moderated", decision: decision };
+			return result;
 		}
 	}
 }

--- a/fixtures/vitest-pool-workers-examples/workflows/test/unit.test.ts
+++ b/fixtures/vitest-pool-workers-examples/workflows/test/unit.test.ts
@@ -117,6 +117,7 @@ it("should be reviewed, accepted and complete", async () => {
 		await m.mockEvent({
 			type: "moderation-decision",
 			payload: { moderatorAction: "approve" },
+			timestamp: new Date("01-01-2033"),
 		});
 	});
 
@@ -129,7 +130,7 @@ it("should be reviewed, accepted and complete", async () => {
 	);
 	expect(
 		await instance.waitForStepResult({ name: "apply moderator decision" })
-	).toEqual({ status: "moderated", decision: "approve" });
+	).toEqual({ status: "moderated", decision: "approve", year: 2033 });
 
 	await expect(instance.waitForStatus(STATUS_COMPLETE)).resolves.not.toThrow();
 });

--- a/packages/vitest-pool-workers/types/cloudflare-test.d.ts
+++ b/packages/vitest-pool-workers/types/cloudflare-test.d.ts
@@ -369,9 +369,13 @@ declare module "cloudflare:test" {
 		 *   );
 		 * ```
 		 *
-		 * @param event - The event to send, including its `type` and `payload`.
+		 * @param event - The event to send, including its `type` and `payload`. A timestamp for the event can also be provided.
 		 */
-		mockEvent(event: { type: string; payload: unknown }): Promise<void>;
+		mockEvent(event: {
+			type: string;
+			payload: unknown;
+			timestamp?: Date;
+		}): Promise<void>;
 
 		/**
 		 * Forces a `step.waitForEvent()` to time out instantly, causing the step to fail.

--- a/packages/workflows-shared/src/modifier.ts
+++ b/packages/workflows-shared/src/modifier.ts
@@ -11,6 +11,7 @@ export type StepSelector = {
 type UserEvent = {
 	type: string;
 	payload: unknown;
+	timestamp?: Date;
 };
 
 export class WorkflowInstanceModifier extends RpcTarget {
@@ -153,7 +154,7 @@ export class WorkflowInstanceModifier extends RpcTarget {
 
 	async mockEvent(event: UserEvent): Promise<void> {
 		const myEvent: Event = {
-			timestamp: new Date(),
+			timestamp: event.timestamp ?? new Date(),
 			payload: event.payload,
 			type: event.type,
 		};


### PR DESCRIPTION
Fixes #[insert GH or internal issue link(s)].

_Describe your change..._

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
