### PR TITLE
ci: enable Node compile cache

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -28,6 +28,12 @@ runs:
         cache: "pnpm"
         registry-url: "https://registry.npmjs.org"
 
+    # Enable node compile cache (effective for Node 22+)
+    # See https://nodejs.org/docs/v24.11.1/api/module.html#module-compile-cache
+    - name: Enable Node Compile Cache
+      shell: bash
+      run: echo "NODE_COMPILE_CACHE=$HOME/.node_compile_cache" >> $GITHUB_ENV
+
     - name: "Configure turbo repo cache environment variables"
       if: inputs.turbo-api
       shell: bash


### PR DESCRIPTION
Using the compile cache makes wrangler 100ms faster (350 ->250) on my local MBP.

Do we want to test that for the CI?

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: ci
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ci
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: ci

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
