### PR TITLE
Wrangler: fix autoconfig using absolute paths for static projects

### DIFF
--- a/.changeset/slick-beers-cover.md
+++ b/.changeset/slick-beers-cover.md
@@ -1,0 +1,41 @@
+---
+"wrangler": patch
+---
+
+Fix autoconfig using absolute paths for static projects
+
+Running the experimental autoconfig logic through `wrangler setup` and `wrangler deploy --x-autoconfig` on a static project results in absolute paths being used, this is incorrect, especially when such paths are being included in the generated wrangler.jsonc, the changes here fix the autoconfig logic to instead use paths relative to the project's root instead.
+
+For example given a project located in `/Users/usr/projects/sites/my-static-site`, before:
+
+```ts
+// wrangler.jsonc at /Users/usr/projects/sites/my-static-site
+  {
+    "$schema": "node_modules/wrangler/config-schema.json",
+    "name": "static",
+    "compatibility_date": "2025-11-27",
+    "observability": {
+      "enabled": true
+    },
+    "assets": {
+      "directory": "/Users/usr/projects/sites/my-static-site/public"
+    }
+  }
+```
+
+and after:
+
+```ts
+// wrangler.jsonc at /Users/usr/projects/sites/my-static-site
+  {
+    "$schema": "node_modules/wrangler/config-schema.json",
+    "name": "static",
+    "compatibility_date": "2025-11-27",
+    "observability": {
+      "enabled": true
+    },
+    "assets": {
+      "directory": "public"
+    }
+  }
+```

--- a/packages/wrangler/src/__tests__/autoconfig/details/get-details-for-auto-config.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/get-details-for-auto-config.test.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 import { writeFile } from "node:fs/promises";
-import { join } from "node:path";
 import { seed } from "@cloudflare/workers-utils/test-helpers";
 import { describe, expect, it } from "vitest";
 import * as details from "../../../autoconfig/details";
@@ -111,7 +110,7 @@ describe("autoconfig details - getDetailsForAutoConfig()", () => {
 		await writeFile("index.html", `<h1>Hello World</h1>`);
 
 		await expect(details.getDetailsForAutoConfig()).resolves.toMatchObject({
-			outputDir: process.cwd(),
+			outputDir: ".",
 		});
 	});
 
@@ -122,7 +121,7 @@ describe("autoconfig details - getDetailsForAutoConfig()", () => {
 		});
 
 		await expect(details.getDetailsForAutoConfig()).resolves.toMatchObject({
-			outputDir: join(process.cwd(), "public"),
+			outputDir: "public",
 		});
 	});
 
@@ -133,7 +132,7 @@ describe("autoconfig details - getDetailsForAutoConfig()", () => {
 		});
 
 		await expect(details.getDetailsForAutoConfig()).resolves.toMatchObject({
-			outputDir: process.cwd(),
+			outputDir: ".",
 		});
 	});
 

--- a/packages/wrangler/src/__tests__/setup.test.ts
+++ b/packages/wrangler/src/__tests__/setup.test.ts
@@ -120,7 +120,7 @@ describe("wrangler setup", () => {
 				Detected Project Settings:
 				 - Worker Name: <WORKER_NAME>
 				 - Framework: Static
-				 - Output Directory: <cwd>/public
+				 - Output Directory: public
 
 
 				📄 Create wrangler.jsonc:

--- a/packages/wrangler/src/autoconfig/details.ts
+++ b/packages/wrangler/src/autoconfig/details.ts
@@ -1,6 +1,6 @@
 import { statSync } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
-import { basename, join, resolve } from "node:path";
+import { basename, join, relative, resolve } from "node:path";
 import { brandColor } from "@cloudflare/cli/colors";
 import {
 	FatalError,
@@ -47,14 +47,14 @@ async function hasIndexHtml(dir: string): Promise<boolean> {
  */
 async function findAssetsDir(from: string): Promise<string | undefined> {
 	if (await hasIndexHtml(from)) {
-		return from;
+		return ".";
 	}
 	const children = await readdir(from);
 	for (const child of children) {
 		const path = join(from, child);
 		const stats = await stat(path);
 		if (stats.isDirectory() && (await hasIndexHtml(path))) {
-			return path;
+			return relative(from, path);
 		}
 	}
 	return undefined;


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-2350

Fixes autoconfig on static projects using absolute paths instead of relative ones (see the changeset for more details)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: autoconfig is not in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
