### PR TITLE
test: handle socket errors in dev.test.ts e2e test

### DIFF
--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -796,7 +796,7 @@ describe("hyperdrive dev tests", () => {
 		});
 
 		const { url } = await worker.waitForReady();
-		const socketMsgPromise = new Promise((resolve, _) => {
+		const socketMsgPromise = new Promise((resolve, reject) => {
 			server.on("connection", (socket) => {
 				socket.on("data", (chunk) => {
 					if (POSTGRES_SSL_REQUEST_PACKET.equals(chunk)) {
@@ -806,6 +806,10 @@ describe("hyperdrive dev tests", () => {
 					expect(new TextDecoder().decode(chunk)).toBe("test string");
 					server.close();
 					resolve({});
+				});
+				socket.on("error", (err) => {
+					console.error("Socket error:", err);
+					reject(err);
 				});
 			});
 		});


### PR DESCRIPTION
A number of e2e test flakes appear to be unhandled rejections in the "uses HYPERDRIVE_LOCAL_CONNECTION_STRING for the localConnectionString variable in the binding" test, where there is a connection reset error (ECONNRESET).

Let's see if this change improves that situation.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test change
- Wrangler V3 Backport
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/11463
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
