### PR TITLE
chore: run account_id test only when credentials is set

### DIFF
--- a/packages/vite-plugin-cloudflare/e2e/remote-bindings.test.ts
+++ b/packages/vite-plugin-cloudflare/e2e/remote-bindings.test.ts
@@ -137,6 +137,28 @@ if (!process.env.CLOUDFLARE_ACCOUNT_ID || !process.env.CLOUDFLARE_API_TOKEN) {
 				);
 			});
 		});
+
+	describe("remote bindings without actually establishing a remote connection", () => {
+		const projectPath = seed("remote-bindings-config-account-id", "pnpm");
+
+		test("for connection to remote bindings during dev the account_id present in the wrangler config file is used", async ({
+			expect,
+		}) => {
+			const proc = await runLongLived("pnpm", "dev", projectPath);
+			await vi.waitFor(
+				async () => {
+					expect(proc.stderr).toMatch(
+						// Note: this error message shows that we're attempting to establish the remote proxy connection
+						//       using the "not-a-valid-account-id-abc" account id
+						/A request to the Cloudflare API \(\/accounts\/not-a-valid-account-id-abc\/.*?\) failed/
+					);
+				},
+				{
+					timeout: 10_000,
+				}
+			);
+		});
+	});
 }
 
 describe("remote bindings disabled", () => {
@@ -159,28 +181,6 @@ describe("remote bindings disabled", () => {
 
 				expect(responseText).toContain("Error");
 				expect(responseText).toContain("Binding AI needs to be run remotely");
-			}
-		);
-	});
-});
-
-describe("remote bindings without actually establishing a remote connection", () => {
-	const projectPath = seed("remote-bindings-config-account-id", "pnpm");
-
-	test("for connection to remote bindings during dev the account_id present in the wrangler config file is used", async ({
-		expect,
-	}) => {
-		const proc = await runLongLived("pnpm", "dev", projectPath);
-		await vi.waitFor(
-			async () => {
-				expect(proc.stderr).toMatch(
-					// Note: this error message shows that we're attempting to establish the remote proxy connection
-					//       using the "not-a-valid-account-id-abc" account id
-					/A request to the Cloudflare API \(\/accounts\/not-a-valid-account-id-abc\/.*?\) failed/
-				);
-			},
-			{
-				timeout: 10_000,
 			}
 		);
 	});


### PR DESCRIPTION
Fixes n/a

The test is added in #11009 and will [fail in PR from fork](https://github.com/cloudflare/workers-sdk/actions/runs/19737811755/job/56574991494?pr=11391#step:6:2116) due to missing credentials.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no feature change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: no feature change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
