### PR TITLE
Update the structure of the `configure` method of autoconfig frameworks

### DIFF
--- a/.changeset/wet-flowers-kiss.md
+++ b/.changeset/wet-flowers-kiss.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Update the structure of the `configure` method of autoconfig frameworks
+
+Update the signature of the `configure` function of autoconfig frameworks (`AutoconfigDetails#Framework`), before they would return a `RawConfig` object to use to update the project's wrangler config file, now they return an object that includes the `RawConfig` and that can potentially also hold additional data relevant to the configuration.

--- a/packages/wrangler/src/__tests__/autoconfig/details/confirm-auto-config-details.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/confirm-auto-config-details.test.ts
@@ -103,7 +103,7 @@ describe("autoconfig details - confirmAutoConfigDetails()", () => {
 				buildCommand: "astro build",
 				framework: {
 					configured: false,
-					configure: () => ({}),
+					configure: () => ({ wranglerConfig: {} }),
 					name: "astro",
 				},
 				outputDir: "<OUTPUT_DIR>",

--- a/packages/wrangler/src/__tests__/autoconfig/details/display-auto-config-details.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/display-auto-config-details.test.ts
@@ -35,7 +35,11 @@ describe("autoconfig details - displayAutoConfigDetails()", () => {
 			configured: false,
 			projectPath: process.cwd(),
 			workerName: "my-astro-app",
-			framework: { name: "Astro", configured: false, configure: () => ({}) },
+			framework: {
+				name: "Astro",
+				configured: false,
+				configure: () => ({ wranglerConfig: {} }),
+			},
 			buildCommand: "astro build",
 			outputDir: "dist",
 		});

--- a/packages/wrangler/src/__tests__/autoconfig/run.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/run.test.ts
@@ -150,7 +150,9 @@ describe("autoconfig (deploy)", () => {
 			});
 			await writeFile(".gitignore", "");
 			const configureSpy = vi.fn(async ({ outputDir }) => ({
-				assets: { directory: outputDir },
+				wranglerConfig: {
+					assets: { directory: outputDir },
+				},
 			}));
 			await run.runAutoConfig({
 				projectPath: process.cwd(),

--- a/packages/wrangler/src/autoconfig/frameworks/astro.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/astro.ts
@@ -3,14 +3,13 @@ import { brandColor, dim } from "@cloudflare/cli/colors";
 import { getPackageManager } from "../../package-manager";
 import { runCommand } from "../c3-vendor/command";
 import { Framework } from ".";
-import type { ConfigurationOptions } from ".";
-import type { RawConfig } from "@cloudflare/workers-utils";
+import type { ConfigurationOptions, ConfigurationResults } from ".";
 
 export class Astro extends Framework {
 	async configure({
 		outputDir,
 		dryRun,
-	}: ConfigurationOptions): Promise<RawConfig> {
+	}: ConfigurationOptions): Promise<ConfigurationResults> {
 		const { npx } = await getPackageManager();
 		if (!dryRun) {
 			await runCommand([npx, "astro", "add", "cloudflare", "-y"], {
@@ -23,11 +22,13 @@ export class Astro extends Framework {
 			writeFileSync("public/.assetsignore", "_worker.js\n_routes.json");
 		}
 		return {
-			main: `${outputDir}/_worker.js/index.js`,
-			compatibility_flags: ["nodejs_compat", "global_fetch_strictly_public"],
-			assets: {
-				binding: "ASSETS",
-				directory: outputDir,
+			wranglerConfig: {
+				main: `${outputDir}/_worker.js/index.js`,
+				compatibility_flags: ["nodejs_compat", "global_fetch_strictly_public"],
+				assets: {
+					binding: "ASSETS",
+					directory: outputDir,
+				},
 			},
 		};
 	}

--- a/packages/wrangler/src/autoconfig/frameworks/index.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/index.ts
@@ -6,6 +6,11 @@ export type ConfigurationOptions = {
 	workerName: string;
 	dryRun: boolean;
 };
+
+export type ConfigurationResults = {
+	wranglerConfig: RawConfig;
+};
+
 export abstract class Framework {
 	constructor(public name: string = "Static") {}
 
@@ -21,7 +26,7 @@ export abstract class Framework {
 
 	abstract configure(
 		options: ConfigurationOptions
-	): Promise<RawConfig> | RawConfig;
+	): Promise<ConfigurationResults> | ConfigurationResults;
 
 	configurationDescription?: string;
 }

--- a/packages/wrangler/src/autoconfig/frameworks/static.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/static.ts
@@ -1,14 +1,13 @@
 import { Framework } from ".";
-import type { ConfigurationOptions } from ".";
-import type { RawConfig } from "@cloudflare/workers-utils";
+import type { ConfigurationOptions, ConfigurationResults } from ".";
 
 export class Static extends Framework {
-	configure({
-		outputDir,
-	}: ConfigurationOptions): Promise<RawConfig> | RawConfig {
+	configure({ outputDir }: ConfigurationOptions): ConfigurationResults {
 		return {
-			assets: {
-				directory: outputDir,
+			wranglerConfig: {
+				assets: {
+					directory: outputDir,
+				},
 			},
 		};
 	}

--- a/packages/wrangler/src/autoconfig/frameworks/sveltekit.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/sveltekit.ts
@@ -4,11 +4,12 @@ import { getPackageManager } from "../../package-manager";
 import { runCommand } from "../c3-vendor/command";
 import { installPackages } from "../c3-vendor/packages";
 import { Framework } from ".";
-import type { ConfigurationOptions } from ".";
-import type { RawConfig } from "@cloudflare/workers-utils";
+import type { ConfigurationOptions, ConfigurationResults } from ".";
 
 export class SvelteKit extends Framework {
-	async configure({ dryRun }: ConfigurationOptions): Promise<RawConfig> {
+	async configure({
+		dryRun,
+	}: ConfigurationOptions): Promise<ConfigurationResults> {
 		const { dlx } = await getPackageManager();
 		if (!dryRun) {
 			await runCommand(
@@ -36,11 +37,13 @@ export class SvelteKit extends Framework {
 			});
 		}
 		return {
-			main: ".svelte-kit/cloudflare/_worker.js",
-			compatibility_flags: ["nodejs_als"],
-			assets: {
-				binding: "ASSETS",
-				directory: ".svelte-kit/cloudflare",
+			wranglerConfig: {
+				main: ".svelte-kit/cloudflare/_worker.js",
+				compatibility_flags: ["nodejs_als"],
+				assets: {
+					binding: "ASSETS",
+					directory: ".svelte-kit/cloudflare",
+				},
 			},
 		};
 	}

--- a/packages/wrangler/src/autoconfig/frameworks/tanstack.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/tanstack.ts
@@ -6,8 +6,7 @@ import * as recast from "recast";
 import { transformFile } from "../c3-vendor/codemod";
 import { installPackages } from "../c3-vendor/packages";
 import { Framework } from ".";
-import type { ConfigurationOptions } from ".";
-import type { RawConfig } from "@cloudflare/workers-utils";
+import type { ConfigurationOptions, ConfigurationResults } from ".";
 import type { types } from "recast";
 
 const b = recast.types.builders;
@@ -128,7 +127,7 @@ export class TanstackStart extends Framework {
 	async configure({
 		dryRun,
 		projectPath,
-	}: ConfigurationOptions): Promise<RawConfig> {
+	}: ConfigurationOptions): Promise<ConfigurationResults> {
 		if (!dryRun) {
 			await installPackages(["@cloudflare/vite-plugin"], {
 				dev: true,
@@ -140,8 +139,10 @@ export class TanstackStart extends Framework {
 		}
 
 		return {
-			compatibility_flags: ["nodejs_compat"],
-			main: "@tanstack/react-start/server-entry",
+			wranglerConfig: {
+				compatibility_flags: ["nodejs_compat"],
+				main: "@tanstack/react-start/server-entry",
+			},
 		};
 	}
 


### PR DESCRIPTION
These changes are a prerequisite for https://github.com/cloudflare/workers-sdk/pull/11301

Update the signature of the `configure` function of autoconfig frameworks (`AutoconfigDetails#Framework`), before they would return a `RawConfig` object to use to update the project's wrangler config file, now they return an object that includes the `RawConfig` and that can potentially also hold additional data relevant to the configuration.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Tests not necessary because
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this will be documented separately
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: autoconfig is not in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
