### PR TITLE
Remove vitest globals from all tests

### DIFF
--- a/packages/containers-shared/tests/helpers/run-in-tmp-dir.ts
+++ b/packages/containers-shared/tests/helpers/run-in-tmp-dir.ts
@@ -10,7 +10,7 @@ import * as fs from "node:fs";
 import { rm } from "node:fs/promises";
 import os from "node:os";
 import * as path from "node:path";
-import { vi } from "vitest";
+import { afterEach, beforeEach, vi } from "vitest";
 
 const originalCwd = process.cwd();
 

--- a/packages/containers-shared/tests/knobs.test.ts
+++ b/packages/containers-shared/tests/knobs.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from "vitest";
 import { getCloudflareContainerRegistry } from "./../src/knobs";
 
 describe("getCloudflareContainerRegistry", () => {

--- a/packages/containers-shared/tests/tsconfig.json
+++ b/packages/containers-shared/tests/tsconfig.json
@@ -2,7 +2,7 @@
 	"extends": "@cloudflare/workers-tsconfig/tsconfig.json",
 	"compilerOptions": {
 		"module": "preserve",
-		"types": ["node", "vitest/globals"]
+		"types": ["node"]
 	},
 	"include": ["**/*.ts"]
 }

--- a/packages/containers-shared/tests/utils.test.ts
+++ b/packages/containers-shared/tests/utils.test.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, writeFileSync } from "node:fs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { checkExposedPorts, isDockerfile } from "./../src/utils";
 import { runInTempDir } from "./helpers/run-in-tmp-dir";
 import type { ContainerDevOptions } from "../src/types";

--- a/packages/workers-shared/asset-worker/tests/assets-manifest.test.ts
+++ b/packages/workers-shared/asset-worker/tests/assets-manifest.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import {
 	CONTENT_HASH_OFFSET,
 	ENTRY_SIZE,

--- a/packages/workers-shared/asset-worker/tests/compatibility-flags.test.ts
+++ b/packages/workers-shared/asset-worker/tests/compatibility-flags.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { resolveCompatibilityOptions } from "../src/compatibility-flags";
 
 describe("resolveCompatibilityOptions", () => {

--- a/packages/workers-shared/asset-worker/tests/handler.test.ts
+++ b/packages/workers-shared/asset-worker/tests/handler.test.ts
@@ -1,4 +1,4 @@
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mockJaegerBinding } from "../../utils/tracing";
 import { Analytics } from "../src/analytics";
 import { SEC_FETCH_MODE_NAVIGATE_HEADER_PREFERS_ASSET_SERVING } from "../src/compatibility-flags";

--- a/packages/workers-shared/asset-worker/tests/kv.test.ts
+++ b/packages/workers-shared/asset-worker/tests/kv.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getAssetWithMetadataFromKV } from "../src/utils/kv";
 import type { AssetMetadata } from "../src/utils/kv";
 import type { MockInstance } from "vitest";

--- a/packages/workers-shared/asset-worker/tests/tsconfig.json
+++ b/packages/workers-shared/asset-worker/tests/tsconfig.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"types": [
 			"@cloudflare/workers-types/experimental",
-			"@cloudflare/vitest-pool-workers",
-			"vitest/globals"
+			"@cloudflare/vitest-pool-workers"
 		]
 	},
 	"include": ["**/*.ts"]

--- a/packages/workers-utils/tests/config/configSchema.test.ts
+++ b/packages/workers-utils/tests/config/configSchema.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { describe, expect, test } from "vitest";
 
 describe("src/config/environment.ts", () => {
 	// `@default` values must not be escaped in order to generate a valid schema.

--- a/packages/workers-utils/tests/parse.test.ts
+++ b/packages/workers-utils/tests/parse.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import {
 	indexLocation,
 	parseByteSize,

--- a/packages/workers-utils/tests/tsconfig.json
+++ b/packages/workers-utils/tests/tsconfig.json
@@ -2,7 +2,7 @@
 	"extends": "@cloudflare/workers-tsconfig/tsconfig.json",
 	"compilerOptions": {
 		"module": "preserve",
-		"types": ["node", "vitest/globals"],
+		"types": ["node"],
 		"jsx": "preserve"
 	},
 	"include": ["../*.d.ts", "**/*.ts", "**/*.tsx", "**/*.js"]

--- a/packages/wrangler/src/__tests__/access.test.ts
+++ b/packages/wrangler/src/__tests__/access.test.ts
@@ -1,4 +1,5 @@
 import { UserError } from "@cloudflare/workers-utils";
+import { beforeEach, describe, expect, it } from "vitest";
 import { domainUsesAccess, getAccessToken } from "../user/access";
 import { msw, mswAccessHandlers } from "./helpers/msw";
 

--- a/packages/wrangler/src/__tests__/ai.local.test.ts
+++ b/packages/wrangler/src/__tests__/ai.local.test.ts
@@ -1,6 +1,7 @@
 import { COMPLIANCE_REGION_CONFIG_UNKNOWN } from "@cloudflare/workers-utils";
 import { Request } from "miniflare";
 import { Headers, Response } from "undici";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { getAIFetcher } from "../ai/fetcher";
 import * as internal from "../cfetch/internal";
 import * as user from "../user";

--- a/packages/wrangler/src/__tests__/ai.test.ts
+++ b/packages/wrangler/src/__tests__/ai.test.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { endEventLoop } from "./helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";

--- a/packages/wrangler/src/__tests__/api-dev.test.ts
+++ b/packages/wrangler/src/__tests__/api-dev.test.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import { Request } from "undici";
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { unstable_dev } from "../api";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";

--- a/packages/wrangler/src/__tests__/api.test.ts
+++ b/packages/wrangler/src/__tests__/api.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
 import { Request } from "undici";
+import { describe, expect, it } from "vitest";
 import { parseRequestInput } from "../api/dev";
 
 describe("parseRequestInput for fetch on unstable dev", () => {

--- a/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { seed } from "@cloudflare/workers-utils/test-helpers";
 import dedent from "ts-dedent";
-import { describe, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { BundlerController } from "../../../api/startDevWorker/BundlerController";
 import { FakeBus } from "../../helpers/fake-bus";
 import { mockConsoleMethods } from "../../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { seed } from "@cloudflare/workers-utils/test-helpers";
 import dedent from "ts-dedent";
-import { describe, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ConfigController } from "../../../api/startDevWorker/ConfigController";
 import { unwrapHook } from "../../../api/startDevWorker/utils";
 import { logger } from "../../../logger";

--- a/packages/wrangler/src/__tests__/api/startDevWorker/utils.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/utils.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { convertConfigBindingsToStartWorkerBindings } from "../../../api/startDevWorker/utils";
 
 describe("convertConfigBindingsToStartWorkerBindings", () => {

--- a/packages/wrangler/src/__tests__/autoconfig/details/confirm-auto-config-details.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/confirm-auto-config-details.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { confirmAutoConfigDetails } from "../../../autoconfig/details";
 import { mockConfirm, mockPrompt } from "../../helpers/mock-dialogs";
 import { useMockIsTTY } from "../../helpers/mock-istty";

--- a/packages/wrangler/src/__tests__/autoconfig/details/display-auto-config-details.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/display-auto-config-details.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { displayAutoConfigDetails } from "../../../autoconfig/details";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 

--- a/packages/wrangler/src/__tests__/autoconfig/details/get-details-for-auto-config.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/get-details-for-auto-config.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { writeFile } from "node:fs/promises";
 import { seed } from "@cloudflare/workers-utils/test-helpers";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as details from "../../../autoconfig/details";
 import { clearOutputFilePath } from "../../../output";
 import { mockConsoleMethods } from "../../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/autoconfig/run-summary.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/run-summary.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 import { Astro } from "../../autoconfig/frameworks/astro";
 import { Static } from "../../autoconfig/frameworks/static";
 import { buildOperationsSummary } from "../../autoconfig/run";

--- a/packages/wrangler/src/__tests__/autoconfig/run.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/run.test.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { FatalError, readFileSync } from "@cloudflare/workers-utils";
-import { vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as c3 from "../../autoconfig/c3-vendor/packages";
 import * as details from "../../autoconfig/details";
 import { Static } from "../../autoconfig/frameworks/static";

--- a/packages/wrangler/src/__tests__/banner.test.ts
+++ b/packages/wrangler/src/__tests__/banner.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { runWrangler } from "./helpers/run-wrangler";

--- a/packages/wrangler/src/__tests__/cert.test.ts
+++ b/packages/wrangler/src/__tests__/cert.test.ts
@@ -1,6 +1,7 @@
 import { writeFileSync } from "node:fs";
 import { COMPLIANCE_REGION_CONFIG_UNKNOWN } from "@cloudflare/workers-utils";
 import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it, test } from "vitest";
 import {
 	deleteMTlsCertificate,
 	getMTlsCertificate,

--- a/packages/wrangler/src/__tests__/cfetch-utils.test.ts
+++ b/packages/wrangler/src/__tests__/cfetch-utils.test.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
 import { extractAccountTag, hasMorePages } from "../cfetch";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";

--- a/packages/wrangler/src/__tests__/check-fetch.test.ts
+++ b/packages/wrangler/src/__tests__/check-fetch.test.ts
@@ -1,4 +1,5 @@
 import "vitest";
+import { describe, expect, it } from "vitest";
 import { shouldCheckFetch } from "../deployment-bundle/bundle";
 
 describe("shouldCheckFetch()", () => {

--- a/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
+++ b/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
@@ -1,5 +1,5 @@
 import { setTimeout } from "node:timers/promises";
-import { vitest } from "vitest";
+import { beforeEach, describe, expect, it, vi, vitest } from "vitest";
 import registerHotKeys from "../cli-hotkeys";
 import { logger } from "../logger";
 import { mockConsoleMethods } from "./helpers/mock-console";

--- a/packages/wrangler/src/__tests__/cli.test.ts
+++ b/packages/wrangler/src/__tests__/cli.test.ts
@@ -1,4 +1,5 @@
 import { grayBar, leftT, spinner } from "@cloudflare/cli/interactive";
+import { describe, expect, test } from "vitest";
 import { collectCLIOutput } from "./helpers/collect-cli-output";
 import { useMockIsTTY } from "./helpers/mock-istty";
 

--- a/packages/wrangler/src/__tests__/cloudchamber/apply.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/apply.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@cloudflare/containers-shared";
 import { http, HttpResponse } from "msw";
 import patchConsole from "patch-console";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockCLIOutput } from "../helpers/mock-cli-output";
 import { mockConsoleMethods } from "../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/cloudchamber/build.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/build.test.ts
@@ -8,6 +8,7 @@ import {
 	runDockerCmdWithOutput,
 } from "@cloudflare/containers-shared";
 import { UserError } from "@cloudflare/workers-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runInTempDir } from "../helpers/run-in-tmp";

--- a/packages/wrangler/src/__tests__/cloudchamber/common.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/common.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { parseImageName } from "../../cloudchamber/common";
 
 describe("parseImageName", () => {

--- a/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import { http, HttpResponse } from "msw";
 import patchConsole from "patch-console";
 import * as TOML from "smol-toml";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { MOCK_DEPLOYMENTS_COMPLEX } from "../helpers/mock-cloudchamber";
 import { mockConsoleMethods } from "../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/cloudchamber/curl.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/curl.test.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 import patchConsole from "patch-console";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { collectCLIOutput } from "../helpers/collect-cli-output";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { MOCK_DEPLOYMENTS_COMPLEX } from "../helpers/mock-cloudchamber";

--- a/packages/wrangler/src/__tests__/cloudchamber/delete.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/delete.test.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 import patchConsole from "patch-console";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { MOCK_DEPLOYMENTS_COMPLEX } from "../helpers/mock-cloudchamber";
 import { mockConsoleMethods } from "../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/cloudchamber/images.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/images.test.ts
@@ -1,6 +1,7 @@
 import { getCloudflareContainerRegistry } from "@cloudflare/containers-shared";
 import { http, HttpResponse } from "msw";
 import patchConsole from "patch-console";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";

--- a/packages/wrangler/src/__tests__/cloudchamber/limits.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/limits.test.ts
@@ -2,6 +2,7 @@ import {
 	dockerImageInspect,
 	InstanceType,
 } from "@cloudflare/containers-shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	ensureContainerLimits,
 	ensureImageFitsLimits,

--- a/packages/wrangler/src/__tests__/cloudchamber/list.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/list.test.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 import patchConsole from "patch-console";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { MOCK_DEPLOYMENTS_COMPLEX } from "../helpers/mock-cloudchamber";
 import { mockConsoleMethods } from "../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/cloudchamber/modify.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/modify.test.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 import patchConsole from "patch-console";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { MOCK_DEPLOYMENTS_COMPLEX } from "../helpers/mock-cloudchamber";
 import { mockConsoleMethods } from "../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/cloudchamber/utils.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/utils.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import { http, HttpResponse } from "msw";
 import * as TOML from "smol-toml";
+import { vi } from "vitest";
 import * as user from "../../user";
 import { msw } from "../helpers/msw";
 import type { CompleteAccountCustomer } from "@cloudflare/containers-shared";

--- a/packages/wrangler/src/__tests__/config-cache-without-cache-dir.test.ts
+++ b/packages/wrangler/src/__tests__/config-cache-without-cache-dir.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { getConfigCache, saveToConfigCache } from "../config-cache";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";

--- a/packages/wrangler/src/__tests__/config-cache.test.ts
+++ b/packages/wrangler/src/__tests__/config-cache.test.ts
@@ -1,4 +1,5 @@
 import { mkdirSync } from "node:fs";
+import { beforeEach, describe, expect, it } from "vitest";
 import { getConfigCache, saveToConfigCache } from "../config-cache";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";

--- a/packages/wrangler/src/__tests__/config-validation-pages.test.ts
+++ b/packages/wrangler/src/__tests__/config-validation-pages.test.ts
@@ -2,6 +2,7 @@ import {
 	defaultWranglerConfig,
 	validatePagesConfig,
 } from "@cloudflare/workers-utils";
+import { describe, expect, it } from "vitest";
 import type { Config } from "@cloudflare/workers-utils";
 
 describe("validatePagesConfig()", () => {

--- a/packages/wrangler/src/__tests__/config/configuration.pages.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.pages.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { normalizeAndValidateConfig } from "@cloudflare/workers-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	generateRawConfigForPages,
 	generateRawEnvConfigForPages,

--- a/packages/wrangler/src/__tests__/config/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.test.ts
@@ -5,6 +5,7 @@ import {
 	normalizeAndValidateConfig,
 } from "@cloudflare/workers-utils";
 import { normalizeString } from "@cloudflare/workers-utils/test-helpers";
+import { describe, expect, it, test, vi } from "vitest";
 import { readConfig } from "../../config";
 import { run } from "../../experimental-flags";
 import { runInTempDir } from "../helpers/run-in-tmp";

--- a/packages/wrangler/src/__tests__/config/loadDotEnv.test.ts
+++ b/packages/wrangler/src/__tests__/config/loadDotEnv.test.ts
@@ -1,5 +1,5 @@
 import { seed } from "@cloudflare/workers-utils/test-helpers";
-import { beforeEach, describe, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { loadDotEnv } from "../../config/dot-env";
 import { logger } from "../../logger";
 import { mockConsoleMethods } from "../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/containers/config.test.ts
+++ b/packages/wrangler/src/__tests__/containers/config.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { getCloudflareContainerRegistry } from "@cloudflare/containers-shared";
 import { UserError } from "@cloudflare/workers-utils";
-import { vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getNormalizedContainerOptions } from "../../containers/config";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { runInTempDir } from "../helpers/run-in-tmp";

--- a/packages/wrangler/src/__tests__/containers/delete.test.ts
+++ b/packages/wrangler/src/__tests__/containers/delete.test.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 import patchConsole from "patch-console";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mockAccount, setWranglerConfig } from "../cloudchamber/utils";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockCLIOutput } from "../helpers/mock-cli-output";

--- a/packages/wrangler/src/__tests__/containers/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/containers/deploy.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@cloudflare/containers-shared";
 import { ApplicationAffinityHardwareGeneration } from "@cloudflare/containers-shared/src/client/models/ApplicationAffinityHardwareGeneration";
 import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearCachedAccount } from "../../cloudchamber/locations";
 import { mockAccountV4 as mockContainersAccount } from "../cloudchamber/utils";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";

--- a/packages/wrangler/src/__tests__/containers/info.test.ts
+++ b/packages/wrangler/src/__tests__/containers/info.test.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 import patchConsole from "patch-console";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as user from "../../user";
 import { mockAccount, setWranglerConfig } from "../cloudchamber/utils";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";

--- a/packages/wrangler/src/__tests__/containers/list.test.ts
+++ b/packages/wrangler/src/__tests__/containers/list.test.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 import patchConsole from "patch-console";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mockAccount, setWranglerConfig } from "../cloudchamber/utils";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { MOCK_APPLICATIONS } from "../helpers/mock-cloudchamber";

--- a/packages/wrangler/src/__tests__/containers/push.test.ts
+++ b/packages/wrangler/src/__tests__/containers/push.test.ts
@@ -3,6 +3,7 @@ import {
 	getCloudflareContainerRegistry,
 	runDockerCmd,
 } from "@cloudflare/containers-shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockAccount, setWranglerConfig } from "../cloudchamber/utils";
 import { mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/containers/registries.test.ts
+++ b/packages/wrangler/src/__tests__/containers/registries.test.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mockAccount } from "../cloudchamber/utils";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockCLIOutput } from "../helpers/mock-cli-output";

--- a/packages/wrangler/src/__tests__/core/command-registration.test.ts
+++ b/packages/wrangler/src/__tests__/core/command-registration.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert";
+import { beforeEach, describe, expect, test } from "vitest";
 import { CommandRegistry } from "../../core/CommandRegistry";
 import {
 	createAlias,

--- a/packages/wrangler/src/__tests__/custom-build.test.ts
+++ b/packages/wrangler/src/__tests__/custom-build.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
 import { UserError } from "@cloudflare/workers-utils";
+import { describe, expect, it } from "vitest";
 import { runCustomBuild } from "../deployment-bundle/run-custom-build";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";

--- a/packages/wrangler/src/__tests__/d1/convert-timestamp-to-iso.test.ts
+++ b/packages/wrangler/src/__tests__/d1/convert-timestamp-to-iso.test.ts
@@ -1,4 +1,4 @@
-import { vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { convertTimestampToISO } from "../../d1/timeTravel/utils";
 
 describe("convertTimestampToISO", () => {

--- a/packages/wrangler/src/__tests__/d1/create.test.ts
+++ b/packages/wrangler/src/__tests__/d1/create.test.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";

--- a/packages/wrangler/src/__tests__/d1/d1.test.ts
+++ b/packages/wrangler/src/__tests__/d1/d1.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runInTempDir } from "../helpers/run-in-tmp";

--- a/packages/wrangler/src/__tests__/d1/delete.test.ts
+++ b/packages/wrangler/src/__tests__/d1/delete.test.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { mockConfirm } from "../helpers/mock-dialogs";

--- a/packages/wrangler/src/__tests__/d1/execute.test.ts
+++ b/packages/wrangler/src/__tests__/d1/execute.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import { join } from "node:path";
 import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";

--- a/packages/wrangler/src/__tests__/d1/export.test.ts
+++ b/packages/wrangler/src/__tests__/d1/export.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import { setTimeout } from "node:timers/promises";
 import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";

--- a/packages/wrangler/src/__tests__/d1/info.test.ts
+++ b/packages/wrangler/src/__tests__/d1/info.test.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";

--- a/packages/wrangler/src/__tests__/d1/insights.test.ts
+++ b/packages/wrangler/src/__tests__/d1/insights.test.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "msw";
-import { vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { getDurationDates } from "../../d1/insights";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/d1/list.test.ts
+++ b/packages/wrangler/src/__tests__/d1/list.test.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";

--- a/packages/wrangler/src/__tests__/d1/migrate.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrate.test.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { describe, expect, it, vi } from "vitest";
 import { reinitialiseAuthTokens } from "../../user";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/d1/splitter.test.ts
+++ b/packages/wrangler/src/__tests__/d1/splitter.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import splitSqlQuery, { mayContainMultipleStatements } from "../../d1/splitter";
 
 describe("mayContainMultipleStatements()", () => {

--- a/packages/wrangler/src/__tests__/d1/timeTravel.test.ts
+++ b/packages/wrangler/src/__tests__/d1/timeTravel.test.ts
@@ -1,5 +1,6 @@
 import { COMPLIANCE_REGION_CONFIG_UNKNOWN } from "@cloudflare/workers-utils";
 import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { throwIfDatabaseIsAlpha } from "../../d1/timeTravel/utils";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/d1/trimmer.test.ts
+++ b/packages/wrangler/src/__tests__/d1/trimmer.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { mayContainTransaction, trimSqlQuery } from "../../d1/trimmer";
 
 describe("mayContainTransaction()", () => {
@@ -57,16 +58,16 @@ describe("trimSqlQuery()", () => {
 		INSERT INTO Customers VALUES(13,'Bs Beverages','Random Name');
 		COMMIT;`)
 		).toMatchInlineSnapshot(`
-		"PRAGMA foreign_keys=OFF;
-				
-				CREATE TABLE d1_kv (key TEXT PRIMARY KEY, value TEXT NOT NULL);
-				CREATE TABLE Customers (CustomerID INT, CompanyName TEXT, ContactName TEXT, PRIMARY KEY ('CustomerID'));
-				INSERT INTO Customers VALUES(1,'Alfreds Futterkiste','Maria Anders');
-				INSERT INTO Customers VALUES(4,'Around the Horn','Thomas Hardy');
-				INSERT INTO Customers VALUES(11,'Bs Beverages','Victoria Ashworth');
-				INSERT INTO Customers VALUES(13,'Bs Beverages','Random Name');
-				"
-	`);
+			"PRAGMA foreign_keys=OFF;
+					
+					CREATE TABLE d1_kv (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+					CREATE TABLE Customers (CustomerID INT, CompanyName TEXT, ContactName TEXT, PRIMARY KEY ('CustomerID'));
+					INSERT INTO Customers VALUES(1,'Alfreds Futterkiste','Maria Anders');
+					INSERT INTO Customers VALUES(4,'Around the Horn','Thomas Hardy');
+					INSERT INTO Customers VALUES(11,'Bs Beverages','Victoria Ashworth');
+					INSERT INTO Customers VALUES(13,'Bs Beverages','Random Name');
+					"
+		`);
 	});
 	it("should throw when provided multiple transactions", () => {
 		expect(() =>

--- a/packages/wrangler/src/__tests__/d1/utils.test.ts
+++ b/packages/wrangler/src/__tests__/d1/utils.test.ts
@@ -1,5 +1,6 @@
 import { type Config } from "@cloudflare/workers-utils";
 import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
 import {
 	getDatabaseByNameOrBinding,
 	getDatabaseInfoFromConfig,

--- a/packages/wrangler/src/__tests__/delete.test.ts
+++ b/packages/wrangler/src/__tests__/delete.test.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { mockConfirm } from "./helpers/mock-dialogs";

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -11,7 +11,7 @@ import * as esbuild from "esbuild";
 import { http, HttpResponse } from "msw";
 import * as TOML from "smol-toml";
 import dedent from "ts-dedent";
-import { vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
 import { printBundleSize } from "../deployment-bundle/bundle-reporter";
 import { clearOutputFilePath } from "../output";
 import { getSubdomainValues } from "../triggers/deploy";
@@ -15079,7 +15079,7 @@ export default{
 			`);
 		});
 
-		test("environments with redirected config", async ({ expect }) => {
+		test("environments with redirected config", async () => {
 			mockGetScriptWithTags(["some-tag"]);
 			mockUploadWorkerRequest({
 				expectedScriptName: "test-name-production",

--- a/packages/wrangler/src/__tests__/deploy/check-remote-secrets-override.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/check-remote-secrets-override.test.ts
@@ -1,3 +1,4 @@
+import { assert, describe, expect, it, vi } from "vitest";
 import { checkRemoteSecretsOverride } from "../../deploy/check-remote-secrets-override";
 import { fetchSecrets } from "../../utils/fetch-secrets";
 import type { Config } from "@cloudflare/workers-utils";

--- a/packages/wrangler/src/__tests__/deploy/get-config-patch.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/get-config-patch.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { getConfigPatch } from "../../deploy/config-diffs";
 
 // Note: __old (as well as *__deleted) is the value in the remote config, __new is the value in the local one, so we do want the

--- a/packages/wrangler/src/__tests__/deploy/get-remote-config-diff.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/get-remote-config-diff.test.ts
@@ -1,3 +1,4 @@
+import { assert, describe, expect, it } from "vitest";
 import { getRemoteConfigDiff } from "../../deploy/config-diffs";
 import type { Config, RawConfig } from "@cloudflare/workers-utils";
 

--- a/packages/wrangler/src/__tests__/deployments.test.ts
+++ b/packages/wrangler/src/__tests__/deployments.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import { thrownIsDoesNotExistError } from "@cloudflare/workers-shared";
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs } from "./helpers/mock-dialogs";

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import * as fs from "node:fs";
 import module from "node:module";
 import {
@@ -7,7 +8,7 @@ import {
 import getPort from "get-port";
 import { http, HttpResponse } from "msw";
 import dedent from "ts-dedent";
-import { vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ConfigController } from "../api/startDevWorker/ConfigController";
 import { unwrapHook } from "../api/startDevWorker/utils";
 import { getWorkerAccountAndContext } from "../dev/remote";

--- a/packages/wrangler/src/__tests__/dev/remote-bindings-errors.test.ts
+++ b/packages/wrangler/src/__tests__/dev/remote-bindings-errors.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it } from "vitest";
+import { assert, beforeEach, describe, expect, it, vi } from "vitest";
 import { startRemoteProxySession } from "../../api";
 import {
 	createPreviewSession,

--- a/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
+++ b/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 import { seed } from "@cloudflare/workers-utils/test-helpers";
 import { fetch } from "undici";
-import { afterEach, beforeEach, describe, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Binding, StartRemoteProxySessionOptions } from "../../api";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/errors.test.ts
+++ b/packages/wrangler/src/__tests__/errors.test.ts
@@ -7,6 +7,7 @@ import {
 	ParseError,
 	UserError,
 } from "@cloudflare/workers-utils";
+import { describe, expect, it } from "vitest";
 
 describe("errors", () => {
 	describe("UserError", () => {

--- a/packages/wrangler/src/__tests__/fetch-graphql-result.test.ts
+++ b/packages/wrangler/src/__tests__/fetch-graphql-result.test.ts
@@ -1,5 +1,6 @@
 import { COMPLIANCE_REGION_CONFIG_UNKNOWN } from "@cloudflare/workers-utils";
 import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
 import { fetchGraphqlResult } from "../cfetch";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { msw } from "./helpers/msw";

--- a/packages/wrangler/src/__tests__/find-additional-modules.test.ts
+++ b/packages/wrangler/src/__tests__/find-additional-modules.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import dedent from "ts-dedent";
+import { describe, expect, it } from "vitest";
 import { findAdditionalModules } from "../deployment-bundle/find-additional-modules";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";

--- a/packages/wrangler/src/__tests__/friendly-validator-errors.test.ts
+++ b/packages/wrangler/src/__tests__/friendly-validator-errors.test.ts
@@ -1,7 +1,7 @@
 import { ParseError } from "@cloudflare/workers-utils";
 import { normalizeString } from "@cloudflare/workers-utils/test-helpers";
 import { FormData } from "undici";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as checkCommands from "../check/commands";
 import { logger } from "../logger";
 import { helpIfErrorIsSizeOrScriptStartup } from "../utils/friendly-validator-errors";

--- a/packages/wrangler/src/__tests__/get-entry.test.ts
+++ b/packages/wrangler/src/__tests__/get-entry.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { defaultWranglerConfig } from "@cloudflare/workers-utils";
 import { seed } from "@cloudflare/workers-utils/test-helpers";
 import dedent from "ts-dedent";
+import { describe, expect, it } from "vitest";
 import { getEntry } from "../deployment-bundle/entry";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";

--- a/packages/wrangler/src/__tests__/get-host-from-url.test.ts
+++ b/packages/wrangler/src/__tests__/get-host-from-url.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { getHostFromUrl } from "../zones";
 
 //return the host given a url-like string

--- a/packages/wrangler/src/__tests__/guess-worker-format.test.ts
+++ b/packages/wrangler/src/__tests__/guess-worker-format.test.ts
@@ -1,5 +1,6 @@
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
+import { describe, expect, it } from "vitest";
 import { guessWorkerFormat } from "../deployment-bundle/guess-worker-format";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";

--- a/packages/wrangler/src/__tests__/hello-world.local.test.ts
+++ b/packages/wrangler/src/__tests__/hello-world.local.test.ts
@@ -1,4 +1,4 @@
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";

--- a/packages/wrangler/src/__tests__/helpers/assert-request.ts
+++ b/packages/wrangler/src/__tests__/helpers/assert-request.ts
@@ -1,3 +1,4 @@
+import { assert, beforeEach, expect, vi } from "vitest";
 import type { mockConsoleMethods } from "./mock-console";
 
 /**

--- a/packages/wrangler/src/__tests__/helpers/collect-cli-output.ts
+++ b/packages/wrangler/src/__tests__/helpers/collect-cli-output.ts
@@ -1,4 +1,5 @@
 import { stderr, stdout } from "@cloudflare/cli/streams";
+import { afterEach, beforeEach } from "vitest";
 
 export function collectCLIOutput() {
 	const std = { out: "", err: "" };

--- a/packages/wrangler/src/__tests__/helpers/mock-account-id.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-account-id.ts
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach, vi } from "vitest";
 import { reinitialiseAuthTokens } from "../../user";
 
 /**

--- a/packages/wrangler/src/__tests__/helpers/mock-auth-domain.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-auth-domain.ts
@@ -1,3 +1,5 @@
+import { afterEach, beforeEach } from "vitest";
+
 const ORIGINAL_WRANGLER_AUTH_DOMAIN = process.env.WRANGLER_AUTH_DOMAIN;
 
 /**

--- a/packages/wrangler/src/__tests__/helpers/mock-cli-output.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-cli-output.ts
@@ -1,6 +1,7 @@
 import * as util from "node:util";
 import * as streams from "@cloudflare/cli/streams";
 import { normalizeString } from "@cloudflare/workers-utils/test-helpers";
+import { afterEach, beforeEach, vi } from "vitest";
 import type { MockInstance } from "vitest";
 
 let outSpy: MockInstance, errSpy: MockInstance;

--- a/packages/wrangler/src/__tests__/helpers/mock-dialogs.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-dialogs.ts
@@ -1,4 +1,5 @@
 import prompts from "prompts";
+import { expect } from "vitest";
 import type { Mock } from "vitest";
 
 /**

--- a/packages/wrangler/src/__tests__/helpers/mock-get-pages-upload-token.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-get-pages-upload-token.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { expect } from "vitest";
 import { msw } from "./msw";
 
 /**

--- a/packages/wrangler/src/__tests__/helpers/mock-get-zone-from-host.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-get-zone-from-host.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { expect } from "vitest";
 import { msw } from "./msw";
 import type { RequestHandlerOptions } from "msw";
 

--- a/packages/wrangler/src/__tests__/helpers/mock-http-server.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-http-server.ts
@@ -1,5 +1,5 @@
 import http from "node:http";
-import { vi } from "vitest";
+import { beforeEach, vi } from "vitest";
 import type { Request } from "undici";
 
 /**

--- a/packages/wrangler/src/__tests__/helpers/mock-istty.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-istty.ts
@@ -1,3 +1,5 @@
+import { afterEach, beforeEach } from "vitest";
+
 const ORIGINAL_STDOUT = process.stdout;
 const ORIGINAL_STDIN = process.stdin;
 

--- a/packages/wrangler/src/__tests__/helpers/mock-kv.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-kv.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { expect } from "vitest";
 import { createFetchResult, msw } from "./msw";
 import type { KVNamespaceInfo, NamespaceKeyInfo } from "../../kv/helpers";
 

--- a/packages/wrangler/src/__tests__/helpers/mock-legacy-script.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-legacy-script.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { expect } from "vitest";
 import { msw } from "./msw";
 
 type LegacyScriptInfo = { id: string; migration_tag?: string };

--- a/packages/wrangler/src/__tests__/helpers/mock-process.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-process.ts
@@ -1,4 +1,4 @@
-import { vi } from "vitest";
+import { afterEach, beforeEach, vi } from "vitest";
 import type { MockInstance } from "vitest";
 
 /**

--- a/packages/wrangler/src/__tests__/helpers/mock-set-timeout.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-set-timeout.ts
@@ -1,4 +1,4 @@
-import { vi } from "vitest";
+import { afterEach, beforeEach, vi } from "vitest";
 import type { MockInstance } from "vitest";
 
 let setTimeoutSpy: MockInstance;

--- a/packages/wrangler/src/__tests__/helpers/mock-stdin.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-stdin.ts
@@ -1,3 +1,5 @@
+import { afterEach, beforeEach } from "vitest";
+
 const ORIGINAL_STDIN = process.stdin;
 
 /**

--- a/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
@@ -1,5 +1,6 @@
 import { ParseError } from "@cloudflare/workers-utils";
 import { http, HttpResponse } from "msw";
+import { expect } from "vitest";
 import {
 	getSubdomainValues,
 	getSubdomainValuesAPIMock,

--- a/packages/wrangler/src/__tests__/helpers/mock-worker-settings.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-worker-settings.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { expect } from "vitest";
 import { msw } from "./msw";
 import type { Settings } from "../../deployment-bundle/bindings";
 

--- a/packages/wrangler/src/__tests__/helpers/mock-workers-subdomain.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-workers-subdomain.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { expect } from "vitest";
 import { createFetchResult, msw } from "./msw";
 
 /** Create a mock handler for the request to get the account's subdomain. */

--- a/packages/wrangler/src/__tests__/helpers/mock-zone-routes.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-zone-routes.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { expect } from "vitest";
 import { msw } from "./msw";
 import type { RequestHandlerOptions } from "msw";
 

--- a/packages/wrangler/src/__tests__/helpers/msw/handlers/deployments.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/handlers/deployments.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { expect } from "vitest";
 import { createFetchResult } from "../index";
 
 const latestDeployment = (scriptTag: string) => ({

--- a/packages/wrangler/src/__tests__/helpers/run-wrangler.ts
+++ b/packages/wrangler/src/__tests__/helpers/run-wrangler.ts
@@ -1,4 +1,5 @@
 import { normalizeString } from "@cloudflare/workers-utils/test-helpers";
+import { vi } from "vitest";
 import { main } from "../../index";
 import * as shellquote from "../../utils/shell-quote";
 

--- a/packages/wrangler/src/__tests__/https-options.test.ts
+++ b/packages/wrangler/src/__tests__/https-options.test.ts
@@ -1,4 +1,6 @@
+import assert from "node:assert";
 import * as fs from "node:fs";
+import { describe, expect, it, vi } from "vitest";
 import { validateHttpsOptions } from "../https-options";
 import { runInTempDir } from "./helpers/run-in-tmp";
 

--- a/packages/wrangler/src/__tests__/hyperdrive.test.ts
+++ b/packages/wrangler/src/__tests__/hyperdrive.test.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "msw";
-import { vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { endEventLoop } from "./helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getPackageManager } from "../package-manager";
 import { updateCheck } from "../update-check";
 import { logPossibleBugMessage } from "../utils/logPossibleBugMessage";

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -6,7 +6,7 @@ import * as TOML from "smol-toml";
 import dedent from "ts-dedent";
 import { parseConfigFileTextToJson } from "typescript";
 import { FormData } from "undici";
-import { vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
 import { downloadWorker } from "../init";
 import { writeMetricsConfig } from "../metrics/metrics-config";
 import { getPackageManager } from "../package-manager";

--- a/packages/wrangler/src/__tests__/is-local.test.ts
+++ b/packages/wrangler/src/__tests__/is-local.test.ts
@@ -1,4 +1,4 @@
-import { it } from "vitest";
+import { expect, it } from "vitest";
 import { isLocal } from "../utils/is-local";
 
 const testCases: [

--- a/packages/wrangler/src/__tests__/kv/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/kv/bulk.test.ts
@@ -1,5 +1,6 @@
 import { writeFileSync } from "node:fs";
 import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { BATCH_MAX_ERRORS_WARNINGS } from "../../kv/helpers";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/kv/help.test.ts
+++ b/packages/wrangler/src/__tests__/kv/help.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach, describe, expect, it, test } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/kv/key.test.ts
+++ b/packages/wrangler/src/__tests__/kv/key.test.ts
@@ -1,5 +1,6 @@
 import { writeFileSync } from "node:fs";
 import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs } from "../helpers/mock-dialogs";

--- a/packages/wrangler/src/__tests__/kv/local.test.ts
+++ b/packages/wrangler/src/__tests__/kv/local.test.ts
@@ -1,5 +1,5 @@
 import { writeFileSync } from "node:fs";
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";

--- a/packages/wrangler/src/__tests__/kv/namespace.test.ts
+++ b/packages/wrangler/src/__tests__/kv/namespace.test.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs, mockConfirm, mockPrompt } from "../helpers/mock-dialogs";

--- a/packages/wrangler/src/__tests__/logger.test.ts
+++ b/packages/wrangler/src/__tests__/logger.test.ts
@@ -1,4 +1,5 @@
 import { error, logRaw, setLogLevel } from "@cloudflare/cli";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Logger } from "../logger";
 import { mockCLIOutput } from "./helpers/mock-cli-output";
 import { mockConsoleMethods } from "./helpers/mock-console";

--- a/packages/wrangler/src/__tests__/logout.test.ts
+++ b/packages/wrangler/src/__tests__/logout.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
 import { getAuthConfigFilePath, writeAuthConfigFile } from "../user";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { msw } from "./helpers/msw";

--- a/packages/wrangler/src/__tests__/metrics.test.ts
+++ b/packages/wrangler/src/__tests__/metrics.test.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import { http, HttpResponse } from "msw";
-import { vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CI } from "../is-ci";
 import { logger } from "../logger";
 import { sendMetricsEvent } from "../metrics";

--- a/packages/wrangler/src/__tests__/middleware.scheduled.test.ts
+++ b/packages/wrangler/src/__tests__/middleware.scheduled.test.ts
@@ -1,5 +1,5 @@
 import * as fs from "node:fs";
-import { vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { unstable_dev } from "../api";
 import { runInTempDir } from "./helpers/run-in-tmp";
 

--- a/packages/wrangler/src/__tests__/middleware.test.ts
+++ b/packages/wrangler/src/__tests__/middleware.test.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import dedent from "ts-dedent";
-import { vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { unstable_dev } from "../api";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";

--- a/packages/wrangler/src/__tests__/mtls-certificates.test.ts
+++ b/packages/wrangler/src/__tests__/mtls-certificates.test.ts
@@ -1,6 +1,7 @@
 import { writeFileSync } from "node:fs";
 import { COMPLIANCE_REGION_CONFIG_UNKNOWN } from "@cloudflare/workers-utils";
 import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it, test } from "vitest";
 import {
 	deleteMTlsCertificate,
 	getMTlsCertificate,

--- a/packages/wrangler/src/__tests__/navigator-user-agent.test.ts
+++ b/packages/wrangler/src/__tests__/navigator-user-agent.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import dedent from "ts-dedent";
-import { vi } from "vitest";
+import { afterEach, describe, expect, it, test, vi } from "vitest";
 import { bundleWorker } from "../deployment-bundle/bundle";
 import { noopModuleCollector } from "../deployment-bundle/module-collection";
 import { isNavigatorDefined } from "../navigator-user-agent";

--- a/packages/wrangler/src/__tests__/output.test.ts
+++ b/packages/wrangler/src/__tests__/output.test.ts
@@ -2,6 +2,7 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { FatalError } from "@cloudflare/workers-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { clearOutputFilePath, writeOutput } from "../output";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";

--- a/packages/wrangler/src/__tests__/package-manager.test.ts
+++ b/packages/wrangler/src/__tests__/package-manager.test.ts
@@ -1,4 +1,4 @@
-import { vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getPackageManager, getPackageManagerName } from "../package-manager";
 import { mockBinary } from "./helpers/mock-bin";
 import { mockConsoleMethods } from "./helpers/mock-console";

--- a/packages/wrangler/src/__tests__/pages/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deploy.test.ts
@@ -4,6 +4,7 @@ import { execa } from "execa";
 import { http, HttpResponse } from "msw";
 import TOML from "smol-toml";
 import dedent from "ts-dedent";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { version } from "../../../package.json";
 import { ROUTES_SPEC_VERSION } from "../../pages/constants";
 import { ApiErrorCodes } from "../../pages/errors";

--- a/packages/wrangler/src/__tests__/pages/deployment-list.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deployment-list.test.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { afterEach, describe, expect, it } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { mockAccountId, mockApiToken } from "./../helpers/mock-account-id";

--- a/packages/wrangler/src/__tests__/pages/dev.test.ts
+++ b/packages/wrangler/src/__tests__/pages/dev.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";

--- a/packages/wrangler/src/__tests__/pages/filepath-routing.test.ts
+++ b/packages/wrangler/src/__tests__/pages/filepath-routing.test.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, writeFileSync } from "node:fs";
+import { describe, expect, it, test } from "vitest";
 import {
 	compareRoutes,
 	generateConfigFromFileTree,

--- a/packages/wrangler/src/__tests__/pages/functions-build.test.ts
+++ b/packages/wrangler/src/__tests__/pages/functions-build.test.ts
@@ -6,6 +6,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import dedent from "ts-dedent";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runInTempDir } from "../helpers/run-in-tmp";

--- a/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { normalizeString } from "@cloudflare/workers-utils/test-helpers";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { logger } from "../../logger";
 import {
 	EXIT_CODE_INVALID_PAGES_CONFIG,

--- a/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
@@ -1,7 +1,7 @@
 import { setTimeout } from "node:timers/promises";
 import { http, HttpResponse } from "msw";
 import { Headers, Request } from "undici";
-import { vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import MockWebSocketServer from "vitest-websocket-mock";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/pages/pages-download-config.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-download-config.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { supportedCompatibilityDate } from "miniflare";
 import { http, HttpResponse } from "msw";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs, mockConfirm } from "../helpers/mock-dialogs";

--- a/packages/wrangler/src/__tests__/pages/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, describe, expect, it } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runInTempDir } from "../helpers/run-in-tmp";

--- a/packages/wrangler/src/__tests__/pages/project-create.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-create.test.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "./../helpers/mock-account-id";
 import { mockConsoleMethods } from "./../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/pages/project-delete.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-delete.test.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/pages/project-list.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-list.test.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { mockAccountId, mockApiToken } from "./../helpers/mock-account-id";

--- a/packages/wrangler/src/__tests__/pages/project-upload.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-upload.test.ts
@@ -1,6 +1,7 @@
 // /* eslint-disable no-shadow */
 import { mkdirSync, writeFileSync } from "node:fs";
 import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/pages/project-validate.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-validate.test.ts
@@ -1,6 +1,6 @@
 // /* eslint-disable no-shadow */
 import { writeFileSync } from "node:fs";
-import { vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runInTempDir } from "../helpers/run-in-tmp";

--- a/packages/wrangler/src/__tests__/pages/routes-consolidation.test.ts
+++ b/packages/wrangler/src/__tests__/pages/routes-consolidation.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import {
 	consolidateRoutes,
 	shortenRoute,

--- a/packages/wrangler/src/__tests__/pages/routes-transformation.test.ts
+++ b/packages/wrangler/src/__tests__/pages/routes-transformation.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, test } from "vitest";
 import {
 	MAX_FUNCTIONS_ROUTES_RULES,
 	ROUTES_SPEC_DESCRIPTION,

--- a/packages/wrangler/src/__tests__/pages/routes-validation.test.ts
+++ b/packages/wrangler/src/__tests__/pages/routes-validation.test.ts
@@ -1,4 +1,5 @@
 import { FatalError } from "@cloudflare/workers-utils";
+import { describe, expect, it } from "vitest";
 import {
 	MAX_FUNCTIONS_ROUTES_RULE_LENGTH,
 	MAX_FUNCTIONS_ROUTES_RULES,

--- a/packages/wrangler/src/__tests__/pages/secret.test.ts
+++ b/packages/wrangler/src/__tests__/pages/secret.test.ts
@@ -1,7 +1,7 @@
 import { writeFileSync } from "node:fs";
 import readline from "node:readline";
 import { http, HttpResponse } from "msw";
-import { vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs, mockConfirm, mockPrompt } from "../helpers/mock-dialogs";

--- a/packages/wrangler/src/__tests__/patch-config.test.ts
+++ b/packages/wrangler/src/__tests__/patch-config.test.ts
@@ -1,6 +1,7 @@
 import { writeFileSync } from "node:fs";
 import { experimental_patchConfig } from "@cloudflare/workers-utils";
 import dedent from "ts-dedent";
+import { describe, expect, it } from "vitest";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { writeWranglerConfig } from "./helpers/write-wrangler-config";
 import type { RawConfig } from "@cloudflare/workers-utils";

--- a/packages/wrangler/src/__tests__/paths.test.ts
+++ b/packages/wrangler/src/__tests__/paths.test.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import { describe, expect, it } from "vitest";
 import { getBasePath, readableRelative } from "../paths";
 
 describe("paths", () => {

--- a/packages/wrangler/src/__tests__/process-env-populated.test.ts
+++ b/packages/wrangler/src/__tests__/process-env-populated.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert";
+import { describe, expect, test } from "vitest";
 import { isProcessEnvPopulated } from "../process-env";
 
 describe("isProcessEnvPopulated", () => {

--- a/packages/wrangler/src/__tests__/provision.test.ts
+++ b/packages/wrangler/src/__tests__/provision.test.ts
@@ -1,6 +1,7 @@
 import { rmSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs, mockPrompt, mockSelect } from "./helpers/mock-dialogs";

--- a/packages/wrangler/src/__tests__/pubsub.test.ts
+++ b/packages/wrangler/src/__tests__/pubsub.test.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { msw } from "./helpers/msw";

--- a/packages/wrangler/src/__tests__/queues/mock-utils.ts
+++ b/packages/wrangler/src/__tests__/queues/mock-utils.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { expect } from "vitest";
 import { EventSourceType } from "../../queues/subscription-types";
 import { msw } from "../helpers/msw";
 import type { QueueResponse } from "../../queues/client";

--- a/packages/wrangler/src/__tests__/queues/queues-subscription.test.ts
+++ b/packages/wrangler/src/__tests__/queues/queues-subscription.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { EventSourceType } from "../../queues/subscription-types";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/queues/queues.test.ts
+++ b/packages/wrangler/src/__tests__/queues/queues.test.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { mockPrompt } from "../helpers/mock-dialogs";

--- a/packages/wrangler/src/__tests__/r2/bucket.test.ts
+++ b/packages/wrangler/src/__tests__/r2/bucket.test.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
 import { actionsForEventCategories } from "../../r2/helpers/notification";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";

--- a/packages/wrangler/src/__tests__/r2/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/r2/bulk.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
 import { MAX_UPLOAD_SIZE_BYTES } from "../../r2/constants";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";

--- a/packages/wrangler/src/__tests__/r2/errors.test.ts
+++ b/packages/wrangler/src/__tests__/r2/errors.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";

--- a/packages/wrangler/src/__tests__/r2/help.test.ts
+++ b/packages/wrangler/src/__tests__/r2/help.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { msw, mswR2handlers } from "../helpers/msw";

--- a/packages/wrangler/src/__tests__/r2/local.test.ts
+++ b/packages/wrangler/src/__tests__/r2/local.test.ts
@@ -1,5 +1,5 @@
 import * as fs from "node:fs";
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";

--- a/packages/wrangler/src/__tests__/r2/notification.test.ts
+++ b/packages/wrangler/src/__tests__/r2/notification.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { logger } from "../../logger";
 import {
 	eventNotificationHeaders,

--- a/packages/wrangler/src/__tests__/r2/object.test.ts
+++ b/packages/wrangler/src/__tests__/r2/object.test.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
 import { MAX_UPLOAD_SIZE_BYTES } from "../../r2/constants";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";

--- a/packages/wrangler/src/__tests__/r2/pipe.test.ts
+++ b/packages/wrangler/src/__tests__/r2/pipe.test.ts
@@ -1,4 +1,5 @@
 import { writeFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";

--- a/packages/wrangler/src/__tests__/r2/sql.test.ts
+++ b/packages/wrangler/src/__tests__/r2/sql.test.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -3,7 +3,7 @@ import { writeFileSync } from "node:fs";
 import readline from "node:readline";
 import { http, HttpResponse } from "msw";
 import * as TOML from "smol-toml";
-import { vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VERSION_NOT_DEPLOYED_ERR_CODE } from "../secret";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";

--- a/packages/wrangler/src/__tests__/secrets-store.test.ts
+++ b/packages/wrangler/src/__tests__/secrets-store.test.ts
@@ -3,7 +3,7 @@ import {
 	mockModifiedDate,
 } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-import { vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { endEventLoop } from "./helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";

--- a/packages/wrangler/src/__tests__/sentry.test.ts
+++ b/packages/wrangler/src/__tests__/sentry.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert";
 import path from "node:path";
 import * as Sentry from "@sentry/node";
 import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs, mockConfirm } from "./helpers/mock-dialogs";

--- a/packages/wrangler/src/__tests__/startup-profiling.test.ts
+++ b/packages/wrangler/src/__tests__/startup-profiling.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { logger } from "../logger";
 import { collectCLIOutput } from "./helpers/collect-cli-output";
 import { mockConsoleMethods } from "./helpers/mock-console";

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -1,7 +1,7 @@
 import { setTimeout } from "node:timers/promises";
 import { http, HttpResponse } from "msw";
 import { Headers, Request } from "undici";
-import { vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import MockWebSocketServer from "vitest-websocket-mock";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";

--- a/packages/wrangler/src/__tests__/tsconfig-sanity.ts
+++ b/packages/wrangler/src/__tests__/tsconfig-sanity.ts
@@ -1,9 +1,6 @@
 // `@types/node` should be included
 Buffer.from("test");
 
-// `@types/jest` should be included
-test("test");
-
 // @ts-expect-error `@cloudflare/workers-types` should NOT be included
 const _handler: ExportedHandler = {};
 // @ts-expect-error `@cloudflare/workers-types` should NOT be included

--- a/packages/wrangler/src/__tests__/tsconfig.json
+++ b/packages/wrangler/src/__tests__/tsconfig.json
@@ -2,7 +2,7 @@
 	"extends": "@cloudflare/workers-tsconfig/tsconfig.json",
 	"compilerOptions": {
 		"module": "preserve",
-		"types": ["node", "vitest/globals"],
+		"types": ["node"],
 		"jsx": "preserve"
 	},
 	"include": ["../*.d.ts", "**/*.ts", "**/*.tsx", "**/*.js"]

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -1,5 +1,14 @@
 import * as fs from "node:fs";
 import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+import {
 	constructTSModuleGlob,
 	constructTypeKey,
 	generateImportSpecifier,

--- a/packages/wrangler/src/__tests__/update-config-file.test.ts
+++ b/packages/wrangler/src/__tests__/update-config-file.test.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createdResourceConfig } from "../utils/add-created-resource-config";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -4,7 +4,7 @@ import {
 } from "@cloudflare/workers-utils";
 import { normalizeString } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-import { vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CI } from "../is-ci";
 import {
 	getAuthConfigFilePath,

--- a/packages/wrangler/src/__tests__/utils-collectKeyValues.test.ts
+++ b/packages/wrangler/src/__tests__/utils-collectKeyValues.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { collectKeyValues } from "../utils/collectKeyValues";
 
 describe("collectKeyValues()", () => {

--- a/packages/wrangler/src/__tests__/utils/create-batches.test.ts
+++ b/packages/wrangler/src/__tests__/utils/create-batches.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from "vitest";
 import { createBatches } from "../../utils/create-batches";
 
 // split a template string into an array of chars (convenience util to make writing inputs/outputs easier)

--- a/packages/wrangler/src/__tests__/utils/format-message.test.ts
+++ b/packages/wrangler/src/__tests__/utils/format-message.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { formatMessage } from "../../utils/format-message";
 import type { Message } from "@cloudflare/workers-utils";
 

--- a/packages/wrangler/src/__tests__/utils/getValidBindingName.test.ts
+++ b/packages/wrangler/src/__tests__/utils/getValidBindingName.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { getValidBindingName } from "../../utils/getValidBindingName";
 
 describe("getValidBindingName", () => {

--- a/packages/wrangler/src/__tests__/utils/retry.test.ts
+++ b/packages/wrangler/src/__tests__/utils/retry.test.ts
@@ -1,4 +1,5 @@
 import { APIError } from "@cloudflare/workers-utils";
+import { beforeEach, describe, expect, it } from "vitest";
 import { logger } from "../../logger";
 import { retryOnAPIFailure } from "../../utils/retry";
 import { mockConsoleMethods } from "../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
+++ b/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { validateQueryFilter } from "../../vectorize/query";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";

--- a/packages/wrangler/src/__tests__/vectorize/vectorize.upsert.test.ts
+++ b/packages/wrangler/src/__tests__/vectorize/vectorize.upsert.test.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import { writeFileSync } from "node:fs";
 import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { msw } from "../helpers/msw";

--- a/packages/wrangler/src/__tests__/version.test.ts
+++ b/packages/wrangler/src/__tests__/version.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { version } from "./../../package.json";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { useMockIsTTY } from "./helpers/mock-istty";

--- a/packages/wrangler/src/__tests__/versions/deployments/deployments.list.test.ts
+++ b/packages/wrangler/src/__tests__/versions/deployments/deployments.list.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, test } from "vitest";
 import { normalizeOutput } from "../../../../e2e/helpers/normalize";
 import { collectCLIOutput } from "../../helpers/collect-cli-output";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";

--- a/packages/wrangler/src/__tests__/versions/deployments/deployments.status.test.ts
+++ b/packages/wrangler/src/__tests__/versions/deployments/deployments.status.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, test } from "vitest";
 import { normalizeOutput } from "../../../../e2e/helpers/normalize";
 import { collectCLIOutput } from "../../helpers/collect-cli-output";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";

--- a/packages/wrangler/src/__tests__/versions/deployments/deployments.view.test.ts
+++ b/packages/wrangler/src/__tests__/versions/deployments/deployments.view.test.ts
@@ -1,4 +1,5 @@
 import { UserError } from "@cloudflare/workers-utils";
+import { describe, expect, test } from "vitest";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { runWrangler } from "../../helpers/run-wrangler";
 

--- a/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
@@ -1,6 +1,6 @@
 import { writeFile } from "node:fs/promises";
 import readline from "node:readline";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, it, test, vi } from "vitest";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { clearDialogs } from "../../helpers/mock-dialogs";

--- a/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
@@ -1,5 +1,5 @@
 import { writeFile } from "node:fs/promises";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, it, test } from "vitest";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { clearDialogs, mockConfirm } from "../../helpers/mock-dialogs";

--- a/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
@@ -1,7 +1,7 @@
 import { writeFile } from "node:fs/promises";
 import { http, HttpResponse } from "msw";
 import { FormData } from "undici";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, it, test } from "vitest";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { clearDialogs, mockPrompt } from "../../helpers/mock-dialogs";

--- a/packages/wrangler/src/__tests__/versions/secrets/utils.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/utils.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 import { FormData } from "undici";
+import { expect } from "vitest";
 import { createFetchResult, msw } from "../../helpers/msw";
 import type { VersionDetails, WorkerVersion } from "../../../versions/secrets";
 import type { WorkerMetadata } from "@cloudflare/workers-utils";

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, test } from "vitest";
 import { normalizeOutput } from "../../../e2e/helpers/normalize";
 import {
 	assignAndDistributePercentages,

--- a/packages/wrangler/src/__tests__/versions/versions.help.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.help.test.ts
@@ -1,4 +1,5 @@
 import { setImmediate } from "node:timers/promises";
+import { describe, expect, test } from "vitest";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runWrangler } from "../helpers/run-wrangler";
 

--- a/packages/wrangler/src/__tests__/versions/versions.list.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.list.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, test } from "vitest";
 import { normalizeOutput } from "../../../e2e/helpers/normalize";
 import { collectCLIOutput } from "../helpers/collect-cli-output";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it, test, vi } from "vitest";
 import { dedent } from "../../utils/dedent";
 import { generatePreviewAlias } from "../../versions/upload";
 import { makeApiRequestAsserter } from "../helpers/assert-request";

--- a/packages/wrangler/src/__tests__/versions/versions.view.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.view.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, test } from "vitest";
 import { normalizeOutput } from "../../../e2e/helpers/normalize";
 import { collectCLIOutput } from "../helpers/collect-cli-output";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";

--- a/packages/wrangler/src/__tests__/vitest.setup.ts
+++ b/packages/wrangler/src/__tests__/vitest.setup.ts
@@ -2,7 +2,7 @@
 import { PassThrough } from "node:stream";
 import chalk from "chalk";
 import { passthrough } from "msw";
-import { afterAll, afterEach, beforeAll, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
 import { msw } from "./helpers/msw";
 
 //turn off chalk for tests due to inconsistencies between operating systems

--- a/packages/wrangler/src/__tests__/vpc.test.ts
+++ b/packages/wrangler/src/__tests__/vpc.test.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "msw";
-import { vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ServiceType } from "../vpc/index";
 import { endEventLoop } from "./helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";

--- a/packages/wrangler/src/__tests__/whoami.test.ts
+++ b/packages/wrangler/src/__tests__/whoami.test.ts
@@ -1,5 +1,6 @@
 import { COMPLIANCE_REGION_CONFIG_UNKNOWN } from "@cloudflare/workers-utils";
 import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { writeAuthConfigFile } from "../user";
 import { getUserInfo } from "../user/whoami";
 import { mockConsoleMethods } from "./helpers/mock-console";

--- a/packages/wrangler/src/__tests__/worker-namespace.test.ts
+++ b/packages/wrangler/src/__tests__/worker-namespace.test.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { printWranglerBanner } from "../wrangler-banner";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";

--- a/packages/wrangler/src/__tests__/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/workflows.test.ts
@@ -6,6 +6,7 @@ import {
 	mockStartDate,
 } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
+import { afterEach, describe, expect, it } from "vitest";
 import { endEventLoop } from "./helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";

--- a/packages/wrangler/src/__tests__/zones.test.ts
+++ b/packages/wrangler/src/__tests__/zones.test.ts
@@ -1,5 +1,6 @@
 import { COMPLIANCE_REGION_CONFIG_UNKNOWN } from "@cloudflare/workers-utils";
 import { http, HttpResponse } from "msw";
+import { describe, expect, test } from "vitest";
 import { getHostFromUrl, getZoneForRoute } from "../zones";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { msw } from "./helpers/msw";


### PR DESCRIPTION
This removes the use of vitest globals from all the tests since they are a bit magical and explicitly importing them is the team's preference

For context: https://github.com/cloudflare/workers-sdk/pull/11460#discussion_r2571559081

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Tests not necessary because
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: infra change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not worth the effort? 😅 

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
