### PR TITLE
Ensure that `wrangler deploy --dry-run` doesn't fetch data from the rest API

### DIFF
--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -473,7 +473,7 @@ export default async function deploy(props: Props): Promise<{
 		}
 	}
 
-	if (isInteractive() || props.strict) {
+	if (accountId && (isInteractive() || props.strict)) {
 		const remoteSecretsCheck = await checkRemoteSecretsOverride(
 			config,
 			props.env


### PR DESCRIPTION
In wrangler `--dry-run` implies that no connections with the rest API should happen, this isn't currently respected for the remote secrets fetching introduced in https://github.com/cloudflare/workers-sdk/pull/11389 and that's what this PR is addressing.

Besides that a test is being added to make sure that also the remote config fetching of `wrangler deploy` doesn't take effect in dry-run mode.

> [!Note]
> No changeset here is required since the changes in https://github.com/cloudflare/workers-sdk/pull/11389 haven't been released yet

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a v3 feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
