### PR TITLE
fix(wrangler): close FileHandle in `wrangler d1 execute` to support Node 25

### DIFF
--- a/.changeset/some-wasps-attack.md
+++ b/.changeset/some-wasps-attack.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Explicitly close FileHandle in `wrangler d1 execute` to support Node 25

--- a/packages/wrangler/src/d1/execute.ts
+++ b/packages/wrangler/src/d1/execute.ts
@@ -620,14 +620,17 @@ function shorten(query: string | undefined, length: number) {
 
 async function checkForSQLiteBinary(filename: string) {
 	const buffer = Buffer.alloc(15);
+	let fd: fs.FileHandle | undefined;
 
 	try {
-		const fd = await fs.open(filename, "r");
+		fd = await fs.open(filename, "r");
 		await fd.read(buffer, 0, 15);
 	} catch {
 		throw new UserError(
 			`Unable to read SQL text file "${filename}". Please check the file path and try again.`
 		);
+	} finally {
+		await fd?.close();
 	}
 
 	if (buffer.toString("utf8") === "SQLite format 3") {


### PR DESCRIPTION
Fixes #11468.

This fixes an error when running `wrangler d1 execute` on [Node 25](https://nodejs.org/api/deprecations.html#dep0137-closing-fsfilehandle-on-garbage-collection):

```sh
> npx wrangler d1 execute test --file schema.sql

 ⛅️ wrangler 4.51.0
───────────────────
Resource location: local 

Use --remote if you want to access the remote instance.

🌀 Executing on local database test (e582c621-5286-41d7-aee3-743c0b3a2302) from .wrangler/state/v3/d1:
🌀 To execute on your remote database, add a --remote flag to your wrangler command.
[Error: A FileHandle object was closed during garbage collection. This used to be allowed with a deprecation warning but is now considered an error. Please close FileHandle objects explicitly. File descriptor: 21 (schema.sql)] {
  code: 'ERR_INVALID_STATE'
}
```

I have tested this manually with the repo provided in #11468.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Tests not necessary because: we don't run test in Node 25. Verified manually.
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/11491
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
