### PR TITLE
Fix flakes by disabling `perMessageDeflate` in `WebSocket` connections in `ProxyController`

### DIFF
--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -269,6 +269,9 @@ export class ProxyController extends Controller {
 
 			webSocket = new WebSocket(inspectorProxyWorkerUrl, {
 				headers: { Authorization: this.secret },
+				// If compression is on, we sometimes get race conditions with MockHttpSocket closing down
+				// while the deflate extension is still trying to send decompressed chunks.
+				perMessageDeflate: false,
 			});
 		} catch (cause) {
 			if (this._torndown) {


### PR DESCRIPTION
The recent update to MSW introduced a major rewrite in how it intercepts network requests.
As a result we started seeing intermittent test failures in `remote-bindings.test.ts` where the
`WebSocket` connections would randomly fail with errors related to per-message deflate.

An AI assisted analysis gave the following explanation:

This is a specific race condition exposed by the new architecture in @mswjs/interceptors v0.40.0.

- Async Operation Starts: Your test (or app) sends a message. The ws library attempts to compress it using permessage-deflate. This is asynchronous (it uses zlib).
- Socket Closure: Before that compression finishes, the socket is closed (either by the test ending, or MSW tearing down the connection).
- Cleanup Triggered: MSW v0.40.0's MockHttpSocket is very aggressive/synchronous about emitting the close event. This triggers WebSocket.emitClose, which calls PerMessageDeflate.cleanup().
- The Breakage: cleanup() destroys the internal zlib deflate stream.
    - In ws, when the deflate stream is destroyed/closed, the pending compression callback fires one last time.
    - Because the stream was destroyed mid-operation, it returns undefined as the buffer (instead of an error or data).
    - The ws Sender callback blindly receives this undefined result and passes it to Sender.frame(undefined), causing the crash.

In v0.29.x, MSW patched the native Node modules in a way that likely preserved the standard Event Loop timing for socket destruction.
In more recent versions, the new MockHttpSocket implementation likely handles `terminate()` or `close()` synchronously or significantly faster than a real network socket would.
In this case, it doesn't allow the "drain" of the zlib queue before destroying the context, leading to this collision where cleanup runs during a compression frame.

It is possible to fix this by disabling per-message deflate in the WebSocket connections made by Wrangler's ProxyController during `wrangler dev`.

---

The remote-binding tests have been run at least 30 times in a row without any failures, which should give confidence that this resolves the problem. E.g. https://github.com/cloudflare/workers-sdk/actions/runs/19831512655/job/56821687529?pr=11486

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Tests not necessary because: test change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> MSW update was not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
