### PR TITLE
Move prisma generate to postinstall script

### DIFF
--- a/packages/vite-plugin-cloudflare/playground/prisma/package.json
+++ b/packages/vite-plugin-cloudflare/playground/prisma/package.json
@@ -3,12 +3,11 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"prebuild": "pnpm generate",
 		"build": "vite build --app",
 		"check:type": "tsc --build",
-		"predev": "pnpm generate",
 		"dev": "vite dev",
 		"generate": "pnpm prisma generate",
+		"postinstall": "pnpm generate",
 		"migrate-db": "pnpm wrangler d1 migrations apply prisma-demo-db --local",
 		"preview": "vite preview",
 		"seed-db": "pnpm wrangler d1 execute prisma-demo-db --command \"INSERT INTO  \"User\" (\"email\", \"name\") VALUES ('jane@prisma.io', 'Jane Doe (Local)');\" --local"


### PR DESCRIPTION
This ensures that the Prisma client is generated before type checking. Moving it to `postinstall` seems best rather than running before multiple commands.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Tests not necessary because: type check change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: type check change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
