### PR TITLE
V3 backport of #11484: close FileHandle in  to support Node 25

### DIFF
--- a/.changeset/some-wasps-attack.md
+++ b/.changeset/some-wasps-attack.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Explicitly close FileHandle in `wrangler d1 execute` to support Node 25

--- a/packages/wrangler/src/d1/execute.ts
+++ b/packages/wrangler/src/d1/execute.ts
@@ -596,14 +596,17 @@ function shorten(query: string | undefined, length: number) {
 
 async function checkForSQLiteBinary(filename: string) {
 	const buffer = Buffer.alloc(15);
+	let fd: fs.FileHandle | undefined;
 
 	try {
-		const fd = await fs.open(filename, "r");
+		fd = await fs.open(filename, "r");
 		await fd.read(buffer, 0, 15);
 	} catch (e) {
 		throw new UserError(
 			`Unable to read SQL text file "${filename}". Please check the file path and try again.`
 		);
+	} finally {
+		await fd?.close();
 	}
 
 	if (buffer.toString("utf8") === "SQLite format 3") {


### PR DESCRIPTION
Wrangler v3 backport of #11484