### PR TITLE
Add `outputDir` to the deploy output entry's `autoconfig_summary` field

### DIFF
--- a/packages/wrangler/src/__tests__/autoconfig/run-summary.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/run-summary.test.ts
@@ -30,6 +30,7 @@ describe("autoconfig run - buildOperationsSummary()", () => {
 					workerName: "worker-name",
 					projectPath: "<PROJECT_PATH>",
 					configured: false,
+					outputDir: "public",
 				},
 				testRawConfig
 			);
@@ -50,6 +51,7 @@ describe("autoconfig run - buildOperationsSummary()", () => {
 
 			expect(summary).toMatchInlineSnapshot(`
 				Object {
+				  "outputDir": "public",
 				  "scripts": Object {},
 				  "wranglerConfig": Object {
 				    "$schema": "node_modules/wrangler/config-schema.json",
@@ -74,6 +76,7 @@ describe("autoconfig run - buildOperationsSummary()", () => {
 						devDependencies: {},
 					},
 					configured: false,
+					outputDir: "dist",
 				},
 				testRawConfig
 			);
@@ -87,6 +90,7 @@ describe("autoconfig run - buildOperationsSummary()", () => {
 
 			expect(summary).toMatchInlineSnapshot(`
 				Object {
+				  "outputDir": "dist",
 				  "scripts": Object {
 				    "deploy": "wrangler deploy",
 				    "preview": "wrangler dev",
@@ -116,6 +120,7 @@ describe("autoconfig run - buildOperationsSummary()", () => {
 						},
 					},
 					configured: false,
+					outputDir: "out",
 				},
 				testRawConfig
 			);
@@ -129,6 +134,7 @@ describe("autoconfig run - buildOperationsSummary()", () => {
 
 			expect(summary).toMatchInlineSnapshot(`
 				Object {
+				  "outputDir": "out",
 				  "scripts": Object {
 				    "deploy": "wrangler deploy",
 				    "preview": "wrangler dev",
@@ -153,6 +159,7 @@ describe("autoconfig run - buildOperationsSummary()", () => {
 					projectPath: "<PROJECT_PATH>",
 					framework: new Astro(),
 					configured: false,
+					outputDir: "dist",
 				},
 				testRawConfig
 			);
@@ -173,6 +180,7 @@ describe("autoconfig run - buildOperationsSummary()", () => {
 					projectPath: "<PROJECT_PATH>",
 					framework: new Static("static"),
 					configured: false,
+					outputDir: "public",
 				},
 				testRawConfig
 			);

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -15831,6 +15831,7 @@ export default{
 				},
 				wranglerInstall: true,
 				wranglerConfig,
+				outputDir: "public",
 			};
 		});
 
@@ -15849,6 +15850,7 @@ export default{
 
 		expect(deployOutputEntry.autoconfig_summary).toMatchInlineSnapshot(`
 			Object {
+			  "outputDir": "public",
 			  "scripts": Object {
 			    "build": "npm run build-my-static-site",
 			  },

--- a/packages/wrangler/src/autoconfig/run.ts
+++ b/packages/wrangler/src/autoconfig/run.ts
@@ -86,10 +86,13 @@ export async function runAutoConfig(
 			dryRun: true,
 		});
 
-	const autoConfigSummary = await buildOperationsSummary(autoConfigDetails, {
-		...wranglerConfig,
-		...dryRunConfigurationResults?.wranglerConfig,
-	});
+	const autoConfigSummary = await buildOperationsSummary(
+		{ ...autoConfigDetails, outputDir: autoConfigDetails.outputDir },
+		{
+			...wranglerConfig,
+			...dryRunConfigurationResults?.wranglerConfig,
+		}
+	);
 
 	if (!(skipConfirmations || (await confirm("Proceed with setup?")))) {
 		throw new FatalError("Setup cancelled");
@@ -196,7 +199,9 @@ export async function runAutoConfig(
 }
 
 export async function buildOperationsSummary(
-	autoConfigDetails: AutoConfigDetails,
+	autoConfigDetails: Omit<AutoConfigDetails, "outputDir"> & {
+		outputDir: NonNullable<AutoConfigDetails["outputDir"]>;
+	},
 	wranglerConfigToWrite: RawConfig,
 	packageJsonScriptsOverrides?: PackageJsonScriptsOverrides
 ): Promise<AutoConfigSummary> {
@@ -206,6 +211,7 @@ export async function buildOperationsSummary(
 		wranglerInstall: false,
 		scripts: {},
 		wranglerConfig: wranglerConfigToWrite,
+		outputDir: autoConfigDetails.outputDir,
 	};
 
 	if (autoConfigDetails.packageJson) {

--- a/packages/wrangler/src/autoconfig/types.ts
+++ b/packages/wrangler/src/autoconfig/types.ts
@@ -40,4 +40,5 @@ export type AutoConfigSummary = {
 	wranglerInstall: boolean;
 	wranglerConfig: RawConfig;
 	frameworkConfiguration?: string;
+	outputDir: string;
 };


### PR DESCRIPTION
Followup to https://github.com/cloudflare/workers-sdk/pull/11500

> [!note]
> This change (currently) does not need a changeset since the changes in #11500 haven't been released yet 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: autoconfig is not in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
