### PR TITLE
WC-4185 Support variable asset count based on claims from upstream

### DIFF
--- a/.changeset/two-comics-win.md
+++ b/.changeset/two-comics-win.md
@@ -1,0 +1,9 @@
+---
+"wrangler": minor
+---
+
+Add ability to enable higher asset count limits for Pages deployments
+
+Wrangler can now read asset count limits from JWT claims during Pages deployments,
+allowing users to be enabled for higher limits (up to 100,000 assets) on a per-account
+basis. The default limit remains at 20,000 assets.

--- a/packages/wrangler/src/pages/constants.ts
+++ b/packages/wrangler/src/pages/constants.ts
@@ -2,7 +2,7 @@ import { version as wranglerVersion } from "../../package.json";
 
 const isWindows = process.platform === "win32";
 
-export const MAX_ASSET_COUNT = 20_000;
+export const MAX_ASSET_COUNT_DEFAULT = 20_000;
 export const MAX_ASSET_SIZE = 25 * 1024 * 1024;
 export const PAGES_CONFIG_CACHE_FILENAME = "pages.json";
 export const MAX_BUCKET_SIZE = 40 * 1024 * 1024;

--- a/packages/wrangler/src/pages/upload.ts
+++ b/packages/wrangler/src/pages/upload.ts
@@ -13,6 +13,7 @@ import isInteractive from "../is-interactive";
 import { logger } from "../logger";
 import {
 	BULK_UPLOAD_CONCURRENCY,
+	MAX_ASSET_COUNT_DEFAULT,
 	MAX_BUCKET_FILE_COUNT,
 	MAX_BUCKET_SIZE,
 	MAX_CHECK_MISSING_ATTEMPTS,
@@ -59,7 +60,12 @@ export const pagesProjectUploadCommand = createCommand({
 			throw new FatalError("No JWT given.", 1);
 		}
 
-		const fileMap = await validate({ directory });
+		const fileMap = await validate({
+			directory,
+			fileCountLimit: maxFileCountAllowedFromClaims(
+				process.env.CF_PAGES_UPLOAD_JWT
+			),
+		});
 
 		const manifest = await upload({
 			fileMap,
@@ -397,6 +403,38 @@ export const isJwtExpired = (token: string): boolean | undefined => {
 		if (e instanceof Error) {
 			throw new Error(`Invalid token: ${e.message}`);
 		}
+	}
+};
+
+export const maxFileCountAllowedFromClaims = (token: string): number => {
+	// During testing we don't use valid JWTs, so don't try and parse them
+	if (
+		typeof vitest !== "undefined" &&
+		(token === "<<funfetti-auth-jwt>>" ||
+			token === "<<funfetti-auth-jwt2>>" ||
+			token === "<<aus-completion-token>>")
+	) {
+		return MAX_ASSET_COUNT_DEFAULT;
+	}
+	try {
+		// Not validating the JWT here, which ordinarily would be a big red flag.
+		// However, if the JWT is invalid, no uploads (calls to /pages/assets/upload)
+		// will succeed.
+		const decodedJwt = JSON.parse(
+			Buffer.from(token.split(".")[1], "base64").toString()
+		);
+
+		const maxFileCountAllowed = decodedJwt["max_file_count_allowed"];
+		if (typeof maxFileCountAllowed == "number") {
+			return maxFileCountAllowed;
+		}
+
+		return MAX_ASSET_COUNT_DEFAULT;
+	} catch (e) {
+		if (e instanceof Error) {
+			throw new Error(`Invalid token: ${e.message}`);
+		}
+		return MAX_ASSET_COUNT_DEFAULT;
 	}
 };
 

--- a/packages/wrangler/src/pages/validate.ts
+++ b/packages/wrangler/src/pages/validate.ts
@@ -5,7 +5,7 @@ import { getType } from "mime";
 import { Minimatch } from "minimatch";
 import prettyBytes from "pretty-bytes";
 import { createCommand } from "../core/create-command";
-import { MAX_ASSET_COUNT, MAX_ASSET_SIZE } from "./constants";
+import { MAX_ASSET_COUNT_DEFAULT, MAX_ASSET_SIZE } from "./constants";
 import { hashFile } from "./hash";
 
 export const pagesProjectValidateCommand = createCommand({
@@ -46,6 +46,7 @@ export type FileContainer = {
 
 export const validate = async (args: {
 	directory: string;
+	fileCountLimit?: number;
 }): Promise<Map<string, FileContainer>> => {
 	const IGNORE_LIST = [
 		"_worker.js",
@@ -67,6 +68,8 @@ export const validate = async (args: {
 	// 	const parsed = parser(process.env.NODE_OPTIONS);
 	// 	maxMemory = (parsed['max-old-space-size'] ? parsed['max-old-space-size'] : parsed['max_old_space_size']) * 1000 * 1000; // Turn MB into bytes
 	// }
+
+	const fileCountLimit = args.fileCountLimit ?? MAX_ASSET_COUNT_DEFAULT;
 
 	const walk = async (
 		dir: string,
@@ -124,9 +127,9 @@ export const validate = async (args: {
 
 	const fileMap = await walk(directory);
 
-	if (fileMap.size > MAX_ASSET_COUNT) {
+	if (fileMap.size > fileCountLimit) {
 		throw new FatalError(
-			`Error: Pages only supports up to ${MAX_ASSET_COUNT.toLocaleString()} files in a deployment. Ensure you have specified your build output directory correctly.`,
+			`Error: Pages only supports up to ${fileCountLimit.toLocaleString()} files in a deployment for your current plan. Ensure you have specified your build output directory correctly.`,
 			1
 		);
 	}


### PR DESCRIPTION
As noted in the comments, normally we'd need to validate this jwt, but since any uploads depend on a valid jwt (and are validated later) it's fine to just decode the jwt and check for this feature

For WC-4185

_Describe your change..._

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal-only change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a patch change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
