### PR TITLE
Add RedwoodSDK to experimental C3 menu

### DIFF
--- a/.changeset/blue-jars-create.md
+++ b/.changeset/blue-jars-create.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": minor
+---
+
+Support RedwoodSDK in `--experimental` mode

--- a/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
+++ b/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
@@ -555,7 +555,7 @@ describe("Create Cloudflare CLI", () => {
 					    npm create cloudflare -- --framework next -- --ts
 					    pnpm create cloudflare --framework next -- --ts
 					    Allowed Values:
-					      angular, astro, docusaurus, gatsby, nuxt, qwik, react, react-router, solid, svelte, tanstack-start, vue
+					      angular, astro, docusaurus, gatsby, nuxt, qwik, react, react-router, redwood, solid, svelte, tanstack-start, vue
 					  --platform=<value>
 					    Whether the application should be deployed to Pages or Workers. This is only applicable for Frameworks templates that support both Pages and Workers.
 					    Allowed Values:

--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -936,6 +936,26 @@ function getExperimentalFrameworkTestConfig(
 			flags: ["--no-install", "--no-git-init"],
 			verifyTypes: false,
 		},
+		{
+			name: "redwood",
+			testCommitMessage: true,
+			timeout: LONG_TIMEOUT,
+			unsupportedOSs: ["win32"],
+			verifyDeploy: {
+				route: "/",
+				expectedText: "RedwoodSDK",
+			},
+			verifyPreview: {
+				build: true,
+				route: "/",
+				expectedText: "RedwoodSDK",
+			},
+			nodeCompat: true,
+			verifyTypes: false,
+			extraEnv: {
+				GITHUB_API_TOKEN: process.env.GITHUB_TOKEN,
+			},
+		},
 	];
 }
 

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -245,6 +245,7 @@ export function getFrameworkMap({ experimental = false }): TemplateMap {
 			qwik: qwikTemplate,
 			react: reactTemplate,
 			"react-router": reactRouterTemplate,
+			redwood: redwoodTemplate,
 			solid: solidTemplate,
 			svelte: svelteTemplate,
 			"tanstack-start": tanStackStartTemplate,


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-2366

RedwoodSDK doesn't actually require any autoconfig logic since it is a framework specifically designed to run on Cloudflare. However here I am adding RedwoodSDK to the C3 experimental menu so that we:
 - include it in the C3 experimental E2E tests and so test that autoconfig doesn't cause any issues here
 - have this already in place for when later we stabilize the experimental menu

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: tracked elsewhere
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a wrangler change
