### PR TITLE
Update help message not to recommend non-applicable `--ts` create-next-app argument

### DIFF
--- a/.changeset/khaki-shrimps-hammer.md
+++ b/.changeset/khaki-shrimps-hammer.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+Update help message not to recommend non-applicable `--ts` create-next-app argument
+
+C3 uses it's own template when running create-next-app, so providing a `--ts` argument to it doesn't have any effect, the C3 help message however shows that as an example on how to pass arguments to underlying framework CLIs. The changes here update the error message to instead use svelte's `--types=ts` as the example

--- a/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
+++ b/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
@@ -552,8 +552,8 @@ describe("Create Cloudflare CLI", () => {
 					    The type of framework to use to create a web application (when using this option "--category" is coerced to "web-framework")
 					    When using the --framework option, C3 will dispatch to the official creation tool used by the framework (e.g. "create-astro" is used for Astro).
 					    You may specify additional arguments to be passed directly to these underlying tools by adding them after a "--" argument, like so:
-					    npm create cloudflare -- --framework next -- --ts
-					    pnpm create cloudflare --framework next -- --ts
+					    npm create cloudflare -- --framework svelte -- --types=ts
+					    pnpm create cloudflare --framework svelte -- --types=ts
 					    Allowed Values:
 					      angular, astro, docusaurus, gatsby, nuxt, qwik, react, react-router, solid, svelte, tanstack-start, vue
 					  --platform=<value>
@@ -654,8 +654,8 @@ describe("Create Cloudflare CLI", () => {
 					    The type of framework to use to create a web application (when using this option "--category" is coerced to "web-framework")
 					    When using the --framework option, C3 will dispatch to the official creation tool used by the framework (e.g. "create-astro" is used for Astro).
 					    You may specify additional arguments to be passed directly to these underlying tools by adding them after a "--" argument, like so:
-					    npm create cloudflare -- --framework next -- --ts
-					    pnpm create cloudflare --framework next -- --ts
+					    npm create cloudflare -- --framework svelte -- --types=ts
+					    pnpm create cloudflare --framework svelte -- --types=ts
 					    Allowed Values:
 					      analog, angular, astro, docusaurus, gatsby, hono, next, nuxt, qwik, react, react-router, redwood, solid, svelte, tanstack-start, vike, vue, waku
 					  --platform=<value>

--- a/packages/create-cloudflare/src/helpers/args.ts
+++ b/packages/create-cloudflare/src/helpers/args.ts
@@ -113,8 +113,8 @@ export const cliDefinition: ArgumentsDefinition = {
 
       You may specify additional arguments to be passed directly to these underlying tools by adding them after a "--" argument, like so:
 
-      npm create cloudflare -- --framework next -- --ts
-      pnpm create cloudflare --framework next -- --ts
+      npm create cloudflare -- --framework svelte -- --types=ts
+      pnpm create cloudflare --framework svelte -- --types=ts
       `,
 			values: (args) =>
 				getNamesAndDescriptions(


### PR DESCRIPTION
C3 uses it's own template when running create-next-app, so providing a `--ts` argument to it doesn't have any effect, the C3 help message however shows that as an example on how to pass arguments to underlying framework CLIs. The changes here update the error message to instead use svelte's `--types=ts` as the example

For context: https://github.com/cloudflare/workers-sdk/pull/11301#discussion_r2603059199

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: help message update
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
