### PR TITLE
fix(cli): correct select pagination for hidden options & resize

### DIFF
--- a/.changeset/fix-select-pagination-resize.md
+++ b/.changeset/fix-select-pagination-resize.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/cli": patch
+---
+
+fix: correct pagination calculations in select prompts to handle hidden options and terminal resize
+
+- Fixed `getSelectRenderers` to use `visibleOptions.length` instead of `options.length` for pagination calculations, preventing incorrect item visibility when hidden options exist
+- Moved terminal `rows` retrieval inside the renderer function in `getSelectListRenderers` so it updates on terminal resize


### PR DESCRIPTION
Fixes https://x.com/wishee0/status/1998463820071874969/photo/1

_Describe your change..._

Claude says
```
Summary
I found and fixed two bugs in packages/cli/interactive.ts that could cause rendering issues when resizing the terminal or when the terminal is too small:
Bug 1: Incorrect pagination calculations in getSelectRenderers (lines 358-388)
Problem: The renderOptionCondition function and the "..." indicators were using options.length (which includes hidden options) instead of visibleOptions.length (which only includes visible options). This mismatch could cause:
- Incorrect pagination calculations when there are hidden options
- Wrong items being shown/hidden based on cursor position
- The "..." pagination indicators appearing incorrectly
Fix: Changed all references from options.length to visibleOptions.length and reordered the code so visibleOptions is defined before being used in closures.
Bug 2: Stale terminal rows in getSelectListRenderers (line 469)
Problem: The terminal rows value was captured once when the renderer was created (const { rows } = stdout), not when each render occurred. This meant that if the user resized the terminal:
- The pagination would still use the old terminal height
- Pages might be calculated with the wrong number of items
- Items could overflow or be cut off incorrectly
Fix: Moved the const { rows } = stdout inside the defaultRenderer function so it gets the current terminal height on each render.
These bugs could cause visual artifacts like "multiple items appearing selected at spaced intervals" because:
1. The wrong items would be displayed due to incorrect pagination
2. The clack library's diff-based rendering might not correctly clear old content when the pagination boundaries changed unexpectedly
```

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Tests not necessary because: Bugfix
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Bugfix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: Bugfix to c3

*A picture of a cute animal (not mandatory, but encouraged)*
Austin office raccoon says hi 
<img width="1512" height="2016" alt="image" src="https://github.com/user-attachments/assets/f8eda007-339c-4e0d-905c-eab0cb0369e3" />


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
