### PR TITLE
ci: the semgrep CI job fails but this doesn't mean anything

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -2,7 +2,6 @@ name: Semgrep config
 
 on:
   workflow_dispatch: {}
-  pull_request: {} # REMOVE THIS: Run on PR to test
   schedule:
     - cron: "0 0 * * *"
 


### PR DESCRIPTION
The job posts to some dashboard that the team has no access to; so the exit code for the job is not relevant to the team.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Tests not necessary because: CI change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: CI change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> CI change

