### PR TITLE
ci: ban landing changes that could lead to a Worker/Pages deployment from workers-sdk

### DIFF
--- a/tools/deployments/validate-changesets.ts
+++ b/tools/deployments/validate-changesets.ts
@@ -3,9 +3,9 @@ import { resolve } from "node:path";
 import parseChangeset from "@changesets/parse";
 
 if (require.main === module) {
-	const packageNames = findPackageNames();
+	const packages = findPackages();
 	const changesets = readChangesets(resolve(__dirname, "../../.changeset"));
-	const errors = validateChangesets(packageNames, changesets);
+	const errors = validateChangesets(packages, changesets);
 	if (errors.length > 0) {
 		console.error("Validation errors in changesets:");
 		for (const error of errors) {
@@ -16,7 +16,7 @@ if (require.main === module) {
 }
 
 export function validateChangesets(
-	packageNames: Set<string>,
+	packages: Map<string, PackageJSON>,
 	changesets: ChangesetFile[]
 ) {
 	const errors: string[] = [];
@@ -24,11 +24,20 @@ export function validateChangesets(
 		try {
 			const changeset = parseChangeset(contents);
 			for (const release of changeset.releases) {
-				if (!packageNames.has(release.name)) {
+				if (!packages.has(release.name)) {
 					errors.push(
-						`Invalid package name "${release.name}" in changeset at "${file}".`
+						`Unknown package name "${release.name}" in changeset at "${file}".`
 					);
 				}
+
+				// TEMPORARILY BLOCK PACKAGES THAT WOULD DEPLOY WORKERS
+				if (packages.get(release.name)?.["workers-sdk"]?.deploy) {
+					errors.push(
+						`Currently we are not allowing changes to package "${release.name}" in changeset at "${file}" since it would trigger a Worker/Pages deployment.`
+					);
+				}
+				// END TEMPORARILY BLOCK PACKAGES THAT WOULD DEPLOY WORKERS
+
 				if (release.type === "major") {
 					errors.push(
 						`Major version bumps are not allowed for package "${release.name}" in changeset at "${file}".`
@@ -69,7 +78,7 @@ export function readChangesets(changesetDir: string): ChangesetFile[] {
  * This is determined by the package containing a package.json that is public or
  * is marked as `"private": true` and has a `deploy` script.
  */
-export function findPackageNames(): Set<string> {
+export function findPackages(): Map<string, PackageJSON> {
 	const packagesDirectory = resolve(__dirname, "../../packages");
 	const allPackageDirectories = readdirSync(packagesDirectory).map((p) =>
 		resolve(packagesDirectory, p)
@@ -84,10 +93,10 @@ export function findPackageNames(): Set<string> {
 			// Do nothing
 		}
 	}
-	const deployablePackages = new Set<string>();
+	const deployablePackages = new Map<string, PackageJSON>();
 	for (const pkg of allPackages) {
 		if (!pkg.private || pkg.scripts?.deploy !== undefined) {
-			deployablePackages.add(pkg.name);
+			deployablePackages.set(pkg.name, pkg);
 		}
 	}
 	return deployablePackages;
@@ -102,4 +111,7 @@ export type PackageJSON = {
 	name: string;
 	private?: boolean;
 	scripts?: Record<string, unknown>;
+	"workers-sdk"?: {
+		deploy?: boolean;
+	};
 };


### PR DESCRIPTION

- Tests
  - [x] Tests included/updated
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: CI change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> Workers are not backported

