### PR TITLE
remove unused flags in the Next tests

### DIFF
--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -344,7 +344,6 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			name: "next",
 			timeout: LONG_TIMEOUT,
 			testCommitMessage: true,
-			flags: ["--yes", "--import-alias", "@/*"],
 			verifyPreview: {
 				previewArgs: ["--", "--inspector-port=0"],
 				route: "/",


### PR DESCRIPTION
Those flags were used when the c3/Next template was still using the `create next-app` cli


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Tests not necessary because: already tested
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal cleanup
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: c3

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
