### PR TITLE
fix prettier warning

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -8,24 +8,38 @@
 		"@ianvs/prettier-plugin-sort-imports",
 		"prettier-plugin-packagejson"
 	],
-	"importOrder": [
-		"<BUILTIN_MODULES>",
-		"<THIRD_PARTY_MODULES>",
-		"^[.]{2}$",
-		"^[.]{2}/",
-		"^[.]/(?!index)",
-		"^[.]$",
-		"^[.]/index$",
-		"<TYPES>"
-	],
-	"importOrderTypeScriptVersion": "5.5.2",
-	"importOrderParserPlugins": [
-		"typescript",
-		"jsx",
-		"decorators",
-		"explicitResourceManagement"
-	],
 	"overrides": [
+		{
+			"files": [
+				"*.js",
+				"*.jsx",
+				"*.ts",
+				"*.tsx",
+				"*.mjs",
+				"*.cjs",
+				"*.mts",
+				"*.cts"
+			],
+			"options": {
+				"importOrder": [
+					"<BUILTIN_MODULES>",
+					"<THIRD_PARTY_MODULES>",
+					"^[.]{2}$",
+					"^[.]{2}/",
+					"^[.]/(?!index)",
+					"^[.]$",
+					"^[.]/index$",
+					"<TYPES>"
+				],
+				"importOrderTypeScriptVersion": "5.5.2",
+				"importOrderParserPlugins": [
+					"typescript",
+					"jsx",
+					"decorators",
+					"explicitResourceManagement"
+				]
+			}
+		},
 		{
 			"files": "packages/vite-plugin-cloudflare/README.md",
 			"options": {


### PR DESCRIPTION
Remove the following warning

```
[warn] Ignored unknown option { importOrder: ["<BUILTIN_MODULES>", "<THIRD_PARTY_MODULES>", "^[.]{2}$", "^[.]{2}/", "^[.]/(?!index)", "^[.]$", "^[.]/index$", "<TYPES>"] }.
[warn] Ignored unknown option { importOrderTypeScriptVersion: "5.5.2" }.
[warn] Ignored unknown option { importOrderParserPlugins: ["typescript", "jsx", "decorators", "explicitResourceManagement"] }.
```

Cuased by the import options do not apply to the README.

Courtesy of Claude


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
