### PR TITLE
ci: auto-assign 'workers for platforms' issues

### DIFF
--- a/tools/github-workflow-helpers/auto-assign-issues.ts
+++ b/tools/github-workflow-helpers/auto-assign-issues.ts
@@ -42,6 +42,7 @@ const TEAM_ASSIGNMENTS: { [label: string]: { [jobRole: string]: string } } = {
 	vectorize: { em: "sejoker", pm: "jonesphillip" },
 	"vite-plugin": { em: "lrapoport-cf", pm: "mattietk" },
 	vitest: { em: "lrapoport-cf", pm: "mattietk" },
+	"workers for platforms": { pm: "dinasaur404" },
 	"workers vpc": { em: "efalcao", pm: "thomasgauvin" },
 	"Workers + Assets": { em: "dcartertwo", pm: "irvinebroque" },
 	"workers ai": {},


### PR DESCRIPTION
Auto-assigns @dinasaur404 any issues labelled with "workers for platforms". Draft as I'm not sure who is the right EM.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated 
  - [x] Tests not necessary because:just CI
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: just CI
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> just CI

*A picture of a cute animal (not mandatory, but encouraged)*

<img width="538" height="400" alt="image" src="https://github.com/user-attachments/assets/e936c71e-fdd1-4053-bed0-300706e9a92d" />


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
