### PR TITLE
fix: respect TypeScript path aliases when resolving non-JS modules with module rules

### DIFF
--- a/.changeset/fix-tsconfig-paths-module-collection.md
+++ b/.changeset/fix-tsconfig-paths-module-collection.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: respect TypeScript path aliases when resolving non-JS modules with module rules
+
+When importing non-JavaScript files (like `.graphql`, `.txt`, etc.) using TypeScript path aliases defined in `tsconfig.json`, Wrangler's module-collection plugin now correctly resolves these imports. Previously, path aliases were only respected for JavaScript/TypeScript files, causing imports like `import schema from '~lib/schema.graphql'` to fail when using module rules.

--- a/packages/wrangler/src/deployment-bundle/module-collection.ts
+++ b/packages/wrangler/src/deployment-bundle/module-collection.ts
@@ -278,7 +278,8 @@ export function createModuleCollector(props: {
 								// and resolve the file path to the correct file.
 								try {
 									const resolved = await build.resolve(args.path, {
-										kind: "import-statement",
+										kind: args.kind,
+										importer: args.importer,
 										resolveDir: args.resolveDir,
 										pluginData: {
 											skip: true,


### PR DESCRIPTION
Fixes #2954.

Devin PR requested by @ascorbic

When importing non-JavaScript files (like `.graphql`, `.txt`, etc.) using TypeScript path aliases defined in `tsconfig.json`, Wrangler's module-collection plugin was not correctly resolving these imports. This was because the `build.resolve()` call was using a hard-coded `kind: "import-statement"` without passing the `importer` context, which prevented esbuild from applying the tsconfig path mappings.

The fix passes `args.kind` and `args.importer` to `build.resolve()`, allowing esbuild to properly resolve path aliases for non-JS modules.

**Example that now works:**
```ts
// tsconfig.json: { "compilerOptions": { "paths": { "~lib/*": ["lib/*"] } } }
// wrangler.toml: rules = [{ type = "Text", globs = ["**/*.graphql"] }]
import schema from '~lib/schema.graphql';
```

---

- Tests
  - [x] Tests included/updated
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is a bug fix for existing functionality
- Wrangler V3 Backport
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/11650
  - [ ] Not necessary because:

---

**Human Review Checklist:**
- [x] Verify passing `args.kind` and `args.importer` doesn't break existing non-aliased module resolution
- [x] Confirm the test correctly validates the fix (uses deterministic SHA1 hash of file content for module name)

Link to Devin run: https://app.devin.ai/sessions/359225f1b8cc46d5a846f1dbd6dcfd26