### PR TITLE
[v3 backport] fix: respect TypeScript path aliases when resolving non-JS modules with module rules

### DIFF
--- a/.changeset/fix-tsconfig-paths-module-collection.md
+++ b/.changeset/fix-tsconfig-paths-module-collection.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: respect TypeScript path aliases when resolving non-JS modules with module rules
+
+When importing non-JavaScript files (like `.graphql`, `.txt`, etc.) using TypeScript path aliases defined in `tsconfig.json`, Wrangler's module-collection plugin now correctly resolves these imports. Previously, path aliases were only respected for JavaScript/TypeScript files, causing imports like `import schema from '~lib/schema.graphql'` to fail when using module rules.

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -10511,6 +10511,39 @@ addEventListener('fetch', event => {});`
 			`);
 		});
 
+		it("should use compilerOptions.paths to resolve non-js modules with module rules", async () => {
+			writeWranglerConfig({
+				main: "index.ts",
+				rules: [{ type: "Text", globs: ["**/*.graphql"], fallthrough: true }],
+			});
+			fs.writeFileSync(
+				"index.ts",
+				`import schema from '~lib/schema.graphql'; export default { fetch() { return new Response(schema)} }`
+			);
+			fs.mkdirSync("lib", { recursive: true });
+			fs.writeFileSync("lib/schema.graphql", `type Query { hello: String }`);
+			fs.writeFileSync(
+				"tsconfig.json",
+				JSON.stringify({
+					compilerOptions: {
+						baseUrl: ".",
+						paths: {
+							"~lib/*": ["lib/*"],
+						},
+					},
+				})
+			);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedModules: {
+					"./bc4a21e10be4cae586632dfe5c3f049299c06466-schema.graphql":
+						"type Query { hello: String }",
+				},
+			});
+			await runWrangler("deploy index.ts");
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
 		it("should output to target es2022 even if tsconfig says otherwise", async () => {
 			writeWranglerConfig();
 			writeWorkerSource();

--- a/packages/wrangler/src/deployment-bundle/module-collection.ts
+++ b/packages/wrangler/src/deployment-bundle/module-collection.ts
@@ -274,7 +274,8 @@ export function createModuleCollector(props: {
 								// and resolve the file path to the correct file.
 								try {
 									const resolved = await build.resolve(args.path, {
-										kind: "import-statement",
+										kind: args.kind,
+										importer: args.importer,
 										resolveDir: args.resolveDir,
 										pluginData: {
 											skip: true,


### PR DESCRIPTION
Backport of https://github.com/cloudflare/workers-sdk/pull/11649

Devin PR requested by @ascorbic

When importing non-JavaScript files (like `.graphql`, `.txt`, etc.) using TypeScript path aliases defined in `tsconfig.json`, Wrangler's module-collection plugin was not correctly resolving these imports. This was because the `build.resolve()` call was using a hard-coded `kind: "import-statement"` without passing the `importer` context, which prevented esbuild from applying the tsconfig path mappings.

The fix passes `args.kind` and `args.importer` to `build.resolve()`, allowing esbuild to properly resolve path aliases for non-JS modules.

**Example that now works:**
```ts
// tsconfig.json: { "compilerOptions": { "paths": { "~lib/*": ["lib/*"] } } }
// wrangler.toml: rules = [{ type = "Text", globs = ["**/*.graphql"] }]
import schema from '~lib/schema.graphql';
```

**Human Review Checklist:**
- [ ] Verify passing `args.kind` and `args.importer` doesn't break existing non-aliased module resolution
- [ ] Confirm the test correctly validates the fix (uses deterministic SHA1 hash of file content for module name)

---

- Tests
  - [x] Tests included
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] Not required because: This is a bundling-time fix, covered by unit tests
- Public documentation
  - [x] Documentation not necessary because: This is a bug fix for existing functionality

Link to Devin run: https://app.devin.ai/sessions/359225f1b8cc46d5a846f1dbd6dcfd26