### PR TITLE
V3 Backport: fix: Automatically convert TOML Date values in `vars` to strings

### DIFF
--- a/.changeset/social-news-flash.md
+++ b/.changeset/social-news-flash.md
@@ -1,0 +1,13 @@
+---
+"wrangler": patch
+---
+
+Improve error message when `vars` in wrangler.toml contains TOML Date values
+
+TOML parses unquoted date values like `DATE = 2024-01-01` as Date objects, which are not valid for environment variables. Previously this caused a confusing error from Miniflare. Now wrangler detects Date values early and provides a helpful error message suggesting to wrap the value in quotes:
+
+```
+The value for "vars.DATE" is a Date object.
+TOML parses dates like `DATE = 2024-01-01` as Date objects.
+To use a date string, wrap the value in quotes: `DATE = "2024-01-01"`.
+```

--- a/packages/wrangler/src/__tests__/config/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.test.ts
@@ -4565,6 +4565,60 @@ describe("normalizeAndValidateConfig()", () => {
 			`);
 		});
 
+		it("should convert Date values in vars to strings (parsed by TOML)", () => {
+			const rawConfig = {
+				vars: {
+					VALID_VAR: "some string",
+					DATE_VAR: new Date("2024-01-01"),
+				},
+			} as unknown as RawConfig;
+
+			const { config, diagnostics } = normalizeAndValidateConfig(
+				rawConfig,
+				undefined,
+				undefined,
+				{ env: undefined }
+			);
+
+			expect(diagnostics.hasErrors()).toBe(false);
+			expect(diagnostics.hasWarnings()).toBe(false);
+
+			// Verify the Date was converted to a string
+			expect(config.vars).toEqual({
+				VALID_VAR: "some string",
+				DATE_VAR: "2024-01-01",
+			});
+		});
+
+		it("should convert Date values in env vars to strings (parsed by TOML)", () => {
+			const rawConfig = {
+				env: {
+					production: {
+						vars: {
+							VALID_VAR: "some string",
+							RELEASE_DATE: new Date("2025-06-15"),
+						},
+					},
+				},
+			} as unknown as RawConfig;
+
+			const { config, diagnostics } = normalizeAndValidateConfig(
+				rawConfig,
+				undefined,
+				undefined,
+				{ env: "production" }
+			);
+
+			expect(diagnostics.hasErrors()).toBe(false);
+			expect(diagnostics.hasWarnings()).toBe(false);
+
+			// Verify the Date was converted to a string
+			expect(config.vars).toEqual({
+				VALID_VAR: "some string",
+				RELEASE_DATE: "2025-06-15",
+			});
+		});
+
 		it("should error on invalid environment values", () => {
 			const expectedConfig: RawEnvironment = {
 				name: 111,


### PR DESCRIPTION
Backport for #11651 