### PR TITLE
Update the signature of ParseTOML to drop the Generics

### DIFF
--- a/.changeset/three-ways-crash.md
+++ b/.changeset/three-ways-crash.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/workers-utils": patch
+---
+
+Update the signature of ParseTOML to drop the Generics.
+
+Use an explicit cast where required.

--- a/packages/workers-utils/src/config/index.ts
+++ b/packages/workers-utils/src/config/index.ts
@@ -103,7 +103,7 @@ export type ConfigBindingOptions = Pick<
 
 const parseRawConfigFile = (configPath: string): RawConfig => {
 	if (configPath.endsWith(".toml")) {
-		return parseTOML(readFileSync(configPath), configPath);
+		return parseTOML(readFileSync(configPath), configPath) as RawConfig;
 	}
 
 	if (configPath.endsWith(".json") || configPath.endsWith(".jsonc")) {

--- a/packages/workers-utils/src/parse.ts
+++ b/packages/workers-utils/src/parse.ts
@@ -82,22 +82,28 @@ export class APIError extends ParseError {
 }
 
 /**
- * A wrapper around `TOML.parse` that throws a `ParseError`.
+ * Parses a TOML string to an object.
+ *
+ * Note: throws a `ParseError` if parsing fails.
+ *
+ * @param tomlContent The TOML content to parse.
+ * @param filePath Optional file path for error reporting.
+ * @returns The parsed TOML object.
  */
-export function parseTOML<T>(input: string, file?: string): T | never {
+export function parseTOML(tomlContent: string, filePath?: string): unknown {
 	try {
-		return TOML.parse(input) as T;
+		return TOML.parse(tomlContent);
 	} catch (err) {
 		if (!(err instanceof TomlError)) {
 			throw err;
 		}
 
 		const location = {
-			lineText: input.split("\n")[err.line - 1],
+			lineText: tomlContent.split("\n")[err.line - 1],
 			line: err.line,
 			column: err.column - 1,
-			file,
-			fileText: input,
+			file: filePath,
+			fileText: tomlContent,
 		};
 		throw new ParseError({
 			text: err.message.substring(0, err.message.indexOf("\n")),

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -928,8 +928,7 @@ export function writeAuthConfigFile(config: UserAuthConfig) {
 }
 
 export function readAuthConfigFile(): UserAuthConfig {
-	const toml = parseTOML<UserAuthConfig>(readFileSync(getAuthConfigFilePath()));
-	return toml;
+	return parseTOML(readFileSync(getAuthConfigFilePath())) as UserAuthConfig;
 }
 
 type LoginProps = {


### PR DESCRIPTION
Using a Generics only to set the return type is not a good practice (and a lie).

It is better to use explicit casts where needed.
The problem is exacerbated when the type parameter is inferred (i.e. return type as shown in the diff, assigning to a type variable, ...)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Tests not necessary because: covered by the check type
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: API update
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: workers-util

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
