### PR TITLE
CC-6583: Add support for SSH TrustedUserCAKeys

### DIFF
--- a/.changeset/brave-plants-dream.md
+++ b/.changeset/brave-plants-dream.md
@@ -1,0 +1,16 @@
+---
+"@cloudflare/containers-shared": minor
+"@cloudflare/workers-utils": minor
+"wrangler": minor
+---
+
+Add support for trusted_user_ca_keys in Wrangler
+
+You can now configure SSH trusted user CA keys for containers. Add the following to your wrangler.toml:
+
+```toml
+[[containers.trusted_user_ca_keys]]
+public_key = "ssh-ed25519 AAAAC3..."
+```
+
+This allows you to specify CA public keys that can be used to verify SSH user certificates.

--- a/packages/containers-shared/src/client/index.ts
+++ b/packages/containers-shared/src/client/index.ts
@@ -193,7 +193,7 @@ export { SecretNotFound } from "./models/SecretNotFound";
 export type { SSHPublicKey } from "./models/SSHPublicKey";
 export type { SSHPublicKeyID } from "./models/SSHPublicKeyID";
 export type { SSHPublicKeyItem } from "./models/SSHPublicKeyItem";
-export type { SSHPublicKeyItemV3 } from "./models/SSHPublicKeyItemV3";
+export type { UserSSHPublicKey } from "./models/UserSSHPublicKey";
 export { SSHPublicKeyNotFoundError } from "./models/SSHPublicKeyNotFoundError";
 export type { UnAuthorizedError } from "./models/UnAuthorizedError";
 export type { UnixTimestamp } from "./models/UnixTimestamp";

--- a/packages/containers-shared/src/client/models/DeploymentV2.ts
+++ b/packages/containers-shared/src/client/models/DeploymentV2.ts
@@ -27,7 +27,7 @@ import type { Observability } from "./Observability";
 import type { Placement } from "./Placement";
 import type { Ref } from "./Ref";
 import type { SSHPublicKeyID } from "./SSHPublicKeyID";
-import type { SSHPublicKeyItemV3 } from "./SSHPublicKeyItemV3";
+import type { UserSSHPublicKey } from "./UserSSHPublicKey";
 import type { WranglerSSHConfig } from "./WranglerSSHConfig";
 
 /**
@@ -44,7 +44,7 @@ export type DeploymentV2 = {
 	image: Image;
 	location: DeploymentLocation;
 	wrangler_ssh?: WranglerSSHConfig;
-	authorized_keys?: Array<SSHPublicKeyItemV3>;
+	authorized_keys?: Array<UserSSHPublicKey>;
 	/**
 	 * A list of SSH public key IDs from the account
 	 */

--- a/packages/containers-shared/src/client/models/ModifyUserDeploymentConfiguration.ts
+++ b/packages/containers-shared/src/client/models/ModifyUserDeploymentConfiguration.ts
@@ -18,7 +18,7 @@ import type { Observability } from "./Observability";
 import type { Port } from "./Port";
 import type { ProvisionerConfiguration } from "./ProvisionerConfiguration";
 import type { SSHPublicKeyID } from "./SSHPublicKeyID";
-import type { SSHPublicKeyItemV3 } from "./SSHPublicKeyItemV3";
+import type { UserSSHPublicKey } from "./UserSSHPublicKey";
 import type { WranglerSSHConfig } from "./WranglerSSHConfig";
 
 /**
@@ -27,7 +27,8 @@ import type { WranglerSSHConfig } from "./WranglerSSHConfig";
 export type ModifyUserDeploymentConfiguration = {
 	image?: Image;
 	wrangler_ssh?: WranglerSSHConfig;
-	authorized_keys?: Array<SSHPublicKeyItemV3>;
+	authorized_keys?: Array<UserSSHPublicKey>;
+	trusted_user_ca_keys?: Array<UserSSHPublicKey>;
 	/**
 	 * A list of SSH public key IDs from the account
 	 */

--- a/packages/containers-shared/src/client/models/UserDeploymentConfiguration.ts
+++ b/packages/containers-shared/src/client/models/UserDeploymentConfiguration.ts
@@ -18,7 +18,7 @@ import type { Observability } from "./Observability";
 import type { Port } from "./Port";
 import type { ProvisionerConfiguration } from "./ProvisionerConfiguration";
 import type { SSHPublicKeyID } from "./SSHPublicKeyID";
-import type { SSHPublicKeyItemV3 } from "./SSHPublicKeyItemV3";
+import type { UserSSHPublicKey } from "./UserSSHPublicKey";
 import type { WranglerSSHConfig } from "./WranglerSSHConfig";
 
 /**
@@ -27,7 +27,8 @@ import type { WranglerSSHConfig } from "./WranglerSSHConfig";
 export type UserDeploymentConfiguration = {
 	image: Image;
 	wrangler_ssh?: WranglerSSHConfig;
-	authorized_keys?: Array<SSHPublicKeyItemV3>;
+	authorized_keys?: Array<UserSSHPublicKey>;
+	trusted_user_ca_keys?: Array<UserSSHPublicKey>;
 	/**
 	 * A list of SSH public key IDs from the account
 	 */

--- a/packages/containers-shared/src/client/models/UserSSHPublicKey.ts
+++ b/packages/containers-shared/src/client/models/UserSSHPublicKey.ts
@@ -5,9 +5,9 @@
 import type { SSHPublicKey } from "./SSHPublicKey";
 
 /**
- * An SSH public key attached to a specific application or account.
+ * SSH public key provided by the user
  */
-export type SSHPublicKeyItemV3 = {
-	name: string;
+export type UserSSHPublicKey = {
+	name?: string;
 	public_key: SSHPublicKey;
 };

--- a/packages/containers-shared/src/types.ts
+++ b/packages/containers-shared/src/types.ts
@@ -2,7 +2,7 @@ import type {
 	ApplicationAffinityColocation,
 	InstanceType,
 	SchedulingPolicy,
-	SSHPublicKeyItemV3,
+	UserSSHPublicKey,
 	WranglerSSHConfig,
 } from "./client";
 import type { ApplicationAffinityHardwareGeneration } from "./client/models/ApplicationAffinityHardwareGeneration";
@@ -79,7 +79,8 @@ export type SharedContainerConfig = {
 	rollout_kind: "full_auto" | "full_manual" | "none";
 	rollout_active_grace_period: number;
 	wrangler_ssh?: WranglerSSHConfig;
-	authorized_keys?: Array<SSHPublicKeyItemV3>;
+	authorized_keys?: Array<UserSSHPublicKey>;
+	trusted_user_ca_keys?: Array<UserSSHPublicKey>;
 	constraints: {
 		regions?: string[];
 		cities?: string[];

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -191,6 +191,11 @@ export type ContainerApp = {
 	authorized_keys?: { name: string; public_key: string }[];
 
 	/**
+	 * Trusted user CA keys to put in the container's trusted_user_ca_keys file.
+	 */
+	trusted_user_ca_keys?: { name?: string; public_key: string }[];
+
+	/**
 	 * @deprecated Use top level `containers` fields instead.
 	 * `configuration.image` should be `image`
 	 * limits should be set via `instance_type`

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -3059,6 +3059,7 @@ function validateContainerApp(
 					"instance_type",
 					"wrangler_ssh",
 					"authorized_keys",
+					"trusted_user_ca_keys",
 					"configuration",
 					"constraints",
 					"affinities",
@@ -3104,15 +3105,6 @@ function validateContainerApp(
 						`${field}.wrangler_ssh.port must be a number between 1 and 65535 inclusive`
 					);
 				}
-
-				if (
-					!("authorized_keys" in containerAppOptional) &&
-					containerAppOptional.wrangler_ssh.enabled
-				) {
-					diagnostics.errors.push(
-						`${field}.authorized_keys must be provided if wrangler ssh is enabled`
-					);
-				}
 			}
 
 			if ("authorized_keys" in containerAppOptional) {
@@ -3124,6 +3116,35 @@ function validateContainerApp(
 						const key = containerAppOptional.authorized_keys[index];
 
 						if (!isRequiredProperty(key, "name", "string")) {
+							diagnostics.errors.push(`${fieldPath}.name must be a string`);
+						}
+
+						if (!isRequiredProperty(key, "public_key", "string")) {
+							diagnostics.errors.push(
+								`${fieldPath}.public_key must be a string`
+							);
+						}
+
+						if (!key.public_key.toLowerCase().startsWith("ssh-ed25519")) {
+							diagnostics.errors.push(
+								`${fieldPath}.public_key is a unsupported key type. Please provide a ED25519 public key.`
+							);
+						}
+					}
+				}
+			}
+
+			if ("trusted_user_ca_keys" in containerAppOptional) {
+				if (!Array.isArray(containerAppOptional.trusted_user_ca_keys)) {
+					diagnostics.errors.push(
+						`${field}.trusted_user_ca_keys must be an array`
+					);
+				} else {
+					for (const index in containerAppOptional.trusted_user_ca_keys) {
+						const fieldPath = `${field}.trusted_user_ca_keys[${index}]`;
+						const key = containerAppOptional.trusted_user_ca_keys[index];
+
+						if (!isOptionalProperty(key, "name", "string")) {
 							diagnostics.errors.push(`${fieldPath}.name must be a string`);
 						}
 

--- a/packages/wrangler/src/__tests__/containers/config.test.ts
+++ b/packages/wrangler/src/__tests__/containers/config.test.ts
@@ -788,6 +788,12 @@ describe("getNormalizedContainerOptions", () => {
 								"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC0chNcjRotdsxXTwPPNoqVCGn4EcEWdUkkBPNm/v4gm",
 						},
 					],
+					trusted_user_ca_keys: [
+						{
+							public_key:
+								"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC0chNcjRotdsxXTwPPNoqVCGn4EcEWdUkkBPNm/v4gm",
+						},
+					],
 				},
 			],
 			durable_objects: {

--- a/packages/wrangler/src/containers/config.ts
+++ b/packages/wrangler/src/containers/config.ts
@@ -126,6 +126,7 @@ export const getNormalizedContainerOptions = async (
 			},
 			wrangler_ssh: container.wrangler_ssh,
 			authorized_keys: container.authorized_keys,
+			trusted_user_ca_keys: container.trusted_user_ca_keys,
 		};
 
 		let instanceTypeOrLimits: InstanceTypeOrLimits;

--- a/packages/wrangler/src/containers/deploy.ts
+++ b/packages/wrangler/src/containers/deploy.ts
@@ -314,7 +314,8 @@ function containerConfigToCreateRequest(
 				prevApp?.configuration.observability
 			),
 			wrangler_ssh: containerApp.wrangler_ssh,
-			authorized_keys: containerApp.authorized_keys ?? undefined,
+			authorized_keys: containerApp.authorized_keys,
+			trusted_user_ca_keys: containerApp.trusted_user_ca_keys,
 		},
 		// deprecated in favour of max_instances
 		instances: 0,


### PR DESCRIPTION
Part of CC-6583.

Add support for `trusted_user_ca_keys`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Tests not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/25076
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not supported in v3

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
