### PR TITLE
chore: skip alert if changeset fails to create PR

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -81,6 +81,7 @@ jobs:
         run: node -r esbuild-register tools/deployments/alert-on-error.ts
         env:
           PUBLISH_STATUS: ${{ steps.changesets.outcome }}
+          HAS_CHANGESETS: ${{ steps.changesets.outputs.hasChangesets }}
           DEPLOYMENT_STATUS: ${{ steps.deploy.outputs.status }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           TOKEN: ${{ secrets.STATUS_BOT_SECRET }}

--- a/tools/deployments/alert-on-error.ts
+++ b/tools/deployments/alert-on-error.ts
@@ -1,7 +1,15 @@
 /* eslint-disable turbo/no-undeclared-env-vars */
 if (require.main === module) {
 	const status = [];
+
 	if (process.env.PUBLISH_STATUS === "failure") {
+		if (process.env.HAS_CHANGESETS === "true") {
+			console.log(
+				"Version PR creation failed. Please retry the job if needed."
+			);
+			process.exit(1);
+		}
+
 		status.push({
 			label: "NPM publish",
 			details: "Packages failed to publish",


### PR DESCRIPTION
Fixes n/a.

This skips creating an alert when changeset fails to update the VP PR (Not when we are landing new release).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/11703">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
