### PR TITLE
ci: skip changeset review if labels are applied

### DIFF
--- a/.github/workflows/changeset-review.yml
+++ b/.github/workflows/changeset-review.yml
@@ -2,7 +2,7 @@ name: Changeset Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - ".changeset/*.md"
   workflow_dispatch:
@@ -11,6 +11,10 @@ on:
         description: "PR number to review"
         required: true
         type: number
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -21,7 +25,7 @@ permissions:
 jobs:
   review-changesets:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository && !contains(github.event.pull_request.labels.*.name, 'skip-changeset-review') && !contains(github.event.pull_request.labels.*.name, 'no-changeset-required')
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4
@@ -56,6 +60,8 @@ jobs:
             If all changesets pass, just output "✅ All changesets look good" - no need for a detailed checklist.
 
             If there are issues, output "⚠️ Issues found" followed by the specific problems.
+
+            If the user has attached an image, use the Read tool to view it. If it's a cute animal, include in your comment a short cuteness report in the style of WeRateDogs (e.g., "This is Barkley. He's wearing a tiny hat and doesn't know why. 13/10").
 
             Return your structured output indicating whether there are blocking issues.
           claude_args: |


### PR DESCRIPTION
Skips changeset review if `skip-changeset-review` or `no-changeset-required` labels are applied. 

Also adds an easter egg for users who include a cute animal.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Tests not necessary because: just CI
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because:  just CI
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->  just CI

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
