### PR TITLE
fix(wrangler): show error when D1 migration commands run without config file

### DIFF
--- a/.changeset/itchy-squids-design.md
+++ b/.changeset/itchy-squids-design.md
@@ -4,6 +4,6 @@
 
 Show an error when D1 migration commands are run without a configuration file
 
-Previously, running `wrangler d1 migrations apply`, `wrangler d1 migrations list`, or `wrangler d1 migrations create` in a directory without a `wrangler.toml` or `wrangler.json` file would silently exit with no feedback. Now these commands display a clear error message:
+Previously, running `wrangler d1 migrations apply`, `wrangler d1 migrations list`, or `wrangler d1 migrations create` in a directory without a Wrangler configuration file would silently exit with no feedback. Now these commands display a clear error message:
 
-"No configuration file found. Create a wrangler.toml or wrangler.json file to define your D1 database."
+"No configuration file found. Create a wrangler.jsonc file to define your D1 database."

--- a/packages/wrangler/src/__tests__/d1/migrate.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrate.test.ts
@@ -38,7 +38,7 @@ describe("migrate", () => {
 			await expect(
 				runWrangler("d1 migrations create DATABASE test-migration")
 			).rejects.toThrowError(
-				"No configuration file found. Create a wrangler.toml or wrangler.json file to define your D1 database."
+				"No configuration file found. Create a wrangler.jsonc file to define your D1 database."
 			);
 		});
 	});
@@ -83,7 +83,7 @@ describe("migrate", () => {
 			await expect(
 				runWrangler("d1 migrations apply DATABASE")
 			).rejects.toThrowError(
-				"No configuration file found. Create a wrangler.toml or wrangler.json file to define your D1 database."
+				"No configuration file found. Create a wrangler.jsonc file to define your D1 database."
 			);
 		});
 
@@ -232,7 +232,7 @@ Your database may not be available to serve requests during the migration, conti
 			await expect(
 				runWrangler("d1 migrations list DATABASE")
 			).rejects.toThrowError(
-				"No configuration file found. Create a wrangler.toml or wrangler.json file to define your D1 database."
+				"No configuration file found. Create a wrangler.jsonc file to define your D1 database."
 			);
 		});
 

--- a/packages/wrangler/src/d1/migrations/apply.ts
+++ b/packages/wrangler/src/d1/migrations/apply.ts
@@ -70,7 +70,7 @@ export const d1MigrationsApplyCommand = createCommand({
 	async handler({ database, local, remote, persistTo, preview }, { config }) {
 		if (!config.configPath) {
 			throw new UserError(
-				"No configuration file found. Create a wrangler.toml or wrangler.json file to define your D1 database."
+				"No configuration file found. Create a wrangler.jsonc file to define your D1 database."
 			);
 		}
 

--- a/packages/wrangler/src/d1/migrations/create.ts
+++ b/packages/wrangler/src/d1/migrations/create.ts
@@ -42,7 +42,7 @@ export const d1MigrationsCreateCommand = createCommand({
 	async handler({ database, message }, { config }) {
 		if (!config.configPath) {
 			throw new UserError(
-				"No configuration file found. Create a wrangler.toml or wrangler.json file to define your D1 database."
+				"No configuration file found. Create a wrangler.jsonc file to define your D1 database."
 			);
 		}
 

--- a/packages/wrangler/src/d1/migrations/list.ts
+++ b/packages/wrangler/src/d1/migrations/list.ts
@@ -56,7 +56,7 @@ export const d1MigrationsListCommand = createCommand({
 
 		if (!config.configPath) {
 			throw new UserError(
-				"No configuration file found. Create a wrangler.toml or wrangler.json file to define your D1 database."
+				"No configuration file found. Create a wrangler.jsonc file to define your D1 database."
 			);
 		}
 


### PR DESCRIPTION
Fixes #11709.

Previously, running `wrangler d1 migrations apply`, `wrangler d1 migrations list`, or `wrangler d1 migrations create` in a directory without a `wrangler.toml` or `wrangler.json` file would silently exit with no feedback, leaving users confused about what went wrong.

Now these commands display a clear error message:
> "No configuration file found. Create a wrangler.toml or wrangler.json file to define your D1 database."

Written using OpenCode and Claude Opus 4.5

Prompt: "Can you solve this issue for me https://github.com/cloudflare/workers-sdk/issues/11709"

---

- Tests
  - [x] Tests included/updated
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is a bug fix that adds an error message; no new features or API changes
- Wrangler V3 Backport
  - [ ] Wrangler PR:
  - [x] Not necessary because: Not a patch change to stable V3; this is a UX improvement for current version
