### PR TITLE
ci: minor changes to changesets review prompt

### DIFF
--- a/.github/workflows/changeset-review.yml
+++ b/.github/workflows/changeset-review.yml
@@ -43,18 +43,19 @@ jobs:
 
       - name: Determine changesets to review
         id: changesets-to-review
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          ALL_CHANGED_FILES: ${{ steps.changed-changesets.outputs.all_changed_files }}
+          ADDED_FILES: ${{ steps.changed-changesets.outputs.added_files }}
         run: |
           # For "Version Packages" release PRs, review all changed changesets
           # For regular PRs, only review newly added changesets (skip minor edits to pre-existing ones)
-          PR_TITLE="${{ github.event.pull_request.title }}"
           if [[ "$PR_TITLE" == "Version Packages" ]]; then
             echo "Release PR detected - reviewing all changesets"
-            echo "files=${{ steps.changed-changesets.outputs.all_changed_files }}" >> $GITHUB_OUTPUT
-            echo "is_release_pr=true" >> $GITHUB_OUTPUT
+            echo "files=$ALL_CHANGED_FILES" >> $GITHUB_OUTPUT
           else
             echo "Regular PR - reviewing only newly added changesets"
-            echo "files=${{ steps.changed-changesets.outputs.added_files }}" >> $GITHUB_OUTPUT
-            echo "is_release_pr=false" >> $GITHUB_OUTPUT
+            echo "files=$ADDED_FILES" >> $GITHUB_OUTPUT
           fi
 
       - name: Review Changesets with Claude


### PR DESCRIPTION
Slme minor changes to the changeset review prompt, based on some examples that I've seen

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Tests not necessary because: just CI
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because:  just CI
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because:  just CI

*A picture of a cute animal (not mandatory, but encouraged)*

🐥

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
