### PR TITLE
remove build-info react-router autoconfig workaround

### DIFF
--- a/packages/wrangler/src/autoconfig/details.ts
+++ b/packages/wrangler/src/autoconfig/details.ts
@@ -124,15 +124,6 @@ export async function getDetailsForAutoConfig({
 
 	const buildSettings = await project.getBuildSettings();
 
-	// Workaround for https://github.com/netlify/build/pull/6806, and can be removed once merged
-	if (
-		buildSettings.length === 2 &&
-		buildSettings[0].framework.id === "react-router" &&
-		buildSettings[1].framework.id === "vite"
-	) {
-		buildSettings.pop();
-	}
-
 	// If we've detected multiple frameworks, it's too complex for us to try and configure—let's just bail
 	if (buildSettings && buildSettings?.length > 1) {
 		throw new MultipleFrameworksError(buildSettings.map((b) => b.name));


### PR DESCRIPTION
https://github.com/netlify/build/pull/6806 has been merged and released so I'm removing the autoconfig workaround that we needed

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Tests not necessary because: this functionality is already tested (via the c3 experimental e2es)
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not a user facing change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
