### PR TITLE
fix(wrangler): configure stdio for cloudflared access token spawning

### DIFF
--- a/packages/workers-utils/src/environment-variables/factory.ts
+++ b/packages/workers-utils/src/environment-variables/factory.ts
@@ -19,6 +19,10 @@ type VariableNames =
 	| "CLOUDFLARE_API_BASE_URL"
 	/** Set to "fedramp_high" for FedRAMP High compliance region. This will update the API/AUTH URLs used to make requests to Cloudflare. */
 	| "CLOUDFLARE_COMPLIANCE_REGION"
+	/** Cloudflare Access service token Client ID for machine-to-machine authentication. Use with CLOUDFLARE_ACCESS_CLIENT_SECRET. */
+	| "CLOUDFLARE_ACCESS_CLIENT_ID"
+	/** Cloudflare Access service token Client Secret for machine-to-machine authentication. Use with CLOUDFLARE_ACCESS_CLIENT_ID. */
+	| "CLOUDFLARE_ACCESS_CLIENT_SECRET"
 	/** API token for R2 SQL service. */
 	| "WRANGLER_R2_SQL_AUTH_TOKEN"
 

--- a/packages/wrangler/src/__tests__/api/startDevWorker/RemoteRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/RemoteRuntimeController.test.ts
@@ -13,7 +13,7 @@ import {
 	createRemoteWorkerInit,
 	getWorkerAccountAndContext,
 } from "../../../dev/remote";
-import { getAccessToken } from "../../../user/access";
+import { getAccessHeaders } from "../../../user/access";
 import { FakeBus } from "../../helpers/fake-bus";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { useTeardown } from "../../helpers/teardown";
@@ -38,7 +38,7 @@ vi.mock("../../../dev/remote", () => ({
 }));
 
 vi.mock("../../../user/access", () => ({
-	getAccessToken: vi.fn(),
+	getAccessHeaders: vi.fn(),
 	domainUsesAccess: vi.fn(),
 }));
 
@@ -167,7 +167,7 @@ describe("RemoteRuntimeController", () => {
 			tailUrl: "wss://test.workers.dev/tail",
 		});
 
-		vi.mocked(getAccessToken).mockResolvedValue(undefined);
+		vi.mocked(getAccessHeaders).mockResolvedValue(undefined);
 
 		vi.mocked(convertBindingsToCfWorkerInitBindings).mockResolvedValue({
 			bindings: {} as CfWorkerInit["bindings"],

--- a/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
@@ -16,7 +16,7 @@ import {
 import { logger } from "../../logger";
 import { TRACE_VERSION } from "../../tail/createTail";
 import { realishPrintLogs } from "../../tail/printing";
-import { getAccessToken } from "../../user/access";
+import { getAccessHeaders } from "../../user/access";
 import { RuntimeController } from "./BaseController";
 import { castErrorCause } from "./events";
 import { convertBindingsToCfWorkerInitBindings, unwrapHook } from "./utils";
@@ -305,7 +305,7 @@ export class RemoteRuntimeController extends RuntimeController {
 			return;
 		}
 
-		const accessToken = await getAccessToken(token.host);
+		const accessHeaders = await getAccessHeaders(token.host);
 
 		this.emitReloadCompleteEvent({
 			type: "reloadComplete",
@@ -329,7 +329,7 @@ export class RemoteRuntimeController extends RuntimeController {
 					: {}),
 				headers: {
 					"cf-workers-preview-token": token.value,
-					...(accessToken ? { Cookie: `CF_Authorization=${accessToken}` } : {}),
+					...accessHeaders,
 					"cf-connecting-ip": "",
 				},
 				liveReload: config.dev.liveReload,


### PR DESCRIPTION
Configure stdio options when spawning cloudflared to inherit stdin and stderr while piping stdout. This ensures proper handling of input/output streams during Access token retrieval.

Fixes #[insert GH or internal issue link(s)].

_Describe your change..._

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Tests not necessary because: inherit shell
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not helpful

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
