### PR TITLE
fix(c3): fix TypeScript detection for web framework templates

### DIFF
--- a/.changeset/fix-c3-ts-detection.md
+++ b/.changeset/fix-c3-ts-detection.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Fix TypeScript detection for web framework templates. Previously, C3 would incorrectly default to JavaScript for web framework templates with a `generate` function, even when the framework generated a TypeScript project. Now, C3 correctly detects TypeScript by checking for `tsconfig.json` after the framework's generate function runs.

--- a/packages/create-cloudflare/src/__tests__/templates.test.ts
+++ b/packages/create-cloudflare/src/__tests__/templates.test.ts
@@ -5,6 +5,7 @@ import { mockSpinner } from "helpers/__tests__/mocks";
 import {
 	appendFile,
 	directoryExists,
+	hasTsConfig,
 	readFile,
 	readJSON,
 	writeFile,
@@ -573,9 +574,7 @@ describe("defaultSelectVariant", () => {
 	});
 
 	test("should return 'ts' if tsconfig.json exists and no lang specified", async () => {
-		vi.mocked(existsSync).mockImplementation(
-			(path) => path === "/some/path/tsconfig.json",
-		);
+		vi.mocked(hasTsConfig).mockReturnValue(true);
 
 		const ctx = {
 			project: { path: "/some/path" },
@@ -588,7 +587,7 @@ describe("defaultSelectVariant", () => {
 	});
 
 	test("should return 'js' if tsconfig.json does not exist and no lang specified", async () => {
-		vi.mocked(existsSync).mockImplementation(() => false);
+		vi.mocked(hasTsConfig).mockReturnValue(false);
 
 		const ctx = {
 			project: { path: "/some/path" },
@@ -601,9 +600,7 @@ describe("defaultSelectVariant", () => {
 	});
 
 	test("should use explicit lang even if tsconfig.json exists", async () => {
-		vi.mocked(existsSync).mockImplementation(
-			(path) => path === "/some/path/tsconfig.json",
-		);
+		vi.mocked(hasTsConfig).mockReturnValue(true);
 
 		const ctx = {
 			project: { path: "/some/path" },

--- a/packages/create-cloudflare/templates/vue/workers/c3.ts
+++ b/packages/create-cloudflare/templates/vue/workers/c3.ts
@@ -66,13 +66,6 @@ const config: TemplateConfig = {
 	displayName: "Vue",
 	path: "templates/vue/workers",
 	copyFiles: {
-		async selectVariant(ctx) {
-			// Note: this `selectVariant` function should not be needed
-			//       this is just a quick workaround until
-			//       https://github.com/cloudflare/workers-sdk/issues/7495
-			//       is resolved
-			return usesTypescript(ctx) ? "ts" : "js";
-		},
 		variants: {
 			ts: {
 				path: "./ts",


### PR DESCRIPTION
Fixes #7495.

Previously, C3 would incorrectly default to JavaScript for web framework templates with a `generate` function, even when the framework generated a TypeScript project. This happened because `hasTsConfig` was called in `createContext` before the `generate` function ran, so the `tsconfig.json` file didn't exist yet.

The fix modifies `defaultSelectVariant` to check for `tsconfig.json` at copy time (after `generate` runs), correctly detecting TypeScript projects. The premature `args.lang = "js"` assignment in `createContext` is removed, allowing the language to be determined after the framework's generate function completes.

Also removes the workaround from the Vue template that was added specifically to address this issue.

**Key changes for review:**
- `defaultSelectVariant` now checks `hasTsConfig(ctx.project.path)` when `ctx.args.lang` is not set
- Removed `args.lang = "js"` assignment for templates with `generate` functions
- Removed the `selectVariant` workaround from Vue workers template

**Suggested review checklist:**
- [ ] Verify `defaultSelectVariant` is called after `generate` runs in the C3 lifecycle
- [ ] Confirm Vue template works correctly for both TS and JS project generation
- [ ] Check other frameworks with `generate` functions (e.g., SvelteKit, Next.js) still detect TS correctly

---

- Tests
  - [x] Tests included/updated
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is a bug fix with no user-facing API changes
- Wrangler V3 Backport
  - [ ] Wrangler PR:
  - [x] Not necessary because: This is a C3-only change

Devin PR requested by @ascorbic

[Link to Devin run](https://app.devin.ai/sessions/fa05d4d5b75947a3af9f2732306f888f)