### PR TITLE
Reintroduce CSS tests for Vite 8

### DIFF
--- a/packages/vite-plugin-cloudflare/playground/assets/__tests__/assets.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/assets/__tests__/assets.spec.ts
@@ -1,25 +1,23 @@
-import { describe, expect, test } from "vitest";
-import { getResponse, isVite8, page, viteTestUrl } from "../../__test-utils__";
+import { expect, test } from "vitest";
+import { getResponse, page, viteTestUrl } from "../../__test-utils__";
 import "./base-tests";
 
-describe.skipIf(isVite8)("Assets", () => {
-	test("fetches transformed HTML asset", async () => {
-		await page.goto(`${viteTestUrl}/transformed-html-asset`);
-		const content = await page.textContent("h1");
-		expect(content).toBe("Modified content");
-	});
+test("fetches transformed HTML asset", async () => {
+	await page.goto(`${viteTestUrl}/transformed-html-asset`);
+	const content = await page.textContent("h1");
+	expect(content).toBe("Modified content");
+});
 
-	test("fetches original public directory asset if requested directly", async () => {
-		const response = await getResponse("/public-image.svg");
-		const contentType = await response.headerValue("content-type");
-		const additionalHeader = await response.headerValue("additional-header");
-		expect(contentType).toBe("image/svg+xml");
-		expect(additionalHeader).toBe(null);
-	});
+test("fetches original public directory asset if requested directly", async () => {
+	const response = await getResponse("/public-image.svg");
+	const contentType = await response.headerValue("content-type");
+	const additionalHeader = await response.headerValue("additional-header");
+	expect(contentType).toBe("image/svg+xml");
+	expect(additionalHeader).toBe(null);
+});
 
-	test("fetches original HTML asset if requested directly", async () => {
-		await page.goto(`${viteTestUrl}/html-page`);
-		const content = await page.textContent("h1");
-		expect(content).toBe("Original content");
-	});
+test("fetches original HTML asset if requested directly", async () => {
+	await page.goto(`${viteTestUrl}/html-page`);
+	const content = await page.textContent("h1");
+	expect(content).toBe("Original content");
 });

--- a/packages/vite-plugin-cloudflare/playground/assets/__tests__/base-tests.ts
+++ b/packages/vite-plugin-cloudflare/playground/assets/__tests__/base-tests.ts
@@ -1,33 +1,31 @@
-import { describe, expect, test } from "vitest";
-import { getResponse, getTextResponse, isVite8 } from "../../__test-utils__";
+import { expect, test } from "vitest";
+import { getResponse, getTextResponse } from "../../__test-utils__";
 
-describe.skipIf(isVite8)("Base tests", () => {
-	test("fetches public directory asset", async () => {
-		const response = await getResponse("/public-directory-asset");
-		const contentType = await response.headerValue("content-type");
-		const additionalHeader = await response.headerValue("additional-header");
-		expect(contentType).toBe("image/svg+xml");
-		expect(additionalHeader).toBe("public-directory-asset");
-	});
+test("fetches public directory asset", async () => {
+	const response = await getResponse("/public-directory-asset");
+	const contentType = await response.headerValue("content-type");
+	const additionalHeader = await response.headerValue("additional-header");
+	expect(contentType).toBe("image/svg+xml");
+	expect(additionalHeader).toBe("public-directory-asset");
+});
 
-	test("fetches imported asset", async () => {
-		const response = await getResponse("/imported-asset");
-		const contentType = await response.headerValue("content-type");
-		const additionalHeader = await response.headerValue("additional-header");
-		expect(contentType).toBe("image/svg+xml");
-		expect(additionalHeader).toBe("imported-asset");
-	});
+test("fetches imported asset", async () => {
+	const response = await getResponse("/imported-asset");
+	const contentType = await response.headerValue("content-type");
+	const additionalHeader = await response.headerValue("additional-header");
+	expect(contentType).toBe("image/svg+xml");
+	expect(additionalHeader).toBe("imported-asset");
+});
 
-	test("fetches imported asset with url suffix", async () => {
-		const text = await getTextResponse("/imported-asset-url-suffix");
-		expect(text).toBe(`The text content is "Text content"`);
-	});
+test("fetches imported asset with url suffix", async () => {
+	const text = await getTextResponse("/imported-asset-url-suffix");
+	expect(text).toBe(`The text content is "Text content"`);
+});
 
-	test("fetches inline asset", async () => {
-		const response = await getResponse("/inline-asset");
-		const contentType = await response.headerValue("content-type");
-		const additionalHeader = await response.headerValue("additional-header");
-		expect(contentType).toBe("image/svg+xml");
-		expect(additionalHeader).toBe("inline-asset");
-	});
+test("fetches inline asset", async () => {
+	const response = await getResponse("/inline-asset");
+	const contentType = await response.headerValue("content-type");
+	const additionalHeader = await response.headerValue("additional-header");
+	expect(contentType).toBe("image/svg+xml");
+	expect(additionalHeader).toBe("inline-asset");
 });

--- a/packages/vite-plugin-cloudflare/playground/assets/__tests__/no-client-entry/assets.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/assets/__tests__/no-client-entry/assets.spec.ts
@@ -1,26 +1,18 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { expect, test, vi } from "vitest";
-import {
-	isBuild,
-	isVite8,
-	testDir,
-	WAIT_FOR_OPTIONS,
-} from "../../../__test-utils__";
+import { isBuild, testDir, WAIT_FOR_OPTIONS } from "../../../__test-utils__";
 import "../base-tests";
 
-test.runIf(isBuild && !isVite8)(
-	"deletes fallback client entry file",
-	async () => {
-		const fallbackEntryPath = path.join(
-			testDir,
-			"dist",
-			"client",
-			"__cloudflare_fallback_entry__"
-		);
+test.runIf(isBuild)("deletes fallback client entry file", async () => {
+	const fallbackEntryPath = path.join(
+		testDir,
+		"dist",
+		"client",
+		"__cloudflare_fallback_entry__"
+	);
 
-		await vi.waitFor(() => {
-			expect(fs.existsSync(fallbackEntryPath)).toBe(false);
-		}, WAIT_FOR_OPTIONS);
-	}
-);
+	await vi.waitFor(() => {
+		expect(fs.existsSync(fallbackEntryPath)).toBe(false);
+	}, WAIT_FOR_OPTIONS);
+});


### PR DESCRIPTION
Reintroduce tests that were skipped on Vite 8 due to LightningCSS incompatibility with the `es2024` `build.cssTarget` value. This has been fixed in https://github.com/vitejs/vite/pull/21294 and released in [8.0.0-beta.4](https://github.com/vitejs/vite/blob/v8.0.0-beta.4/packages/vite/CHANGELOG.md#800-beta4-2025-12-22).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: testing change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
