### PR TITLE
Simplify Workflows playground tests

### DIFF
--- a/packages/vite-plugin-cloudflare/playground/external-workflows/__tests__/workflows.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/external-workflows/__tests__/workflows.spec.ts
@@ -8,14 +8,6 @@ test("creates a Workflow with an ID", async () => {
 
 	await vi.waitFor(async () => {
 		expect(await getJsonResponse(`/get?id=${instanceId}`)).toEqual({
-			status: "running",
-			__LOCAL_DEV_STEP_OUTPUTS: [{ output: "First step result" }],
-			output: null,
-		});
-	}, WAIT_FOR_OPTIONS);
-
-	await vi.waitFor(async () => {
-		expect(await getJsonResponse(`/get?id=${instanceId}`)).toEqual({
 			status: "complete",
 			__LOCAL_DEV_STEP_OUTPUTS: [
 				{ output: "First step result" },

--- a/packages/vite-plugin-cloudflare/playground/workflows/__tests__/workflows.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/workflows/__tests__/workflows.spec.ts
@@ -8,14 +8,6 @@ test("creates a Workflow with an ID", async () => {
 
 	await vi.waitFor(async () => {
 		expect(await getJsonResponse(`/get?id=${instanceId}`)).toEqual({
-			status: "running",
-			__LOCAL_DEV_STEP_OUTPUTS: [{ output: "First step result" }],
-			output: null,
-		});
-	}, WAIT_FOR_OPTIONS);
-
-	await vi.waitFor(async () => {
-		expect(await getJsonResponse(`/get?id=${instanceId}`)).toEqual({
 			status: "complete",
 			__LOCAL_DEV_STEP_OUTPUTS: [
 				{ output: "First step result" },


### PR DESCRIPTION
Removing the check on the intermediary step as we don't need to test Workflows themselves (that is already done in the in the fixture). We only need to check that they work with the plugin.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: testing change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
