### PR TITLE
fix(wrangler): fix r2 data catalog snapshot expiration api call payload

### DIFF
--- a/.changeset/fix-r2-catalog-snapshot-expiration-field-names.md
+++ b/.changeset/fix-r2-catalog-snapshot-expiration-field-names.md
@@ -1,0 +1,14 @@
+---
+"wrangler": patch
+---
+
+Fix R2 Data Catalog snapshot-expiration API field names
+
+The `wrangler r2 bucket catalog snapshot-expiration enable` command was sending incorrect field names
+to the Cloudflare API, resulting in a 422 Unprocessable Entity error. This fix updates the API request
+body to use the correct field names:
+
+- `olderThanDays` -> `max_snapshot_age` (as duration string, e.g., "30d")
+- `retainLast` -> `min_snapshots_to_keep`
+
+The CLI options (`--older-than-days` and `--retain-last`) remain unchanged.

--- a/packages/wrangler/src/__tests__/r2/bucket.test.ts
+++ b/packages/wrangler/src/__tests__/r2/bucket.test.ts
@@ -1666,8 +1666,8 @@ describe("r2", () => {
 									expect(body).toEqual({
 										snapshot_expiration: {
 											state: "enabled",
-											olderThanDays: 30,
-											retainLast: 5,
+											max_snapshot_age: "30d",
+											min_snapshots_to_keep: 5,
 										},
 									});
 									return HttpResponse.json(
@@ -1717,8 +1717,8 @@ describe("r2", () => {
 									expect(body).toEqual({
 										snapshot_expiration: {
 											state: "enabled",
-											olderThanDays: 60,
-											retainLast: 10,
+											max_snapshot_age: "60d",
+											min_snapshots_to_keep: 10,
 										},
 									});
 									return HttpResponse.json(

--- a/packages/wrangler/src/r2/helpers/catalog.ts
+++ b/packages/wrangler/src/r2/helpers/catalog.ts
@@ -108,10 +108,10 @@ type R2CatalogSnapshotExpirationConfig = {
 	state: "enabled" | "disabled";
 
 	// If undefined, the service will set the default value
-	olderThanDays?: number;
+	max_snapshot_age?: string;
 
 	// If undefined, the service will set the default value
-	retainLast?: number;
+	min_snapshots_to_keep?: number;
 };
 
 type R2CatalogSnapshotExpirationResponse = {
@@ -127,8 +127,8 @@ export async function enableR2CatalogSnapshotExpiration(
 ): Promise<R2CatalogSnapshotExpirationResponse> {
 	const config: R2CatalogSnapshotExpirationConfig = {
 		state: "enabled",
-		olderThanDays: olderThanDays ?? 30,
-		retainLast: retainLast ?? 5,
+		max_snapshot_age: `${olderThanDays ?? 30}d`,
+		min_snapshots_to_keep: retainLast ?? 5,
 	};
 
 	return await fetchResult(


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/11763.

_Describe your change..._

I made a modification to send a payload that conforms to the Cloudflare API.
There seems no description about the snapshot expiration API on the developer guide, so I tested the field name with curl.

```sh
# Found that `max_snapshot_age` is necessary. This is likely a replacement for `olderThanDays`.
$ curl -X POST "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/r2-catalog/${BUCKET_NAME}/maintenance-configs" \
    -H "Authorization: Bearer ${API_TOKEN}" `
    -H "Content-Type: application/json" `
    -d '{
      "snapshot_expiration": {
        "state": "enabled",
        "olderThanDays": 30,
        "retainLast": 5
      }
    }'
Failed to deserialize the JSON body into the target type: snapshot_expiration: missing field `max_snapshot_age` at line 6 column 7

# Found that `max_snapshot_age` requires the string something like "30d" 
$ curl -X POST "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/r2-catalog/${BUCKET_NAME}/maintenance-configs" \
    -H "Authorization: Bearer ${API_TOKEN}" `
    -H "Content-Type: application/json" `
    -d '{
      "snapshot_expiration": {
        "state": "enabled",
        "max_snapshot_age": 30,
        "retainLast": 5
      }
    }'
Failed to deserialize the JSON body into the target type: snapshot_expiration.max_snapshot_age: Invalid duration suffix '0'. Use d, h, m, or s at line 4 column 32

# The API call succeeded. It appears the field `min_snapshots_to_keep` is being used instead of `retainLast`
$ curl -X POST "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/r2-catalog/${BUCKET_NAME}/maintenance-configs" \
    -H "Authorization: Bearer ${API_TOKEN}" `
    -H "Content-Type: application/json" `
    -d '{
      "snapshot_expiration": {
        "state": "enabled",
        "max_snapshot_age": "30d",
        "retainLast": 5
      }
    }'
{"result":{"compaction":{"state":"enabled","target_size_mb":"512"},"snapshot_expiration":{"state":"enabled","min_snapshots_to_keep":100,"max_snapshot_age":"30d"}},"result_info":null,"success":true,"errors":[],"messages":[]}

# Successfully configured.
$ curl -X POST "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/r2-catalog/${BUCKET_NAME}/maintenance-configs" \
    -H "Authorization: Bearer ${API_TOKEN}" `
    -H "Content-Type: application/json" `
    -d '{
      "snapshot_expiration": {
        "state": "enabled",
        "max_snapshot_age": "30d",
        "min_snapshots_to_keep": 5
      }
    }'
{"result":{"compaction":{"state":"enabled","target_size_mb":"512"},"snapshot_expiration":{"state":"enabled","min_snapshots_to_keep":5,"max_snapshot_age":"30d"}},"result_info":null,"success":true,"errors":[],"messages":[]}

```
---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: there are no changes to the interface.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
