### PR TITLE
[wrangler] Add fuzzy search to account and project selection prompts

### DIFF
--- a/.changeset/fuzzy-select-prompts.md
+++ b/.changeset/fuzzy-select-prompts.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add fuzzy search filtering to account and project selection prompts.
+
+When selecting an account or Pages project from the command line, you can now type to filter the list using fuzzy search. This makes it easier to find the right option when you have many accounts or projects.

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -129,6 +129,7 @@
 		"esprima": "4.0.1",
 		"execa": "^6.1.0",
 		"find-up": "^6.3.0",
+		"fuse.js": "^7.1.0",
 		"get-port": "^7.0.0",
 		"glob-to-regexp": "^0.4.1",
 		"https-proxy-agent": "7.0.2",

--- a/packages/wrangler/src/__tests__/vitest.setup.ts
+++ b/packages/wrangler/src/__tests__/vitest.setup.ts
@@ -181,7 +181,7 @@ vi.mock("prompts", () => {
 			throw new Error(
 				`Unexpected call to \`prompts("${JSON.stringify(
 					args
-				)}")\`.\nYou should use \`mockConfirm()/mockSelect()/mockPrompt()\` to mock calls to \`confirm()\` with expectations.`
+				)}")\`.\nYou should use \`mockConfirm()/mockSelect()/mockAutoCompleteSelect()/mockPrompt()\` to mock calls to \`confirm()\` with expectations.`
 			);
 		}),
 	};

--- a/packages/wrangler/src/pages/prompt-select-project.ts
+++ b/packages/wrangler/src/pages/prompt-select-project.ts
@@ -1,4 +1,4 @@
-import { select } from "../dialogs";
+import { autoCompleteSelect } from "../dialogs";
 import { listProjects } from "./projects";
 
 export async function promptSelectProject({
@@ -8,7 +8,7 @@ export async function promptSelectProject({
 }): Promise<string> {
 	const projects = await listProjects({ accountId });
 
-	return select("Select a project:", {
+	return autoCompleteSelect("Select a project:", {
 		choices: projects.map((project) => ({
 			title: project.name,
 			value: project.name,

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -229,7 +229,7 @@ import {
 	purgeConfigCaches,
 	saveToConfigCache,
 } from "../config-cache";
-import { NoDefaultValueProvided, select } from "../dialogs";
+import { autoCompleteSelect, NoDefaultValueProvided } from "../dialogs";
 import { isNonInteractiveOrCI } from "../is-interactive";
 import { logger } from "../logger";
 import openInBrowser from "../open-in-browser";
@@ -1283,7 +1283,7 @@ export async function getAccountId(
 	}
 
 	try {
-		const accountID = await select("Select an account", {
+		const accountID = await autoCompleteSelect("Select an account", {
 			choices: accounts.map((account) => ({
 				title: account.name,
 				value: account.id,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4022,6 +4022,9 @@ importers:
       find-up:
         specifier: ^6.3.0
         version: 6.3.0
+      fuse.js:
+        specifier: ^7.1.0
+        version: 7.1.0
       get-port:
         specifier: ^7.0.0
         version: 7.0.0
@@ -10030,6 +10033,10 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  fuse.js@7.1.0:
+    resolution: {integrity: sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==}
+    engines: {node: '>=10'}
 
   generate-function@2.3.1:
     resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
@@ -21147,6 +21154,8 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  fuse.js@7.1.0: {}
 
   generate-function@2.3.1:
     dependencies:


### PR DESCRIPTION
When selecting an account or Pages project, users with a ton of options had to scroll and look for their account.

This PR:

- adds fuzzy search to the select inputs for accounts & Pages projects
- uses Fuse.js (v. popular + small) with a threshold of 0.4, which provides a balance between tolerating typos and avoiding false matches. This can be tuned but appears to be a commonly used default.

Out of scope

- Resource binding selection (KV, D1, R2) is intentionally left out of scope for this initial change.
- We appear to use `clack` in some newer parts of wrangler, but there isn't a fuzzy search component as part of Clack. Since this change is small, this made sense.

- Tests
  - [x] Tests included/updated
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: input selection change, not a functionality/API change

mandatory cat pic:

![cat](https://github.com/user-attachments/assets/4357f587-1175-44fa-bbf7-b245513eb008)