### PR TITLE
CC-6293: Replace "durable_objects_active" with "active"

### DIFF
--- a/.changeset/brave-wings-judge.md
+++ b/.changeset/brave-wings-judge.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/containers-shared": patch
+---
+
+Rename "durable_objects_active" field in ApplicationHealthInstances to "active"

--- a/packages/containers-shared/src/client/models/ApplicationHealthInstances.ts
+++ b/packages/containers-shared/src/client/models/ApplicationHealthInstances.ts
@@ -4,10 +4,10 @@
 
 export type ApplicationHealthInstances = {
 	/**
-	 * Number of active durable object containers in this application.
+	 * Number of active containers in this application.
 	 *
 	 */
-	durable_objects_active?: number;
+	active: number;
 	/**
 	 * Number of healthy instances. If the application is attached to a DO namespace,
 	 * this represents the number of prepared container instances.


### PR DESCRIPTION
Fixes CC-6293.

"durable_objects_active" is deprecated in favor of the new field "active".

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Tests not necessary because: only type definitions are changed, which don't have tests
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: `durable_objects_active` is not documented

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
