### PR TITLE
[wrangler] fix: prevent secret bulk from hanging when no file is provided

### DIFF
--- a/.changeset/brave-candles-lead.md
+++ b/.changeset/brave-candles-lead.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: prevent `wrangler secret bulk` from hanging when no file is provided
+
+Previously, running `wrangler secret bulk`, `wrangler versions secret bulk`, or `wrangler pages secret bulk` without a file argument would cause the command to hang indefinitely while waiting for stdin input. Now, when running interactively without a file, the command displays a helpful error message with usage examples instead of hanging silently.

--- a/packages/wrangler/src/__tests__/pages/secret.test.ts
+++ b/packages/wrangler/src/__tests__/pages/secret.test.ts
@@ -538,6 +538,18 @@ describe("wrangler pages secret", () => {
 			);
 		});
 
+		it("should error when no file is provided and stdin is a TTY", async () => {
+			setIsTTY({ stdin: true, stdout: true });
+			await expect(
+				runWrangler(`pages secret bulk --project some-project-name`)
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: No file provided. Please provide a JSON file or .dev.vars file as an argument, or pipe input to stdin.
+For example:
+  wrangler pages secret bulk ./secrets.json
+  echo '{"SECRET":"value"}' | wrangler pages secret bulk]`
+			);
+		});
+
 		it("should use secret bulk w/ pipe input", async () => {
 			vi.spyOn(readline, "createInterface").mockImplementation(
 				() =>

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -972,16 +972,27 @@ describe("wrangler secret", () => {
 				`
 				"
 				 ⛅️ wrangler x.x.x
-				──────────────────
-				🌀 Creating the secrets for the Worker \\"script-name\\" "
+				──────────────────"
 			`
 			);
 			expect(std.err).toMatchInlineSnapshot(`
-				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 No content found in file, or piped input.[0m
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 No content found in file or piped input.[0m
 
 				"
 			`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
+
+		it("should error when no file is provided and stdin is a TTY", async () => {
+			setIsTTY({ stdin: true, stdout: true });
+			await expect(
+				runWrangler(`secret bulk --name script-name`)
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: No file provided. Please provide a JSON file or .dev.vars file as an argument, or pipe input to stdin.
+For example:
+  wrangler secret bulk ./secrets.json
+  echo '{"SECRET":"value"}' | wrangler secret bulk]`
+			);
 		});
 
 		it("should use secret bulk w/ pipe input", async () => {

--- a/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
@@ -214,7 +214,7 @@ For example:
 		`
 		);
 		expect(std.err).toMatchInlineSnapshot(`
-			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 No content found in file or piped input.[0m
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 No content found in file or piped input.[0m
 
 			"
 		`);

--- a/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, test, vi } from "vitest";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { clearDialogs } from "../../helpers/mock-dialogs";
+import { useMockIsTTY } from "../../helpers/mock-istty";
 import { runInTempDir } from "../../helpers/run-in-tmp";
 import { runWrangler } from "../../helpers/run-wrangler";
 import { mockPostVersion, mockSetupApiCalls } from "./utils";
@@ -12,11 +13,24 @@ import type { Interface } from "node:readline";
 
 describe("versions secret bulk", () => {
 	const std = mockConsoleMethods();
+	const { setIsTTY } = useMockIsTTY();
 	runInTempDir();
 	mockAccountId();
 	mockApiToken();
 	afterEach(() => {
 		clearDialogs();
+	});
+
+	test("should error when no file is provided and stdin is a TTY", async () => {
+		setIsTTY({ stdin: true, stdout: true });
+		await expect(
+			runWrangler(`versions secret bulk --name script-name`)
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: No file provided. Please provide a JSON file or .dev.vars file as an argument, or pipe input to stdin.
+For example:
+  wrangler versions secret bulk ./secrets.json
+  echo '{"SECRET":"value"}' | wrangler versions secret bulk]`
+		);
 	});
 
 	test("should fail secret bulk w/ no pipe or JSON input", async () => {
@@ -28,12 +42,11 @@ describe("versions secret bulk", () => {
 			`
 			"
 			 ⛅️ wrangler x.x.x
-			──────────────────
-			🌀 Creating the secrets for the Worker \\"script-name\\" "
+			──────────────────"
 		`
 		);
 		expect(std.err).toMatchInlineSnapshot(`
-			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNo content found in file or piped input.[0m
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 No content found in file or piped input.[0m
 
 			"
 		`);
@@ -197,12 +210,11 @@ describe("versions secret bulk", () => {
 			`
 			"
 			 ⛅️ wrangler x.x.x
-			──────────────────
-			🌀 Creating the secrets for the Worker \\"script-name\\" "
+			──────────────────"
 		`
 		);
 		expect(std.err).toMatchInlineSnapshot(`
-			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNo content found in file or piped input.[0m
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 No content found in file or piped input.[0m
 
 			"
 		`);

--- a/packages/wrangler/src/pages/secret/index.ts
+++ b/packages/wrangler/src/pages/secret/index.ts
@@ -13,7 +13,7 @@ import { confirm, prompt } from "../../dialogs";
 import isInteractive from "../../is-interactive";
 import { logger } from "../../logger";
 import * as metrics from "../../metrics";
-import { parseBulkInputToObject } from "../../secret";
+import { NoInputError, parseBulkInputToObject } from "../../secret";
 import { requireAuth } from "../../user";
 import { readFromStdin, trimTrailingWhitespace } from "../../utils/std";
 import { PAGES_CONFIG_CACHE_FILENAME } from "../constants";
@@ -206,6 +206,25 @@ export const pagesSecretBulkCommand = createCommand({
 	},
 	positionalArgs: ["file"],
 	async handler(args) {
+		let content: Record<string, string> | undefined;
+		try {
+			content = await parseBulkInputToObject(args.file);
+		} catch (e) {
+			if (e instanceof NoInputError) {
+				throw new FatalError(
+					"No file provided. Please provide a JSON file or .dev.vars file as an argument, or pipe input to stdin.\n" +
+						"For example:\n" +
+						"  wrangler pages secret bulk ./secrets.json\n" +
+						'  echo \'{"SECRET":"value"}\' | wrangler pages secret bulk'
+				);
+			}
+			throw e;
+		}
+
+		if (!content) {
+			throw new FatalError(`🚨 No content found in file or piped input.`);
+		}
+
 		const { env, project, accountId } = await pagesProject(
 			args.env,
 			args.projectName
@@ -214,11 +233,6 @@ export const pagesSecretBulkCommand = createCommand({
 		logger.log(
 			`🌀 Creating the secrets for the Pages project "${project.name}" (${env})`
 		);
-		const content = await parseBulkInputToObject(args.file);
-
-		if (!content) {
-			throw new FatalError(`🚨 No content found in file or piped input.`);
-		}
 
 		const upsertBindings = Object.fromEntries(
 			Object.entries(content).map(([key, value]) => {

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -26,6 +26,18 @@ import type { Config, WorkerMetadataBinding } from "@cloudflare/workers-utils";
 
 export const VERSION_NOT_DEPLOYED_ERR_CODE = 10215;
 
+/**
+ * Error thrown when parseBulkInputToObject is called without a file
+ * and stdin is a TTY (interactive terminal). Callers should catch this
+ * and re-throw with context-specific messaging.
+ */
+export class NoInputError extends Error {
+	constructor() {
+		super("No input provided and stdin is a TTY");
+		Object.setPrototypeOf(this, new.target.prototype);
+	}
+}
+
 type SecretBindingUpload = {
 	type: "secret_text";
 	name: string;
@@ -443,17 +455,30 @@ export const secretBulkCommand = createCommand({
 
 		const accountId = await requireAuth(config);
 
+		let content: Record<string, string> | undefined;
+		try {
+			content = await parseBulkInputToObject(args.file);
+		} catch (e) {
+			if (e instanceof NoInputError) {
+				throw new UserError(
+					"No file provided. Please provide a JSON file or .dev.vars file as an argument, or pipe input to stdin.\n" +
+						"For example:\n" +
+						"  wrangler secret bulk ./secrets.json\n" +
+						'  echo \'{"SECRET":"value"}\' | wrangler secret bulk'
+				);
+			}
+			throw e;
+		}
+
+		if (!content) {
+			return logger.error(`🚨 No content found in file or piped input.`);
+		}
+
 		logger.log(
 			`🌀 Creating the secrets for the Worker "${scriptName}" ${
 				isServiceEnv ? `(${args.env})` : ""
 			}`
 		);
-
-		const content = await parseBulkInputToObject(args.file);
-
-		if (!content) {
-			return logger.error(`🚨 No content found in file, or piped input.`);
-		}
 
 		function getSettings() {
 			const url = isServiceEnv
@@ -583,6 +608,9 @@ export async function parseBulkInputToObject(input?: string) {
 		}
 		validateFileSecrets(content, input);
 	} else {
+		if (process.stdin.isTTY) {
+			throw new NoInputError();
+		}
 		try {
 			const rl = readline.createInterface({ input: process.stdin });
 			let pipedInput = "";


### PR DESCRIPTION
## Summary

- Fix `wrangler secret bulk`, `wrangler versions secret bulk`, and `wrangler pages secret bulk` commands hanging indefinitely when no file argument is provided in an interactive terminal
- Add tests for the new TTY detection behaviour

## Details

Previously, running these commands without a file argument would cause `parseBulkInputToObject` to create a readline interface on stdin and wait indefinitely for input. Users would see "Creating the secrets for..." and then the command would appear to hang.

This fix:
1. Adds TTY detection in `parseBulkInputToObject` - throws `NoInputError` when stdin is interactive and no file is provided
2. Each caller catches `NoInputError` and re-throws with context-specific error messaging showing the correct command syntax
3. Moves the "Creating secrets" log message after input validation so users don't see misleading progress before an error

Piping input via stdin still works as expected (e.g., `echo '{"SECRET":"value"}' | wrangler secret bulk`).

### Tests
- [x] Tests included
- Tests not necessary because:
### Public documentation
- Cloudflare docs PR(s):
- [x] Documentation not necessary because: UX improvement