### PR TITLE
[wrangler] Add `wrangler analytics-engine` command for querying Workers Analytics Engine

### DIFF
--- a/.changeset/analytics-engine-command.md
+++ b/.changeset/analytics-engine-command.md
@@ -1,0 +1,13 @@
+---
+"wrangler": minor
+---
+
+Add `wrangler analytics-engine` command for querying Workers Analytics Engine
+
+Query your Analytics Engine datasets directly from the CLI:
+
+- `wrangler analytics-engine run "SELECT * FROM my_dataset LIMIT 10"`
+- `wrangler analytics-engine run --file=query.sql`
+- `wrangler ae run "SHOW TABLES" --format=json`
+
+The `ae` alias is available for convenience. Output defaults to table format in interactive terminals and JSON when piped.

--- a/packages/wrangler/src/__tests__/analytics-engine.test.ts
+++ b/packages/wrangler/src/__tests__/analytics-engine.test.ts
@@ -1,0 +1,247 @@
+import { writeFileSync } from "node:fs";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { endEventLoop } from "./helpers/end-event-loop";
+import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import { useMockIsTTY } from "./helpers/mock-istty";
+import { msw } from "./helpers/msw";
+import { runInTempDir } from "./helpers/run-in-tmp";
+import { runWrangler } from "./helpers/run-wrangler";
+
+describe("wrangler analytics-engine", () => {
+	const std = mockConsoleMethods();
+	mockAccountId();
+	mockApiToken();
+	runInTempDir();
+
+	describe("help", () => {
+		it("should show help when no subcommand is passed", async () => {
+			await runWrangler("analytics-engine");
+			await endEventLoop();
+			expect(std.out).toContain("wrangler analytics-engine");
+			expect(std.out).toContain("Query Workers Analytics Engine datasets");
+			expect(std.out).toContain("wrangler analytics-engine run [query]");
+		});
+
+		it("should show help for run command", async () => {
+			await runWrangler("analytics-engine run --help");
+			await endEventLoop();
+			expect(std.out).toContain(
+				"Run a SQL query against your Analytics Engine datasets"
+			);
+			expect(std.out).toContain("query");
+			expect(std.out).toContain("The SQL query to execute");
+			expect(std.out).toContain("--file");
+			expect(std.out).toContain("--format");
+		});
+
+		it("should work with ae alias", async () => {
+			await runWrangler("ae");
+			await endEventLoop();
+			expect(std.out).toContain("wrangler ae");
+			expect(std.out).toContain("wrangler ae run [query]");
+		});
+	});
+
+	describe("run", () => {
+		const { setIsTTY } = useMockIsTTY();
+
+		it("should require either query or --file", async () => {
+			setIsTTY(false);
+			await expect(runWrangler("analytics-engine run")).rejects.toThrowError(
+				"Must specify either a query or a file containing a query."
+			);
+		});
+
+		it("should not allow both query and --file", async () => {
+			setIsTTY(false);
+			writeFileSync("query.sql", "SELECT 1");
+			await expect(
+				runWrangler('analytics-engine run "SELECT 1" --file=query.sql')
+			).rejects.toThrowError(
+				"Cannot specify both a query and a file. Please use one or the other."
+			);
+		});
+
+		it("should execute query and display table results", async () => {
+			setIsTTY(true);
+			const mockResponse = {
+				data: [
+					{ message: "Hello", count: 42 },
+					{ message: "World", count: 100 },
+				],
+				meta: [
+					{ name: "message", type: "String" },
+					{ name: "count", type: "UInt64" },
+				],
+			};
+
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/analytics_engine/sql",
+					async ({ request }) => {
+						const body = await request.text();
+						expect(body).toBe("SELECT * FROM my_dataset");
+						return HttpResponse.json(mockResponse);
+					},
+					{ once: true }
+				)
+			);
+
+			await runWrangler(
+				'analytics-engine run "SELECT * FROM my_dataset" --format=table'
+			);
+
+			expect(std.out).toContain("message");
+			expect(std.out).toContain("count");
+			expect(std.out).toContain("Hello");
+			expect(std.out).toContain("World");
+			expect(std.out).toContain("42");
+			expect(std.out).toContain("100");
+		});
+
+		it("should execute query and display JSON results with --format=json", async () => {
+			setIsTTY(false);
+			const mockResponse = {
+				data: [{ message: "Hello Analytics Engine" }],
+				meta: [{ name: "message", type: "String" }],
+			};
+
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/analytics_engine/sql",
+					async () => {
+						return HttpResponse.json(mockResponse);
+					},
+					{ once: true }
+				)
+			);
+
+			await runWrangler(
+				"analytics-engine run \"SELECT 'Hello Analytics Engine' AS message\" --format=json"
+			);
+
+			const output = JSON.parse(std.out);
+			expect(output).toEqual(mockResponse);
+		});
+
+		it("should read query from file with --file", async () => {
+			setIsTTY(false);
+			const query =
+				"SELECT * FROM temperatures WHERE timestamp > NOW() - INTERVAL '1' DAY";
+			writeFileSync("query.sql", query);
+
+			const mockResponse = {
+				data: [{ temp: 72.5 }],
+				meta: [{ name: "temp", type: "Float64" }],
+			};
+
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/analytics_engine/sql",
+					async ({ request }) => {
+						const body = await request.text();
+						expect(body).toBe(query);
+						return HttpResponse.json(mockResponse);
+					},
+					{ once: true }
+				)
+			);
+
+			await runWrangler("analytics-engine run --file=query.sql --format=json");
+
+			const output = JSON.parse(std.out);
+			expect(output).toEqual(mockResponse);
+		});
+
+		it("should handle empty results", async () => {
+			setIsTTY(true);
+			const mockResponse = {
+				data: [],
+				meta: [{ name: "message", type: "String" }],
+			};
+
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/analytics_engine/sql",
+					async () => {
+						return HttpResponse.json(mockResponse);
+					},
+					{ once: true }
+				)
+			);
+
+			await runWrangler(
+				'analytics-engine run "SELECT * FROM empty_table" --format=table'
+			);
+
+			expect(std.out).toContain("Query executed successfully with no results.");
+		});
+
+		it("should handle API errors gracefully", async () => {
+			setIsTTY(false);
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/analytics_engine/sql",
+					async () => {
+						return HttpResponse.json(
+							{ error: "Syntax error in SQL query" },
+							{ status: 400 }
+						);
+					},
+					{ once: true }
+				)
+			);
+
+			await expect(
+				runWrangler('analytics-engine run "INVALID SQL" --format=json')
+			).rejects.toThrowError("Analytics Engine API error");
+		});
+
+		it("should pass through non-JSON responses for FORMAT TabSeparated", async () => {
+			setIsTTY(true);
+			const tsvResponse = "message\tcount\nHello\t42\nWorld\t100";
+
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/analytics_engine/sql",
+					async () => {
+						return HttpResponse.text(tsvResponse);
+					},
+					{ once: true }
+				)
+			);
+
+			await runWrangler(
+				'analytics-engine run "SELECT * FROM my_dataset FORMAT TabSeparated" --format=table'
+			);
+
+			expect(std.out).toContain("message\tcount");
+			expect(std.out).toContain("Hello\t42");
+		});
+
+		it("should use ae alias for run command", async () => {
+			setIsTTY(false);
+			const mockResponse = {
+				data: [{ result: 1 }],
+				meta: [{ name: "result", type: "UInt8" }],
+			};
+
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/analytics_engine/sql",
+					async () => {
+						return HttpResponse.json(mockResponse);
+					},
+					{ once: true }
+				)
+			);
+
+			await runWrangler('ae run "SELECT 1 AS result" --format=json');
+
+			const output = JSON.parse(std.out);
+			expect(output).toEqual(mockResponse);
+		});
+	});
+});

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -57,6 +57,7 @@ describe("wrangler", () => {
 				  wrangler d1                     🗄 Manage Workers D1 databases
 				  wrangler vectorize              🧮 Manage Vectorize indexes
 				  wrangler hyperdrive             🚀 Manage Hyperdrive databases
+				  wrangler analytics-engine       📊 Query Workers Analytics Engine datasets
 				  wrangler cert                   🪪 Manage client mTLS certificates and CA certificate chains used for secured connections [open beta]
 				  wrangler pages                  ⚡️ Configure Cloudflare Pages
 				  wrangler mtls-certificate       🪪 Manage certificates used for mTLS connections
@@ -122,6 +123,7 @@ describe("wrangler", () => {
 				  wrangler d1                     🗄 Manage Workers D1 databases
 				  wrangler vectorize              🧮 Manage Vectorize indexes
 				  wrangler hyperdrive             🚀 Manage Hyperdrive databases
+				  wrangler analytics-engine       📊 Query Workers Analytics Engine datasets
 				  wrangler cert                   🪪 Manage client mTLS certificates and CA certificate chains used for secured connections [open beta]
 				  wrangler pages                  ⚡️ Configure Cloudflare Pages
 				  wrangler mtls-certificate       🪪 Manage certificates used for mTLS connections
@@ -149,10 +151,10 @@ describe("wrangler", () => {
 				Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose"
 			`);
 			expect(std.err).toMatchInlineSnapshot(`
-			        "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown argument: invalid-command[0m
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown argument: invalid-command[0m
 
-			        "
-		      `);
+				"
+			`);
 		});
 	});
 

--- a/packages/wrangler/src/analytics-engine/index.ts
+++ b/packages/wrangler/src/analytics-engine/index.ts
@@ -1,0 +1,152 @@
+import { APIError, readFileSync, UserError } from "@cloudflare/workers-utils";
+import { performApiFetch } from "../cfetch/internal";
+import {
+	createAlias,
+	createCommand,
+	createNamespace,
+} from "../core/create-command";
+import { logger } from "../logger";
+import { requireAuth } from "../user";
+
+export const analyticsEngineNamespace = createNamespace({
+	metadata: {
+		description: "📊 Query Workers Analytics Engine datasets",
+		status: "stable",
+		owner: "Workers: Workers Observability",
+	},
+});
+
+export const analyticsEngineAlias = createAlias({
+	aliasOf: "wrangler analytics-engine",
+	metadata: {
+		hidden: true,
+	},
+});
+
+interface AnalyticsEngineRow {
+	[key: string]: unknown;
+}
+
+interface AnalyticsEngineResult {
+	data: AnalyticsEngineRow[];
+	meta: { name: string; type: string }[];
+}
+
+export const analyticsEngineRunCommand = createCommand({
+	metadata: {
+		description: "Run a SQL query against your Analytics Engine datasets",
+		status: "stable",
+		owner: "Workers: Workers Observability",
+	},
+	behaviour: {
+		printBanner: (args) => args.format !== "json",
+	},
+	positionalArgs: ["query"],
+	args: {
+		query: {
+			describe: "The SQL query to execute",
+			type: "string",
+		},
+		file: {
+			describe: "A file containing the SQL query to execute",
+			type: "string",
+		},
+		format: {
+			describe: "Output format",
+			type: "string",
+			choices: ["json", "table"] as const,
+		},
+	},
+	async handler(args, { config }) {
+		const { query: queryArg, file, format: formatArg } = args;
+
+		// Validate input - must have either query or file, but not both
+		if (queryArg && file) {
+			throw new UserError(
+				"Cannot specify both a query and a file. Please use one or the other."
+			);
+		}
+
+		if (!queryArg && !file) {
+			throw new UserError(
+				"Must specify either a query or a file containing a query."
+			);
+		}
+
+		// Read query from file or use positional argument
+		const query = file ? readFileSync(file) : queryArg;
+
+		if (!query) {
+			throw new UserError("Query cannot be empty.");
+		}
+
+		// Determine output format - default to table for TTY, json otherwise
+		const format = formatArg ?? (process.stdout.isTTY ? "table" : "json");
+
+		const accountId = await requireAuth(config);
+
+		// Use performApiFetch which handles auth consistently with other wrangler commands
+		// Analytics Engine API returns raw data, not Cloudflare API envelope
+		let response;
+		try {
+			response = await performApiFetch(
+				config,
+				`/accounts/${accountId}/analytics_engine/sql`,
+				{
+					method: "POST",
+					headers: {
+						"Content-Type": "text/plain",
+					},
+					body: query,
+				}
+			);
+		} catch (error) {
+			throw new APIError({
+				text: `Failed to connect to Analytics Engine API: ${error instanceof Error ? error.message : String(error)}`,
+			});
+		}
+
+		const text = await response.text();
+
+		if (!response.ok) {
+			throw new APIError({
+				text: `Analytics Engine API error: ${response.status} ${response.statusText}`,
+				notes: [{ text }],
+				status: response.status,
+			});
+		}
+
+		// Handle output based on format
+		if (format === "table") {
+			// Try to parse as JSON for table display
+			try {
+				const data = JSON.parse(text) as AnalyticsEngineResult;
+				if (data.data && data.meta && Array.isArray(data.data)) {
+					if (data.data.length === 0) {
+						logger.log("Query executed successfully with no results.");
+						return;
+					}
+
+					const columns = data.meta.map((col) => col.name);
+					logger.table(
+						data.data.map((row) =>
+							Object.fromEntries(
+								columns.map((col) => [col, String(row[col] ?? "")])
+							)
+						),
+						{ wordWrap: true, head: columns }
+					);
+				} else {
+					// JSON but not in expected format - output as-is
+					logger.log(text);
+				}
+			} catch {
+				// Not JSON (user used FORMAT TabSeparated, etc.) - output raw
+				logger.log(text);
+			}
+		} else {
+			// JSON format - output as-is
+			logger.log(text);
+		}
+	},
+});

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -15,6 +15,11 @@ import { aiFineTuneNamespace, aiNamespace } from "./ai";
 import { aiFineTuneCreateCommand } from "./ai/createFinetune";
 import { aiModelsCommand } from "./ai/listCatalog";
 import { aiFineTuneListCommand } from "./ai/listFinetune";
+import {
+	analyticsEngineAlias,
+	analyticsEngineNamespace,
+	analyticsEngineRunCommand,
+} from "./analytics-engine";
 import { buildCommand } from "./build";
 import {
 	certDeleteCommand,
@@ -1129,6 +1134,20 @@ export function createCLIParser(argv: string[]) {
 		},
 	]);
 	registry.registerNamespace("hyperdrive");
+
+	// analytics-engine
+	registry.define([
+		{
+			command: "wrangler analytics-engine",
+			definition: analyticsEngineNamespace,
+		},
+		{
+			command: "wrangler analytics-engine run",
+			definition: analyticsEngineRunCommand,
+		},
+		{ command: "wrangler ae", definition: analyticsEngineAlias },
+	]);
+	registry.registerNamespace("analytics-engine");
 
 	// cert - includes mtls-certificates and CA cert management
 	registry.define([


### PR DESCRIPTION
## Summary

Add a new subcommand to query Workers Analytics Engine datasets directly from wrangler:

- `wrangler analytics-engine run <QUERY>` - Run a SQL query
- `wrangler analytics-engine run --file=query.sql` - Run query from file
- `wrangler ae run <QUERY> --format=json` - Output as JSON (ae is an alias)

Output defaults to table format in interactive terminals and JSON when piped.

```
➜ ./bin/wrangler.js analytics-engine run "SELECT blob1 AS event_type, SUM(_sample_interval) AS count FROM bonk_events WHERE timestamp > NOW() - INTERVAL '30' DAY GROUP BY event_type ORDER BY count DESC" --format=json | jq -r '.data[] | "\(.event_type) \(.count)"' | uvx termgraph --title "Bonk Events (Last 30 Days)" --width 20 --format '{:.0f}'

# Bonk Events (Last 30 Days)

webhook : ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 42
finalize: ▏ 2
track   : ▏ 1
setup   : ▏ 1

```

### Implementation Details

- Uses standard `createCommand`/`createNamespace`/`createAlias` pattern
- Uses `fetchResult` for API calls with standard authentication via `requireAuth`
- API endpoint: `POST /accounts/{account_id}/analytics_engine/sql`
- Follows existing conventions from `r2 sql`, `pipelines`, and `hyperdrive` commands

---

- Tests
  - [x] Tests included/updated
  - [ ] Tests not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/27368
  - [ ] Documentation not necessary because: API docs already exist at https://developers.cloudflare.com/analytics/analytics-engine/sql-api/
  
 - Bonus:
  - [x] Mandatory cute animal photo:
![maite](https://github.com/user-attachments/assets/4846c842-cdea-4ffa-a6d3-1920bb9fbb9b)
