### PR TITLE
fix(c3): update Waku wrangler.jsonc main entry path

### DIFF
--- a/.changeset/quiet-animals-rest.md
+++ b/.changeset/quiet-animals-rest.md
@@ -1,0 +1,9 @@
+---
+"create-cloudflare": patch
+---
+
+Update Waku framework template wrangler.jsonc main entry path
+
+Waku changed the worker main entry build path for v1.0. https://github.com/wakujs/waku/pull/1758
+
+Removed not_found_handling so the worker will be invoked when no asset is found. This avoids 404 errors Waku server-side routes when assets_navigation_prefers_asset_serving is enabled. https://developers.cloudflare.com/workers/configuration/compatibility-flags/#navigation-requests-prefer-asset-serving

--- a/packages/create-cloudflare/templates/waku/wrangler.jsonc
+++ b/packages/create-cloudflare/templates/waku/wrangler.jsonc
@@ -1,17 +1,16 @@
 {
 	"name": "<WORKER_NAME>",
-	"main": "./dist/worker/serve-cloudflare.js",
-	// https://developers.cloudflare.com/workers/platform/compatibility-dates
-	"compatibility_date": "<COMPATIBILITY_DATE>",
+	"main": "./dist/server/serve-cloudflare.js",
 	// nodejs_als is required for Waku server-side request context
 	// It can be removed if only building static pages
 	"compatibility_flags": ["nodejs_als"],
-	// https://developers.cloudflare.com/workers/static-assets/binding/
+	// https://developers.cloudflare.com/workers/platform/compatibility-dates
+	"compatibility_date": "<COMPATIBILITY_DATE>",
 	"assets": {
+		// https://developers.cloudflare.com/workers/static-assets/binding/
 		"binding": "ASSETS",
-		"directory": "./dist/assets",
-		"html_handling": "drop-trailing-slash",
-		"not_found_handling": "404-page"
+		"directory": "./dist/public",
+		"html_handling": "drop-trailing-slash"
 	},
 	"vars": {
 		"MAX_ITEMS": 10


### PR DESCRIPTION
Waku changed the worker main entry build path for v1.0. https://github.com/wakujs/waku/pull/1758

Also removed `not_found_handling` so the worker will be invoked when no asset is found. This avoids 404 errors Waku server-side routes when assets_navigation_prefers_asset_serving is enabled. https://developers.cloudflare.com/workers/configuration/compatibility-flags/#navigation-requests-prefer-asset-serving

---

- Tests
  - [x] Tests included/updated
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: the wrangler.jsonc is not mentioned in the docs. https://developers.cloudflare.com/workers/framework-guides/web-apps/more-web-frameworks/waku/

<img width="187.5" height="250" alt="image" src="https://github.com/user-attachments/assets/21a7b5f0-9c47-4169-8027-a98ce081eac3" />
