### PR TITLE
[github-actions]: add Jesse to workers ai

### DIFF
--- a/tools/github-workflow-helpers/auto-assign-issues.ts
+++ b/tools/github-workflow-helpers/auto-assign-issues.ts
@@ -37,6 +37,7 @@ const TEAM_ASSIGNMENTS: { [label: string]: { [jobRole: string]: string } } = {
 	"start-dev-worker": { em: "lrapoport-cf", pm: "mattietk" },
 	templates: { em: "lrapoport-cf", pm: "mattietk" },
 	types: { em: "lrapoport-cf", pm: "mattietk" },
+	"types-ai": { em: "jkipp-cloudflare" },
 	unenv: { em: "lrapoport-cf", pm: "mattietk" },
 	unstable_dev: { em: "lrapoport-cf", pm: "mattietk" },
 	vectorize: { em: "sejoker", pm: "jonesphillip" },
@@ -44,7 +45,7 @@ const TEAM_ASSIGNMENTS: { [label: string]: { [jobRole: string]: string } } = {
 	vitest: { em: "lrapoport-cf", pm: "mattietk" },
 	"workers vpc": { em: "efalcao", pm: "thomasgauvin" },
 	"Workers + Assets": { em: "dcartertwo", pm: "irvinebroque" },
-	"workers ai": {},
+	"workers ai": { em: "jkipp-cloudflare" },
 	"workers-builds": {
 		director: "dcartertwo",
 		pm: "yomna-shousha",


### PR DESCRIPTION
This adds @jkipp-cloudflare as the default assignee for Workers AI issues and AI types issues

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Tests not necessary because: issue assignment change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: issue assignment change
