### PR TITLE
ci: fix changeset review for Version Packages PRs

### DIFF
--- a/.github/workflows/changeset-review.yml
+++ b/.github/workflows/changeset-review.yml
@@ -41,7 +41,7 @@ jobs:
           files_ignore: |
             .changeset/README.md
           # Recover deleted files so Claude can read them (needed for Version Packages PRs)
-          recover_deleted_files: true
+          recover_deleted_files: ${{ github.event.pull_request.title == 'Version Packages' }}
 
       - name: Review Changesets with Claude
         id: claude-review


### PR DESCRIPTION
Fixes the Claude changeset review step being skipped on "Version Packages" PRs.

**Root cause:** For "Version Packages" PRs created by the changesets bot, the changeset files are being *deleted* (their content moves to changelogs), not added or modified. The `tj-actions/changed-files` action's `all_changed_files` output doesn't include deleted files, so it was empty for these PRs, causing the Claude review step to be skipped.

**Fix:**
Uses the `recover_deleted_files` option from `tj-actions/changed-files` to automatically restore deleted files to their original paths, allowing Claude to read them. The option is conditionally enabled only for Version Packages PRs:
```yaml
recover_deleted_files: ${{ github.event.pull_request.title == 'Version Packages' }}
```

This simplifies the workflow by:
- Removing the intermediate `changesets-to-review` step
- Using a direct condition on the Claude review step: run for Version Packages PRs (which delete changesets) or regular PRs with new changesets

**Suggested human review checklist:**
- [ ] Verify the conditional expression evaluates correctly as an action input (boolean → string coercion)
- [ ] Verify `recover_deleted_files` restores files to their original paths (not a separate directory)
- [ ] Verify the condition `github.event.pull_request.title == 'Version Packages' || steps.changed-changesets.outputs.added_files_count > 0` correctly handles both PR types
- [ ] The fix can only be fully validated when the next Version Packages PR is created

---

- Tests
  - [ ] Tests included/updated
  - [x] Tests not necessary because: This is a CI workflow change that will be validated when the next Version Packages PR is created
- Public documentation
  - [x] Documentation not necessary because: Internal CI workflow change
- Wrangler V3 Backport
  - [x] Not necessary because: CI workflow only exists on main branch

Link to Devin run: https://app.devin.ai/sessions/d116e84674024804880b1aeb12c51d2b
Devin PR requested by @petebacondarwin