### PR TITLE
feat: update CI workflow for other Node versions

### DIFF
--- a/.github/workflows/test-and-check-other-node.yml
+++ b/.github/workflows/test-and-check-other-node.yml
@@ -27,7 +27,6 @@ jobs:
           - { node_version: 20, description: "Node 20" }
           - { node_version: 24, description: "Node 24", expected_to_fail: true }
           - { node_version: 25, description: "Node 25", expected_to_fail: true }
-          - { node_version: 26, description: "Node 26", expected_to_fail: true }
 
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
Devin PR requested by @petebacondarwin

[Link to Devin run](https://app.devin.ai/sessions/8e0f537ad1bd4f939642febaa637badb)

Updates the `test-and-check-other-node.yml` workflow with the following changes:

- Add Node.js 25 to the test matrix (with `expected_to_fail: true`)
- Add two new test commands:
  - `pnpm test:e2e --filter wrangler -- unenv-preset`
  - `pnpm test:ci --filter @cloudflare/vite-plugin`
- Introduce `expected_to_fail` matrix field to control which Node versions are skipped on normal PRs
- Node 20 tests run on all PRs (no `expected_to_fail` field, defaults to false)
- Node 24+ tests (`expected_to_fail: true`) are skipped on normal PRs but run when:
  - The PR is a Version Packages PR (head branch is `changeset-release/main`), OR
  - The `test all node versions` label is added to the PR
- Deduplicate condition logic using a "Check if should run tests" step that outputs a result

**For reviewer:**
1. The bash condition logic in "Check if should run tests" step determines whether tests should run - please verify the logic is correct
2. The `expected_to_fail` field relies on falsy default for Node 20 - verify this works as expected

---

- Tests
  - [ ] Tests included/updated
  - [x] Tests not necessary because: CI workflow changes are tested by running the actual CI
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Internal CI workflow change