### PR TITLE
ci: e2e tests use the default Node version

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ jobs:
   e2e-wrangler-test:
     name: ${{ format('Wrangler E2E ({0})', matrix.description) }}
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.node }}-wrangler
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-wrangler
       cancel-in-progress: true
     timeout-minutes: 60
     strategy:
@@ -19,11 +19,11 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            description: v20, macOS
+            description: macOS
           - os: windows-latest
-            description: v20, Windows
+            description: Windows
           - os: ubuntu-latest
-            description: v20, Linux
+            description: Linux
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -79,13 +79,13 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: turbo-runs-${{ matrix.os }}-${{ matrix.node }}
+          name: turbo-runs-${{ matrix.os }}
           path: .turbo/runs
 
   e2e-vite-plugin-test:
     name: ${{ format('Vite Plugin E2E ({0})', matrix.description) }}
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.node }}-vite
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-vite
       cancel-in-progress: true
     timeout-minutes: 60
     strategy:
@@ -142,5 +142,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: turbo-runs-${{ matrix.os }}-${{ matrix.node }}
+          name: turbo-runs-${{ matrix.os }}
           path: .turbo/runs


### PR DESCRIPTION
That's 22 as of today.

-> remove ref to "v20" and useless `matrix.node` dep

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Tests not necessary because: ci
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ci

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
