### PR TITLE
refactor handling of Node built-in modules

### DIFF
--- a/.changeset/purple-eggs-relate.md
+++ b/.changeset/purple-eggs-relate.md
@@ -2,4 +2,6 @@
 "@cloudflare/unenv-preset": minor
 ---
 
-Add lists of node modules (with and without the `node:` prefix)
+Export the list of built-in node modules that are available without the `node:` prefix.
+Modules that are only available with the `node:` are not included (i.e. `node:sqlite`).
+Note that new modules will be added with the `node:` prefix only and not be added to the list.

--- a/packages/unenv-preset/src/index.ts
+++ b/packages/unenv-preset/src/index.ts
@@ -82,18 +82,6 @@ export const nonPrefixedNodeModules = [
 ];
 
 /**
- * List of the Node.js built-in modules that must be imported with the `node:` prefix.
- *
- * Generated using `module.builtinModules` in Node.js 24.11.1
- */
-export const prefixedOnlyNodeModules = [
-	"node:sea",
-	"node:sqlite",
-	"node:test",
-	"node:test/reporters",
-];
-
-/**
  * @deprecated Use getCloudflarePreset instead.
  */
 export const cloudflare = getCloudflarePreset({});

--- a/packages/vite-plugin-cloudflare/src/plugins/nodejs-compat.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/nodejs-compat.ts
@@ -1,8 +1,5 @@
 import assert from "node:assert";
-import {
-	nonPrefixedNodeModules,
-	prefixedOnlyNodeModules,
-} from "@cloudflare/unenv-preset";
+import { nonPrefixedNodeModules } from "@cloudflare/unenv-preset";
 import {
 	assertHasNodeJsCompat,
 	hasNodeJsAls,
@@ -54,9 +51,16 @@ export const nodeJsCompatPlugin = createPlugin("nodejs-compat", (ctx) => {
 						// But also we want to avoid following the ones that are polyfilled since the dependency-optimizer import analyzer does not
 						// resolve these imports using our `resolveId()` hook causing the optimization step to fail.
 						exclude: [
+							// The `node:` prefix is optional for older built-in modules.
 							...nonPrefixedNodeModules,
 							...nonPrefixedNodeModules.map((module) => `node:${module}`),
-							...prefixedOnlyNodeModules,
+							// New Node.js built-in modules are only published with the `node:` prefix.
+							...[
+								"node:sea",
+								"node:sqlite",
+								"node:test",
+								"node:test/reporters",
+							],
 						],
 					},
 				};


### PR DESCRIPTION
Follow up for https://github.com/cloudflare/workers-sdk/pull/11834

The list of prefixed Node modules will change when new modules are added to Node.

The only usage we have of this list is in Vite and we plan to drop it at some point.

So this PR drops the list from unenv to avoid having to maintain it.