### PR TITLE
remove track_progress from claude changeset review job

### DIFF
--- a/.github/workflows/changeset-review.yml
+++ b/.github/workflows/changeset-review.yml
@@ -51,7 +51,6 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: "devin-ai-integration[bot]"
-          track_progress: true
           use_sticky_comment: true
           prompt: |
             Review the changeset files in this PR.


### PR DESCRIPTION
The job fails when you change a label since this `track_progress` feature does not support label events.

For example https://github.com/cloudflare/workers-sdk/actions/runs/20831304803/job/59845904429?pr=11841#step:4:154

We don't need this feature - it is to emulate agent mode where you are having a conversation with Claude via the PR comments

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Tests not necessary because: CI config change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: CI change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
