### PR TITLE
fix: improve handling of pages deploy command

### DIFF
--- a/.changeset/fix-pages-deploy-command-injection.md
+++ b/.changeset/fix-pages-deploy-command-injection.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Use argument array when executing git commands with `wrangler pages deploy`
+
+Pass user provided values from `--commit-hash` safely to underlying git command.

--- a/packages/wrangler/src/pages/deploy.ts
+++ b/packages/wrangler/src/pages/deploy.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
@@ -361,7 +361,12 @@ export const pagesDeployCommand = createCommand({
 				}
 
 				if (!commitMessage) {
-					commitMessage = execSync(`git show -s --format=%B ${commitHash}`)
+					commitMessage = execFileSync("git", [
+						"show",
+						"-s",
+						"--format=%B",
+						commitHash,
+					])
 						.toString()
 						.trim();
 				}


### PR DESCRIPTION
use array of args to execute git command with user input, instead of unsanitised string.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: fix

A picture of a cute animal (not mandatory, but encouraged)

![chomp](https://github.com/user-attachments/assets/f7228466-a3bd-4b8d-b91f-2c5e608fcd73)


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
