### PR TITLE
[wrangler] Surface remote proxy session errors

### DIFF
--- a/.changeset/remote-proxy-session-errors.md
+++ b/.changeset/remote-proxy-session-errors.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+Surface remote proxy session errors
+
+When remote bindings fail to start, include the controller reason and root
+cause in the error message to make failures like missing `cloudflared` clearer.

--- a/fixtures/get-platform-proxy-remote-bindings/tests/index.test.ts
+++ b/fixtures/get-platform-proxy-remote-bindings/tests/index.test.ts
@@ -246,8 +246,8 @@ if (auth) {
 					}>({
 						configPath: "./.tmp/config-with-invalid-account-id/wrangler.json",
 					})
-				).rejects.toMatchInlineSnapshot(
-					`[Error: Failed to start the remote proxy session. There is likely additional logging output above.]`
+				).rejects.toThrowError(
+					/Failed to start the remote proxy session\. Failed to create a preview token/
 				);
 
 				expect(errorSpy).toHaveBeenCalledOnce();

--- a/packages/vite-plugin-cloudflare/e2e/remote-bindings.test.ts
+++ b/packages/vite-plugin-cloudflare/e2e/remote-bindings.test.ts
@@ -185,8 +185,8 @@ if (isWindows) {
 				expect(proc.stderr).toContain(
 					"R2 bucket 'non-existent-r2-bucket' not found. Verify the bucket exists in your account and that the bucket_name in your configuration is correct. [code: 10085]"
 				);
-				expect(proc.stderr).toContain(
-					"Error: Failed to start the remote proxy session. There is likely additional logging output above."
+				expect(proc.stderr).toMatch(
+					/Error: Failed to start the remote proxy session\./
 				);
 			});
 		});

--- a/packages/wrangler/e2e/remote-binding/remote-bindings-api.test.ts
+++ b/packages/wrangler/e2e/remote-binding/remote-bindings-api.test.ts
@@ -99,8 +99,8 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 							},
 						}
 					)
-				).rejects.toMatchInlineSnapshot(
-					`[Error: Failed to start the remote proxy session. There is likely additional logging output above.]`
+				).rejects.toThrowError(
+					/Failed to start the remote proxy session\. Failed to create a preview token/
 				);
 			});
 		});
@@ -156,8 +156,8 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 							},
 						}
 					)
-				).rejects.toMatchInlineSnapshot(
-					`[Error: Failed to start the remote proxy session. There is likely additional logging output above.]`
+				).rejects.toThrowError(
+					/Failed to start the remote proxy session\. Failed to create a preview token/
 				);
 			});
 		});

--- a/packages/wrangler/src/__tests__/dev/remote-bindings-errors.test.ts
+++ b/packages/wrangler/src/__tests__/dev/remote-bindings-errors.test.ts
@@ -88,7 +88,7 @@ describe("errors during dev with remote bindings", () => {
 		assert(thrownError);
 
 		expect(thrownError).toMatchInlineSnapshot(
-			`[Error: Failed to start the remote proxy session. There is likely additional logging output above.]`
+			`[Error: Failed to start the remote proxy session. Failed to obtain a preview token: The remote worker preview failed.]`
 		);
 
 		expect(thrownError.cause).toMatchInlineSnapshot(`

--- a/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
+++ b/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
@@ -6,6 +6,7 @@ import { getBasePath } from "../../paths";
 import { startWorker } from "../startDevWorker";
 import type { LoggerLevel } from "../../logger";
 import type { StartDevWorkerInput, Worker } from "../startDevWorker";
+import type { ErrorEvent } from "../startDevWorker/events";
 import type { Config } from "@cloudflare/workers-utils";
 import type { RemoteProxyConnectionString } from "miniflare";
 
@@ -15,6 +16,46 @@ export type StartRemoteProxySessionOptions = {
 	/** If running in a non-public compliance region, set this here. */
 	complianceRegion?: Config["compliance_region"];
 };
+
+function isErrorEvent(error: unknown): error is ErrorEvent {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"type" in error &&
+		(error as { type?: string }).type === "error" &&
+		"reason" in error &&
+		"cause" in error
+	);
+}
+
+function getErrorMessage(error: unknown): string | undefined {
+	if (error instanceof Error) {
+		return getErrorMessage(error.cause) ?? error.message;
+	}
+
+	if (typeof error === "string") {
+		return error;
+	}
+
+	if (typeof error === "object" && error !== null) {
+		const maybeMessage = (error as { message?: unknown }).message;
+		if (typeof maybeMessage === "string") {
+			const maybeCause = (error as { cause?: unknown }).cause;
+			return getErrorMessage(maybeCause) ?? maybeMessage;
+		}
+	}
+
+	return undefined;
+}
+
+function formatRemoteProxySessionError(error: unknown): string | undefined {
+	if (isErrorEvent(error)) {
+		const causeMessage = getErrorMessage(error.cause);
+		return causeMessage ? `${error.reason}: ${causeMessage}` : error.reason;
+	}
+
+	return getErrorMessage(error);
+}
 
 export async function startRemoteProxySession(
 	bindings: StartDevWorkerInput["bindings"],
@@ -74,8 +115,11 @@ export async function startRemoteProxySession(
 	]);
 
 	if (maybeError && maybeError.error) {
+		const details = formatRemoteProxySessionError(maybeError.error);
 		throw new Error(
-			"Failed to start the remote proxy session. There is likely additional logging output above.",
+			details
+				? `Failed to start the remote proxy session. ${details}`
+				: "Failed to start the remote proxy session. There is likely additional logging output above.",
 			{
 				cause: maybeError.error,
 			}

--- a/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
+++ b/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
@@ -8,6 +8,7 @@ import { getBasePath } from "../../paths";
 import { startWorker } from "../startDevWorker";
 import type { LoggerLevel } from "../../logger";
 import type { StartDevWorkerInput, Worker } from "../startDevWorker";
+import type { ErrorEvent } from "../startDevWorker/events";
 import type { Config } from "@cloudflare/workers-utils";
 import type { RemoteProxyConnectionString } from "miniflare";
 
@@ -17,6 +18,46 @@ export type StartRemoteProxySessionOptions = {
 	/** If running in a non-public compliance region, set this here. */
 	complianceRegion?: Config["compliance_region"];
 };
+
+function isErrorEvent(error: unknown): error is ErrorEvent {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"type" in error &&
+		(error as { type?: string }).type === "error" &&
+		"reason" in error &&
+		"cause" in error
+	);
+}
+
+function getErrorMessage(error: unknown): string | undefined {
+	if (error instanceof Error) {
+		return getErrorMessage(error.cause) ?? error.message;
+	}
+
+	if (typeof error === "string") {
+		return error;
+	}
+
+	if (typeof error === "object" && error !== null) {
+		const maybeMessage = (error as { message?: unknown }).message;
+		if (typeof maybeMessage === "string") {
+			const maybeCause = (error as { cause?: unknown }).cause;
+			return getErrorMessage(maybeCause) ?? maybeMessage;
+		}
+	}
+
+	return undefined;
+}
+
+function formatRemoteProxySessionError(error: unknown): string | undefined {
+	if (isErrorEvent(error)) {
+		const causeMessage = getErrorMessage(error.cause);
+		return causeMessage ? `${error.reason}: ${causeMessage}` : error.reason;
+	}
+
+	return getErrorMessage(error);
+}
 
 export async function startRemoteProxySession(
 	bindings: StartDevWorkerInput["bindings"],
@@ -77,8 +118,11 @@ export async function startRemoteProxySession(
 	]);
 
 	if (maybeError && maybeError.error) {
+		const details = formatRemoteProxySessionError(maybeError.error);
 		throw new Error(
-			"Failed to start the remote proxy session. There is likely additional logging output above.",
+			details
+				? `Failed to start the remote proxy session. ${details}`
+				: "Failed to start the remote proxy session. There is likely additional logging output above.",
 			{
 				cause: maybeError.error,
 			}


### PR DESCRIPTION
Fixes #11098.

_Describe your change..._
- Include controller reason and root cause in startRemoteProxySession errors so Access/cloudflared issues are visible.
- Update remote bindings tests to match the richer error message.
- Add wrangler changeset.

Tests: pnpm test:ci -F wrangler -- remote-bindings-errors
E2E tests not run (requires Cloudflare credentials).

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: error messaging change only.

*A picture of a cute animal (not mandatory, but encouraged)*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/11896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
