### PR TITLE
Temporarily disable media binding test

### DIFF
--- a/packages/wrangler/e2e/remote-binding/miniflare-remote-resources.test.ts
+++ b/packages/wrangler/e2e/remote-binding/miniflare-remote-resources.test.ts
@@ -347,26 +347,26 @@ const testCases: TestCase[] = [
 		}),
 		expectFetchToMatch: [expect.stringContaining(`image/avif`)],
 	},
-	{
-		name: "Media",
-		scriptPath: "media.js",
-		setup: () => ({
-			remoteProxySessionConfig: {
-				bindings: {
-					MEDIA: {
-						type: "media",
-					},
-				},
-			},
-			miniflareConfig: (connection) => ({
-				media: {
-					binding: "MEDIA",
-					remoteProxyConnectionString: connection,
-				},
-			}),
-		}),
-		expectFetchToMatch: [expect.stringContaining(`image/jpeg`)],
-	},
+	// {
+	// 	name: "Media",
+	// 	scriptPath: "media.js",
+	// 	setup: () => ({
+	// 		remoteProxySessionConfig: {
+	// 			bindings: {
+	// 				MEDIA: {
+	// 					type: "media",
+	// 				},
+	// 			},
+	// 		},
+	// 		miniflareConfig: (connection) => ({
+	// 			media: {
+	// 				binding: "MEDIA",
+	// 				remoteProxyConnectionString: connection,
+	// 			},
+	// 		}),
+	// 	}),
+	// 	expectFetchToMatch: [expect.stringContaining(`image/jpeg`)],
+	// },
 	{
 		name: "Dispatch Namespace",
 		scriptPath: "dispatch-namespace.js",


### PR DESCRIPTION
The media binding is unreleased, and making some internal changes that has caused our e2e tests to break - temporarily disabling this test while that stabilises.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: testing change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: testing change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
