### PR TITLE
Allow worker assets redirect `/` to `/index.html` when HTML handling is disabled

### DIFF
--- a/.changeset/fix-infinite-loop-detection.md
+++ b/.changeset/fix-infinite-loop-detection.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+Fix false positive infinite loop detection for exact path redirects
+
+Fixed an issue where the redirect validation incorrectly flagged exact path redirects like `/ /index.html 200` as infinite loops. This was particularly problematic when `html_handling` is set to "none", where such redirects are valid.
+
+The fix makes the validation more specific to only block wildcard patterns (like `/* /index.html`) that would actually cause infinite loops, while allowing exact path matches that are valid in certain configurations.
+
+Fixes: https://github.com/cloudflare/workers-sdk/issues/11824

--- a/packages/miniflare/src/plugins/assets/index.ts
+++ b/packages/miniflare/src/plugins/assets/index.ts
@@ -112,7 +112,9 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 
 		let parsedRedirects: AssetConfig["redirects"] | undefined;
 		if (redirectsContents !== undefined) {
-			const redirects = parseRedirects(redirectsContents);
+			const redirects = parseRedirects(redirectsContents, {
+				htmlHandling: options.assets.assetConfig?.html_handling,
+			});
 			parsedRedirects = RedirectsSchema.parse(
 				constructRedirects({
 					redirects,

--- a/packages/vite-plugin-cloudflare/src/asset-config.ts
+++ b/packages/vite-plugin-cloudflare/src/asset-config.ts
@@ -108,7 +108,9 @@ export function getAssetsConfig(
 		redirectsContents &&
 		RedirectsSchema.parse(
 			constructRedirects({
-				redirects: parseRedirects(redirectsContents),
+				redirects: parseRedirects(redirectsContents, {
+					htmlHandling: assetsConfig?.html_handling,
+				}),
 				redirectsFile,
 				logger,
 			}).redirects

--- a/packages/wrangler/src/miniflare-cli/assets.ts
+++ b/packages/wrangler/src/miniflare-cli/assets.ts
@@ -155,7 +155,9 @@ async function generateAssetsFetch(
 	let redirects: ParsedRedirects | undefined;
 	if (existsSync(redirectsFile)) {
 		const contents = readFileSync(redirectsFile, "utf-8");
-		redirects = parseRedirects(contents);
+		redirects = parseRedirects(contents, {
+			htmlHandling: undefined, // Pages dev server doesn't expose html_handling configuration in this context.
+		});
 	}
 
 	let headers: ParsedHeaders | undefined;
@@ -185,7 +187,9 @@ async function generateAssetsFetch(
 				case redirectsFile: {
 					log.log("_redirects modified. Re-evaluating...");
 					const contents = readFileSync(redirectsFile).toString();
-					redirects = parseRedirects(contents);
+					redirects = parseRedirects(contents, {
+						htmlHandling: undefined, // Pages dev server doesn't expose html_handling configuration in this context.
+					});
 					break;
 				}
 			}


### PR DESCRIPTION
Tracked internally: https://jira.cfdata.org/browse/WC-4372

_Describe your change..._

fix(wrangler): resolve false positive infinite loop detection for exact path redirects

- Fixed validation logic to only block wildcard patterns like '/* /index.html'
- Allow exact path matches like '/ /index.html' which are valid when html_handling is 'none'
- Updated tests to reflect the corrected behavior
- Added comprehensive test case documenting the fix

 Fixes: https://github.com/cloudflare/workers-sdk/issues/11824

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Fixing existing logic that should not fail.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
