### PR TITLE
[workers-utils] Fix compat date resolution in workspaces

### DIFF
--- a/.changeset/fix-miniflare-resolve.md
+++ b/.changeset/fix-miniflare-resolve.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/workers-utils": patch
+---
+
+Fix miniflare resolution when getting local workerd compatibility date
+
+Previously, `getLocalWorkerdCompatibilityDate()` resolved `miniflare` to its main entry point, which could be a nested file deep in the package. This caused module resolution issues when subsequently requiring `workerd` from that location. Now resolves `miniflare/package.json` instead, ensuring consistent resolution from the package root.

--- a/packages/workers-utils/src/compatibility-date.ts
+++ b/packages/workers-utils/src/compatibility-date.ts
@@ -40,7 +40,7 @@ export function getLocalWorkerdCompatibilityDate({
 		const projectRequire = module.createRequire(
 			path.join(projectPath, "package.json")
 		);
-		const miniflareEntry = projectRequire.resolve("miniflare");
+		const miniflareEntry = projectRequire.resolve("miniflare/package.json");
 		const miniflareRequire = module.createRequire(miniflareEntry);
 		const miniflareWorkerd = miniflareRequire("workerd") as {
 			compatibilityDate: string;

--- a/packages/workers-utils/tests/compatibility-date.test.ts
+++ b/packages/workers-utils/tests/compatibility-date.test.ts
@@ -1,5 +1,6 @@
 import module from "node:module";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { beforeEach, describe, it, vi } from "vitest";
 import { getLocalWorkerdCompatibilityDate } from "../src/compatibility-date";
 


### PR DESCRIPTION
`getLocalWorkerdCompatibilityDate()` could fail in workspaces because it used `require.resolve("miniflare")`, and `miniflare`’s `main` points at `dist/` (which may not exist until built). That caused the function to fall back even though `workerd` is installed.

This change:
- Resolves `miniflare/package.json` instead, so resolution works even before `miniflare` is built
- Updates the unit test to use Wrangler’s workspace context for resolution
- Adds a changeset for `@cloudflare/workers-utils`

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:

Commands run:
- `pnpm check`
- `pnpm test:ci --filter @cloudflare/workers-utils`

- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: no user-facing behavior/docs change (internal resolution fix + tests)

*A picture of a cute animal (not mandatory, but encouraged)*

 /\_/\ 
( o.o )
 > ^ <

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/11910">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
