### PR TITLE
Skip changeset review on dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,7 @@ updates:
       - "c3"
       - "dependencies"
       - "skip-pr-description-validation"
+      - "skip-changeset-review"
 
   # Check for workerd & workers-types updates for Miniflare
   - package-ecosystem: "npm"

--- a/.github/workflows/changeset-review.yml
+++ b/.github/workflows/changeset-review.yml
@@ -62,6 +62,8 @@ jobs:
             1. **Version Type**: Correct patch/minor/major (major forbidden for wrangler)
             2. **Changelog Quality**: Meaningful descriptions with examples for features
             3. **Markdown Headers**: No h1/h2/h3 headers (breaks changelog formatting)
+            4. **Analytics**: If the change collects more analytics, it should be a minor even though there is no user-visible change
+            5. **Dependabot**: Do not validate dependency update changesets for create-cloudflare
 
             If all changesets pass, just output "✅ All changesets look good" - no need for a detailed checklist.
 


### PR DESCRIPTION
Fixes n/a
Add the skip-changeset-review label automatically on dependabot updates since they're auto generated and perfectly adequate.

also add that to the prompt for VP review, and that analytics change = minor exception for visibility that @lrapoport-cf requested.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: ci change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ci change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
