### PR TITLE
Reduce ttl to 10s for asset-worker

### DIFF
--- a/.changeset/bright-eggs-draw.md
+++ b/.changeset/bright-eggs-draw.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+The asset-worker now uses a shorter 10-second TTL for cached assets, down from 60 seconds. This ensures that asset updates are reflected more quickly during development and deployment, reducing the window where stale assets might be served.

--- a/packages/workers-shared/asset-worker/src/utils/kv.ts
+++ b/packages/workers-shared/asset-worker/src/utils/kv.ts
@@ -23,11 +23,11 @@ export async function getAssetWithMetadataFromKV(
 			);
 
 			if (asset.value === null) {
-				// Don't cache a 404 for a year by re-requesting with a minimum cacheTtl
+				// Don't cache a 404 for a year by re-requesting with a short cacheTtl
 				const retriedAsset =
 					await assetsKVNamespace.getWithMetadata<AssetMetadata>(assetKey, {
 						type: "stream",
-						cacheTtl: 60, // Minimum value allowed
+						cacheTtl: 10,
 					});
 
 				if (retriedAsset.value !== null && sentry) {

--- a/packages/workers-shared/asset-worker/tests/kv.test.ts
+++ b/packages/workers-shared/asset-worker/tests/kv.test.ts
@@ -78,7 +78,7 @@ describe("[Asset Worker] Fetching assets from KV", () => {
 			expect(spy).toHaveBeenCalledTimes(2);
 		});
 
-		it("should retry on 404 and cache with 30s ttl", async () => {
+		it("should retry on 404 with short cache ttl", async () => {
 			let attempts = 0;
 			spy.mockImplementation(() => {
 				if (attempts++ === 0) {


### PR DESCRIPTION
Fixes #WC-4388 

Drop TTL to 10s

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal

*A picture of a cute animal (not mandatory, but encouraged)*
<img width="201" height="251" alt="image" src="https://github.com/user-attachments/assets/79e2e854-6cb9-4e53-bd76-030363128572" />


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
