### PR TITLE
[wrangler] Avoid eager zone lookups when deploying routes

### DIFF
--- a/.changeset/lazy-route-conflict-check.md
+++ b/.changeset/lazy-route-conflict-check.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Avoid unnecessary route conflict lookups during deploy
+
+When deploying with routes, Wrangler now only queries the Zones API to diagnose route conflicts after the bulk routes update fails, instead of doing so on successful deploys. This can reduce deploy latency and API traffic while still surfacing a clear error when a route is already assigned to a different worker.

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -45,10 +45,7 @@ import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockAuthDomain } from "./helpers/mock-auth-domain";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs, mockConfirm, mockPrompt } from "./helpers/mock-dialogs";
-import {
-	mockGetZones,
-	mockGetZonesMulti,
-} from "./helpers/mock-get-zone-from-host";
+import { mockGetZones } from "./helpers/mock-get-zone-from-host";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import {
 	mockKeyListRequest,
@@ -67,10 +64,7 @@ import {
 	mockSubDomainRequest,
 	mockUpdateWorkerSubdomain,
 } from "./helpers/mock-workers-subdomain";
-import {
-	mockGetZoneWorkerRoutes,
-	mockGetZoneWorkerRoutesMulti,
-} from "./helpers/mock-zone-routes";
+import { mockGetZoneWorkerRoutes } from "./helpers/mock-zone-routes";
 import {
 	createFetchResult,
 	msw,
@@ -1234,13 +1228,7 @@ describe("deploy", () => {
 				routes: ["example.com/some-route/*"],
 			});
 			writeWorkerSource();
-			mockUpdateWorkerSubdomain({ enabled: false });
 			mockUploadWorkerRequest({ expectedType: "esm" });
-			// These run during route conflict resolution.
-			// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-			mockGetZones("example.com", [{ id: "example-com-id" }]);
-			mockGetZoneWorkerRoutes("example-com-id");
-			// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 			mockPublishRoutesRequest({ routes: ["example.com/some-route/*"] });
 			await runWrangler("deploy ./index");
 		});
@@ -1294,43 +1282,6 @@ describe("deploy", () => {
 			writeWorkerSource();
 			mockUpdateWorkerSubdomain({ enabled: false });
 			mockUploadWorkerRequest({ expectedType: "esm" });
-			// These run during route conflict resolution.
-			// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-			mockGetZonesMulti({
-				"some-example.com": {
-					accountId: "some-account-id",
-					zones: [{ id: "some-example-com-id" }],
-				},
-				"a-boring-website.com": {
-					accountId: "some-account-id",
-					zones: [{ id: "a-boring-website-id" }],
-				},
-				"another-boring-website.com": {
-					accountId: "some-account-id",
-					zones: [{ id: "another-boring-website-id" }],
-				},
-				"some-zone.com": {
-					accountId: "some-account-id",
-					zones: [{ id: "some-zone-id" }],
-				},
-				"example.com": {
-					accountId: "some-account-id",
-					zones: [{ id: "example-com-id" }],
-				},
-				"more-examples.com": {
-					accountId: "some-account-id",
-					zones: [{ id: "more-examples-id" }],
-				},
-			});
-			mockGetZoneWorkerRoutesMulti({
-				"some-example-com-id": [],
-				"a-boring-website-id": [],
-				"another-boring-website-id": [],
-				"some-zone-id": [],
-				"example-com-id": [],
-				"more-examples-id": [],
-			});
-			// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 			mockPublishRoutesRequest({
 				routes: [
 					"some-example.com/some-route/*",
@@ -1380,8 +1331,6 @@ describe("deploy", () => {
 			writeWorkerSource();
 			mockUploadWorkerRequest();
 			mockGetWorkerSubdomain({ enabled: false });
-			mockGetZones("owned-zone.com", [{ id: "owned-zone-id-1" }]);
-			mockGetZoneWorkerRoutes("owned-zone-id-1");
 			mockPublishRoutesRequest({
 				routes: [
 					{
@@ -1423,8 +1372,6 @@ describe("deploy", () => {
 			writeWorkerSource();
 			mockUploadWorkerRequest();
 			mockGetWorkerSubdomain({ enabled: false });
-			mockGetZones("owned-zone.com", [{ id: "owned-zone-id-1" }]);
-			mockGetZoneWorkerRoutes("owned-zone-id-1");
 			mockPublishRoutesRequest({
 				routes: [
 					{
@@ -1489,43 +1436,6 @@ describe("deploy", () => {
 				useServiceEnvironments: true,
 				useOldUploadApi: true,
 			});
-			// These run during route conflict resolution.
-			// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-			mockGetZonesMulti({
-				"some-example.com": {
-					accountId: "some-account-id",
-					zones: [{ id: "some-example-com-id" }],
-				},
-				"a-boring-website.com": {
-					accountId: "some-account-id",
-					zones: [{ id: "a-boring-website-id" }],
-				},
-				"another-boring-website.com": {
-					accountId: "some-account-id",
-					zones: [{ id: "another-boring-website-id" }],
-				},
-				"some-zone.com": {
-					accountId: "some-account-id",
-					zones: [{ id: "some-zone-id" }],
-				},
-				"example.com": {
-					accountId: "some-account-id",
-					zones: [{ id: "example-com-id" }],
-				},
-				"more-examples.com": {
-					accountId: "some-account-id",
-					zones: [{ id: "more-examples-id" }],
-				},
-			});
-			mockGetZoneWorkerRoutesMulti({
-				"some-example-com-id": [],
-				"a-boring-website-id": [],
-				"another-boring-website-id": [],
-				"some-zone-id": [],
-				"example-com-id": [],
-				"more-examples-id": [],
-			});
-			// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 			mockPublishRoutesRequest({
 				routes: [
 					"some-example.com/some-route/*",
@@ -1589,23 +1499,6 @@ describe("deploy", () => {
 				useServiceEnvironments: false,
 				env: "dev",
 			});
-			// These run during route conflict resolution.
-			// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-			mockGetZonesMulti({
-				"example.com": {
-					accountId: "some-account-id",
-					zones: [{ id: "example-com-id" }],
-				},
-				"dev-example.com": {
-					accountId: "some-account-id",
-					zones: [{ id: "dev-example-com-id" }],
-				},
-			});
-			mockGetZoneWorkerRoutesMulti({
-				"example-com-id": [],
-				"dev-example-com-id": [],
-			});
-			// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 			mockPublishRoutesRequest({
 				routes: ["dev-example.com/some-route/*"],
 				useServiceEnvironments: false,
@@ -1629,28 +1522,59 @@ describe("deploy", () => {
 				expectedType: "esm",
 				env: "dev",
 			});
-			// These run during route conflict resolution.
-			// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-			mockGetZonesMulti({
-				"example.com": {
-					accountId: "some-account-id",
-					zones: [{ id: "example-com-id" }],
-				},
-				"dev-example.com": {
-					accountId: "some-account-id",
-					zones: [{ id: "dev-example-com-id" }],
-				},
-			});
-			mockGetZoneWorkerRoutesMulti({
-				"example-com-id": [],
-				"dev-example-com-id": [],
-			});
-			// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 			mockPublishRoutesRequest({
 				routes: ["dev-example.com/some-route/*"],
 				env: "dev",
 			});
 			await runWrangler("deploy ./index --env dev --legacy-env false");
+		});
+
+		it("should surface a helpful error if a route is already assigned to another worker", async () => {
+			writeWranglerConfig({
+				routes: ["example.com/some-route/*"],
+			});
+			writeWorkerSource();
+			mockUploadWorkerRequest({ expectedType: "esm" });
+
+			// Simulate the bulk-routes API failing for an already-assigned route.
+			msw.use(
+				http.put(
+					"*/accounts/:accountId/workers/scripts/:scriptName/routes",
+					() => {
+						return HttpResponse.json(
+							createFetchResult(null, false, [
+								{
+									message: "Route already assigned",
+									code: 10042,
+								},
+							])
+						);
+					},
+					{ once: true }
+				)
+			);
+
+			mockGetZones("example.com", [{ id: "example-com-id" }]);
+			mockGetZoneWorkerRoutes("example-com-id", [
+				{ pattern: "example.com/some-route/*", script: "other-worker" },
+			]);
+
+			let caught: unknown;
+			try {
+				await runWrangler("deploy ./index");
+			} catch (error) {
+				caught = error;
+			}
+
+			expect(caught).toBeInstanceOf(Error);
+			expect((caught as Error).message).toContain(
+				"Can't deploy routes that are assigned to another worker."
+			);
+			expect((caught as Error).message).toContain('"other-worker"');
+			expect((caught as Error).message).toContain("example.com/some-route/*");
+			expect((caught as Error).message).toContain(
+				"https://dash.cloudflare.com/some-account-id/workers/overview"
+			);
 		});
 
 		it("should fallback to the Wrangler v1 zone-based API if the bulk-routes API fails", async () => {
@@ -1660,8 +1584,7 @@ describe("deploy", () => {
 			writeWorkerSource();
 			mockUpdateWorkerSubdomain({ enabled: false });
 			mockUploadWorkerRequest({ expectedType: "esm" });
-			// These run during route conflict resolution.
-			// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+			// These run during zone-based publishRoutes fallback.
 			mockGetZones("example.com", [{ id: "example-com-id" }]);
 			mockGetZoneWorkerRoutes("example-com-id", [
 				// Simulate that the worker has already been deployed to another route.
@@ -1670,7 +1593,6 @@ describe("deploy", () => {
 					script: "test-name",
 				},
 			]);
-			// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 			// Simulate the bulk-routes API failing with a not authorized error.
 			mockUnauthorizedPublishRoutesRequest();
 			mockPublishRoutesFallbackRequest({
@@ -1716,8 +1638,7 @@ describe("deploy", () => {
 			writeWorkerSource();
 			mockUploadWorkerRequest({ env: "staging", expectedType: "esm" });
 			mockUpdateWorkerSubdomain({ env: "staging", enabled: false });
-			// These run during route conflict resolution.
-			// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+			// These run during zone-based publishRoutes fallback.
 			mockGetZones("example.com", [{ id: "example-com-id" }]);
 			mockGetZoneWorkerRoutes("example-com-id", [
 				// Simulate that the worker has already been deployed to another route.
@@ -1726,7 +1647,6 @@ describe("deploy", () => {
 					script: "test-name",
 				},
 			]);
-			// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 			// Simulate the bulk-routes API failing with a not authorized error.
 			mockUnauthorizedPublishRoutesRequest({ env: "staging" });
 			mockPublishRoutesFallbackRequest({
@@ -1748,11 +1668,6 @@ describe("deploy", () => {
 				writeWorkerSource();
 				mockUpdateWorkerSubdomain({ enabled: false });
 				mockUploadWorkerRequest({ expectedType: "esm" });
-				// These run during route conflict resolution.
-				// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-				mockGetZones("api.example.com", [{ id: "api-example-com-id" }]);
-				mockGetZoneWorkerRoutes("api-example-com-id", []);
-				// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 				mockCustomDomainsChangesetRequest({});
 				mockPublishCustomDomainsRequest({
 					publishFlags: {
@@ -1773,11 +1688,6 @@ describe("deploy", () => {
 				writeWorkerSource();
 				mockUpdateWorkerSubdomain({ enabled: false });
 				mockUploadWorkerRequest({ expectedType: "esm" });
-				// These run during route conflict resolution.
-				// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-				mockGetZones("api.example.com", [{ id: "api-example-com-id" }]);
-				mockGetZoneWorkerRoutes("api-example-com-id", []);
-				// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 				mockCustomDomainsChangesetRequest({
 					originConflicts: [
 						{
@@ -1823,11 +1733,6 @@ Update them to point to this script instead?`,
 				writeWorkerSource();
 				mockUpdateWorkerSubdomain({ enabled: false });
 				mockUploadWorkerRequest({ expectedType: "esm" });
-				// These run during route conflict resolution.
-				// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-				mockGetZones("api.example.com", [{ id: "api-example-com-id" }]);
-				mockGetZoneWorkerRoutes("api-example-com-id", []);
-				// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 				mockCustomDomainsChangesetRequest({
 					dnsRecordConflicts: [
 						{
@@ -1865,11 +1770,6 @@ Update them to point to this script instead?`,
 				writeWorkerSource();
 				mockUpdateWorkerSubdomain({ enabled: false });
 				mockUploadWorkerRequest({ expectedType: "esm" });
-				// These run during route conflict resolution.
-				// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-				mockGetZones("api.example.com", [{ id: "api-example-com-id" }]);
-				mockGetZoneWorkerRoutes("api-example-com-id", []);
-				// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 				mockCustomDomainsChangesetRequest({
 					originConflicts: [
 						{
@@ -1962,11 +1862,6 @@ Update them to point to this script instead?`,
 				writeWorkerSource();
 				mockUpdateWorkerSubdomain({ enabled: false });
 				mockUploadWorkerRequest({ expectedType: "esm" });
-				// These run during route conflict resolution.
-				// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-				mockGetZones("api.example.com", [{ id: "api-example-com-id" }]);
-				mockGetZoneWorkerRoutes("api-example-com-id", []);
-				// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 				mockCustomDomainsChangesetRequest({
 					originConflicts: [
 						{
@@ -2052,23 +1947,6 @@ Update them to point to this script instead?`,
 				mockSubDomainRequest();
 				mockUpdateWorkerSubdomain({ enabled: false });
 				mockUploadWorkerRequest({ expectedType: "esm" });
-				// These run during route conflict resolution.
-				// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-				mockGetZonesMulti({
-					"example.com": {
-						accountId: "some-account-id",
-						zones: [{ id: "example-com-id" }],
-					},
-					"api.example.com": {
-						accountId: "some-account-id",
-						zones: [{ id: "api-example-com-id" }],
-					},
-				});
-				mockGetZoneWorkerRoutesMulti({
-					"example-com-id": [],
-					"api-example-com-id": [],
-				});
-				// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 				mockCustomDomainsChangesetRequest({});
 				mockPublishCustomDomainsRequest({
 					publishFlags: {
@@ -2135,28 +2013,6 @@ Update them to point to this script instead?`,
 				mockSubDomainRequest();
 				mockUpdateWorkerSubdomain({ enabled: false });
 				mockUploadWorkerRequest({ expectedType: "esm" });
-				// These run during route conflict resolution.
-				// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-				mockGetZonesMulti({
-					"config.com": {
-						accountId: "some-account-id",
-						zones: [{ id: "config-com-id" }],
-					},
-					"api.example.com": {
-						accountId: "some-account-id",
-						zones: [{ id: "api-example-com-id" }],
-					},
-					"cli.com": {
-						accountId: "some-account-id",
-						zones: [{ id: "cli-com-id" }],
-					},
-				});
-				mockGetZoneWorkerRoutesMulti({
-					"config-com-id": [],
-					"api-example-com-id": [],
-					"cli-com-id": [],
-				});
-				// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 				mockCustomDomainsChangesetRequest({});
 				mockPublishCustomDomainsRequest({
 					publishFlags: {
@@ -2249,23 +2105,6 @@ Update them to point to this script instead?`,
 					},
 					expectedType: "none",
 				});
-				// These run during route conflict resolution.
-				// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-				mockGetZonesMulti({
-					"simple.co.uk": {
-						accountId: "some-account-id",
-						zones: [{ id: "simple-co-uk-id" }],
-					},
-					"example.com": {
-						accountId: "some-account-id",
-						zones: [{ id: "example-com-id" }],
-					},
-				});
-				mockGetZoneWorkerRoutesMulti({
-					"simple-co-uk-id": [],
-					"example-com-id": [],
-				});
-				// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 				mockPublishRoutesRequest({
 					routes: [
 						// @ts-expect-error - this is what is expected
@@ -2354,11 +2193,6 @@ Update them to point to this script instead?`,
 					},
 					expectedType: "none",
 				});
-				// These run during route conflict resolution.
-				// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-				mockGetZones("example.com", [{ id: "example-com-id" }]);
-				mockGetZoneWorkerRoutes("example-com-id", []);
-				// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 				mockPublishRoutesRequest({
 					routes: [
 						{
@@ -2426,11 +2260,6 @@ Update them to point to this script instead?`,
 					expectedType: "esm",
 					expectedMainModule: "index.js",
 				});
-				// These run during route conflict resolution.
-				// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-				mockGetZones("example.com", [{ id: "example-com-id" }]);
-				mockGetZoneWorkerRoutes("example-com-id", []);
-				// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 				mockPublishRoutesRequest({
 					routes: [
 						{
@@ -2505,23 +2334,6 @@ Update them to point to this script instead?`,
 					},
 					expectedType: "none",
 				});
-				// These run during route conflict resolution.
-				// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-				mockGetZonesMulti({
-					"simple.co.uk": {
-						accountId: "some-account-id",
-						zones: [{ id: "simple-co-uk-id" }],
-					},
-					"example.com": {
-						accountId: "some-account-id",
-						zones: [{ id: "example-com-id" }],
-					},
-				});
-				mockGetZoneWorkerRoutesMulti({
-					"simple-co-uk-id": [],
-					"example-com-id": [],
-				});
-				// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 				mockPublishRoutesRequest({
 					routes: [
 						// @ts-expect-error - this is what is expected


### PR DESCRIPTION
_Describe your change..._

When deploying with `routes`, Wrangler previously queried the Zones API during successful deployments to try to detect route conflicts.

This PR defers that work until the bulk routes update fails, reducing unnecessary API calls and deploy latency. When a conflict is detected, Wrangler surfaces a clearer error that points to the dashboard and lists the conflicting worker(s) + route patterns.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this is an internal deploy-path optimization + improved error message.

*A picture of a cute animal (not mandatory, but encouraged)*

(=^..^=)

Test evidence:
- `pnpm exec cross-env NODE_OPTIONS="$(node scripts/node-options-for-tests.js)" vitest run src/__tests__/deploy.test.ts` (from `packages/wrangler`)
- `pnpm --filter wrangler check:type`
- `pnpm --filter wrangler check:lint`

Changeset:
- Added a patch changeset for `wrangler`.
