### PR TITLE
misc CI fixes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -89,6 +89,7 @@ jobs:
       cancel-in-progress: true
     timeout-minutes: 60
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: macos-latest

--- a/tools/deployments/validate-changesets.ts
+++ b/tools/deployments/validate-changesets.ts
@@ -31,7 +31,11 @@ export function validateChangesets(
 				}
 
 				// TEMPORARILY BLOCK PACKAGES THAT WOULD DEPLOY WORKERS
-				if (packages.get(release.name)?.["workers-sdk"]?.deploy) {
+				if (
+					packages.get(release.name)?.["workers-sdk"]?.deploy &&
+					// Exception: deployments for these workers are allowed now
+					release.name !== "@cloudflare/workers-shared"
+				) {
 					errors.push(
 						`Currently we are not allowing changes to package "${release.name}" in changeset at "${file}" since it would trigger a Worker/Pages deployment.`
 					);


### PR DESCRIPTION
1. don't fail all vite e2e's when one vite e2e test fails
2. don't block asset/router worker deployments any more

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: ci change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
