### PR TITLE
chore: allow quick-edit worker deployments via changesets

### DIFF
--- a/tools/deployments/validate-changesets.ts
+++ b/tools/deployments/validate-changesets.ts
@@ -31,10 +31,14 @@ export function validateChangesets(
 				}
 
 				// TEMPORARILY BLOCK PACKAGES THAT WOULD DEPLOY WORKERS
+				const ALLOWED_PRIVATE_PACKAGES = [
+					"@cloudflare/workers-shared",
+					"@cloudflare/quick-edit",
+				];
 				if (
 					packages.get(release.name)?.["workers-sdk"]?.deploy &&
 					// Exception: deployments for these workers are allowed now
-					release.name !== "@cloudflare/workers-shared"
+					!ALLOWED_PRIVATE_PACKAGES.includes(release.name)
 				) {
 					errors.push(
 						`Currently we are not allowing changes to package "${release.name}" in changeset at "${file}" since it would trigger a Worker/Pages deployment.`


### PR DESCRIPTION
The quick-edit deployment does not hit the production dashboard until a change is made to the internal dashboard project, so it is safe to deploy this worker via the changeset-triggered deployment process.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: CI check
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: CI check

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
