### PR TITLE
Bump the version of `@cloudflare/vitest-pool-workers` in the hello-world templates from `^0.8.19` to `^0.12.4`

### DIFF
--- a/.changeset/happy-clubs-kiss.md
+++ b/.changeset/happy-clubs-kiss.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+Bump the version of `@cloudflare/vitest-pool-workers` in the hello-world templates from `^0.8.19` to `^0.12.4`
+
+The version of the `@cloudflare/vitest-pool-workers` in the hello-world templates is currently `^0.8.19`, since the package is pre v1, the Caret syntax only installs the latest `0.8.x` version of the package, which is a bit outdated. So the changes here manually keep the package more up to date.

--- a/packages/create-cloudflare/templates/hello-world-with-assets/js/package.json
+++ b/packages/create-cloudflare/templates/hello-world-with-assets/js/package.json
@@ -9,7 +9,7 @@
 		"test": "vitest"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.8.19",
+		"@cloudflare/vitest-pool-workers": "^0.12.4",
 		"wrangler": "^3.101.0",
 		"vitest": "~3.2.0"
 	}

--- a/packages/create-cloudflare/templates/hello-world-with-assets/ts/package.json
+++ b/packages/create-cloudflare/templates/hello-world-with-assets/ts/package.json
@@ -10,7 +10,7 @@
 		"cf-typegen": "wrangler types"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.8.19",
+		"@cloudflare/vitest-pool-workers": "^0.12.4",
 		"typescript": "^5.5.2",
 		"vitest": "~3.2.0",
 		"wrangler": "^3.101.0"

--- a/packages/create-cloudflare/templates/hello-world/js/package.json
+++ b/packages/create-cloudflare/templates/hello-world/js/package.json
@@ -9,7 +9,7 @@
 		"test": "vitest"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.8.19",
+		"@cloudflare/vitest-pool-workers": "^0.12.4",
 		"wrangler": "^3.101.0",
 		"vitest": "~3.2.0"
 	}

--- a/packages/create-cloudflare/templates/hello-world/ts/package.json
+++ b/packages/create-cloudflare/templates/hello-world/ts/package.json
@@ -10,7 +10,7 @@
 		"cf-typegen": "wrangler types"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.8.19",
+		"@cloudflare/vitest-pool-workers": "^0.12.4",
 		"typescript": "^5.5.2",
 		"vitest": "~3.2.0",
 		"wrangler": "^3.101.0"


### PR DESCRIPTION
The version of the `@cloudflare/vitest-pool-workers` in the hello-world templates is currently `^0.8.19`, since the package is pre v1, the Caret syntax only installs the latest `0.8.x` version of the package, which is a bit outdated. So the changes here manually keep the package more up to date.

Thanks @vicb for the insight on the Caret 😄 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this is already covered by the c3 e2e tests
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: it's just a dependency bump

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
