### PR TITLE
Re-enable Media binding e2e tests

### DIFF
--- a/packages/wrangler/e2e/remote-binding/miniflare-remote-resources.test.ts
+++ b/packages/wrangler/e2e/remote-binding/miniflare-remote-resources.test.ts
@@ -347,28 +347,26 @@ const testCases: TestCase[] = [
 		}),
 		expectFetchToMatch: [expect.stringContaining(`image/avif`)],
 	},
-	// TODO: re-enable when Media binding is stable again
-	// (this is an unreleased feature that temporarily broke in the course of development)
-	// {
-	// 	name: "Media",
-	// 	scriptPath: "media.js",
-	// 	setup: () => ({
-	// 		remoteProxySessionConfig: {
-	// 			bindings: {
-	// 				MEDIA: {
-	// 					type: "media",
-	// 				},
-	// 			},
-	// 		},
-	// 		miniflareConfig: (connection) => ({
-	// 			media: {
-	// 				binding: "MEDIA",
-	// 				remoteProxyConnectionString: connection,
-	// 			},
-	// 		}),
-	// 	}),
-	// 	expectFetchToMatch: [expect.stringContaining(`image/jpeg`)],
-	// },
+	{
+		name: "Media",
+		scriptPath: "media.js",
+		setup: () => ({
+			remoteProxySessionConfig: {
+				bindings: {
+					MEDIA: {
+						type: "media",
+					},
+				},
+			},
+			miniflareConfig: (connection) => ({
+				media: {
+					binding: "MEDIA",
+					remoteProxyConnectionString: connection,
+				},
+			}),
+		}),
+		expectFetchToMatch: [expect.stringContaining(`image/jpeg`)],
+	},
 	{
 		name: "Dispatch Namespace",
 		scriptPath: "dispatch-namespace.js",

--- a/packages/wrangler/e2e/remote-binding/workers/media.js
+++ b/packages/wrangler/e2e/remote-binding/workers/media.js
@@ -8,7 +8,7 @@ export default {
 
 		const contentType = await env.MEDIA.input(image.body)
 			.transform({ width: 10 })
-			.output({ mode: "frame", format: "image/jpeg" })
+			.output({ mode: "frame", format: "jpg" })
 			.contentType();
 
 		return new Response(contentType);


### PR DESCRIPTION
Backend changes are released and this is now stable again.

Sorry team!

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: tests only

*A picture of a cute animal (not mandatory, but encouraged)*

![cat](https://github.com/user-attachments/assets/62470475-0d71-4c5f-8851-7e4eccdd5121)