### PR TITLE
Wrangler: cache chosen account in memory to avoid repeated prompts

### DIFF
--- a/.changeset/gold-forks-build.md
+++ b/.changeset/gold-forks-build.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Cache chosen account in memory to avoid repeated prompts
+
+When users have multiple accounts and no `node_modules` directory exists for file caching, Wrangler (run via `npx` and equivalent commands) would prompt for account selection multiple times during a single command. Now the selected account is also stored in process memory, preventing duplicate prompts and potential issues from inconsistent account choices.

--- a/packages/wrangler/src/user/choose-account.ts
+++ b/packages/wrangler/src/user/choose-account.ts
@@ -1,26 +1,22 @@
 import { configFileName, UserError } from "@cloudflare/workers-utils";
 import { fetchPagedListResult } from "../cfetch";
 import { getCloudflareAccountIdFromEnv } from "./auth-variables";
+import type { Account } from "./shared";
 import type { ComplianceConfig } from "@cloudflare/workers-utils";
-
-export type ChooseAccountItem = {
-	id: string;
-	name: string;
-};
 
 /**
  * Infer a list of available accounts for the current user.
  */
 export async function getAccountChoices(
 	complianceConfig: ComplianceConfig
-): Promise<ChooseAccountItem[]> {
+): Promise<Account[]> {
 	const accountIdFromEnv = getCloudflareAccountIdFromEnv();
 	if (accountIdFromEnv) {
 		return [{ id: accountIdFromEnv, name: "" }];
 	} else {
 		try {
 			const response = await fetchPagedListResult<{
-				account: ChooseAccountItem;
+				account: Account;
 			}>(complianceConfig, `/memberships`);
 			const accounts = response.map((r) => r.account);
 			if (accounts.length === 0) {

--- a/packages/wrangler/src/user/shared.ts
+++ b/packages/wrangler/src/user/shared.ts
@@ -1,0 +1,4 @@
+/**
+ * Details for one of the user's accounts
+ */
+export type Account = { id: string; name: string };


### PR DESCRIPTION
Ensure that a chosen account is persisted in the local process state

Some Wrangler commands need to interact with the user's account more than once. If the user has more than one account, for these commands Wrangler prompts the user to choose one of their accounts, such account's details are then saved in a cache file under `node_modules`, such details are then used for all the consecutive logic (for future Wrangler executions as well as the current one).

This generally works well, however if Wrangler cannot find a `node_modules` to save the account to, it will end up prompting the user multiple times for their account. This provides a poor UX and can also introduce very unexpected behaviors if the user chooses different accounts.

So the changes here change wrangler to also save the chosen account in the process' local state and to prioritize that over the file cache. This fixes the issue above, as well as other similar potential issues (e.g. the user deleting the cache file mid-process). This also (minimally) helps in performances since Wrangler no longer needlessly accesses the filesystem for the account details.

> [!Note]
> To manually see the issue, try to run `npx wrangler deploy` on a project that hasn't gotten a `node_modules` folder, if your user has multiple accounts see that you get prompted twice for the user selection

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
