### PR TITLE
Wrangler: Make `name` the positional argument for `wrangler delete` instead of `script`

### DIFF
--- a/.changeset/green-bears-wave.md
+++ b/.changeset/green-bears-wave.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Make `name` the positional argument for `wrangler delete` instead of `script`
+
+The `script` argument was meaningless for the delete command since it deletes by worker name, not by entry point path. The `name` argument is now accepted as a positional argument, allowing users to run `wrangler delete my-worker` instead of `wrangler delete --name my-worker`. The `script` argument is now hidden but still accepted for backwards compatibility.

--- a/packages/wrangler/src/__tests__/delete.test.ts
+++ b/packages/wrangler/src/__tests__/delete.test.ts
@@ -46,6 +46,57 @@ describe("delete", () => {
 		`);
 	});
 
+	it("should delete a service using positional name argument", async () => {
+		mockConfirm({
+			text: `Are you sure you want to delete my-positional-worker? This action cannot be undone.`,
+			result: true,
+		});
+		mockListKVNamespacesRequest();
+		mockListReferencesRequest("my-positional-worker");
+		mockListTailsByConsumerRequest("my-positional-worker");
+		mockDeleteWorkerRequest({ name: "my-positional-worker" });
+		await runWrangler("delete my-positional-worker");
+
+		expect(std).toMatchInlineSnapshot(`
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "info": "",
+			  "out": "
+			 ⛅️ wrangler x.x.x
+			──────────────────
+			Successfully deleted my-positional-worker",
+			  "warn": "",
+			}
+		`);
+	});
+
+	it("should use positional name argument over the name from the Wrangler config file", async () => {
+		writeWranglerConfig({ name: "config-provided-name" });
+		mockConfirm({
+			text: `Are you sure you want to delete cli-provided-name? This action cannot be undone.`,
+			result: true,
+		});
+		mockListKVNamespacesRequest();
+		mockListReferencesRequest("cli-provided-name");
+		mockListTailsByConsumerRequest("cli-provided-name");
+		mockDeleteWorkerRequest({ name: "cli-provided-name" });
+		await runWrangler("delete cli-provided-name");
+
+		expect(std).toMatchInlineSnapshot(`
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "info": "",
+			  "out": "
+			 ⛅️ wrangler x.x.x
+			──────────────────
+			Successfully deleted cli-provided-name",
+			  "warn": "",
+			}
+		`);
+	});
+
 	it("should delete a script by configuration", async () => {
 		mockConfirm({
 			text: `Are you sure you want to delete test-name? This action cannot be undone.`,

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -47,7 +47,7 @@ describe("wrangler", () => {
 				COMPUTE & AI
 				  wrangler ai                     🤖 Manage AI models
 				  wrangler containers             📦 Manage Containers [open beta]
-				  wrangler delete [script]        🗑️ Delete a Worker from Cloudflare
+				  wrangler delete [name]          🗑️ Delete a Worker from Cloudflare
 				  wrangler deploy [script]        🆙 Deploy a Worker to Cloudflare
 				  wrangler deployments            🚢 List and view the current and past deployments for your Worker
 				  wrangler dev [script]           👂 Start a local server for developing your Worker
@@ -118,7 +118,7 @@ describe("wrangler", () => {
 				COMPUTE & AI
 				  wrangler ai                     🤖 Manage AI models
 				  wrangler containers             📦 Manage Containers [open beta]
-				  wrangler delete [script]        🗑️ Delete a Worker from Cloudflare
+				  wrangler delete [name]          🗑️ Delete a Worker from Cloudflare
 				  wrangler deploy [script]        🆙 Deploy a Worker to Cloudflare
 				  wrangler deployments            🚢 List and view the current and past deployments for your Worker
 				  wrangler dev [script]           👂 Start a local server for developing your Worker

--- a/packages/wrangler/src/delete.ts
+++ b/packages/wrangler/src/delete.ts
@@ -70,6 +70,9 @@ export const deleteCommand = createCommand({
 			describe: "The path to an entry point for your worker",
 			type: "string",
 			requiresArg: true,
+			// TODO: the script argument is meaningless for the delete command, we haven't removed it as that could be
+			//       considered a breaking change, we should do so in the next major Wrangler release
+			hidden: true,
 		},
 		name: {
 			describe: "Name of the worker",
@@ -91,7 +94,7 @@ export const deleteCommand = createCommand({
 			hidden: true,
 		},
 	},
-	positionalArgs: ["script"],
+	positionalArgs: ["name"],
 	async handler(args, { config }) {
 		if (config.pages_build_output_dir) {
 			throw new UserError(


### PR DESCRIPTION
The `script` argument was meaningless for the delete command since it deletes by worker name, not by entry point path. The `name` argument is now accepted as a positional argument, allowing users to run `wrangler delete my-worker` instead of `wrangler delete --name my-worker`. The `script` argument is now hidden but still accepted for backwards compatibility.

> [!Note]
> To see the issue in the current version of wrangler try running `npx wrangler delete any-worker-name` in the directory of a worker.
> If in the directory there isn't any wrangler config file then the command will error asking you to specify the worker name via the `--name` flag, but even worse, if there is a wrangler config file, the name passed to the command will be completely ignored and the wrong worker might end up getting deleted

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: the changes will be automatically picked up at some point I believe?

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
