### PR TITLE
[PoC] feat(vite-plugin-cloudflare): generate sourcemap for worker environments in build if `upload_source_maps: true`

### DIFF
--- a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
+++ b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
@@ -192,6 +192,7 @@ export function createCloudflareEnvironmentOptions({
 	workerConfig,
 	userConfig,
 	mode,
+	command,
 	environmentName,
 	isEntryWorker,
 	isParentEnvironment,
@@ -200,6 +201,7 @@ export function createCloudflareEnvironmentOptions({
 	workerConfig: ResolvedWorkerConfig;
 	userConfig: vite.UserConfig;
 	mode: vite.ConfigEnv["mode"];
+	command: vite.ConfigEnv["command"];
 	environmentName: string;
 	isEntryWorker: boolean;
 	isParentEnvironment: boolean;
@@ -236,6 +238,10 @@ export function createCloudflareEnvironmentOptions({
 			createEnvironment(name, config) {
 				return new vite.BuildEnvironment(name, config);
 			},
+			sourcemap:
+				workerConfig.upload_source_maps === true && command === "build"
+					? true
+					: undefined,
 			target,
 			emitAssets: true,
 			manifest: isEntryWorker,

--- a/packages/vite-plugin-cloudflare/src/plugins/config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/config.ts
@@ -48,7 +48,12 @@ export const configPlugin = createPlugin("config", (ctx) => {
 						deny: [...defaultDeniedFiles, ".dev.vars", ".dev.vars.*"],
 					},
 				},
-				environments: getEnvironmentsConfig(ctx, userConfig, env.mode),
+				environments: getEnvironmentsConfig(
+					ctx,
+					userConfig,
+					env.mode,
+					env.command
+				),
 				builder: {
 					buildApp:
 						userConfig.builder?.buildApp ??
@@ -144,7 +149,8 @@ export const configPlugin = createPlugin("config", (ctx) => {
 function getEnvironmentsConfig(
 	ctx: PluginContext,
 	userConfig: UserConfig,
-	mode: ConfigEnv["mode"]
+	mode: ConfigEnv["mode"],
+	command: ConfigEnv["command"]
 ): Record<string, EnvironmentOptions> | undefined {
 	if (ctx.resolvedPluginConfig.type !== "workers") {
 		return undefined;
@@ -164,6 +170,7 @@ function getEnvironmentsConfig(
 					workerConfig: worker.config,
 					userConfig,
 					mode,
+					command,
 					hasNodeJsCompat: ctx.getNodeJsCompat(environmentName) !== undefined,
 				};
 


### PR DESCRIPTION
issue: https://github.com/cloudflare/workers-sdk/issues/11963

Still WIP, since not added tests and changesets yet

_Describe your change..._

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
