### PR TITLE
Mock createRequire call in `getLocalWorkerdCompatibilityDate` to ensure that the tests don't rely on the miniflare package

### DIFF
--- a/packages/workers-utils/tests/compatibility-date.test.ts
+++ b/packages/workers-utils/tests/compatibility-date.test.ts
@@ -19,7 +19,7 @@ describe("getLocalWorkerdCompatibilityDate", () => {
 			return mockedRequire;
 		});
 		const { date, source } = getLocalWorkerdCompatibilityDate();
-		expect(date).toMatch(/\d{4}-\d{2}-\d{2}/);
+		expect(date).toBe("2025-01-10");
 		expect(source).toEqual("workerd");
 	});
 


### PR DESCRIPTION
The `getLocalWorkerdCompatibilityDate` unit tests currently rely on the miniflare build, this generally works very well locally when developers are likely to have a working miniflare build present. This however makes the test quite unstable in CI where the presence of such build is not guaranteed (also locally there is no guarantee that such build exists).

So the changes here mock the `createRequire` present in the tests that generates this dependency to the miniflare package.

Example of this failing in CI: https://github.com/cloudflare/workers-sdk/actions/runs/21146342156/job/60815273917#step:6:66

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ci fix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
