### PR TITLE
Change type of changeset for wrangler-init sentry fix from `minor` to `patch`

### DIFF
--- a/.changeset/fair-tools-happen.md
+++ b/.changeset/fair-tools-happen.md
@@ -1,5 +1,5 @@
 ---
-"wrangler": minor
+"wrangler": patch
 ---
 
 Improve telemetry errors being sent to Sentry by `wrangler init` when it delegates to C3 by ensuring that they contain the output of the C3 execution.


### PR DESCRIPTION
The changes in https://github.com/cloudflare/workers-sdk/pull/11922 improve/augment the information included in sentry reports for `wrangler init` errors, so since they don't introduce a new type of information being reported, this change should not be considered a `minor` but `patch` instead.