### PR TITLE
[vitest-pool-workers] Filter deprecation warnings in snapshot test

### DIFF
--- a/packages/vitest-pool-workers/test/helpers.ts
+++ b/packages/vitest-pool-workers/test/helpers.ts
@@ -47,6 +47,28 @@ export interface Process {
 	readonly exitCode: Promise<number>;
 }
 
+/**
+ * Filter out Node.js deprecation warnings from stderr.
+ * These warnings (e.g., DEP0040 for punycode) can appear in child processes
+ * and are not relevant to the actual test assertions.
+ */
+export function filterDeprecationWarnings(stderr: string): string {
+	return stderr
+		.split("\n")
+		.filter((line) => {
+			// Filter out deprecation warning lines and their "Use node --trace-deprecation" hints
+			if (/\[DEP\d+\] DeprecationWarning:/.test(line)) {
+				return false;
+			}
+			if (/\(Use `node --trace-deprecation \.\.\.`/.test(line)) {
+				return false;
+			}
+			return true;
+		})
+		.join("\n")
+		.trim();
+}
+
 function wrap(proc: childProcess.ChildProcess): Process {
 	let stdout = "";
 	let stderr = "";

--- a/packages/vitest-pool-workers/test/snapshots.test.ts
+++ b/packages/vitest-pool-workers/test/snapshots.test.ts
@@ -2,7 +2,11 @@ import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import dedent from "ts-dedent";
-import { minimalVitestConfig, test } from "./helpers";
+import {
+	filterDeprecationWarnings,
+	minimalVitestConfig,
+	test,
+} from "./helpers";
 
 test(
 	"disk snapshots",
@@ -130,7 +134,7 @@ test.skipIf(process.platform === "win32")(
 		`,
 		});
 		let result = await vitestRun();
-		expect(result.stderr).toEqual("");
+		expect(filterDeprecationWarnings(result.stderr)).toEqual("");
 		let exitCode = await result.exitCode;
 		expect(result.stdout).toMatch("Snapshots  2 written");
 		expect(exitCode).toBe(0);


### PR DESCRIPTION
## Summary

The `inline snapshots` test asserts that stderr is empty, but Node.js deprecation warnings (e.g., DEP0040 for punycode from whatwg-url) can appear in child processes.

This PR adds a helper to filter out Node.js deprecation warnings from stderr before the assertion.

Related: https://github.com/cloudflare/workers-sdk/actions/runs/21170102377/job/60892759559