### PR TITLE
[test] Trigger CI with pinned Node 25.3.0

### DIFF
--- a/.github/workflows/test-and-check-other-node.yml
+++ b/.github/workflows/test-and-check-other-node.yml
@@ -95,3 +95,4 @@ jobs:
           NODE_OPTIONS: "--max_old_space_size=8192"
           WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-debug-logs/
           CI_OS: ${{ matrix.description }}
+# Test trigger for Node 25.3.0 pinning hypothesis


### PR DESCRIPTION
## Summary

This PR triggers CI against the `edmundhung/test-pin-node-25-version` branch which has Node 25 pinned to 25.3.0.

This tests the hypothesis that Node 25.4.0 changed deprecation warning behavior, causing the `inline snapshots` test to fail.

- Passing CI run (Jan 19 16:50) used Node 25.3.0
- Failing CI run (Jan 19 20:07) used Node 25.4.0

If this PR's CI passes, it confirms Node 25.4.0 is the culprit.

Related: https://github.com/cloudflare/workers-sdk/actions/runs/21170102377/job/60892759559