### PR TITLE
fix(wrangler): suppress deprecation warnings

### DIFF
--- a/.changeset/suppress-deprecation-warnings.md
+++ b/.changeset/suppress-deprecation-warnings.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Suppress Node.js deprecation warnings in wrangler CLI.

--- a/packages/wrangler/bin/wrangler.js
+++ b/packages/wrangler/bin/wrangler.js
@@ -26,6 +26,7 @@ Consider using a Node.js version manager such as https://volta.sh/ or https://gi
 		process.execPath,
 		[
 			"--no-warnings",
+			"--no-deprecation",
 			"--experimental-vm-modules",
 			...process.execArgv,
 			path.join(__dirname, "../wrangler-dist/cli.js"),


### PR DESCRIPTION
Fixes n/a.

The punycode deprecation warning from bundled whatwg-url appears in stderr which breaks a snapshot in Node 25.

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: We can confirm this if the Node 25 Tests pass
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no feature change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
