### PR TITLE
fix(vitest-pool-workers): suppress deprecation warnings in snapshot test

### DIFF
--- a/packages/vitest-pool-workers/test/helpers.ts
+++ b/packages/vitest-pool-workers/test/helpers.ts
@@ -156,5 +156,10 @@ function getNoCIEnv(): typeof process.env {
 	const env = { ...process.env };
 	env.CI = undefined;
 	env.GITHUB_ACTIONS = undefined;
+	// Suppress Node.js deprecation warnings in spawned processes to prevent
+	// them from appearing in stderr (which breaks tests that assert stderr is empty)
+	env.NODE_OPTIONS = [env.NODE_OPTIONS, "--no-deprecation"]
+		.filter(Boolean)
+		.join(" ");
 	return env;
 }


### PR DESCRIPTION
Fixes n/a.

Node 25.4.0+ emits deprecation warnings (DEP0040 for punycode) to stderr, which breaks tests that assert stderr is empty. This adds `--no-deprecation` to `NODE_OPTIONS` in spawned test processes.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: Confirmed with the Node 25 tests
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no new feature

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
