### PR TITLE
[wrangler] Add support for customising inspector IP address

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -91,6 +91,8 @@ The changelog uses h3 for section headers, so any headers in changeset content m
 
 For new features or significant changes, include a brief usage example. This helps users understand how to use the new functionality.
 
+When showing Wrangler configuration examples, use `wrangler.json` (with JSONC syntax for comments) rather than `wrangler.toml`.
+
 ## Multiple Changesets
 
 If your PR makes multiple distinct user-facing changes, create separate changesets so each gets its own changelog entry. Don't lump unrelated changes together, and don't mix different types of changes (e.g., bug fix + new feature) in a single changeset.

--- a/.changeset/custom-inspector-ip.md
+++ b/.changeset/custom-inspector-ip.md
@@ -1,0 +1,25 @@
+---
+"wrangler": minor
+"miniflare": minor
+"@cloudflare/workers-utils": minor
+---
+
+Add support for customising the inspector IP address
+
+Adds a new `--inspector-ip` CLI flag and `dev.inspector_ip` configuration option to allow customising the IP address that the inspector server listens on. Previously, the inspector was hardcoded to listen only on `127.0.0.1`.
+
+Example usage:
+
+```bash
+# CLI flag
+wrangler dev --inspector-ip 0.0.0.0
+```
+
+```jsonc
+// wrangler.json
+{
+	"dev": {
+		"inspector_ip": "0.0.0.0",
+	},
+}
+```

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1003,6 +1003,7 @@ export class Miniflare {
 
 			this.#maybeInspectorProxyController = new InspectorProxyController(
 				this.#sharedOpts.core.inspectorPort,
+				this.#sharedOpts.core.inspectorHost,
 				this.#log,
 				workerNamesToProxy
 			);
@@ -2042,6 +2043,7 @@ export class Miniflare {
 			} else {
 				await this.#maybeInspectorProxyController.updateConnection(
 					this.#sharedOpts.core.inspectorPort,
+					this.#sharedOpts.core.inspectorHost ?? "127.0.0.1",
 					maybePort,
 					this.#workerNamesToProxy()
 				);

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -239,6 +239,7 @@ export const CoreSharedOptionsSchema = z
 		httpsCertPath: z.string().optional(),
 
 		inspectorPort: z.number().optional(),
+		inspectorHost: z.string().optional(),
 
 		verbose: z.boolean().optional(),
 

--- a/packages/workers-utils/src/config/config.ts
+++ b/packages/workers-utils/src/config/config.ts
@@ -218,6 +218,13 @@ export interface DevConfig {
 	inspector_port: number | undefined;
 
 	/**
+	 * IP address for the local dev server's inspector to listen on
+	 *
+	 * @default 127.0.0.1
+	 */
+	inspector_ip: string | undefined;
+
+	/**
 	 * Protocol that local wrangler dev server listens to requests on.
 	 *
 	 * @default http
@@ -299,6 +306,7 @@ export const defaultWranglerConfig: Config = {
 		ip: process.platform === "win32" ? "127.0.0.1" : "localhost",
 		port: undefined, // the default of 8787 is set at runtime
 		inspector_port: undefined, // the default of 9229 is set at runtime
+		inspector_ip: undefined, // the default of 127.0.0.1 is set at runtime
 		local_protocol: "http",
 		upstream_protocol: "http",
 		host: undefined,

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -598,6 +598,7 @@ function normalizeAndValidateDev(
 		ip = process.platform === "win32" ? "127.0.0.1" : "localhost",
 		port,
 		inspector_port,
+		inspector_ip,
 		local_protocol = localProtocolArg ?? "http",
 		// In remote mode upstream_protocol must be https, otherwise it defaults to local_protocol.
 		upstream_protocol = upstreamProtocolArg ?? remoteArg
@@ -619,6 +620,13 @@ function normalizeAndValidateDev(
 		"inspector_port",
 		inspector_port,
 		"number"
+	);
+	validateOptionalProperty(
+		diagnostics,
+		"dev",
+		"inspector_ip",
+		inspector_ip,
+		"string"
 	);
 	validateOptionalProperty(
 		diagnostics,
@@ -665,6 +673,7 @@ function normalizeAndValidateDev(
 		ip,
 		port,
 		inspector_port,
+		inspector_ip,
 		local_protocol,
 		upstream_protocol,
 		host,

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -44,6 +44,7 @@ describe("normalizeAndValidateConfig()", () => {
 				host: undefined,
 				enable_containers: true,
 				inspector_port: undefined,
+				inspector_ip: undefined,
 				container_engine: undefined,
 				generate_types: false,
 			},

--- a/packages/wrangler/src/__tests__/config-validation-pages.test.ts
+++ b/packages/wrangler/src/__tests__/config-validation-pages.test.ts
@@ -181,6 +181,7 @@ describe("validatePagesConfig()", () => {
 						ip: "127.0.0.0",
 						port: 1234,
 						inspector_port: 5678,
+						inspector_ip: undefined,
 						local_protocol: "https",
 						upstream_protocol: "https",
 						host: "test-host",

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -186,6 +186,7 @@ export async function unstable_dev(
 		compatibilityFlags: options?.compatibilityFlags,
 		ip: "127.0.0.1",
 		inspectorPort: options?.inspectorPort ?? 0,
+		inspectorIp: undefined,
 		v: undefined,
 		cwd: undefined,
 		localProtocol: options?.localProtocol,

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -123,10 +123,12 @@ export async function convertToConfigBundle(
 			? {
 					inspect: false,
 					inspectorPort: undefined,
+					inspectorHost: undefined,
 				}
 			: {
 					inspect: true,
 					inspectorPort: 0,
+					inspectorHost: event.config.dev.inspector?.hostname,
 				}),
 		localPersistencePath: event.config.dev.persist,
 		liveReload: event.config.dev?.liveReload ?? false,

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -108,6 +108,10 @@ export const dev = createCommand({
 			describe: "Port for devtools to connect to",
 			type: "number",
 		},
+		"inspector-ip": {
+			describe: "IP address for devtools to connect to",
+			type: "string",
+		},
 		routes: {
 			describe: "Routes to upload",
 			alias: "route",

--- a/packages/wrangler/src/dev/miniflare/index.ts
+++ b/packages/wrangler/src/dev/miniflare/index.ts
@@ -72,6 +72,7 @@ export interface ConfigBundle {
 	initialIp: string;
 	rules: Config["rules"];
 	inspectorPort: number | undefined;
+	inspectorHost: string | undefined;
 	localPersistencePath: string | null;
 	liveReload: boolean;
 	crons: Config["triggers"]["crons"];
@@ -855,6 +856,7 @@ export async function buildMiniflareOptions(
 		host: config.initialIp,
 		port: config.initialPort,
 		inspectorPort: config.inspect ? config.inspectorPort : undefined,
+		inspectorHost: config.inspect ? config.inspectorHost : undefined,
 		liveReload: config.liveReload,
 		upstream,
 		unsafeDevRegistryPath: config.devRegistry,

--- a/packages/wrangler/src/dev/start-dev.ts
+++ b/packages/wrangler/src/dev/start-dev.ts
@@ -272,6 +272,7 @@ async function setupDevEnv(
 					httpsKeyPath: args.httpsKeyPath,
 				},
 				inspector: {
+					hostname: args.inspectorIp,
 					port: args.inspectorPort,
 				},
 				origin: {

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -920,6 +920,7 @@ export const pagesDevCommand = createCommand({
 					ip,
 					port,
 					inspectorPort,
+					inspectorIp: undefined,
 					localProtocol,
 					httpsKeyPath: args.httpsKeyPath,
 					httpsCertPath: args.httpsCertPath,


### PR DESCRIPTION
Fixes #5603

This PR adds support for customising the IP address that the inspector server listens on via a new `--inspector-ip` CLI flag and `dev.inspector_ip` configuration option.

## Problem

Previously, the inspector was hardcoded to listen only on `127.0.0.1`, which prevented debugging in Docker containers and other environments where external access is needed.

## Solution

- Added `--inspector-ip` CLI flag to `wrangler dev`
- Added `dev.inspector_ip` configuration option in `wrangler.json`/`wrangler.toml`
- Updated the inspector proxy controller to accept and use a custom hostname
- Added comprehensive tests for the new functionality
- Default remains `127.0.0.1` for security

## Example Usage

```bash
# CLI flag
wrangler dev --inspector-ip 0.0.0.0
```

```jsonc
// wrangler.json
{
  "dev": {
    "inspector_ip": "0.0.0.0"
  }
}
```

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): 
  - [x] Documentation not necessary because: CLI flag and config option are self-documenting, and the changeset includes usage examples