### PR TITLE
fix(vitest-pool-workers): allow Vite query parameters like `?raw` on module imports

### DIFF
--- a/.changeset/fix-raw-imports.md
+++ b/.changeset/fix-raw-imports.md
@@ -1,0 +1,10 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+fix: allow Vite query parameters like `?raw` on `.sql` file imports
+
+Importing `.sql` files with Vite query parameters (e.g., `import sql from "./query.sql?raw"`) would fail with "No such module" errors in vitest-pool-workers 0.12.x. Both import styles now work:
+
+- `import sql from "./query.sql?raw"` (Vite handles the `?raw` transform)
+- `import sql from "./query.sql"` (loaded as Text module)

--- a/fixtures/vitest-pool-workers-examples/module-resolution/src/test.sql
+++ b/fixtures/vitest-pool-workers-examples/module-resolution/src/test.sql
@@ -1,0 +1,1 @@
+SELECT * FROM users WHERE id = 1;

--- a/fixtures/vitest-pool-workers-examples/module-resolution/test/index.d.ts
+++ b/fixtures/vitest-pool-workers-examples/module-resolution/test/index.d.ts
@@ -2,3 +2,9 @@ declare module "ext-dep" {
 	var x: number;
 	export default x;
 }
+
+// .sql files are loaded as Text modules by default in wrangler
+declare module "*.sql" {
+	const content: string;
+	export default content;
+}

--- a/fixtures/vitest-pool-workers-examples/module-resolution/test/index.spec.ts
+++ b/fixtures/vitest-pool-workers-examples/module-resolution/test/index.spec.ts
@@ -2,6 +2,8 @@ import { instrument } from "@microlabs/otel-cf-workers";
 import { Utils } from "discord-api-types/v10";
 import dep from "ext-dep";
 import { assert, describe, test } from "vitest";
+import sqlPlain from "../src/test.sql";
+import sqlRaw from "../src/test.sql?raw";
 
 describe("test", () => {
 	test("resolves commonjs directory dependencies correctly", async () => {
@@ -16,5 +18,11 @@ describe("test", () => {
 	// This requires the `deps.optimizer` option to be set in the vitest config
 	test("resolves dependency with mapping on the browser field", async () => {
 		assert.isFunction(instrument);
+	});
+
+	// Regression test for https://github.com/cloudflare/workers-sdk/issues/12049
+	// Vite query parameters like ?raw should be handled by Vite, not module rules
+	test("resolves file with ?raw query parameter", async () => {
+		assert.equal(sqlRaw, sqlPlain);
 	});
 });

--- a/fixtures/vitest-pool-workers-examples/tsconfig.workerd-test.json
+++ b/fixtures/vitest-pool-workers-examples/tsconfig.workerd-test.json
@@ -3,7 +3,8 @@
 	"compilerOptions": {
 		"types": [
 			"@cloudflare/workers-types/experimental",
-			"@cloudflare/vitest-pool-workers" // For `cloudflare:test` types
+			"@cloudflare/vitest-pool-workers", // For `cloudflare:test` types
+			"vite/client" // For `?raw`, `?url`, etc. import types
 		]
 	}
 }

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -936,7 +936,9 @@ async function runTests(
 			const maybeRule = compiledRules.find((rule) =>
 				testRegExps(rule.include, specifier)
 			);
-			if (maybeRule !== undefined) {
+
+			// Skip if specifier already has query params (e.g. `?raw`), letting Vite handle it.
+			if (maybeRule !== undefined && !specifier.includes("?")) {
 				const externalize = specifier + `?mf_vitest_force=${maybeRule.type}`;
 				return { externalize };
 			}


### PR DESCRIPTION
Fixes #12049

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12056">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
