### PR TITLE
chore: fix run-ci-for-external-forks workflow not triggering CI

### DIFF
--- a/.github/workflows/run-ci-for-external-forks.yml
+++ b/.github/workflows/run-ci-for-external-forks.yml
@@ -56,10 +56,8 @@ jobs:
 
       - name: Push Branch
         run: |
-          # Rewrite last commit so GitHub considers it new and runs the CI jobs with our secrets
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          git commit --amend --no-edit
           git push origin HEAD --force
 
       - name: "Create Draft PR"
@@ -75,3 +73,12 @@ jobs:
           PR_NUM: ${{ inputs.pr-number }}
           TITLE: "Run CI on behalf of #${{ inputs.pr-number }} @${{ inputs.commit-sha }}"
           BODY: "This PR runs CI on behalf of #${{ inputs.pr-number }} at commit ${{ inputs.commit-sha }}. It can be closed after the CI run is complete."
+
+      - name: "Trigger CI"
+        run: |
+          # Push an empty commit to trigger CI workflows
+          # This ensures CI runs because the PR already exists when this push happens
+          git commit --allow-empty -m "Trigger CI for #$PR_NUM"
+          git push origin HEAD
+        env:
+          PR_NUM: ${{ inputs.pr-number }}


### PR DESCRIPTION
Fixes #12136.

I ran the workflow for #12064 but notice the CI didn't trigger on #12136. End up fixing it by manually pushing an empty commit, so this PR does the same automatically.

Not entirely sure why the original amend approach didn't work. It might be `GITHUB_TOKEN` not triggering workflows, or some timing issue with the branch push happening before the PR exists.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12137">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
