### PR TITLE
[quick-edit] Use X-Forwarded-Host header for extension authority when behind a proxy

### DIFF
--- a/.changeset/quick-edit-x-forwarded-host.md
+++ b/.changeset/quick-edit-x-forwarded-host.md
@@ -2,9 +2,6 @@
 "@cloudflare/quick-edit": patch
 ---
 
-Use X-Forwarded-Host header for extension authority when behind a proxy
+Use `X-Forwarded-Host` header for extension authority when behind a proxy
 
-When Quick Edit is accessed through a proxy, the `X-Forwarded-Host` header is now used
-to determine the authority for loading builtin extensions. This ensures extensions load
-correctly when the Worker is behind a reverse proxy. The header value is only used if it
-matches `*.devprod.cloudflare.dev` for security.
+When Quick Edit is accessed through a proxy, the `X-Forwarded-Host` header is now used to determine the authority for loading builtin extensions. This ensures extensions load correctly when the Worker is behind a reverse proxy. The header value is only used if it matches `*.devprod.cloudflare.dev` for security.

--- a/packages/quick-edit/src/index.ts
+++ b/packages/quick-edit/src/index.ts
@@ -50,12 +50,12 @@ export default {
 					{
 						scheme: url.protocol === "https:" ? "https" : "http",
 						path: "/quick-edit-extension",
-						authority: authority,
+						authority,
 					},
 					{
 						scheme: url.protocol === "https:" ? "https" : "http",
 						path: "/solarflare-theme",
-						authority: authority,
+						authority,
 					},
 				],
 			}).replace(/"/g, "&quot;"),


### PR DESCRIPTION
When Quick Edit is accessed through a proxy (e.g., on devprod.cloudflare.dev), the browser sees the proxy's host, but the Worker receives its own host in the URL. The `additionalBuiltinExtensions` config tells VS Code where to load extensions from, so we need to use the proxy's host for the browser to load them correctly.

This change:
- Reads the `X-Forwarded-Host` header from incoming requests
- Validates it matches `*.devprod.cloudflare.dev` for security
- Uses it as the authority for extension URLs when valid, falling back to `url.host` otherwise

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: This is a small, self-contained change that only affects the authority used for extension loading when behind a validated proxy
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is an internal implementation detail for proxy support
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12154">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
