### PR TITLE
[workers-utils] Fix compatibility date detection in create-cloudflare

### DIFF
--- a/.changeset/gyena-uqept-nmcqg.md
+++ b/.changeset/gyena-uqept-nmcqg.md
@@ -1,0 +1,12 @@
+---
+"@cloudflare/workers-utils": patch
+"create-cloudflare": patch
+---
+
+Fix compatibility date detection failing when creating new projects
+
+Previously, `getLocalWorkerdCompatibilityDate()` would fail to find the locally installed `miniflare` and `workerd` packages, causing `npm create cloudflare@latest` to fall back to a hardcoded date (2025-09-27) instead of using the current workerd compatibility date.
+
+The issue was that `module.createRequire()` was called with a directory path. Node.js treats this as a filename at that location and looks for `node_modules` in the parent directory rather than the intended directory. This is now fixed by appending `package.json` to the path, which ensures module resolution starts from the correct location.
+
+Fixes #12155

--- a/packages/workers-utils/src/compatibility-date.ts
+++ b/packages/workers-utils/src/compatibility-date.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
 import module from "node:module";
+import path from "node:path";
 
 type YYYY = `${number}${number}${number}${number}`;
 type MM = `${number}${number}`;
@@ -33,7 +34,12 @@ export function getLocalWorkerdCompatibilityDate({
 	projectPath = process.cwd(),
 }: GetCompatDateOptions = {}): GetCompatDateResult {
 	try {
-		const projectRequire = module.createRequire(projectPath);
+		// Note: createRequire expects a filename, not a directory. When given a directory,
+		// Node.js looks for node_modules in the parent directory instead of the given directory.
+		// Appending package.json ensures resolution starts from the correct location.
+		const projectRequire = module.createRequire(
+			path.join(projectPath, "package.json")
+		);
 		const miniflareEntry = projectRequire.resolve("miniflare");
 		const miniflareRequire = module.createRequire(miniflareEntry);
 		const miniflareWorkerd = miniflareRequire("workerd") as {

--- a/packages/workers-utils/tests/compatibility-date.test.ts
+++ b/packages/workers-utils/tests/compatibility-date.test.ts
@@ -1,4 +1,5 @@
 import module from "node:module";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getLocalWorkerdCompatibilityDate } from "../src/compatibility-date";
 
@@ -8,31 +9,47 @@ describe("getLocalWorkerdCompatibilityDate", () => {
 	});
 
 	it("should successfully get the local latest compatibility date from the local workerd instance", () => {
-		vi.spyOn(module, "createRequire").mockImplementation(() => {
-			const mockedRequire = ((pkg: string) => {
-				if (pkg === "workerd") {
-					return { compatibilityDate: "2025-01-10" };
-				}
-				return {};
-			}) as NodeJS.Require;
-			mockedRequire.resolve = (() => "") as unknown as NodeJS.RequireResolve;
-			return mockedRequire;
+		const createRequireSpy = vi
+			.spyOn(module, "createRequire")
+			.mockImplementation(() => {
+				const mockedRequire = ((pkg: string) => {
+					if (pkg === "workerd") {
+						return { compatibilityDate: "2025-01-10" };
+					}
+					return {};
+				}) as NodeJS.Require;
+				mockedRequire.resolve = (() => "") as unknown as NodeJS.RequireResolve;
+				return mockedRequire;
+			});
+		const { date, source } = getLocalWorkerdCompatibilityDate({
+			projectPath: "/test/project",
 		});
-		const { date, source } = getLocalWorkerdCompatibilityDate();
 		expect(date).toBe("2025-01-10");
 		expect(source).toEqual("workerd");
+		// Verify createRequire is called with a file path (package.json), not just a directory
+		expect(createRequireSpy).toHaveBeenCalledWith(
+			path.join("/test/project", "package.json")
+		);
 	});
 
 	it("should fallback to the fallback date if it fails to get the date from a local workerd instance", () => {
-		vi.spyOn(module, "createRequire").mockImplementation(
-			// This breaks the require function that createRequire generate, causing us not to find
-			// the local miniflare/workerd instance
-			() => ({}) as NodeJS.Require
-		);
-		const { date, source } = getLocalWorkerdCompatibilityDate();
+		const createRequireSpy = vi
+			.spyOn(module, "createRequire")
+			.mockImplementation(
+				// This breaks the require function that createRequire generate, causing us not to find
+				// the local miniflare/workerd instance
+				() => ({}) as NodeJS.Require
+			);
+		const { date, source } = getLocalWorkerdCompatibilityDate({
+			projectPath: "/test/project",
+		});
 		const fallbackCompatDate = "2025-09-27";
 		expect(date).toEqual(fallbackCompatDate);
 		expect(source).toEqual("fallback");
+		// Verify createRequire is called with a file path even when resolution fails
+		expect(createRequireSpy).toHaveBeenCalledWith(
+			path.join("/test/project", "package.json")
+		);
 	});
 
 	it("should use today's date if the local workerd's date is in the future", async () => {
@@ -47,9 +64,11 @@ describe("getLocalWorkerdCompatibilityDate", () => {
 			mockedRequire.resolve = (() => "") as unknown as NodeJS.RequireResolve;
 			return mockedRequire;
 		});
-		const { date, source } = getLocalWorkerdCompatibilityDate();
-		const fallbackCompatDate = "2025-01-09";
-		expect(date).toEqual(fallbackCompatDate);
+		const { date, source } = getLocalWorkerdCompatibilityDate({
+			projectPath: "/test/project",
+		});
+		const todaysDate = "2025-01-09";
+		expect(date).toEqual(todaysDate);
 		expect(source).toEqual("workerd");
 	});
 });


### PR DESCRIPTION
Fixes #12155.

When running `npm create cloudflare@latest`, the compatibility date detection was failing and falling back to a hardcoded date (2025-09-27) instead of using the current workerd compatibility date.

**Root Cause:** `module.createRequire()` was being called with a directory path (e.g., `/path/to/project`). Node.js treats this as a filename at that location and starts module resolution from the **parent** directory (`/path/to`). This caused `getLocalWorkerdCompatibilityDate()` to fail to find `miniflare` in the project's `node_modules`.

**Fix:** Append `package.json` to the project path when calling `createRequire()`, ensuring module resolution starts from the correct directory.

```javascript
// Before (broken - looks in parent directory's node_modules)
module.createRequire('/path/to/project')

// After (fixed - looks in project's node_modules)  
module.createRequire('/path/to/project/package.json')
```

---

Example output:

```
npx https://pkg.pr.new/create-cloudflare@12156

...

╭ Configuring your application for Cloudflare Step 2 of 3
│
├ Installing wrangler A command line tool for building Cloudflare Workers
│ installed via `npm install wrangler --save-dev`
│
├ Retrieving current workerd compatibility date
│ compatibility date 2026-01-20
```

^ correct compat date — versus #12155 shows wrong compat date

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is an internal bug fix with no user-facing API changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12156">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
