### PR TITLE
Improve spa-with-api playground test resilience

### DIFF
--- a/packages/vite-plugin-cloudflare/playground/spa-with-api/__tests__/base-tests.ts
+++ b/packages/vite-plugin-cloudflare/playground/spa-with-api/__tests__/base-tests.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "vitest";
-import { page } from "../../__test-utils__";
+import { expect, test, vi } from "vitest";
+import { page, WAIT_FOR_OPTIONS } from "../../__test-utils__";
 
 test("returns the correct home page", async () => {
 	const content = await page.textContent("h1");
@@ -10,11 +10,9 @@ test("returns the response from the API", async () => {
 	const button = page.getByRole("button", { name: "get-name" });
 	const contentBefore = await button.innerText();
 	expect(contentBefore).toBe("Name from API is: unknown");
-	const responsePromise = page.waitForResponse((response) =>
-		response.url().endsWith("/api/")
-	);
 	await button.click();
-	await responsePromise;
-	const contentAfter = await button.innerText();
-	expect(contentAfter).toBe("Name from API is: Cloudflare");
+	await vi.waitFor(async () => {
+		const contentAfter = await button.innerText();
+		expect(contentAfter).toBe("Name from API is: Cloudflare");
+	}, WAIT_FOR_OPTIONS);
 });


### PR DESCRIPTION
Improve spa-with-api playground test resilience. These tests were previously flaky because they assumed that the UI update was instant.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: tests update

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12188">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
