### PR TITLE
fix(vite-plugin): ignoreOutdatedRequests in client environment

### DIFF
--- a/.changeset/fair-papers-allow.md
+++ b/.changeset/fair-papers-allow.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Work around a Vite bug that caused 504 errors when using React in Astro

--- a/packages/vite-plugin-cloudflare/src/plugins/config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/config.ts
@@ -206,6 +206,11 @@ function getEnvironmentsConfig(
 				// Some frameworks allow users to mix client and server code in the same file and then extract the server code.
 				// As the dependency optimization may happen before the server code is extracted, we should exclude Cloudflare built-ins from client optimization.
 				exclude: [...cloudflareBuiltInModules],
+				// Workaround for https://github.com/vitejs/vite/issues/20867
+				// When SSR environment triggers dep re-bundling mid-request, in-flight client
+				// requests would fail with 504 because their browserHash becomes stale.
+				// @ts-expect-error - option added in Vite 7.3.1
+				ignoreOutdatedRequests: true,
 			},
 		},
 	};


### PR DESCRIPTION
A follow-on from #11815, this also applies `ignoreOutdatedRequests: true` to the client environment. 

The `@cloudflare/vite-plugin` sets `ignoreOutdatedRequests: true` on the SSR environment
but not the client environment. When the SSR environment triggers a dep re-bundle,
in-flight client requests fail because Vite checks `ignoreOutdatedRequests` on the
client environment's config (which is `false` by default).

This was causing errors when using React with Astro 6.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12191">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
