### PR TITLE
ci: fix the changeset-review job not posting a comment to GH PRs

### DIFF
--- a/.github/workflows/changeset-review.yml
+++ b/.github/workflows/changeset-review.yml
@@ -2,15 +2,8 @@ name: Changeset Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - ".changeset/*.md"
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: "PR number to review"
-        required: true
-        type: number
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,7 +18,7 @@ permissions:
 jobs:
   review-changesets:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository && !contains(github.event.pull_request.labels.*.name, 'skip-changeset-review') && !contains(github.event.pull_request.labels.*.name, 'no-changeset-required')
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4
@@ -52,6 +45,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: "devin-ai-integration[bot]"
           use_sticky_comment: true
+          track_progress: true
           prompt: |
             Review the changeset files in this PR.
 


### PR DESCRIPTION
The changeset-review CI job has stopped posting comments on PRs.

I suspect this was because we removed the `track_progress` property from the Claude action. According to searches, this (along with the custom prompt) can cause Claude to exit "agent" mode, and so not try to post any comments.

We removed that because it was not compatible with label change Github Action events. But since we are no longer blocking PRs on this job we don't need to check for label changes anymore.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: CI job change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because:  CI job change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12200">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
