### PR TITLE
ci: add merge_group trigger to vite-plugin-playgrounds workflow

### DIFF
--- a/.github/workflows/vite-plugin-playgrounds.yml
+++ b/.github/workflows/vite-plugin-playgrounds.yml
@@ -1,6 +1,7 @@
 name: Vite plugin playgrounds
 
 on:
+  merge_group:
   pull_request:
 
 permissions:


### PR DESCRIPTION
Adds `merge_group` event trigger to the Vite plugin playgrounds CI workflow so that these tests run when PRs are added to the merge queue.

This matches the pattern used by other CI workflows in this repo (e.g., `test-and-check.yml`, `e2e.yml`, `c3-e2e.yml`).

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: This is a CI workflow change that will be validated by GitHub Actions

- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Internal CI configuration change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12202">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
