### PR TITLE
Deprecate 'wrangler cloudchamber apply' in favor of 'wrangler deploy'

### DIFF
--- a/.changeset/fuzzy-items-listen.md
+++ b/.changeset/fuzzy-items-listen.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Deprecate 'wrangler cloudchamber apply' in favor of 'wrangler deploy'

--- a/packages/wrangler/src/cloudchamber/apply.ts
+++ b/packages/wrangler/src/cloudchamber/apply.ts
@@ -678,7 +678,11 @@ export const cloudchamberApplyCommand = createCommand({
 		description: "Apply the changes in the container applications to deploy",
 		status: "alpha",
 		owner: "Product: Cloudchamber",
-		hidden: false,
+		hidden: true,
+		deprecated: true,
+		deprecatedMessage:
+			"`wrangler cloudchamber apply` is deprecated and will be removed in the next major version.\n" +
+			"Please use `wrangler deploy` instead.",
 	},
 	args: {
 		"skip-defaults": {


### PR DESCRIPTION
Fixes CC-6777.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: it is an "internal" command.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12216">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
