### PR TITLE
Unskip debug tests

### DIFF
--- a/packages/vite-plugin-cloudflare/playground/__test-utils__/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/__test-utils__/index.ts
@@ -11,9 +11,6 @@ export function satisfiesViteVersion(minVersion: string): boolean {
 	return semverGte(viteVersion, minVersion);
 }
 
-// TODO: remove when all tests are passing with Vite 8
-export const isVite8 = viteVersion.split(".")[0] === "8";
-
 /** Common options to use with `vi.waitFor()` */
 export const WAIT_FOR_OPTIONS = {
 	timeout: isWindows ? 10_000 : 5_000,

--- a/packages/vite-plugin-cloudflare/playground/node-compat/__tests__/worker-debug/debug.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/__tests__/worker-debug/debug.spec.ts
@@ -1,13 +1,7 @@
 import { expect, test, vi } from "vitest";
-import {
-	getJsonResponse,
-	isVite8,
-	WAIT_FOR_OPTIONS,
-} from "../../../__test-utils__";
+import { getJsonResponse, WAIT_FOR_OPTIONS } from "../../../__test-utils__";
 
-// See https://github.com/rolldown/rolldown/issues/7973
-// Will be fixed in rolldown@1.0.0-rc.2
-test.skipIf(isVite8)("debug is resolved correctly", async () => {
+test("debug is resolved correctly", async () => {
 	await vi.waitFor(async () => {
 		expect(await getJsonResponse()).toEqual([
 			"test Test import message 1",


### PR DESCRIPTION
This reinstates the final test that was skipped for Vite 8 now that https://github.com/rolldown/rolldown/issues/7973 has been resolved and [vite@v8.0.0-beta.11](https://github.com/vitejs/vite/blob/v8.0.0-beta.11/packages/vite/CHANGELOG.md) has been released.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: testing change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12238">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
