### PR TITLE
[wrangler] Fix error report prompt default value

### DIFF
--- a/.changeset/fix-error-report-default.md
+++ b/.changeset/fix-error-report-default.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Default error report prompt to "no" when pressing Enter
+
+Previously, the error report prompt ("Would you like to report this error to Cloudflare?") defaulted to "yes" when pressing Enter. This caused users to accidentally submit error reports without explicitly consenting. The prompt now defaults to "no", requiring users to explicitly type "y" or "yes" to consent to submitting reports.

--- a/packages/wrangler/src/sentry/index.ts
+++ b/packages/wrangler/src/sentry/index.ts
@@ -165,7 +165,7 @@ export async function captureGlobalException(e: unknown) {
 				? sendErrorReportsEnvVar
 				: await confirm(
 						"Would you like to report this error to Cloudflare? Wrangler's output and the error details will be shared with the Wrangler team to help us diagnose and fix the issue.",
-						{ fallbackValue: false }
+						{ defaultValue: false, fallbackValue: false }
 					);
 
 		if (!sentryReportingAllowed) {


### PR DESCRIPTION
Fixes #10452.

The error report prompt ("Would you like to report this error to Cloudflare?") was defaulting to "yes" when the user pressed Enter without typing a response. This caused users to accidentally submit error reports without explicitly consenting.

This change adds `defaultValue: false` to the `confirm()` call, so pressing Enter now defaults to "no", requiring users to explicitly type "y" or "yes" to consent to submitting reports.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: This is a simple parameter change; existing sentry tests pass.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is a user-facing behavior fix that doesn't require documentation changes.