### PR TITLE
[wrangler] Fix vectorize list commands JSON output

### DIFF
--- a/.changeset/fix-vectorize-list-json-output.md
+++ b/.changeset/fix-vectorize-list-json-output.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Suppress log messages in vectorize list commands when using --json flag
+
+The `wrangler vectorize list --json` and `wrangler vectorize list-metadata-index --json` commands were outputting log messages before the JSON data, making the output invalid JSON and breaking programmatic parsing. These log messages are now only shown when the --json flag is not set.

--- a/packages/wrangler/src/vectorize/list.ts
+++ b/packages/wrangler/src/vectorize/list.ts
@@ -25,7 +25,9 @@ export const vectorizeListCommand = createCommand({
 		},
 	},
 	async handler(args, { config }) {
-		logger.log(`📋 Listing Vectorize indexes...`);
+		if (!args.json) {
+			logger.log(`📋 Listing Vectorize indexes...`);
+		}
 		const indexes = await listIndexes(config, args.deprecatedV1);
 
 		if (indexes.length === 0) {

--- a/packages/wrangler/src/vectorize/listMetadataIndex.ts
+++ b/packages/wrangler/src/vectorize/listMetadataIndex.ts
@@ -26,7 +26,9 @@ export const vectorizeListMetadataIndexCommand = createCommand({
 	},
 	positionalArgs: ["name"],
 	async handler(args, { config }) {
-		logger.log(`📋 Fetching metadata indexes...`);
+		if (!args.json) {
+			logger.log(`📋 Fetching metadata indexes...`);
+		}
 		const res = await listMetadataIndex(config, args.name);
 
 		if (res.metadataIndexes.length === 0) {


### PR DESCRIPTION
Fixes #11011.

The `wrangler vectorize list --json` and `wrangler vectorize list-metadata-index --json` commands were outputting log messages before the JSON data, making the output invalid JSON. This was caused by `logger.log` being called unconditionally before outputting the JSON.

This change wraps the log messages in `if (!args.json)` conditionals so they are only shown when the `--json` flag is not set.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: Existing vectorize tests pass and the change is trivial (conditional logging)
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is a bug fix for existing behavior, no new API
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12271">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
