### PR TITLE
[wrangler] Fix Windows path display in error messages

### DIFF
--- a/.changeset/fix-windows-path-display.md
+++ b/.changeset/fix-windows-path-display.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+"@cloudflare/workers-utils": patch
+---
+
+Properly display Windows paths in error messages
+
+Windows file paths containing backslash-escape sequences (like `\t` in usernames such as `thepl`) were being interpreted as control characters in error messages, causing paths like `C:\Users\thepl\...` to display incorrectly with tab characters. Paths in error messages are now normalized to use forward slashes, ensuring consistent and readable output across all platforms.

--- a/packages/workers-utils/src/index.ts
+++ b/packages/workers-utils/src/index.ts
@@ -41,6 +41,7 @@ export {
 	parseHumanDuration,
 	parseNonHyphenedUuid,
 	parseByteSize,
+	displayPath,
 } from "./parse";
 export {
 	friendlyBindingNames,

--- a/packages/workers-utils/src/parse.ts
+++ b/packages/workers-utils/src/parse.ts
@@ -6,6 +6,18 @@ import { UserError } from "./errors";
 import type { TelemetryMessage } from "./errors";
 import type { ParseError as JsoncParseError } from "jsonc-parser";
 
+/**
+ * Converts Windows backslashes to forward slashes for display purposes.
+ * This prevents backslash sequences like `\t` (in paths like `C:\Users\thepl\...`)
+ * from being interpreted as escape characters in error messages.
+ *
+ * @param filePath The file path to normalize for display
+ * @returns The path with backslashes replaced by forward slashes
+ */
+export function displayPath(filePath: string): string {
+	return filePath.replace(/\\/g, "/");
+}
+
 export type Message = {
 	text: string;
 	location?: Location;
@@ -174,10 +186,10 @@ export function readFileSyncToBuffer(file: string): Buffer {
 	} catch (err) {
 		const { message } = err as Error;
 		throw new ParseError({
-			text: `Could not read file: ${file}`,
+			text: `Could not read file: ${displayPath(file)}`,
 			notes: [
 				{
-					text: message.replace(file, resolve(file)),
+					text: message.replace(file, displayPath(resolve(file))),
 				},
 			],
 		});
@@ -198,10 +210,10 @@ export function readFileSync(file: string): string {
 
 		const { message } = err as Error;
 		throw new ParseError({
-			text: `Could not read file: ${file}`,
+			text: `Could not read file: ${displayPath(file)}`,
 			notes: [
 				{
-					text: message.replace(file, resolve(file)),
+					text: message.replace(file, displayPath(resolve(file))),
 				},
 			],
 			telemetryMessage: "Could not read file",
@@ -413,10 +425,10 @@ function removeBOMAndValidate(buffer: Buffer, file: string): string {
 				text: `Configuration file contains ${bom.encoding} byte order marker`,
 				notes: [
 					{
-						text: `The file "${file}" appears to be encoded as ${bom.encoding}. Please save the file as UTF-8 without BOM.`,
+						text: `The file "${displayPath(file)}" appears to be encoded as ${bom.encoding}. Please save the file as UTF-8 without BOM.`,
 					},
 				],
-				location: { file, line: 1, column: 0 },
+				location: { file: displayPath(file), line: 1, column: 0 },
 				telemetryMessage: `${bom.encoding} BOM detected`,
 			});
 		}

--- a/packages/workers-utils/tests/parse.test.ts
+++ b/packages/workers-utils/tests/parse.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	displayPath,
 	indexLocation,
 	parseByteSize,
 	parseJSON,
@@ -402,5 +403,42 @@ describe("parseByteSize", () => {
 		expect(parseByteSize(".B")).toBeNaN();
 		expect(parseByteSize("3iB")).toBeNaN();
 		expect(parseByteSize("3ib")).toBeNaN();
+	});
+});
+
+describe("displayPath", () => {
+	it("should convert Windows backslashes to forward slashes", () => {
+		expect(displayPath("C:\\Users\\thepl\\project\\wrangler.json")).toBe(
+			"C:/Users/thepl/project/wrangler.json"
+		);
+	});
+
+	it("should handle paths with escape sequence characters", () => {
+		// These paths contain characters that would form escape sequences
+		// \t = tab, \n = newline, \r = carriage return
+		expect(displayPath("C:\\Users\\thepl\\temp\\file.txt")).toBe(
+			"C:/Users/thepl/temp/file.txt"
+		);
+		expect(displayPath("C:\\Users\\neil\\project")).toBe(
+			"C:/Users/neil/project"
+		);
+		expect(displayPath("C:\\Users\\robin\\folder")).toBe(
+			"C:/Users/robin/folder"
+		);
+	});
+
+	it("should leave Unix paths unchanged", () => {
+		expect(displayPath("/home/user/project/wrangler.json")).toBe(
+			"/home/user/project/wrangler.json"
+		);
+	});
+
+	it("should handle relative paths", () => {
+		expect(displayPath("src\\index.ts")).toBe("src/index.ts");
+		expect(displayPath("./src/index.ts")).toBe("./src/index.ts");
+	});
+
+	it("should handle empty strings", () => {
+		expect(displayPath("")).toBe("");
 	});
 });


### PR DESCRIPTION
Fixes #8714.

Windows file paths containing backslash-escape sequences (like `\t` in usernames such as `thepl`) were being interpreted as control characters in error messages. This caused paths like `C:\Users\thepl\...` to display incorrectly with tab characters instead of the proper path.

This PR adds a `displayPath()` helper function that normalizes Windows paths to use forward slashes in error messages, ensuring consistent and readable output across all platforms.

**Changes:**
- Add `displayPath()` function in `packages/workers-utils/src/parse.ts` that converts backslashes to forward slashes
- Export the function for potential use in other parts of the codebase  
- Apply the normalization to paths in `readFileSync()`, `readFileSyncToBuffer()`, and `removeBOMAndValidate()` error messages
- Add comprehensive tests for the `displayPath()` function

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is an internal bug fix that doesn't change user-facing behavior except for displaying paths correctly