### PR TITLE
[wrangler] Warn when multiple config files exist

### DIFF
--- a/.changeset/warn-multiple-config-files.md
+++ b/.changeset/warn-multiple-config-files.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Warn when multiple configuration files exist in the same directory
+
+When both `wrangler.json` and `wrangler.toml` (or any combination of supported config files) exist in the same directory, Wrangler now displays a warning explaining which file is being used and which are being ignored. The warning also explains how to resolve the conflict by either deleting unused config files or using the `--config` flag to explicitly specify which file to use.

--- a/packages/workers-utils/tests/config/findWranglerConfig.test.ts
+++ b/packages/workers-utils/tests/config/findWranglerConfig.test.ts
@@ -79,6 +79,73 @@ describe("config findWranglerConfig()", () => {
 			});
 		});
 
+		describe("multiple config file warning", () => {
+			it("should warn when both wrangler.json and wrangler.toml exist", async () => {
+				await seed({
+					"wrangler.json": "{}",
+					"wrangler.toml": "",
+				});
+
+				const warnings: string[] = [];
+				findWranglerConfig(".", { onWarning: (msg) => warnings.push(msg) });
+
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0]).toContain("Multiple configuration files found");
+				expect(warnings[0]).toContain("Using: wrangler.json");
+				expect(warnings[0]).toContain("Ignoring: wrangler.toml");
+			});
+
+			it("should warn when wrangler.json, wrangler.jsonc, and wrangler.toml all exist", async () => {
+				await seed({
+					"wrangler.json": "{}",
+					"wrangler.jsonc": "{}",
+					"wrangler.toml": "",
+				});
+
+				const warnings: string[] = [];
+				findWranglerConfig(".", { onWarning: (msg) => warnings.push(msg) });
+
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0]).toContain("Using: wrangler.json");
+				expect(warnings[0]).toContain(
+					"Ignoring: wrangler.jsonc, wrangler.toml"
+				);
+			});
+
+			it("should not warn when only one config file exists", async () => {
+				await seed({
+					"wrangler.toml": "",
+				});
+
+				const warnings: string[] = [];
+				findWranglerConfig(".", { onWarning: (msg) => warnings.push(msg) });
+
+				expect(warnings).toHaveLength(0);
+			});
+
+			it("should not warn when no onWarning callback is provided", async () => {
+				await seed({
+					"wrangler.json": "{}",
+					"wrangler.toml": "",
+				});
+
+				// Should not throw
+				expect(() => findWranglerConfig(".")).not.toThrow();
+			});
+
+			it("should not warn when config files are in different directories", async () => {
+				await seed({
+					"wrangler.json": "{}",
+					"foo/wrangler.toml": "",
+				});
+
+				const warnings: string[] = [];
+				findWranglerConfig("./foo", { onWarning: (msg) => warnings.push(msg) });
+
+				expect(warnings).toHaveLength(0);
+			});
+		});
+
 		it("should return user config path even if a deploy config is found", async () => {
 			await seed({
 				[`wrangler.toml`]: "DUMMY",

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -15909,6 +15909,18 @@ export default{
 		async function mockOpenNextLikeProject() {
 			vi.mocked(getInstalledPackageVersion).mockReturnValue("1.14.4");
 
+			// Remove any existing config files first to ensure we only have wrangler.jsonc
+			// This avoids warnings about multiple config files
+			for (const configFile of [
+				"./wrangler.toml",
+				"./wrangler.json",
+				"./wrangler.jsonc",
+			]) {
+				if (fs.existsSync(configFile)) {
+					fs.rmSync(configFile);
+				}
+			}
+
 			fs.mkdirSync("./.open-next/assets", { recursive: true });
 			fs.writeFileSync(
 				"./.open-next/worker.js",

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -61,7 +61,10 @@ export function readConfig(
 		userConfigPath,
 		deployConfigPath,
 		redirected,
-	} = experimental_readRawConfig(args, options);
+	} = experimental_readRawConfig(args, {
+		...options,
+		onWarning: options.hideWarnings ? undefined : (msg) => logger.warn(msg),
+	});
 	if (redirected) {
 		assert(configPath, "Redirected config found without a configPath");
 		assert(
@@ -105,7 +108,10 @@ export function readPagesConfig(
 	let deployConfigPath: string | undefined;
 	try {
 		({ rawConfig, configPath, userConfigPath, deployConfigPath, redirected } =
-			experimental_readRawConfig(args, options));
+			experimental_readRawConfig(args, {
+				...options,
+				onWarning: options.hideWarnings ? undefined : (msg) => logger.warn(msg),
+			}));
 		if (redirected) {
 			assert(configPath, "Redirected config found without a configPath");
 			assert(


### PR DESCRIPTION
Fixes #8722.

When both `wrangler.json` and `wrangler.toml` (or any combination of supported config files) exist in the same directory, wrangler now silently prefers the JSON config without informing the user. This can lead to confusion when users expect their `.toml` file to be used.

This PR adds a warning that:
- Lists which configuration file is being used
- Lists which configuration files are being ignored
- Provides guidance on how to resolve the conflict (delete unused files or use `--config` flag)
- Shows the priority order: `wrangler.json` > `wrangler.jsonc` > `wrangler.toml`

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: The warning message itself provides sufficient guidance