### PR TITLE
[wrangler] Add deprecation warning for queue delivery_delay

### DIFF
--- a/.changeset/deprecate-queue-delivery-delay.md
+++ b/.changeset/deprecate-queue-delivery-delay.md
@@ -6,6 +6,6 @@
 Add deprecation warning for `delivery_delay` in queue producer bindings
 
 The `delivery_delay` setting in `[[queues.producers]]` was silently having no effect since 2024.
-This change adds a deprecation warning when the setting is used, informing users that queue-level 
-settings should be configured using `wrangler queues update` instead. The setting will be removed 
+This change adds a deprecation warning when the setting is used, informing users that queue-level
+settings should be configured using `wrangler queues update` instead. The setting will be removed
 in a future version.

--- a/.changeset/deprecate-queue-delivery-delay.md
+++ b/.changeset/deprecate-queue-delivery-delay.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+"@cloudflare/workers-utils": patch
+---
+
+Add deprecation warning for `delivery_delay` in queue producer bindings
+
+The `delivery_delay` setting in `[[queues.producers]]` was silently having no effect since the
+functionality was removed in PR #10288. This change adds a deprecation warning when the setting
+is used, informing users that queue-level settings should be configured using `wrangler queues update`
+instead. The setting will be removed in a future version.

--- a/.changeset/deprecate-queue-delivery-delay.md
+++ b/.changeset/deprecate-queue-delivery-delay.md
@@ -5,7 +5,7 @@
 
 Add deprecation warning for `delivery_delay` in queue producer bindings
 
-The `delivery_delay` setting in `[[queues.producers]]` was silently having no effect since the
-functionality was removed in PR #10288. This change adds a deprecation warning when the setting
-is used, informing users that queue-level settings should be configured using `wrangler queues update`
-instead. The setting will be removed in a future version.
+The `delivery_delay` setting in `[[queues.producers]]` was silently having no effect since 2024.
+This change adds a deprecation warning when the setting is used, informing users that queue-level 
+settings should be configured using `wrangler queues update` instead. The setting will be removed 
+in a future version.

--- a/.changeset/deprecate-queue-delivery-delay.md
+++ b/.changeset/deprecate-queue-delivery-delay.md
@@ -1,11 +1,8 @@
 ---
-"wrangler": patch
-"@cloudflare/workers-utils": patch
+"wrangler": minor
+"@cloudflare/workers-utils": minor
 ---
 
 Add deprecation warning for `delivery_delay` in queue producer bindings
 
-The `delivery_delay` setting in `[[queues.producers]]` was silently having no effect since 2024.
-This change adds a deprecation warning when the setting is used, informing users that queue-level
-settings should be configured using `wrangler queues update` instead. The setting will be removed
-in a future version.
+The `delivery_delay` setting in `[[queues.producers]]` was silently having no effect since 2024. This change adds a deprecation warning when the setting is used, informing users that queue-level settings should be configured using `wrangler queues update` instead. The setting will be removed in a future version.

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -3823,7 +3823,7 @@ const validateQueueBinding: ValidatorFn = (diagnostics, field, value) => {
 	) {
 		diagnostics.warnings.push(
 			`The "delivery_delay" field in "${field}" is deprecated and has no effect. ` +
-				`Queue-level settings should be configured using "wrangler queues update" instead. ` +
+				`Queue settings should be configured using "wrangler queues update" instead. ` +
 				`This setting will be removed in a future version.`
 		);
 	}

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -3823,8 +3823,8 @@ const validateQueueBinding: ValidatorFn = (diagnostics, field, value) => {
 	) {
 		diagnostics.warnings.push(
 			`The "delivery_delay" field in "${field}" is deprecated and has no effect. ` +
-				`Queue settings should be configured using "wrangler queues update" instead. ` +
-				`This setting will be removed in the next major version.`
+				`Queue-level settings should be configured using "wrangler queues update" instead. ` +
+				`This setting will be removed in a future version.`
 		);
 	}
 

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -3816,6 +3816,18 @@ const validateQueueBinding: ValidatorFn = (diagnostics, field, value) => {
 		}
 	}
 
+	// Warn if delivery_delay is set, as it is deprecated and has no effect
+	if (
+		hasProperty(value, "delivery_delay") &&
+		value.delivery_delay !== undefined
+	) {
+		diagnostics.warnings.push(
+			`The "delivery_delay" field in "${field}" is deprecated and has no effect. ` +
+				`Queue-level settings should be configured using "wrangler queues update" instead. ` +
+				`This setting will be removed in a future version.`
+		);
+	}
+
 	if (!isRemoteValid(value, field, diagnostics)) {
 		isValid = false;
 	}

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -3824,7 +3824,7 @@ const validateQueueBinding: ValidatorFn = (diagnostics, field, value) => {
 		diagnostics.warnings.push(
 			`The "delivery_delay" field in "${field}" is deprecated and has no effect. ` +
 				`Queue settings should be configured using "wrangler queues update" instead. ` +
-				`This setting will be removed in a future version.`
+				`This setting will be removed in the next major version.`
 		);
 	}
 

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -3908,7 +3908,7 @@ const validateQueueBinding: ValidatorFn = (diagnostics, field, value) => {
 		diagnostics.warnings.push(
 			`The "delivery_delay" field in "${field}" is deprecated and has no effect. ` +
 				`Queue settings should be configured using "wrangler queues update" instead. ` +
-				`This setting will be removed in a future version.`
+				`This setting will be removed in the next major version.`
 		);
 	}
 

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -3900,6 +3900,18 @@ const validateQueueBinding: ValidatorFn = (diagnostics, field, value) => {
 		}
 	}
 
+	// Warn if delivery_delay is set, as it is deprecated and has no effect
+	if (
+		hasProperty(value, "delivery_delay") &&
+		value.delivery_delay !== undefined
+	) {
+		diagnostics.warnings.push(
+			`The "delivery_delay" field in "${field}" is deprecated and has no effect. ` +
+				`Queue-level settings should be configured using "wrangler queues update" instead. ` +
+				`This setting will be removed in a future version.`
+		);
+	}
+
 	if (!isRemoteValid(value, field, diagnostics)) {
 		isValid = false;
 	}

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -3907,8 +3907,8 @@ const validateQueueBinding: ValidatorFn = (diagnostics, field, value) => {
 	) {
 		diagnostics.warnings.push(
 			`The "delivery_delay" field in "${field}" is deprecated and has no effect. ` +
-				`Queue settings should be configured using "wrangler queues update" instead. ` +
-				`This setting will be removed in the next major version.`
+				`Queue-level settings should be configured using "wrangler queues update" instead. ` +
+				`This setting will be removed in a future version.`
 		);
 	}
 

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -3907,7 +3907,7 @@ const validateQueueBinding: ValidatorFn = (diagnostics, field, value) => {
 	) {
 		diagnostics.warnings.push(
 			`The "delivery_delay" field in "${field}" is deprecated and has no effect. ` +
-				`Queue-level settings should be configured using "wrangler queues update" instead. ` +
+				`Queue settings should be configured using "wrangler queues update" instead. ` +
 				`This setting will be removed in a future version.`
 		);
 	}

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -3718,9 +3718,9 @@ describe("normalizeAndValidateConfig()", () => {
 				);
 
 				expect(config.queues.producers).toHaveLength(2);
-				expect(config.queues.producers?.[1]).toMatchObject(
-					{ delivery_delay: 60 }
-				);
+				expect(config.queues.producers?.[1]).toMatchObject({
+					delivery_delay: 60,
+				});
 				expect(diagnostics.hasErrors()).toBe(false);
 				expect(diagnostics.hasWarnings()).toBe(true);
 				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -3718,8 +3718,8 @@ describe("normalizeAndValidateConfig()", () => {
 				);
 
 				expect(config.queues.producers).toHaveLength(2);
-				expect(config.queues.producers?.[1]).toEqual(
-					expect.objectContaining({ delivery_delay: 60 })
+				expect(config.queues.producers?.[1]).toMatchObject(
+					{ delivery_delay: 60 }
 				);
 				expect(diagnostics.hasErrors()).toBe(false);
 				expect(diagnostics.hasWarnings()).toBe(true);

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -3697,6 +3697,37 @@ describe("normalizeAndValidateConfig()", () => {
 					  - "queues.consumers[3]" should, optionally, have a number "max_concurrency" field but got {"queue":"myQueue","max_batch_size":"3","max_batch_timeout":null,"max_retries":"hello","dead_letter_queue":5,"max_concurrency":"hello"}."
 				`);
 			});
+
+			it("should warn if delivery_delay is set on a queue producer", () => {
+				const { config, diagnostics } = normalizeAndValidateConfig(
+					{
+						queues: {
+							producers: [
+								{ binding: "QUEUE_BINDING_1", queue: "queue1" },
+								{
+									binding: "QUEUE_BINDING_2",
+									queue: "queue2",
+									delivery_delay: 60,
+								},
+							],
+						},
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(config.queues.producers).toHaveLength(2);
+				expect(config.queues.producers?.[1]).toEqual(
+					expect.objectContaining({ delivery_delay: 60 })
+				);
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(diagnostics.hasWarnings()).toBe(true);
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - The \\"delivery_delay\\" field in \\"queues.producers[1]\\" is deprecated and has no effect. Queue-level settings should be configured using \\"wrangler queues update\\" instead. This setting will be removed in a future version."
+				`);
+			});
 		});
 
 		describe("[r2_buckets]", () => {

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -3780,6 +3780,37 @@ describe("normalizeAndValidateConfig()", () => {
 					  - "queues.consumers[3]" should, optionally, have a number "max_concurrency" field but got {"queue":"myQueue","max_batch_size":"3","max_batch_timeout":null,"max_retries":"hello","dead_letter_queue":5,"max_concurrency":"hello"}."
 				`);
 			});
+
+			it("should warn if delivery_delay is set on a queue producer", () => {
+				const { config, diagnostics } = normalizeAndValidateConfig(
+					{
+						queues: {
+							producers: [
+								{ binding: "QUEUE_BINDING_1", queue: "queue1" },
+								{
+									binding: "QUEUE_BINDING_2",
+									queue: "queue2",
+									delivery_delay: 60,
+								},
+							],
+						},
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(config.queues.producers).toHaveLength(2);
+				expect(config.queues.producers?.[1]).toEqual(
+					expect.objectContaining({ delivery_delay: 60 })
+				);
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(diagnostics.hasWarnings()).toBe(true);
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - The \\"delivery_delay\\" field in \\"queues.producers[1]\\" is deprecated and has no effect. Queue-level settings should be configured using \\"wrangler queues update\\" instead. This setting will be removed in a future version."
+				`);
+			});
 		});
 
 		describe("[r2_buckets]", () => {

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -3781,7 +3781,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should warn if delivery_delay is set on a queue producer", () => {
+			it("should warn if delivery_delay is set on a queue producer", ({
+				expect,
+			}) => {
 				const { config, diagnostics } = normalizeAndValidateConfig(
 					{
 						queues: {
@@ -3808,7 +3810,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBe(true);
 				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
-					  - The \\"delivery_delay\\" field in \\"queues.producers[1]\\" is deprecated and has no effect. Queue-level settings should be configured using \\"wrangler queues update\\" instead. This setting will be removed in a future version."
+					  - The "delivery_delay" field in "queues.producers[1]" is deprecated and has no effect. Queue-level settings should be configured using "wrangler queues update" instead. This setting will be removed in a future version."
 				`);
 			});
 		});

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -3801,8 +3801,8 @@ describe("normalizeAndValidateConfig()", () => {
 				);
 
 				expect(config.queues.producers).toHaveLength(2);
-				expect(config.queues.producers?.[1]).toEqual(
-					expect.objectContaining({ delivery_delay: 60 })
+				expect(config.queues.producers?.[1]).toMatchObject(
+					{ delivery_delay: 60 }
 				);
 				expect(diagnostics.hasErrors()).toBe(false);
 				expect(diagnostics.hasWarnings()).toBe(true);

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -3801,9 +3801,9 @@ describe("normalizeAndValidateConfig()", () => {
 				);
 
 				expect(config.queues.producers).toHaveLength(2);
-				expect(config.queues.producers?.[1]).toMatchObject(
-					{ delivery_delay: 60 }
-				);
+				expect(config.queues.producers?.[1]).toMatchObject({
+					delivery_delay: 60,
+				});
 				expect(diagnostics.hasErrors()).toBe(false);
 				expect(diagnostics.hasWarnings()).toBe(true);
 				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`


### PR DESCRIPTION
Part of #10286.

The `delivery_delay` setting in `[[queues.producers]]` was silently having no effect since PR #10288 removed the functionality that used it. This PR adds a deprecation warning when the setting is used, informing users that queue-level settings should be configured using `wrangler queues update` instead.

## Changes

- Added deprecation warning in `validateQueueBinding` function when `delivery_delay` is set
- Added test case for the new deprecation warning
- Added changeset for the patch release

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is a deprecation warning that guides users to use `wrangler queues update` instead, which is already documented.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12279">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
