### PR TITLE
[vitest-pool-workers] Fix SELF type for RPC workers

### DIFF
--- a/.changeset/fix-self-type-for-rpc-workers.md
+++ b/.changeset/fix-self-type-for-rpc-workers.md
@@ -1,0 +1,24 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Add `ProvidedWorker` interface to allow typing `SELF` for RPC workers
+
+The `SELF` export in `cloudflare:test` was previously typed as `Fetcher`, which prevented TypeScript from recognizing RPC methods when testing workers that extend `WorkerEntrypoint`.
+
+You can now configure the type of `SELF` via module augmentation:
+
+```ts
+import type MyWorker from "./src/index";
+
+declare module "cloudflare:test" {
+	interface ProvidedWorker {
+		default: typeof MyWorker;
+	}
+}
+
+// Now SELF will have your RPC methods typed:
+const result = await SELF.myRpcMethod("test");
+```
+
+When `ProvidedWorker.default` is not set, `SELF` defaults to `Fetcher` for backward compatibility.


### PR DESCRIPTION
Fixes #9770.

The `SELF` export in `cloudflare:test` was typed as `Fetcher` without a type parameter, which prevented TypeScript from recognizing RPC methods when testing workers that extend `WorkerEntrypoint`.

This PR adds a `ProvidedWorker` interface that users can augment to provide their worker's type, allowing `SELF` to be properly typed as `Service<T>` for RPC-enabled workers:

```ts
import type MyWorker from "./src/index";

declare module "cloudflare:test" {
  interface ProvidedWorker {
    default: typeof MyWorker;
  }
}

// Now SELF will have your RPC methods typed:
const result = await SELF.myRpcMethod("test");
```

When `ProvidedWorker.default` is not set, `SELF` defaults to `Fetcher` for backward compatibility.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: This is a type-only change that doesn't affect runtime behavior. Type checking passes via `pnpm check --filter @cloudflare/vitest-pool-workers`.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [ ] Documentation not necessary because: The type definitions include comprehensive JSDoc comments explaining how to use the new `ProvidedWorker` interface.