### PR TITLE
[vitest-pool-workers] Fix test rerun after subset execution

### DIFF
--- a/.changeset/fix-vitest-pool-rerun.md
+++ b/.changeset/fix-vitest-pool-rerun.md
@@ -1,0 +1,11 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Fix test rerun crash when running all tests after running a subset
+
+When using `isolatedStorage: true` without `singleWorker`, running a subset of tests first
+(e.g., via VSCode or with a file filter) and then running all tests would crash with an
+assertion error. This was because Miniflare instances were only created for test files
+discovered during the initial run. Now, when reusing isolated Miniflare instances, new
+instances are created for any newly discovered test files.


### PR DESCRIPTION
Fixes #11022.

When using `isolatedStorage: true` without `singleWorker`, running a subset of tests first (e.g., via VSCode or with a file filter) and then running all tests would crash with an assertion error:

```
assert(fileMf !== undefined)
```

This was because Miniflare instances were only created for test files discovered during the initial run. When running all tests afterwards, new test files would not have corresponding Miniflare instances in the Map.

This fix modifies `getProjectMiniflare()` to check for newly discovered test files when reusing isolated Miniflare instances, creating new instances as needed.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: This is a race condition bug that's difficult to test automatically - the fix adds defensive handling for newly discovered test files
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Bug fix only, no new features or API changes