### PR TITLE
[wrangler] Decode HTML entities in Early Hints hrefs

### DIFF
--- a/.changeset/decode-early-hints-html-entities.md
+++ b/.changeset/decode-early-hints-html-entities.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/pages-shared": patch
+---
+
+Decode HTML entities in Early Hints href attributes
+
+The automatic Early Hints feature now properly decodes HTML entities (like `&amp;`, `&lt;`, `&#38;`, `&#x26;`) in `<link>` element `href` attributes before constructing the Link header. Previously, URLs containing HTML entities would be passed through literally, causing browsers to fetch the wrong URL and resulting in duplicate resource requests.


### PR DESCRIPTION
Fixes #6527.

The automatic Early Hints feature now properly decodes HTML entities in `<link>` element `href` attributes before constructing the Link header.

Previously, when extracting links for Early Hints, `HTMLRewriter.getAttribute("href")` returned raw attribute values without decoding HTML entities. This meant URLs containing entities like `&amp;` (the correct HTML encoding for `&` in attribute values) were passed through literally.

For example, given:
```html
<link rel="preload" href="/script.js?a=1&amp;b=2" as="script"/>
```

The Link header would contain the literal `&amp;`:
```
Link: </script.js?a=1&amp;b=2>; rel="preload"; as=script
```

This caused browsers to fetch the wrong URL from the Early Hint, then later fetch the correct decoded URL when parsing the HTML, resulting in duplicate resource requests.

#### Changes
- Added `decodeHtmlEntities()` helper function to decode common HTML entities (named, decimal numeric, and hexadecimal numeric)
- Applied decoding to `href` attributes when extracting Early Hints links
- Added comprehensive tests for both the helper function and the integration with Early Hints

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is a bug fix with no user-facing API changes