### PR TITLE
[quick-edit] Add C++20 compatibility fix for Node.js 24

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -61,6 +61,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
+      # Switch to Node 22 for non-npm package deployments because quick-edit
+      # builds native modules (tree-sitter) that are not compatible with
+      # Node 24's C++20 requirement for V8 headers.
+      - name: Switch to Node 22 for non-npm package deployments
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Deploy non-NPM Packages
         id: deploy
         run: |

--- a/.github/workflows/deploy-pages-previews.yml
+++ b/.github/workflows/deploy-pages-previews.yml
@@ -43,9 +43,6 @@ jobs:
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
-        with:
-          # Use Node 24 to test nvm fallback to Node 22 for quick-edit native module compilation
-          node-version: 24
 
       - name: Build tools and libraries
         run: pnpm run build
@@ -63,14 +60,6 @@ jobs:
           echo "VITE_DEVTOOLS_PREVIEW_URL=$url" >> $GITHUB_ENV
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-
-      # Quick Edit requires Node 22 because it builds native modules (tree-sitter)
-      # that are not compatible with Node 24's C++20 requirement for V8 headers
-      - name: Switch to Node 22 for Quick Edit
-        if: contains(github.event.*.labels.*.name, 'preview:quick-edit')
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
 
       - name: Build and Deploy Quick Edit preview
         if: contains(github.event.*.labels.*.name, 'preview:quick-edit')

--- a/packages/quick-edit/setup.sh
+++ b/packages/quick-edit/setup.sh
@@ -1,5 +1,14 @@
 set -eu
 
+# Quick Edit requires Node 22 because it builds native modules (tree-sitter)
+# that are not compatible with Node 24's C++20 requirement for V8 headers.
+NODE_MAJOR_VERSION=$(node -v | cut -d'.' -f1 | tr -d 'v')
+if [ "$NODE_MAJOR_VERSION" != "22" ]; then
+    echo "Error: Quick Edit requires Node.js 22, but found $(node -v)"
+    echo "Please switch to Node 22 before running this script."
+    exit 1
+fi
+
 # The upstream VSCode version (tag) to build from
 VERSION="1.102.1"
 


### PR DESCRIPTION
This PR fixes the quick-edit deployment failure on Node.js 24 caused by native module compilation errors.

## Problem

Node.js 24 requires C++20 for V8 headers. When building quick-edit, the `tree-sitter` native module in VSCode's `vendor/vscode/build/` directory fails to compile with errors like:

```
error: "C++20 or later required."
error: unknown type name 'concept'
error: use of undeclared identifier 'requires'
```

## Solution

This change takes a two-part approach:

1. **`packages/quick-edit/setup.sh`**: Added a Node version check that fails fast with a clear error message if not running on Node 22. This ensures the requirement is enforced regardless of how quick-edit is built.

2. **Workflow updates**: Updated workflows to ensure Node 22 is used when building quick-edit:
   - `changesets.yml`: Added a step to switch to Node 22 before deploying non-npm packages
   - `deploy-pages-previews.yml`: Already uses Node 22 by default (removed testing code)

## Changes

| File | Change |
|------|--------|
| `packages/quick-edit/setup.sh` | Added Node 22 version check that fails fast |
| `.github/workflows/changesets.yml` | Added setup-node step to switch to Node 22 before deployments |
| `.github/workflows/deploy-pages-previews.yml` | Removed Node 24 testing code, uses default Node 22 |

## Testing

To test this fix:
1. Add the `preview:quick-edit` label to this PR
2. The deploy-pages-previews workflow will run with Node 22 (the default)
3. Monitor the workflow to verify quick-edit builds successfully

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: This fix will be validated by the preview workflow when the `preview:quick-edit` label is added
- Public documentation
  - [x] Documentation not necessary because: Internal CI/build fix only
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12287">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
