### PR TITLE
Add `versionCommand` to the `autoconfig_summary` field in the autoconfig output entry

### DIFF
--- a/.changeset/cyan-bugs-hunt.md
+++ b/.changeset/cyan-bugs-hunt.md
@@ -1,0 +1,15 @@
+---
+"wrangler": patch
+---
+
+Add `versionCommand` to the `autoconfig_summary` field in the autoconfig output entry
+
+Add the version upload command to the output being printed by `wrangler deploy` to `WRANGLER_OUTPUT_FILE_DIRECTORY`/`WRANGLER_OUTPUT_FILE_PATH`. This complements the existing `buildCommand` and `deployCommand` fields and allows CI systems to know how to upload new versions of Workers.
+
+For example, for a standard npm project this would be:
+
+- Version command: `npx wrangler versions upload`
+
+While for a Next.js project it would be:
+
+- Version command: `npx @opennextjs/cloudflare upload`

--- a/packages/wrangler/src/__tests__/autoconfig/run-summary.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/run-summary.test.ts
@@ -36,6 +36,7 @@ describe("autoconfig run - buildOperationsSummary()", () => {
 				{
 					build: "npm run build",
 					deploy: "npx wrangler deploy",
+					version: "npx wrangler versions upload",
 				}
 			);
 
@@ -60,6 +61,7 @@ describe("autoconfig run - buildOperationsSummary()", () => {
 				  "frameworkId": undefined,
 				  "outputDir": "public",
 				  "scripts": Object {},
+				  "versionCommand": "npx wrangler versions upload",
 				  "wranglerConfig": Object {
 				    "$schema": "node_modules/wrangler/config-schema.json",
 				    "compatibility_date": "2025-01-01",
@@ -89,6 +91,7 @@ describe("autoconfig run - buildOperationsSummary()", () => {
 				{
 					build: "npm run build",
 					deploy: "npx wrangler deploy",
+					version: "npx wrangler versions upload",
 				}
 			);
 
@@ -109,6 +112,7 @@ describe("autoconfig run - buildOperationsSummary()", () => {
 				    "deploy": "wrangler deploy",
 				    "preview": "wrangler dev",
 				  },
+				  "versionCommand": "npx wrangler versions upload",
 				  "wranglerConfig": Object {
 				    "$schema": "node_modules/wrangler/config-schema.json",
 				    "compatibility_date": "2025-01-01",
@@ -140,6 +144,7 @@ describe("autoconfig run - buildOperationsSummary()", () => {
 				{
 					build: "npm run build",
 					deploy: "npx wrangler deploy",
+					version: "npx wrangler versions upload",
 				}
 			);
 
@@ -160,6 +165,7 @@ describe("autoconfig run - buildOperationsSummary()", () => {
 				    "deploy": "wrangler deploy",
 				    "preview": "wrangler dev",
 				  },
+				  "versionCommand": "npx wrangler versions upload",
 				  "wranglerConfig": Object {
 				    "$schema": "node_modules/wrangler/config-schema.json",
 				    "compatibility_date": "2025-01-01",

--- a/packages/wrangler/src/__tests__/setup.test.ts
+++ b/packages/wrangler/src/__tests__/setup.test.ts
@@ -169,6 +169,7 @@ describe("wrangler setup", () => {
 			    "deploy": "wrangler deploy",
 			    "preview": "wrangler dev",
 			  },
+			  "versionCommand": "npx wrangler versions upload",
 			  "wranglerConfig": Object {
 			    "$schema": "node_modules/wrangler/config-schema.json",
 			    "assets": Object {

--- a/packages/wrangler/src/autoconfig/frameworks/index.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/index.ts
@@ -23,6 +23,8 @@ export type ConfigurationResults = {
 	buildCommandOverride?: string;
 	// Deploy command to override the standard one (`npx wrangler deploy`)
 	deployCommandOverride?: string;
+	// Version command to override the standard one (`npx wrangler versions upload`)
+	versionCommandOverride?: string;
 };
 
 export abstract class Framework {

--- a/packages/wrangler/src/autoconfig/frameworks/next.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/next.ts
@@ -54,6 +54,7 @@ export class NextJs extends Framework {
 			},
 			buildCommandOverride: `${npx} @opennextjs/cloudflare build`,
 			deployCommandOverride: `${npx} @opennextjs/cloudflare deploy`,
+			versionCommandOverride: `${npx} @opennextjs/cloudflare upload`,
 		};
 	}
 

--- a/packages/wrangler/src/autoconfig/run.ts
+++ b/packages/wrangler/src/autoconfig/run.ts
@@ -124,6 +124,9 @@ export async function runAutoConfig(
 			deploy:
 				dryRunConfigurationResults?.deployCommandOverride ??
 				`${npx} wrangler deploy`,
+			version:
+				dryRunConfigurationResults?.versionCommandOverride ??
+				`${npx} wrangler versions upload`,
 		},
 		dryRunConfigurationResults?.packageJsonScriptsOverrides
 	);
@@ -283,6 +286,7 @@ export async function buildOperationsSummary(
 	projectCommands: {
 		build?: string;
 		deploy: string;
+		version?: string;
 	},
 	packageJsonScriptsOverrides?: PackageJsonScriptsOverrides
 ): Promise<AutoConfigSummary> {
@@ -296,6 +300,7 @@ export async function buildOperationsSummary(
 		frameworkId: autoConfigDetails.framework?.id,
 		buildCommand: projectCommands.build,
 		deployCommand: projectCommands.deploy,
+		versionCommand: projectCommands.version,
 	};
 
 	if (autoConfigDetails.packageJson) {

--- a/packages/wrangler/src/autoconfig/types.ts
+++ b/packages/wrangler/src/autoconfig/types.ts
@@ -48,4 +48,5 @@ export type AutoConfigSummary = {
 	frameworkId?: string;
 	buildCommand?: string;
 	deployCommand?: string;
+	versionCommand?: string;
 };


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-2441

This PR adds the version upload command to the output being printed by `wrangler deploy` to `WRANGLER_OUTPUT_FILE_DIRECTORY`/`WRANGLER_OUTPUT_FILE_PATH`. This complements the existing `buildCommand` and `deployCommand` fields and allows CI systems to know how to upload new versions of Workers.

For example, for a standard npm project this would be:

- Version command: `npx wrangler versions upload`

While for a Next.js project it would be:

- Version command: `npx @opennextjs/cloudflare upload`


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is mostly for internal usage

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12292">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
