### PR TITLE
Fix flaky workflow-multiple fixture test

### DIFF
--- a/fixtures/workflow-multiple/tests/index.test.ts
+++ b/fixtures/workflow-multiple/tests/index.test.ts
@@ -42,53 +42,17 @@ describe("Workflows", () => {
 	}
 
 	it("creates two instances with same id in two different workflows", async () => {
-		const createResult = {
-			id: "test",
-			status: {
-				status: "running",
-				__LOCAL_DEV_STEP_OUTPUTS: [],
-				output: null,
-			},
-		};
-
+		// Create both workflow instances
+		// Note: We don't assert the intermediate "running" status because the workflow
+		// may complete before we can observe it, causing flaky tests on fast CI machines
 		await Promise.all([
-			expect(
-				fetchJson(`http://${ip}:${port}/create?workflowName=1&id=test`)
-			).resolves.toStrictEqual(createResult),
-			expect(
-				fetchJson(`http://${ip}:${port}/create?workflowName=2&id=test`)
-			).resolves.toStrictEqual(createResult),
+			fetchJson(`http://${ip}:${port}/create?workflowName=1&id=test`),
+			fetchJson(`http://${ip}:${port}/create?workflowName=2&id=test`),
 		]);
 
-		const firstResult = {
-			id: "test",
-			status: {
-				status: "running",
-				__LOCAL_DEV_STEP_OUTPUTS: [{ output: "First step result" }],
-				output: null,
-			},
-		};
+		// Wait for both workflows to complete with their final outputs
 		await Promise.all([
 			vi.waitFor(
-				async () => {
-					await expect(
-						fetchJson(`http://${ip}:${port}/status?workflowName=1&id=test`)
-					).resolves.toStrictEqual(firstResult);
-				},
-				{ timeout: 5000 }
-			),
-			vi.waitFor(
-				async () => {
-					await expect(
-						fetchJson(`http://${ip}:${port}/status?workflowName=2&id=test`)
-					).resolves.toStrictEqual(firstResult);
-				},
-				{ timeout: 5000 }
-			),
-		]);
-
-		await Promise.all([
-			await vi.waitFor(
 				async () => {
 					await expect(
 						fetchJson(`http://${ip}:${port}/status?workflowName=1&id=test`)
@@ -104,9 +68,9 @@ describe("Workflows", () => {
 						},
 					});
 				},
-				{ timeout: 5000 }
+				{ timeout: 10000 }
 			),
-			await vi.waitFor(
+			vi.waitFor(
 				async () => {
 					await expect(
 						fetchJson(`http://${ip}:${port}/status?workflowName=2&id=test`)
@@ -122,7 +86,7 @@ describe("Workflows", () => {
 						},
 					});
 				},
-				{ timeout: 5000 }
+				{ timeout: 10000 }
 			),
 		]);
 	});


### PR DESCRIPTION
This PR fixes the flaky `@fixture/workflow-multiple:test:ci` test.

## Problem

The test was flaky because it expected to observe intermediate "running" states immediately after creating workflow instances. On fast CI machines, workflows would complete before the test could verify these intermediate states.

The test had assertions for:
1. Initial state after `/create` (status: "running", empty outputs)
2. Intermediate state after first step (status: "running", one output)
3. Final state (status: "complete", all outputs)

But workflows could progress or complete before the test could catch states 1 and 2.

## Solution

- Remove assertions for intermediate states - just call `/create` without asserting the response
- Only verify the final "complete" state using `vi.waitFor()` to poll until workflows complete
- Increase timeout from 5000ms to 10000ms to allow more time for workflows to complete on slower CI environments
- Fix redundant `await await` pattern in the original code

The test now reliably verifies that:
- Two workflow instances with the same ID can be created in different workflows
- Each workflow completes with the correct final output

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: This PR fixes test flakiness; the test itself validates the fix
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Internal test fix only
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12297">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
