### PR TITLE
[ci] Allow Claude GitHub Action to run pnpm check and tests

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,8 +29,29 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: "Bash(pnpm check),Bash(pnpm test:ci*)"
+          custom_instructions: |
+            When running tests, ALWAYS use the --filter flag to run tests for a specific package only.
+            Never run `pnpm test:ci` without a filter - this would run tests across the entire monorepo and take too long.
+
+            Correct usage: `pnpm test:ci --filter <package-name>`
+            Example: `pnpm test:ci --filter wrangler`
+
+            You can also run a specific test by pattern: `pnpm test:ci --filter <package-name> "test pattern"`


### PR DESCRIPTION
Updates the Claude GitHub Action workflow to:
- Set up pnpm and Node.js with caching
- Install dependencies
- Allow Claude to run `pnpm check` and `pnpm test:ci --filter <package>`
- Add custom instructions to ensure tests are always run with `--filter` to avoid running the entire monorepo's test suite

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: CI workflow configuration change

- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Internal CI tooling change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12302">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
