### PR TITLE
chore: changesets can optionally use conventional commit prefixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,5 +130,5 @@ Every change to package code requires a changeset or it will not trigger a relea
 
 **Changeset Format:**
 
-The changeset descriptions can either use conventional commit prefixes (e.g., `fix:`, `feat:`) or
-start with a capital letter and describe the change directly (e.g., "Remove unused option" not "fix: remove unused option").
+The changeset descriptions can either use conventional commit prefixes (e.g., "fix: remove unused option") or
+start with a capital letter and describe the change directly (e.g., "Remove unused option" not").


### PR DESCRIPTION
We should optionally allow cc prefixes.

Discusses [here internally](https://chat.google.com/room/AAAAukxNOBI/SNshSqj7eDE/SNshSqj7eDE?cls=10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12303">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
