### PR TITLE
refactor: move `isAuthenticationError` together with similar predicates

### DIFF
--- a/packages/wrangler/src/core/handle-errors.ts
+++ b/packages/wrangler/src/core/handle-errors.ts
@@ -14,7 +14,6 @@ import dedent from "ts-dedent";
 import { createCLIParser } from "..";
 import { renderError } from "../cfetch";
 import { readConfig } from "../config";
-import { isAuthenticationError } from "../deploy/deploy";
 import {
 	isBuildFailure,
 	isBuildFailureFromCause,
@@ -257,6 +256,13 @@ function isContainersAuthenticationError(e: unknown): e is UserError {
 		e.cause instanceof ApiError &&
 		e.cause.status === 403
 	);
+}
+
+/**
+ * @returns whether `e` is a standard Cloudflare API authentication error
+ */
+export function isAuthenticationError(e: unknown): e is ParseError {
+	return e instanceof ParseError && (e as { code?: number }).code === 10000;
 }
 
 /**

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -11,7 +11,6 @@ import {
 	formatCompatibilityDate,
 	formatConfigSnippet,
 	getDockerPath,
-	ParseError,
 	parseNonHyphenedUuid,
 	UserError,
 } from "@cloudflare/workers-utils";
@@ -22,6 +21,7 @@ import { fetchListResult, fetchResult } from "../cfetch";
 import { buildContainer } from "../containers/build";
 import { getNormalizedContainerOptions } from "../containers/config";
 import { deployContainers } from "../containers/deploy";
+import { isAuthenticationError } from "../core/handle-errors";
 import { getBindings, provisionBindings } from "../deployment-bundle/bindings";
 import { bundleWorker } from "../deployment-bundle/bundle";
 import { printBundleSize } from "../deployment-bundle/bundle-reporter";
@@ -1392,11 +1392,6 @@ async function publishRoutesFallback(
 	}
 
 	return deployedRoutes;
-}
-
-export function isAuthenticationError(e: unknown): e is ParseError {
-	// TODO: don't want to report these
-	return e instanceof ParseError && (e as { code?: number }).code === 10000;
 }
 
 export async function updateQueueConsumers(

--- a/packages/wrangler/src/user/whoami.ts
+++ b/packages/wrangler/src/user/whoami.ts
@@ -1,7 +1,7 @@
 import { getCloudflareComplianceRegion } from "@cloudflare/workers-utils";
 import chalk from "chalk";
 import { fetchPagedListResult, fetchResult } from "../cfetch";
-import { isAuthenticationError } from "../deploy/deploy";
+import { isAuthenticationError } from "../core/handle-errors";
 import { logger } from "../logger";
 import { formatMessage } from "../utils/format-message";
 import { fetchMembershipRoles } from "./membership";


### PR DESCRIPTION


Fixes https://github.com/cloudflare/workers-sdk/issues/12132 (together with the previous https://github.com/cloudflare/workers-sdk/pull/12298)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: already covered
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: refactor, not a user facing change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12304">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
