### PR TITLE
Skip vitest pool tests on windows

### DIFF
--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -133,6 +133,8 @@ jobs:
         # We are running the package tests first be able to get early feedback on changes.
         # There is no point in running the fixtures if a package is broken.
         if: steps.changes.outputs.everything_but_markdown == 'true'
+        # We skip @cloudflare/vitest-pool-workers tests in CI on Windows because they're very flaky. We still run the vitest-pool-workers-examples fixture, which is a comprehensive set of example tests and gives us a lot of confidence.
+        # The @cloudflare/vitest-pool-workers tests skipped are things like watch mode, which constantly times out probably due to the github runners in use.
         run: pnpm run test:ci --log-order=stream --concurrency=1 --filter="./packages/*" ${{ matrix.os == 'windows-latest' && '--filter="!./packages/vitest-pool-workers"' || '' }}
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"


### PR DESCRIPTION
Justification—they're flaky and are currently costing us more in lost productivity than in extra confidence. We still run the vitest-pool-workers-examples tests in CI, which is a comprehensive set of example tests. The tests skipped in this PR are things like watch mode, which constantly times out, probably due to the github runners in use.

e.g. https://github.com/cloudflare/workers-sdk/actions/runs/21517879577/job/62000792095?pr=12280
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12305">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
