### PR TITLE
Use vitest#expect from the local context

### DIFF
--- a/packages/containers-shared/eslint.config.mjs
+++ b/packages/containers-shared/eslint.config.mjs
@@ -2,4 +2,13 @@ import sharedConfig from "@cloudflare/eslint-config-shared";
 import { defineConfig, globalIgnores } from "eslint/config";
 
 // src/client/** is a generated client that we shouldn't lint
-export default defineConfig(globalIgnores(["src/client/**"]), sharedConfig);
+export default defineConfig([
+	globalIgnores(["src/client/**"]),
+	sharedConfig,
+	{
+		files: ["tests/**/*.test.ts"],
+		rules: {
+			"workers-sdk/no-vitest-import-expect": "error",
+		},
+	},
+]);

--- a/packages/containers-shared/tests/docker-context.test.ts
+++ b/packages/containers-shared/tests/docker-context.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { UserError } from "@cloudflare/workers-utils";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, it, vi } from "vitest";
 import { resolveDockerHost } from "../src/utils";
 
 vi.mock("node:child_process");
@@ -13,7 +13,7 @@ describe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
 			vi.unstubAllEnvs();
 		});
 
-		it("should return WRANGLER_DOCKER_HOST when set", async () => {
+		it("should return WRANGLER_DOCKER_HOST when set", async ({ expect }) => {
 			vi.stubEnv(
 				"WRANGLER_DOCKER_HOST",
 				"unix:///FROM/WRANGLER/DOCKER/HOST/wrangler/socket"
@@ -24,7 +24,9 @@ describe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
 			expect(result).toBe("unix:///FROM/WRANGLER/DOCKER/HOST/wrangler/socket");
 		});
 
-		it("should return DOCKER_HOST when WRANGLER_DOCKER_HOST is not set", async () => {
+		it("should return DOCKER_HOST when WRANGLER_DOCKER_HOST is not set", async ({
+			expect,
+		}) => {
 			vi.stubEnv("WRANGLER_DOCKER_HOST", undefined);
 			vi.stubEnv("DOCKER_HOST", "unix:///FROM/DOCKER/HOST/docker/socket");
 
@@ -32,7 +34,9 @@ describe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
 			expect(result).toBe("unix:///FROM/DOCKER/HOST/docker/socket");
 		});
 
-		it("should use Docker context when no env vars are set", async () => {
+		it("should use Docker context when no env vars are set", async ({
+			expect,
+		}) => {
 			vi.mocked(execFileSync)
 				.mockReturnValue(`{"Current":true,"Description":"Current DOCKER_HOST based configuration","DockerEndpoint":"unix:///FROM/CURRENT/CONTEXT/run/docker.sock","Error":"","Name":"default"}
 {"Current":false,"Description":"Docker Desktop","DockerEndpoint":"unix:///FROM/OTHER/CONTEXT/run/docker.sock","Error":"","Name":"desktop-linux"}`);
@@ -40,7 +44,9 @@ describe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
 			expect(result).toBe("unix:///FROM/CURRENT/CONTEXT/run/docker.sock");
 		});
 
-		it("should fall back to platform default when context fails", () => {
+		it("should fall back to platform default when context fails", ({
+			expect,
+		}) => {
 			vi.mocked(execFileSync).mockImplementation(() => {
 				throw new UserError("Docker command failed");
 			});

--- a/packages/containers-shared/tests/knobs.test.ts
+++ b/packages/containers-shared/tests/knobs.test.ts
@@ -1,14 +1,14 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, it, vi } from "vitest";
 import { getCloudflareContainerRegistry } from "./../src/knobs";
 
 describe("getCloudflareContainerRegistry", () => {
-	it("should return the managed registry", () => {
+	it("should return the managed registry", ({ expect }) => {
 		expect(getCloudflareContainerRegistry()).toBe("registry.cloudflare.com");
 		vi.stubEnv("WRANGLER_API_ENVIRONMENT", "production");
 		expect(getCloudflareContainerRegistry()).toBe("registry.cloudflare.com");
 	});
 
-	it("should return the staging registry", () => {
+	it("should return the staging registry", ({ expect }) => {
 		vi.stubEnv("WRANGLER_API_ENVIRONMENT", "staging");
 		expect(getCloudflareContainerRegistry()).toBe(
 			"staging.registry.cloudflare.com"

--- a/packages/containers-shared/tests/utils.test.ts
+++ b/packages/containers-shared/tests/utils.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, it, vi } from "vitest";
 import { checkExposedPorts } from "./../src/utils";
 import type { ContainerDevOptions } from "../src/types";
 
@@ -21,14 +21,16 @@ describe("checkExposedPorts", () => {
 		docketImageInspectResult = "1";
 	});
 
-	it("should not error when some ports are exported", async () => {
+	it("should not error when some ports are exported", async ({ expect }) => {
 		docketImageInspectResult = "1";
 		await expect(
 			checkExposedPorts("docker", containerConfig)
 		).resolves.toBeUndefined();
 	});
 
-	it("should error, with an appropriate message when no ports are exported", async () => {
+	it("should error, with an appropriate message when no ports are exported", async ({
+		expect,
+	}) => {
 		docketImageInspectResult = "0";
 		await expect(checkExposedPorts("docker", containerConfig)).rejects
 			.toThrowErrorMatchingInlineSnapshot(`

--- a/packages/edge-preview-authenticated-proxy/eslint.config.mjs
+++ b/packages/edge-preview-authenticated-proxy/eslint.config.mjs
@@ -1,4 +1,12 @@
 import sharedConfig from "@cloudflare/eslint-config-shared";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig(sharedConfig);
+export default defineConfig([
+	sharedConfig,
+	{
+		files: ["tests/**/*.test.ts"],
+		rules: {
+			"workers-sdk/no-vitest-import-expect": "error",
+		},
+	},
+]);

--- a/packages/edge-preview-authenticated-proxy/tests/index.test.ts
+++ b/packages/edge-preview-authenticated-proxy/tests/index.test.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { unstable_dev } from "wrangler";
 import type { Unstable_DevWorker } from "wrangler";

--- a/packages/playground-preview-worker/eslint.config.mjs
+++ b/packages/playground-preview-worker/eslint.config.mjs
@@ -1,4 +1,12 @@
 import sharedConfig from "@cloudflare/eslint-config-shared";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig(sharedConfig);
+export default defineConfig([
+	sharedConfig,
+	{
+		files: ["tests/**/*.test.ts"],
+		rules: {
+			"workers-sdk/no-vitest-import-expect": "error",
+		},
+	},
+]);

--- a/packages/playground-preview-worker/tests/index.test.ts
+++ b/packages/playground-preview-worker/tests/index.test.ts
@@ -1,4 +1,5 @@
 import { fetch } from "undici";
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
 import { beforeAll, describe, expect, it } from "vitest";
 
 const REMOTE = "https://playground-testing.devprod.cloudflare.dev";

--- a/packages/vitest-pool-workers/eslint.config.mjs
+++ b/packages/vitest-pool-workers/eslint.config.mjs
@@ -34,4 +34,10 @@ export default defineConfig([
 			},
 		},
 	},
+	{
+		files: ["test/**/*.test.ts"],
+		rules: {
+			"workers-sdk/no-vitest-import-expect": "error",
+		},
+	},
 ]);

--- a/packages/vitest-pool-workers/test/compatibility-flag-assertions.test.ts
+++ b/packages/vitest-pool-workers/test/compatibility-flag-assertions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import { CompatibilityFlagAssertions } from "../src/pool/compatibility-flag-assertions";
 
 describe("FlagAssertions", () => {
@@ -7,7 +7,7 @@ describe("FlagAssertions", () => {
 		relativeProjectPath: "/path/to/project",
 	};
 	describe("assertDisableFlagNotPresent", () => {
-		it("returns error message when the flag is present", () => {
+		it("returns error message when the flag is present", ({ expect }) => {
 			const options = {
 				...baseOptions,
 				compatibilityFlags: ["disable-flag", "another-flag"],
@@ -23,7 +23,9 @@ describe("FlagAssertions", () => {
 			);
 		});
 
-		it("includes relativeWranglerConfigPath in error message when provided", () => {
+		it("includes relativeWranglerConfigPath in error message when provided", ({
+			expect,
+		}) => {
 			const options = {
 				...baseOptions,
 				compatibilityFlags: ["disable-flag"],
@@ -39,7 +41,9 @@ describe("FlagAssertions", () => {
 			);
 		});
 
-		it("correctly formats error message when relative Wrangler configPath is present", () => {
+		it("correctly formats error message when relative Wrangler configPath is present", ({
+			expect,
+		}) => {
 			const options = {
 				...baseOptions,
 				compatibilityFlags: ["disable-flag"],
@@ -58,7 +62,7 @@ describe("FlagAssertions", () => {
 	});
 
 	describe("assertEnableFlagOrCompatibilityDate", () => {
-		it("returns true when the flag is present", () => {
+		it("returns true when the flag is present", ({ expect }) => {
 			const options = {
 				...baseOptions,
 				compatibilityDate: "2022-12-31",
@@ -73,7 +77,7 @@ describe("FlagAssertions", () => {
 			expect(result.isValid).toBe(true);
 		});
 
-		it("returns true when compatibility date is sufficient", () => {
+		it("returns true when compatibility date is sufficient", ({ expect }) => {
 			const options = {
 				...baseOptions,
 				compatibilityDate: "2023-01-02",
@@ -88,7 +92,9 @@ describe("FlagAssertions", () => {
 			expect(result.isValid).toBe(true);
 		});
 
-		it("returns error message when neither flag is present nor date is sufficient", () => {
+		it("returns error message when neither flag is present nor date is sufficient", ({
+			expect,
+		}) => {
 			const options = {
 				...baseOptions,
 				compatibilityDate: "2022-12-31",
@@ -106,7 +112,9 @@ describe("FlagAssertions", () => {
 			);
 		});
 
-		it("returns error message when compatibilityDate is undefined", () => {
+		it("returns error message when compatibilityDate is undefined", ({
+			expect,
+		}) => {
 			const options = {
 				...baseOptions,
 				compatibilityDate: undefined,
@@ -124,7 +132,7 @@ describe("FlagAssertions", () => {
 			);
 		});
 
-		it("throws error when defaultOnDate is invalid", () => {
+		it("throws error when defaultOnDate is invalid", ({ expect }) => {
 			const options = {
 				...baseOptions,
 				compatibilityDate: "2023-01-02",
@@ -140,7 +148,7 @@ describe("FlagAssertions", () => {
 			}).toThrowError('Invalid date format: "invalid-date"');
 		});
 
-		it("throws error when compatibilityDate is invalid", () => {
+		it("throws error when compatibilityDate is invalid", ({ expect }) => {
 			const options = {
 				...baseOptions,
 				compatibilityDate: "invalid-date",
@@ -158,7 +166,9 @@ describe("FlagAssertions", () => {
 	});
 
 	describe("assertAtLeastOneFlagExists", () => {
-		it("returns true when at least one of the flags is present", () => {
+		it("returns true when at least one of the flags is present", ({
+			expect,
+		}) => {
 			const options = {
 				...baseOptions,
 				compatibilityDate: "2020-01-01",
@@ -169,7 +179,7 @@ describe("FlagAssertions", () => {
 			expect(result.isValid).toBe(true);
 		});
 
-		it("returns true when multiple flags are present", () => {
+		it("returns true when multiple flags are present", ({ expect }) => {
 			const options = {
 				...baseOptions,
 				compatibilityDate: "2020-01-01",
@@ -183,7 +193,7 @@ describe("FlagAssertions", () => {
 			expect(result.isValid).toBe(true);
 		});
 
-		it("returns false when none of the flags are present", () => {
+		it("returns false when none of the flags are present", ({ expect }) => {
 			const options = {
 				...baseOptions,
 				compatibilityDate: "2020-01-01",
@@ -200,7 +210,9 @@ describe("FlagAssertions", () => {
 			);
 		});
 
-		it("includes relativeWranglerConfigPath in error message when provided", () => {
+		it("includes relativeWranglerConfigPath in error message when provided", ({
+			expect,
+		}) => {
 			const options = {
 				...baseOptions,
 				compatibilityDate: "2020-01-01",
@@ -218,7 +230,7 @@ describe("FlagAssertions", () => {
 			);
 		});
 
-		it("returns true when all flags are present", () => {
+		it("returns true when all flags are present", ({ expect }) => {
 			const options = {
 				...baseOptions,
 				compatibilityDate: "2020-01-01",
@@ -233,7 +245,7 @@ describe("FlagAssertions", () => {
 			expect(result.isValid).toBe(true);
 		});
 
-		it("returns false when compatibilityFlags is empty", () => {
+		it("returns false when compatibilityFlags is empty", ({ expect }) => {
 			const options = {
 				...baseOptions,
 				compatibilityDate: "2020-01-01",
@@ -250,7 +262,7 @@ describe("FlagAssertions", () => {
 			);
 		});
 
-		it("returns true when flags array is empty", () => {
+		it("returns true when flags array is empty", ({ expect }) => {
 			const options = {
 				...baseOptions,
 				compatibilityDate: "2020-01-01",

--- a/packages/workers-shared/asset-worker/tests/assets-manifest.test.ts
+++ b/packages/workers-shared/asset-worker/tests/assets-manifest.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
 import { describe, expect, it } from "vitest";
 import {
 	CONTENT_HASH_OFFSET,

--- a/packages/workers-shared/asset-worker/tests/compatibility-flags.test.ts
+++ b/packages/workers-shared/asset-worker/tests/compatibility-flags.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
 import { describe, expect, test } from "vitest";
 import { resolveCompatibilityOptions } from "../src/compatibility-flags";
 

--- a/packages/workers-shared/asset-worker/tests/handler.test.ts
+++ b/packages/workers-shared/asset-worker/tests/handler.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
 import { describe, expect, it, vi } from "vitest";
 import { mockJaegerBinding } from "../../utils/tracing";
 import { Analytics } from "../src/analytics";

--- a/packages/workers-shared/asset-worker/tests/kv.test.ts
+++ b/packages/workers-shared/asset-worker/tests/kv.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getAssetWithMetadataFromKV } from "../src/utils/kv";
 import type { AssetMetadata } from "../src/utils/kv";

--- a/packages/workers-shared/asset-worker/tests/rules-engine.test.ts
+++ b/packages/workers-shared/asset-worker/tests/rules-engine.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
 import { describe, expect, test } from "vitest";
 import {
 	generateRulesMatcher,

--- a/packages/workers-shared/eslint.config.mjs
+++ b/packages/workers-shared/eslint.config.mjs
@@ -1,4 +1,12 @@
 import sharedConfig from "@cloudflare/eslint-config-shared";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig(sharedConfig);
+export default defineConfig([
+	sharedConfig,
+	{
+		files: ["**/tests/**/*.test.ts"],
+		rules: {
+			"workers-sdk/no-vitest-import-expect": "error",
+		},
+	},
+]);

--- a/packages/workers-shared/router-worker/tests/index.test.ts
+++ b/packages/workers-shared/router-worker/tests/index.test.ts
@@ -1,4 +1,5 @@
 import { createExecutionContext } from "cloudflare:test";
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
 import { describe, expect, it } from "vitest";
 import worker from "../src/worker";
 import type { Env } from "../src/worker";

--- a/packages/workers-shared/utils/tests/helpers.test.ts
+++ b/packages/workers-shared/utils/tests/helpers.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
 import { describe, expect, it } from "vitest";
 import { createAssetsIgnoreFunction, getContentType } from "../helpers";
 

--- a/packages/workers-shared/utils/tests/parseHeaders.invalid.test.ts
+++ b/packages/workers-shared/utils/tests/parseHeaders.invalid.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
 import { expect, test } from "vitest";
 import { parseHeaders } from "../configuration/parseHeaders";
 

--- a/packages/workers-shared/utils/tests/parseHeaders.valid.test.ts
+++ b/packages/workers-shared/utils/tests/parseHeaders.valid.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
 import { expect, test } from "vitest";
 import { parseHeaders } from "../configuration/parseHeaders";
 

--- a/packages/workers-shared/utils/tests/parseRedirects.invalid.test.ts
+++ b/packages/workers-shared/utils/tests/parseRedirects.invalid.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
 import { expect, test } from "vitest";
 import { parseRedirects } from "../configuration/parseRedirects";
 

--- a/packages/workers-shared/utils/tests/parseRedirects.valid.test.ts
+++ b/packages/workers-shared/utils/tests/parseRedirects.valid.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
 import { expect, test } from "vitest";
 import { parseRedirects } from "../configuration/parseRedirects";
 

--- a/packages/workers-shared/utils/tests/parseStaticRouting.test.ts
+++ b/packages/workers-shared/utils/tests/parseStaticRouting.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
 import { describe, expect, it } from "vitest";
 import { parseStaticRouting } from "../configuration/parseStaticRouting";
 

--- a/packages/workers-utils/eslint.config.mjs
+++ b/packages/workers-utils/eslint.config.mjs
@@ -26,4 +26,10 @@ export default defineConfig([
 			],
 		},
 	},
+	{
+		files: ["**/*.test.ts"],
+		rules: {
+			"workers-sdk/no-vitest-import-expect": "error",
+		},
+	},
 ]);

--- a/packages/workers-utils/tests/compatibility-date.test.ts
+++ b/packages/workers-utils/tests/compatibility-date.test.ts
@@ -1,6 +1,6 @@
 import module from "node:module";
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, it, vi } from "vitest";
 import { getLocalWorkerdCompatibilityDate } from "../src/compatibility-date";
 
 describe("getLocalWorkerdCompatibilityDate", () => {
@@ -8,7 +8,9 @@ describe("getLocalWorkerdCompatibilityDate", () => {
 		vi.setSystemTime(vi.getRealSystemTime());
 	});
 
-	it("should successfully get the local latest compatibility date from the local workerd instance", () => {
+	it("should successfully get the local latest compatibility date from the local workerd instance", ({
+		expect,
+	}) => {
 		const createRequireSpy = vi
 			.spyOn(module, "createRequire")
 			.mockImplementation(() => {
@@ -32,7 +34,9 @@ describe("getLocalWorkerdCompatibilityDate", () => {
 		);
 	});
 
-	it("should fallback to the fallback date if it fails to get the date from a local workerd instance", () => {
+	it("should fallback to the fallback date if it fails to get the date from a local workerd instance", ({
+		expect,
+	}) => {
 		const createRequireSpy = vi
 			.spyOn(module, "createRequire")
 			.mockImplementation(
@@ -52,7 +56,9 @@ describe("getLocalWorkerdCompatibilityDate", () => {
 		);
 	});
 
-	it("should use today's date if the local workerd's date is in the future", async () => {
+	it("should use today's date if the local workerd's date is in the future", async ({
+		expect,
+	}) => {
 		vi.setSystemTime("2025-01-09T23:59:59.999Z");
 		vi.spyOn(module, "createRequire").mockImplementation(() => {
 			const mockedRequire = ((pkg: string) => {

--- a/packages/workers-utils/tests/config/config-format.test.ts
+++ b/packages/workers-utils/tests/config/config-format.test.ts
@@ -1,23 +1,23 @@
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import { configFileName, configFormat } from "../../src/config";
 
 describe("configFormat", () => {
-	it("returns 'toml' for .toml files", () => {
+	it("returns 'toml' for .toml files", ({ expect }) => {
 		expect(configFormat("wrangler.toml")).toBe("toml");
 		expect(configFormat("/path/to/wrangler.toml")).toBe("toml");
 	});
 
-	it("returns 'json' for .json files", () => {
+	it("returns 'json' for .json files", ({ expect }) => {
 		expect(configFormat("wrangler.json")).toBe("json");
 		expect(configFormat("/path/to/wrangler.json")).toBe("json");
 	});
 
-	it("returns 'jsonc' for .jsonc files", () => {
+	it("returns 'jsonc' for .jsonc files", ({ expect }) => {
 		expect(configFormat("wrangler.jsonc")).toBe("jsonc");
 		expect(configFormat("/path/to/wrangler.jsonc")).toBe("jsonc");
 	});
 
-	it("returns 'none' for unknown formats", () => {
+	it("returns 'none' for unknown formats", ({ expect }) => {
 		expect(configFormat("wrangler.yaml")).toBe("none");
 		expect(configFormat("wrangler.yml")).toBe("none");
 		expect(configFormat(undefined)).toBe("none");
@@ -25,22 +25,22 @@ describe("configFormat", () => {
 });
 
 describe("configFileName", () => {
-	it("returns 'wrangler.toml' for .toml config paths", () => {
+	it("returns 'wrangler.toml' for .toml config paths", ({ expect }) => {
 		expect(configFileName("wrangler.toml")).toBe("wrangler.toml");
 		expect(configFileName("/path/to/wrangler.toml")).toBe("wrangler.toml");
 	});
 
-	it("returns 'wrangler.json' for .json config paths", () => {
+	it("returns 'wrangler.json' for .json config paths", ({ expect }) => {
 		expect(configFileName("wrangler.json")).toBe("wrangler.json");
 		expect(configFileName("/path/to/wrangler.json")).toBe("wrangler.json");
 	});
 
-	it("returns 'wrangler.jsonc' for .jsonc config paths", () => {
+	it("returns 'wrangler.jsonc' for .jsonc config paths", ({ expect }) => {
 		expect(configFileName("wrangler.jsonc")).toBe("wrangler.jsonc");
 		expect(configFileName("/path/to/wrangler.jsonc")).toBe("wrangler.jsonc");
 	});
 
-	it("returns 'Wrangler configuration' for unknown formats", () => {
+	it("returns 'Wrangler configuration' for unknown formats", ({ expect }) => {
 		expect(configFileName("wrangler.yaml")).toBe("Wrangler configuration");
 		expect(configFileName(undefined)).toBe("Wrangler configuration");
 	});

--- a/packages/workers-utils/tests/config/configSchema.test.ts
+++ b/packages/workers-utils/tests/config/configSchema.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
 import { describe, expect, test } from "vitest";
 
 describe("src/config/environment.ts", () => {

--- a/packages/workers-utils/tests/config/findWranglerConfig.test.ts
+++ b/packages/workers-utils/tests/config/findWranglerConfig.test.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
 import { describe, expect, it } from "vitest";
 import { findWranglerConfig } from "../../src/config/config-helpers";
 import {

--- a/packages/workers-utils/tests/config/patch-config.test.ts
+++ b/packages/workers-utils/tests/config/patch-config.test.ts
@@ -1,6 +1,7 @@
 import { writeFileSync } from "node:fs";
 import { experimental_patchConfig } from "@cloudflare/workers-utils";
 import dedent from "ts-dedent";
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
 import { describe, expect, it } from "vitest";
 import { runInTempDir, writeWranglerConfig } from "../../src/test-helpers";
 import type { RawConfig } from "@cloudflare/workers-utils";

--- a/packages/workers-utils/tests/config/validation/isDockerFile.test.ts
+++ b/packages/workers-utils/tests/config/validation/isDockerFile.test.ts
@@ -1,5 +1,5 @@
 import { mkdirSync, writeFileSync } from "node:fs";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, it } from "vitest";
 import { isDockerfile } from "../../../src/config/validation";
 import { runInTempDir } from "../../../src/test-helpers";
 
@@ -14,23 +14,29 @@ describe("isDockerfile", () => {
 		writeFileSync("./container-context/Dockerfile", dockerfile);
 	});
 
-	it("should return true if given a valid dockerfile path", async () => {
+	it("should return true if given a valid dockerfile path", async ({
+		expect,
+	}) => {
 		expect(isDockerfile("./container-context/Dockerfile", undefined)).toBe(
 			true
 		);
 	});
 
-	it("should find a dockerfile relative to the wrangler config path", async () => {
+	it("should find a dockerfile relative to the wrangler config path", async ({
+		expect,
+	}) => {
 		expect(
 			isDockerfile("./Dockerfile", "./container-context/wrangler.json")
 		).toBe(true);
 	});
 
-	it("should return false if given a valid image registry path", async () => {
+	it("should return false if given a valid image registry path", async ({
+		expect,
+	}) => {
 		expect(isDockerfile("docker.io/httpd:1", undefined)).toBe(false);
 	});
 
-	it("should error if given a non existent dockerfile", async () => {
+	it("should error if given a non existent dockerfile", async ({ expect }) => {
 		expect(() => isDockerfile("./FakeDockerfile", undefined))
 			.toThrowErrorMatchingInlineSnapshot(`
 				[Error: The image "./FakeDockerfile" does not appear to be a valid path to a Dockerfile, or a valid image registry path:
@@ -38,14 +44,18 @@ describe("isDockerfile", () => {
 			`);
 	});
 
-	it("should error if given a directory instead of a dockerfile", async () => {
+	it("should error if given a directory instead of a dockerfile", async ({
+		expect,
+	}) => {
 		expect(() => isDockerfile("./container-context", undefined))
 			.toThrowErrorMatchingInlineSnapshot(`
 			[Error: ./container-context is a directory, you should specify a path to the Dockerfile]
 		`);
 	});
 
-	it("should error if image registry reference contains the protocol part", async () => {
+	it("should error if image registry reference contains the protocol part", async ({
+		expect,
+	}) => {
 		expect(() =>
 			isDockerfile("http://registry.cloudflare.com/image:tag", undefined)
 		).toThrowErrorMatchingInlineSnapshot(`
@@ -54,7 +64,9 @@ describe("isDockerfile", () => {
 		`);
 	});
 
-	it("should error if image registry reference does not contain a tag", async () => {
+	it("should error if image registry reference does not contain a tag", async ({
+		expect,
+	}) => {
 		expect(() => isDockerfile("docker.io/httpd", undefined))
 			.toThrowErrorMatchingInlineSnapshot(`
 				[Error: The image "docker.io/httpd" does not appear to be a valid path to a Dockerfile, or a valid image registry path:

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.pages.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.pages.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { normalizeAndValidateConfig } from "@cloudflare/workers-utils";
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RawConfig, RawEnvironment } from "@cloudflare/workers-utils";
 

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import TOML from "smol-toml";
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
 import { describe, expect, it, test, vi } from "vitest";
 import { normalizeAndValidateConfig } from "../../../src/config/validation";
 import { normalizeString } from "../../../src/test-helpers";

--- a/packages/workers-utils/tests/parse.test.ts
+++ b/packages/workers-utils/tests/parse.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
 import { describe, expect, it } from "vitest";
 import {
 	indexLocation,

--- a/packages/workflows-shared/eslint.config.mjs
+++ b/packages/workflows-shared/eslint.config.mjs
@@ -1,4 +1,12 @@
 import sharedConfig from "@cloudflare/eslint-config-shared";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig(sharedConfig);
+export default defineConfig([
+	sharedConfig,
+	{
+		files: ["tests/**/*.test.ts"],
+		rules: {
+			"workers-sdk/no-vitest-import-expect": "error",
+		},
+	},
+]);

--- a/packages/workflows-shared/tests/binding.test.ts
+++ b/packages/workflows-shared/tests/binding.test.ts
@@ -3,7 +3,7 @@ import {
 	env,
 	runInDurableObject,
 } from "cloudflare:test";
-import { describe, expect, it, vi } from "vitest";
+import { describe, it, vi } from "vitest";
 import { WorkflowBinding } from "../src/binding";
 import type { Engine } from "../src/engine";
 import type { ProvidedEnv } from "cloudflare:test";
@@ -34,7 +34,9 @@ async function setWorkflowEntrypoint(
 }
 
 describe("WorkflowBinding", () => {
-	it("should not call dispose when sending an event to an instance", async () => {
+	it("should not call dispose when sending an event to an instance", async ({
+		expect,
+	}) => {
 		const instanceId = "test-instance-with-event";
 		const ctx = createExecutionContext();
 

--- a/packages/workflows-shared/tests/engine.test.ts
+++ b/packages/workflows-shared/tests/engine.test.ts
@@ -4,7 +4,7 @@ import {
 	runInDurableObject,
 } from "cloudflare:test";
 import { NonRetryableError } from "cloudflare:workflows";
-import { describe, expect, it, vi } from "vitest";
+import { describe, it, vi } from "vitest";
 import { InstanceEvent, InstanceStatus } from "../src";
 import type {
 	DatabaseInstance,
@@ -81,7 +81,9 @@ async function runWorkflowDefer(
 }
 
 describe("Engine", () => {
-	it("should not retry after NonRetryableError is thrown", async () => {
+	it("should not retry after NonRetryableError is thrown", async ({
+		expect,
+	}) => {
 		const engineStub = await runWorkflow(
 			"MOCK-INSTANCE-ID",
 			async (event, step) => {
@@ -101,7 +103,9 @@ describe("Engine", () => {
 		).toHaveLength(1);
 	});
 
-	it("should not error out if step fails but is try-catched", async () => {
+	it("should not error out if step fails but is try-catched", async ({
+		expect,
+	}) => {
 		const engineStub = await runWorkflow(
 			"MOCK-INSTANCE-ID",
 			async (event, step) => {
@@ -205,7 +209,9 @@ describe("Engine", () => {
 		}, 500);
 	});
 
-	it("should restore state from storage when accountId is undefined", async () => {
+	it("should restore state from storage when accountId is undefined", async ({
+		expect,
+	}) => {
 		const instanceId = "RESTORE-TEST-INSTANCE";
 		const accountId = 12345;
 		const workflow: DatabaseWorkflow = {

--- a/packages/workflows-shared/tests/validators.test.ts
+++ b/packages/workflows-shared/tests/validators.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
 import { describe, expect, it } from "vitest";
 import {
 	isValidStepName,


### PR DESCRIPTION
Part of https://github.com/cloudflare/workers-sdk/issues/12346
Follow up of https://github.com/cloudflare/workers-sdk/pull/12347

The code changes are courtesy of OpenCode/Opus

## Summary

This PR migrates test files to use `expect` from the local test context instead of importing it from `vitest`. This change improves concurrency safety when running tests with `.concurrent`.

## Background

When running tests concurrently with Vitest, the global `expect` imported from `vitest` can cause issues because it cannot reliably detect which test is running. The [Vitest documentation recommends](https://vitest.dev/guide/features.html#running-tests-concurrently) using `expect` from the local test context instead.

## Changes

**Before:**

```ts
import { expect, test } from "vitest";
test("name", () => {
  expect(value).toBe(1);
});
```

**After:**


```ts
import { test } from "vitest";
test("name", ({ expect }) => {
  expect(value).toBe(1);
});
```

## ESLint Rule

A new ESLint rule workers-sdk/no-vitest-import-expect was added to enforce this pattern. The rule is enabled per-package as they are migrated.
For files with complex patterns (e.g., test.each, helper functions using expect at module scope), an eslint-disable comment is added:

```ts
// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
import { expect, test } from "vitest";
```

## Migrated Packages

| Package | Test Files | Trivial | Complex (disabled) |
|---------|------------|---------|-------------------|
| pages-shared | 3 | 2 | 1 |
| vitest-pool-workers | 1 | 1 | 0 |
| edge-preview-authenticated-proxy | 1 | 0 | 1 |
| playground-preview-worker | 1 | 0 | 1 |
| containers-shared | 3 | 3 | 0 |
| workflows-shared | 3 | 2 | 1 |
| workers-utils | 9 | 3 | 6 |
| workers-shared | 12 | 0 | 12 |

## Remaining Packages (future PRs)

- create-cloudflare (31 files)
- vite-plugin-cloudflare (102 files)
- wrangler (216 files)
- fixtures/ (115 files)


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not a user facing change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12356">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
