### PR TITLE
[vite-plugin] Add retry logic for transient connection errors in dev server

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -127,10 +127,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
+      # TEMPORARY: timeout increased from 15 to 45 for flaky test reproduction (50 iterations)
       - name: Run Vite plugin E2E tests
         if: steps.changes.outputs.everything_but_markdown == 'true'
         run: pnpm test:e2e -F @cloudflare/vite-plugin --log-order=stream
-        timeout-minutes: 15
+        timeout-minutes: 45
         env:
           NODE_DEBUG: "vite-plugin:test"
           # The remote-binding tests need to connect to Cloudflare


### PR DESCRIPTION
This PR adds retry logic to fix flaky e2e tests caused by transient connection errors.

## Problem

The remote-bindings e2e tests were flaky in CI, failing intermittently with:

```
TypeError: fetch failed
  [cause]: SocketError: other side closed
    code: 'UND_ERR_SOCKET'
```

or:

```
TypeError: fetch failed  
  [cause]: AggregateError
    code: 'ECONNREFUSED'
```

## Root Cause

There's a brief race condition where workerd accepts TCP connections but isn't fully ready to handle HTTP requests immediately after the server starts listening.

## Solution

Added retry logic to `createRequestHandler()` in `utils.ts` to handle transient connection errors:
- Retries up to 3 times with 50ms delay between attempts
- Only retries on specific transient errors: `ECONNREFUSED`, `UND_ERR_SOCKET`, `ECONNRESET`
- Uses existing `debuglog()` for logging retries

## Testing

This PR also temporarily modifies the e2e tests to run 10 iterations of the flaky test to verify the fix works across different OSes in CI.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Internal fix, no user-facing API changes