### PR TITLE
fix: correctly handle aliases for telemetry

### DIFF
--- a/.changeset/open-eels-peel.md
+++ b/.changeset/open-eels-peel.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: correctly handle aliases for telemetry

--- a/packages/wrangler/src/__tests__/metrics/sanitization.test.ts
+++ b/packages/wrangler/src/__tests__/metrics/sanitization.test.ts
@@ -7,6 +7,7 @@ import {
 	sanitizeArgValues,
 } from "../../../src/metrics/sanitization";
 import type { AllowedArgs, AllowList } from "../../../src/metrics/sanitization";
+import type { NamedArgDefinitions } from "../../core/types";
 
 describe("sanitizeArgKeys", () => {
 	it("should sanitize arg keys based on argv", () => {
@@ -32,12 +33,325 @@ describe("sanitizeArgKeys", () => {
 			"--arg-two",
 			"--experimental-new-idea",
 		];
-		const sanitized = sanitizeArgKeys(args, argv);
+		const sanitized = sanitizeArgKeys(undefined, args, argv);
 		expect(sanitized).toEqual({
 			config: "wrangler.toml",
 			argOne: true,
 			argTwo: true,
 			xNewIdea: true,
+		});
+	});
+
+	it("should recognize single-character aliases from argDefs", () => {
+		const args = {
+			config: "wrangler.toml",
+			message: "rollback reason",
+			$0: "wrangler",
+			_: [],
+		};
+		const argv = ["node", "wrangler", "rollback", "-c", "wrangler.toml", "-m"];
+		const argDefs: NamedArgDefinitions = {
+			config: { type: "string", alias: "c" },
+			message: { type: "string", alias: "m" },
+		};
+		const sanitized = sanitizeArgKeys(argDefs, args, argv);
+		expect(sanitized).toEqual({
+			config: "wrangler.toml",
+			message: "rollback reason",
+		});
+	});
+
+	it("should recognize long aliases from an array of aliases", () => {
+		const args = {
+			triggers: ["0 * * * *"],
+			$0: "wrangler",
+			_: [],
+		};
+		const argv = ["node", "wrangler", "deploy", "--schedule"];
+		const argDefs: NamedArgDefinitions = {
+			triggers: {
+				type: "string",
+				array: true,
+				alias: ["schedule", "schedules"],
+			},
+		};
+		const sanitized = sanitizeArgKeys(argDefs, args, argv);
+		expect(sanitized).toEqual({
+			triggers: ["0 * * * *"],
+		});
+	});
+
+	it("should recognize long aliases with double dash", () => {
+		const args = {
+			"project-name": "my-project",
+			$0: "wrangler",
+			_: [],
+		};
+		const argv = ["node", "wrangler", "pages", "secret", "put", "--project"];
+		const argDefs: NamedArgDefinitions = {
+			"project-name": { type: "string", alias: "project" },
+		};
+		const sanitized = sanitizeArgKeys(argDefs, args, argv);
+		expect(sanitized).toEqual({
+			projectName: "my-project",
+		});
+	});
+
+	it("should work without argDefs (backwards compatibility)", () => {
+		const args = {
+			config: "wrangler.toml",
+			$0: "wrangler",
+			_: [],
+		};
+		const argv = ["node", "wrangler", "deploy", "--config", "wrangler.toml"];
+		const sanitized = sanitizeArgKeys(undefined, args, argv);
+		expect(sanitized).toEqual({
+			config: "wrangler.toml",
+		});
+	});
+
+	it("should include all args when argv is undefined", () => {
+		const args = {
+			config: "wrangler.toml",
+			env: "production",
+			$0: "wrangler",
+			_: [],
+		};
+		const sanitized = sanitizeArgKeys(undefined, args, undefined);
+		expect(sanitized).toEqual({
+			config: "wrangler.toml",
+			env: "production",
+		});
+	});
+
+	it("should recognize uppercase single-character aliases", () => {
+		const args = {
+			jurisdiction: "eu",
+			$0: "wrangler",
+			_: [],
+		};
+		const argv = ["node", "wrangler", "r2", "bucket", "create", "-J", "eu"];
+		const argDefs: NamedArgDefinitions = {
+			jurisdiction: { type: "string", alias: "J" },
+		};
+		const sanitized = sanitizeArgKeys(argDefs, args, argv);
+		expect(sanitized).toEqual({
+			jurisdiction: "eu",
+		});
+	});
+
+	it("should handle alias that differs from first character of arg name", () => {
+		const args = {
+			force: true,
+			$0: "wrangler",
+			_: [],
+		};
+		// "force" uses "y" as alias (for "yes" semantics), not "f"
+		const argv = ["node", "wrangler", "r2", "lock", "-y"];
+		const argDefs: NamedArgDefinitions = {
+			force: { type: "boolean", alias: "y" },
+		};
+		const sanitized = sanitizeArgKeys(argDefs, args, argv);
+		expect(sanitized).toEqual({
+			force: true,
+		});
+	});
+
+	it("should not match when using wrong short flag without argDefs", () => {
+		const args = {
+			force: true,
+			$0: "wrangler",
+			_: [],
+		};
+		// Without argDefs, -y won't match "force" (old behavior would check -f)
+		const argv = ["node", "wrangler", "command", "-y"];
+		const sanitized = sanitizeArgKeys(undefined, args, argv);
+		expect(sanitized).toEqual({});
+	});
+
+	it("should handle mix of long-form and short aliases in same command", () => {
+		const args = {
+			config: "wrangler.toml",
+			env: "production",
+			yes: true,
+			$0: "wrangler",
+			_: [],
+		};
+		const argv = [
+			"node",
+			"wrangler",
+			"deploy",
+			"--config",
+			"wrangler.toml",
+			"-e",
+			"production",
+			"-y",
+		];
+		const argDefs: NamedArgDefinitions = {
+			config: { type: "string", alias: "c" },
+			env: { type: "string", alias: "e" },
+			yes: { type: "boolean", alias: "y" },
+		};
+		const sanitized = sanitizeArgKeys(argDefs, args, argv);
+		expect(sanitized).toEqual({
+			config: "wrangler.toml",
+			env: "production",
+			yes: true,
+		});
+	});
+
+	it("should handle arg with no alias defined in argDefs", () => {
+		const args = {
+			config: "wrangler.toml",
+			"dry-run": true,
+			$0: "wrangler",
+			_: [],
+		};
+		const argv = ["node", "wrangler", "deploy", "-c", "wrangler.toml"];
+		const argDefs: NamedArgDefinitions = {
+			config: { type: "string", alias: "c" },
+			"dry-run": { type: "boolean" }, // no alias
+		};
+		const sanitized = sanitizeArgKeys(argDefs, args, argv);
+		// dry-run has no alias and --dry-run wasn't in argv, so it's excluded
+		expect(sanitized).toEqual({
+			config: "wrangler.toml",
+		});
+	});
+
+	it("should not include arg when neither long form nor alias is in argv", () => {
+		const args = {
+			config: "wrangler.toml",
+			env: "production",
+			$0: "wrangler",
+			_: [],
+		};
+		const argv = ["node", "wrangler", "deploy", "--config", "wrangler.toml"];
+		const argDefs: NamedArgDefinitions = {
+			config: { type: "string", alias: "c" },
+			env: { type: "string", alias: "e" },
+		};
+		const sanitized = sanitizeArgKeys(argDefs, args, argv);
+		// env is in args but neither --env nor -e is in argv
+		expect(sanitized).toEqual({
+			config: "wrangler.toml",
+		});
+	});
+
+	it("should handle empty alias array", () => {
+		const args = {
+			config: "wrangler.toml",
+			$0: "wrangler",
+			_: [],
+		};
+		const argv = ["node", "wrangler", "deploy", "--config", "wrangler.toml"];
+		const argDefs: NamedArgDefinitions = {
+			config: { type: "string", alias: [] },
+		};
+		const sanitized = sanitizeArgKeys(argDefs, args, argv);
+		expect(sanitized).toEqual({
+			config: "wrangler.toml",
+		});
+	});
+
+	it("should recognize single-char aliases in short option groups", () => {
+		const args = {
+			config: "wrangler.toml",
+			yes: true,
+			force: true,
+			$0: "wrangler",
+			_: [],
+		};
+		// yargs parses -yf as -y -f (short option groups)
+		const argv = ["node", "wrangler", "deploy", "-yf", "--config"];
+		const argDefs: NamedArgDefinitions = {
+			config: { type: "string", alias: "c" },
+			yes: { type: "boolean", alias: "y" },
+			force: { type: "boolean", alias: "f" },
+		};
+		const sanitized = sanitizeArgKeys(argDefs, args, argv);
+		expect(sanitized).toEqual({
+			config: "wrangler.toml",
+			yes: true,
+			force: true,
+		});
+	});
+
+	it("should recognize single-char alias in longer short option group", () => {
+		const args = {
+			a: true,
+			b: true,
+			c: true,
+			$0: "wrangler",
+			_: [],
+		};
+		// yargs parses -abc as -a -b -c
+		const argv = ["node", "wrangler", "command", "-abc"];
+		const argDefs: NamedArgDefinitions = {
+			a: { type: "boolean", alias: "a" },
+			b: { type: "boolean", alias: "b" },
+			c: { type: "boolean", alias: "c" },
+		};
+		const sanitized = sanitizeArgKeys(argDefs, args, argv);
+		expect(sanitized).toEqual({
+			a: true,
+			b: true,
+			c: true,
+		});
+	});
+
+	it("should handle flags with = sign (--config=value)", () => {
+		const args = {
+			config: "wrangler.toml",
+			env: "production",
+			$0: "wrangler",
+			_: [],
+		};
+		const argv = [
+			"node",
+			"wrangler",
+			"deploy",
+			"--config=wrangler.toml",
+			"--env=production",
+		];
+		const argDefs: NamedArgDefinitions = {
+			config: { type: "string", alias: "c" },
+			env: { type: "string", alias: "e" },
+		};
+		const sanitized = sanitizeArgKeys(argDefs, args, argv);
+		expect(sanitized).toEqual({
+			config: "wrangler.toml",
+			env: "production",
+		});
+	});
+
+	it("should handle short flags with = sign (-c=value)", () => {
+		const args = {
+			config: "wrangler.toml",
+			$0: "wrangler",
+			_: [],
+		};
+		const argv = ["node", "wrangler", "deploy", "-c=wrangler.toml"];
+		const argDefs: NamedArgDefinitions = {
+			config: { type: "string", alias: "c" },
+		};
+		const sanitized = sanitizeArgKeys(argDefs, args, argv);
+		expect(sanitized).toEqual({
+			config: "wrangler.toml",
+		});
+	});
+
+	it("should handle flags with spaces around = sign (quoted '--arg = value')", () => {
+		const args = {
+			arg: "value",
+			$0: "wrangler",
+			_: [],
+		};
+		// This can happen if argv is constructed programmatically or quoted in shell
+		const argv = ["node", "wrangler", "command", "--arg = value"];
+		const sanitized = sanitizeArgKeys(undefined, args, argv);
+		expect(sanitized).toEqual({
+			arg: "value",
 		});
 	});
 });

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -113,13 +113,20 @@ export function createRegisterYargsCommand(
 	};
 }
 
+/**
+ * Creates the yargs handler function for a command.
+ *
+ * @param def The yargs command definition.
+ * @param argv The full `argv` array passed to wrangler.
+ * @returns The yargs handler function.
+ */
 function createHandler(def: InternalCommandDefinition, argv: string[]) {
 	// Strip "wrangler " prefix to get just the command (e.g., "wrangler dev" -> "dev").
 	// What is left is safe to use in metrics and sentry messages as the parts of the command are taken directly from the command definition.
 	const sanitizedCommand = def.command.replace(/^wrangler\s+/, "");
 
 	return async function handler(args: HandlerArgs<NamedArgDefinitions>) {
-		const startTime = Date.now();
+		const startTimeMs = Date.now();
 
 		// The command definition's `command` string is safe to use in sentry messages.
 		// Sentry breadcrumbs expect the `wrangler` prefix.
@@ -223,7 +230,7 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 					COMMAND_ARG_ALLOW_LIST,
 					sanitizedCommand
 				);
-				const argsWithSanitizedKeys = sanitizeArgKeys(args, argv);
+				const argsWithSanitizedKeys = sanitizeArgKeys(def.args, args, argv);
 				const sanitizedArgs = sanitizeArgValues(
 					argsWithSanitizedKeys,
 					allowedArgs
@@ -249,7 +256,7 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 						fetchResult,
 					});
 
-					const durationMs = Date.now() - startTime;
+					const durationMs = Date.now() - startTimeMs;
 					dispatcher.sendCommandEvent(
 						"wrangler command completed",
 						{
@@ -269,7 +276,7 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 						throw err;
 					}
 
-					const durationMs = Date.now() - startTime;
+					const durationMs = Date.now() - startTimeMs;
 					dispatcher.sendCommandEvent(
 						"wrangler command errored",
 						{

--- a/packages/wrangler/src/metrics/sanitization.ts
+++ b/packages/wrangler/src/metrics/sanitization.ts
@@ -1,25 +1,125 @@
+import type { NamedArgDefinitions } from "../core/types";
+
+/**
+ * Parses argv to extract all flag keys that were provided.
+ *
+ * Due to yargs-parser's "short-option-groups" behavior, a single dash followed by
+ * multiple characters is treated as multiple single-character boolean flags
+ * (e.g., -abc becomes -a -b -c).
+ *
+ * @returns An object with:
+ *   - `longKeys`: Set of long flag names (without -- prefix), e.g., "config", "project"
+ *   - `shortKeys`: Set of single characters from short options, e.g., "c", "y", "f"
+ *
+ * @see https://github.com/yargs/yargs-parser#short-option-groups
+ */
+function parseArgvFlagKeys(argv: string[]): {
+	longKeys: Set<string>;
+	shortKeys: Set<string>;
+} {
+	const longKeys = new Set<string>();
+	const shortKeys = new Set<string>();
+
+	for (const a of argv) {
+		if (a.startsWith("--")) {
+			// Long flag: --config, --project, --arg=value, etc.
+			// Extract just the flag name (before any = sign) and trim whitespace
+			// to handle edge cases like quoted '--arg = value'
+			longKeys.add(a.slice(2).split("=")[0].trim());
+		} else if (a[0] === "-" && a[1] !== "-" && a[1] !== undefined) {
+			// Short option group: -c, -yf, -abc, -c=value, etc.
+			// Each character after the dash is a separate flag
+			for (const char of a.slice(1)) {
+				if (char === "=" || char === " ") {
+					// Stop at = sign or space
+					break;
+				}
+				shortKeys.add(char);
+			}
+		}
+	}
+
+	return { longKeys, shortKeys };
+}
+
+/**
+ * Checks if an argument (by its main name or any alias) was provided in argv.
+ *
+ * @param yargsArgDefs The argument definitions containing alias information.
+ * @param yargsArgKey The argument name to check (e.g., "config", "content-type").
+ * @param parsedArgvFlagKeys The pre-parsed flags from argv, as returned by `parseArgvFlagKeys`.
+ * @returns true if the argument or any of its aliases was found in the parsed flags.
+ */
+function wasArgProvided(
+	yargsArgDefs: NamedArgDefinitions | undefined,
+	yargsArgKey: string,
+	parsedArgvFlagKeys: { longKeys: Set<string>; shortKeys: Set<string> }
+): boolean {
+	const { longKeys, shortKeys } = parsedArgvFlagKeys;
+
+	// Check the main argument name (always uses -- prefix)
+	if (longKeys.has(yargsArgKey)) {
+		return true;
+	}
+
+	// Check all aliases
+	const argDef = yargsArgDefs?.[yargsArgKey];
+	if (argDef?.alias) {
+		const aliases = Array.isArray(argDef.alias) ? argDef.alias : [argDef.alias];
+		for (const alias of aliases) {
+			// Single-char aliases can be in short option groups
+			if (alias.length === 1 && shortKeys.has(alias)) {
+				return true;
+			}
+			// All aliases can use -- prefix
+			if (longKeys.has(alias)) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
 /**
  * Sanitizes the non-positional args provided to the command for metrics reporting.
  *
  * Removes non-canonical args and filters out args that were not provided on the command line.
+ *
+ * Note: This function is designed to work with yargs-parsed arguments. It expects the `args`
+ * object to follow yargs conventions, including special keys like `$0` and `_`.
+ *
+ * @param yargsArgDefs The argument definitions for the command, used to determine aliases.
+ * @param yargsParsedArgs The full set of parsed arguments from yargs.
+ * @param argv The original argv array passed to the CLI.
  */
 export function sanitizeArgKeys(
-	args: Record<string, unknown>,
+	yargsArgDefs: NamedArgDefinitions | undefined,
+	yargsParsedArgs: Record<string, unknown>,
 	argv: string[] | undefined
 ) {
-	const special = new Set(["$0", "_"]);
 	const sanitizedArgs: Record<string, unknown> = {};
 
-	for (const arg of Object.keys(args)) {
+	// Parse argv once to extract all flags
+	const parsedArgv = argv ? parseArgvFlagKeys(argv) : null;
+
+	for (const yargsArgKey of Object.keys(yargsParsedArgs)) {
+		if (yargsArgKey === "_" || yargsArgKey === "$0") {
+			// Yargs adds special keys to the parsed args object:
+			// - `$0`: the script name or command that was invoked
+			// - `_`: an array of positional arguments
+			// These should be excluded from sanitized args.
+			continue;
+		}
+
 		if (
-			!special.has(arg) &&
-			(argv === undefined ||
-				argv.includes(`--${arg}`) ||
-				argv.includes(`-${arg[0]}`))
+			parsedArgv === null ||
+			wasArgProvided(yargsArgDefs, yargsArgKey, parsedArgv)
 		) {
-			sanitizedArgs[canonicalArg(arg)] = args[arg];
+			sanitizedArgs[canonicalArg(yargsArgKey)] = yargsParsedArgs[yargsArgKey];
 		}
 	}
+
 	return sanitizedArgs;
 }
 
@@ -41,8 +141,10 @@ export type AllowList = Record<string, AllowedArgs>;
  *
  * Each arg can have one of three values:
  * - an array of strings: only those specific values are allowed
- * - REDACT: the arg value will always be redacted
- * - ALLOW: all values for that arg are allowed
+ * - `REDACT`: the arg value will always be redacted
+ * - `ALLOW`: all values for that arg are allowed
+ *
+ * @see `getAllowedArgs` for more details.
  */
 export const COMMAND_ARG_ALLOW_LIST: AllowList = {
 	// * applies to all commands
@@ -58,14 +160,18 @@ export const COMMAND_ARG_ALLOW_LIST: AllowList = {
 };
 
 /**
- * Returns the allowed args for a given command.
+ * Extracts the args allowed by an allow list for a given command.
  *
- * @param commandArgAllowList An object describing what args are allowed to be used in metrics.
- * This takes into account:
+ * This is used to filter the args that will be reported to telemetry.
+ *
+ * This Allow list supports:
  * - Global "*" allow-list that applies to all commands
  * - Wildcard commands (e.g., "deploy *" for subcommands)
  * - Specific command entries that override less specific ones
- * See `COMMAND_ARG_ALLOW_LIST` for more details.
+ *
+ * @see `COMMAND_ARG_ALLOW_LIST` for more details.
+ *
+ * @param commandArgAllowList An object describing what args are allowed to be used in metrics.
  * @param command The command being run (e.g., "deploy", "publish", etc.), which does not include the binary (e.g. `wrangler`).
  */
 export function getAllowedArgs(
@@ -113,8 +219,10 @@ export function sanitizeArgValues(
 
 /**
  * Returns the canonical argument name for metrics reporting.
+ *
+ * @return the camelCased name with "experimental" is replaced with "x".
  */
-export function canonicalArg(arg: string) {
+export function canonicalArg(arg: string): string {
 	const camelize = (str: string) =>
 		str.replace(/-./g, (x) => x[1].toUpperCase());
 	return camelize(arg.replace("experimental", "x"));


### PR DESCRIPTION
Relates to https://github.com/cloudflare/workers-sdk/issues/12193

This first PR only fixes issues with how `sanitizeArgKeys` handles aliases

The code was written by OpenCode/Opus with a lot of guidance:

**Summary**

Fixes argument alias detection in sanitizeArgKeys for metrics reporting. The original code assumed that the shorthand for an argument was always the first character (arg[0]), but yargs aliases can be arbitrary (e.g., jurisdiction → "J", content-type → "ct", force → "y").

**Changes**

packages/wrangler/src/metrics/sanitization.ts
- Fixed alias detection: Now uses the actual alias definitions from yargs instead of assuming arg[0]
- Handles short option groups: Correctly detects flags in combined short options (e.g., -yf is parsed as -y and -f) per yargs-parser's short-option-groups behavior (https://github.com/yargs/yargs-parser#short-option-groups)
- Handles = syntax: Supports --config=value and -c=value formats
- Handles edge cases: Trims whitespace to handle quoted args like '--arg = value'
- Added documentation: JSDoc comments with @see links to yargs-parser docs
packages/wrangler/src/core/register-yargs-command.ts

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: fix, not user facing

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
