### PR TITLE
Use vitest#expect from the local context

### DIFF
--- a/packages/create-cloudflare/e2e/helpers/framework-helpers.ts
+++ b/packages/create-cloudflare/e2e/helpers/framework-helpers.ts
@@ -15,6 +15,7 @@ import { detectPackageManager } from "helpers/packageManagers";
 import { retry } from "helpers/retry";
 import * as jsonc from "jsonc-parser";
 import { fetch } from "undici";
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- helper module with expect at module scope
 import { expect } from "vitest";
 import { version } from "../../package.json";
 import { getFrameworkMap } from "../../src/templates";

--- a/packages/create-cloudflare/e2e/helpers/to-exist.ts
+++ b/packages/create-cloudflare/e2e/helpers/to-exist.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs";
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- extends vitest expect with custom matcher
 import { expect } from "vitest";
 
 declare module "vitest" {

--- a/packages/create-cloudflare/e2e/helpers/workers-helpers.ts
+++ b/packages/create-cloudflare/e2e/helpers/workers-helpers.ts
@@ -3,6 +3,7 @@ import getPort from "get-port";
 import { detectPackageManager } from "helpers/packageManagers";
 import { retry } from "helpers/retry";
 import { fetch } from "undici";
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- helper module with expect at module scope
 import { expect } from "vitest";
 import { isExperimental, runDeployTests } from "./constants";
 import { runC3 } from "./run-c3";

--- a/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
+++ b/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
@@ -2,6 +2,7 @@ import { execSync } from "node:child_process";
 import fs, { readFileSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
 import { detectPackageManager } from "helpers/packageManagers";
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- e2e test with complex patterns
 import { beforeAll, describe, expect } from "vitest";
 import { version } from "../../../package.json";
 import {

--- a/packages/create-cloudflare/e2e/tests/frameworks/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/frameworks.test.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { cp } from "node:fs/promises";
 import { join } from "node:path";
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- e2e test with complex patterns
 import { beforeAll, describe, expect } from "vitest";
 import { deleteProject, deleteWorker } from "../../../scripts/common";
 import {

--- a/packages/create-cloudflare/e2e/tests/workers/workers.test.ts
+++ b/packages/create-cloudflare/e2e/tests/workers/workers.test.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { readJSON, readToml } from "helpers/files";
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- e2e test with complex patterns
 import { beforeAll, describe, expect } from "vitest";
 import { deleteWorker } from "../../../scripts/common";
 import {

--- a/packages/create-cloudflare/eslint.config.mjs
+++ b/packages/create-cloudflare/eslint.config.mjs
@@ -11,4 +11,17 @@ export default defineConfig([
 		"scripts/**",
 	]),
 	{ extends: [sharedConfig], rules: { "no-console": "error" } },
+	// Enable no-vitest-import-expect for test files
+	{
+		files: [
+			"**/*.test.ts",
+			"**/*.spec.ts",
+			"**/test/**/*.ts",
+			"**/__tests__/**/*.ts",
+			"**/e2e/**/*.ts",
+		],
+		rules: {
+			"workers-sdk/no-vitest-import-expect": "error",
+		},
+	},
 ]);

--- a/packages/create-cloudflare/src/__tests__/deploy.test.ts
+++ b/packages/create-cloudflare/src/__tests__/deploy.test.ts
@@ -2,7 +2,7 @@ import { inputPrompt } from "@cloudflare/cli/interactive";
 import { mockPackageManager, mockSpinner } from "helpers/__tests__/mocks";
 import { runCommand } from "helpers/command";
 import { readFile } from "helpers/files";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, test, vi } from "vitest";
 import { offerToDeploy, runDeploy } from "../deploy";
 import { chooseAccount, wranglerLogin } from "../wrangler/accounts";
 import { createTestContext } from "./helpers";
@@ -43,7 +43,7 @@ describe("deploy helpers", async () => {
 	});
 
 	describe("offerToDeploy", async () => {
-		test("user selects yes and succeeds", async () => {
+		test("user selects yes and succeeds", async ({ expect }) => {
 			const ctx = createTestContext();
 			ctx.template.platform = "pages";
 			// mock the user selecting yes when asked to deploy
@@ -54,7 +54,7 @@ describe("deploy helpers", async () => {
 			await expect(offerToDeploy(ctx)).resolves.toBe(true);
 		});
 
-		test("project is undeployable (simple binding)", async () => {
+		test("project is undeployable (simple binding)", async ({ expect }) => {
 			const ctx = createTestContext();
 			// Can't deploy things with bindings (yet!)
 			vi.mocked(readFile).mockReturnValue(`binding = "MY_QUEUE"`);
@@ -65,7 +65,7 @@ describe("deploy helpers", async () => {
 			expect(wranglerLogin).not.toHaveBeenCalled();
 		});
 
-		test("project is undeployable (complex binding)", async () => {
+		test("project is undeployable (complex binding)", async ({ expect }) => {
 			const ctx = createTestContext();
 			// Can't deploy things with bindings (yet!)
 			vi.mocked(readFile).mockReturnValue(`
@@ -82,7 +82,9 @@ describe("deploy helpers", async () => {
 			expect(wranglerLogin).not.toHaveBeenCalled();
 		});
 
-		test("assets project is deployable (no other bindings)", async () => {
+		test("assets project is deployable (no other bindings)", async ({
+			expect,
+		}) => {
 			const ctx = createTestContext();
 			vi.mocked(readFile).mockReturnValue(`
 				assets = { directory = "./dist", binding = "ASSETS" }
@@ -98,7 +100,7 @@ describe("deploy helpers", async () => {
 			expect(wranglerLogin).toHaveBeenCalled();
 		});
 
-		test("--no-deploy from command line", async () => {
+		test("--no-deploy from command line", async ({ expect }) => {
 			const ctx = createTestContext();
 			ctx.args.deploy = false;
 			ctx.template.platform = "pages";
@@ -109,7 +111,7 @@ describe("deploy helpers", async () => {
 			expect(wranglerLogin).not.toHaveBeenCalled();
 		});
 
-		test("wrangler login failure", async () => {
+		test("wrangler login failure", async ({ expect }) => {
 			const ctx = createTestContext();
 			ctx.template.platform = "pages";
 			vi.mocked(inputPrompt).mockResolvedValueOnce(true);
@@ -124,7 +126,7 @@ describe("deploy helpers", async () => {
 		const commitMsg = "initial commit";
 		const deployedUrl = "https://test-project-1234.pages.dev";
 
-		test("happy path", async () => {
+		test("happy path", async ({ expect }) => {
 			const ctx = createTestContext();
 			ctx.account = { id: "test1234", name: "Test Account" };
 			ctx.template.platform = "pages";
@@ -142,7 +144,7 @@ describe("deploy helpers", async () => {
 			expect(ctx.deployment.url).toBe(deployedUrl);
 		});
 
-		test("no account in ctx", async () => {
+		test("no account in ctx", async ({ expect }) => {
 			const ctx = createTestContext();
 			ctx.account = undefined;
 			await expect(() => runDeploy(ctx)).rejects.toThrow(
@@ -150,7 +152,7 @@ describe("deploy helpers", async () => {
 			);
 		});
 
-		test("Failed deployment", async () => {
+		test("Failed deployment", async ({ expect }) => {
 			const ctx = createTestContext();
 			ctx.account = { id: "test1234", name: "Test Account" };
 			ctx.template.platform = "pages";

--- a/packages/create-cloudflare/src/__tests__/dialog.test.ts
+++ b/packages/create-cloudflare/src/__tests__/dialog.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, test } from "vitest";
 import { collectCLIOutput, normalizeOutput } from "../../../cli/test-util";
 import { printSummary, printWelcomeMessage } from "../dialog";
 import type { C3Context } from "types";
@@ -16,7 +16,7 @@ describe("dialog helpers", () => {
 	});
 
 	describe("printWelcomeMessage", () => {
-		test("with telemetry disabled", () => {
+		test("with telemetry disabled", ({ expect }) => {
 			printWelcomeMessage("0.0.0", false, {});
 
 			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
@@ -29,7 +29,7 @@ describe("dialog helpers", () => {
 			`);
 		});
 
-		test("with telemetry enabled", () => {
+		test("with telemetry enabled", ({ expect }) => {
 			printWelcomeMessage("0.0.0", true, {});
 
 			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
@@ -45,7 +45,7 @@ describe("dialog helpers", () => {
 			`);
 		});
 
-		test("with telemetry disabled in experimental mode", () => {
+		test("with telemetry disabled in experimental mode", ({ expect }) => {
 			printWelcomeMessage("0.0.0", false, { experimental: true });
 
 			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
@@ -60,7 +60,7 @@ describe("dialog helpers", () => {
 			`);
 		});
 
-		test("with telemetry enabled in experimental mode", () => {
+		test("with telemetry enabled in experimental mode", ({ expect }) => {
 			printWelcomeMessage("0.0.0", true, { experimental: true });
 
 			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
@@ -113,7 +113,7 @@ describe("dialog helpers", () => {
 			process.stdout.columns = originalStdoutColumns;
 		});
 
-		test("with deploy", async () => {
+		test("with deploy", async ({ expect }) => {
 			await printSummary(ctx);
 
 			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
@@ -141,7 +141,7 @@ describe("dialog helpers", () => {
 			`);
 		});
 
-		test("with no deploy", async () => {
+		test("with no deploy", async ({ expect }) => {
 			await printSummary({
 				...ctx,
 				account: undefined,

--- a/packages/create-cloudflare/src/__tests__/git.test.ts
+++ b/packages/create-cloudflare/src/__tests__/git.test.ts
@@ -2,7 +2,7 @@ import { updateStatus } from "@cloudflare/cli";
 import { mockSpinner } from "helpers/__tests__/mocks";
 import { processArgument } from "helpers/args";
 import { runCommand } from "helpers/command";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, test, vi } from "vitest";
 import {
 	getProductionBranch,
 	gitCommit,
@@ -60,7 +60,7 @@ const mockDefaultBranchName = (branch = "main") => {
 
 describe("git helpers", () => {
 	describe("isGitConfigured", () => {
-		test("fully configured", async () => {
+		test("fully configured", async ({ expect }) => {
 			vi.mocked(runCommand).mockImplementation((cmd) =>
 				Promise.resolve(cmd.includes("email") ? "test@user.com" : "test user"),
 			);
@@ -68,63 +68,63 @@ describe("git helpers", () => {
 			await expect(isGitConfigured()).resolves.toBe(true);
 		});
 
-		test("no name", async () => {
+		test("no name", async ({ expect }) => {
 			vi.mocked(runCommand).mockImplementation((cmd) =>
 				Promise.resolve(cmd.includes("email") ? "test@user.com" : ""),
 			);
 			await expect(isGitConfigured()).resolves.toBe(false);
 		});
 
-		test("no email", async () => {
+		test("no email", async ({ expect }) => {
 			vi.mocked(runCommand).mockImplementation((cmd) =>
 				Promise.resolve(cmd.includes("name") ? "test user" : ""),
 			);
 			await expect(isGitConfigured()).resolves.toBe(false);
 		});
 
-		test("runCommand fails", async () => {
+		test("runCommand fails", async ({ expect }) => {
 			vi.mocked(runCommand).mockRejectedValue(new Error("git not found"));
 			await expect(isGitConfigured()).resolves.toBe(false);
 		});
 	});
 
 	describe("isGitInstalled", async () => {
-		test("installed", async () => {
+		test("installed", async ({ expect }) => {
 			mockGitInstalled(true);
 			await expect(isGitInstalled()).resolves.toBe(true);
 		});
 
-		test("not installed", async () => {
+		test("not installed", async ({ expect }) => {
 			mockGitInstalled(false);
 			await expect(isGitInstalled()).resolves.toBe(false);
 		});
 	});
 
 	describe("isInsideGitRepo", async () => {
-		test("inside git repo", async () => {
+		test("inside git repo", async ({ expect }) => {
 			mockInsideGitRepo(true);
 			await expect(isInsideGitRepo("")).resolves.toBe(true);
 		});
-		test("is not inside git repo", async () => {
+		test("is not inside git repo", async ({ expect }) => {
 			mockInsideGitRepo(false);
 			await expect(isInsideGitRepo(".")).resolves.toBe(false);
 		});
 	});
 
 	describe("getProductionBranch", async () => {
-		test("happy path", async () => {
+		test("happy path", async ({ expect }) => {
 			vi.mocked(runCommand).mockResolvedValueOnce("production");
 			await expect(getProductionBranch(".")).resolves.toBe("production");
 		});
 
-		test("error", async () => {
+		test("error", async ({ expect }) => {
 			vi.mocked(runCommand).mockRejectedValueOnce(new Error());
 			await expect(getProductionBranch(".")).resolves.toBe("main");
 		});
 	});
 
 	describe("initializeGit", async () => {
-		test("happy path", async () => {
+		test("happy path", async ({ expect }) => {
 			mockDefaultBranchName("production");
 
 			await initializeGit(".");
@@ -134,7 +134,7 @@ describe("git helpers", () => {
 			);
 		});
 
-		test("error - fallback to default", async () => {
+		test("error - fallback to default", async ({ expect }) => {
 			vi.mocked(runCommand).mockRejectedValueOnce(new Error());
 
 			await initializeGit(".");
@@ -146,7 +146,7 @@ describe("git helpers", () => {
 	});
 
 	describe("offerGit", async () => {
-		test("happy path", async () => {
+		test("happy path", async ({ expect }) => {
 			// The testCreateContext() helper sets up the ctx.args to be all the C3_DEFAULT_ARGS values, which undermines the idea that the user has not provided any command line args.
 			// By providing an args object here (and elsewhere in this file) we ensure that none of the CLI args are set so that we have control over them in the tests.
 
@@ -169,7 +169,9 @@ describe("git helpers", () => {
 			expect(ctx.args.git).toBe(true);
 		});
 
-		test("git not installed will not ask the user whether to use git and will not use git", async () => {
+		test("git not installed will not ask the user whether to use git and will not use git", async ({
+			expect,
+		}) => {
 			const ctx = createTestContext("test", { projectName: "test" });
 			mockGitInstalled(false);
 
@@ -180,7 +182,7 @@ describe("git helpers", () => {
 			expect(ctx.args.git).toBe(false);
 		});
 
-		test("git not installed, but requested", async () => {
+		test("git not installed, but requested", async ({ expect }) => {
 			const ctx = createTestContext("test", { projectName: "test", git: true });
 			mockGitInstalled(false);
 
@@ -193,7 +195,7 @@ describe("git helpers", () => {
 			expect(ctx.args.git).toBe(false);
 		});
 
-		test("git not configured", async () => {
+		test("git not configured", async ({ expect }) => {
 			const ctx = createTestContext("test", { projectName: "test" });
 			mockGitInstalled(false);
 
@@ -204,7 +206,7 @@ describe("git helpers", () => {
 			expect(ctx.args.git).toBe(false);
 		});
 
-		test("git not configured, but requested", async () => {
+		test("git not configured, but requested", async ({ expect }) => {
 			const ctx = createTestContext("test", { projectName: "test", git: true });
 			mockGitInstalled(false);
 
@@ -217,7 +219,7 @@ describe("git helpers", () => {
 			expect(ctx.args.git).toBe(false);
 		});
 
-		test("inside existing git repo", async () => {
+		test("inside existing git repo", async ({ expect }) => {
 			const ctx = createTestContext("test", { projectName: "test" });
 			// This property is set in the normal ctx creation helper.
 			ctx.gitRepoAlreadyExisted = true;
@@ -239,7 +241,7 @@ describe("git helpers", () => {
 			);
 		});
 
-		test("user selects no git", async () => {
+		test("user selects no git", async ({ expect }) => {
 			const ctx = createTestContext("test", { projectName: "test" });
 			mockGitInstalled(true);
 
@@ -259,7 +261,7 @@ describe("git helpers", () => {
 			expect(ctx.args.git).toBe(false);
 		});
 
-		test("user selects no git, inside a git repository", async () => {
+		test("user selects no git, inside a git repository", async ({ expect }) => {
 			const ctx = createTestContext("test", { projectName: "test" });
 			ctx.gitRepoAlreadyExisted = true;
 			mockGitInstalled(true);
@@ -289,7 +291,7 @@ describe("git helpers", () => {
 			mockGitInstalled(true);
 		});
 
-		test("happy path", async () => {
+		test("happy path", async ({ expect }) => {
 			const ctx = createTestContext("test", { projectName: "test" });
 			ctx.args.git = true;
 
@@ -313,7 +315,7 @@ describe("git helpers", () => {
 			expect(ctx.commitMessage).toBeDefined();
 		});
 
-		test("git not selected", async () => {
+		test("git not selected", async ({ expect }) => {
 			const ctx = createTestContext("test", { projectName: "test" });
 			ctx.args.git = false;
 
@@ -332,7 +334,7 @@ describe("git helpers", () => {
 			expect(ctx.commitMessage).toBeDefined();
 		});
 
-		test("git repo already existed", async () => {
+		test("git repo already existed", async ({ expect }) => {
 			const ctx = createTestContext("test", { projectName: "test" });
 			ctx.args.git = true;
 			ctx.gitRepoAlreadyExisted = true;
@@ -352,7 +354,7 @@ describe("git helpers", () => {
 			expect(ctx.commitMessage).toBeDefined();
 		});
 
-		test("commit failure is handled gracefully", async () => {
+		test("commit failure is handled gracefully", async ({ expect }) => {
 			const ctx = createTestContext("test", { projectName: "test" });
 			ctx.args.git = true;
 

--- a/packages/create-cloudflare/src/__tests__/metrics.test.ts
+++ b/packages/create-cloudflare/src/__tests__/metrics.test.ts
@@ -1,7 +1,7 @@
 import { CancelError } from "@cloudflare/cli/error";
 import { detectPackageManager } from "helpers/packageManagers";
 import { hasSparrowSourceKey, sendEvent } from "helpers/sparrow";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, test, vi } from "vitest";
 import { collectCLIOutput, normalizeOutput } from "../../../cli/test-util";
 import { version as c3Version } from "../../package.json";
 import {
@@ -43,7 +43,9 @@ describe("createReporter", () => {
 		vi.unstubAllEnvs();
 	});
 
-	test("sends started and completed event to sparrow if the promise resolves", async () => {
+	test("sends started and completed event to sparrow if the promise resolves", async ({
+		expect,
+	}) => {
 		const deferred = promiseWithResolvers<string>();
 		const reporter = createReporter();
 		const operation = reporter.collectAsyncMetrics({
@@ -106,7 +108,9 @@ describe("createReporter", () => {
 		expect(sendEvent).toBeCalledTimes(2);
 	});
 
-	test("sends event with logs enabled if CREATE_CLOUDFLARE_TELEMETRY_DEBUG is set to `1`", async () => {
+	test("sends event with logs enabled if CREATE_CLOUDFLARE_TELEMETRY_DEBUG is set to `1`", async ({
+		expect,
+	}) => {
 		vi.stubEnv("CREATE_CLOUDFLARE_TELEMETRY_DEBUG", "1");
 
 		const deferred = promiseWithResolvers<string>();
@@ -171,7 +175,7 @@ describe("createReporter", () => {
 		expect(sendEvent).toBeCalledTimes(2);
 	});
 
-	test("sends no event if no sparrow source key", async () => {
+	test("sends no event if no sparrow source key", async ({ expect }) => {
 		vi.mocked(hasSparrowSourceKey).mockReturnValue(false);
 
 		const deferred = promiseWithResolvers<string>();
@@ -196,7 +200,9 @@ describe("createReporter", () => {
 		expect(sendEvent).toBeCalledTimes(0);
 	});
 
-	test("sends no event if the c3 permission is disabled", async () => {
+	test("sends no event if the c3 permission is disabled", async ({
+		expect,
+	}) => {
 		vi.mocked(readMetricsConfig).mockReturnValueOnce({
 			c3permission: {
 				enabled: false,
@@ -226,7 +232,9 @@ describe("createReporter", () => {
 		expect(sendEvent).toBeCalledTimes(0);
 	});
 
-	test("sends no event if the CREATE_CLOUDFLARE_TELEMETRY_DISABLED env is set to '1'", async () => {
+	test("sends no event if the CREATE_CLOUDFLARE_TELEMETRY_DISABLED env is set to '1'", async ({
+		expect,
+	}) => {
 		vi.stubEnv("CREATE_CLOUDFLARE_TELEMETRY_DISABLED", "1");
 
 		const deferred = promiseWithResolvers<string>();
@@ -251,7 +259,9 @@ describe("createReporter", () => {
 		expect(sendEvent).toBeCalledTimes(0);
 	});
 
-	test("sends started and cancelled event to sparrow if the promise reject with a CancelError", async () => {
+	test("sends started and cancelled event to sparrow if the promise reject with a CancelError", async ({
+		expect,
+	}) => {
 		const deferred = promiseWithResolvers<string>();
 		const reporter = createReporter();
 		const operation = reporter.collectAsyncMetrics({
@@ -313,7 +323,9 @@ describe("createReporter", () => {
 		expect(sendEvent).toBeCalledTimes(2);
 	});
 
-	test("sends started and errored event to sparrow if the promise reject with a non CancelError", async () => {
+	test("sends started and errored event to sparrow if the promise reject with a non CancelError", async ({
+		expect,
+	}) => {
 		const deferred = promiseWithResolvers<string>();
 		const reporter = createReporter();
 		const process = reporter.collectAsyncMetrics({
@@ -378,7 +390,9 @@ describe("createReporter", () => {
 		expect(sendEvent).toBeCalledTimes(2);
 	});
 
-	test("sends cancelled event if a SIGINT signal is received", async () => {
+	test("sends cancelled event if a SIGINT signal is received", async ({
+		expect,
+	}) => {
 		const deferred = promiseWithResolvers<string>();
 		const reporter = createReporter();
 
@@ -442,7 +456,9 @@ describe("createReporter", () => {
 		expect(sendEvent).toBeCalledTimes(2);
 	});
 
-	test("sends cancelled event if a SIGTERM signal is received", async () => {
+	test("sends cancelled event if a SIGTERM signal is received", async ({
+		expect,
+	}) => {
 		const deferred = promiseWithResolvers<string>();
 		const reporter = createReporter();
 		const run = reporter.collectAsyncMetrics({
@@ -517,7 +533,9 @@ describe("runTelemetryCommand", () => {
 		vi.useRealTimers();
 	});
 
-	test("run telemetry status when c3permission is disabled", async () => {
+	test("run telemetry status when c3permission is disabled", async ({
+		expect,
+	}) => {
 		vi.mocked(readMetricsConfig).mockReturnValueOnce({
 			c3permission: {
 				enabled: false,
@@ -534,7 +552,9 @@ describe("runTelemetryCommand", () => {
 		`);
 	});
 
-	test("run telemetry status when c3permission is enabled", async () => {
+	test("run telemetry status when c3permission is enabled", async ({
+		expect,
+	}) => {
 		vi.mocked(readMetricsConfig).mockReturnValueOnce({
 			c3permission: {
 				enabled: true,
@@ -551,7 +571,9 @@ describe("runTelemetryCommand", () => {
 		`);
 	});
 
-	test("run telemetry enable when c3permission is disabled", async () => {
+	test("run telemetry enable when c3permission is disabled", async ({
+		expect,
+	}) => {
 		vi.mocked(readMetricsConfig).mockReturnValueOnce({
 			c3permission: {
 				enabled: false,
@@ -575,7 +597,9 @@ describe("runTelemetryCommand", () => {
 		`);
 	});
 
-	test("run telemetry enable when c3permission is enabled", async () => {
+	test("run telemetry enable when c3permission is enabled", async ({
+		expect,
+	}) => {
 		vi.mocked(readMetricsConfig).mockReturnValueOnce({
 			c3permission: {
 				enabled: true,
@@ -594,7 +618,9 @@ describe("runTelemetryCommand", () => {
 		`);
 	});
 
-	test("run telemetry disable when c3permission is enabled", async () => {
+	test("run telemetry disable when c3permission is enabled", async ({
+		expect,
+	}) => {
 		vi.mocked(readMetricsConfig).mockReturnValueOnce({
 			c3permission: {
 				enabled: true,
@@ -618,7 +644,9 @@ describe("runTelemetryCommand", () => {
 		`);
 	});
 
-	test("run telemetry disable when c3permission is disabled", async () => {
+	test("run telemetry disable when c3permission is disabled", async ({
+		expect,
+	}) => {
 		vi.mocked(readMetricsConfig).mockReturnValueOnce({
 			c3permission: {
 				enabled: false,

--- a/packages/create-cloudflare/src/__tests__/pre-existing.test.ts
+++ b/packages/create-cloudflare/src/__tests__/pre-existing.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, it, vi } from "vitest";
 import { buildConfigure } from "../../templates/pre-existing/c3";
 import type { ConfigureParams } from "../../templates/pre-existing/c3";
 import type { C3Context } from "types";
@@ -8,7 +8,9 @@ describe("configure function", () => {
 		args: { deploy: true },
 	} as C3Context;
 
-	it("should successfully configure when login is successful", async () => {
+	it("should successfully configure when login is successful", async ({
+		expect,
+	}) => {
 		const params: ConfigureParams = {
 			login: vi.fn().mockResolvedValue(true),
 			chooseAccount: vi.fn().mockResolvedValue(undefined),
@@ -24,7 +26,7 @@ describe("configure function", () => {
 		expect(ctx.args.deploy).toBe(false);
 	});
 
-	it("should throw an error when login fails", async () => {
+	it("should throw an error when login fails", async ({ expect }) => {
 		const params: ConfigureParams = {
 			login: vi.fn().mockResolvedValue(false),
 			chooseAccount: vi.fn(),

--- a/packages/create-cloudflare/src/__tests__/templates.test.ts
+++ b/packages/create-cloudflare/src/__tests__/templates.test.ts
@@ -10,7 +10,7 @@ import {
 	writeFile,
 	writeJSON,
 } from "helpers/files";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, test, vi } from "vitest";
 import {
 	addWranglerToGitIgnore,
 	deriveCorrelatedArgs,
@@ -48,7 +48,9 @@ describe("addWranglerToGitIgnore", () => {
 		);
 	});
 
-	test("should append the wrangler section to a standard gitignore file", () => {
+	test("should append the wrangler section to a standard gitignore file", ({
+		expect,
+	}) => {
 		mockGitIgnore(
 			"my-project/.gitignore",
 			`
@@ -76,7 +78,9 @@ describe("addWranglerToGitIgnore", () => {
 			]
 		`);
 	});
-	test("should not touch the gitignore file if it already contains all wrangler files", () => {
+	test("should not touch the gitignore file if it already contains all wrangler files", ({
+		expect,
+	}) => {
 		mockGitIgnore(
 			"my-project/.gitignore",
 			`
@@ -96,7 +100,9 @@ describe("addWranglerToGitIgnore", () => {
 		expect(appendFileMock).not.toHaveBeenCalled();
 	});
 
-	test("should not touch the gitignore file if contains all wrangler files (and can cope with comments)", () => {
+	test("should not touch the gitignore file if contains all wrangler files (and can cope with comments)", ({
+		expect,
+	}) => {
 		mockGitIgnore(
 			"my-project/.gitignore",
 			`
@@ -116,7 +122,9 @@ describe("addWranglerToGitIgnore", () => {
 		expect(appendFileMock).not.toHaveBeenCalled();
 	});
 
-	test("should append to the gitignore file the missing wrangler files when some are already present (should add the section heading if including .wrangler and some others)", () => {
+	test("should append to the gitignore file the missing wrangler files when some are already present (should add the section heading if including .wrangler and some others)", ({
+		expect,
+	}) => {
 		mockGitIgnore(
 			"my-project/.gitignore",
 			`
@@ -145,7 +153,9 @@ describe("addWranglerToGitIgnore", () => {
 		`);
 	});
 
-	test("should append to the gitignore file the missing wrangler files when some are already present (should not add the section heading if .wrangler already exists)", () => {
+	test("should append to the gitignore file the missing wrangler files when some are already present (should not add the section heading if .wrangler already exists)", ({
+		expect,
+	}) => {
 		mockGitIgnore(
 			"my-project/.gitignore",
 			`
@@ -173,7 +183,9 @@ describe("addWranglerToGitIgnore", () => {
 		`);
 	});
 
-	test("should append to the gitignore file the missing wrangler files when some are already present (should not add the section heading if only adding .wrangler)", () => {
+	test("should append to the gitignore file the missing wrangler files when some are already present (should not add the section heading if only adding .wrangler)", ({
+		expect,
+	}) => {
 		mockGitIgnore(
 			"my-project/.gitignore",
 			`
@@ -201,7 +213,9 @@ describe("addWranglerToGitIgnore", () => {
 		`);
 	});
 
-	test("when it appends to the gitignore file it doesn't include an empty line only if there was one already", () => {
+	test("when it appends to the gitignore file it doesn't include an empty line only if there was one already", ({
+		expect,
+	}) => {
 		mockGitIgnore(
 			"my-project/.gitignore",
 			`
@@ -230,7 +244,9 @@ describe("addWranglerToGitIgnore", () => {
 		`);
 	});
 
-	test("should create the gitignore file if it didn't exist already", () => {
+	test("should create the gitignore file if it didn't exist already", ({
+		expect,
+	}) => {
 		// let's mock a gitignore file to be read by readFile
 		mockGitIgnore("my-project/.gitignore", "");
 		// but let's pretend that it doesn't exist
@@ -271,7 +287,9 @@ describe("addWranglerToGitIgnore", () => {
 		`);
 	});
 
-	test("should not create the gitignore file the project doesn't use git", () => {
+	test("should not create the gitignore file the project doesn't use git", ({
+		expect,
+	}) => {
 		// no .gitignore file exists
 		vi.mocked(existsSync).mockImplementation(() => false);
 		// neither a .git directory does
@@ -284,7 +302,9 @@ describe("addWranglerToGitIgnore", () => {
 		expect(writeFileMock).not.toHaveBeenCalled();
 	});
 
-	test("should add the wildcard .dev.vars* entry even if a .dev.vars is already included", () => {
+	test("should add the wildcard .dev.vars* entry even if a .dev.vars is already included", ({
+		expect,
+	}) => {
 		mockGitIgnore(
 			"my-project/.gitignore",
 			`
@@ -314,7 +334,9 @@ describe("addWranglerToGitIgnore", () => {
 		`);
 	});
 
-	test("should not add the .env entries if some form of .env entries are already included", () => {
+	test("should not add the .env entries if some form of .env entries are already included", ({
+		expect,
+	}) => {
 		mockGitIgnore(
 			"my-project/.gitignore",
 			`
@@ -342,7 +364,9 @@ describe("addWranglerToGitIgnore", () => {
 		`);
 	});
 
-	test("should not add the .wrangler entry if a .wrangler/ is already included)", () => {
+	test("should not add the .wrangler entry if a .wrangler/ is already included)", ({
+		expect,
+	}) => {
 		mockGitIgnore(
 			"my-project/.gitignore",
 			`
@@ -389,14 +413,14 @@ describe("downloadRemoteTemplate", () => {
 		} as unknown as ReturnType<typeof degit>);
 	});
 
-	test("should download template using degit", async () => {
+	test("should download template using degit", async ({ expect }) => {
 		await downloadRemoteTemplate("cloudflare/workers-sdk");
 
 		expect(degit).toHaveBeenCalled();
 		expect(cloneMock).toHaveBeenCalled();
 	});
 
-	test("should not use a spinner", async () => {
+	test("should not use a spinner", async ({ expect }) => {
 		// Degit runs `git clone` internally which might prompt for credentials
 		// A spinner will suppress the prompt and keep the CLI waiting in the cloning stage
 		await downloadRemoteTemplate("cloudflare/workers-sdk");
@@ -404,7 +428,9 @@ describe("downloadRemoteTemplate", () => {
 		expect(spinner).not.toHaveBeenCalled();
 	});
 
-	test("should call degit with a mode of undefined if not specified", async () => {
+	test("should call degit with a mode of undefined if not specified", async ({
+		expect,
+	}) => {
 		await downloadRemoteTemplate("cloudflare/workers-sdk");
 
 		expect(degit).toHaveBeenCalledWith("cloudflare/workers-sdk", {
@@ -415,7 +441,9 @@ describe("downloadRemoteTemplate", () => {
 		});
 	});
 
-	test("should call degit with a mode of 'git' if specified", async () => {
+	test("should call degit with a mode of 'git' if specified", async ({
+		expect,
+	}) => {
 		await downloadRemoteTemplate("cloudflare/workers-sdk", { mode: "git" });
 
 		expect(degit).toHaveBeenCalledWith("cloudflare/workers-sdk", {
@@ -426,7 +454,7 @@ describe("downloadRemoteTemplate", () => {
 		});
 	});
 
-	test("should clone into the passed folder", async () => {
+	test("should clone into the passed folder", async ({ expect }) => {
 		await downloadRemoteTemplate("cloudflare/workers-sdk", {
 			intoFolder: "/path/to/clone",
 		});
@@ -434,7 +462,9 @@ describe("downloadRemoteTemplate", () => {
 		expect(cloneMock).toHaveBeenCalledWith("/path/to/clone");
 	});
 
-	test("should transform GitHub URL without path to degit format", async () => {
+	test("should transform GitHub URL without path to degit format", async ({
+		expect,
+	}) => {
 		await downloadRemoteTemplate(
 			"https://github.com/cloudflare/workers-graphql-server",
 		);
@@ -445,7 +475,9 @@ describe("downloadRemoteTemplate", () => {
 		);
 	});
 
-	test("should transform GitHub URL with trailing slash to degit format", async () => {
+	test("should transform GitHub URL with trailing slash to degit format", async ({
+		expect,
+	}) => {
 		await downloadRemoteTemplate("https://github.com/cloudflare/workers-sdk/");
 
 		expect(degit).toHaveBeenCalledWith(
@@ -454,7 +486,9 @@ describe("downloadRemoteTemplate", () => {
 		);
 	});
 
-	test("should transform GitHub URL with subdirectory to degit format", async () => {
+	test("should transform GitHub URL with subdirectory to degit format", async ({
+		expect,
+	}) => {
 		await downloadRemoteTemplate(
 			"https://github.com/cloudflare/workers-sdk/templates/worker-r2",
 		);
@@ -465,7 +499,9 @@ describe("downloadRemoteTemplate", () => {
 		);
 	});
 
-	test("should transform GitHub URL with tree/main to degit format", async () => {
+	test("should transform GitHub URL with tree/main to degit format", async ({
+		expect,
+	}) => {
 		await downloadRemoteTemplate(
 			"https://github.com/cloudflare/workers-sdk/tree/main",
 		);
@@ -476,7 +512,9 @@ describe("downloadRemoteTemplate", () => {
 		);
 	});
 
-	test("should transform GitHub URL with tree/main/subdirectory to degit format", async () => {
+	test("should transform GitHub URL with tree/main/subdirectory to degit format", async ({
+		expect,
+	}) => {
 		await downloadRemoteTemplate(
 			"https://github.com/cloudflare/workers-sdk/tree/main/templates",
 		);
@@ -487,7 +525,9 @@ describe("downloadRemoteTemplate", () => {
 		);
 	});
 
-	test("should throw error when using a branch other than main", async () => {
+	test("should throw error when using a branch other than main", async ({
+		expect,
+	}) => {
 		await expect(
 			downloadRemoteTemplate(
 				"https://github.com/cloudflare/workers-sdk/tree/dev",
@@ -499,7 +539,9 @@ describe("downloadRemoteTemplate", () => {
 });
 
 describe("deriveCorrelatedArgs", () => {
-	test("should derive the lang as TypeScript if `--ts` is specified", () => {
+	test("should derive the lang as TypeScript if `--ts` is specified", ({
+		expect,
+	}) => {
 		const args: Partial<C3Args> = {
 			ts: true,
 		};
@@ -509,7 +551,9 @@ describe("deriveCorrelatedArgs", () => {
 		expect(args.lang).toBe("ts");
 	});
 
-	test("should derive the lang as JavaScript if `--ts=false` is specified", () => {
+	test("should derive the lang as JavaScript if `--ts=false` is specified", ({
+		expect,
+	}) => {
 		const args: Partial<C3Args> = {
 			ts: false,
 		};
@@ -519,7 +563,9 @@ describe("deriveCorrelatedArgs", () => {
 		expect(args.lang).toBe("js");
 	});
 
-	test("should crash if both the lang and ts arguments are specified", () => {
+	test("should crash if both the lang and ts arguments are specified", ({
+		expect,
+	}) => {
 		expect(() =>
 			deriveCorrelatedArgs({
 				lang: "ts",
@@ -548,7 +594,7 @@ describe("updatePackageName", () => {
 		vi.mocked(readFile).mockReturnValue("");
 	});
 
-	test('should update the "name" field in package.json', () => {
+	test('should update the "name" field in package.json', ({ expect }) => {
 		const ctx = {
 			project: { path: "my-project", name: "my-project" },
 			args: {},
@@ -570,7 +616,7 @@ describe("updatePackageName", () => {
 		);
 	});
 
-	test("it should update pyproject.toml if it exists", () => {
+	test("it should update pyproject.toml if it exists", ({ expect }) => {
 		const ctx = {
 			project: { path: "my-project", name: "my-project" },
 			args: {},

--- a/packages/create-cloudflare/src/__tests__/validators.test.ts
+++ b/packages/create-cloudflare/src/__tests__/validators.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- test.each pattern
 import { describe, expect, test } from "vitest";
 import {
 	isAllowedExistingFile,

--- a/packages/create-cloudflare/src/__tests__/workers.test.ts
+++ b/packages/create-cloudflare/src/__tests__/workers.test.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { mockSpinner } from "helpers/__tests__/mocks";
 import { getLatestTypesEntrypoint } from "helpers/compatDate";
 import { readFile, writeFile } from "helpers/files";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, test, vi } from "vitest";
 import { updateTsConfig } from "../workers";
 import { createTestContext } from "./helpers";
 import type { C3Context } from "types";
@@ -35,7 +35,7 @@ describe("updateTsConfig", () => {
 		);
 	});
 
-	test("installing workers types", async () => {
+	test("installing workers types", async ({ expect }) => {
 		ctx.template.workersTypes = "installed";
 
 		await updateTsConfig(ctx, { usesNodeCompat: false });
@@ -47,13 +47,13 @@ describe("updateTsConfig", () => {
 		);
 	});
 
-	test("tsconfig.json not found", async () => {
+	test("tsconfig.json not found", async ({ expect }) => {
 		vi.mocked(existsSync).mockImplementation(() => false);
 		await updateTsConfig(ctx, { usesNodeCompat: false });
 		expect(writeFile).not.toHaveBeenCalled();
 	});
 
-	test("latest entrypoint not found", async () => {
+	test("latest entrypoint not found", async ({ expect }) => {
 		ctx.template.workersTypes = "installed";
 
 		vi.mocked(getLatestTypesEntrypoint).mockReturnValue(null);
@@ -62,7 +62,7 @@ describe("updateTsConfig", () => {
 		expect(writeFile).not.toHaveBeenCalled();
 	});
 
-	test("don't clobber existing entrypoints", async () => {
+	test("don't clobber existing entrypoints", async ({ expect }) => {
 		ctx.template.workersTypes = "installed";
 		vi.mocked(readFile).mockImplementation(
 			() =>
@@ -75,7 +75,9 @@ describe("updateTsConfig", () => {
 		);
 	});
 
-	test("will remove workers-types when generating types, if generated types include runtime types", async () => {
+	test("will remove workers-types when generating types, if generated types include runtime types", async ({
+		expect,
+	}) => {
 		vi.mocked(readFile).mockImplementation((path) => {
 			if (path.includes("tsconfig.json")) {
 				return `{ "compilerOptions": { "types" : ["@cloudflare/workers-types/2021-03-20"]} }`;
@@ -89,7 +91,9 @@ describe("updateTsConfig", () => {
 		);
 	});
 
-	test("will NOT remove workers-types when generating types, if generated types don't include runtime types", async () => {
+	test("will NOT remove workers-types when generating types, if generated types don't include runtime types", async ({
+		expect,
+	}) => {
 		vi.mocked(readFile).mockImplementation((path) => {
 			if (path.includes("tsconfig.json")) {
 				return `{ "compilerOptions": { "types" : ["@cloudflare/workers-types/2021-03-20"]} }`;
@@ -104,14 +108,16 @@ describe("updateTsConfig", () => {
 		);
 	});
 
-	test("will add generated types file", async () => {
+	test("will add generated types file", async ({ expect }) => {
 		await updateTsConfig(ctx, { usesNodeCompat: false });
 		expect(vi.mocked(writeFile).mock.calls[0][1]).toContain(
 			`./worker-configuration.d.ts`,
 		);
 	});
 
-	test("skips modification when tsconfig uses project references", async () => {
+	test("skips modification when tsconfig uses project references", async ({
+		expect,
+	}) => {
 		vi.mocked(readFile).mockImplementation(
 			() => `{
 				"files": [],
@@ -125,7 +131,9 @@ describe("updateTsConfig", () => {
 		expect(writeFile).not.toHaveBeenCalled();
 	});
 
-	test("modifies tsconfig when references array is empty", async () => {
+	test("modifies tsconfig when references array is empty", async ({
+		expect,
+	}) => {
 		ctx.template.workersTypes = "installed";
 		vi.mocked(readFile).mockImplementation(
 			() => `{

--- a/packages/create-cloudflare/src/frameworks/__tests__/index.test.ts
+++ b/packages/create-cloudflare/src/frameworks/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import { mockPackageManager } from "helpers/__tests__/mocks";
 import { runCommand } from "helpers/command";
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- test.each pattern
 import { describe, expect, test, vi } from "vitest";
 import { getFrameworkCli, runFrameworkGenerator } from "..";
 import { createTestContext } from "../../__tests__/helpers";

--- a/packages/create-cloudflare/src/helpers/__tests__/args.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/args.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- test.each pattern
 import { assert, describe, expect, test, vi } from "vitest";
 import { parseArgs } from "../args";
 

--- a/packages/create-cloudflare/src/helpers/__tests__/cli.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/cli.test.ts
@@ -1,6 +1,6 @@
 import { SemVer } from "semver";
 import { getGlobalDispatcher, MockAgent, setGlobalDispatcher } from "undici";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, test, vi } from "vitest";
 import { version as currentVersion } from "../../../package.json";
 import { isUpdateAvailable } from "../cli";
 import { mockSpinner } from "./mocks";
@@ -28,7 +28,7 @@ describe("isUpdateAvailable", () => {
 		setGlobalDispatcher(originalDispatcher);
 	});
 
-	test("is not available if fetch fails", async () => {
+	test("is not available if fetch fails", async ({ expect }) => {
 		agent
 			.get("https://registry.npmjs.org")
 			.intercept({ path: "/create-cloudflare" })
@@ -36,21 +36,27 @@ describe("isUpdateAvailable", () => {
 		expect(await isUpdateAvailable()).toBe(false);
 	});
 
-	test("is not available if fetched latest version is older by a minor", async () => {
+	test("is not available if fetched latest version is older by a minor", async ({
+		expect,
+	}) => {
 		const latestVersion = new SemVer(currentVersion);
 		latestVersion.minor--;
 		replyWithLatest(latestVersion);
 		expect(await isUpdateAvailable()).toBe(false);
 	});
 
-	test("is available if fetched latest version is newer by a minor", async () => {
+	test("is available if fetched latest version is newer by a minor", async ({
+		expect,
+	}) => {
 		const latestVersion = new SemVer(currentVersion);
 		latestVersion.minor++;
 		replyWithLatest(latestVersion);
 		expect(await isUpdateAvailable()).toBe(true);
 	});
 
-	test("is not available if fetched latest version is newer by a major", async () => {
+	test("is not available if fetched latest version is newer by a major", async ({
+		expect,
+	}) => {
 		const latestVersion = new SemVer(currentVersion);
 		latestVersion.major++;
 		replyWithLatest(latestVersion);

--- a/packages/create-cloudflare/src/helpers/__tests__/codemod.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/codemod.test.ts
@@ -1,7 +1,8 @@
 import { mergeObjectProperties } from "helpers/codemod";
 import * as recast from "recast";
 import parser from "recast/parsers/babel";
-import { describe, expect, test } from "vitest";
+import { describe, test } from "vitest";
+import type { ExpectStatic } from "vitest";
 
 describe("mergeObjectProperties", () => {
 	const tests = [
@@ -93,19 +94,24 @@ describe("mergeObjectProperties", () => {
 	}[];
 
 	tests.forEach(({ testName, ...testObjects }) =>
-		test(testName, () => testMergeObjectProperties(testObjects)),
+		test(testName, ({ expect }) =>
+			testMergeObjectProperties(testObjects, expect),
+		),
 	);
 });
 
-const testMergeObjectProperties = ({
-	sourcePropertiesObject,
-	newPropertiesObject,
-	expectedPropertiesObject,
-}: {
-	sourcePropertiesObject: Record<string, unknown>;
-	newPropertiesObject: Record<string, unknown>;
-	expectedPropertiesObject: Record<string, unknown>;
-}) => {
+const testMergeObjectProperties = (
+	{
+		sourcePropertiesObject,
+		newPropertiesObject,
+		expectedPropertiesObject,
+	}: {
+		sourcePropertiesObject: Record<string, unknown>;
+		newPropertiesObject: Record<string, unknown>;
+		expectedPropertiesObject: Record<string, unknown>;
+	},
+	expect: ExpectStatic,
+) => {
 	const sourceObj = createObjectExpression(sourcePropertiesObject);
 	const newProperties = createObjectExpression(newPropertiesObject)
 		.properties as recast.types.namedTypes.ObjectProperty[];

--- a/packages/create-cloudflare/src/helpers/__tests__/command.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/command.test.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs";
 import { spawn } from "cross-spawn";
 import { readMetricsConfig } from "helpers/metrics-config";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, test, vi } from "vitest";
 import whichPMRuns from "which-pm-runs";
 import { quoteShellArgs, runCommand } from "../command";
 import type { ChildProcess } from "node:child_process";
@@ -52,7 +52,7 @@ describe("Command Helpers", () => {
 		vi.mocked(existsSync).mockImplementation(() => false);
 	});
 
-	test("runCommand", async () => {
+	test("runCommand", async ({ expect }) => {
 		await runCommand(["ls", "-l"]);
 		expect(spawn).toHaveBeenCalledWith("ls", ["-l"], {
 			stdio: "inherit",
@@ -62,7 +62,9 @@ describe("Command Helpers", () => {
 	});
 
 	describe("respect telemetry permissions when running wrangler", () => {
-		test("runCommand has WRANGLER_SEND_METRICS=false if its a wrangler command and c3 telemetry is disabled", async () => {
+		test("runCommand has WRANGLER_SEND_METRICS=false if its a wrangler command and c3 telemetry is disabled", async ({
+			expect,
+		}) => {
 			vi.mocked(readMetricsConfig).mockReturnValue({
 				c3permission: {
 					enabled: false,
@@ -80,7 +82,9 @@ describe("Command Helpers", () => {
 			);
 		});
 
-		test("runCommand doesn't have WRANGLER_SEND_METRICS=false if its a wrangler command and c3 telemetry is enabled", async () => {
+		test("runCommand doesn't have WRANGLER_SEND_METRICS=false if its a wrangler command and c3 telemetry is enabled", async ({
+			expect,
+		}) => {
 			vi.mocked(readMetricsConfig).mockReturnValue({
 				c3permission: {
 					enabled: true,
@@ -98,7 +102,9 @@ describe("Command Helpers", () => {
 			);
 		});
 
-		test("runCommand doesn't have WRANGLER_SEND_METRICS=false if not a wrangler command", async () => {
+		test("runCommand doesn't have WRANGLER_SEND_METRICS=false if not a wrangler command", async ({
+			expect,
+		}) => {
 			vi.mocked(readMetricsConfig).mockReturnValue({
 				c3permission: {
 					enabled: false,
@@ -118,7 +124,7 @@ describe("Command Helpers", () => {
 	});
 
 	describe("quoteShellArgs", () => {
-		test.runIf(process.platform !== "win32")("mac", async () => {
+		test.runIf(process.platform !== "win32")("mac", async ({ expect }) => {
 			expect(quoteShellArgs([`pages:dev`])).toEqual("pages:dev");
 			expect(quoteShellArgs([`24.02 foo-bar`])).toEqual(`'24.02 foo-bar'`);
 			expect(quoteShellArgs([`foo/10 bar/20-baz/`])).toEqual(
@@ -126,7 +132,7 @@ describe("Command Helpers", () => {
 			);
 		});
 
-		test.runIf(process.platform === "win32")("windows", async () => {
+		test.runIf(process.platform === "win32")("windows", async ({ expect }) => {
 			expect(quoteShellArgs([`pages:dev`])).toEqual("pages:dev");
 			expect(quoteShellArgs([`24.02 foo-bar`])).toEqual(`"24.02 foo-bar"`);
 			expect(quoteShellArgs([`foo/10 bar/20-baz/`])).toEqual(

--- a/packages/create-cloudflare/src/helpers/__tests__/compatDate.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/compatDate.test.ts
@@ -3,7 +3,7 @@ import {
 	getLatestTypesEntrypoint,
 	getWorkerdCompatibilityDate,
 } from "helpers/compatDate";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, test, vi } from "vitest";
 import { createTestContext } from "../../__tests__/helpers";
 import { mockSpinner, mockWorkersTypesDirectory } from "./mocks";
 
@@ -24,7 +24,7 @@ describe("Compatibility Date Helpers", () => {
 	});
 
 	describe("getWorkerdCompatibilityDate()", () => {
-		test("normal flow", async () => {
+		test("normal flow", async ({ expect }) => {
 			vi.mocked(getLocalWorkerdCompatibilityDate).mockReturnValue({
 				date: "2025-01-10",
 				source: "workerd",
@@ -40,7 +40,7 @@ describe("Compatibility Date Helpers", () => {
 			);
 		});
 
-		test("fallback result", async () => {
+		test("fallback result", async ({ expect }) => {
 			vi.mocked(getLocalWorkerdCompatibilityDate).mockReturnValue({
 				date: "2025-09-27",
 				source: "fallback",
@@ -60,14 +60,14 @@ describe("Compatibility Date Helpers", () => {
 	describe("getLatestTypesEntrypoint", () => {
 		const ctx = createTestContext();
 
-		test("happy path", async () => {
+		test("happy path", async ({ expect }) => {
 			mockWorkersTypesDirectory();
 
 			const entrypoint = getLatestTypesEntrypoint(ctx);
 			expect(entrypoint).toBe("2023-07-01");
 		});
 
-		test("read error", async () => {
+		test("read error", async ({ expect }) => {
 			mockWorkersTypesDirectory(() => {
 				throw new Error("ENOENT: no such file or directory");
 			});
@@ -76,14 +76,14 @@ describe("Compatibility Date Helpers", () => {
 			expect(entrypoint).toBe(null);
 		});
 
-		test("empty directory", async () => {
+		test("empty directory", async ({ expect }) => {
 			mockWorkersTypesDirectory(() => []);
 
 			const entrypoint = getLatestTypesEntrypoint(ctx);
 			expect(entrypoint).toBe(null);
 		});
 
-		test("no compat dates found", async () => {
+		test("no compat dates found", async ({ expect }) => {
 			mockWorkersTypesDirectory(() => ["foo", "bar"]);
 
 			const entrypoint = getLatestTypesEntrypoint(ctx);

--- a/packages/create-cloudflare/src/helpers/__tests__/json.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/json.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, test, vi } from "vitest";
 import * as files from "../files";
 import {
 	addJSONComment,
@@ -22,7 +22,7 @@ describe("json helpers", () => {
 	});
 
 	describe("readJSONWithComments", () => {
-		test("reads and parses JSON file with comments", () => {
+		test("reads and parses JSON file with comments", ({ expect }) => {
 			mockReadFile.mockReturnValue(
 				'{\n/* a comment */\n "name": "test"\n}\n// post-comment',
 			);
@@ -31,7 +31,7 @@ describe("json helpers", () => {
 			expect(result).toEqual({ name: "test" });
 		});
 
-		test("using a reviver function", () => {
+		test("using a reviver function", ({ expect }) => {
 			mockReadFile.mockReturnValue(
 				JSON.stringify({
 					name: "test",
@@ -62,7 +62,7 @@ describe("json helpers", () => {
 	});
 
 	describe("writeJSONWithComments", () => {
-		test("stringifies and writes JSON object with comments", () => {
+		test("stringifies and writes JSON object with comments", ({ expect }) => {
 			mockReadFile.mockReturnValue(
 				'{\n\t/* a comment */\n\t"name": "test"\n}\n// post-comment',
 			);
@@ -82,7 +82,7 @@ describe("json helpers", () => {
 	});
 
 	describe("addJSONComment", () => {
-		test("adds a string comment to JSON object", () => {
+		test("adds a string comment to JSON object", ({ expect }) => {
 			const jsonObject = { name: "foo" } as unknown as CommentObject;
 
 			addJSONComment(jsonObject, "before:name", " This is a comment ");
@@ -99,7 +99,7 @@ describe("json helpers", () => {
 			`);
 		});
 
-		test("adds multiple comments to JSON object", () => {
+		test("adds multiple comments to JSON object", ({ expect }) => {
 			const jsonObject = { name: "foo" } as unknown as CommentObject;
 
 			addJSONComment(jsonObject, "before:name", [
@@ -120,7 +120,7 @@ describe("json helpers", () => {
 			`);
 		});
 
-		test("appends to existing comments", () => {
+		test("appends to existing comments", ({ expect }) => {
 			const jsonObject = { name: "foo" } as unknown as CommentObject;
 			addJSONComment(jsonObject, "before:name", " This is a comment ");
 
@@ -141,7 +141,9 @@ describe("json helpers", () => {
 	});
 
 	describe("appendJSONProperty", () => {
-		test("appends property to JSON object, maintaining comments", () => {
+		test("appends property to JSON object, maintaining comments", ({
+			expect,
+		}) => {
 			mockReadFile.mockReturnValue(
 				'{\n/* a comment */\n "existing": "value"\n}\n// post-comment',
 			);
@@ -164,7 +166,9 @@ describe("json helpers", () => {
 	});
 
 	describe("insertJSONProperty", () => {
-		test("inserts property at the beginning of JSON object, maintaining comments", () => {
+		test("inserts property at the beginning of JSON object, maintaining comments", ({
+			expect,
+		}) => {
 			mockReadFile.mockReturnValue(
 				'{\n/* a comment */\n "existing": "value"\n}\n// post-comment',
 			);

--- a/packages/create-cloudflare/src/helpers/__tests__/mocks.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/mocks.ts
@@ -1,5 +1,6 @@
 import { readdirSync } from "node:fs";
 import { spinner } from "@cloudflare/cli/interactive";
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- helper module with expect at module scope
 import { expect, vi } from "vitest";
 import whichPMRuns from "which-pm-runs";
 import type { Dirent } from "node:fs";

--- a/packages/create-cloudflare/src/helpers/__tests__/packageManagers.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/packageManagers.test.ts
@@ -3,6 +3,7 @@ import {
 	detectPackageManager,
 	detectPmMismatch,
 } from "helpers/packageManagers";
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- test.each pattern
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import whichPMRuns from "which-pm-runs";
 import { mockPackageManager } from "./mocks";

--- a/packages/create-cloudflare/src/helpers/__tests__/packages.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/packages.test.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { runCommand } from "helpers/command";
 import { installPackages, installWrangler, npmInstall } from "helpers/packages";
+// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- test.each pattern
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import whichPMRuns from "which-pm-runs";
 import { createTestContext } from "../../__tests__/helpers";

--- a/packages/create-cloudflare/src/helpers/__tests__/retry.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/retry.test.ts
@@ -1,8 +1,8 @@
 import { retry } from "helpers/retry";
-import { describe, expect, test } from "vitest";
+import { describe, test } from "vitest";
 
 describe("retry", () => {
-	test("success on first try", async () => {
+	test("success on first try", async ({ expect }) => {
 		let tries = 0;
 		await retry({ times: 3 }, async () => {
 			tries++;
@@ -11,7 +11,7 @@ describe("retry", () => {
 		expect(tries).toBe(1);
 	});
 
-	test("success after one failure", async () => {
+	test("success after one failure", async ({ expect }) => {
 		let tries = 0;
 		await retry({ times: 3 }, async () => {
 			tries++;
@@ -23,7 +23,7 @@ describe("retry", () => {
 		expect(tries).toBe(2);
 	});
 
-	test("success after multiple failures", async () => {
+	test("success after multiple failures", async ({ expect }) => {
 		let tries = 0;
 		let fails = 2;
 
@@ -39,7 +39,7 @@ describe("retry", () => {
 		expect(tries).toBe(3);
 	});
 
-	test("hard failure", async () => {
+	test("hard failure", async ({ expect }) => {
 		await expect(async () => {
 			await retry({ times: 3 }, async () => {
 				throw Error("testing");
@@ -47,7 +47,7 @@ describe("retry", () => {
 		}).rejects.toThrowError("testing");
 	});
 
-	test("exit condition encountered", async () => {
+	test("exit condition encountered", async ({ expect }) => {
 		let tries = 0;
 
 		await expect(async () => {

--- a/packages/create-cloudflare/src/wrangler/__tests__/accounts.test.ts
+++ b/packages/create-cloudflare/src/wrangler/__tests__/accounts.test.ts
@@ -1,7 +1,7 @@
 import { mockPackageManager, mockSpinner } from "helpers/__tests__/mocks";
 import { runCommand } from "helpers/command";
 import { hasSparrowSourceKey } from "helpers/sparrow";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, test, vi } from "vitest";
 import { createTestContext } from "../../__tests__/helpers";
 import { isLoggedIn, listAccounts, wranglerLogin } from "../accounts";
 
@@ -48,7 +48,7 @@ describe("wrangler account helpers", () => {
 	});
 
 	describe("wranglerLogin", async () => {
-		test("logged in", async () => {
+		test("logged in", async ({ expect }) => {
 			const mock = vi
 				.mocked(runCommand)
 				.mockReturnValueOnce(Promise.resolve(loggedInWhoamiOutput));
@@ -68,7 +68,7 @@ describe("wrangler account helpers", () => {
 			expect(spinner.stop).toHaveBeenCalledOnce();
 		});
 
-		test("logged out (successful login)", async () => {
+		test("logged out (successful login)", async ({ expect }) => {
 			const mock = vi
 				.mocked(runCommand)
 				.mockReturnValueOnce(Promise.resolve(loggedOutWhoamiOutput))
@@ -89,7 +89,7 @@ describe("wrangler account helpers", () => {
 			expect(spinner.stop).toHaveBeenCalledTimes(2);
 		});
 
-		test("logged out (login denied)", async () => {
+		test("logged out (login denied)", async ({ expect }) => {
 			const mock = vi
 				.mocked(runCommand)
 				.mockReturnValueOnce(Promise.resolve(loggedOutWhoamiOutput))
@@ -111,7 +111,7 @@ describe("wrangler account helpers", () => {
 		});
 	});
 
-	test("listAccounts", async () => {
+	test("listAccounts", async ({ expect }) => {
 		const mock = vi
 			.mocked(runCommand)
 			.mockReturnValueOnce(Promise.resolve(loggedInWhoamiOutput));
@@ -125,7 +125,7 @@ describe("wrangler account helpers", () => {
 	});
 
 	describe("isLoggedIn", async () => {
-		test("logged in", async () => {
+		test("logged in", async ({ expect }) => {
 			const mock = vi
 				.mocked(runCommand)
 				.mockReturnValueOnce(Promise.resolve(loggedInWhoamiOutput));
@@ -139,7 +139,7 @@ describe("wrangler account helpers", () => {
 			);
 		});
 
-		test("logged out", async () => {
+		test("logged out", async ({ expect }) => {
 			const mock = vi
 				.mocked(runCommand)
 				.mockReturnValueOnce(Promise.resolve(loggedOutWhoamiOutput));
@@ -153,7 +153,7 @@ describe("wrangler account helpers", () => {
 			);
 		});
 
-		test("wrangler whoami error", async () => {
+		test("wrangler whoami error", async ({ expect }) => {
 			const mock = vi
 				.mocked(runCommand)
 				.mockRejectedValueOnce(new Error("fail!"));

--- a/packages/create-cloudflare/src/wrangler/__tests__/config.test.ts
+++ b/packages/create-cloudflare/src/wrangler/__tests__/config.test.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { mockWorkersTypesDirectory } from "helpers/__tests__/mocks";
 import { getWorkerdCompatibilityDate } from "helpers/compatDate";
 import { readFile, writeFile } from "helpers/files";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, test, vi } from "vitest";
 import { createTestContext } from "../../__tests__/helpers";
 import { updateWranglerConfig } from "../config";
 
@@ -28,7 +28,7 @@ describe("update wrangler config", () => {
 		);
 	});
 
-	test("placeholder replacement `<TBD>`", async () => {
+	test("placeholder replacement `<TBD>`", async ({ expect }) => {
 		const toml = [
 			`name = "<TBD>"`,
 			`main = "src/index.ts"`,
@@ -84,7 +84,7 @@ describe("update wrangler config", () => {
 		`);
 	});
 
-	test("placeholder replacement", async () => {
+	test("placeholder replacement", async ({ expect }) => {
 		const toml = [
 			`name = "<WORKER_NAME>"`,
 			`main = "src/index.ts"`,
@@ -140,7 +140,7 @@ describe("update wrangler config", () => {
 		`);
 	});
 
-	test("placeholder replacement `<TBD>` (json)", async () => {
+	test("placeholder replacement `<TBD>` (json)", async ({ expect }) => {
 		vi.mocked(existsSync).mockImplementationOnce((f) =>
 			(f as string).endsWith(".json"),
 		);
@@ -206,7 +206,7 @@ describe("update wrangler config", () => {
 		`);
 	});
 
-	test("placeholder replacement (json)", async () => {
+	test("placeholder replacement (json)", async ({ expect }) => {
 		vi.mocked(existsSync).mockImplementationOnce((f) =>
 			(f as string).endsWith(".json"),
 		);
@@ -272,7 +272,7 @@ describe("update wrangler config", () => {
 		`);
 	});
 
-	test("string literal replacement", async () => {
+	test("string literal replacement", async ({ expect }) => {
 		const toml = [`name = "my-cool-worker"`, `main = "src/index.ts"`].join(
 			"\n",
 		);
@@ -325,7 +325,7 @@ describe("update wrangler config", () => {
 		`);
 	});
 
-	test("missing name and compat date", async () => {
+	test("missing name and compat date", async ({ expect }) => {
 		const toml = `main = "src/index.ts"`;
 		vi.mocked(readFile).mockReturnValue(toml);
 
@@ -376,7 +376,7 @@ describe("update wrangler config", () => {
 		`);
 	});
 
-	test("dont replace valid existing compatibility date", async () => {
+	test("dont replace valid existing compatibility date", async ({ expect }) => {
 		const toml = [
 			`name = "super-old-worker"`,
 			`compatibility_date = "2001-10-12"`,
@@ -429,7 +429,7 @@ describe("update wrangler config", () => {
 		`);
 	});
 
-	test("placeholder replacement with Workflows (json)", async () => {
+	test("placeholder replacement with Workflows (json)", async ({ expect }) => {
 		vi.mocked(existsSync).mockImplementationOnce((f) =>
 			(f as string).endsWith(".json"),
 		);


### PR DESCRIPTION
Part of https://github.com/cloudflare/workers-sdk/issues/12346
Part of a series (#12347, #12356) handling simple refactors, one package at a time to keep the review simpler.

The code changes are courtesy of OpenCode/Opus

Note that the tests inside the templates have not been updated

**Summary**

I've successfully migrated the create-cloudflare package to use context-based expect for vitest concurrency safety. Here's the breakdown:

**Changes Made**

1. ESLint Configuration (eslint.config.mjs)
- Enabled the workers-sdk/no-vitest-import-expect rule for test files

2. Trivial Files Migrated (18 files)
These files were converted to use { expect } from the test context:

| File | Tests |
|------|-------|
| src/__tests__/deploy.test.ts | 9 |
| src/__tests__/dialog.test.ts | 6 |
| src/__tests__/git.test.ts | 24 |
| src/__tests__/metrics.test.ts | 15 |
| src/__tests__/pre-existing.test.ts | 2 |
| src/__tests__/templates.test.ts | 28 |
| src/__tests__/workers.test.ts | 9 |
| src/helpers/__tests__/cli.test.ts | 4 |
| src/helpers/__tests__/codemod.test.ts | 3 |
| src/helpers/__tests__/command.test.ts | 6 |
| src/helpers/__tests__/compatDate.test.ts | 6 |
| src/helpers/__tests__/json.test.ts | 8 |
| src/helpers/__tests__/retry.test.ts | 5 |
| src/wrangler/__tests__/accounts.test.ts | 7 |
| src/wrangler/__tests__/config.test.ts | 8 |

3. Complex Files (12 files with eslint-disable)
These files use patterns incompatible with context-based expect:

| File | Reason |
|------|--------|
| e2e/helpers/framework-helpers.ts | Helper module with expect at module scope |
| e2e/helpers/to-exist.ts | Extends vitest expect with custom matcher |
| e2e/helpers/workers-helpers.ts | Helper module with expect at module scope |
| src/helpers/__tests__/mocks.ts | Helper module with expect at module scope |
| src/helpers/__tests__/packages.test.ts | Uses test.each |
| src/helpers/__tests__/packageManagers.test.ts | Uses test.each |
| src/frameworks/__tests__/index.test.ts | Uses test.each |
| src/helpers/__tests__/args.test.ts | Uses test.each |
| src/__tests__/validators.test.ts | Uses test.each |
| e2e/tests/cli/cli.test.ts | E2E test with complex patterns |
| e2e/tests/frameworks/frameworks.test.ts | E2E test with complex patterns |
| e2e/tests/workers/workers.test.ts | E2E test with complex patterns |

**Verification**

- ✅ Lint passes: pnpm --filter create-cloudflare check:lint
- ✅ Tests pass: 206 tests passed (1 skipped)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not user facing

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12373">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
