### PR TITLE
Generate typed pipeline bindings from stream schemas

### DIFF
--- a/.changeset/shaggy-phones-stay.md
+++ b/.changeset/shaggy-phones-stay.md
@@ -1,0 +1,27 @@
+---
+"wrangler": minor
+---
+
+Generate typed pipeline bindings from stream schemas
+
+When running `wrangler types`, pipeline bindings now generate TypeScript types based on the stream's schema definition. This gives you full autocomplete and type checking when sending data to your pipelines.
+
+```jsonc
+// wrangler.json
+{
+	"pipelines": [{ "binding": "ANALYTICS", "pipeline": "analytics-stream-id" }],
+}
+```
+
+If your stream has a schema with fields like `user_id` (string) and `event_count` (int32), the generated types will be:
+
+```typescript
+declare namespace Cloudflare {
+	type AnalyticsStreamRecord = { user_id: string; event_count: number };
+	interface Env {
+		ANALYTICS: Pipeline<Cloudflare.AnalyticsStreamRecord>;
+	}
+}
+```
+
+For unstructured streams or when not authenticated, bindings fall back to the generic `Pipeline<PipelineRecord>` type.

--- a/packages/wrangler/src/__tests__/type-generation-pipeline-schema.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation-pipeline-schema.test.ts
@@ -1,0 +1,328 @@
+import { describe, it } from "vitest";
+import {
+	generatePipelineTypeFromSchema,
+	GENERIC_PIPELINE_TYPE,
+	streamNameToTypeName,
+} from "../type-generation/pipeline-schema";
+
+describe("streamNameToTypeName", () => {
+	it("should convert snake_case to PascalCase with Record suffix", ({
+		expect,
+	}) => {
+		expect(streamNameToTypeName("analytics_stream")).toBe(
+			"AnalyticsStreamRecord"
+		);
+	});
+
+	it("should convert kebab-case to PascalCase with Record suffix", ({
+		expect,
+	}) => {
+		expect(streamNameToTypeName("my-events")).toBe("MyEventsRecord");
+	});
+
+	it("should handle single word", ({ expect }) => {
+		expect(streamNameToTypeName("events")).toBe("EventsRecord");
+	});
+});
+
+describe("generatePipelineTypeFromSchema", () => {
+	it("should return generic type for null schema", ({ expect }) => {
+		const result = generatePipelineTypeFromSchema(null);
+		expect(result.typeReference).toBe(GENERIC_PIPELINE_TYPE);
+		expect(result.typeDefinition).toBeNull();
+		expect(result.typeName).toBeNull();
+	});
+
+	it("should return generic type for schema with empty fields", ({
+		expect,
+	}) => {
+		const result = generatePipelineTypeFromSchema({ fields: [] });
+		expect(result.typeReference).toBe(GENERIC_PIPELINE_TYPE);
+		expect(result.typeDefinition).toBeNull();
+		expect(result.typeName).toBeNull();
+	});
+
+	it("should return generic type for schema with empty fields even when stream name is provided", ({
+		expect,
+	}) => {
+		const result = generatePipelineTypeFromSchema({ fields: [] }, "my_stream");
+		expect(result.typeReference).toBe(GENERIC_PIPELINE_TYPE);
+		expect(result.typeDefinition).toBeNull();
+		expect(result.typeName).toBeNull();
+	});
+
+	it("should return generic type for schema with non-array fields", ({
+		expect,
+	}) => {
+		// @ts-expect-error Testing invalid input
+		const result = generatePipelineTypeFromSchema({ fields: "invalid" });
+		expect(result.typeReference).toBe(GENERIC_PIPELINE_TYPE);
+		expect(result.typeDefinition).toBeNull();
+	});
+
+	it("should generate named type when stream name is provided", ({
+		expect,
+	}) => {
+		const schema = {
+			fields: [{ name: "user_id", type: "string" as const, required: true }],
+		};
+		const result = generatePipelineTypeFromSchema(schema, "analytics_stream");
+		expect(result.typeReference).toBe(
+			'import("cloudflare:pipelines").Pipeline<Cloudflare.AnalyticsStreamRecord>'
+		);
+		expect(result.typeDefinition).toBe(
+			"type AnalyticsStreamRecord = { user_id: string };"
+		);
+		expect(result.typeName).toBe("AnalyticsStreamRecord");
+	});
+
+	it("should generate inline type when stream name is not provided", ({
+		expect,
+	}) => {
+		const schema = {
+			fields: [{ name: "user_id", type: "string" as const, required: true }],
+		};
+		const result = generatePipelineTypeFromSchema(schema);
+		expect(result.typeReference).toBe(
+			'import("cloudflare:pipelines").Pipeline<{ user_id: string }>'
+		);
+		expect(result.typeDefinition).toBeNull();
+		expect(result.typeName).toBeNull();
+	});
+
+	it("should generate type for optional field", ({ expect }) => {
+		const schema = {
+			fields: [{ name: "user_id", type: "string" as const, required: false }],
+		};
+		const result = generatePipelineTypeFromSchema(schema, "my_stream");
+		expect(result.typeDefinition).toBe(
+			"type MyStreamRecord = { user_id?: string };"
+		);
+	});
+
+	it("should generate types for all primitive types", ({ expect }) => {
+		const schema = {
+			fields: [
+				{ name: "str", type: "string" as const, required: true },
+				{ name: "bool_val", type: "bool" as const, required: true },
+				{ name: "int32_val", type: "int32" as const, required: true },
+				{ name: "int64_val", type: "int64" as const, required: true },
+				{ name: "uint32_val", type: "uint32" as const, required: true },
+				{ name: "uint64_val", type: "uint64" as const, required: true },
+				{ name: "float32_val", type: "float32" as const, required: true },
+				{ name: "float64_val", type: "float64" as const, required: true },
+				{ name: "decimal128_val", type: "decimal128" as const, required: true },
+				{ name: "timestamp_val", type: "timestamp" as const, required: true },
+				{ name: "json_val", type: "json" as const, required: true },
+				{ name: "bytes_val", type: "bytes" as const, required: true },
+			],
+		};
+		const result = generatePipelineTypeFromSchema(schema, "test_stream");
+		expect(result.typeDefinition).toContain("str: string");
+		expect(result.typeDefinition).toContain("bool_val: boolean");
+		expect(result.typeDefinition).toContain("int32_val: number");
+		expect(result.typeDefinition).toContain("int64_val: number");
+		expect(result.typeDefinition).toContain("uint32_val: number");
+		expect(result.typeDefinition).toContain("uint64_val: number");
+		expect(result.typeDefinition).toContain("float32_val: number");
+		expect(result.typeDefinition).toContain("float64_val: number");
+		expect(result.typeDefinition).toContain("decimal128_val: number");
+		expect(result.typeDefinition).toContain("timestamp_val: string | number");
+		expect(result.typeDefinition).toContain(
+			"json_val: Record<string, unknown>"
+		);
+		// Binary data is base64-encoded when sent as JSON
+		expect(result.typeDefinition).toContain("bytes_val: string");
+	});
+
+	it("should generate type for list field", ({ expect }) => {
+		const schema = {
+			fields: [
+				{
+					name: "tags",
+					type: "list" as const,
+					required: true,
+					items: { name: "", type: "string" as const, required: true },
+				},
+			],
+		};
+		const result = generatePipelineTypeFromSchema(schema, "my_stream");
+		expect(result.typeDefinition).toBe(
+			"type MyStreamRecord = { tags: Array<string> };"
+		);
+	});
+
+	it("should generate type for nested struct field", ({ expect }) => {
+		const schema = {
+			fields: [
+				{
+					name: "metadata",
+					type: "struct" as const,
+					required: false,
+					fields: [
+						{ name: "source", type: "string" as const, required: false },
+						{ name: "priority", type: "int32" as const, required: true },
+					],
+				},
+			],
+		};
+		const result = generatePipelineTypeFromSchema(schema, "my_stream");
+		expect(result.typeDefinition).toContain("metadata?:");
+		expect(result.typeDefinition).toContain("source?: string");
+		expect(result.typeDefinition).toContain("priority: number");
+	});
+
+	it("should generate type for complex schema with multiple field types", ({
+		expect,
+	}) => {
+		const schema = {
+			fields: [
+				{ name: "user_id", type: "string" as const, required: true },
+				{ name: "amount", type: "float64" as const, required: false },
+				{
+					name: "tags",
+					type: "list" as const,
+					required: false,
+					items: { name: "", type: "string" as const, required: true },
+				},
+				{
+					name: "metadata",
+					type: "struct" as const,
+					required: false,
+					fields: [
+						{ name: "source", type: "string" as const, required: false },
+						{ name: "priority", type: "int32" as const, required: false },
+					],
+				},
+			],
+		};
+		const result = generatePipelineTypeFromSchema(schema, "my_stream");
+		expect(result.typeDefinition).toContain("user_id: string");
+		expect(result.typeDefinition).toContain("amount?: number");
+		expect(result.typeDefinition).toContain("tags?: Array<string>");
+		expect(result.typeDefinition).toContain("metadata?:");
+	});
+
+	it("should quote field names that are not valid identifiers", ({
+		expect,
+	}) => {
+		const schema = {
+			fields: [
+				{ name: "valid_name", type: "string" as const, required: true },
+				{ name: "invalid-name", type: "string" as const, required: true },
+				{ name: "123invalid", type: "string" as const, required: true },
+			],
+		};
+		const result = generatePipelineTypeFromSchema(schema, "my_stream");
+		expect(result.typeDefinition).toContain("valid_name: string");
+		expect(result.typeDefinition).toContain('"invalid-name": string');
+		expect(result.typeDefinition).toContain('"123invalid": string');
+	});
+
+	it("should escape special characters in field names", ({ expect }) => {
+		const schema = {
+			fields: [
+				{
+					name: 'field"with"quotes',
+					type: "string" as const,
+					required: true,
+				},
+				{
+					name: "field\nwith\nnewlines",
+					type: "string" as const,
+					required: true,
+				},
+				{
+					name: "field\\with\\backslash",
+					type: "string" as const,
+					required: true,
+				},
+			],
+		};
+		const result = generatePipelineTypeFromSchema(schema, "my_stream");
+		// Should produce valid TypeScript without breaking the string
+		expect(result.typeDefinition).toContain('"field\\"with\\"quotes": string');
+		expect(result.typeDefinition).toContain(
+			'"field\\nwith\\nnewlines": string'
+		);
+		expect(result.typeDefinition).toContain(
+			'"field\\\\with\\\\backslash": string'
+		);
+	});
+
+	it("should handle list without items definition", ({ expect }) => {
+		const schema = {
+			fields: [
+				{
+					name: "unknown_list",
+					type: "list" as const,
+					required: true,
+				},
+			],
+		};
+		const result = generatePipelineTypeFromSchema(schema, "my_stream");
+		expect(result.typeDefinition).toContain("unknown_list: unknown[]");
+	});
+
+	it("should handle struct without fields definition", ({ expect }) => {
+		const schema = {
+			fields: [
+				{
+					name: "empty_struct",
+					type: "struct" as const,
+					required: true,
+				},
+			],
+		};
+		const result = generatePipelineTypeFromSchema(schema, "my_stream");
+		expect(result.typeDefinition).toContain(
+			"empty_struct: Record<string, unknown>"
+		);
+	});
+
+	it("should handle unknown field types gracefully", ({ expect }) => {
+		const schema = {
+			fields: [
+				{
+					name: "mystery_field",
+					type: "unknown_type" as "string",
+					required: true,
+				},
+			],
+		};
+		const result = generatePipelineTypeFromSchema(schema, "my_stream");
+		expect(result.typeDefinition).toContain("mystery_field: unknown");
+	});
+
+	it("should limit nesting depth to prevent stack overflow", ({ expect }) => {
+		// Create a deeply nested struct (more than 10 levels)
+		type NestedField = {
+			name: string;
+			type: "string" | "struct";
+			required: boolean;
+			fields?: NestedField[];
+		};
+
+		const createNestedStruct = (depth: number): NestedField => {
+			if (depth === 0) {
+				return { name: "leaf", type: "string", required: true };
+			}
+			return {
+				name: `level_${depth}`,
+				type: "struct",
+				required: true,
+				fields: [createNestedStruct(depth - 1)],
+			};
+		};
+
+		const schema = {
+			fields: [createNestedStruct(15)], // 15 levels deep
+		};
+
+		// Should not throw and should eventually return "unknown" for deeply nested
+		const result = generatePipelineTypeFromSchema(schema, "my_stream");
+		expect(result.typeDefinition).toBeDefined();
+		// At depth > 10, it should fall back to "unknown"
+		expect(result.typeDefinition).toContain("unknown");
+	});
+});

--- a/packages/wrangler/src/pipelines/types.ts
+++ b/packages/wrangler/src/pipelines/types.ts
@@ -137,8 +137,11 @@ export type SchemaField = {
 		| "bool"
 		| "int32"
 		| "int64"
+		| "uint32"
+		| "uint64"
 		| "float32"
 		| "float64"
+		| "decimal128"
 		| "string"
 		| "timestamp"
 		| "json"
@@ -149,6 +152,8 @@ export type SchemaField = {
 	fields?: SchemaField[];
 	items?: SchemaField;
 	unit?: "second" | "millisecond" | "microsecond" | "nanosecond"; // For timestamp type
+	precision?: number; // For decimal128 type
+	scale?: number; // For decimal128 type
 };
 
 export type Sink = {

--- a/packages/wrangler/src/type-generation/pipeline-schema.ts
+++ b/packages/wrangler/src/type-generation/pipeline-schema.ts
@@ -1,0 +1,272 @@
+import { logger } from "../logger";
+import { getStream } from "../pipelines/client";
+import { getAPIToken } from "../user";
+import { toPascalCase } from "./helpers";
+import { escapeTypeScriptString, isValidIdentifier } from "./index";
+import type { SchemaField, Stream } from "../pipelines/types";
+import type { Config } from "@cloudflare/workers-utils";
+
+/**
+ * Maximum nesting depth for struct/list types to prevent stack overflow
+ */
+const MAX_NESTING_DEPTH = 10;
+
+/**
+ * The default generic pipeline type when schema is unavailable
+ */
+export const GENERIC_PIPELINE_TYPE =
+	'import("cloudflare:pipelines").Pipeline<import("cloudflare:pipelines").PipelineRecord>';
+
+/**
+ * Converts a pipeline schema field type to its TypeScript equivalent
+ *
+ * @param field - The schema field to convert
+ * @param depth - Current nesting depth (for recursion protection)
+ * @returns The TypeScript type string
+ */
+function schemaFieldTypeToTypeScript(field: SchemaField, depth = 0): string {
+	if (depth > MAX_NESTING_DEPTH) {
+		logger.warn(
+			`Schema nesting depth exceeded ${MAX_NESTING_DEPTH} for field '${field.name}', using unknown type`
+		);
+		return "unknown";
+	}
+
+	switch (field.type) {
+		case "string":
+			return "string";
+		case "bool":
+			return "boolean";
+		case "int32":
+		case "int64":
+		case "uint32":
+		case "uint64":
+		case "float32":
+		case "float64":
+		case "decimal128":
+			return "number";
+		case "timestamp":
+			// Timestamps can be RFC 3339 strings or numeric Unix timestamps
+			return "string | number";
+		case "json":
+			return "Record<string, unknown>";
+		case "bytes":
+			// Binary data is base64-encoded when sent as JSON
+			return "string";
+		case "list":
+			if (field.items) {
+				const itemType = schemaFieldTypeToTypeScript(field.items, depth + 1);
+				return `Array<${itemType}>`;
+			}
+			return "unknown[]";
+		case "struct":
+			if (
+				field.fields &&
+				Array.isArray(field.fields) &&
+				field.fields.length > 0
+			) {
+				return schemaFieldsToTypeScript(field.fields, depth + 1);
+			}
+			return "Record<string, unknown>";
+		default:
+			return "unknown";
+	}
+}
+
+/**
+ * Converts an array of schema fields to a TypeScript object type string
+ *
+ * @param fields - The array of schema fields
+ * @param depth - Current nesting depth (for recursion protection)
+ * @returns TypeScript object type string
+ */
+function schemaFieldsToTypeScript(fields: SchemaField[], depth = 0): string {
+	if (fields.length === 0) {
+		return "Record<string, unknown>";
+	}
+
+	const properties = fields.map((field) => {
+		const optional = field.required ? "" : "?";
+		const fieldType = schemaFieldTypeToTypeScript(field, depth);
+		// Use quotes for field names that aren't valid identifiers, with proper escaping
+		const fieldName = isValidIdentifier(field.name)
+			? field.name
+			: `"${escapeTypeScriptString(field.name)}"`;
+		return `${fieldName}${optional}: ${fieldType}`;
+	});
+
+	return `{ ${properties.join("; ")} }`;
+}
+
+/**
+ * Converts a stream name to a TypeScript type name in PascalCase with "Record" suffix
+ *
+ * @example
+ * streamNameToTypeName("analytics_stream") // "AnalyticsStreamRecord"
+ * streamNameToTypeName("my-events") // "MyEventsRecord"
+ */
+export function streamNameToTypeName(streamName: string): string {
+	const pascalCase = toPascalCase(streamName);
+	return `${pascalCase}Record`;
+}
+
+/**
+ * Result of generating pipeline type from schema
+ */
+export interface PipelineSchemaTypeResult {
+	/** The type reference to use in the binding (e.g., "Pipeline<MyStreamRecord>") */
+	typeReference: string;
+	/** The type definition to include at the top of the file, or null if using generic type */
+	typeDefinition: string | null;
+	/** The name of the generated type, or null if using generic type */
+	typeName: string | null;
+}
+
+/**
+ * Generates a TypeScript type for a pipeline binding based on its stream schema
+ *
+ * @param schema - The stream schema (or null for unstructured streams)
+ * @param streamName - The name of the stream (used for type naming)
+ * @returns Object containing the type reference and optional type definition
+ */
+export function generatePipelineTypeFromSchema(
+	schema: Stream["schema"],
+	streamName?: string
+): PipelineSchemaTypeResult {
+	if (!schema || !Array.isArray(schema.fields) || schema.fields.length === 0) {
+		// Unstructured stream - use generic type
+		return {
+			typeReference: GENERIC_PIPELINE_TYPE,
+			typeDefinition: null,
+			typeName: null,
+		};
+	}
+
+	const recordType = schemaFieldsToTypeScript(schema.fields);
+	const typeName = streamName ? streamNameToTypeName(streamName) : null;
+
+	if (typeName) {
+		// Type is inside Cloudflare namespace, so reference it with Cloudflare. prefix
+		return {
+			typeReference: `import("cloudflare:pipelines").Pipeline<Cloudflare.${typeName}>`,
+			typeDefinition: `type ${typeName} = ${recordType};`,
+			typeName,
+		};
+	}
+
+	// Fallback to inline type if no stream name available
+	return {
+		typeReference: `import("cloudflare:pipelines").Pipeline<${recordType}>`,
+		typeDefinition: null,
+		typeName: null,
+	};
+}
+
+/**
+ * Fetches the stream data from the API
+ *
+ * @param config - The wrangler config
+ * @param streamId - The stream/pipeline ID
+ * @returns The stream data, or null if unavailable
+ */
+export async function fetchStream(
+	config: Config,
+	streamId: string
+): Promise<Stream | null> {
+	try {
+		return await getStream(config, streamId);
+	} catch (error) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		logger.debug(
+			`Failed to fetch stream '${streamId}': ${errorMessage}. Using generic type.`
+		);
+		return null;
+	}
+}
+
+/**
+ * Checks if the user has an API token configured
+ */
+export function hasApiToken(): boolean {
+	return getAPIToken() !== undefined;
+}
+
+/**
+ * Result of fetching pipeline types
+ */
+export interface PipelineTypeResult {
+	binding: string;
+	type: string;
+	typeDefinition: string | null;
+	typeName: string | null;
+}
+
+/**
+ * Fetches pipeline types for all pipeline bindings in the config
+ *
+ * If authenticated, attempts to fetch schemas from the API.
+ * Falls back to generic types if not authenticated or on error.
+ *
+ * @param config - The wrangler config
+ * @param pipelines - Array of pipeline bindings from config
+ * @returns Array of pipeline type results
+ */
+export async function fetchPipelineTypes(
+	config: Config,
+	pipelines: Array<{ binding: string; pipeline: string }>
+): Promise<PipelineTypeResult[]> {
+	if (pipelines.length === 0) {
+		return [];
+	}
+
+	if (!hasApiToken()) {
+		logger.warn(
+			"Not authenticated - using generic types for pipeline bindings. Run `wrangler login` to enable typed pipeline bindings."
+		);
+		return pipelines.map((p) => ({
+			binding: p.binding,
+			type: GENERIC_PIPELINE_TYPE,
+			typeDefinition: null,
+			typeName: null,
+		}));
+	}
+
+	// Fetch all streams in parallel for better performance
+	const streams = await Promise.all(
+		pipelines.map((p) => fetchStream(config, p.pipeline))
+	);
+
+	const results = pipelines.map((pipeline, i) => {
+		const stream = streams[i];
+		if (stream) {
+			const schemaResult = generatePipelineTypeFromSchema(
+				stream.schema,
+				stream.name
+			);
+			return {
+				binding: pipeline.binding,
+				type: schemaResult.typeReference,
+				typeDefinition: schemaResult.typeDefinition,
+				typeName: schemaResult.typeName,
+			};
+		}
+		return {
+			binding: pipeline.binding,
+			type: GENERIC_PIPELINE_TYPE,
+			typeDefinition: null,
+			typeName: null,
+		};
+	});
+
+	const fetchedCount = streams.filter(Boolean).length;
+	if (fetchedCount > 0) {
+		logger.debug(`Fetched schemas for ${fetchedCount} pipeline binding(s)`);
+	}
+	if (fetchedCount < pipelines.length) {
+		logger.warn(
+			`Could not fetch schemas for ${pipelines.length - fetchedCount} pipeline binding(s) - using generic types`
+		);
+	}
+
+	return results;
+}


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/PIPE-519

Generate typed pipeline bindings from stream schemas

When running `wrangler types`, pipeline bindings now generate TypeScript types based on the stream's schema definition. This gives you full autocomplete and type checking when sending data to your pipelines.

```jsonc
// wrangler.json
{
	"pipelines": [{ "binding": "ANALYTICS", "pipeline": "analytics-stream-id" }],
}
```

If your stream has a schema with fields like `user_id` (string) and `event_count` (int32), the generated types will be:

```typescript
declare namespace Cloudflare {
	type AnalyticsStreamRecord = { user_id: string; event_count: number };
	interface Env {
		ANALYTICS: Pipeline<Cloudflare.AnalyticsStreamRecord>;
	}
}
```

Generated types are in the Cloudflare namespace, so we don't conflict with any user defined types. 

For unstructured streams or when not authenticated, bindings fall back to the generic `Pipeline<PipelineRecord>` type.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [X] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: Should be transparent to the user.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
