### PR TITLE
[create-cloudflare] Enable nodejs_compat by default for new projects

### DIFF
--- a/.changeset/nodejs-compat-default.md
+++ b/.changeset/nodejs-compat-default.md
@@ -1,0 +1,15 @@
+---
+"create-cloudflare": minor
+---
+
+Enable `nodejs_compat` by default for new projects
+
+New projects created with C3 will now have the `nodejs_compat` compatibility flag automatically enabled. This makes it easier to get started with Workers, as many npm packages require Node.js compatibility to work correctly.
+
+If you don't want `nodejs_compat` enabled, you can remove it from your `wrangler.json` or `wrangler.toml` configuration file:
+
+```json
+{
+	"compatibility_flags": []
+}
+```

--- a/packages/create-cloudflare/src/wrangler/__tests__/config.test.ts
+++ b/packages/create-cloudflare/src/wrangler/__tests__/config.test.ts
@@ -49,6 +49,7 @@ describe("update wrangler config", () => {
 			name = "test"
 			main = "src/index.ts"
 			compatibility_date = "2024-01-17"
+			compatibility_flags = [ "nodejs_compat" ]
 
 			[[services]]
 			binding = "SELF_SERVICE"
@@ -105,6 +106,7 @@ describe("update wrangler config", () => {
 			name = "test"
 			main = "src/index.ts"
 			compatibility_date = "2024-01-17"
+			compatibility_flags = [ "nodejs_compat" ]
 
 			[[services]]
 			binding = "SELF_SERVICE"
@@ -178,7 +180,10 @@ describe("update wrangler config", () => {
 				],
 				"observability": {
 					"enabled": true
-				}
+				},
+				"compatibility_flags": [
+					"nodejs_compat"
+				]
 				/**
 				 * Smart Placement
 				 * https://developers.cloudflare.com/workers/configuration/smart-placement/#smart-placement
@@ -244,7 +249,10 @@ describe("update wrangler config", () => {
 				],
 				"observability": {
 					"enabled": true
-				}
+				},
+				"compatibility_flags": [
+					"nodejs_compat"
+				]
 				/**
 				 * Smart Placement
 				 * https://developers.cloudflare.com/workers/configuration/smart-placement/#smart-placement
@@ -288,6 +296,7 @@ describe("update wrangler config", () => {
 			name = "test"
 			main = "src/index.ts"
 			compatibility_date = "2024-01-17"
+			compatibility_flags = [ "nodejs_compat" ]
 
 			[observability]
 			enabled = true
@@ -339,6 +348,7 @@ describe("update wrangler config", () => {
 			main = "src/index.ts"
 			name = "test"
 			compatibility_date = "2024-01-17"
+			compatibility_flags = [ "nodejs_compat" ]
 
 			[observability]
 			enabled = true
@@ -392,6 +402,7 @@ describe("update wrangler config", () => {
 			# https://developers.cloudflare.com/workers/wrangler/configuration/
 			name = "test"
 			compatibility_date = "2001-10-12"
+			compatibility_flags = [ "nodejs_compat" ]
 
 			[observability]
 			enabled = true
@@ -465,7 +476,10 @@ describe("update wrangler config", () => {
 				],
 				"observability": {
 					"enabled": true
-				}
+				},
+				"compatibility_flags": [
+					"nodejs_compat"
+				]
 				/**
 				 * Smart Placement
 				 * https://developers.cloudflare.com/workers/configuration/smart-placement/#smart-placement
@@ -496,5 +510,115 @@ describe("update wrangler config", () => {
 				// "services": [  {   "binding": "MY_SERVICE",   "service": "my-service"  } ]
 			}"
 		`);
+	});
+
+	test("does not add nodejs_compat if already present (toml)", async ({
+		expect,
+	}) => {
+		const toml = [
+			`name = "my-worker"`,
+			`main = "src/index.ts"`,
+			`compatibility_flags = ["nodejs_compat"]`,
+		].join("\n");
+		vi.mocked(readFile).mockReturnValue(toml);
+
+		await updateWranglerConfig(ctx);
+
+		const newToml = vi.mocked(writeFile).mock.calls[0][1];
+		expect(newToml).toContain('compatibility_flags = [ "nodejs_compat" ]');
+		expect(newToml.match(/nodejs_compat/g)?.length).toBe(1);
+	});
+
+	test("does not add nodejs_compat if nodejs_compat_v2 is present (toml)", async ({
+		expect,
+	}) => {
+		const toml = [
+			`name = "my-worker"`,
+			`main = "src/index.ts"`,
+			`compatibility_flags = ["nodejs_compat_v2"]`,
+		].join("\n");
+		vi.mocked(readFile).mockReturnValue(toml);
+
+		await updateWranglerConfig(ctx);
+
+		const newToml = vi.mocked(writeFile).mock.calls[0][1];
+		expect(newToml).toContain('compatibility_flags = [ "nodejs_compat_v2" ]');
+		expect(newToml).not.toContain('"nodejs_compat"');
+	});
+
+	test("preserves existing compatibility flags when adding nodejs_compat (toml)", async ({
+		expect,
+	}) => {
+		const toml = [
+			`name = "my-worker"`,
+			`main = "src/index.ts"`,
+			`compatibility_flags = ["some_other_flag"]`,
+		].join("\n");
+		vi.mocked(readFile).mockReturnValue(toml);
+
+		await updateWranglerConfig(ctx);
+
+		const newToml = vi.mocked(writeFile).mock.calls[0][1];
+		expect(newToml).toContain("nodejs_compat");
+		expect(newToml).toContain("some_other_flag");
+	});
+
+	test("does not add nodejs_compat if already present (json)", async ({
+		expect,
+	}) => {
+		vi.mocked(existsSync).mockImplementationOnce((f) =>
+			(f as string).endsWith(".json"),
+		);
+		const json = JSON.stringify({
+			name: "my-worker",
+			main: "src/index.ts",
+			compatibility_flags: ["nodejs_compat"],
+		});
+		vi.mocked(readFile).mockReturnValueOnce(json);
+
+		await updateWranglerConfig(ctx);
+
+		const newConfig = vi.mocked(writeFile).mock.calls[0][1];
+		expect(newConfig.match(/nodejs_compat/g)?.length).toBe(1);
+	});
+
+	test("does not add nodejs_compat if nodejs_compat_v2 is present (json)", async ({
+		expect,
+	}) => {
+		vi.mocked(existsSync).mockImplementationOnce((f) =>
+			(f as string).endsWith(".json"),
+		);
+		const json = JSON.stringify({
+			name: "my-worker",
+			main: "src/index.ts",
+			compatibility_flags: ["nodejs_compat_v2"],
+		});
+		vi.mocked(readFile).mockReturnValueOnce(json);
+
+		await updateWranglerConfig(ctx);
+
+		const newConfig = vi.mocked(writeFile).mock.calls[0][1];
+		expect(newConfig).toContain("nodejs_compat_v2");
+		expect(newConfig).not.toContain('"nodejs_compat"');
+	});
+
+	test("preserves existing compatibility flags when adding nodejs_compat (json)", async ({
+		expect,
+	}) => {
+		vi.mocked(existsSync).mockImplementationOnce((f) =>
+			(f as string).endsWith(".json"),
+		);
+		const json = JSON.stringify({
+			name: "my-worker",
+			main: "src/index.ts",
+			compatibility_flags: ["some_other_flag"],
+		});
+		vi.mocked(readFile).mockReturnValueOnce(json);
+
+		await updateWranglerConfig(ctx);
+
+		const newConfig = vi.mocked(writeFile).mock.calls[0][1];
+		expect(newConfig).toContain("nodejs_compat");
+		expect(newConfig).toContain("some_other_flag");
 	});
 });


### PR DESCRIPTION
Refs https://github.com/cloudflare/workers-sdk/pull/8310

This PR implements @penalosa's suggestion from PR #8310 to automatically add `nodejs_compat` via C3 rather than manually adding it to each template.

Instead of modifying every template's `wrangler.jsonc` file, this change adds the `nodejs_compat` flag automatically in C3's `updateWranglerConfig` function when creating new projects. This approach:

- Centralizes the logic in one place rather than duplicating across templates
- Handles both JSON/JSONC and TOML config formats
- Preserves any existing compatibility flags
- Skips adding `nodejs_compat` if it or `nodejs_compat_v2` is already present

Devin PR requested by @petebacondarwin

Link to Devin run: https://app.devin.ai/sessions/7a606cdbe6d148a48d02975f027bf808

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is a sensible default change that doesn't require user action or documentation updates

**Human review checklist:**
- [ ] Verify the logic in `addNodejsCompatFlag` and `addNodejsCompatFlagToToml` correctly handles edge cases
- [ ] Confirm this approach aligns with the suggestion in PR #8310