### PR TITLE
Filter compatibility date fallback warning when no update is available

### DIFF
--- a/.changeset/quiet-birds-fly.md
+++ b/.changeset/quiet-birds-fly.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Filter compatibility date fallback warning when no update is available
+
+The compatibility date warning from workerd (e.g., "The latest compatibility date supported by the installed Cloudflare Workers Runtime is...") is now only shown when a newer version of `@cloudflare/vite-plugin` is available. This matches the behavior in Wrangler and reduces noise when the user is already on the latest version.

--- a/.changeset/quiet-birds-fly.md
+++ b/.changeset/quiet-birds-fly.md
@@ -1,7 +1,10 @@
 ---
 "@cloudflare/vite-plugin": patch
+"@cloudflare/workers-utils": patch
 ---
 
 Filter compatibility date fallback warning when no update is available
 
 The compatibility date warning from workerd (e.g., "The latest compatibility date supported by the installed Cloudflare Workers Runtime is...") is now only shown when a newer version of `@cloudflare/vite-plugin` is available. This matches the behavior in Wrangler and reduces noise when the user is already on the latest version.
+
+The update-check logic has been extracted to `@cloudflare/workers-utils` so it can be shared across packages.

--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -73,7 +73,6 @@
 		"tree-kill": "catalog:default",
 		"tsdown": "0.16.3",
 		"typescript": "catalog:default",
-		"update-check": "^1.5.4",
 		"vite": "catalog:default",
 		"vite-legacy": "npm:vite@7.1.12",
 		"vitest": "catalog:default"

--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -73,6 +73,7 @@
 		"tree-kill": "catalog:default",
 		"tsdown": "0.16.3",
 		"typescript": "catalog:default",
+		"update-check": "^1.5.4",
 		"vite": "catalog:default",
 		"vite-legacy": "npm:vite@7.1.12",
 		"vitest": "catalog:default"

--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -74,7 +74,6 @@
 		"tree-kill": "catalog:default",
 		"tsdown": "0.16.3",
 		"typescript": "catalog:default",
-		"update-check": "^1.5.4",
 		"vite": "catalog:default",
 		"vite-legacy": "npm:vite@7.1.12",
 		"vitest": "catalog:default"

--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -74,6 +74,7 @@
 		"tree-kill": "catalog:default",
 		"tsdown": "0.16.3",
 		"typescript": "catalog:default",
+		"update-check": "^1.5.4",
 		"vite": "catalog:default",
 		"vite-legacy": "npm:vite@7.1.12",
 		"vitest": "catalog:default"

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -713,12 +713,9 @@ class ViteMiniflareLogger extends Log {
 				if (maybeNewVersion === undefined) {
 					return;
 				}
-				message += [
-					"",
-					"Features enabled by your requested compatibility date may not be available.",
-					`Upgrade to \`@cloudflare/vite-plugin@${maybeNewVersion}\` to remove this warning.`,
-				].join("\n");
-				this.logger.warn(message);
+				this.logger.warn(
+					`${message}\nFeatures enabled by your requested compatibility date may not be available. Upgrade to \`@cloudflare/vite-plugin@${maybeNewVersion}\` to remove this warning.`
+				);
 			});
 		}
 		this.logger.warn(message);

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -33,6 +33,7 @@ import { getContainerOptions, getDockerPath } from "./containers";
 import { getInputInspectorPort } from "./debug";
 import { additionalModuleRE } from "./plugins/additional-modules";
 import { ENVIRONMENT_NAME_HEADER } from "./shared";
+import { updateCheck } from "./update-check";
 import { satisfiesMinimumViteVersion, withTrailingSlash } from "./utils";
 import type { CloudflareDevEnvironment } from "./cloudflare-environment";
 import type { ContainerTagToOptionsMap } from "./containers";
@@ -680,7 +681,10 @@ export async function getPreviewMiniflareOptions(
  * A Miniflare logger that forwards messages onto a Vite logger.
  */
 class ViteMiniflareLogger extends Log {
+	#warnedCompatibilityDateFallback = false;
+
 	private logger: vite.Logger;
+
 	constructor(config: vite.ResolvedConfig) {
 		super(miniflareLogLevelFromViteLogLevel(config.logLevel));
 		this.logger = config.logger;
@@ -695,6 +699,29 @@ class ViteMiniflareLogger extends Log {
 			case LogLevel.INFO:
 				return this.logger.info(message);
 		}
+	}
+
+	override warn(message: string): void {
+		// Only log warning about requesting a compatibility date after the workerd
+		// binary's version once, and only if there's an update available.
+		if (message.startsWith("The latest compatibility date supported by")) {
+			if (this.#warnedCompatibilityDateFallback) {
+				return;
+			}
+			this.#warnedCompatibilityDateFallback = true;
+			return void updateCheck().then((maybeNewVersion) => {
+				if (maybeNewVersion === undefined) {
+					return;
+				}
+				message += [
+					"",
+					"Features enabled by your requested compatibility date may not be available.",
+					`Upgrade to \`@cloudflare/vite-plugin@${maybeNewVersion}\` to remove this warning.`,
+				].join("\n");
+				this.logger.warn(message);
+			});
+		}
+		this.logger.warn(message);
 	}
 
 	override logReady() {

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -678,6 +678,14 @@ export async function getPreviewMiniflareOptions(
 }
 
 /**
+ * Prefix of the workerd warning emitted when the requested compatibility date
+ * is newer than the binary supports. Used to intercept the message and
+ * conditionally suppress it when no plugin update is available.
+ */
+const COMPAT_DATE_FALLBACK_WARNING_PREFIX =
+	"The latest compatibility date supported by";
+
+/**
  * A Miniflare logger that forwards messages onto a Vite logger.
  */
 class ViteMiniflareLogger extends Log {
@@ -702,23 +710,25 @@ class ViteMiniflareLogger extends Log {
 	}
 
 	override warn(message: string): void {
-		// Only log warning about requesting a compatibility date after the workerd
-		// binary's version once, and only if there's an update available.
-		if (message.startsWith("The latest compatibility date supported by")) {
-			if (this.#warnedCompatibilityDateFallback) {
+		if (!message.startsWith(COMPAT_DATE_FALLBACK_WARNING_PREFIX)) {
+			this.logger.warn(message);
+			return;
+		}
+
+		if (this.#warnedCompatibilityDateFallback) {
+			return;
+		}
+		this.#warnedCompatibilityDateFallback = true;
+
+		return void updateCheck().then((maybeNewVersion) => {
+			if (maybeNewVersion === undefined) {
 				return;
 			}
-			this.#warnedCompatibilityDateFallback = true;
-			return void updateCheck().then((maybeNewVersion) => {
-				if (maybeNewVersion === undefined) {
-					return;
-				}
-				this.logger.warn(
-					`${message}\nFeatures enabled by your requested compatibility date may not be available. Upgrade to \`@cloudflare/vite-plugin@${maybeNewVersion}\` to remove this warning.`
-				);
-			});
-		}
-		this.logger.warn(message);
+			this.logger.warn(
+				`${message}\nFeatures enabled by your requested compatibility date may not be available.` +
+					`\nUpgrade to \`@cloudflare/vite-plugin@${maybeNewVersion}\` to remove this warning.`
+			);
+		});
 	}
 
 	override logReady() {

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -33,7 +33,7 @@ import { getContainerOptions, getDockerPath } from "./containers";
 import { getInputInspectorPort } from "./debug";
 import { additionalModuleRE } from "./plugins/additional-modules";
 import { ENVIRONMENT_NAME_HEADER } from "./shared";
-import { updateCheck } from "./update-check";
+import { checkForNpmUpdate } from "./update-check";
 import { satisfiesMinimumViteVersion, withTrailingSlash } from "./utils";
 import type { CloudflareDevEnvironment } from "./cloudflare-environment";
 import type { ContainerTagToOptionsMap } from "./containers";
@@ -678,14 +678,6 @@ export async function getPreviewMiniflareOptions(
 }
 
 /**
- * Prefix of the workerd warning emitted when the requested compatibility date
- * is newer than the binary supports. Used to intercept the message and
- * conditionally suppress it when no plugin update is available.
- */
-const COMPAT_DATE_FALLBACK_WARNING_PREFIX =
-	"The latest compatibility date supported by";
-
-/**
  * A Miniflare logger that forwards messages onto a Vite logger.
  */
 class ViteMiniflareLogger extends Log {
@@ -710,7 +702,11 @@ class ViteMiniflareLogger extends Log {
 	}
 
 	override warn(message: string): void {
-		if (!message.startsWith(COMPAT_DATE_FALLBACK_WARNING_PREFIX)) {
+		// workerd emits a warning when the requested compatibility date is newer
+		// than the binary supports. We intercept it here so we only show it once
+		// and only when a newer version of the plugin is actually available on
+		// npm — otherwise the warning is just noise the user cannot act on.
+		if (!message.startsWith("The latest compatibility date supported by")) {
 			this.logger.warn(message);
 			return;
 		}
@@ -720,7 +716,7 @@ class ViteMiniflareLogger extends Log {
 		}
 		this.#warnedCompatibilityDateFallback = true;
 
-		return void updateCheck().then((maybeNewVersion) => {
+		return void checkForNpmUpdate().then((maybeNewVersion) => {
 			if (maybeNewVersion === undefined) {
 				return;
 			}

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -716,14 +716,15 @@ class ViteMiniflareLogger extends Log {
 		}
 		this.#warnedCompatibilityDateFallback = true;
 
-		return void checkForNpmUpdate().then((maybeNewVersion) => {
-			if (maybeNewVersion === undefined) {
+		return void checkForNpmUpdate().then((result) => {
+			if (result.status !== "update-available") {
 				return;
 			}
 			this.logger.warn(
 				`${message}\nFeatures enabled by your requested compatibility date may not be available.` +
-					`\nUpgrade to \`@cloudflare/vite-plugin@${maybeNewVersion}\` to remove this warning.`
+					`\nUpgrade to \`@cloudflare/vite-plugin@${result.latest}\` to remove this warning.`
 			);
+			return;
 		});
 	}
 

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -721,12 +721,9 @@ class ViteMiniflareLogger extends Log {
 				if (maybeNewVersion === undefined) {
 					return;
 				}
-				message += [
-					"",
-					"Features enabled by your requested compatibility date may not be available.",
-					`Upgrade to \`@cloudflare/vite-plugin@${maybeNewVersion}\` to remove this warning.`,
-				].join("\n");
-				this.logger.warn(message);
+				this.logger.warn(
+					`${message}\nFeatures enabled by your requested compatibility date may not be available. Upgrade to \`@cloudflare/vite-plugin@${maybeNewVersion}\` to remove this warning.`
+				);
 			});
 		}
 		this.logger.warn(message);

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -686,6 +686,14 @@ export async function getPreviewMiniflareOptions(
 }
 
 /**
+ * Prefix of the workerd warning emitted when the requested compatibility date
+ * is newer than the binary supports. Used to intercept the message and
+ * conditionally suppress it when no plugin update is available.
+ */
+const COMPAT_DATE_FALLBACK_WARNING_PREFIX =
+	"The latest compatibility date supported by";
+
+/**
  * A Miniflare logger that forwards messages onto a Vite logger.
  */
 class ViteMiniflareLogger extends Log {
@@ -710,23 +718,25 @@ class ViteMiniflareLogger extends Log {
 	}
 
 	override warn(message: string): void {
-		// Only log warning about requesting a compatibility date after the workerd
-		// binary's version once, and only if there's an update available.
-		if (message.startsWith("The latest compatibility date supported by")) {
-			if (this.#warnedCompatibilityDateFallback) {
+		if (!message.startsWith(COMPAT_DATE_FALLBACK_WARNING_PREFIX)) {
+			this.logger.warn(message);
+			return;
+		}
+
+		if (this.#warnedCompatibilityDateFallback) {
+			return;
+		}
+		this.#warnedCompatibilityDateFallback = true;
+
+		return void updateCheck().then((maybeNewVersion) => {
+			if (maybeNewVersion === undefined) {
 				return;
 			}
-			this.#warnedCompatibilityDateFallback = true;
-			return void updateCheck().then((maybeNewVersion) => {
-				if (maybeNewVersion === undefined) {
-					return;
-				}
-				this.logger.warn(
-					`${message}\nFeatures enabled by your requested compatibility date may not be available. Upgrade to \`@cloudflare/vite-plugin@${maybeNewVersion}\` to remove this warning.`
-				);
-			});
-		}
-		this.logger.warn(message);
+			this.logger.warn(
+				`${message}\nFeatures enabled by your requested compatibility date may not be available.` +
+					`\nUpgrade to \`@cloudflare/vite-plugin@${maybeNewVersion}\` to remove this warning.`
+			);
+		});
 	}
 
 	override logReady() {

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -34,6 +34,7 @@ import { getContainerOptions, getDockerPath } from "./containers";
 import { getInputInspectorPort } from "./debug";
 import { additionalModuleRE } from "./plugins/additional-modules";
 import { ENVIRONMENT_NAME_HEADER } from "./shared";
+import { updateCheck } from "./update-check";
 import { satisfiesMinimumViteVersion, withTrailingSlash } from "./utils";
 import type { CloudflareDevEnvironment } from "./cloudflare-environment";
 import type { ContainerTagToOptionsMap } from "./containers";
@@ -688,7 +689,10 @@ export async function getPreviewMiniflareOptions(
  * A Miniflare logger that forwards messages onto a Vite logger.
  */
 class ViteMiniflareLogger extends Log {
+	#warnedCompatibilityDateFallback = false;
+
 	private logger: vite.Logger;
+
 	constructor(config: vite.ResolvedConfig) {
 		super(miniflareLogLevelFromViteLogLevel(config.logLevel));
 		this.logger = config.logger;
@@ -703,6 +707,29 @@ class ViteMiniflareLogger extends Log {
 			case LogLevel.INFO:
 				return this.logger.info(message);
 		}
+	}
+
+	override warn(message: string): void {
+		// Only log warning about requesting a compatibility date after the workerd
+		// binary's version once, and only if there's an update available.
+		if (message.startsWith("The latest compatibility date supported by")) {
+			if (this.#warnedCompatibilityDateFallback) {
+				return;
+			}
+			this.#warnedCompatibilityDateFallback = true;
+			return void updateCheck().then((maybeNewVersion) => {
+				if (maybeNewVersion === undefined) {
+					return;
+				}
+				message += [
+					"",
+					"Features enabled by your requested compatibility date may not be available.",
+					`Upgrade to \`@cloudflare/vite-plugin@${maybeNewVersion}\` to remove this warning.`,
+				].join("\n");
+				this.logger.warn(message);
+			});
+		}
+		this.logger.warn(message);
 	}
 
 	override logReady() {

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -724,14 +724,15 @@ class ViteMiniflareLogger extends Log {
 		}
 		this.#warnedCompatibilityDateFallback = true;
 
-		return void checkForNpmUpdate().then((maybeNewVersion) => {
-			if (maybeNewVersion === undefined) {
+		return void checkForNpmUpdate().then((result) => {
+			if (result.status !== "update-available") {
 				return;
 			}
 			this.logger.warn(
 				`${message}\nFeatures enabled by your requested compatibility date may not be available.` +
-					`\nUpgrade to \`@cloudflare/vite-plugin@${maybeNewVersion}\` to remove this warning.`
+					`\nUpgrade to \`@cloudflare/vite-plugin@${result.latest}\` to remove this warning.`
 			);
+			return;
 		});
 	}
 

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -34,7 +34,7 @@ import { getContainerOptions, getDockerPath } from "./containers";
 import { getInputInspectorPort } from "./debug";
 import { additionalModuleRE } from "./plugins/additional-modules";
 import { ENVIRONMENT_NAME_HEADER } from "./shared";
-import { updateCheck } from "./update-check";
+import { checkForNpmUpdate } from "./update-check";
 import { satisfiesMinimumViteVersion, withTrailingSlash } from "./utils";
 import type { CloudflareDevEnvironment } from "./cloudflare-environment";
 import type { ContainerTagToOptionsMap } from "./containers";
@@ -686,14 +686,6 @@ export async function getPreviewMiniflareOptions(
 }
 
 /**
- * Prefix of the workerd warning emitted when the requested compatibility date
- * is newer than the binary supports. Used to intercept the message and
- * conditionally suppress it when no plugin update is available.
- */
-const COMPAT_DATE_FALLBACK_WARNING_PREFIX =
-	"The latest compatibility date supported by";
-
-/**
  * A Miniflare logger that forwards messages onto a Vite logger.
  */
 class ViteMiniflareLogger extends Log {
@@ -718,7 +710,11 @@ class ViteMiniflareLogger extends Log {
 	}
 
 	override warn(message: string): void {
-		if (!message.startsWith(COMPAT_DATE_FALLBACK_WARNING_PREFIX)) {
+		// workerd emits a warning when the requested compatibility date is newer
+		// than the binary supports. We intercept it here so we only show it once
+		// and only when a newer version of the plugin is actually available on
+		// npm — otherwise the warning is just noise the user cannot act on.
+		if (!message.startsWith("The latest compatibility date supported by")) {
 			this.logger.warn(message);
 			return;
 		}
@@ -728,7 +724,7 @@ class ViteMiniflareLogger extends Log {
 		}
 		this.#warnedCompatibilityDateFallback = true;
 
-		return void updateCheck().then((maybeNewVersion) => {
+		return void checkForNpmUpdate().then((maybeNewVersion) => {
 			if (maybeNewVersion === undefined) {
 				return;
 			}

--- a/packages/vite-plugin-cloudflare/src/update-check.ts
+++ b/packages/vite-plugin-cloudflare/src/update-check.ts
@@ -1,6 +1,16 @@
 import checkForUpdate from "update-check";
 import type { Result } from "update-check";
 
+/**
+ * Checks if a newer version of the vite-plugin-cloudflare package is available.
+ *
+ * This function dynamically imports the package.json to get the current version,
+ * then uses the `update-check` library to query npm for the latest version.
+ * The dist tag used for comparison depends on the current version - "beta" for
+ * pre-release versions (0.0.0-*) and "latest" for stable versions.
+ *
+ * @returns The latest available version string if an update is available, or `undefined` if the package is up-to-date or the check fails
+ */
 async function doUpdateCheck(): Promise<string | undefined> {
 	let update: Result | null = null;
 	// Use dynamic import with JSON assertion to avoid bundler issues

--- a/packages/vite-plugin-cloudflare/src/update-check.ts
+++ b/packages/vite-plugin-cloudflare/src/update-check.ts
@@ -1,0 +1,32 @@
+import checkForUpdate from "update-check";
+import type { Result } from "update-check";
+
+async function doUpdateCheck(): Promise<string | undefined> {
+	let update: Result | null = null;
+	// Use dynamic import with JSON assertion to avoid bundler issues
+	const pkg = (
+		await import("../package.json", {
+			with: { type: "json" },
+		})
+	).default;
+	try {
+		// default cache for update check is 1 day
+		update = await checkForUpdate(
+			{ name: pkg.name, version: pkg.version },
+			{
+				distTag: pkg.version.startsWith("0.0.0") ? "beta" : "latest",
+			}
+		);
+	} catch {
+		// ignore error
+	}
+	return update?.latest;
+}
+
+// Memoise update check promise, so we can call this multiple times as required
+// without having to prop drill the result. It's unlikely to change through the
+// process lifetime.
+let updateCheckPromise: Promise<string | undefined>;
+export function updateCheck(): Promise<string | undefined> {
+	return (updateCheckPromise ??= doUpdateCheck());
+}

--- a/packages/vite-plugin-cloudflare/src/update-check.ts
+++ b/packages/vite-plugin-cloudflare/src/update-check.ts
@@ -1,42 +1,32 @@
-import checkForUpdate from "update-check";
-import type { Result } from "update-check";
-
-/**
- * Checks if a newer version of the vite-plugin-cloudflare package is available.
- *
- * This function dynamically imports the package.json to get the current version,
- * then uses the `update-check` library to query npm for the latest version.
- * The dist tag used for comparison depends on the current version - "beta" for
- * pre-release versions (0.0.0-*) and "latest" for stable versions.
- *
- * @returns The latest available version string if an update is available, or `undefined` if the package is up-to-date or the check fails
- */
-async function doUpdateCheck(): Promise<string | undefined> {
-	let update: Result | null = null;
-	// Use dynamic import with JSON assertion to avoid bundler issues
-	const pkg = (
-		await import("../package.json", {
-			with: { type: "json" },
-		})
-	).default;
-	try {
-		// default cache for update check is 1 day
-		update = await checkForUpdate(
-			{ name: pkg.name, version: pkg.version },
-			{
-				distTag: pkg.version.startsWith("0.0.0") ? "beta" : "latest",
-			}
-		);
-	} catch {
-		// ignore error
-	}
-	return update?.latest;
-}
+import { doUpdateCheck } from "@cloudflare/workers-utils";
 
 // Memoise update check promise, so we can call this multiple times as required
 // without having to prop drill the result. It's unlikely to change through the
 // process lifetime.
 let updateCheckPromise: Promise<string | undefined>;
+
+/**
+ * Checks if a newer version of `@cloudflare/vite-plugin` is available on npm.
+ *
+ * The result is memoised so the check is only performed once per process
+ * lifetime — callers can invoke this freely without worrying about redundant
+ * network requests.
+ *
+ * @returns The latest available version string if an update exists, or `undefined` if up-to-date or the check fails
+ */
 export function updateCheck(): Promise<string | undefined> {
-	return (updateCheckPromise ??= doUpdateCheck());
+	return (updateCheckPromise ??= resolveUpdateCheck());
+}
+
+async function resolveUpdateCheck(): Promise<string | undefined> {
+	try {
+		const pkg = (
+			await import("../package.json", {
+				with: { type: "json" },
+			})
+		).default;
+		return doUpdateCheck(pkg.name, pkg.version);
+	} catch {
+		return undefined;
+	}
 }

--- a/packages/vite-plugin-cloudflare/src/update-check.ts
+++ b/packages/vite-plugin-cloudflare/src/update-check.ts
@@ -1,4 +1,4 @@
-import { doUpdateCheck } from "@cloudflare/workers-utils";
+import { fetchLatestNpmVersion } from "@cloudflare/workers-utils";
 
 // Memoise update check promise, so we can call this multiple times as required
 // without having to prop drill the result. It's unlikely to change through the
@@ -14,19 +14,17 @@ let updateCheckPromise: Promise<string | undefined>;
  *
  * @returns The latest available version string if an update exists, or `undefined` if up-to-date or the check fails
  */
-export function updateCheck(): Promise<string | undefined> {
-	return (updateCheckPromise ??= resolveUpdateCheck());
-}
-
-async function resolveUpdateCheck(): Promise<string | undefined> {
-	try {
-		const pkg = (
-			await import("../package.json", {
-				with: { type: "json" },
-			})
-		).default;
-		return doUpdateCheck(pkg.name, pkg.version);
-	} catch {
-		return undefined;
-	}
+export function checkForNpmUpdate(): Promise<string | undefined> {
+	return (updateCheckPromise ??= (async () => {
+		try {
+			const pkg = (
+				await import("../package.json", {
+					with: { type: "json" },
+				})
+			).default;
+			return fetchLatestNpmVersion(pkg.name, pkg.version);
+		} catch {
+			return undefined;
+		}
+	})());
 }

--- a/packages/vite-plugin-cloudflare/src/update-check.ts
+++ b/packages/vite-plugin-cloudflare/src/update-check.ts
@@ -1,9 +1,10 @@
 import { fetchLatestNpmVersion } from "@cloudflare/workers-utils";
+import type { NpmVersionCheckResult } from "@cloudflare/workers-utils";
 
 // Memoise update check promise, so we can call this multiple times as required
 // without having to prop drill the result. It's unlikely to change through the
 // process lifetime.
-let updateCheckPromise: Promise<string | undefined>;
+let updateCheckPromise: Promise<NpmVersionCheckResult>;
 
 /**
  * Checks if a newer version of `@cloudflare/vite-plugin` is available on npm.
@@ -12,9 +13,10 @@ let updateCheckPromise: Promise<string | undefined>;
  * lifetime — callers can invoke this freely without worrying about redundant
  * network requests.
  *
- * @returns The latest available version string if an update exists, or `undefined` if up-to-date or the check fails
+ * @returns A discriminated result indicating whether an update is available,
+ *   the package is already up-to-date, or the check failed
  */
-export function checkForNpmUpdate(): Promise<string | undefined> {
+export function checkForNpmUpdate(): Promise<NpmVersionCheckResult> {
 	return (updateCheckPromise ??= (async () => {
 		try {
 			const pkg = (
@@ -24,7 +26,7 @@ export function checkForNpmUpdate(): Promise<string | undefined> {
 			).default;
 			return fetchLatestNpmVersion(pkg.name, pkg.version);
 		} catch {
-			return undefined;
+			return { status: "failed" };
 		}
 	})());
 }

--- a/packages/workers-utils/package.json
+++ b/packages/workers-utils/package.json
@@ -58,6 +58,7 @@
 		"tsup": "8.3.0",
 		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"update-check": "^1.5.4",
 		"vitest": "catalog:default",
 		"xdg-app-paths": "^8.3.0"
 	},

--- a/packages/workers-utils/package.json
+++ b/packages/workers-utils/package.json
@@ -63,6 +63,7 @@
 		"tsdown": "^0.15.9",
 		"tsup": "8.3.0",
 		"typescript": "catalog:default",
+		"update-check": "^1.5.4",
 		"vitest": "catalog:default",
 		"xdg-app-paths": "^8.3.0"
 	},

--- a/packages/workers-utils/src/index.ts
+++ b/packages/workers-utils/src/index.ts
@@ -98,3 +98,5 @@ export type { Counter } from "./prometheus-metrics";
 export type { Tunnel, TunnelOptions } from "./tunnel";
 export { startTunnel } from "./tunnel";
 export { spawnCloudflared } from "./cloudflared";
+
+export { doUpdateCheck } from "./update-check";

--- a/packages/workers-utils/src/index.ts
+++ b/packages/workers-utils/src/index.ts
@@ -100,3 +100,4 @@ export { startTunnel } from "./tunnel";
 export { spawnCloudflared } from "./cloudflared";
 
 export { fetchLatestNpmVersion } from "./update-check";
+export type { NpmVersionCheckResult } from "./update-check";

--- a/packages/workers-utils/src/index.ts
+++ b/packages/workers-utils/src/index.ts
@@ -99,4 +99,4 @@ export type { Tunnel, TunnelOptions } from "./tunnel";
 export { startTunnel } from "./tunnel";
 export { spawnCloudflared } from "./cloudflared";
 
-export { doUpdateCheck } from "./update-check";
+export { fetchLatestNpmVersion } from "./update-check";

--- a/packages/workers-utils/src/index.ts
+++ b/packages/workers-utils/src/index.ts
@@ -111,4 +111,4 @@ export type { Tunnel, TunnelOptions } from "./tunnel";
 export { startTunnel } from "./tunnel";
 export { spawnCloudflared } from "./cloudflared";
 
-export { doUpdateCheck } from "./update-check";
+export { fetchLatestNpmVersion } from "./update-check";

--- a/packages/workers-utils/src/index.ts
+++ b/packages/workers-utils/src/index.ts
@@ -110,3 +110,5 @@ export type { Counter } from "./prometheus-metrics";
 export type { Tunnel, TunnelOptions } from "./tunnel";
 export { startTunnel } from "./tunnel";
 export { spawnCloudflared } from "./cloudflared";
+
+export { doUpdateCheck } from "./update-check";

--- a/packages/workers-utils/src/index.ts
+++ b/packages/workers-utils/src/index.ts
@@ -112,3 +112,4 @@ export { startTunnel } from "./tunnel";
 export { spawnCloudflared } from "./cloudflared";
 
 export { fetchLatestNpmVersion } from "./update-check";
+export type { NpmVersionCheckResult } from "./update-check";

--- a/packages/workers-utils/src/update-check.ts
+++ b/packages/workers-utils/src/update-check.ts
@@ -1,0 +1,46 @@
+import checkForUpdate from "update-check";
+import type { Result } from "update-check";
+
+// Safety-net timeout for the update check network request.
+// The `update-check` library has its own 2s socket timeout, but if the first
+// request gets a 4xx it retries with auth — potentially doubling the wait.
+// This caps the total wall-clock time for the entire operation.
+const UPDATE_CHECK_TIMEOUT_MS = 3000;
+
+/**
+ * Checks if a newer version of a package is available on npm.
+ *
+ * Uses the `update-check` library to query the npm registry for the latest
+ * version. The dist tag used for comparison depends on the current version —
+ * "beta" for pre-release versions (0.0.0-*) and "latest" for stable versions.
+ *
+ * @param name - The npm package name to check
+ * @param version - The currently installed version
+ * @returns The latest available version string if an update is available, or `undefined` if the package is up-to-date or the check fails
+ */
+export async function doUpdateCheck(
+	name: string,
+	version: string
+): Promise<string | undefined> {
+	let update: Result | null = null;
+	try {
+		// Race with a timeout as a safety net — the library's own 2s socket
+		// timeout handles most cases, but the auth-retry path can take up to 4s.
+		update = await Promise.race([
+			checkForUpdate(
+				{ name, version },
+				{
+					distTag: version.startsWith("0.0.0") ? "beta" : "latest",
+				}
+			),
+			new Promise<null>((resolve) => {
+				const timer = setTimeout(() => resolve(null), UPDATE_CHECK_TIMEOUT_MS);
+				// Don't let the orphaned timer prevent process exit
+				timer.unref();
+			}),
+		]);
+	} catch {
+		// ignore error
+	}
+	return update?.latest;
+}

--- a/packages/workers-utils/src/update-check.ts
+++ b/packages/workers-utils/src/update-check.ts
@@ -1,4 +1,4 @@
-import { setTimeout } from "node:timers/promises";
+import * as timersPromises from "node:timers/promises";
 import checkForUpdate from "update-check";
 import type { Result } from "update-check";
 
@@ -45,7 +45,7 @@ export async function fetchLatestNpmVersion(
 					distTag: version.startsWith("0.0.0") ? "beta" : "latest",
 				}
 			),
-			setTimeout(UPDATE_CHECK_TIMEOUT_MS, TIMED_OUT, { ref: false }),
+			timersPromises.setTimeout(UPDATE_CHECK_TIMEOUT_MS, TIMED_OUT, { ref: false }),
 		]);
 	} catch {
 		return { status: "failed" };

--- a/packages/workers-utils/src/update-check.ts
+++ b/packages/workers-utils/src/update-check.ts
@@ -35,7 +35,7 @@ export async function fetchLatestNpmVersion(
 					distTag: version.startsWith("0.0.0") ? "beta" : "latest",
 				}
 			),
-			setTimeout(UPDATE_CHECK_TIMEOUT_MS, null),
+			setTimeout(UPDATE_CHECK_TIMEOUT_MS, null, { ref: false }),
 		]);
 	} catch {
 		// ignore error

--- a/packages/workers-utils/src/update-check.ts
+++ b/packages/workers-utils/src/update-check.ts
@@ -26,9 +26,10 @@ export type NpmVersionCheckResult =
  *
  * @param name - The npm package name to check
  * @param version - The current version to compare against
- * @returns A discriminated result indicating whether an update is available,
- *   the package is already up-to-date, or the check failed (network error,
- *   timeout, etc.)
+ * @returns A discriminated result:
+ *   - `{ status: "update-available", latest: string }` if a newer version exists
+ *   - `{ status: "up-to-date" }` if the installed version is already the latest
+ *   - `{ status: "failed" }` if the check could not be completed (network error, timeout, etc.)
  */
 export async function fetchLatestNpmVersion(
 	name: string,
@@ -45,7 +46,9 @@ export async function fetchLatestNpmVersion(
 					distTag: version.startsWith("0.0.0") ? "beta" : "latest",
 				}
 			),
-			timersPromises.setTimeout(UPDATE_CHECK_TIMEOUT_MS, TIMED_OUT, { ref: false }),
+			timersPromises.setTimeout(UPDATE_CHECK_TIMEOUT_MS, TIMED_OUT, {
+				ref: false,
+			}),
 		]);
 	} catch {
 		return { status: "failed" };

--- a/packages/workers-utils/src/update-check.ts
+++ b/packages/workers-utils/src/update-check.ts
@@ -8,6 +8,15 @@ import type { Result } from "update-check";
 // This caps the total wall-clock time for the entire operation.
 const UPDATE_CHECK_TIMEOUT_MS = 3000;
 
+// Sentinel value used to distinguish a timeout from the library returning null
+// (which means "already up-to-date").
+const TIMED_OUT: unique symbol = Symbol("timed_out");
+
+export type NpmVersionCheckResult =
+	| { status: "up-to-date" }
+	| { status: "update-available"; latest: string }
+	| { status: "failed" };
+
 /**
  * Checks if a newer version of a package is available on npm.
  *
@@ -17,28 +26,36 @@ const UPDATE_CHECK_TIMEOUT_MS = 3000;
  *
  * @param name - The npm package name to check
  * @param version - The current version to compare against
- * @returns The latest available version string if an update is available,
- *   or `undefined` if the package is already up-to-date or the check fails
+ * @returns A discriminated result indicating whether an update is available,
+ *   the package is already up-to-date, or the check failed (network error,
+ *   timeout, etc.)
  */
 export async function fetchLatestNpmVersion(
 	name: string,
 	version: string
-): Promise<string | undefined> {
-	let update: Result | null = null;
+): Promise<NpmVersionCheckResult> {
+	let result: Result | null | typeof TIMED_OUT = null;
 	try {
 		// Race with a timeout as a safety net — the library's own 2s socket
 		// timeout handles most cases, but the auth-retry path can take up to 4s.
-		update = await Promise.race([
+		result = await Promise.race([
 			checkForUpdate(
 				{ name, version },
 				{
 					distTag: version.startsWith("0.0.0") ? "beta" : "latest",
 				}
 			),
-			setTimeout(UPDATE_CHECK_TIMEOUT_MS, null, { ref: false }),
+			setTimeout(UPDATE_CHECK_TIMEOUT_MS, TIMED_OUT, { ref: false }),
 		]);
 	} catch {
-		// ignore error
+		return { status: "failed" };
 	}
-	return update?.latest;
+
+	if (result === TIMED_OUT) {
+		return { status: "failed" };
+	}
+	if (result === null) {
+		return { status: "up-to-date" };
+	}
+	return { status: "update-available", latest: result.latest };
 }

--- a/packages/workers-utils/src/update-check.ts
+++ b/packages/workers-utils/src/update-check.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from "node:timers/promises";
 import checkForUpdate from "update-check";
 import type { Result } from "update-check";
 
@@ -15,10 +16,11 @@ const UPDATE_CHECK_TIMEOUT_MS = 3000;
  * "beta" for pre-release versions (0.0.0-*) and "latest" for stable versions.
  *
  * @param name - The npm package name to check
- * @param version - The currently installed version
- * @returns The latest available version string if an update is available, or `undefined` if the package is up-to-date or the check fails
+ * @param version - The current version to compare against
+ * @returns The latest available version string if an update is available,
+ *   or `undefined` if the package is already up-to-date or the check fails
  */
-export async function doUpdateCheck(
+export async function fetchLatestNpmVersion(
 	name: string,
 	version: string
 ): Promise<string | undefined> {
@@ -33,11 +35,7 @@ export async function doUpdateCheck(
 					distTag: version.startsWith("0.0.0") ? "beta" : "latest",
 				}
 			),
-			new Promise<null>((resolve) => {
-				const timer = setTimeout(() => resolve(null), UPDATE_CHECK_TIMEOUT_MS);
-				// Don't let the orphaned timer prevent process exit
-				timer.unref();
-			}),
+			setTimeout(UPDATE_CHECK_TIMEOUT_MS, null),
 		]);
 	} catch {
 		// ignore error

--- a/packages/workers-utils/src/update-check.ts
+++ b/packages/workers-utils/src/update-check.ts
@@ -6,7 +6,7 @@ import type { Result } from "update-check";
 // The `update-check` library has its own 2s socket timeout, but if the first
 // request gets a 4xx it retries with auth — potentially doubling the wait.
 // This caps the total wall-clock time for the entire operation.
-const UPDATE_CHECK_TIMEOUT_MS = 3000;
+const UPDATE_CHECK_TIMEOUT_MS = 3_000;
 
 // Sentinel value used to distinguish a timeout from the library returning null
 // (which means "already up-to-date").

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -160,7 +160,6 @@
 		"tsup": "8.3.0",
 		"typescript": "catalog:default",
 		"undici": "catalog:default",
-		"update-check": "^1.5.4",
 		"vitest": "catalog:default",
 		"vitest-websocket-mock": "^0.4.0",
 		"ws": "catalog:default",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -163,7 +163,6 @@
 		"tsup": "8.3.0",
 		"typescript": "catalog:default",
 		"undici": "catalog:default",
-		"update-check": "^1.5.4",
 		"vitest": "catalog:default",
 		"vitest-websocket-mock": "^0.4.0",
 		"ws": "catalog:default",

--- a/packages/wrangler/src/__tests__/config/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.test.ts
@@ -15,7 +15,7 @@ describe("readConfig() upgrade hint", () => {
 	it("should not show an upgrade hint when unexpected fields are found but no update is available", async ({
 		expect,
 	}) => {
-		vi.mocked(updateCheck).mockResolvedValue(undefined);
+		vi.mocked(updateCheck).mockResolvedValue({ status: "up-to-date" });
 		writeWranglerConfig({
 			// @ts-expect-error intentional unknown field for test
 			unknown_field: "some_value",
@@ -29,7 +29,10 @@ describe("readConfig() upgrade hint", () => {
 	it("should show an upgrade hint when unexpected fields are found and an update is available", async ({
 		expect,
 	}) => {
-		vi.mocked(updateCheck).mockResolvedValue("9.9.9");
+		vi.mocked(updateCheck).mockResolvedValue({
+			status: "update-available",
+			latest: "9.9.9",
+		});
 		writeWranglerConfig({
 			// @ts-expect-error intentional unknown field for test
 			unknown_field: "some_value",
@@ -47,7 +50,10 @@ describe("readConfig() upgrade hint", () => {
 	it("should not show an upgrade hint when warnings are unrelated to unexpected fields", async ({
 		expect,
 	}) => {
-		vi.mocked(updateCheck).mockResolvedValue("9.9.9");
+		vi.mocked(updateCheck).mockResolvedValue({
+			status: "update-available",
+			latest: "9.9.9",
+		});
 		// legacy_env: false produces a "Service environments are deprecated" warning
 		// but does NOT trigger validateAdditionalProperties, so no upgrade hint
 		writeWranglerConfig({ legacy_env: false });

--- a/packages/wrangler/src/__tests__/config/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.test.ts
@@ -16,7 +16,7 @@ describe("readConfig() upgrade hint", () => {
 	it("should not show an upgrade hint when unexpected fields are found but no update is available", async ({
 		expect,
 	}) => {
-		vi.mocked(updateCheck).mockResolvedValue(undefined);
+		vi.mocked(updateCheck).mockResolvedValue({ status: "up-to-date" });
 		writeWranglerConfig({
 			// @ts-expect-error intentional unknown field for test
 			unknown_field: "some_value",
@@ -30,7 +30,10 @@ describe("readConfig() upgrade hint", () => {
 	it("should show an upgrade hint when unexpected fields are found and an update is available", async ({
 		expect,
 	}) => {
-		vi.mocked(updateCheck).mockResolvedValue("9.9.9");
+		vi.mocked(updateCheck).mockResolvedValue({
+			status: "update-available",
+			latest: "9.9.9",
+		});
 		writeWranglerConfig({
 			// @ts-expect-error intentional unknown field for test
 			unknown_field: "some_value",
@@ -48,7 +51,10 @@ describe("readConfig() upgrade hint", () => {
 	it("should not show an upgrade hint when warnings are unrelated to unexpected fields", async ({
 		expect,
 	}) => {
-		vi.mocked(updateCheck).mockResolvedValue("9.9.9");
+		vi.mocked(updateCheck).mockResolvedValue({
+			status: "update-available",
+			latest: "9.9.9",
+		});
 		// legacy_env: false produces a "Service environments are deprecated" warning
 		// but does NOT trigger validateAdditionalProperties, so no upgrade hint
 		writeWranglerConfig({ legacy_env: false });

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -400,7 +400,10 @@ describe("wrangler", () => {
 		it("should display a 'try updating' message if there is one available", async ({
 			expect,
 		}) => {
-			(updateCheck as Mock).mockImplementation(async () => "123.123.123");
+			(updateCheck as Mock).mockImplementation(async () => ({
+				status: "update-available",
+				latest: "123.123.123",
+			}));
 			await logPossibleBugMessage();
 			expect(std.out).toMatchInlineSnapshot(`
 			"[32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose[0m

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -411,7 +411,10 @@ describe("wrangler", () => {
 		it("should display a 'try updating' message if there is one available", async ({
 			expect,
 		}) => {
-			(updateCheck as Mock).mockImplementation(async () => "123.123.123");
+			(updateCheck as Mock).mockImplementation(async () => ({
+				status: "update-available",
+				latest: "123.123.123",
+			}));
 			await logPossibleBugMessage();
 			expect(std.out).toMatchInlineSnapshot(`
 			"[32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose[0m

--- a/packages/wrangler/src/__tests__/vitest.setup.ts
+++ b/packages/wrangler/src/__tests__/vitest.setup.ts
@@ -124,7 +124,13 @@ vi.mock("../package-manager", async (importOriginal) => {
 	return mocked;
 });
 
-vi.mock("../update-check");
+vi.mock("../update-check", async (importOriginal) => {
+	const mod = await importOriginal<typeof import("../update-check")>();
+	return {
+		...mod,
+		updateCheck: vi.fn().mockResolvedValue({ status: "up-to-date" }),
+	};
+});
 
 beforeAll(() => {
 	msw.listen({

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -51,11 +51,11 @@ async function logWarningsWithUpgradeHint(
 	}
 	logger.warn(diagnostics.renderWarnings());
 	if (diagnostics.hasUnexpectedFieldsInTree()) {
-		const latestVersion = await updateCheck();
-		if (latestVersion !== undefined) {
+		const result = await updateCheck();
+		if (result.status === "update-available") {
 			logger.log(
 				`There is a newer version of Wrangler available ` +
-					`(current: ${wranglerVersion}, latest: ${latestVersion}). ` +
+					`(current: ${wranglerVersion}, latest: ${result.latest}). ` +
 					`Try upgrading, as it might support this configuration option.`
 			);
 		}

--- a/packages/wrangler/src/dev/miniflare/index.ts
+++ b/packages/wrangler/src/dev/miniflare/index.ts
@@ -126,14 +126,14 @@ export class WranglerLog extends Log {
 				return;
 			}
 			this.#warnedCompatibilityDateFallback = true;
-			return void updateCheck().then((maybeNewVersion) => {
-				if (maybeNewVersion === undefined) {
+			return void updateCheck().then((result) => {
+				if (result.status !== "update-available") {
 					return;
 				}
 				message += [
 					"",
 					"Features enabled by your requested compatibility date may not be available.",
-					`Upgrade to \`wrangler@${maybeNewVersion}\` to remove this warning.`,
+					`Upgrade to \`wrangler@${result.latest}\` to remove this warning.`,
 				].join("\n");
 				super.warn(message);
 			});

--- a/packages/wrangler/src/update-check.ts
+++ b/packages/wrangler/src/update-check.ts
@@ -1,42 +1,23 @@
-import checkForUpdate from "update-check";
+import { doUpdateCheck } from "@cloudflare/workers-utils";
 import {
 	name as wranglerName,
 	version as wranglerVersion,
 } from "../package.json";
-import type { Result } from "update-check";
-
-// Safety-net timeout for the update check network request.
-// The `update-check` library has its own 2s socket timeout, but if the first
-// request gets a 4xx it retries with auth — potentially doubling the wait.
-// This caps the total wall-clock time for the entire operation.
-const UPDATE_CHECK_TIMEOUT_MS = 3000;
-
-async function doUpdateCheck(): Promise<string | undefined> {
-	let update: Result | null = null;
-	const pkg = { name: wranglerName, version: wranglerVersion };
-	try {
-		// Race with a timeout as a safety net — the library's own 2s socket
-		// timeout handles most cases, but the auth-retry path can take up to 4s.
-		update = await Promise.race([
-			checkForUpdate(pkg, {
-				distTag: pkg.version.startsWith("0.0.0") ? "beta" : "latest",
-			}),
-			new Promise<null>((resolve) => {
-				const timer = setTimeout(() => resolve(null), UPDATE_CHECK_TIMEOUT_MS);
-				// Don't let the orphaned timer prevent process exit
-				timer.unref();
-			}),
-		]);
-	} catch {
-		// ignore error
-	}
-	return update?.latest;
-}
 
 // Memoise update check promise, so we can call this multiple times as required
 // without having to prop drill the result. It's unlikely to change through the
 // process lifetime.
 let updateCheckPromise: Promise<string | undefined>;
+
+/**
+ * Checks if a newer version of `wrangler` is available on npm.
+ *
+ * The result is memoised so the check is only performed once per process
+ * lifetime — callers can invoke this freely without worrying about redundant
+ * network requests.
+ *
+ * @returns The latest available version string if an update exists, or `undefined` if up-to-date or the check fails
+ */
 export function updateCheck(): Promise<string | undefined> {
-	return (updateCheckPromise ??= doUpdateCheck());
+	return (updateCheckPromise ??= doUpdateCheck(wranglerName, wranglerVersion));
 }

--- a/packages/wrangler/src/update-check.ts
+++ b/packages/wrangler/src/update-check.ts
@@ -1,4 +1,4 @@
-import { doUpdateCheck } from "@cloudflare/workers-utils";
+import { fetchLatestNpmVersion } from "@cloudflare/workers-utils";
 import {
 	name as wranglerName,
 	version as wranglerVersion,
@@ -19,5 +19,8 @@ let updateCheckPromise: Promise<string | undefined>;
  * @returns The latest available version string if an update exists, or `undefined` if up-to-date or the check fails
  */
 export function updateCheck(): Promise<string | undefined> {
-	return (updateCheckPromise ??= doUpdateCheck(wranglerName, wranglerVersion));
+	return (updateCheckPromise ??= fetchLatestNpmVersion(
+		wranglerName,
+		wranglerVersion
+	));
 }

--- a/packages/wrangler/src/update-check.ts
+++ b/packages/wrangler/src/update-check.ts
@@ -3,11 +3,12 @@ import {
 	name as wranglerName,
 	version as wranglerVersion,
 } from "../package.json";
+import type { NpmVersionCheckResult } from "@cloudflare/workers-utils";
 
 // Memoise update check promise, so we can call this multiple times as required
 // without having to prop drill the result. It's unlikely to change through the
 // process lifetime.
-let updateCheckPromise: Promise<string | undefined>;
+let updateCheckPromise: Promise<NpmVersionCheckResult>;
 
 /**
  * Checks if a newer version of `wrangler` is available on npm.
@@ -16,9 +17,10 @@ let updateCheckPromise: Promise<string | undefined>;
  * lifetime — callers can invoke this freely without worrying about redundant
  * network requests.
  *
- * @returns The latest available version string if an update exists, or `undefined` if up-to-date or the check fails
+ * @returns A discriminated result indicating whether an update is available,
+ *   the package is already up-to-date, or the check failed
  */
-export function updateCheck(): Promise<string | undefined> {
+export function updateCheck(): Promise<NpmVersionCheckResult> {
 	return (updateCheckPromise ??= fetchLatestNpmVersion(
 		wranglerName,
 		wranglerVersion

--- a/packages/wrangler/src/utils/logPossibleBugMessage.ts
+++ b/packages/wrangler/src/utils/logPossibleBugMessage.ts
@@ -16,10 +16,10 @@ export async function logPossibleBugMessage() {
 		`${fgGreenColor}%s${resetColor}`,
 		"If you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose"
 	);
-	const latestVersion = await updateCheck();
-	if (latestVersion) {
+	const result = await updateCheck();
+	if (result.status === "update-available") {
 		logger.log(
-			`Note that there is a newer version of Wrangler available (${latestVersion}). Consider checking whether upgrading resolves this error.`
+			`Note that there is a newer version of Wrangler available (${result.latest}). Consider checking whether upgrading resolves this error.`
 		);
 	}
 }

--- a/packages/wrangler/src/wrangler-banner.ts
+++ b/packages/wrangler/src/wrangler-banner.ts
@@ -6,6 +6,7 @@ import supportsColor from "supports-color";
 import { version as wranglerVersion } from "../package.json";
 import { logger } from "./logger";
 import { updateCheck } from "./update-check";
+import type { NpmVersionCheckResult } from "@cloudflare/workers-utils";
 
 const MIN_NODE_VERSION = "22.0.0";
 
@@ -27,14 +28,14 @@ export async function printWranglerBanner(performUpdateCheck = true) {
 		typeof WRANGLER_PRERELEASE_LABEL === "undefined"
 			? ` ⛅️ wrangler ${wranglerVersion}`
 			: ` ⛅️ wrangler ${wranglerVersion} (${chalk.blue(WRANGLER_PRERELEASE_LABEL)})`;
-	let maybeNewVersion: string | undefined;
+	let updateResult: NpmVersionCheckResult | undefined;
 	if (performUpdateCheck) {
 		// Race the update check against a short grace period. On a cache
 		// hit the library's readFile I/O completes within the first event-
 		// loop tick (<1 ms on SSD), so the result is almost always available.
 		// On a cache miss or slow network the timer wins and the banner
 		// prints immediately — no blocking.
-		maybeNewVersion = await Promise.race([
+		updateResult = await Promise.race([
 			updateCheck(),
 			new Promise<undefined>((resolve) => {
 				const timer = setTimeout(
@@ -44,8 +45,8 @@ export async function printWranglerBanner(performUpdateCheck = true) {
 				timer.unref();
 			}),
 		]);
-		if (maybeNewVersion !== undefined) {
-			text += ` (update available ${chalk.green(maybeNewVersion)})`;
+		if (updateResult?.status === "update-available") {
+			text += ` (update available ${chalk.green(updateResult.latest)})`;
 		}
 	}
 
@@ -67,9 +68,9 @@ export async function printWranglerBanner(performUpdateCheck = true) {
 	}
 
 	// Log a slightly more noticeable message if this is a major bump
-	if (maybeNewVersion !== undefined) {
+	if (updateResult?.status === "update-available") {
 		const currentMajor = parseInt(wranglerVersion.split(".")[0]);
-		const newMajor = parseInt(maybeNewVersion.split(".")[0]);
+		const newMajor = parseInt(updateResult.latest.split(".")[0]);
 		if (newMajor > currentMajor) {
 			logger.warn(
 				`The version of Wrangler you are using is now out-of-date.

--- a/packages/wrangler/src/wrangler-banner.ts
+++ b/packages/wrangler/src/wrangler-banner.ts
@@ -6,6 +6,7 @@ import supportsColor from "supports-color";
 import { version as wranglerVersion } from "../package.json";
 import { logger } from "./logger";
 import { updateCheck } from "./update-check";
+import type { NpmVersionCheckResult } from "@cloudflare/workers-utils";
 
 const MIN_NODE_VERSION = "20.0.0";
 
@@ -27,14 +28,14 @@ export async function printWranglerBanner(performUpdateCheck = true) {
 		typeof WRANGLER_PRERELEASE_LABEL === "undefined"
 			? ` ⛅️ wrangler ${wranglerVersion}`
 			: ` ⛅️ wrangler ${wranglerVersion} (${chalk.blue(WRANGLER_PRERELEASE_LABEL)})`;
-	let maybeNewVersion: string | undefined;
+	let updateResult: NpmVersionCheckResult | undefined;
 	if (performUpdateCheck) {
 		// Race the update check against a short grace period. On a cache
 		// hit the library's readFile I/O completes within the first event-
 		// loop tick (<1 ms on SSD), so the result is almost always available.
 		// On a cache miss or slow network the timer wins and the banner
 		// prints immediately — no blocking.
-		maybeNewVersion = await Promise.race([
+		updateResult = await Promise.race([
 			updateCheck(),
 			new Promise<undefined>((resolve) => {
 				const timer = setTimeout(
@@ -44,8 +45,8 @@ export async function printWranglerBanner(performUpdateCheck = true) {
 				timer.unref();
 			}),
 		]);
-		if (maybeNewVersion !== undefined) {
-			text += ` (update available ${chalk.green(maybeNewVersion)})`;
+		if (updateResult?.status === "update-available") {
+			text += ` (update available ${chalk.green(updateResult.latest)})`;
 		}
 	}
 
@@ -67,9 +68,9 @@ export async function printWranglerBanner(performUpdateCheck = true) {
 	}
 
 	// Log a slightly more noticeable message if this is a major bump
-	if (maybeNewVersion !== undefined) {
+	if (updateResult?.status === "update-available") {
 		const currentMajor = parseInt(wranglerVersion.split(".")[0]);
-		const newMajor = parseInt(maybeNewVersion.split(".")[0]);
+		const newMajor = parseInt(updateResult.latest.split(".")[0]);
 		if (newMajor > currentMajor) {
 			logger.warn(
 				`The version of Wrangler you are using is now out-of-date.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2423,9 +2423,6 @@ importers:
       typescript:
         specifier: catalog:default
         version: 5.8.3
-      update-check:
-        specifier: ^1.5.4
-        version: 1.5.4
       vite:
         specifier: catalog:default
         version: 8.0.1(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1)
@@ -3875,6 +3872,9 @@ importers:
       undici:
         specifier: catalog:default
         version: 7.24.8
+      update-check:
+        specifier: ^1.5.4
+        version: 1.5.4
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.0.1(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -4201,9 +4201,6 @@ importers:
       undici:
         specifier: catalog:default
         version: 7.24.8
-      update-check:
-        specifier: ^1.5.4
-        version: 1.5.4
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.0.1(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2423,6 +2423,9 @@ importers:
       typescript:
         specifier: catalog:default
         version: 5.8.3
+      update-check:
+        specifier: ^1.5.4
+        version: 1.5.4
       vite:
         specifier: catalog:default
         version: 8.0.1(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2465,6 +2465,9 @@ importers:
       typescript:
         specifier: catalog:default
         version: 5.8.3
+      update-check:
+        specifier: ^1.5.4
+        version: 1.5.4
       vite:
         specifier: catalog:default
         version: 8.0.13(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ catalogs:
       version: 1.5.2
     tinyglobby:
       specifier: ^0.2.12
-      version: 0.2.15
+      version: 0.2.16
     tree-kill:
       specifier: ^1.2.2
       version: 1.2.2
@@ -1752,7 +1752,7 @@ importers:
         version: 1.5.2
       tinyglobby:
         specifier: catalog:default
-        version: 0.2.15
+        version: 0.2.16
       tree-kill:
         specifier: catalog:default
         version: 1.2.2
@@ -2455,7 +2455,7 @@ importers:
         version: 7.7.3
       tinyglobby:
         specifier: catalog:default
-        version: 0.2.15
+        version: 0.2.16
       tree-kill:
         specifier: catalog:default
         version: 1.2.2
@@ -2465,9 +2465,6 @@ importers:
       typescript:
         specifier: catalog:default
         version: 5.8.3
-      update-check:
-        specifier: ^1.5.4
-        version: 1.5.4
       vite:
         specifier: catalog:default
         version: 8.0.13(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1)
@@ -3924,6 +3921,9 @@ importers:
       typescript:
         specifier: catalog:default
         version: 5.8.3
+      update-check:
+        specifier: ^1.5.4
+        version: 1.5.4
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.0.13(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -4259,9 +4259,6 @@ importers:
       undici:
         specifier: catalog:default
         version: 7.24.8
-      update-check:
-        specifier: ^1.5.4
-        version: 1.5.4
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.0.13(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
@@ -4310,7 +4307,7 @@ importers:
         version: 7.7.3
       tinyglobby:
         specifier: catalog:default
-        version: 0.2.15
+        version: 0.2.16
       ts-dedent:
         specifier: ^2.2.0
         version: 2.2.0
@@ -18525,10 +18522,10 @@ snapshots:
       '@rollup/pluginutils': 5.1.4(rollup@4.30.1)
       commondir: 1.0.1
       estree-walker: 2.0.2
-      fdir: 6.5.0(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.4)
       is-reference: 1.2.1
       magic-string: 0.30.21
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       rollup: 4.30.1
 
@@ -18567,7 +18564,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       rollup: 4.30.1
 
@@ -19585,7 +19582,7 @@ snapshots:
       babel-dead-code-elimination: 1.0.12
       diff: 8.0.3
       pathe: 2.0.3
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
     transitivePeerDependencies:
       - supports-color
 
@@ -20151,7 +20148,7 @@ snapshots:
       flatted: 3.4.0
       pathe: 2.0.3
       sirv: 3.0.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tinyrainbow: 3.0.3
       vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.0.13(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
 
@@ -23331,7 +23328,7 @@ snapshots:
       postcss: 8.5.8
       postcss-nested: 7.0.2(postcss@8.5.8)
       semver: 7.7.3
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
     optionalDependencies:
       typescript: 5.8.3
       vue-tsc: 2.0.29(typescript@5.8.3)
@@ -25779,7 +25776,7 @@ snapshots:
       rolldown-plugin-dts: 0.17.6(ms@2.1.3)(rolldown@1.0.0-beta.49)(typescript@5.8.3)
       semver: 7.7.3
       tinyexec: 1.0.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tree-kill: 1.2.2
       unconfig-core: 7.4.1
       unrun: 0.2.8(synckit@0.11.12)
@@ -26066,7 +26063,7 @@ snapshots:
       rollup: 4.30.1
       rollup-plugin-dts: 6.1.1(rollup@4.30.1)(typescript@5.8.3)
       scule: 1.3.0
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       untyped: 1.5.2
     optionalDependencies:
       typescript: 5.8.3
@@ -26356,7 +26353,7 @@ snapshots:
       picomatch: 4.0.3
       postcss: 8.5.6
       rollup: 4.57.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 22.15.17
       fsevents: 2.3.3
@@ -26415,11 +26412,11 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tinyrainbow: 3.0.3
       vite: 8.0.13(@types/node@22.15.17)(esbuild@0.23.1)(jiti@2.6.1)(tsx@3.12.10)(yaml@2.8.1)
       why-is-node-running: 2.3.0
@@ -26444,11 +26441,11 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tinyrainbow: 3.0.3
       vite: 8.0.13(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1)
       why-is-node-running: 2.3.0
@@ -26473,11 +26470,11 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tinyrainbow: 3.0.3
       vite: 8.0.13(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1)
       why-is-node-running: 2.3.0


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-2442

This PR updates the compatibility date warning from workerd (e.g., "The latest compatibility date supported by the installed Cloudflare Workers Runtime is...") so that now is only shown when a newer version of `@cloudflare/vite-plugin` is available. This matches the behavior in Wrangler and reduces noise when the user is already on the latest version.

> [!Note]
> This PR was fully authored by Claude Opus 4.5, I've reviewed the changes

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this is a minimal DX improvement (this breaking won't significantly impact users), this is also not tested in `wrangler` (I'm happy to add tests both for the vite plugin and wrangler is people feel that this should have tests)
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: DX improvement

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12400">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
