### PR TITLE
Use vitest#expect from the local context

### DIFF
--- a/packages/wrangler/eslint.config.mjs
+++ b/packages/wrangler/eslint.config.mjs
@@ -37,4 +37,11 @@ export default defineConfig([
 			],
 		},
 	},
+	// Bucket 1: pages, d1, kv, queues
+	{
+		files: ["src/__tests__/{pages,d1,kv,queues}/**/*.test.ts"],
+		rules: {
+			"workers-sdk/no-vitest-import-expect": "error",
+		},
+	},
 ]);

--- a/packages/wrangler/src/__tests__/d1/convert-timestamp-to-iso.test.ts
+++ b/packages/wrangler/src/__tests__/d1/convert-timestamp-to-iso.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, it, vi } from "vitest";
 import { convertTimestampToISO } from "../../d1/timeTravel/utils";
 
 describe("convertTimestampToISO", () => {
@@ -12,7 +12,7 @@ describe("convertTimestampToISO", () => {
 		vi.useRealTimers();
 	});
 
-	it("should reject invalid date strings", () => {
+	it("should reject invalid date strings", ({ expect }) => {
 		const timestamp = "asdf";
 		let error = "";
 		try {
@@ -29,20 +29,22 @@ describe("convertTimestampToISO", () => {
 	`);
 	});
 
-	it("should convert a JS timestamp to an ISO string", () => {
+	it("should convert a JS timestamp to an ISO string", ({ expect }) => {
 		const now = +new Date();
 		const converted = convertTimestampToISO(String(now));
 		expect(converted).toEqual(new Date(now).toISOString());
 	});
 
-	it("should automagically convert a unix timestamp to an ISO string", () => {
+	it("should automagically convert a unix timestamp to an ISO string", ({
+		expect,
+	}) => {
 		const date = "1689355284"; // 2023-07-14T17:21:24.000Z
 		const convertedDate = new Date(1689355284000);
 		const output = convertTimestampToISO(String(date));
 		expect(output).toEqual(convertedDate.toISOString());
 	});
 
-	it("should reject unix timestamps older than 30 days", () => {
+	it("should reject unix timestamps older than 30 days", ({ expect }) => {
 		const timestamp = "1626168000";
 		expect(() =>
 			convertTimestampToISO(timestamp)
@@ -51,7 +53,7 @@ describe("convertTimestampToISO", () => {
 		);
 	});
 
-	it("should reject JS timestamps from the future", () => {
+	it("should reject JS timestamps from the future", ({ expect }) => {
 		const date = String(+new Date() + 10000);
 
 		let error = "";
@@ -65,14 +67,16 @@ describe("convertTimestampToISO", () => {
 		);
 	});
 
-	it("should return an ISO string when provided an ISO string", () => {
+	it("should return an ISO string when provided an ISO string", ({
+		expect,
+	}) => {
 		const date = "2023-07-15T11:45:11.522Z";
 
 		const iso = convertTimestampToISO(date);
 		expect(iso).toEqual(date);
 	});
 
-	it("should reject ISO strings older than 30 days", () => {
+	it("should reject ISO strings older than 30 days", ({ expect }) => {
 		const date = "1975-07-17T11:45:11.522Z";
 
 		expect(() =>
@@ -82,7 +86,7 @@ describe("convertTimestampToISO", () => {
 		);
 	});
 
-	it("should reject ISO strings from the future", () => {
+	it("should reject ISO strings from the future", ({ expect }) => {
 		// TODO: fix Y3k bug
 		const date = "3000-01-01T00:00:00.001Z";
 

--- a/packages/wrangler/src/__tests__/d1/create.test.ts
+++ b/packages/wrangler/src/__tests__/d1/create.test.ts
@@ -1,6 +1,6 @@
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
@@ -17,19 +17,19 @@ describe("create", () => {
 	const std = mockConsoleMethods();
 	const { setIsTTY } = useMockIsTTY();
 
-	it("should throw if local flag is provided", async () => {
+	it("should throw if local flag is provided", async ({ expect }) => {
 		await expect(runWrangler("d1 create test --local")).rejects.toThrowError(
 			`Unknown argument: local`
 		);
 	});
 
-	it("should throw if remote flag is provided", async () => {
+	it("should throw if remote flag is provided", async ({ expect }) => {
 		await expect(runWrangler("d1 create test --remote")).rejects.toThrowError(
 			`Unknown argument: remote`
 		);
 	});
 
-	it("should throw if location flag isn't in the list", async () => {
+	it("should throw if location flag isn't in the list", async ({ expect }) => {
 		setIsTTY(false);
 		mockGetMemberships([
 			{ id: "IG-88", account: { id: "1701", name: "enterprise" } },
@@ -41,7 +41,9 @@ describe("create", () => {
 		`);
 	});
 
-	it("should try send a request to the API for a valid input", async () => {
+	it("should try send a request to the API for a valid input", async ({
+		expect,
+	}) => {
 		writeWranglerConfig({ name: "worker" }, "wrangler.json");
 
 		setIsTTY(false);
@@ -84,7 +86,9 @@ describe("create", () => {
 		`);
 	});
 
-	it("should fail if the jurisdiction provided is not supported", async () => {
+	it("should fail if the jurisdiction provided is not supported", async ({
+		expect,
+	}) => {
 		writeWranglerConfig({ name: "worker" }, "wrangler.json");
 
 		await expect(runWrangler("d1 create test --jurisdiction something")).rejects
@@ -94,7 +98,9 @@ describe("create", () => {
 		`);
 	});
 
-	it("should try send jurisdiction to the API if it is a valid input", async () => {
+	it("should try send jurisdiction to the API if it is a valid input", async ({
+		expect,
+	}) => {
 		writeWranglerConfig({ name: "worker" }, "wrangler.json");
 
 		setIsTTY(false);

--- a/packages/wrangler/src/__tests__/d1/d1.test.ts
+++ b/packages/wrangler/src/__tests__/d1/d1.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runInTempDir } from "../helpers/run-in-tmp";
@@ -8,7 +8,7 @@ describe("d1", () => {
 	const std = mockConsoleMethods();
 	runInTempDir();
 
-	it("should show help when no argument is passed", async () => {
+	it("should show help when no argument is passed", async ({ expect }) => {
 		await runWrangler("d1");
 		await endEventLoop();
 
@@ -38,7 +38,9 @@ describe("d1", () => {
 		`);
 	});
 
-	it("should show help when an invalid argument is passed", async () => {
+	it("should show help when an invalid argument is passed", async ({
+		expect,
+	}) => {
 		await expect(() => runWrangler("d1 asdf")).rejects.toThrow(
 			"Unknown argument: asdf"
 		);
@@ -75,7 +77,9 @@ describe("d1", () => {
 		`);
 	});
 
-	it("should show help when the migrations command is passed", async () => {
+	it("should show help when the migrations command is passed", async ({
+		expect,
+	}) => {
 		await runWrangler("d1 migrations");
 		await endEventLoop();
 
@@ -99,7 +103,9 @@ describe("d1", () => {
 		`);
 	});
 
-	it("should show help when the time travel command is passed", async () => {
+	it("should show help when the time travel command is passed", async ({
+		expect,
+	}) => {
 		await runWrangler("d1 time-travel");
 		await endEventLoop();
 		expect(std.out).toMatchInlineSnapshot(`

--- a/packages/wrangler/src/__tests__/d1/delete.test.ts
+++ b/packages/wrangler/src/__tests__/d1/delete.test.ts
@@ -1,5 +1,7 @@
 import { http, HttpResponse } from "msw";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- expect used in helper function */
 import { beforeEach, describe, expect, it } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { mockConfirm } from "../helpers/mock-dialogs";

--- a/packages/wrangler/src/__tests__/d1/execute.test.ts
+++ b/packages/wrangler/src/__tests__/d1/execute.test.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { UserError } from "@cloudflare/workers-utils";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
@@ -20,7 +20,7 @@ describe("execute", () => {
 	// We turn on SENTRY reporting so that we can prove that Wrangler will not attempt to report user errors.
 	useSentry();
 
-	it("should require login when running against prod", async () => {
+	it("should require login when running against prod", async ({ expect }) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			d1_databases: [
@@ -35,7 +35,7 @@ describe("execute", () => {
 		);
 	});
 
-	it("should expect either --command or --file", async () => {
+	it("should expect either --command or --file", async ({ expect }) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			d1_databases: [
@@ -48,7 +48,7 @@ describe("execute", () => {
 		);
 	});
 
-	it("should reject use of both --command and --file", async () => {
+	it("should reject use of both --command and --file", async ({ expect }) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			d1_databases: [
@@ -68,7 +68,7 @@ describe("execute", () => {
 		);
 	});
 
-	it("should reject the use of --remote with --local", async () => {
+	it("should reject the use of --remote with --local", async ({ expect }) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			d1_databases: [
@@ -83,7 +83,7 @@ describe("execute", () => {
 		);
 	});
 
-	it("should reject the use of --preview with --local", async () => {
+	it("should reject the use of --preview with --local", async ({ expect }) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			d1_databases: [
@@ -96,7 +96,9 @@ describe("execute", () => {
 		).rejects.toThrowError(`Error: can't use --preview without --remote`);
 	});
 
-	it("should reject the use of --preview with --local with --json", async () => {
+	it("should reject the use of --preview with --local with --json", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			d1_databases: [
@@ -119,7 +121,7 @@ describe("execute", () => {
 		);
 	});
 
-	it("should reject a binary SQLite DB", async () => {
+	it("should reject a binary SQLite DB", async ({ expect }) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			d1_databases: [
@@ -144,7 +146,7 @@ describe("execute", () => {
 		);
 	});
 
-	it("should throw a UserError if file does not exist", async () => {
+	it("should throw a UserError if file does not exist", async ({ expect }) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			d1_databases: [
@@ -162,7 +164,9 @@ describe("execute", () => {
 		`);
 	});
 
-	it("should treat SQLite constraint errors as UserErrors", async () => {
+	it("should treat SQLite constraint errors as UserErrors", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			d1_databases: [
@@ -187,7 +191,7 @@ describe("execute", () => {
 		).rejects.toThrow(UserError);
 	});
 
-	it("should show banner by default", async () => {
+	it("should show banner by default", async ({ expect }) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			d1_databases: [
@@ -199,7 +203,7 @@ describe("execute", () => {
 		expect(std.out).toContain("⛅️ wrangler x.x.x");
 	});
 
-	it("should execute locally without database_id", async () => {
+	it("should execute locally without database_id", async ({ expect }) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			d1_databases: [{ binding: "D1", database_name: "D1" }],
@@ -209,7 +213,7 @@ describe("execute", () => {
 		expect(std.out).toContain("1 command executed successfully");
 	});
 
-	it("should not show banner if --json=true", async () => {
+	it("should not show banner if --json=true", async ({ expect }) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			d1_databases: [
@@ -225,7 +229,9 @@ describe("execute", () => {
 		mockAccountId({ accountId: "some-account-id" });
 		mockApiToken();
 
-		it("should format duration to 2 decimal places in milliseconds for remote execution", async () => {
+		it("should format duration to 2 decimal places in milliseconds for remote execution", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 			writeWranglerConfig({
 				d1_databases: [
@@ -268,7 +274,9 @@ describe("execute", () => {
 			expect(std.out).toMatch("🚣 Executed 1 command in 123.46ms");
 		});
 
-		it("should format batch execution duration with 2 decimal places", async () => {
+		it("should format batch execution duration with 2 decimal places", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 			writeWranglerConfig({
 				d1_databases: [

--- a/packages/wrangler/src/__tests__/d1/export.test.ts
+++ b/packages/wrangler/src/__tests__/d1/export.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import { setTimeout } from "node:timers/promises";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
@@ -18,13 +18,13 @@ describe("export", () => {
 	runInTempDir();
 	const { setIsTTY } = useMockIsTTY();
 
-	it("should throw if output is missing", async () => {
+	it("should throw if output is missing", async ({ expect }) => {
 		await expect(runWrangler("d1 export db")).rejects.toThrowError(
 			`Missing required argument: output`
 		);
 	});
 
-	it("should throw if output is a directory", async () => {
+	it("should throw if output is a directory", async ({ expect }) => {
 		fs.mkdirSync("test-dir");
 
 		await expect(
@@ -34,13 +34,13 @@ describe("export", () => {
 		);
 	});
 
-	it("should throw if local and remote are both set", async () => {
+	it("should throw if local and remote are both set", async ({ expect }) => {
 		await expect(
 			runWrangler("d1 export db --local --remote --output test-local.sql")
 		).rejects.toThrowError("Arguments local and remote are mutually exclusive");
 	});
 
-	it("should handle local", async () => {
+	it("should handle local", async ({ expect }) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			d1_databases: [
@@ -113,7 +113,7 @@ describe("export", () => {
 		);
 	});
 
-	it("should handle remote", async () => {
+	it("should handle remote", async ({ expect }) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			d1_databases: [
@@ -137,7 +137,7 @@ describe("export", () => {
 		expect(fs.readFileSync("test-remote.sql", "utf8")).toBe(mockSqlContent);
 	});
 
-	it("should handle remote presigned URL errors", async () => {
+	it("should handle remote presigned URL errors", async ({ expect }) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			d1_databases: [
@@ -166,7 +166,7 @@ describe("export", () => {
 		);
 	});
 
-	it("should export locally without database_id", async () => {
+	it("should export locally without database_id", async ({ expect }) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			d1_databases: [{ binding: "D1", database_name: "D1" }],
@@ -176,7 +176,7 @@ describe("export", () => {
 		expect(std.out).toContain("Exporting SQL to test-remote.sql...");
 	});
 
-	it("should not export remotely without database_id", async () => {
+	it("should not export remotely without database_id", async ({ expect }) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			d1_databases: [{ binding: "D1", database_name: "D1" }],

--- a/packages/wrangler/src/__tests__/d1/info.test.ts
+++ b/packages/wrangler/src/__tests__/d1/info.test.ts
@@ -1,6 +1,6 @@
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
@@ -32,7 +32,7 @@ describe("info", () => {
 			],
 		});
 	});
-	it("should display version when alpha", async () => {
+	it("should display version when alpha", async ({ expect }) => {
 		msw.use(
 			http.get("*/accounts/:accountId/d1/database/*", async () => {
 				return HttpResponse.json(
@@ -68,7 +68,7 @@ describe("info", () => {
 	`);
 	});
 
-	it("should not display version when not alpha", async () => {
+	it("should not display version when not alpha", async ({ expect }) => {
 		msw.use(
 			http.get("*/accounts/:accountId/d1/database/*", async () => {
 				return HttpResponse.json(
@@ -126,7 +126,9 @@ describe("info", () => {
 	`);
 	});
 
-	it("should pretty print by default, incl. the wrangler banner", async () => {
+	it("should pretty print by default, incl. the wrangler banner", async ({
+		expect,
+	}) => {
 		msw.use(
 			http.get("*/accounts/:accountId/d1/database/*", async () => {
 				return HttpResponse.json(

--- a/packages/wrangler/src/__tests__/d1/insights.test.ts
+++ b/packages/wrangler/src/__tests__/d1/insights.test.ts
@@ -1,6 +1,6 @@
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, it, vi } from "vitest";
 import { getDurationDates } from "../../d1/insights";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -21,28 +21,34 @@ describe("getDurationDates()", () => {
 		vi.useRealTimers();
 	});
 
-	it("should throw an error if duration is greater than 31 days (in days)", () => {
+	it("should throw an error if duration is greater than 31 days (in days)", ({
+		expect,
+	}) => {
 		expect(() => getDurationDates("32d")).toThrowError(
 			"Duration cannot be greater than 31 days"
 		);
 	});
-	it("should throw an error if duration is greater than 31 days (in minutes)", () => {
+	it("should throw an error if duration is greater than 31 days (in minutes)", ({
+		expect,
+	}) => {
 		expect(() => getDurationDates("44641m")).toThrowError(
 			"Duration cannot be greater than 44640 minutes (31 days)"
 		);
 	});
 
-	it("should throw an error if duration is greater than 31 days (in hours)", () => {
+	it("should throw an error if duration is greater than 31 days (in hours)", ({
+		expect,
+	}) => {
 		expect(() => getDurationDates("745h")).toThrowError(
 			"Duration cannot be greater than 744 hours (31 days)"
 		);
 	});
 
-	it("should throw an error if duration unit is invalid", () => {
+	it("should throw an error if duration unit is invalid", ({ expect }) => {
 		expect(() => getDurationDates("1y")).toThrowError("Invalid duration unit");
 	});
 
-	it("should return the correct start and end dates", () => {
+	it("should return the correct start and end dates", ({ expect }) => {
 		const [startDate, endDate] = getDurationDates("5d");
 
 		expect(+new Date(startDate)).toBe(+new Date(2023, 6, 27));
@@ -58,7 +64,7 @@ describe("insights", () => {
 	const std = mockConsoleMethods();
 	const { setIsTTY } = useMockIsTTY();
 
-	it("should throw if a database name is not provided", async () => {
+	it("should throw if a database name is not provided", async ({ expect }) => {
 		await expect(() => runWrangler("d1 insights")).rejects.toThrow(
 			"Not enough non-option arguments: got 0, need at least 1"
 		);
@@ -70,7 +76,7 @@ describe("insights", () => {
   `);
 	});
 
-	it("should throw if database doesn't exist", async () => {
+	it("should throw if database doesn't exist", async ({ expect }) => {
 		setIsTTY(false);
 		mockGetMemberships([
 			{ id: "IG-88", account: { id: "1701", name: "enterprise" } },
@@ -107,7 +113,7 @@ describe("insights", () => {
 		);
 	});
 
-	it("should display the expected output", async () => {
+	it("should display the expected output", async ({ expect }) => {
 		setIsTTY(false);
 		mockGetMemberships([
 			{ id: "IG-88", account: { id: "1701", name: "enterprise" } },

--- a/packages/wrangler/src/__tests__/d1/list.test.ts
+++ b/packages/wrangler/src/__tests__/d1/list.test.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "msw";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
@@ -46,7 +46,9 @@ describe("list", () => {
 			})
 		);
 	});
-	it("should print as json if `--json` flag is specified, without wrangler banner", async () => {
+	it("should print as json if `--json` flag is specified, without wrangler banner", async ({
+		expect,
+	}) => {
 		await runWrangler("d1 list --json");
 		expect(std.out).toMatchInlineSnapshot(`
 			"[
@@ -64,7 +66,9 @@ describe("list", () => {
 		`);
 	});
 
-	it("should pretty print by default, including the wrangler banner", async () => {
+	it("should pretty print by default, including the wrangler banner", async ({
+		expect,
+	}) => {
 		await runWrangler("d1 list");
 		expect(std.out).toMatchInlineSnapshot(`
 			"

--- a/packages/wrangler/src/__tests__/d1/migrate.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrate.test.ts
@@ -1,6 +1,6 @@
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-import { describe, expect, it, vi } from "vitest";
+import { describe, it, vi } from "vitest";
 import { reinitialiseAuthTokens } from "../../user";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -20,7 +20,7 @@ describe("migrate", () => {
 	const { setIsTTY } = useMockIsTTY();
 
 	describe("create", () => {
-		it("should reject the --local flag for create", async () => {
+		it("should reject the --local flag for create", async ({ expect }) => {
 			setIsTTY(false);
 			writeWranglerConfig({
 				d1_databases: [
@@ -33,7 +33,7 @@ describe("migrate", () => {
 			).rejects.toThrowError(`Unknown argument: local`);
 		});
 
-		it("should error when no config file is present", async () => {
+		it("should error when no config file is present", async ({ expect }) => {
 			setIsTTY(false);
 			await expect(
 				runWrangler("d1 migrations create DATABASE test-migration")
@@ -42,7 +42,7 @@ describe("migrate", () => {
 			);
 		});
 
-		it("should work without a database_id", async () => {
+		it("should work without a database_id", async ({ expect }) => {
 			setIsTTY(false);
 			writeWranglerConfig({
 				d1_databases: [{ binding: "D1", database_name: "D1" }],
@@ -56,7 +56,7 @@ describe("migrate", () => {
 	describe("apply", () => {
 		mockAccountId({ accountId: null });
 		mockApiToken();
-		it("should not attempt to login in local mode", async () => {
+		it("should not attempt to login in local mode", async ({ expect }) => {
 			setIsTTY(false);
 			writeWranglerConfig({
 				d1_databases: [
@@ -69,7 +69,9 @@ describe("migrate", () => {
 			).rejects.toThrowError(`No migrations present at <cwd>/migrations.`);
 		});
 
-		it("should try to read D1 config from wrangler.toml", async () => {
+		it("should try to read D1 config from wrangler.toml", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 			writeWranglerConfig();
 			await expect(
@@ -79,7 +81,9 @@ describe("migrate", () => {
 			);
 		});
 
-		it("should not try to read wrangler.toml in local mode", async () => {
+		it("should not try to read wrangler.toml in local mode", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 			writeWranglerConfig();
 			// If we get to the point where we are checking for migrations then we have not checked wrangler.toml.
@@ -88,7 +92,7 @@ describe("migrate", () => {
 			).rejects.toThrowError(`No migrations present at <cwd>/migrations.`);
 		});
 
-		it("should error when no config file is present", async () => {
+		it("should error when no config file is present", async ({ expect }) => {
 			setIsTTY(false);
 			await expect(
 				runWrangler("d1 migrations apply DATABASE")
@@ -97,7 +101,9 @@ describe("migrate", () => {
 			);
 		});
 
-		it("should reject the use of --preview with --local", async () => {
+		it("should reject the use of --preview with --local", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 			writeWranglerConfig({
 				d1_databases: [
@@ -111,7 +117,9 @@ describe("migrate", () => {
 			).rejects.toThrowError(`Error: can't use --preview without --remote`);
 		});
 
-		it("multiple accounts: should throw when trying to apply migrations without an account_id in config", async () => {
+		it("multiple accounts: should throw when trying to apply migrations without an account_id in config", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 
 			writeWranglerConfig({
@@ -145,7 +153,9 @@ Your database may not be available to serve requests during the migration, conti
 				`More than one account available but unable to select one in non-interactive mode.`
 			);
 		});
-		it("multiple accounts: should let the user apply migrations with an account_id in config", async () => {
+		it("multiple accounts: should let the user apply migrations with an account_id in config", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 			const std = mockConsoleMethods();
 			msw.use(
@@ -224,7 +234,7 @@ Your database may not be available to serve requests during the migration, conti
 		mockAccountId();
 		mockApiToken({ apiToken: null });
 
-		it("should not attempt to login in local mode", async () => {
+		it("should not attempt to login in local mode", async ({ expect }) => {
 			setIsTTY(false);
 			writeWranglerConfig({
 				d1_databases: [
@@ -237,7 +247,7 @@ Your database may not be available to serve requests during the migration, conti
 			).rejects.toThrowError(`No migrations present at <cwd>/migrations.`);
 		});
 
-		it("should error when no config file is present", async () => {
+		it("should error when no config file is present", async ({ expect }) => {
 			setIsTTY(false);
 			await expect(
 				runWrangler("d1 migrations list DATABASE")
@@ -246,7 +256,9 @@ Your database may not be available to serve requests during the migration, conti
 			);
 		});
 
-		it("should use the custom migrations folder when provided", async () => {
+		it("should use the custom migrations folder when provided", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 			writeWranglerConfig({
 				d1_databases: [
@@ -265,7 +277,9 @@ Your database may not be available to serve requests during the migration, conti
 			);
 		});
 
-		it("should try to read D1 config from wrangler.toml when logged in", async () => {
+		it("should try to read D1 config from wrangler.toml when logged in", async ({
+			expect,
+		}) => {
 			vi.stubEnv("CLOUDFLARE_API_TOKEN", "api-token");
 			reinitialiseAuthTokens();
 			setIsTTY(false);
@@ -277,7 +291,9 @@ Your database may not be available to serve requests during the migration, conti
 			);
 		});
 
-		it("should throw if user is not authenticated and not using --local", async () => {
+		it("should throw if user is not authenticated and not using --local", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 
 			await expect(
@@ -287,7 +303,9 @@ Your database may not be available to serve requests during the migration, conti
 			);
 		});
 
-		it("should not try to read wrangler.toml in local mode", async () => {
+		it("should not try to read wrangler.toml in local mode", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 			writeWranglerConfig();
 			// If we get to the point where we are checking for migrations then we have not checked wrangler.toml.

--- a/packages/wrangler/src/__tests__/d1/splitter.test.ts
+++ b/packages/wrangler/src/__tests__/d1/splitter.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import splitSqlQuery, { mayContainMultipleStatements } from "../../d1/splitter";
 
 describe("mayContainMultipleStatements()", () => {
-	it("should return false if there is only a semi-colon at the end", () => {
+	it("should return false if there is only a semi-colon at the end", ({
+		expect,
+	}) => {
 		expect(mayContainMultipleStatements(`SELECT * FROM my_table`)).toBe(false);
 		expect(
 			mayContainMultipleStatements(`SELECT * FROM my_table WHERE id = 42;`)
@@ -12,7 +14,9 @@ describe("mayContainMultipleStatements()", () => {
 		).toBe(false);
 	});
 
-	it("should return true if there is a semi-colon before the end of the string", () => {
+	it("should return true if there is a semi-colon before the end of the string", ({
+		expect,
+	}) => {
 		expect(
 			mayContainMultipleStatements(
 				`SELECT * FROM my_table WHERE val = "foo;bar";`
@@ -20,7 +24,7 @@ describe("mayContainMultipleStatements()", () => {
 		).toBe(true);
 	});
 
-	it("should return true if there is more than one statement", () => {
+	it("should return true if there is more than one statement", ({ expect }) => {
 		expect(
 			mayContainMultipleStatements(
 				`
@@ -33,7 +37,7 @@ describe("mayContainMultipleStatements()", () => {
 });
 
 describe("splitSqlQuery()", () => {
-	it("should trim a regular old sqlite dump", () => {
+	it("should trim a regular old sqlite dump", ({ expect }) => {
 		expect(
 			splitSqlQuery(`PRAGMA foreign_keys=OFF;
 		BEGIN TRANSACTION;
@@ -56,7 +60,9 @@ describe("splitSqlQuery()", () => {
 		]
 	`);
 	});
-	it("should return original SQL if there are no real statements", () => {
+	it("should return original SQL if there are no real statements", ({
+		expect,
+	}) => {
 		expect(splitSqlQuery(`;;;`)).toMatchInlineSnapshot(`
 		Array [
 		  ";;;",
@@ -64,7 +70,7 @@ describe("splitSqlQuery()", () => {
 	`);
 	});
 
-	it("should not split single statements", () => {
+	it("should not split single statements", ({ expect }) => {
 		expect(splitSqlQuery(`SELECT * FROM my_table`)).toMatchInlineSnapshot(`
 		Array [
 		  "SELECT * FROM my_table",
@@ -91,7 +97,7 @@ describe("splitSqlQuery()", () => {
 	`);
 	});
 
-	it("should handle strings", () => {
+	it("should handle strings", ({ expect }) => {
 		expect(
 			splitSqlQuery(
 				`
@@ -105,7 +111,7 @@ describe("splitSqlQuery()", () => {
 	`);
 	});
 
-	it("should handle inline comments", () => {
+	it("should handle inline comments", ({ expect }) => {
 		expect(
 			splitSqlQuery(
 				`SELECT * FROM my_table -- semicolons; in; comments; don't count;
@@ -121,7 +127,7 @@ describe("splitSqlQuery()", () => {
 		`);
 	});
 
-	it("should handle block comments", () => {
+	it("should handle block comments", ({ expect }) => {
 		expect(
 			splitSqlQuery(
 				`/****
@@ -138,7 +144,7 @@ describe("splitSqlQuery()", () => {
 		`);
 	});
 
-	it("should split multiple statements", () => {
+	it("should split multiple statements", ({ expect }) => {
 		expect(
 			splitSqlQuery(
 				`
@@ -154,7 +160,7 @@ describe("splitSqlQuery()", () => {
 	`);
 	});
 
-	it("should ignore comment at the end", () => {
+	it("should ignore comment at the end", ({ expect }) => {
 		expect(
 			splitSqlQuery(
 				`
@@ -170,7 +176,7 @@ describe("splitSqlQuery()", () => {
 		`);
 	});
 
-	it("should handle whitespace between statements", () => {
+	it("should handle whitespace between statements", ({ expect }) => {
 		expect(
 			splitSqlQuery(`
         CREATE DOMAIN custom_types.email AS TEXT CHECK (VALUE ~ '^.+@.+$');
@@ -218,7 +224,7 @@ describe("splitSqlQuery()", () => {
 	`);
 	});
 
-	it("should handle $...$ style string markers", () => {
+	it("should handle $...$ style string markers", ({ expect }) => {
 		expect(
 			splitSqlQuery(`
           CREATE OR REPLACE FUNCTION update_updated_at_column()
@@ -254,7 +260,7 @@ describe("splitSqlQuery()", () => {
 	`);
 	});
 
-	it("should handle compound statements for BEGINs", () => {
+	it("should handle compound statements for BEGINs", ({ expect }) => {
 		expect(
 			splitSqlQuery(`
     CREATE TRIGGER IF NOT EXISTS update_trigger AFTER UPDATE ON items
@@ -322,7 +328,7 @@ describe("splitSqlQuery()", () => {
 		`);
 	});
 
-	it("should handle compound statements for CASEs", () => {
+	it("should handle compound statements for CASEs", ({ expect }) => {
 		expect(
 			splitSqlQuery(`
 				CREATE TRIGGER test_after_insert_trigger AFTER

--- a/packages/wrangler/src/__tests__/d1/timeTravel.test.ts
+++ b/packages/wrangler/src/__tests__/d1/timeTravel.test.ts
@@ -1,7 +1,7 @@
 import { COMPLIANCE_REGION_CONFIG_UNKNOWN } from "@cloudflare/workers-utils";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { throwIfDatabaseIsAlpha } from "../../d1/timeTravel/utils";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -19,7 +19,9 @@ describe("time-travel", () => {
 	const { setIsTTY } = useMockIsTTY();
 
 	describe("restore", () => {
-		it("should reject the use of --timestamp with --bookmark", async () => {
+		it("should reject the use of --timestamp with --bookmark", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 			writeWranglerConfig({
 				d1_databases: [
@@ -38,7 +40,7 @@ describe("time-travel", () => {
 	});
 
 	describe("throwIfDatabaseIsAlpha", () => {
-		it("should throw for alpha dbs", async () => {
+		it("should throw for alpha dbs", async ({ expect }) => {
 			writeWranglerConfig({
 				d1_databases: [
 					{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
@@ -78,7 +80,7 @@ describe("time-travel", () => {
 				"Time travel is not available for alpha D1 databases. You will need to migrate to a new database for access to this feature."
 			);
 		});
-		it("should not throw for non-alpha dbs", async () => {
+		it("should not throw for non-alpha dbs", async ({ expect }) => {
 			writeWranglerConfig({
 				d1_databases: [
 					{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
@@ -173,7 +175,9 @@ describe("time-travel", () => {
 			vi.useRealTimers();
 		});
 		describe("restore", () => {
-			it("should print as json, without wrangler banner", async () => {
+			it("should print as json, without wrangler banner", async ({
+				expect,
+			}) => {
 				await runWrangler(
 					`d1 time-travel restore db --timestamp=2011-09-05T14:48:00.000Z --json`
 				);
@@ -184,7 +188,7 @@ describe("time-travel", () => {
 				`);
 			});
 
-			it("should pretty print by default", async () => {
+			it("should pretty print by default", async ({ expect }) => {
 				await runWrangler(
 					`d1 time-travel restore db --timestamp=2011-09-05T14:48:00.000Z"`
 				);
@@ -209,7 +213,9 @@ describe("time-travel", () => {
 			});
 		});
 		describe("info", () => {
-			it("should print as json, without wrangler banner", async () => {
+			it("should print as json, without wrangler banner", async ({
+				expect,
+			}) => {
 				await runWrangler(
 					`d1 time-travel info db --timestamp=2011-09-05T14:48:00.000Z --json`
 				);
@@ -225,7 +231,7 @@ describe("time-travel", () => {
 					}"
 				`);
 			});
-			it("should pretty print by default", async () => {
+			it("should pretty print by default", async ({ expect }) => {
 				await runWrangler(
 					`d1 time-travel info db --timestamp=2011-09-05T14:48:00.000Z"`
 				);

--- a/packages/wrangler/src/__tests__/d1/trimmer.test.ts
+++ b/packages/wrangler/src/__tests__/d1/trimmer.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import { mayContainTransaction, trimSqlQuery } from "../../d1/trimmer";
 
 describe("mayContainTransaction()", () => {
-	it("should return false if there for regular queries", () => {
+	it("should return false if there for regular queries", ({ expect }) => {
 		expect(mayContainTransaction(`SELECT * FROM my_table`)).toBe(false);
 		expect(mayContainTransaction(`SELECT * FROM my_table WHERE id = 42;`)).toBe(
 			false
@@ -12,7 +12,7 @@ describe("mayContainTransaction()", () => {
 		).toBe(false);
 	});
 
-	it("should return true if there is a transaction", () => {
+	it("should return true if there is a transaction", ({ expect }) => {
 		expect(
 			mayContainTransaction(
 				`PRAGMA foreign_keys=OFF;
@@ -30,11 +30,13 @@ describe("mayContainTransaction()", () => {
 });
 
 describe("trimSqlQuery()", () => {
-	it("should return original SQL if there are no real statements", () => {
+	it("should return original SQL if there are no real statements", ({
+		expect,
+	}) => {
 		expect(trimSqlQuery(`;;;`)).toMatchInlineSnapshot(`";;;"`);
 	});
 
-	it("should not trim single statements", () => {
+	it("should not trim single statements", ({ expect }) => {
 		expect(trimSqlQuery(`SELECT * FROM my_table`)).toMatchInlineSnapshot(
 			`"SELECT * FROM my_table"`
 		);
@@ -46,7 +48,7 @@ describe("trimSqlQuery()", () => {
 		).toMatchInlineSnapshot(`"SELECT * FROM my_table WHERE id = 42;"`);
 	});
 
-	it("should trim a regular old sqlite dump", () => {
+	it("should trim a regular old sqlite dump", ({ expect }) => {
 		expect(
 			trimSqlQuery(`PRAGMA foreign_keys=OFF;
 		BEGIN TRANSACTION;
@@ -69,7 +71,7 @@ describe("trimSqlQuery()", () => {
 					"
 		`);
 	});
-	it("should throw when provided multiple transactions", () => {
+	it("should throw when provided multiple transactions", ({ expect }) => {
 		expect(() =>
 			trimSqlQuery(`PRAGMA foreign_keys=OFF;
 		BEGIN TRANSACTION;
@@ -89,7 +91,7 @@ describe("trimSqlQuery()", () => {
 		`);
 	});
 
-	it("should handle strings", () => {
+	it("should handle strings", ({ expect }) => {
 		expect(
 			trimSqlQuery(`SELECT * FROM my_table WHERE val = "foo;bar";`)
 		).toMatchInlineSnapshot(
@@ -97,7 +99,7 @@ describe("trimSqlQuery()", () => {
 		);
 	});
 
-	it("should handle inline comments", () => {
+	it("should handle inline comments", ({ expect }) => {
 		expect(
 			trimSqlQuery(
 				`SELECT * FROM my_table -- semicolons; in; comments; don't count;
@@ -111,7 +113,7 @@ describe("trimSqlQuery()", () => {
 	`);
 	});
 
-	it("should handle block comments", () => {
+	it("should handle block comments", ({ expect }) => {
 		expect(
 			trimSqlQuery(
 				`/****
@@ -129,7 +131,7 @@ describe("trimSqlQuery()", () => {
 	`);
 	});
 
-	it("should split multiple statements", () => {
+	it("should split multiple statements", ({ expect }) => {
 		expect(
 			trimSqlQuery(
 				`INSERT INTO my_table (id, value) VALUES (42, 'foo');SELECT * FROM my_table WHERE id = 42 - 10;`
@@ -139,7 +141,7 @@ describe("trimSqlQuery()", () => {
 		);
 	});
 
-	it("should handle whitespace between statements", () => {
+	it("should handle whitespace between statements", ({ expect }) => {
 		expect(
 			trimSqlQuery(`CREATE DOMAIN custom_types.email AS TEXT CHECK (VALUE ~ '^.+@.+$');
         CREATE TYPE custom_types.currency AS ENUM('USD', 'GBP');
@@ -185,7 +187,7 @@ describe("trimSqlQuery()", () => {
 	`);
 	});
 
-	it("should handle $...$ style string markers", () => {
+	it("should handle $...$ style string markers", ({ expect }) => {
 		expect(
 			trimSqlQuery(`CREATE OR REPLACE FUNCTION update_updated_at_column()
           RETURNS TRIGGER AS $$
@@ -214,7 +216,7 @@ describe("trimSqlQuery()", () => {
 		);
 	});
 
-	it("should handle compound statements", () => {
+	it("should handle compound statements", ({ expect }) => {
 		expect(
 			trimSqlQuery(
 				`CREATE TRIGGER IF NOT EXISTS update_trigger AFTER UPDATE ON items

--- a/packages/wrangler/src/__tests__/d1/utils.test.ts
+++ b/packages/wrangler/src/__tests__/d1/utils.test.ts
@@ -1,6 +1,6 @@
 import { type Config } from "@cloudflare/workers-utils";
 import { http, HttpResponse } from "msw";
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import {
 	getDatabaseByNameOrBinding,
 	getDatabaseInfoFromConfig,
@@ -10,14 +10,14 @@ import { mockGetMemberships } from "../helpers/mock-oauth-flow";
 import { msw } from "../helpers/msw";
 
 describe("getDatabaseInfoFromConfig", () => {
-	it("should handle no database", () => {
+	it("should handle no database", ({ expect }) => {
 		const config = {
 			d1_databases: [],
 		} as unknown as Config;
 		expect(getDatabaseInfoFromConfig(config, "db")).toBeNull();
 	});
 
-	it("should handle no matching database", () => {
+	it("should handle no matching database", ({ expect }) => {
 		const config = {
 			d1_databases: [
 				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
@@ -26,7 +26,7 @@ describe("getDatabaseInfoFromConfig", () => {
 		expect(getDatabaseInfoFromConfig(config, "db2")).toBeNull();
 	});
 
-	it("should handle matching database", () => {
+	it("should handle matching database", ({ expect }) => {
 		const config = {
 			d1_databases: [
 				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
@@ -43,7 +43,9 @@ describe("getDatabaseInfoFromConfig", () => {
 		});
 	});
 
-	it("should handle matching a database with a custom migrations folder", () => {
+	it("should handle matching a database with a custom migrations folder", ({
+		expect,
+	}) => {
 		const config = {
 			d1_databases: [
 				{
@@ -65,7 +67,9 @@ describe("getDatabaseInfoFromConfig", () => {
 		});
 	});
 
-	it("should handle matching a database with custom migrations table", () => {
+	it("should handle matching a database with custom migrations table", ({
+		expect,
+	}) => {
 		const config = {
 			d1_databases: [
 				{
@@ -87,7 +91,9 @@ describe("getDatabaseInfoFromConfig", () => {
 		});
 	});
 
-	it("should handle matching a database when there are multiple databases", () => {
+	it("should handle matching a database when there are multiple databases", ({
+		expect,
+	}) => {
 		const config = {
 			d1_databases: [
 				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
@@ -110,7 +116,7 @@ describe("getDatabaseByNameOrBinding", () => {
 	mockAccountId({ accountId: null });
 	mockApiToken();
 
-	it("should handle no database", async () => {
+	it("should handle no database", async ({ expect }) => {
 		mockGetMemberships([
 			{ id: "IG-88", account: { id: "1701", name: "enterprise" } },
 		]);
@@ -143,7 +149,7 @@ describe("getDatabaseByNameOrBinding", () => {
 		).rejects.toThrowError("Couldn't find DB with name 'db'");
 	});
 
-	it("should handle a matching database", async () => {
+	it("should handle a matching database", async ({ expect }) => {
 		mockGetMemberships([
 			{ id: "IG-88", account: { id: "1701", name: "enterprise" } },
 		]);

--- a/packages/wrangler/src/__tests__/kv/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/kv/bulk.test.ts
@@ -1,6 +1,8 @@
 import { writeFileSync } from "node:fs";
 import { http, HttpResponse } from "msw";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- expect used in MSW handlers */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { BATCH_MAX_ERRORS_WARNINGS } from "../../kv/helpers";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -124,17 +126,17 @@ describe("kv", () => {
 						`kv bulk put --remote --namespace-id some-namespace-id keys.json`
 					)
 				).rejects.toThrowErrorMatchingInlineSnapshot(`
-					[Error: Unexpected JSON input from "keys.json".
-					Expected an array of key-value objects but got type "object".]
-				`);
+				[Error: Unexpected JSON input from "keys.json".
+				Expected an array of key-value objects but got type "object".]
+			`);
 				expect(std.out).toMatchInlineSnapshot(`
-					"
-					 ⛅️ wrangler x.x.x
-					──────────────────
-					Resource location: remote
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				Resource location: remote
 
-					"
-				`);
+				"
+			`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 
@@ -483,18 +485,18 @@ describe("kv", () => {
 						`kv bulk delete --remote --namespace-id some-namespace-id keys.json`
 					)
 				).rejects.toThrowErrorMatchingInlineSnapshot(`
-					[Error: Unexpected JSON input from "keys.json".
-					Expected an array of strings but got:
-					12354]
-				`);
+				[Error: Unexpected JSON input from "keys.json".
+				Expected an array of strings but got:
+				12354]
+			`);
 				expect(std.out).toMatchInlineSnapshot(`
-					"
-					 ⛅️ wrangler x.x.x
-					──────────────────
-					Resource location: remote
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				Resource location: remote
 
-					"
-				`);
+				"
+			`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 
@@ -510,20 +512,20 @@ describe("kv", () => {
 						`kv bulk delete --remote --namespace-id some-namespace-id keys.json`
 					)
 				).rejects.toThrowErrorMatchingInlineSnapshot(`
-					[Error: Unexpected JSON input from "keys.json".
-					Expected an array of strings or objects with a "name" key.
-					The item at index 1 is type: "number" - 12354
-					The item at index 2 is type: "object" - {"key":"someKey"}
-					The item at index 3 is type: "object" - null]
-				`);
+				[Error: Unexpected JSON input from "keys.json".
+				Expected an array of strings or objects with a "name" key.
+				The item at index 1 is type: "number" - 12354
+				The item at index 2 is type: "object" - {"key":"someKey"}
+				The item at index 3 is type: "object" - null]
+			`);
 				expect(std.out).toMatchInlineSnapshot(`
-					"
-					 ⛅️ wrangler x.x.x
-					──────────────────
-					Resource location: remote
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				Resource location: remote
 
-					"
-				`);
+				"
+			`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 		});

--- a/packages/wrangler/src/__tests__/kv/help.test.ts
+++ b/packages/wrangler/src/__tests__/kv/help.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, test } from "vitest";
+import { afterEach, beforeEach, describe, it, test } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -23,7 +23,7 @@ describe("kv", () => {
 	});
 
 	describe("help", () => {
-		test("kv --help", async () => {
+		test("kv --help", async ({ expect }) => {
 			const result = runWrangler("kv --help");
 
 			await expect(result).resolves.toBeUndefined();
@@ -47,7 +47,7 @@ describe("kv", () => {
 			`);
 		});
 
-		it("should show help when no argument is passed", async () => {
+		it("should show help when no argument is passed", async ({ expect }) => {
 			await runWrangler("kv");
 			await endEventLoop();
 			expect(std.out).toMatchInlineSnapshot(`
@@ -70,7 +70,9 @@ describe("kv", () => {
 			`);
 		});
 
-		it("should show help when an invalid argument is passed", async () => {
+		it("should show help when an invalid argument is passed", async ({
+			expect,
+		}) => {
 			await expect(() => runWrangler("kv asdf")).rejects.toThrow(
 				"Unknown argument: asdf"
 			);

--- a/packages/wrangler/src/__tests__/kv/key.test.ts
+++ b/packages/wrangler/src/__tests__/kv/key.test.ts
@@ -1,7 +1,9 @@
 import { writeFileSync } from "node:fs";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- expect used in MSW handlers */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs } from "../helpers/mock-dialogs";

--- a/packages/wrangler/src/__tests__/kv/local.test.ts
+++ b/packages/wrangler/src/__tests__/kv/local.test.ts
@@ -1,5 +1,5 @@
 import { writeFileSync } from "node:fs";
-import { describe, expect, it, vi } from "vitest";
+import { describe, it, vi } from "vitest";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
@@ -11,7 +11,7 @@ describe("kv", () => {
 	const std = mockConsoleMethods();
 
 	describe("local", () => {
-		it("should put local kv storage", async () => {
+		it("should put local kv storage", async ({ expect }) => {
 			await runWrangler(
 				`kv key get val --namespace-id some-namespace-id  --text`
 			);
@@ -37,7 +37,7 @@ describe("kv", () => {
 			expect(std.getAndClearOut()).toMatchInlineSnapshot(`"value"`);
 		});
 
-		it("should list local kv storage", async () => {
+		it("should list local kv storage", async ({ expect }) => {
 			await runWrangler(`kv key list --namespace-id some-namespace-id`);
 			expect(std.out).toMatchInlineSnapshot(`"[]"`);
 			const keyValues = [
@@ -121,7 +121,7 @@ describe("kv", () => {
 			`);
 		});
 
-		it("should delete local kv storage", async () => {
+		it("should delete local kv storage", async ({ expect }) => {
 			await runWrangler(
 				`kv key put val value --namespace-id some-namespace-id`
 			);
@@ -157,7 +157,7 @@ describe("kv", () => {
 			expect(std.getAndClearOut()).toMatchInlineSnapshot(`"Value not found"`);
 		});
 
-		it("should put local bulk kv storage", async () => {
+		it("should put local bulk kv storage", async ({ expect }) => {
 			await runWrangler(`kv key list --namespace-id bulk-namespace-id`);
 			expect(std.getAndClearOut()).toMatchInlineSnapshot(`"[]"`);
 
@@ -217,7 +217,7 @@ describe("kv", () => {
 			`);
 		});
 
-		it("should delete local bulk kv storage", async () => {
+		it("should delete local bulk kv storage", async ({ expect }) => {
 			const keyValues = [
 				{
 					key: "hello",
@@ -271,7 +271,7 @@ describe("kv", () => {
 			expect(std.getAndClearOut()).toMatchInlineSnapshot(`"[]"`);
 		});
 
-		it("should delete local bulk kv storage ({ name })", async () => {
+		it("should delete local bulk kv storage ({ name })", async ({ expect }) => {
 			const keyValues = [
 				{
 					key: "hello",
@@ -332,7 +332,7 @@ describe("kv", () => {
 			expect(std.getAndClearOut()).toMatchInlineSnapshot(`"[]"`);
 		});
 
-		it("should get local bulk kv storage", async () => {
+		it("should get local bulk kv storage", async ({ expect }) => {
 			const keyValues = [
 				{
 					key: "hello",
@@ -385,7 +385,7 @@ describe("kv", () => {
 			`);
 		});
 
-		it("should follow persist-to for local kv storage", async () => {
+		it("should follow persist-to for local kv storage", async ({ expect }) => {
 			await runWrangler(
 				`kv key put val value --namespace-id some-namespace-id`
 			);

--- a/packages/wrangler/src/__tests__/kv/namespace.test.ts
+++ b/packages/wrangler/src/__tests__/kv/namespace.test.ts
@@ -1,7 +1,9 @@
 import { readFile } from "node:fs/promises";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- test.each */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs, mockConfirm, mockPrompt } from "../helpers/mock-dialogs";

--- a/packages/wrangler/src/__tests__/pages/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deploy.test.ts
@@ -5,7 +5,9 @@ import { execa } from "execa";
 import { http, HttpResponse } from "msw";
 import TOML from "smol-toml";
 import dedent from "ts-dedent";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- test.each */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { version } from "../../../package.json";
 import { ROUTES_SPEC_VERSION } from "../../pages/constants";
 import { ApiErrorCodes } from "../../pages/errors";

--- a/packages/wrangler/src/__tests__/pages/deployment-list.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deployment-list.test.ts
@@ -1,5 +1,7 @@
 import { http, HttpResponse } from "msw";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- expect used in MSW handlers */
 import { afterEach, describe, expect, it } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { mockAccountId, mockApiToken } from "./../helpers/mock-account-id";

--- a/packages/wrangler/src/__tests__/pages/dev.test.ts
+++ b/packages/wrangler/src/__tests__/pages/dev.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
@@ -11,7 +11,9 @@ describe("pages dev", () => {
 	runInTempDir();
 	mockConsoleMethods();
 
-	it("should error if neither [<directory>] nor [--<command>] command line args were specified", async () => {
+	it("should error if neither [<directory>] nor [--<command>] command line args were specified", async ({
+		expect,
+	}) => {
 		await expect(
 			runWrangler("pages dev")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -19,7 +21,9 @@ describe("pages dev", () => {
 		);
 	});
 
-	it("should error if both [<directory>] and [--<command>] command line args were specified", async () => {
+	it("should error if both [<directory>] and [--<command>] command line args were specified", async ({
+		expect,
+	}) => {
 		await expect(
 			runWrangler("pages dev public -- yarn dev")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -27,7 +31,9 @@ describe("pages dev", () => {
 		);
 	});
 
-	it("should error if the [--config] command line arg was specified", async () => {
+	it("should error if the [--config] command line arg was specified", async ({
+		expect,
+	}) => {
 		await expect(
 			runWrangler("pages dev public --config=/path/to/wrangler.toml")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -35,7 +41,9 @@ describe("pages dev", () => {
 		);
 	});
 
-	it("should error if the [--env] command line arg was specified", async () => {
+	it("should error if the [--env] command line arg was specified", async ({
+		expect,
+	}) => {
 		await expect(
 			runWrangler("pages dev public --env=production")
 		).rejects.toThrowErrorMatchingInlineSnapshot(

--- a/packages/wrangler/src/__tests__/pages/filepath-routing.test.ts
+++ b/packages/wrangler/src/__tests__/pages/filepath-routing.test.ts
@@ -1,5 +1,5 @@
 import { mkdirSync, writeFileSync } from "node:fs";
-import { describe, expect, it, test } from "vitest";
+import { describe, it, test } from "vitest";
 import {
 	compareRoutes,
 	generateConfigFromFileTree,
@@ -11,7 +11,7 @@ import type { UrlPath } from "../../paths";
 
 describe("filepath-routing", () => {
 	describe("compareRoutes()", () => {
-		test("routes / last", () => {
+		test("routes / last", ({ expect }) => {
 			expect(
 				compareRoutes(routeConfig("/"), routeConfig("/foo"))
 			).toBeGreaterThanOrEqual(1);
@@ -23,7 +23,9 @@ describe("filepath-routing", () => {
 			).toBeGreaterThanOrEqual(1);
 		});
 
-		test("routes with fewer segments come after those with more segments", () => {
+		test("routes with fewer segments come after those with more segments", ({
+			expect,
+		}) => {
 			expect(
 				compareRoutes(routeConfig("/foo"), routeConfig("/foo/bar"))
 			).toBeGreaterThanOrEqual(1);
@@ -32,36 +34,48 @@ describe("filepath-routing", () => {
 			).toBeGreaterThanOrEqual(1);
 		});
 
-		test("routes with wildcard segments come after those without", () => {
+		test("routes with wildcard segments come after those without", ({
+			expect,
+		}) => {
 			expect(compareRoutes(routeConfig("/:foo*"), routeConfig("/foo"))).toBe(1);
 			expect(compareRoutes(routeConfig("/:foo*"), routeConfig("/:foo"))).toBe(
 				1
 			);
 		});
 
-		test("routes with dynamic segments come after those without", () => {
+		test("routes with dynamic segments come after those without", ({
+			expect,
+		}) => {
 			expect(compareRoutes(routeConfig("/:foo"), routeConfig("/foo"))).toBe(1);
 		});
 
-		test("routes with dynamic segments occurring earlier come after those with dynamic segments in later positions", () => {
+		test("routes with dynamic segments occurring earlier come after those with dynamic segments in later positions", ({
+			expect,
+		}) => {
 			expect(
 				compareRoutes(routeConfig("/foo/:id/bar"), routeConfig("/foo/bar/:id"))
 			).toBe(1);
 		});
 
-		test("routes with no HTTP method come after those specifying a method", () => {
+		test("routes with no HTTP method come after those specifying a method", ({
+			expect,
+		}) => {
 			expect(
 				compareRoutes(routeConfig("/foo"), routeConfig("/foo", "GET"))
 			).toBe(1);
 		});
 
-		test("two equal routes are sorted according to their original position in the list", () => {
+		test("two equal routes are sorted according to their original position in the list", ({
+			expect,
+		}) => {
 			expect(
 				compareRoutes(routeConfig("/foo", "GET"), routeConfig("/foo", "GET"))
 			).toBe(0);
 		});
 
-		test("it returns -1 if the first argument should appear first in the list", () => {
+		test("it returns -1 if the first argument should appear first in the list", ({
+			expect,
+		}) => {
 			expect(
 				compareRoutes(routeConfig("/foo", "GET"), routeConfig("/foo"))
 			).toBe(-1);
@@ -71,7 +85,9 @@ describe("filepath-routing", () => {
 	describe("generateConfigFromFileTree", () => {
 		runInTempDir();
 
-		it("should generate a route entry for each file in the tree", async () => {
+		it("should generate a route entry for each file in the tree", async ({
+			expect,
+		}) => {
 			writeFileSync(
 				"foo.ts",
 				`
@@ -227,7 +243,9 @@ describe("filepath-routing", () => {
       `);
 		});
 
-		it("should display an error if a simple route param name is invalid", async () => {
+		it("should display an error if a simple route param name is invalid", async ({
+			expect,
+		}) => {
 			mkdirSync("foo");
 			writeFileSync(
 				"foo/[hyphen-not-allowed].ts",
@@ -243,7 +261,9 @@ describe("filepath-routing", () => {
 			);
 		});
 
-		it("should display an error if a catch-all route param name is invalid", async () => {
+		it("should display an error if a catch-all route param name is invalid", async ({
+			expect,
+		}) => {
 			mkdirSync("foo");
 			writeFileSync(
 				"foo/[[hyphen-not-allowed]].ts",

--- a/packages/wrangler/src/__tests__/pages/functions-build.test.ts
+++ b/packages/wrangler/src/__tests__/pages/functions-build.test.ts
@@ -6,7 +6,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import dedent from "ts-dedent";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runInTempDir } from "../helpers/run-in-tmp";
@@ -23,12 +23,14 @@ describe("pages functions build", () => {
 		await endEventLoop();
 	});
 
-	it("should throw an error if no worker script and no Functions directory was found", async () => {
+	it("should throw an error if no worker script and no Functions directory was found", async ({
+		expect,
+	}) => {
 		await expect(runWrangler("pages functions build")).rejects.toThrowError();
 		expect(std.err).toContain("Could not find anything to build.");
 	});
 
-	it("should build functions", async () => {
+	it("should build functions", async ({ expect }) => {
 		/* ---------------------------- */
 		/*       Set up Functions       */
 		/* ---------------------------- */
@@ -57,7 +59,9 @@ describe("pages functions build", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	it("should include any external modules imported by functions in the output bundle", async () => {
+	it("should include any external modules imported by functions in the output bundle", async ({
+		expect,
+	}) => {
 		/* ---------------------------- */
 		/*       Set up wasm files      */
 		/* ---------------------------- */
@@ -136,7 +140,7 @@ describe("pages functions build", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	it("should output a directory with --outdir", async () => {
+	it("should output a directory with --outdir", async ({ expect }) => {
 		/* ---------------------------- */
 		/*       Set up wasm files      */
 		/* ---------------------------- */
@@ -184,7 +188,7 @@ describe("pages functions build", () => {
 	`);
 	});
 
-	it("should output a metafile when --metafile is set", async () => {
+	it("should output a metafile when --metafile is set", async ({ expect }) => {
 		// Setup a basic pages function
 		mkdirSync("functions");
 		writeFileSync(
@@ -207,7 +211,7 @@ describe("pages functions build", () => {
 		expect(meta.outputs).toBeDefined();
 	});
 
-	it("should build _worker.js", async () => {
+	it("should build _worker.js", async ({ expect }) => {
 		/* ---------------------------- */
 		/*       Set up js files        */
 		/* ---------------------------- */
@@ -289,7 +293,9 @@ export default {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	it("should include all external modules imported by _worker.js in the output bundle, when bundling _worker.js", async () => {
+	it("should include all external modules imported by _worker.js in the output bundle, when bundling _worker.js", async ({
+		expect,
+	}) => {
 		/* ---------------------------- */
 		/*       Set up wasm files      */
 		/* ---------------------------- */
@@ -365,7 +371,9 @@ export default {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	it("should build _worker.js over /functions, if both are present", async () => {
+	it("should build _worker.js over /functions, if both are present", async ({
+		expect,
+	}) => {
 		/* ---------------------------- */
 		/*       Set up _worker.js      */
 		/* ---------------------------- */
@@ -444,7 +452,9 @@ export default {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	it("should leave Node.js imports when the `nodejs_compat` compatibility flag is set", async () => {
+	it("should leave Node.js imports when the `nodejs_compat` compatibility flag is set", async ({
+		expect,
+	}) => {
 		mkdirSync("functions");
 		writeFileSync(
 			"functions/hello.js",
@@ -475,7 +485,9 @@ export default {
 		);
 	});
 
-	it("should warn at Node.js imports when the `nodejs_compat` compatibility flag is not set", async () => {
+	it("should warn at Node.js imports when the `nodejs_compat` compatibility flag is not set", async ({
+		expect,
+	}) => {
 		mkdirSync("functions");
 		writeFileSync(
 			"functions/hello.js",
@@ -504,7 +516,7 @@ export default {
 		`);
 	});
 
-	it("should compile a _worker.js/ directory", async () => {
+	it("should compile a _worker.js/ directory", async ({ expect }) => {
 		mkdirSync("public");
 		mkdirSync("public/_worker.js");
 		writeFileSync(
@@ -614,7 +626,9 @@ describe("functions build w/ config", () => {
 		vi.stubEnv("PAGES_ENVIRONMENT", "production");
 	});
 
-	it("should include all config in the _worker.bundle metadata", async () => {
+	it("should include all config in the _worker.bundle metadata", async ({
+		expect,
+	}) => {
 		// Write an example wrangler.toml file with a _lot_ of config
 		writeFileSync(
 			"wrangler.toml",
@@ -792,7 +806,9 @@ export default {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	it("should ignore config with a non-pages config file", async () => {
+	it("should ignore config with a non-pages config file", async ({
+		expect,
+	}) => {
 		writeFileSync(
 			"wrangler.toml",
 			dedent`
@@ -965,7 +981,9 @@ export default {
 
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
-	it("should ignore config with a non-pages config file w/ invalid environment", async () => {
+	it("should ignore config with a non-pages config file w/ invalid environment", async ({
+		expect,
+	}) => {
 		writeFileSync(
 			"wrangler.toml",
 			dedent`
@@ -1138,7 +1156,7 @@ export default {
 
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
-	it("should ignore unparseable config file", async () => {
+	it("should ignore unparseable config file", async ({ expect }) => {
 		writeFileSync(
 			"wrangler.toml",
 			dedent`

--- a/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
@@ -3,7 +3,7 @@ import {
 	normalizeString,
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { logger } from "../../logger";
 import {
 	EXIT_CODE_INVALID_PAGES_CONFIG,
@@ -24,7 +24,7 @@ describe("pages build env", () => {
 		vi.stubEnv("PAGES_ENVIRONMENT", "production");
 	});
 
-	it("should render empty object", async () => {
+	it("should render empty object", async ({ expect }) => {
 		writeWranglerConfig({
 			pages_build_output_dir: "./dist",
 			vars: {},
@@ -45,7 +45,7 @@ describe("pages build env", () => {
 		);
 	});
 
-	it("should fail with no project dir", async () => {
+	it("should fail with no project dir", async ({ expect }) => {
 		await expect(
 			runWrangler("pages functions build-env")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -53,7 +53,7 @@ describe("pages build env", () => {
 		);
 	});
 
-	it("should fail with no outfile", async () => {
+	it("should fail with no outfile", async ({ expect }) => {
 		await expect(
 			runWrangler("pages functions build-env .")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -61,7 +61,9 @@ describe("pages build env", () => {
 		);
 	});
 
-	it("should exit with specific exit code if no config file is found", async () => {
+	it("should exit with specific exit code if no config file is found", async ({
+		expect,
+	}) => {
 		logger.loggerLevel = "debug";
 		await runWrangler("pages functions build-env . --outfile out.json");
 
@@ -79,7 +81,9 @@ describe("pages build env", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	it("should exit with specific code if a non-pages config file is found", async () => {
+	it("should exit with specific code if a non-pages config file is found", async ({
+		expect,
+	}) => {
 		logger.loggerLevel = "debug";
 		writeWranglerConfig({
 			vars: {
@@ -123,7 +127,9 @@ describe("pages build env", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	it("should exit correctly with an unparseable non-pages config file", async () => {
+	it("should exit correctly with an unparseable non-pages config file", async ({
+		expect,
+	}) => {
 		logger.loggerLevel = "debug";
 
 		writeFileSync("./wrangler.toml", 'INVALID "FILE');
@@ -151,7 +157,9 @@ describe("pages build env", () => {
 		expect(std.debug).toContain("wrangler.toml file is invalid. Exiting.");
 	});
 
-	it("should exit correctly with a non-pages config file w/ invalid environment", async () => {
+	it("should exit correctly with a non-pages config file w/ invalid environment", async ({
+		expect,
+	}) => {
 		logger.loggerLevel = "debug";
 		writeWranglerConfig({
 			vars: {
@@ -195,7 +203,9 @@ describe("pages build env", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	it("should throw an error if an invalid pages confg file is found", async () => {
+	it("should throw an error if an invalid pages confg file is found", async ({
+		expect,
+	}) => {
 		writeWranglerConfig({
 			pages_build_output_dir: "dist",
 			vars: {
@@ -219,7 +229,9 @@ describe("pages build env", () => {
 		`);
 	});
 
-	it("should exit if an unparseable pages confg file is found", async () => {
+	it("should exit if an unparseable pages confg file is found", async ({
+		expect,
+	}) => {
 		writeFileSync(
 			"./wrangler.toml",
 			`
@@ -243,7 +255,7 @@ describe("pages build env", () => {
 		`);
 	});
 
-	it("should return top-level by default", async () => {
+	it("should return top-level by default", async ({ expect }) => {
 		vi.stubEnv("PAGES_ENVIRONMENT", "");
 		writeWranglerConfig({
 			pages_build_output_dir: "./dist",
@@ -289,7 +301,7 @@ describe("pages build env", () => {
 		);
 	});
 
-	it("should return top-level by default (json)", async () => {
+	it("should return top-level by default (json)", async ({ expect }) => {
 		vi.stubEnv("PAGES_ENVIRONMENT", "");
 		writeWranglerConfig(
 			{
@@ -338,7 +350,7 @@ describe("pages build env", () => {
 		);
 	});
 
-	it("should return production", async () => {
+	it("should return production", async ({ expect }) => {
 		vi.stubEnv("PAGES_ENVIRONMENT", "production");
 		writeWranglerConfig({
 			pages_build_output_dir: "./dist",
@@ -385,7 +397,7 @@ describe("pages build env", () => {
 		);
 	});
 
-	it("should return preview", async () => {
+	it("should return preview", async ({ expect }) => {
 		vi.stubEnv("PAGES_ENVIRONMENT", "preview");
 		writeWranglerConfig({
 			pages_build_output_dir: "./dist",
@@ -432,7 +444,9 @@ describe("pages build env", () => {
 		);
 	});
 
-	it("should render output directory path relative to project directory, even if wrangler config is redirected", async () => {
+	it("should render output directory path relative to project directory, even if wrangler config is redirected", async ({
+		expect,
+	}) => {
 		vi.stubEnv("PAGES_ENVIRONMENT", "");
 		writeWranglerConfig(
 			{

--- a/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
@@ -1,7 +1,7 @@
 import { setTimeout } from "node:timers/promises";
 import { http, HttpResponse } from "msw";
 import { Headers, Request } from "undici";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, it, vi } from "vitest";
 import MockWebSocketServer from "vitest-websocket-mock";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -69,7 +69,9 @@ describe("pages deployment tail", () => {
 	 * deletion, and connection.
 	 */
 	describe("API interaction", () => {
-		it("should throw an error if deployment isn't provided", async () => {
+		it("should throw an error if deployment isn't provided", async ({
+			expect,
+		}) => {
 			api = mockTailAPIs();
 			await expect(
 				runWrangler("pages deployment tail")
@@ -80,7 +82,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("creates and then delete tails by deployment ID", async () => {
+		it("creates and then delete tails by deployment ID", async ({ expect }) => {
 			api = mockTailAPIs();
 			expect(api.requests.creation.length).toStrictEqual(0);
 
@@ -97,7 +99,9 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("only uses deployments with status=success and name=deploy", async () => {
+		it("only uses deployments with status=success and name=deploy", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 
 			api = mockTailAPIs("mock-deployment-id");
@@ -114,7 +118,9 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("creates and then deletes tails by deployment URL", async () => {
+		it("creates and then deletes tails by deployment URL", async ({
+			expect,
+		}) => {
 			api = mockTailAPIs();
 			expect(api.requests.creation.length).toStrictEqual(0);
 
@@ -131,7 +137,9 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("errors when passing in a deployment without a project", async () => {
+		it("errors when passing in a deployment without a project", async ({
+			expect,
+		}) => {
 			await expect(
 				runWrangler("pages deployment tail foo")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -139,7 +147,7 @@ describe("pages deployment tail", () => {
 			);
 		});
 
-		it("creates and then delete tails by project name", async () => {
+		it("creates and then delete tails by project name", async ({ expect }) => {
 			api = mockTailAPIs();
 			expect(api.requests.creation.length).toStrictEqual(0);
 
@@ -155,7 +163,7 @@ describe("pages deployment tail", () => {
 			expect(api.requests.deletion.count).toStrictEqual(1);
 		});
 
-		it("errors when the websocket closes unexpectedly", async () => {
+		it("errors when the websocket closes unexpectedly", async ({ expect }) => {
 			api = mockTailAPIs();
 			await api.closeHelper();
 
@@ -168,7 +176,9 @@ describe("pages deployment tail", () => {
 			);
 		});
 
-		it("activates debug mode when the cli arg is passed in", async () => {
+		it("activates debug mode when the cli arg is passed in", async ({
+			expect,
+		}) => {
 			api = mockTailAPIs();
 			await runWrangler(
 				"pages deployment tail mock-deployment-id --project-name mock-project --debug"
@@ -180,7 +190,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("passes default environment to deployments list", async () => {
+		it("passes default environment to deployments list", async ({ expect }) => {
 			api = mockTailAPIs();
 			expect(api.requests.creation.length).toStrictEqual(0);
 
@@ -199,7 +209,9 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("passes production environment to deployments list", async () => {
+		it("passes production environment to deployments list", async ({
+			expect,
+		}) => {
 			api = mockTailAPIs();
 			expect(api.requests.creation.length).toStrictEqual(0);
 
@@ -218,7 +230,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("passes preview environment to deployments list", async () => {
+		it("passes preview environment to deployments list", async ({ expect }) => {
 			api = mockTailAPIs();
 			expect(api.requests.creation.length).toStrictEqual(0);
 
@@ -239,7 +251,9 @@ describe("pages deployment tail", () => {
 	});
 
 	describe("filtering", () => {
-		it("should throw for bad sampling rate filters ranges", async () => {
+		it("should throw for bad sampling rate filters ranges", async ({
+			expect,
+		}) => {
 			const tooHigh = runWrangler(
 				"pages deployment tail mock-deployment-id --project-name mock-project --sampling-rate 10"
 			);
@@ -252,7 +266,7 @@ describe("pages deployment tail", () => {
 			await expect(tooLow).rejects.toThrow();
 		});
 
-		it("should send sampling rate filter", async () => {
+		it("should send sampling rate filter", async ({ expect }) => {
 			api = mockTailAPIs();
 			await runWrangler(
 				"pages deployment tail mock-deployment-id --project-name mock-project --sampling-rate 0.25"
@@ -263,7 +277,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("sends single status filters", async () => {
+		it("sends single status filters", async ({ expect }) => {
 			api = mockTailAPIs();
 			await runWrangler(
 				"pages deployment tail mock-deployment-id --project-name mock-project --status error"
@@ -278,7 +292,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("sends multiple status filters", async () => {
+		it("sends multiple status filters", async ({ expect }) => {
 			api = mockTailAPIs();
 			await runWrangler(
 				"pages deployment tail mock-deployment-id --project-name mock-project --status error --status canceled"
@@ -299,7 +313,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("sends single HTTP method filters", async () => {
+		it("sends single HTTP method filters", async ({ expect }) => {
 			api = mockTailAPIs();
 			await runWrangler(
 				"pages deployment tail mock-deployment-id --project-name mock-project --method POST"
@@ -310,7 +324,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("sends multiple HTTP method filters", async () => {
+		it("sends multiple HTTP method filters", async ({ expect }) => {
 			api = mockTailAPIs();
 			await runWrangler(
 				"pages deployment tail mock-deployment-id --project-name mock-project --method POST --method GET"
@@ -321,7 +335,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("sends header filters without a query", async () => {
+		it("sends header filters without a query", async ({ expect }) => {
 			api = mockTailAPIs();
 			await runWrangler(
 				"pages deployment tail mock-deployment-id --project-name mock-project --header X-CUSTOM-HEADER"
@@ -332,7 +346,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("sends header filters with a query", async () => {
+		it("sends header filters with a query", async ({ expect }) => {
 			api = mockTailAPIs();
 			await runWrangler(
 				"pages deployment tail mock-deployment-id --project-name mock-project --header X-CUSTOM-HEADER:some-value"
@@ -343,7 +357,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("sends single IP filters", async () => {
+		it("sends single IP filters", async ({ expect }) => {
 			api = mockTailAPIs();
 			const fakeIp = "192.0.2.1";
 
@@ -356,7 +370,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("sends multiple IP filters", async () => {
+		it("sends multiple IP filters", async ({ expect }) => {
 			api = mockTailAPIs();
 			const fakeIp = "192.0.2.1";
 
@@ -369,7 +383,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("sends search filters", async () => {
+		it("sends search filters", async ({ expect }) => {
 			api = mockTailAPIs();
 			const search = "filterMe";
 
@@ -382,7 +396,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("sends everything but the kitchen sink", async () => {
+		it("sends everything but the kitchen sink", async ({ expect }) => {
 			api = mockTailAPIs();
 			const sampling_rate = 0.69;
 			const status = ["ok", "error"];
@@ -428,7 +442,7 @@ describe("pages deployment tail", () => {
 	});
 
 	describe("printing", () => {
-		it("logs request messages in JSON format", async () => {
+		it("logs request messages in JSON format", async ({ expect }) => {
 			api = mockTailAPIs();
 			await runWrangler(
 				"pages deployment tail mock-deployment-id --project-name mock-project --format json"
@@ -445,7 +459,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs scheduled messages in JSON format", async () => {
+		it("logs scheduled messages in JSON format", async ({ expect }) => {
 			api = mockTailAPIs();
 			await runWrangler(
 				"pages deployment tail mock-deployment-id --project-name mock-project --format json"
@@ -462,7 +476,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs alarm messages in json format", async () => {
+		it("logs alarm messages in json format", async ({ expect }) => {
 			api = mockTailAPIs();
 			await runWrangler(
 				"pages deployment tail mock-deployment-id --project-name mock-project --format json"
@@ -479,7 +493,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs email messages in json format", async () => {
+		it("logs email messages in json format", async ({ expect }) => {
 			api = mockTailAPIs();
 			await runWrangler(
 				"pages deployment tail mock-deployment-id --project-name mock-project --format json"
@@ -496,7 +510,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs queue messages in json format", async () => {
+		it("logs queue messages in json format", async ({ expect }) => {
 			api = mockTailAPIs();
 			await runWrangler(
 				"pages deployment tail mock-deployment-id --project-name mock-project --format json"
@@ -513,7 +527,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs request messages in pretty format", async () => {
+		it("logs request messages in pretty format", async ({ expect }) => {
 			api = mockTailAPIs();
 			await runWrangler(
 				"pages deployment tail mock-deployment-id --project-name mock-project --format pretty"
@@ -544,7 +558,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs scheduled messages in pretty format", async () => {
+		it("logs scheduled messages in pretty format", async ({ expect }) => {
 			api = mockTailAPIs();
 			await runWrangler(
 				"pages deployment tail mock-deployment-id --project-name mock-project --format pretty"
@@ -575,7 +589,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs alarm messages in pretty format", async () => {
+		it("logs alarm messages in pretty format", async ({ expect }) => {
 			api = mockTailAPIs();
 			await runWrangler(
 				"pages deployment tail mock-deployment-id --project-name mock-project --format pretty"
@@ -606,7 +620,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs email messages in pretty format", async () => {
+		it("logs email messages in pretty format", async ({ expect }) => {
 			api = mockTailAPIs();
 			await runWrangler(
 				"pages deployment tail mock-deployment-id --project-name mock-project --format pretty"
@@ -637,7 +651,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs queue messages in pretty format", async () => {
+		it("logs queue messages in pretty format", async ({ expect }) => {
 			api = mockTailAPIs();
 			await runWrangler(
 				"pages deployment tail mock-deployment-id --project-name mock-project --format pretty"
@@ -668,7 +682,9 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("should not crash when the tail message has a void event", async () => {
+		it("should not crash when the tail message has a void event", async ({
+			expect,
+		}) => {
 			api = mockTailAPIs();
 			await runWrangler(
 				"pages deployment tail mock-deployment-id --project-name mock-project --format pretty"
@@ -698,7 +714,9 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("defaults to logging in pretty format when the output is a TTY", async () => {
+		it("defaults to logging in pretty format when the output is a TTY", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 			api = mockTailAPIs();
 			await runWrangler(
@@ -730,7 +748,9 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("defaults to logging in json format when the output is not a TTY", async () => {
+		it("defaults to logging in json format when the output is not a TTY", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 
 			api = mockTailAPIs();
@@ -749,7 +769,7 @@ describe("pages deployment tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs console messages and exceptions", async () => {
+		it("logs console messages and exceptions", async ({ expect }) => {
 			setIsTTY(true);
 			api = mockTailAPIs();
 

--- a/packages/wrangler/src/__tests__/pages/pages-download-config.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-download-config.test.ts
@@ -3,7 +3,9 @@ import { readFile } from "node:fs/promises";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { supportedCompatibilityDate } from "miniflare";
 import { http, HttpResponse } from "msw";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- expect used in MSW handlers */
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs, mockConfirm } from "../helpers/mock-dialogs";

--- a/packages/wrangler/src/__tests__/pages/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, it } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runInTempDir } from "../helpers/run-in-tmp";
@@ -14,7 +14,9 @@ describe("pages", () => {
 		await endEventLoop();
 	});
 
-	it("should display a list of available subcommands, for pages with no subcommand", async () => {
+	it("should display a list of available subcommands, for pages with no subcommand", async ({
+		expect,
+	}) => {
 		await runWrangler("pages");
 		await endEventLoop();
 
@@ -40,7 +42,9 @@ describe("pages", () => {
 		`);
 	});
 
-	it("should display a list of available subcommands, for 'pages dev help'", async () => {
+	it("should display a list of available subcommands, for 'pages dev help'", async ({
+		expect,
+	}) => {
 		await runWrangler("pages dev help");
 		await endEventLoop();
 
@@ -86,7 +90,9 @@ describe("pages", () => {
 		`);
 	});
 
-	it("should display a list of available subcommands for 'pages project help`", async () => {
+	it("should display a list of available subcommands for 'pages project help`", async ({
+		expect,
+	}) => {
 		await runWrangler("pages project help");
 		await endEventLoop();
 
@@ -108,7 +114,9 @@ describe("pages", () => {
 		`);
 	});
 
-	it("should display a list of available subcommands for 'pages deployment'", async () => {
+	it("should display a list of available subcommands for 'pages deployment'", async ({
+		expect,
+	}) => {
 		await runWrangler("pages deployment help");
 		await endEventLoop();
 
@@ -132,7 +140,9 @@ describe("pages", () => {
 		`);
 	});
 
-	it("should display a list of available subcommands for 'pages deploy'", async () => {
+	it("should display a list of available subcommands for 'pages deploy'", async ({
+		expect,
+	}) => {
 		await runWrangler("pages deploy help");
 		await endEventLoop();
 
@@ -162,7 +172,9 @@ describe("pages", () => {
 		`);
 	});
 
-	it("should display a list of available subcommands for 'pages secret'", async () => {
+	it("should display a list of available subcommands for 'pages secret'", async ({
+		expect,
+	}) => {
 		await runWrangler("pages secret help");
 		await endEventLoop();
 
@@ -185,7 +197,9 @@ describe("pages", () => {
 		`);
 	});
 
-	it("should display a list of available subcommands for 'pages download'", async () => {
+	it("should display a list of available subcommands for 'pages download'", async ({
+		expect,
+	}) => {
 		await runWrangler("pages download help");
 		await endEventLoop();
 
@@ -206,7 +220,7 @@ describe("pages", () => {
 	});
 
 	describe("deprecation message for deprecated options", () => {
-		it("should display for 'pages dev -- <command>'", async () => {
+		it("should display for 'pages dev -- <command>'", async ({ expect }) => {
 			await expect(
 				runWrangler("pages dev -- echo 'hi'")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -222,7 +236,7 @@ describe("pages", () => {
 				"
 			`);
 		});
-		it("should display for 'pages dev --script-path'", async () => {
+		it("should display for 'pages dev --script-path'", async ({ expect }) => {
 			await expect(
 				runWrangler("pages dev --script-path=_worker.js -- echo 'hi'")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -247,7 +261,7 @@ describe("pages", () => {
 	});
 
 	describe("beta message for subcommands", () => {
-		it("should display for pages:dev", async () => {
+		it("should display for pages:dev", async ({ expect }) => {
 			await expect(
 				runWrangler("pages dev")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -262,7 +276,7 @@ describe("pages", () => {
 			`);
 		});
 
-		it("should display for pages:functions:build", async () => {
+		it("should display for pages:functions:build", async ({ expect }) => {
 			await expect(runWrangler("pages functions build")).rejects.toThrowError();
 
 			expect(std.out).toMatchInlineSnapshot(`
@@ -273,7 +287,9 @@ describe("pages", () => {
 			`);
 		});
 
-		it("should display for pages:functions:optimize-routes", async () => {
+		it("should display for pages:functions:optimize-routes", async ({
+			expect,
+		}) => {
 			await expect(
 				runWrangler(
 					'pages functions optimize-routes --routes-path="/build/_routes.json" --output-routes-path="/build/_optimized-routes.json"'

--- a/packages/wrangler/src/__tests__/pages/project-create.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-create.test.ts
@@ -1,5 +1,7 @@
 import { http, HttpResponse } from "msw";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- expect used in MSW handlers */
 import { afterEach, describe, expect, it, vi } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "./../helpers/mock-account-id";
 import { mockConsoleMethods } from "./../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/pages/project-delete.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-delete.test.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "msw";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -30,7 +30,7 @@ describe("pages project delete", () => {
 		clearDialogs();
 	});
 
-	it("should delete a project with the given name", async () => {
+	it("should delete a project with the given name", async ({ expect }) => {
 		msw.use(
 			http.delete(
 				"*/accounts/:accountId/pages/projects/:projectName",
@@ -67,7 +67,7 @@ describe("pages project delete", () => {
 		`);
 	});
 
-	it("should error if no project name is specified", async () => {
+	it("should error if no project name is specified", async ({ expect }) => {
 		await expect(
 			runWrangler("pages project delete")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -75,7 +75,9 @@ describe("pages project delete", () => {
 		);
 	});
 
-	it("should not delete a project if confirmation refused", async () => {
+	it("should not delete a project if confirmation refused", async ({
+		expect,
+	}) => {
 		mockConfirm({
 			text: `Are you sure you want to delete "some-project-name-2"? This action cannot be undone.`,
 			result: false,
@@ -90,7 +92,9 @@ describe("pages project delete", () => {
 		`);
 	});
 
-	it("should delete a project without asking if --yes provided", async () => {
+	it("should delete a project without asking if --yes provided", async ({
+		expect,
+	}) => {
 		msw.use(
 			http.delete(
 				"*/accounts/:accountId/pages/projects/:projectName",
@@ -122,7 +126,9 @@ describe("pages project delete", () => {
 		`);
 	});
 
-	it("should override cached accountId with CLOUDFLARE_ACCOUNT_ID environmental variable if provided", async () => {
+	it("should override cached accountId with CLOUDFLARE_ACCOUNT_ID environmental variable if provided", async ({
+		expect,
+	}) => {
 		msw.use(
 			http.delete(
 				"*/accounts/:accountId/pages/projects/:projectName",

--- a/packages/wrangler/src/__tests__/pages/project-list.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-list.test.ts
@@ -1,5 +1,7 @@
 import { http, HttpResponse } from "msw";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- expect used in MSW handlers */
 import { afterEach, describe, expect, it, vi } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { mockAccountId, mockApiToken } from "./../helpers/mock-account-id";

--- a/packages/wrangler/src/__tests__/pages/project-upload.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-upload.test.ts
@@ -1,7 +1,9 @@
 // /* eslint-disable no-shadow */
 import { mkdirSync, writeFileSync } from "node:fs";
 import { http, HttpResponse } from "msw";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- expect used in MSW handlers */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { maxFileCountAllowedFromClaims } from "../../pages/upload";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";

--- a/packages/wrangler/src/__tests__/pages/project-validate.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-validate.test.ts
@@ -1,6 +1,6 @@
 // /* eslint-disable no-shadow */
 import { writeFileSync } from "node:fs";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, it, vi } from "vitest";
 import { validate } from "../../pages/validate";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -24,7 +24,7 @@ describe("pages project validate", () => {
 		await endEventLoop();
 	});
 
-	it("should exit cleanly for a good directory", async () => {
+	it("should exit cleanly for a good directory", async ({ expect }) => {
 		writeFileSync("logo.png", "foobar");
 
 		await runWrangler("pages project validate .");
@@ -37,7 +37,7 @@ describe("pages project validate", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	it("should error for a large file", async () => {
+	it("should error for a large file", async ({ expect }) => {
 		writeFileSync("logo.png", Buffer.alloc(1 * 1024 * 1024 + 1));
 
 		await expect(() => runWrangler("pages project validate .")).rejects
@@ -47,7 +47,7 @@ describe("pages project validate", () => {
 		`);
 	});
 
-	it("should error for a large directory", async () => {
+	it("should error for a large directory", async ({ expect }) => {
 		for (let i = 0; i < 10 + 1; i++) {
 			writeFileSync(`logo${i}.png`, Buffer.alloc(1));
 		}
@@ -59,7 +59,9 @@ describe("pages project validate", () => {
 		);
 	});
 
-	it("should succeed with custom fileCountLimit even when exceeding default limit", async () => {
+	it("should succeed with custom fileCountLimit even when exceeding default limit", async ({
+		expect,
+	}) => {
 		// Create 11 files, which exceeds the mocked MAX_ASSET_COUNT_DEFAULT of 10
 		for (let i = 0; i < 11; i++) {
 			writeFileSync(`logo${i}.png`, Buffer.alloc(1));
@@ -70,7 +72,9 @@ describe("pages project validate", () => {
 		expect(fileMap.size).toBe(11);
 	});
 
-	it("should error with custom fileCountLimit when exceeding custom limit", async () => {
+	it("should error with custom fileCountLimit when exceeding custom limit", async ({
+		expect,
+	}) => {
 		// Create 6 files
 		for (let i = 0; i < 6; i++) {
 			writeFileSync(`logo${i}.png`, Buffer.alloc(1));
@@ -84,7 +88,9 @@ describe("pages project validate", () => {
 		);
 	});
 
-	it("should use fileCountLimit from CF_PAGES_UPLOAD_JWT when set", async () => {
+	it("should use fileCountLimit from CF_PAGES_UPLOAD_JWT when set", async ({
+		expect,
+	}) => {
 		// Create 11 files, which exceeds the mocked MAX_ASSET_COUNT_DEFAULT of 10
 		for (let i = 0; i < 11; i++) {
 			writeFileSync(`logo${i}.png`, Buffer.alloc(1));
@@ -111,7 +117,9 @@ describe("pages project validate", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	it("should error when file count exceeds limit from CF_PAGES_UPLOAD_JWT", async () => {
+	it("should error when file count exceeds limit from CF_PAGES_UPLOAD_JWT", async ({
+		expect,
+	}) => {
 		// Create 6 files
 		for (let i = 0; i < 6; i++) {
 			writeFileSync(`logo${i}.png`, Buffer.alloc(1));

--- a/packages/wrangler/src/__tests__/pages/routes-consolidation.test.ts
+++ b/packages/wrangler/src/__tests__/pages/routes-consolidation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import {
 	consolidateRoutes,
 	shortenRoute,
@@ -7,7 +7,7 @@ import {
 describe("route-consolidation", () => {
 	const maxRuleLength = 100; // from constants.MAX_FUNCTIONS_ROUTES_RULE_LENGTH
 	describe("consolidateRoutes()", () => {
-		it("should consolidate redundant routes", () => {
+		it("should consolidate redundant routes", ({ expect }) => {
 			expect(consolidateRoutes(["/api/foo", "/api/*"])).toEqual(["/api/*"]);
 			expect(
 				consolidateRoutes([
@@ -23,7 +23,7 @@ describe("route-consolidation", () => {
 				])
 			).toEqual(["/api/*", "/foo", "/foo/bar", "/bar/*"]);
 		});
-		it("should consolidate thousands of redundant routes", () => {
+		it("should consolidate thousands of redundant routes", ({ expect }) => {
 			// Test to make sure the consolidator isn't horribly slow
 			const routes: string[] = [];
 			const limit = 1000;
@@ -42,7 +42,7 @@ describe("route-consolidation", () => {
 			).toEqual(true);
 		});
 
-		it("should consolidate many redundant sub-routes", () => {
+		it("should consolidate many redundant sub-routes", ({ expect }) => {
 			const routes: string[] = [];
 			const limit = 15;
 
@@ -68,7 +68,9 @@ describe("route-consolidation", () => {
 			).toEqual(true);
 		});
 
-		it("should truncate long single-level path into catch-all path, removing other paths", () => {
+		it("should truncate long single-level path into catch-all path, removing other paths", ({
+			expect,
+		}) => {
 			expect(
 				consolidateRoutes([
 					// [/aaaaaaa, /foo] -> [/*]
@@ -80,7 +82,9 @@ describe("route-consolidation", () => {
 			).toEqual(["/*"]);
 		});
 
-		it("should truncate long nested path, removing other paths", () => {
+		it("should truncate long nested path, removing other paths", ({
+			expect,
+		}) => {
 			expect(
 				consolidateRoutes([
 					// [/aaaaaaa, /foo] -> [/*]
@@ -92,7 +96,7 @@ describe("route-consolidation", () => {
 	});
 
 	describe(`shortenRoute()`, () => {
-		it("should allow max length path", () => {
+		it("should allow max length path", ({ expect }) => {
 			const route = "/" + "a".repeat(maxRuleLength - 1);
 			// Make sure we don't have an off-by-one error, that'd be embarrassing...
 			expect(route.length).toEqual(maxRuleLength);
@@ -102,7 +106,7 @@ describe("route-consolidation", () => {
 			).toEqual(route);
 		});
 
-		it("should allow max length path (with slash)", () => {
+		it("should allow max length path (with slash)", ({ expect }) => {
 			const route = "/" + "a".repeat(maxRuleLength - 2) + "/";
 			expect(route.length).toEqual(maxRuleLength);
 			expect(
@@ -111,7 +115,7 @@ describe("route-consolidation", () => {
 			).toEqual(route);
 		});
 
-		it("should allow max length wildcard path", () => {
+		it("should allow max length wildcard path", ({ expect }) => {
 			const route = "/" + "a".repeat(maxRuleLength - 3) + "/*";
 			expect(route.length).toEqual(maxRuleLength);
 			expect(
@@ -120,7 +124,9 @@ describe("route-consolidation", () => {
 			).toEqual(route);
 		});
 
-		it("should truncate long specific path to shorter wildcard path", () => {
+		it("should truncate long specific path to shorter wildcard path", ({
+			expect,
+		}) => {
 			const short = shortenRoute(
 				// /aaa/bbb -> /aaa/*
 				"/" +
@@ -132,7 +138,9 @@ describe("route-consolidation", () => {
 			expect(short.length).toBeLessThanOrEqual(maxRuleLength);
 		});
 
-		it("should truncate long specific path (with slash) to shorter wildcard path", () => {
+		it("should truncate long specific path (with slash) to shorter wildcard path", ({
+			expect,
+		}) => {
 			const short = shortenRoute(
 				// /aaa/bbb/ -> /aaa/*
 				"/" +
@@ -145,7 +153,9 @@ describe("route-consolidation", () => {
 			expect(short.length).toBeLessThanOrEqual(maxRuleLength);
 		});
 
-		it("should truncate long wildcard path to shorter wildcard path", () => {
+		it("should truncate long wildcard path to shorter wildcard path", ({
+			expect,
+		}) => {
 			const short = shortenRoute(
 				// /aaa/bbb/* -> /aaa/*
 				"/" +
@@ -158,7 +168,9 @@ describe("route-consolidation", () => {
 			expect(short.length).toBeLessThanOrEqual(maxRuleLength);
 		});
 
-		it("should truncate long single-level specific path to catch-all path", () => {
+		it("should truncate long single-level specific path to catch-all path", ({
+			expect,
+		}) => {
 			expect(
 				shortenRoute(
 					// /aaa -> /*
@@ -167,7 +179,9 @@ describe("route-consolidation", () => {
 			).toEqual("/*");
 		});
 
-		it("should truncate long single-level specific path (with slash) to catch-all path", () => {
+		it("should truncate long single-level specific path (with slash) to catch-all path", ({
+			expect,
+		}) => {
 			expect(
 				shortenRoute(
 					// /aaa/ -> /*
@@ -176,7 +190,9 @@ describe("route-consolidation", () => {
 			).toEqual("/*");
 		});
 
-		it("should truncate long single-level wildcard path to catch-all path", () => {
+		it("should truncate long single-level wildcard path to catch-all path", ({
+			expect,
+		}) => {
 			expect(
 				shortenRoute(
 					// /aaa/* -> /*
@@ -185,7 +201,7 @@ describe("route-consolidation", () => {
 			).toEqual("/*");
 		});
 
-		it("should truncate many single-character segements", () => {
+		it("should truncate many single-character segements", ({ expect }) => {
 			const short = shortenRoute(
 				// /a/a/a -> /a/a/*
 				"/a".repeat(maxRuleLength) // 2x limit
@@ -195,7 +211,7 @@ describe("route-consolidation", () => {
 			expect(short.length).toEqual(maxRuleLength);
 		});
 
-		it("should truncate many double-character segements", () => {
+		it("should truncate many double-character segements", ({ expect }) => {
 			// === odd ===
 			const short = shortenRoute(
 				// /aa/aa/aa -> /aa/aa/*
@@ -206,7 +222,9 @@ describe("route-consolidation", () => {
 			expect(short.length).toEqual(maxRuleLength - 2); // -2 because of the odd number
 		});
 
-		it("should truncate many single-character segements with wildcard", () => {
+		it("should truncate many single-character segements with wildcard", ({
+			expect,
+		}) => {
 			const short = shortenRoute(
 				// /a/a/a -> /a/a/*
 				"/a".repeat(maxRuleLength) + "/*" // 2x limit
@@ -216,7 +234,9 @@ describe("route-consolidation", () => {
 			expect(short.length).toEqual(maxRuleLength);
 		});
 
-		it("should truncate many double-character segements with wildcard", () => {
+		it("should truncate many double-character segements with wildcard", ({
+			expect,
+		}) => {
 			const short = shortenRoute(
 				// /aa/aa/aa -> /aa/*
 				"/aa".repeat(maxRuleLength) + "/*" // 2x limit
@@ -231,7 +251,9 @@ describe("route-consolidation", () => {
 		// The other tests are great for ensuring exact sequences instead of only asserting length, though.
 		for (const suffix of ["", "/", "/*"]) {
 			// Test each type of path: /a, /a/a, /a/*
-			it(`should truncate many variable-character segements (suffix="${suffix}") without truncating to /*`, () => {
+			it(`should truncate many variable-character segements (suffix="${suffix}") without truncating to /*`, ({
+				expect,
+			}) => {
 				// "/" + 97 chars + "/*" === 100
 				for (let i = 1; i < maxRuleLength - 2; i++) {
 					const segment = "/" + "a".repeat(i);

--- a/packages/wrangler/src/__tests__/pages/routes-transformation.test.ts
+++ b/packages/wrangler/src/__tests__/pages/routes-transformation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { describe, it, test } from "vitest";
 import {
 	MAX_FUNCTIONS_ROUTES_RULES,
 	ROUTES_SPEC_DESCRIPTION,
@@ -16,7 +16,7 @@ import { toUrlPath } from "../../paths";
 // of `convertRoutesToGlobPatterns` inputs from a string array
 describe("route-paths-to-glob-patterns", () => {
 	describe("convertRoutePathsToGlobPatterns()", () => {
-		it("should pass through routes with no wildcards", () => {
+		it("should pass through routes with no wildcards", ({ expect }) => {
 			expect(
 				convertRoutesToGlobPatterns([{ routePath: toUrlPath("/api/foo") }])
 			).toEqual(["/api/foo"]);
@@ -35,7 +35,7 @@ describe("route-paths-to-glob-patterns", () => {
 			).toEqual(["/api/foo", "/api/bar/foo", "/foo/bar"]);
 		});
 
-		it("should escalate a single param route to a wildcard", () => {
+		it("should escalate a single param route to a wildcard", ({ expect }) => {
 			expect(
 				convertRoutesToGlobPatterns([{ routePath: toUrlPath("/api/:foo") }])
 			).toEqual(["/api/*"]);
@@ -61,7 +61,7 @@ describe("route-paths-to-glob-patterns", () => {
 			).toEqual(["/api/*", "/bar/*", "/foo/bar/*"]);
 		});
 
-		it("should pass through a single wildcard route", () => {
+		it("should pass through a single wildcard route", ({ expect }) => {
 			expect(
 				convertRoutesToGlobPatterns([{ routePath: toUrlPath("/api/:baz*") }])
 			).toEqual(["/api/*"]);
@@ -94,7 +94,7 @@ describe("route-paths-to-glob-patterns", () => {
 			).toEqual(["/api/*", "/api/foo/bar/*"]);
 		});
 
-		it("should deduplicate identical rules", () => {
+		it("should deduplicate identical rules", ({ expect }) => {
 			expect(
 				convertRoutesToGlobPatterns([
 					{ routePath: toUrlPath("/api/foo") },
@@ -124,7 +124,7 @@ describe("route-paths-to-glob-patterns", () => {
 			).toEqual(["/api/*"]);
 		});
 
-		it("should handle middleware mounting", () => {
+		it("should handle middleware mounting", ({ expect }) => {
 			expect(
 				convertRoutesToGlobPatterns([
 					{
@@ -155,7 +155,7 @@ describe("route-paths-to-glob-patterns", () => {
 	});
 
 	describe("convertRoutesToRoutesJSONSpec()", () => {
-		it("should convert and consolidate routes into JSONSpec", () => {
+		it("should convert and consolidate routes into JSONSpec", ({ expect }) => {
 			expect(
 				convertRoutesToRoutesJSONSpec([
 					{ routePath: toUrlPath("/api/foo/bar") },
@@ -175,7 +175,7 @@ describe("route-paths-to-glob-patterns", () => {
 			});
 		});
 
-		it("should truncate all routes if over limit", () => {
+		it("should truncate all routes if over limit", ({ expect }) => {
 			const routes = [];
 			for (let i = 0; i < MAX_FUNCTIONS_ROUTES_RULES + 1; i++) {
 				routes.push({ routePath: toUrlPath(`/api/foo-${i}`) });
@@ -188,7 +188,7 @@ describe("route-paths-to-glob-patterns", () => {
 			});
 		});
 
-		it("should allow max routes", () => {
+		it("should allow max routes", ({ expect }) => {
 			const routes = [];
 			for (let i = 0; i < MAX_FUNCTIONS_ROUTES_RULES; i++) {
 				routes.push({ routePath: toUrlPath(`/api/foo-${i}`) });
@@ -200,7 +200,7 @@ describe("route-paths-to-glob-patterns", () => {
 	});
 
 	describe("optimizeRoutesJSONSpec()", () => {
-		it("should convert and consolidate routes into JSONSpec", () => {
+		it("should convert and consolidate routes into JSONSpec", ({ expect }) => {
 			expect(
 				optimizeRoutesJSONSpec({
 					version: ROUTES_SPEC_VERSION,
@@ -222,7 +222,7 @@ describe("route-paths-to-glob-patterns", () => {
 			});
 		});
 
-		it("should truncate all routes if over limit", () => {
+		it("should truncate all routes if over limit", ({ expect }) => {
 			const include: string[] = [];
 			for (let i = 0; i < MAX_FUNCTIONS_ROUTES_RULES + 1; i++) {
 				include.push(`/api/foo-${i}`);
@@ -242,7 +242,7 @@ describe("route-paths-to-glob-patterns", () => {
 			});
 		});
 
-		it("should allow max routes", () => {
+		it("should allow max routes", ({ expect }) => {
 			const include: string[] = [];
 			for (let i = 0; i < MAX_FUNCTIONS_ROUTES_RULES; i++) {
 				include.push(`/api/foo-${i}`);
@@ -260,22 +260,28 @@ describe("route-paths-to-glob-patterns", () => {
 
 	describe("compareRoutes()", () => {
 		describe("compareRoutes()", () => {
-			test("routes / last", () => {
+			test("routes / last", ({ expect }) => {
 				expect(compareRoutes("/", "/foo")).toBeGreaterThanOrEqual(1);
 				expect(compareRoutes("/", "/*")).toBeGreaterThanOrEqual(1);
 			});
 
-			test("routes with fewer segments come after those with more segments", () => {
+			test("routes with fewer segments come after those with more segments", ({
+				expect,
+			}) => {
 				expect(compareRoutes("/foo", "/foo/bar")).toBeGreaterThanOrEqual(1);
 				expect(compareRoutes("/foo", "/foo/bar/cat")).toBeGreaterThanOrEqual(1);
 			});
 
-			test("routes with wildcard segments come after those without", () => {
+			test("routes with wildcard segments come after those without", ({
+				expect,
+			}) => {
 				expect(compareRoutes("/*", "/foo")).toBe(1);
 				expect(compareRoutes("/foo/*", "/foo/bar")).toBe(1);
 			});
 
-			test("routes with dynamic segments occurring earlier come after those with dynamic segments in later positions", () => {
+			test("routes with dynamic segments occurring earlier come after those with dynamic segments in later positions", ({
+				expect,
+			}) => {
 				expect(compareRoutes("/foo/*/bar", "/foo/bar/*")).toBe(1);
 			});
 		});

--- a/packages/wrangler/src/__tests__/pages/routes-validation.test.ts
+++ b/packages/wrangler/src/__tests__/pages/routes-validation.test.ts
@@ -1,5 +1,5 @@
 import { FatalError } from "@cloudflare/workers-utils";
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import {
 	MAX_FUNCTIONS_ROUTES_RULE_LENGTH,
 	MAX_FUNCTIONS_ROUTES_RULES,
@@ -15,7 +15,9 @@ import type { RoutesJSONSpec } from "../../pages/functions/routes-transformation
 
 describe("routes-validation", () => {
 	describe("isRoutesJSONSpec", () => {
-		it("should return true if the given routes are in a valid RoutesJSONSpec format", () => {
+		it("should return true if the given routes are in a valid RoutesJSONSpec format", ({
+			expect,
+		}) => {
 			const routes = {
 				version: ROUTES_SPEC_VERSION,
 				description: "Test routes Object",
@@ -32,7 +34,7 @@ describe("routes-validation", () => {
 			expect(isRoutesJSONSpec(routesWithoutDescription)).toBeTruthy();
 		});
 
-		it("should return false otherwise", () => {
+		it("should return false otherwise", ({ expect }) => {
 			const routesWithMissingVersion = {
 				include: [],
 				exclude: [],
@@ -93,7 +95,7 @@ describe("routes-validation", () => {
 			return `/${Array(charCount).fill("a").join("")}`;
 		};
 
-		it("should return if the given routes are valid", () => {
+		it("should return if the given routes are valid", ({ expect }) => {
 			const routes: RoutesJSONSpec = {
 				version: ROUTES_SPEC_VERSION,
 				description: "Test routes Object",
@@ -112,7 +114,9 @@ describe("routes-validation", () => {
 			).not.toThrow();
 		});
 
-		it("should throw a fatal error if the routes are not a valid RoutesJSONSpec object", () => {
+		it("should throw a fatal error if the routes are not a valid RoutesJSONSpec object", ({
+			expect,
+		}) => {
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 			// @ts-ignore: sanity check
 			const routesWithoutVersion: RoutesJSONSpec = {
@@ -153,7 +157,9 @@ describe("routes-validation", () => {
 			);
 		});
 
-		it("should throw a fatal error if there are no include routing rules", () => {
+		it("should throw a fatal error if there are no include routing rules", ({
+			expect,
+		}) => {
 			const routesWithoutIncludeRules: RoutesJSONSpec = {
 				version: ROUTES_SPEC_VERSION,
 				description: "Test routes Object",
@@ -174,7 +180,9 @@ describe("routes-validation", () => {
 			);
 		});
 
-		it("should throw a fatal error if there are more than MAX_FUNCTIONS_ROUTES_RULES include and exclude routing rules combined", () => {
+		it("should throw a fatal error if there are more than MAX_FUNCTIONS_ROUTES_RULES include and exclude routing rules combined", ({
+			expect,
+		}) => {
 			const routesWithMaxIncludeRules: RoutesJSONSpec = {
 				version: ROUTES_SPEC_VERSION,
 				description: "Test routes Object",
@@ -235,7 +243,9 @@ describe("routes-validation", () => {
 			);
 		});
 
-		it("should throw a fatal error if any include or exclude routing rule is more than MAX_FUNCTIONS_ROUTES_RULE_LENGTH chars long", () => {
+		it("should throw a fatal error if any include or exclude routing rule is more than MAX_FUNCTIONS_ROUTES_RULE_LENGTH chars long", ({
+			expect,
+		}) => {
 			const routesWithMaxCharLengthIncludeRules: RoutesJSONSpec = {
 				version: ROUTES_SPEC_VERSION,
 				description: "Test routes Object",
@@ -292,7 +302,9 @@ describe("routes-validation", () => {
 			);
 		});
 
-		it("should throw a fatal error if any include or exclude routing rule does not start with a `/`", () => {
+		it("should throw a fatal error if any include or exclude routing rule does not start with a `/`", ({
+			expect,
+		}) => {
 			const routesWithInvalidIncludeRules: RoutesJSONSpec = {
 				version: ROUTES_SPEC_VERSION,
 				description: "Test routes Object",
@@ -349,7 +361,9 @@ describe("routes-validation", () => {
 			);
 		});
 
-		it("should throw a fatal error if there are overlapping include rules or overlapping exclude rules", () => {
+		it("should throw a fatal error if there are overlapping include rules or overlapping exclude rules", ({
+			expect,
+		}) => {
 			const routesWithOverlappingIncludeRules: RoutesJSONSpec = {
 				version: ROUTES_SPEC_VERSION,
 				include: [

--- a/packages/wrangler/src/__tests__/pages/secret.test.ts
+++ b/packages/wrangler/src/__tests__/pages/secret.test.ts
@@ -1,7 +1,9 @@
 import { writeFileSync } from "node:fs";
 import readline from "node:readline";
 import { http, HttpResponse } from "msw";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- expect used in MSW handlers */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs, mockConfirm, mockPrompt } from "../helpers/mock-dialogs";

--- a/packages/wrangler/src/__tests__/queues/queues-subscription.test.ts
+++ b/packages/wrangler/src/__tests__/queues/queues-subscription.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import { EventSourceType } from "../../queues/subscription-types";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -62,7 +62,7 @@ describe("queues subscription", () => {
 	};
 
 	describe("create", () => {
-		it("should show the correct help text", async () => {
+		it("should show the correct help text", async ({ expect }) => {
 			await runWrangler("queues subscription create --help");
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.out).toMatchInlineSnapshot(`
@@ -92,7 +92,9 @@ describe("queues subscription", () => {
 			`);
 		});
 
-		it("should create a subscription for workersBuilds.worker source", async () => {
+		it("should create a subscription for workersBuilds.worker source", async ({
+			expect,
+		}) => {
 			const queueNameResolveRequest = mockGetQueueByNameRequest(
 				expectedQueueName,
 				{
@@ -138,7 +140,9 @@ describe("queues subscription", () => {
 			`);
 		});
 
-		it("should create subscription with custom name and disabled state", async () => {
+		it("should create subscription with custom name and disabled state", async ({
+			expect,
+		}) => {
 			const queueNameResolveRequest = mockGetQueueByNameRequest(
 				expectedQueueName,
 				{
@@ -184,7 +188,9 @@ describe("queues subscription", () => {
 			`);
 		});
 
-		it("should show error when worker-name is missing for workersBuilds.worker source", async () => {
+		it("should show error when worker-name is missing for workersBuilds.worker source", async ({
+			expect,
+		}) => {
 			await expect(
 				runWrangler(
 					"queues subscription create testQueue --source workersBuilds.worker --events build.completed"
@@ -194,7 +200,7 @@ describe("queues subscription", () => {
 			);
 		});
 
-		it("should show error for invalid source type", async () => {
+		it("should show error for invalid source type", async ({ expect }) => {
 			await expect(
 				runWrangler(
 					"queues subscription create testQueue --source invalid --events test"
@@ -205,7 +211,7 @@ describe("queues subscription", () => {
 			`);
 		});
 
-		it("should show error when no events are provided", async () => {
+		it("should show error when no events are provided", async ({ expect }) => {
 			await expect(
 				runWrangler(
 					"queues subscription create testQueue --source workersBuilds.worker --events '' --worker-name my-worker"
@@ -215,7 +221,7 @@ describe("queues subscription", () => {
 			);
 		});
 
-		it("should show error when queue does not exist", async () => {
+		it("should show error when queue does not exist", async ({ expect }) => {
 			const queueNameResolveRequest = mockGetQueueByNameRequest(
 				"nonexistent",
 				null
@@ -234,7 +240,7 @@ describe("queues subscription", () => {
 	});
 
 	describe("list", () => {
-		it("should show the correct help text", async () => {
+		it("should show the correct help text", async ({ expect }) => {
 			await runWrangler("queues subscription list --help");
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.out).toMatchInlineSnapshot(`
@@ -260,7 +266,9 @@ describe("queues subscription", () => {
 			`);
 		});
 
-		it("should show message when no subscriptions exist", async () => {
+		it("should show message when no subscriptions exist", async ({
+			expect,
+		}) => {
 			const queueNameResolveRequest = mockGetQueueByNameRequest(
 				expectedQueueName,
 				{
@@ -290,7 +298,7 @@ describe("queues subscription", () => {
 			`);
 		});
 
-		it("should list subscriptions for a queue", async () => {
+		it("should list subscriptions for a queue", async ({ expect }) => {
 			const queueNameResolveRequest = mockGetQueueByNameRequest(
 				expectedQueueName,
 				{
@@ -330,7 +338,7 @@ describe("queues subscription", () => {
 			`);
 		});
 
-		it('supports json output with "--json" flag', async () => {
+		it('supports json output with "--json" flag', async ({ expect }) => {
 			mockGetQueueByNameRequest(expectedQueueName, {
 				queue_id: expectedQueueId,
 				queue_name: expectedQueueName,
@@ -391,7 +399,7 @@ describe("queues subscription", () => {
 			`);
 		});
 
-		it("should show error when queue does not exist", async () => {
+		it("should show error when queue does not exist", async ({ expect }) => {
 			const queueNameResolveRequest = mockGetQueueByNameRequest(
 				"nonexistent",
 				null
@@ -408,7 +416,7 @@ describe("queues subscription", () => {
 	});
 
 	describe("get", () => {
-		it("should show the correct help text", async () => {
+		it("should show the correct help text", async ({ expect }) => {
 			await runWrangler("queues subscription get --help");
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.out).toMatchInlineSnapshot(`
@@ -433,7 +441,7 @@ describe("queues subscription", () => {
 			`);
 		});
 
-		it("should get a subscription by ID", async () => {
+		it("should get a subscription by ID", async ({ expect }) => {
 			mockGetQueueByNameRequest("testQueue", {
 				queue_id: expectedQueueId,
 				queue_name: "testQueue",
@@ -469,7 +477,7 @@ describe("queues subscription", () => {
 			`);
 		});
 
-		it('supports json output with "--json" flag', async () => {
+		it('supports json output with "--json" flag', async ({ expect }) => {
 			mockGetQueueByNameRequest("testQueue", {
 				queue_id: expectedQueueId,
 				queue_name: "testQueue",
@@ -510,7 +518,9 @@ describe("queues subscription", () => {
 			`);
 		});
 
-		it("should show error when subscription does not exist", async () => {
+		it("should show error when subscription does not exist", async ({
+			expect,
+		}) => {
 			const getRequest = mockGetSubscriptionRequest("nonexistent-id", null);
 
 			await expect(
@@ -526,7 +536,7 @@ describe("queues subscription", () => {
 	describe("delete", () => {
 		const { setIsTTY } = useMockIsTTY();
 
-		it("should show the correct help text", async () => {
+		it("should show the correct help text", async ({ expect }) => {
 			await runWrangler("queues subscription delete --help");
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.out).toMatchInlineSnapshot(`
@@ -551,7 +561,9 @@ describe("queues subscription", () => {
 			`);
 		});
 
-		it("should delete a subscription after confirmation", async () => {
+		it("should delete a subscription after confirmation", async ({
+			expect,
+		}) => {
 			mockGetQueueByNameRequest("testQueue", {
 				queue_id: expectedQueueId,
 				queue_name: "testQueue",
@@ -587,7 +599,9 @@ describe("queues subscription", () => {
 			`);
 		});
 
-		it("should delete subscription without confirmation when --force is used", async () => {
+		it("should delete subscription without confirmation when --force is used", async ({
+			expect,
+		}) => {
 			mockGetQueueByNameRequest("testQueue", {
 				queue_id: expectedQueueId,
 				queue_name: "testQueue",
@@ -619,7 +633,9 @@ describe("queues subscription", () => {
 			`);
 		});
 
-		it("should show error when subscription does not exist", async () => {
+		it("should show error when subscription does not exist", async ({
+			expect,
+		}) => {
 			const getRequest = mockGetSubscriptionRequest("nonexistent-id", null);
 			const deleteRequest = mockDeleteSubscriptionRequest("nonexistent-id");
 
@@ -635,7 +651,9 @@ describe("queues subscription", () => {
 	});
 
 	describe("update", () => {
-		it("should update subscription with multiple fields", async () => {
+		it("should update subscription with multiple fields", async ({
+			expect,
+		}) => {
 			const subscriptionId = "subscription-123";
 			mockGetQueueByNameRequest("test-queue", {
 				queue_id: "queue-id-1",
@@ -683,7 +701,7 @@ describe("queues subscription", () => {
 			`);
 		});
 
-		it('supports json output with "--json" flag', async () => {
+		it('supports json output with "--json" flag', async ({ expect }) => {
 			const subscriptionId = "subscription-123";
 			mockGetQueueByNameRequest("test-queue", {
 				queue_id: "queue-id-1",
@@ -743,7 +761,7 @@ describe("queues subscription", () => {
 			`);
 		});
 
-		it("should error when no fields provided", async () => {
+		it("should error when no fields provided", async ({ expect }) => {
 			const subscriptionId = "subscription-123";
 			mockGetQueueByNameRequest("test-queue", {
 				queue_id: "queue-id-1",

--- a/packages/wrangler/src/__tests__/queues/queues.test.ts
+++ b/packages/wrangler/src/__tests__/queues/queues.test.ts
@@ -1,6 +1,8 @@
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- test.each */
 import { beforeEach, describe, expect, it } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { mockPrompt } from "../helpers/mock-dialogs";


### PR DESCRIPTION
Part of https://github.com/cloudflare/workers-sdk/issues/12346

Part of a series (https://github.com/cloudflare/workers-sdk/pull/12347, https://github.com/cloudflare/workers-sdk/pull/12356, https://github.com/cloudflare/workers-sdk/pull/12373, #12385) handling simple refactors, one package at a time to keep the review simpler.

This PR handles bucket 1 out of 4 of the wrangler package.

Code was created by OpenNext/Opus:

# Wrangler Bucket 1 Migration Summary

## Overview

Migrated 39 test files in `packages/wrangler/src/__tests__/` from directories `pages/`, `d1/`, `kv/`, and `queues/` to use `expect` from the test context instead of importing it from vitest.

## ESLint Configuration

Added to `packages/wrangler/eslint.config.mjs`:

```javascript
// Bucket 1: pages, d1, kv, queues
{
  files: ["src/__tests__/{pages,d1,kv,queues}/**/*.test.ts"],
  rules: {
    "workers-sdk/no-vitest-import-expect": "error",
  },
},
```

## Files Changed

### Trivial Files Migrated (27)

These files were fully converted to use `expect` from the test context:

**d1/ (13 files):**

- `convert-timestamp-to-iso.test.ts`
- `create.test.ts`
- `d1.test.ts`
- `execute.test.ts`
- `export.test.ts`
- `info.test.ts`
- `insights.test.ts`
- `list.test.ts`
- `migrate.test.ts`
- `splitter.test.ts`
- `timeTravel.test.ts`
- `trimmer.test.ts`
- `utils.test.ts`

**kv/ (2 files):**

- `help.test.ts`
- `local.test.ts`

**pages/ (11 files):**

- `dev.test.ts`
- `filepath-routing.test.ts`
- `functions-build.test.ts`
- `pages-build-env.test.ts`
- `pages-deployment-tail.test.ts`
- `pages.test.ts`
- `project-delete.test.ts`
- `project-validate.test.ts`
- `routes-consolidation.test.ts`
- `routes-transformation.test.ts`
- `routes-validation.test.ts`

**queues/ (1 file):**

- `queues-subscription.test.ts`

### Complex Files Disabled (12)

These files have the lint rule disabled with `/* eslint-disable workers-sdk/no-vitest-import-expect */`:

| File                                  | Reason                                                |
| ------------------------------------- | ----------------------------------------------------- |
| `d1/delete.test.ts`                   | `expect` used in `mockDatabaseDelete` helper function |
| `kv/bulk.test.ts`                     | `expect` used in MSW request handlers                 |
| `kv/key.test.ts`                      | `expect` used in MSW request handlers                 |
| `kv/namespace.test.ts`                | Uses `test.each` patterns                             |
| `pages/deploy.test.ts`                | Uses `test.each` patterns                             |
| `pages/deployment-list.test.ts`       | `expect` used in MSW handlers                         |
| `pages/pages-download-config.test.ts` | `expect` used in MSW handlers                         |
| `pages/project-create.test.ts`        | `expect` used in MSW handlers                         |
| `pages/project-list.test.ts`          | `expect` used in MSW handlers                         |
| `pages/project-upload.test.ts`        | `expect` used in MSW handlers                         |
| `pages/secret.test.ts`                | `expect` used in MSW handlers                         |
| `queues/queues.test.ts`               | Uses `test.each` patterns                             |

## Conversion Pattern

**Before:**

```typescript
import { describe, expect, it } from "vitest";

it("should work", async () => {
  expect(value).toBe(1);
});
```

**After:**

```typescript
import { describe, it } from "vitest";

it("should work", async ({ expect }) => {
  expect(value).toBe(1);
});
```

## Verification

- **Lint:** `pnpm --filter wrangler check:lint` passes with 0 errors
- **Tests:** All 2841 tests pass (2829 passed, 3 skipped, 9 todo)

## Remaining Buckets

| Bucket | Directories                                                                                     | Files | Status        |
| ------ | ----------------------------------------------------------------------------------------------- | ----- | ------------- |
| 1      | `pages/`, `d1/`, `kv/`, `queues/`                                                               | 39    | **Completed** |
| 2      | `r2/`, `cloudchamber/`, `containers/`, `vectorize/`                                             | 31    | Pending       |
| 3      | `versions/`, `autoconfig/`, `api/`, `deploy/`, `dev/`, `config/`, `utils/`, `core/`, `metrics/` | 40    | Pending       |
| 4      | Root-level files                                                                                | 66    | Pending       |

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user facing changes

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12403">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
