### PR TITLE
test: add missing vitest configs to fixtures

### DIFF
--- a/fixtures/d1-read-replication-app/vitest.config.mts
+++ b/fixtures/d1-read-replication-app/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../vitest.shared";
+
+export default mergeConfig(
+	configShared,
+	defineProject({
+		test: {},
+	})
+);

--- a/fixtures/dynamic-worker-loading/vitest.config.mts
+++ b/fixtures/dynamic-worker-loading/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../vitest.shared";
+
+export default mergeConfig(
+	configShared,
+	defineProject({
+		test: {},
+	})
+);

--- a/fixtures/unbound-durable-object/vitest.config.mts
+++ b/fixtures/unbound-durable-object/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../vitest.shared";
+
+export default mergeConfig(
+	configShared,
+	defineProject({
+		test: {},
+	})
+);

--- a/fixtures/worker-logs/vitest.config.mts
+++ b/fixtures/worker-logs/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../vitest.shared";
+
+export default mergeConfig(
+	configShared,
+	defineProject({
+		test: {},
+	})
+);

--- a/fixtures/workers-with-assets-only/vitest.config.mts
+++ b/fixtures/workers-with-assets-only/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../vitest.shared";
+
+export default mergeConfig(
+	configShared,
+	defineProject({
+		test: {},
+	})
+);

--- a/fixtures/workers-with-assets-run-worker-first/vitest.config.mts
+++ b/fixtures/workers-with-assets-run-worker-first/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../vitest.shared";
+
+export default mergeConfig(
+	configShared,
+	defineProject({
+		test: {},
+	})
+);

--- a/fixtures/workers-with-assets-static-routing/vitest.config.mts
+++ b/fixtures/workers-with-assets-static-routing/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../vitest.shared";
+
+export default mergeConfig(
+	configShared,
+	defineProject({
+		test: {},
+	})
+);

--- a/fixtures/workers-with-assets/vitest.config.mts
+++ b/fixtures/workers-with-assets/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../vitest.shared";
+
+export default mergeConfig(
+	configShared,
+	defineProject({
+		test: {},
+	})
+);


### PR DESCRIPTION
Running fixture tests independently would error:

<img width="512" height="127" alt="image" src="https://github.com/user-attachments/assets/e0cf241a-7a6c-4922-82f0-a0f029754e1a" />

OpenCode/Claude came with this fix.

_The PR originally updated `@fixture/get-platform-proxy-remote-bindings` but e2e tests fails with that so it has been reverted._

[Internal discussion](https://chat.google.com/room/AAAAukxNOBI/r25xICSBD4k/r25xICSBD4k?cls=10)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: test config update
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: just test config change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12405">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
