### PR TITLE
[ci] Increase Vite plugin E2E test timeout to 20 minutes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Run Vite plugin E2E tests
         if: steps.changes.outputs.everything_but_markdown == 'true'
         run: pnpm test:e2e -F @cloudflare/vite-plugin --log-order=stream
-        timeout-minutes: 15
+        timeout-minutes: 20
         env:
           NODE_DEBUG: "vite-plugin:test"
           # The remote-binding tests need to connect to Cloudflare


### PR DESCRIPTION
The Vite plugin E2E tests have been timing out intermittently at 15 minutes. This increases the timeout to 20 minutes to provide more headroom.

In particular the Windows tests - e.g. https://github.com/cloudflare/workers-sdk/actions/runs/21667260184/job/62465813084?pr=12383

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: This is a CI configuration change

- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is an internal CI change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12408">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
