### PR TITLE
Potential fix for code scanning alert no. 217: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/opencode-issue-solver.yml
+++ b/.github/workflows/opencode-issue-solver.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   assess-issue:
     runs-on: ubuntu-latest
+    permissions: {}
 
     steps:
       - name: Exit


### PR DESCRIPTION
Potential fix for [https://github.com/cloudflare/workers-sdk/security/code-scanning/217](https://github.com/cloudflare/workers-sdk/security/code-scanning/217)

In general, to fix this problem you must add an explicit `permissions:` block either at the root of the workflow (applies to all jobs) or within the specific job that lacks it, granting only the minimal required scopes. For jobs that do not use the `GITHUB_TOKEN` at all, you can disable all permissions with `permissions: {}`.

For this specific workflow, the `assess-issue` job just runs `exit 1` and does not need any GitHub API access. The least-privilege, non-breaking change is to add `permissions: {}` to that job, directly under `runs-on: ubuntu-latest`. No other functionality changes are required because no steps rely on the token.

Concretely, in `.github/workflows/opencode-issue-solver.yml`, between line 13 (`runs-on: ubuntu-latest`) and line 15 (`steps:`), add a `permissions: {}` line with correct indentation so the job explicitly disables all `GITHUB_TOKEN` permissions. No imports or other definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: Infra change only
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Infra change only

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12409">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
