### PR TITLE
chore: update version of undici in import-npm fixture

### DIFF
--- a/fixtures/import-npm/packages/import-example/package.json
+++ b/fixtures/import-npm/packages/import-example/package.json
@@ -15,7 +15,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "../../../../packages/workers-tsconfig",
-		"undici": "^5.29.0",
+		"undici": "^7.18.2",
 		"wrangler": "../../../../packages/wrangler"
 	}
 }


### PR DESCRIPTION
## Summary

Updates the `import-npm` fixture to use the 7.18.2 version of `undici` instead of the outdated pinned version.

This aligns the fixture with all other packages in the repo that already reference `undici` via `catalog:default`.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: This is a devDependency version alignment change to a private test fixture
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Internal fixture change only
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12410">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
