### PR TITLE
Use vitest#expect from the local context

### DIFF
--- a/packages/wrangler/eslint.config.mjs
+++ b/packages/wrangler/eslint.config.mjs
@@ -53,4 +53,13 @@ export default defineConfig([
 			"workers-sdk/no-vitest-import-expect": "error",
 		},
 	},
+	// Bucket 3: versions, autoconfig, api, deploy, dev, config, utils, core, metrics
+	{
+		files: [
+			"src/__tests__/{versions,autoconfig,api,deploy,dev,config,utils,core,metrics}/**/*.test.ts",
+		],
+		rules: {
+			"workers-sdk/no-vitest-import-expect": "error",
+		},
+	},
 ]);

--- a/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
@@ -1,7 +1,9 @@
 import path from "node:path";
 import { seed } from "@cloudflare/workers-utils/test-helpers";
 import dedent from "ts-dedent";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- expect used in vi.waitFor callbacks */
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { BundlerController } from "../../../api/startDevWorker/BundlerController";
 import { FakeBus } from "../../helpers/fake-bus";
 import { mockConsoleMethods } from "../../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
@@ -1,7 +1,9 @@
 import path from "node:path";
 import { seed } from "@cloudflare/workers-utils/test-helpers";
 import dedent from "ts-dedent";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- expect used in vi.waitFor callbacks */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { ConfigController } from "../../../api/startDevWorker/ConfigController";
 import { unwrapHook } from "../../../api/startDevWorker/utils";
 import { logger } from "../../../logger";

--- a/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
@@ -6,7 +6,9 @@ import util from "node:util";
 import { DeferredPromise, Response } from "miniflare";
 import dedent from "ts-dedent";
 import { fetch } from "undici";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- large test file with many patterns */
 import { assert, describe, expect, it } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import WebSocket from "ws";
 import { createPostgresEchoHandler } from "../../../../e2e/helpers/postgres-echo-handler";
 import { LocalRuntimeController } from "../../../api/startDevWorker/LocalRuntimeController";

--- a/packages/wrangler/src/__tests__/api/startDevWorker/RemoteRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/RemoteRuntimeController.test.ts
@@ -1,4 +1,6 @@
+/* eslint-disable workers-sdk/no-vitest-import-expect -- expect used in vi.waitFor callbacks */
 import { beforeEach, describe, expect, it, vi } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { RemoteRuntimeController } from "../../../api/startDevWorker/RemoteRuntimeController";
 import {
 	convertBindingsToCfWorkerInitBindings,

--- a/packages/wrangler/src/__tests__/api/startDevWorker/utils.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/utils.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert";
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import { convertConfigBindingsToStartWorkerBindings } from "../../../api/startDevWorker/utils";
 
 describe("convertConfigBindingsToStartWorkerBindings", () => {
-	it("converts config bindings into startWorker bindings", async () => {
+	it("converts config bindings into startWorker bindings", async ({
+		expect,
+	}) => {
 		const result = convertConfigBindingsToStartWorkerBindings({
 			kv_namespaces: [
 				{
@@ -138,7 +140,9 @@ describe("convertConfigBindingsToStartWorkerBindings", () => {
 		});
 	});
 
-	it("prioritizes preview values compared to their standard counterparts", async () => {
+	it("prioritizes preview values compared to their standard counterparts", async ({
+		expect,
+	}) => {
 		const result = convertConfigBindingsToStartWorkerBindings({
 			ai: undefined,
 			browser: undefined,

--- a/packages/wrangler/src/__tests__/autoconfig/details/confirm-auto-config-details.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/confirm-auto-config-details.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { describe, test, vi } from "vitest";
 import { confirmAutoConfigDetails } from "../../../autoconfig/details";
 import { Static } from "../../../autoconfig/frameworks/static";
 import { mockConfirm, mockPrompt } from "../../helpers/mock-dialogs";
@@ -18,7 +18,7 @@ describe("autoconfig details - confirmAutoConfigDetails()", () => {
 	const { setIsTTY } = useMockIsTTY();
 
 	describe("interactive mode", () => {
-		test("no modifications applied", async () => {
+		test("no modifications applied", async ({ expect }) => {
 			setIsTTY(true);
 
 			mockConfirm({
@@ -49,7 +49,9 @@ describe("autoconfig details - confirmAutoConfigDetails()", () => {
 			`);
 		});
 
-		test("settings can be updated in a plain static site without a framework nor a build script", async () => {
+		test("settings can be updated in a plain static site without a framework nor a build script", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 
 			mockConfirm({
@@ -94,7 +96,9 @@ describe("autoconfig details - confirmAutoConfigDetails()", () => {
 			`);
 		});
 
-		test("settings can be updated in a static app using a framework", async () => {
+		test("settings can be updated in a static app using a framework", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 
 			mockConfirm({
@@ -151,7 +155,9 @@ describe("autoconfig details - confirmAutoConfigDetails()", () => {
 	});
 
 	describe("non-interactive mode", () => {
-		test("no modifications are applied in non-interactive", async () => {
+		test("no modifications are applied in non-interactive", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 
 			const updatedAutoConfigDetails = await confirmAutoConfigDetails({

--- a/packages/wrangler/src/__tests__/autoconfig/details/display-auto-config-details.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/display-auto-config-details.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, it, vi } from "vitest";
 import { displayAutoConfigDetails } from "../../../autoconfig/details";
 import { Static } from "../../../autoconfig/frameworks/static";
 import { mockConsoleMethods } from "../../helpers/mock-console";
@@ -16,7 +16,9 @@ vi.mock("../../../package-manager", () => ({
 describe("autoconfig details - displayAutoConfigDetails()", () => {
 	const std = mockConsoleMethods();
 
-	it("should cleanly handle a case in which only the worker name has been detected", () => {
+	it("should cleanly handle a case in which only the worker name has been detected", ({
+		expect,
+	}) => {
 		displayAutoConfigDetails({
 			configured: false,
 			projectPath: process.cwd(),
@@ -34,7 +36,9 @@ describe("autoconfig details - displayAutoConfigDetails()", () => {
 		);
 	});
 
-	it("should display all the project settings provided by the details object", () => {
+	it("should display all the project settings provided by the details object", ({
+		expect,
+	}) => {
 		displayAutoConfigDetails({
 			configured: false,
 			projectPath: process.cwd(),
@@ -63,7 +67,9 @@ describe("autoconfig details - displayAutoConfigDetails()", () => {
 		`);
 	});
 
-	it("should omit the framework and build command entries when they are not part of the details object", () => {
+	it("should omit the framework and build command entries when they are not part of the details object", ({
+		expect,
+	}) => {
 		displayAutoConfigDetails({
 			configured: false,
 			projectPath: process.cwd(),

--- a/packages/wrangler/src/__tests__/autoconfig/details/get-details-for-auto-config.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/get-details-for-auto-config.test.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from "node:crypto";
 import { writeFile } from "node:fs/promises";
 import { seed } from "@cloudflare/workers-utils/test-helpers";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- it.each patterns */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import * as details from "../../../autoconfig/details";
 import { clearOutputFilePath } from "../../../output";
 import {

--- a/packages/wrangler/src/__tests__/autoconfig/details/get-worker-name-from-project.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/get-worker-name-from-project.test.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
 import { seed } from "@cloudflare/workers-utils/test-helpers";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- it.each patterns */
 import { afterEach, describe, expect, it, vi } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { getWorkerNameFromProject } from "../../../autoconfig/details";
 import { runInTempDir } from "../../helpers/run-in-tmp";
 

--- a/packages/wrangler/src/__tests__/autoconfig/get-installed-package-version.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/get-installed-package-version.test.ts
@@ -1,11 +1,11 @@
 import { seed } from "@cloudflare/workers-utils/test-helpers";
-import { describe, expect, test } from "vitest";
+import { describe, test } from "vitest";
 import { getInstalledPackageVersion } from "../../autoconfig/frameworks/utils/packages";
 import { runInTempDir } from "../helpers/run-in-tmp";
 
 describe("getInstalledPackageVersion()", () => {
 	runInTempDir();
-	test("happy path", async () => {
+	test("happy path", async ({ expect }) => {
 		await seed({
 			"node_modules/react-router/package.json": JSON.stringify({
 				name: "react-router",
@@ -19,7 +19,7 @@ describe("getInstalledPackageVersion()", () => {
 		);
 	});
 
-	test("no node_modules", async () => {
+	test("no node_modules", async ({ expect }) => {
 		expect(
 			getInstalledPackageVersion("react-router", process.cwd())
 		).toBeUndefined();

--- a/packages/wrangler/src/__tests__/autoconfig/run-summary.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/run-summary.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, test } from "vitest";
 import { Astro } from "../../autoconfig/frameworks/astro";
 import { Static } from "../../autoconfig/frameworks/static";
 import { buildOperationsSummary } from "../../autoconfig/run";
@@ -24,7 +24,9 @@ describe("autoconfig run - buildOperationsSummary()", () => {
 	});
 
 	describe("interactive mode", () => {
-		test("presents a summary for a simple project where only a wrangler.jsonc file needs to be created", async () => {
+		test("presents a summary for a simple project where only a wrangler.jsonc file needs to be created", async ({
+			expect,
+		}) => {
 			const summary = await buildOperationsSummary(
 				{
 					workerName: "worker-name",
@@ -76,7 +78,9 @@ describe("autoconfig run - buildOperationsSummary()", () => {
 			`);
 		});
 
-		test("shows that wrangler will be added as a devDependency when not already installed as such", async () => {
+		test("shows that wrangler will be added as a devDependency when not already installed as such", async ({
+			expect,
+		}) => {
 			const summary = await buildOperationsSummary(
 				{
 					workerName: "worker-name",
@@ -128,7 +132,9 @@ describe("autoconfig run - buildOperationsSummary()", () => {
 			`);
 		});
 
-		test("when a package.json is present wrangler@latest will be unconditionally installed (even if already present)", async () => {
+		test("when a package.json is present wrangler@latest will be unconditionally installed (even if already present)", async ({
+			expect,
+		}) => {
 			const summary = await buildOperationsSummary(
 				{
 					workerName: "worker-name",
@@ -182,7 +188,9 @@ describe("autoconfig run - buildOperationsSummary()", () => {
 			`);
 		});
 
-		test("shows that when needed a framework specific configuration will be run", async () => {
+		test("shows that when needed a framework specific configuration will be run", async ({
+			expect,
+		}) => {
 			const summary = await buildOperationsSummary(
 				{
 					workerName: "worker-name",
@@ -209,7 +217,9 @@ describe("autoconfig run - buildOperationsSummary()", () => {
 			expect(summary.frameworkId).toBe("astro");
 		});
 
-		test("doesn't show the framework specific configuration step for the Static framework", async () => {
+		test("doesn't show the framework specific configuration step for the Static framework", async ({
+			expect,
+		}) => {
 			const summary = await buildOperationsSummary(
 				{
 					workerName: "worker-name",

--- a/packages/wrangler/src/__tests__/autoconfig/run.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/run.test.ts
@@ -2,7 +2,9 @@ import { existsSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { FatalError, readFileSync } from "@cloudflare/workers-utils";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- expect used in helper function at module scope */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import * as c3 from "../../autoconfig/c3-vendor/packages";
 import * as details from "../../autoconfig/details";
 import { Static } from "../../autoconfig/frameworks/static";

--- a/packages/wrangler/src/__tests__/autoconfig/vite-config.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/vite-config.test.ts
@@ -1,5 +1,5 @@
 import { writeFile } from "node:fs/promises";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, it } from "vitest";
 import {
 	checkIfViteConfigUsesCloudflarePlugin,
 	transformViteConfig,
@@ -17,7 +17,9 @@ describe("vite-config utils", () => {
 	});
 
 	describe("checkIfViteConfigUsesCloudflarePlugin", () => {
-		it("should handle vite config with function-based defineConfig", async () => {
+		it("should handle vite config with function-based defineConfig", async ({
+			expect,
+		}) => {
 			await writeFile(
 				"vite.config.ts",
 				`
@@ -34,7 +36,9 @@ export default defineConfig(() => ({
 			expect(std.debug).toContain("Vite config uses a non-object expression");
 		});
 
-		it("should handle vite config without plugins array", async () => {
+		it("should handle vite config without plugins array", async ({
+			expect,
+		}) => {
 			await writeFile(
 				"vite.config.ts",
 				`
@@ -53,7 +57,7 @@ export default defineConfig({
 			);
 		});
 
-		it("should detect cloudflare plugin correctly", async () => {
+		it("should detect cloudflare plugin correctly", async ({ expect }) => {
 			await writeFile(
 				"vite.config.ts",
 				`
@@ -72,7 +76,9 @@ export default defineConfig({
 	});
 
 	describe("transformViteConfig", () => {
-		it("should throw UserError for function-based defineConfig", async () => {
+		it("should throw UserError for function-based defineConfig", async ({
+			expect,
+		}) => {
 			await writeFile(
 				"vite.config.ts",
 				`
@@ -89,7 +95,9 @@ export default defineConfig(() => ({
 			);
 		});
 
-		it("should throw UserError when plugins array is missing", async () => {
+		it("should throw UserError when plugins array is missing", async ({
+			expect,
+		}) => {
 			await writeFile(
 				"vite.config.ts",
 				`
@@ -106,7 +114,9 @@ export default defineConfig({
 			);
 		});
 
-		it("should successfully transform valid vite config", async () => {
+		it("should successfully transform valid vite config", async ({
+			expect,
+		}) => {
 			await writeFile(
 				"vite.config.ts",
 				`

--- a/packages/wrangler/src/__tests__/config/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.test.ts
@@ -1,7 +1,9 @@
 import * as fs from "node:fs";
 import { experimental_readRawConfig } from "@cloudflare/workers-utils";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- describe.each pattern */
 import { describe, expect, it } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { readConfig } from "../../config";
 import { runInTempDir } from "../helpers/run-in-tmp";
 

--- a/packages/wrangler/src/__tests__/config/loadDotEnv.test.ts
+++ b/packages/wrangler/src/__tests__/config/loadDotEnv.test.ts
@@ -1,5 +1,5 @@
 import { seed } from "@cloudflare/workers-utils/test-helpers";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, it } from "vitest";
 import { loadDotEnv } from "../../config/dot-env";
 import { logger } from "../../logger";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -21,7 +21,9 @@ describe("loadDotEnv()", () => {
 		return () => logger.resetLoggerLevel();
 	});
 
-	it("should load environment variables from .env files", async () => {
+	it("should load environment variables from .env files", async ({
+		expect,
+	}) => {
 		await seed({
 			".env": "FOO=bar\nBAZ=${FOO}\n",
 			".env.local": "FOO=qux\n",
@@ -39,7 +41,7 @@ describe("loadDotEnv()", () => {
 		`);
 	});
 
-	it("should support silent processing", async () => {
+	it("should support silent processing", async ({ expect }) => {
 		await seed({
 			".env": "FOO=bar\nBAZ=${FOO}\n",
 			".env.local": "FOO=qux\n",
@@ -54,7 +56,7 @@ describe("loadDotEnv()", () => {
 		expect(std.out).toMatchInlineSnapshot(`""`);
 	});
 
-	it("should debug log if .env files are missing", async () => {
+	it("should debug log if .env files are missing", async ({ expect }) => {
 		const envPaths = ["./.env.missing"];
 		const result = loadDotEnv(envPaths, {
 			includeProcessEnv: false,
@@ -69,7 +71,7 @@ describe("loadDotEnv()", () => {
 
 	it.skipIf(isWindows)(
 		"should have case sensitive env properties",
-		async () => {
+		async ({ expect }) => {
 			await seed({
 				".env": "FOO=bar",
 			});
@@ -85,7 +87,7 @@ describe("loadDotEnv()", () => {
 
 	it.skipIf(!isWindows)(
 		"should have case insensitive env properties",
-		async () => {
+		async ({ expect }) => {
 			await seed({
 				".env": "FOO=bar",
 			});
@@ -99,7 +101,9 @@ describe("loadDotEnv()", () => {
 		}
 	);
 
-	it("should include process.env variables if specified", async () => {
+	it("should include process.env variables if specified", async ({
+		expect,
+	}) => {
 		process.env = {
 			TEST_ENV_VAR: "test_value",
 		};

--- a/packages/wrangler/src/__tests__/core/command-registration.test.ts
+++ b/packages/wrangler/src/__tests__/core/command-registration.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, test } from "vitest";
 import { CommandRegistry } from "../../core/CommandRegistry";
 import {
 	createAlias,
@@ -30,7 +30,7 @@ describe("CommandRegistry", () => {
 		);
 	});
 
-	test("can define a command", () => {
+	test("can define a command", ({ expect }) => {
 		registry.define([
 			{
 				command: "wrangler my-test-command",
@@ -58,7 +58,7 @@ describe("CommandRegistry", () => {
 		expect(node?.definition?.command).toBe("wrangler my-test-command");
 	});
 
-	test("throws on duplicate command definition", () => {
+	test("throws on duplicate command definition", ({ expect }) => {
 		// @ts-expect-error missing command definition
 		const definition = createCommand({});
 
@@ -81,7 +81,7 @@ describe("CommandRegistry", () => {
 		);
 	});
 
-	test("can define a namespace", () => {
+	test("can define a namespace", ({ expect }) => {
 		const definition = createNamespace({
 			// @ts-expect-error missing metadata
 			metadata: {
@@ -102,7 +102,7 @@ describe("CommandRegistry", () => {
 		expect(node?.definition?.command).toBe("wrangler one");
 	});
 
-	test("can alias a command", () => {
+	test("can alias a command", ({ expect }) => {
 		const definition = createCommand({
 			// @ts-expect-error missing metadata
 			metadata: {
@@ -138,7 +138,7 @@ describe("CommandRegistry", () => {
 		expect(def.aliasOf).toBe("wrangler my-test-command");
 	});
 
-	test("throws on alias to undefined command", () => {
+	test("throws on alias to undefined command", ({ expect }) => {
 		registry.define([
 			{
 				command: "wrangler my-alias-command",
@@ -153,7 +153,7 @@ describe("CommandRegistry", () => {
 		);
 	});
 
-	test("throws on missing namespace definition", () => {
+	test("throws on missing namespace definition", ({ expect }) => {
 		registry.define([
 			{
 				command: "wrangler known-namespace",
@@ -174,7 +174,7 @@ describe("CommandRegistry", () => {
 		);
 	});
 
-	test("correctly resolves definition chain for alias", () => {
+	test("correctly resolves definition chain for alias", ({ expect }) => {
 		registry.define([
 			{
 				command: "wrangler original-command",
@@ -198,7 +198,7 @@ describe("CommandRegistry", () => {
 		expect(def.aliasOf).toBe("wrangler original-command");
 	});
 
-	test("can resolve a command definition with its metadata", () => {
+	test("can resolve a command definition with its metadata", ({ expect }) => {
 		const commandMetadata: Metadata = {
 			description: "Test command",
 			status: "stable",
@@ -222,7 +222,7 @@ describe("CommandRegistry", () => {
 		expect(node.definition?.metadata).toEqual(commandMetadata);
 	});
 
-	test("correctly resolves multiple alias chains", () => {
+	test("correctly resolves multiple alias chains", ({ expect }) => {
 		registry.define([
 			{
 				command: "wrangler original-command",
@@ -259,7 +259,9 @@ describe("CommandRegistry", () => {
 		expect(def.aliasOf).toBe("wrangler alias-command-1");
 	});
 
-	test("throws on invalid namespace resolution (namespace not defined)", () => {
+	test("throws on invalid namespace resolution (namespace not defined)", ({
+		expect,
+	}) => {
 		registry.define([
 			{
 				command: "wrangler invalid-namespace subcommand",

--- a/packages/wrangler/src/__tests__/core/handle-errors.test.ts
+++ b/packages/wrangler/src/__tests__/core/handle-errors.test.ts
@@ -1,10 +1,12 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, it, vi } from "vitest";
 import { getErrorType, handleError } from "../../core/handle-errors";
 import { mockConsoleMethods } from "../helpers/mock-console";
 
 describe("getErrorType", () => {
 	describe("DNS errors", () => {
-		it("should return 'DNSError' for ENOTFOUND to api.cloudflare.com", () => {
+		it("should return 'DNSError' for ENOTFOUND to api.cloudflare.com", ({
+			expect,
+		}) => {
 			const error = Object.assign(
 				new Error("getaddrinfo ENOTFOUND api.cloudflare.com"),
 				{
@@ -17,7 +19,9 @@ describe("getErrorType", () => {
 			expect(getErrorType(error)).toBe("DNSError");
 		});
 
-		it("should return 'DNSError' for ENOTFOUND to dash.cloudflare.com", () => {
+		it("should return 'DNSError' for ENOTFOUND to dash.cloudflare.com", ({
+			expect,
+		}) => {
 			const error = Object.assign(
 				new Error("getaddrinfo ENOTFOUND dash.cloudflare.com"),
 				{
@@ -29,7 +33,9 @@ describe("getErrorType", () => {
 			expect(getErrorType(error)).toBe("DNSError");
 		});
 
-		it("should return 'DNSError' for DNS errors in error cause", () => {
+		it("should return 'DNSError' for DNS errors in error cause", ({
+			expect,
+		}) => {
 			const cause = Object.assign(
 				new Error("getaddrinfo ENOTFOUND api.cloudflare.com"),
 				{
@@ -42,7 +48,9 @@ describe("getErrorType", () => {
 			expect(getErrorType(error)).toBe("DNSError");
 		});
 
-		it("should NOT return 'DNSError' for non-Cloudflare hostnames", () => {
+		it("should NOT return 'DNSError' for non-Cloudflare hostnames", ({
+			expect,
+		}) => {
 			const error = Object.assign(
 				new Error("getaddrinfo ENOTFOUND example.com"),
 				{
@@ -56,7 +64,9 @@ describe("getErrorType", () => {
 	});
 
 	describe("Connection timeout errors", () => {
-		it("should return 'ConnectionTimeout' for api.cloudflare.com timeouts", () => {
+		it("should return 'ConnectionTimeout' for api.cloudflare.com timeouts", ({
+			expect,
+		}) => {
 			const error = Object.assign(
 				new Error("Connect Timeout Error: https://api.cloudflare.com/endpoint"),
 				{ code: "UND_ERR_CONNECT_TIMEOUT" }
@@ -65,7 +75,9 @@ describe("getErrorType", () => {
 			expect(getErrorType(error)).toBe("ConnectionTimeout");
 		});
 
-		it("should return 'ConnectionTimeout' for dash.cloudflare.com timeouts", () => {
+		it("should return 'ConnectionTimeout' for dash.cloudflare.com timeouts", ({
+			expect,
+		}) => {
 			const error = Object.assign(
 				new Error("Connect Timeout Error: https://dash.cloudflare.com/api"),
 				{ code: "UND_ERR_CONNECT_TIMEOUT" }
@@ -74,7 +86,9 @@ describe("getErrorType", () => {
 			expect(getErrorType(error)).toBe("ConnectionTimeout");
 		});
 
-		it("should return 'ConnectionTimeout' for timeout errors in error cause", () => {
+		it("should return 'ConnectionTimeout' for timeout errors in error cause", ({
+			expect,
+		}) => {
 			const cause = Object.assign(
 				new Error("timeout connecting to api.cloudflare.com"),
 				{ code: "UND_ERR_CONNECT_TIMEOUT" }
@@ -84,7 +98,9 @@ describe("getErrorType", () => {
 			expect(getErrorType(error)).toBe("ConnectionTimeout");
 		});
 
-		it("should return 'ConnectionTimeout' when Cloudflare URL is in parent message", () => {
+		it("should return 'ConnectionTimeout' when Cloudflare URL is in parent message", ({
+			expect,
+		}) => {
 			const cause = Object.assign(new Error("connect timeout"), {
 				code: "UND_ERR_CONNECT_TIMEOUT",
 			});
@@ -96,7 +112,9 @@ describe("getErrorType", () => {
 			expect(getErrorType(error)).toBe("ConnectionTimeout");
 		});
 
-		it("should NOT return 'ConnectionTimeout' for non-Cloudflare URLs", () => {
+		it("should NOT return 'ConnectionTimeout' for non-Cloudflare URLs", ({
+			expect,
+		}) => {
 			const error = Object.assign(
 				new Error("Connect Timeout Error: https://example.com/api"),
 				{ code: "UND_ERR_CONNECT_TIMEOUT" }
@@ -105,7 +123,9 @@ describe("getErrorType", () => {
 			expect(getErrorType(error)).not.toBe("ConnectionTimeout");
 		});
 
-		it("should NOT return 'ConnectionTimeout' for user's dev server timeouts", () => {
+		it("should NOT return 'ConnectionTimeout' for user's dev server timeouts", ({
+			expect,
+		}) => {
 			const cause = Object.assign(
 				new Error("timeout connecting to localhost:8787"),
 				{ code: "UND_ERR_CONNECT_TIMEOUT" }
@@ -117,7 +137,7 @@ describe("getErrorType", () => {
 	});
 
 	describe("Permission errors", () => {
-		it("should return 'PermissionError' for EPERM errors", () => {
+		it("should return 'PermissionError' for EPERM errors", ({ expect }) => {
 			const error = Object.assign(
 				new Error(
 					"EPERM: operation not permitted, open '/Users/user/.wrangler/logs/wrangler.log'"
@@ -133,7 +153,7 @@ describe("getErrorType", () => {
 			expect(getErrorType(error)).toBe("PermissionError");
 		});
 
-		it("should return 'PermissionError' for EACCES errors", () => {
+		it("should return 'PermissionError' for EACCES errors", ({ expect }) => {
 			const error = Object.assign(
 				new Error(
 					"EACCES: permission denied, open '/Users/user/Library/Preferences/.wrangler/config/default.toml'"
@@ -149,7 +169,9 @@ describe("getErrorType", () => {
 			expect(getErrorType(error)).toBe("PermissionError");
 		});
 
-		it("should return 'PermissionError' for EPERM errors without path", () => {
+		it("should return 'PermissionError' for EPERM errors without path", ({
+			expect,
+		}) => {
 			const error = Object.assign(
 				new Error("EPERM: operation not permitted, mkdir"),
 				{
@@ -160,7 +182,9 @@ describe("getErrorType", () => {
 			expect(getErrorType(error)).toBe("PermissionError");
 		});
 
-		it("should return 'PermissionError' for EPERM errors in error cause", () => {
+		it("should return 'PermissionError' for EPERM errors in error cause", ({
+			expect,
+		}) => {
 			const cause = Object.assign(
 				new Error(
 					"EPERM: operation not permitted, open '/var/logs/wrangler.log'"
@@ -175,7 +199,9 @@ describe("getErrorType", () => {
 			expect(getErrorType(error)).toBe("PermissionError");
 		});
 
-		it("should NOT return 'PermissionError' for non-EPERM/EACCES errors", () => {
+		it("should NOT return 'PermissionError' for non-EPERM/EACCES errors", ({
+			expect,
+		}) => {
 			const error = Object.assign(new Error("ENOENT: file not found"), {
 				code: "ENOENT",
 			});
@@ -185,7 +211,9 @@ describe("getErrorType", () => {
 	});
 
 	describe("File not found errors", () => {
-		it("should return 'FileNotFoundError' for ENOENT errors with path", () => {
+		it("should return 'FileNotFoundError' for ENOENT errors with path", ({
+			expect,
+		}) => {
 			const error = Object.assign(
 				new Error("ENOENT: no such file or directory, open 'wrangler.toml'"),
 				{
@@ -199,7 +227,9 @@ describe("getErrorType", () => {
 			expect(getErrorType(error)).toBe("FileNotFoundError");
 		});
 
-		it("should return 'FileNotFoundError' for ENOENT errors without path", () => {
+		it("should return 'FileNotFoundError' for ENOENT errors without path", ({
+			expect,
+		}) => {
 			const error = Object.assign(
 				new Error("ENOENT: no such file or directory"),
 				{
@@ -210,7 +240,9 @@ describe("getErrorType", () => {
 			expect(getErrorType(error)).toBe("FileNotFoundError");
 		});
 
-		it("should return 'FileNotFoundError' for ENOENT errors in error cause", () => {
+		it("should return 'FileNotFoundError' for ENOENT errors in error cause", ({
+			expect,
+		}) => {
 			const cause = Object.assign(
 				new Error("ENOENT: no such file or directory, stat '.wrangler'"),
 				{
@@ -225,13 +257,15 @@ describe("getErrorType", () => {
 	});
 
 	describe("Fallback behavior", () => {
-		it("should return constructor name for unknown Error types", () => {
+		it("should return constructor name for unknown Error types", ({
+			expect,
+		}) => {
 			const error = new TypeError("Something went wrong");
 
 			expect(getErrorType(error)).toBe("TypeError");
 		});
 
-		it("should return undefined for non-Error values", () => {
+		it("should return undefined for non-Error values", ({ expect }) => {
 			expect(getErrorType("string error")).toBe(undefined);
 			expect(getErrorType(null)).toBe(undefined);
 			expect(getErrorType(undefined)).toBe(undefined);
@@ -247,7 +281,9 @@ describe("handleError", () => {
 	});
 
 	describe("SSL/TLS certificate errors", () => {
-		it("should log a warning for self-signed certificate errors", async () => {
+		it("should log a warning for self-signed certificate errors", async ({
+			expect,
+		}) => {
 			const error = new Error("self-signed certificate in certificate chain");
 
 			await handleError(error, {}, []);
@@ -259,7 +295,9 @@ describe("handleError", () => {
 			expect(std.warn).toContain("install the missing system roots");
 		});
 
-		it("should log a warning for unable to verify first certificate errors", async () => {
+		it("should log a warning for unable to verify first certificate errors", async ({
+			expect,
+		}) => {
 			const error = new Error("unable to verify the first certificate");
 
 			await handleError(error, {}, []);
@@ -269,7 +307,9 @@ describe("handleError", () => {
 			);
 		});
 
-		it("should log a warning for unable to get local issuer certificate errors", async () => {
+		it("should log a warning for unable to get local issuer certificate errors", async ({
+			expect,
+		}) => {
 			const error = new Error("unable to get local issuer certificate");
 
 			await handleError(error, {}, []);
@@ -279,7 +319,9 @@ describe("handleError", () => {
 			);
 		});
 
-		it("should log a warning when certificate error is in error cause", async () => {
+		it("should log a warning when certificate error is in error cause", async ({
+			expect,
+		}) => {
 			const cause = new Error("self-signed certificate in certificate chain");
 			const error = new Error("fetch failed", { cause });
 
@@ -290,7 +332,9 @@ describe("handleError", () => {
 			);
 		});
 
-		it("should log a warning when certificate error is part of a longer message", async () => {
+		it("should log a warning when certificate error is part of a longer message", async ({
+			expect,
+		}) => {
 			const error = new Error(
 				"Request failed: self-signed certificate in certificate chain (details: some info)"
 			);
@@ -302,7 +346,7 @@ describe("handleError", () => {
 			);
 		});
 
-		it("should not log a warning for unrelated errors", async () => {
+		it("should not log a warning for unrelated errors", async ({ expect }) => {
 			const error = new Error("Connection refused");
 
 			await handleError(error, {}, []);
@@ -312,7 +356,9 @@ describe("handleError", () => {
 			);
 		});
 
-		it("should still log the original error after the warning", async () => {
+		it("should still log the original error after the warning", async ({
+			expect,
+		}) => {
 			const error = new Error("self-signed certificate in certificate chain");
 
 			await handleError(error, {}, []);
@@ -327,7 +373,9 @@ describe("handleError", () => {
 	});
 
 	describe("Cloudflare API connection timeout errors", () => {
-		it("should show user-friendly message for api.cloudflare.com timeouts", async () => {
+		it("should show user-friendly message for api.cloudflare.com timeouts", async ({
+			expect,
+		}) => {
 			const error = Object.assign(
 				new Error("Connect Timeout Error: https://api.cloudflare.com/endpoint"),
 				{ code: "UND_ERR_CONNECT_TIMEOUT" }
@@ -340,7 +388,9 @@ describe("handleError", () => {
 			expect(std.err).toContain("Please check your internet connection");
 		});
 
-		it("should show user-friendly message for dash.cloudflare.com timeouts", async () => {
+		it("should show user-friendly message for dash.cloudflare.com timeouts", async ({
+			expect,
+		}) => {
 			const error = Object.assign(
 				new Error("Connect Timeout Error: https://dash.cloudflare.com/api"),
 				{ code: "UND_ERR_CONNECT_TIMEOUT" }
@@ -351,7 +401,7 @@ describe("handleError", () => {
 			expect(std.err).toContain("The request to Cloudflare's API timed out");
 		});
 
-		it("should handle timeout errors in error cause", async () => {
+		it("should handle timeout errors in error cause", async ({ expect }) => {
 			const cause = Object.assign(
 				new Error("timeout connecting to api.cloudflare.com"),
 				{ code: "UND_ERR_CONNECT_TIMEOUT" }
@@ -363,7 +413,9 @@ describe("handleError", () => {
 			expect(std.err).toContain("The request to Cloudflare's API timed out");
 		});
 
-		it("should handle timeout when Cloudflare URL is in parent message", async () => {
+		it("should handle timeout when Cloudflare URL is in parent message", async ({
+			expect,
+		}) => {
 			const cause = Object.assign(new Error("connect timeout"), {
 				code: "UND_ERR_CONNECT_TIMEOUT",
 			});
@@ -377,7 +429,9 @@ describe("handleError", () => {
 			expect(std.err).toContain("The request to Cloudflare's API timed out");
 		});
 
-		it("should NOT show timeout message for non-Cloudflare URLs", async () => {
+		it("should NOT show timeout message for non-Cloudflare URLs", async ({
+			expect,
+		}) => {
 			const error = Object.assign(
 				new Error("Connect Timeout Error: https://example.com/api"),
 				{ code: "UND_ERR_CONNECT_TIMEOUT" }
@@ -390,7 +444,9 @@ describe("handleError", () => {
 			);
 		});
 
-		it("should NOT show timeout message for user's dev server timeouts", async () => {
+		it("should NOT show timeout message for user's dev server timeouts", async ({
+			expect,
+		}) => {
 			const cause = Object.assign(
 				new Error("timeout connecting to localhost:8787"),
 				{ code: "UND_ERR_CONNECT_TIMEOUT" }
@@ -406,7 +462,9 @@ describe("handleError", () => {
 	});
 
 	describe("Permission errors (EPERM, EACCES)", () => {
-		it("should show user-friendly message for EPERM errors with path", async () => {
+		it("should show user-friendly message for EPERM errors with path", async ({
+			expect,
+		}) => {
 			const error = Object.assign(
 				new Error(
 					"EPERM: operation not permitted, open '/Users/user/.wrangler/logs/wrangler.log'"
@@ -430,7 +488,9 @@ describe("handleError", () => {
 			expect(std.err).toContain("Insufficient file or directory permissions");
 		});
 
-		it("should show user-friendly message for EACCES errors with path", async () => {
+		it("should show user-friendly message for EACCES errors with path", async ({
+			expect,
+		}) => {
 			const error = Object.assign(
 				new Error(
 					"EACCES: permission denied, open '/Users/user/Library/Preferences/.wrangler/config/default.toml'"
@@ -454,7 +514,9 @@ describe("handleError", () => {
 			expect(std.err).toContain("Insufficient file or directory permissions");
 		});
 
-		it("should show error message when path is not available", async () => {
+		it("should show error message when path is not available", async ({
+			expect,
+		}) => {
 			const error = Object.assign(
 				new Error("EPERM: operation not permitted, mkdir"),
 				{
@@ -471,7 +533,7 @@ describe("handleError", () => {
 			expect(std.err).not.toContain("Affected path:");
 		});
 
-		it("should handle EPERM errors in error cause", async () => {
+		it("should handle EPERM errors in error cause", async ({ expect }) => {
 			const cause = Object.assign(
 				new Error(
 					"EPERM: operation not permitted, open '/var/logs/wrangler.log'"
@@ -491,7 +553,9 @@ describe("handleError", () => {
 			expect(std.err).toContain("Affected path: /var/logs/wrangler.log");
 		});
 
-		it("should NOT treat non-EPERM errors as permission errors", async () => {
+		it("should NOT treat non-EPERM errors as permission errors", async ({
+			expect,
+		}) => {
 			const error = Object.assign(new Error("ENOENT: file not found"), {
 				code: "ENOENT",
 			});
@@ -505,7 +569,9 @@ describe("handleError", () => {
 	});
 
 	describe("DNS resolution errors (ENOTFOUND)", () => {
-		it("should show user-friendly message for ENOTFOUND to api.cloudflare.com", async () => {
+		it("should show user-friendly message for ENOTFOUND to api.cloudflare.com", async ({
+			expect,
+		}) => {
 			const error = Object.assign(
 				new Error("getaddrinfo ENOTFOUND api.cloudflare.com"),
 				{
@@ -523,7 +589,9 @@ describe("handleError", () => {
 			expect(std.err).toContain("DNS resolver not configured");
 		});
 
-		it("should show user-friendly message for ENOTFOUND to dash.cloudflare.com", async () => {
+		it("should show user-friendly message for ENOTFOUND to dash.cloudflare.com", async ({
+			expect,
+		}) => {
 			const error = Object.assign(
 				new Error("getaddrinfo ENOTFOUND dash.cloudflare.com"),
 				{
@@ -537,7 +605,7 @@ describe("handleError", () => {
 			expect(std.err).toContain("Unable to resolve Cloudflare's API hostname");
 		});
 
-		it("should handle DNS errors in error cause", async () => {
+		it("should handle DNS errors in error cause", async ({ expect }) => {
 			const cause = Object.assign(
 				new Error("getaddrinfo ENOTFOUND api.cloudflare.com"),
 				{
@@ -552,7 +620,9 @@ describe("handleError", () => {
 			expect(std.err).toContain("Unable to resolve Cloudflare's API hostname");
 		});
 
-		it("should NOT show DNS error for non-Cloudflare hostnames", async () => {
+		it("should NOT show DNS error for non-Cloudflare hostnames", async ({
+			expect,
+		}) => {
 			const error = Object.assign(
 				new Error("getaddrinfo ENOTFOUND example.com"),
 				{
@@ -570,7 +640,9 @@ describe("handleError", () => {
 	});
 
 	describe("File not found errors (ENOENT)", () => {
-		it("should show user-friendly message for ENOENT errors with path", async () => {
+		it("should show user-friendly message for ENOENT errors with path", async ({
+			expect,
+		}) => {
 			const error = Object.assign(
 				new Error("ENOENT: no such file or directory, open 'wrangler.toml'"),
 				{
@@ -588,7 +660,9 @@ describe("handleError", () => {
 			expect(std.err).toContain("The file or directory does not exist");
 		});
 
-		it("should show error message when path is not available", async () => {
+		it("should show error message when path is not available", async ({
+			expect,
+		}) => {
 			const error = Object.assign(
 				new Error("ENOENT: no such file or directory"),
 				{
@@ -603,7 +677,7 @@ describe("handleError", () => {
 			expect(std.err).not.toContain("Missing file or directory:");
 		});
 
-		it("should handle ENOENT errors in error cause", async () => {
+		it("should handle ENOENT errors in error cause", async ({ expect }) => {
 			const cause = Object.assign(
 				new Error("ENOENT: no such file or directory, stat '.wrangler'"),
 				{

--- a/packages/wrangler/src/__tests__/deploy/check-remote-secrets-override.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/check-remote-secrets-override.test.ts
@@ -1,4 +1,4 @@
-import { assert, describe, expect, it, vi } from "vitest";
+import { assert, describe, it, vi } from "vitest";
 import { checkRemoteSecretsOverride } from "../../deploy/check-remote-secrets-override";
 import { fetchSecrets } from "../../utils/fetch-secrets";
 import type { Config } from "@cloudflare/workers-utils";
@@ -16,7 +16,9 @@ async function runMockedCheckRemoteSecretsOverride(
 }
 
 describe("checkRemoteSecretsOverride", () => {
-	it("should return { override: false } when there are no possible overrides", async () => {
+	it("should return { override: false } when there are no possible overrides", async ({
+		expect,
+	}) => {
 		const checkResult = await runMockedCheckRemoteSecretsOverride(
 			{
 				vars: {
@@ -34,7 +36,9 @@ describe("checkRemoteSecretsOverride", () => {
 		expect(checkResult.override).toBe(false);
 	});
 
-	it("should detect and provide a valid deploy error message when a variable name overrides a secret", async () => {
+	it("should detect and provide a valid deploy error message when a variable name overrides a secret", async ({
+		expect,
+	}) => {
 		const checkResult = await runMockedCheckRemoteSecretsOverride(
 			{
 				vars: {
@@ -58,7 +62,9 @@ describe("checkRemoteSecretsOverride", () => {
 		);
 	});
 
-	it("should detect and provide a valid deploy error message when multiple (2) variable names override secrets", async () => {
+	it("should detect and provide a valid deploy error message when multiple (2) variable names override secrets", async ({
+		expect,
+	}) => {
 		const checkResult = await runMockedCheckRemoteSecretsOverride(
 			{
 				vars: {
@@ -82,7 +88,9 @@ describe("checkRemoteSecretsOverride", () => {
 		);
 	});
 
-	it("should detect and provide a valid deploy error message when multiple (3) variable names override secrets", async () => {
+	it("should detect and provide a valid deploy error message when multiple (3) variable names override secrets", async ({
+		expect,
+	}) => {
 		const checkResult = await runMockedCheckRemoteSecretsOverride(
 			{
 				vars: {
@@ -107,7 +115,9 @@ describe("checkRemoteSecretsOverride", () => {
 		);
 	});
 
-	it("should detect and provide a valid deploy error message when a binding name overrides a secret", async () => {
+	it("should detect and provide a valid deploy error message when a binding name overrides a secret", async ({
+		expect,
+	}) => {
 		const checkResult = await runMockedCheckRemoteSecretsOverride(
 			{
 				vars: {
@@ -133,7 +143,9 @@ describe("checkRemoteSecretsOverride", () => {
 		);
 	});
 
-	it("should detect and provide a valid deploy error message when multiple binding names override secrets", async () => {
+	it("should detect and provide a valid deploy error message when multiple binding names override secrets", async ({
+		expect,
+	}) => {
 		const checkResult = await runMockedCheckRemoteSecretsOverride(
 			{
 				vars: {
@@ -163,7 +175,9 @@ describe("checkRemoteSecretsOverride", () => {
 		);
 	});
 
-	it("should detect and provide a valid deploy error message when a combination of variables and binding names override secrets", async () => {
+	it("should detect and provide a valid deploy error message when a combination of variables and binding names override secrets", async ({
+		expect,
+	}) => {
 		const checkResult = await runMockedCheckRemoteSecretsOverride(
 			{
 				vars: {
@@ -186,7 +200,9 @@ describe("checkRemoteSecretsOverride", () => {
 		);
 	});
 
-	it("should not unnecessarily fetch secrets when there are no env vars nor bindings in the config file", async () => {
+	it("should not unnecessarily fetch secrets when there are no env vars nor bindings in the config file", async ({
+		expect,
+	}) => {
 		const result = await runMockedCheckRemoteSecretsOverride({}, ["MY_SECRET"]);
 		expect(result.override).toBeFalsy();
 		expect(fetchSecrets).not.toHaveBeenCalled();

--- a/packages/wrangler/src/__tests__/deploy/get-config-patch.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/get-config-patch.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, test } from "vitest";
+import { describe, test } from "vitest";
 import { getConfigPatch } from "../../deploy/config-diffs";
 
 // Note: __old (as well as *__deleted) is the value in the remote config, __new is the value in the local one, so we do want the
 //       __old one to override the __new
 
 describe("getConfigPatch", () => {
-	test("top level config updated", () => {
+	test("top level config updated", ({ expect }) => {
 		expect(
 			getConfigPatch({
 				preview_urls: {
@@ -18,7 +18,7 @@ describe("getConfigPatch", () => {
 		});
 	});
 
-	test("env var present remotely but deleted locally", () => {
+	test("env var present remotely but deleted locally", ({ expect }) => {
 		expect(
 			getConfigPatch({
 				vars: {
@@ -32,7 +32,7 @@ describe("getConfigPatch", () => {
 		});
 	});
 
-	test("updated value of env var", () => {
+	test("updated value of env var", ({ expect }) => {
 		expect(
 			getConfigPatch({
 				vars: {
@@ -49,7 +49,7 @@ describe("getConfigPatch", () => {
 		});
 	});
 
-	test("env var renamed", () => {
+	test("env var renamed", ({ expect }) => {
 		expect(
 			getConfigPatch({
 				vars: {
@@ -64,7 +64,7 @@ describe("getConfigPatch", () => {
 		});
 	});
 
-	test("deleted version metadata binding", () => {
+	test("deleted version metadata binding", ({ expect }) => {
 		expect(
 			getConfigPatch({
 				version_metadata: {
@@ -81,7 +81,7 @@ describe("getConfigPatch", () => {
 		});
 	});
 
-	test("deleted KV binding (only one KV)", () => {
+	test("deleted KV binding (only one KV)", ({ expect }) => {
 		expect(
 			getConfigPatch({
 				kv_namespaces: [
@@ -104,7 +104,7 @@ describe("getConfigPatch", () => {
 		});
 	});
 
-	test("deleted second KV binding in the kv_namespaces array", () => {
+	test("deleted second KV binding in the kv_namespaces array", ({ expect }) => {
 		expect(
 			getConfigPatch({
 				kv_namespaces: [
@@ -131,7 +131,7 @@ describe("getConfigPatch", () => {
 		});
 	});
 
-	test("modified KV binding", () => {
+	test("modified KV binding", ({ expect }) => {
 		expect(
 			getConfigPatch({
 				kv_namespaces: [
@@ -155,7 +155,9 @@ describe("getConfigPatch", () => {
 		});
 	});
 
-	test("deleted second KV binding in the kv_namespaces array and modified first one", () => {
+	test("deleted second KV binding in the kv_namespaces array and modified first one", ({
+		expect,
+	}) => {
 		expect(
 			getConfigPatch({
 				kv_namespaces: [
@@ -182,7 +184,9 @@ describe("getConfigPatch", () => {
 		});
 	});
 
-	test("deleted KV binding from the middle of the kv_namespaces array", () => {
+	test("deleted KV binding from the middle of the kv_namespaces array", ({
+		expect,
+	}) => {
 		expect(
 			getConfigPatch({
 				kv_namespaces: [
@@ -214,7 +218,9 @@ describe("getConfigPatch", () => {
 		});
 	});
 
-	test("flipped observability.logs.invocation_logs off (nested field)", () => {
+	test("flipped observability.logs.invocation_logs off (nested field)", ({
+		expect,
+	}) => {
 		expect(
 			getConfigPatch({
 				observability: {
@@ -235,7 +241,7 @@ describe("getConfigPatch", () => {
 		});
 	});
 
-	test("renamed version metadata binding", () => {
+	test("renamed version metadata binding", ({ expect }) => {
 		expect(
 			getConfigPatch({
 				version_metadata: {
@@ -252,7 +258,7 @@ describe("getConfigPatch", () => {
 		});
 	});
 
-	test("configs get added/set to a target environment", () => {
+	test("configs get added/set to a target environment", ({ expect }) => {
 		/*
 			Note: in the remote configuration we don't know if a value is actually there because
 			      inherited from the top level or not, so to be safe we just add it to the target

--- a/packages/wrangler/src/__tests__/deploy/get-remote-config-diff.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/get-remote-config-diff.test.ts
@@ -1,4 +1,4 @@
-import { assert, describe, expect, it } from "vitest";
+import { assert, describe, it } from "vitest";
 import { getRemoteConfigDiff } from "../../deploy/config-diffs";
 import type { Config, RawConfig } from "@cloudflare/workers-utils";
 
@@ -17,7 +17,9 @@ function normalizeDiff(log: string): string {
 }
 
 describe("getRemoteConfigsDiff", () => {
-	it("should handle a very simple diffing scenario (no diffs, random order)", () => {
+	it("should handle a very simple diffing scenario (no diffs, random order)", ({
+		expect,
+	}) => {
 		const { diff, nonDestructive } = getRemoteConfigDiff(
 			{
 				name: "my-worker-id",
@@ -48,7 +50,9 @@ describe("getRemoteConfigsDiff", () => {
 		expect(nonDestructive).toBe(true);
 	});
 
-	it("should handle a very simple diffing scenario where there is only an addition to an array (specifically in `kv_namespaces`)", () => {
+	it("should handle a very simple diffing scenario where there is only an addition to an array (specifically in `kv_namespaces`)", ({
+		expect,
+	}) => {
 		const { diff, nonDestructive } = getRemoteConfigDiff(
 			{
 				name: "my-worker-id",
@@ -81,7 +85,9 @@ describe("getRemoteConfigsDiff", () => {
 		expect(nonDestructive).toBe(false);
 	});
 
-	it("should handle a very simple diffing scenario (some diffs, random order)", () => {
+	it("should handle a very simple diffing scenario (some diffs, random order)", ({
+		expect,
+	}) => {
 		const { diff, nonDestructive } = getRemoteConfigDiff(
 			{
 				name: "my-worker-id",
@@ -119,7 +125,7 @@ describe("getRemoteConfigsDiff", () => {
 		expect(nonDestructive).toBe(false);
 	});
 
-	it("should handle a diffing scenario with only additions", () => {
+	it("should handle a diffing scenario with only additions", ({ expect }) => {
 		const { diff, nonDestructive } = getRemoteConfigDiff(
 			{
 				name: "my-worker-id",
@@ -161,7 +167,7 @@ describe("getRemoteConfigsDiff", () => {
 		expect(nonDestructive).toBe(true);
 	});
 
-	it("should handle a diffing scenario with only deletions", () => {
+	it("should handle a diffing scenario with only deletions", ({ expect }) => {
 		const { diff, nonDestructive } = getRemoteConfigDiff(
 			{
 				name: "my-worker-id",
@@ -204,7 +210,9 @@ describe("getRemoteConfigsDiff", () => {
 		expect(nonDestructive).toBe(false);
 	});
 
-	it("should handle a diffing scenario with modifications and removals", () => {
+	it("should handle a diffing scenario with modifications and removals", ({
+		expect,
+	}) => {
 		const { diff, nonDestructive } = getRemoteConfigDiff(
 			{
 				name: "my-worker-id",
@@ -254,7 +262,9 @@ describe("getRemoteConfigsDiff", () => {
 		expect(nonDestructive).toBe(false);
 	});
 
-	it("should ignore local-only configs such as `dev` and `build`", () => {
+	it("should ignore local-only configs such as `dev` and `build`", ({
+		expect,
+	}) => {
 		const { diff } = getRemoteConfigDiff(
 			{
 				name: "my-worker-id",
@@ -283,7 +293,9 @@ describe("getRemoteConfigsDiff", () => {
 		expect(diff).toBeNull();
 	});
 
-	it("should ignore the `remote` field of bindings during the diffing process (since remote bindings are a local-only concept)", () => {
+	it("should ignore the `remote` field of bindings during the diffing process (since remote bindings are a local-only concept)", ({
+		expect,
+	}) => {
 		const { diff } = getRemoteConfigDiff(
 			{
 				name: "my-worker-id",
@@ -481,7 +493,9 @@ describe("getRemoteConfigsDiff", () => {
 		expect(diff).toBeNull();
 	});
 
-	it("should ignore all fields from an assets binding besides the binding name (since remotely only that information is stored)", () => {
+	it("should ignore all fields from an assets binding besides the binding name (since remotely only that information is stored)", ({
+		expect,
+	}) => {
 		const { diff, nonDestructive } = getRemoteConfigDiff(
 			{
 				name: "my-worker-id",
@@ -544,7 +558,9 @@ describe("getRemoteConfigsDiff", () => {
 			);
 		}
 
-		it("shouldn't present any diff when the local config is just { enabled: true } and the remote observability is enabled with its default values", () => {
+		it("shouldn't present any diff when the local config is just { enabled: true } and the remote observability is enabled with its default values", ({
+			expect,
+		}) => {
 			const { diff, nonDestructive } = getObservabilityDiff(
 				{
 					enabled: true,
@@ -563,7 +579,9 @@ describe("getRemoteConfigsDiff", () => {
 			expect(nonDestructive).toBe(true);
 		});
 
-		it("should treat a remote undefined equal to a remote { enabled: false }", () => {
+		it("should treat a remote undefined equal to a remote { enabled: false }", ({
+			expect,
+		}) => {
 			const { diff } = getObservabilityDiff(
 				// remotely the observability field is undefined when observability is disabled
 				undefined,
@@ -572,7 +590,9 @@ describe("getRemoteConfigsDiff", () => {
 			expect(diff).toBe(null);
 		});
 
-		it("should treat a remote undefined equal to a remote { enabled: false, logs: { enabled: false } }", () => {
+		it("should treat a remote undefined equal to a remote { enabled: false, logs: { enabled: false } }", ({
+			expect,
+		}) => {
 			const { diff } = getObservabilityDiff(
 				// remotely the observability field is undefined when observability is disabled
 				undefined,
@@ -581,7 +601,9 @@ describe("getRemoteConfigsDiff", () => {
 			expect(diff).toBe(null);
 		});
 
-		it("should correctly show the diff of boolean when the remote is undefined and the local is { enabled: true }", () => {
+		it("should correctly show the diff of boolean when the remote is undefined and the local is { enabled: true }", ({
+			expect,
+		}) => {
 			const { diff } = getObservabilityDiff(
 				// remotely the observability field is undefined when observability is disabled
 				undefined,
@@ -603,7 +625,9 @@ describe("getRemoteConfigsDiff", () => {
 			`);
 		});
 
-		it("should correctly show the diff of boolean when the remote is undefined and the local is { logs: { enabled: false } }", () => {
+		it("should correctly show the diff of boolean when the remote is undefined and the local is { logs: { enabled: false } }", ({
+			expect,
+		}) => {
 			const { diff } = getObservabilityDiff(
 				// remotely the observability field is undefined when observability is disabled
 				undefined,
@@ -623,7 +647,9 @@ describe("getRemoteConfigsDiff", () => {
 			`);
 		});
 
-		it("should correctly not show head_sampling_rate being added remotely", () => {
+		it("should correctly not show head_sampling_rate being added remotely", ({
+			expect,
+		}) => {
 			const { diff } = getObservabilityDiff(
 				// remotely head_sampling_rate is set to 1 even if enabled is false
 				{ enabled: false, head_sampling_rate: 1, logs: { enabled: true } },
@@ -632,7 +658,9 @@ describe("getRemoteConfigsDiff", () => {
 			expect(diff).toBe(null);
 		});
 
-		it("should correctly not show logs.invocation_logs being added remotely", () => {
+		it("should correctly not show logs.invocation_logs being added remotely", ({
+			expect,
+		}) => {
 			const { diff } = getObservabilityDiff(
 				// remotely head_sampling_rate is set to 1 even if enabled is false
 				{

--- a/packages/wrangler/src/__tests__/dev/remote-bindings-errors.test.ts
+++ b/packages/wrangler/src/__tests__/dev/remote-bindings-errors.test.ts
@@ -1,4 +1,4 @@
-import { assert, beforeEach, describe, expect, it, vi } from "vitest";
+import { assert, beforeEach, describe, it, vi } from "vitest";
 import { startRemoteProxySession } from "../../api";
 import {
 	createPreviewSession,
@@ -24,7 +24,9 @@ describe("errors during dev with remote bindings", () => {
 		msw.use(...mswSuccessUserHandlers);
 	});
 
-	it("errors triggered when creating the remote proxy session are surfaced", async () => {
+	it("errors triggered when creating the remote proxy session are surfaced", async ({
+		expect,
+	}) => {
 		let thrownError: Error | undefined;
 
 		try {
@@ -53,7 +55,9 @@ describe("errors during dev with remote bindings", () => {
 		);
 	});
 
-	it("errors triggered when establishing the remote proxy session (after it has been created) are surfaced", async () => {
+	it("errors triggered when establishing the remote proxy session (after it has been created) are surfaced", async ({
+		expect,
+	}) => {
 		vi.mocked(createPreviewSession).mockResolvedValue({
 			id: "test-session-id",
 			value: "test-session-value",

--- a/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
+++ b/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 import { seed } from "@cloudflare/workers-utils/test-helpers";
 import { fetch } from "undici";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- it.each pattern and expect in vi.waitFor callbacks */
 import {
 	afterEach,
 	beforeEach,
@@ -10,6 +11,7 @@ import {
 	onTestFailed,
 	vi,
 } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { Binding, StartRemoteProxySessionOptions } from "../../api";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/metrics/sanitization.test.ts
+++ b/packages/wrangler/src/__tests__/metrics/sanitization.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import {
 	ALLOW,
 	getAllowedArgs,
@@ -9,7 +9,7 @@ import {
 import type { AllowedArgs, AllowList } from "../../../src/metrics/sanitization";
 
 describe("sanitizeArgKeys", () => {
-	it("should sanitize arg keys based on argv", () => {
+	it("should sanitize arg keys based on argv", ({ expect }) => {
 		const args = {
 			config: "wrangler.toml",
 			env: "production",
@@ -43,7 +43,9 @@ describe("sanitizeArgKeys", () => {
 });
 
 describe("sanitizeArgValues", () => {
-	it("should redact and allow arg values based on allowedArgs", () => {
+	it("should redact and allow arg values based on allowedArgs", ({
+		expect,
+	}) => {
 		const sanitizedArgs = {
 			config: "wrangler.toml",
 			env: "production",
@@ -65,7 +67,7 @@ describe("sanitizeArgValues", () => {
 });
 
 describe("getAllowedArgs", () => {
-	it("should return allowed args for a given command", () => {
+	it("should return allowed args for a given command", ({ expect }) => {
 		const commandArgAllowList: AllowList = {
 			deploy: {
 				config: REDACT,
@@ -97,7 +99,9 @@ describe("getAllowedArgs", () => {
 		});
 	});
 
-	it("should allow more specific command rules to override less specific ones", () => {
+	it("should allow more specific command rules to override less specific ones", ({
+		expect,
+	}) => {
 		const commandArgAllowList: AllowList = {
 			"*": { global: ALLOW, sharedArg: REDACT },
 			"r2 bucket create": { sharedArg: REDACT, createOnly: ALLOW },

--- a/packages/wrangler/src/__tests__/utils/create-batches.test.ts
+++ b/packages/wrangler/src/__tests__/utils/create-batches.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, test } from "vitest";
 import { createBatches } from "../../utils/create-batches";
 
 // split a template string into an array of chars (convenience util to make writing inputs/outputs easier)
@@ -24,7 +24,7 @@ describe("createBatches", () => {
 	];
 
 	for (const { input, batchSize, output } of data) {
-		test(`${input} in batches of ${batchSize}`, () => {
+		test(`${input} in batches of ${batchSize}`, ({ expect }) => {
 			expect([...createBatches(input, batchSize)]).toEqual(output);
 		});
 	}

--- a/packages/wrangler/src/__tests__/utils/format-message.test.ts
+++ b/packages/wrangler/src/__tests__/utils/format-message.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import { formatMessage } from "../../utils/format-message";
 import type { Message } from "@cloudflare/workers-utils";
 
@@ -8,7 +8,7 @@ describe("formatMessage", () => {
 		return formatMessage(input, false).substring(2);
 	};
 
-	it("should format message without location", () => {
+	it("should format message without location", ({ expect }) => {
 		expect(
 			format({
 				text: "Invalid argument",
@@ -21,7 +21,7 @@ describe("formatMessage", () => {
     `);
 	});
 
-	it("should format message with location", () => {
+	it("should format message with location", ({ expect }) => {
 		expect(
 			format({
 				text: "Missing property: main",
@@ -44,7 +44,7 @@ describe("formatMessage", () => {
     `);
 	});
 
-	it("should format message with location and notes", () => {
+	it("should format message with location and notes", ({ expect }) => {
 		expect(
 			format({
 				text: "Invalid property: type",

--- a/packages/wrangler/src/__tests__/utils/getValidBindingName.test.ts
+++ b/packages/wrangler/src/__tests__/utils/getValidBindingName.test.ts
@@ -1,38 +1,44 @@
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import { getValidBindingName } from "../../utils/getValidBindingName";
 
 describe("getValidBindingName", () => {
-	it("should replace dashes with underscores", () => {
+	it("should replace dashes with underscores", ({ expect }) => {
 		expect(getValidBindingName("MY-NAME", "FALLBACK")).toBe("MY_NAME");
 	});
 
-	it("should replace consecutive underscores with single underscore", () => {
+	it("should replace consecutive underscores with single underscore", ({
+		expect,
+	}) => {
 		expect(getValidBindingName("MY-_ NAME", "FALLBACK")).toBe("MY_NAME");
 	});
 
-	it("should prepend an underscore if it starts with a number", () => {
+	it("should prepend an underscore if it starts with a number", ({
+		expect,
+	}) => {
 		expect(getValidBindingName("123", "FALLBACK")).toBe("_123");
 	});
 
-	it("should replace whitespaces with underscores", () => {
+	it("should replace whitespaces with underscores", ({ expect }) => {
 		expect(getValidBindingName("MY NAME", "FALLBACK")).toBe("MY_NAME");
 		expect(getValidBindingName("MY	NAME", "FALLBACK")).toBe("MY_NAME");
 		expect(getValidBindingName("MY\nNAME", "FALLBACK")).toBe("MY_NAME");
 	});
 
-	it("should remove all invalid character", () => {
+	it("should remove all invalid character", ({ expect }) => {
 		expect(getValidBindingName("NAME$", "FALLBACK")).toBe("NAME");
 	});
 
-	it("should not remove alphabetic characters, numbers, or underscores", () => {
+	it("should not remove alphabetic characters, numbers, or underscores", ({
+		expect,
+	}) => {
 		expect(getValidBindingName("my_NAME", "FALLBACK")).toBe("my_NAME");
 	});
 
-	it("should fallback if no valid binding name is possible", () => {
+	it("should fallback if no valid binding name is possible", ({ expect }) => {
 		expect(getValidBindingName("$$$", "FALLBACK")).toBe("FALLBACK");
 	});
 
-	it("should fallback if output is only underscores", () => {
+	it("should fallback if output is only underscores", ({ expect }) => {
 		expect(getValidBindingName("___", "FALLBACK")).toBe("FALLBACK");
 	});
 });

--- a/packages/wrangler/src/__tests__/utils/log-file.test.ts
+++ b/packages/wrangler/src/__tests__/utils/log-file.test.ts
@@ -1,6 +1,8 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- expect used in helper function at module scope */
 import { beforeEach, describe, expect, it, vi } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { appendToDebugLogFile, debugLogFilepath } from "../../utils/log-file";
 import { runInTempDir } from "../helpers/run-in-tmp";
 

--- a/packages/wrangler/src/__tests__/utils/retry.test.ts
+++ b/packages/wrangler/src/__tests__/utils/retry.test.ts
@@ -1,5 +1,5 @@
 import { APIError } from "@cloudflare/workers-utils";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, it } from "vitest";
 import { logger } from "../../logger";
 import { retryOnAPIFailure } from "../../utils/retry";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -13,7 +13,9 @@ describe("retryOnAPIFailure", () => {
 		return () => (logger.loggerLevel = level);
 	});
 
-	it("should retry 5xx errors and succeed if the 3rd try succeeds", async () => {
+	it("should retry 5xx errors and succeed if the 3rd try succeeds", async ({
+		expect,
+	}) => {
 		let attempts = 0;
 
 		await retryOnAPIFailure(() => {
@@ -33,7 +35,7 @@ describe("retryOnAPIFailure", () => {
 		`);
 	});
 
-	it("should throw 5xx error after all retries fail", async () => {
+	it("should throw 5xx error after all retries fail", async ({ expect }) => {
 		let attempts = 0;
 
 		await expect(() =>
@@ -55,7 +57,7 @@ describe("retryOnAPIFailure", () => {
 		`);
 	});
 
-	it("should not retry non-5xx errors", async () => {
+	it("should not retry non-5xx errors", async ({ expect }) => {
 		let attempts = 0;
 
 		await expect(() =>
@@ -68,7 +70,7 @@ describe("retryOnAPIFailure", () => {
 		expect(getRetryAndErrorLogs(std.debug)).toMatchInlineSnapshot(`Array []`);
 	});
 
-	it("should retry TypeError", async () => {
+	it("should retry TypeError", async ({ expect }) => {
 		let attempts = 0;
 
 		await expect(() =>
@@ -87,7 +89,7 @@ describe("retryOnAPIFailure", () => {
 		`);
 	});
 
-	it("should not retry other errors", async () => {
+	it("should not retry other errors", async ({ expect }) => {
 		let attempts = 0;
 
 		await expect(() =>
@@ -100,7 +102,9 @@ describe("retryOnAPIFailure", () => {
 		expect(getRetryAndErrorLogs(std.debug)).toMatchInlineSnapshot(`Array []`);
 	});
 
-	it("should retry custom APIError implementation with non-5xx error", async () => {
+	it("should retry custom APIError implementation with non-5xx error", async ({
+		expect,
+	}) => {
 		let checkedCustomIsRetryable = false;
 		class CustomAPIError extends APIError {
 			isRetryable(): boolean {

--- a/packages/wrangler/src/__tests__/versions/deployments/deployments.list.test.ts
+++ b/packages/wrangler/src/__tests__/versions/deployments/deployments.list.test.ts
@@ -1,5 +1,5 @@
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, test } from "vitest";
 import { normalizeOutput } from "../../../../e2e/helpers/normalize";
 import { collectCLIOutput } from "../../helpers/collect-cli-output";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
@@ -20,7 +20,7 @@ describe("deployments list", () => {
 	});
 
 	describe("without wrangler.toml", () => {
-		test("fails with no args", async () => {
+		test("fails with no args", async ({ expect }) => {
 			const result = runWrangler("deployments list");
 
 			await expect(result).rejects.toMatchInlineSnapshot(
@@ -32,7 +32,7 @@ describe("deployments list", () => {
 			expect(normalizeOutput(std.err)).toMatchInlineSnapshot(`""`);
 		});
 
-		test("prints deployments to stdout", async () => {
+		test("prints deployments to stdout", async ({ expect }) => {
 			const result = runWrangler("deployments list --name test-name");
 
 			await expect(result).resolves.toBeUndefined();
@@ -99,7 +99,7 @@ describe("deployments list", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		test("prints deployments to stdout as --json", async () => {
+		test("prints deployments to stdout as --json", async ({ expect }) => {
 			const result = runWrangler("deployments list --name test-name --json");
 
 			await expect(result).resolves.toBeUndefined();
@@ -195,7 +195,7 @@ describe("deployments list", () => {
 	describe("with wrangler.toml", () => {
 		beforeEach(() => writeWranglerConfig());
 
-		test("prints deployments to stdout", async () => {
+		test("prints deployments to stdout", async ({ expect }) => {
 			const result = runWrangler("deployments list");
 
 			await expect(result).resolves.toBeUndefined();
@@ -262,7 +262,7 @@ describe("deployments list", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		test("prints deployments to stdout as --json", async () => {
+		test("prints deployments to stdout as --json", async ({ expect }) => {
 			const result = runWrangler("deployments list --json");
 
 			await expect(result).resolves.toBeUndefined();

--- a/packages/wrangler/src/__tests__/versions/deployments/deployments.status.test.ts
+++ b/packages/wrangler/src/__tests__/versions/deployments/deployments.status.test.ts
@@ -1,5 +1,5 @@
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, test } from "vitest";
 import { normalizeOutput } from "../../../../e2e/helpers/normalize";
 import { collectCLIOutput } from "../../helpers/collect-cli-output";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
@@ -20,7 +20,7 @@ describe("deployments list", () => {
 	});
 
 	describe("without wrangler.toml", () => {
-		test("fails with no args", async () => {
+		test("fails with no args", async ({ expect }) => {
 			const result = runWrangler("deployments status");
 
 			await expect(result).rejects.toMatchInlineSnapshot(
@@ -32,7 +32,7 @@ describe("deployments list", () => {
 			expect(normalizeOutput(std.err)).toMatchInlineSnapshot(`""`);
 		});
 
-		test("prints latest deployment to stdout", async () => {
+		test("prints latest deployment to stdout", async ({ expect }) => {
 			const result = runWrangler("deployments status --name test-name");
 
 			await expect(result).resolves.toBeUndefined();
@@ -57,7 +57,7 @@ describe("deployments list", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		test("prints latest deployment to stdout as --json", async () => {
+		test("prints latest deployment to stdout as --json", async ({ expect }) => {
 			const result = runWrangler("deployments status --name test-name --json");
 
 			await expect(result).resolves.toBeUndefined();
@@ -92,7 +92,7 @@ describe("deployments list", () => {
 	describe("with wrangler.toml", () => {
 		beforeEach(() => writeWranglerConfig());
 
-		test("prints latest deployment to stdout", async () => {
+		test("prints latest deployment to stdout", async ({ expect }) => {
 			const result = runWrangler("deployments status");
 
 			await expect(result).resolves.toBeUndefined();
@@ -117,7 +117,7 @@ describe("deployments list", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		test("prints latest deployment to stdout as --json", async () => {
+		test("prints latest deployment to stdout as --json", async ({ expect }) => {
 			const result = runWrangler("deployments status --json");
 
 			await expect(result).resolves.toBeUndefined();

--- a/packages/wrangler/src/__tests__/versions/deployments/deployments.view.test.ts
+++ b/packages/wrangler/src/__tests__/versions/deployments/deployments.view.test.ts
@@ -1,12 +1,12 @@
 import { UserError } from "@cloudflare/workers-utils";
-import { describe, expect, test } from "vitest";
+import { describe, test } from "vitest";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { runWrangler } from "../../helpers/run-wrangler";
 
 describe("deployments view", () => {
 	mockConsoleMethods();
 
-	test("error when run with no args", async () => {
+	test("error when run with no args", async ({ expect }) => {
 		const result = runWrangler("deployments view");
 
 		await expect(result).rejects.toMatchInlineSnapshot(
@@ -15,7 +15,7 @@ describe("deployments view", () => {
 		await expect(result).rejects.toBeInstanceOf(UserError);
 	});
 
-	test("error when run with positional arg", async () => {
+	test("error when run with positional arg", async ({ expect }) => {
 		const result = runWrangler("deployments view dummy-id");
 
 		await expect(result).rejects.toMatchInlineSnapshot(

--- a/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
@@ -1,7 +1,9 @@
 import { writeFile } from "node:fs/promises";
 import readline from "node:readline";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- expect used in mockPostVersion callback */
 import { afterEach, describe, expect, it, test, vi } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { clearDialogs } from "../../helpers/mock-dialogs";

--- a/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
@@ -1,6 +1,8 @@
 import { writeFile } from "node:fs/promises";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- expect used in mockPostVersion callback */
 import { afterEach, describe, expect, it, test } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { clearDialogs, mockConfirm } from "../../helpers/mock-dialogs";

--- a/packages/wrangler/src/__tests__/versions/secrets/list.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/list.test.ts
@@ -1,7 +1,9 @@
 import { writeFile } from "node:fs/promises";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- expect used in MSW handler callbacks */
 import { describe, expect, test } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { createFetchResult, msw } from "../../helpers/msw";

--- a/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
@@ -2,7 +2,9 @@ import { writeFile } from "node:fs/promises";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { FormData } from "undici";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- expect used in mockPostVersion callback */
 import { afterEach, describe, expect, it, test } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { clearDialogs, mockPrompt } from "../../helpers/mock-dialogs";

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -1,5 +1,7 @@
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- uses test.each patterns */
 import { beforeEach, describe, expect, it, test } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { normalizeOutput } from "../../../e2e/helpers/normalize";
 import {
 	assignAndDistributePercentages,

--- a/packages/wrangler/src/__tests__/versions/versions.help.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.help.test.ts
@@ -1,12 +1,12 @@
 import { setImmediate } from "node:timers/promises";
-import { describe, expect, test } from "vitest";
+import { describe, test } from "vitest";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runWrangler } from "../helpers/run-wrangler";
 
 describe("versions --help", () => {
 	const std = mockConsoleMethods();
 
-	test("shows versions help w/ --help", async () => {
+	test("shows versions help w/ --help", async ({ expect }) => {
 		const result = runWrangler("versions --help");
 
 		await expect(result).resolves.toBeUndefined();
@@ -37,7 +37,7 @@ describe("versions --help", () => {
 describe("versions subhelp", () => {
 	const std = mockConsoleMethods();
 
-	test("shows implicit subhelp", async () => {
+	test("shows implicit subhelp", async ({ expect }) => {
 		const result = runWrangler("versions");
 
 		await expect(result).resolves.toBeUndefined();

--- a/packages/wrangler/src/__tests__/versions/versions.list.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.list.test.ts
@@ -1,5 +1,5 @@
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, test } from "vitest";
 import { normalizeOutput } from "../../../e2e/helpers/normalize";
 import { collectCLIOutput } from "../helpers/collect-cli-output";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
@@ -22,7 +22,7 @@ describe("versions list", () => {
 	});
 
 	describe("without wrangler.toml", () => {
-		test("fails with no args", async () => {
+		test("fails with no args", async ({ expect }) => {
 			const result = runWrangler("versions list --json");
 
 			await expect(result).rejects.toMatchInlineSnapshot(
@@ -34,7 +34,7 @@ describe("versions list", () => {
 			expect(normalizeOutput(std.err)).toMatchInlineSnapshot(`""`);
 		});
 
-		test("prints versions to stdout", async () => {
+		test("prints versions to stdout", async ({ expect }) => {
 			const result = runWrangler("versions list --name test-name");
 
 			await expect(result).resolves.toBeUndefined();
@@ -76,7 +76,7 @@ describe("versions list", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		test("prints versions to stdout as --json", async () => {
+		test("prints versions to stdout as --json", async ({ expect }) => {
 			const result = runWrangler("versions list --name test-name --json");
 
 			await expect(result).resolves.toBeUndefined();
@@ -156,7 +156,7 @@ describe("versions list", () => {
 	describe("with wrangler.toml", () => {
 		beforeEach(() => writeWranglerConfig());
 
-		test("prints versions to stdout", async () => {
+		test("prints versions to stdout", async ({ expect }) => {
 			const result = runWrangler("versions list");
 
 			await expect(result).resolves.toBeUndefined();
@@ -196,7 +196,7 @@ describe("versions list", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		test("prints versions to as --json", async () => {
+		test("prints versions to as --json", async ({ expect }) => {
 			const result = runWrangler("versions list --json");
 
 			await expect(result).resolves.toBeUndefined();

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -3,7 +3,9 @@ import {
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
+/* eslint-disable workers-sdk/no-vitest-import-expect -- expect used in MSW handler callbacks */
 import { beforeEach, describe, expect, it, test, vi } from "vitest";
+/* eslint-enable workers-sdk/no-vitest-import-expect */
 import { dedent } from "../../utils/dedent";
 import { generatePreviewAlias } from "../../versions/upload";
 import { makeApiRequestAsserter } from "../helpers/assert-request";

--- a/packages/wrangler/src/__tests__/versions/versions.view.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.view.test.ts
@@ -1,5 +1,5 @@
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, test } from "vitest";
 import { normalizeOutput } from "../../../e2e/helpers/normalize";
 import { collectCLIOutput } from "../helpers/collect-cli-output";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
@@ -18,7 +18,7 @@ describe("versions view", () => {
 	describe("without wrangler.toml", () => {
 		beforeEach(() => msw.use(mswGetVersion()));
 
-		test("fails with no args", async () => {
+		test("fails with no args", async ({ expect }) => {
 			const result = runWrangler("versions view");
 
 			await expect(result).rejects.toMatchInlineSnapshot(
@@ -30,7 +30,7 @@ describe("versions view", () => {
 			expect(normalizeOutput(std.err)).toMatchInlineSnapshot(`""`);
 		});
 
-		test("fails with --name arg only", async () => {
+		test("fails with --name arg only", async ({ expect }) => {
 			const result = runWrangler("versions view --name test-name");
 
 			await expect(result).rejects.toMatchInlineSnapshot(
@@ -42,7 +42,7 @@ describe("versions view", () => {
 			expect(normalizeOutput(std.err)).toMatchInlineSnapshot(`""`);
 		});
 
-		test("fails with positional version-id arg only", async () => {
+		test("fails with positional version-id arg only", async ({ expect }) => {
 			const result = runWrangler(
 				"versions view 10000000-0000-0000-0000-000000000000"
 			);
@@ -56,7 +56,9 @@ describe("versions view", () => {
 			expect(normalizeOutput(std.err)).toMatchInlineSnapshot(`""`);
 		});
 
-		test("succeeds with positional version-id arg and --name arg", async () => {
+		test("succeeds with positional version-id arg and --name arg", async ({
+			expect,
+		}) => {
 			const result = runWrangler(
 				"versions view 10000000-0000-0000-0000-000000000000 --name test-name"
 			);
@@ -91,7 +93,7 @@ describe("versions view", () => {
 			expect(normalizeOutput(std.err)).toMatchInlineSnapshot(`""`);
 		});
 
-		test("prints version to stdout as --json", async () => {
+		test("prints version to stdout as --json", async ({ expect }) => {
 			const result = runWrangler(
 				"versions view 10000000-0000-0000-0000-000000000000 --name test-name --json"
 			);
@@ -159,7 +161,7 @@ describe("versions view", () => {
 			writeWranglerConfig();
 		});
 
-		test("fails with no args", async () => {
+		test("fails with no args", async ({ expect }) => {
 			const result = runWrangler("versions view");
 
 			await expect(result).rejects.toMatchInlineSnapshot(
@@ -171,7 +173,7 @@ describe("versions view", () => {
 			expect(normalizeOutput(std.err)).toMatchInlineSnapshot(`""`);
 		});
 
-		test("succeeds with positional version-id arg only", async () => {
+		test("succeeds with positional version-id arg only", async ({ expect }) => {
 			const result = runWrangler(
 				"versions view 10000000-0000-0000-0000-000000000000"
 			);
@@ -205,7 +207,7 @@ describe("versions view", () => {
 			expect(normalizeOutput(std.err)).toMatchInlineSnapshot(`""`);
 		});
 
-		test("fails with non-existent version-id", async () => {
+		test("fails with non-existent version-id", async ({ expect }) => {
 			const result = runWrangler(
 				"versions view ffffffff-ffff-ffff-ffff-ffffffffffff"
 			);
@@ -219,7 +221,7 @@ describe("versions view", () => {
 			expect(normalizeOutput(std.err)).toMatchInlineSnapshot(`""`);
 		});
 
-		test("prints version to stdout as --json", async () => {
+		test("prints version to stdout as --json", async ({ expect }) => {
 			const result = runWrangler(
 				"versions view 10000000-0000-0000-0000-000000000000 --json"
 			);
@@ -280,7 +282,9 @@ describe("versions view", () => {
 	});
 
 	describe("test output", () => {
-		test("no secrets, bindings or compat info is logged if not existing", async () => {
+		test("no secrets, bindings or compat info is logged if not existing", async ({
+			expect,
+		}) => {
 			msw.use(
 				mswGetVersion({
 					id: "ce15c78b-cc43-4f60-b5a9-15ce4f298c2a",
@@ -326,7 +330,7 @@ describe("versions view", () => {
 			`);
 		});
 
-		test("compat date is logged if provided", async () => {
+		test("compat date is logged if provided", async ({ expect }) => {
 			msw.use(
 				mswGetVersion({
 					id: "ce15c78b-cc43-4f60-b5a9-15ce4f298c2a",
@@ -374,7 +378,7 @@ describe("versions view", () => {
 			`);
 		});
 
-		test("compat flag is logged if provided", async () => {
+		test("compat flag is logged if provided", async ({ expect }) => {
 			msw.use(
 				mswGetVersion({
 					id: "ce15c78b-cc43-4f60-b5a9-15ce4f298c2a",
@@ -424,7 +428,7 @@ describe("versions view", () => {
 			`);
 		});
 
-		test("secrets are logged if provided", async () => {
+		test("secrets are logged if provided", async ({ expect }) => {
 			msw.use(
 				mswGetVersion({
 					id: "ce15c78b-cc43-4f60-b5a9-15ce4f298c2a",
@@ -480,7 +484,7 @@ describe("versions view", () => {
 			`);
 		});
 
-		test("env vars are logged if provided", async () => {
+		test("env vars are logged if provided", async ({ expect }) => {
 			msw.use(
 				mswGetVersion({
 					id: "ce15c78b-cc43-4f60-b5a9-15ce4f298c2a",
@@ -533,7 +537,7 @@ describe("versions view", () => {
 			`);
 		});
 
-		test("bindings are logged if provided", async () => {
+		test("bindings are logged if provided", async ({ expect }) => {
 			msw.use(
 				mswGetVersion({
 					id: "ce15c78b-cc43-4f60-b5a9-15ce4f298c2a",


### PR DESCRIPTION
Part of https://github.com/cloudflare/workers-sdk/issues/12346

Part of a series (https://github.com/cloudflare/workers-sdk/pull/12347, https://github.com/cloudflare/workers-sdk/pull/12356, https://github.com/cloudflare/workers-sdk/pull/12373, https://github.com/cloudflare/workers-sdk/pull/12385, https://github.com/cloudflare/workers-sdk/pull/12403, #12412) handling simple refactors, one package at a time to keep the review simpler.

This PR handles bucket 3 out of 4 of the wrangler package.

Code was created by OpenNext/Opus:

## Overview

Bucket 3 migration for the `no-vitest-import-expect` ESLint rule. Migration involved converting trivial files to use `{ expect }` from test context and adding eslint-disable comments to complex files.

## All Changed Files (41 files)

### ESLint Configuration

- `packages/wrangler/eslint.config.mjs` - Added bucket 3 pattern

### `versions/` (12 files)

#### Trivial (converted to `{ expect }`)

- `deployments/deployments.list.test.ts`
- `deployments/deployments.status.test.ts`
- `deployments/deployments.view.test.ts`
- `versions.help.test.ts`
- `versions.list.test.ts`
- `versions.view.test.ts`

#### Complex (eslint-disable added)

| File | Reason |
|------|--------|
| `secrets/bulk.test.ts` | `expect` in `mockPostVersion` callback |
| `secrets/delete.test.ts` | `expect` in `mockPostVersion` callback |
| `secrets/list.test.ts` | `expect` in MSW handler callbacks |
| `secrets/put.test.ts` | `expect` in `mockPostVersion` callback |
| `versions.deploy.test.ts` | Uses `test.each` patterns |
| `versions.upload.test.ts` | `expect` in MSW handler callbacks |

### `autoconfig/` (8 files)

#### Trivial (converted to `{ expect }`)
- `get-installed-package-version.test.ts`
- `run-summary.test.ts`
- `vite-config.test.ts`
- `details/confirm-auto-config-details.test.ts`
- `details/display-auto-config-details.test.ts`

#### Complex (eslint-disable added)

| File | Reason |
|------|--------|
| `run.test.ts` | `expect` in module-scope helper function |
| `details/get-details-for-auto-config.test.ts` | `expect` in helper functions |
| `details/get-worker-name-from-project.test.ts` | `expect` in helper functions |

### `api/startDevWorker/` (5 files)

#### Trivial (converted to `{ expect }`)
- `utils.test.ts`

#### Complex (eslint-disable added)

| File | Reason |
|------|--------|
| `BundleController.test.ts` | Complex test patterns |
| `ConfigController.test.ts` | Complex test patterns |
| `LocalRuntimeController.test.ts` | Complex test patterns |
| `RemoteRuntimeController.test.ts` | Complex test patterns |

### `deploy/` (3 files)

#### Trivial (converted to `{ expect }`)
- `check-remote-secrets-override.test.ts`
- `get-config-patch.test.ts`
- `get-remote-config-diff.test.ts`

### `dev/` (2 files)

#### Trivial (converted to `{ expect }`)
- `remote-bindings.test.ts`
- `remote-bindings-errors.test.ts`

### `config/` (2 files)

#### Trivial (converted to `{ expect }`)
- `loadDotEnv.test.ts`

#### Complex (eslint-disable added)
| File | Reason |
|------|--------|
| `configuration.test.ts` | Large file with complex patterns |

### `utils/` (5 files)

#### Trivial (converted to `{ expect }`)
- `create-batches.test.ts`
- `format-message.test.ts`
- `getValidBindingName.test.ts`
- `retry.test.ts`

#### Complex (eslint-disable added)
| File | Reason |
|------|--------|
| `log-file.test.ts` | `expect` in helper functions |

### `core/` (2 files)

#### Trivial (converted to `{ expect }`)
- `command-registration.test.ts`
- `handle-errors.test.ts`

### `metrics/` (1 file)

#### Trivial (converted to `{ expect }`)

- `sanitization.test.ts`

## Summary Statistics

| Category | Count |
|----------|-------|
| **Total files changed** | 41 |
| **Trivial files migrated** | 26 |
| **Complex files (eslint-disable)** | 14 |
| **Config files** | 1 |

## ESLint Configuration

The bucket 3 pattern added to `packages/wrangler/eslint.config.mjs`:

```javascript
// Bucket 3: versions, autoconfig, api, deploy, dev, config, utils, core, metrics
{
  files: [
    "src/__tests__/{versions,autoconfig,api,deploy,dev,config,utils,core,metrics}/**/*.test.ts",
  ],
  rules: {
    "workers-sdk/no-vitest-import-expect": "error",
  },
},
```

## Verification

```bash
pnpm --filter wrangler check:lint
```

Passes with no errors related to `no-vitest-import-expect` in bucket 3 directories.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user f

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12415">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
