### PR TITLE
Revert "WC-4389 Reduce ttl to 10s for asset-worker"

### DIFF
--- a/.changeset/quiet-moose-judge.md
+++ b/.changeset/quiet-moose-judge.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+Revert reduced cache TTL. Restore 60-second TTL for KV asset fetches.

--- a/packages/workers-shared/asset-worker/src/utils/kv.ts
+++ b/packages/workers-shared/asset-worker/src/utils/kv.ts
@@ -23,11 +23,11 @@ export async function getAssetWithMetadataFromKV(
 			);
 
 			if (asset.value === null) {
-				// Don't cache a 404 for a year by re-requesting with a short cacheTtl
+				// Don't cache a 404 for a year by re-requesting with a minimum cacheTtl
 				const retriedAsset =
 					await assetsKVNamespace.getWithMetadata<AssetMetadata>(assetKey, {
 						type: "stream",
-						cacheTtl: 10,
+						cacheTtl: 60, // Minimum value allowed
 					});
 
 				if (retriedAsset.value !== null && sentry) {

--- a/packages/workers-shared/asset-worker/tests/kv.test.ts
+++ b/packages/workers-shared/asset-worker/tests/kv.test.ts
@@ -79,7 +79,7 @@ describe("[Asset Worker] Fetching assets from KV", () => {
 			expect(spy).toHaveBeenCalledTimes(2);
 		});
 
-		it("should retry on 404 with short cache ttl", async () => {
+		it("should retry on 404 and cache with shorter ttl", async () => {
 			let attempts = 0;
 			spy.mockImplementation(() => {
 				if (attempts++ === 0) {


### PR DESCRIPTION
This reverts commit 9a27dc2f8592705d10fee528b92fc606ff328c80.

Fixes WC-4456

_Describe your change..._

---

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: n/a
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: n/a

*A picture of a cute animal (not mandatory, but encouraged)*
<img width="204" height="247" alt="image" src="https://github.com/user-attachments/assets/583998f0-dd76-4630-bec8-ee554a868033" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12416">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
