### PR TITLE
[devprod-status-bot] Simplify Version Packages PR CI failure alerts

### DIFF
--- a/.changeset/simplify-version-packages-ci-alerts.md
+++ b/.changeset/simplify-version-packages-ci-alerts.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/devprod-status-bot": patch
+---
+
+Simplify Version Packages PR CI failure alerts
+
+The bot now sends an alert for any failing CI job on the Version Packages PR, instead of first fetching the required status checks from GitHub's branch protection API and filtering. This removes unnecessary complexity and ensures all CI failures are reported.


### PR DESCRIPTION
Simplify the Version Packages PR CI failure alert logic by removing the required status checks fetch from GitHub's branch protection API.

The bot now sends an alert for **any** failing CI job on the Version Packages PR, instead of first fetching the required status checks and filtering. This removes unnecessary complexity and ensures all CI failures are reported.

**Changes:**
- Removed `RequiredStatusChecksResult` type
- Removed `getRequiredStatusChecks()` function
- Removed `sendGitHubAPIFailureAlert()` function  
- Simplified the CI failure handling logic

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: This is a simplification that removes code paths; the remaining logic is straightforward
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Internal tooling change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
