### PR TITLE
[vite-plugin] Skip remote bindings e2e tests on Windows

### DIFF
--- a/packages/vite-plugin-cloudflare/e2e/remote-bindings.test.ts
+++ b/packages/vite-plugin-cloudflare/e2e/remote-bindings.test.ts
@@ -12,8 +12,17 @@ import {
 } from "./helpers.js";
 
 const commands = ["dev", "buildAndPreview"] as const;
+const isWindows = process.platform === "win32";
 
-if (!process.env.CLOUDFLARE_ACCOUNT_ID || !process.env.CLOUDFLARE_API_TOKEN) {
+// Remote bindings tests are skipped on Windows due to slow/unreliable remote proxy
+// session initialization times in CI, which causes intermittent timeout failures.
+// See: https://jira.cfdata.org/browse/DEVX-2030
+if (isWindows) {
+	describe.skip("Skipping remote bindings tests on Windows.");
+} else if (
+	!process.env.CLOUDFLARE_ACCOUNT_ID ||
+	!process.env.CLOUDFLARE_API_TOKEN
+) {
 	describe.skip("Skipping remote bindings tests without account credentials.");
 } else {
 	describe
@@ -160,55 +169,41 @@ if (!process.env.CLOUDFLARE_ACCOUNT_ID || !process.env.CLOUDFLARE_API_TOKEN) {
 		});
 	});
 
-	describe("failure to connect to remote bindings", () => {
+	describe.skipIf(isWindows)("failure to connect to remote bindings", () => {
 		const projectPath = seed("remote-bindings-incorrect-r2-config", {
 			pm: "pnpm",
 		});
 
 		describe.each(commands)('with "%s" command', (command) => {
-			// On Windows the path for the miniflare dependency gets pretty long and this fails in node < 22.7
-			// (see: https://github.com/shellscape/jsx-email/issues/225#issuecomment-2420567832), so
-			// we need to skip this on windows since in CI we're using node 20
-			// we should look into re-enable this once we can move to a node a newer version of node
-			test.skipIf(process.platform === "win32")(
-				"exit with a non zero error code and log an error",
-				async () => {
-					const proc = await runLongLived("pnpm", command, projectPath);
+			test("exit with a non zero error code and log an error", async () => {
+				const proc = await runLongLived("pnpm", command, projectPath);
 
-					expect(await proc.exitCode).not.toBe(0);
-					expect(proc.stderr).toContain(
-						"R2 bucket 'non-existent-r2-bucket' not found. Please use a different name and try again. [code: 10085]"
-					);
-					expect(proc.stderr).toContain(
-						"Error: Failed to start the remote proxy session. There is likely additional logging output above."
-					);
-				}
-			);
+				expect(await proc.exitCode).not.toBe(0);
+				expect(proc.stderr).toContain(
+					"R2 bucket 'non-existent-r2-bucket' not found. Please use a different name and try again. [code: 10085]"
+				);
+				expect(proc.stderr).toContain(
+					"Error: Failed to start the remote proxy session. There is likely additional logging output above."
+				);
+			});
 		});
 	});
 }
 
-describe("remote bindings disabled", () => {
+describe.skipIf(isWindows)("remote bindings disabled", () => {
 	const projectPath = seed("remote-bindings-disabled", { pm: "pnpm" });
 
 	describe.each(commands)('with "%s" command', (command) => {
-		// On Windows the path for the miniflare dependency gets pretty long and this fails in node < 22.7
-		// (see: https://github.com/shellscape/jsx-email/issues/225#issuecomment-2420567832), so
-		// we need to skip this on windows since in CI we're using node 20
-		// we should look into re-enable this once we can move to a node a newer version of node
-		test.skipIf(process.platform === "win32")(
-			"cannot connect to remote bindings",
-			async () => {
-				const proc = await runLongLived("pnpm", command, projectPath);
-				const url = await waitForReady(proc);
+		test("cannot connect to remote bindings", async () => {
+			const proc = await runLongLived("pnpm", command, projectPath);
+			const url = await waitForReady(proc);
 
-				const response = await fetch(url);
+			const response = await fetch(url);
 
-				const responseText = await response.text();
+			const responseText = await response.text();
 
-				expect(responseText).toContain("Error");
-				expect(responseText).toContain("Binding AI needs to be run remotely");
-			}
-		);
+			expect(responseText).toContain("Error");
+			expect(responseText).toContain("Binding AI needs to be run remotely");
+		});
 	});
 });


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-2030

## Summary

Skip all vite-plugin remote bindings e2e tests on Windows due to slow/unreliable remote proxy session initialization times in CI, which causes intermittent timeout failures during Vite dev server startup.

### Root Cause Analysis

The first Vite dev server startup with remote bindings is slower than subsequent runs because it creates a brand new `DevEnv` instance for each worker's remote proxy session. This involves:

1. **Port allocation** via `getPort()`
2. **Authentication** - `requireAuth()` and `requireApiToken()` calls
3. **Remote preview session creation** - API calls to `/accounts/{id}/workers/subdomain/edge-preview`
4. **Proxy worker upload** and waiting for readiness

On Windows CI, these operations can take longer than the 20-second `waitForReady` timeout, causing intermittent test failures.

### Changes

- Adds a Windows platform check that skips all remote bindings tests
- Removes redundant individual `test.skipIf(process.platform === "win32")` conditions
- Consolidates skip logic at the describe block level with a clear comment explaining why

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: This change only skips tests on Windows

- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Internal test change only
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
