### PR TITLE
minor changes in miniflare build scripts

### DIFF
--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -36,7 +36,7 @@
 		"check:lint": "eslint --max-warnings=0 --cache \"{src,test}/**/*.ts\" \"types/**/*.ts\"",
 		"check:type": "tsc",
 		"clean": "node -r esbuild-register ../../tools/clean/clean.ts ./dist ./dist-types",
-		"dev": "concurrently -n esbuild,typechk,typewrk -c yellow,blue,blue.dim \"node scripts/build.mjs watch\" \"node scripts/types.mjs tsconfig.json --bundle watch\" \"node scripts/types.mjs src/workers/tsconfig.json watch\"",
+		"dev": "concurrently -n esbuild,typechk,typewrk -c yellow,blue,blue.dim \"node scripts/build.mjs --watch\" \"node scripts/types.mjs tsconfig.json --bundle --watch\" \"node scripts/types.mjs src/workers/tsconfig.json --watch\"",
 		"generate:api": "pnpm generate:openapi && pnpm generate:types",
 		"generate:openapi": "node -r esbuild-register scripts/filter-openapi.ts -i $OPENAPI_INPUT_PATH",
 		"generate:types": "openapi-ts && prettier --write src/workers/local-explorer/openapi.local.json src/workers/local-explorer/generated",

--- a/packages/miniflare/scripts/build.mjs
+++ b/packages/miniflare/scripts/build.mjs
@@ -5,10 +5,10 @@
  * It does NOT handle type declarations (.d.ts) — see types.mjs for that.
  *
  * Usage:
- *   node scripts/build.mjs [watch]
+ *   node scripts/build.mjs [--watch]
  *
  * Arguments:
- *   watch   Re-build on file changes (uses esbuild's watch API).
+ *   --watch   Re-build on file changes (uses esbuild's watch API).
  *
  * What it does:
  *   1. Bundles the main entry points (src/index.ts, dev-registry worker,
@@ -39,7 +39,7 @@ import { getPackage, pkgRoot } from "./common.mjs";
 // --- CLI argument parsing ---
 
 const argv = process.argv.slice(2);
-const watch = argv[0] === "watch";
+const watch = argv[0] === "--watch";
 
 // --- Helpers ---
 

--- a/packages/miniflare/scripts/types.mjs
+++ b/packages/miniflare/scripts/types.mjs
@@ -3,24 +3,24 @@
  * single rolled-up declaration file using API Extractor.
  *
  * Usage:
- *   node scripts/types.mjs <tsconfig> [--bundle] [watch]
+ *   node scripts/types.mjs <tsconfig> [--bundle] [--watch]
  *
  * Arguments:
  *   <tsconfig>  Path to a tsconfig.json file (relative to the package root).
  *   --bundle    After emitting declarations, run API Extractor to roll up all
  *               .d.ts files into a single dist/src/index.d.ts. Only meaningful
  *               when the tsconfig emits declarations (emitDeclarationOnly).
- *   watch       Re-run on file changes (uses the TS compiler watch API).
+ *   --watch     Re-run on file changes (uses the TS compiler watch API).
  *
  * Examples:
  *   # Build: emit .d.ts to dist-types/, then bundle into dist/src/index.d.ts
  *   node scripts/types.mjs tsconfig.json --bundle
  *
  *   # Dev: emit + bundle in watch mode
- *   node scripts/types.mjs tsconfig.json --bundle watch
+ *   node scripts/types.mjs tsconfig.json --bundle --watch
  *
  *   # Dev: type-check workers in watch mode (no emit, no bundle)
- *   node scripts/types.mjs src/workers/tsconfig.json watch
+ *   node scripts/types.mjs src/workers/tsconfig.json --watch
  *
  * How it works:
  *   1. Reads the given tsconfig and creates a TypeScript program.
@@ -48,7 +48,7 @@ const configName = argv[0];
 /** When set, run API Extractor after emitting declarations. */
 const bundle = argv.includes("--bundle");
 /** When set, use the TS watch API to re-run on file changes. */
-const watch = argv.includes("watch");
+const watch = argv.includes("--watch");
 
 // --- Diagnostics formatting ---
 


### PR DESCRIPTION
There is one functional difference.

Before this PR, `types.mjs` would decide whether to bundle according to the path to the tsconfig is receives.

This is now explicit and you have to pass the `--bundle` to bundle.

All the rest is comments, mostly by OC/Claude.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: already tested
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: adding comments

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
