### PR TITLE
[wrangler] Add User-Agent header to remote dev inspector WebSocket connections

### DIFF
--- a/.changeset/user-agent-remote-dev.md
+++ b/.changeset/user-agent-remote-dev.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Add User-Agent header to remote dev inspector WebSocket connections
+
+When running `wrangler dev --remote`, the inspector WebSocket connection now includes a `User-Agent` header (`wrangler/<version>`). This resolves issues where WAF rules blocking empty User-Agent headers prevented remote dev mode from working with custom domains.

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -7,6 +7,7 @@ import { LogLevel, Miniflare, Mutex, Response } from "miniflare";
 import inspectorProxyWorkerPath from "worker:startDevWorker/InspectorProxyWorker";
 import proxyWorkerPath from "worker:startDevWorker/ProxyWorker";
 import WebSocket from "ws";
+import { version as packageVersion } from "../../../package.json";
 import {
 	logConsoleMessage,
 	maybeHandleNetworkLoadResource,
@@ -161,6 +162,7 @@ export class ProxyController extends Controller {
 				},
 				bindings: {
 					PROXY_CONTROLLER_AUTH_SECRET: this.secret,
+					WRANGLER_VERSION: packageVersion,
 				},
 
 				unsafeDirectSockets: [

--- a/packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts
@@ -309,6 +309,7 @@ export class InspectorProxyWorker implements DurableObject {
 		const upgrade = await fetch(runtimeWebSocketUrl, {
 			headers: {
 				...this.proxyData.headers,
+				"User-Agent": `wrangler/${this.env.WRANGLER_VERSION}`,
 				Upgrade: "websocket",
 			},
 			signal: this.runtimeAbortController.signal,


### PR DESCRIPTION
Fixes #4529.

When running `wrangler dev --remote`, the inspector WebSocket connection to `/cdn-cgi/workers/preview/inspector` now includes a `User-Agent` header (`wrangler/<version>`). This resolves issues where WAF rules blocking empty User-Agent headers prevented remote dev mode from working with custom domains.

#### Changes

- Pass `WRANGLER_VERSION` binding to the `InspectorProxyWorker` (the binding was already defined in the `Env` interface but wasn't being passed)
- Add `User-Agent` header to the WebSocket upgrade request in `InspectorProxyWorker.ts`

This follows the existing pattern used for tail logs WebSocket connections in `RemoteRuntimeController.ts`.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: This is a minimal change that follows existing patterns. The fix adds a header to an existing WebSocket request. Existing tests pass and manual verification would require a WAF rule setup.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is an internal implementation detail fix that doesn't change any user-facing API or behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
