### PR TITLE
[wrangler] Add debug logs for git branch detection in pages deploy

### DIFF
--- a/.changeset/add-git-debug-logs.md
+++ b/.changeset/add-git-debug-logs.md
@@ -1,0 +1,20 @@
+---
+"wrangler": patch
+---
+
+Add debug logs for git branch detection in `wrangler pages deploy` command
+
+When running `wrangler pages deploy`, the command automatically detects git information (branch, commit hash, commit message, dirty state) from the local repository. Previously, when this detection failed, there was no way to troubleshoot the issue.
+
+Now, running with `WRANGLER_LOG=debug` will output detailed information about:
+
+- Whether a git repository is detected
+- Each git command being executed and its result
+- The detected values (branch, commit hash, commit message, dirty status)
+- Any errors that occur during detection
+
+Example usage:
+
+```bash
+WRANGLER_LOG=debug wrangler pages deploy ./dist --project-name=my-project
+```

--- a/packages/wrangler/src/pages/projects.ts
+++ b/packages/wrangler/src/pages/projects.ts
@@ -138,13 +138,20 @@ export const pagesProjectCreateCommand = createCommand({
 		}
 
 		if (!productionBranch && isInteractive) {
+			logger.debug(
+				"pages project create: Detecting git repository for production branch suggestion..."
+			);
 			let isGitDir = true;
 			try {
 				execSync(`git rev-parse --is-inside-work-tree`, {
 					stdio: "ignore",
 				});
-			} catch {
+				logger.debug("pages project create: Git repository detected");
+			} catch (err) {
 				isGitDir = false;
+				logger.debug(
+					`pages project create: Not a git repository: ${err instanceof Error ? err.message : String(err)}`
+				);
 			}
 
 			if (isGitDir) {
@@ -152,7 +159,14 @@ export const pagesProjectCreateCommand = createCommand({
 					productionBranch = execSync(`git rev-parse --abbrev-ref HEAD`)
 						.toString()
 						.trim();
-				} catch {}
+					logger.debug(
+						`pages project create: Detected branch for suggestion: "${productionBranch}"`
+					);
+				} catch (err) {
+					logger.debug(
+						`pages project create: Failed to detect branch: ${err instanceof Error ? err.message : String(err)}`
+					);
+				}
 			}
 
 			productionBranch = await prompt("Enter the production branch name:", {


### PR DESCRIPTION
Fixes #3073.

When running `wrangler pages deploy`, the command automatically detects git information (branch, commit hash, commit message, dirty state) from the local repository. Previously, when this detection failed, there was no way to troubleshoot the issue.

Now, running with `WRANGLER_LOG=debug` will output detailed information about:
- Whether a git repository is detected
- Each git command being executed and its result
- The detected values (branch, commit hash, commit message, dirty status)
- Any errors that occur during detection

Example usage:
```bash
WRANGLER_LOG=debug wrangler pages deploy ./dist --project-name=my-project
```

This also adds debug logging to git detection in:
- `pages deploy` (for deployment git metadata)
- `pages deploy` (for production branch suggestion during project creation)
- `pages project create` (for production branch suggestion)

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is an internal debugging feature that users enable via environment variable, documented in the changeset.

*A picture of a cute animal (not mandatory, but encouraged)*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
