### PR TITLE
[wrangler] Add WRANGLER_COMMAND environment variable to custom build commands

### DIFF
--- a/.changeset/wrangler-command-env-var.md
+++ b/.changeset/wrangler-command-env-var.md
@@ -1,0 +1,19 @@
+---
+"wrangler": minor
+---
+
+Add `WRANGLER_COMMAND` environment variable to custom build commands
+
+When using a custom build command in `wrangler.toml`, you can now detect whether `wrangler dev` or `wrangler deploy` triggered the build by reading the `WRANGLER_COMMAND` environment variable.
+
+This variable will be set to `"dev"`, `"deploy"`, `"versions upload"`, or `"types"` depending on which command invoked the build. This allows you to customize your build process based on the deployment context.
+
+Example usage in a build script:
+
+```bash
+if [ "$WRANGLER_COMMAND" = "dev" ]; then
+  echo "Building for development..."
+else
+  echo "Building for production..."
+fi
+```

--- a/packages/wrangler/src/__tests__/custom-build.test.ts
+++ b/packages/wrangler/src/__tests__/custom-build.test.ts
@@ -1,13 +1,16 @@
 import assert from "node:assert";
 import { UserError } from "@cloudflare/workers-utils";
 import { describe, it } from "vitest";
-import { runCustomBuild } from "../deployment-bundle/run-custom-build";
+import {
+	runCommand,
+	runCustomBuild,
+} from "../deployment-bundle/run-custom-build";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";
 
 describe("Custom Builds", () => {
 	runInTempDir();
-	mockConsoleMethods();
+	const std = mockConsoleMethods();
 
 	it("runCustomBuild throws UserError when a command fails", async ({
 		expect,
@@ -27,5 +30,66 @@ describe("Custom Builds", () => {
 				`"Running custom build \`node -e \\"process.exit(1)\\"\` failed. There are likely more logs from your build command above."`
 			);
 		}
+	});
+
+	describe("WRANGLER_COMMAND environment variable", () => {
+		it("should set WRANGLER_COMMAND=dev when wranglerCommand is dev", async ({
+			expect,
+		}) => {
+			await runCommand(
+				`node -e "console.log('WRANGLER_COMMAND=' + process.env.WRANGLER_COMMAND)"`,
+				process.cwd(),
+				"[test]",
+				"dev"
+			);
+			expect(std.out).toContain("WRANGLER_COMMAND=dev");
+		});
+
+		it("should set WRANGLER_COMMAND=deploy when wranglerCommand is deploy", async ({
+			expect,
+		}) => {
+			await runCommand(
+				`node -e "console.log('WRANGLER_COMMAND=' + process.env.WRANGLER_COMMAND)"`,
+				process.cwd(),
+				"[test]",
+				"deploy"
+			);
+			expect(std.out).toContain("WRANGLER_COMMAND=deploy");
+		});
+
+		it("should set WRANGLER_COMMAND for versions upload", async ({
+			expect,
+		}) => {
+			await runCommand(
+				`node -e "console.log('WRANGLER_COMMAND=' + process.env.WRANGLER_COMMAND)"`,
+				process.cwd(),
+				"[test]",
+				"versions upload"
+			);
+			expect(std.out).toContain("WRANGLER_COMMAND=versions upload");
+		});
+
+		it("should set WRANGLER_COMMAND=types when wranglerCommand is types", async ({
+			expect,
+		}) => {
+			await runCommand(
+				`node -e "console.log('WRANGLER_COMMAND=' + process.env.WRANGLER_COMMAND)"`,
+				process.cwd(),
+				"[test]",
+				"types"
+			);
+			expect(std.out).toContain("WRANGLER_COMMAND=types");
+		});
+
+		it("should not set WRANGLER_COMMAND when wranglerCommand is undefined", async ({
+			expect,
+		}) => {
+			await runCommand(
+				`node -e "console.log('WRANGLER_COMMAND=' + (process.env.WRANGLER_COMMAND || 'undefined'))"`,
+				process.cwd(),
+				"[test]"
+			);
+			expect(std.out).toContain("WRANGLER_COMMAND=undefined");
+		});
 	});
 });

--- a/packages/wrangler/src/api/startDevWorker/BundlerController.ts
+++ b/packages/wrangler/src/api/startDevWorker/BundlerController.ts
@@ -53,7 +53,8 @@ export class BundlerController extends Controller {
 					cwd: config.build?.custom?.workingDirectory,
 					command: config.build?.custom?.command,
 				},
-				config.config
+				config.config,
+				"dev"
 			);
 			if (buildAborter.signal.aborted) {
 				return;

--- a/packages/wrangler/src/deployment-bundle/entry.ts
+++ b/packages/wrangler/src/deployment-bundle/entry.ts
@@ -125,7 +125,8 @@ export async function getEntry(
 		paths.absolutePath,
 		paths.relativePath,
 		config.build,
-		config.configPath
+		config.configPath,
+		command
 	);
 
 	const projectRoot = paths.projectRoot ?? process.cwd();


### PR DESCRIPTION
Fixes #2634.

When using a custom build command in `wrangler.toml`, users can now detect whether `wrangler dev` or `wrangler deploy` triggered the build by reading the `WRANGLER_COMMAND` environment variable.

This variable will be set to `"dev"`, `"deploy"`, `"versions upload"`, or `"types"` depending on which command invoked the build. This allows customizing the build process based on the deployment context.

Example usage in a build script:

```bash
if [ "$WRANGLER_COMMAND" = "dev" ]; then
  echo "Building for development..."
else
  echo "Building for production..."
fi
```

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/28207
  - [ ] Documentation not necessary because: The changeset includes documentation of the new feature, and a separate docs PR can be created to add this to the custom builds documentation page.

*A picture of a cute animal (not mandatory, but encouraged)*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
