### PR TITLE
[wrangler] Improve D1 database limit error message

### DIFF
--- a/.changeset/friendly-d1-limit-error.md
+++ b/.changeset/friendly-d1-limit-error.md
@@ -1,0 +1,13 @@
+---
+"wrangler": patch
+---
+
+Improve D1 database limit error message to match Cloudflare dashboard
+
+When attempting to create a D1 database after reaching your account's limit, the CLI now shows a more helpful error message with actionable guidance instead of the raw API error.
+
+The new message includes:
+
+- A clear explanation that the account limit has been reached
+- A link to D1 documentation
+- Commands to list and delete databases

--- a/packages/wrangler/src/d1/constants.ts
+++ b/packages/wrangler/src/d1/constants.ts
@@ -2,3 +2,4 @@ export const DEFAULT_MIGRATION_PATH = "./migrations";
 export const DEFAULT_MIGRATION_TABLE = "d1_migrations";
 export const LOCATION_CHOICES = ["weur", "eeur", "apac", "oc", "wnam", "enam"];
 export const JURISDICTION_CHOICES = ["eu", "fedramp"];
+export const D1_DOCS_URL = "https://developers.cloudflare.com/d1/";


### PR DESCRIPTION
Fixes #2913.

Improves the error message shown when users try to create a D1 database but have reached their account's database limit. The new message matches the user-friendly format used in the Cloudflare Dashboard and provides actionable guidance.

**Before (raw API error):**
```
✘ [ERROR] A request to the Cloudflare API (/accounts/.../d1/database) failed.

  System limit reached: databases per account (10) [code: 7406]
```

**After (user-friendly message):**
```
You have reached the maximum number of D1 databases for your account.
Please consider deleting unused databases, or visit the D1 documentation to learn more: https://developers.cloudflare.com/d1/

To list your existing databases, run: wrangler d1 list
To delete a database, run: wrangler d1 delete <database-name>
```

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is a CLI UX improvement - the error message itself provides all necessary guidance
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
