### PR TITLE
[create-cloudflare] Quarantine Qwik E2E tests (upstream eslint conflict)

### DIFF
--- a/.changeset/quarantine-qwik-tests.md
+++ b/.changeset/quarantine-qwik-tests.md
@@ -1,8 +1,0 @@
----
-"create-cloudflare": patch
----
-
-Temporarily quarantine Qwik framework E2E tests
-
-- Disable Qwik framework E2E tests (`qwik:pages` and `qwik:workers`) while an upstream ESLint dependency conflict is resolved.
-- No user-facing behavior changes in create-cloudflare; this patch is to keep CI green until the upstream fix lands.


### PR DESCRIPTION
Relates to failing CI run: https://github.com/cloudflare/workers-sdk/actions/runs/21779975611/job/62842418743?pr=12454

Background and root cause
The Qwik CLI (`create-qwik@1.19.0`) scaffolds projects with `@eslint/js` set to `"latest"` in `devDependencies`. This recently started resolving to `@eslint/js@10.0.1`, which declares `peerOptional eslint@"^10.0.0"`. Since the generated project also pins `eslint@9.32.0`, `npm install` fails with an `ERESOLVE` peer dependency conflict, causing the Qwik framework E2E tests to fail.

Updates since last revision
- Reverted the C3 Qwik template changes (no longer pinning `@eslint/js` in generated projects).
- Quarantined Qwik framework tests:
  - Added `quarantine: true` to `qwik:pages` and both `qwik:workers` entries (non-experimental and experimental) in e2e/frameworks test config.
- Removed the changeset that corresponded to the now-reverted C3 change.
- Intention: keep C3 logic unchanged and skip Qwik E2E tests until the upstream issue is fixed (e.g. Qwik stops using `"latest"` for `@eslint/js` or we adopt `eslint@^10`).

Diff summary
- e2e: Set `quarantine: true` for:
  - `qwik:pages`
  - `qwik:workers` (in both framework lists)
- Reverted template modifications in:
  - `packages/create-cloudflare/templates/qwik/pages/c3.ts`
  - `packages/create-cloudflare/templates/qwik/workers/c3.ts`
- Deleted `.changeset/fix-qwik-eslint-dep.md` (no user-facing change now)

Follow-up plan
- Track upstream resolution and re-enable Qwik tests by removing `quarantine: true`.
- If needed later, consider a separate targeted change with maintainers’ approval.

Devin PR requested by pbacondarwin@cloudflare.com  
Link to Devin run: https://app.devin.ai/sessions/cd621af804534520b84576eea09116fb

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this change only quarantines internal E2E tests and reverts a prior internal code change; no user-facing behavior or APIs changed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
