### PR TITLE
Add framework selection prompt during autoconfig

### DIFF
--- a/.changeset/friendly-icons-dance.md
+++ b/.changeset/friendly-icons-dance.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add framework selection prompt during autoconfig
+
+When running autoconfig in interactive mode, users are now prompted to confirm or change the detected framework. This allows correcting misdetected frameworks or selecting a framework when none was detected, defaulting to "Static" in that case.

--- a/packages/wrangler/src/__tests__/autoconfig/details/confirm-auto-config-details.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/confirm-auto-config-details.test.ts
@@ -1,9 +1,13 @@
 import { describe, test, vi } from "vitest";
 import { confirmAutoConfigDetails } from "../../../autoconfig/details";
+import { Astro } from "../../../autoconfig/frameworks/astro";
 import { Static } from "../../../autoconfig/frameworks/static";
-import { mockConfirm, mockPrompt } from "../../helpers/mock-dialogs";
+import {
+	mockConfirm,
+	mockPrompt,
+	mockSelect,
+} from "../../helpers/mock-dialogs";
 import { useMockIsTTY } from "../../helpers/mock-istty";
-import type { Framework } from "../../../autoconfig/frameworks";
 
 vi.mock("../../../package-manager", () => ({
 	getPackageManager() {
@@ -62,6 +66,10 @@ describe("autoconfig details - confirmAutoConfigDetails()", () => {
 				text: "What do you want to name your Worker?",
 				result: "new-name",
 			});
+			mockSelect({
+				text: "What framework is your application using?",
+				result: "static",
+			});
 			mockPrompt({
 				text: "What directory contains your applications' output/asset files?",
 				result: "./_public_",
@@ -109,6 +117,10 @@ describe("autoconfig details - confirmAutoConfigDetails()", () => {
 				text: "What do you want to name your Worker?",
 				result: "my-astro-worker",
 			});
+			mockSelect({
+				text: "What framework is your application using?",
+				result: "astro",
+			});
 			mockPrompt({
 				text: "What directory contains your applications' output/asset files?",
 				result: "",
@@ -121,16 +133,7 @@ describe("autoconfig details - confirmAutoConfigDetails()", () => {
 			const updatedAutoConfigDetails = await confirmAutoConfigDetails({
 				workerName: "my-astro-site",
 				buildCommand: "astro build",
-				framework: {
-					isConfigured: () => false,
-					id: "astro",
-					configure: () =>
-						({
-							wranglerConfig: {},
-						}) satisfies ReturnType<Framework["configure"]>,
-					name: "astro",
-					autoConfigSupported: true,
-				},
+				framework: new Astro({ id: "astro", name: "Astro" }),
 				outputDir: "<OUTPUT_DIR>",
 				projectPath: "<PROJECT_PATH>",
 				configured: false,
@@ -139,18 +142,56 @@ describe("autoconfig details - confirmAutoConfigDetails()", () => {
 				Object {
 				  "buildCommand": "npm run build",
 				  "configured": false,
-				  "framework": Object {
+				  "framework": Astro {
 				    "autoConfigSupported": true,
-				    "configure": [Function],
+				    "configurationDescription": "Configuring project for Astro with \\"astro add cloudflare\\"",
 				    "id": "astro",
-				    "isConfigured": [Function],
-				    "name": "astro",
+				    "name": "Astro",
 				  },
 				  "outputDir": "",
 				  "projectPath": "<PROJECT_PATH>",
 				  "workerName": "my-astro-worker",
 				}
 			`);
+		});
+
+		test("framework can be changed from a detected framework to another", async ({
+			expect,
+		}) => {
+			setIsTTY(true);
+
+			mockConfirm({
+				text: "Do you want to modify these settings?",
+				result: true,
+			});
+			mockPrompt({
+				text: "What do you want to name your Worker?",
+				result: "my-nuxt-worker",
+			});
+			mockSelect({
+				text: "What framework is your application using?",
+				result: "nuxt",
+			});
+			mockPrompt({
+				text: "What directory contains your applications' output/asset files?",
+				result: "./dist",
+			});
+			mockPrompt({
+				text: "What is your application's build command?",
+				result: "npm run build",
+			});
+
+			const updatedAutoConfigDetails = await confirmAutoConfigDetails({
+				workerName: "my-astro-site",
+				buildCommand: "astro build",
+				framework: new Astro({ id: "astro", name: "Astro" }),
+				outputDir: "<OUTPUT_DIR>",
+				projectPath: "<PROJECT_PATH>",
+				configured: false,
+			});
+
+			expect(updatedAutoConfigDetails.framework?.id).toBe("nuxt");
+			expect(updatedAutoConfigDetails.framework?.name).toBe("Nuxt");
 		});
 	});
 

--- a/packages/wrangler/src/__tests__/autoconfig/frameworks/get-framework.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/frameworks/get-framework.test.ts
@@ -1,0 +1,31 @@
+import { describe, it } from "vitest";
+import { getFramework } from "../../../autoconfig/frameworks/get-framework";
+
+describe("getFramework()", () => {
+	it("should return a Static framework when frameworkId is undefined", ({
+		expect,
+	}) => {
+		const framework = getFramework(undefined);
+
+		expect(framework.id).toBe("static");
+		expect(framework.name).toBe("Static");
+	});
+
+	it("should return a Static framework when frameworkId is unknown", ({
+		expect,
+	}) => {
+		const framework = getFramework("unknown-framework");
+
+		expect(framework.id).toBe("static");
+		expect(framework.name).toBe("Static");
+	});
+
+	it("should return a target framework when frameworkId is known", ({
+		expect,
+	}) => {
+		const framework = getFramework("next");
+
+		expect(framework.id).toBe("next");
+		expect(framework.name).toBe("Next.js");
+	});
+});

--- a/packages/wrangler/src/__tests__/autoconfig/run.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/run.test.ts
@@ -13,7 +13,12 @@ import * as format from "../../deployment-bundle/guess-worker-format";
 import { clearOutputFilePath } from "../../output";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import { clearDialogs, mockConfirm, mockPrompt } from "../helpers/mock-dialogs";
+import {
+	clearDialogs,
+	mockConfirm,
+	mockPrompt,
+	mockSelect,
+} from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
@@ -272,6 +277,10 @@ describe("autoconfig (deploy)", () => {
 			mockPrompt({
 				text: "What do you want to name your Worker?",
 				result: "edited-worker-name",
+			});
+			mockSelect({
+				text: "What framework is your application using?",
+				result: "static",
 			});
 			mockPrompt({
 				text: "What directory contains your applications' output/asset files?",

--- a/packages/wrangler/src/autoconfig/details.ts
+++ b/packages/wrangler/src/autoconfig/details.ts
@@ -12,11 +12,11 @@ import {
 import { Project } from "@netlify/build-info";
 import { NodeFS } from "@netlify/build-info/node";
 import { captureException } from "@sentry/node";
-import { confirm, prompt } from "../dialogs";
+import { confirm, prompt, select } from "../dialogs";
 import { logger } from "../logger";
 import { sendMetricsEvent } from "../metrics";
 import { getPackageManager } from "../package-manager";
-import { getFramework } from "./frameworks/get-framework";
+import { allKnownFrameworks, getFramework } from "./frameworks/get-framework";
 import {
 	getAutoConfigId,
 	getAutoConfigTriggerCommand,
@@ -165,7 +165,7 @@ export async function getDetailsForAutoConfig({
 
 	const detectedFramework = buildSettings.at(0);
 
-	const framework = getFramework(detectedFramework?.framework);
+	const framework = getFramework(detectedFramework?.framework?.id);
 	const packageJsonPath = resolve(projectPath, "package.json");
 
 	let packageJson: PackageJSON | undefined;
@@ -373,6 +373,30 @@ export async function confirmAutoConfigDetails(
 	});
 
 	updatedAutoConfigDetails.workerName = workerName;
+
+	const frameworkId = await select(
+		"What framework is your application using?",
+		{
+			choices: allKnownFrameworks.map((f) => ({
+				title: f.name,
+				value: f.id,
+				description:
+					f.id === "static"
+						? "No framework at all, or a static framework such as Vite, React or Gatsby."
+						: `The ${f.name} JavaScript framework`,
+			})),
+			defaultOption: allKnownFrameworks.findIndex((framework) => {
+				if (!autoConfigDetails?.framework) {
+					// If there is no framework already detected let's default to the static one
+					// (note: there should always be a framework at this point)
+					return framework.id === "static";
+				}
+				return autoConfigDetails.framework.id === framework.id;
+			}),
+		}
+	);
+
+	updatedAutoConfigDetails.framework = getFramework(frameworkId);
 
 	const outputDir = await prompt(
 		"What directory contains your applications' output/asset files?",

--- a/packages/wrangler/src/autoconfig/frameworks/get-framework.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/get-framework.ts
@@ -18,39 +18,37 @@ import type { Framework } from ".";
 export type FrameworkInfo = {
 	id: string;
 	name: string;
+	class: typeof Framework;
 };
 
-export function getFramework(detectedFramework?: FrameworkInfo): Framework {
-	switch (detectedFramework?.id) {
-		case "astro":
-			return new Astro(detectedFramework);
-		case "svelte-kit":
-			return new SvelteKit(detectedFramework);
-		case "tanstack-start":
-			return new TanstackStart(detectedFramework);
-		case "react-router":
-			return new ReactRouter(detectedFramework);
-		case "angular":
-			return new Angular(detectedFramework);
-		case "nuxt":
-			return new Nuxt(detectedFramework);
-		case "solid-start":
-			return new SolidStart(detectedFramework);
-		case "qwik":
-			return new Qwik(detectedFramework);
-		case "vite":
-			return new Vite(detectedFramework);
-		case "analog":
-			return new Analog(detectedFramework);
-		case "next":
-			return new NextJs(detectedFramework);
-		case "hono":
-			return new Hono(detectedFramework);
-		case "vike":
-			return new Vike(detectedFramework);
-		case "waku":
-			return new Waku(detectedFramework);
-		default:
-			return new Static(detectedFramework ?? { id: "static", name: "Static" });
-	}
+const staticFramework = {
+	id: "static",
+	name: "Static",
+	class: Static,
+} as const satisfies FrameworkInfo;
+
+export const allKnownFrameworks = [
+	staticFramework,
+	{ id: "analog", name: "Analog", class: Analog },
+	{ id: "angular", name: "Angular", class: Angular },
+	{ id: "astro", name: "Astro", class: Astro },
+	{ id: "hono", name: "Hono", class: Hono },
+	{ id: "next", name: "Next.js", class: NextJs },
+	{ id: "nuxt", name: "Nuxt", class: Nuxt },
+	{ id: "qwik", name: "Qwik", class: Qwik },
+	{ id: "react-router", name: "React Router", class: ReactRouter },
+	{ id: "solid-start", name: "Solid Start", class: SolidStart },
+	{ id: "svelte-kit", name: "SvelteKit", class: SvelteKit },
+	{ id: "tanstack-start", name: "TanStack Start", class: TanstackStart },
+	{ id: "vite", name: "Vite", class: Vite },
+	{ id: "vike", name: "Vike", class: Vike },
+	{ id: "waku", name: "Waku", class: Waku },
+] as const satisfies FrameworkInfo[];
+
+export function getFramework(frameworkId?: FrameworkInfo["id"]): Framework {
+	const targetedFramework = allKnownFrameworks.find(
+		(framework) => framework.id === frameworkId
+	);
+	const framework = targetedFramework ?? staticFramework;
+	return new framework.class({ id: framework.id, name: framework.name });
 }

--- a/packages/wrangler/src/autoconfig/frameworks/index.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/index.ts
@@ -31,7 +31,7 @@ export abstract class Framework {
 	readonly id: string;
 	readonly name: string;
 
-	constructor(frameworkInfo: FrameworkInfo) {
+	constructor(frameworkInfo: Pick<FrameworkInfo, "id" | "name">) {
 		this.id = frameworkInfo.id;
 		this.name = frameworkInfo.name;
 	}


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-2457

When running autoconfig in interactive mode, users are now prompted to confirm or change the detected framework. This allows correcting misdetected frameworks or selecting a framework when none was detected, defaulting to "Static" in that case.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: self-explanatory UX improvement

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
