### PR TITLE
feat: supporting importing md files in vite plugin

### DIFF
--- a/.changeset/vite-plugin-markdown-support.md
+++ b/.changeset/vite-plugin-markdown-support.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": minor
+---
+
+Add support for importing `.md` (markdown) files as Text modules. You can now `import content from './file.md'` and receive the file contents as a string, consistent with `.txt`, `.html`, and `.sql` as documented in [Non-JavaScript modules](https://developers.cloudflare.com/workers/vite-plugin/reference/non-javascript-modules/).

--- a/packages/vite-plugin-cloudflare/playground/additional-modules/__tests__/additional-modules.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/additional-modules/__tests__/additional-modules.spec.ts
@@ -27,6 +27,12 @@ test("supports Text modules with a '.sql' extension", async ({ expect }) => {
 	expect(result).toBe("SELECT * FROM users;\n");
 });
 
+test("supports Text modules with a '.md' extension", async ({ expect }) => {
+	const result = await getTextResponse("/md");
+	expect(result).toContain("# Example Markdown");
+	expect(result).toContain("**markdown**");
+});
+
 test("supports modules with `__`s in the filename", async ({ expect }) => {
 	const result = await getTextResponse("/text2");
 	expect(result).toBe("Example text content 2");

--- a/packages/vite-plugin-cloudflare/playground/additional-modules/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/additional-modules/src/index.ts
@@ -1,5 +1,6 @@
 import bin from "./modules/bin-example.bin";
 import html from "./modules/html-example.html";
+import markdown from "./modules/markdown-example.md";
 import sql from "./modules/sql-example.sql";
 import text2 from "./modules/text__example__2.txt";
 import text from "./modules/text-example.txt";
@@ -32,6 +33,11 @@ export default {
 			}
 			case "/sql": {
 				return new Response(sql);
+			}
+			case "/md": {
+				return new Response(markdown, {
+					headers: { "Content-Type": "text/markdown" },
+				});
 			}
 			case "/wasm": {
 				const instance = (await WebAssembly.instantiate(wasm)) as Instance;

--- a/packages/vite-plugin-cloudflare/playground/additional-modules/src/modules/markdown-example.md
+++ b/packages/vite-plugin-cloudflare/playground/additional-modules/src/modules/markdown-example.md
@@ -1,0 +1,3 @@
+# Example Markdown
+
+This is **markdown** content.

--- a/packages/vite-plugin-cloudflare/playground/additional-modules/src/types.d.ts
+++ b/packages/vite-plugin-cloudflare/playground/additional-modules/src/types.d.ts
@@ -13,6 +13,11 @@ declare module '*.sql' {
   export default sql
 }
 
+declare module '*.md' {
+	const markdown: string;
+	export default markdown;
+}
+
 declare module '*.wasm' {
 	const wasm: WebAssembly.Module
 	export default wasm

--- a/packages/vite-plugin-cloudflare/src/plugins/additional-modules.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/additional-modules.ts
@@ -134,7 +134,7 @@ type ModuleRules = Array<{
 const moduleRules: ModuleRules = [
 	{ type: "CompiledWasm", pattern: /\.wasm(\?module)?$/ },
 	{ type: "Data", pattern: /\.bin$/ },
-	{ type: "Text", pattern: /\.(txt|html|sql)$/ },
+	{ type: "Text", pattern: /\.(txt|html|sql|md)$/ },
 ];
 
 const moduleRuleFilters = moduleRules.map((rule) => rule.pattern);


### PR DESCRIPTION
Given we're working with LLMs a lot these days, writing in markdown files is pretty common. Currently you can only import  txt/html/sql files as strings, this PR allows you to also import markdown files.

> Note, I'm not really familiar with the codebase, so the PR has been very much LLM'd.

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

If this PR is ok, I'm happy to whack a PR up on the docs site too.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
