### PR TITLE
Use vitest#expect from the local context

### DIFF
--- a/fixtures/workers-shared-asset-config/html-handling.test.ts
+++ b/fixtures/workers-shared-asset-config/html-handling.test.ts
@@ -2,8 +2,7 @@ import Worker from "@cloudflare/workers-shared/asset-worker";
 import { normalizeConfiguration } from "@cloudflare/workers-shared/asset-worker/src/configuration";
 import { getAssetWithMetadataFromKV } from "@cloudflare/workers-shared/asset-worker/src/utils/kv";
 import { SELF } from "cloudflare:test";
-// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- complex test with .each patterns
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { encodingTestCases } from "./test-cases/encoding-test-cases";
 import { htmlHandlingTestCases } from "./test-cases/html-handling-test-cases";
 import type { AssetMetadata } from "@cloudflare/workers-shared/asset-worker/src/utils/kv";
@@ -73,9 +72,9 @@ describe.each(testSuites)("$title", ({ title, suite }) => {
 				not_found_handling: "none",
 			}));
 		});
-		it.each(cases)(
+		it.for(cases)(
 			"$title",
-			async ({ files, requestPath, matchedFile, finalPath }) => {
+			async ({ files, requestPath, matchedFile, finalPath }, { expect }) => {
 				existsMock(new Set(files));
 				const request = new IncomingRequest(BASE_URL + requestPath);
 				let response = await SELF.fetch(request);

--- a/packages/create-cloudflare/src/__tests__/validators.test.ts
+++ b/packages/create-cloudflare/src/__tests__/validators.test.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- test.each pattern
-import { describe, expect, test } from "vitest";
+import { describe, test } from "vitest";
 import {
 	isAllowedExistingFile,
 	validateProjectDirectory,
@@ -10,14 +9,14 @@ describe("validators", () => {
 	describe("validateProjectDirectory", () => {
 		let args = {};
 
-		test("allow valid project names", async () => {
+		test("allow valid project names", async ({ expect }) => {
 			expect(validateProjectDirectory("foo", args)).toBeUndefined();
 			expect(validateProjectDirectory("foo/bar/baz", args)).toBeUndefined();
 			expect(validateProjectDirectory("./foobar", args)).toBeUndefined();
 			expect(validateProjectDirectory("f".repeat(58), args)).toBeUndefined();
 		});
 
-		test("disallow invalid project names", async () => {
+		test("disallow invalid project names", async ({ expect }) => {
 			// Invalid pages project names should return an error
 			expect(validateProjectDirectory("foobar-", args)).not.toBeUndefined();
 			expect(validateProjectDirectory("-foobar-", args)).not.toBeUndefined();
@@ -27,12 +26,14 @@ describe("validators", () => {
 			).not.toBeUndefined();
 		});
 
-		test("disallow existing, non-empty directories", async () => {
+		test("disallow existing, non-empty directories", async ({ expect }) => {
 			// Existing, non-empty directories should return an error
 			expect(validateProjectDirectory(".", args)).not.toBeUndefined();
 		});
 
-		test("Relax validation when --existing-script is passed", async () => {
+		test("Relax validation when --existing-script is passed", async ({
+			expect,
+		}) => {
 			args = { existingScript: "FooBar" };
 			expect(validateProjectDirectory("foobar-", args)).toBeUndefined();
 			expect(validateProjectDirectory("FooBar", args)).toBeUndefined();
@@ -49,12 +50,12 @@ describe("validators", () => {
 			".git",
 			".DS_Store",
 		];
-		test.each(allowed)("%s", (val) => {
+		test.for(allowed)("%s", (val, { expect }) => {
 			expect(isAllowedExistingFile(val)).toBe(true);
 		});
 
 		const disallowed = ["foobar", "potato"];
-		test.each(disallowed)("%s", (val) => {
+		test.for(disallowed)("%s", (val, { expect }) => {
 			expect(isAllowedExistingFile(val)).toBe(false);
 		});
 	});
@@ -71,7 +72,7 @@ describe("validators", () => {
 			"gitlab:user/my-template",
 		];
 
-		test.each(allowed)("%s", (val) => {
+		test.for(allowed)("%s", (val, { expect }) => {
 			expect(validateTemplateUrl(val)).toBeUndefined();
 		});
 
@@ -81,7 +82,7 @@ describe("validators", () => {
 			"ftp://foo.com/user/my-template",
 		];
 
-		test.each(disallowed)("%s", (val) => {
+		test.for(disallowed)("%s", (val, { expect }) => {
 			expect(validateTemplateUrl(val)).toEqual(expect.any(String));
 		});
 	});

--- a/packages/create-cloudflare/src/frameworks/__tests__/index.test.ts
+++ b/packages/create-cloudflare/src/frameworks/__tests__/index.test.ts
@@ -1,7 +1,6 @@
 import { mockPackageManager } from "helpers/__tests__/mocks";
 import { runCommand } from "helpers/command";
-// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- test.each pattern
-import { describe, expect, test, vi } from "vitest";
+import { describe, test, vi } from "vitest";
 import { getFrameworkCli, runFrameworkGenerator } from "..";
 import { createTestContext } from "../../__tests__/helpers";
 
@@ -41,7 +40,7 @@ describe("frameworks", () => {
 			},
 		];
 
-		test.each(cases)("$pm", async ({ pm, pmCmd, env }) => {
+		test.for(cases)("$pm", async ({ pm, pmCmd, env }, { expect }) => {
 			mockPackageManager(pm);
 
 			await runFrameworkGenerator(ctx, ["-p", "my-project"]);

--- a/packages/create-cloudflare/src/helpers/__tests__/args.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/args.test.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- test.each pattern
-import { assert, describe, expect, test, vi } from "vitest";
+import { assert, describe, test, vi } from "vitest";
 import { parseArgs } from "../args";
 
 vi.mock("@cloudflare/cli");
@@ -7,7 +6,7 @@ vi.mock("yargs/helpers", () => ({ hideBin: (x: string[]) => x }));
 
 describe("Cli", () => {
 	describe("parseArgs", () => {
-		test("no arguments provide", async () => {
+		test("no arguments provide", async ({ expect }) => {
 			const result = await parseArgs([]);
 
 			assert(result.type === "default");
@@ -15,14 +14,16 @@ describe("Cli", () => {
 			expect(result.args.additionalArgs).toEqual([]);
 		});
 
-		test("parsing the first argument as the projectName", async () => {
+		test("parsing the first argument as the projectName", async ({
+			expect,
+		}) => {
 			const result = await parseArgs(["my-project"]);
 
 			assert(result.type === "default");
 			expect(result.args.projectName).toBe("my-project");
 		});
 
-		test("too many positional arguments provided", async () => {
+		test("too many positional arguments provided", async ({ expect }) => {
 			const result = await parseArgs(["my-project", "123"]);
 
 			assert(result.type === "unknown");
@@ -33,14 +34,16 @@ describe("Cli", () => {
 			);
 		});
 
-		test("not parsing first argument as the projectName if it is after --", async () => {
+		test("not parsing first argument as the projectName if it is after --", async ({
+			expect,
+		}) => {
 			const result = await parseArgs(["--", "my-project"]);
 
 			assert(result.type === "default");
 			expect(result.args.projectName).toBeFalsy();
 		});
 
-		test("parsing optional C3 arguments correctly", async () => {
+		test("parsing optional C3 arguments correctly", async ({ expect }) => {
 			const result = await parseArgs(["--framework", "angular", "--ts=true"]);
 
 			assert(result.type === "default");
@@ -50,7 +53,9 @@ describe("Cli", () => {
 			expect(result.args.additionalArgs).toEqual([]);
 		});
 
-		test("parsing positional + optional C3 arguments correctly", async () => {
+		test("parsing positional + optional C3 arguments correctly", async ({
+			expect,
+		}) => {
 			const result = await parseArgs([
 				"my-project",
 				"--framework",
@@ -68,7 +73,9 @@ describe("Cli", () => {
 			expect(result.args.additionalArgs).toEqual([]);
 		});
 
-		test("parsing optional C3 arguments + additional arguments correctly", async () => {
+		test("parsing optional C3 arguments + additional arguments correctly", async ({
+			expect,
+		}) => {
 			const result = await parseArgs([
 				"--framework",
 				"react",
@@ -90,7 +97,9 @@ describe("Cli", () => {
 			]);
 		});
 
-		test("parsing positional + optional C3 arguments + additional arguments correctly", async () => {
+		test("parsing positional + optional C3 arguments + additional arguments correctly", async ({
+			expect,
+		}) => {
 			const result = await parseArgs([
 				"my-react-project",
 				"--framework",
@@ -114,7 +123,7 @@ describe("Cli", () => {
 		});
 
 		const stringArgs = ["framework", "template", "type", "existing-script"];
-		test.each(stringArgs)("%s requires an argument", async (arg) => {
+		test.for(stringArgs)("%s requires an argument", async (arg, { expect }) => {
 			const logSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 			await expect(
 				parseArgs(["my-react-project", `--${arg}`]),
@@ -134,7 +143,9 @@ describe("Cli", () => {
 			assert(result.args.templateMode === "git");
 		});
 
-		test("template-mode correctly defaults to be undefined", async () => {
+		test("template-mode correctly defaults to be undefined", async ({
+			expect,
+		}) => {
 			const result = await parseArgs([
 				"--template",
 				"git@github.com:user/repo",

--- a/packages/create-cloudflare/src/helpers/__tests__/packageManagers.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/packageManagers.test.ts
@@ -3,8 +3,7 @@ import {
 	detectPackageManager,
 	detectPmMismatch,
 } from "helpers/packageManagers";
-// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- test.each pattern
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, test, vi } from "vitest";
 import whichPMRuns from "which-pm-runs";
 import { mockPackageManager } from "./mocks";
 import type { C3Context } from "types";
@@ -21,13 +20,13 @@ describe("Package Managers", () => {
 	describe("detectPackageManager", async () => {
 		let pm = detectPackageManager();
 
-		test("npm", () => {
+		test("npm", ({ expect }) => {
 			expect(pm.npm).toBe("npm");
 			expect(pm.npx).toBe("npx");
 			expect(pm.dlx).toEqual(["npx"]);
 		});
 
-		test("pnpm", () => {
+		test("pnpm", ({ expect }) => {
 			vi.mocked(whichPMRuns).mockReturnValue({
 				name: "pnpm",
 				version: "8.5.1",
@@ -56,7 +55,7 @@ describe("Package Managers", () => {
 			expect(pm.dlx).toEqual(["pnpx"]);
 		});
 
-		test("yarn", () => {
+		test("yarn", ({ expect }) => {
 			vi.mocked(whichPMRuns).mockReturnValue({
 				name: "yarn",
 				version: "3.5.1",
@@ -83,12 +82,12 @@ describe("Package Managers", () => {
 				mockPackageManager("pnpm");
 			});
 
-			test.each([
+			test.for([
 				["yarn.lock", true],
 				["pnpm-lock.yaml", false],
 				["bun.lock", true],
 				["bun.lockb", true],
-			])("with %s", (file, isMismatch) => {
+			] as const)("with %s", ([file, isMismatch], { expect }) => {
 				vi.mocked(existsSync).mockImplementationOnce(
 					(path) => !!(path as string).includes(file),
 				);
@@ -103,12 +102,12 @@ describe("Package Managers", () => {
 				mockPackageManager("yarn");
 			});
 
-			test.each([
+			test.for([
 				["yarn.lock", false],
 				["pnpm-lock.yaml", true],
 				["bun.lock", true],
 				["bun.lockb", true],
-			])("with %s", (file, isMismatch) => {
+			] as const)("with %s", ([file, isMismatch], { expect }) => {
 				vi.mocked(existsSync).mockImplementationOnce(
 					(path) => !!(path as string).includes(file),
 				);
@@ -123,12 +122,12 @@ describe("Package Managers", () => {
 				mockPackageManager("bun");
 			});
 
-			test.each([
+			test.for([
 				["yarn.lock", true],
 				["pnpm-lock.yaml", true],
 				["bun.lock", false],
 				["bun.lockb", false],
-			])("with %s", (file, isMismatch) => {
+			] as const)("with %s", ([file, isMismatch], { expect }) => {
 				vi.mocked(existsSync).mockImplementationOnce(
 					(path) => !!(path as string).includes(file),
 				);

--- a/packages/create-cloudflare/src/helpers/__tests__/packages.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/packages.test.ts
@@ -2,8 +2,7 @@ import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { runCommand } from "helpers/command";
 import { installPackages, installWrangler, npmInstall } from "helpers/packages";
-// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- test.each pattern
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, test, vi } from "vitest";
 import whichPMRuns from "which-pm-runs";
 import { createTestContext } from "../../__tests__/helpers";
 import * as files from "../files";
@@ -31,7 +30,7 @@ describe("Package Helpers", () => {
 	});
 
 	describe("npmInstall", () => {
-		test("npm", async () => {
+		test("npm", async ({ expect }) => {
 			await npmInstall(createTestContext());
 
 			expect(vi.mocked(runCommand)).toHaveBeenCalledWith(
@@ -40,7 +39,7 @@ describe("Package Helpers", () => {
 			);
 		});
 
-		test("pnpm", async () => {
+		test("pnpm", async ({ expect }) => {
 			mockPackageManager("pnpm", "8.5.1");
 
 			await npmInstall(createTestContext());
@@ -65,9 +64,9 @@ describe("Package Helpers", () => {
 			{ pm: "yarn", initialArgs: ["yarn", "add"] },
 		];
 
-		test.each(cases)(
+		test.for(cases)(
 			"with $pm",
-			async ({ pm, initialArgs, additionalArgs }) => {
+			async ({ pm, initialArgs, additionalArgs }, { expect }) => {
 				mockPackageManager(pm);
 				mockReadJSON.mockReturnValue({
 					["dependencies"]: {
@@ -110,9 +109,9 @@ describe("Package Helpers", () => {
 			{ pm: "yarn", initialArgs: ["yarn", "add", "-D"] },
 		];
 
-		test.each(devCases)(
+		test.for(devCases)(
 			"with $pm (dev = true)",
-			async ({ pm, initialArgs, additionalArgs }) => {
+			async ({ pm, initialArgs, additionalArgs }, { expect }) => {
 				mockPackageManager(pm);
 				mockReadJSON.mockReturnValue({
 					["devDependencies"]: {
@@ -149,7 +148,7 @@ describe("Package Helpers", () => {
 		);
 	});
 
-	test("installWrangler", async () => {
+	test("installWrangler", async ({ expect }) => {
 		mockReadJSON.mockReturnValue({
 			["devDependencies"]: {
 				wrangler: "^4.0.0",

--- a/packages/edge-preview-authenticated-proxy/tests/index.test.ts
+++ b/packages/edge-preview-authenticated-proxy/tests/index.test.ts
@@ -2,8 +2,7 @@ import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, it, vi } from "vitest";
 import { unstable_dev } from "wrangler";
 import type { Unstable_DevWorker } from "wrangler";
 
@@ -92,7 +91,7 @@ compatibility_date = "2023-01-01"
 
 	let tokenId: string | null = null;
 
-	it("should obtain token from exchange_url", async () => {
+	it("should obtain token from exchange_url", async ({ expect }) => {
 		const resp = await worker.fetch(
 			`https://preview.devprod.cloudflare.dev/exchange?exchange_url=${encodeURIComponent(
 				`http://127.0.0.1:${remote.port}/exchange`
@@ -111,7 +110,7 @@ compatibility_date = "2023-01-01"
 		`
 		);
 	});
-	it("should reject invalid exchange_url", async () => {
+	it("should reject invalid exchange_url", async ({ expect }) => {
 		vi.spyOn(console, "error").mockImplementation(() => {});
 		const resp = await worker.fetch(
 			`https://preview.devprod.cloudflare.dev/exchange?exchange_url=not_an_exchange_url`,
@@ -122,7 +121,7 @@ compatibility_date = "2023-01-01"
 			`"{"error":"Error","message":"Invalid URL"}"`
 		);
 	});
-	it("should allow tokens > 4096 bytes", async () => {
+	it("should allow tokens > 4096 bytes", async ({ expect }) => {
 		// 4096 is the size limit for cookies
 		const token = randomBytes(4096).toString("hex");
 		expect(token.length).toBe(8192);
@@ -170,7 +169,7 @@ compatibility_date = "2023-01-01"
 			headers: expect.arrayContaining([["cf-workers-preview-token", token]]),
 		});
 	});
-	it("should be redirected with cookie", async () => {
+	it("should be redirected with cookie", async ({ expect }) => {
 		const resp = await worker.fetch(
 			`https://random-data.preview.devprod.cloudflare.dev/.update-preview-token?token=TEST_TOKEN&prewarm=${encodeURIComponent(
 				`http://127.0.0.1:${remote.port}/prewarm`
@@ -194,7 +193,7 @@ compatibility_date = "2023-01-01"
 			.split(";")[0]
 			.split("=")[1];
 	});
-	it("should reject invalid prewarm url", async () => {
+	it("should reject invalid prewarm url", async ({ expect }) => {
 		vi.spyOn(console, "error").mockImplementation(() => {});
 		const resp = await worker.fetch(
 			`https://random-data.preview.devprod.cloudflare.dev/.update-preview-token?token=TEST_TOKEN&prewarm=not_a_prewarm_url&remote=${encodeURIComponent(
@@ -206,7 +205,7 @@ compatibility_date = "2023-01-01"
 			`"{"error":"Error","message":"Invalid URL"}"`
 		);
 	});
-	it("should reject invalid remote url", async () => {
+	it("should reject invalid remote url", async ({ expect }) => {
 		vi.spyOn(console, "error").mockImplementation(() => {});
 		const resp = await worker.fetch(
 			`https://random-data.preview.devprod.cloudflare.dev/.update-preview-token?token=TEST_TOKEN&prewarm=${encodeURIComponent(
@@ -219,7 +218,7 @@ compatibility_date = "2023-01-01"
 		);
 	});
 
-	it("should convert cookie to header", async () => {
+	it("should convert cookie to header", async ({ expect }) => {
 		const resp = await worker.fetch(
 			`https://random-data.preview.devprod.cloudflare.dev`,
 			{
@@ -238,7 +237,7 @@ compatibility_date = "2023-01-01"
 			]),
 		});
 	});
-	it("should not follow redirects", async () => {
+	it("should not follow redirects", async ({ expect }) => {
 		const resp = await worker.fetch(
 			`https://random-data.preview.devprod.cloudflare.dev/redirect`,
 			{
@@ -256,7 +255,7 @@ compatibility_date = "2023-01-01"
 		);
 		expect(await resp.text()).toMatchInlineSnapshot('""');
 	});
-	it("should return method", async () => {
+	it("should return method", async ({ expect }) => {
 		const resp = await worker.fetch(
 			`https://random-data.preview.devprod.cloudflare.dev/method`,
 			{
@@ -270,7 +269,7 @@ compatibility_date = "2023-01-01"
 
 		expect(await resp.text()).toMatchInlineSnapshot('"PUT"');
 	});
-	it("should return header", async () => {
+	it("should return header", async ({ expect }) => {
 		const resp = await worker.fetch(
 			`https://random-data.preview.devprod.cloudflare.dev/header`,
 			{
@@ -285,7 +284,7 @@ compatibility_date = "2023-01-01"
 
 		expect(await resp.text()).toMatchInlineSnapshot('"custom"');
 	});
-	it("should return status", async () => {
+	it("should return status", async ({ expect }) => {
 		const resp = await worker.fetch(
 			`https://random-data.preview.devprod.cloudflare.dev/status`,
 			{
@@ -384,7 +383,9 @@ compatibility_date = "2023-01-01"
 		await worker.stop();
 	});
 
-	it("should allow arbitrary headers in cross-origin requests", async () => {
+	it("should allow arbitrary headers in cross-origin requests", async ({
+		expect,
+	}) => {
 		const resp = await worker.fetch(
 			`https://0000.rawhttp.devprod.cloudflare.dev`,
 			{
@@ -399,7 +400,9 @@ compatibility_date = "2023-01-01"
 		expect(resp.headers.get("Access-Control-Allow-Headers")).toBe("foo");
 	});
 
-	it("should allow arbitrary methods in cross-origin requests", async () => {
+	it("should allow arbitrary methods in cross-origin requests", async ({
+		expect,
+	}) => {
 		const resp = await worker.fetch(
 			`https://0000.rawhttp.devprod.cloudflare.dev`,
 			{
@@ -414,7 +417,7 @@ compatibility_date = "2023-01-01"
 		expect(resp.headers.get("Access-Control-Allow-Methods")).toBe("*");
 	});
 
-	it("should preserve multiple cookies", async () => {
+	it("should preserve multiple cookies", async ({ expect }) => {
 		const token = randomBytes(4096).toString("hex");
 		const resp = await worker.fetch(
 			`https://0000.rawhttp.devprod.cloudflare.dev/cookies`,
@@ -434,7 +437,7 @@ compatibility_date = "2023-01-01"
 		);
 	});
 
-	it("should pass headers to the user-worker", async () => {
+	it("should pass headers to the user-worker", async ({ expect }) => {
 		const token = randomBytes(4096).toString("hex");
 		const resp = await worker.fetch(
 			`https://0000.rawhttp.devprod.cloudflare.dev/`,
@@ -472,7 +475,9 @@ compatibility_date = "2023-01-01"
 		`);
 	});
 
-	it("should use the method specified on the X-CF-Http-Method header", async () => {
+	it("should use the method specified on the X-CF-Http-Method header", async ({
+		expect,
+	}) => {
 		const token = randomBytes(4096).toString("hex");
 		const resp = await worker.fetch(
 			`https://0000.rawhttp.devprod.cloudflare.dev/method`,
@@ -490,9 +495,9 @@ compatibility_date = "2023-01-01"
 		expect(await resp.text()).toEqual("PUT");
 	});
 
-	it.each(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"])(
+	it.for(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"])(
 		"should support %s method specified on the X-CF-Http-Method header",
-		async (method) => {
+		async (method, { expect }) => {
 			const token = randomBytes(4096).toString("hex");
 			const resp = await worker.fetch(
 				`https://0000.rawhttp.devprod.cloudflare.dev/method`,
@@ -514,7 +519,9 @@ compatibility_date = "2023-01-01"
 		}
 	);
 
-	it("should fallback to the request method if the X-CF-Http-Method header is missing", async () => {
+	it("should fallback to the request method if the X-CF-Http-Method header is missing", async ({
+		expect,
+	}) => {
 		const token = randomBytes(4096).toString("hex");
 		const resp = await worker.fetch(
 			`https://0000.rawhttp.devprod.cloudflare.dev/method`,
@@ -531,7 +538,9 @@ compatibility_date = "2023-01-01"
 		expect(await resp.text()).toEqual("PUT");
 	});
 
-	it("should strip cf-ew-raw- prefix from headers which have it before hitting the user-worker", async () => {
+	it("should strip cf-ew-raw- prefix from headers which have it before hitting the user-worker", async ({
+		expect,
+	}) => {
 		const token = randomBytes(4096).toString("hex");
 		const resp = await worker.fetch(
 			`https://0000.rawhttp.devprod.cloudflare.dev/`,

--- a/packages/workers-shared/asset-worker/tests/handler.test.ts
+++ b/packages/workers-shared/asset-worker/tests/handler.test.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
-import { describe, expect, it, vi } from "vitest";
+import { describe, it, vi } from "vitest";
 import { mockJaegerBinding } from "../../utils/tracing";
 import { Analytics } from "../src/analytics";
 import { SEC_FETCH_MODE_NAVIGATE_HEADER_PREFERS_ASSET_SERVING } from "../src/compatibility-flags";
@@ -14,7 +13,7 @@ const mockEnv = {
 describe("[Asset Worker] `handleRequest`", () => {
 	const analytics = new Analytics();
 
-	it("attaches ETag headers to responses", async () => {
+	it("attaches ETag headers to responses", async ({ expect }) => {
 		const configuration: AssetConfig = normalizeConfiguration({
 			html_handling: "none",
 			not_found_handling: "none",
@@ -41,7 +40,9 @@ describe("[Asset Worker] `handleRequest`", () => {
 		expect(response.headers.get("ETag")).toBe(`"${eTag}"`);
 	});
 
-	it("returns 304 Not Modified responses for a valid strong ETag in If-None-Match", async () => {
+	it("returns 304 Not Modified responses for a valid strong ETag in If-None-Match", async ({
+		expect,
+	}) => {
 		const configuration: AssetConfig = normalizeConfiguration({
 			html_handling: "none",
 			not_found_handling: "none",
@@ -69,7 +70,9 @@ describe("[Asset Worker] `handleRequest`", () => {
 		expect(response.status).toBe(304);
 	});
 
-	it("returns 304 Not Modified responses for a valid weak ETag in If-None-Match", async () => {
+	it("returns 304 Not Modified responses for a valid weak ETag in If-None-Match", async ({
+		expect,
+	}) => {
 		const configuration: AssetConfig = normalizeConfiguration({
 			html_handling: "none",
 			not_found_handling: "none",
@@ -97,7 +100,9 @@ describe("[Asset Worker] `handleRequest`", () => {
 		expect(response.status).toBe(304);
 	});
 
-	it("returns 200 OK responses for an invalid ETag in If-None-Match", async () => {
+	it("returns 200 OK responses for an invalid ETag in If-None-Match", async ({
+		expect,
+	}) => {
 		const configuration: AssetConfig = normalizeConfiguration({
 			html_handling: "none",
 			not_found_handling: "none",
@@ -125,7 +130,7 @@ describe("[Asset Worker] `handleRequest`", () => {
 		expect(response.status).toBe(200);
 	});
 
-	it("cannot fetch assets outside of configured path", async () => {
+	it("cannot fetch assets outside of configured path", async ({ expect }) => {
 		const assets: Record<string, string> = {
 			"/blog/test.html": "aaaaaaaaaa",
 			"/blog/index.html": "bbbbbbbbbb",
@@ -182,7 +187,7 @@ describe("[Asset Worker] `handleRequest`", () => {
 		expect(response.status).toBe(404);
 	});
 
-	it("returns expected responses for malformed path", async () => {
+	it("returns expected responses for malformed path", async ({ expect }) => {
 		const assets: Record<string, string> = {
 			"/index.html": "aaaaaaaaaa",
 			"/%A0%A0.html": "bbbbbbbbbb",
@@ -226,7 +231,7 @@ describe("[Asset Worker] `handleRequest`", () => {
 		expect(response2.status).toBe(307);
 	});
 
-	it("attaches CF-Cache-Status headers to responses", async () => {
+	it("attaches CF-Cache-Status headers to responses", async ({ expect }) => {
 		const configuration: AssetConfig = normalizeConfiguration({
 			html_handling: "none",
 			not_found_handling: "none",
@@ -275,7 +280,7 @@ describe("[Asset Worker] `handleRequest`", () => {
 	});
 
 	describe("_headers", () => {
-		it("attaches custom headers", async () => {
+		it("attaches custom headers", async ({ expect }) => {
 			const configuration: AssetConfig = normalizeConfiguration({
 				html_handling: "none",
 				not_found_handling: "none",
@@ -548,7 +553,7 @@ describe("[Asset Worker] `handleRequest`", () => {
 	});
 
 	describe("_redirects", () => {
-		it("evaluates custom redirects", async () => {
+		it("evaluates custom redirects", async ({ expect }) => {
 			const configuration: AssetConfig = normalizeConfiguration({
 				html_handling: "none",
 				not_found_handling: "none",
@@ -1028,7 +1033,9 @@ describe("[Asset Worker] `handleRequest`", () => {
 			expect(response.status).toBe(200);
 		});
 
-		it("should prevent external redirects via double slash", async () => {
+		it("should prevent external redirects via double slash", async ({
+			expect,
+		}) => {
 			const configuration: AssetConfig = normalizeConfiguration({
 				html_handling: "none",
 				not_found_handling: "none",
@@ -1073,7 +1080,9 @@ describe("[Asset Worker] `handleRequest`", () => {
 });
 
 describe("[Asset Worker] `canFetch`", () => {
-	it('should return "true" if for exact and nearby assets with html_handling on', async () => {
+	it('should return "true" if for exact and nearby assets with html_handling on', async ({
+		expect,
+	}) => {
 		const exists = (pathname: string) => {
 			if (pathname === "/foo.html") {
 				return "some-etag";
@@ -1113,7 +1122,7 @@ describe("[Asset Worker] `canFetch`", () => {
 		).toBeTruthy();
 	});
 
-	it("should not consider 404s or SPAs", async () => {
+	it("should not consider 404s or SPAs", async ({ expect }) => {
 		const exists = (pathname: string) => {
 			if (["/404.html", "/index.html", "/foo.html"].includes(pathname)) {
 				return "some-etag";
@@ -1196,7 +1205,9 @@ describe("[Asset Worker] `canFetch`", () => {
 						has_static_routing: true,
 					});
 
-					it(`notFoundHandling=${notFoundHandling} Sec-Fetch-Mode=${headers["Sec-Fetch-Mode"]} flags=${flags}`, async () => {
+					it(`notFoundHandling=${notFoundHandling} Sec-Fetch-Mode=${headers["Sec-Fetch-Mode"]} flags=${flags}`, async ({
+						expect,
+					}) => {
 						expect(
 							await canFetch(
 								new Request("https://example.com/foo", { headers }),
@@ -1242,7 +1253,7 @@ describe("[Asset Worker] `canFetch`", () => {
 		}
 	});
 
-	it('should return "true" even for a bad method', async () => {
+	it('should return "true" even for a bad method', async ({ expect }) => {
 		const exists = (pathname: string) => {
 			if (pathname === "/foo.html") {
 				return "some-etag";
@@ -1272,7 +1283,9 @@ describe("[Asset Worker] `canFetch`", () => {
 		).toBeFalsy();
 	});
 
-	it('should return "true" for custom redirects without underlying assets', async () => {
+	it('should return "true" for custom redirects without underlying assets', async ({
+		expect,
+	}) => {
 		const exists = (pathname: string) => {
 			if (["/404.html", "/does-exist"].includes(pathname)) {
 				return "some-etag";
@@ -1468,16 +1481,19 @@ describe("[Asset Worker] `canFetch`", () => {
 			}
 		}
 
-		it.each(matrix)(
+		it.for(matrix)(
 			"compatibility_date $compatibilityDate, compatibility_flags $compatibilityFlags, not_found_handling $notFoundHandling, headers: $headers, hasStaticRouting $hasStaticRouting -> $expected",
-			async ({
-				compatibilityDate,
-				compatibilityFlags,
-				notFoundHandling,
-				headers,
-				hasStaticRouting,
-				expected,
-			}) => {
+			async (
+				{
+					compatibilityDate,
+					compatibilityFlags,
+					notFoundHandling,
+					headers,
+					hasStaticRouting,
+					expected,
+				},
+				{ expect }
+			) => {
 				expect(
 					await canFetch(
 						new Request("https://example.com/foo", { headers }),

--- a/packages/workers-shared/router-worker/tests/index.test.ts
+++ b/packages/workers-shared/router-worker/tests/index.test.ts
@@ -1,11 +1,12 @@
 import { createExecutionContext } from "cloudflare:test";
-// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import worker from "../src/worker";
 import type { Env } from "../src/worker";
 
 describe("unit tests", async () => {
-	it("fails if specify running user worker ahead of assets, without user worker", async () => {
+	it("fails if specify running user worker ahead of assets, without user worker", async ({
+		expect,
+	}) => {
 		const request = new Request("https://example.com");
 		const ctx = createExecutionContext();
 
@@ -23,7 +24,9 @@ describe("unit tests", async () => {
 		);
 	});
 
-	it("it returns fetch from user worker when invoke_user_worker_ahead_of_assets true", async () => {
+	it("it returns fetch from user worker when invoke_user_worker_ahead_of_assets true", async ({
+		expect,
+	}) => {
 		const request = new Request("https://example.com");
 		const ctx = createExecutionContext();
 
@@ -51,7 +54,9 @@ describe("unit tests", async () => {
 		expect(await response.text()).toEqual("hello from user worker");
 	});
 
-	it("it returns fetch from asset worker when matching existing asset path", async () => {
+	it("it returns fetch from asset worker when matching existing asset path", async ({
+		expect,
+	}) => {
 		const request = new Request("https://example.com");
 		const ctx = createExecutionContext();
 
@@ -74,7 +79,9 @@ describe("unit tests", async () => {
 		expect(await response.text()).toEqual("hello from asset worker");
 	});
 
-	it("it returns fetch from asset worker when matching existing asset path and invoke_user_worker_ahead_of_assets is not provided", async () => {
+	it("it returns fetch from asset worker when matching existing asset path and invoke_user_worker_ahead_of_assets is not provided", async ({
+		expect,
+	}) => {
 		const request = new Request("https://example.com");
 		const ctx = createExecutionContext();
 
@@ -96,7 +103,9 @@ describe("unit tests", async () => {
 		expect(await response.text()).toEqual("hello from asset worker");
 	});
 
-	it("it returns fetch from user worker when static_routing user_worker rule matches", async () => {
+	it("it returns fetch from user worker when static_routing user_worker rule matches", async ({
+		expect,
+	}) => {
 		const request = new Request("https://example.com/api/includeme");
 		const ctx = createExecutionContext();
 
@@ -126,7 +135,9 @@ describe("unit tests", async () => {
 		expect(await response.text()).toEqual("hello from user worker");
 	});
 
-	it("it returns fetch from asset worker when static_routing asset_worker rule matches", async () => {
+	it("it returns fetch from asset worker when static_routing asset_worker rule matches", async ({
+		expect,
+	}) => {
 		const request = new Request("https://example.com/api/excludeme");
 		const ctx = createExecutionContext();
 
@@ -157,7 +168,9 @@ describe("unit tests", async () => {
 		expect(await response.text()).toEqual("hello from asset worker");
 	});
 
-	it("it returns fetch from asset worker when static_routing asset_worker and user_worker rule matches", async () => {
+	it("it returns fetch from asset worker when static_routing asset_worker and user_worker rule matches", async ({
+		expect,
+	}) => {
 		const request = new Request("https://example.com/api/excludeme");
 		const ctx = createExecutionContext();
 
@@ -188,7 +201,9 @@ describe("unit tests", async () => {
 		expect(await response.text()).toEqual("hello from asset worker");
 	});
 
-	it("it returns fetch from asset worker when no static_routing rule matches but asset exists", async () => {
+	it("it returns fetch from asset worker when no static_routing rule matches but asset exists", async ({
+		expect,
+	}) => {
 		const request = new Request("https://example.com/someasset");
 		const ctx = createExecutionContext();
 
@@ -218,7 +233,9 @@ describe("unit tests", async () => {
 		expect(await response.text()).toEqual("hello from asset worker");
 	});
 
-	it("it returns fetch from user worker when no static_routing rule matches and no asset exists", async () => {
+	it("it returns fetch from user worker when no static_routing rule matches and no asset exists", async ({
+		expect,
+	}) => {
 		const request = new Request("https://example.com/somemissingasset");
 		const ctx = createExecutionContext();
 
@@ -251,7 +268,9 @@ describe("unit tests", async () => {
 	describe.each(["/some/subpath/", "/"])(
 		"blocking /_next/image requests hosted at %s with remote URLs",
 		(subpath) => {
-			it("blocks /_next/image requests with remote URLs when not fetched as image", async () => {
+			it("blocks /_next/image requests with remote URLs when not fetched as image", async ({
+				expect,
+			}) => {
 				const request = new Request(
 					`https://example.com${subpath}_next/image?url=https://evil.com/ssrf`
 				);
@@ -287,7 +306,7 @@ describe("unit tests", async () => {
 				}
 			});
 
-			it.each([
+			it.for([
 				{
 					description:
 						"allows /_next/image requests with remote URLs when fetched as image",
@@ -376,13 +395,10 @@ describe("unit tests", async () => {
 				},
 			])(
 				"$description",
-				async ({
-					url,
-					headers,
-					userWorkerResponse,
-					expectedStatus,
-					expectedBody,
-				}) => {
+				async (
+					{ url, headers, userWorkerResponse, expectedStatus, expectedBody },
+					{ expect }
+				) => {
 					const request = new Request(url, { headers });
 					const ctx = createExecutionContext();
 
@@ -412,7 +428,9 @@ describe("unit tests", async () => {
 	);
 
 	describe("blocking /_image requests with protocol relative URLs as the image source", () => {
-		it("blocks protocol relative URLs with a different hostname when not fetched as an image", async () => {
+		it("blocks protocol relative URLs with a different hostname when not fetched as an image", async ({
+			expect,
+		}) => {
 			const request = new Request(
 				"https://example.com/_image?href=//evil.com/ssrf"
 			);
@@ -436,7 +454,7 @@ describe("unit tests", async () => {
 			expect(await response.text()).toBe("Blocked");
 		});
 
-		it.each([
+		it.for([
 			{
 				description: "allows protocol relative URLs with the same hostname",
 				url: "https://example.com/_image?href=//example.com/image.jpg",
@@ -463,13 +481,10 @@ describe("unit tests", async () => {
 			},
 		])(
 			"$description",
-			async ({
-				url,
-				headers,
-				userWorkerResponse,
-				expectedStatus,
-				expectedBody,
-			}) => {
+			async (
+				{ url, headers, userWorkerResponse, expectedStatus, expectedBody },
+				{ expect }
+			) => {
 				const request = new Request(url, { headers });
 				const env = {
 					CONFIG: {
@@ -495,7 +510,7 @@ describe("unit tests", async () => {
 	});
 
 	describe("free tier limiting", () => {
-		it("returns fetch from asset worker for assets", async () => {
+		it("returns fetch from asset worker for assets", async ({ expect }) => {
 			const request = new Request("https://example.com/asset");
 			const ctx = createExecutionContext();
 
@@ -523,7 +538,9 @@ describe("unit tests", async () => {
 			expect(await response.text()).toEqual("hello from asset worker");
 		});
 
-		it("returns error page instead of user worker when no asset found", async () => {
+		it("returns error page instead of user worker when no asset found", async ({
+			expect,
+		}) => {
 			const request = new Request("https://example.com/asset");
 			const ctx = createExecutionContext();
 
@@ -554,7 +571,9 @@ describe("unit tests", async () => {
 			expect(text).toContain("This website has been temporarily rate limited");
 		});
 
-		it("returns error page instead of user worker for invoke_user_worker_ahead_of_assets", async () => {
+		it("returns error page instead of user worker for invoke_user_worker_ahead_of_assets", async ({
+			expect,
+		}) => {
 			const request = new Request("https://example.com/asset");
 			const ctx = createExecutionContext();
 
@@ -586,7 +605,9 @@ describe("unit tests", async () => {
 			expect(text).toContain("This website has been temporarily rate limited");
 		});
 
-		it("returns error page instead of user worker for user_worker rules", async () => {
+		it("returns error page instead of user worker for user_worker rules", async ({
+			expect,
+		}) => {
 			const request = new Request("https://example.com/api/asset");
 			const ctx = createExecutionContext();
 
@@ -620,7 +641,9 @@ describe("unit tests", async () => {
 			expect(text).toContain("This website has been temporarily rate limited");
 		});
 
-		it("returns fetch from asset worker for asset_worker rules", async () => {
+		it("returns fetch from asset worker for asset_worker rules", async ({
+			expect,
+		}) => {
 			const request = new Request("https://example.com/api/asset");
 			const ctx = createExecutionContext();
 

--- a/packages/workers-utils/tests/config/findWranglerConfig.test.ts
+++ b/packages/workers-utils/tests/config/findWranglerConfig.test.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
-// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import { findWranglerConfig } from "../../src/config/config-helpers";
 import {
 	mockConsoleMethods,
@@ -15,9 +14,9 @@ describe("config findWranglerConfig()", () => {
 	const NO_LOGS = { debug: "", err: "", info: "", out: "", warn: "" };
 
 	describe("(useRedirectIfAvailable: false)", () => {
-		it.each(["toml", "json", "jsonc"])(
+		it.for(["toml", "json", "jsonc"])(
 			"should find the nearest wrangler.%s to the reference directory",
-			async (ext) => {
+			async (ext, { expect }) => {
 				await seed({
 					[`wrangler.${ext}`]: "DUMMY",
 					[`foo/wrangler.${ext}`]: "DUMMY",
@@ -53,7 +52,7 @@ describe("config findWranglerConfig()", () => {
 			["json", "toml"],
 			["jsonc", "toml"],
 		])("should prefer the wrangler.%s over wrangler.%s", (ext1, ext2) => {
-			it("in the same directory", async () => {
+			it("in the same directory", async ({ expect }) => {
 				await seed({
 					[`wrangler.${ext1}`]: "DUMMY",
 					[`wrangler.${ext2}`]: "DUMMY",
@@ -66,7 +65,7 @@ describe("config findWranglerConfig()", () => {
 				expect(std).toMatchObject(NO_LOGS);
 			});
 
-			it("in different directories", async () => {
+			it("in different directories", async ({ expect }) => {
 				await seed({
 					[`wrangler.${ext1}`]: "DUMMY",
 					[`foo/wrangler.${ext2}`]: "DUMMY",
@@ -80,7 +79,9 @@ describe("config findWranglerConfig()", () => {
 			});
 		});
 
-		it("should return user config path even if a deploy config is found", async () => {
+		it("should return user config path even if a deploy config is found", async ({
+			expect,
+		}) => {
 			await seed({
 				[`wrangler.toml`]: "DUMMY",
 				[".wrangler/deploy/config.json"]: `{"configPath": "../../dist/wrangler.json" }`,
@@ -96,7 +97,9 @@ describe("config findWranglerConfig()", () => {
 	});
 
 	describe("(useRedirectIfAvailable: true)", () => {
-		it("should return redirected config path if no user config and a deploy config is found", async () => {
+		it("should return redirected config path if no user config and a deploy config is found", async ({
+			expect,
+		}) => {
 			await seed({
 				[".wrangler/deploy/config.json"]: `{"configPath": "../../dist/wrangler.json" }`,
 				[`dist/wrangler.json`]: "DUMMY",
@@ -119,7 +122,9 @@ describe("config findWranglerConfig()", () => {
 			expect(std).toMatchObject(NO_LOGS);
 		});
 
-		it("should return redirected config path if matching user config and a deploy config is found", async () => {
+		it("should return redirected config path if matching user config and a deploy config is found", async ({
+			expect,
+		}) => {
 			await seed({
 				[`wrangler.toml`]: "DUMMY",
 				[".wrangler/deploy/config.json"]: `{"configPath": "../../dist/wrangler.json" }`,
@@ -145,7 +150,9 @@ describe("config findWranglerConfig()", () => {
 			expect(std).toMatchObject(NO_LOGS);
 		});
 
-		it("should error if deploy config is not valid JSON", async () => {
+		it("should error if deploy config is not valid JSON", async ({
+			expect,
+		}) => {
 			await seed({
 				[".wrangler/deploy/config.json"]: `INVALID JSON`,
 			});
@@ -163,7 +170,9 @@ describe("config findWranglerConfig()", () => {
 			expect(std).toMatchObject(NO_LOGS);
 		});
 
-		it("should error if deploy config does not contain a `configPath` property", async () => {
+		it("should error if deploy config does not contain a `configPath` property", async ({
+			expect,
+		}) => {
 			await seed({
 				[".wrangler/deploy/config.json"]: `{}`,
 			});
@@ -186,7 +195,9 @@ describe("config findWranglerConfig()", () => {
 			expect(std).toMatchObject(NO_LOGS);
 		});
 
-		it("should error if redirected config file does not exist", async () => {
+		it("should error if redirected config file does not exist", async ({
+			expect,
+		}) => {
 			await seed({
 				[".wrangler/deploy/config.json"]: `{ "configPath": "missing/wrangler.json" }`,
 			});
@@ -205,7 +216,9 @@ describe("config findWranglerConfig()", () => {
 			expect(std).toMatchObject(NO_LOGS);
 		});
 
-		it("should error if deploy config file and user config file do not have the same base path", async () => {
+		it("should error if deploy config file and user config file do not have the same base path", async ({
+			expect,
+		}) => {
 			await seed({
 				[`foo/wrangler.toml`]: "DUMMY",
 				["foo/bar/.wrangler/deploy/config.json"]: `{ "configPath": "../../dist/wrangler.json" }`,

--- a/packages/workers-utils/tests/config/patch-config.test.ts
+++ b/packages/workers-utils/tests/config/patch-config.test.ts
@@ -1,8 +1,7 @@
 import { writeFileSync } from "node:fs";
 import { experimental_patchConfig } from "@cloudflare/workers-utils";
 import dedent from "ts-dedent";
-// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import { runInTempDir, writeWranglerConfig } from "../../src/test-helpers";
 import type { RawConfig } from "@cloudflare/workers-utils";
 
@@ -491,7 +490,7 @@ describe("experimental_patchConfig()", () => {
 				expectedJson,
 				expectedToml,
 			}) => {
-				it.each(["json", "toml"])("%s", (configType) => {
+				it.for(["json", "toml"])("%s", (configType, { expect }) => {
 					writeWranglerConfig(
 						original,
 						configType === "json" ? "./wrangler.json" : "./wrangler.toml"
@@ -513,7 +512,7 @@ describe("experimental_patchConfig()", () => {
 		describe.each(replacingOnlyTestCases)(
 			`$name`,
 			({ original, replacingPatch, expectedJson, expectedToml }) => {
-				it.each(["json", "toml"])("%s", (configType) => {
+				it.for(["json", "toml"])("%s", (configType, { expect }) => {
 					writeWranglerConfig(
 						original,
 						configType === "json" ? "./wrangler.json" : "./wrangler.toml"
@@ -534,7 +533,7 @@ describe("experimental_patchConfig()", () => {
 
 	describe("jsonc", () => {
 		describe("add multiple bindings", () => {
-			it("isArrayInsertion = true", () => {
+			it("isArrayInsertion = true", ({ expect }) => {
 				const jsonc = `
 				{
 					// a comment
@@ -605,7 +604,7 @@ describe("experimental_patchConfig()", () => {
 					}"
 				`);
 			});
-			it("isArrayInsertion = false ", () => {
+			it("isArrayInsertion = false ", ({ expect }) => {
 				const jsonc = dedent`
 		{
 			// a comment
@@ -688,7 +687,7 @@ describe("experimental_patchConfig()", () => {
 			});
 		});
 
-		it("should not error if a `null` is passed in", () => {
+		it("should not error if a `null` is passed in", ({ expect }) => {
 			const jsonc = `
 				{
 					"compatibility_date": "2022-01-12",
@@ -717,7 +716,7 @@ describe("experimental_patchConfig()", () => {
 		});
 
 		describe("edit existing bindings", () => {
-			it("isArrayInsertion = false", () => {
+			it("isArrayInsertion = false", ({ expect }) => {
 				const jsonc = `
 				{
 					// comment one
@@ -782,7 +781,7 @@ describe("experimental_patchConfig()", () => {
 		});
 
 		describe("edit existing bindings with patch array in a different order (will mess up comments)", () => {
-			it("isArrayInsertion = false", () => {
+			it("isArrayInsertion = false", ({ expect }) => {
 				const jsonc = `
 				{
 					// comment one
@@ -849,7 +848,7 @@ describe("experimental_patchConfig()", () => {
 		});
 
 		describe("delete existing bindings (cannot preserve comments)", () => {
-			it("isArrayInsertion = false", () => {
+			it("isArrayInsertion = false", ({ expect }) => {
 				const jsonc = `
 				{
 					// comment one

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
 import TOML from "smol-toml";
-// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
-import { describe, expect, it, test, vi } from "vitest";
+import { describe, it, test, vi } from "vitest";
 import { normalizeAndValidateConfig } from "../../../src/config/validation";
 import { normalizeString } from "../../../src/test-helpers";
 import type {
@@ -14,7 +13,7 @@ import type {
 import type { RedirectedRawConfig } from "../../../src/config/config";
 
 describe("normalizeAndValidateConfig()", () => {
-	it("should use defaults for empty configuration", () => {
+	it("should use defaults for empty configuration", ({ expect }) => {
 		const { config, diagnostics } = normalizeAndValidateConfig(
 			{},
 			undefined,
@@ -135,7 +134,7 @@ describe("normalizeAndValidateConfig()", () => {
 	});
 
 	describe("top-level non-environment configuration", () => {
-		it("should override config defaults with provided values", () => {
+		it("should override config defaults with provided values", ({ expect }) => {
 			const expectedConfig: Partial<ConfigFields<RawDevConfig>> = {
 				legacy_env: true,
 				send_metrics: false,
@@ -161,7 +160,7 @@ describe("normalizeAndValidateConfig()", () => {
 			expect(diagnostics.hasWarnings()).toBe(false);
 		});
 
-		it("should error on invalid top level fields", () => {
+		it("should error on invalid top level fields", ({ expect }) => {
 			const expectedConfig = {
 				legacy_env: "FOO",
 				send_metrics: "BAD",
@@ -204,7 +203,9 @@ describe("normalizeAndValidateConfig()", () => {
 			`);
 		});
 
-		it("should warn on and remove unexpected top level fields", () => {
+		it("should warn on and remove unexpected top level fields", ({
+			expect,
+		}) => {
 			const expectedConfig = {
 				unexpected: {
 					subkey: "some-value",
@@ -227,7 +228,9 @@ describe("normalizeAndValidateConfig()", () => {
 			`);
 		});
 
-		it("should report a deprecation warning if `miniflare` appears at the top level", () => {
+		it("should report a deprecation warning if `miniflare` appears at the top level", ({
+			expect,
+		}) => {
 			const expectedConfig = {
 				miniflare: {
 					host: "localhost",
@@ -250,7 +253,7 @@ describe("normalizeAndValidateConfig()", () => {
 			`);
 		});
 
-		it("should normalise a blank route value to be undefined", () => {
+		it("should normalise a blank route value to be undefined", ({ expect }) => {
 			const expectedConfig = {
 				route: "",
 			};
@@ -273,7 +276,9 @@ describe("normalizeAndValidateConfig()", () => {
 			`);
 		});
 
-		it("should normalise a blank account_id value to be undefined", () => {
+		it("should normalise a blank account_id value to be undefined", ({
+			expect,
+		}) => {
 			const expectedConfig = {
 				account_id: "",
 			};
@@ -297,7 +302,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("compatibility_date", () => {
-			it("should allow valid values", () => {
+			it("should allow valid values", ({ expect }) => {
 				const expectedConfig: RawConfig = {
 					compatibility_date: "2024-10-01",
 				};
@@ -315,7 +320,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
-			it("should error for en-dashes", () => {
+			it("should error for en-dashes", ({ expect }) => {
 				const expectedConfig: RawConfig = {
 					compatibility_date: "2024–10–01", // en-dash
 				};
@@ -340,7 +345,7 @@ describe("normalizeAndValidateConfig()", () => {
 					`);
 			});
 
-			it("should error for em-dashes", () => {
+			it("should error for em-dashes", ({ expect }) => {
 				const expectedConfig = {
 					compatibility_date: "2024—10—01", // em-dash
 				};
@@ -365,7 +370,7 @@ describe("normalizeAndValidateConfig()", () => {
 					`);
 			});
 
-			it("should error for invalid date values", () => {
+			it("should error for invalid date values", ({ expect }) => {
 				const expectedConfig: RawConfig = {
 					compatibility_date: "abc",
 				};
@@ -388,7 +393,9 @@ describe("normalizeAndValidateConfig()", () => {
 					`);
 			});
 
-			it("should error for dates that are both invalid and include en/em dashes", () => {
+			it("should error for dates that are both invalid and include en/em dashes", ({
+				expect,
+			}) => {
 				const expectedConfig = {
 					compatibility_date: "2024—100—01", // invalid date + em-dash
 				};
@@ -416,7 +423,9 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[site]", () => {
-			it("should override `site` config defaults with provided values", () => {
+			it("should override `site` config defaults with provided values", ({
+				expect,
+			}) => {
 				const expectedConfig: RawConfig = {
 					site: {
 						bucket: "BUCKET",
@@ -449,7 +458,7 @@ describe("normalizeAndValidateConfig()", () => {
 					`);
 			});
 
-			it("should error if `site` config is missing `bucket`", () => {
+			it("should error if `site` config is missing `bucket`", ({ expect }) => {
 				const expectedConfig: RawConfig = {
 					// @ts-expect-error we're intentionally passing an invalid configuration here
 					site: {
@@ -487,7 +496,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error on invalid `site` values", () => {
+			it("should error on invalid `site` values", ({ expect }) => {
 				const expectedConfig = {
 					site: {
 						bucket: "BUCKET",
@@ -527,7 +536,9 @@ describe("normalizeAndValidateConfig()", () => {
 					`);
 			});
 
-			it("should log a deprecation warning if entry-point is defined", async () => {
+			it("should log a deprecation warning if entry-point is defined", async ({
+				expect,
+			}) => {
 				const { config, diagnostics } = normalizeAndValidateConfig(
 					{
 						site: {
@@ -565,7 +576,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[alias]", () => {
-			it("errors with a non-object", () => {
+			it("errors with a non-object", ({ expect }) => {
 				const { config: _config, diagnostics } = normalizeAndValidateConfig(
 					{
 						alias: "some silly string",
@@ -585,7 +596,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("errors with non string values", () => {
+			it("errors with non string values", ({ expect }) => {
 				const { config: _config, diagnostics } = normalizeAndValidateConfig(
 					{
 						alias: {
@@ -607,7 +618,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("returns the alias config when valid", () => {
+			it("returns the alias config when valid", ({ expect }) => {
 				const { config, diagnostics } = normalizeAndValidateConfig(
 					{
 						alias: {
@@ -631,7 +642,9 @@ describe("normalizeAndValidateConfig()", () => {
 			});
 		});
 
-		it("should map `wasm_module` paths from relative to the config path to relative to the cwd", () => {
+		it("should map `wasm_module` paths from relative to the config path to relative to the cwd", ({
+			expect,
+		}) => {
 			const expectedConfig: RawConfig = {
 				wasm_modules: {
 					MODULE_1: "path/to/module_1.mjs",
@@ -659,7 +672,7 @@ describe("normalizeAndValidateConfig()", () => {
 			expect(diagnostics.hasWarnings()).toBe(false);
 		});
 
-		it("should warn on unexpected fields on `triggers`", async () => {
+		it("should warn on unexpected fields on `triggers`", async ({ expect }) => {
 			const expectedConfig: RawConfig = {
 				triggers: {
 					crons: ["1 * * * *"],
@@ -694,7 +707,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 		});
 
-		it("should error on invalid `wasm_modules` paths", () => {
+		it("should error on invalid `wasm_modules` paths", ({ expect }) => {
 			const expectedConfig = {
 				wasm_modules: {
 					MODULE_1: 111,
@@ -722,7 +735,9 @@ describe("normalizeAndValidateConfig()", () => {
 			`);
 		});
 
-		it("should map `text_blobs` paths from relative to the config path to relative to the cwd", () => {
+		it("should map `text_blobs` paths from relative to the config path to relative to the cwd", ({
+			expect,
+		}) => {
 			const expectedConfig: RawConfig = {
 				text_blobs: {
 					BLOB_1: "path/to/text1.txt",
@@ -749,7 +764,7 @@ describe("normalizeAndValidateConfig()", () => {
 			expect(diagnostics.hasWarnings()).toBe(false);
 		});
 
-		it("should error on invalid `text_blob` paths", () => {
+		it("should error on invalid `text_blob` paths", ({ expect }) => {
 			const expectedConfig = {
 				text_blobs: {
 					MODULE_1: 111,
@@ -777,7 +792,9 @@ describe("normalizeAndValidateConfig()", () => {
 			`);
 		});
 
-		it("should map `data_blobs` paths from relative to the config path to relative to the cwd", () => {
+		it("should map `data_blobs` paths from relative to the config path to relative to the cwd", ({
+			expect,
+		}) => {
 			const expectedConfig: RawConfig = {
 				data_blobs: {
 					BLOB_1: "path/to/data1.bin",
@@ -804,7 +821,7 @@ describe("normalizeAndValidateConfig()", () => {
 			expect(diagnostics.hasWarnings()).toBe(false);
 		});
 
-		it("should error on invalid `data_blob` paths", () => {
+		it("should error on invalid `data_blob` paths", ({ expect }) => {
 			const expectedConfig = {
 				data_blobs: {
 					MODULE_1: 111,
@@ -832,7 +849,9 @@ describe("normalizeAndValidateConfig()", () => {
 			`);
 		});
 
-		it("should resolve tsconfig relative to wrangler.toml", async () => {
+		it("should resolve tsconfig relative to wrangler.toml", async ({
+			expect,
+		}) => {
 			const expectedConfig: RawEnvironment = {
 				tsconfig: "path/to/some-tsconfig.json",
 			};
@@ -854,7 +873,7 @@ describe("normalizeAndValidateConfig()", () => {
 			expect(diagnostics.hasWarnings()).toBe(false);
 		});
 
-		it("should warn on unsafe binding metadata usage", () => {
+		it("should warn on unsafe binding metadata usage", ({ expect }) => {
 			const expectedConfig: RawConfig = {
 				unsafe: {
 					bindings: [
@@ -899,7 +918,7 @@ describe("normalizeAndValidateConfig()", () => {
 	});
 
 	describe("top-level environment configuration", () => {
-		it("should override config defaults with provided values", () => {
+		it("should override config defaults with provided values", ({ expect }) => {
 			const main = "src/index.ts";
 			const resolvedMain = path.resolve(process.cwd(), main);
 
@@ -1064,7 +1083,7 @@ describe("normalizeAndValidateConfig()", () => {
 			`);
 		});
 
-		it("should error on invalid environment values", () => {
+		it("should error on invalid environment values", ({ expect }) => {
 			const expectedConfig: RawEnvironment = {
 				name: 111,
 				account_id: 222,
@@ -1217,7 +1236,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("name", () => {
-			it("should error on invalid `name` value with spaces", () => {
+			it("should error on invalid `name` value with spaces", ({ expect }) => {
 				const expectedConfig: RawEnvironment = {
 					name: "this has spaces",
 				} as unknown as RawEnvironment;
@@ -1238,7 +1257,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should be valid `name` with underscores", () => {
+			it("should be valid `name` with underscores", ({ expect }) => {
 				const expectedConfig: RawEnvironment = {
 					name: "enterprise_nx_01",
 				} as unknown as RawEnvironment;
@@ -1255,7 +1274,9 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
-			it("should error on invalid `name` value with special characters", () => {
+			it("should error on invalid `name` value with special characters", ({
+				expect,
+			}) => {
 				const expectedConfig: RawEnvironment = {
 					name: "Thy'lek-Shran",
 				} as unknown as RawEnvironment;
@@ -1275,7 +1296,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error on invalid `name` value with only special characters", () => {
+			it("should error on invalid `name` value with only special characters", ({
+				expect,
+			}) => {
 				const expectedConfig: RawEnvironment = {
 					name: "!@#$%^&*(()",
 				} as unknown as RawEnvironment;
@@ -1295,7 +1318,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should accept any Worker name if the dispatch-namespace flag is used", () => {
+			it("should accept any Worker name if the dispatch-namespace flag is used", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						name: "example.com",
@@ -1311,7 +1336,9 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[build]", () => {
-			it("should default custom build watch directories to src", () => {
+			it("should default custom build watch directories to src", ({
+				expect,
+			}) => {
 				const expectedConfig: RawEnvironment = {
 					build: {
 						command: "execute some --build",
@@ -1336,7 +1363,9 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBe(false);
 			});
 
-			it("should resolve custom build watch directories relative to wrangler.toml", async () => {
+			it("should resolve custom build watch directories relative to wrangler.toml", async ({
+				expect,
+			}) => {
 				const expectedConfig: RawEnvironment = {
 					build: {
 						command: "execute some --build",
@@ -1362,7 +1391,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBe(false);
 			});
 
-			it("should allow watch_dir to be an array of paths", () => {
+			it("should allow watch_dir to be an array of paths", ({ expect }) => {
 				const expectedConfig: RawEnvironment = {
 					build: {
 						command: "execute some --build",
@@ -1392,7 +1421,9 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBe(false);
 			});
 
-			it("should error when the watch_dir array isn't an array of strings", () => {
+			it("should error when the watch_dir array isn't an array of strings", ({
+				expect,
+			}) => {
 				const expectedConfig: RawEnvironment = {
 					build: {
 						command: "execute some --build",
@@ -1441,7 +1472,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[durable_objects]", () => {
-			it("should error if durable_objects is an array", () => {
+			it("should error if durable_objects is an array", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ durable_objects: [] } as unknown as RawConfig,
 					undefined,
@@ -1456,7 +1487,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if durable_objects is a string", () => {
+			it("should error if durable_objects is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ durable_objects: "BAD" } as unknown as RawConfig,
 					undefined,
@@ -1471,7 +1502,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if durable_objects is a number", () => {
+			it("should error if durable_objects is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ durable_objects: 999 } as unknown as RawConfig,
 					undefined,
@@ -1486,7 +1517,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if durable_objects is null", () => {
+			it("should error if durable_objects is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ durable_objects: null } as unknown as RawConfig,
 					undefined,
@@ -1501,7 +1532,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if durable_objects.bindings is not defined", () => {
+			it("should error if durable_objects.bindings is not defined", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ durable_objects: {} } as unknown as RawConfig,
 					undefined,
@@ -1516,7 +1549,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if durable_objects.bindings is an object", () => {
+			it("should error if durable_objects.bindings is an object", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ durable_objects: { bindings: {} } } as unknown as RawConfig,
 					undefined,
@@ -1531,7 +1566,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if durable_objects.bindings is a string", () => {
+			it("should error if durable_objects.bindings is a string", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ durable_objects: { bindings: "BAD" } } as unknown as RawConfig,
 					undefined,
@@ -1546,7 +1583,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if durable_objects.bindings is a number", () => {
+			it("should error if durable_objects.bindings is a number", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ durable_objects: { bindings: 999 } } as unknown as RawConfig,
 					undefined,
@@ -1561,7 +1600,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if durable_objects.bindings is null", () => {
+			it("should error if durable_objects.bindings is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ durable_objects: { bindings: null } } as unknown as RawConfig,
 					undefined,
@@ -1576,7 +1615,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if durable_objects.bindings are not valid", () => {
+			it("should error if durable_objects.bindings are not valid", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						durable_objects: {
@@ -1654,7 +1695,9 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[migrations]", () => {
-			it("should override `migrations` config defaults with provided values", () => {
+			it("should override `migrations` config defaults with provided values", ({
+				expect,
+			}) => {
 				const expectedConfig: RawConfig = {
 					migrations: [
 						{
@@ -1684,7 +1727,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBe(false);
 			});
 
-			it("should error on invalid `migrations` values", () => {
+			it("should error on invalid `migrations` values", ({ expect }) => {
 				const expectedConfig = {
 					migrations: [
 						{
@@ -1724,7 +1767,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should warn/error on unexpected fields on `migrations`", async () => {
+			it("should warn/error on unexpected fields on `migrations`", async ({
+				expect,
+			}) => {
 				const expectedConfig = {
 					migrations: [
 						{
@@ -1780,7 +1825,9 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[assets]", () => {
-			it("should override `assets` config defaults with provided values", () => {
+			it("should override `assets` config defaults with provided values", ({
+				expect,
+			}) => {
 				const expectedConfig: RawConfig = {
 					assets: {
 						directory: "public/",
@@ -1800,7 +1847,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBe(false);
 			});
 
-			it("should error on invalid `assets` values", () => {
+			it("should error on invalid `assets` values", ({ expect }) => {
 				const expectedConfig = {
 					assets: {
 						binding: 2,
@@ -1827,7 +1874,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error on invalid `assets` config values", () => {
+			it("should error on invalid `assets` config values", ({ expect }) => {
 				const expectedConfig = {
 					assets: {
 						directory: "./public",
@@ -1856,7 +1903,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should accept valid `assets` config values", () => {
+			it("should accept valid `assets` config values", ({ expect }) => {
 				const expectedConfig: RawConfig = {
 					assets: {
 						directory: "./public",
@@ -1877,7 +1924,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
-			it("should error on invalid additional fields", () => {
+			it("should error on invalid additional fields", ({ expect }) => {
 				const expectedConfig = {
 					assets: {
 						directory: "./public",
@@ -1903,7 +1950,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[browser]", () => {
-			it("should error if browser is an array", () => {
+			it("should error if browser is an array", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ browser: [] } as unknown as RawConfig,
 					undefined,
@@ -1918,7 +1965,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if browser is a string", () => {
+			it("should error if browser is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ browser: "BAD" } as unknown as RawConfig,
 					undefined,
@@ -1933,7 +1980,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if browser is a number", () => {
+			it("should error if browser is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ browser: 999 } as unknown as RawConfig,
 					undefined,
@@ -1948,7 +1995,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if browser is null", () => {
+			it("should error if browser is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ browser: null } as unknown as RawConfig,
 					undefined,
@@ -1966,7 +2013,7 @@ describe("normalizeAndValidateConfig()", () => {
 
 		// Vectorize
 		describe("[vectorize]", () => {
-			it("should error if vectorize is an object", () => {
+			it("should error if vectorize is an object", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ vectorize: {} } as unknown as RawConfig,
 					undefined,
@@ -1981,7 +2028,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if vectorize bindings are not valid", () => {
+			it("should error if vectorize bindings are not valid", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						vectorize: [
@@ -2011,7 +2058,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if vectorize is a string", () => {
+			it("should error if vectorize is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ vectorize: "BAD" } as unknown as RawConfig,
 					undefined,
@@ -2026,7 +2073,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if vectorize is a number", () => {
+			it("should error if vectorize is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ vectorize: 999 } as unknown as RawConfig,
 					undefined,
@@ -2041,7 +2088,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if vectorize is null", () => {
+			it("should error if vectorize is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ vectorize: null } as unknown as RawConfig,
 					undefined,
@@ -2059,7 +2106,7 @@ describe("normalizeAndValidateConfig()", () => {
 
 		// AI
 		describe("[ai]", () => {
-			it("should error if ai is an array", () => {
+			it("should error if ai is an array", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ ai: [] } as unknown as RawConfig,
 					undefined,
@@ -2074,7 +2121,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if ai is a string", () => {
+			it("should error if ai is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ ai: "BAD" } as unknown as RawConfig,
 					undefined,
@@ -2089,7 +2136,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if ai is a number", () => {
+			it("should error if ai is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ ai: 999 } as unknown as RawConfig,
 					undefined,
@@ -2104,7 +2151,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if ai is null", () => {
+			it("should error if ai is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ ai: null } as unknown as RawConfig,
 					undefined,
@@ -2122,7 +2169,7 @@ describe("normalizeAndValidateConfig()", () => {
 
 		// Images
 		describe("[images]", () => {
-			it("should error if images is an array", () => {
+			it("should error if images is an array", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ images: [] } as unknown as RawConfig,
 					undefined,
@@ -2137,7 +2184,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if images is a string", () => {
+			it("should error if images is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ images: "BAD" } as unknown as RawConfig,
 					undefined,
@@ -2152,7 +2199,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if images is a number", () => {
+			it("should error if images is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ images: 999 } as unknown as RawConfig,
 					undefined,
@@ -2167,7 +2214,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if ai is null", () => {
+			it("should error if ai is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ images: null } as unknown as RawConfig,
 					undefined,
@@ -2185,7 +2232,7 @@ describe("normalizeAndValidateConfig()", () => {
 
 		// Media
 		describe("[media]", () => {
-			it("should error if media is an array", () => {
+			it("should error if media is an array", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ media: [] } as unknown as RawConfig,
 					undefined,
@@ -2200,7 +2247,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if media is a string", () => {
+			it("should error if media is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ media: "BAD" } as unknown as RawConfig,
 					undefined,
@@ -2215,7 +2262,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if media is a number", () => {
+			it("should error if media is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ media: 999 } as unknown as RawConfig,
 					undefined,
@@ -2230,7 +2277,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if media is null", () => {
+			it("should error if media is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ media: null } as unknown as RawConfig,
 					undefined,
@@ -2248,7 +2295,7 @@ describe("normalizeAndValidateConfig()", () => {
 
 		// Worker Version Metadata
 		describe("[version_metadata]", () => {
-			it("should error if version_metadata is an array", () => {
+			it("should error if version_metadata is an array", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ version_metadata: [] } as unknown as RawConfig,
 					undefined,
@@ -2263,7 +2310,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if version_metadata is a string", () => {
+			it("should error if version_metadata is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ version_metadata: "BAD" } as unknown as RawConfig,
 					undefined,
@@ -2278,7 +2325,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if version_metadata is a number", () => {
+			it("should error if version_metadata is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ version_metadata: 999 } as unknown as RawConfig,
 					undefined,
@@ -2293,7 +2340,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if version_metadata is null", () => {
+			it("should error if version_metadata is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ version_metadata: null } as unknown as RawConfig,
 					undefined,
@@ -2310,7 +2357,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[cloudchamber]", () => {
-			it("should error if cloudchamber is null", () => {
+			it("should error if cloudchamber is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ cloudchamber: null } as unknown as RawConfig,
 					undefined,
@@ -2325,7 +2372,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if cloudchamber is an array", () => {
+			it("should error if cloudchamber is an array", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ cloudchamber: [] } as unknown as RawConfig,
 					undefined,
@@ -2340,7 +2387,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if cloudchamber is a string", () => {
+			it("should error if cloudchamber is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ cloudchamber: "test" } as unknown as RawConfig,
 					undefined,
@@ -2355,7 +2402,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if cloudchamber is a number", () => {
+			it("should error if cloudchamber is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ cloudchamber: 22 } as unknown as RawConfig,
 					undefined,
@@ -2370,7 +2417,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if cloudchamber bindings are not valid", () => {
+			it("should error if cloudchamber bindings are not valid", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						cloudchamber: {
@@ -2399,7 +2448,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[containers]", () => {
-			it("should error if containers is not an object", () => {
+			it("should error if containers is not an object", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ containers: "test" } as unknown as RawConfig,
 					undefined,
@@ -2414,7 +2463,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if containers is an object that is not an array", () => {
+			it("should error if containers is an object that is not an array", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ containers: { something: "here" } } as unknown as RawConfig,
 					undefined,
@@ -2429,7 +2480,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if containers is a string", () => {
+			it("should error if containers is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ containers: "test" } as unknown as RawConfig,
 					undefined,
@@ -2444,7 +2495,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if containers is a number", () => {
+			it("should error if containers is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ containers: 22 } as unknown as RawConfig,
 					undefined,
@@ -2459,7 +2510,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if no containers name and no worker name are provided", () => {
+			it("should error if no containers name and no worker name are provided", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						containers: [
@@ -2480,7 +2533,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should provide a name if no container name is provided and worker name exists", () => {
+			it("should provide a name if no container name is provided and worker name exists", ({
+				expect,
+			}) => {
 				const { diagnostics, config } = normalizeAndValidateConfig(
 					{
 						name: "test-worker-name",
@@ -2513,7 +2568,7 @@ describe("normalizeAndValidateConfig()", () => {
 				}
 			});
 
-			it("should error for invalid container app fields", () => {
+			it("should error for invalid container app fields", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						name: "test-worker",
@@ -2557,7 +2612,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if rollout_active_grace_period and rollout_step_percentage are out of range", () => {
+			it("should error if rollout_active_grace_period and rollout_step_percentage are out of range", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						name: "test-worker",
@@ -2584,7 +2641,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should warn for deprecated container fields", () => {
+			it("should warn for deprecated container fields", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						name: "test-worker",
@@ -2614,7 +2671,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error for invalid containers.configuration fields", () => {
+			it("should error for invalid containers.configuration fields", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						name: "test-worker",
@@ -2647,9 +2706,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it.each([{ value: 25 }, { value: [20, 50, 100] }])(
+			it.for([{ value: 25 }, { value: [20, 50, 100] }])(
 				"should accept rollout_step_percentage set to $value",
-				(value) => {
+				(value, { expect }) => {
 					const { diagnostics } = normalizeAndValidateConfig(
 						{
 							name: "test-worker",
@@ -2671,7 +2730,9 @@ describe("normalizeAndValidateConfig()", () => {
 				}
 			);
 
-			it("should error for invalid rollout_step_percentage number values", () => {
+			it("should error for invalid rollout_step_percentage number values", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						name: "test-worker",
@@ -2695,7 +2756,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error for rollout_step_percentage array with invalid items", () => {
+			it("should error for rollout_step_percentage array with invalid items", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						name: "test-worker",
@@ -2721,7 +2784,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error when rollout_step_percentage has more steps than max_instances", () => {
+			it("should error when rollout_step_percentage has more steps than max_instances", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						name: "test-worker",
@@ -2754,7 +2819,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should warn when dev instance type is used", () => {
+			it("should warn when dev instance type is used", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						name: "test-worker",
@@ -2792,7 +2857,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error when both constraints.tier and constraints.tiers are set", () => {
+			it("should error when both constraints.tier and constraints.tiers are set", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						name: "test-worker",
@@ -2822,7 +2889,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error when constraints.tiers is not an array of numbers", () => {
+			it("should error when constraints.tiers is not an array of numbers", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						name: "test-worker",
@@ -2849,7 +2918,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should allow valid constraints.tiers array of numbers", () => {
+			it("should allow valid constraints.tiers array of numbers", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						name: "test-worker",
@@ -2874,7 +2945,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[kv_namespaces]", () => {
-			it("should error if kv_namespaces is an object", () => {
+			it("should error if kv_namespaces is an object", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ kv_namespaces: {} } as unknown as RawConfig,
 					undefined,
@@ -2889,7 +2960,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if kv_namespaces is a string", () => {
+			it("should error if kv_namespaces is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ kv_namespaces: "BAD" } as unknown as RawConfig,
 					undefined,
@@ -2904,7 +2975,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if kv_namespaces is a number", () => {
+			it("should error if kv_namespaces is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ kv_namespaces: 999 } as unknown as RawConfig,
 					undefined,
@@ -2919,7 +2990,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if kv_namespaces is null", () => {
+			it("should error if kv_namespaces is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ kv_namespaces: null } as unknown as RawConfig,
 					undefined,
@@ -2934,7 +3005,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if kv_namespaces.bindings are not valid", () => {
+			it("should error if kv_namespaces.bindings are not valid", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						kv_namespaces: [
@@ -2965,7 +3038,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should allow the id field to be omitted (resource provisioning)", () => {
+			it("should allow the id field to be omitted (resource provisioning)", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						kv_namespaces: [{ binding: "VALID" }],
@@ -2980,7 +3055,7 @@ describe("normalizeAndValidateConfig()", () => {
 			});
 		});
 
-		it("should error if send_email.bindings are not valid", () => {
+		it("should error if send_email.bindings are not valid", ({ expect }) => {
 			const { diagnostics } = normalizeAndValidateConfig(
 				{
 					send_email: [
@@ -3015,7 +3090,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[d1_databases]", () => {
-			it("should error if d1_databases is an object", () => {
+			it("should error if d1_databases is an object", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ d1_databases: {} } as unknown as RawConfig,
 					undefined,
@@ -3030,7 +3105,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if d1_databases is a string", () => {
+			it("should error if d1_databases is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ d1_databases: "BAD" } as unknown as RawConfig,
 					undefined,
@@ -3045,7 +3120,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if d1_databases is a number", () => {
+			it("should error if d1_databases is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ d1_databases: 999 } as unknown as RawConfig,
 					undefined,
@@ -3060,7 +3135,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if d1_databases is null", () => {
+			it("should error if d1_databases is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ d1_databases: null } as unknown as RawConfig,
 					undefined,
@@ -3075,7 +3150,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if d1_databases.bindings are not valid", () => {
+			it("should error if d1_databases.bindings are not valid", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						d1_databases: [
@@ -3108,7 +3185,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should allow the database_id field to be omitted (resource provisioning)", () => {
+			it("should allow the database_id field to be omitted (resource provisioning)", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						d1_databases: [{ binding: "VALID" }],
@@ -3124,7 +3203,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[hyperdrive]", () => {
-			it("should error if hyperdrive is an object", () => {
+			it("should error if hyperdrive is an object", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ hyperdrive: {} } as unknown as RawConfig,
 					undefined,
@@ -3139,7 +3218,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if hyperdrive is a string", () => {
+			it("should error if hyperdrive is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ hyperdrive: "BAD" } as unknown as RawConfig,
 					undefined,
@@ -3154,7 +3233,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if hyperdrive is a number", () => {
+			it("should error if hyperdrive is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ hyperdrive: 999 } as unknown as RawConfig,
 					undefined,
@@ -3169,7 +3248,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if hyperdrive is null", () => {
+			it("should error if hyperdrive is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ hyperdrive: null } as unknown as RawConfig,
 					undefined,
@@ -3184,7 +3263,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should accept valid bindings", () => {
+			it("should accept valid bindings", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						hyperdrive: [
@@ -3199,7 +3278,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
-			it("should error if hyperdrive.bindings are not valid", () => {
+			it("should error if hyperdrive.bindings are not valid", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						hyperdrive: [
@@ -3228,7 +3307,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[queues]", () => {
-			it("should error if queues is not an object", () => {
+			it("should error if queues is not an object", ({ expect }) => {
 				const { config, diagnostics } = normalizeAndValidateConfig(
 					{ queues: [] } as unknown as RawConfig,
 					undefined,
@@ -3246,7 +3325,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if queues producer bindings are not valid", () => {
+			it("should error if queues producer bindings are not valid", ({
+				expect,
+			}) => {
 				const { config, diagnostics } = normalizeAndValidateConfig(
 					{
 						queues: {
@@ -3286,7 +3367,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if queues consumers are not valid", () => {
+			it("should error if queues consumers are not valid", ({ expect }) => {
 				const { config, diagnostics } = normalizeAndValidateConfig(
 					{
 						queues: {
@@ -3337,7 +3418,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[r2_buckets]", () => {
-			it("should error if r2_buckets is an object", () => {
+			it("should error if r2_buckets is an object", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ r2_buckets: {} } as unknown as RawConfig,
 					undefined,
@@ -3352,7 +3433,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if r2_buckets is a string", () => {
+			it("should error if r2_buckets is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ r2_buckets: "BAD" } as unknown as RawConfig,
 					undefined,
@@ -3367,7 +3448,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if r2_buckets is a number", () => {
+			it("should error if r2_buckets is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ r2_buckets: 999 } as unknown as RawConfig,
 					undefined,
@@ -3382,7 +3463,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if r2_buckets is null", () => {
+			it("should error if r2_buckets is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ r2_buckets: null } as unknown as RawConfig,
 					undefined,
@@ -3397,7 +3478,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if r2_buckets.bindings are not valid", () => {
+			it("should error if r2_buckets.bindings are not valid", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						r2_buckets: [
@@ -3436,7 +3517,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should allow the bucket_name field to be omitted (resource provisioning)", () => {
+			it("should allow the bucket_name field to be omitted (resource provisioning)", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						d1_databases: [{ binding: "VALID" }],
@@ -3452,7 +3535,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[services]", () => {
-			it("should error if services is an object", () => {
+			it("should error if services is an object", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ services: {} } as unknown as RawConfig,
 					undefined,
@@ -3472,7 +3555,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if services is a string", () => {
+			it("should error if services is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ services: "BAD" } as unknown as RawConfig,
 					undefined,
@@ -3492,7 +3575,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if services is a number", () => {
+			it("should error if services is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ services: 999 } as unknown as RawConfig,
 					undefined,
@@ -3512,7 +3595,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if services is null", () => {
+			it("should error if services is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ services: null } as unknown as RawConfig,
 					undefined,
@@ -3532,7 +3615,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if services bindings are not valid", () => {
+			it("should error if services bindings are not valid", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						services: [
@@ -3598,7 +3681,9 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[analytics_engine_datasets]", () => {
-			it("should error if analytics_engine_datasets is an object", () => {
+			it("should error if analytics_engine_datasets is an object", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ analytics_engine_datasets: {} } as unknown as RawConfig,
 					undefined,
@@ -3613,7 +3698,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if analytics_engine_datasets is a string", () => {
+			it("should error if analytics_engine_datasets is a string", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ analytics_engine_datasets: "BAD" } as unknown as RawConfig,
 					undefined,
@@ -3628,7 +3715,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if analytics_engine_datasets is a number", () => {
+			it("should error if analytics_engine_datasets is a number", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ analytics_engine_datasets: 999 } as unknown as RawConfig,
 					undefined,
@@ -3643,7 +3732,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if analytics_engine_datasets is null", () => {
+			it("should error if analytics_engine_datasets is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ analytics_engine_datasets: null } as unknown as RawConfig,
 					undefined,
@@ -3658,7 +3747,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if analytics_engine_datasets.bindings are not valid", () => {
+			it("should error if analytics_engine_datasets.bindings are not valid", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						analytics_engine_datasets: [
@@ -3689,7 +3780,9 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[dispatch_namespaces]", () => {
-			it("should error if dispatch_namespaces is not an array", () => {
+			it("should error if dispatch_namespaces is not an array", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						dispatch_namespaces: "just a string",
@@ -3707,7 +3800,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error on non valid dispatch_namespaces", () => {
+			it("should error on non valid dispatch_namespaces", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						dispatch_namespaces: [
@@ -3755,7 +3848,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			test("should error on invalid outbounds for a namespace", () => {
+			test("should error on invalid outbounds for a namespace", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						dispatch_namespaces: [
@@ -3865,7 +3960,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[mtls_certificates]", () => {
-			it("should error if mtls_certificates is not an array", () => {
+			it("should error if mtls_certificates is not an array", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						mtls_certificates: "just a string",
@@ -3883,7 +3978,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error on non valid mtls_certificates", () => {
+			it("should error on non valid mtls_certificates", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						mtls_certificates: [
@@ -3942,7 +4037,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[pipelines]", () => {
-			it("should error if pipelines is an object", () => {
+			it("should error if pipelines is an object", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					// @ts-expect-error purposely using an invalid value
 					{ pipelines: {} },
@@ -3958,7 +4053,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if pipelines is a string", () => {
+			it("should error if pipelines is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					// @ts-expect-error purposely using an invalid value
 					{ pipelines: "BAD" },
@@ -3974,7 +4069,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if pipelines is a number", () => {
+			it("should error if pipelines is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					// @ts-expect-error purposely using an invalid value
 					{ pipelines: 999 },
@@ -3990,7 +4085,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if pipelines is null", () => {
+			it("should error if pipelines is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					// @ts-expect-error purposely using an invalid value
 					{ pipelines: null },
@@ -4006,7 +4101,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should accept valid bindings", () => {
+			it("should accept valid bindings", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						pipelines: [
@@ -4024,7 +4119,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
-			it("should error if pipelines.bindings are not valid", () => {
+			it("should error if pipelines.bindings are not valid", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						pipelines: [
@@ -4056,7 +4151,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[secrets_store_secrets]", () => {
-			it("should error if secrets_store_secrets is an object", () => {
+			it("should error if secrets_store_secrets is an object", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					// @ts-expect-error purposely using an invalid value
 					{ secrets_store_secrets: {} },
@@ -4072,7 +4167,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if secrets_store_secrets is null", () => {
+			it("should error if secrets_store_secrets is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					// @ts-expect-error purposely using an invalid value
 					{ secrets_store_secrets: null },
@@ -4088,7 +4183,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should accept valid bindings", () => {
+			it("should accept valid bindings", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						secrets_store_secrets: [
@@ -4107,7 +4202,9 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
-			it("should error if secrets_store_secrets.bindings are not valid", () => {
+			it("should error if secrets_store_secrets.bindings are not valid", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						secrets_store_secrets: [
@@ -4149,7 +4246,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[worker_loaders]", () => {
-			it("should error if worker_loaders is an object", () => {
+			it("should error if worker_loaders is an object", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					// @ts-expect-error purposely using an invalid value
 					{ worker_loaders: {} },
@@ -4165,7 +4262,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if worker_loaders is null", () => {
+			it("should error if worker_loaders is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					// @ts-expect-error purposely using an invalid value
 					{ worker_loaders: null },
@@ -4181,7 +4278,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should accept valid bindings", () => {
+			it("should accept valid bindings", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						worker_loaders: [
@@ -4198,7 +4295,9 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
-			it("should error if worker_loaders bindings are not valid", () => {
+			it("should error if worker_loaders bindings are not valid", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						worker_loaders: [
@@ -4234,7 +4333,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[unsafe_hello_world]", () => {
-			it("should error if unsafe_hello_world is an object", () => {
+			it("should error if unsafe_hello_world is an object", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					// @ts-expect-error purposely using an invalid value
 					{ unsafe_hello_world: {} },
@@ -4250,7 +4349,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe_hello_world is null", () => {
+			it("should error if unsafe_hello_world is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					// @ts-expect-error purposely using an invalid value
 					{ unsafe_hello_world: null },
@@ -4266,7 +4365,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should accept valid bindings", () => {
+			it("should accept valid bindings", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						unsafe_hello_world: [
@@ -4284,7 +4383,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
-			it("should error if hello_world.bindings are not valid", () => {
+			it("should error if hello_world.bindings are not valid", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						unsafe_hello_world: [
@@ -4324,7 +4423,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[ratelimit]", () => {
-			it("should error if ratelimit is an object", () => {
+			it("should error if ratelimit is an object", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					// @ts-expect-error purposely using an invalid value
 					{ ratelimits: {} },
@@ -4340,7 +4439,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if ratelimit is null", () => {
+			it("should error if ratelimit is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					// @ts-expect-error purposely using an invalid value
 					{ ratelimits: null },
@@ -4356,7 +4455,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should accept valid bindings", () => {
+			it("should accept valid bindings", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						ratelimits: [
@@ -4378,7 +4477,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
-			it("should error if ratelimit bindings are not valid", () => {
+			it("should error if ratelimit bindings are not valid", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						ratelimits: [
@@ -4439,7 +4538,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[vpc_services]", () => {
-			it("should accept valid bindings", () => {
+			it("should accept valid bindings", ({ expect }) => {
 				const { config, diagnostics } = normalizeAndValidateConfig(
 					{
 						vpc_services: [
@@ -4471,7 +4570,9 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
-			it("should error if vpc_services bindings are not valid", () => {
+			it("should error if vpc_services bindings are not valid", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						vpc_services: [
@@ -4502,7 +4603,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[unsafe.bindings]", () => {
-			it("should error if unsafe is an array", () => {
+			it("should error if unsafe is an array", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ unsafe: [] } as unknown as RawConfig,
 					undefined,
@@ -4520,7 +4621,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe is a string", () => {
+			it("should error if unsafe is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ unsafe: "BAD" } as unknown as RawConfig,
 					undefined,
@@ -4538,7 +4639,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe is a number", () => {
+			it("should error if unsafe is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ unsafe: 999 } as unknown as RawConfig,
 					undefined,
@@ -4556,7 +4657,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe is null", () => {
+			it("should error if unsafe is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ unsafe: null } as unknown as RawConfig,
 					undefined,
@@ -4574,7 +4675,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should not error if unsafe is an empty object", () => {
+			it("should not error if unsafe is an empty object", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ unsafe: {} } satisfies RawConfig,
 					undefined,
@@ -4592,7 +4693,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe contains unexpected properties", () => {
+			it("should error if unsafe contains unexpected properties", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						unsafe: {
@@ -4615,7 +4718,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe.bindings is an object", () => {
+			it("should error if unsafe.bindings is an object", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ unsafe: { bindings: {} } } as RawConfig,
 					undefined,
@@ -4633,7 +4736,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe.bindings is a string", () => {
+			it("should error if unsafe.bindings is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ unsafe: { bindings: "BAD" } } as unknown as RawConfig,
 					undefined,
@@ -4651,7 +4754,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe.bindings is a number", () => {
+			it("should error if unsafe.bindings is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ unsafe: { bindings: 999 } } as unknown as RawConfig,
 					undefined,
@@ -4669,7 +4772,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe.bindings is null", () => {
+			it("should error if unsafe.bindings is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ unsafe: { bindings: null } } as unknown as RawConfig,
 					undefined,
@@ -4687,7 +4790,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if durable_objects.bindings are not valid", () => {
+			it("should error if durable_objects.bindings are not valid", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						unsafe: {
@@ -4728,7 +4833,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe.metadata is an array", () => {
+			it("should error if unsafe.metadata is an array", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ unsafe: { metadata: [] } } as unknown as RawConfig,
 					undefined,
@@ -4746,7 +4851,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe.metadata is a string", () => {
+			it("should error if unsafe.metadata is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ unsafe: { metadata: "BAD" } } as unknown as RawConfig,
 					undefined,
@@ -4764,7 +4869,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe.metadata is a number", () => {
+			it("should error if unsafe.metadata is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ unsafe: { metadata: 999 } } as unknown as RawConfig,
 					undefined,
@@ -4782,7 +4887,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe.metadata is null", () => {
+			it("should error if unsafe.metadata is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ unsafe: { metadata: null } } as unknown as RawConfig,
 					undefined,
@@ -4800,7 +4905,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should not provide an unsafe warning when the environment variable is specified", () => {
+			it("should not provide an unsafe warning when the environment variable is specified", ({
+				expect,
+			}) => {
 				vi.stubEnv("WRANGLER_DISABLE_EXPERIMENTAL_WARNING", "1");
 
 				const { diagnostics } = normalizeAndValidateConfig(
@@ -4815,7 +4922,7 @@ describe("normalizeAndValidateConfig()", () => {
 			});
 		});
 
-		it("should accept unsafe fields under containers", () => {
+		it("should accept unsafe fields under containers", ({ expect }) => {
 			const { diagnostics } = normalizeAndValidateConfig(
 				{
 					containers: [
@@ -4845,7 +4952,9 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[placement]", () => {
-			it(`should error if placement hint is set with placement mode "off"`, () => {
+			it(`should error if placement hint is set with placement mode "off"`, ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ placement: { mode: "off", hint: "wnam" } },
 					undefined,
@@ -4859,7 +4968,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it(`should not error if placement hint is set with placement mode "smart"`, () => {
+			it(`should not error if placement hint is set with placement mode "smart"`, ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ placement: { mode: "smart", hint: "wnam" } },
 					undefined,
@@ -4870,7 +4981,9 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
-			it(`should error if placement hint object is set with placement mode "targeted"`, () => {
+			it(`should error if placement hint object is set with placement mode "targeted"`, ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						placement: { mode: "targeted", hint: "wnam" },
@@ -4887,7 +5000,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it(`should not error if hostname field is set with placement mode "targeted"`, () => {
+			it(`should not error if hostname field is set with placement mode "targeted"`, ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ placement: { hostname: "example.com" } },
 					undefined,
@@ -4898,7 +5013,9 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
-			it(`should not error if host field is set with placement mode "targeted"`, () => {
+			it(`should not error if host field is set with placement mode "targeted"`, ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ placement: { host: "example.com:5432" } },
 					undefined,
@@ -4909,7 +5026,9 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
-			it(`should not error if host field is set with placement mode "targeted"`, () => {
+			it(`should not error if host field is set with placement mode "targeted"`, ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ placement: { region: "aws:us-east-1" } },
 					undefined,
@@ -4920,7 +5039,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
-			it(`should error if placement has an invalid field`, () => {
+			it(`should error if placement has an invalid field`, ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ placement: { shoeSize: 13 } } as unknown as RawConfig,
 					undefined,
@@ -4933,7 +5052,9 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("route & routes fields", () => {
-			it("should error if both route and routes are specified", () => {
+			it("should error if both route and routes are specified", ({
+				expect,
+			}) => {
 				const rawConfig: RawConfig = {
 					route: "route1",
 					routes: ["route2", "route3"],
@@ -4955,7 +5076,9 @@ describe("normalizeAndValidateConfig()", () => {
 	});
 
 	describe("named environments", () => {
-		it("should use --env CLI arg to select the active environment", () => {
+		it("should use --env CLI arg to select the active environment", ({
+			expect,
+		}) => {
 			const rawConfig: RawConfig = {
 				name: "my-worker",
 				env: {
@@ -4992,7 +5115,9 @@ describe("normalizeAndValidateConfig()", () => {
 			);
 		});
 
-		it("should use CLOUDFLARE_ENV environment variable to select the active environment", () => {
+		it("should use CLOUDFLARE_ENV environment variable to select the active environment", ({
+			expect,
+		}) => {
 			const rawConfig: RawConfig = {
 				name: "my-worker",
 				env: {
@@ -5031,7 +5156,9 @@ describe("normalizeAndValidateConfig()", () => {
 			);
 		});
 
-		it("should use the `--env` CLI arg over the CLOUDFLARE_ENV environment variable to select the active environment", () => {
+		it("should use the `--env` CLI arg over the CLOUDFLARE_ENV environment variable to select the active environment", ({
+			expect,
+		}) => {
 			const rawConfig: RawConfig = {
 				name: "my-worker",
 				env: {
@@ -5057,7 +5184,9 @@ describe("normalizeAndValidateConfig()", () => {
 			);
 		});
 
-		it("should warn if we specify an environment but there are no named environments", () => {
+		it("should warn if we specify an environment but there are no named environments", ({
+			expect,
+		}) => {
 			const rawConfig: RawConfig = {
 				name: "my-worker",
 				kv_namespaces: [{ binding: "KV", id: "xxxx-xxxx-xxxx-xxxx" }],
@@ -5094,7 +5223,9 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("with redirected config", () => {
-			it("should error if we specify an environment via an argument that doesn't match the original target environment", () => {
+			it("should error if we specify an environment via an argument that doesn't match the original target environment", ({
+				expect,
+			}) => {
 				const rawConfig: RedirectedRawConfig = {
 					name: "my-worker",
 					targetEnvironment: "prod",
@@ -5116,7 +5247,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if we specify an environment via an environment variable that doesn't match the original target environment", () => {
+			it("should error if we specify an environment via an environment variable that doesn't match the original target environment", ({
+				expect,
+			}) => {
 				const rawConfig: RedirectedRawConfig = {
 					name: "my-worker",
 					targetEnvironment: "prod",
@@ -5137,7 +5270,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if we specify an environment via both an argument and CLOUDFLARE_ENV that doesn't match the original target environment", () => {
+			it("should error if we specify an environment via both an argument and CLOUDFLARE_ENV that doesn't match the original target environment", ({
+				expect,
+			}) => {
 				const rawConfig: RedirectedRawConfig = {
 					name: "my-worker",
 					targetEnvironment: "prod",
@@ -5161,7 +5296,9 @@ describe("normalizeAndValidateConfig()", () => {
 			});
 		});
 
-		it("should error if we specify an environment that does not match the named environments", () => {
+		it("should error if we specify an environment that does not match the named environments", ({
+			expect,
+		}) => {
 			const rawConfig: RawConfig = { env: { ENV1: {} } };
 			const { diagnostics } = normalizeAndValidateConfig(
 				rawConfig,
@@ -5189,7 +5326,9 @@ describe("normalizeAndValidateConfig()", () => {
 			`);
 		});
 
-		it("should use top-level values for inheritable config fields", () => {
+		it("should use top-level values for inheritable config fields", ({
+			expect,
+		}) => {
 			const main = "src/index.ts";
 			const resolvedMain = path.resolve(process.cwd(), main);
 			const rawConfig: RawConfig = {
@@ -5239,7 +5378,9 @@ describe("normalizeAndValidateConfig()", () => {
 			expect(diagnostics.hasWarnings()).toBe(false);
 		});
 
-		it("should override top-level values for inheritable config fields", () => {
+		it("should override top-level values for inheritable config fields", ({
+			expect,
+		}) => {
 			const main = "src/index.ts";
 			const resolvedMain = path.resolve(process.cwd(), main);
 			const rawEnv: RawEnvironment = {
@@ -5317,7 +5458,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("non-legacy", () => {
-			it("should use top-level `name` field", () => {
+			it("should use top-level `name` field", ({ expect }) => {
 				const rawConfig: RawConfig = {
 					name: "mock-name",
 					legacy_env: false,
@@ -5341,7 +5482,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if named environment contains a `name` field, even if there is no top-level name", () => {
+			it("should error if named environment contains a `name` field, even if there is no top-level name", ({
+				expect,
+			}) => {
 				const rawConfig: RawConfig = {
 					legacy_env: false,
 					env: {
@@ -5374,7 +5517,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if top-level config and a named environment both contain a `name` field", () => {
+			it("should error if top-level config and a named environment both contain a `name` field", ({
+				expect,
+			}) => {
 				const rawConfig: RawConfig = {
 					name: "mock-name",
 					legacy_env: false,
@@ -5408,7 +5553,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if named environment contains a `account_id` field, even if there is no top-level name", () => {
+			it("should error if named environment contains a `account_id` field, even if there is no top-level name", ({
+				expect,
+			}) => {
 				const rawConfig: RawConfig = {
 					legacy_env: false,
 					env: {
@@ -5440,7 +5587,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if top-level config and a named environment both contain a `account_id` field", () => {
+			it("should error if top-level config and a named environment both contain a `account_id` field", ({
+				expect,
+			}) => {
 				const rawConfig: RawConfig = {
 					account_id: "ACCOUNT_ID",
 					legacy_env: false,
@@ -5475,7 +5624,9 @@ describe("normalizeAndValidateConfig()", () => {
 			});
 		});
 
-		it("should warn for non-inherited fields that are missing in environments", () => {
+		it("should warn for non-inherited fields that are missing in environments", ({
+			expect,
+		}) => {
 			const define: RawConfig["define"] = {
 				abc: "123",
 			};
@@ -5553,7 +5704,7 @@ describe("normalizeAndValidateConfig()", () => {
 			`);
 		});
 
-		it("should error on Date values in vars (parsed by TOML)", () => {
+		it("should error on Date values in vars (parsed by TOML)", ({ expect }) => {
 			const rawConfig = TOML.parse(`
 				[vars]
 				VALID_VAR = "some string"
@@ -5574,7 +5725,9 @@ describe("normalizeAndValidateConfig()", () => {
 			`);
 		});
 
-		it("should error on Date values in env vars (parsed by TOML)", () => {
+		it("should error on Date values in env vars (parsed by TOML)", ({
+			expect,
+		}) => {
 			const rawConfig = TOML.parse(`
 				[env.production.vars]
 				VALID_VAR = "some string"
@@ -5597,7 +5750,7 @@ describe("normalizeAndValidateConfig()", () => {
 			`);
 		});
 
-		it("should error on node_compat", () => {
+		it("should error on node_compat", ({ expect }) => {
 			const { diagnostics } = normalizeAndValidateConfig(
 				// @ts-expect-error node_compat has been removed
 				{ env: { ENV1: { node_compat: true } } },
@@ -5615,7 +5768,7 @@ describe("normalizeAndValidateConfig()", () => {
 			`);
 		});
 
-		it("should error on invalid environment values", () => {
+		it("should error on invalid environment values", ({ expect }) => {
 			const expectedConfig: RawEnvironment = {
 				name: 111,
 				account_id: 222,
@@ -5680,7 +5833,7 @@ describe("normalizeAndValidateConfig()", () => {
 			`);
 		});
 
-		it("should warn on unexpected fields", () => {
+		it("should warn on unexpected fields", ({ expect }) => {
 			const { diagnostics } = normalizeAndValidateConfig(
 				// @ts-expect-error purposely using an invalid field
 				{ env: { ENV1: { bla: "haj" } } },
@@ -5698,7 +5851,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[define]", () => {
-			it("should accept valid values for config.define", () => {
+			it("should accept valid values for config.define", ({ expect }) => {
 				const rawConfig: RawConfig = {
 					define: {
 						abc: "def",
@@ -5717,7 +5870,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
-			it("should error if config.define is not an object", () => {
+			it("should error if config.define is not an object", ({ expect }) => {
 				const rawConfig: RawConfig = {
 					// @ts-expect-error purposely using an invalid value
 					define: 123,
@@ -5740,7 +5893,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if the values on config.define are not strings", () => {
+			it("should error if the values on config.define are not strings", ({
+				expect,
+			}) => {
 				const rawConfig: RawConfig = {
 					define: {
 						// @ts-expect-error purposely using an invalid value
@@ -5775,7 +5930,9 @@ describe("normalizeAndValidateConfig()", () => {
 			});
 
 			describe("named environments", () => {
-				it("should accept valid values for config.define inside an environment", () => {
+				it("should accept valid values for config.define inside an environment", ({
+					expect,
+				}) => {
 					const rawConfig: RawConfig = {
 						define: {
 							abc: "def",
@@ -5803,7 +5960,9 @@ describe("normalizeAndValidateConfig()", () => {
 					expect(diagnostics.hasErrors()).toBe(false);
 				});
 
-				it("should error if config.define is not an object inside an environment", () => {
+				it("should error if config.define is not an object inside an environment", ({
+					expect,
+				}) => {
 					const rawConfig: RawConfig = {
 						define: {
 							abc: "def",
@@ -5837,7 +5996,9 @@ describe("normalizeAndValidateConfig()", () => {
 					`);
 				});
 
-				it("should warn if if the shape of .define inside an environment doesn't match the shape of the top level .define", () => {
+				it("should warn if if the shape of .define inside an environment doesn't match the shape of the top level .define", ({
+					expect,
+				}) => {
 					const rawConfig: RawConfig = {
 						define: {
 							abc: "def",
@@ -5877,7 +6038,9 @@ describe("normalizeAndValidateConfig()", () => {
 					`);
 				});
 
-				it("should error if the values on config.define in an environment are not strings", () => {
+				it("should error if the values on config.define in an environment are not strings", ({
+					expect,
+				}) => {
 					const rawConfig: RawConfig = {
 						define: {
 							abc: "123",
@@ -5927,7 +6090,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[durable_objects]", () => {
-			it("should error if durable_objects is an array", () => {
+			it("should error if durable_objects is an array", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ env: { ENV1: { durable_objects: [] } } } as unknown as RawConfig,
 					undefined,
@@ -5944,7 +6107,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if durable_objects is a string", () => {
+			it("should error if durable_objects is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ env: { ENV1: { durable_objects: "BAD" } } } as unknown as RawConfig,
 					undefined,
@@ -5961,7 +6124,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if durable_objects is a number", () => {
+			it("should error if durable_objects is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ env: { ENV1: { durable_objects: 999 } } } as unknown as RawConfig,
 					undefined,
@@ -5978,7 +6141,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if durable_objects is null", () => {
+			it("should error if durable_objects is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ env: { ENV1: { durable_objects: null } } } as unknown as RawConfig,
 					undefined,
@@ -5995,7 +6158,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if durable_objects.bindings is not defined", () => {
+			it("should error if durable_objects.bindings is not defined", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ env: { ENV1: { durable_objects: {} } } } as unknown as RawConfig,
 					undefined,
@@ -6012,7 +6177,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if durable_objects.bindings is an object", () => {
+			it("should error if durable_objects.bindings is an object", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: { ENV1: { durable_objects: { bindings: {} } } },
@@ -6031,7 +6198,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if durable_objects.bindings is a string", () => {
+			it("should error if durable_objects.bindings is a string", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: { ENV1: { durable_objects: { bindings: "BAD" } } },
@@ -6050,7 +6219,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if durable_objects.bindings is a number", () => {
+			it("should error if durable_objects.bindings is a number", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: { ENV1: { durable_objects: { bindings: 999 } } },
@@ -6069,7 +6240,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if durable_objects.bindings is null", () => {
+			it("should error if durable_objects.bindings is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: { ENV1: { durable_objects: { bindings: null } } },
@@ -6088,7 +6259,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if durable_objects.bindings are not valid", () => {
+			it("should error if durable_objects.bindings are not valid", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: {
@@ -6140,7 +6313,9 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[migrations]", () => {
-			it("should override `migrations` config defaults with provided values", () => {
+			it("should override `migrations` config defaults with provided values", ({
+				expect,
+			}) => {
 				const expectedConfig: RawConfig = {
 					migrations: [
 						{
@@ -6169,7 +6344,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBe(false);
 			});
 
-			it("should error on invalid `migrations` values", () => {
+			it("should error on invalid `migrations` values", ({ expect }) => {
 				const expectedConfig = {
 					migrations: [
 						{
@@ -6211,7 +6386,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should warn/error on unexpected fields on `migrations`", async () => {
+			it("should warn/error on unexpected fields on `migrations`", async ({
+				expect,
+			}) => {
 				const expectedConfig = {
 					migrations: [
 						{
@@ -6258,7 +6435,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[kv_namespaces]", () => {
-			it("should error if kv_namespaces is an object", () => {
+			it("should error if kv_namespaces is an object", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ env: { ENV1: { kv_namespaces: {} } } } as unknown as RawConfig,
 					undefined,
@@ -6275,7 +6452,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if kv_namespaces is a string", () => {
+			it("should error if kv_namespaces is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ env: { ENV1: { kv_namespaces: "BAD" } } } as unknown as RawConfig,
 					undefined,
@@ -6292,7 +6469,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if kv_namespaces is a number", () => {
+			it("should error if kv_namespaces is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ env: { ENV1: { kv_namespaces: 999 } } } as unknown as RawConfig,
 					undefined,
@@ -6309,7 +6486,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if kv_namespaces is null", () => {
+			it("should error if kv_namespaces is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ env: { ENV1: { kv_namespaces: null } } } as unknown as RawConfig,
 					undefined,
@@ -6326,7 +6503,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if kv_namespaces.bindings are not valid", () => {
+			it("should error if kv_namespaces.bindings are not valid", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: {
@@ -6363,7 +6542,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[r2_buckets]", () => {
-			it("should error if r2_buckets is an object", () => {
+			it("should error if r2_buckets is an object", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ env: { ENV1: { r2_buckets: {} } } } as unknown as RawConfig,
 					undefined,
@@ -6380,7 +6559,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if r2_buckets is a string", () => {
+			it("should error if r2_buckets is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ env: { ENV1: { r2_buckets: "BAD" } } } as unknown as RawConfig,
 					undefined,
@@ -6397,7 +6576,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if r2_buckets is a number", () => {
+			it("should error if r2_buckets is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ env: { ENV1: { r2_buckets: 999 } } } as unknown as RawConfig,
 					undefined,
@@ -6414,7 +6593,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if r2_buckets is null", () => {
+			it("should error if r2_buckets is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ env: { ENV1: { r2_buckets: null } } } as unknown as RawConfig,
 					undefined,
@@ -6431,7 +6610,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if r2_buckets.bindings are not valid", () => {
+			it("should error if r2_buckets.bindings are not valid", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: {
@@ -6469,7 +6648,9 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[analytics_engine_datasets]", () => {
-			it("should error if analytics_engine_datasets is an object", () => {
+			it("should error if analytics_engine_datasets is an object", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: { ENV1: { analytics_engine_datasets: {} } },
@@ -6488,7 +6669,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if analytics_engine_datasets is a string", () => {
+			it("should error if analytics_engine_datasets is a string", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: { ENV1: { analytics_engine_datasets: "BAD" } },
@@ -6507,7 +6690,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if analytics_engine_datasets is a number", () => {
+			it("should error if analytics_engine_datasets is a number", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: { ENV1: { analytics_engine_datasets: 999 } },
@@ -6526,7 +6711,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if analytics_engine_datasets is null", () => {
+			it("should error if analytics_engine_datasets is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: { ENV1: { analytics_engine_datasets: null } },
@@ -6545,7 +6730,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if analytics_engine_datasets.bindings are not valid", () => {
+			it("should error if analytics_engine_datasets.bindings are not valid", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: {
@@ -6582,7 +6769,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[unsafe.bindings]", () => {
-			it("should error if unsafe is an array", () => {
+			it("should error if unsafe is an array", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ env: { ENV1: { unsafe: [] } } } as unknown as RawConfig,
 					undefined,
@@ -6604,7 +6791,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe is a string", () => {
+			it("should error if unsafe is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ env: { ENV1: { unsafe: "BAD" } } } as unknown as RawConfig,
 					undefined,
@@ -6626,7 +6813,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe is a number", () => {
+			it("should error if unsafe is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ env: { ENV1: { unsafe: 999 } } } as unknown as RawConfig,
 					undefined,
@@ -6648,7 +6835,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe is null", () => {
+			it("should error if unsafe is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ env: { ENV1: { unsafe: null } } } as unknown as RawConfig,
 					undefined,
@@ -6670,7 +6857,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should not error if unsafe is an empty object", () => {
+			it("should not error if unsafe is an empty object", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ env: { ENV1: { unsafe: {} } } } as RawConfig,
 					undefined,
@@ -6690,7 +6877,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should not error if at least unsafe.bindings is undefined", () => {
+			it("should not error if at least unsafe.bindings is undefined", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: { ENV1: { unsafe: { bindings: [] } } },
@@ -6709,7 +6898,9 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
-			it("should error if unsafe contains unexpected properties", () => {
+			it("should error if unsafe contains unexpected properties", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: { ENV1: { unsafe: { invalid: true } } },
@@ -6732,7 +6923,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe.bindings is an object", () => {
+			it("should error if unsafe.bindings is an object", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: { ENV1: { unsafe: { bindings: {} } } },
@@ -6756,7 +6947,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe.bindings is a string", () => {
+			it("should error if unsafe.bindings is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: { ENV1: { unsafe: { bindings: "BAD" } } },
@@ -6780,7 +6971,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe.bindings is a number", () => {
+			it("should error if unsafe.bindings is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: { ENV1: { unsafe: { bindings: 999 } } },
@@ -6804,7 +6995,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe.bindings is null", () => {
+			it("should error if unsafe.bindings is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: { ENV1: { unsafe: { bindings: null } } },
@@ -6828,7 +7019,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe.bindings are not valid", () => {
+			it("should error if unsafe.bindings are not valid", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: {
@@ -6877,7 +7068,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe.metadata is an array", () => {
+			it("should error if unsafe.metadata is an array", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: { ENV1: { unsafe: { metadata: [] } } },
@@ -6901,7 +7092,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe.metadata is a string", () => {
+			it("should error if unsafe.metadata is a string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: { ENV1: { unsafe: { metadata: "BAD" } } },
@@ -6925,7 +7116,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe.metadata is a number", () => {
+			it("should error if unsafe.metadata is a number", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: { ENV1: { unsafe: { metadata: 999 } } },
@@ -6949,7 +7140,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if unsafe.metadata is null", () => {
+			it("should error if unsafe.metadata is null", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						env: { ENV1: { unsafe: { metadata: null } } },
@@ -6975,7 +7166,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[tail_consumers]", () => {
-			it("should error if tail_consumers is not an array", () => {
+			it("should error if tail_consumers is not an array", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						tail_consumers: "this sure isn't an array",
@@ -6993,7 +7184,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error on invalid tail_consumers", () => {
+			it("should error on invalid tail_consumers", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						tail_consumers: [
@@ -7032,7 +7223,9 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[streaming_tail_consumers]", () => {
-			it("should error if streaming_tail_consumers is not an array", () => {
+			it("should error if streaming_tail_consumers is not an array", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						streaming_tail_consumers: "this sure isn't an array",
@@ -7050,7 +7243,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error on invalid streaming_tail_consumers", () => {
+			it("should error on invalid streaming_tail_consumers", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						streaming_tail_consumers: [
@@ -7088,7 +7281,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[observability]", () => {
-			it("should error on invalid observability", () => {
+			it("should error on invalid observability", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						observability: {
@@ -7115,7 +7308,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should not warn on full observability config", () => {
+			it("should not warn on full observability config", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						observability: {
@@ -7145,7 +7338,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
-			it("should error on invalid observability.logs", () => {
+			it("should error on invalid observability.logs", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						observability: {
@@ -7171,7 +7364,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should not error on nested [observability.logs] config only", () => {
+			it("should not error on nested [observability.logs] config only", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						observability: {
@@ -7194,7 +7389,9 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
-			it("should not error on nested [observability.traces] config only", () => {
+			it("should not error on nested [observability.traces] config only", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						observability: {
@@ -7217,7 +7414,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
-			it("should not error on mixed observability config", () => {
+			it("should not error on mixed observability config", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						observability: {
@@ -7243,7 +7440,7 @@ describe("normalizeAndValidateConfig()", () => {
 
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
-			it("should error on a sampling rate out of range", () => {
+			it("should error on a sampling rate out of range", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						observability: {
@@ -7264,7 +7461,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error on invalid additional fields", () => {
+			it("should error on invalid additional fields", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						observability: {
@@ -7288,7 +7485,9 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("route & routes fields", () => {
-			it("should error if both route and routes are specified in the same environment", () => {
+			it("should error if both route and routes are specified in the same environment", ({
+				expect,
+			}) => {
 				const environment: RawEnvironment = {
 					name: "mock-env-name",
 					account_id: "ENV_ACCOUNT_ID",
@@ -7335,7 +7534,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if both route and routes are specified in the top-level environment", () => {
+			it("should error if both route and routes are specified in the top-level environment", ({
+				expect,
+			}) => {
 				const environment: RawEnvironment = {
 					name: "mock-env-name",
 					account_id: "ENV_ACCOUNT_ID",
@@ -7380,7 +7581,9 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should not error if <env>.route and <top-level>.routes are specified", () => {
+			it("should not error if <env>.route and <top-level>.routes are specified", ({
+				expect,
+			}) => {
 				const environment: RawEnvironment = {
 					name: "mock-env-name",
 					account_id: "ENV_ACCOUNT_ID",
@@ -7419,7 +7622,9 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBe(false);
 			});
 
-			it("should not error if <env>.routes and <top-level>.route are specified", () => {
+			it("should not error if <env>.routes and <top-level>.route are specified", ({
+				expect,
+			}) => {
 				const environment: RawEnvironment = {
 					name: "mock-env-name",
 					account_id: "ENV_ACCOUNT_ID",
@@ -7458,7 +7663,9 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBe(false);
 			});
 
-			it("should not error if <env1>.route and <env2>.routes are specified", () => {
+			it("should not error if <env1>.route and <env2>.routes are specified", ({
+				expect,
+			}) => {
 				const environment1: RawEnvironment = {
 					name: "mock-env-name",
 					account_id: "ENV_ACCOUNT_ID",
@@ -7526,7 +7733,7 @@ describe("normalizeAndValidateConfig()", () => {
 		});
 
 		describe("[assets]", () => {
-			it("should inherit from top-level assets", () => {
+			it("should inherit from top-level assets", ({ expect }) => {
 				const rawConfig: RawConfig = {
 					assets: {
 						directory: "dist",
@@ -7556,7 +7763,9 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBe(false);
 			});
 
-			it("should resolve assets in named env with top-level env also including assets", () => {
+			it("should resolve assets in named env with top-level env also including assets", ({
+				expect,
+			}) => {
 				const rawConfig: RawConfig = {
 					assets: {
 						directory: "dist",

--- a/packages/workflows-shared/tests/validators.test.ts
+++ b/packages/workflows-shared/tests/validators.test.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line workers-sdk/no-vitest-import-expect -- see #12346
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import {
 	isValidStepName,
 	isValidWorkflowInstanceId,
@@ -10,7 +9,7 @@ import {
 } from "../src/lib/validators";
 
 describe("Workflow name validation", () => {
-	it.each([
+	it.for([
 		"",
 		NaN,
 		undefined,
@@ -19,22 +18,22 @@ describe("Workflow name validation", () => {
 		"w".repeat(MAX_WORKFLOW_NAME_LENGTH + 1),
 		"#1231231!!!!",
 		"-badName",
-	])("should reject invalid names", function (value) {
+	])("should reject invalid names", (value, { expect }) => {
 		expect(isValidWorkflowName(value as string)).toBe(false);
 	});
 
-	it.each([
+	it.for([
 		"abc",
 		"NAME_123-hello",
 		"a-valid-string",
 		"w".repeat(MAX_WORKFLOW_NAME_LENGTH),
-	])("should accept valid names", function (value) {
+	])("should accept valid names", (value, { expect }) => {
 		expect(isValidWorkflowName(value as string)).toBe(true);
 	});
 });
 
 describe("Workflow instance ID validation", () => {
-	it.each([
+	it.for([
 		"",
 		NaN,
 		undefined,
@@ -42,35 +41,35 @@ describe("Workflow instance ID validation", () => {
 		"\n\nhello",
 		"w".repeat(MAX_WORKFLOW_INSTANCE_ID_LENGTH + 1),
 		"#1231231!!!!",
-	])("should reject invalid IDs", function (value) {
+	])("should reject invalid IDs", (value, { expect }) => {
 		expect(isValidWorkflowInstanceId(value as string)).toBe(false);
 	});
 
-	it.each([
+	it.for([
 		"abc",
 		"NAME_123-hello",
 		"a-valid-string",
 		"w".repeat(MAX_WORKFLOW_INSTANCE_ID_LENGTH),
-	])("should accept valid IDs", function (value) {
+	])("should accept valid IDs", (value, { expect }) => {
 		expect(isValidWorkflowInstanceId(value as string)).toBe(true);
 	});
 });
 
 describe("Workflow instance step name validation", () => {
-	it.each(["\x00", "w".repeat(MAX_STEP_NAME_LENGTH + 1)])(
+	it.for(["\x00", "w".repeat(MAX_STEP_NAME_LENGTH + 1)])(
 		"should reject invalid names",
-		function (value) {
+		(value, { expect }) => {
 			expect(isValidStepName(value as string)).toBe(false);
 		}
 	);
 
-	it.each([
+	it.for([
 		"abc",
 		"NAME_123-hello",
 		"a-valid-string",
 		"w".repeat(MAX_STEP_NAME_LENGTH),
 		"valid step name",
-	])("should accept valid names", function (value) {
+	])("should accept valid names", (value, { expect }) => {
 		expect(isValidStepName(value as string)).toBe(true);
 	});
 });

--- a/packages/wrangler/src/__tests__/autoconfig/details/get-worker-name-from-project.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/get-worker-name-from-project.test.ts
@@ -1,8 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { seed } from "@cloudflare/workers-utils/test-helpers";
-/* eslint-disable workers-sdk/no-vitest-import-expect -- it.each patterns */
-import { afterEach, describe, expect, it, vi } from "vitest";
-/* eslint-enable workers-sdk/no-vitest-import-expect */
+import { afterEach, describe, it, vi } from "vitest";
 import { getWorkerNameFromProject } from "../../../autoconfig/details";
 import { runInTempDir } from "../../helpers/run-in-tmp";
 
@@ -25,9 +23,12 @@ describe("autoconfig details - getWorkerNameFromProject()", () => {
 		},
 	];
 
-	it.each(workerNamesToTest)(
+	it.for(workerNamesToTest)(
 		"should use the directory name as the worker name when no package.json, normalizing if needed (%s)",
-		async ({ rawName: dirname, normalizedName: expectedWorkerName }) => {
+		async (
+			{ rawName: dirname, normalizedName: expectedWorkerName },
+			{ expect }
+		) => {
 			await seed({
 				[`./${dirname}/index.html`]: "<h1>Hello World</h1>",
 			});
@@ -35,9 +36,12 @@ describe("autoconfig details - getWorkerNameFromProject()", () => {
 		}
 	);
 
-	it.each(workerNamesToTest)(
+	it.for(workerNamesToTest)(
 		"should use the name from package.json when available, normalizing if needed (%s)",
-		async ({ rawName: projectName, normalizedName: expectedWorkerName }) => {
+		async (
+			{ rawName: projectName, normalizedName: expectedWorkerName },
+			{ expect }
+		) => {
 			const dirname = `project-${randomUUID()}`;
 			await seed({
 				[`./${dirname}/package.json`]: JSON.stringify({ name: projectName }),
@@ -46,7 +50,9 @@ describe("autoconfig details - getWorkerNameFromProject()", () => {
 		}
 	);
 
-	it("should fall back to directory name when package.json has no name field", async () => {
+	it("should fall back to directory name when package.json has no name field", async ({
+		expect,
+	}) => {
 		const dirname = "my-test-project";
 		await seed({
 			[`./${dirname}/package.json`]: JSON.stringify({ version: "1.0.0" }),
@@ -54,7 +60,9 @@ describe("autoconfig details - getWorkerNameFromProject()", () => {
 		expect(getWorkerNameFromProject(`./${dirname}`)).toBe(dirname);
 	});
 
-	it("should fall back to directory name when package.json is invalid", async () => {
+	it("should fall back to directory name when package.json is invalid", async ({
+		expect,
+	}) => {
 		const dirname = "my-test-project";
 		await seed({
 			[`./${dirname}/package.json`]: "not valid json",
@@ -62,7 +70,9 @@ describe("autoconfig details - getWorkerNameFromProject()", () => {
 		expect(getWorkerNameFromProject(`./${dirname}`)).toBe(dirname);
 	});
 
-	it("WRANGLER_CI_OVERRIDE_NAME should override the worker name", async () => {
+	it("WRANGLER_CI_OVERRIDE_NAME should override the worker name", async ({
+		expect,
+	}) => {
 		vi.stubEnv("WRANGLER_CI_OVERRIDE_NAME", "overridden-worker-name");
 
 		await seed({

--- a/packages/wrangler/src/__tests__/config/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.test.ts
@@ -1,15 +1,15 @@
 import * as fs from "node:fs";
 import { experimental_readRawConfig } from "@cloudflare/workers-utils";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
-/* eslint-disable workers-sdk/no-vitest-import-expect -- describe.each pattern */
-import { describe, expect, it } from "vitest";
-/* eslint-enable workers-sdk/no-vitest-import-expect */
+import { describe, it } from "vitest";
 import { readConfig } from "../../config";
 import { runInTempDir } from "../helpers/run-in-tmp";
 
 describe("readConfig()", () => {
 	runInTempDir();
-	it("should not error if a python entrypoint is used with the right compatibility_flag", () => {
+	it("should not error if a python entrypoint is used with the right compatibility_flag", ({
+		expect,
+	}) => {
 		writeWranglerConfig({
 			main: "index.py",
 			compatibility_flags: ["python_workers"],
@@ -26,7 +26,9 @@ describe("readConfig()", () => {
 			]
 		`);
 	});
-	it("should error if a python entrypoint is used without the right compatibility_flag", () => {
+	it("should error if a python entrypoint is used without the right compatibility_flag", ({
+		expect,
+	}) => {
 		writeWranglerConfig({
 			main: "index.py",
 		});
@@ -46,7 +48,9 @@ describe("experimental_readRawConfig()", () => {
 		`with %s config files`,
 		(configType) => {
 			runInTempDir();
-			it(`should find a ${configType} config file given a specific path`, () => {
+			it(`should find a ${configType} config file given a specific path`, ({
+				expect,
+			}) => {
 				fs.mkdirSync("../folder", { recursive: true });
 				writeWranglerConfig(
 					{ name: "config-one" },
@@ -63,7 +67,7 @@ describe("experimental_readRawConfig()", () => {
 				);
 			});
 
-			it("should find a config file given a specific script", () => {
+			it("should find a config file given a specific script", ({ expect }) => {
 				fs.mkdirSync("./path/to", { recursive: true });
 				writeWranglerConfig(
 					{ name: "config-one" },
@@ -101,7 +105,7 @@ describe("experimental_readRawConfig()", () => {
 describe("BOM (Byte Order Marker) handling", () => {
 	runInTempDir();
 
-	it("should remove UTF-8 BOM from TOML config files", () => {
+	it("should remove UTF-8 BOM from TOML config files", ({ expect }) => {
 		const configContent = `name = "test-worker"
 compatibility_date = "2022-01-12"`;
 
@@ -118,7 +122,7 @@ compatibility_date = "2022-01-12"`;
 		expect(config.compatibility_date).toBe("2022-01-12");
 	});
 
-	it("should remove UTF-8 BOM from JSON config files", () => {
+	it("should remove UTF-8 BOM from JSON config files", ({ expect }) => {
 		const configContent = `{
 	"name": "test-worker",
 	"compatibility_date": "2022-01-12"
@@ -137,7 +141,7 @@ compatibility_date = "2022-01-12"`;
 		expect(config.compatibility_date).toBe("2022-01-12");
 	});
 
-	it("should error on UTF-16 BE BOM", () => {
+	it("should error on UTF-16 BE BOM", ({ expect }) => {
 		const bomBytes = Buffer.from([0xfe, 0xff]);
 		const configContent = Buffer.from('{"name": "test"}', "utf-8");
 		fs.writeFileSync("wrangler.json", Buffer.concat([bomBytes, configContent]));
@@ -147,7 +151,7 @@ compatibility_date = "2022-01-12"`;
 		);
 	});
 
-	it("should error on UTF-16 LE BOM", () => {
+	it("should error on UTF-16 LE BOM", ({ expect }) => {
 		const bomBytes = Buffer.from([0xff, 0xfe]);
 		const configContent = Buffer.from('{"name": "test"}', "utf-8");
 		fs.writeFileSync("wrangler.json", Buffer.concat([bomBytes, configContent]));
@@ -157,7 +161,7 @@ compatibility_date = "2022-01-12"`;
 		);
 	});
 
-	it("should error on UTF-32 BE BOM", () => {
+	it("should error on UTF-32 BE BOM", ({ expect }) => {
 		const bomBytes = Buffer.from([0x00, 0x00, 0xfe, 0xff]);
 		const configContent = Buffer.from('{"name": "test"}', "utf-8");
 		fs.writeFileSync("wrangler.json", Buffer.concat([bomBytes, configContent]));
@@ -167,7 +171,7 @@ compatibility_date = "2022-01-12"`;
 		);
 	});
 
-	it("should error on UTF-32 LE BOM", () => {
+	it("should error on UTF-32 LE BOM", ({ expect }) => {
 		const bomBytes = Buffer.from([0xff, 0xfe, 0x00, 0x00]);
 		const configContent = Buffer.from('{"name": "test"}', "utf-8");
 		fs.writeFileSync("wrangler.json", Buffer.concat([bomBytes, configContent]));
@@ -177,7 +181,7 @@ compatibility_date = "2022-01-12"`;
 		);
 	});
 
-	it("should handle files without BOM normally", () => {
+	it("should handle files without BOM normally", ({ expect }) => {
 		writeWranglerConfig({ name: "no-bom-test" });
 
 		const config = readConfig({ config: "wrangler.toml" });

--- a/packages/wrangler/src/__tests__/find-additional-modules.test.ts
+++ b/packages/wrangler/src/__tests__/find-additional-modules.test.ts
@@ -1,9 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import dedent from "ts-dedent";
-/* eslint-disable workers-sdk/no-vitest-import-expect -- uses .each */
-import { describe, expect, it } from "vitest";
-/* eslint-enable workers-sdk/no-vitest-import-expect */
+import { describe, it } from "vitest";
 import { findAdditionalModules } from "../deployment-bundle/find-additional-modules";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";
@@ -20,7 +18,7 @@ describe("traverse module graph", () => {
 	runInTempDir();
 	mockConsoleMethods();
 
-	it("should not detect JS without module rules", async () => {
+	it("should not detect JS without module rules", async ({ expect }) => {
 		await writeFile(
 			"./index.js",
 			dedent/* javascript */ `
@@ -54,10 +52,10 @@ describe("traverse module graph", () => {
 		expect(modules).toStrictEqual([]);
 	});
 
-	it.each([
+	it.for([
 		["ESModule", "esm"],
 		["CommonJS", "commonjs"],
-	])("should detect JS as %s", async (type, format) => {
+	])("should detect JS as %s", async ([type, format], { expect }) => {
 		await writeFile(
 			"./index.js",
 			dedent/* javascript */ `
@@ -91,7 +89,7 @@ describe("traverse module graph", () => {
 		expect(modules[0].type).toStrictEqual(format);
 	});
 
-	it("should not resolve JS outside the module root", async () => {
+	it("should not resolve JS outside the module root", async ({ expect }) => {
 		await mkdir("./src/nested", { recursive: true });
 		await writeFile(
 			"./src/nested/index.js",
@@ -127,7 +125,7 @@ describe("traverse module graph", () => {
 		expect(modules).toStrictEqual([]);
 	});
 
-	it("should resolve JS with module root", async () => {
+	it("should resolve JS with module root", async ({ expect }) => {
 		await mkdir("./src/nested", { recursive: true });
 		await writeFile(
 			"./src/nested/index.js",
@@ -163,7 +161,7 @@ describe("traverse module graph", () => {
 		expect(modules[0].name).toStrictEqual("other.js");
 	});
 
-	it("should ignore files not matched by glob", async () => {
+	it("should ignore files not matched by glob", async ({ expect }) => {
 		await mkdir("./src/nested", { recursive: true });
 		await writeFile(
 			"./src/nested/index.js",
@@ -199,7 +197,7 @@ describe("traverse module graph", () => {
 		expect(modules.length).toStrictEqual(0);
 	});
 
-	it("should ignore Wrangler files", async () => {
+	it("should ignore Wrangler files", async ({ expect }) => {
 		await mkdir("./src", { recursive: true });
 		await writeFile(
 			"./src/index.js",
@@ -248,7 +246,9 @@ describe("traverse module graph", () => {
 		expect(modules.map((m) => m.name)).toMatchInlineSnapshot(`[]`);
 	});
 
-	it("should resolve files that match the default rules", async () => {
+	it("should resolve files that match the default rules", async ({
+		expect,
+	}) => {
 		await mkdir("./src", { recursive: true });
 		await writeFile(
 			"./src/index.js",
@@ -284,7 +284,9 @@ describe("traverse module graph", () => {
 		expect(modules[0].name).toStrictEqual("other.txt");
 	});
 
-	it("should error if a rule is ignored because the previous was not marked 'fall-through'", async () => {
+	it("should error if a rule is ignored because the previous was not marked 'fall-through'", async ({
+		expect,
+	}) => {
 		await mkdir("./src", { recursive: true });
 		await writeFile(
 			"./src/index.js",
@@ -329,7 +331,9 @@ describe("Python modules", () => {
 	runInTempDir();
 	mockConsoleMethods();
 
-	it("should find python_modules with forward slashes (for cross-platform deploy)", async () => {
+	it("should find python_modules with forward slashes (for cross-platform deploy)", async ({
+		expect,
+	}) => {
 		await mkdir("./python_modules/pkg/subpkg", { recursive: true });
 		await writeFile("./index.py", "def fetch(request): pass");
 		await writeFile("./python_modules/pkg/__init__.py", "");
@@ -362,7 +366,9 @@ describe("Python modules", () => {
 		});
 	});
 
-	it("should exclude files matching pythonModulesExcludes patterns", async () => {
+	it("should exclude files matching pythonModulesExcludes patterns", async ({
+		expect,
+	}) => {
 		await mkdir("./python_modules", { recursive: true });
 		await writeFile("./index.py", "def fetch(request): pass");
 		await writeFile("./python_modules/module.py", "x = 1");

--- a/packages/wrangler/src/__tests__/is-local.test.ts
+++ b/packages/wrangler/src/__tests__/is-local.test.ts
@@ -1,6 +1,4 @@
-/* eslint-disable workers-sdk/no-vitest-import-expect -- uses .each */
-import { expect, it } from "vitest";
-/* eslint-enable workers-sdk/no-vitest-import-expect */
+import { it } from "vitest";
 import { isLocal } from "../utils/is-local";
 
 const testCases: [
@@ -20,6 +18,9 @@ const testCases: [
 	[{ remote: undefined, local: undefined }, false, false],
 ];
 
-it.each(testCases)("isLocal(%j, %o) -> %o", (args, defaultValue, expected) => {
-	expect(isLocal(args, defaultValue)).toBe(expected);
-});
+it.for(testCases)(
+	"isLocal(%j, %o) -> %o",
+	([args, defaultValue, expected], { expect }) => {
+		expect(isLocal(args, defaultValue)).toBe(expected);
+	}
+);

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -1,7 +1,5 @@
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
-/* eslint-disable workers-sdk/no-vitest-import-expect -- uses test.each patterns */
-import { beforeEach, describe, expect, it, test } from "vitest";
-/* eslint-enable workers-sdk/no-vitest-import-expect */
+import { beforeEach, describe, it, test } from "vitest";
 import { normalizeOutput } from "../../../e2e/helpers/normalize";
 import {
 	assignAndDistributePercentages,
@@ -54,7 +52,9 @@ describe("versions deploy", () => {
 	});
 
 	describe("legacy deploy", () => {
-		test("should warn user when worker has deployment with multiple versions", async () => {
+		test("should warn user when worker has deployment with multiple versions", async ({
+			expect,
+		}) => {
 			msw.use(
 				...mswSuccessDeploymentScriptMetadata,
 				...mswListNewDeploymentsLatestFiftyFifty
@@ -91,7 +91,7 @@ describe("versions deploy", () => {
 	});
 
 	describe("without wrangler.toml", () => {
-		test("succeeds with --name arg", async () => {
+		test("succeeds with --name arg", async ({ expect }) => {
 			const result = runWrangler(
 				"versions deploy 10000000-0000-0000-0000-000000000000 --name named-worker --yes"
 			);
@@ -142,7 +142,7 @@ describe("versions deploy", () => {
 			);
 		});
 
-		test("fails without --name arg", async () => {
+		test("fails without --name arg", async ({ expect }) => {
 			const result = runWrangler(
 				"versions deploy 10000000-0000-0000-0000-000000000000 --yes"
 			);
@@ -156,7 +156,7 @@ describe("versions deploy", () => {
 	describe("with wrangler.toml", () => {
 		beforeEach(() => writeWranglerConfig());
 
-		test("no args", async () => {
+		test("no args", async ({ expect }) => {
 			const result = runWrangler("versions deploy --yes");
 
 			await expect(result).rejects.toMatchInlineSnapshot(
@@ -188,7 +188,7 @@ describe("versions deploy", () => {
 			`);
 		});
 
-		test("1 version @ (implicit) 100%", async () => {
+		test("1 version @ (implicit) 100%", async ({ expect }) => {
 			const result = runWrangler(
 				"versions deploy 10000000-0000-0000-0000-000000000000 --yes"
 			);
@@ -235,7 +235,7 @@ describe("versions deploy", () => {
 			`);
 		});
 
-		test("1 version @ (explicit) 100%", async () => {
+		test("1 version @ (explicit) 100%", async ({ expect }) => {
 			const result = runWrangler(
 				"versions deploy 10000000-0000-0000-0000-000000000000@100% --yes"
 			);
@@ -282,7 +282,7 @@ describe("versions deploy", () => {
 			`);
 		});
 
-		test("2 versions @ (implicit) 50% each", async () => {
+		test("2 versions @ (implicit) 50% each", async ({ expect }) => {
 			const result = runWrangler(
 				"versions deploy 10000000-0000-0000-0000-000000000000 20000000-0000-0000-0000-000000000000 --yes"
 			);
@@ -337,7 +337,7 @@ describe("versions deploy", () => {
 			`);
 		});
 
-		test("1 version @ (explicit) 100%", async () => {
+		test("1 version @ (explicit) 100%", async ({ expect }) => {
 			const result = runWrangler(
 				"versions deploy 10000000-0000-0000-0000-000000000000@100% --yes"
 			);
@@ -384,7 +384,7 @@ describe("versions deploy", () => {
 			`);
 		});
 
-		test("2 versions @ (explicit) 30% + (implicit) 70%", async () => {
+		test("2 versions @ (explicit) 30% + (implicit) 70%", async ({ expect }) => {
 			const result = runWrangler(
 				"versions deploy 10000000-0000-0000-0000-000000000000@30% 20000000-0000-0000-0000-000000000000 --yes"
 			);
@@ -439,7 +439,7 @@ describe("versions deploy", () => {
 			`);
 		});
 
-		test("2 versions @ (explicit) 40% + (explicit) 60%", async () => {
+		test("2 versions @ (explicit) 40% + (explicit) 60%", async ({ expect }) => {
 			const result = runWrangler(
 				"versions deploy 10000000-0000-0000-0000-000000000000@40% 20000000-0000-0000-0000-000000000000@60% --yes"
 			);
@@ -495,7 +495,7 @@ describe("versions deploy", () => {
 		});
 
 		describe("max versions restrictions (temp)", () => {
-			test("2+ versions fails", async () => {
+			test("2+ versions fails", async ({ expect }) => {
 				const result = runWrangler(
 					"versions deploy 10000000-0000-0000-0000-000000000000 20000000-0000-0000-0000-000000000000 30000000-0000-0000-0000-000000000000 --yes"
 				);
@@ -544,7 +544,7 @@ describe("versions deploy", () => {
 				`);
 			});
 
-			test("--max-versions allows > 2 versions", async () => {
+			test("--max-versions allows > 2 versions", async ({ expect }) => {
 				const result = runWrangler(
 					"versions deploy 10000000-0000-0000-0000-000000000000 20000000-0000-0000-0000-000000000000 30000000-0000-0000-0000-000000000000 --max-versions=3 --yes"
 				);
@@ -610,7 +610,7 @@ describe("versions deploy", () => {
 			});
 		});
 
-		test("with a message", async () => {
+		test("with a message", async ({ expect }) => {
 			const result = runWrangler(
 				"versions deploy 10000000-0000-0000-0000-000000000000 --message 'My versioned deployment message' --yes"
 			);
@@ -658,7 +658,7 @@ describe("versions deploy", () => {
 			`);
 		});
 
-		test("with logpush in wrangler.toml", async () => {
+		test("with logpush in wrangler.toml", async ({ expect }) => {
 			writeWranglerConfig({
 				logpush: true,
 			});
@@ -715,7 +715,7 @@ describe("versions deploy", () => {
 			`);
 		});
 
-		test("with observability disabled in wrangler.toml", async () => {
+		test("with observability disabled in wrangler.toml", async ({ expect }) => {
 			writeWranglerConfig({
 				observability: {
 					enabled: false,
@@ -774,7 +774,9 @@ describe("versions deploy", () => {
 			`);
 		});
 
-		test("with logpush, tail_consumers, and observability in wrangler.toml", async () => {
+		test("with logpush, tail_consumers, and observability in wrangler.toml", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				logpush: false,
 				observability: {
@@ -843,7 +845,9 @@ describe("versions deploy", () => {
 			`);
 		});
 
-		test("with logpush, streaming_tail_consumers, and observability in wrangler.toml", async () => {
+		test("with logpush, streaming_tail_consumers, and observability in wrangler.toml", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				logpush: false,
 				observability: {
@@ -912,7 +916,7 @@ describe("versions deploy", () => {
 			`);
 		});
 
-		test("fails for non-existent versionId", async () => {
+		test("fails for non-existent versionId", async ({ expect }) => {
 			const result = runWrangler(
 				"versions deploy ffffffff-ffff-ffff-ffff-ffffffffffff --yes"
 			);
@@ -944,7 +948,7 @@ describe("versions deploy", () => {
 			`);
 		});
 
-		test("fails if --percentage > 100", async () => {
+		test("fails if --percentage > 100", async ({ expect }) => {
 			const result = runWrangler(
 				"versions deploy 10000000-0000-0000-0000-000000000000 --percentage 101 --yes"
 			);
@@ -956,7 +960,7 @@ describe("versions deploy", () => {
 			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`""`);
 		});
 
-		test("fails if --percentage < 0", async () => {
+		test("fails if --percentage < 0", async ({ expect }) => {
 			const result = runWrangler(
 				"versions deploy 10000000-0000-0000-0000-000000000000 --percentage -1 --yes"
 			);
@@ -968,7 +972,7 @@ describe("versions deploy", () => {
 			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`""`);
 		});
 
-		test("fails if version-spec percentage > 100", async () => {
+		test("fails if version-spec percentage > 100", async ({ expect }) => {
 			const result = runWrangler(
 				"versions deploy 10000000-0000-0000-0000-000000000000 --percentage 101 --yes"
 			);
@@ -980,7 +984,7 @@ describe("versions deploy", () => {
 			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`""`);
 		});
 
-		test("fails if version-spec percentage < 0", async () => {
+		test("fails if version-spec percentage < 0", async ({ expect }) => {
 			const result = runWrangler(
 				"versions deploy 10000000-0000-0000-0000-000000000000 --percentage -1 --yes"
 			);
@@ -993,7 +997,9 @@ describe("versions deploy", () => {
 		});
 
 		describe("multi-env warning", () => {
-			it("should warn if the wrangler config contains environments but none was specified in the command", async () => {
+			it("should warn if the wrangler config contains environments but none was specified in the command", async ({
+				expect,
+			}) => {
 				writeWranglerConfig({
 					env: {
 						test: {},
@@ -1016,7 +1022,9 @@ describe("versions deploy", () => {
 				`);
 			});
 
-			it("should not warn if the wrangler config contains environments and one was specified in the command", async () => {
+			it("should not warn if the wrangler config contains environments and one was specified in the command", async ({
+				expect,
+			}) => {
 				writeWranglerConfig({
 					env: {
 						test: {},
@@ -1030,7 +1038,9 @@ describe("versions deploy", () => {
 				expect(consoleStd.warn).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async () => {
+			it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async ({
+				expect,
+			}) => {
 				writeWranglerConfig();
 
 				await runWrangler(
@@ -1045,13 +1055,13 @@ describe("versions deploy", () => {
 
 describe("units", () => {
 	describe("parseVersionSpecs", () => {
-		test("no args", () => {
+		test("no args", ({ expect }) => {
 			const result = parseVersionSpecs({});
 
 			expect(result).toMatchObject(new Map());
 		});
 
-		test("1 positional arg", () => {
+		test("1 positional arg", ({ expect }) => {
 			const result = parseVersionSpecs({
 				versionSpecs: ["10000000-0000-0000-0000-000000000000@10%"],
 			});
@@ -1060,7 +1070,7 @@ describe("units", () => {
 				"10000000-0000-0000-0000-000000000000": 10,
 			});
 		});
-		test("2 positional args", () => {
+		test("2 positional args", ({ expect }) => {
 			const result = parseVersionSpecs({
 				versionSpecs: [
 					"10000000-0000-0000-0000-000000000000@10%",
@@ -1074,7 +1084,7 @@ describe("units", () => {
 			});
 		});
 
-		test("1 pair of named args", () => {
+		test("1 pair of named args", ({ expect }) => {
 			const result = parseVersionSpecs({
 				percentage: [10],
 				versionId: ["10000000-0000-0000-0000-000000000000"],
@@ -1084,7 +1094,7 @@ describe("units", () => {
 				"10000000-0000-0000-0000-000000000000": 10,
 			});
 		});
-		test("2 pairs of named args", () => {
+		test("2 pairs of named args", ({ expect }) => {
 			const result = parseVersionSpecs({
 				percentage: [10, 90],
 				versionId: [
@@ -1098,7 +1108,7 @@ describe("units", () => {
 				"20000000-0000-0000-0000-000000000000": 90,
 			});
 		});
-		test("unpaired named args", () => {
+		test("unpaired named args", ({ expect }) => {
 			const result = parseVersionSpecs({
 				percentage: [10],
 				versionId: [
@@ -1115,28 +1125,70 @@ describe("units", () => {
 	});
 
 	describe("assignAndDistributePercentages distributes remaining share of 100%", () => {
-		test.each`
-			description                                              | versionIds                  | optionalVersionTraffic | expected
-			${"from 1 specified value across 1 unspecified value"}   | ${["v1", "v2"]}             | ${{ v1: 10 }}          | ${{ v1: 10, v2: 90 }}
-			${"from 1 specified value across 2 unspecified values"}  | ${["v1", "v2", "v3"]}       | ${{ v1: 10 }}          | ${{ v1: 10, v2: 45, v3: 45 }}
-			${"from 2 specified values across 1 unspecified value"}  | ${["v1", "v2", "v3"]}       | ${{ v1: 10, v2: 60 }}  | ${{ v1: 10, v2: 60, v3: 30 }}
-			${"from 2 specified values across 2 unspecified values"} | ${["v1", "v2", "v3", "v4"]} | ${{ v1: 10, v2: 60 }}  | ${{ v1: 10, v2: 60, v3: 15, v4: 15 }}
-			${"limited to specified versionIds"}                     | ${["v1", "v3"]}             | ${{ v1: 10, v2: 70 }}  | ${{ v1: 10, v3: 90 }}
-			${"zero when no share remains"}                          | ${["v1", "v2", "v3"]}       | ${{ v1: 10, v2: 90 }}  | ${{ v1: 10, v2: 90, v3: 0 }}
-			${"unchanged when fully specified (adding to 100)"}      | ${["v1", "v2"]}             | ${{ v1: 10, v2: 90 }}  | ${{ v1: 10, v2: 90 }}
-			${"unchanged when fully specified (adding to < 100)"}    | ${["v1", "v2"]}             | ${{ v1: 10, v2: 20 }}  | ${{ v1: 10, v2: 20 }}
-		`(" $description", ({ versionIds, optionalVersionTraffic, expected }) => {
-			const result = assignAndDistributePercentages(
-				versionIds,
-				new Map(Object.entries(optionalVersionTraffic))
-			);
+		test.for([
+			{
+				description: "from 1 specified value across 1 unspecified value",
+				versionIds: ["v1", "v2"],
+				optionalVersionTraffic: { v1: 10 },
+				expected: { v1: 10, v2: 90 },
+			},
+			{
+				description: "from 1 specified value across 2 unspecified values",
+				versionIds: ["v1", "v2", "v3"],
+				optionalVersionTraffic: { v1: 10 },
+				expected: { v1: 10, v2: 45, v3: 45 },
+			},
+			{
+				description: "from 2 specified values across 1 unspecified value",
+				versionIds: ["v1", "v2", "v3"],
+				optionalVersionTraffic: { v1: 10, v2: 60 },
+				expected: { v1: 10, v2: 60, v3: 30 },
+			},
+			{
+				description: "from 2 specified values across 2 unspecified values",
+				versionIds: ["v1", "v2", "v3", "v4"],
+				optionalVersionTraffic: { v1: 10, v2: 60 },
+				expected: { v1: 10, v2: 60, v3: 15, v4: 15 },
+			},
+			{
+				description: "limited to specified versionIds",
+				versionIds: ["v1", "v3"],
+				optionalVersionTraffic: { v1: 10, v2: 70 },
+				expected: { v1: 10, v3: 90 },
+			},
+			{
+				description: "zero when no share remains",
+				versionIds: ["v1", "v2", "v3"],
+				optionalVersionTraffic: { v1: 10, v2: 90 },
+				expected: { v1: 10, v2: 90, v3: 0 },
+			},
+			{
+				description: "unchanged when fully specified (adding to 100)",
+				versionIds: ["v1", "v2"],
+				optionalVersionTraffic: { v1: 10, v2: 90 },
+				expected: { v1: 10, v2: 90 },
+			},
+			{
+				description: "unchanged when fully specified (adding to < 100)",
+				versionIds: ["v1", "v2"],
+				optionalVersionTraffic: { v1: 10, v2: 20 },
+				expected: { v1: 10, v2: 20 },
+			},
+		])(
+			" $description",
+			({ versionIds, optionalVersionTraffic, expected }, { expect }) => {
+				const result = assignAndDistributePercentages(
+					versionIds,
+					new Map(Object.entries(optionalVersionTraffic))
+				);
 
-			expect(Object.fromEntries(result)).toMatchObject(expected);
-		});
+				expect(Object.fromEntries(result)).toMatchObject(expected);
+			}
+		);
 	});
 
 	describe("summariseVersionTraffic", () => {
-		test("none unspecified", () => {
+		test("none unspecified", ({ expect }) => {
 			const result = summariseVersionTraffic(
 				new Map(
 					Object.entries({
@@ -1153,7 +1205,7 @@ describe("units", () => {
 			});
 		});
 
-		test("subtotal above 100", () => {
+		test("subtotal above 100", ({ expect }) => {
 			const result = summariseVersionTraffic(
 				new Map(
 					Object.entries({
@@ -1170,7 +1222,7 @@ describe("units", () => {
 			});
 		});
 
-		test("subtotal below 100", () => {
+		test("subtotal below 100", ({ expect }) => {
 			const result = summariseVersionTraffic(
 				new Map(
 					Object.entries({
@@ -1187,7 +1239,7 @@ describe("units", () => {
 			});
 		});
 
-		test("counts unspecified", () => {
+		test("counts unspecified", ({ expect }) => {
 			const result = summariseVersionTraffic(
 				new Map(
 					Object.entries({
@@ -1206,28 +1258,30 @@ describe("units", () => {
 	});
 
 	describe("validateTrafficSubtotal", () => {
-		test("errors if subtotal above max", () => {
+		test("errors if subtotal above max", ({ expect }) => {
 			expect(() =>
 				validateTrafficSubtotal(101, { min: 0, max: 100 })
 			).toThrowErrorMatchingInlineSnapshot(
 				`[Error: Sum of specified percentages (101%) must be at most 100%]`
 			);
 		});
-		test("errors if subtotal below min", () => {
+		test("errors if subtotal below min", ({ expect }) => {
 			expect(() =>
 				validateTrafficSubtotal(-1, { min: 0, max: 100 })
 			).toThrowErrorMatchingInlineSnapshot(
 				`[Error: Sum of specified percentages (-1%) must be at least 0%]`
 			);
 		});
-		test("different error message if min === max", () => {
+		test("different error message if min === max", ({ expect }) => {
 			expect(() =>
 				validateTrafficSubtotal(101, { min: 100, max: 100 })
 			).toThrowErrorMatchingInlineSnapshot(
 				`[Error: Sum of specified percentages (101%) must be 100%]`
 			);
 		});
-		test("no error if subtotal above max but not above max + EPSILON", () => {
+		test("no error if subtotal above max but not above max + EPSILON", ({
+			expect,
+		}) => {
 			expect(() => validateTrafficSubtotal(100.001)).not.toThrow();
 
 			expect(() =>
@@ -1236,7 +1290,9 @@ describe("units", () => {
 				`[Error: Sum of specified percentages (100.01%) must be 100%]`
 			);
 		});
-		test("no error if subtotal below min but not below min - EPSILON", () => {
+		test("no error if subtotal below min but not below min - EPSILON", ({
+			expect,
+		}) => {
 			expect(() => validateTrafficSubtotal(99.999)).not.toThrow();
 
 			expect(() =>


### PR DESCRIPTION
Part of https://github.com/cloudflare/workers-sdk/issues/12346

Typing `test.each()` is not easy with vitest.

@petebacondarwin figured out that using [`test.for()`](https://vitest.dev/api/#test-for) is designed to make this easier.

This PR migrates to using `for` and allow using `expect` from the test context.

OC/Claude report:

# Report: Migrate `.each` to `.for` for `expect` context support

## TLDR

- Converted 22 test files from `test.each`/`it.each` to `test.for`/`it.for` to obtain `expect` from the test context
- Removed all `eslint-disable workers-sdk/no-vitest-import-expect` comments from these files
- All regular `test`/`it` callbacks in these files also migrated to use `({ expect })`
- All ESLint, TypeScript, and test checks pass across 8 affected packages
- 11 files still have `eslint-disable` because they have other complex patterns (MSW handlers, module-scope helpers, etc.) — those are a separate effort

### Details

The `no-vitest-import-expect` ESLint rule enforces getting `expect` from the test context for concurrency safety. Files using `test.each`/`it.each` were exempted because `.each` doesn't provide access to the test context. Vitest's `test.for`/`it.for` (available since vitest 2.x) solves this by passing `TestContext` as a second callback argument:

```ts
// Before: .each doesn't provide context
it.each([[1, 2, 3]])("add %i + %i", (a, b, expected) => {
expect(a + b).toBe(expected); // imported from vitest
});

// After: .for provides context as 2nd arg
it.for([[1, 2, 3]])("add %i + %i", ([a, b, expected], { expect }) => {
expect(a + b).toBe(expected); // from test context
});
```

Key difference: `.for` does **not** spread array arguments — they must be destructured from a single array parameter.

`describe.each` was kept as-is since `describe` doesn't provide test context; inner `test`/`it` callbacks were migrated instead.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: tests, not user facing

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
