### PR TITLE
[miniflare] Fix Buffer type not accepted for D1 blob bindings

### DIFF
--- a/.changeset/fix-buffer-devalue.md
+++ b/.changeset/fix-buffer-devalue.md
@@ -1,0 +1,13 @@
+---
+"miniflare": patch
+---
+
+fix: normalise typed array subclasses in devalue serialization
+
+Node.js `Buffer` extends `Uint8Array` but isn't available in all runtimes. When
+a `Buffer` was passed through the proxy serialization bridge (e.g. as a D1 bind
+parameter via `getPlatformProxy()`), the reviver would fail because `"Buffer"`
+isn't in the allowed constructor list and may not exist on `globalThis` in workerd.
+
+The reducer now normalises subclass constructor names to the nearest standard
+typed array parent before serialization, matching structured clone behaviour.

--- a/packages/miniflare/src/workers/core/devalue.ts
+++ b/packages/miniflare/src/workers/core/devalue.ts
@@ -52,12 +52,18 @@ export const structuredSerializableReducers: ReducersRevivers = {
 	},
 	ArrayBufferView(value) {
 		if (ArrayBuffer.isView(value)) {
-			return [
-				value.constructor.name,
-				value.buffer,
-				value.byteOffset,
-				value.byteLength,
-			];
+			let name = value.constructor.name;
+			// Subclasses like Node.js `Buffer` extend standard typed arrays but
+			// aren't available in all runtimes. Normalise to the parent constructor.
+			if (!ALLOWED_ARRAY_BUFFER_VIEW_CONSTRUCTORS.some((c) => c.name === name)) {
+				for (const ctor of ALLOWED_ARRAY_BUFFER_VIEW_CONSTRUCTORS) {
+					if (value instanceof ctor) {
+						name = ctor.name;
+						break;
+					}
+				}
+			}
+			return [name, value.buffer, value.byteOffset, value.byteLength];
 		}
 	},
 	RegExp(value) {

--- a/packages/miniflare/src/workers/core/devalue.ts
+++ b/packages/miniflare/src/workers/core/devalue.ts
@@ -65,7 +65,13 @@ export const structuredSerializableReducers: ReducersRevivers = {
 					}
 				}
 			}
-			return [name, value.buffer, value.byteOffset, value.byteLength];
+			let buf = value.buffer;
+			let off = value.byteOffset;
+			if (off !== 0 || buf.byteLength !== value.byteLength) {
+				buf = buf.slice(off, off + value.byteLength);
+				off = 0;
+			}
+			return [name, buf, off, value.byteLength];
 		}
 	},
 	RegExp(value) {

--- a/packages/miniflare/src/workers/core/devalue.ts
+++ b/packages/miniflare/src/workers/core/devalue.ts
@@ -55,7 +55,9 @@ export const structuredSerializableReducers: ReducersRevivers = {
 			let name = value.constructor.name;
 			// Subclasses like Node.js `Buffer` extend standard typed arrays but
 			// aren't available in all runtimes. Normalise to the parent constructor.
-			if (!ALLOWED_ARRAY_BUFFER_VIEW_CONSTRUCTORS.some((c) => c.name === name)) {
+			if (
+				!ALLOWED_ARRAY_BUFFER_VIEW_CONSTRUCTORS.some((c) => c.name === name)
+			) {
 				for (const ctor of ALLOWED_ARRAY_BUFFER_VIEW_CONSTRUCTORS) {
 					if (value instanceof ctor) {
 						name = ctor.name;

--- a/packages/miniflare/test/workers/core/serialize.spec.ts
+++ b/packages/miniflare/test/workers/core/serialize.spec.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { parse, stringify } from "devalue";
 import {
 	createHTTPReducers,
@@ -7,6 +8,19 @@ import {
 } from "miniflare";
 import { test } from "vitest";
 import { NODE_PLATFORM_IMPL } from "../../../src/plugins/core/proxy/types";
+
+test("serialize Buffer as Uint8Array", ({ expect }) => {
+	const input = Buffer.from([99, 88, 77]);
+
+	const serialized = stringify(input, structuredSerializableReducers);
+	const deserialized = parse(serialized, structuredSerializableRevivers);
+
+	// Buffer should round-trip as Uint8Array since Buffer isn't available in all runtimes
+	expect(deserialized).toBeInstanceOf(Uint8Array);
+	expect(new Uint8Array(deserialized as ArrayBuffer)).toEqual(
+		new Uint8Array([99, 88, 77])
+	);
+});
 
 test("serialize RegExp object consisting of only ascii chars", ({ expect }) => {
 	const input = new RegExp(/HelloWorld/);


### PR DESCRIPTION
Fixes #5771.

The `ArrayBufferView` devalue reducer serialises typed arrays by constructor name. Node.js `Buffer` extends `Uint8Array`, so `ArrayBuffer.isView()` matches it and serialises `["Buffer", ...]`. On the workerd side, the reviver fails because:

1. `globalThis.Buffer` may not exist in workerd
2. `Buffer` isn't in `ALLOWED_ARRAY_BUFFER_VIEW_CONSTRUCTORS`

The fix normalises subclass constructor names to the nearest standard typed array parent in the **reducer** (not the reviver). This matches structured clone behaviour — `Buffer` is serialised as `Uint8Array`, which is what it extends.

This affects anyone passing a `Buffer` as a D1 bind parameter via `getPlatformProxy()` or the Miniflare API.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Bug fix with no API change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
