### PR TITLE
[c3] Bump create-vite to 8.3.0 and update React test expected text

### DIFF
--- a/.changeset/c3-frameworks-update-11859.md
+++ b/.changeset/c3-frameworks-update-11859.md
@@ -1,0 +1,11 @@
+---
+"create-cloudflare": patch
+---
+
+Update dependencies of "create-cloudflare"
+
+The following dependency versions have been updated:
+
+| Dependency  | From  | To    |
+| ----------- | ----- | ----- |
+| create-vite | 7.1.1 | 8.3.0 |

--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -410,12 +410,17 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			timeout: LONG_TIMEOUT,
 			verifyDeploy: {
 				route: "/",
-				expectedText: "Vite + React",
+				// Note that this is the text in the static HTML that is returned
+				// This React SPA will change this at runtime but we are only making a fetch request
+				// not actually running the client side JS.
+				// create-vite 8+ changed the <title> from "Vite + React + TS" to the project name,
+				// so we match on the React root element instead.
+				expectedText: '<div id="root">',
 			},
 			verifyPreview: {
 				previewArgs: ["--inspector-port=0"],
 				route: "/",
-				expectedText: "Vite + React",
+				expectedText: '<div id="root">',
 			},
 			nodeCompat: false,
 		},
@@ -435,7 +440,9 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 				// Note that this is the text in the static HTML that is returned
 				// This React SPA will change this at runtime but we are only making a fetch request
 				// not actually running the client side JS.
-				expectedText: "Vite + React + TS",
+				// create-vite 8+ changed the <title> from "Vite + React + TS" to the project name,
+				// so we match on the React root element instead.
+				expectedText: '<div id="root">',
 			},
 			verifyPreview: {
 				route: "/",
@@ -445,7 +452,7 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 				// Note that this is the text in the static HTML that is returned
 				// This React SPA will change this at runtime but we are only making a fetch request
 				// not actually running the client side JS.
-				expectedText: "Vite + React + TS",
+				expectedText: '<div id="root">',
 			},
 			nodeCompat: false,
 		},
@@ -892,7 +899,9 @@ function getExperimentalFrameworkTestConfig(
 				// Note that this is the text in the static HTML that is returned
 				// This React SPA will change this at runtime but we are only making a fetch request
 				// not actually running the client side JS.
-				expectedText: "Vite + React + TS",
+				// create-vite 8+ changed the <title> from "Vite + React + TS" to the project name,
+				// so we match on the React root element instead.
+				expectedText: '<div id="root">',
 			},
 			verifyPreview: {
 				route: "/",
@@ -902,7 +911,7 @@ function getExperimentalFrameworkTestConfig(
 				// Note that this is the text in the static HTML that is returned
 				// This React SPA will change this at runtime but we are only making a fetch request
 				// not actually running the client side JS.
-				expectedText: "Vite + React + TS",
+				expectedText: '<div id="root">',
 			},
 			nodeCompat: false,
 			verifyTypes: false,

--- a/packages/create-cloudflare/src/frameworks/package.json
+++ b/packages/create-cloudflare/src/frameworks/package.json
@@ -12,7 +12,7 @@
 		"create-hono": "0.19.4",
 		"create-next-app": "15.5.6",
 		"create-qwik": "1.19.0",
-		"create-vite": "7.1.1",
+		"create-vite": "8.3.0",
 		"create-rwsdk": "3.1.3",
 		"create-react-router": "7.13.0",
 		"create-solid": "0.6.11",


### PR DESCRIPTION
Supersedes #11859.

create-vite 8.x changed the default React template's `<title>` from `Vite + React + TS` to the project name. Since the C3 E2E tests verify the page content via a fetch request (no client-side JS execution), they only see the static HTML — which no longer contains the old title text.

This PR:
- Bumps `create-vite` from 7.1.1 to 8.3.0 (same as #11859)
- Updates the React test `expectedText` from `"Vite + React"` / `"Vite + React + TS"` to `'<div id="root">'` — the React mount point that's always present in the static HTML

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: No user-facing behavior change beyond the dep bump
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
