### PR TITLE
feat(vite-plugin-cloudflare): disable rsc server handler by default

### DIFF
--- a/.changeset/disable-rsc-server-handler.md
+++ b/.changeset/disable-rsc-server-handler.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": minor
+---
+
+Set `{ serverHandler: false }` automatically when using `@vitejs/plugin-rsc`
+
+By default, `@vitejs/plugin-rsc` adds dev and preview server middleware that imports the RSC entry in Node.js. This fails with `cloudflare:*` imports (`ERR_UNSUPPORTED_ESM_URL_SCHEME`) and is unnecessary since the Cloudflare plugin handles requests via workerd. Users no longer need to pass `rsc({ serverHandler: false })` manually.

--- a/packages/vite-plugin-cloudflare/src/plugins/config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/config.ts
@@ -21,7 +21,10 @@ export const configPlugin = createPlugin("config", (ctx) => {
 	return {
 		config(userConfig, env) {
 			if (ctx.resolvedPluginConfig.type === "preview") {
-				return { appType: "custom" };
+				return {
+					appType: "custom",
+					rsc: { serverHandler: false },
+				};
 			}
 
 			if (!ctx.hasShownWorkerConfigWarnings) {
@@ -43,6 +46,7 @@ export const configPlugin = createPlugin("config", (ctx) => {
 
 			return {
 				appType: "custom",
+				rsc: { serverHandler: false },
 				server: {
 					fs: {
 						deny: [...defaultDeniedFiles, ".dev.vars", ".dev.vars.*"],


### PR DESCRIPTION
Fixes n/a.

By default, `@vitejs/plugin-rsc` adds middleware that imports the RSC entry in Node.js. That doesn't work with `cloudflare:*` imports and isn't needed anyway since we handle requests through workerd.

Previously, users had to work around this by passing `rsc({ serverHandler: false })` themselves. This is now configured by us directly using the [rsc](https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-rsc#vitejsplugin-rsc-1) config option.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows:
    I can't find an easy way to setup a rsc playground without coupling with a framework.
    To test this:
    - Checkout the `custom-entry` branch from https://github.com/edmundhung/cloudflare-react-router-rsc
    - Remove `{ serverHandler: false }` from the rsc vite plugin
    - Reproduce the error by running `pnpm run preview`
    - Try again with the pre-release in this PR.
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: We don't have any docs related to RSC yet. 

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
