### PR TITLE
Update release to only require wrangler team approval

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -37,11 +37,11 @@
 /packages/workflows-shared/ @cloudflare/workflows @cloudflare/wrangler
 
 # unenv-preset ownership
-/packages/unenv-preset/ @cloudflare/workers-frameworks @cloudflare/wrangler
+/packages/unenv-preset/ @cloudflare/wrangler
 
 # vite-plugin-cloudflare ownership
-/packages/vite-plugin-cloudflare/ @cloudflare/workers-frameworks @cloudflare/wrangler
-/packages/workers-tsconfig/ @cloudflare/workers-frameworks @cloudflare/wrangler
+/packages/vite-plugin-cloudflare/ @cloudflare/wrangler
+/packages/workers-tsconfig/ @cloudflare/wrangler
 
 # Owners intentionally left blank on these shared directories / files
 # to avoid noisy review requests


### PR DESCRIPTION
Remove requirement for wrangler-admin approval on releases. Releases now only require approval from a member of the wrangler team.

This also removes the wrangler-frameworks team from codeowners as it no longer exists.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
