### PR TITLE
Move rsc config to separate plugin with enforce: 'pre'

### DIFF
--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -12,6 +12,7 @@ import {
 } from "./plugins/nodejs-compat";
 import { outputConfigPlugin } from "./plugins/output-config";
 import { previewPlugin } from "./plugins/preview";
+import { rscPlugin } from "./plugins/rsc";
 import { shortcutsPlugin } from "./plugins/shortcuts";
 import { triggerHandlersPlugin } from "./plugins/trigger-handlers";
 import {
@@ -75,6 +76,7 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 			},
 		},
 		configPlugin(ctx),
+		rscPlugin(ctx),
 		devPlugin(ctx),
 		previewPlugin(ctx),
 		shortcutsPlugin(ctx),

--- a/packages/vite-plugin-cloudflare/src/plugins/config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/config.ts
@@ -21,10 +21,7 @@ export const configPlugin = createPlugin("config", (ctx) => {
 	return {
 		config(userConfig, env) {
 			if (ctx.resolvedPluginConfig.type === "preview") {
-				return {
-					appType: "custom",
-					rsc: { serverHandler: false },
-				};
+				return { appType: "custom" };
 			}
 
 			if (!ctx.hasShownWorkerConfigWarnings) {
@@ -46,7 +43,6 @@ export const configPlugin = createPlugin("config", (ctx) => {
 
 			return {
 				appType: "custom",
-				rsc: { serverHandler: false },
 				server: {
 					fs: {
 						deny: [...defaultDeniedFiles, ".dev.vars", ".dev.vars.*"],

--- a/packages/vite-plugin-cloudflare/src/plugins/rsc.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/rsc.ts
@@ -1,0 +1,14 @@
+import { createPlugin } from "../utils";
+import type * as vite from "vite";
+
+/**
+ * Plugin to pass options to `@vitejs/plugin-rsc`
+ */
+export const rscPlugin = createPlugin("rsc", () => {
+	return {
+		enforce: "pre",
+		config() {
+			return { rsc: { serverHandler: false } } as vite.UserConfig;
+		},
+	};
+});


### PR DESCRIPTION
Follow up to https://github.com/cloudflare/workers-sdk/pull/12535. Ensures that the `rsc` config is returned ahead of the `rsc` plugin, regardless of the plugin order.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows:
    - Checkout https://github.com/edmundhung/cloudflare-react-router-rsc
    - Place the `cloudflare` plugin after the `rsc` plugin and remove `serverHandler: false`
    - Reproduce the error by running `pnpm dev`
    - Try again with the pre-release in this PR
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
