### PR TITLE
[wrangler] Add --tag and --message to deploy command (#12445)

### DIFF
--- a/.changeset/salty-mirrors-turn.md
+++ b/.changeset/salty-mirrors-turn.md
@@ -1,0 +1,11 @@
+---
+"wrangler": minor
+---
+
+Support `--tag` and `--message` flags on `wrangler deploy`
+
+They have the same behavior that they do as during `wrangler versions upload`, as both
+are set on the version.
+
+The message is also reused for the deployment as well, with the same behavior as used
+during `wrangler versions deploy`.

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -16696,6 +16696,89 @@ export default{
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 	});
+
+	describe("--tag and --message", () => {
+		it("should send tag and message annotations via the new versions API", async () => {
+			writeWranglerConfig();
+			writeWorkerSource();
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedAnnotations: {
+					"workers/message": "my deploy message",
+					"workers/tag": "v1.0.0",
+				},
+				expectedDeploymentMessage: "my deploy message",
+			});
+
+			await runWrangler(
+				'deploy ./index --tag v1.0.0 --message "my deploy message"'
+			);
+			expect(std.out).toContain("Uploaded test-name");
+			expect(std.out).toContain("Current Version ID: Galaxy-Class");
+		});
+
+		it("should send tag and message annotations via the legacy PUT API", async () => {
+			writeWranglerConfig();
+			writeWorkerSource();
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedAnnotations: {
+					"workers/message": "legacy deploy msg",
+					"workers/tag": "v2.0.0",
+				},
+				expectedDispatchNamespace: "test-dispatch-namespace",
+			});
+
+			await runWrangler(
+				'deploy ./index --dispatch-namespace test-dispatch-namespace --tag v2.0.0 --message "legacy deploy msg"'
+			);
+			expect(std.out).toContain("Uploaded test-name");
+		});
+
+		it("should send only --tag without --message", async () => {
+			writeWranglerConfig();
+			writeWorkerSource();
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedAnnotations: {
+					"workers/message": undefined,
+					"workers/tag": "v1.0.0",
+				},
+				expectedDeploymentMessage: undefined,
+			});
+
+			await runWrangler("deploy ./index --tag v1.0.0");
+			expect(std.out).toContain("Uploaded test-name");
+		});
+
+		it("should send only --message without --tag", async () => {
+			writeWranglerConfig();
+			writeWorkerSource();
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedAnnotations: {
+					"workers/message": "just a message",
+					"workers/tag": undefined,
+				},
+				expectedDeploymentMessage: "just a message",
+			});
+
+			await runWrangler('deploy ./index --message "just a message"');
+			expect(std.out).toContain("Uploaded test-name");
+		});
+
+		it("should not set annotations when neither --tag nor --message is provided", async () => {
+			writeWranglerConfig();
+			writeWorkerSource();
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedAnnotations: undefined,
+			});
+
+			await runWrangler("deploy ./index");
+			expect(std.out).toContain("Uploaded test-name");
+		});
+	});
 });
 
 /** Write mock assets to the file system so they can be uploaded. */

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -134,6 +134,8 @@ type Props = {
 	metafile: string | boolean | undefined;
 	containersRollout: "immediate" | "gradual" | undefined;
 	strict: boolean | undefined;
+	tag: string | undefined;
+	message: string | undefined;
 };
 
 export type RouteObject = ZoneIdRoute | ZoneNameRoute | CustomDomainRoute;
@@ -858,6 +860,13 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			tail_consumers: config.tail_consumers,
 			streaming_tail_consumers: config.streaming_tail_consumers,
 			limits: config.limits,
+			annotations:
+				props.tag || props.message
+					? {
+							"workers/message": props.message,
+							"workers/tag": props.tag,
+						}
+					: undefined,
 			assets:
 				props.assetsOptions && assetsJwt
 					? {
@@ -1014,7 +1023,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 						accountId,
 						scriptName,
 						versionMap,
-						undefined
+						props.message
 					);
 
 					// Update service and environment tags when using environments

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -235,6 +235,16 @@ export const deployCommand = createCommand({
 				"Rollout strategy for Containers changes. If set to immediate, it will override `rollout_percentage_steps` if configured and roll out to 100% of instances in one step. ",
 			choices: ["immediate", "gradual"] as const,
 		},
+		tag: {
+			describe: "A tag for this Worker Version",
+			type: "string",
+			requiresArg: true,
+		},
+		message: {
+			describe: "A descriptive message for this Worker Version and Deployment",
+			type: "string",
+			requiresArg: true,
+		},
 		strict: {
 			describe:
 				"Enables strict mode for the deploy command, this prevents deployments to occur when there are even small potential risks.",
@@ -492,6 +502,8 @@ export const deployCommand = createCommand({
 			experimentalAutoCreate: args.experimentalAutoCreate,
 			containersRollout: args.containersRollout,
 			strict: args.strict,
+			tag: args.tag,
+			message: args.message,
 		});
 
 		writeOutput({


### PR DESCRIPTION
Fixes #12445.

Support --tag and --message on wrangler deploy, matching the behavior of wrangler versions upload. In the 2-step deploy flow, annotations are sent on the version upload and the message is also sent on the deployment. In the legacy 1-step flow, both are sent in the same API request.

Created with opencode and opus 4.6

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/28339


*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
