### PR TITLE
[wrangler][C3] Use qwik add cloudflare-workers instead of cloudflare-pages

### DIFF
--- a/.changeset/fix-qwik-adapter.md
+++ b/.changeset/fix-qwik-adapter.md
@@ -1,0 +1,20 @@
+---
+"wrangler": patch
+"create-cloudflare": patch
+---
+
+Use `qwik add cloudflare-workers` instead of `qwik add cloudflare-pages` for Workers targets
+
+Both the wrangler autoconfig and C3 Workers template for Qwik were running
+`qwik add cloudflare-pages` even when targeting Cloudflare Workers. This
+caused the wrong adapter directory structure to be scaffolded
+(`adapters/cloudflare-pages/` instead of `adapters/cloudflare-workers/`),
+and required post-hoc cleanup of Pages-specific files like `_routes.json`.
+
+Qwik now provides a dedicated `cloudflare-workers` adapter that generates
+the correct Workers configuration, including `wrangler.jsonc` with `main`
+and `assets` fields, a `public/.assetsignore` file, and the correct
+`adapters/cloudflare-workers/vite.config.ts`.
+
+Also adds `--skipConfirmation=true` to all `qwik add` invocations so the
+interactive prompt is skipped in automated contexts.

--- a/packages/create-cloudflare/templates/qwik/pages/c3.ts
+++ b/packages/create-cloudflare/templates/qwik/pages/c3.ts
@@ -19,7 +19,13 @@ const generate = async (ctx: C3Context) => {
 const configure = async (ctx: C3Context) => {
 	// Add the pages integration
 	// For some reason `pnpx qwik add` fails for qwik so we use `pnpm qwik add` instead.
-	const cmd = [name === "pnpm" ? npm : npx, "qwik", "add", "cloudflare-pages"];
+	const cmd = [
+		name === "pnpm" ? npm : npx,
+		"qwik",
+		"add",
+		"cloudflare-pages",
+		"--skipConfirmation=true",
+	];
 	endSection(`Running ${quoteShellArgs(cmd)}`);
 	await runCommand(cmd);
 

--- a/packages/create-cloudflare/templates/qwik/workers/c3.ts
+++ b/packages/create-cloudflare/templates/qwik/workers/c3.ts
@@ -4,7 +4,7 @@ import { spinner } from "@cloudflare/cli/interactive";
 import { runFrameworkGenerator } from "frameworks/index";
 import { loadTemplateSnippets, transformFile } from "helpers/codemod";
 import { quoteShellArgs, runCommand } from "helpers/command";
-import { removeFile, usesTypescript } from "helpers/files";
+import { usesTypescript } from "helpers/files";
 import { detectPackageManager } from "helpers/packageManagers";
 import * as recast from "recast";
 import type { TemplateConfig } from "../../../src/templates";
@@ -17,14 +17,17 @@ const generate = async (ctx: C3Context) => {
 };
 
 const configure = async (ctx: C3Context) => {
-	// Add the pages integration
+	// Add the workers integration
 	// For some reason `pnpx qwik add` fails for qwik so we use `pnpm qwik add` instead.
-	const cmd = [name === "pnpm" ? npm : npx, "qwik", "add", "cloudflare-pages"];
+	const cmd = [
+		name === "pnpm" ? npm : npx,
+		"qwik",
+		"add",
+		"cloudflare-workers",
+		"--skipConfirmation=true",
+	];
 	endSection(`Running ${quoteShellArgs(cmd)}`);
 	await runCommand(cmd);
-
-	// Remove the extraneous Pages files
-	removeFile("./public/_routes.json");
 
 	addBindingsProxy(ctx);
 };

--- a/packages/wrangler/src/autoconfig/frameworks/qwik.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/qwik.ts
@@ -1,4 +1,3 @@
-import { writeFile } from "node:fs/promises";
 import { endSection } from "@cloudflare/cli";
 import { brandColor } from "@cloudflare/cli/colors";
 import { spinner } from "@cloudflare/cli/interactive";
@@ -18,7 +17,7 @@ export class Qwik extends Framework {
 		packageManager,
 	}: ConfigurationOptions): Promise<ConfigurationResults> {
 		if (!dryRun) {
-			// Add the pages integration
+			// Add the workers integration
 			const cmd = [
 				// For some reason `pnpx qwik add` fails for qwik so we use `pnpm qwik add` instead.
 				packageManager.type === "pnpm"
@@ -26,14 +25,13 @@ export class Qwik extends Framework {
 					: packageManager.npx,
 				"qwik",
 				"add",
-				"cloudflare-pages",
+				"cloudflare-workers",
+				"--skipConfirmation=true",
 			];
 			endSection(`Running ${quoteShellArgs(cmd)}`);
 			await runCommand(cmd);
 
 			addBindingsProxy(projectPath);
-
-			await addAssetsIgnoreFile(projectPath);
 		}
 		return {
 			wranglerConfig: {
@@ -52,7 +50,7 @@ export class Qwik extends Framework {
 	}
 
 	configurationDescription =
-		'Configuring project for Qwik with "qwik add cloudflare-pages"';
+		'Configuring project for Qwik with "qwik add cloudflare-workers"';
 }
 
 function addBindingsProxy(projectPath: string) {
@@ -128,13 +126,4 @@ function addBindingsProxy(projectPath: string) {
 	});
 
 	s.stop(`${brandColor("updated")} \`vite.config.ts\``);
-}
-
-async function addAssetsIgnoreFile(projectPath: string) {
-	const toAdd = ["_worker.js", "_routes.json", "_headers", "_redirects"];
-
-	await writeFile(
-		`${projectPath}/public/.assetsignore`,
-		`${toAdd.join("\n")}\n`
-	);
 }


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-2443
___

_Use the correct Qwik adapter (`cloudflare-workers`) when targeting Workers, instead of running the Pages adapter and cleaning up after it._

---

Both the wrangler autoconfig (`packages/wrangler/src/autoconfig/frameworks/qwik.ts`) and the C3 Workers template (`packages/create-cloudflare/templates/qwik/workers/c3.ts`) were running `qwik add cloudflare-pages` even when targeting Cloudflare Workers. This caused the wrong adapter directory structure to be scaffolded (`adapters/cloudflare-pages/` instead of `adapters/cloudflare-workers/`), and required post-hoc cleanup of Pages-specific files like `_routes.json` and manual creation of `.assetsignore`.

Qwik provides a dedicated `cloudflare-workers` adapter (`qwik add cloudflare-workers`) that generates the correct Workers configuration out of the box:

- `adapters/cloudflare-workers/vite.config.ts` (correct adapter directory)
- `wrangler.jsonc` with `main` and `assets` fields
- `public/.assetsignore` with the correct entries
- Workers-appropriate `package.json` scripts

#### Changes

**`packages/wrangler/src/autoconfig/frameworks/qwik.ts`:**
- `qwik add cloudflare-pages` → `qwik add cloudflare-workers`
- Added `--skipConfirmation=true` to skip Qwik's interactive prompt
- Removed `addAssetsIgnoreFile()` function (the adapter now generates this)
- Removed unused `writeFile` import
- Updated `configurationDescription` string

**`packages/create-cloudflare/templates/qwik/workers/c3.ts`:**
- `qwik add cloudflare-pages` → `qwik add cloudflare-workers`
- Added `--skipConfirmation=true`
- Removed `removeFile("./public/_routes.json")` (the workers adapter doesn't generate this)
- Removed unused `removeFile` import

**`packages/create-cloudflare/templates/qwik/pages/c3.ts`:**
- Added `--skipConfirmation=true` for consistency

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: The Qwik E2E tests are currently quarantined due to upstream eslint compatibility issues. The autoconfig unit tests that ran (18/18) all pass. The change is a direct swap of the adapter name argument with cleanup of now-unnecessary workarounds.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This aligns the tooling with Qwik's existing documentation for the cloudflare-workers deployment target.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
