### PR TITLE
[unenv-preset] Support native child_process module when experimental flag is enabled

### DIFF
--- a/.changeset/native-child-process-module.md
+++ b/.changeset/native-child-process-module.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/unenv-preset": minor
+---
+
+Add support for native `node:child_process` module from workerd when the `enable_nodejs_child_process_module` compatibility flag is enabled.
+
+This feature is currently experimental and requires both the `enable_nodejs_child_process_module` and `experimental` compatibility flags to be set.

--- a/packages/unenv-preset/src/preset.ts
+++ b/packages/unenv-preset/src/preset.ts
@@ -82,6 +82,7 @@ export function getCloudflarePreset({
 	const processOverrides = getProcessOverrides(compat);
 	const v8Overrides = getV8Overrides(compat);
 	const ttyOverrides = getTtyOverrides(compat);
+	const childProcessOverrides = getChildProcessOverrides(compat);
 
 	// "dynamic" as they depend on the compatibility date and flags
 	const dynamicNativeModules = [
@@ -105,6 +106,7 @@ export function getCloudflarePreset({
 		...processOverrides.nativeModules,
 		...v8Overrides.nativeModules,
 		...ttyOverrides.nativeModules,
+		...childProcessOverrides.nativeModules,
 	];
 
 	// "dynamic" as they depend on the compatibility date and flags
@@ -128,6 +130,7 @@ export function getCloudflarePreset({
 		...processOverrides.hybridModules,
 		...v8Overrides.hybridModules,
 		...ttyOverrides.hybridModules,
+		...childProcessOverrides.hybridModules,
 	];
 
 	return {
@@ -971,6 +974,42 @@ function getTtyOverrides({
 	return enabled
 		? {
 				nativeModules: ["tty"],
+				hybridModules: [],
+			}
+		: {
+				nativeModules: [],
+				hybridModules: [],
+			};
+}
+
+/**
+ * Returns the overrides for `node:child_process` (unenv or workerd)
+ *
+ * The native child_process implementation:
+ * - is experimental and has no default enable date
+ * - can be enabled with the "enable_nodejs_child_process_module" flag
+ * - can be disabled with the "disable_nodejs_child_process_module" flag
+ */
+function getChildProcessOverrides({
+	compatibilityFlags,
+}: {
+	compatibilityDate: string;
+	compatibilityFlags: string[];
+}): { nativeModules: string[]; hybridModules: string[] } {
+	const disabledByFlag = compatibilityFlags.includes(
+		"disable_nodejs_child_process_module"
+	);
+
+	const enabledByFlag =
+		compatibilityFlags.includes("enable_nodejs_child_process_module") &&
+		compatibilityFlags.includes("experimental");
+
+	const enabled = enabledByFlag && !disabledByFlag;
+
+	// When enabled, use the native `child_process` module from workerd
+	return enabled
+		? {
+				nativeModules: ["child_process"],
 				hybridModules: [],
 			}
 		: {

--- a/packages/wrangler/e2e/unenv-preset/preset.test.ts
+++ b/packages/wrangler/e2e/unenv-preset/preset.test.ts
@@ -676,6 +676,33 @@ const localTestConfigs: TestConfig[] = [
 			},
 		},
 	],
+	// node:child_process (experimental, no default enable date)
+	[
+		// TODO: add test for disabled by date (no date defined yet)
+		// TODO: add test for enabled by date (no date defined yet)
+		{
+			name: "child_process enabled by flag",
+			compatibilityDate: "2024-09-23",
+			compatibilityFlags: [
+				"enable_nodejs_child_process_module",
+				"experimental",
+			],
+			expectRuntimeFlags: {
+				enable_nodejs_child_process_module: true,
+			},
+		},
+		{
+			name: "child_process disabled by flag",
+			compatibilityDate: "2024-09-23",
+			compatibilityFlags: [
+				"disable_nodejs_child_process_module",
+				"experimental",
+			],
+			expectRuntimeFlags: {
+				enable_nodejs_child_process_module: false,
+			},
+		},
+	],
 ].flat() as TestConfig[];
 
 describe.each(localTestConfigs)(

--- a/packages/wrangler/e2e/unenv-preset/worker/index.ts
+++ b/packages/wrangler/e2e/unenv-preset/worker/index.ts
@@ -913,6 +913,45 @@ export const WorkerdTests: Record<string, () => void> = {
 		assert.doesNotThrow(() => new tty.ReadStream(0));
 		assert.doesNotThrow(() => new tty.WriteStream(1));
 	},
+
+	async testChildProcess() {
+		const childProcess = await import("node:child_process");
+
+		// Common exports (both unenv stub and native workerd)
+		assertTypeOfProperties(childProcess, {
+			ChildProcess: "function",
+			exec: "function",
+			execFile: "function",
+			execFileSync: "function",
+			execSync: "function",
+			fork: "function",
+			spawn: "function",
+			spawnSync: "function",
+		});
+
+		assertTypeOfProperties(childProcess.default, {
+			ChildProcess: "function",
+			exec: "function",
+			execFile: "function",
+			execFileSync: "function",
+			execSync: "function",
+			fork: "function",
+			spawn: "function",
+			spawnSync: "function",
+		});
+
+		// Both implementations throw when calling spawn()
+		assert.throws(
+			() => childProcess.spawn("ls"),
+			/not implemented|ERR_METHOD_NOT_IMPLEMENTED/
+		);
+
+		// Both implementations throw when calling exec()
+		assert.throws(
+			() => childProcess.exec("ls"),
+			/not implemented|ERR_METHOD_NOT_IMPLEMENTED/
+		);
+	},
 };
 
 /**


### PR DESCRIPTION
Support the native `node:child_process` module from workerd when the `enable_nodejs_child_process_module` and `experimental` compatibility flags are enabled.

The native `child_process` module in workerd (like the unenv polyfill) is a stub - all methods throw errors. The key differences:
- **workerd**: Throws `ERR_METHOD_NOT_IMPLEMENTED` (Node.js-style error), validates arguments before throwing
- **unenv**: Throws generic `Error` with `"[unenv] ... is not implemented yet!"`, has `__unenv__: true` marker

Since both implementations are non-functional stubs that throw errors, the breaking change risk is low.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is an experimental feature that follows the existing pattern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
