### PR TITLE
Support programmatic TypeScript config (cf.config.ts)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,7 +172,6 @@ dist
 # End of https://www.toptal.com/developers/gitignore/api/node,macos
 
 wrangler-dist/
-miniflare-dist
 packages/wrangler/wrangler.toml
 packages/wrangler/Dockerfile
 packages/wrangler/src/cloudchamber/internal

--- a/fixtures/worker-ts/cf.config.ts
+++ b/fixtures/worker-ts/cf.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "wrangler/config";
+
+export default defineConfig({
+	name: "worker-ts",
+	main: "src/index.ts",
+	compatibility_date: "2023-05-04",
+	vars: {
+		MY_TEXT: "test2",
+	},
+	r2_buckets: [
+		{
+			binding: "MY_OTHER",
+		},
+	],
+});

--- a/fixtures/worker-ts/wrangler.jsonc
+++ b/fixtures/worker-ts/wrangler.jsonc
@@ -1,6 +1,0 @@
-{
-	"$schema": "node_modules/wrangler/config-schema.json",
-	"name": "worker-ts",
-	"main": "src/index.ts",
-	"compatibility_date": "2023-05-04",
-}

--- a/packages/vite-plugin-cloudflare/playground/bindings/__tests__/shortcuts.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/bindings/__tests__/shortcuts.spec.ts
@@ -28,14 +28,14 @@ describe.skipIf(!satisfiesViteVersion("7.2.7"))("shortcuts", () => {
 		process.stdin.isTTY = false;
 	});
 
-	test("display binding shortcut hint", ({ expect }) => {
+	test("display binding shortcut hint", async ({ expect }) => {
 		// Set up the shortcut wrapper (after stubs are in place from beforeAll)
 		const mockContext = new PluginContext({
 			hasShownWorkerConfigWarnings: false,
 			isRestartingDevServer: false,
 		});
 		mockContext.setResolvedPluginConfig(
-			resolvePluginConfig(
+			await resolvePluginConfig(
 				{
 					configPath: path.resolve(__dirname, "../wrangler.jsonc"),
 				},
@@ -63,7 +63,7 @@ describe.skipIf(!satisfiesViteVersion("7.2.7"))("shortcuts", () => {
 			"press b + enter to list configured Cloudflare bindings"
 		);
 	});
-	test("prints bindings with a single Worker", ({ expect }) => {
+	test("prints bindings with a single Worker", async ({ expect }) => {
 		// Create a test server with a spy on bindCLIShortcuts
 		const mockBindCLIShortcuts = vi.spyOn(viteServer, "bindCLIShortcuts");
 		// Create mock plugin context
@@ -73,7 +73,7 @@ describe.skipIf(!satisfiesViteVersion("7.2.7"))("shortcuts", () => {
 		});
 
 		mockContext.setResolvedPluginConfig(
-			resolvePluginConfig(
+			await resolvePluginConfig(
 				{
 					configPath: path.resolve(__dirname, "../wrangler.jsonc"),
 				},
@@ -119,7 +119,7 @@ describe.skipIf(!satisfiesViteVersion("7.2.7"))("shortcuts", () => {
 		`);
 	});
 
-	test("prints bindings with multi Workers", ({ expect }) => {
+	test("prints bindings with multi Workers", async ({ expect }) => {
 		// Create a test server with a spy on bindCLIShortcuts
 		const mockBindCLIShortcuts = vi.spyOn(viteServer, "bindCLIShortcuts");
 		// Create mock plugin context
@@ -129,7 +129,7 @@ describe.skipIf(!satisfiesViteVersion("7.2.7"))("shortcuts", () => {
 		});
 
 		mockContext.setResolvedPluginConfig(
-			resolvePluginConfig(
+			await resolvePluginConfig(
 				{
 					configPath: path.resolve(__dirname, "../wrangler.jsonc"),
 					auxiliaryWorkers: [

--- a/packages/workers-utils/package.json
+++ b/packages/workers-utils/package.json
@@ -19,6 +19,10 @@
 			"import": "./dist/index.mjs",
 			"types": "./dist/index.d.mts"
 		},
+		"./programmatic": {
+			"import": "./dist/config/programmatic.mjs",
+			"types": "./dist/config/programmatic.d.mts"
+		},
 		"./test-helpers": {
 			"import": "./dist/test-helpers/index.mjs",
 			"types": "./dist/test-helpers/index.d.mts"
@@ -45,6 +49,7 @@
 		"@vitest/ui": "catalog:default",
 		"cloudflare": "^5.2.0",
 		"concurrently": "^8.2.2",
+		"esbuild": "catalog:default",
 		"eslint": "catalog:default",
 		"find-up": "^6.3.0",
 		"jsonc-parser": "catalog:default",

--- a/packages/workers-utils/src/config/programmatic.ts
+++ b/packages/workers-utils/src/config/programmatic.ts
@@ -1,0 +1,235 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as esbuild from "esbuild";
+import type { RawConfig } from "./config";
+
+/**
+ * Get common esbuild options for loading a Wrangler config file
+ */
+function getEsbuildOptions(
+	configPath: string,
+	tmpFile: string
+): esbuild.BuildOptions {
+	return {
+		entryPoints: [configPath],
+		bundle: true,
+		platform: "node",
+		format: "esm",
+		outfile: tmpFile,
+		// Externalize all node_modules, which will be resolved at runtime
+		packages: "external",
+		logLevel: "error",
+	};
+}
+
+/**
+ * Load config directly from a bundled config file, which exports either a function or an object
+ */
+async function loadFunctionOrObjectConfig(
+	file: string,
+	ctx: WorkerConfigContext
+): Promise<WorkerConfig> {
+	// Use file:// URL for cross-platform compatibility
+	const fileUrl = `file://${file}`;
+	const module = await import(fileUrl);
+
+	const configFnOrValue = module.default;
+
+	if (typeof configFnOrValue === "function") {
+		// Of the form `defineConfig(() => ({...}))`
+		return await configFnOrValue(ctx);
+	} else if (configFnOrValue && typeof configFnOrValue === "object") {
+		// Of the form `defineConfig({...})`
+		return configFnOrValue;
+	}
+
+	throw new Error(
+		`Config file must export the defineConfig() function, with either a function or object config. ` +
+			`Instead, the default export was of type: ${typeof configFnOrValue}. Use: export default defineConfig(() => ({ ... }))`
+	);
+}
+
+export interface WorkerConfigContext {
+	/**
+	 * The environment name from the `--env` CLI flag.
+	 * Undefined if no `--env` flag was provided.
+	 */
+	env: string | undefined;
+}
+
+/**
+ * The subset of RawConfig exposed in programmatic config.
+ * We omit `env` because a programmatic config should not have statically defined environments.
+ * Instead, the return value should be dynamic based on the `ctx.env` argument
+ */
+export type WorkerConfig = Omit<RawConfig, "env">;
+
+/**
+ * A function that returns worker configuration.
+ * Can be synchronous or asynchronous.
+ */
+export type WorkerConfigFn = (
+	ctx: WorkerConfigContext
+) => WorkerConfig | Promise<WorkerConfig>;
+
+/**
+ * Helper function to define a worker configuration with type safety.
+ * Accepts either a config object directly or a function that returns one.
+ * TODO(followup): return the inferred `Env` type rather than `WorkerConfigFn`
+ */
+export function defineConfig(
+	fnOrConfig: WorkerConfigFn | WorkerConfig
+): WorkerConfigFn | WorkerConfig {
+	return fnOrConfig;
+}
+
+export interface LoadProgrammaticConfigOptions {
+	/** The path to the programmatic config file (.ts or .js) */
+	configPath: string;
+	/** The environment name from --env flag */
+	env: string | undefined;
+}
+
+/**
+ * Load and execute a programmatic config file.
+ */
+export async function loadProgrammaticConfig({
+	configPath,
+	env,
+}: LoadProgrammaticConfigOptions): Promise<WorkerConfig> {
+	const tmpDir = path.join(path.dirname(configPath), ".wrangler/config");
+	// Make sure the output directory exists
+	await fs.promises.mkdir(tmpDir, { recursive: true });
+
+	const tmpFile = path.join(
+		tmpDir,
+		`cf-config-${Date.now()}-${Math.random().toString(36).slice(2)}.mjs`
+	);
+
+	try {
+		await esbuild.build(getEsbuildOptions(configPath, tmpFile));
+
+		return await loadFunctionOrObjectConfig(tmpFile, { env });
+	} catch (e) {
+		const error = new Error(`Failed to load config file: ${configPath}`);
+		error.cause = e;
+		throw error;
+	} finally {
+		try {
+			await fs.promises.unlink(tmpFile);
+		} catch {
+			// Ignore cleanup errors (especially on Windows)
+		}
+	}
+}
+
+/**
+ * Watch a programmatic config file for changes.
+ *
+ * Uses esbuild's watch mode which automatically tracks all dependencies
+ * and triggers a rebuild when any of them change.
+ *
+ * @returns A ConfigWatcher with a stop() method to clean up
+ */
+export async function watchProgrammaticConfig({
+	configPath,
+	env,
+	onChange,
+	onError,
+}: LoadProgrammaticConfigOptions & {
+	/** Callback when config changes (after successful rebuild) */
+	onChange: (result: WorkerConfig) => void;
+	/** Callback when an error occurs during rebuild */
+	onError?: (error: Error) => void;
+}): Promise<{
+	close: () => Promise<void>;
+	closed: boolean;
+}> {
+	const tmpDir = path.join(path.dirname(configPath), ".wrangler/config");
+	// Make sure the output directory exists
+	await fs.promises.mkdir(tmpDir, { recursive: true });
+
+	const tmpFile = path.join(tmpDir, `cf-config-watch.mjs`);
+
+	let isInitialBuild = true;
+
+	// AbortController to cancel in-flight config loads when a new build comes in
+	// This prevents race conditions where an older build's async work completes
+	// after a newer build has already started processing
+	let loadAbortController = new AbortController();
+
+	const watchPlugin: esbuild.Plugin = {
+		name: "config-watch-plugin",
+		setup(build) {
+			build.onEnd(async (result) => {
+				/**
+				 * Skip the initial build. Instead, consumers should call `loadProgrammaticConfig()`  directly.
+				 * This matches how chokidar is set up for file watching in Wrangler, and allows this function to be slotted
+				 * in more easily. In future we can re-evaluate and potentially refactor.
+				 */
+				if (isInitialBuild) {
+					isInitialBuild = false;
+					return;
+				}
+
+				loadAbortController.abort();
+				loadAbortController = new AbortController();
+				const signal = loadAbortController.signal;
+
+				if (result.errors.length > 0) {
+					const errorMessage = result.errors.map((e) => e.text).join("\n");
+					onError?.(new Error(`Failed to load config file:\n${errorMessage}`));
+					// Skip loading the config if there are errors
+					return;
+				}
+
+				try {
+					const workerConfig = await loadFunctionOrObjectConfig(tmpFile, {
+						env,
+					});
+
+					if (signal.aborted) {
+						return;
+					}
+
+					onChange(workerConfig);
+				} catch (e) {
+					// Don't report errors if this load was aborted
+					if (signal.aborted) {
+						return;
+					}
+					const error = new Error(
+						`Failed to reload config file: ${configPath}`
+					);
+					error.cause = e;
+					onError?.(error);
+				}
+			});
+		},
+	};
+
+	const ctx = await esbuild.context({
+		...getEsbuildOptions(configPath, tmpFile),
+		plugins: [watchPlugin],
+	});
+
+	await ctx.watch();
+
+	let closed = false;
+
+	return {
+		close: async () => {
+			closed = true;
+			loadAbortController.abort();
+			await ctx?.dispose();
+			try {
+				await fs.promises.unlink(tmpFile);
+			} catch {
+				// Ignore cleanup errors
+			}
+		},
+		get closed() {
+			return closed;
+		},
+	};
+}

--- a/packages/workers-utils/src/index.ts
+++ b/packages/workers-utils/src/index.ts
@@ -15,6 +15,14 @@ export {
 	configFormat,
 	configFileName,
 	experimental_readRawConfig,
+	isProgrammaticConfigPath,
+	loadProgrammaticConfig,
+	watchProgrammaticConfig,
+	defineConfig,
+	type WorkerConfig,
+	type WorkerConfigContext,
+	type WorkerConfigFn,
+	type LoadProgrammaticConfigOptions,
 } from "./config";
 export {
 	experimental_patchConfig,

--- a/packages/workers-utils/tsup.config.ts
+++ b/packages/workers-utils/tsup.config.ts
@@ -4,7 +4,12 @@ export default defineConfig(() => [
 	{
 		treeshake: true,
 		keepNames: true,
-		entry: ["src/index.ts", "src/browser.ts", "src/test-helpers/index.ts"],
+		entry: [
+			"src/index.ts",
+			"src/browser.ts",
+			"src/test-helpers/index.ts",
+			"src/config/programmatic.ts",
+		],
 		platform: "node",
 		format: "esm",
 		dts: true,
@@ -15,6 +20,6 @@ export default defineConfig(() => [
 		define: {
 			"process.env.NODE_ENV": `'${"production"}'`,
 		},
-		external: ["@cloudflare/*", "vitest", "msw", "undici"],
+		external: ["@cloudflare/*", "vitest", "msw", "undici", "esbuild"],
 	},
 ]);

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -17,9 +17,7 @@
 		"assembly",
 		"webassembly",
 		"rust",
-		"emscripten",
 		"typescript",
-		"graphql",
 		"router",
 		"http",
 		"cli"
@@ -35,6 +33,18 @@
 	},
 	"license": "MIT OR Apache-2.0",
 	"author": "wrangler@cloudflare.com",
+	"exports": {
+		".": {
+			"types": "./wrangler-dist/cli.d.ts",
+			"require": "./wrangler-dist/cli.js",
+			"default": "./wrangler-dist/cli.js"
+		},
+		"./config": {
+			"types": "./wrangler-dist/config.d.mts",
+			"import": "./wrangler-dist/config.mjs"
+		},
+		"./*": "./*"
+	},
 	"main": "wrangler-dist/cli.js",
 	"types": "wrangler-dist/cli.d.ts",
 	"bin": {
@@ -43,7 +53,6 @@
 	},
 	"files": [
 		"bin",
-		"miniflare-dist",
 		"wrangler-dist",
 		"templates",
 		"kv-asset-handler.js",
@@ -54,7 +63,7 @@
 		"build": "pnpm run clean && pnpm tsup && pnpm run generate-json-schema",
 		"check:lint": "eslint . --max-warnings=0 --cache",
 		"check:type": "tsc -p ./tsconfig.json && tsc -p ./templates/tsconfig.json",
-		"clean": "node -r esbuild-register ../../tools/clean/clean.ts wrangler-dist miniflare-dist emitted-types",
+		"clean": "node -r esbuild-register ../../tools/clean/clean.ts wrangler-dist emitted-types",
 		"dev": "pnpm run clean && concurrently -c black,blue --kill-others-on-fail false \"pnpm tsup --watch src --watch ../containers-shared/src --watch ../cli\" \"pnpm run check:type --watch --preserveWatchOutput\"",
 		"generate-json-schema": "node -r esbuild-register scripts/generate-json-schema.ts",
 		"start": "pnpm run build && cross-env NODE_OPTIONS=--enable-source-maps ./bin/wrangler.js",

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1959,7 +1959,7 @@ describe.sequential("wrangler dev", () => {
 			await expect(
 				runWrangler("dev --site")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Not enough arguments following: site]`
+				`[YError: Not enough arguments following: site]`
 			);
 		});
 

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -1307,7 +1307,7 @@ describe("init", () => {
 			await expect(
 				runWrangler("init --from-dash")
 			).rejects.toMatchInlineSnapshot(
-				`[Error: Not enough arguments following: from-dash]`
+				`[YError: Not enough arguments following: from-dash]`
 			);
 			checkFiles({
 				items: {

--- a/packages/wrangler/src/config/worker.ts
+++ b/packages/wrangler/src/config/worker.ts
@@ -1,0 +1,26 @@
+/**
+ * Programmatic configuration types for Cloudflare Workers.
+ *
+ * This module re-exports the programmatic config types from @cloudflare/workers-utils
+ * via the `wrangler/config` subpath.
+ *
+ * @example
+ * ```ts
+ * // cf.config.ts
+ * import { defineConfig } from "wrangler/config";
+ *
+ * export default defineConfig((ctx) => ({
+ *   name: `my-app-${ctx.env ?? "dev"}`
+ * }));
+ * ```
+ */
+
+export {
+	defineConfig,
+	type WorkerConfig,
+	type WorkerConfigContext,
+	type WorkerConfigFn,
+} from "@cloudflare/workers-utils/programmatic";
+
+// Re-export the Binding and Trigger types that WorkerConfig uses
+export type { Binding, Trigger } from "@cloudflare/workers-utils";

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -1,11 +1,12 @@
 import {
 	defaultWranglerConfig,
+	experimental_readRawConfig,
 	FatalError,
 	getWranglerHideBanner,
+	isProgrammaticConfigPath,
 	UserError,
 } from "@cloudflare/workers-utils";
 import chalk from "chalk";
-import { experimental_readRawConfig } from "../../../workers-utils/src";
 import { fetchResult } from "../cfetch";
 import { createCloudflareClient } from "../cfetch/internal";
 import { readConfig } from "../config";
@@ -199,7 +200,11 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 				});
 
 				if (def.behaviour?.warnIfMultipleEnvsConfiguredButNoneSpecified) {
-					if (!("env" in args) && config.configPath) {
+					if (
+						!("env" in args) &&
+						config.configPath &&
+						!isProgrammaticConfigPath(config.configPath)
+					) {
 						const { rawConfig } = await experimental_readRawConfig(
 							{
 								config: config.configPath,

--- a/packages/wrangler/tsup.config.ts
+++ b/packages/wrangler/tsup.config.ts
@@ -110,4 +110,16 @@ export default defineConfig((options) => [
 		},
 		esbuildPlugins: [embedWorkersPlugin({ isWatch: !!options.watch })],
 	},
+	{
+		treeshake: true,
+		keepNames: true,
+		entry: { config: "src/config/worker.ts" },
+		platform: "node",
+		format: ["esm"],
+		dts: true,
+		outDir: "wrangler-dist",
+		tsconfig: "tsconfig.json",
+		external: EXTERNAL_DEPENDENCIES,
+		sourcemap: process.env.SOURCEMAPS !== "false",
+	},
 ]);

--- a/packages/wrangler/turbo.json
+++ b/packages/wrangler/turbo.json
@@ -4,12 +4,7 @@
 	"tasks": {
 		"build": {
 			"inputs": ["$TURBO_DEFAULT$", "!**/__tests__/**", "!e2e/**"],
-			"outputs": [
-				"miniflare-dist/**",
-				"emitted-types/**",
-				"wrangler-dist/**",
-				"config-schema.json"
-			],
+			"outputs": ["emitted-types/**", "wrangler-dist/**", "config-schema.json"],
 			"env": [
 				"ALGOLIA_APP_ID",
 				"ALGOLIA_PUBLIC_KEY",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4032,6 +4032,9 @@ importers:
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
+      esbuild:
+        specifier: catalog:default
+        version: 0.27.0
       eslint:
         specifier: catalog:default
         version: 9.39.1(jiti@2.6.1)


### PR DESCRIPTION
One step along the road of supporting programmatic config in Wrangler. This part adds support for programmatic config with the existing config file structure, to make the diff semi easy to read.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: still experimental

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
