### PR TITLE
[wrangler] Fix AI Search RPC changeset

### DIFF
--- a/.changeset/chatty-rivers-punch.md
+++ b/.changeset/chatty-rivers-punch.md
@@ -3,6 +3,6 @@
 "wrangler": patch
 ---
 
-Fix AI Search binding failing over RPC in local dev
+Fix AI Search binding failing in local dev
 
-The AI Search binding uses an RPC-based protocol, but its raw workerd binding has a non-standard prototype that capnp-over-RPC classifies as "unsupported", causing `wrangler dev` to fail with "RPC stub points at a non-serializable type". The binding is now wrapped in a plain object that delegates only the allowed RPC methods (`aiSearch`), giving the serializer a target it can handle. A new `MF-Binding-Type` parameter is threaded from the miniflare AI plugin so the wrapping only applies to actual AI bindings, not other service bindings that happen to share method names.
+Using AI Search bindings with `wrangler dev` would fail with "RPC stub points at a non-serializable type". AI Search bindings now work correctly in local development.


### PR DESCRIPTION
The changeset from #12543 described the change as a `minor` "Add support for AI Search RPC method", but it was actually a bug fix — AI Search bindings didn't work at all in local dev. This updates it to `patch` with a proper description of the root cause and fix.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: changeset-only change
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: changeset-only change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
