### PR TITLE
fix: cleanup resources aggresively on vite-plugin

### DIFF
--- a/.changeset/lucky-chairs-relate.md
+++ b/.changeset/lucky-chairs-relate.md
@@ -4,6 +4,4 @@
 
 Fix --variant flag being ignored for pages
 
-When creating a Pages project using `npm create cloudflare -- --type pages --variant <variant>`, 
-the `--variant` flag was being ignored, causing users to be prompted for variant selection 
-or defaulting to an unexpected variant. This now correctly passes the variant to the project setup.
+When creating a Pages project using `npm create cloudflare -- --type pages --variant <variant>`, the `--variant` flag was being ignored, causing users to be prompted for variant selection or defaulting to an unexpected variant. This now correctly passes the variant to the project setup.

--- a/.changeset/quiet-taxis-rest.md
+++ b/.changeset/quiet-taxis-rest.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Clean up Vite dev server listeners and module tracking on HMR shutdown to reduce memory growth.

--- a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
+++ b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
@@ -128,7 +128,12 @@ export class CloudflareDevEnvironment extends vite.DevEnvironment {
 		const webSocket = response.webSocket;
 		assert(webSocket, "Failed to establish WebSocket");
 		webSocket.accept();
+		const isReInit = this.#webSocketContainer.webSocket !== undefined;
 		this.#webSocketContainer.webSocket = webSocket;
+
+		if (isReInit) {
+			this.hot.listen();
+		}
 	}
 
 	async fetchWorkerExportTypes(

--- a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
+++ b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
@@ -103,6 +103,11 @@ export class CloudflareDevEnvironment extends vite.DevEnvironment {
 		workerConfig: ResolvedWorkerConfig,
 		options: { isEntryWorker: boolean; isParentEnvironment: boolean }
 	): Promise<void> {
+		if (this.#webSocketContainer.webSocket) {
+			this.hot.close();
+			this.#webSocketContainer.webSocket.close();
+		}
+
 		const response = await miniflare.dispatchFetch(
 			new URL(INIT_PATH, UNKNOWN_HOST),
 			{

--- a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
+++ b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
@@ -104,7 +104,7 @@ export class CloudflareDevEnvironment extends vite.DevEnvironment {
 		options: { isEntryWorker: boolean; isParentEnvironment: boolean }
 	): Promise<void> {
 		if (this.#webSocketContainer.webSocket) {
-			this.hot.close();
+			await this.hot.close();
 			this.#webSocketContainer.webSocket.close();
 		}
 

--- a/packages/vite-plugin-cloudflare/src/plugins/additional-modules.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/additional-modules.ts
@@ -17,6 +17,14 @@ export const additionalModulesPlugin = createPlugin(
 			// We set `enforce: "pre"` so that this plugin runs before the Vite core plugins.
 			// Otherwise the `vite:wasm-fallback` plugin prevents the `.wasm` extension being used for module imports.
 			enforce: "pre",
+			configureServer(viteDevServer) {
+				additionalModulePaths.clear();
+				const cleanup = () => {
+					additionalModulePaths.clear();
+				};
+				viteDevServer.httpServer?.once("close", cleanup);
+				viteDevServer.watcher.on("close", cleanup);
+			},
 			applyToEnvironment(environment) {
 				return ctx.getWorkerConfig(environment.name) !== undefined;
 			},

--- a/packages/vite-plugin-cloudflare/src/plugins/additional-modules.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/additional-modules.ts
@@ -12,18 +12,33 @@ export const additionalModulesPlugin = createPlugin(
 	"additional-modules",
 	(ctx) => {
 		const additionalModulePaths = new Set<string>();
+		let serverCleanup: (() => void) | undefined;
 
 		return {
 			// We set `enforce: "pre"` so that this plugin runs before the Vite core plugins.
 			// Otherwise the `vite:wasm-fallback` plugin prevents the `.wasm` extension being used for module imports.
 			enforce: "pre",
 			configureServer(viteDevServer) {
+				// Clean up handlers from previous server (e.g., on restart)
+				serverCleanup?.();
+				serverCleanup = undefined;
+
 				additionalModulePaths.clear();
-				const cleanup = () => {
+
+				const onHttpServerClose = () => {
 					additionalModulePaths.clear();
 				};
-				viteDevServer.httpServer?.once("close", cleanup);
-				viteDevServer.watcher.on("close", cleanup);
+				const onWatcherClose = () => {
+					additionalModulePaths.clear();
+				};
+
+				viteDevServer.httpServer?.once("close", onHttpServerClose);
+				viteDevServer.watcher.on("close", onWatcherClose);
+
+				serverCleanup = () => {
+					viteDevServer.httpServer?.off("close", onHttpServerClose);
+					viteDevServer.watcher.off("close", onWatcherClose);
+				};
 			},
 			applyToEnvironment(environment) {
 				return ctx.getWorkerConfig(environment.name) !== undefined;

--- a/packages/vite-plugin-cloudflare/src/plugins/dev.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/dev.ts
@@ -17,7 +17,6 @@ import {
 	compareWorkerNameToExportTypesMaps,
 	getCurrentWorkerNameToExportTypesMap,
 } from "../export-types";
-import type { ExportTypes } from "../export-types";
 import {
 	disposeRemoteProxySessions,
 	getDevMiniflareOptions,
@@ -25,6 +24,7 @@ import {
 import { UNKNOWN_HOST } from "../shared";
 import { createPlugin, createRequestHandler, debuglog } from "../utils";
 import { handleWebSocket } from "../websockets";
+import type { ExportTypes } from "../export-types";
 import type { StaticRouting } from "@cloudflare/workers-shared/utils/types";
 import type * as vite from "vite";
 


### PR DESCRIPTION
An attempt to cleanup resources more aggresively on vite-plugin.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: impossible to test in an isolated way
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user facing change.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
