### PR TITLE
Nest child environment build output in parent environment build output directory

### DIFF
--- a/.changeset/gentle-animals-fail.md
+++ b/.changeset/gentle-animals-fail.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": minor
+---
+
+Nest child environment build output in parent environment build output directory.
+
+This ensures that a single output directory is used for the Worker without additional configuration.

--- a/packages/vite-plugin-cloudflare/playground/child-environment/__tests__/child-environment.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/child-environment/__tests__/child-environment.spec.ts
@@ -1,10 +1,24 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { test } from "vitest";
-import { getTextResponse, isBuild } from "../../__test-utils__";
+import { getTextResponse, isBuild, testDir } from "../../__test-utils__";
 
 test.runIf(!isBuild)(
 	"can import module from child environment",
 	async ({ expect }) => {
 		const response = await getTextResponse();
 		expect(response).toBe("Hello from the child environment");
+	}
+);
+
+test.runIf(isBuild)(
+	"nests child environment output in parent environment output directory",
+	({ expect }) => {
+		const childEnvironmentEntryPath = path.join(
+			testDir,
+			"dist/parent/child/child-environment-module.js"
+		);
+
+		expect(fs.existsSync(childEnvironmentEntryPath)).toBe(true);
 	}
 );

--- a/packages/vite-plugin-cloudflare/playground/child-environment/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/child-environment/vite.config.ts
@@ -1,7 +1,30 @@
+import assert from "node:assert";
+import * as path from "node:path";
 import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
 
 export default defineConfig({
+	environments: {
+		child: {
+			build: {
+				rollupOptions: {
+					input: path.resolve(__dirname, "src/child-environment-module.ts"),
+				},
+			},
+		},
+	},
+	builder: {
+		async buildApp(builder) {
+			const parentEnvironment = builder.environments.parent;
+			const childEnvironment = builder.environments.child;
+
+			assert(parentEnvironment, `No "parent" environment`);
+			assert(childEnvironment, `No "child" environment`);
+
+			await builder.build(parentEnvironment);
+			await builder.build(childEnvironment);
+		},
+	},
 	plugins: [
 		cloudflare({
 			inspectorPort: false,

--- a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
+++ b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
@@ -14,7 +14,12 @@ import {
 	VIRTUAL_WORKER_ENTRY,
 	WORKER_ENTRY_PATH_HEADER,
 } from "./shared";
-import { debuglog, getOutputDirectory, isRolldown } from "./utils";
+import {
+	debuglog,
+	getChildOutputDirectory,
+	getOutputDirectory,
+	isRolldown,
+} from "./utils";
 import type { ExportTypes } from "./export-types";
 import type {
 	ResolvedWorkerConfig,
@@ -196,7 +201,7 @@ export function createCloudflareEnvironmentOptions({
 	mode,
 	environmentName,
 	isEntryWorker,
-	isParentEnvironment,
+	parentEnvironmentOptions,
 	hasNodeJsCompat,
 }: {
 	workerConfig: ResolvedWorkerConfig;
@@ -204,10 +209,10 @@ export function createCloudflareEnvironmentOptions({
 	mode: vite.ConfigEnv["mode"];
 	environmentName: string;
 	isEntryWorker: boolean;
-	isParentEnvironment: boolean;
 	hasNodeJsCompat: boolean;
+	parentEnvironmentOptions: vite.EnvironmentOptions | undefined;
 }): vite.EnvironmentOptions {
-	const rollupOptions: vite.Rollup.RollupOptions = isParentEnvironment
+	const rollupOptions: vite.Rollup.RollupOptions = !parentEnvironmentOptions
 		? {
 				input: {
 					[MAIN_ENTRY_NAME]: VIRTUAL_WORKER_ENTRY,
@@ -254,7 +259,9 @@ export function createCloudflareEnvironmentOptions({
 			target,
 			emitAssets: true,
 			manifest: isEntryWorker,
-			outDir: getOutputDirectory(userConfig, environmentName),
+			outDir: parentEnvironmentOptions
+				? getChildOutputDirectory(parentEnvironmentOptions, environmentName)
+				: getOutputDirectory(userConfig, environmentName),
 			copyPublicDir: false,
 			ssr: true,
 			...(isRolldown

--- a/packages/vite-plugin-cloudflare/src/plugins/config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/config.ts
@@ -174,14 +174,16 @@ function getEnvironmentsConfig(
 						environmentName ===
 							ctx.resolvedPluginConfig.entryWorkerEnvironmentName);
 
+				const parentEnvironmentOptions = createCloudflareEnvironmentOptions({
+					...sharedOptions,
+					environmentName,
+					isEntryWorker,
+					parentEnvironmentOptions: undefined,
+				});
+
 				const parentConfig = [
 					environmentName,
-					createCloudflareEnvironmentOptions({
-						...sharedOptions,
-						environmentName,
-						isEntryWorker,
-						isParentEnvironment: true,
-					}),
+					parentEnvironmentOptions,
 				] as const;
 
 				const childConfigs = childEnvironmentNames.map(
@@ -192,7 +194,7 @@ function getEnvironmentsConfig(
 								...sharedOptions,
 								environmentName: childEnvironmentName,
 								isEntryWorker: false,
-								isParentEnvironment: false,
+								parentEnvironmentOptions,
 							}),
 						] as const
 				);

--- a/packages/vite-plugin-cloudflare/src/utils.ts
+++ b/packages/vite-plugin-cloudflare/src/utils.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import * as nodePath from "node:path";
 import * as util from "node:util";
 import { createRequest, sendResponse } from "@remix-run/node-fetch-server";
@@ -41,6 +42,16 @@ export function getOutputDirectory(
 		userConfig.environments?.[environmentName]?.build?.outDir ??
 		nodePath.join(rootOutputDirectory, environmentName)
 	);
+}
+
+export function getChildOutputDirectory(
+	parentEnvironmentOptions: vite.EnvironmentOptions,
+	childEnvironmentName: string
+): string {
+	const parentOutDir = parentEnvironmentOptions.build?.outDir;
+	assert(parentOutDir, "Parent environment outDir is not defined");
+
+	return nodePath.join(parentOutDir, childEnvironmentName);
 }
 
 const postfixRE = /[?#].*$/;


### PR DESCRIPTION
Nest child environment build output in parent environment build output directory.

This ensures that a single output directory is used for the Worker without additional configuration.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: N/A

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
