### PR TITLE
[vite-plugin] fix: use direct fetch in workflows tests to avoid Windows flakes

### DIFF
--- a/packages/vite-plugin-cloudflare/playground/__test-utils__/responses.ts
+++ b/packages/vite-plugin-cloudflare/playground/__test-utils__/responses.ts
@@ -1,5 +1,22 @@
 import { page, viteTestUrl } from "./index";
 
+/**
+ * Fetches JSON from the server using direct fetch (no browser).
+ * Use this for tests that only need to hit API endpoints without browser interaction.
+ * This avoids the race condition in `getJsonResponse` which uses Playwright's
+ * `page.waitForResponse()` that can hang on Windows.
+ */
+export async function fetchJson(path = "/"): Promise<unknown> {
+	const url = `${viteTestUrl}${path}`;
+	const response = await fetch(url);
+	const text = await response.text();
+	try {
+		return JSON.parse(text);
+	} catch {
+		throw new Error("Invalid JSON response:\n" + text);
+	}
+}
+
 export async function getTextResponse(path = "/"): Promise<string> {
 	const response = await getResponse(path);
 	return response.text();

--- a/packages/vite-plugin-cloudflare/playground/external-workflows/__tests__/workflows.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/external-workflows/__tests__/workflows.spec.ts
@@ -1,13 +1,13 @@
 import { test, vi } from "vitest";
-import { getJsonResponse, WAIT_FOR_OPTIONS } from "../../__test-utils__";
+import { fetchJson, WAIT_FOR_OPTIONS } from "../../__test-utils__";
 
 test("creates a Workflow with an ID", async ({ expect }) => {
 	const instanceId = "external-workflows-test-id";
 
-	await getJsonResponse(`/create?id=${instanceId}`);
+	await fetchJson(`/create?id=${instanceId}`);
 
 	await vi.waitFor(async () => {
-		expect(await getJsonResponse(`/get?id=${instanceId}`)).toEqual({
+		expect(await fetchJson(`/get?id=${instanceId}`)).toEqual({
 			status: "complete",
 			__LOCAL_DEV_STEP_OUTPUTS: [
 				{ output: "First step result" },

--- a/packages/vite-plugin-cloudflare/playground/workflows/__tests__/workflows.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/workflows/__tests__/workflows.spec.ts
@@ -1,13 +1,13 @@
 import { test, vi } from "vitest";
-import { getJsonResponse, WAIT_FOR_OPTIONS } from "../../__test-utils__";
+import { fetchJson, WAIT_FOR_OPTIONS } from "../../__test-utils__";
 
 test("creates a Workflow with an ID", async ({ expect }) => {
 	const instanceId = "workflows-test-id";
 
-	await getJsonResponse(`/create?id=${instanceId}`);
+	await fetchJson(`/create?id=${instanceId}`);
 
 	await vi.waitFor(async () => {
-		expect(await getJsonResponse(`/get?id=${instanceId}`)).toEqual({
+		expect(await fetchJson(`/get?id=${instanceId}`)).toEqual({
 			status: "complete",
 			__LOCAL_DEV_STEP_OUTPUTS: [
 				{ output: "First step result" },


### PR DESCRIPTION
The workflow playground tests were experiencing ~5% flake rate on Windows CI.

## Root Cause

The issue was that `getJsonResponse()` uses Playwright's `page.waitForResponse()` which:
1. Has a 30-second default timeout independent of `vi.waitFor()`'s timeout
2. Can hang due to race conditions between setting up the response listener and page navigation
3. Adds unnecessary browser overhead for simple API calls

## Solution

This change:
- Adds a new `fetchJson()` helper that uses direct Node.js `fetch` instead of Playwright
- Updates the workflows and external-workflows tests to use `fetchJson` instead of `getJsonResponse`

This eliminates the browser overhead and race condition for tests that only need to hit API endpoints without actually interacting with a browser.

## Previous Attempt

A similar approach was attempted in #12360 which tried to replace Playwright with direct `fetch` globally across all playground tests. That was reverted in #12372 because it "resulted in different rather than fewer errors" and added complexity.

This PR takes a more targeted approach - only updating the specific workflow tests that don't need browser interaction, leaving other tests unchanged. This minimizes risk while fixing the flake for these specific tests.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal test infrastructure change