### PR TITLE
[wrangler] Add `wrangler api` command

### DIFF
--- a/.changeset/wrangler-api-command.md
+++ b/.changeset/wrangler-api-command.md
@@ -1,0 +1,15 @@
+---
+"wrangler": minor
+---
+
+Add `wrangler api` command for making authenticated requests to the Cloudflare API
+
+You can now make authenticated GET requests to any Cloudflare API endpoint using your existing Wrangler credentials:
+
+```bash
+wrangler api /zones
+wrangler api /accounts/:account_id/workers/scripts
+wrangler api /zones -H "X-Custom-Header: value"
+```
+
+The `:account_id` placeholder is automatically replaced with your resolved account ID. Custom headers can be passed with `-H`. This follows the pattern established by `gh api` and `glab api`, and is particularly useful for agents and one-off API calls.

--- a/packages/wrangler/src/__tests__/api-command.test.ts
+++ b/packages/wrangler/src/__tests__/api-command.test.ts
@@ -1,0 +1,238 @@
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, it } from "vitest";
+import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import { useMockIsTTY } from "./helpers/mock-istty";
+import { createFetchResult, msw } from "./helpers/msw";
+import { runInTempDir } from "./helpers/run-in-tmp";
+import { runWrangler } from "./helpers/run-wrangler";
+
+describe("wrangler api", () => {
+	mockAccountId();
+	mockApiToken();
+	runInTempDir();
+	const std = mockConsoleMethods();
+	const { setIsTTY } = useMockIsTTY();
+
+	beforeEach(() => {
+		setIsTTY(true);
+	});
+
+	it("should error if no endpoint is provided", async ({ expect }) => {
+		await expect(runWrangler("api")).rejects.toThrowError(
+			/Not enough non-option arguments/
+		);
+	});
+
+	it("should error if endpoint does not start with /", async ({ expect }) => {
+		await expect(runWrangler("api zones")).rejects.toThrowError(
+			/Endpoint must start with "\/"/
+		);
+	});
+
+	it("should make a GET request and output JSON", async ({ expect }) => {
+		const zones = [
+			{ id: "zone-1", name: "example.com" },
+			{ id: "zone-2", name: "example.org" },
+		];
+
+		msw.use(
+			http.get(
+				"*/zones",
+				() => {
+					return HttpResponse.json(createFetchResult(zones));
+				},
+				{ once: true }
+			)
+		);
+
+		await runWrangler("api /zones");
+
+		const output = JSON.parse(std.out);
+		expect(output.success).toBe(true);
+		expect(output.result).toEqual(zones);
+	});
+
+	it("should pass custom headers", async ({ expect }) => {
+		msw.use(
+			http.get(
+				"*/zones",
+				({ request }) => {
+					const customHeader = request.headers.get("X-Custom-Header");
+					return HttpResponse.json(
+						createFetchResult({ receivedHeader: customHeader })
+					);
+				},
+				{ once: true }
+			)
+		);
+
+		await runWrangler('api /zones -H "X-Custom-Header: my-value"');
+
+		const output = JSON.parse(std.out);
+		expect(output.result.receivedHeader).toBe("my-value");
+	});
+
+	it("should support multiple custom headers", async ({ expect }) => {
+		msw.use(
+			http.get(
+				"*/zones",
+				({ request }) => {
+					return HttpResponse.json(
+						createFetchResult({
+							header1: request.headers.get("X-Header-1"),
+							header2: request.headers.get("X-Header-2"),
+						})
+					);
+				},
+				{ once: true }
+			)
+		);
+
+		await runWrangler(
+			'api /zones -H "X-Header-1: value1" -H "X-Header-2: value2"'
+		);
+
+		const output = JSON.parse(std.out);
+		expect(output.result.header1).toBe("value1");
+		expect(output.result.header2).toBe("value2");
+	});
+
+	it("should replace :account_id with resolved account ID", async ({
+		expect,
+	}) => {
+		msw.use(
+			http.get(
+				"*/accounts/:accountId/workers/scripts",
+				({ params }) => {
+					return HttpResponse.json(
+						createFetchResult({ accountId: params["accountId"] })
+					);
+				},
+				{ once: true }
+			)
+		);
+
+		await runWrangler("api /accounts/:account_id/workers/scripts");
+
+		const output = JSON.parse(std.out);
+		expect(output.result.accountId).toBe("some-account-id");
+	});
+
+	it("should use --account-id flag for :account_id replacement", async ({
+		expect,
+	}) => {
+		msw.use(
+			http.get(
+				"*/accounts/:accountId/workers/scripts",
+				({ params }) => {
+					return HttpResponse.json(
+						createFetchResult({ accountId: params["accountId"] })
+					);
+				},
+				{ once: true }
+			)
+		);
+
+		await runWrangler(
+			"api /accounts/:account_id/workers/scripts --account-id custom-account-123"
+		);
+
+		const output = JSON.parse(std.out);
+		expect(output.result.accountId).toBe("custom-account-123");
+	});
+
+	it("should not resolve account ID when :account_id is not in the endpoint", async ({
+		expect,
+	}) => {
+		msw.use(
+			http.get(
+				"*/zones",
+				() => {
+					return HttpResponse.json(createFetchResult([]));
+				},
+				{ once: true }
+			)
+		);
+
+		// This should work without needing account ID resolution
+		await runWrangler("api /zones");
+
+		const output = JSON.parse(std.out);
+		expect(output.success).toBe(true);
+	});
+
+	it("should show a hint on 403 responses", async ({ expect }) => {
+		msw.use(
+			http.get(
+				"*/zones",
+				() => {
+					return HttpResponse.json(
+						createFetchResult(null, false, [
+							{ code: 9109, message: "Forbidden" },
+						]),
+						{ status: 403 }
+					);
+				},
+				{ once: true }
+			)
+		);
+
+		await runWrangler("api /zones");
+
+		expect(std.out).toContain("Forbidden");
+		expect(std.warn).toContain(
+			"You may need to re-authenticate with additional scopes"
+		);
+		expect(std.warn).toContain("wrangler login");
+	});
+
+	it("should handle non-JSON responses", async ({ expect }) => {
+		msw.use(
+			http.get(
+				"*/zones",
+				() => {
+					return new HttpResponse("plain text response", {
+						status: 200,
+						headers: { "Content-Type": "text/plain" },
+					});
+				},
+				{ once: true }
+			)
+		);
+
+		await runWrangler("api /zones");
+
+		expect(std.out).toContain("plain text response");
+	});
+
+	it("should error on invalid header format", async ({ expect }) => {
+		await expect(
+			runWrangler('api /zones -H "bad-header-no-colon"')
+		).rejects.toThrowError(/Invalid header format/);
+	});
+
+	it("should error on empty header name", async ({ expect }) => {
+		await expect(
+			runWrangler('api /zones -H ": some-value"')
+		).rejects.toThrowError(/Header name cannot be empty/);
+	});
+
+	it("should pretty-print JSON output", async ({ expect }) => {
+		msw.use(
+			http.get(
+				"*/zones",
+				() => {
+					return HttpResponse.json(createFetchResult({ id: "test" }));
+				},
+				{ once: true }
+			)
+		);
+
+		await runWrangler("api /zones");
+
+		// Output should be indented (pretty-printed)
+		expect(std.out).toContain("  ");
+		expect(std.out).toContain('"success": true');
+	});
+});

--- a/packages/wrangler/src/__tests__/api-command.test.ts
+++ b/packages/wrangler/src/__tests__/api-command.test.ts
@@ -1,10 +1,10 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { createFetchResult, msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 
 describe("wrangler api", () => {

--- a/packages/wrangler/src/api-command/index.ts
+++ b/packages/wrangler/src/api-command/index.ts
@@ -1,0 +1,143 @@
+import { UserError } from "@cloudflare/workers-utils";
+import { performApiFetch } from "../cfetch";
+import { createCommand } from "../core/create-command";
+import { logger } from "../logger";
+import { requireAuth } from "../user";
+import type { Config } from "@cloudflare/workers-utils";
+
+/**
+ * Parse a header string in "Key: Value" format into [key, value].
+ * Throws if the format is invalid.
+ */
+function parseHeader(header: string): [string, string] {
+	const colonIndex = header.indexOf(":");
+	if (colonIndex === -1) {
+		throw new UserError(
+			`Invalid header format: "${header}". Expected "Key: Value".`
+		);
+	}
+	const key = header.slice(0, colonIndex).trim();
+	const value = header.slice(colonIndex + 1).trim();
+	if (!key) {
+		throw new UserError(
+			`Invalid header format: "${header}". Header name cannot be empty.`
+		);
+	}
+	return [key, value];
+}
+
+/**
+ * Replace :account_id placeholder in the endpoint path with the resolved account ID.
+ * Only resolves the account ID if the placeholder is present.
+ */
+async function resolveEndpoint(
+	endpoint: string,
+	config: Config,
+	accountIdFlag: string | undefined
+): Promise<string> {
+	if (!endpoint.includes(":account_id")) {
+		return endpoint;
+	}
+
+	// If --account-id flag was provided, use it directly
+	if (accountIdFlag) {
+		return endpoint.replaceAll(":account_id", accountIdFlag);
+	}
+
+	// Otherwise, resolve account ID through the normal flow
+	const accountId = await requireAuth(config);
+	return endpoint.replaceAll(":account_id", accountId);
+}
+
+export const apiCommand = createCommand({
+	metadata: {
+		description: "Make authenticated HTTP requests to the Cloudflare API",
+		status: "open beta",
+		owner: "Workers: Authoring and Testing",
+	},
+	behaviour: {
+		printBanner: false,
+		printConfigWarnings: false,
+		provideConfig: true,
+	},
+	args: {
+		endpoint: {
+			describe: "The API endpoint to request (e.g. /zones)",
+			type: "string",
+			demandOption: true,
+		},
+		header: {
+			describe: "Add an HTTP request header in Key: Value format",
+			type: "string",
+			array: true,
+			alias: "H",
+		},
+		"account-id": {
+			describe: "Account ID to use for :account_id in the endpoint path",
+			type: "string",
+		},
+	},
+	positionalArgs: ["endpoint"],
+	async handler(args, { config }) {
+		const endpoint = args.endpoint;
+
+		// Validate endpoint starts with /
+		if (!endpoint.startsWith("/")) {
+			throw new UserError(
+				`Endpoint must start with "/", but got "${endpoint}".`
+			);
+		}
+
+		// Parse custom headers
+		const headers: Record<string, string> = {};
+		if (args.header) {
+			for (const h of args.header) {
+				const [key, value] = parseHeader(h);
+				headers[key] = value;
+			}
+		}
+
+		// Resolve :account_id placeholder if present
+		const resolvedEndpoint = await resolveEndpoint(
+			endpoint,
+			config,
+			args.accountId
+		);
+
+		// Make the authenticated GET request
+		const response = await performApiFetch(config, resolvedEndpoint, {
+			method: "GET",
+			headers,
+		});
+
+		// Read the response body
+		const responseText = await response.text();
+
+		// Try to pretty-print JSON, fall back to raw text
+		try {
+			const json = JSON.parse(responseText);
+
+			// On 403, add a helpful hint
+			if (response.status === 403) {
+				logger.log(JSON.stringify(json, null, 2));
+				logger.warn(
+					"You may need to re-authenticate with additional scopes. Run `wrangler login` to get a new token."
+				);
+				return;
+			}
+
+			logger.log(JSON.stringify(json, null, 2));
+		} catch {
+			// Not JSON — print raw
+			if (response.status === 403) {
+				logger.log(responseText);
+				logger.warn(
+					"You may need to re-authenticate with additional scopes. Run `wrangler login` to get a new token."
+				);
+				return;
+			}
+
+			logger.log(responseText);
+		}
+	},
+});

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -36,6 +36,7 @@ import { aiFineTuneCreateCommand } from "./ai/createFinetune";
 import { aiModelsCommand, aiModelsListCommand } from "./ai/listCatalog";
 import { aiFineTuneListCommand } from "./ai/listFinetune";
 import { aiModelsSchemaCommand } from "./ai/modelSchema";
+import { apiCommand } from "./api-command";
 import {
 	artifactsNamespace,
 	artifactsNamespacesGetCommand,
@@ -802,6 +803,15 @@ export function createCLIParser(argv: string[]) {
 		},
 	]);
 	registry.registerNamespace("complete");
+
+	// api
+	registry.define([
+		{
+			command: "wrangler api",
+			definition: apiCommand,
+		},
+	]);
+	registry.registerNamespace("api");
 
 	/******************** CMD GROUP ***********************/
 


### PR DESCRIPTION
Adds a `wrangler api` command for making authenticated requests to the Cloudflare API.

```bash
wrangler api /zones
wrangler api /accounts/:account_id/workers/scripts
wrangler api /zones -H "X-Custom-Header: value"
```

#### MVP scope
- GET-only (other methods in a follow-up)
- Full V4 envelope output, pretty-printed
- `:account_id` auto-replacement from flag/config/env/cache/prompt
- Custom headers via `-H`
- 403 hint suggesting `wrangler login`
- No banner (clean for piping/agents)
- Works without wrangler.toml

#### Future iterations
- `-X`/`--method` for POST, PUT, PATCH, DELETE
- `-d`/`--data` for request bodies
- `--paginate` for auto-pagination
- Interactive mode / endpoint listing from OpenAPI spec

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [ ] Documentation not necessary because: