### PR TITLE
[wrangler] Add worker cache configuration support

### DIFF
--- a/.changeset/seven-squids-dream.md
+++ b/.changeset/seven-squids-dream.md
@@ -1,0 +1,20 @@
+---
+"wrangler": minor
+"@cloudflare/workers-utils": minor
+---
+
+Add `cache` configuration option for enabling worker cache (experimental)
+
+You can now enable cache before worker execution using the new `cache` configuration:
+
+```jsonc
+{
+	"cache": {
+		"enabled": true,
+	},
+}
+```
+
+This setting is environment-inheritable and opt-in. When enabled, cache behavior is applied before your worker runs.
+
+Note: This feature is experimental. The runtime API is not yet generally available.

--- a/packages/workers-utils/src/config/config.ts
+++ b/packages/workers-utils/src/config/config.ts
@@ -388,6 +388,7 @@ export const defaultWranglerConfig: Config = {
 	upload_source_maps: undefined,
 	assets: undefined,
 	observability: { enabled: true },
+	cache: undefined,
 	/** The default here is undefined so that we can delegate to the CLOUDFLARE_COMPLIANCE_REGION environment variable. */
 	compliance_region: undefined,
 	python_modules: { exclude: ["**/*.pyc"] },

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -621,6 +621,14 @@ interface EnvironmentInheritable {
 	observability: Observability | undefined;
 
 	/**
+	 * Specify the cache behavior of the Worker.
+	 *
+	 * @inheritable
+	 * @hidden
+	 */
+	cache: CacheOptions | undefined;
+
+	/**
 	 * Specify the compliance region mode of the Worker.
 	 *
 	 * Although if the user does not specify a compliance region, the default is `public`,
@@ -1426,6 +1434,11 @@ export interface Observability {
 		 */
 		destinations?: string[];
 	};
+}
+
+export interface CacheOptions {
+	/** If cache is enabled for this Worker */
+	enabled: boolean;
 }
 
 export type DockerConfiguration = {

--- a/packages/workers-utils/src/config/index.ts
+++ b/packages/workers-utils/src/config/index.ts
@@ -13,6 +13,7 @@ export type {
 	RawDevConfig,
 } from "./config";
 export type {
+	CacheOptions,
 	ConfigModuleRuleType,
 	Environment,
 	RawEnvironment,

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -40,6 +40,7 @@ import type { Binding } from "../types";
 import type { Config, DevConfig, RawConfig, RawDevConfig } from "./config";
 import type {
 	Assets,
+	CacheOptions,
 	DispatchNamespaceOutbound,
 	Environment,
 	Observability,
@@ -1934,6 +1935,14 @@ function normalizeAndValidateEnvironment(
 			rawEnv,
 			"observability",
 			validateObservability,
+			undefined
+		),
+		cache: inheritable(
+			diagnostics,
+			topLevelEnv,
+			rawEnv,
+			"cache",
+			validateCache,
 			undefined
 		),
 		compliance_region: inheritable(
@@ -4911,6 +4920,38 @@ const validateObservability: ValidatorFn = (diagnostics, field, value) => {
 			`"${field}.head_sampling_rate" must be a value between 0 and 1.`
 		);
 	}
+
+	return isValid;
+};
+
+const validateCache: ValidatorFn = (diagnostics, field, value) => {
+	if (value === undefined) {
+		return true;
+	}
+
+	if (typeof value !== "object" || value === null) {
+		diagnostics.errors.push(
+			`"${field}" should be an object but got ${JSON.stringify(value)}.`
+		);
+		return false;
+	}
+
+	const val = value as CacheOptions;
+	let isValid = true;
+
+	isValid =
+		validateRequiredProperty(
+			diagnostics,
+			field,
+			"enabled",
+			val.enabled,
+			"boolean"
+		) && isValid;
+
+	isValid =
+		validateAdditionalProperties(diagnostics, field, Object.keys(val), [
+			"enabled",
+		]) && isValid;
 
 	return isValid;
 };

--- a/packages/workers-utils/src/worker.ts
+++ b/packages/workers-utils/src/worker.ts
@@ -1,4 +1,4 @@
-import type { Observability, Route } from "./config/environment";
+import type { CacheOptions, Observability, Route } from "./config/environment";
 import type { INHERIT_SYMBOL } from "./constants";
 import type { Json, WorkerMetadata } from "./types";
 import type { AssetConfig, RouterConfig } from "@cloudflare/workers-shared";
@@ -428,6 +428,7 @@ export interface CfWorkerInit {
 		  }
 		| undefined;
 	observability: Observability | undefined;
+	cache: CacheOptions | undefined;
 }
 
 export interface CfWorkerContext {

--- a/packages/wrangler/src/__tests__/api/startDevWorker/RemoteRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/RemoteRuntimeController.test.ts
@@ -156,6 +156,7 @@ describe("RemoteRuntimeController", () => {
 			limits: undefined,
 			observability: undefined,
 			containers: undefined,
+			cache: undefined,
 		});
 
 		vi.mocked(createWorkerPreview).mockResolvedValue({

--- a/packages/wrangler/src/__tests__/create-worker-upload-form/helpers.ts
+++ b/packages/wrangler/src/__tests__/create-worker-upload-form/helpers.ts
@@ -44,6 +44,7 @@ export function createEsmWorker(
 		tail_consumers: undefined,
 		limits: undefined,
 		observability: undefined,
+		cache: undefined,
 		...overrides,
 	};
 }
@@ -77,6 +78,7 @@ export function createCjsWorker(
 		tail_consumers: undefined,
 		limits: undefined,
 		observability: undefined,
+		cache: undefined,
 		...overrides,
 	};
 }

--- a/packages/wrangler/src/__tests__/create-worker-upload-form/metadata.test.ts
+++ b/packages/wrangler/src/__tests__/create-worker-upload-form/metadata.test.ts
@@ -183,6 +183,12 @@ describe("createWorkerUploadForm — optional metadata fields", () => {
 			expected: { enabled: true },
 		},
 		{
+			label: "cache",
+			overrides: { cache: { enabled: true } },
+			key: "cache_options",
+			expected: { enabled: true },
+		},
+		{
 			label: "annotations",
 			overrides: {
 				annotations: {

--- a/packages/wrangler/src/api/pages/create-worker-bundle-contents.ts
+++ b/packages/wrangler/src/api/pages/create-worker-bundle-contents.ts
@@ -74,6 +74,7 @@ function createWorkerBundleFormData(
 			assets: undefined,
 			containers: undefined, // containers are not supported in Pages
 			observability: undefined,
+			cache: undefined, // cache is not supported in Pages
 		},
 		getBindings(config, { pages: true })
 	);

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -879,6 +879,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 						}
 					: undefined,
 			observability: config.observability,
+			cache: config.cache,
 		};
 
 		sourceMapSize = worker.sourceMaps?.reduce(

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -81,6 +81,7 @@ export function createWorkerUploadForm(
 		keep_assets,
 		assets,
 		observability,
+		cache,
 	} = worker;
 
 	const assetConfig: AssetConfigMetadata = {
@@ -726,6 +727,7 @@ export function createWorkerUploadForm(
 			},
 		}),
 		...(observability && { observability }),
+		...(cache && { cache_options: cache }),
 	};
 
 	if (options?.unsafe?.metadata !== undefined) {

--- a/packages/wrangler/src/dev/remote.ts
+++ b/packages/wrangler/src/dev/remote.ts
@@ -204,6 +204,7 @@ export async function createRemoteWorkerInit(props: {
 		streaming_tail_consumers: undefined,
 		limits: undefined, // no limits in preview - not supported yet but can be added
 		observability: undefined, // no observability in dev,
+		cache: undefined, // no cache in dev
 	};
 
 	return init;

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -91,6 +91,7 @@ async function createDraftWorker({
 					assets: undefined,
 					containers: undefined,
 					observability: undefined,
+					cache: undefined,
 				},
 				{}
 			),

--- a/packages/wrangler/src/versions/secrets/index.ts
+++ b/packages/wrangler/src/versions/secrets/index.ts
@@ -70,6 +70,7 @@ export interface VersionDetails {
 			limits: CfUserLimits;
 		};
 	};
+	cache_options?: { enabled: boolean };
 }
 
 interface ScriptSettings {
@@ -191,6 +192,7 @@ export async function copyWorkerVersionWithNewSecrets({
 		keep_assets: true,
 		assets: undefined,
 		observability: scriptSettings.observability,
+		cache: versionInfo.cache_options,
 	};
 
 	const body = createWorkerUploadForm(worker, bindings, {

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -728,8 +728,9 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 							run_worker_first: props.assetsOptions.run_worker_first,
 						}
 					: undefined,
-			logpush: undefined, // both logpush and observability are not supported in versions upload
+			logpush: undefined, // logpush and observability are non-versioned settings
 			observability: undefined,
+			cache: config.cache, // cache is a versioned setting
 		};
 
 		if (config.containers && config.containers.length > 0) {


### PR DESCRIPTION
Add top-level cache field for enabling cache before worker execution. Field is environment-inheritable and opt-in.

wrangler.toml:
[cache]
enabled = true

wrangler.jsonc:
{ "cache": { "enabled": true } }

Fixes #WC-4500

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Not yet released

*A picture of a cute animal (not mandatory, but encouraged)*
<img width="828" height="466" alt="image" src="https://github.com/user-attachments/assets/cf6c6d2c-68ad-487f-96d4-362c4157851d" />


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
