### PR TITLE
fix: merge incoming request query params with redirect destination query params

### DIFF
--- a/.changeset/fix-redirect-query-merge.md
+++ b/.changeset/fix-redirect-query-merge.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+fix: merge incoming request query params with redirect destination query params
+
+Previously, when a `_redirects` rule's destination contained query parameters (e.g. `/products?code=:code&name=:name`), any additional query parameters from the incoming request were silently dropped. The logic used an either/or choice (`destination.search || search`) rather than merging both sets of parameters.
+
+Now, query parameters from the incoming request are merged with those from the redirect destination, with destination parameters taking precedence when the same key appears in both.


### PR DESCRIPTION
## Summary

- Merges incoming request query parameters with redirect destination query parameters in the static assets layer
- Adds a `mergeSearchParams` helper that combines both sets of params, with destination params taking precedence
- Adds test coverage for query string preservation during redirects

## Behaviour change

Given a `_redirects` rule:
```
/products/:code/:name /products?code=:code&name=:name
```

A request to `/products/42/widget?tracking=abc` currently produces:
```
Location: /products?code=42&name=widget
```

The `tracking=abc` parameter from the incoming request is not carried through. The existing logic at `handler.ts:1035` uses `destination.search || search`, which selects one or the other rather than merging.

### After this change
```
Location: /products?tracking=abc&code=42&name=widget
```

Incoming params are merged in, with destination params taking precedence for duplicate keys.

## Prior art

Netlify's `_redirects` format documents this merging behaviour. From [their redirect options docs](https://docs.netlify.com/manage/routing/redirects/redirect-options/#query-parameters):

> While our service automatically passes on all query string parameters to destination paths for redirects with `200`, `301`, and `302` HTTP status, you can also choose to define a redirect path based on a specific parameter or combination of parameters.

Our docs for [Pages redirects](https://developers.cloudflare.com/pages/configuration/redirects/) and [Workers static assets redirects](https://developers.cloudflare.com/workers/static-assets/redirects/) include the `/products/:code/:name /products?code=:code&name=:name` example, where this behaviour is relevant. A follow-up docs PR could document the expected query string handling.

## Changes

- `packages/workers-shared/asset-worker/src/handler.ts` – Added `mergeSearchParams()` helper, replaced the `||`/ternary logic with a call to it
- `packages/workers-shared/asset-worker/tests/handler.test.ts` – Added 5 tests covering query string preservation on static redirects, dynamic redirects, param merging with precedence, and cross-origin redirects
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
