### PR TITLE
Simplify `Commands` section of wrangler readme

### DIFF
--- a/packages/wrangler/README.md
+++ b/packages/wrangler/README.md
@@ -54,24 +54,10 @@ For more detailed information about configuration, refer to the [documentation](
 
 ## Commands
 
-### Workers
+The `wrangler` CLI offers various commands, the most popular being:
 
-#### `wrangler dev`
+- `wrangler dev` to start a local development server, with live reloading and devtools.
 
-Start a local development server, with live reloading and devtools.
+- `wrangler deploy` to deploy a Worker to the Cloudflare's global network.
 
-#### `wrangler deploy`
-
-Publish the given script to Cloudflare's global network.
-
-For more commands and options, refer to the [documentation](https://developers.cloudflare.com/workers/wrangler/commands/).
-
-### Pages
-
-#### `wrangler pages dev [directory]`
-
-Serves a static build asset directory.
-
-Builds and runs functions from a `./functions` directory or uses a `_worker.js` file inside the static build asset directory.
-
-For more commands and options, refer to the [documentation](https://developers.cloudflare.com/pages/platform/functions#develop-and-preview-locally) or run `wrangler pages dev --help`.
+There are many more commands and options available, for a full list refer to the [official Cloudflare documentation](https://developers.cloudflare.com/workers/wrangler/commands/).


### PR DESCRIPTION
This is pretty minimal, but I feel that the current `Commands` section of the wrangler readme can be improved:
https://github.com/cloudflare/workers-sdk/blob/d02e70eff6bb68f1ac12ca59de74c6ee0422deb1/packages/wrangler/README.md?plain=1#L55-L77

It documents `wrangler dev`, `wrangler deploy` and `wrangler pages dev` which seems to me a bit unclear. At a first/quick glance to me it makes it sound like those are all the commands supported by wrangler. It also feels a bit arbitrary to include `wrangler pages dev` (why not other commands like `wrangler pages deploy` for example?).

So to me it seems a bit clearer to be pretty short, introduce (if we want to) only the most basic/useful commands (`wrangler dev` and `wrangler deploy`) and then simply redirect to the official docs.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: readme change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: readme change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
