### PR TITLE
Add check for changeset formatting in the CI check workflow

### DIFF
--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -44,6 +44,13 @@ jobs:
       - name: Check the changesets
         run: node -r esbuild-register tools/deployments/validate-changesets.ts
 
+      - name: Check for changeset formatting errors
+        # Note: we want to run the changesets format check before running the changeset step which deletes the changeset files
+        run: pnpm run check:format:changesets
+        env:
+          CI_OS: ${{ runner.os }}
+          NODE_OPTIONS: "--max_old_space_size=8192"
+
       - name: Bump package versions
         run: node .github/changeset-version.js
         env:

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"check:deployments": "node -r esbuild-register tools/deployments/deploy-non-npm-packages.ts check",
 		"check:fixtures": "node -r esbuild-register tools/deployments/validate-fixtures.ts",
 		"check:format": "prettier . --check --ignore-unknown --cache",
+		"check:format:changesets": "prettier .changeset/*.md --check",
 		"check:lint": "dotenv -- turbo check:lint",
 		"check:package-deps": "node -r esbuild-register tools/deployments/validate-package-dependencies.ts",
 		"check:private-packages": "node -r esbuild-register tools/deployments/validate-private-packages.ts",

--- a/turbo.json
+++ b/turbo.json
@@ -53,6 +53,10 @@
 		},
 		"//#check:format": {
 			"cache": true
+		},
+		"check:format:changesets": {
+			"inputs": [".changeset/*.mdx"],
+			"cache": true
 		}
 	}
 }

--- a/turbo.json
+++ b/turbo.json
@@ -55,7 +55,7 @@
 			"cache": true
 		},
 		"check:format:changesets": {
-			"inputs": [".changeset/*.mdx"],
+			"inputs": [".changeset/*.md"],
 			"cache": true
 		}
 	}


### PR DESCRIPTION
We're not currently checking the formatting of changeset files in CI, sometimes requiring PRs such as:
 - https://github.com/cloudflare/workers-sdk/pull/12638
 - https://github.com/cloudflare/workers-sdk/pull/12571

So here I am adding a step to the CI check workflow to ensure that changeset files are checked on all PRs

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows:
    - In a previous run in this PR I updated a changeset to contain a formatting issue and as you can see in https://github.com/cloudflare/workers-sdk/actions/runs/22300912762/job/64508282608 this check worked as intended
  - [ ] Additional testing not necessary because: infra change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: infra change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
