### PR TITLE
containers: retry docker image inspect on missing cloudflare-dev tags…

### DIFF
--- a/packages/containers-shared/src/inspect.ts
+++ b/packages/containers-shared/src/inspect.ts
@@ -5,29 +5,77 @@ export async function dockerImageInspect(
 	dockerPath: string,
 	options: { imageTag: string; formatString: string }
 ): Promise<string> {
-	return new Promise((resolve, reject) => {
-		const proc = spawn(
-			dockerPath,
-			["image", "inspect", options.imageTag, "--format", options.formatString],
-			{
-				stdio: ["ignore", "pipe", "pipe"],
-			}
+	const sleep = (ms: number) =>
+		new Promise((resolve) => setTimeout(resolve, ms));
+
+	const isTransientMissingImage = (stderr: string): boolean => {
+		const message = stderr.toLowerCase();
+		return (
+			message.includes("no such image") ||
+			message.includes("failed to find image")
 		);
+	};
 
-		let stdout = "";
-		let stderr = "";
+	const inspectOnce = async (): Promise<string> => {
+		return new Promise((resolve, reject) => {
+			const proc = spawn(
+				dockerPath,
+				[
+					"image",
+					"inspect",
+					options.imageTag,
+					"--format",
+					options.formatString,
+				],
+				{
+					stdio: ["ignore", "pipe", "pipe"],
+				}
+			);
 
-		proc.stdout.on("data", (chunk) => (stdout += chunk));
-		proc.stderr.on("data", (chunk) => (stderr += chunk));
+			let stdout = "";
+			let stderr = "";
 
-		proc.on("close", (code) => {
-			if (code !== 0) {
-				return reject(
-					new UserError(`failed inspecting image locally: ${stderr.trim()}`)
-				);
-			}
-			resolve(stdout.trim());
+			proc.stdout.on("data", (chunk) => (stdout += chunk));
+			proc.stderr.on("data", (chunk) => (stderr += chunk));
+
+			proc.on("close", (code) => {
+				if (code !== 0) {
+					return reject(
+						Object.assign(
+							new UserError(
+								`failed inspecting image locally: ${stderr.trim()}`
+							),
+							{ __stderr: stderr }
+						)
+					);
+				}
+				resolve(stdout.trim());
+			});
+			proc.on("error", (err) => reject(err));
 		});
-		proc.on("error", (err) => reject(err));
-	});
+	};
+
+	// `docker build --load` / `docker tag` can be briefly inconsistent in local dev,
+	// especially when Wrangler uses buildx under the hood. Retry a handful of times
+	// only for missing-image errors.
+	const maxAttempts = 5;
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		try {
+			return await inspectOnce();
+		} catch (err) {
+			const stderr = (err as { __stderr?: string } | undefined)?.__stderr;
+			if (
+				attempt < maxAttempts &&
+				typeof stderr === "string" &&
+				isTransientMissingImage(stderr)
+			) {
+				await sleep(200);
+				continue;
+			}
+			throw err;
+		}
+	}
+
+	// Unreachable, but keeps TypeScript happy.
+	throw new UserError("failed inspecting image locally: unknown error");
 }

--- a/packages/containers-shared/src/inspect.ts
+++ b/packages/containers-shared/src/inspect.ts
@@ -4,6 +4,11 @@ import { UserError } from "@cloudflare/workers-utils";
 const MAX_INSPECT_RETRIES = 5;
 const RETRY_DELAY_MS = 100;
 
+type InspectError = Error & {
+	stderr: string;
+	transientMissingImage: boolean;
+};
+
 const isTransientMissingImage = (stderr: string): boolean => {
 	const message = stderr.toLowerCase();
 	return (
@@ -12,13 +17,20 @@ const isTransientMissingImage = (stderr: string): boolean => {
 	);
 };
 
-const createInspectError = (stderr: string): UserError => {
+const createInspectError = (stderr: string): InspectError => {
 	const error = new UserError(
 		`failed inspecting image locally: ${stderr.trim()}`
 	);
 	return Object.assign(error, {
 		stderr: stderr.trim(),
 		transientMissingImage: isTransientMissingImage(stderr),
+	});
+};
+
+const createSpawnError = (error: Error): InspectError => {
+	return Object.assign(error, {
+		stderr: "",
+		transientMissingImage: false,
 	});
 };
 
@@ -54,33 +66,35 @@ const inspectOnce = async (
 			}
 			resolve(stdout.trim());
 		});
-		proc.on("error", (err) => reject(err));
+		proc.on("error", (error) => reject(createSpawnError(error)));
 	});
+};
+
+const isRetryableInspectError = (error: unknown): error is InspectError => {
+	return (
+		error instanceof Error &&
+		"transientMissingImage" in error &&
+		error.transientMissingImage === true
+	);
 };
 
 export async function dockerImageInspect(
 	dockerPath: string,
 	options: { imageTag: string; formatString: string }
 ): Promise<string> {
-	let lastError: unknown;
+	let attempt = 0;
 
-	for (let attempt = 1; attempt <= MAX_INSPECT_RETRIES; attempt++) {
+	while (true) {
+		attempt++;
+
 		try {
 			return await inspectOnce(dockerPath, options);
 		} catch (error) {
-			lastError = error;
-			const isRetryable =
-				error instanceof Error &&
-				"transientMissingImage" in error &&
-				(Boolean((error as { transientMissingImage?: boolean }).transientMissingImage));
-
-			if (!isRetryable || attempt === MAX_INSPECT_RETRIES) {
+			if (!isRetryableInspectError(error) || attempt === MAX_INSPECT_RETRIES) {
 				throw error;
 			}
 
 			await sleep(RETRY_DELAY_MS);
 		}
 	}
-
-	throw lastError;
 }

--- a/packages/containers-shared/src/inspect.ts
+++ b/packages/containers-shared/src/inspect.ts
@@ -1,10 +1,34 @@
 import { spawn } from "node:child_process";
 import { UserError } from "@cloudflare/workers-utils";
 
-export async function dockerImageInspect(
+const MAX_INSPECT_RETRIES = 5;
+const RETRY_DELAY_MS = 100;
+
+const isTransientMissingImage = (stderr: string): boolean => {
+	const message = stderr.toLowerCase();
+	return (
+		message.includes("no such image") ||
+		message.includes("failed to find image")
+	);
+};
+
+const createInspectError = (stderr: string): UserError => {
+	const error = new UserError(
+		`failed inspecting image locally: ${stderr.trim()}`
+	);
+	return Object.assign(error, {
+		stderr: stderr.trim(),
+		transientMissingImage: isTransientMissingImage(stderr),
+	});
+};
+
+const sleep = (ms: number): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, ms));
+
+const inspectOnce = async (
 	dockerPath: string,
 	options: { imageTag: string; formatString: string }
-): Promise<string> {
+): Promise<string> => {
 	return new Promise((resolve, reject) => {
 		const proc = spawn(
 			dockerPath,
@@ -17,17 +41,46 @@ export async function dockerImageInspect(
 		let stdout = "";
 		let stderr = "";
 
-		proc.stdout.on("data", (chunk) => (stdout += chunk));
-		proc.stderr.on("data", (chunk) => (stderr += chunk));
+		proc.stdout.on("data", (chunk) => {
+			stdout += chunk.toString();
+		});
+		proc.stderr.on("data", (chunk) => {
+			stderr += chunk.toString();
+		});
 
 		proc.on("close", (code) => {
 			if (code !== 0) {
-				return reject(
-					new UserError(`failed inspecting image locally: ${stderr.trim()}`)
-				);
+				return reject(createInspectError(stderr));
 			}
 			resolve(stdout.trim());
 		});
 		proc.on("error", (err) => reject(err));
 	});
+};
+
+export async function dockerImageInspect(
+	dockerPath: string,
+	options: { imageTag: string; formatString: string }
+): Promise<string> {
+	let lastError: unknown;
+
+	for (let attempt = 1; attempt <= MAX_INSPECT_RETRIES; attempt++) {
+		try {
+			return await inspectOnce(dockerPath, options);
+		} catch (error) {
+			lastError = error;
+			const isRetryable =
+				error instanceof Error &&
+				"transientMissingImage" in error &&
+				(Boolean((error as { transientMissingImage?: boolean }).transientMissingImage));
+
+			if (!isRetryable || attempt === MAX_INSPECT_RETRIES) {
+				throw error;
+			}
+
+			await sleep(RETRY_DELAY_MS);
+		}
+	}
+
+	throw lastError;
 }

--- a/packages/containers-shared/tests/inspect.test.ts
+++ b/packages/containers-shared/tests/inspect.test.ts
@@ -1,0 +1,91 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", async () => {
+	return {
+		spawn: vi.fn(),
+	};
+});
+
+const getSpawnMock = async () => {
+	const mod = await import("node:child_process");
+	return mod.spawn as unknown as ReturnType<typeof vi.fn>;
+};
+
+const createMockProc = (
+	stdoutText: string,
+	stderrText: string,
+	exitCode: number
+) => {
+	const proc = new EventEmitter() as any;
+	proc.stdout = new EventEmitter();
+	proc.stderr = new EventEmitter();
+
+	setTimeout(() => {
+		if (stderrText) {
+			proc.stderr.emit("data", Buffer.from(stderrText));
+		}
+		if (stdoutText) {
+			proc.stdout.emit("data", Buffer.from(stdoutText));
+		}
+		proc.emit("close", exitCode);
+	}, 0);
+
+	return proc;
+};
+
+describe("dockerImageInspect", () => {
+	it("retries on transient missing-image errors and eventually resolves", async () => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		const spawn = await getSpawnMock();
+
+		let call = 0;
+		spawn.mockImplementation(() => {
+			call++;
+			if (call <= 2) {
+				return createMockProc(
+					"",
+					"Error response from daemon: No such image: cloudflare-dev/test:deadbeef",
+					1
+				);
+			}
+			return createMockProc("42\n", "", 0);
+		});
+
+		const { dockerImageInspect } = await import("../src/inspect");
+
+		const promise = dockerImageInspect("docker", {
+			imageTag: "cloudflare-dev/test:deadbeef",
+			formatString: "{{ .Id }}",
+		});
+		const assertion = expect(promise).resolves.toBe("42");
+
+		await vi.runAllTimersAsync();
+		await assertion;
+		expect(spawn).toHaveBeenCalledTimes(3);
+	});
+
+	it("does not retry on non-transient inspect failures", async () => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		const spawn = await getSpawnMock();
+		spawn.mockImplementation(() => {
+			return createMockProc("", "permission denied", 1);
+		});
+
+		const { dockerImageInspect } = await import("../src/inspect");
+
+		const promise = dockerImageInspect("docker", {
+			imageTag: "cloudflare-dev/test:deadbeef",
+			formatString: "{{ .Id }}",
+		});
+		const assertion = expect(promise).rejects.toThrow(
+			/failed inspecting image locally/i
+		);
+
+		await vi.runAllTimersAsync();
+		await assertion;
+		expect(spawn).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/containers-shared/tests/inspect.test.ts
+++ b/packages/containers-shared/tests/inspect.test.ts
@@ -1,0 +1,97 @@
+import { EventEmitter } from "node:events";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { describe, it, vi } from "vitest";
+
+vi.mock("node:child_process", async () => {
+	return {
+		spawn: vi.fn(),
+	};
+});
+
+const getSpawnMock = async () => {
+	const mod = await import("node:child_process");
+	return vi.mocked(mod.spawn);
+};
+
+const createMockProc = (
+	stdoutText: string,
+	stderrText: string,
+	exitCode: number
+) => {
+	const proc = new EventEmitter() as unknown as ChildProcessWithoutNullStreams;
+	(proc as unknown as { stdout: EventEmitter }).stdout = new EventEmitter();
+	(proc as unknown as { stderr: EventEmitter }).stderr = new EventEmitter();
+
+	setTimeout(() => {
+		if (stderrText) {
+			proc.stderr.emit("data", Buffer.from(stderrText));
+		}
+		if (stdoutText) {
+			proc.stdout.emit("data", Buffer.from(stdoutText));
+		}
+		proc.emit("close", exitCode);
+	}, 0);
+
+	return proc;
+};
+
+describe("dockerImageInspect", () => {
+	it("retries on transient missing-image errors and eventually resolves", async ({ expect }) => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		const spawn = await getSpawnMock();
+
+		let call = 0;
+		spawn.mockImplementation(() => {
+			call++;
+			if (call <= 2) {
+				return createMockProc(
+					"",
+					"Error response from daemon: No such image: cloudflare-dev/test:deadbeef",
+					1
+				);
+			}
+			return createMockProc("42\n", "", 0);
+		});
+
+		const { dockerImageInspect } = await import("../src/inspect");
+
+		const promise = dockerImageInspect("docker", {
+			imageTag: "cloudflare-dev/test:deadbeef",
+			formatString: "{{ .Id }}",
+		});
+		const assertion = expect(promise).resolves.toBe("42");
+
+		await vi.runAllTimersAsync();
+		await assertion;
+		expect(spawn).toHaveBeenCalledTimes(3);
+	});
+
+	it("does not retry on non-transient inspect failures", async ({ expect }) => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		const spawn = await getSpawnMock();
+
+		spawn.mockImplementation(() =>
+			createMockProc(
+				"",
+				"Error response from daemon: invalid reference format",
+				1
+			)
+		);
+
+		const { dockerImageInspect } = await import("../src/inspect");
+
+		const promise = dockerImageInspect("docker", {
+			imageTag: "cloudflare-dev/test:deadbeef",
+			formatString: "{{ .Id }}",
+		});
+		const assertion = expect(promise).rejects.toThrow(
+			"failed inspecting image locally: Error response from daemon: invalid reference format"
+		);
+
+		await vi.runAllTimersAsync();
+		await assertion;
+		expect(spawn).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/containers-shared/tests/inspect.test.ts
+++ b/packages/containers-shared/tests/inspect.test.ts
@@ -67,6 +67,65 @@ describe("dockerImageInspect", () => {
 		expect(spawn).toHaveBeenCalledTimes(3);
 	});
 
+	it("retries on transient failed-to-find-image errors and eventually resolves", async ({ expect }) => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		const spawn = await getSpawnMock();
+
+		let call = 0;
+		spawn.mockImplementation(() => {
+			call++;
+			if (call <= 2) {
+				return createMockProc(
+					"",
+					"Error response from daemon: failed to find image: cloudflare-dev/test:deadbeef",
+					1
+				);
+			}
+			return createMockProc("42\n", "", 0);
+		});
+
+		const { dockerImageInspect } = await import("../src/inspect");
+
+		const promise = dockerImageInspect("docker", {
+			imageTag: "cloudflare-dev/test:deadbeef",
+			formatString: "{{ .Id }}",
+		});
+		const assertion = expect(promise).resolves.toBe("42");
+
+		await vi.runAllTimersAsync();
+		await assertion;
+		expect(spawn).toHaveBeenCalledTimes(3);
+	});
+
+	it("throws after exhausting all transient missing-image retries", async ({ expect }) => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		const spawn = await getSpawnMock();
+
+		spawn.mockImplementation(() =>
+			createMockProc(
+				"",
+				"Error response from daemon: No such image: cloudflare-dev/test:deadbeef",
+				1
+			)
+		);
+
+		const { dockerImageInspect } = await import("../src/inspect");
+
+		const promise = dockerImageInspect("docker", {
+			imageTag: "cloudflare-dev/test:deadbeef",
+			formatString: "{{ .Id }}",
+		});
+		const assertion = expect(promise).rejects.toThrow(
+			"failed inspecting image locally: Error response from daemon: No such image: cloudflare-dev/test:deadbeef"
+		);
+
+		await vi.runAllTimersAsync();
+		await assertion;
+		expect(spawn).toHaveBeenCalledTimes(5);
+	});
+
 	it("does not retry on non-transient inspect failures", async ({ expect }) => {
 		vi.useFakeTimers();
 		vi.clearAllMocks();


### PR DESCRIPTION
* Added retry logic to `dockerImageInspect` in `inspect.ts`, so it attempts up to five times when encountering transient missing-image errors (e.g., "no such image"), with a short delay between retries. This helps address inconsistencies during local development when Docker images may not be immediately available. [[1]](diffhunk://#diff-6f7d9ae8fe3a4b69c4ab9d4145eec5ef0f4aa45fca7b1796e50e01db93fdd76cR8-R29) [[2]](diffhunk://#diff-6f7d9ae8fe3a4b69c4ab9d4145eec5ef0f4aa45fca7b1796e50e01db93fdd76cL26-R80)
* Improved error reporting by attaching the original `stderr` output to thrown `UserError` objects, making debugging easier.

**Test coverage additions:**

* Added new tests in `inspect.test.ts` to verify that `dockerImageInspect` retries on transient missing-image errors and does not retry on other errors, using mocked child process behavior.… (#155)

Fixes #[insert GH or internal issue link(s)].

_Describe your change..._

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated: inspect.test.ts added and pnpm -C packages/containers-shared run test:ci passes
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal/dev behavior change + tests cover it (no user-facing docs change)

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
