### PR TITLE
Quarantine all the Angular C3 e2e tests

### DIFF
--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -167,6 +167,9 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			},
 			nodeCompat: false,
 			flags: ["--style", "sass"],
+			// TODO: currently the Angular tests are failing with `URL with hostname "localhost" is not allowed.`
+			//       we need to investigate this so that we can un-quarantine the Angular tests
+			quarantine: true,
 		},
 		{
 			name: "angular:workers",
@@ -186,6 +189,9 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			},
 			nodeCompat: false,
 			flags: ["--style", "sass"],
+			// TODO: currently the Angular tests are failing with `URL with hostname "localhost" is not allowed.`
+			//       we need to investigate this so that we can un-quarantine the Angular tests
+			quarantine: true,
 		},
 		{
 			name: "gatsby:pages",
@@ -784,6 +790,9 @@ function getExperimentalFrameworkTestConfig(
 			nodeCompat: false,
 			flags: ["--style", "sass"],
 			verifyTypes: false,
+			// TODO: currently the Angular tests are failing with `URL with hostname "localhost" is not allowed.`
+			//       we need to investigate this so that we can un-quarantine the Angular tests
+			quarantine: true,
 		},
 		{
 			name: "nuxt:workers",


### PR DESCRIPTION
Skipping the C3 Angular e2es since they are currently failing and blocking the Autoconfig release, we'll investigate these issues and re-enable the tests later

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal tests change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
