### PR TITLE
Revert "Autoconfig GA  (#12614)"

### DIFF
--- a/.changeset/gentle-moons-argue.md
+++ b/.changeset/gentle-moons-argue.md
@@ -1,5 +1,0 @@
----
-"wrangler": minor
----
-
-Enable autoconfig for `wrangler deploy` by default (while allowing users to still disable it via `--x-autoconfig=false` if necessary)

--- a/.changeset/yummy-snails-stand.md
+++ b/.changeset/yummy-snails-stand.md
@@ -1,5 +1,0 @@
----
-"wrangler": minor
----
-
-Mark the `wrangler setup` command as stable

--- a/packages/wrangler/src/__tests__/autoconfig/run.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/run.test.ts
@@ -94,11 +94,11 @@ describe("autoconfig (deploy)", () => {
 		clearOutputFilePath();
 	});
 
-	it("should not check for autoconfig when `deploy` is run with `--x-autoconfig=false`", async () => {
+	it("should not check for autoconfig without flag", async () => {
 		writeWorkerSource();
 		writeWranglerConfig({ main: "index.js" });
 		const getDetailsSpy = vi.spyOn(details, "getDetailsForAutoConfig");
-		await runDeploy(`--x-autoconfig=false`);
+		await runDeploy();
 
 		expect(getDetailsSpy).not.toHaveBeenCalled();
 	});

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -114,7 +114,9 @@ vi.mock("../package-manager", async (importOriginal) => ({
 	},
 }));
 
+vi.mock("../autoconfig/details");
 vi.mock("../autoconfig/run");
+vi.mock("../autoconfig/frameworks");
 vi.mock("../autoconfig/frameworks/utils/packages");
 vi.mock("../autoconfig/c3-vendor/command");
 
@@ -564,34 +566,18 @@ describe("deploy", () => {
 		`);
 	});
 
-	it("should error helpfully if pages_build_output_dir is set in wrangler.toml when --x-autoconfig=false", async () => {
+	it("should error helpfully if pages_build_output_dir is set in wrangler.toml", async () => {
 		writeWranglerConfig({
 			pages_build_output_dir: "public",
 			name: "test-name",
 		});
 		await expect(
-			runWrangler("deploy --x-autoconfig=false")
+			runWrangler("deploy")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
 			`
 			[Error: It looks like you've run a Workers-specific command in a Pages project.
 			For Pages, please run \`wrangler pages deploy\` instead.]
 		`
-		);
-	});
-
-	it("should error helpfully if pages_build_output_dir is set in wrangler.toml and --x-autoconfig is provided", async () => {
-		mockConfirm({
-			text: "Are you sure that you want to proceed?",
-			result: true,
-		});
-
-		writeWranglerConfig({
-			pages_build_output_dir: "public",
-			name: "test-name",
-		});
-		await expect(runWrangler("deploy --x-autoconfig")).rejects.toThrowError();
-		expect(std.warn).toContain(
-			"It seems that you have run `wrangler deploy` on a Pages project, `wrangler pages deploy` should be used instead."
 		);
 	});
 
@@ -603,7 +589,7 @@ describe("deploy", () => {
 
 		const getDetailsForAutoConfigSpy = vi
 			.spyOn(await import("../autoconfig/details"), "getDetailsForAutoConfig")
-			.mockResolvedValueOnce({
+			.mockResolvedValue({
 				configured: false,
 				projectPath: process.cwd(),
 				workerName: "test-name",
@@ -642,7 +628,7 @@ describe("deploy", () => {
 
 		const getDetailsForAutoConfigSpy = vi
 			.spyOn(await import("../autoconfig/details"), "getDetailsForAutoConfig")
-			.mockResolvedValueOnce({
+			.mockResolvedValue({
 				configured: false,
 				projectPath: process.cwd(),
 				workerName: "test-name",
@@ -16617,13 +16603,13 @@ export default{
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should not delegate to open-next deploy when --x-autoconfig=false is provided", async () => {
+		it("should not delegate to open-next deploy when the --x-autoconfig flag is not provided", async () => {
 			const runCommandSpy = (await import("../autoconfig/c3-vendor/command"))
 				.runCommand;
 
 			await mockOpenNextLikeProject();
 
-			await runWrangler("deploy --x-autoconfig=false");
+			await runWrangler("deploy");
 
 			expect(runCommandSpy).not.toHaveBeenCalledOnce();
 

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -58,7 +58,7 @@ describe("wrangler", () => {
 				  wrangler queues                 📬 Manage Workers Queues
 				  wrangler rollback [version-id]  🔙 Rollback a deployment for a Worker
 				  wrangler secret                 🤫 Generate a secret that can be referenced in a Worker
-				  wrangler setup                  🪄 Setup a project to work on Cloudflare
+				  wrangler setup                  🪄 Setup a project to work on Cloudflare [experimental]
 				  wrangler tail [worker]          🦚 Start a log tailing session for a Worker
 				  wrangler triggers               🎯 Updates the triggers of your current deployment [experimental]
 				  wrangler types [path]           📝 Generate types from your Worker configuration
@@ -129,7 +129,7 @@ describe("wrangler", () => {
 				  wrangler queues                 📬 Manage Workers Queues
 				  wrangler rollback [version-id]  🔙 Rollback a deployment for a Worker
 				  wrangler secret                 🤫 Generate a secret that can be referenced in a Worker
-				  wrangler setup                  🪄 Setup a project to work on Cloudflare
+				  wrangler setup                  🪄 Setup a project to work on Cloudflare [experimental]
 				  wrangler tail [worker]          🦚 Start a log tailing session for a Worker
 				  wrangler triggers               🎯 Updates the triggers of your current deployment [experimental]
 				  wrangler types [path]           📝 Generate types from your Worker configuration

--- a/packages/wrangler/src/__tests__/setup.test.ts
+++ b/packages/wrangler/src/__tests__/setup.test.ts
@@ -35,7 +35,7 @@ describe("wrangler setup", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"wrangler setup
 
-			🪄 Setup a project to work on Cloudflare
+			🪄 Setup a project to work on Cloudflare [experimental]
 
 			GLOBAL FLAGS
 			  -c, --config    Path to Wrangler configuration file  [string]

--- a/packages/wrangler/src/autoconfig/details.ts
+++ b/packages/wrangler/src/autoconfig/details.ts
@@ -253,7 +253,6 @@ async function detectFramework(
 					name: "Cloudflare Pages",
 					id: "cloudflare-pages",
 				},
-				dist: wranglerConfig?.pages_build_output_dir,
 			},
 			packageManager,
 		};

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -256,7 +256,7 @@ export const deployCommand = createCommand({
 			describe:
 				"Experimental: Enables framework detection and automatic configuration when deploying",
 			type: "boolean",
-			default: true,
+			default: false,
 		},
 	},
 	behaviour: {

--- a/packages/wrangler/src/setup.ts
+++ b/packages/wrangler/src/setup.ts
@@ -14,7 +14,7 @@ export const setupCommand = createCommand({
 	metadata: {
 		description: "🪄 Setup a project to work on Cloudflare",
 		owner: "Workers: Authoring and Testing",
-		status: "stable",
+		status: "experimental",
 		category: "Compute & AI",
 	},
 	args: {


### PR DESCRIPTION
This reverts commit 8d882fa1c4aa812482e53df2b668bf3b28549ece.

Revert PR for autoconfig GA, just in case 😅 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
