### PR TITLE
Adds option to skip container rollout on deploy

### DIFF
--- a/.changeset/dry-sloths-roll.md
+++ b/.changeset/dry-sloths-roll.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/containers-shared": minor
+"wrangler": minor
+---
+
+Add `--containers-rollout=none`
+
+This allows you to skip deploying a container. This is useful if you know that your container is not going to be updated or you don't have Docker locally, but still want to make changes to your Worker.

--- a/packages/containers-shared/src/utils.ts
+++ b/packages/containers-shared/src/utils.ts
@@ -101,11 +101,17 @@ export const verifyDockerInstalled = async (
 ) => {
 	const dockerIsRunning = await isDockerRunning(dockerPath);
 	if (!dockerIsRunning) {
-		throw new UserError(
+		let message =
 			`The Docker CLI could not be launched. Please ensure that the Docker CLI is installed and the daemon is running.\n` +
-				`Other container tooling that is compatible with the Docker CLI and engine may work, but is not yet guaranteed to do so. You can specify an executable with the environment variable WRANGLER_DOCKER_BIN and a socket with DOCKER_HOST.` +
-				`${isDev ? "\nTo suppress this error if you do not intend on triggering any container instances, set dev.enable_containers to false in your Wrangler config or passing in --enable-containers=false." : ""}`
-		);
+			`Other container tooling that is compatible with the Docker CLI and engine may work, but is not yet guaranteed to do so. You can specify an executable with the environment variable WRANGLER_DOCKER_BIN and a socket with DOCKER_HOST.`;
+		if (isDev) {
+			message +=
+				"\nTo suppress this error if you do not intend on triggering any container instances, set dev.enable_containers to false in your Wrangler config or passing in --enable-containers=false.";
+		} else {
+			message +=
+				"\nIf you cannot run Docker locally, you can still deploy your Worker by passing --containers-rollout=none. This will not deploy or update your Container.";
+		}
+		throw new UserError(message);
 	}
 };
 

--- a/packages/containers-shared/src/utils.ts
+++ b/packages/containers-shared/src/utils.ts
@@ -110,12 +110,17 @@ export const verifyDockerInstalled = async (
 ) => {
 	const dockerIsRunning = await isDockerRunning(dockerPath);
 	if (!dockerIsRunning) {
-		throw new UserError(
+		let message =
 			`The Docker CLI could not be launched. Please ensure that the Docker CLI is installed and the daemon is running.\n` +
-				`Other container tooling that is compatible with the Docker CLI and engine may work, but is not yet guaranteed to do so. You can specify an executable with the environment variable WRANGLER_DOCKER_BIN and a socket with DOCKER_HOST.` +
-				`${isDev ? "\nTo suppress this error if you do not intend on triggering any container instances, set dev.enable_containers to false in your Wrangler config or passing in --enable-containers=false." : ""}`,
-			{ telemetryMessage: false }
-		);
+			`Other container tooling that is compatible with the Docker CLI and engine may work, but is not yet guaranteed to do so. You can specify an executable with the environment variable WRANGLER_DOCKER_BIN and a socket with DOCKER_HOST.`;
+		if (isDev) {
+			message +=
+				"\nTo suppress this error if you do not intend on triggering any container instances, set dev.enable_containers to false in your Wrangler config or passing in --enable-containers=false.";
+		} else {
+			message +=
+				"\nIf you cannot run Docker locally, you can still deploy your Worker by passing --containers-rollout=none. This will not deploy or update your Container.";
+		}
+		throw new UserError(message, { telemetryMessage: false });
 	}
 };
 

--- a/packages/wrangler/src/__tests__/containers/config.test.ts
+++ b/packages/wrangler/src/__tests__/containers/config.test.ts
@@ -720,7 +720,9 @@ describe("getNormalizedContainerOptions", () => {
 		expect(result[0].rollout_step_percentage).toBe(100);
 	});
 
-	it("should set rollout_kind to none when containersRollout is none", async () => {
+	it("should set rollout_kind to none when containersRollout is none", async ({
+		expect,
+	}) => {
 		const config: Config = {
 			name: "test-worker",
 			configPath: "/test/wrangler.toml",

--- a/packages/wrangler/src/__tests__/containers/config.test.ts
+++ b/packages/wrangler/src/__tests__/containers/config.test.ts
@@ -720,6 +720,38 @@ describe("getNormalizedContainerOptions", () => {
 		expect(result[0].rollout_step_percentage).toBe(100);
 	});
 
+	it("should set rollout_kind to none when containersRollout is none", async () => {
+		const config: Config = {
+			name: "test-worker",
+			configPath: "/test/wrangler.toml",
+			userConfigPath: "/test/wrangler.toml",
+			topLevelName: "test-worker",
+			containers: [
+				{
+					class_name: "TestContainer",
+					image: `${getCloudflareContainerRegistry()}/test:latest`,
+					name: "test-container",
+					max_instances: 10,
+					rollout_kind: "full_auto",
+				},
+			],
+			durable_objects: {
+				bindings: [
+					{
+						name: "TEST_DO",
+						class_name: "TestContainer",
+					},
+				],
+			},
+		} as Partial<Config> as Config;
+
+		const result = await getNormalizedContainerOptions(config, {
+			containersRollout: "none",
+		});
+		expect(result).toHaveLength(1);
+		expect(result[0].rollout_kind).toBe("none");
+	});
+
 	describe("image validation and resolution", async () => {
 		it("should allow any image registry", async ({ expect }) => {
 			const config: Config = {

--- a/packages/wrangler/src/__tests__/containers/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/containers/deploy.test.ts
@@ -1132,7 +1132,9 @@ describe("wrangler deploy with containers", () => {
 		});
 	});
 
-	it("should skip Docker check and container deploy when --containers-rollout=none", async () => {
+	it("should skip Docker check and container deploy when --containers-rollout=none", async ({
+		expect,
+	}) => {
 		vi.stubEnv("WRANGLER_DOCKER_BIN", "/usr/bin/bad-docker-path");
 		writeWranglerConfig({
 			...DEFAULT_DURABLE_OBJECTS,
@@ -1143,7 +1145,7 @@ describe("wrangler deploy with containers", () => {
 
 		mockGetVersion("Galaxy-Class");
 		mockGetApplications([]);
-		mockCreateApplication();
+		mockCreateApplication(expect);
 
 		fs.writeFileSync(
 			"index.js",
@@ -1154,16 +1156,10 @@ describe("wrangler deploy with containers", () => {
 		// With the flag, it should skip Docker verification entirely and proceed
 		// to deploy the Worker (the deploy itself may fail for unrelated mock reasons,
 		// but the key assertion is that no Docker error is thrown).
-		let thrownError: Error | undefined;
-		try {
-			await runWrangler("deploy index.js --containers-rollout=none");
-		} catch (e) {
-			thrownError = e as Error;
-		}
 
-		expect(thrownError?.message ?? "").not.toContain(
-			"The Docker CLI could not be launched"
-		);
+		await expect(
+			runWrangler("deploy index.js --containers-rollout=none")
+		).resolves.not.toThrow();
 	});
 
 	describe("observability config resolution", () => {
@@ -2426,7 +2422,9 @@ describe("wrangler deploy with containers dry run", () => {
 		vi.unstubAllEnvs();
 	});
 
-	it("builds the image without pushing", async ({ expect }) => {
+	it("builds the image without pushing when given a dockerfile", async ({
+		expect,
+	}) => {
 		// Reduced mock chain for dry run (no delete, push)
 		vi.mocked(spawn)
 			.mockImplementationOnce(mockDockerInfo(expect))
@@ -2469,7 +2467,49 @@ describe("wrangler deploy with containers dry run", () => {
 		expect(cliStd.stdout).toMatchInlineSnapshot(`""`);
 	});
 
-	it("builds the image without pushing", async ({ expect }) => {
+	it("does not build when --containers-rollout=none", async ({ expect }) => {
+		// Reduced mock chain for dry run (no delete, push)
+		vi.mocked(spawn)
+			.mockImplementationOnce(mockDockerInfo(expect))
+			.mockImplementationOnce(
+				mockDockerBuild(
+					expect,
+					"my-container",
+					"worker",
+					"FROM scratch",
+					process.cwd()
+				)
+			);
+		vi.stubEnv("WRANGLER_DOCKER_BIN", "/usr/bin/docker");
+		fs.writeFileSync("./Dockerfile", "FROM scratch");
+		fs.writeFileSync(
+			"index.js",
+			`export class ExampleDurableObject {}; export default{};`
+		);
+		writeWranglerConfig({
+			...DEFAULT_DURABLE_OBJECTS,
+			containers: [DEFAULT_CONTAINER_FROM_DOCKERFILE],
+		});
+
+		await runWrangler("deploy --dry-run --containers-rollout=none index.js");
+		expect(std.out).toMatchInlineSnapshot(`
+			"
+			 ⛅️ wrangler x.x.x
+			──────────────────
+			Total Upload: xx KiB / gzip: xx KiB
+			Your Worker has access to the following bindings:
+			Binding                                            Resource
+			env.EXAMPLE_DO_BINDING (ExampleDurableObject)      Durable Object
+
+			The following containers are available:
+			- my-container (<cwd>/Dockerfile)
+
+			--dry-run: exiting now."
+		`);
+		expect(cliStd.stdout).toMatchInlineSnapshot(`""`);
+	});
+
+	it("does not push when given a registry link", async ({ expect }) => {
 		// No docker mocks at all
 
 		fs.writeFileSync(

--- a/packages/wrangler/src/__tests__/containers/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/containers/deploy.test.ts
@@ -72,7 +72,8 @@ describe("wrangler deploy with containers", () => {
 		).rejects.toThrowErrorMatchingInlineSnapshot(
 			`
 			[Error: The Docker CLI could not be launched. Please ensure that the Docker CLI is installed and the daemon is running.
-			Other container tooling that is compatible with the Docker CLI and engine may work, but is not yet guaranteed to do so. You can specify an executable with the environment variable WRANGLER_DOCKER_BIN and a socket with DOCKER_HOST.]
+			Other container tooling that is compatible with the Docker CLI and engine may work, but is not yet guaranteed to do so. You can specify an executable with the environment variable WRANGLER_DOCKER_BIN and a socket with DOCKER_HOST.
+			If you cannot run Docker locally, you can still deploy your Worker by passing --containers-rollout=none. This will not deploy or update your Container.]
 		`
 		);
 	});
@@ -1129,6 +1130,40 @@ describe("wrangler deploy with containers", () => {
 
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
+	});
+
+	it("should skip Docker check and container deploy when --containers-rollout=none", async () => {
+		vi.stubEnv("WRANGLER_DOCKER_BIN", "/usr/bin/bad-docker-path");
+		writeWranglerConfig({
+			...DEFAULT_DURABLE_OBJECTS,
+			containers: [DEFAULT_CONTAINER_FROM_DOCKERFILE],
+		});
+
+		fs.writeFileSync("./Dockerfile", "FROM scratch");
+
+		mockGetVersion("Galaxy-Class");
+		mockGetApplications([]);
+		mockCreateApplication();
+
+		fs.writeFileSync(
+			"index.js",
+			`export class ExampleDurableObject {}; export default{};`
+		);
+
+		// Without --containers-rollout=none, this would fail with a Docker error.
+		// With the flag, it should skip Docker verification entirely and proceed
+		// to deploy the Worker (the deploy itself may fail for unrelated mock reasons,
+		// but the key assertion is that no Docker error is thrown).
+		let thrownError: Error | undefined;
+		try {
+			await runWrangler("deploy index.js --containers-rollout=none");
+		} catch (e) {
+			thrownError = e as Error;
+		}
+
+		expect(thrownError?.message ?? "").not.toContain(
+			"The Docker CLI could not be launched"
+		);
 	});
 
 	describe("observability config resolution", () => {

--- a/packages/wrangler/src/__tests__/containers/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/containers/deploy.test.ts
@@ -1133,7 +1133,9 @@ describe("wrangler deploy with containers", () => {
 		});
 	});
 
-	it("should skip Docker check and container deploy when --containers-rollout=none", async () => {
+	it("should skip Docker check and container deploy when --containers-rollout=none", async ({
+		expect,
+	}) => {
 		vi.stubEnv("WRANGLER_DOCKER_BIN", "/usr/bin/bad-docker-path");
 		writeWranglerConfig({
 			...DEFAULT_DURABLE_OBJECTS,
@@ -1144,7 +1146,7 @@ describe("wrangler deploy with containers", () => {
 
 		mockGetVersion("Galaxy-Class");
 		mockGetApplications([]);
-		mockCreateApplication();
+		mockCreateApplication(expect);
 
 		fs.writeFileSync(
 			"index.js",
@@ -1155,16 +1157,10 @@ describe("wrangler deploy with containers", () => {
 		// With the flag, it should skip Docker verification entirely and proceed
 		// to deploy the Worker (the deploy itself may fail for unrelated mock reasons,
 		// but the key assertion is that no Docker error is thrown).
-		let thrownError: Error | undefined;
-		try {
-			await runWrangler("deploy index.js --containers-rollout=none");
-		} catch (e) {
-			thrownError = e as Error;
-		}
 
-		expect(thrownError?.message ?? "").not.toContain(
-			"The Docker CLI could not be launched"
-		);
+		await expect(
+			runWrangler("deploy index.js --containers-rollout=none")
+		).resolves.not.toThrow();
 	});
 
 	describe("observability config resolution", () => {
@@ -2427,7 +2423,9 @@ describe("wrangler deploy with containers dry run", () => {
 		vi.unstubAllEnvs();
 	});
 
-	it("builds the image without pushing", async ({ expect }) => {
+	it("builds the image without pushing when given a dockerfile", async ({
+		expect,
+	}) => {
 		// Reduced mock chain for dry run (no delete, push)
 		vi.mocked(spawn)
 			.mockImplementationOnce(mockDockerInfo(expect))
@@ -2470,7 +2468,49 @@ describe("wrangler deploy with containers dry run", () => {
 		expect(cliStd.stdout).toMatchInlineSnapshot(`""`);
 	});
 
-	it("builds the image without pushing", async ({ expect }) => {
+	it("does not build when --containers-rollout=none", async ({ expect }) => {
+		// Reduced mock chain for dry run (no delete, push)
+		vi.mocked(spawn)
+			.mockImplementationOnce(mockDockerInfo(expect))
+			.mockImplementationOnce(
+				mockDockerBuild(
+					expect,
+					"my-container",
+					"worker",
+					"FROM scratch",
+					process.cwd()
+				)
+			);
+		vi.stubEnv("WRANGLER_DOCKER_BIN", "/usr/bin/docker");
+		fs.writeFileSync("./Dockerfile", "FROM scratch");
+		fs.writeFileSync(
+			"index.js",
+			`export class ExampleDurableObject {}; export default{};`
+		);
+		writeWranglerConfig({
+			...DEFAULT_DURABLE_OBJECTS,
+			containers: [DEFAULT_CONTAINER_FROM_DOCKERFILE],
+		});
+
+		await runWrangler("deploy --dry-run --containers-rollout=none index.js");
+		expect(std.out).toMatchInlineSnapshot(`
+			"
+			 ⛅️ wrangler x.x.x
+			──────────────────
+			Total Upload: xx KiB / gzip: xx KiB
+			Your Worker has access to the following bindings:
+			Binding                                            Resource
+			env.EXAMPLE_DO_BINDING (ExampleDurableObject)      Durable Object
+
+			The following containers are available:
+			- my-container (<cwd>/Dockerfile)
+
+			--dry-run: exiting now."
+		`);
+		expect(cliStd.stdout).toMatchInlineSnapshot(`""`);
+	});
+
+	it("does not push when given a registry link", async ({ expect }) => {
 		// No docker mocks at all
 
 		fs.writeFileSync(

--- a/packages/wrangler/src/__tests__/containers/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/containers/deploy.test.ts
@@ -73,7 +73,8 @@ describe("wrangler deploy with containers", () => {
 		).rejects.toThrowErrorMatchingInlineSnapshot(
 			`
 			[Error: The Docker CLI could not be launched. Please ensure that the Docker CLI is installed and the daemon is running.
-			Other container tooling that is compatible with the Docker CLI and engine may work, but is not yet guaranteed to do so. You can specify an executable with the environment variable WRANGLER_DOCKER_BIN and a socket with DOCKER_HOST.]
+			Other container tooling that is compatible with the Docker CLI and engine may work, but is not yet guaranteed to do so. You can specify an executable with the environment variable WRANGLER_DOCKER_BIN and a socket with DOCKER_HOST.
+			If you cannot run Docker locally, you can still deploy your Worker by passing --containers-rollout=none. This will not deploy or update your Container.]
 		`
 		);
 	});
@@ -1130,6 +1131,40 @@ describe("wrangler deploy with containers", () => {
 
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
+	});
+
+	it("should skip Docker check and container deploy when --containers-rollout=none", async () => {
+		vi.stubEnv("WRANGLER_DOCKER_BIN", "/usr/bin/bad-docker-path");
+		writeWranglerConfig({
+			...DEFAULT_DURABLE_OBJECTS,
+			containers: [DEFAULT_CONTAINER_FROM_DOCKERFILE],
+		});
+
+		fs.writeFileSync("./Dockerfile", "FROM scratch");
+
+		mockGetVersion("Galaxy-Class");
+		mockGetApplications([]);
+		mockCreateApplication();
+
+		fs.writeFileSync(
+			"index.js",
+			`export class ExampleDurableObject {}; export default{};`
+		);
+
+		// Without --containers-rollout=none, this would fail with a Docker error.
+		// With the flag, it should skip Docker verification entirely and proceed
+		// to deploy the Worker (the deploy itself may fail for unrelated mock reasons,
+		// but the key assertion is that no Docker error is thrown).
+		let thrownError: Error | undefined;
+		try {
+			await runWrangler("deploy index.js --containers-rollout=none");
+		} catch (e) {
+			thrownError = e as Error;
+		}
+
+		expect(thrownError?.message ?? "").not.toContain(
+			"The Docker CLI could not be launched"
+		);
 	});
 
 	describe("observability config resolution", () => {

--- a/packages/wrangler/src/containers/config.ts
+++ b/packages/wrangler/src/containers/config.ts
@@ -49,7 +49,7 @@ export const getNormalizedContainerOptions = async (
 	config: Config,
 	args: {
 		/** set by args.containersRollout */
-		containersRollout?: "gradual" | "immediate";
+		containersRollout?: "gradual" | "immediate" | "none";
 		dryRun?: boolean;
 	}
 ): Promise<ContainerNormalizedConfig[]> => {
@@ -126,7 +126,10 @@ export const getNormalizedContainerOptions = async (
 					? 100
 					: (container.rollout_step_percentage ??
 						rolloutStepPercentageFallback),
-			rollout_kind: container.rollout_kind ?? "full_auto",
+			rollout_kind:
+				args?.containersRollout === "none"
+					? "none"
+					: (container.rollout_kind ?? "full_auto"),
 			rollout_active_grace_period: container.rollout_active_grace_period ?? 0,
 			observability: {
 				logs_enabled:

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -961,7 +961,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		if (props.dryRun) {
 			if (normalisedContainerConfig.length) {
 				for (const container of normalisedContainerConfig) {
-					if ("dockerfile" in container) {
+					if ("dockerfile" in container && props.containersRollout !== "none") {
 						await buildContainer(
 							container,
 							workerTag ?? "worker-tag",

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -136,7 +136,7 @@ type Props = {
 	dispatchNamespace: string | undefined;
 	experimentalAutoCreate: boolean;
 	metafile: string | boolean | undefined;
-	containersRollout: "immediate" | "gradual" | undefined;
+	containersRollout: "immediate" | "gradual" | "none" | undefined;
 	strict: boolean | undefined;
 	tag: string | undefined;
 	message: string | undefined;
@@ -945,7 +945,10 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		// and we have containers so that we don't get into a
 		// disjointed state where the worker updates but the container
 		// fails.
-		if (normalisedContainerConfig.length) {
+		if (
+			normalisedContainerConfig.length &&
+			props.containersRollout !== "none"
+		) {
 			// if you have a registry url specified, you don't need docker
 			const hasDockerfiles = normalisedContainerConfig.some(
 				(container) => "dockerfile" in container
@@ -1272,7 +1275,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		return { versionId, workerTag };
 	}
 
-	if (normalisedContainerConfig.length) {
+	if (normalisedContainerConfig.length && props.containersRollout !== "none") {
 		assert(versionId && accountId);
 		await deployContainers(config, normalisedContainerConfig, {
 			versionId,

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -136,7 +136,7 @@ type Props = {
 	dispatchNamespace: string | undefined;
 	experimentalAutoCreate: boolean;
 	metafile: string | boolean | undefined;
-	containersRollout: "immediate" | "gradual" | undefined;
+	containersRollout: "immediate" | "gradual" | "none" | undefined;
 	strict: boolean | undefined;
 	tag: string | undefined;
 	message: string | undefined;
@@ -968,7 +968,10 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		// and we have containers so that we don't get into a
 		// disjointed state where the worker updates but the container
 		// fails.
-		if (normalisedContainerConfig.length) {
+		if (
+			normalisedContainerConfig.length &&
+			props.containersRollout !== "none"
+		) {
 			// if you have a registry url specified, you don't need docker
 			const hasDockerfiles = normalisedContainerConfig.some(
 				(container) => "dockerfile" in container
@@ -1289,7 +1292,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 	logger.log("Uploaded", workerName, formatTime(uploadMs));
 
-	if (normalisedContainerConfig.length) {
+	if (normalisedContainerConfig.length && props.containersRollout !== "none") {
 		assert(versionId && accountId);
 		await deployContainers(config, normalisedContainerConfig, {
 			versionId,

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -984,7 +984,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		if (props.dryRun) {
 			if (normalisedContainerConfig.length) {
 				for (const container of normalisedContainerConfig) {
-					if ("dockerfile" in container) {
+					if ("dockerfile" in container && props.containersRollout !== "none") {
 						await buildContainer(
 							container,
 							workerTag ?? "worker-tag",

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -232,8 +232,8 @@ export const deployCommand = createCommand({
 		},
 		"containers-rollout": {
 			describe:
-				"Rollout strategy for Containers changes. If set to immediate, it will override `rollout_percentage_steps` if configured and roll out to 100% of instances in one step. ",
-			choices: ["immediate", "gradual"] as const,
+				"Rollout strategy for Containers changes. If set to immediate, it will override `rollout_percentage_steps` if configured and roll out to 100% of instances in one step. If set to none, the Worker will be deployed without building or updating any Containers.",
+			choices: ["immediate", "gradual", "none"] as const,
 		},
 		tag: {
 			describe: "A tag for this Worker Version",

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -85,8 +85,8 @@ export const deployCommand = createCommand({
 		},
 		"containers-rollout": {
 			describe:
-				"Rollout strategy for Containers changes. If set to immediate, it will override `rollout_percentage_steps` if configured and roll out to 100% of instances in one step. ",
-			choices: ["immediate", "gradual"] as const,
+				"Rollout strategy for Containers changes. If set to immediate, it will override `rollout_percentage_steps` if configured and roll out to 100% of instances in one step. If set to none, the Worker will be deployed without building or updating any Containers.",
+			choices: ["immediate", "gradual", "none"] as const,
 		},
 		strict: {
 			describe:


### PR DESCRIPTION
This allows you to skip deploying a container. This is useful if you know that your container is not going to be updated or you don't have Docker locally, but still want to make changes to your Worker.

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/30089
  - [ ] Documentation not necessary because:

<img width="1920" height="1439" alt="image" src="https://github.com/user-attachments/assets/ec758bf2-c525-48c4-8f95-912f72bb63e6" />
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
