### PR TITLE
Updated getAccessToken to respect AbortSignal and timeout correctly

### DIFF
--- a/packages/wrangler/src/__tests__/access.test.ts
+++ b/packages/wrangler/src/__tests__/access.test.ts
@@ -1,7 +1,24 @@
 import { UserError } from "@cloudflare/workers-utils";
-import { beforeEach, describe, it } from "vitest";
+import { beforeEach, describe, it, vi } from "vitest";
 import { domainUsesAccess, getAccessToken } from "../user/access";
 import { msw, mswAccessHandlers } from "./helpers/msw";
+
+vi.mock("node:child_process", () => {
+	return {
+		execFile: (
+			_file: string,
+			_args: string[],
+			_opts: unknown,
+			callback: (err: Error | null, stdout?: string, stderr?: string) => void
+		) => {
+			const err = new Error("spawn cloudflared ENOENT") as Error & {
+				code: string;
+			};
+			err.code = "ENOENT";
+			process.nextTick(() => callback(err));
+		},
+	};
+});
 
 describe("access", () => {
 	beforeEach(() => {

--- a/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
@@ -300,7 +300,10 @@ export class RemoteRuntimeController extends RuntimeController {
 			return;
 		}
 
-		const accessToken = await getAccessToken(token.host);
+		const accessToken = await getAccessToken(
+			token.host,
+			this.#abortController.signal
+		);
 
 		this.emitReloadCompleteEvent({
 			type: "reloadComplete",

--- a/packages/wrangler/src/dev/create-worker-preview.ts
+++ b/packages/wrangler/src/dev/create-worker-preview.ts
@@ -183,7 +183,10 @@ export async function createPreviewSession(
 	const switchedExchangeUrl = switchHost(exchange_url, ctx.host, !!ctx.zone);
 
 	const headers: HeadersInit = {};
-	const accessToken = await getAccessToken(switchedExchangeUrl.hostname);
+	const accessToken = await getAccessToken(
+		switchedExchangeUrl.hostname,
+		abortSignal
+	);
 
 	if (accessToken) {
 		headers.cookie = `CF_Authorization=${accessToken}`;
@@ -347,7 +350,10 @@ export async function createWorkerPreview(
 		abortSignal,
 		minimal_mode
 	);
-	const accessToken = await getAccessToken(token.prewarmUrl.hostname);
+	const accessToken = await getAccessToken(
+		token.prewarmUrl.hostname,
+		abortSignal
+	);
 
 	const headers: HeadersInit = { "cf-workers-preview-token": token.value };
 	if (accessToken) {

--- a/packages/wrangler/src/user/access.ts
+++ b/packages/wrangler/src/user/access.ts
@@ -1,7 +1,10 @@
-import { spawnSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { UserError } from "@cloudflare/workers-utils";
 import { fetch } from "undici";
 import { logger } from "../logger";
+
+const execFileAsync = promisify(execFile);
 
 const cache: Record<string, string> = {};
 
@@ -44,7 +47,8 @@ export async function domainUsesAccess(domain: string): Promise<boolean> {
 	}
 }
 export async function getAccessToken(
-	domain: string
+	domain: string,
+	signal?: AbortSignal
 ): Promise<string | undefined> {
 	if (!(await domainUsesAccess(domain))) {
 		return undefined;
@@ -54,15 +58,51 @@ export async function getAccessToken(
 		logger.debug("Using cached Access token for domain:", cache[domain]);
 		return cache[domain];
 	}
+	logger.log(
+		"Cloudflare Access is enabled for this domain. Launching cloudflared to authenticate..."
+	);
 	logger.debug("Spawning cloudflared to get Access token for domain:");
-	const output = spawnSync("cloudflared", ["access", "login", domain]);
-	if (output.error) {
-		// The cloudflared binary is not installed
-		throw new UserError(
-			"To use Wrangler with Cloudflare Access, please install `cloudflared` from https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation"
+
+	const timeoutSignal = AbortSignal.timeout(60_000);
+	const combinedSignal = signal
+		? AbortSignal.any([timeoutSignal, signal])
+		: timeoutSignal;
+
+	let stringOutput: string;
+
+	try {
+		const { stdout } = await execFileAsync(
+			"cloudflared",
+			["access", "login", domain],
+			{
+				signal: combinedSignal,
+			}
 		);
+		stringOutput = stdout;
+	} catch (err) {
+		if (
+			err instanceof Error &&
+			"code" in err &&
+			(err as Error & { code: string }).code === "ENOENT"
+		) {
+			throw new UserError(
+				"To use Wrangler with Cloudflare Access, please install `cloudflared` from https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation"
+			);
+		}
+
+		if (
+			err instanceof Error &&
+			err.name === "AbortError" &&
+			timeoutSignal.aborted
+		) {
+			throw new UserError(
+				"Cloudflare Access authentication timed out after 60 seconds. Please try again."
+			);
+		}
+
+		throw err;
 	}
-	const stringOutput = output.stdout.toString();
+
 	logger.debug("cloudflared output:", stringOutput);
 	const matches = stringOutput.match(/fetched your token:\n\n(.*)/m);
 	if (matches && matches.length >= 2) {


### PR DESCRIPTION
getAccessToken used spawnSync that stops abort signals being received and seems to timeout forever if you never make it to the accept page for access.

- Tests
  - [ x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ x] Documentation not necessary


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
