### PR TITLE
Update error messages in e2e tests

### DIFF
--- a/packages/vite-plugin-cloudflare/e2e/remote-bindings.test.ts
+++ b/packages/vite-plugin-cloudflare/e2e/remote-bindings.test.ts
@@ -183,7 +183,7 @@ if (isWindows) {
 
 				expect(await proc.exitCode).not.toBe(0);
 				expect(proc.stderr).toContain(
-					"R2 bucket 'non-existent-r2-bucket' not found. Please use a different name and try again. [code: 10085]"
+					"R2 bucket 'non-existent-r2-bucket' not found. Verify the bucket exists in your account and that the bucket_name in your configuration is correct. [code: 10085]"
 				);
 				expect(proc.stderr).toContain(
 					"Error: Failed to start the remote proxy session. There is likely additional logging output above."

--- a/packages/wrangler/e2e/remote-binding/dev-remote-bindings.test.ts
+++ b/packages/wrangler/e2e/remote-binding/dev-remote-bindings.test.ts
@@ -209,7 +209,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 				await vi.waitFor(
 					() =>
 						expect(worker.currentOutput).toContain(
-							"Could not resolve service binding 'REMOTE_WORKER'. Target script 'non-existent-service-binding' not found."
+							"Service binding 'REMOTE_WORKER' references Worker 'non-existent-service-binding' which was not found."
 						),
 					7_000
 				);


### PR DESCRIPTION
Looks like the Cloudflare API returns different error messages now.

This PR syncs the e2e tests

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not user facing

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
