### PR TITLE
[wrangler] fix: bundled undici now respects NODE_EXTRA_CA_CERTS

### DIFF
--- a/.changeset/undici-ca-certs-fix.md
+++ b/.changeset/undici-ca-certs-fix.md
@@ -1,0 +1,13 @@
+---
+"wrangler": patch
+---
+
+fix: bundled undici now respects `NODE_EXTRA_CA_CERTS`
+
+Wrangler imports `fetch` from undici directly, which bypasses Node's built-in
+`NODE_EXTRA_CA_CERTS` handling. This caused `SELF_SIGNED_CERT_IN_CHAIN` errors
+for users behind TLS-intercepting proxies (Cloudflare WARP, corporate proxies).
+
+The fix reads `NODE_EXTRA_CA_CERTS` and configures undici's global dispatcher
+with the extra CA certificates — both in the CLI entry point and the API entry
+point (used by `@cloudflare/vitest-pool-workers`).

--- a/packages/wrangler/src/__tests__/shared/ca-certs.test.ts
+++ b/packages/wrangler/src/__tests__/shared/ca-certs.test.ts
@@ -1,0 +1,380 @@
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { createServer } from "node:https";
+import { join } from "node:path";
+import { rootCertificates } from "node:tls";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
+import {
+	Agent,
+	EnvHttpProxyAgent,
+	fetch,
+	getGlobalDispatcher,
+	setGlobalDispatcher,
+} from "undici";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
+import type { Server } from "node:https";
+import type { Dispatcher } from "undici";
+
+const FAKE_CERT_1 = `-----BEGIN CERTIFICATE-----
+MIIC0zCCAjmgAwIBAgIJALlSS3oardigMAoGCCqGSM49BAMCMIGgMQswCQYDVQQG
+-----END CERTIFICATE-----`;
+
+const FAKE_CERT_2 = `-----BEGIN CERTIFICATE-----
+AAAA0zCAAjmgAwIBAgIJALlSS3oardigMAoGCCqGSM49BAMCMIGgMQswCQYDVQQG
+-----END CERTIFICATE-----`;
+
+/**
+ * Import a fresh copy of the module with its memoization cache reset.
+ * `vi.resetModules()` clears the module registry so the next dynamic
+ * import evaluates the module from scratch (new `cached = null`).
+ */
+async function freshImport() {
+	vi.resetModules();
+	const mod = await import("../../shared/ca-certs");
+	return mod.getNodeExtraCaCerts;
+}
+
+// -- Unit tests: getNodeExtraCaCerts() parsing + memoization --
+
+describe("getNodeExtraCaCerts()", () => {
+	runInTempDir();
+
+	beforeEach(() => {
+		vi.spyOn(process, "emitWarning").mockImplementation(() => {});
+	});
+
+	it("returns undefined when NODE_EXTRA_CA_CERTS is not set", async ({
+		expect,
+	}) => {
+		vi.stubEnv("NODE_EXTRA_CA_CERTS", "");
+		const getNodeExtraCaCerts = await freshImport();
+
+		expect(getNodeExtraCaCerts()).toBeUndefined();
+		expect(process.emitWarning).not.toHaveBeenCalled();
+	});
+
+	it("returns root certs + extra certs for a valid single-cert PEM", async ({
+		expect,
+	}) => {
+		const certPath = join(process.cwd(), "test-certs.pem");
+		writeFileSync(certPath, FAKE_CERT_1);
+		vi.stubEnv("NODE_EXTRA_CA_CERTS", certPath);
+		const getNodeExtraCaCerts = await freshImport();
+
+		const result = getNodeExtraCaCerts();
+
+		expect(result).toBeDefined();
+		expect(result).toHaveLength(rootCertificates.length + 1);
+		expect(result?.slice(0, rootCertificates.length)).toEqual(rootCertificates);
+		expect(result?.at(-1)).toBe(FAKE_CERT_1);
+		expect(process.emitWarning).not.toHaveBeenCalled();
+	});
+
+	it("returns root certs + all certs from a multi-cert PEM bundle", async ({
+		expect,
+	}) => {
+		const certPath = join(process.cwd(), "bundle.pem");
+		writeFileSync(certPath, `${FAKE_CERT_1}\n\n${FAKE_CERT_2}\n`);
+		vi.stubEnv("NODE_EXTRA_CA_CERTS", certPath);
+		const getNodeExtraCaCerts = await freshImport();
+
+		const result = getNodeExtraCaCerts();
+
+		expect(result).toBeDefined();
+		expect(result).toHaveLength(rootCertificates.length + 2);
+		expect(result?.at(-2)).toBe(FAKE_CERT_1);
+		expect(result?.at(-1)).toBe(FAKE_CERT_2);
+	});
+
+	it("emits warning and returns undefined when file does not exist", async ({
+		expect,
+	}) => {
+		vi.stubEnv("NODE_EXTRA_CA_CERTS", "/nonexistent/path/certs.pem");
+		const getNodeExtraCaCerts = await freshImport();
+
+		expect(getNodeExtraCaCerts()).toBeUndefined();
+		expect(process.emitWarning).toHaveBeenCalledOnce();
+		expect(process.emitWarning).toHaveBeenCalledWith(
+			expect.stringContaining("Failed to read NODE_EXTRA_CA_CERTS"),
+			"WranglerWarning"
+		);
+	});
+
+	it("emits warning and returns undefined when file has no PEM blocks", async ({
+		expect,
+	}) => {
+		const certPath = join(process.cwd(), "not-a-cert.txt");
+		writeFileSync(certPath, "this is not a PEM file\njust some text\n");
+		vi.stubEnv("NODE_EXTRA_CA_CERTS", certPath);
+		const getNodeExtraCaCerts = await freshImport();
+
+		expect(getNodeExtraCaCerts()).toBeUndefined();
+		expect(process.emitWarning).toHaveBeenCalledOnce();
+		expect(process.emitWarning).toHaveBeenCalledWith(
+			expect.stringContaining("contains no PEM certificates"),
+			"WranglerWarning"
+		);
+	});
+
+	it("memoizes the result across repeated calls", async ({ expect }) => {
+		const certPath = join(process.cwd(), "memo.pem");
+		writeFileSync(certPath, FAKE_CERT_1);
+		vi.stubEnv("NODE_EXTRA_CA_CERTS", certPath);
+		const getNodeExtraCaCerts = await freshImport();
+
+		const first = getNodeExtraCaCerts();
+		const second = getNodeExtraCaCerts();
+
+		expect(first).toBe(second); // same reference, not just deep-equal
+	});
+
+	it("memoizes undefined when env var is not set", async ({ expect }) => {
+		vi.stubEnv("NODE_EXTRA_CA_CERTS", "");
+		const getNodeExtraCaCerts = await freshImport();
+
+		getNodeExtraCaCerts();
+		// Set env var AFTER first call — memoized undefined should persist
+		vi.stubEnv("NODE_EXTRA_CA_CERTS", "/some/path.pem");
+		expect(getNodeExtraCaCerts()).toBeUndefined();
+	});
+});
+
+// -- Integration: undici fetch against self-signed HTTPS server --
+
+/**
+ * Generate a self-signed CA + server cert using openssl CLI.
+ * Returns paths to { caCert, serverCert, serverKey } PEM files.
+ */
+function generateSelfSignedCerts(dir: string) {
+	execSync(
+		`openssl req -x509 -newkey rsa:2048 -keyout ca-key.pem -out ca-cert.pem -days 1 -nodes -subj "/CN=Test CA"`,
+		{ cwd: dir, stdio: "pipe" }
+	);
+	execSync(
+		`openssl req -newkey rsa:2048 -keyout server-key.pem -out server.csr -nodes -subj "/CN=localhost"`,
+		{ cwd: dir, stdio: "pipe" }
+	);
+	writeFileSync(
+		join(dir, "ext.cnf"),
+		"subjectAltName=DNS:localhost,IP:127.0.0.1\n"
+	);
+	execSync(
+		`openssl x509 -req -in server.csr -CA ca-cert.pem -CAkey ca-key.pem -CAcreateserial -out server-cert.pem -days 1 -extfile ext.cnf`,
+		{ cwd: dir, stdio: "pipe" }
+	);
+
+	return {
+		caCert: join(dir, "ca-cert.pem"),
+		serverCert: join(dir, "server-cert.pem"),
+		serverKey: join(dir, "server-key.pem"),
+	};
+}
+
+function startHttpsServer(
+	certPath: string,
+	keyPath: string
+): Promise<{ server: Server; port: number }> {
+	return new Promise((resolve) => {
+		const server = createServer(
+			{
+				cert: readFileSync(certPath),
+				key: readFileSync(keyPath),
+			},
+			(_req, res) => {
+				res.writeHead(200, { "Content-Type": "text/plain" });
+				res.end("ok");
+			}
+		);
+		server.listen(0, "127.0.0.1", () => {
+			const addr = server.address();
+			if (typeof addr === "object" && addr !== null) {
+				resolve({ server, port: addr.port });
+			}
+		});
+	});
+}
+
+describe("undici fetch with CA cert dispatcher", () => {
+	runInTempDir();
+
+	let server: Server | undefined;
+	let port: number;
+	let originalDispatcher: Dispatcher;
+
+	beforeEach(() => {
+		originalDispatcher = getGlobalDispatcher();
+	});
+
+	afterEach(async () => {
+		setGlobalDispatcher(originalDispatcher);
+		if (server) {
+			await new Promise<void>((resolve) => server?.close(() => resolve()));
+			server = undefined;
+		}
+	});
+
+	it("fetch fails against self-signed cert without CA dispatcher", async ({
+		expect,
+	}) => {
+		const certs = generateSelfSignedCerts(process.cwd());
+		({ server, port } = await startHttpsServer(
+			certs.serverCert,
+			certs.serverKey
+		));
+
+		// Default dispatcher — no custom CA, should reject self-signed cert
+		await expect(fetch(`https://127.0.0.1:${port}`)).rejects.toThrowError();
+	});
+
+	it("fetch succeeds against self-signed cert with Agent CA dispatcher", async ({
+		expect,
+	}) => {
+		const certs = generateSelfSignedCerts(process.cwd());
+		({ server, port } = await startHttpsServer(
+			certs.serverCert,
+			certs.serverKey
+		));
+
+		// Matches the non-proxy path: Agent({ connect: { ca } })
+		const caCertPem = readFileSync(certs.caCert, "utf8");
+		setGlobalDispatcher(
+			new Agent({ connect: { ca: [...rootCertificates, caCertPem] } })
+		);
+
+		const response = await fetch(`https://127.0.0.1:${port}`);
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("ok");
+	});
+
+	it("end-to-end: getNodeExtraCaCerts + Agent dispatcher resolves self-signed cert", async ({
+		expect,
+	}) => {
+		const certs = generateSelfSignedCerts(process.cwd());
+		({ server, port } = await startHttpsServer(
+			certs.serverCert,
+			certs.serverKey
+		));
+
+		// Point NODE_EXTRA_CA_CERTS at the CA cert — simulates corporate proxy CA
+		vi.stubEnv("NODE_EXTRA_CA_CERTS", certs.caCert);
+		const getNodeExtraCaCerts = await freshImport();
+
+		const ca = getNodeExtraCaCerts();
+		expect(ca).toBeDefined();
+
+		setGlobalDispatcher(new Agent({ connect: { ca } }));
+
+		const response = await fetch(`https://127.0.0.1:${port}`);
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("ok");
+	});
+});
+
+// -- initUndiciDispatcher(): idempotent global dispatcher setup --
+
+/**
+ * Import a fresh copy of the dispatcher module with its `initialized`
+ * guard reset. Must also reset ca-certs to clear memoization.
+ */
+async function freshDispatcherImport() {
+	vi.resetModules();
+	const mod = await import("../../shared/undici-dispatcher");
+	return mod.initUndiciDispatcher;
+}
+
+describe("initUndiciDispatcher()", () => {
+	runInTempDir();
+
+	let originalDispatcher: Dispatcher;
+
+	beforeEach(() => {
+		originalDispatcher = getGlobalDispatcher();
+		vi.spyOn(process, "emitWarning").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		setGlobalDispatcher(originalDispatcher);
+	});
+
+	it("installs Agent dispatcher when NODE_EXTRA_CA_CERTS is set (no proxy)", async ({
+		expect,
+	}) => {
+		const certPath = join(process.cwd(), "ca.pem");
+		writeFileSync(certPath, FAKE_CERT_1);
+		vi.stubEnv("NODE_EXTRA_CA_CERTS", certPath);
+		// Ensure no proxy env vars
+		vi.stubEnv("HTTPS_PROXY", "");
+		vi.stubEnv("https_proxy", "");
+		vi.stubEnv("HTTP_PROXY", "");
+		vi.stubEnv("http_proxy", "");
+		const initUndiciDispatcher = await freshDispatcherImport();
+
+		const result = initUndiciDispatcher();
+
+		expect(result).toEqual({ proxy: false });
+		// Dispatcher was changed from the original
+		expect(getGlobalDispatcher()).not.toBe(originalDispatcher);
+	});
+
+	it("returns { proxy: false } and does not change dispatcher when no certs or proxy", async ({
+		expect,
+	}) => {
+		vi.stubEnv("NODE_EXTRA_CA_CERTS", "");
+		vi.stubEnv("HTTPS_PROXY", "");
+		vi.stubEnv("https_proxy", "");
+		vi.stubEnv("HTTP_PROXY", "");
+		vi.stubEnv("http_proxy", "");
+		const initUndiciDispatcher = await freshDispatcherImport();
+
+		const result = initUndiciDispatcher();
+
+		expect(result).toEqual({ proxy: false });
+		// Dispatcher unchanged — no CA certs, no proxy
+		expect(getGlobalDispatcher()).toBe(originalDispatcher);
+	});
+
+	it("is idempotent — second call is a no-op", async ({ expect }) => {
+		const certPath = join(process.cwd(), "ca.pem");
+		writeFileSync(certPath, FAKE_CERT_1);
+		vi.stubEnv("NODE_EXTRA_CA_CERTS", certPath);
+		vi.stubEnv("HTTPS_PROXY", "");
+		vi.stubEnv("https_proxy", "");
+		vi.stubEnv("HTTP_PROXY", "");
+		vi.stubEnv("http_proxy", "");
+		const initUndiciDispatcher = await freshDispatcherImport();
+
+		initUndiciDispatcher();
+		const dispatcherAfterFirst = getGlobalDispatcher();
+
+		const secondResult = initUndiciDispatcher();
+		expect(secondResult).toEqual({ proxy: false });
+		// Dispatcher not replaced on second call
+		expect(getGlobalDispatcher()).toBe(dispatcherAfterFirst);
+	});
+
+	it("EnvHttpProxyAgent accepts requestTls and proxyTls with CA certs", ({
+		expect,
+	}) => {
+		// Constructor contract test — verifies the API used by the proxy path
+		const ca = [...rootCertificates, FAKE_CERT_1];
+
+		const agent = new EnvHttpProxyAgent({
+			noProxy: "localhost,127.0.0.1,::1",
+			requestTls: { ca },
+			proxyTls: { ca },
+		});
+
+		expect(agent).toBeInstanceOf(EnvHttpProxyAgent);
+		void agent.close();
+	});
+
+	it("Agent accepts connect.ca with string array", ({ expect }) => {
+		// Constructor contract test — verifies the API used by the non-proxy path
+		const ca = [...rootCertificates, FAKE_CERT_1];
+
+		const agent = new Agent({ connect: { ca } });
+
+		expect(agent).toBeInstanceOf(Agent);
+		void agent.close();
+	});
+});

--- a/packages/wrangler/src/api/index.ts
+++ b/packages/wrangler/src/api/index.ts
@@ -1,3 +1,10 @@
+import { initUndiciDispatcher } from "../shared/undici-dispatcher";
+
+// When wrangler is imported as a library (e.g. by vitest-pool-workers),
+// the CLI entry point doesn't run. Ensure undici respects NODE_EXTRA_CA_CERTS
+// and proxy env vars.
+initUndiciDispatcher();
+
 export { unstable_dev } from "./dev";
 export type { Unstable_DevWorker, Unstable_DevOptions } from "./dev";
 export { unstable_pages } from "./pages";

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -6,7 +6,6 @@ import {
 	experimental_readRawConfig,
 } from "@cloudflare/workers-utils";
 import chalk from "chalk";
-import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 import makeCLI from "yargs";
 import { version as wranglerVersion } from "../package.json";
 import { aiFineTuneNamespace, aiNamespace } from "./ai";
@@ -327,6 +326,7 @@ import {
 } from "./secrets-store/commands";
 import { closeSentry, setupSentry } from "./sentry";
 import { setupCommand } from "./setup";
+import { initUndiciDispatcher } from "./shared/undici-dispatcher";
 import { tailCommand } from "./tail";
 import { triggersDeployCommand, triggersNamespace } from "./triggers";
 import { typesCommand } from "./type-generation";
@@ -337,7 +337,6 @@ import {
 	logoutCommand,
 	whoamiCommand,
 } from "./user/commands";
-import { noProxy, proxy } from "./utils/constants";
 import { debugLogFilepath } from "./utils/log-file";
 import { vectorizeCreateCommand } from "./vectorize/create";
 import { vectorizeCreateMetadataIndexCommand } from "./vectorize/createMetadataIndex";
@@ -393,10 +392,8 @@ import type { ReadConfigCommandArgs } from "./config";
 import type { LoggerLevel } from "./logger";
 import type { CommonYargsArgv, SubHelp } from "./yargs-types";
 
-if (proxy) {
-	setGlobalDispatcher(
-		new EnvHttpProxyAgent({ noProxy: noProxy || "localhost,127.0.0.1,::1" })
-	);
+const { proxy: usingProxy } = initUndiciDispatcher();
+if (usingProxy) {
 	logger.log(
 		`Proxy environment variables detected. We'll use your proxy for fetch requests.`
 	);

--- a/packages/wrangler/src/shared/ca-certs.ts
+++ b/packages/wrangler/src/shared/ca-certs.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { rootCertificates } from "node:tls";
+
+// null = not yet computed, undefined = computed but no certs
+let cached: string[] | undefined | null = null;
+
+/**
+ * Read NODE_EXTRA_CA_CERTS and return combined CA certificates for undici.
+ *
+ * Node's built-in fetch/https respects NODE_EXTRA_CA_CERTS automatically,
+ * but wrangler imports fetch from undici directly. Bundled undici uses its
+ * own TLS config and does not read this env var. This bridges the gap.
+ *
+ * Result is memoized — safe to call from multiple entry points without
+ * redundant filesystem reads.
+ *
+ * @returns Combined root + extra CA certs, or undefined if not configured.
+ */
+export function getNodeExtraCaCerts(): string[] | undefined {
+	if (cached !== null) {
+		return cached;
+	}
+
+	const extraCertsPath = process.env.NODE_EXTRA_CA_CERTS;
+	if (!extraCertsPath) {
+		cached = undefined;
+		return undefined;
+	}
+
+	try {
+		const extra = readFileSync(extraCertsPath, "utf8");
+		// Split PEM bundle into individual certificates (same regex as miniflare)
+		const certs = extra.match(
+			/-----BEGIN CERTIFICATE-----[\s\S]+?-----END CERTIFICATE-----/g
+		);
+		if (certs === null) {
+			process.emitWarning(
+				`NODE_EXTRA_CA_CERTS (${extraCertsPath}) contains no PEM certificates`,
+				"WranglerWarning"
+			);
+			cached = undefined;
+			return undefined;
+		}
+		cached = [...rootCertificates, ...certs];
+		return cached;
+	} catch (err) {
+		process.emitWarning(
+			`Failed to read NODE_EXTRA_CA_CERTS from ${extraCertsPath}: ${err instanceof Error ? err.message : String(err)}`,
+			"WranglerWarning"
+		);
+		cached = undefined;
+		return undefined;
+	}
+}

--- a/packages/wrangler/src/shared/undici-dispatcher.ts
+++ b/packages/wrangler/src/shared/undici-dispatcher.ts
@@ -1,0 +1,43 @@
+import { Agent, EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
+import { noProxy, proxy } from "../utils/constants";
+import { getNodeExtraCaCerts } from "./ca-certs";
+
+let initialized = false;
+
+/**
+ * Idempotent global undici dispatcher setup.
+ *
+ * Configures:
+ * - HTTP(S) proxy support via EnvHttpProxyAgent when proxy env vars are set
+ * - NODE_EXTRA_CA_CERTS for TLS connections (corporate proxies, WARP, etc.)
+ *
+ * Safe to call from multiple entry points (CLI + library API). Only the first
+ * call takes effect; subsequent calls are no-ops.
+ *
+ * @returns `{ proxy: true }` when a proxy dispatcher was installed,
+ *          `{ proxy: false }` otherwise.
+ */
+export function initUndiciDispatcher(): { proxy: boolean } {
+	if (initialized) {
+		return { proxy: Boolean(proxy) };
+	}
+	initialized = true;
+
+	const ca = getNodeExtraCaCerts();
+
+	if (proxy) {
+		setGlobalDispatcher(
+			new EnvHttpProxyAgent({
+				noProxy: noProxy || "localhost,127.0.0.1,::1",
+				...(ca ? { requestTls: { ca }, proxyTls: { ca } } : {}),
+			})
+		);
+		return { proxy: true };
+	}
+
+	if (ca) {
+		setGlobalDispatcher(new Agent({ connect: { ca } }));
+	}
+
+	return { proxy: false };
+}


### PR DESCRIPTION
Fixes #5693, #8415, #1136.

## Problem

Wrangler imports `fetch` from its bundled undici, which bypasses Node's built-in `NODE_EXTRA_CA_CERTS` handling. Users behind TLS-intercepting proxies (Cloudflare WARP, corporate proxies) get `SELF_SIGNED_CERT_IN_CHAIN` errors on any undici-based request (API calls, `wrangler dev`, `wrangler tail`, etc.).

This has been reported repeatedly since 2022 and never fixed at the undici dispatcher level:

| PR/Issue | What it did | Gap |
|----------|------------|-----|
| [#348](https://github.com/cloudflare/workers-sdk/pull/348) (2022) | Replaced node-fetch with undici | **Introduced** the root cause — bundled undici ignores `NODE_EXTRA_CA_CERTS` |
| [#963](https://github.com/cloudflare/workers-sdk/pull/963) (2022) | Shipped `Cloudflare_CA.pem`, set `NODE_EXTRA_CA_CERTS` in `bin/wrangler.js` | Only fixed the CLI shim's Node process; bundled undici still ignores it |
| [#1136](https://github.com/cloudflare/workers-sdk/issues/1136) (2022) | Cert warnings with Yarn PnP | Closed as workaround-able; underlying undici issue not addressed |
| [#5693](https://github.com/cloudflare/workers-sdk/issues/5693) (2024) | `wrangler tail` fails with WARP | Closed without fix; same root cause |
| [#9089](https://github.com/cloudflare/workers-sdk/pull/9089) (2025) | Fixed PEM parsing regex in miniflare | Only fixed miniflare's cert handling for workerd; did **not** touch undici dispatcher |
| [#8415](https://github.com/cloudflare/workers-sdk/issues/8415) (2025) | `NODE_EXTRA_CA_CERTS` — login works, dev fails | Closed by #9089 but only partially — miniflare/workerd side fixed, undici side was not |
| [#8051](https://github.com/cloudflare/workers-sdk/issues/8051) (2025) | Fetch with certs fails locally | Closed as workerd cert issue, not undici |

No prior PR has attempted a `setGlobalDispatcher` + CA certs fix. This PR fills that gap.

## Solution

Three-layer fix:

### 1. `shared/ca-certs.ts` — cert reading

Reads `NODE_EXTRA_CA_CERTS`, parses PEM blocks, returns combined root + extra certs. Memoized. Warns on failure via `process.emitWarning()`.

```typescript
export function getNodeExtraCaCerts(): string[] | undefined {
  if (cached !== null) return cached;

  const extraCertsPath = process.env.NODE_EXTRA_CA_CERTS;
  if (!extraCertsPath) { cached = undefined; return undefined; }

  const extra = readFileSync(extraCertsPath, "utf8");
  const certs = extra.match(
    /-----BEGIN CERTIFICATE-----[\s\S]+?-----END CERTIFICATE-----/g
  );
  // ...warning on failure...
  cached = [...rootCertificates, ...certs];
  return cached;
}
```

Root certs are included because Node's TLS `ca` option *replaces* the default CA store entirely. The PEM regex matches the one used in miniflare ([PR #9089](https://github.com/cloudflare/workers-sdk/pull/9089)).

### 2. `shared/undici-dispatcher.ts` — idempotent dispatcher setup

Single function called from both entry points. Boolean guard ensures it runs exactly once regardless of import order.

```typescript
export function initUndiciDispatcher(): { proxy: boolean } {
  if (initialized) return { proxy: false };
  initialized = true;

  const ca = getNodeExtraCaCerts();

  if (proxy) {
    setGlobalDispatcher(new EnvHttpProxyAgent({
      noProxy: noProxy || "localhost,127.0.0.1,::1",
      ...(ca ? { requestTls: { ca }, proxyTls: { ca } } : {}),
    }));
    return { proxy: true };
  }

  if (ca) {
    setGlobalDispatcher(new Agent({ connect: { ca } }));
  }
  return { proxy: false };
}
```

### 3. Entry point wiring

**CLI** (`index.ts`) — was 12 lines of inline dispatcher setup, now:
```typescript
const { proxy: usingProxy } = initUndiciDispatcher();
if (usingProxy) {
  logger.log(`Proxy environment variables detected. We'll use your proxy for fetch requests.`);
}
```

**Library API** (`api/index.ts`) — ensures the fix works when wrangler is imported as a library (e.g. by `@cloudflare/vitest-pool-workers`):
```typescript
import { initUndiciDispatcher } from "../shared/undici-dispatcher";
initUndiciDispatcher();
```

This also gives the library path proxy support it didn't have before.

## Tests

15 tests in `src/__tests__/shared/ca-certs.test.ts`:

- **7 unit** — `getNodeExtraCaCerts()` parsing, memoization, warning behavior
- **3 integration** — real self-signed HTTPS server with undici fetch: failure without CA, success with CA, end-to-end with `getNodeExtraCaCerts()`
- **5 dispatcher** — `initUndiciDispatcher()` CA-only path, no-op path, idempotency, constructor contract tests for both `Agent` and `EnvHttpProxyAgent`

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal behavior change, no user-facing config
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12669" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
