### PR TITLE
fix: restrict account name redaction to CI environments only

### DIFF
--- a/.changeset/narrow-account-redaction-to-ci.md
+++ b/.changeset/narrow-account-redaction-to-ci.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+fix: Only redact account names in CI environments, not all non-interactive contexts
+
+The multi-account selection error in `getAccountId` now only redacts account names
+when running in a CI environment (detected via `ci-info`). Non-interactive terminals
+such as coding agents and piped commands can now see account names, which they need
+to identify which account to configure. CI logs remain protected.

--- a/packages/wrangler/src/__tests__/kv/key.test.ts
+++ b/packages/wrangler/src/__tests__/kv/key.test.ts
@@ -1119,8 +1119,8 @@ describe("kv", () => {
 						[Error: More than one account available but unable to select one in non-interactive mode.
 						Please set the appropriate \`account_id\` in your Wrangler configuration file or assign it to the \`CLOUDFLARE_ACCOUNT_ID\` environment variable.
 						Available accounts are (\`<name>\`: \`<account_id>\`):
-						  \`(redacted)\`: \`1\`
-						  \`(redacted)\`: \`2\`]
+						  \`one\`: \`1\`
+						  \`two\`: \`2\`]
 					`);
 				});
 
@@ -1136,8 +1136,8 @@ describe("kv", () => {
 						[Error: More than one account available but unable to select one in non-interactive mode.
 						Please set the appropriate \`account_id\` in your Wrangler configuration file or assign it to the \`CLOUDFLARE_ACCOUNT_ID\` environment variable.
 						Available accounts are (\`<name>\`: \`<account_id>\`):
-						  \`(redacted)\`: \`1\`
-						  \`(redacted)\`: \`2\`]
+						  \`one\`: \`1\`
+						  \`two\`: \`2\`]
 					`);
 				});
 
@@ -1179,8 +1179,8 @@ describe("kv", () => {
 						[Error: More than one account available but unable to select one in non-interactive mode.
 						Please set the appropriate \`account_id\` in your Wrangler configuration file or assign it to the \`CLOUDFLARE_ACCOUNT_ID\` environment variable.
 						Available accounts are (\`<name>\`: \`<account_id>\`):
-						  \`(redacted)\`: \`1\`
-						  \`(redacted)\`: \`2\`]
+						  \`one\`: \`1\`
+						  \`two\`: \`2\`]
 					`);
 				});
 			});

--- a/packages/wrangler/src/__tests__/pages/secret.test.ts
+++ b/packages/wrangler/src/__tests__/pages/secret.test.ts
@@ -287,9 +287,9 @@ describe("wrangler pages secret", () => {
 						[Error: More than one account available but unable to select one in non-interactive mode.
 						Please set the appropriate \`account_id\` in your Wrangler configuration file or assign it to the \`CLOUDFLARE_ACCOUNT_ID\` environment variable.
 						Available accounts are (\`<name>\`: \`<account_id>\`):
-						  \`(redacted)\`: \`account-id-1\`
-						  \`(redacted)\`: \`account-id-2\`
-						  \`(redacted)\`: \`account-id-3\`]
+						  \`account-name-1\`: \`account-id-1\`
+						  \`account-name-2\`: \`account-id-2\`
+						  \`account-name-3\`: \`account-id-3\`]
 					`);
 				});
 			});

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -459,9 +459,9 @@ describe("wrangler secret", () => {
 						[Error: More than one account available but unable to select one in non-interactive mode.
 						Please set the appropriate \`account_id\` in your Wrangler configuration file or assign it to the \`CLOUDFLARE_ACCOUNT_ID\` environment variable.
 						Available accounts are (\`<name>\`: \`<account_id>\`):
-						  \`(redacted)\`: \`account-id-1\`
-						  \`(redacted)\`: \`account-id-2\`
-						  \`(redacted)\`: \`account-id-3\`]
+						  \`account-name-1\`: \`account-id-1\`
+						  \`account-name-2\`: \`account-id-2\`
+						  \`account-name-3\`: \`account-id-3\`]
 					`);
 				});
 			});


### PR DESCRIPTION
_Describe your change..._

Fixes internal discussion around redaction only in CI environments, and non-interactive environments (eg agents) having this redaction removed.

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: fixing a regression to local experience

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
