### PR TITLE
use bonk in changeset review part 2

### DIFF
--- a/.changeset/nice-clubs-press.md
+++ b/.changeset/nice-clubs-press.md
@@ -3,3 +3,5 @@
 ---
 
 feat: loads of new things for c3!
+
+no details, its a surprise

--- a/.github/workflows/changeset-review.yml
+++ b/.github/workflows/changeset-review.yml
@@ -63,11 +63,11 @@ jobs:
 
             If all changesets pass, just output "✅ All changesets look good" - no need for a detailed checklist. If the changesets have already been approved, do not leave a new comment.
 
-            IMPORTANT: Only use Read, Glob, and Grep tools. Do not use other tools or make any changes to the repository.
+            If there are issues, use `gh pr review` to submit a PR review that leaves a PR review comment on the changeset file with "⚠️ Issues found" followed by the specific problems. Do not request changes.
+
+            Only use Read, Glob, and Grep tools. Do not use other tools or make any changes to the repository.
 
             Do not review other files, only the changesets. This is specifically a changeset review action.
-
-            If there are issues, leave a PR review comment on the changeset file with "⚠️ Issues found" followed by the specific problems.
 
             If the user has attached an image, use the Read tool to view it. If and only if it's a cute animal, include in your comment a short cuteness report in the style of WeRateDogs (e.g., "This is Barkley. He's wearing a tiny hat and doesn't know why. 13/10"). If it's not an animal, silently ignore the image. If there is more than one image, check each one to find an animal. If you do not find an animal, do not include any reference to a cuteness report.
 


### PR DESCRIPTION
Use ask-bonk (ie opencode) instead of claude cli in our changeset review.

Note afaict bonk doesn't have the ability to do sticky comments - instead it will leave a review comment on the changeset which can be resolved to minimise noise.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: see comments in this PR
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal tool

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
