### PR TITLE
chore(create-cloudflare): remove unused chalk dependency

### DIFF
--- a/.changeset/remove-chalk-create-cloudflare.md
+++ b/.changeset/remove-chalk-create-cloudflare.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Remove unused `chalk` dependency from create-cloudflare.

--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -58,7 +58,6 @@
 		"@types/semver": "^7.5.1",
 		"@types/which-pm-runs": "^1.0.0",
 		"@types/yargs": "^17.0.22",
-		"chalk": "^5.2.0",
 		"command-exists": "^1.2.9",
 		"comment-json": "^4.5.0",
 		"cross-spawn": "^7.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1853,9 +1853,6 @@ importers:
       '@types/yargs':
         specifier: ^17.0.22
         version: 17.0.24
-      chalk:
-        specifier: ^5.2.0
-        version: 5.3.0
       command-exists:
         specifier: ^1.2.9
         version: 1.2.9
@@ -9385,6 +9382,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
 
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
@@ -16439,7 +16437,7 @@ snapshots:
       devalue: 5.3.2
       miniflare: 4.20251210.0
       semver: 7.7.3
-      vitest: 3.2.3(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/ui@3.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.0(@types/node@20.19.9)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 3.2.3(@types/debug@4.1.12)(@types/node@20.19.9)(@vitest/ui@3.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.0(@types/node@20.19.9)(typescript@5.8.3))(supports-color@9.2.2)(tsx@4.21.0)(yaml@2.8.1)
       wrangler: 4.54.0(@cloudflare/workers-types@4.20260305.0)
       zod: 3.25.76
     transitivePeerDependencies:


### PR DESCRIPTION
Part of #11854.

`chalk` is listed as a `devDependency` in `create-cloudflare` but is not
imported anywhere in the package. The color utilities used by
create-cloudflare come from `@cloudflare/cli/colors`, which has its own
chalk dependency. This stale devDependency was left behind when the color
code was extracted to `@cloudflare/cli` in #4189.

```sh
# Confirmed no chalk imports in create-cloudflare source
> grep -r "from ['\"]chalk" packages/create-cloudflare/src/
(blank)
```

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: Dependency removal only, all 219 existing unit tests pass
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Infra change only
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
