### PR TITLE
fix: use correct R2 Catalog error code in pipelines setup

### DIFF
--- a/.changeset/rude-ends-battle.md
+++ b/.changeset/rude-ends-battle.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler pipelines setup` failing for Data Catalog sinks on new buckets by using the correct R2 Catalog API error code (`40401`).

--- a/packages/wrangler/src/__tests__/pipelines-setup.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines-setup.test.ts
@@ -365,7 +365,7 @@ describe("wrangler pipelines setup", () => {
 					if (!exists) {
 						return HttpResponse.json(
 							createFetchResult(null, false, [
-								{ code: 10006, message: "catalog not found" },
+								{ code: 40401, message: "Warehouse not found" },
 							]),
 							{ status: 404 }
 						);

--- a/packages/wrangler/src/pipelines/cli/setup.ts
+++ b/packages/wrangler/src/pipelines/cli/setup.ts
@@ -130,7 +130,7 @@ async function ensureCatalogEnabled(
 		const catalog = await getR2Catalog(config, accountId, bucketName);
 		catalogEnabled = catalog.status === "active";
 	} catch (err) {
-		if (err instanceof APIError && err.code === 10006) {
+		if (err instanceof APIError && err.code === 40401) {
 			// Catalog not enabled yet
 		} else {
 			throw err;


### PR DESCRIPTION
This change fixes the wrangler pipelines setup to use the correct error code when a catalog is not enabled on a bucket.
---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: minor fix in existing command
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: minor fix in existing command

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
