### PR TITLE
feat(miniflare): implement analytics engine local dev writes

### DIFF
--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -40,6 +40,7 @@ import {
 	Response,
 } from "./http";
 import {
+	ANALYTICS_ENGINE_PLUGIN_NAME,
 	D1_PLUGIN_NAME,
 	DURABLE_OBJECTS_PLUGIN_NAME,
 	DurableObjectClassNames,
@@ -149,6 +150,19 @@ import type {
 	R2Bucket,
 } from "@cloudflare/workers-types/experimental";
 import type { Process } from "@puppeteer/browsers";
+
+// RFC 4180 CSV escaping: quote fields containing commas, quotes, or newlines
+function csvEscape(value: string): string {
+	if (
+		value.includes(",") ||
+		value.includes('"') ||
+		value.includes("\n") ||
+		value.includes("\r")
+	) {
+		return `"${value.replace(/"/g, '""')}"`;
+	}
+	return value;
+}
 
 const DEFAULT_HOST = "127.0.0.1";
 function getURLSafeHost(host: string) {
@@ -956,6 +970,19 @@ export class Miniflare {
 	#hyperdriveProxyController: HyperdriveProxyController =
 		new HyperdriveProxyController();
 
+	// Analytics Engine write buffer: dataset name → array of row objects
+	#analyticsEngineBuffers: Map<
+		string,
+		{
+			dataset: string;
+			timestamp: string;
+			index1: string;
+			blobs: string[];
+			doubles: number[];
+		}[]
+	> = new Map();
+	#analyticsEngineFlushTimer?: ReturnType<typeof setInterval>;
+
 	constructor(opts: MiniflareOptions) {
 		// Split and validate options
 		const [sharedOpts, workerOpts] = validateOptions(opts);
@@ -1216,6 +1243,88 @@ export class Miniflare {
 		}
 	}
 
+	async #handleAnalyticsEngineWrite(request: Request): Promise<Response> {
+		const payload = (await request.json()) as {
+			dataset: string;
+			timestamp: string;
+			index1: string;
+			blobs: string[];
+			doubles: number[];
+		};
+
+		let buffer = this.#analyticsEngineBuffers.get(payload.dataset);
+		if (!buffer) {
+			buffer = [];
+			this.#analyticsEngineBuffers.set(payload.dataset, buffer);
+		}
+		buffer.push(payload);
+
+		// Start the flush timer on first write
+		if (this.#analyticsEngineFlushTimer === undefined) {
+			this.#analyticsEngineFlushTimer = setInterval(() => {
+				void this.#flushAnalyticsEngine();
+			}, 30_000);
+			// Don't prevent the process from exiting
+			this.#analyticsEngineFlushTimer.unref();
+		}
+
+		return new Response(null, { status: 204 });
+	}
+
+	async #flushAnalyticsEngine(): Promise<void> {
+		const aeSharedOpts = this.#sharedOpts["analytics-engine"];
+		const coreSharedOpts = this.#sharedOpts.core;
+		const persistPath = getPersistPath(
+			ANALYTICS_ENGINE_PLUGIN_NAME,
+			this.#tmpPath,
+			coreSharedOpts.defaultPersistRoot,
+			aeSharedOpts.analyticsEngineDatasetsPersist
+		);
+
+		for (const [dataset, rows] of this.#analyticsEngineBuffers) {
+			if (rows.length === 0) {
+				continue;
+			}
+
+			const csvPath = path.join(persistPath, `${dataset}.csv`);
+			await fs.promises.mkdir(path.dirname(csvPath), { recursive: true });
+
+			// Check if file exists to determine whether to write header
+			const fileExists = fs.existsSync(csvPath);
+
+			const header = [
+				"dataset",
+				"timestamp",
+				"index1",
+				...Array.from({ length: 20 }, (_, i) => `blob${i + 1}`),
+				...Array.from({ length: 20 }, (_, i) => `double${i + 1}`),
+				"_sample_interval",
+			];
+
+			let csvContent = "";
+			if (!fileExists) {
+				csvContent += header.join(",") + "\n";
+			}
+
+			for (const row of rows) {
+				const fields = [
+					csvEscape(row.dataset),
+					csvEscape(row.timestamp),
+					csvEscape(row.index1),
+					...row.blobs.map(csvEscape),
+					...row.doubles.map(String),
+					"1", // _sample_interval
+				];
+				csvContent += fields.join(",") + "\n";
+			}
+
+			await fs.promises.appendFile(csvPath, csvContent);
+		}
+
+		// Clear all buffers after flushing
+		this.#analyticsEngineBuffers.clear();
+	}
+
 	get #workerSrcOpts(): NameSourceOptions[] {
 		return this.#workerOpts.map<NameSourceOptions>(({ core }) => core);
 	}
@@ -1344,6 +1453,11 @@ export class Miniflare {
 				response = new Response(filePath, { status: 200 });
 			} else if (url.pathname.startsWith("/core/do-storage/")) {
 				response = await this.#handleLoopbackDOStorageRequest(url);
+			} else if (url.pathname === "/analytics-engine/write") {
+				response = await this.#handleAnalyticsEngineWrite(request);
+			} else if (url.pathname === "/analytics-engine/flush") {
+				await this.#flushAnalyticsEngine();
+				response = new Response(null, { status: 204 });
 			}
 		} catch (e: any) {
 			this.#log.error(e);
@@ -2771,6 +2885,14 @@ export class Miniflare {
 
 	async dispose(): Promise<void> {
 		this.#disposeController.abort();
+
+		// Flush any buffered analytics engine writes before shutdown
+		if (this.#analyticsEngineFlushTimer !== undefined) {
+			clearInterval(this.#analyticsEngineFlushTimer);
+			this.#analyticsEngineFlushTimer = undefined;
+		}
+		await this.#flushAnalyticsEngine();
+
 		// The `ProxyServer` "heap" will be destroyed when `workerd` shuts down,
 		// invalidating all existing native references. Mark all proxies as invalid.
 		// Note `dispose()`ing the `#proxyClient` implicitly poison's proxies, but

--- a/packages/miniflare/src/plugins/analytics-engine/index.ts
+++ b/packages/miniflare/src/plugins/analytics-engine/index.ts
@@ -2,6 +2,7 @@ import ANALYTICS_ENGINE from "worker:analytics-engine/analytics-engine";
 import { z } from "zod";
 import { Worker_Binding } from "../../runtime";
 import { PersistenceSchema, Plugin, ProxyNodeBinding } from "../shared";
+import { SERVICE_LOOPBACK } from "../shared/constants";
 
 const AnalyticsEngineSchema = z.record(
 	z.object({
@@ -41,6 +42,10 @@ export const ANALYTICS_ENGINE_PLUGIN: Plugin<
 						{
 							name: "dataset",
 							json: JSON.stringify(config.dataset),
+						},
+						{
+							name: "persistence",
+							service: { name: SERVICE_LOOPBACK },
 						},
 					],
 				},

--- a/packages/miniflare/src/workers/analytics-engine/analytics-engine.worker.ts
+++ b/packages/miniflare/src/workers/analytics-engine/analytics-engine.worker.ts
@@ -1,10 +1,44 @@
 interface Env {
 	dataset: string;
+	persistence: Fetcher;
 }
 class LocalAnalyticsEngineDataset implements AnalyticsEngineDataset {
 	constructor(private env: Env) {}
-	writeDataPoint(_event?: AnalyticsEngineDataPoint): void {
-		// no op in dev
+	writeDataPoint(event?: AnalyticsEngineDataPoint): void {
+		const indexes = event?.indexes ?? [];
+		const blobs = event?.blobs ?? [];
+		const doubles = event?.doubles ?? [];
+
+		const payload = {
+			dataset: this.env.dataset,
+			timestamp: new Date().toISOString(),
+			index1: indexes[0] ?? "",
+			blobs: Array.from({ length: 20 }, (_, i) => {
+				const val = i < blobs.length ? blobs[i] : null;
+				if (val === null || val === undefined) {
+					return "";
+				}
+				if (val instanceof ArrayBuffer) {
+					return Array.from(new Uint8Array(val))
+						.map((b) => b.toString(16).padStart(2, "0"))
+						.join("");
+				}
+				return String(val);
+			}),
+			doubles: Array.from({ length: 20 }, (_, i) =>
+				i < doubles.length ? doubles[i] ?? 0 : 0
+			),
+		};
+
+		// Fire-and-forget: workerd tracks this subrequest within the I/O context
+		this.env.persistence
+			.fetch("http://localhost/analytics-engine/write", {
+				method: "POST",
+				body: JSON.stringify(payload),
+			})
+			.catch(() => {
+				// Silently swallow write errors in local dev
+			});
 	}
 }
 

--- a/packages/miniflare/src/workers/analytics-engine/read-spec.md
+++ b/packages/miniflare/src/workers/analytics-engine/read-spec.md
@@ -1,0 +1,439 @@
+# Analytics Engine Local Dev — Reads Spec
+
+## Goal
+
+Allow developers to query their locally-written Analytics Engine data using the same SQL API they use in production, running entirely locally via DuckDB with the `chsql` ClickHouse compatibility extension.
+
+## How Production WAE SQL Works
+
+In production, a developer queries the WAE SQL API at:
+
+```
+POST /client/v4/accounts/<account_id>/analytics_engine/sql
+```
+
+The dataset name is used directly as a table name in SQL:
+
+```sql
+SELECT blob1 AS city, SUM(double2) AS total
+FROM my_dataset
+WHERE double1 > 0
+GROUP BY city
+ORDER BY total DESC
+LIMIT 10
+```
+
+### Supported SQL Subset
+
+WAE SQL is intentionally limited ([docs](https://developers.cloudflare.com/analytics/analytics-engine/sql-reference/statements/)):
+
+- `SELECT <expressions>` with aliases
+- `FROM <dataset>` or `FROM (<subquery>)` — **single table only, no JOINs, no UNIONs**
+- `WHERE`, `GROUP BY`, `HAVING`, `ORDER BY`, `LIMIT`, `OFFSET`
+- Aggregate functions (SUM, COUNT, AVG, MIN, MAX, etc.)
+- ClickHouse functions: `toStartOfInterval`, `intDiv`, `quantile`, date/time functions, etc.
+- `FORMAT` clause (JSON, JSONEachRow, TabSeparated)
+
+### What's NOT supported
+
+- `JOIN`, `UNION`, `INSERT`, `UPDATE`, `DELETE`, `CREATE`
+- Multiple tables in a single query
+- CTEs (`WITH` clause) — not documented as supported in WAE
+
+## Query Engine: DuckDB + chsql
+
+### Why DuckDB?
+
+We evaluated three options for the local query engine:
+
+| Engine                     | Binary size                        | ClickHouse SQL compat                       | Install                                          | Notes                                                                      |
+| -------------------------- | ---------------------------------- | ------------------------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------- |
+| chdb (embedded ClickHouse) | 116-169 MB + manual system install | Native                                      | Broken npm story, requires `libchdb` outside npm | Too heavy, bad DX                                                          |
+| SQLite (via DO)            | 0 (built-in)                       | None                                        | Free                                             | No ClickHouse function support, can't register custom functions in workerd |
+| **DuckDB + chsql**         | **59-110 MB per platform**         | **100+ ClickHouse functions via extension** | **Clean npm install, per-platform packages**     | **Best trade-off**                                                         |
+
+### DuckDB
+
+[DuckDB](https://duckdb.org/) is an embedded OLAP database — the "SQLite of analytics." It runs in-process with no server.
+
+Node.js packages use the same per-platform optional dependency pattern as `esbuild`, `swc`, and `turbo`:
+
+- `@duckdb/node-bindings-darwin-arm64` (~110 MB)
+- `@duckdb/node-bindings-linux-x64` (~65 MB)
+- `@duckdb/node-bindings-linux-arm64` (~59 MB)
+- npm resolves the correct platform automatically — developers only download their platform's binary
+
+Key capabilities:
+
+- `read_csv()` table function to query CSV files directly
+- Full SQL support (SELECT, WHERE, GROUP BY, HAVING, ORDER BY, LIMIT, subqueries, CTEs)
+- Community extension system for additional functionality
+- In-process — no network, no server
+
+### chsql Extension
+
+[`chsql`](https://github.com/Query-farm/clickhouse-sql) is a DuckDB community extension that implements **100+ ClickHouse SQL functions** as DuckDB macros:
+
+- `toStartOfInterval(ts, INTERVAL 1 HOUR)`
+- `intDiv(a, b)`
+- `toDateTime`, `toDate`, `toString`
+- ClickHouse date/time functions, string functions, math functions
+- System table emulation
+
+The extension is **lazy-loaded** — it downloads on first use, not on `npm install`:
+
+```sql
+INSTALL chsql FROM community;
+LOAD chsql;
+```
+
+This means the base DuckDB binary is all that ships with the npm install. The ClickHouse compat layer is pulled in automatically on first analytics engine query.
+
+## Local Dev Approach
+
+### The Problem
+
+Locally, each dataset is stored as a CSV file:
+
+```
+.wrangler/state/v3/analytics-engine/my_dataset.csv
+```
+
+DuckDB can query CSV files directly using `read_csv()`:
+
+```sql
+SELECT * FROM read_csv('/path/to/my_dataset.csv', header=true)
+```
+
+But the user writes SQL with bare table names (`FROM my_dataset`), not `read_csv()` calls.
+
+### The Solution: CTE Rewriting (mirroring production)
+
+In production, all datasets live in a single ClickHouse table. When a user queries `FROM my_dataset`, the WAE SQL API rewrites the query to scope it to that dataset — the user never sees this.
+
+We mimic the same pattern locally. We parse the user's SQL to extract the table name, then prepend a `WITH` CTE that defines that table name as a filtered view over the CSV file:
+
+**User writes:**
+
+```sql
+SELECT blob1, SUM(double1) FROM my_dataset WHERE index1 = 'foo' GROUP BY blob1
+```
+
+**We rewrite to:**
+
+```sql
+INSTALL chsql FROM community;
+LOAD chsql;
+WITH my_dataset AS (
+  SELECT * FROM read_csv('/path/to/my_dataset.csv', header=true)
+  WHERE dataset = 'my_dataset'
+)
+SELECT blob1, SUM(double1) FROM my_dataset WHERE index1 = 'foo' GROUP BY blob1
+```
+
+**Why this approach:**
+
+- **Mirrors production** — production does the same conceptual rewrite (scope query to dataset). The CTE makes the dataset name "just work" as a table reference without modifying the user's query body at all.
+- **User's SQL is untouched** — we only prepend the CTE. The `FROM my_dataset` in their query resolves to the CTE, not a real table. No AST surgery on their SELECT/WHERE/GROUP BY.
+- **Forward-compatible** — if we later move to a single CSV for all datasets (closer to prod's single table), the `WHERE dataset = 'my_dataset'` filter already handles it. We'd just change the `read_csv()` path.
+- **Subqueries work** — CTEs are scoped to the entire statement, so nested subqueries resolve the table name to the CTE automatically:
+  ```sql
+  WITH my_dataset AS (...)
+  SELECT * FROM (
+    SELECT blob1, SUM(double1) as total
+    FROM my_dataset  -- resolves to CTE
+    GROUP BY blob1
+  ) WHERE total > 100
+  ```
+
+**DuckDB executes it** with full ClickHouse function support via chsql, and returns results.
+
+## SQL Parsing: `node-sql-parser` (MySQL mode)
+
+We use [`node-sql-parser`](https://github.com/taozhi8833998/node-sql-parser) to parse the user's SQL and extract the dataset table name.
+
+Production WAE uses a Rust parser ([sql-ast](https://docs.rs/sql-ast/latest/sql_ast/)) which isn't usable from Node.js. `node-sql-parser` is the best JS alternative:
+
+- **WAE SQL is standard SQL** — the supported subset (SELECT, FROM, WHERE, GROUP BY, HAVING, ORDER BY, LIMIT) is plain ANSI SQL. No ClickHouse-specific syntax needs parsing. MySQL mode handles it all.
+- **AST table extraction** — parse to AST, walk all `FROM` clauses (including inside subqueries) to find the single dataset table name. Since WAE is single-table only, there will be exactly one distinct table name across the entire query. We only need to extract it — the CTE approach means we don't rewrite the user's SQL, just prepend to it.
+- **Well-maintained** — 4M+ weekly downloads, ~150K per dialect build.
+- **Runs on Node.js side only** — not bundled into workerd, so dependency size is not a concern for the worker bundle.
+
+## Rewrite Flow
+
+```
+User SQL string
+  │
+  ▼
+┌─────────────────────────────────────┐
+│  node-sql-parser.parse(sql)         │
+│  → AST                              │
+└──────────────┬──────────────────────┘
+               │
+               ▼
+┌─────────────────────────────────────┐
+│  Extract table name from AST        │
+│  e.g. "my_dataset"                  │
+│                                     │
+│  Validate dataset exists (CSV file  │
+│  exists on disk)                    │
+└──────────────┬──────────────────────┘
+               │
+               ▼
+┌─────────────────────────────────────┐
+│  Prepend CTE + chsql setup:        │
+│                                     │
+│  INSTALL chsql FROM community;      │
+│  LOAD chsql;                        │
+│  WITH my_dataset AS (               │
+│    SELECT * FROM read_csv('...csv', │
+│      header=true)                   │
+│    WHERE dataset = 'my_dataset'     │
+│  )                                  │
+│  <original user SQL>                │
+└──────────────┬──────────────────────┘
+               │
+               ▼
+┌─────────────────────────────────────┐
+│  duckdb.query(rewrittenSql)         │
+│  → query result                     │
+└─────────────────────────────────────┘
+```
+
+## Local SQL API Endpoint
+
+The SQL API is exposed on the existing `wrangler dev` server using the `/cdn-cgi/` route convention — the same pattern used for triggering scheduled handlers (`/cdn-cgi/handler/scheduled`), email handlers (`/cdn-cgi/handler/email`), and the local explorer (`/cdn-cgi/explorer`).
+
+These routes are intercepted by Miniflare's entry worker (`packages/miniflare/src/workers/core/entry.worker.ts`) before reaching the user's worker, so there's no conflict with user routes.
+
+### Endpoint
+
+```
+POST http://localhost:8787/cdn-cgi/analytics-engine/sql
+```
+
+No separate port. Runs on the same dev server, gated behind a feature flag (similar to `unsafeTriggerHandlers` / `unsafeLocalExplorer`).
+
+### Request Format
+
+- **Method:** `POST` (matching production — production is POST only, query as raw body)
+- **Body:** Raw SQL string (not JSON-wrapped)
+- **No authentication** — local dev, no token needed
+
+```bash
+curl -X POST http://localhost:8787/cdn-cgi/analytics-engine/sql \
+  --data "SELECT blob1, SUM(double1) FROM my_dataset GROUP BY blob1"
+```
+
+### Request Flow
+
+```
+POST /cdn-cgi/analytics-engine/sql
+  │
+  ▼
+Entry Worker (workerd)
+  │  intercepts /cdn-cgi/analytics-engine/*
+  │  forwards to loopback
+  ▼
+Node.js Loopback Handler
+  │  parse SQL → extract table name
+  │  prepend CTE with read_csv() path
+  │  load chsql extension
+  │  duckdb.query(rewrittenSql)
+  ▼
+Response to client
+```
+
+### Response Format
+
+Matches the production response shape. The `FORMAT` clause in the SQL controls the output format (JSON default, JSONEachRow, TabSeparated). DuckDB supports JSON and CSV output natively; we may need to map WAE FORMAT values to DuckDB equivalents.
+
+## Query Binding (`AnalyticsEngineSQL`)
+
+In addition to the HTTP endpoint, we expose a query binding that workers can use directly — modeled after the [`@clickhouse/client-web`](https://github.com/ClickHouse/clickhouse-js) API.
+
+### Usage
+
+```ts
+// In worker code
+const result = await env.MY_DATASET_SQL.query({
+	query: "SELECT blob1, SUM(double1) FROM my_dataset GROUP BY blob1",
+});
+
+const json = await result.json(); // parsed JS object
+const text = await result.text(); // raw string
+const stream = result.stream(); // ReadableStream<Uint8Array>
+```
+
+### Why not `Row[]` for stream?
+
+The `@clickhouse/client-web` streams `Row[]` objects, but our binding crosses a service binding boundary (workerd ↔ Node.js via `fetch()`). Service bindings can only transport bytes, not structured objects. So `.stream()` returns a `ReadableStream<Uint8Array>` of the raw response body.
+
+For structured streaming, the user would use `JSONEachRow` format and parse line-by-line:
+
+```ts
+const result = await env.MY_DATASET_SQL.query({
+	query: "SELECT * FROM my_dataset FORMAT JSONEachRow",
+});
+for await (const chunk of result.stream()) {
+	// each chunk is UTF-8 bytes, lines are newline-delimited JSON objects
+}
+```
+
+### Implementation
+
+The binding is a thin wrapper around a service binding `fetch()` to the same Node.js query function that powers the HTTP endpoint. The result object wraps the `Response`:
+
+```ts
+class AnalyticsEngineSQLResult {
+	#response: Response;
+	constructor(response: Response) {
+		this.#response = response;
+	}
+
+	json() {
+		return this.#response.json();
+	}
+	text() {
+		return this.#response.text();
+	}
+	stream() {
+		return this.#response.body;
+	}
+}
+```
+
+### Architecture — Shared Query Function
+
+Both the HTTP endpoint and the binding call the same underlying Node.js query function. Two entry points, one implementation:
+
+```
+env.MY_DATASET_SQL.query()                          curl POST /cdn-cgi/analytics-engine/sql
+  │                                                    │
+  ▼                                                    ▼
+Wrapped Binding Worker (workerd)                   Entry Worker (workerd)
+  │  fetch() via service binding                       │  forward to loopback
+  ▼                                                    ▼
+  └──────────────────┐              ┌──────────────────┘
+                     ▼              ▼
+              Node.js Query Function
+              │  parse SQL (node-sql-parser)
+              │  extract table name
+              │  prepend CTE with read_csv() path
+              │  INSTALL/LOAD chsql
+              │  duckdb.query(rewrittenSql)
+              ▼
+           Response (bytes)
+```
+
+The binding goes directly through the service binding to Node.js — it does **not** loop through the HTTP endpoint. No unnecessary serialization roundtrip.
+
+## Dependencies
+
+| Dependency                 | Purpose                          | Size                                                          | Install       |
+| -------------------------- | -------------------------------- | ------------------------------------------------------------- | ------------- |
+| `@duckdb/node-api`         | Query engine                     | 59-110 MB (per-platform, auto-resolved via npm optional deps) | `npm install` |
+| `chsql` (DuckDB extension) | ClickHouse SQL function compat   | Small (lazy-downloaded by DuckDB on first use)                | Automatic     |
+| `node-sql-parser`          | Extract table name from user SQL | ~150K                                                         | `npm install` |
+
+All dependencies run on the Node.js side only. None are bundled into workerd.
+
+DuckDB should be an **optional dependency** — only needed when analytics engine datasets are configured. If not installed, `writeDataPoint()` still works (writes CSV), but queries return a clear error asking the user to install DuckDB.
+
+## Testing
+
+Following the repo's established testing tiers:
+
+### Tier 1: Miniflare Plugin Unit Tests
+
+**Location:** `packages/miniflare/test/plugins/analytics-engine/index.spec.ts`
+
+Uses `miniflareTest()` to spin up a real Miniflare instance. Tests exercise the full write→read roundtrip: write data points, then query them via the SQL endpoint or binding.
+
+**SQL query tests (via HTTP endpoint):**
+
+- **Basic SELECT** — Write data points, query `SELECT * FROM dataset`, verify all columns returned
+- **WHERE filtering** — `WHERE index1 = 'x'` returns only matching rows
+- **Aggregations** — `SUM(double1)`, `COUNT(*)`, `AVG(double2)` return correct values
+- **GROUP BY** — Grouping by blob columns produces correct groups
+- **ORDER BY / LIMIT** — Results are ordered and limited correctly
+- **Subqueries** — `SELECT * FROM (SELECT ... FROM dataset GROUP BY ...) WHERE ...` works
+- **ClickHouse functions** — `toStartOfInterval`, `intDiv` work via chsql extension
+- **Empty dataset** — Query against a dataset with no writes returns empty results
+- **Non-existent dataset** — Query against unknown dataset returns a clear error
+- **Multiple datasets** — Write to two datasets, query each independently
+
+**Binding tests:**
+
+- **`.json()`** — Returns parsed JSON object matching query results
+- **`.text()`** — Returns raw string response
+- **`.stream()`** — Returns `ReadableStream<Uint8Array>` with valid data
+- **FORMAT clause** — `FORMAT JSONEachRow` and `FORMAT TabSeparated` produce correct output
+
+**Error handling:**
+
+- **Invalid SQL** — Returns error response, does not crash
+- **SQL injection via table name** — Rewriting is safe against injection
+
+**Verification approach:** Each test writes known data points using `writeDataPoint()`, calls `POST /cdn-cgi/analytics-engine/flush` to force the write buffer to disk, then queries via `POST /cdn-cgi/analytics-engine/sql` and asserts on the parsed response.
+
+```ts
+test("SELECT with GROUP BY returns aggregated results", async () => {
+	// Write data points
+	await ctx.mf.dispatchFetch("http://localhost/write"); // triggers writeDataPoint
+
+	// Flush buffer to CSV
+	await ctx.mf.dispatchFetch(
+		"http://localhost/cdn-cgi/analytics-engine/flush",
+		{ method: "POST" }
+	);
+
+	// Query via HTTP endpoint
+	const response = await ctx.mf.dispatchFetch(
+		"http://localhost/cdn-cgi/analytics-engine/sql",
+		{
+			method: "POST",
+			body: "SELECT blob1, SUM(double1) as total FROM my_dataset GROUP BY blob1",
+		}
+	);
+	const result = await response.json();
+	expect(result).toContainEqual({ blob1: "Seattle", total: 25 });
+});
+```
+
+### Tier 2: Wrangler E2E Tests
+
+**Location:** `packages/wrangler/e2e/dev.test.ts`
+
+Extend the existing analytics engine E2E test to cover the full write→query cycle:
+
+- Seed a worker that writes data points on fetch
+- Run `wrangler dev`, hit the worker endpoint to trigger writes
+- Query via `POST /cdn-cgi/analytics-engine/sql` and verify results
+- Test with ClickHouse-specific functions (`toStartOfInterval`, etc.)
+
+### Tier 3: Vite Plugin Playground
+
+**Location:** `packages/vite-plugin-cloudflare/playground/bindings/`
+
+Add a test that uses the query binding to read back data written by `writeDataPoint()`.
+
+## Open Questions
+
+1. **FORMAT mapping** — DuckDB's output formats may not exactly match ClickHouse's `FORMAT JSON|JSONEachRow|TabSeparated`. Need to verify and map where necessary.
+2. **Response envelope** — Does the production JSON response include metadata (schema, rows_read, etc.) beyond the query results? If so, do we need to match it?
+3. **chsql coverage** — The extension implements 100+ functions but may not cover every WAE-supported function. Need to audit the WAE function list against chsql's implementations.
+4. **SHOW TABLES** — Production supports `SHOW TABLES` to list datasets. Locally we'd list CSV files in the persist directory. Can be detected as a special case before parsing.
+5. **Binding naming** — Is the SQL query binding a separate binding from the write binding (`AnalyticsEngineDataset`), or combined? Production has them separate (write via worker binding, read via HTTP API), so separate bindings makes sense.
+6. **DuckDB lifecycle** — Should we keep a single DuckDB instance alive for the duration of `wrangler dev`, or create one per query? A persistent instance avoids re-loading chsql on every query.
+
+## Sources
+
+- [WAE SQL Reference](https://developers.cloudflare.com/analytics/analytics-engine/sql-reference/)
+- [WAE SQL Statements](https://developers.cloudflare.com/analytics/analytics-engine/sql-reference/statements/)
+- [DuckDB Node.js API](https://duckdb.org/docs/api/nodejs/overview)
+- [DuckDB read_csv](https://duckdb.org/docs/data/csv/overview)
+- [chsql DuckDB Extension](https://github.com/Query-farm/clickhouse-sql)
+- [chsql on DuckDB Community Extensions](https://duckdb.org/community_extensions/extensions/chsql)
+- [node-sql-parser GitHub](https://github.com/taozhi8833998/node-sql-parser)
+- [@clickhouse/client-web](https://github.com/ClickHouse/clickhouse-js)

--- a/packages/miniflare/src/workers/analytics-engine/write-spec.md
+++ b/packages/miniflare/src/workers/analytics-engine/write-spec.md
@@ -1,0 +1,232 @@
+# Analytics Engine Local Dev — Writes Spec
+
+## Goal
+
+Make `writeDataPoint()` actually persist data locally during development, instead of being a no-op. The storage format should be as close to the production ClickHouse schema as possible, so that future read support (SQL queries) can work against the same data.
+
+## Architecture
+
+The core constraint is that the wrapped binding worker (`analytics-engine.worker.ts`) runs inside **workerd** — a sandboxed runtime with no filesystem or Node.js access. To persist data, we bridge back to Node.js using a **service binding backed by a Node.js function**, the same pattern used by Miniflare's `serviceBindings` feature (see the `mini-kv` example in the Miniflare README).
+
+### Components
+
+```
+User Worker
+  │
+  │  env.MY_DATASET.writeDataPoint({ ... })
+  ▼
+┌─────────────────────────────────────────────┐
+│  Wrapped Binding Worker  (workerd)          │
+│  analytics-engine.worker.ts                 │
+│                                             │
+│  - Receives writeDataPoint() call           │
+│  - Serializes the data point to JSON        │
+│  - Sends it via fetch() to the service      │
+│    binding: env.persistence                 │
+└──────────────┬──────────────────────────────┘
+               │  fetch("http://placeholder/", {
+               │    method: "POST",
+               │    body: JSON.stringify(dataPoint)
+               │  })
+               ▼
+┌─────────────────────────────────────────────┐
+│  Node.js Service Function                   │
+│  (runs in Miniflare host process)           │
+│                                             │
+│  - Full Node.js access (fs, modules, etc.)  │
+│  - Receives the serialized data point       │
+│  - Appends a row to a CSV file on disk      │
+│  - Returns 200 OK                           │
+└─────────────────────────────────────────────┘
+```
+
+### Part 1: Wrapped Binding Worker (`analytics-engine.worker.ts`)
+
+**Runs in:** workerd (sandboxed)
+
+**Role:** Receives `writeDataPoint()` calls from the user's worker and forwards them to the Node.js side.
+
+**What changes:**
+
+- The `Env` interface gains a `persistence` service binding (a `Fetcher`)
+- `writeDataPoint()` stops being a no-op — it serializes the data point and POSTs it to `env.persistence`
+- The worker adds `dataset` (from its existing `env.dataset` binding) and `timestamp` (generated at call time) before sending
+
+**Why this part exists:** The wrapped binding is the interface that workerd presents to the user's code as `AnalyticsEngineDataset`. It must implement `writeDataPoint()` and is the only place where that method is called. But it cannot persist data itself — it has no disk access.
+
+### Part 2: Plugin (`plugins/analytics-engine/index.ts`)
+
+**Runs in:** Node.js (Miniflare host)
+
+**Role:** Wires everything together — creates the service, registers the service binding as an inner binding on the wrapped binding, and defines the Node.js function that handles persistence.
+
+**What changes:**
+
+- `getBindings()` adds a new `innerBinding` to the wrapped binding: a service binding named `persistence` pointing to a dedicated analytics engine service
+- `getServices()` (currently returns `[]`) returns a service for each dataset, backed by a Node.js function that handles the CSV write
+- The persist path is resolved using the existing `analyticsEngineDatasetsPersist` shared option, following Miniflare conventions (defaults to `.wrangler/state/v3/analytics-engine/`)
+
+**Why this part exists:** The plugin is the glue layer. It knows about the user's config (which datasets exist, where to persist), and it's responsible for creating the workerd service graph. It's the only place that can define a Node.js-backed service and inject it as a binding into the wrapped worker.
+
+### Part 3: Node.js Persistence Function
+
+**Runs in:** Node.js (Miniflare host)
+
+**Role:** Receives serialized data points via fetch and appends them to CSV files on disk.
+
+**What it does:**
+
+1. Receives a POST request with a JSON body containing the data point
+2. Maps the fields to the CSV column schema (see below)
+3. Creates the CSV file with a header row if it doesn't exist
+4. Appends one row per `writeDataPoint()` call
+5. Returns `200 OK`
+
+**Why this part exists:** This is where the actual I/O happens. It runs in Node.js so it has full access to `fs`, and in the future could use `chdb-node` or any other Node.js library for ClickHouse-compatible storage/querying.
+
+## Data Schema
+
+Each row mirrors the production ClickHouse table:
+
+| Column                 | Type   | Source                                                |
+| ---------------------- | ------ | ----------------------------------------------------- |
+| `dataset`              | string | From the binding config (inner binding `env.dataset`) |
+| `timestamp`            | string | ISO 8601, generated at write time                     |
+| `index1`               | string | `indexes[0]`                                          |
+| `blob1` – `blob20`     | string | `blobs[0..19]`, ArrayBuffer values hex-encoded        |
+| `double1` – `double20` | number | `doubles[0..19]`                                      |
+| `_sample_interval`     | number | Always `1` in local dev (no sampling)                 |
+
+## Storage Format: CSV
+
+**File location:**
+
+```
+<persist-path>/analytics-engine/<dataset-name>.csv
+```
+
+**Why CSV:**
+
+- Analytics Engine is **append-only** — no updates, no deletes. CSV append (`fs.appendFileSync`) is a natural fit.
+- **Zero dependencies** — no SQLite, no extra runtime, just `node:fs`.
+- **Human-inspectable** — developers can `cat`, `tail -f`, or open the file to see what their worker is writing.
+- **Future-compatible** — `chdb-node` can query CSV files directly with ClickHouse SQL (`SELECT * FROM file('path.csv', CSV)`), so when we add read support we don't need to migrate data or change the write format.
+
+**Format rules:**
+
+- Header row written on file creation
+- One row per `writeDataPoint()` call
+- Columns in fixed order: `dataset`, `timestamp`, `index1`, `blob1`–`blob20`, `double1`–`double20`, `_sample_interval`
+- Empty/unset fields: empty string for blobs, empty for doubles
+- Standard CSV escaping (quote fields containing commas, quotes, or newlines)
+
+## Field Mapping
+
+```ts
+interface AnalyticsEngineDataPoint {
+	indexes?: string[]; // indexes[0] → index1
+	blobs?: (string | ArrayBuffer | null)[]; // blobs[0..19] → blob1..blob20
+	doubles?: number[]; // doubles[0..19] → double1..double20
+}
+```
+
+- `indexes[0]` → `index1` (only one index exists in production)
+- `blobs[0..19]` → `blob1..blob20` (ArrayBuffer → hex string)
+- `doubles[0..19]` → `double1..double20`
+- `_sample_interval` → hardcoded `1` (no sampling in local dev)
+- `timestamp` → `new Date().toISOString()` at write time
+- `dataset` → from the binding's inner env
+
+## Write Buffering
+
+Writes are **buffered in memory** and flushed to CSV on a 30-second interval, matching the eventual consistency behavior of production Analytics Engine where data takes ~30-60 seconds to appear in SQL queries.
+
+**Why buffer:**
+
+- **Dev/prod parity** — if writes are instant locally, developers write code that queries immediately after writing. This works in dev but breaks in production. The buffer surfaces this timing issue early.
+- **Matches production mental model** — Analytics Engine is not a real-time database. The delay reminds developers to design for eventual consistency.
+
+**Flush behavior:**
+
+- Data points accumulate in an in-memory array per dataset
+- Every 30 seconds, the buffer is flushed: all buffered rows are appended to the CSV file in one batch
+- On `wrangler dev` shutdown, any remaining buffered data is flushed before exit
+- The flush interval (30s) is chosen to be noticeable but not painful for local dev
+
+**Testing escape hatch:**
+
+- Expose `POST /cdn-cgi/analytics-engine/flush` to force an immediate flush — useful for tests that need to write-then-read without waiting
+- This endpoint is local-dev only, not a production API
+
+## Persistence Behavior
+
+- Data **persists across restarts** — consistent with KV, D1, R2, and other local bindings
+- No file rotation or size limits for now — local dev datasets are small
+- Writes are serialized through the flush interval, so no concurrent append issues
+
+## Testing
+
+Following the repo's established testing tiers:
+
+### Tier 1: Miniflare Plugin Unit Tests
+
+**Location:** `packages/miniflare/test/plugins/analytics-engine/index.spec.ts`
+
+Uses the `miniflareTest()` helper to spin up a real Miniflare instance with analytics engine configured. Tests exercise the full write path (workerd → service binding → Node.js → CSV).
+
+**Test cases:**
+
+- **Basic write** — `writeDataPoint()` with blobs, doubles, and indexes creates a CSV row with correct values
+- **Empty fields** — `writeDataPoint({})` with no data writes a row with empty fields
+- **Partial fields** — Only blobs, only doubles, only indexes — each maps correctly
+- **ArrayBuffer blobs** — Binary data is hex-encoded in the CSV
+- **Null blobs** — Null entries in the blobs array are written as empty strings
+- **Field limits** — 20 blobs and 20 doubles max; extra values are ignored (matching production)
+- **Multiple writes** — Sequential `writeDataPoint()` calls append rows to the same file
+- **Multiple datasets** — Different dataset bindings write to separate CSV files
+- **Persistence across restarts** — Data survives Miniflare `setOptions()` (reconfiguration)
+- **CSV header** — First write creates the header row; subsequent writes do not duplicate it
+- **CSV escaping** — Blob values containing commas, quotes, and newlines are properly escaped
+- **Timestamp** — Each row has a valid ISO 8601 timestamp
+- **`_sample_interval`** — Always `1`
+- **`dataset` column** — Matches the configured dataset name
+
+**Verification approach:** After writing, call `POST /cdn-cgi/analytics-engine/flush` to force a flush, then read the CSV file directly from the persist directory using `node:fs` and assert on the contents. This follows the same pattern as KV/Cache tests that inspect persisted state via `MiniflareDurableObjectControlStub.sqlQuery()`.
+
+```ts
+const opts: Partial<MiniflareOptions> = {
+	analyticsEngineDatasets: {
+		ANALYTICS: { dataset: "my_dataset" },
+	},
+};
+const ctx = miniflareTest(opts, async (global, env) => {
+	env.ANALYTICS.writeDataPoint({
+		blobs: ["Seattle", "USA"],
+		doubles: [25, 0.5],
+		indexes: ["a3cd45"],
+	});
+	return new global.Response("ok");
+});
+
+test("writeDataPoint persists to CSV", async () => {
+	await ctx.mf.dispatchFetch("http://localhost/");
+	// Read CSV from persist directory and verify contents
+});
+```
+
+### Tier 2: Wrangler E2E Tests
+
+**Location:** `packages/wrangler/e2e/dev.test.ts`
+
+An E2E test already exists (lines 1098-1190) that verifies `writeDataPoint` doesn't crash. Extend it to verify data is actually persisted:
+
+- Seed a worker that calls `writeDataPoint()` on fetch
+- Run `wrangler dev`, hit the endpoint
+- Verify the CSV file exists in `.wrangler/state/v3/analytics-engine/`
+- Verify the CSV contains the expected data
+
+### Tier 3: Vite Plugin Playground
+
+**Location:** `packages/vite-plugin-cloudflare/playground/bindings/`
+
+The existing playground already has a `WAE` binding configured. Update the test to verify writes persist (currently only tests that `writeDataPoint` doesn't throw).

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -415,6 +415,13 @@ export default <ExportedHandler<Env>>{
 					return await env[CoreBindings.SERVICE_LOCAL_EXPLORER].fetch(request);
 				}
 			}
+			if (url.pathname === "/cdn-cgi/analytics-engine/flush") {
+				return env[CoreBindings.SERVICE_LOOPBACK].fetch(
+					"http://localhost/analytics-engine/flush",
+					{ method: "POST" }
+				);
+			}
+
 			if (env[CoreBindings.TRIGGER_HANDLERS]) {
 				if (
 					url.pathname === "/cdn-cgi/handler/scheduled" ||

--- a/packages/miniflare/test/plugins/analytics-engine/index.spec.ts
+++ b/packages/miniflare/test/plugins/analytics-engine/index.spec.ts
@@ -1,0 +1,567 @@
+import fs from "node:fs";
+import path from "node:path";
+import { Miniflare } from "miniflare";
+import { test } from "vitest";
+import { useDispose, useTmp } from "../../test-shared";
+
+function makeWorkerScript() {
+	return `
+		export default {
+			async fetch(request, env) {
+				const url = new URL(request.url);
+				if (url.pathname === "/write") {
+					const body = await request.json();
+					if (body.ANALYTICS) {
+						env.ANALYTICS.writeDataPoint(body.ANALYTICS);
+					}
+					return new Response("ok");
+				}
+				return new Response("not found", { status: 404 });
+			},
+		}
+	`;
+}
+
+// Small delay to allow fire-and-forget fetch from wrapped binding to complete
+async function settle() {
+	await new Promise((r) => setTimeout(r, 100));
+}
+
+async function writeAndFlush(
+	mf: Miniflare,
+	body: Record<string, unknown>
+): Promise<void> {
+	const res = await mf.dispatchFetch("http://localhost/write", {
+		method: "POST",
+		body: JSON.stringify(body),
+	});
+	await res.text(); // consume body
+	await settle();
+}
+
+async function flush(mf: Miniflare): Promise<void> {
+	const res = await mf.dispatchFetch(
+		"http://localhost/cdn-cgi/analytics-engine/flush",
+		{ method: "POST" }
+	);
+	await res.text(); // consume body
+}
+
+function readCSV(
+	persistPath: string,
+	dataset: string
+): { header: string[]; rows: string[][] } {
+	const csvPath = path.join(persistPath, `${dataset}.csv`);
+	const content = fs.readFileSync(csvPath, "utf-8");
+	const lines = content.trim().split("\n");
+	const header = parseCSVLine(lines[0]);
+	const rows = lines.slice(1).map(parseCSVLine);
+	return { header, rows };
+}
+
+// Simple CSV parser that handles quoted fields with commas, quotes, and newlines
+function parseCSVLine(line: string): string[] {
+	const fields: string[] = [];
+	let current = "";
+	let inQuotes = false;
+	let i = 0;
+
+	while (i < line.length) {
+		if (inQuotes) {
+			if (line[i] === '"') {
+				if (i + 1 < line.length && line[i + 1] === '"') {
+					current += '"';
+					i += 2;
+				} else {
+					inQuotes = false;
+					i++;
+				}
+			} else {
+				current += line[i];
+				i++;
+			}
+		} else {
+			if (line[i] === '"') {
+				inQuotes = true;
+				i++;
+			} else if (line[i] === ",") {
+				fields.push(current);
+				current = "";
+				i++;
+			} else {
+				current += line[i];
+				i++;
+			}
+		}
+	}
+	fields.push(current);
+	return fields;
+}
+
+test("basic write — blobs, doubles, indexes map to correct CSV columns", async ({
+	expect,
+}) => {
+	const tmp = await useTmp();
+	const persistPath = path.join(tmp, "persist");
+	const mf = new Miniflare({
+		analyticsEngineDatasets: {
+			ANALYTICS: { dataset: "my_dataset" },
+		},
+		analyticsEngineDatasetsPersist: persistPath,
+		modules: true,
+		script: makeWorkerScript(),
+	});
+	useDispose(mf);
+
+	await writeAndFlush(mf, {
+		ANALYTICS: {
+			blobs: ["Seattle", "USA"],
+			doubles: [25, 0.5],
+			indexes: ["a3cd45"],
+		},
+	});
+	await flush(mf);
+
+	const { header, rows } = readCSV(persistPath, "my_dataset");
+
+	expect(header[0]).toBe("dataset");
+	expect(header[1]).toBe("timestamp");
+	expect(header[2]).toBe("index1");
+	expect(header[3]).toBe("blob1");
+	expect(header[22]).toBe("blob20");
+	expect(header[23]).toBe("double1");
+	expect(header[42]).toBe("double20");
+	expect(header[43]).toBe("_sample_interval");
+
+	expect(rows).toHaveLength(1);
+	const row = rows[0];
+	expect(row[0]).toBe("my_dataset"); // dataset
+	expect(row[2]).toBe("a3cd45"); // index1
+	expect(row[3]).toBe("Seattle"); // blob1
+	expect(row[4]).toBe("USA"); // blob2
+	expect(row[23]).toBe("25"); // double1
+	expect(row[24]).toBe("0.5"); // double2
+});
+
+test("empty write — writeDataPoint({}) writes a row with empty fields", async ({
+	expect,
+}) => {
+	const tmp = await useTmp();
+	const persistPath = path.join(tmp, "persist");
+	const mf = new Miniflare({
+		analyticsEngineDatasets: {
+			ANALYTICS: { dataset: "empty_test" },
+		},
+		analyticsEngineDatasetsPersist: persistPath,
+		modules: true,
+		script: makeWorkerScript(),
+	});
+	useDispose(mf);
+
+	await writeAndFlush(mf, { ANALYTICS: {} });
+	await flush(mf);
+
+	const { rows } = readCSV(persistPath, "empty_test");
+	expect(rows).toHaveLength(1);
+	const row = rows[0];
+	expect(row[0]).toBe("empty_test");
+	expect(row[2]).toBe(""); // index1 empty
+	for (let i = 3; i <= 22; i++) {
+		expect(row[i]).toBe("");
+	}
+	for (let i = 23; i <= 42; i++) {
+		expect(row[i]).toBe("0");
+	}
+});
+
+test("partial fields — only blobs", async ({ expect }) => {
+	const tmp = await useTmp();
+	const persistPath = path.join(tmp, "persist");
+	const mf = new Miniflare({
+		analyticsEngineDatasets: {
+			ANALYTICS: { dataset: "partial_blobs" },
+		},
+		analyticsEngineDatasetsPersist: persistPath,
+		modules: true,
+		script: makeWorkerScript(),
+	});
+	useDispose(mf);
+
+	await writeAndFlush(mf, { ANALYTICS: { blobs: ["hello"] } });
+	await flush(mf);
+
+	const { rows } = readCSV(persistPath, "partial_blobs");
+	expect(rows).toHaveLength(1);
+	expect(rows[0][3]).toBe("hello"); // blob1
+	expect(rows[0][4]).toBe(""); // blob2 empty
+	expect(rows[0][2]).toBe(""); // index1 empty
+	expect(rows[0][23]).toBe("0"); // double1 is 0
+});
+
+test("partial fields — only doubles", async ({ expect }) => {
+	const tmp = await useTmp();
+	const persistPath = path.join(tmp, "persist");
+	const mf = new Miniflare({
+		analyticsEngineDatasets: {
+			ANALYTICS: { dataset: "partial_doubles" },
+		},
+		analyticsEngineDatasetsPersist: persistPath,
+		modules: true,
+		script: makeWorkerScript(),
+	});
+	useDispose(mf);
+
+	await writeAndFlush(mf, { ANALYTICS: { doubles: [42, 3.14] } });
+	await flush(mf);
+
+	const { rows } = readCSV(persistPath, "partial_doubles");
+	expect(rows).toHaveLength(1);
+	expect(rows[0][23]).toBe("42"); // double1
+	expect(rows[0][24]).toBe("3.14"); // double2
+	expect(rows[0][3]).toBe(""); // blob1 empty
+});
+
+test("partial fields — only indexes", async ({ expect }) => {
+	const tmp = await useTmp();
+	const persistPath = path.join(tmp, "persist");
+	const mf = new Miniflare({
+		analyticsEngineDatasets: {
+			ANALYTICS: { dataset: "partial_indexes" },
+		},
+		analyticsEngineDatasetsPersist: persistPath,
+		modules: true,
+		script: makeWorkerScript(),
+	});
+	useDispose(mf);
+
+	await writeAndFlush(mf, { ANALYTICS: { indexes: ["myindex"] } });
+	await flush(mf);
+
+	const { rows } = readCSV(persistPath, "partial_indexes");
+	expect(rows).toHaveLength(1);
+	expect(rows[0][2]).toBe("myindex"); // index1
+	expect(rows[0][3]).toBe(""); // blob1 empty
+	expect(rows[0][23]).toBe("0"); // double1 is 0
+});
+
+test("null blobs — null entries become empty strings", async ({ expect }) => {
+	const tmp = await useTmp();
+	const persistPath = path.join(tmp, "persist");
+	const mf = new Miniflare({
+		analyticsEngineDatasets: {
+			ANALYTICS: { dataset: "null_blobs" },
+		},
+		analyticsEngineDatasetsPersist: persistPath,
+		modules: true,
+		script: makeWorkerScript(),
+	});
+	useDispose(mf);
+
+	await writeAndFlush(mf, {
+		ANALYTICS: { blobs: ["first", null, "third"] },
+	});
+	await flush(mf);
+
+	const { rows } = readCSV(persistPath, "null_blobs");
+	expect(rows).toHaveLength(1);
+	expect(rows[0][3]).toBe("first"); // blob1
+	expect(rows[0][4]).toBe(""); // blob2 (null)
+	expect(rows[0][5]).toBe("third"); // blob3
+});
+
+test("field limits — >20 blobs/doubles truncated to 20", async ({ expect }) => {
+	const tmp = await useTmp();
+	const persistPath = path.join(tmp, "persist");
+	const mf = new Miniflare({
+		analyticsEngineDatasets: {
+			ANALYTICS: { dataset: "limits_test" },
+		},
+		analyticsEngineDatasetsPersist: persistPath,
+		modules: true,
+		script: makeWorkerScript(),
+	});
+	useDispose(mf);
+
+	const blobs = Array.from({ length: 25 }, (_, i) => `blob_${i}`);
+	const doubles = Array.from({ length: 25 }, (_, i) => i * 10);
+
+	await writeAndFlush(mf, { ANALYTICS: { blobs, doubles } });
+	await flush(mf);
+
+	const { rows } = readCSV(persistPath, "limits_test");
+	expect(rows).toHaveLength(1);
+	expect(rows[0][22]).toBe("blob_19"); // blob20
+	expect(rows[0][42]).toBe("190"); // double20
+	// Total fields: dataset + timestamp + index1 + 20 blobs + 20 doubles + _sample_interval = 44
+	expect(rows[0]).toHaveLength(44);
+});
+
+test("multiple writes — two calls produce two CSV rows", async ({ expect }) => {
+	const tmp = await useTmp();
+	const persistPath = path.join(tmp, "persist");
+	const mf = new Miniflare({
+		analyticsEngineDatasets: {
+			ANALYTICS: { dataset: "multi_write" },
+		},
+		analyticsEngineDatasetsPersist: persistPath,
+		modules: true,
+		script: makeWorkerScript(),
+	});
+	useDispose(mf);
+
+	await writeAndFlush(mf, { ANALYTICS: { blobs: ["first"] } });
+	await writeAndFlush(mf, { ANALYTICS: { blobs: ["second"] } });
+	await flush(mf);
+
+	const { rows } = readCSV(persistPath, "multi_write");
+	expect(rows).toHaveLength(2);
+	expect(rows[0][3]).toBe("first");
+	expect(rows[1][3]).toBe("second");
+});
+
+test("multiple datasets — separate bindings write to separate files", async ({
+	expect,
+}) => {
+	const tmp = await useTmp();
+	const persistPath = path.join(tmp, "persist");
+	const mf = new Miniflare({
+		analyticsEngineDatasets: {
+			DATASET_A: { dataset: "dataset_a" },
+			DATASET_B: { dataset: "dataset_b" },
+		},
+		analyticsEngineDatasetsPersist: persistPath,
+		modules: true,
+		script: `
+			export default {
+				async fetch(request, env) {
+					const body = await request.json();
+					if (body.DATASET_A) env.DATASET_A.writeDataPoint(body.DATASET_A);
+					if (body.DATASET_B) env.DATASET_B.writeDataPoint(body.DATASET_B);
+					return new Response("ok");
+				},
+			}
+		`,
+	});
+	useDispose(mf);
+
+	const res = await mf.dispatchFetch("http://localhost/write", {
+		method: "POST",
+		body: JSON.stringify({
+			DATASET_A: { blobs: ["from_a"] },
+			DATASET_B: { blobs: ["from_b"] },
+		}),
+	});
+	await res.text();
+	await settle();
+	await flush(mf);
+
+	const resultA = readCSV(persistPath, "dataset_a");
+	const resultB = readCSV(persistPath, "dataset_b");
+
+	expect(resultA.rows).toHaveLength(1);
+	expect(resultA.rows[0][0]).toBe("dataset_a");
+	expect(resultA.rows[0][3]).toBe("from_a");
+
+	expect(resultB.rows).toHaveLength(1);
+	expect(resultB.rows[0][0]).toBe("dataset_b");
+	expect(resultB.rows[0][3]).toBe("from_b");
+});
+
+test("CSV header — written once, not duplicated on subsequent writes", async ({
+	expect,
+}) => {
+	const tmp = await useTmp();
+	const persistPath = path.join(tmp, "persist");
+	const mf = new Miniflare({
+		analyticsEngineDatasets: {
+			ANALYTICS: { dataset: "header_test" },
+		},
+		analyticsEngineDatasetsPersist: persistPath,
+		modules: true,
+		script: makeWorkerScript(),
+	});
+	useDispose(mf);
+
+	// First write + flush
+	await writeAndFlush(mf, { ANALYTICS: { blobs: ["first"] } });
+	await flush(mf);
+
+	// Second write + flush
+	await writeAndFlush(mf, { ANALYTICS: { blobs: ["second"] } });
+	await flush(mf);
+
+	const csvPath = path.join(persistPath, "header_test.csv");
+	const content = fs.readFileSync(csvPath, "utf-8");
+	const lines = content.trim().split("\n");
+
+	// Should have 1 header + 2 data rows = 3 lines
+	expect(lines).toHaveLength(3);
+	expect(lines[0]).toContain("dataset");
+	expect(lines[1]).toMatch(/^header_test,/);
+	expect(lines[2]).toMatch(/^header_test,/);
+});
+
+test("CSV escaping — commas, quotes, newlines in blob values", async ({
+	expect,
+}) => {
+	const tmp = await useTmp();
+	const persistPath = path.join(tmp, "persist");
+	const mf = new Miniflare({
+		analyticsEngineDatasets: {
+			ANALYTICS: { dataset: "escape_test" },
+		},
+		analyticsEngineDatasetsPersist: persistPath,
+		modules: true,
+		script: makeWorkerScript(),
+	});
+	useDispose(mf);
+
+	await writeAndFlush(mf, {
+		ANALYTICS: {
+			blobs: ["hello, world", 'say "hi"', "line1\nline2"],
+		},
+	});
+	await flush(mf);
+
+	const csvPath = path.join(persistPath, "escape_test.csv");
+	const content = fs.readFileSync(csvPath, "utf-8");
+
+	expect(content).toContain('"hello, world"');
+	expect(content).toContain('"say ""hi"""');
+	expect(content).toContain('"line1\nline2"');
+});
+
+test("timestamp present and valid ISO 8601", async ({ expect }) => {
+	const tmp = await useTmp();
+	const persistPath = path.join(tmp, "persist");
+	const mf = new Miniflare({
+		analyticsEngineDatasets: {
+			ANALYTICS: { dataset: "timestamp_test" },
+		},
+		analyticsEngineDatasetsPersist: persistPath,
+		modules: true,
+		script: makeWorkerScript(),
+	});
+	useDispose(mf);
+
+	const before = new Date();
+	await writeAndFlush(mf, { ANALYTICS: { blobs: ["test"] } });
+	const after = new Date();
+	await flush(mf);
+
+	const { rows } = readCSV(persistPath, "timestamp_test");
+	expect(rows).toHaveLength(1);
+
+	const timestamp = new Date(rows[0][1]);
+	expect(timestamp.getTime()).not.toBeNaN();
+	expect(timestamp.getTime()).toBeGreaterThanOrEqual(before.getTime() - 1000);
+	expect(timestamp.getTime()).toBeLessThanOrEqual(after.getTime() + 1000);
+});
+
+test("_sample_interval always 1", async ({ expect }) => {
+	const tmp = await useTmp();
+	const persistPath = path.join(tmp, "persist");
+	const mf = new Miniflare({
+		analyticsEngineDatasets: {
+			ANALYTICS: { dataset: "interval_test" },
+		},
+		analyticsEngineDatasetsPersist: persistPath,
+		modules: true,
+		script: makeWorkerScript(),
+	});
+	useDispose(mf);
+
+	await writeAndFlush(mf, { ANALYTICS: { blobs: ["test"] } });
+	await flush(mf);
+
+	const { rows } = readCSV(persistPath, "interval_test");
+	expect(rows).toHaveLength(1);
+	expect(rows[0][43]).toBe("1");
+});
+
+test("dataset column matches config", async ({ expect }) => {
+	const tmp = await useTmp();
+	const persistPath = path.join(tmp, "persist");
+	const mf = new Miniflare({
+		analyticsEngineDatasets: {
+			ANALYTICS: { dataset: "my_custom_dataset" },
+		},
+		analyticsEngineDatasetsPersist: persistPath,
+		modules: true,
+		script: makeWorkerScript(),
+	});
+	useDispose(mf);
+
+	await writeAndFlush(mf, { ANALYTICS: { blobs: ["test"] } });
+	await flush(mf);
+
+	const { rows } = readCSV(persistPath, "my_custom_dataset");
+	expect(rows).toHaveLength(1);
+	expect(rows[0][0]).toBe("my_custom_dataset");
+});
+
+test("persistence across restarts — data survives dispose + recreate", async ({
+	expect,
+}) => {
+	const tmp = await useTmp();
+	const persistPath = path.join(tmp, "persist");
+	const opts = {
+		analyticsEngineDatasets: {
+			ANALYTICS: { dataset: "persist_test" },
+		},
+		analyticsEngineDatasetsPersist: persistPath,
+		modules: true,
+		script: makeWorkerScript(),
+	} as const;
+
+	// First instance — write and flush
+	const mf1 = new Miniflare(opts);
+	await writeAndFlush(mf1, { ANALYTICS: { blobs: ["before_restart"] } });
+	await flush(mf1);
+	await mf1.dispose();
+
+	// Second instance — write more data
+	const mf2 = new Miniflare(opts);
+	useDispose(mf2);
+	await writeAndFlush(mf2, { ANALYTICS: { blobs: ["after_restart"] } });
+	await flush(mf2);
+
+	const { rows } = readCSV(persistPath, "persist_test");
+	expect(rows).toHaveLength(2);
+	expect(rows[0][3]).toBe("before_restart");
+	expect(rows[1][3]).toBe("after_restart");
+});
+
+test("buffering — writes don't appear in CSV until flush", async ({
+	expect,
+}) => {
+	const tmp = await useTmp();
+	const persistPath = path.join(tmp, "persist");
+	const mf = new Miniflare({
+		analyticsEngineDatasets: {
+			ANALYTICS: { dataset: "buffer_test" },
+		},
+		analyticsEngineDatasetsPersist: persistPath,
+		modules: true,
+		script: makeWorkerScript(),
+	});
+	useDispose(mf);
+
+	const res = await mf.dispatchFetch("http://localhost/write", {
+		method: "POST",
+		body: JSON.stringify({ ANALYTICS: { blobs: ["buffered"] } }),
+	});
+	await res.text();
+	await settle();
+
+	// Before flush, CSV should not exist
+	const csvPath = path.join(persistPath, "buffer_test.csv");
+	expect(fs.existsSync(csvPath)).toBe(false);
+
+	// After flush, CSV should exist with the data
+	await flush(mf);
+	expect(fs.existsSync(csvPath)).toBe(true);
+	const { rows } = readCSV(persistPath, "buffer_test");
+	expect(rows).toHaveLength(1);
+	expect(rows[0][3]).toBe("buffered");
+});


### PR DESCRIPTION
Add local persistence for writeDataPoint() so analytics engine data is stored to CSV files during local development instead of being a no-op.

Data flows from the wrapped binding worker through a loopback service to Node.js where it's buffered and flushed to CSV files on a 30s interval to simulate production. A /cdn-cgi/analytics-engine/flush endpoint enables immediate flushing for tests.

Fixes #[insert GH or internal issue link(s)].

_Describe your change..._

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
