### PR TITLE
Update outdated code comment mentioning `findUpSync`

### DIFF
--- a/packages/wrangler/src/__tests__/config-cache.test.ts
+++ b/packages/wrangler/src/__tests__/config-cache.test.ts
@@ -70,12 +70,12 @@ describe("config cache", () => {
 			expect,
 		}) => {
 			// Don't create node_modules - this forces .wrangler/cache
-			// Note: findUpSync may find a parent node_modules, but we're testing
-			// the case where there's no existing cache in any found node_modules
+			// Note: wrangler, when looking up the filesystem, may find a parent node_modules,
+			// but we're testing the case where there's no existing cache in any found node_modules
 			const cacheFolder = getCacheFolder();
 			// In a clean temp directory with no node_modules, should use .wrangler/cache
-			// However, findUpSync may find a parent node_modules, so we just verify
-			// that getCacheFolder returns a valid path
+			// However, wrangler, when looking up the filesystem, may find a parent node_modules,
+			// so we just verify that getCacheFolder returns a valid path
 			expect(cacheFolder).toBeTruthy();
 			expect(typeof cacheFolder).toBe("string");
 		});


### PR DESCRIPTION
In https://github.com/cloudflare/workers-sdk/pull/12601 we're removed the use of `findUpSync`, but the function is still mentioned in 2 code comments, this PR is updating these to be generic instead.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: just a code comment fix
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: just a code comment fix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
