### PR TITLE
Fix docs: Update wrangler version warning message

### DIFF
--- a/packages/wrangler/README.md
+++ b/packages/wrangler/README.md
@@ -10,7 +10,7 @@
 
 > [!WARNING]
 >
-> Wrangler v2 is **only receiving critical security updates.** We recommend you [migrate to Wrangler v3](https://developers.cloudflare.com/workers/wrangler/migration/update-v2-to-v3/) if you can.
+> Wrangler v3 is **only receiving critical security updates.** We recommend you update to the latest version of wrangler (wrangler@latest).
 
 ## Quick Start
 


### PR DESCRIPTION
Fixes #12721. Updates the README warning message to recommend wrangler@latest instead of migrating to v3.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
