### PR TITLE
Use dedicated CODEOWNERS_GITHUB_PAT secret for codeowners workflow

### DIFF
--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -34,12 +34,12 @@ jobs:
       - name: "Fetch PR Head (for diff computation)"
         run: git fetch origin +refs/pull/${{ github.event.pull_request.number }}/head
         env:
-          GITHUB_TOKEN: "${{ secrets.READ_ONLY_ORG_GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.CODEOWNERS_GITHUB_PAT }}"
 
       - name: "Codeowners Plus"
         uses: multimediallc/codeowners-plus@ff02aa993a92e8efe01642916d0877beb9439e9f # v1.9.0
         with:
-          github-token: "${{ secrets.READ_ONLY_ORG_GITHUB_TOKEN }}"
+          github-token: "${{ secrets.CODEOWNERS_GITHUB_PAT }}"
           pr: "${{ github.event.pull_request.number }}"
           verbose: true
           quiet: ${{ github.event.pull_request.draft }}


### PR DESCRIPTION
Updates the codeowners GitHub Actions workflow to use the new `CODEOWNERS_GITHUB_PAT` secret instead of `READ_ONLY_ORG_GITHUB_TOKEN`, which has the correct permissions for resolving org team memberships.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this is a secret rename in a workflow file
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: no user-facing change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
