### PR TITLE
Fix SolidStart autoconfig for projects using version 2.0.0-alpha or later

### DIFF
--- a/.changeset/dry-shoes-cheat.md
+++ b/.changeset/dry-shoes-cheat.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix SolidStart autoconfig for projects using version 2.0.0-alpha or later
+
+SolidStart v2.0.0-alpha introduced a breaking change where configuration moved from `app.config.(js|ts)` to `vite.config.(js|ts)`. Wrangler's autoconfig now detects the installed SolidStart version and based on it updates the appropriate configuration file

--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -813,8 +813,6 @@ function getExperimentalFrameworkTestConfig(
 		},
 		{
 			name: "solid",
-			// quarantined: SolidStart moved from app.config to vite.config with Nitro plugin
-			quarantine: true,
 			promptHandlers: [
 				{
 					matcher: /Which template would you like to use/,

--- a/packages/wrangler/src/autoconfig/frameworks/solid-start.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/solid-start.ts
@@ -1,9 +1,12 @@
+import assert from "node:assert";
 import { updateStatus } from "@cloudflare/cli";
 import { blue } from "@cloudflare/cli/colors";
 import { getLocalWorkerdCompatibilityDate } from "@cloudflare/workers-utils";
 import * as recast from "recast";
+import semiver from "semiver";
 import { mergeObjectProperties, transformFile } from "../c3-vendor/codemod";
 import { usesTypescript } from "../uses-typescript";
+import { getInstalledPackageVersion } from "./utils/packages";
 import { Framework } from ".";
 import type { ConfigurationOptions, ConfigurationResults } from ".";
 
@@ -13,45 +16,13 @@ export class SolidStart extends Framework {
 		dryRun,
 	}: ConfigurationOptions): Promise<ConfigurationResults> {
 		if (!dryRun) {
-			const filePath = `app.config.${usesTypescript(projectPath) ? "ts" : "js"}`;
+			const solidStartVersion = getSolidStartVersion(projectPath);
 
-			const { date: compatDate } = getLocalWorkerdCompatibilityDate({
-				projectPath,
-			});
-
-			updateStatus(`Updating configuration in ${blue(filePath)}`);
-
-			transformFile(filePath, {
-				visitCallExpression: function (n) {
-					const callee = n.node.callee as recast.types.namedTypes.Identifier;
-					if (callee.name !== "defineConfig") {
-						return this.traverse(n);
-					}
-
-					const b = recast.types.builders;
-					mergeObjectProperties(
-						n.node.arguments[0] as recast.types.namedTypes.ObjectExpression,
-						[
-							b.objectProperty(
-								b.identifier("server"),
-								b.objectExpression([
-									// preset: "cloudflare_module"
-									b.objectProperty(
-										b.identifier("preset"),
-										b.stringLiteral("cloudflare_module")
-									),
-									b.objectProperty(
-										b.identifier("compatibilityDate"),
-										b.stringLiteral(compatDate)
-									),
-								])
-							),
-						]
-					);
-
-					return false;
-				},
-			});
+			if (semiver(solidStartVersion, "2.0.0-alpha") < 0) {
+				updateAppConfigFile(projectPath);
+			} else {
+				updateViteConfigFile(projectPath);
+			}
 		}
 
 		return {
@@ -64,4 +35,114 @@ export class SolidStart extends Framework {
 			},
 		};
 	}
+}
+
+/**
+ * This functions updates the `vite.config.(js|ts)` files used by SolidStart applications
+ * to use the `cloudflare-module` preset to target Cloudflare Workers.
+ *
+ * Note: SolidStart projects prior to version `2.0.0-alpha` used to have an `app.config.(js|ts)` file instead
+ *
+ * @param projectPath The path of the project
+ */
+function updateViteConfigFile(projectPath: string): void {
+	const filePath = `vite.config.${usesTypescript(projectPath) ? "ts" : "js"}`;
+
+	transformFile(filePath, {
+		visitCallExpression: function (n) {
+			const callee = n.node.callee as recast.types.namedTypes.Identifier;
+			if (callee.name !== "nitro") {
+				return this.traverse(n);
+			}
+
+			const b = recast.types.builders;
+			const presetProp = b.objectProperty(
+				b.identifier("preset"),
+				b.stringLiteral("cloudflare-module")
+			);
+
+			if (n.node.arguments.length === 0) {
+				n.node.arguments.push(b.objectExpression([presetProp]));
+			} else {
+				mergeObjectProperties(
+					n.node.arguments[0] as recast.types.namedTypes.ObjectExpression,
+					[presetProp]
+				);
+			}
+
+			return false;
+		},
+	});
+}
+
+/**
+ * SolidStart apps used to have an `app.config.(js|ts)` before version `2.0.0-alpha`
+ * (afterwards this has been replaced by `vite.config.(js|ts)`).
+ * Reference: https://github.com/solidjs/templates/commit/c4cd73e08bdc
+ *
+ * This functions updates the `app.config.(js|ts)` to use the `cloudflare_module` preset
+ * to target Cloudflare Workers.
+ *
+ * @param projectPath The path of the project
+ */
+function updateAppConfigFile(projectPath: string): void {
+	const filePath = `app.config.${usesTypescript(projectPath) ? "ts" : "js"}`;
+
+	const { date: compatDate } = getLocalWorkerdCompatibilityDate({
+		projectPath,
+	});
+
+	updateStatus(`Updating configuration in ${blue(filePath)}`);
+
+	transformFile(filePath, {
+		visitCallExpression: function (n) {
+			const callee = n.node.callee as recast.types.namedTypes.Identifier;
+			if (callee.name !== "defineConfig") {
+				return this.traverse(n);
+			}
+
+			const b = recast.types.builders;
+			mergeObjectProperties(
+				n.node.arguments[0] as recast.types.namedTypes.ObjectExpression,
+				[
+					b.objectProperty(
+						b.identifier("server"),
+						b.objectExpression([
+							// preset: "cloudflare_module"
+							b.objectProperty(
+								b.identifier("preset"),
+								b.stringLiteral("cloudflare_module")
+							),
+							b.objectProperty(
+								b.identifier("compatibilityDate"),
+								b.stringLiteral(compatDate)
+							),
+						])
+					),
+				]
+			);
+
+			return false;
+		},
+	});
+}
+
+/**
+ * Gets the installed version of the "@solidjs/start" package
+ *
+ * @param projectPath The path of the project
+ */
+function getSolidStartVersion(projectPath: string): string {
+	const packageName = "@solidjs/start";
+	const solidStartVersion = getInstalledPackageVersion(
+		packageName,
+		projectPath
+	);
+
+	assert(
+		solidStartVersion,
+		`Unable to discern the version of the \`${packageName}\` package`
+	);
+
+	return solidStartVersion;
 }


### PR DESCRIPTION
SolidStart v2.0.0-alpha introduced a breaking change where configuration moved from `app.config.(js|ts)` to `vite.config.(js|ts)`. This PR updates Wrangler's autoconfig to instead detect the installed SolidStart version and based on it update the appropriate configuration file

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: fixing a broken/expected behavior

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
