### PR TITLE
fix(vite-plugin-cloudflare): add hot channel api for ssrLoadModule compatibility

### DIFF
--- a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
+++ b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert";
+import { EventEmitter } from "node:events";
 import { nonPrefixedNodeModules } from "@cloudflare/unenv-preset";
 import { CoreHeaders } from "miniflare";
 import * as vite from "vite";
@@ -35,6 +36,8 @@ function createHotChannel(
 	webSocketContainer: WebSocketContainer
 ): vite.HotChannel {
 	const listenersMap = new Map<string, Set<vite.HotChannelListener>>();
+	const innerEmitter = new EventEmitter();
+	const outsideEmitter = new EventEmitter();
 
 	const client: vite.HotChannelClient = {
 		send(payload) {
@@ -60,6 +63,7 @@ function createHotChannel(
 			assert(webSocket, webSocketUndefinedError);
 
 			webSocket.send(JSON.stringify(payload));
+			outsideEmitter.emit("send", payload);
 		},
 		on(event: string, listener: vite.HotChannelListener) {
 			const listeners = listenersMap.get(event) ?? new Set();
@@ -75,12 +79,19 @@ function createHotChannel(
 			assert(webSocket, webSocketUndefinedError);
 
 			webSocket.addEventListener("message", onMessage);
+			innerEmitter.emit("connection");
 		},
 		close() {
 			const webSocket = webSocketContainer.webSocket;
 			assert(webSocket, webSocketUndefinedError);
 
 			webSocket.removeEventListener("message", onMessage);
+			innerEmitter.removeAllListeners();
+			outsideEmitter.removeAllListeners();
+		},
+		api: {
+			innerEmitter,
+			outsideEmitter,
 		},
 	};
 }


### PR DESCRIPTION
## Summary

`CloudflareDevEnvironment`'s hot channel is missing the `api` property (`innerEmitter` / `outsideEmitter`), which causes `server.ssrLoadModule()` to crash when called by other Vite plugins on a dev server where `@cloudflare/vite-plugin` is active:

```
TypeError: Cannot read properties of undefined (reading 'outsideEmitter')
    at Object.connect (createServerModuleRunnerTransport)
    at new SSRCompatModuleRunner
    at ssrLoadModule
```

### Root cause

`ssrLoadModule()` creates an `SSRCompatModuleRunner` whose transport accesses `environment.hot.api.outsideEmitter`. Vite's built-in `createServerHotChannel()` (used by `RunnableDevEnvironment`) provides this `api` property, but `CloudflareDevEnvironment`'s `createHotChannel()` does not.

The `HotChannel` interface defines `api` as optional (`api?: Api`), but `createServerModuleRunnerTransport` unconditionally accesses it.

### Fix

Add `api: { innerEmitter, outsideEmitter }` to `createHotChannel()`, matching what `createServerHotChannel()` provides. This makes `CloudflareDevEnvironment` compatible with `ssrLoadModule()` without changing its existing WebSocket-based module execution.

### Use case

Framework plugins that perform SSG/prerendering call `server.ssrLoadModule()` during build to execute exports from page files (e.g. collecting prerender paths for static site generation). When `@cloudflare/vite-plugin` is present in the user's config, this crashes because the SSR environment is a `CloudflareDevEnvironment` with an incomplete hot channel.

### Related

- vitejs/vite#21726 — original issue report
- vitejs/vite#21739 — Vite PR to improve the error message (confirms `ssrLoadModule` requires a runnable environment, but the hot channel `api` gap is on the plugin side)