### PR TITLE
Remove workers-utils from changeset

### DIFF
--- a/.changeset/empty-radios-happen.md
+++ b/.changeset/empty-radios-happen.md
@@ -1,12 +1,10 @@
 ---
 "@cloudflare/vite-plugin": minor
 "@cloudflare/containers-shared": minor
-"@cloudflare/workers-utils": minor
 "miniflare": minor
 "wrangler": minor
 ---
 
 Add experimental support for containers to workers communication with interceptOutboundHttp
 
-This feature is experimental and requires adding the "experimental"
-compatibility flag to your Wrangler configuration.
+This feature is experimental and requires adding the "experimental" compatibility flag to your Wrangler configuration.


### PR DESCRIPTION
Remove workers-utils from changeset as it is no longer published.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: changeset change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: changeset change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
