### PR TITLE
Add option to disable smart dismissal of reviews

### DIFF
--- a/codeowners.toml
+++ b/codeowners.toml
@@ -8,6 +8,9 @@ ignore = [".changeset", "fixtures"]
 # Show detailed file-to-owner mapping in PR comments
 detailed_reviewers = true
 
+# Don't dismiss stale reviews when new changes are pushed
+disable_smart_dismissal = true
+
 # Suppress warnings for intentionally unowned files (e.g. pnpm-lock.yaml)
 suppress_unowned_warning = true
 


### PR DESCRIPTION
We have not been getting Github to dismiss reviews on new changes, so no reason to start now with codeowners-plus.

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: CI change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: CI change

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
