### PR TITLE
Skip codeowners-plus checks for Version Packages PRs

### DIFF
--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -27,16 +27,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Base Branch"
+        if: github.event.pull_request.head.ref != 'changeset-release/main'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: "Fetch PR Head (for diff computation)"
+        if: github.event.pull_request.head.ref != 'changeset-release/main'
         run: git fetch origin +refs/pull/${{ github.event.pull_request.number }}/head
         env:
           GITHUB_TOKEN: "${{ secrets.CODEOWNERS_GITHUB_PAT }}"
 
       - name: "Codeowners Plus"
+        if: github.event.pull_request.head.ref != 'changeset-release/main'
         uses: multimediallc/codeowners-plus@ff02aa993a92e8efe01642916d0877beb9439e9f # v1.9.0
         with:
           github-token: "${{ secrets.CODEOWNERS_GITHUB_PAT }}"


### PR DESCRIPTION
Skip codeowners-plus checks for Version Packages PRs.

The Version Packages PR (`changeset-release/main`) gets updated on every merge to `main`, causing codeowners-plus to re-run, fail the status check, and generate noisy PR comments and notifications. These PRs only need a wrangler team member approval and are already protected by native GitHub CODEOWNERS.

This adds `if` conditions to each step in the codeowners workflow so that the job still runs and reports a **passing** status check for Version Packages PRs, but skips the checkout, diff fetch, and codeowners-plus evaluation entirely.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: CI workflow change — will be validated when the next Version Packages PR is created
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal CI workflow change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
