### PR TITLE
Make worker deletion in e2e less flaky

### DIFF
--- a/packages/wrangler/e2e/deployments.test.ts
+++ b/packages/wrangler/e2e/deployments.test.ts
@@ -266,8 +266,13 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("Workers + Assets deployment", () => {
 
 	describe("Workers", () => {
 		afterEach(async () => {
-			// clean up user Worker after each test
-			await helper.run(`wrangler delete`);
+			// clean up user Worker after each test (best-effort, don't fail if slow)
+			// afterEach timing out (10s) will cause the test to fail
+			// these are cleaned up anyway in e2eCleanup.ts
+			await Promise.race([
+				helper.run(`wrangler delete`),
+				new Promise((resolve) => setTimeout(resolve, 9_000)),
+			]);
 		});
 
 		it("deploys a Workers + Assets project with assets only", async () => {
@@ -582,11 +587,18 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("Workers + Assets deployment", () => {
 		});
 
 		afterEach(async () => {
-			// clean up dispatch Worker
-			await helper.run(`wrangler delete -c dispatch-worker/wrangler.toml`);
-			await helper.run(
-				`wrangler dispatch-namespace delete ${dispatchNamespaceName}`
-			);
+			// clean up dispatch Worker (best-effort, don't fail if slow)
+			// afterEach timing out (10s) will cause the test to fail
+			// these are cleaned up anyway in e2eCleanup.ts
+			await Promise.race([
+				(async () => {
+					await helper.run(`wrangler delete -c dispatch-worker/wrangler.toml`);
+					await helper.run(
+						`wrangler dispatch-namespace delete ${dispatchNamespaceName}`
+					);
+				})(),
+				new Promise((resolve) => setTimeout(resolve, 9_000)),
+			]);
 		});
 
 		it("deploys a Workers + Assets project with assets only", async () => {


### PR DESCRIPTION
I think the e2e test flakes are due to the delete worker hooks timing out.

```
Error: Hook timed out in 10000ms.
  wrangler:test:e2e: If this is a long-running hook, pass a timeout value as the last argument or configure it globally with "hookTimeout".
  wrangler:test:e2e:  ❯ e2e/deployments.test.ts:270:3
  wrangler:test:e2e:     268| 
  wrangler:test:e2e:     269|  describe("Workers", () => {
  wrangler:test:e2e:     270|   afterEach(async () => {
  wrangler:test:e2e:        |   ^
  wrangler:test:e2e:     271|    // clean up user Worker after each test
  wrangler:test:e2e:     272|    await helper.run(`wrangler delete`);
```

We clean up these workers in a nightly job anyway, so lets give it 9s, (afterEach times out in 10), and then just carrying on.


But the actual root issue has been fixed so we could close this too :)


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: test change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
