### PR TITLE
[workers-shared] fix: Normalize backslash characters in /cdn-cgi paths

### DIFF
--- a/.changeset/short-sloths-bake.md
+++ b/.changeset/short-sloths-bake.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+fix: Normalize backslash characters in `/cdn-cgi` paths
+
+Requests containing backslash characters in `/cdn-cgi` paths are now redirected to their normalized equivalents with forward slashes. This ensures consistent URL handling across different browsers and HTTP clients.

--- a/packages/workers-shared/router-worker/src/analytics.ts
+++ b/packages/workers-shared/router-worker/src/analytics.ts
@@ -55,6 +55,8 @@ type Data = {
 	abuseMitigationURLHost?: string;
 	// blob7 - XSS detection href parameter value
 	xssDetectionImageHref?: string;
+	// blob8 - cdn-cgi backslash bypass attempt URL
+	cdnCgiBackslashBypassUrl?: string;
 };
 
 export class Analytics {
@@ -110,6 +112,7 @@ export class Analytics {
 				this.data.coloRegion, // blob5
 				this.data.abuseMitigationURLHost, // blob6
 				this.data.xssDetectionImageHref, // blob7
+				this.data.cdnCgiBackslashBypassUrl?.substring(0, 256), // blob8 - trim to 256 bytes
 			],
 		});
 	}

--- a/packages/workers-shared/router-worker/src/worker.ts
+++ b/packages/workers-shared/router-worker/src/worker.ts
@@ -1,5 +1,6 @@
 import { generateStaticRoutingRuleMatcher } from "../../asset-worker/src/utils/rules-engine";
 import { PerformanceTimer } from "../../utils/performance";
+import { TemporaryRedirectResponse } from "../../utils/responses";
 import { setupSentry } from "../../utils/sentry";
 import { mockJaegerBinding } from "../../utils/tracing";
 import { Analytics, DISPATCH_TYPE, STATIC_ROUTING_DECISION } from "./analytics";
@@ -80,6 +81,19 @@ export default {
 					version: env.VERSION_METADATA.tag,
 					userWorkerAhead: config.invoke_user_worker_ahead_of_assets,
 				});
+			}
+
+			// Handle /cdn-cgi\... backslash bypass attempts
+			// - in production if pathname starts with `/cdn-cgi/` then it bypassed the external
+			//   routing and so must have actually started with `/cdn-cgi\`.
+			// - in local dev it is possible for pathname to start with `/cdn-cgi/`
+			//   even if it doesn't start with `/cdn-cgi\` so we also check the raw URL for that.
+			if (
+				url.pathname.startsWith("/cdn-cgi/") &&
+				request.url.includes("/cdn-cgi\\")
+			) {
+				analytics.setData({ cdnCgiBackslashBypassUrl: request.url });
+				return new TemporaryRedirectResponse(url.href);
 			}
 
 			const routeToUserWorker = async ({

--- a/packages/workers-shared/router-worker/tests/index.test.ts
+++ b/packages/workers-shared/router-worker/tests/index.test.ts
@@ -509,6 +509,323 @@ describe("unit tests", async () => {
 		);
 	});
 
+	describe(
+		String.raw`Handling /cdn-cgi\ backslash bypass with redirect`,
+		() => {
+			const backslashBypassCases = [
+				{
+					description: String.raw`/cdn-cgi\image bypass`,
+					rawUrl: String.raw`https://example.com/cdn-cgi\image/q=75/https://evil.com/ssrf`,
+					expectedLocation:
+						"https://example.com/cdn-cgi/image/q=75/https://evil.com/ssrf",
+				},
+				{
+					description: String.raw`/cdn-cgi\_next_cache bypass`,
+					rawUrl: String.raw`https://example.com/cdn-cgi\_next_cache/some-data`,
+					expectedLocation: "https://example.com/cdn-cgi/_next_cache/some-data",
+				},
+				{
+					description: String.raw`/cdn-cgi\ bypass with arbitrary subpath`,
+					rawUrl: String.raw`https://example.com/cdn-cgi\something-else/path`,
+					expectedLocation: "https://example.com/cdn-cgi/something-else/path",
+				},
+				{
+					description: String.raw`/cdn-cgi\ bypass with query params`,
+					rawUrl: String.raw`https://example.com/cdn-cgi\something-else/path?value=/cdn-cgi/param=foo`,
+					expectedLocation:
+						"https://example.com/cdn-cgi/something-else/path?value=/cdn-cgi/param=foo",
+				},
+			];
+
+			it.for(backslashBypassCases)(
+				"redirects $description to normalized URL when invoke_user_worker_ahead_of_assets is true",
+				async ({ rawUrl, expectedLocation }, { expect }) => {
+					const request = new Request(rawUrl);
+					// In production, raw backslashes in URLs are preserved in request.url by the
+					// Workers runtime. The Request constructor normalizes backslashes to forward
+					// slashes, so we use Object.defineProperty to simulate production behavior.
+					Object.defineProperty(request, "url", {
+						value: rawUrl,
+						configurable: true,
+					});
+
+					const env = {
+						CONFIG: {
+							has_user_worker: true,
+							invoke_user_worker_ahead_of_assets: true,
+						},
+						USER_WORKER: {
+							async fetch(_: Request): Promise<Response> {
+								return new Response(
+									"should not reach user worker as it should be redirected by the router worker"
+								);
+							},
+						},
+					} as Env;
+					const ctx = createExecutionContext();
+
+					const response = await worker.fetch(request, env, ctx);
+					expect(response.status).toBe(307);
+					expect(response.headers.get("Location")).toBe(expectedLocation);
+				}
+			);
+
+			it.for(backslashBypassCases)(
+				"redirects $description to normalized URL when invoke_user_worker_ahead_of_assets is false and no asset matches",
+				async ({ rawUrl, expectedLocation }, { expect }) => {
+					const request = new Request(rawUrl);
+					Object.defineProperty(request, "url", {
+						value: rawUrl,
+						configurable: true,
+					});
+
+					const env = {
+						CONFIG: {
+							has_user_worker: true,
+							invoke_user_worker_ahead_of_assets: false,
+						},
+						USER_WORKER: {
+							async fetch(_: Request): Promise<Response> {
+								return new Response(
+									"should not reach user worker as it should be redirected by the router worker"
+								);
+							},
+						},
+						ASSET_WORKER: {
+							async fetch(_: Request): Promise<Response> {
+								return new Response(
+									"should not reach asset worker as it should be redirected by the router worker"
+								);
+							},
+							async unstable_canFetch(_: Request): Promise<boolean> {
+								return false;
+							},
+						},
+					} as Env;
+					const ctx = createExecutionContext();
+
+					const response = await worker.fetch(request, env, ctx);
+					expect(response.status).toBe(307);
+					expect(response.headers.get("Location")).toBe(expectedLocation);
+				}
+			);
+
+			it.for(backslashBypassCases)(
+				"redirects $description to normalized URL when invoke_user_worker_ahead_of_assets is false even if asset exists",
+				async ({ rawUrl, expectedLocation }, { expect }) => {
+					const request = new Request(rawUrl);
+					Object.defineProperty(request, "url", {
+						value: rawUrl,
+						configurable: true,
+					});
+
+					const env = {
+						CONFIG: {
+							has_user_worker: true,
+							invoke_user_worker_ahead_of_assets: false,
+						},
+						USER_WORKER: {
+							async fetch(_: Request): Promise<Response> {
+								return new Response(
+									"should not reach user worker as it should be redirected by the router worker"
+								);
+							},
+						},
+						ASSET_WORKER: {
+							async fetch(_: Request): Promise<Response> {
+								return new Response(
+									"should not reach asset worker as it should be redirected by the router worker"
+								);
+							},
+							async unstable_canFetch(_: Request): Promise<boolean> {
+								return true;
+							},
+						},
+					} as Env;
+					const ctx = createExecutionContext();
+
+					const response = await worker.fetch(request, env, ctx);
+					expect(response.status).toBe(307);
+					expect(response.headers.get("Location")).toBe(expectedLocation);
+				}
+			);
+
+			const nonInterferenceCases = [
+				{
+					description:
+						"does not interfere with legitimate /cdn-cgi/ forward-slash requests",
+					url: "https://example.com/cdn-cgi/image/q=75/https://other.com/image.jpg",
+					userWorkerResponse: {
+						body: "image data",
+						headers: { "content-type": "image/jpeg" },
+						status: 200,
+					},
+					expectedStatus: 200,
+					expectedBody: "image data",
+				},
+				{
+					description:
+						"does not interfere with escaped backslashes /cdn-cgi%5C requests",
+					url: "https://example.com/cdn-cgi%5Cimage/q=75/https://other.com/image.jpg",
+					userWorkerResponse: {
+						body: "image data",
+						headers: { "content-type": "image/jpeg" },
+						status: 200,
+					},
+					expectedStatus: 200,
+					expectedBody: "image data",
+				},
+				{
+					description:
+						"does not interfere with escaped forward slashes /cdn-cgi%2F requests",
+					url: "https://example.com/cdn-cgi%2Fimage/q=75/https://other.com/image.jpg",
+					userWorkerResponse: {
+						body: "image data",
+						headers: { "content-type": "image/jpeg" },
+						status: 200,
+					},
+					expectedStatus: 200,
+					expectedBody: "image data",
+				},
+				{
+					description: "does not interfere with non-cdn-cgi requests",
+					url: "https://example.com/some-page",
+					userWorkerResponse: {
+						body: "page content",
+						headers: { "content-type": "text/html" },
+						status: 200,
+					},
+					expectedStatus: 200,
+					expectedBody: "page content",
+				},
+				{
+					description: String.raw`does not interfere with non-cdn-cgi requests with /cdn-cgi\ in query`,
+					url: String.raw`https://example.com/some-page?redirect=/cdn-cgi\image`,
+					userWorkerResponse: {
+						body: "page content",
+						headers: { "content-type": "text/html" },
+						status: 200,
+					},
+					expectedStatus: 200,
+					expectedBody: "page content",
+				},
+			];
+
+			it.for(nonInterferenceCases)(
+				"$description when invoke_user_worker_ahead_of_assets is true",
+				async (
+					{ url, userWorkerResponse, expectedStatus, expectedBody },
+					{ expect }
+				) => {
+					const request = new Request(url);
+					const env = {
+						CONFIG: {
+							has_user_worker: true,
+							invoke_user_worker_ahead_of_assets: true,
+						},
+						USER_WORKER: {
+							async fetch(userWorkerRequest: Request): Promise<Response> {
+								const response = new Response(userWorkerResponse.body, {
+									status: userWorkerResponse.status,
+									headers: userWorkerResponse.headers,
+								});
+								Object.defineProperty(response, "url", {
+									value: userWorkerRequest.url,
+									configurable: true,
+								});
+								return response;
+							},
+						},
+					} as Env;
+					const ctx = createExecutionContext();
+
+					const response = await worker.fetch(request, env, ctx);
+					expect(response.url).toBe(url);
+					expect(response.status).toBe(expectedStatus);
+					expect(await response.text()).toBe(expectedBody);
+				}
+			);
+
+			it.for(nonInterferenceCases)(
+				"$description when invoke_user_worker_ahead_of_assets is false and no asset matches",
+				async (
+					{ url, userWorkerResponse, expectedStatus, expectedBody },
+					{ expect }
+				) => {
+					const request = new Request(url);
+					const env = {
+						CONFIG: {
+							has_user_worker: true,
+							invoke_user_worker_ahead_of_assets: false,
+						},
+						USER_WORKER: {
+							async fetch(userWorkerRequest: Request): Promise<Response> {
+								const response = new Response(userWorkerResponse.body, {
+									status: userWorkerResponse.status,
+									headers: userWorkerResponse.headers,
+								});
+								Object.defineProperty(response, "url", {
+									value: userWorkerRequest.url,
+									configurable: true,
+								});
+								return response;
+							},
+						},
+						ASSET_WORKER: {
+							async fetch(_: Request): Promise<Response> {
+								return new Response(
+									"should not reach asset worker as asset does not exist"
+								);
+							},
+							async unstable_canFetch(_: Request): Promise<boolean> {
+								return false;
+							},
+						},
+					} as Env;
+					const ctx = createExecutionContext();
+
+					const response = await worker.fetch(request, env, ctx);
+					expect(response.url).toBe(url);
+					expect(response.status).toBe(expectedStatus);
+					expect(await response.text()).toBe(expectedBody);
+				}
+			);
+
+			it.for(nonInterferenceCases)(
+				"$description when invoke_user_worker_ahead_of_assets is false even if asset exists",
+				async ({ url }, { expect }) => {
+					const request = new Request(url);
+					const env = {
+						CONFIG: {
+							has_user_worker: true,
+							invoke_user_worker_ahead_of_assets: false,
+						},
+						USER_WORKER: {
+							async fetch(_: Request): Promise<Response> {
+								return new Response(
+									"should not reach user worker as it should be handled by asset worker"
+								);
+							},
+						},
+						ASSET_WORKER: {
+							async fetch(_: Request): Promise<Response> {
+								return new Response("hello from asset worker");
+							},
+							async unstable_canFetch(_: Request): Promise<boolean> {
+								return true;
+							},
+						},
+					} as Env;
+					const ctx = createExecutionContext();
+
+					const response = await worker.fetch(request, env, ctx);
+					expect(response.status).toBe(200);
+					expect(await response.text()).toBe("hello from asset worker");
+				}
+			);
+		}
+	);
+
 	describe("free tier limiting", () => {
 		it("returns fetch from asset worker for assets", async ({ expect }) => {
 			const request = new Request("https://example.com/asset");


### PR DESCRIPTION
Redirect requests containing backslash characters in /cdn-cgi paths to their normalized equivalents. Some browsers and HTTP clients treat backslashes as path separators inconsistently, which could lead to unexpected routing behavior.

This change normalizes the URL and issues a 307 redirect to ensure consistent handling across all clients.

Fixes #WC-4546

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: N/A

*A picture of a cute animal (not mandatory, but encouraged)*
<img width="435" height="304" alt="image" src="https://github.com/user-attachments/assets/ef23e4ad-51ef-4920-bcaf-bf2d09246780" />


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
