### PR TITLE
Fix duplicate Code Owners checks on PRs

### DIFF
--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -1,6 +1,8 @@
 name: "Code Owners"
 
-# Re-evaluate when PRs are opened/updated, and when reviews are submitted/dismissed.
+# Re-evaluate when PRs are opened/updated.
+# When reviews are submitted/dismissed, the separate rerun_codeowners.yml workflow
+# re-runs this check (rather than creating a second check context).
 # Using pull_request_target (not pull_request) so the workflow has access to secrets
 # for fork PRs. This is safe because:
 #   - The checkout is the BASE branch (ownership rules come from the protected branch)
@@ -9,8 +11,6 @@ name: "Code Owners"
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
-  pull_request_review:
-    types: [submitted, dismissed]
 
 concurrency:
   group: codeowners-${{ github.event.pull_request.number }}

--- a/.github/workflows/rerun_codeowners.yml
+++ b/.github/workflows/rerun_codeowners.yml
@@ -1,0 +1,40 @@
+name: "Rerun Code Owners"
+
+# When a review is submitted or dismissed, re-run the Code Owners check from the
+# main codeowners.yml workflow (triggered by pull_request_target) rather than
+# running the check again under a separate event context. This avoids duplicate
+# "Code Owners" checks appearing on the PR.
+on:
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions: {}
+
+jobs:
+  rerun-codeowners:
+    name: "Rerun Codeowners Plus"
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      checks: read
+    steps:
+      - name: "Re-run Codeowners Check"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Find the "Run Codeowners Plus" check run for the PR head commit
+          # and extract the Actions job ID from its details URL.
+          # Using the commit SHA (not branch name) so this works for fork PRs
+          # where the branch name doesn't exist in the base repository.
+          job_id=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?check_name=Run+Codeowners+Plus" \
+            --jq '(.check_runs[0].details_url // "") | split("/") | last | split("?") | first' || true)
+
+          if [ -n "$job_id" ]; then
+            gh api "repos/${REPO}/actions/jobs/${job_id}/rerun" --method POST \
+              || echo "Job may already be running"
+            echo "Re-triggered 'Run Codeowners Plus' (job ${job_id})"
+          else
+            echo "Check 'Run Codeowners Plus' not found for SHA ${HEAD_SHA}"
+          fi


### PR DESCRIPTION
Fixes the issue where PRs show two separate "Code Owners" checks — one passing and one failing.

**Problem:** When `pull_request_target` and `pull_request_review` triggers are in the same workflow file, GitHub creates separate check contexts for each event type (`Code Owners on: pull_request_target` and `Code Owners on: pull_request_review`). This means:
1. PR opened → `pull_request_target` fires → codeowners-plus evaluates → fails (no approvals yet)
2. Review submitted → `pull_request_review` fires → codeowners-plus evaluates → passes
3. The stale `pull_request_target` check still shows as failed alongside the passing `pull_request_review` check

**Fix:** Split into two workflows, following the [pattern recommended by codeowners-plus](https://github.com/multimediallc/codeowners-plus#github-configuration):
- **`codeowners.yml`** — keeps only the `pull_request_target` trigger and runs the actual codeowners-plus evaluation (single check context)
- **`rerun_codeowners.yml`** (new) — triggered by `pull_request_review`, re-runs the existing check job via the GitHub API using `gh` CLI (no third-party action needed). This updates the original check rather than creating a second one.

Also skips codeowners-plus evaluation for Version Packages PRs (`changeset-release/main`) which only need wrangler team approval and are already protected by native GitHub CODEOWNERS. The job still runs and reports a passing status, but skips the checkout, diff fetch, and evaluation steps. (Supersedes #12749.)

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: CI workflow change — will be validated when the next review is submitted on a PR
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal CI workflow change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
