### PR TITLE
fix: add missing `await` in format-errors catch block

### DIFF
--- a/packages/format-errors/src/index.ts
+++ b/packages/format-errors/src/index.ts
@@ -167,7 +167,7 @@ export default {
 		}
 
 		try {
-			return handlePrettyErrorRequest(payload);
+			return await handlePrettyErrorRequest(payload);
 		} catch (e) {
 			sentry.captureException(e);
 			const errorCounter = registry.create(


### PR DESCRIPTION
## Summary

This PR adds the missing `await` keyword to the `handlePrettyErrorRequest` function call within the `catch` block in `packages/format-errors/src/index.ts`. This ensures that asynchronous errors are properly caught and handled, preventing unhandled promise rejections and ensuring correct error reporting.

Fixes cloudflare/workers-sdk#12755
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
