### PR TITLE
Add `populateProcessEnv` option to `getPlatformProxy` to populate `process.env` with text and JSON bindings

### DIFF
--- a/.changeset/get-platform-proxy-populate-process-env.md
+++ b/.changeset/get-platform-proxy-populate-process-env.md
@@ -1,0 +1,41 @@
+---
+"wrangler": minor
+---
+
+Add `populateProcessEnv` option to `getPlatformProxy` to populate `process.env` with text and JSON bindings
+
+The `getPlatformProxy` utility now supports an optional `populateProcessEnv` option that mirrors the workerd behavior of the `nodejs_compat_populate_process_env` compatibility flag.
+
+When enabled, `process.env` is side-effectfully updated with environment variables and secrets from your wrangler configuration and `.env` files. JSON values are stringified. The original `process.env` values are restored when `dispose()` is called.
+
+Behavior:
+
+- `populateProcessEnv: true` - Always populate `process.env`
+- `populateProcessEnv: false` - Never populate `process.env`
+- `populateProcessEnv: undefined` (default) - Follows the same rules as workerd:
+  - Enabled when `nodejs_compat` compatibility flag is set AND either:
+    - `compatibility_date` is `"2025-04-01"` or later, OR
+    - `nodejs_compat_populate_process_env` flag is explicitly set
+  - Disabled when `nodejs_compat_do_not_populate_process_env` flag is set
+
+Example:
+
+```typescript
+import { getPlatformProxy } from "wrangler";
+
+// Uses default behavior based on your wrangler.json compat settings
+const { env, dispose } = await getPlatformProxy();
+
+// process.env now contains your vars and secrets (if enabled)
+console.log(process.env.MY_VAR);
+
+// Cleanup restores original process.env
+await dispose();
+```
+
+```typescript
+// Explicitly enable regardless of compat settings
+const { env, dispose } = await getPlatformProxy({
+	populateProcessEnv: true,
+});
+```

--- a/fixtures/get-platform-proxy/tests/get-platform-proxy.process-env.test.ts
+++ b/fixtures/get-platform-proxy/tests/get-platform-proxy.process-env.test.ts
@@ -1,0 +1,239 @@
+import path from "node:path";
+import { beforeEach, describe, it, vi } from "vitest";
+import { getPlatformProxy } from "wrangler";
+
+const modernConfigPath = path.join(
+	__dirname,
+	"..",
+	"wrangler_process_env_modern.jsonc"
+);
+const oldConfigPath = path.join(
+	__dirname,
+	"..",
+	"wrangler_process_env_old.jsonc"
+);
+const oldWithFlagConfigPath = path.join(
+	__dirname,
+	"..",
+	"wrangler_process_env_old_with_flag.jsonc"
+);
+const modernDisabledConfigPath = path.join(
+	__dirname,
+	"..",
+	"wrangler_process_env_modern_disabled.jsonc"
+);
+
+describe("getPlatformProxy - process.env population", () => {
+	beforeEach(() => {
+		// Hide stdout messages from the test logs
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+	});
+
+	describe("explicit populateProcessEnv option", () => {
+		it("populates process.env when populateProcessEnv is true", async ({
+			expect,
+		}) => {
+			const originalMyVar = process.env.MY_VAR;
+			const originalMyJsonVar = process.env.MY_JSON_VAR;
+
+			// Use old config (which wouldn't auto-enable) but explicitly enable
+			const { dispose } = await getPlatformProxy({
+				configPath: oldConfigPath,
+				populateProcessEnv: true,
+				persist: false,
+			});
+
+			try {
+				expect(process.env.MY_VAR).toBe("my-var-value");
+				expect(process.env.MY_JSON_VAR).toBe(
+					JSON.stringify({ test: true, nested: { value: 123 } })
+				);
+			} finally {
+				await dispose();
+			}
+
+			expect(process.env.MY_VAR).toEqual(originalMyVar);
+			expect(process.env.MY_JSON_VAR).toEqual(originalMyJsonVar);
+		});
+
+		it("does NOT populate process.env when populateProcessEnv is false", async ({
+			expect,
+		}) => {
+			// Use modern config (which would auto-enable) but explicitly disable
+			const originalMyVar = process.env.MY_VAR;
+			const originalMyJsonVar = process.env.MY_JSON_VAR;
+
+			const { dispose } = await getPlatformProxy({
+				configPath: modernConfigPath,
+				populateProcessEnv: false,
+				persist: false,
+			});
+
+			try {
+				expect(process.env.MY_VAR).toEqual(originalMyVar);
+				expect(process.env.MY_JSON_VAR).toEqual(originalMyJsonVar);
+			} finally {
+				await dispose();
+			}
+		});
+	});
+
+	describe("default behavior based on compat date/flags", () => {
+		it("auto-enables for modern compat date (>= 2025-04-01) with nodejs_compat", async ({
+			expect,
+		}) => {
+			const originalMyVar = process.env.MY_VAR;
+			const originalMyJsonVar = process.env.MY_JSON_VAR;
+
+			const { dispose } = await getPlatformProxy({
+				configPath: modernConfigPath,
+				persist: false,
+			});
+
+			try {
+				expect(process.env.MY_VAR).toBe("my-var-value");
+				expect(process.env.MY_JSON_VAR).toBe(
+					JSON.stringify({ test: true, nested: { value: 123 } })
+				);
+			} finally {
+				await dispose();
+			}
+
+			expect(process.env.MY_VAR).toEqual(originalMyVar);
+			expect(process.env.MY_JSON_VAR).toEqual(originalMyJsonVar);
+		});
+
+		it("does NOT auto-enable for old compat date (< 2025-04-01)", async ({
+			expect,
+		}) => {
+			const originalMyVar = process.env.MY_VAR;
+			const originalMyJsonVar = process.env.MY_JSON_VAR;
+
+			const { dispose } = await getPlatformProxy({
+				configPath: oldConfigPath,
+				persist: false,
+			});
+
+			try {
+				expect(process.env.MY_VAR).toEqual(originalMyVar);
+				expect(process.env.MY_JSON_VAR).toEqual(originalMyJsonVar);
+			} finally {
+				await dispose();
+			}
+		});
+
+		it("auto-enables for old compat date with explicit nodejs_compat_populate_process_env flag", async ({
+			expect,
+		}) => {
+			const originalMyVar = process.env.MY_VAR;
+			const originalMyJsonVar = process.env.MY_JSON_VAR;
+
+			const { dispose } = await getPlatformProxy({
+				configPath: oldWithFlagConfigPath,
+				persist: false,
+			});
+
+			try {
+				expect(process.env.MY_VAR).toBe("my-var-value");
+				expect(process.env.MY_JSON_VAR).toBe(
+					JSON.stringify({ test: true, nested: { value: 123 } })
+				);
+			} finally {
+				await dispose();
+			}
+
+			expect(process.env.MY_VAR).toEqual(originalMyVar);
+			expect(process.env.MY_JSON_VAR).toEqual(originalMyJsonVar);
+		});
+
+		it("does NOT auto-enable for modern compat date with nodejs_compat_do_not_populate_process_env flag", async ({
+			expect,
+		}) => {
+			const originalMyVar = process.env.MY_VAR;
+			const originalMyJsonVar = process.env.MY_JSON_VAR;
+
+			const { dispose } = await getPlatformProxy({
+				configPath: modernDisabledConfigPath,
+				persist: false,
+			});
+
+			try {
+				expect(process.env.MY_VAR).toEqual(originalMyVar);
+				expect(process.env.MY_JSON_VAR).toEqual(originalMyJsonVar);
+			} finally {
+				await dispose();
+			}
+		});
+	});
+
+	describe("dispose() behavior", () => {
+		it("restores original process.env values on dispose", async ({
+			expect,
+		}) => {
+			process.env.MY_VAR = "original-value";
+			process.env.MY_JSON_VAR = "original-json";
+
+			const { dispose } = await getPlatformProxy({
+				configPath: modernConfigPath,
+				persist: false,
+			});
+
+			expect(process.env.MY_VAR).toBe("my-var-value");
+			expect(process.env.MY_JSON_VAR).toBe(
+				JSON.stringify({ test: true, nested: { value: 123 } })
+			);
+
+			await dispose();
+
+			expect(process.env.MY_VAR).toEqual("original-value");
+			expect(process.env.MY_JSON_VAR).toEqual("original-json");
+
+			delete process.env.MY_VAR;
+			delete process.env.MY_JSON_VAR;
+		});
+
+		it("deletes keys that did not exist before getPlatformProxy was called", async ({
+			expect,
+		}) => {
+			delete process.env.MY_VAR;
+			delete process.env.MY_JSON_VAR;
+
+			const { dispose } = await getPlatformProxy({
+				configPath: modernConfigPath,
+				persist: false,
+			});
+
+			expect(process.env.MY_VAR).toBe("my-var-value");
+			expect(process.env.MY_JSON_VAR).toBeDefined();
+
+			await dispose();
+
+			expect("MY_VAR" in process.env).toBe(false);
+			expect("MY_JSON_VAR" in process.env).toBe(false);
+		});
+	});
+
+	describe("JSON value handling", () => {
+		it("stringifies JSON values when adding to process.env", async ({
+			expect,
+		}) => {
+			const { dispose } = await getPlatformProxy({
+				configPath: modernConfigPath,
+				persist: false,
+			});
+
+			try {
+				const jsonValue = process.env.MY_JSON_VAR;
+				expect(typeof jsonValue).toBe("string");
+				expect(JSON.parse(jsonValue!)).toEqual({
+					test: true,
+					nested: { value: 123 },
+				});
+			} finally {
+				await dispose();
+			}
+		});
+	});
+});

--- a/fixtures/get-platform-proxy/wrangler_process_env_modern.jsonc
+++ b/fixtures/get-platform-proxy/wrangler_process_env_modern.jsonc
@@ -1,0 +1,15 @@
+{
+	// Modern compat date (>= 2025-04-01) with nodejs_compat
+	// This should auto-enable process.env population
+	"name": "get-platform-proxy-process-env-modern",
+	"main": "src/index.ts",
+	"compatibility_date": "2025-04-01",
+	"compatibility_flags": ["nodejs_compat"],
+	"vars": {
+		"MY_VAR": "my-var-value",
+		"MY_JSON_VAR": {
+			"test": true,
+			"nested": { "value": 123 },
+		},
+	},
+}

--- a/fixtures/get-platform-proxy/wrangler_process_env_modern_disabled.jsonc
+++ b/fixtures/get-platform-proxy/wrangler_process_env_modern_disabled.jsonc
@@ -1,0 +1,18 @@
+{
+	// Modern compat date but with explicit disable flag
+	// This should NOT auto-enable process.env population
+	"name": "get-platform-proxy-process-env-modern-disabled",
+	"main": "src/index.ts",
+	"compatibility_date": "2025-04-01",
+	"compatibility_flags": [
+		"nodejs_compat",
+		"nodejs_compat_do_not_populate_process_env",
+	],
+	"vars": {
+		"MY_VAR": "my-var-value",
+		"MY_JSON_VAR": {
+			"test": true,
+			"nested": { "value": 123 },
+		},
+	},
+}

--- a/fixtures/get-platform-proxy/wrangler_process_env_old.jsonc
+++ b/fixtures/get-platform-proxy/wrangler_process_env_old.jsonc
@@ -1,0 +1,15 @@
+{
+	// Old compat date (< 2025-04-01) with nodejs_compat
+	// This should NOT auto-enable process.env population
+	"name": "get-platform-proxy-process-env-old",
+	"main": "src/index.ts",
+	"compatibility_date": "2024-01-01",
+	"compatibility_flags": ["nodejs_compat"],
+	"vars": {
+		"MY_VAR": "my-var-value",
+		"MY_JSON_VAR": {
+			"test": true,
+			"nested": { "value": 123 },
+		},
+	},
+}

--- a/fixtures/get-platform-proxy/wrangler_process_env_old_with_flag.jsonc
+++ b/fixtures/get-platform-proxy/wrangler_process_env_old_with_flag.jsonc
@@ -1,0 +1,18 @@
+{
+	// Old compat date but with explicit nodejs_compat_populate_process_env flag
+	// This should auto-enable process.env population
+	"name": "get-platform-proxy-process-env-old-with-flag",
+	"main": "src/index.ts",
+	"compatibility_date": "2024-01-01",
+	"compatibility_flags": [
+		"nodejs_compat",
+		"nodejs_compat_populate_process_env",
+	],
+	"vars": {
+		"MY_VAR": "my-var-value",
+		"MY_JSON_VAR": {
+			"test": true,
+			"nested": { "value": 123 },
+		},
+	},
+}

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -18,6 +18,7 @@ import {
 	getImageNameFromDOClassName,
 } from "../../../dev/miniflare";
 import { logger } from "../../../logger";
+import { isProcessEnvPopulated } from "../../../process-env";
 import { getSiteAssetPaths } from "../../../sites";
 import { dedent } from "../../../utils/dedent";
 import { maybeStartOrUpdateRemoteProxySession } from "../../remoteBindings";
@@ -105,6 +106,27 @@ export type GetPlatformProxyOptions = {
 	 * Whether remote bindings should be enabled or not (defaults to `true`)
 	 */
 	remoteBindings?: boolean;
+	/**
+	 * When `true`, side-effectfully populates `process.env` with environment variable
+	 * and secret bindings from the wrangler configuration and .env files.
+	 *
+	 * This mirrors the behavior of workerd with the `nodejs_compat_populate_process_env`
+	 * compatibility flag.
+	 * See: https://developers.cloudflare.com/workers/configuration/compatibility-flags/#enable-auto-populating-processenv.
+	 *
+	 * When `undefined` (the default), the behavior is determined by the wrangler
+	 * configuration's `compatibility_date` and `compatibility_flags`:
+	 * - Enabled by default when `nodejs_compat` is set AND either:
+	 *   - `compatibility_date` is "2025-04-01" or later, OR
+	 *   - `nodejs_compat_populate_process_env` flag is explicitly set
+	 * - Disabled when `nodejs_compat_do_not_populate_process_env` flag is set
+	 *
+	 * When `false`, `process.env` will not be modified regardless of config settings.
+	 *
+	 * JSON values are stringified when added to `process.env`.
+	 * Original `process.env` values are restored when `dispose()` is called.
+	 */
+	populateProcessEnv?: boolean;
 };
 
 /**
@@ -181,12 +203,24 @@ export async function getPlatformProxy<
 	const cf = await mf.getCf();
 	deepFreeze(cf);
 
+	const shouldPopulateProcessEnv =
+		options.populateProcessEnv ??
+		isProcessEnvPopulated(
+			config.compatibility_date,
+			config.compatibility_flags
+		);
+
+	const restoreOriginalProcessEnv = !shouldPopulateProcessEnv
+		? () => {}
+		: populateProcessEnv(config, options);
+
 	return {
 		env: bindings,
 		cf: cf as CfProperties,
 		ctx: new ExecutionContext(),
 		caches: new CacheStorage(),
 		dispose: async () => {
+			restoreOriginalProcessEnv();
 			await remoteProxySession?.dispose();
 			await mf.dispose();
 		},
@@ -528,5 +562,68 @@ export function unstable_getMiniflareWorkerOptions(
 		define: config.define,
 		main: config.main,
 		externalWorkers,
+	};
+}
+
+/**
+ * Populates `process.env` with text, secret, and JSON bindings from the wrangler
+ * configuration and .env files. This mirrors the behavior of workerd with the
+ * `nodejs_compat_populate_process_env` compatibility flag.
+ *
+ * JSON binding values are stringified before being added to `process.env`.
+ *
+ * @param config The wrangler configuration object containing binding definitions
+ * @param options Options for getPlatformProxy, used to determine environment and env files
+ * @returns A cleanup function that restores `process.env` to its original state
+ */
+function populateProcessEnv(
+	config: Config,
+	options: GetPlatformProxyOptions
+): () => void {
+	const originalProcessEnvValues: Record<string, string | undefined> = {};
+
+	const rawBindings = getBindings(
+		config,
+		options.environment,
+		options.envFiles,
+		true,
+		{},
+		{}
+	);
+
+	for (const [key, binding] of Object.entries(rawBindings ?? {})) {
+		if (
+			binding &&
+			typeof binding === "object" &&
+			"type" in binding &&
+			"value" in binding
+		) {
+			const bindingType = binding.type;
+			if (
+				bindingType === "plain_text" ||
+				bindingType === "secret_text" ||
+				bindingType === "json"
+			) {
+				originalProcessEnvValues[key] = process.env[key];
+
+				if (bindingType === "json") {
+					process.env[key] = JSON.stringify(binding.value);
+				} else {
+					process.env[key] = binding.value as string;
+				}
+			}
+		}
+	}
+
+	return () => {
+		for (const [key, originalValue] of Object.entries(
+			originalProcessEnvValues
+		)) {
+			if (originalValue === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = originalValue;
+			}
+		}
 	};
 }


### PR DESCRIPTION
This PR augments `getPlatformProxy` to also populate `process.env` in the same way workerd does.

> [!WARNING]
> I am not completely sure if this is ok as on by default, or if maybe it should be opt-in 🤔 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/28789
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
