### PR TITLE
Add support for worker connect handler in miniflare

### DIFF
--- a/.changeset/ten-dancers-know.md
+++ b/.changeset/ten-dancers-know.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+Add support for worker connect handler in miniflare

--- a/packages/miniflare/src/shared/external-service.ts
+++ b/packages/miniflare/src/shared/external-service.ts
@@ -354,6 +354,7 @@ const PROXY_ENTRYPOINT_HEADER = "X-Miniflare-Proxy-Entrypoint";
 const CREATE_PROXY_PROTOTYPE_CLASS_HELPER_SCRIPT = `
     const HANDLER_RESERVED_KEYS = new Set([
         "alarm",
+        "connect",
         "scheduled",
         "self",
         "tail",


### PR DESCRIPTION
This is needed to add initial support for the connect handler in workerd (experimental-only for now).

Part of EW-9330. Updates miniflare so that the connect handler is marked as reserved. This is needed for https://github.com/cloudflare/workerd/pull/6059 to land, additional changes are included in #12802 which needs the workerd PR to be merged first. This PR should be sufficient for allowing the workerd PR to land: Reordering the steps in workerd CI [shows](https://github.com/cloudflare/workerd/actions/runs/22805783114/job/66155261833?pr=6059) that while miniflare tests are failing, vite and vitest tests are not so this one change should be sufficient to allow merging the workerd PR.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated: Intended to be tested with https://github.com/cloudflare/workerd/pull/6059
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Feature is behind experimental compat flag for now.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
