### PR TITLE
Prototype: createServer API for local Worker sessions

### DIFF
--- a/fixtures/create-server/package.json
+++ b/fixtures/create-server/package.json
@@ -1,0 +1,26 @@
+{
+	"name": "@fixture/create-server",
+	"private": true,
+	"description": "Integration tests with createServer API",
+	"type": "module",
+	"scripts": {
+		"check:type": "tsc",
+		"test:ci": "vite build && vitest run",
+		"type:tests": "tsc -p ./tests/tsconfig.json"
+	},
+	"devDependencies": {
+		"@cloudflare/vite-plugin": "workspace:*",
+		"@cloudflare/workers-tsconfig": "workspace:*",
+		"@cloudflare/workers-types": "catalog:default",
+		"@fixture/shared": "workspace:*",
+		"@types/node": "catalog:default",
+		"msw": "catalog:default",
+		"typescript": "catalog:default",
+		"vite": "catalog:default",
+		"vitest": "catalog:default",
+		"wrangler": "workspace:*"
+	},
+	"volta": {
+		"extends": "../../package.json"
+	}
+}

--- a/fixtures/create-server/src/auxiliary.ts
+++ b/fixtures/create-server/src/auxiliary.ts
@@ -1,0 +1,19 @@
+let lastTriggeredCron: string | null = null;
+
+async function fetchMock() {
+	const response = await fetch(`http://example.com/auxiliary`);
+	return await response.text();
+}
+
+export default {
+	async fetch() {
+		return Response.json({
+			worker: "auxiliary",
+			mockResult: await fetchMock(),
+			lastTriggeredCron,
+		});
+	},
+	async scheduled(event) {
+		lastTriggeredCron = event.cron;
+	},
+} satisfies ExportedHandler;

--- a/fixtures/create-server/src/primary.ts
+++ b/fixtures/create-server/src/primary.ts
@@ -1,0 +1,19 @@
+let lastTriggeredCron: string | null = null;
+
+async function fetchMock() {
+	const response = await fetch(`http://example.com/primary`);
+	return await response.text();
+}
+
+export default {
+	async fetch() {
+		return Response.json({
+			worker: "primary",
+			mockResult: await fetchMock(),
+			lastTriggeredCron,
+		});
+	},
+	async scheduled(event) {
+		lastTriggeredCron = event.cron;
+	},
+} satisfies ExportedHandler;

--- a/fixtures/create-server/tests/tsconfig.json
+++ b/fixtures/create-server/tests/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "@cloudflare/workers-tsconfig/tsconfig.json",
+	"compilerOptions": {
+		"module": "esnext",
+		"types": ["node"]
+	},
+	"include": ["**/*.ts"],
+	"exclude": []
+}

--- a/fixtures/create-server/tests/vite.test.ts
+++ b/fixtures/create-server/tests/vite.test.ts
@@ -1,0 +1,76 @@
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, beforeAll, describe, it } from "vitest";
+import { createServer } from "wrangler";
+
+const mockServer = setupServer(
+	http.get("http://example.com/:worker", ({ params }) => {
+		return HttpResponse.text(`mock:${params.worker}`);
+	})
+);
+const workerServer = createServer({
+	workers: [{ deployConfig: true }],
+});
+const primary = workerServer.getWorker();
+const auxiliary = workerServer.getWorker("auxiliary-worker");
+
+describe("createServer: vite project setup", () => {
+	beforeAll(async () => {
+		mockServer.listen({ onUnhandledRequest: "error" });
+		await workerServer.listen();
+	});
+
+	afterAll(async () => {
+		mockServer.close();
+		await workerServer.close();
+	});
+
+	it("could fetch workers with mocking support", async ({ expect }) => {
+		const primaryResponse = await primary.fetch("http://example.com", {
+			signal: AbortSignal.timeout(10_000),
+		});
+		expect(await primaryResponse.json()).toMatchObject({
+			worker: "primary",
+			mockResult: "mock:primary",
+		});
+		const auxiliaryResponse = await auxiliary.fetch("http://example.com", {
+			signal: AbortSignal.timeout(10_000),
+		});
+		expect(await auxiliaryResponse.json()).toMatchObject({
+			worker: "auxiliary",
+			mockResult: "mock:auxiliary",
+		});
+	});
+
+	it("support triggering scheduled events with custom scheduledTime", async ({
+		expect,
+	}) => {
+		expect(
+			await primary.scheduled({
+				cron: "* * * * *",
+				scheduledTime: new Date(1_700_000_100_000),
+			})
+		).toEqual({ outcome: "ok", noRetry: false });
+
+		const primaryResponse = await primary.fetch("http://example.com", {
+			signal: AbortSignal.timeout(10_000),
+		});
+		expect(await primaryResponse.json()).toMatchObject({
+			lastTriggeredCron: "* * * * *",
+		});
+
+		expect(
+			await auxiliary.scheduled({
+				cron: "*/5 * * * *",
+				scheduledTime: new Date(1_700_000_101_000),
+			})
+		).toEqual({ outcome: "ok", noRetry: false });
+
+		const auxiliaryResponse = await auxiliary.fetch("http://example.com", {
+			signal: AbortSignal.timeout(10_000),
+		});
+		expect(await auxiliaryResponse.json()).toMatchObject({
+			lastTriggeredCron: "*/5 * * * *",
+		});
+	});
+});

--- a/fixtures/create-server/tests/wrangler.test.ts
+++ b/fixtures/create-server/tests/wrangler.test.ts
@@ -1,0 +1,79 @@
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, beforeAll, describe, it } from "vitest";
+import { createServer } from "wrangler";
+
+const mockServer = setupServer(
+	http.get("http://example.com/:worker", ({ params }) => {
+		return HttpResponse.text(`mock:${params.worker}`);
+	})
+);
+const workerServer = createServer({
+	workers: [
+		{ configPath: "./wrangler.primary.jsonc" },
+		{ configPath: "./wrangler.auxiliary.jsonc" },
+	],
+});
+const primary = workerServer.getWorker();
+const auxiliary = workerServer.getWorker("auxiliary-worker");
+
+describe("createServer: wrangler project setup", () => {
+	beforeAll(async () => {
+		mockServer.listen({ onUnhandledRequest: "error" });
+		await workerServer.listen();
+	});
+
+	afterAll(async () => {
+		mockServer.close();
+		await workerServer.close();
+	});
+
+	it("could fetch workers with mocking support", async ({ expect }) => {
+		const primaryResponse = await primary.fetch("http://example.com", {
+			signal: AbortSignal.timeout(10_000),
+		});
+		expect(await primaryResponse.json()).toMatchObject({
+			worker: "primary",
+			mockResult: "mock:primary",
+		});
+		const auxiliaryResponse = await auxiliary.fetch("http://example.com", {
+			signal: AbortSignal.timeout(10_000),
+		});
+		expect(await auxiliaryResponse.json()).toMatchObject({
+			worker: "auxiliary",
+			mockResult: "mock:auxiliary",
+		});
+	});
+
+	it("support triggering scheduled events with custom scheduledTime", async ({
+		expect,
+	}) => {
+		expect(
+			await primary.scheduled({
+				cron: "* * * * *",
+				scheduledTime: new Date(1_700_000_100_000),
+			})
+		).toEqual({ outcome: "ok", noRetry: false });
+
+		const primaryResponse = await primary.fetch("http://example.com", {
+			signal: AbortSignal.timeout(10_000),
+		});
+		expect(await primaryResponse.json()).toMatchObject({
+			lastTriggeredCron: "* * * * *",
+		});
+
+		expect(
+			await auxiliary.scheduled({
+				cron: "*/5 * * * *",
+				scheduledTime: new Date(1_700_000_101_000),
+			})
+		).toEqual({ outcome: "ok", noRetry: false });
+
+		const auxiliaryResponse = await auxiliary.fetch("http://example.com", {
+			signal: AbortSignal.timeout(10_000),
+		});
+		expect(await auxiliaryResponse.json()).toMatchObject({
+			lastTriggeredCron: "*/5 * * * *",
+		});
+	});
+});

--- a/fixtures/create-server/tsconfig.json
+++ b/fixtures/create-server/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"isolatedModules": true,
+		"esModuleInterop": true,
+		"allowSyntheticDefaultImports": true,
+		"moduleResolution": "node",
+		"resolveJsonModule": true,
+		"target": "esnext",
+		"strict": true,
+		"noEmit": true,
+		"types": ["@cloudflare/workers-types", "node"],
+		"lib": ["esnext"],
+		"skipLibCheck": true
+	},
+	"include": ["**/*.ts"],
+	"exclude": ["tests"]
+}

--- a/fixtures/create-server/vite.config.ts
+++ b/fixtures/create-server/vite.config.ts
@@ -1,0 +1,13 @@
+import { cloudflare } from "@cloudflare/vite-plugin";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+	plugins: [
+		cloudflare({
+			configPath: "./wrangler.primary.jsonc",
+			auxiliaryWorkers: [{ configPath: "./wrangler.auxiliary.jsonc" }],
+			inspectorPort: false,
+			persistState: false,
+		}),
+	],
+});

--- a/fixtures/create-server/vitest.config.ts
+++ b/fixtures/create-server/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../vitest.shared";
+
+export default mergeConfig(
+	configShared,
+	defineProject({
+		test: {},
+	})
+);

--- a/fixtures/create-server/wrangler.auxiliary.jsonc
+++ b/fixtures/create-server/wrangler.auxiliary.jsonc
@@ -1,0 +1,5 @@
+{
+	"name": "auxiliary-worker",
+	"main": "src/auxiliary.ts",
+	"compatibility_date": "2024-09-23",
+}

--- a/fixtures/create-server/wrangler.primary.jsonc
+++ b/fixtures/create-server/wrangler.primary.jsonc
@@ -1,0 +1,5 @@
+{
+	"name": "primary-worker",
+	"main": "src/primary.ts",
+	"compatibility_date": "2024-09-23",
+}

--- a/packages/vite-plugin-cloudflare/src/context.ts
+++ b/packages/vite-plugin-cloudflare/src/context.ts
@@ -77,6 +77,9 @@ export class PluginContext {
 
 		const miniflareInspectorUrl =
 			await this.#sharedContext.miniflare.getInspectorURL();
+		if (!miniflareInspectorUrl) {
+			return null;
+		}
 
 		return Number.parseInt(miniflareInspectorUrl.port);
 	}

--- a/packages/wrangler/src/api/index.ts
+++ b/packages/wrangler/src/api/index.ts
@@ -53,6 +53,10 @@ export type {
 } from "./startDevWorker/events";
 export type { DevToolsEvent } from "./startDevWorker/devtools";
 
+// Exports from ./runtime
+export { createServer } from "./server";
+export type { InspectorOptions, ServerOptions, WorkerInput, WorkerServer } from "./server";
+
 // Exports from ./integrations
 export {
 	unstable_getVarsForDev,

--- a/packages/wrangler/src/api/server.ts
+++ b/packages/wrangler/src/api/server.ts
@@ -1,0 +1,586 @@
+import assert from "node:assert";
+import events from "node:events";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Headers, Request } from "miniflare";
+import registerDevHotKeys from "../dev/hotkeys";
+import { logger } from "../logger";
+import { requireApiToken, requireAuth } from "../user";
+import { DevEnv } from "./startDevWorker/DevEnv";
+import { MultiworkerRuntimeController } from "./startDevWorker/MultiworkerRuntimeController";
+import { NoOpProxyController } from "./startDevWorker/NoOpProxyController";
+import { convertConfigToBindings } from "./startDevWorker/utils";
+import type {
+	LogLevel,
+	ServiceFetch,
+	StartDevWorkerInput,
+	StartDevWorkerOptions,
+} from "./startDevWorker/types";
+import type {
+	FetcherScheduledOptions,
+	FetcherScheduledResult,
+} from "@cloudflare/workers-types/experimental";
+import type { Config } from "@cloudflare/workers-utils";
+import type { DispatchFetch } from "miniflare";
+
+export type WorkerInput =
+	| {
+			configPath: string | URL;
+			env?: string;
+			projectRoot?: string | URL;
+	  }
+	| {
+			deployConfig: true | string | URL;
+			projectRoot?: string | URL;
+	  }
+	| {
+			config: Config;
+	  };
+
+type DevServerOptions = Exclude<
+	NonNullable<StartDevWorkerInput["dev"]>["server"],
+	undefined
+>;
+
+export type InspectorOptions = Exclude<
+	NonNullable<StartDevWorkerInput["dev"]>["inspector"],
+	undefined
+>;
+
+export type ServerOptions = {
+	workers: WorkerInput[];
+	server?: DevServerOptions;
+	inspector?: InspectorOptions;
+	watch?: boolean;
+	logLevel?: LogLevel;
+	accountId?: string;
+	outbound?: ServiceFetch | null;
+};
+
+export type ServerHotKeysOptions = {
+	render?: boolean;
+	forceLocal?: boolean;
+	experimentalTailLogs: boolean;
+	remote: boolean;
+};
+
+export type Worker = {
+	fetch: DispatchFetch;
+	scheduled(options: FetcherScheduledOptions): Promise<FetcherScheduledResult>;
+};
+
+export type WorkerServer = {
+	listen(): Promise<{
+		url: URL;
+		inspectorUrl: URL | undefined;
+	}>;
+	waitUntilExit(): Promise<void>;
+	fetch: DispatchFetch;
+	getWorker(name?: string): Worker;
+	registerHotKeys(options: ServerHotKeysOptions): void;
+	update(
+		options: ServerOptions | ((current: ServerOptions) => ServerOptions)
+	): Promise<void>;
+	close(): Promise<void>;
+};
+
+type ServerSession = {
+	primaryDevEnv: DevEnv;
+	devEnvs: DevEnv[];
+};
+
+type DeployConfig = {
+	configPath: string;
+	auxiliaryWorkers?: Array<{ configPath: string }>;
+};
+
+type ServerAuthHook = NonNullable<
+	NonNullable<StartDevWorkerInput["dev"]>["auth"]
+>;
+
+function isDeployConfig(value: unknown): value is DeployConfig {
+	if (typeof value !== "object" || value === null) {
+		return false;
+	}
+	const maybeConfig = value as Record<string, unknown>;
+	return typeof maybeConfig.configPath === "string";
+}
+
+function resolvePathFrom(basePath: string, maybePath: string): string {
+	return path.isAbsolute(maybePath)
+		? maybePath
+		: path.resolve(basePath, maybePath);
+}
+
+function resolvePathInput(basePath: string, maybePath: string | URL): string {
+	if (maybePath instanceof URL) {
+		return fileURLToPath(maybePath);
+	}
+
+	return resolvePathFrom(basePath, maybePath);
+}
+
+function resolveProjectRoot(projectRoot: string | URL | undefined): string {
+	if (projectRoot === undefined) {
+		return process.cwd();
+	}
+
+	return resolvePathInput(process.cwd(), projectRoot);
+}
+
+function resolveDeployConfigWorkerInputs(
+	deployConfigPath: string,
+): StartDevWorkerInput[] {
+	let rawParsed: unknown;
+
+	try {
+		rawParsed = JSON.parse(readFileSync(deployConfigPath, "utf8"));
+	} catch (error) {
+		throw new Error(`Failed to read deploy config at "${deployConfigPath}".`, {
+			cause: error,
+		});
+	}
+
+	if (!isDeployConfig(rawParsed)) {
+		throw new Error(
+			`Invalid deploy config at "${deployConfigPath}": missing "configPath".`,
+		);
+	}
+
+	const configDir = path.dirname(deployConfigPath);
+	const workers: StartDevWorkerInput[] = [
+		{
+			config: resolvePathFrom(configDir, rawParsed.configPath),
+		},
+	];
+
+	for (const auxiliaryWorker of rawParsed.auxiliaryWorkers ?? []) {
+		workers.push({
+			config: resolvePathFrom(configDir, auxiliaryWorker.configPath),
+		});
+	}
+
+	return workers;
+}
+
+function inlineConfigToStartDevWorkerInput(config: Config): StartDevWorkerInput {
+	const basePath = config.configPath
+		? path.dirname(config.configPath)
+		: process.cwd();
+
+	return {
+		// FIXME: to avoid dev env from auto discovering a config file and merging it with the inline config
+		config: '',
+		name: config.name,
+		entrypoint: config.main
+			? resolvePathInput(basePath, config.main)
+			: undefined,
+		compatibilityDate: config.compatibility_date,
+		compatibilityFlags: config.compatibility_flags,
+		complianceRegion: config.compliance_region,
+		bindings: convertConfigToBindings(config, { usePreviewIds: true }),
+		migrations: config.migrations,
+		containers: config.containers,
+		triggers: config.triggers.crons?.map((cron) => ({
+			type: "cron",
+			cron,
+		})),
+		tailConsumers: config.tail_consumers,
+		streamingTailConsumers: config.streaming_tail_consumers,
+		sendMetrics: config.send_metrics,
+		assets: config.assets?.directory,
+	};
+}
+
+function resolveWorkerInputs(options: ServerOptions, auth: ServerAuthHook): StartDevWorkerInput[] {
+	if (options.workers.length === 0) {
+		throw new Error("Worker server requires at least one worker.");
+	}
+
+	return options.workers.flatMap((input, index, list) => {
+		const isPrimaryWorker = index === 0;
+		const isMultiworker = list.length > 1;
+		const dev: StartDevWorkerInput['dev'] = {
+			auth,
+			server: options.server ?? { hostname: "127.0.0.1", port: 0 },
+			logLevel: options.logLevel ?? "error",
+			watch: options.watch ?? false,
+			inspector: options.inspector ?? false,
+			outboundService: options.outbound ?? ((request) => {
+				return globalThis.fetch(request.url, request);
+			}),
+			multiworkerPrimary: isPrimaryWorker && isMultiworker ? true : undefined,
+		};
+
+		if ("config" in input) {
+			return [{
+				...inlineConfigToStartDevWorkerInput(input.config),
+				dev,
+			}];
+		}
+
+		const projectRoot = resolveProjectRoot(input.projectRoot);
+
+		if ("configPath" in input) {
+			return [
+				{
+					config: resolvePathInput(projectRoot, input.configPath),
+					env: input.env,
+					dev,
+				},
+			];
+		}
+
+		const deployConfigPath =
+			input.deployConfig === true
+				? path.join(projectRoot, ".wrangler", "deploy", "config.json")
+				: resolvePathInput(projectRoot, input.deployConfig);
+
+		return resolveDeployConfigWorkerInputs(deployConfigPath).map((input, index, resolvedInputs) => {
+			const isPrimaryWorker = index === 0;
+			const isMultiworker = resolvedInputs.length > 1;
+
+			return {
+				...input,
+				dev: {
+					...dev,
+					multiworkerPrimary: isPrimaryWorker && (dev.multiworkerPrimary || isMultiworker) ? true : undefined,
+				},
+			};
+		});
+	});
+}
+
+async function createSession(
+	options: ServerOptions,
+	auth: ServerAuthHook,
+): Promise<ServerSession> {
+	const inputs = resolveWorkerInputs(options, auth);
+	const [, ...auxiliaryWorkers] = inputs;
+	const isMultiworker = auxiliaryWorkers.length > 0;
+	const primaryDevEnv = isMultiworker
+		? new DevEnv({
+				runtimeFactories: [
+					(devEnv) =>
+						new MultiworkerRuntimeController(devEnv, inputs.length),
+				],
+			})
+		: new DevEnv();
+	const auxiliaryDevEnvs = auxiliaryWorkers.map(
+		() =>
+			new DevEnv({
+				runtimeFactories: [() => primaryDevEnv.runtimes[0]],
+				proxyFactory: (devEnv) => new NoOpProxyController(devEnv),
+			}),
+	);
+	const session: ServerSession = {
+		primaryDevEnv,
+		devEnvs: [primaryDevEnv, ...auxiliaryDevEnvs],
+	};
+
+	await updateConfig(session, inputs);
+
+	return session;
+}
+
+async function updateConfig(
+	session: ServerSession,
+	inputs: StartDevWorkerInput[],
+) {
+	try {
+		for (const [index, workerInput] of inputs.entries()) {
+			const devEnv = session.devEnvs[index];
+			await devEnv.config.set(workerInput, true);
+		}
+	} catch (error) {
+		await Promise.allSettled(session.devEnvs.map((devEnv) => devEnv.teardown()));
+		throw error;
+	}
+}
+
+function maybePrintScheduledWorkerWarning(
+	serverSession: ServerSession,
+	url: URL,
+): void {
+	const workersWithCronTriggers = serverSession.devEnvs
+		.map((devEnv) => devEnv.config.latestConfig)
+		.filter((config): config is StartDevWorkerOptions => config !== undefined)
+		.filter((config) =>
+			config.triggers?.some((trigger) => trigger.type === "cron"),
+		);
+
+	if (workersWithCronTriggers.length === 0) {
+		return;
+	}
+
+	const testScheduled = workersWithCronTriggers.every(
+		(config) => config.dev.testScheduled,
+	);
+	if (testScheduled) {
+		return;
+	}
+
+	const host =
+		url.hostname === "0.0.0.0" || url.hostname === "::"
+			? "localhost"
+			: url.hostname.includes(":")
+				? `[${url.hostname}]`
+				: url.hostname;
+
+	logger.once.warn(
+		`Scheduled Workers are not automatically triggered during local development.\n` +
+			`To manually trigger a scheduled event, run:\n` +
+			`  curl "http://${host}:${url.port}/cdn-cgi/handler/scheduled"\n` +
+			`For more details, see https://developers.cloudflare.com/workers/configuration/cron-triggers/#test-cron-triggers-locally`,
+	);
+}
+
+/**
+ * Creates a worker server with a small, migration-focused API surface.
+ *
+ * This intentionally reuses DevEnv/controller internals with minimal behavior changes.
+ */
+export function createServer(options: ServerOptions): WorkerServer {
+	let currentOptions = options;
+	let accountId = options.accountId;
+
+	let serverSession: ServerSession | undefined;
+	let startPromise: Promise<void> | undefined;
+	let unregisterHotKeys: (() => void) | undefined;
+	let hotKeysOptions: ServerHotKeysOptions | undefined;
+	let shouldRenderHotKeys = true;
+
+	const resolveSession = () => {
+		assert(
+			serverSession,
+			"Worker server has not been started. Call server.listen().",
+		);
+		return serverSession;
+	};
+
+	const unregisterActiveHotKeys = () => {
+		unregisterHotKeys?.();
+		unregisterHotKeys = undefined;
+	};
+
+	const registerActiveHotKeys = (
+		session: ServerSession,
+		render = shouldRenderHotKeys,
+	) => {
+		if (!hotKeysOptions) {
+			return;
+		}
+
+		unregisterActiveHotKeys();
+		unregisterHotKeys = registerDevHotKeys(
+			session.devEnvs,
+			hotKeysOptions,
+			render,
+		);
+	};
+
+	const serverAuthHook: ServerAuthHook = async (config) => {
+		if (accountId) {
+			return {
+				accountId,
+				apiToken: requireApiToken(),
+			};
+		}
+
+		unregisterActiveHotKeys();
+
+		try {
+			accountId = await requireAuth(config);
+			return {
+				accountId,
+				apiToken: requireApiToken(),
+			};
+		} finally {
+			if (serverSession) {
+				registerActiveHotKeys(serverSession, false);
+			}
+		}
+	};
+
+	const teardownSession = async (session: ServerSession) => {
+		await Promise.all(session.devEnvs.map((devEnv) => devEnv.teardown()));
+	};
+
+	const waitForPrimaryReady = async (session: ServerSession) => {
+		return new Promise<
+			Awaited<typeof session.primaryDevEnv.proxy.ready.promise>
+		>((resolve, reject) => {
+			const onError = (error: unknown) => {
+				session.primaryDevEnv.off("error", onError);
+				reject(error);
+			};
+
+			session.primaryDevEnv.once("error", onError);
+			void session.primaryDevEnv.proxy.ready.promise.then(
+				(ready) => {
+					session.primaryDevEnv.off("error", onError);
+					resolve(ready);
+				},
+				(error: unknown) => {
+					session.primaryDevEnv.off("error", onError);
+					reject(error);
+				},
+			);
+		});
+	};
+
+	const startServerSession = async (renderHotKeys = shouldRenderHotKeys) => {
+		const session = await createSession(currentOptions, serverAuthHook);
+
+		try {
+			const ready = await waitForPrimaryReady(session);
+			serverSession = session;
+			maybePrintScheduledWorkerWarning(session, ready.url);
+			registerActiveHotKeys(session, renderHotKeys);
+		} catch (error) {
+			await teardownSession(session);
+			throw error;
+		}
+	};
+
+	const workerServer: WorkerServer = {
+		async listen() {
+			if (!serverSession) {
+				if (!startPromise) {
+					startPromise = startServerSession().finally(() => {
+						startPromise = undefined;
+					});
+				}
+
+				await startPromise;
+			}
+
+			assert(serverSession, "Worker server has no active session.");
+			const ready = await serverSession.primaryDevEnv.proxy.ready.promise;
+
+			return {
+				url: ready.url,
+				inspectorUrl: ready.inspectorUrl,
+			};
+		},
+		async waitUntilExit() {
+			if (!serverSession && startPromise) {
+				await startPromise;
+			}
+			const session = resolveSession();
+			await events.once(session.primaryDevEnv, "teardown");
+		},
+		async fetch(info, init) {
+			const session = resolveSession();
+			const miniflare = session.primaryDevEnv.proxy.proxyWorker;
+			assert(miniflare, "The proxy worker is not available yet. Did you call server.listen()?");
+
+			return miniflare.dispatchFetch(info, init);
+		},
+		getWorker(name?: string) {
+			const getRuntimeMiniflare = async () => {
+				const session = resolveSession();
+				await session.primaryDevEnv.proxy.runtimeMessageMutex.drained();
+				const miniflare = session.primaryDevEnv.runtimes[0].mf;
+				assert(miniflare, "Worker runtime is not available.");
+				return miniflare;
+			};
+
+			return {
+				async fetch(requestInput, requestInit) {
+					const miniflare = await getRuntimeMiniflare();
+					const request = new Request(requestInput, requestInit);
+					const headers = new Headers(request.headers);
+
+					headers.set("MF-Original-URL", request.url);
+					headers.set("MF-Disable-Pretty-Error", "true");
+
+					if (name !== undefined) {
+						headers.set("MF-Route-Override", name);
+					}
+
+					return miniflare.dispatchFetch(request, {
+						headers,
+					});
+				},
+				async scheduled(scheduledOptions) {
+					const miniflare = await getRuntimeMiniflare();
+					const url = new URL("http://localhost/cdn-cgi/handler/scheduled");
+					if (scheduledOptions?.cron !== undefined) {
+						url.searchParams.set("cron", scheduledOptions.cron);
+					}
+					if (scheduledOptions?.scheduledTime !== undefined) {
+						url.searchParams.set(
+							"time",
+							String(scheduledOptions.scheduledTime.getTime()),
+						);
+					}
+					const headers = new Headers();
+					headers.set("MF-Original-URL", url.toString());
+					headers.set("MF-Disable-Pretty-Error", "true");
+
+					if (name !== undefined) {
+						headers.set("MF-Route-Override", name);
+					}
+					const response = await miniflare.dispatchFetch(url, {
+						headers,
+					});
+					const outcomeText = await response.text();
+					const outcome: FetcherScheduledResult["outcome"] =
+						outcomeText === "ok" || outcomeText === "exception"
+							? outcomeText
+							: "exception";
+
+					return {
+						outcome,
+						// FIXME: scheduled handler should include noRetry info in the response
+						noRetry: false,
+					};
+				},
+			};
+		},
+		registerHotKeys(serverHotKeysOptions) {
+			hotKeysOptions = serverHotKeysOptions;
+			shouldRenderHotKeys = serverHotKeysOptions.render ?? true;
+
+			if (serverSession) {
+				registerActiveHotKeys(serverSession, shouldRenderHotKeys);
+			}
+		},
+		async update(updateInput) {
+			currentOptions =
+				typeof updateInput === "function"
+					? updateInput(currentOptions)
+					: updateInput;
+			accountId = currentOptions.accountId ?? accountId;
+
+			if (serverSession) {
+				const nextInputs = resolveWorkerInputs(currentOptions, serverAuthHook);
+
+				if (nextInputs.length !== serverSession.devEnvs.length) {
+					const previousSession = serverSession;
+					serverSession = undefined;
+					await teardownSession(previousSession);
+					await startServerSession(false);
+					return;
+				}
+
+				await updateConfig(serverSession, nextInputs);
+			}
+		},
+		async close() {
+			if (startPromise) {
+				await startPromise.catch(() => undefined);
+				startPromise = undefined;
+			}
+			if (serverSession) {
+				unregisterActiveHotKeys();
+				await teardownSession(serverSession);
+				serverSession = undefined;
+			}
+		},
+	};
+
+	return workerServer;
+}

--- a/packages/wrangler/src/api/startDevWorker/BaseController.ts
+++ b/packages/wrangler/src/api/startDevWorker/BaseController.ts
@@ -9,6 +9,7 @@ import type {
 	ReloadCompleteEvent,
 	ReloadStartEvent,
 } from "./events";
+import type { Miniflare } from "miniflare";
 
 export type ControllerEvent =
 	| ErrorEvent
@@ -56,6 +57,11 @@ export abstract class RuntimeController extends Controller {
 	abstract onBundleStart(_: BundleStartEvent): void;
 	abstract onBundleComplete(_: BundleCompleteEvent): void;
 	abstract onPreviewTokenExpired(_: PreviewTokenExpiredEvent): void;
+
+	// *********************
+	//   Runtime Accessors
+	// *********************
+	mf: Miniflare | undefined;
 
 	// *********************
 	//   Event Dispatchers

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -133,6 +133,7 @@ async function resolveDevConfig(
 	return {
 		auth,
 		remote: input.dev?.remote,
+		outboundService: input.dev?.outboundService,
 		server: {
 			hostname: input.dev?.server?.hostname || config.dev.ip,
 			port:

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -136,6 +136,7 @@ export async function convertToConfigBundle(
 		localUpstream: event.config.dev?.origin?.hostname,
 		upstreamProtocol: event.config.dev?.origin?.secure ? "https" : "http",
 		testScheduled: !!event.config.dev.testScheduled,
+		outboundService: event.config.dev.outboundService,
 		tails: event.config.tailConsumers,
 		streamingTails: event.config.streamingTailConsumers,
 		containerDOClassNames: new Set(
@@ -166,7 +167,6 @@ export class LocalRuntimeController extends RuntimeController {
 	// updates were submitted, the second may apply before the first. Therefore,
 	// wrap updates in a mutex, so they're always applied in invocation order.
 	#mutex = new Mutex();
-	#mf?: Miniflare;
 
 	#remoteProxySessionData: {
 		session: RemoteProxySession;
@@ -296,13 +296,13 @@ export class LocalRuntimeController extends RuntimeController {
 				}
 			);
 			options.liveReload = false; // TODO: set in buildMiniflareOptions once old code path is removed
-			if (this.#mf === undefined) {
+			if (this.mf === undefined) {
 				logger.log(chalk.dim("⎔ Starting local server..."));
-				this.#mf = new Miniflare(options);
+				this.mf = new Miniflare(options);
 			} else {
 				logger.log(chalk.dim("⎔ Reloading local server..."));
 
-				await this.#mf.setOptions(options);
+				await this.mf.setOptions(options);
 
 				logger.log(chalk.dim("⎔ Local server updated and ready"));
 			}
@@ -310,14 +310,14 @@ export class LocalRuntimeController extends RuntimeController {
 			// calls to complete before resolving. To ensure we get the `url` and
 			// `inspectorUrl` for this set of `options`, we protect `#mf` with a mutex,
 			// so only one update can happen at a time.
-			const userWorkerUrl = await this.#mf.ready;
+			const userWorkerUrl = await this.mf.ready;
 			// TODO: Miniflare should itself return undefined on
 			//       `getInspectorURL` when no inspector is in use
 			//       (currently the function just hangs)
 			const userWorkerInspectorUrl =
 				options.inspectorPort === undefined
 					? undefined
-					: await this.#mf.getInspectorURL();
+					: await this.mf.getInspectorURL();
 			// If we received a new `bundleComplete` event before we were able to
 			// dispatch a `reloadComplete` for this bundle, ignore this bundle.
 			if (id !== this.#currentBundleId) {
@@ -414,12 +414,12 @@ export class LocalRuntimeController extends RuntimeController {
 		process.off("exit", this.cleanupContainers);
 		this.cleanupContainers();
 
-		if (this.#mf) {
+		if (this.mf) {
 			logger.log(chalk.dim("⎔ Shutting down local server..."));
 		}
 
-		await this.#mf?.dispose();
-		this.#mf = undefined;
+		await this.mf?.dispose();
+		this.mf = undefined;
 
 		if (this.#remoteProxySessionData) {
 			logger.log(chalk.dim("⎔ Shutting down remote connection..."));

--- a/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
@@ -67,7 +67,6 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 	// updates were submitted, the second may apply before the first. Therefore,
 	// wrap updates in a mutex, so they're always applied in invocation order.
 	#mutex = new Mutex();
-	#mf?: Miniflare;
 
 	#options = new Map<string, { options: MF.Options; primary: boolean }>();
 
@@ -200,13 +199,13 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 			if (this.#canStartMiniflare()) {
 				const mergedMfOptions = ensureMatchingSql(this.#mergedMfOptions());
 
-				if (this.#mf === undefined) {
+				if (this.mf === undefined) {
 					logger.log(chalk.dim("⎔ Starting local server..."));
-					this.#mf = new Miniflare(mergedMfOptions);
+					this.mf = new Miniflare(mergedMfOptions);
 				} else {
 					logger.log(chalk.dim("⎔ Reloading local server..."));
 
-					await this.#mf.setOptions(mergedMfOptions);
+					await this.mf.setOptions(mergedMfOptions);
 
 					logger.log(chalk.dim("⎔ Local server updated and ready"));
 				}
@@ -215,8 +214,11 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 				// calls to complete before resolving. To ensure we get the `url` and
 				// `inspectorUrl` for this set of `options`, we protect `#mf` with a mutex,
 				// so only one update can happen at a time.
-				const userWorkerUrl = await this.#mf.ready;
-				const userWorkerInspectorUrl = await this.#mf.getInspectorURL();
+				const userWorkerUrl = await this.mf.ready;
+				const userWorkerInspectorUrl =
+					mergedMfOptions.inspectorPort === undefined
+						? undefined
+						: await this.mf.getInspectorURL();
 				// If we received a new `bundleComplete` event before we were able to
 				// dispatch a `reloadComplete` for this bundle, ignore this bundle.
 				if (id !== this.#currentBundleId) {
@@ -233,12 +235,14 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 							hostname: userWorkerUrl.hostname,
 							port: userWorkerUrl.port,
 						},
-						userWorkerInspectorUrl: {
-							protocol: userWorkerInspectorUrl.protocol,
-							hostname: userWorkerInspectorUrl.hostname,
-							port: userWorkerInspectorUrl.port,
-							pathname: `/core:user:${data.config.name}`,
-						},
+						...(userWorkerInspectorUrl && {
+							userWorkerInspectorUrl: {
+								protocol: userWorkerInspectorUrl.protocol,
+								hostname: userWorkerInspectorUrl.hostname,
+								port: userWorkerInspectorUrl.port,
+								pathname: `/core:user:${data.config.name}`,
+							},
+						}),
 						userWorkerInnerUrlOverrides: {
 							protocol: data.config?.dev?.origin?.secure ? "https:" : "http:",
 							hostname: data.config?.dev?.origin?.hostname,
@@ -292,12 +296,12 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 
 	#teardown = async (): Promise<void> => {
 		logger.debug("MultiworkerRuntimeController teardown beginning...");
-		if (this.#mf) {
+		if (this.mf) {
 			logger.log(chalk.dim("⎔ Shutting down local server..."));
 		}
 
-		await this.#mf?.dispose();
-		this.#mf = undefined;
+		await this.mf?.dispose();
+		this.mf = undefined;
 
 		if (this.#remoteProxySessionsData.size > 0) {
 			logger.log(chalk.dim("⎔ Shutting down remote connections..."));

--- a/packages/wrangler/src/cli.ts
+++ b/packages/wrangler/src/cli.ts
@@ -9,6 +9,7 @@ import { FatalError } from "@cloudflare/workers-utils";
 import { hideBin } from "yargs/helpers";
 import {
 	convertConfigBindingsToStartWorkerBindings,
+	createServer,
 	DevEnv,
 	getPlatformProxy,
 	maybeStartOrUpdateRemoteProxySession,
@@ -35,8 +36,12 @@ import type {
 	Unstable_DevOptions,
 	Unstable_DevWorker,
 	Unstable_MiniflareWorkerOptions,
+	InspectorOptions,
+	ServerOptions,
 	Unstable_RawConfig,
 	Unstable_RawEnvironment,
+	WorkerInput,
+	WorkerServer,
 } from "./api";
 import type { Logger } from "./logger";
 import type { Request, Response } from "miniflare";
@@ -64,6 +69,7 @@ export {
 	unstable_pages,
 	DevEnv as unstable_DevEnv,
 	startWorker as unstable_startWorker,
+	createServer,
 	unstable_getVarsForDev,
 	unstable_readConfig,
 	unstable_getDurableObjectClassNameToUseSQLiteMap,
@@ -76,9 +82,13 @@ export {
 export type {
 	Unstable_DevWorker,
 	Unstable_DevOptions,
+	InspectorOptions,
+	ServerOptions,
 	Unstable_Config,
 	Unstable_RawConfig,
 	Unstable_RawEnvironment,
+	WorkerInput,
+	WorkerServer,
 	GetPlatformProxyOptions,
 	PlatformProxy,
 	SourcelessWorkerOptions,

--- a/packages/wrangler/src/dev/miniflare/index.ts
+++ b/packages/wrangler/src/dev/miniflare/index.ts
@@ -36,6 +36,7 @@ import type {
 	CfWorkflow,
 	Config,
 	ContainerEngine,
+	ServiceFetch,
 } from "@cloudflare/workers-utils";
 import type {
 	DOContainerOptions,
@@ -91,6 +92,7 @@ export interface ConfigBundle {
 	localUpstream: string | undefined;
 	upstreamProtocol: "http" | "https";
 	inspect: boolean;
+	outboundService: ServiceFetch;
 	tails: Config["tail_consumers"] | undefined;
 	streamingTails: Config["streaming_tail_consumers"] | undefined;
 	testScheduled: boolean;
@@ -1033,6 +1035,7 @@ export async function buildMiniflareOptions(
 				...bindingOptions,
 				...sitesOptions,
 				...assetOptions,
+				outboundService: config.outboundService,
 				// Allow each entrypoint to be accessed directly over `127.0.0.1:0`
 				unsafeDirectSockets: entrypointNames.map((name) => ({
 					host: "127.0.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,39 @@ importers:
         specifier: workspace:*
         version: link:../../packages/wrangler
 
+  fixtures/create-server:
+    devDependencies:
+      '@cloudflare/vite-plugin':
+        specifier: workspace:*
+        version: link:../../packages/vite-plugin-cloudflare
+      '@cloudflare/workers-tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/workers-tsconfig
+      '@cloudflare/workers-types':
+        specifier: catalog:default
+        version: 4.20260405.1
+      '@fixture/shared':
+        specifier: workspace:*
+        version: link:../shared
+      '@types/node':
+        specifier: ^22.10.1
+        version: 22.15.17
+      msw:
+        specifier: catalog:default
+        version: 2.12.4(@types/node@22.15.17)(typescript@5.8.3)
+      typescript:
+        specifier: catalog:default
+        version: 5.8.3
+      vite:
+        specifier: catalog:default
+        version: 8.0.1(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1)
+      vitest:
+        specifier: catalog:default
+        version: 4.1.0(@opentelemetry/api@1.7.0)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.0.1(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
+      wrangler:
+        specifier: workspace:*
+        version: link:../../packages/wrangler
+
   fixtures/d1-read-replication-app:
     devDependencies:
       '@cloudflare/workers-tsconfig':
@@ -14259,10 +14292,6 @@ packages:
     resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
     engines: {node: '>=10'}
 
-  type-fest@4.26.1:
-    resolution: {integrity: sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==}
-    engines: {node: '>=16'}
-
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
@@ -15426,7 +15455,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.1(supports-color@9.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -20934,7 +20963,7 @@ snapshots:
 
   dot-prop@9.0.0:
     dependencies:
-      type-fest: 4.26.1
+      type-fest: 4.41.0
 
   dotenv-cli@7.3.0:
     dependencies:
@@ -21705,7 +21734,7 @@ snapshots:
       escape-html: 1.0.3
       on-finished: 2.4.1
       parseurl: 1.3.3
-      statuses: 2.0.1
+      statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -24107,7 +24136,7 @@ snapshots:
       '@types/normalize-package-data': 2.4.4
       normalize-package-data: 6.0.2
       parse-json: 8.3.0
-      type-fest: 4.26.1
+      type-fest: 4.41.0
       unicorn-magic: 0.1.0
 
   read-yaml-file@1.1.0:
@@ -24552,7 +24581,7 @@ snapshots:
       ms: 2.1.3
       on-finished: 2.4.1
       range-parser: 1.2.1
-      statuses: 2.0.1
+      statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -25429,8 +25458,6 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-fest@1.4.0: {}
-
-  type-fest@4.26.1: {}
 
   type-fest@4.41.0: {}
 


### PR DESCRIPTION
Fixes n/a.

Here is a prototype `createServer()` API for starting local Worker sessions from Node.js.

The goal is to explore a stable replacement path for `unstable_startWorker()` and `unstable_dev()` that:
- works well for integration testing
- supports multiple workers in one session
- works across Wrangler, Vite and OpenNext project
- can also serve as the programmatic API for starting local dev server sessions

The prototype keeps the implementation small by wrapping the existing `DevEnv` runtime used by `wrangler dev` / `wrangler pages dev`, while exposing a narrower API shape.

- `listen()` to start the server,
- `close()` to dispose the resoruces,
- `getWorker(name?)` to interact with a dedicate worker,

For wrangler users, they will need to create a worker server by specifying the `configPath`. This will start a dev server that builds the project right away:

```ts
const server = createServer({
  workers: [
    { config: "wrangler.primary.jsonc" },
    { config: "wrangler.auxiliary.jsonc" },
  ],
});
```

For vite users, we will rely on the deploy config / redirected config instead and skip the build. 

> It might be worth making `wrangler build` output a deploy config as well so wrangler user could build it once before starting any tests and then reuse the build throughout.

```ts
const server = createServer({
  workers: [
    { deployConfig: true },
  ]
});
```

This also includes a `create-server` fixture demonstrating the intended testing workflow for both Wrangler and Vite projects, including outbound request mocking via MSW.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
