### PR TITLE
Remove temporary block on Worker/Pages deployment changesets

### DIFF
--- a/tools/deployments/__tests__/validate-changesets.test.ts
+++ b/tools/deployments/__tests__/validate-changesets.test.ts
@@ -94,7 +94,6 @@ describe("validateChangesets()", () => {
 				["package-a", { name: "package-a" }],
 				["package-b", { name: "package-b" }],
 				["package-c", { name: "package-c" }],
-				["package-d", { name: "package-d", "workers-sdk": { deploy: true } }],
 			]),
 			[
 				{
@@ -152,15 +151,6 @@ describe("validateChangesets()", () => {
 
 						docs: test`,
 				},
-				{
-					file: "deployable-package.md",
-					contents: dedent`
-						---
-						"package-d": patch
-						---
-
-						fix: test`,
-				},
 			]
 		);
 		expect(errors).toMatchInlineSnapshot(`
@@ -168,7 +158,6 @@ describe("validateChangesets()", () => {
 			  "Error: could not parse changeset - invalid frontmatter: at file "invalid-frontmatter.md"",
 			  "Unknown package name "package-invalid" in changeset at "invalid-package.md".",
 			  "Invalid type "foo" for package "package-a" in changeset at "invalid-type.md".",
-			  "Currently we are not allowing changes to package "package-d" in changeset at "deployable-package.md" since it would trigger a Worker/Pages deployment.",
 			]
 		`);
 	});

--- a/tools/deployments/validate-changesets.ts
+++ b/tools/deployments/validate-changesets.ts
@@ -30,24 +30,6 @@ export function validateChangesets(
 					);
 				}
 
-				// TEMPORARILY BLOCK PACKAGES THAT WOULD DEPLOY WORKERS
-				const ALLOWED_PRIVATE_PACKAGES = [
-					"@cloudflare/workers-shared",
-					"@cloudflare/quick-edit",
-					"@cloudflare/devprod-status-bot",
-					"@cloudflare/workers-playground",
-				];
-				if (
-					packages.get(release.name)?.["workers-sdk"]?.deploy &&
-					// Exception: deployments for these workers are allowed now
-					!ALLOWED_PRIVATE_PACKAGES.includes(release.name)
-				) {
-					errors.push(
-						`Currently we are not allowing changes to package "${release.name}" in changeset at "${file}" since it would trigger a Worker/Pages deployment.`
-					);
-				}
-				// END TEMPORARILY BLOCK PACKAGES THAT WOULD DEPLOY WORKERS
-
 				if (release.type === "major") {
 					errors.push(
 						`Major version bumps are not allowed for package "${release.name}" in changeset at "${file}".`


### PR DESCRIPTION
This removes the temporary validation block in `validate-changesets.ts` that prevented changesets for packages with `workers-sdk.deploy: true` (unless they were in an explicit allowlist). The following packages are now unblocked:

- `@cloudflare/turbo-r2-archive`
- `@cloudflare/playground-preview-worker`
- `@cloudflare/format-errors`
- `@cloudflare/edge-preview-authenticated-proxy`
- `@cloudflare/chrome-devtools-patches`

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal tooling change only
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
