### PR TITLE
Pin all third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -17,7 +17,7 @@ runs:
   using: "composite"
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
       with:
         version: 9.12.0
 

--- a/.github/actions/install-python-uv/action.yml
+++ b/.github/actions/install-python-uv/action.yml
@@ -3,7 +3,7 @@ runs:
   using: "composite"
   steps:
     - name: Install uv for Python
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
       with:
         version: "0.9.3"
         enable-cache: false

--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: 22 # need this version for `Set` methods
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
         with:
           version: 9.12.0
 

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: changes
         with:
           filters: |

--- a/.github/workflows/changeset-review.yml
+++ b/.github/workflows/changeset-review.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Get changed changeset files
         id: changed-changesets
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45
         with:
           files: |
             .changeset/*.md
@@ -79,7 +79,7 @@ jobs:
 
       - name: Post review comment
         if: steps.opencode-review.outcome == 'success'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           header: changeset-review
           path: changeset-review.md

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Create Version PR or Publish to NPM
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1
         with:
           version: node .github/changeset-version.js
           publish: pnpm exec changeset publish

--- a/.github/workflows/deploy-pages-previews.yml
+++ b/.github/workflows/deploy-pages-previews.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: "Comment on PR with Devtools Link"
         if: contains(github.event.*.labels.*.name, 'preview:chrome-devtools-patches')
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           header: ${{ steps.finder.outputs.pr }}
           message: |
@@ -102,7 +102,7 @@ jobs:
 
       - name: "Comment on PR with Combined Link"
         if: contains(github.event.*.labels.*.name, 'preview:chrome-devtools-patches') && contains(github.event.*.labels.*.name, 'preview:workers-playground')
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           header: ${{ steps.finder.outputs.pr }}
           append: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: changes
         with:
           filters: |
@@ -106,7 +106,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: changes
         with:
           filters: |

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check user for team affiliation
-        uses: tspascoal/get-user-teams-membership@v2
+        uses: tspascoal/get-user-teams-membership@ba78054988f58bea69b7c6136d563236f8ed2fc0 # v2
         id: teamAffiliation
         with:
           GITHUB_TOKEN: ${{ secrets.READ_ONLY_ORG_GITHUB_TOKEN }}

--- a/.github/workflows/test-and-check-other-node.yml
+++ b/.github/workflows/test-and-check-other-node.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 1
 
       - name: Filter changed paths
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: changes
         with:
           filters: |

--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -98,7 +98,7 @@ jobs:
           fetch-depth: 0
 
       - name: Filter changed paths
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: changes
         with:
           filters: |

--- a/.github/workflows/validate-pr-description.yml
+++ b/.github/workflows/validate-pr-description.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: changes
         with:
           filters: |
@@ -52,7 +52,7 @@ jobs:
       - name: List changed files
         if: steps.changes.outputs.everything_but_markdown == 'true'
         id: files
-        uses: Ana06/get-changed-files@v2.3.0
+        uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c # v2.3.0
         with:
           format: "json"
 

--- a/.github/workflows/vite-plugin-playgrounds.yml
+++ b/.github/workflows/vite-plugin-playgrounds.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
       - name: Filter changed paths
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: changes
         with:
           filters: |


### PR DESCRIPTION
N/A - supply chain security improvement, no issue.

Pin all 8 unpinned third-party GitHub Actions to their current commit SHAs to improve supply chain security. This prevents a compromised upstream action from executing arbitrary code in our CI pipelines.

**Actions pinned (17 occurrences across 13 files):**

| Action | Version | SHA |
|--------|---------|-----|
| `dorny/paths-filter` | v3 | `de90cc6fb38fc0963ad72b210f1f284cd68cea36` |
| `marocchino/sticky-pull-request-comment` | v2 | `773744901bac0e8cbb5a0dc842800d45e9b2b405` |
| `pnpm/action-setup` | v4 | `41ff72655975bd51cab0327fa583b6e92b6d3061` |
| `changesets/action` | v1 (branch) | `6a0a831ff30acef54f2c6aa1cbbc1096b066edaf` |
| `tj-actions/changed-files` | v45 | `48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c` |
| `Ana06/get-changed-files` | v2.3.0 | `25f79e676e7ea1868813e21465014798211fad8c` |
| `tspascoal/get-user-teams-membership` | v2 | `ba78054988f58bea69b7c6136d563236f8ed2fc0` |
| `astral-sh/setup-uv` | v6 | `d0cc045d04ccac9d8b7881df0226f9e82c39688e` |

Each pinned reference includes a `# version` comment for readability, following the convention already established in `codeowners.yml`. Also resolves an inconsistency where `tspascoal/get-user-teams-membership` was pinned in `run-ci-for-external-forks.yml` but unpinned in `hotfix-release.yml`.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: CI workflow syntax is unchanged, only action references are pinned to specific commits
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal CI change only
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
