### PR TITLE
Add support for connect handler in vitest and vite tests

### DIFF
--- a/packages/vite-plugin-cloudflare/src/workers/runner-worker/keys.ts
+++ b/packages/vite-plugin-cloudflare/src/workers/runner-worker/keys.ts
@@ -9,6 +9,7 @@ export const IGNORED_KEYS = ["self"] as const;
 
 /** Available methods for `WorkerEntrypoint` class */
 export const WORKER_ENTRYPOINT_KEYS = [
+	"connect",
 	"email",
 	"fetch",
 	"queue",
@@ -22,6 +23,7 @@ export const WORKER_ENTRYPOINT_KEYS = [
 /** Available methods for `DurableObject` class */
 export const DURABLE_OBJECT_KEYS = [
 	"alarm",
+	"connect",
 	"fetch",
 	"webSocketClose",
 	"webSocketError",

--- a/packages/vitest-pool-workers/src/worker/entrypoints.ts
+++ b/packages/vitest-pool-workers/src/worker/entrypoints.ts
@@ -184,6 +184,7 @@ const WORKER_ENTRYPOINT_KEYS = [
 	"queue",
 	"test",
 	"email",
+	"connect",
 ] as const;
 const DURABLE_OBJECT_KEYS = [
 	"fetch",
@@ -191,6 +192,7 @@ const DURABLE_OBJECT_KEYS = [
 	"webSocketMessage",
 	"webSocketClose",
 	"webSocketError",
+	"connect",
 ] as const;
 
 // This type will grab the keys from T and remove "branded" keys


### PR DESCRIPTION
Follow-up to https://github.com/cloudflare/workers-sdk/pull/12775 and part of EW-9330. Updates tests so that the connect handler is marked as reserved and as a potential member of the WorkerEntrypoint class. ~Needs https://github.com/cloudflare/workerd/pull/6059 to land first, which in turn requires https://github.com/cloudflare/workers-sdk/pull/12775.~ Other PRs have landed, just need to update to workerd 
v1.20260324.1 (or higher) first.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated: Tests should pass after https://github.com/cloudflare/workerd/pull/6059 has landed.
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Feature is behind experimental compat flag for now.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
