### PR TITLE
[wrangler] Fix d1 execute --json returning string "null" for SQL NULL values

### DIFF
--- a/.changeset/fix-d1-json-null-values.md
+++ b/.changeset/fix-d1-json-null-values.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler d1 execute --json` returning `"null"` (string) instead of `null` (JSON null) for SQL NULL values
+
+When using `wrangler d1 execute --json` with local execution, SQL NULL values were incorrectly serialized as the string `"null"` instead of JSON `null`. This produced invalid JSON output that violated RFC 4627. The fix removes the explicit null-to-string conversion so NULL values are preserved as proper JSON null in the output.

--- a/packages/wrangler/src/__tests__/d1/execute.test.ts
+++ b/packages/wrangler/src/__tests__/d1/execute.test.ts
@@ -230,6 +230,23 @@ describe("execute", () => {
 		]);
 	});
 
+	it("should output JSON null for SQL NULL values with --json flag", async ({
+		expect,
+	}) => {
+		setIsTTY(false);
+		writeWranglerConfig({
+			d1_databases: [
+				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+			],
+		});
+
+		await runWrangler(
+			"d1 execute db --command 'SELECT 1 as id, null as name;' --json"
+		);
+		const parsed = JSON.parse(std.out);
+		expect(parsed[0].results[0].name).toBeNull();
+	});
+
 	describe("duration formatting", () => {
 		mockAccountId({ accountId: "some-account-id" });
 		mockApiToken();

--- a/packages/wrangler/src/d1/execute.ts
+++ b/packages/wrangler/src/d1/execute.ts
@@ -33,7 +33,7 @@ import type { D1Result } from "@cloudflare/workers-types/experimental";
 import type { ComplianceConfig, Config } from "@cloudflare/workers-utils";
 
 export type QueryResult = {
-	results: Record<string, string | number | boolean>[];
+	results: Record<string, string | number | boolean | null>[];
 	success: boolean;
 	meta?: {
 		duration?: number;
@@ -327,9 +327,6 @@ async function executeLocally({
 				Object.entries(row).map(([key, value]) => {
 					if (Array.isArray(value)) {
 						value = `[${value.join(", ")}]`;
-					}
-					if (value === null) {
-						value = "null";
 					}
 					return [key, value];
 				})


### PR DESCRIPTION
Fixes #6378.

When using `wrangler d1 execute --json` with local execution, SQL NULL values were incorrectly serialized as the string `"null"` instead of JSON `null`. This produced invalid JSON output that violated RFC 4627.

The bug was in `executeLocally()` in `packages/wrangler/src/d1/execute.ts`, where the result mapping explicitly converted `null` values to the string `"null"`:

```ts
if (value === null) {
    value = "null";
}
```

This fix:
1. Removes that null-to-string conversion so SQL NULLs are preserved as JSON `null`
2. Updates the `QueryResult` type to include `null` in the value union (`string | number | boolean | null`)
3. Adds a test verifying NULL values produce JSON `null` in `--json` output

The table display path (non-JSON) already handles this correctly via `String(v)` which renders null as "null" for terminal display, so no change is needed there.

> Note: This PR was authored by an AI (Claude). Full transparency: I am an AI contributor working on open-source issues. See [maxwellcalkin/README](https://github.com/maxwellcalkin) for details.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is a bug fix with no API change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
