### PR TITLE
fix(d1): allow remote d1 migrations when id is not specified

### DIFF
--- a/.changeset/silver-pears-burn.md
+++ b/.changeset/silver-pears-burn.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix D1 remote database resolution to fall back to `database_name` when a binding in config does not have a `database_id`. This allows commands like `wrangler d1 migrations apply --remote` to work after [deploy-time auto provisioning](https://developers.cloudflare.com/workers/wrangler/configuration/#automatic-provisioning).

--- a/packages/wrangler/src/__tests__/d1/migrate.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrate.test.ts
@@ -56,6 +56,81 @@ describe("migrate", () => {
 	describe("apply", () => {
 		mockAccountId({ accountId: null });
 		mockApiToken();
+
+		it("should apply remote migrations when config has database_name but no database_id", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			mockGetMemberships([
+				{ id: "IG-88", account: { id: "1701", name: "enterprise" } },
+			]);
+
+			writeWranglerConfig({
+				d1_databases: [{ binding: "DATABASE", database_name: "db" }],
+			});
+
+			const seenDatabaseIds: string[] = [];
+
+			msw.use(
+				http.get("*/accounts/:accountId/d1/database", async () => {
+					return HttpResponse.json(
+						{
+							result: [
+								{
+									file_size: 7421952,
+									name: "db",
+									num_tables: 2,
+									uuid: "resolved-db-id",
+									version: "production",
+								},
+							],
+							success: true,
+							errors: [],
+							messages: [],
+						},
+						{ status: 200 }
+					);
+				}),
+				http.post(
+					"*/accounts/:accountId/d1/database/:databaseId/query",
+					async ({ params }) => {
+						seenDatabaseIds.push(params.databaseId as string);
+						return HttpResponse.json(
+							{
+								result: [
+									{
+										results: [],
+										success: true,
+										meta: {},
+									},
+								],
+								success: true,
+								errors: [],
+								messages: [],
+							},
+							{ status: 200 }
+						);
+					}
+				)
+			);
+
+			mockConfirm({
+				text: `No migrations folder found. Set \`migrations_dir\` in your wrangler.toml file to choose a different path.
+Ok to create <cwd>/migrations?`,
+				result: true,
+			});
+			await runWrangler("d1 migrations create DATABASE test");
+
+			mockConfirm({
+				text: `About to apply 1 migration(s)
+Your database may not be available to serve requests during the migration, continue?`,
+				result: true,
+			});
+
+			await runWrangler("d1 migrations apply DATABASE --remote");
+			expect(seenDatabaseIds).toContain("resolved-db-id");
+		});
+
 		it("should not attempt to login in local mode", async ({ expect }) => {
 			setIsTTY(false);
 			writeWranglerConfig({

--- a/packages/wrangler/src/__tests__/d1/utils.test.ts
+++ b/packages/wrangler/src/__tests__/d1/utils.test.ts
@@ -180,4 +180,76 @@ describe("getDatabaseByNameOrBinding", () => {
 			getDatabaseByNameOrBinding(config, "123", "db")
 		).resolves.toStrictEqual(mockDb);
 	});
+
+	it("should resolve a config database without database_id via remote lookup", async ({
+		expect,
+	}) => {
+		mockGetMemberships([
+			{ id: "IG-88", account: { id: "1701", name: "enterprise" } },
+		]);
+		const mockDb = {
+			file_size: 7421952,
+			name: "db-from-config",
+			num_tables: 2,
+			uuid: "7b0c1d24-ec57-4179-8663-9b82dafe9277",
+			version: "alpha",
+		};
+
+		msw.use(
+			http.get("*/accounts/:accountId/d1/database", async () => {
+				return HttpResponse.json(
+					{
+						result: [mockDb],
+						success: true,
+						errors: [],
+						messages: [],
+					},
+					{ status: 200 }
+				);
+			})
+		);
+
+		const config = {
+			d1_databases: [
+				{
+					binding: "DB_BINDING",
+					database_name: "db-from-config",
+				},
+			],
+		} as unknown as Config;
+
+		await expect(
+			getDatabaseByNameOrBinding(config, "123", "DB_BINDING")
+		).resolves.toStrictEqual(mockDb);
+	});
+
+	it("should still error when config has no database_id and database_name cannot be resolved", async ({
+		expect,
+	}) => {
+		mockGetMemberships([
+			{ id: "IG-88", account: { id: "1701", name: "enterprise" } },
+		]);
+
+		msw.use(
+			http.get("*/accounts/:accountId/d1/database", async () => {
+				return HttpResponse.json(
+					{
+						result: [],
+						success: true,
+						errors: [],
+						messages: [],
+					},
+					{ status: 200 }
+				);
+			})
+		);
+
+		const config = {
+			d1_databases: [{ binding: "DB_BINDING" }],
+		} as unknown as Config;
+
+		await expect(
+			getDatabaseByNameOrBinding(config, "123", "DB_BINDING")
+		).rejects.toThrowError("Couldn't find DB with name 'DB_BINDING'");
+	});
 });

--- a/packages/wrangler/src/d1/migrations/apply.ts
+++ b/packages/wrangler/src/d1/migrations/apply.ts
@@ -6,7 +6,6 @@ import { createCommand } from "../../core/create-command";
 import { confirm } from "../../dialogs";
 import { isNonInteractiveOrCI } from "../../is-interactive";
 import { logger } from "../../logger";
-import { isLocal } from "../../utils/is-local";
 import { DEFAULT_MIGRATION_PATH, DEFAULT_MIGRATION_TABLE } from "../constants";
 import { executeSql } from "../execute";
 import { getDatabaseInfoFromConfig } from "../utils";
@@ -75,8 +74,10 @@ export const d1MigrationsApplyCommand = createCommand({
 			);
 		}
 
+		// Migrations config lookup is only for local metadata (folder/table names).
+		// Remote execution resolves the real database UUID separately.
 		const databaseInfo = getDatabaseInfoFromConfig(config, database, {
-			requireDatabaseId: !isLocal({ local, remote }),
+			requireDatabaseId: false,
 		});
 
 		if (!databaseInfo && remote) {

--- a/packages/wrangler/src/d1/migrations/list.ts
+++ b/packages/wrangler/src/d1/migrations/list.ts
@@ -3,7 +3,6 @@ import { configFileName, UserError } from "@cloudflare/workers-utils";
 import { createCommand } from "../../core/create-command";
 import { logger } from "../../logger";
 import { requireAuth } from "../../user";
-import { isLocal } from "../../utils/is-local";
 import { DEFAULT_MIGRATION_PATH, DEFAULT_MIGRATION_TABLE } from "../constants";
 import { getDatabaseInfoFromConfig } from "../utils";
 import {
@@ -61,8 +60,10 @@ export const d1MigrationsListCommand = createCommand({
 			);
 		}
 
+		// Migrations config lookup is only for local metadata (folder/table names).
+		// Remote execution resolves the real database UUID separately.
 		const databaseInfo = getDatabaseInfoFromConfig(config, database, {
-			requireDatabaseId: !isLocal({ local, remote }), // Only require database_id for remote operations
+			requireDatabaseId: false,
 		});
 		if (!databaseInfo && remote) {
 			throw new UserError(

--- a/packages/wrangler/src/d1/utils.ts
+++ b/packages/wrangler/src/d1/utils.ts
@@ -53,15 +53,28 @@ export const getDatabaseByNameOrBinding = async (
 	accountId: string,
 	name: string
 ): Promise<Database> => {
-	const dbFromConfig = getDatabaseInfoFromConfig(config, name);
-	if (dbFromConfig) {
+	/**
+	 * Resolve a D1 database from a config binding/name for remote operations.
+	 *
+	 * If the binding in config already has a `database_id`, return that directly.
+	 * If it doesn't (for example, resource provisioning happened at deploy time),
+	 * fall back to account-level lookup by `database_name` so remote commands still work.
+	 */
+	const dbFromConfig = getDatabaseInfoFromConfig(config, name, {
+		requireDatabaseId: false,
+	});
+	if (
+		dbFromConfig?.uuid !== undefined &&
+		dbFromConfig.uuid !== dbFromConfig.binding
+	) {
 		return dbFromConfig;
 	}
 
 	const allDBs = await listDatabases(config, accountId);
-	const matchingDB = allDBs.find((db) => db.name === name);
+	const remoteLookupName = dbFromConfig?.name ?? name;
+	const matchingDB = allDBs.find((db) => db.name === remoteLookupName);
 	if (!matchingDB) {
-		throw new UserError(`Couldn't find DB with name '${name}'`);
+		throw new UserError(`Couldn't find DB with name '${remoteLookupName}'`);
 	}
 	return matchingDB;
 };


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/12809

_Describe your change..._

allow remote d1 migrations when id is not specified.

Perform a look up when ID is missing to allow running migrations when the DB is [auto-provisioned from the wrangler file](https://developers.cloudflare.com/workers/wrangler/configuration/#automatic-provisioning).

See the issue for more context (I couldn't run the remote migration if the ID is not specified in the wrangler.jsonc file.)

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: it's a bug

*A picture of a cute animal (not mandatory, but encouraged)*

<img width="116" height="123" alt="random cat pic from google :D" src="https://github.com/user-attachments/assets/7dd0951f-c1aa-4f27-9b48-994c0b857586" />

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.

yes I did
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
