### PR TITLE
Add workers-utils back into changesets

### DIFF
--- a/packages/workers-utils/package.json
+++ b/packages/workers-utils/package.json
@@ -32,6 +32,7 @@
 		"build": "tsup",
 		"check:lint": "eslint . --max-warnings=0 --cache",
 		"check:type": "tsc -p ./tsconfig.json",
+		"deploy": "echo 'no deploy'",
 		"dev": "concurrently -c black,blue --kill-others-on-fail false \"pnpm tsup --watch src\" \"pnpm run check:type --watch --preserveWatchOutput\"",
 		"test": "vitest",
 		"test:ci": "vitest run",

--- a/tools/deployments/__tests__/validate-changesets.test.ts
+++ b/tools/deployments/__tests__/validate-changesets.test.ts
@@ -39,6 +39,7 @@ describe("findPackageNames()", () => {
 				"@cloudflare/workers-editor-shared",
 				"@cloudflare/workers-playground",
 				"@cloudflare/workers-shared",
+				"@cloudflare/workers-utils",
 				"@cloudflare/workflows-shared",
 				"create-cloudflare",
 				"miniflare",


### PR DESCRIPTION
Add workers-utils back into changesets

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12817" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
