### PR TITLE
SQC-792 add .dev.vars env file support for hyperdrive binding

### DIFF
--- a/.changeset/metal-clowns-throw.md
+++ b/.changeset/metal-clowns-throw.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Adds env file support for local hyperdrive binding

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -955,6 +955,150 @@ describe.each(HYPERDRIVE_DATABASES)(
 			await socketMsgPromise;
 		});
 
+		it("uses CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE from .dev.vars", async ({
+			expect,
+		}) => {
+			const helper = new WranglerE2ETestHelper();
+			let port: number = defaultPort;
+			if (server.address() && typeof server.address() !== "string") {
+				port = (server.address() as nodeNet.AddressInfo).port;
+			}
+			await helper.seed({
+				".dev.vars": dedent`
+					CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE= "${scheme}://user:pass@127.0.0.1:${port}/some_db"
+				`,
+				"wrangler.toml": dedent`
+					name = "${workerName}"
+					main = "src/index.ts"
+					compatibility_date = "2023-10-25"
+
+					[[hyperdrive]]
+					binding = "HYPERDRIVE"
+					id = "hyperdrive_id"
+			`,
+				"src/index.ts": dedent`
+					export default {
+						async fetch(request, env) {
+							if (request.url.includes("connect")) {
+								const conn = env.HYPERDRIVE.connect();
+								await conn.writable.getWriter().write(new TextEncoder().encode("test string"));
+							}
+							return new Response(env.HYPERDRIVE?.connectionString ?? "no")
+						}
+					}`,
+				"package.json": dedent`
+					{
+						"name": "worker",
+						"version": "0.0.0",
+						"private": true
+					}
+					`,
+			});
+
+			const worker = helper.runLongLived("wrangler dev");
+
+			const { url } = await worker.waitForReady();
+			const socketMsgPromise = new Promise((resolve, reject) => {
+				server.on("connection", (socket) => {
+					// For MySQL, send initial handshake first
+					if (scheme === "mysql") {
+						socket.write(MYSQL_INITIAL_HANDSHAKE_PACKET);
+					}
+					socket.on("data", (chunk) => {
+						if (
+							scheme === "postgresql" &&
+							POSTGRES_SSL_REQUEST_PACKET.equals(chunk)
+						) {
+							socket.write("N");
+							return;
+						}
+						expect(new TextDecoder().decode(chunk)).toBe("test string");
+						server.close();
+						resolve({});
+					});
+					socket.on("error", (err) => {
+						console.error("Socket error:", err);
+						reject(err);
+					});
+				});
+			});
+			await fetch(`${url}/connect`);
+
+			await socketMsgPromise;
+		});
+
+		it("uses CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE from .env", async ({
+			expect,
+		}) => {
+			const helper = new WranglerE2ETestHelper();
+			let port: number = defaultPort;
+			if (server.address() && typeof server.address() !== "string") {
+				port = (server.address() as nodeNet.AddressInfo).port;
+			}
+			await helper.seed({
+				".env": dedent`
+					CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE= "${scheme}://user:pass@127.0.0.1:${port}/some_db"
+				`,
+				"wrangler.toml": dedent`
+					name = "${workerName}"
+					main = "src/index.ts"
+					compatibility_date = "2023-10-25"
+
+					[[hyperdrive]]
+					binding = "HYPERDRIVE"
+					id = "hyperdrive_id"
+			`,
+				"src/index.ts": dedent`
+					export default {
+						async fetch(request, env) {
+							if (request.url.includes("connect")) {
+								const conn = env.HYPERDRIVE.connect();
+								await conn.writable.getWriter().write(new TextEncoder().encode("test string"));
+							}
+							return new Response(env.HYPERDRIVE?.connectionString ?? "no")
+						}
+					}`,
+				"package.json": dedent`
+					{
+						"name": "worker",
+						"version": "0.0.0",
+						"private": true
+					}
+					`,
+			});
+
+			const worker = helper.runLongLived("wrangler dev");
+
+			const { url } = await worker.waitForReady();
+			const socketMsgPromise = new Promise((resolve, reject) => {
+				server.on("connection", (socket) => {
+					// For MySQL, send initial handshake first
+					if (scheme === "mysql") {
+						socket.write(MYSQL_INITIAL_HANDSHAKE_PACKET);
+					}
+					socket.on("data", (chunk) => {
+						if (
+							scheme === "postgresql" &&
+							POSTGRES_SSL_REQUEST_PACKET.equals(chunk)
+						) {
+							socket.write("N");
+							return;
+						}
+						expect(new TextDecoder().decode(chunk)).toBe("test string");
+						server.close();
+						resolve({});
+					});
+					socket.on("error", (err) => {
+						console.error("Socket error:", err);
+						reject(err);
+					});
+				});
+			});
+			await fetch(`${url}/connect`);
+
+			await socketMsgPromise;
+		});
+
 		it.skipIf(!CLOUDFLARE_ACCOUNT_ID || !process.env[envVar])(
 			"does not require local connection string when running `wrangler dev --remote`",
 			async () => {

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -2053,6 +2053,115 @@ describe.sequential("wrangler dev", () => {
 		});
 	});
 
+	describe("hyperdrive local connection strings", () => {
+		const processEnv = process.env;
+		beforeEach(() => (process.env = { ...processEnv }));
+		afterEach(() => (process.env = processEnv));
+
+		function writeHyperdriveWorkerConfig() {
+			fs.writeFileSync("index.js", `export default {};`);
+			writeWranglerConfig({
+				main: "index.js",
+				hyperdrive: [{ binding: "DB", id: "db-id" }],
+			});
+		}
+
+		it("should prefer .dev.vars over .env, process.env, and config for Hyperdrive bindings", async ({
+			expect,
+		}) => {
+			fs.writeFileSync("index.js", `export default {};`);
+			writeWranglerConfig({
+				main: "index.js",
+				hyperdrive: [
+					{
+						binding: "DB",
+						id: "db-id",
+						localConnectionString:
+							"postgres://user:pass@127.0.0.1:5432/config-db",
+					},
+				],
+			});
+			fs.writeFileSync(
+				".env",
+				"CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_DB=postgres://user:pass@127.0.0.1:5432/dot-env-db\n"
+			);
+			fs.writeFileSync(
+				".dev.vars",
+				"CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_DB=postgres://user:pass@127.0.0.1:5432/dev-vars-db\n"
+			);
+			// eslint-disable-next-line turbo/no-undeclared-env-vars
+			process.env.CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_DB =
+				"postgres://user:pass@127.0.0.1:5432/process-env-db";
+			// eslint-disable-next-line turbo/no-undeclared-env-vars
+			process.env.WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_DB =
+				"postgres://user:pass@127.0.0.1:5432/deprecated-process-env-db";
+
+			const config = await runWranglerUntilConfig("dev");
+
+			expect(config.bindings?.DB).toMatchObject({
+				type: "hyperdrive",
+				id: "db-id",
+				localConnectionString:
+					"postgres://user:pass@127.0.0.1:5432/dev-vars-db",
+			});
+		});
+
+		it("should sync a Hyperdrive local connection string from process.env into bindings", async ({
+			expect,
+		}) => {
+			writeHyperdriveWorkerConfig();
+			// eslint-disable-next-line turbo/no-undeclared-env-vars
+			process.env.CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_DB =
+				"postgres://user:pass@127.0.0.1:5432/process-env-db";
+
+			const config = await runWranglerUntilConfig("dev");
+
+			expect(config.bindings?.DB).toMatchObject({
+				type: "hyperdrive",
+				id: "db-id",
+				localConnectionString:
+					"postgres://user:pass@127.0.0.1:5432/process-env-db",
+			});
+		});
+
+		it("should sync a Hyperdrive local connection string from .env into bindings", async ({
+			expect,
+		}) => {
+			writeHyperdriveWorkerConfig();
+			fs.writeFileSync(
+				".env",
+				"CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_DB=postgres://user:pass@127.0.0.1:5432/dot-env-db\n"
+			);
+
+			const config = await runWranglerUntilConfig("dev");
+
+			expect(config.bindings?.DB).toMatchObject({
+				type: "hyperdrive",
+				id: "db-id",
+				localConnectionString: "postgres://user:pass@127.0.0.1:5432/dot-env-db",
+			});
+		});
+
+		it("should sync a Hyperdrive local connection string from .dev.vars into bindings", async ({
+			expect,
+		}) => {
+			writeHyperdriveWorkerConfig();
+			fs.writeFileSync(
+				".dev.vars",
+				"CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_DB=postgres://user:pass@127.0.0.1:5432/dev-vars-db\n"
+			);
+
+			const config = await runWranglerUntilConfig("dev");
+
+			expect(config.bindings?.DB).toMatchObject({
+				type: "hyperdrive",
+				id: "db-id",
+				localConnectionString:
+					"postgres://user:pass@127.0.0.1:5432/dev-vars-db",
+			});
+		});
+	});
+
 	describe(".env in local dev", () => {
 		const processEnv = process.env;
 		beforeEach(() => (process.env = { ...processEnv }));

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -15,6 +15,7 @@ import { startDev } from "./dev/start-dev";
 import { logger } from "./logger";
 import { getHostFromRoute } from "./zones";
 import type { StartDevWorkerInput, Trigger } from "./api";
+import type { VarBinding } from "./dev/dev-vars";
 import type { EnablePagesAssetsServiceBindingOptions } from "./miniflare-cli/types";
 import type {
 	Binding,
@@ -433,15 +434,28 @@ export function getInferredHost(
  * Checks for CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_* env vars
  * and applies them to the config's hyperdrive bindings.
  */
-function applyHyperdriveEnvVars(config: Config, local: boolean): void {
+function applyHyperdriveEnvVars(
+	config: Config,
+	local: boolean,
+	localDevVars: Record<string, VarBinding>
+): void {
 	for (const hyperdrive of config.hyperdrive ?? []) {
 		const prefix = `CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_`;
-		const deprecatedPrefix = `WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_`;
-
 		let varName = `${prefix}${hyperdrive.binding}`;
 		let connectionStringFromEnv = process.env[varName];
+		// local .dev.vars or .env files overrides if binding name matches
+		if (varName in localDevVars) {
+			hyperdrive.localConnectionString =
+				localDevVars[varName].value?.toString();
+			continue; // move on to next binding
+		}
 
-		if (!connectionStringFromEnv) {
+		// fallback to deprecated prefix
+		const deprecatedPrefix = `WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_`;
+		if (
+			!connectionStringFromEnv &&
+			hyperdrive.localConnectionString === undefined
+		) {
 			varName = `${deprecatedPrefix}${hyperdrive.binding}`;
 			connectionStringFromEnv = process.env[varName];
 		}
@@ -473,6 +487,18 @@ function applyHyperdriveEnvVars(config: Config, local: boolean): void {
 		}
 	}
 }
+
+function syncHyperdriveBindingConnectionStrings(
+	config: Config,
+	bindings: NonNullable<StartDevWorkerInput["bindings"]>
+): void {
+	for (const hyperdrive of config.hyperdrive ?? []) {
+		const binding = bindings[hyperdrive.binding];
+		if (binding?.type === "hyperdrive") {
+			binding.localConnectionString = hyperdrive.localConnectionString;
+		}
+	}
+}
 /**
  * Gets the bindings for the Cloudflare Worker.
  *
@@ -492,8 +518,6 @@ export function getBindings(
 	inputBindings: StartDevWorkerInput["bindings"],
 	defaultBindings: StartDevWorkerInput["bindings"]
 ): StartDevWorkerInput["bindings"] {
-	applyHyperdriveEnvVars(configParam, local);
-
 	const bindings = convertConfigToBindings(configParam, {
 		usePreviewIds: true,
 	});
@@ -510,6 +534,11 @@ export function getBindings(
 		false,
 		configParam.secrets
 	);
+
+	// apply hyperdrive env variables after local dev vars to read file once
+	applyHyperdriveEnvVars(configParam, local, vars);
+	syncHyperdriveBindingConnectionStrings(configParam, bindings);
+
 	for (const [name, binding] of Object.entries(vars)) {
 		// Only override plain_text/json/secret_text vars, not other binding types like kv_namespace
 		const existingBinding = bindings[name];


### PR DESCRIPTION
Fixes SQC-792.

Adds .dev.vars env file support for hyperdrive binding when running `wrangler dev`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [X] Tests included/updated
  - [X] Automated tests not possible - manual testing has been completed as follows: 
Built wrangler locally: pnpm run build --filter wrangler
Run built version of wrangler against local worker with .dev.vars file and CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE pointing at remote db:
node ~/cf-hyperdrive/workers-sdk/packages/wrangler/wrangler-dist/cli.js dev

  - [X] Additional testing not necessary because: tests full use case
- Public documentation
  - [X] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/28905

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
