### PR TITLE
Generate `app/env.d.ts` and `server/env.d.ts` for Nuxt applications

### DIFF
--- a/.changeset/ripe-pants-start.md
+++ b/.changeset/ripe-pants-start.md
@@ -1,0 +1,9 @@
+---
+"create-cloudflare": patch
+---
+
+Generate `app/env.d.ts` and `server/env.d.ts` for Nuxt applications
+
+Previously, only a top-level `env.d.ts` was created, which meant server files didn't receive Cloudflare types. Now the CLI generates separate `app/env.d.ts` and `server/env.d.ts` files, both importing from a shared `_cloudflare/env.d.ts` to avoid duplication.
+
+This ensures Cloudflare types are available in both app and server directories.

--- a/packages/create-cloudflare/templates/nuxt/pages/templates/_cloudflare/env.d.ts
+++ b/packages/create-cloudflare/templates/nuxt/pages/templates/_cloudflare/env.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="./worker-configuration.d.ts" />
+/// <reference types="../worker-configuration.d.ts" />
 
 declare module "h3" {
   interface H3EventContext {

--- a/packages/create-cloudflare/templates/nuxt/pages/templates/app/env.d.ts
+++ b/packages/create-cloudflare/templates/nuxt/pages/templates/app/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="../_cloudflare/env.d.ts" />

--- a/packages/create-cloudflare/templates/nuxt/pages/templates/server/env.d.ts
+++ b/packages/create-cloudflare/templates/nuxt/pages/templates/server/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="../_cloudflare/env.d.ts" />

--- a/packages/create-cloudflare/templates/nuxt/workers/templates/_cloudflare/env.d.ts
+++ b/packages/create-cloudflare/templates/nuxt/workers/templates/_cloudflare/env.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="./worker-configuration.d.ts" />
+/// <reference types="../worker-configuration.d.ts" />
 
 declare module "h3" {
   interface H3EventContext {

--- a/packages/create-cloudflare/templates/nuxt/workers/templates/app/env.d.ts
+++ b/packages/create-cloudflare/templates/nuxt/workers/templates/app/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="../_cloudflare/env.d.ts" />

--- a/packages/create-cloudflare/templates/nuxt/workers/templates/server/env.d.ts
+++ b/packages/create-cloudflare/templates/nuxt/workers/templates/server/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="../_cloudflare/env.d.ts" />


### PR DESCRIPTION
Fixes #11727 

Previously, only a top-level `env.d.ts` was created, which meant server files didn't receive Cloudflare types. Now the CLI generates separate `app/env.d.ts` and `server/env.d.ts` files, both importing from a shared `_cloudflare/env.d.ts` to avoid duplication.

This ensures Cloudflare types are available in both app and server directories.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows:
     - Run this PR's C3 prerelease to create a Nuxt application
     - Create an `api/hello.ts` file in the `server` directory with the following content:
        ```ts
        export default defineEventHandler((event) => {
           const { cloudflare } = event.context;

           return 'Hello';
        });
        ```
     - run the `build` script (that generates the Nuxt types)
     - ensure that the `cloudflare` context has the correct type (i.e. it is not an `any` nor `unknown`)
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: The types aspect of Nuxt is not part of our documentation: https://developers.cloudflare.com/workers/framework-guides/web-apps/more-web-frameworks/nuxt/

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
