### PR TITLE
[wrangler] fix: suppress status log messages when --json is used in vectorize list commands

### DIFF
--- a/.changeset/fix-vectorize-json-log-output.md
+++ b/.changeset/fix-vectorize-json-log-output.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: suppress status log messages when `--json` flag is used in `vectorize list` and `vectorize list-metadata-index` commands
+
+Previously, these commands printed a status message (e.g. "📋 Listing Vectorize indexes...") to stdout before the JSON output, making the combined output invalid JSON and breaking tools like `jq`. The status messages are now suppressed when `--json` is passed.

--- a/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
+++ b/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
@@ -356,6 +356,35 @@ describe("vectorize commands", () => {
 		`);
 	});
 
+	it("should handle listing vectorize indexes with valid JSON output", async () => {
+		mockVectorizeV2Request();
+		await runWrangler("vectorize list --json");
+		expect(JSON.parse(std.out)).toMatchInlineSnapshot(`
+			[
+			  {
+			    "config": {
+			      "dimensions": 1536,
+			      "metric": "euclidean",
+			    },
+			    "created_on": "2024-07-11T13:02:18.00268Z",
+			    "description": "test-desc",
+			    "modified_on": "2024-07-11T13:02:18.00268Z",
+			    "name": "test-index",
+			  },
+			  {
+			    "config": {
+			      "dimensions": 32,
+			      "metric": "dot-product",
+			    },
+			    "created_on": "2024-07-11T13:02:18.00268Z",
+			    "description": "another-desc",
+			    "modified_on": "2024-07-11T13:02:18.00268Z",
+			    "name": "another-index",
+			  },
+			]
+		`);
+	});
+
 	it("should warn when there are no vectorize indexes", async () => {
 		mockVectorizeV2RequestError();
 		await runWrangler("vectorize list");
@@ -853,6 +882,27 @@ describe("vectorize commands", () => {
 			├─┼─┤
 			│ bool-prop │ boolean │
 			└─┴─┘"
+		`);
+	});
+
+	it("should handle list metadata index with valid JSON output", async () => {
+		mockVectorizeV2Request();
+		await runWrangler("vectorize list-metadata-index test-index --json");
+		expect(JSON.parse(std.out)).toMatchInlineSnapshot(`
+			[
+			  {
+			    "indexType": "string",
+			    "propertyName": "string-prop",
+			  },
+			  {
+			    "indexType": "number",
+			    "propertyName": "num-prop",
+			  },
+			  {
+			    "indexType": "boolean",
+			    "propertyName": "bool-prop",
+			  },
+			]
 		`);
 	});
 

--- a/packages/wrangler/src/vectorize/list.ts
+++ b/packages/wrangler/src/vectorize/list.ts
@@ -25,7 +25,9 @@ export const vectorizeListCommand = createCommand({
 		},
 	},
 	async handler(args, { config }) {
-		logger.log(`📋 Listing Vectorize indexes...`);
+		if (!args.json) {
+			logger.log(`📋 Listing Vectorize indexes...`);
+		}
 		const indexes = await listIndexes(config, args.deprecatedV1);
 
 		if (indexes.length === 0) {

--- a/packages/wrangler/src/vectorize/listMetadataIndex.ts
+++ b/packages/wrangler/src/vectorize/listMetadataIndex.ts
@@ -26,7 +26,9 @@ export const vectorizeListMetadataIndexCommand = createCommand({
 	},
 	positionalArgs: ["name"],
 	async handler(args, { config }) {
-		logger.log(`📋 Fetching metadata indexes...`);
+		if (!args.json) {
+			logger.log(`📋 Fetching metadata indexes...`);
+		}
 		const res = await listMetadataIndex(config, args.name);
 
 		if (res.metadataIndexes.length === 0) {


### PR DESCRIPTION
Fixes #11011.

\`wrangler vectorize list --json\` and \`wrangler vectorize list-metadata-index --json\` were printing a status message (e.g. \`📋 Listing Vectorize indexes...\`) to stdout **before** the JSON array, making the combined output invalid JSON and breaking piping to tools like \`jq\`.

This was fixed in \`vectorize list-vectors\` (see #10508) but not in the other two list commands. This PR applies the same pattern used there.

**Before:**
\`\`\`
📋 Listing Vectorize indexes...
[{ ... }]
\`\`\`

**After (\`--json\`):**
\`\`\`
[{ ... }]
\`\`\`

---

- Tests
  - [x] Tests included/updated — 2 new tests verify \`JSON.parse(stdout)\` succeeds when \`--json\` is passed
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: bug fix for existing behaviour, no API change