### PR TITLE
Strip query strings from module names when writing to disk

### DIFF
--- a/.changeset/fix-wasm-query-string-windows.md
+++ b/.changeset/fix-wasm-query-string-windows.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Strip query strings from module names before writing to disk
+
+When bundling modules with query string suffixes (e.g. `.wasm?module`), the `?` character was included in the output filename. Since `?` is not a valid filename character on Windows, this caused an ENOENT error during `wrangler dev`. This was particularly visible when using Prisma Client with the D1 adapter, which imports `.wasm?module` files.
+
+The fix strips query strings from module names before writing them to disk, while preserving correct module resolution.

--- a/packages/wrangler/src/__tests__/deploy/formats.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/formats.test.ts
@@ -344,6 +344,47 @@ describe("deploy", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
+		it("should strip query string suffixes from module names (esm)", async () => {
+			writeWranglerConfig();
+			fs.writeFileSync(
+				"./index.js",
+				`import hello from './hello.wasm?module'; export default {};`
+			);
+			fs.writeFileSync("./hello.wasm", "SOME WASM CONTENT");
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedType: "esm",
+				expectedBindings: [],
+				expectedModules: {
+					"./94b240d0d692281e6467aa42043986e5c7eea034-hello.wasm":
+						"SOME WASM CONTENT",
+				},
+			});
+			await runWrangler("deploy index.js");
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
+		it("should strip query string suffixes from module names with preserve_file_names (esm)", async () => {
+			writeWranglerConfig({
+				preserve_file_names: true,
+			});
+			fs.writeFileSync(
+				"./index.js",
+				`import hello from './hello.wasm?module'; export default {};`
+			);
+			fs.writeFileSync("./hello.wasm", "SOME WASM CONTENT");
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedType: "esm",
+				expectedBindings: [],
+				expectedModules: {
+					"./hello.wasm": "SOME WASM CONTENT",
+				},
+			});
+			await runWrangler("deploy index.js");
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
 		describe("inject process.env.NODE_ENV", () => {
 			beforeEach(() => {
 				vi.stubEnv("NODE_ENV", "some-node-env");

--- a/packages/wrangler/src/deployment-bundle/module-collection.ts
+++ b/packages/wrangler/src/deployment-bundle/module-collection.ts
@@ -44,6 +44,13 @@ export const RuleTypeToModuleType: Record<ConfigModuleRuleType, CfModuleType> =
 
 export const ModuleTypeToRuleType = flipObject(RuleTypeToModuleType);
 
+// Strip query string suffixes (e.g. `?module`) from module paths so that
+// file paths and module names don't contain characters invalid on Windows.
+function stripQueryString(modulePath: string): string {
+	const queryIndex = modulePath.indexOf("?");
+	return queryIndex !== -1 ? modulePath.slice(0, queryIndex) : modulePath;
+}
+
 // This is a combination of an esbuild plugin and a mutable array
 // that we use to collect module references from source code.
 // There will be modules that _shouldn't_ be inlined directly into
@@ -202,10 +209,11 @@ export function createModuleCollector(props: {
 
 							// take the file and massage it to a
 							// transportable/manageable format
+							const cleanedPath = stripQueryString(args.path);
 							const filePath = path.join(
 								// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 								props.wrangler1xLegacyModuleReferences!.rootDirectory,
-								args.path
+								cleanedPath
 							);
 							const fileContent = (await readFile(
 								filePath
@@ -215,8 +223,8 @@ export function createModuleCollector(props: {
 								.update(fileContent)
 								.digest("hex");
 							const fileName = props.preserveFileNames
-								? args.path
-								: `./${fileHash}-${path.basename(args.path)}`;
+								? cleanedPath
+								: `./${fileHash}-${path.basename(cleanedPath)}`;
 
 							const { rule } =
 								rulesMatchers.find(({ regex }) => regex.test(fileName)) || {};
@@ -257,13 +265,17 @@ export function createModuleCollector(props: {
 								// take the file and massage it to a
 								// transportable/manageable format
 
-								let filePath = path.join(args.resolveDir, args.path);
+								// Strip query string suffixes (e.g. `?module`) from the import
+								// path. The `?` character is not valid in filenames on Windows
+								// and would cause ENOENT errors when writing modules to disk.
+								const cleanedPath = stripQueryString(args.path);
+								let filePath = path.join(args.resolveDir, cleanedPath);
 
 								// If this was a found additional module, mark it as external.
 								// Note, there's no need to watch the file here as we already
 								// watch all `foundModulePaths` with `wrangler:modules-watch`.
 								if (foundModulePaths.includes(filePath)) {
-									return { path: args.path, external: true };
+									return { path: cleanedPath, external: true };
 								}
 								// For JavaScript module rules, we only register this onResolve
 								// callback if `findAdditionalModules` is true. If we didn't
@@ -277,7 +289,7 @@ export function createModuleCollector(props: {
 								// and if so, validate the import against the package.json exports
 								// and resolve the file path to the correct file.
 								try {
-									const resolved = await build.resolve(args.path, {
+									const resolved = await build.resolve(cleanedPath, {
 										kind: args.kind,
 										importer: args.importer,
 										resolveDir: args.resolveDir,
@@ -295,7 +307,7 @@ export function createModuleCollector(props: {
 
 								// Next try to resolve using the node module resolution algorithm
 								try {
-									const resolved = resolveSync(args.path, {
+									const resolved = resolveSync(cleanedPath, {
 										basedir: args.resolveDir,
 									});
 									filePath = resolved;
@@ -314,8 +326,8 @@ export function createModuleCollector(props: {
 									.update(fileContent)
 									.digest("hex");
 								const fileName = props.preserveFileNames
-									? args.path
-									: `./${fileHash}-${path.basename(args.path)}`;
+									? cleanedPath
+									: `./${fileHash}-${path.basename(cleanedPath)}`;
 
 								// add the module to the array
 								modules.push({


### PR DESCRIPTION
Fixes #11535.

Strip query strings from module names before writing to disk

When bundling modules with query string suffixes (e.g. `.wasm?module`), the `?` character was included in the output filename. Since `?` is not a valid filename character on Windows, this caused an ENOENT error during `wrangler dev`. This was particularly visible when using Prisma Client with the D1 adapter, which imports `.wasm?module` files.

The fix strips query strings from module names before writing them to disk, while preserving correct module resolution.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
