### PR TITLE
fix bonk membership check

### DIFF
--- a/.github/workflows/bonk-pr-review.yml
+++ b/.github/workflows/bonk-pr-review.yml
@@ -24,7 +24,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /orgs/cloudflare/members/${{ github.event.pull_request.user.login }} \
-            --silent -i 2>/dev/null | head -1 | awk '{print $2}')
+            --silent -i 2>/dev/null | head -1 | awk '{print $2}') || true
           if [ "$STATUS" != "204" ]; then
             echo "User ${{ github.event.pull_request.user.login }} is not a member of the Cloudflare organization"
             exit 1

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -27,7 +27,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /orgs/cloudflare/members/${{ github.event.comment.user.login }} \
-            --silent -i 2>/dev/null | head -1 | awk '{print $2}')
+            --silent -i 2>/dev/null | head -1 | awk '{print $2}') || true
           if [ "$STATUS" != "204" ]; then
             echo "User ${{ github.event.comment.user.login }} is not a member of the Cloudflare organization"
             exit 1


### PR DESCRIPTION
Fixes n/a

Previously we were relying on `author_association` in the workflow context, but this wouldn't work for users who have their org membership set to private.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: CI
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
