### PR TITLE
Fix execution freezing on `debugger` statements when DevTools is not attached

### DIFF
--- a/.changeset/open-apples-heal.md
+++ b/.changeset/open-apples-heal.md
@@ -4,4 +4,4 @@
 
 Fix execution freezing on `debugger` statements when DevTools is not attached
 
-Previously, `wrangler` always sent `Debugger.enable` to the runtime on connection, even when DevTools wasn't open. This caused scripts to freeze on `debugger` statements. Now `Debugger.enable` is only sent when DevTools is actually attached.
+Previously, `wrangler` always sent `Debugger.enable` to the runtime on connection, even when DevTools wasn't open. This caused scripts to freeze on `debugger` statements. Now `Debugger.enable` is only sent when DevTools is actually attached, and `Debugger.disable` is sent when DevTools disconnects to stop the runtime from performing debugging work.

--- a/packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts
@@ -555,24 +555,31 @@ export class InspectorProxyWorker implements DurableObject {
 			);
 		} else {
 			devtools.addEventListener("message", this.handleDevToolsIncomingMessage);
+			const disconnectDevtools = () => {
+				if (this.websockets.devtools === devtools) {
+					this.websockets.devtools = undefined;
+
+					// Notify the runtime to disable the debugger when DevTools disconnects.
+					if (this.websockets.runtime) {
+						this.sendRuntimeMessage({
+							id: this.nextCounter(),
+							method: "Debugger.disable",
+						});
+					}
+				}
+			};
 			devtools.addEventListener("close", (event) => {
 				this.sendDebugLog(
 					"DEVTOOLS WEBSOCKET CLOSED",
 					event.code,
 					event.reason
 				);
-
-				if (this.websockets.devtools === devtools) {
-					this.websockets.devtools = undefined;
-				}
+				disconnectDevtools();
 			});
 			devtools.addEventListener("error", (event) => {
 				const error = serialiseError(event.error);
 				this.sendDebugLog("DEVTOOLS WEBSOCKET ERROR", error);
-
-				if (this.websockets.devtools === devtools) {
-					this.websockets.devtools = undefined;
-				}
+				disconnectDevtools();
 			});
 
 			// Since Wrangler proxies the inspector, reloading Chrome DevTools won't trigger debugger initialisation events (because it's connecting to an extant session).


### PR DESCRIPTION
Fixes #7956 

Previously, `wrangler` always tried to connect to an inspector debugger, even when DevTools wasn't open. This caused scripts to freeze on `debugger` statements. Now the connection is only made when DevTools is actually attached.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows:
     - pull down the issue's [minimal reproduction](https://github.com/dario-piotrowicz/my-create-cloudflare-worker-29-01-2025)
     - run `npm i` and `npm start`, try fetching/visiting the worker's url and notice its execution being blocked
     - install this PR's prerelease (`npm i https://pkg.pr.new/wrangler@12835`)
     - try `npm start` again and see that the execution is no longer blocked
     - press the `d` hotkey and fetch from the worker again, see that debugging still works as expected
     - try to run `npm start` in a vscode debugger terminal and see that debugging still works as expected
     - run again the command normally and try to debug via chome's `chrome://inspect` page, see that debugging still works as expected
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
