### PR TITLE
Fix unclear error when assets upload session returns a `null` response

### DIFF
--- a/.changeset/olive-heads-arrive.md
+++ b/.changeset/olive-heads-arrive.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix unclear error when assets upload session returns a `null` response
+
+When deploying assets, if the Cloudflare API returns a `null` response object, Wrangler now provides a clear error message asking users to retry instead of failing with a confusing error.

--- a/packages/wrangler/src/__tests__/deploy/assets.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/assets.test.ts
@@ -1195,5 +1195,37 @@ describe("deploy", () => {
 			});
 			await runWrangler("deploy --dispatch-namespace my-namespace");
 		});
+
+		it("should error when assets upload session response is null", async () => {
+			const assets = [{ filePath: "file-1.txt", content: "Content of file-1" }];
+			writeAssets(assets);
+			writeWranglerConfig({
+				assets: { directory: "assets" },
+			});
+
+			// Mock the AUS endpoint to return a null result
+			msw.use(
+				http.post(
+					`*/accounts/some-account-id/workers/scripts/test-name/assets-upload-session`,
+					() => {
+						return HttpResponse.json(
+							{
+								success: true,
+								errors: [],
+								messages: [],
+								result: null,
+							},
+							{ status: 201 }
+						);
+					}
+				)
+			);
+
+			await expect(
+				runWrangler("deploy")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: An unexpected response has been received from the Cloudflare API for assets upload. Please try again.]`
+			);
+		});
 	});
 });

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -71,15 +71,24 @@ export const syncAssets = async (
 
 	// 2. fetch buckets w/ hashes
 	logger.info("🌀 Starting asset upload...");
-	const initializeAssetsResponse = await fetchResult<InitializeAssetsResponse>(
-		complianceConfig,
-		url,
-		{
+	const initializeAssetsResponse =
+		await fetchResult<InitializeAssetsResponse | null>(complianceConfig, url, {
 			headers: { "Content-Type": "application/json" },
 			method: "POST",
 			body: JSON.stringify({ manifest: manifest }),
-		}
-	);
+		});
+
+	// In the past we've seen the endpoint return that incorrectly doesn't contain
+	// a null response (see: https://github.com/cloudflare/workers-sdk/issues/9465).
+	// So just to be extra sure here we check the object and provide a clear error message to the user
+	// if it is falsy.
+	if (!initializeAssetsResponse) {
+		throw new FatalError(
+			"An unexpected response has been received from the Cloudflare API for assets upload. Please try again.",
+			1,
+			{ telemetryMessage: true }
+		);
+	}
 
 	// if nothing to upload, return
 	if (initializeAssetsResponse.buckets.flat().length === 0) {


### PR DESCRIPTION
Fixes #9465 

When deploying assets, if the Cloudflare API returns a `null` response object, Wrangler now provides a clear error message asking users to retry instead of failing with a confusing error.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this simply improves an error message

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12841" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
