### PR TITLE
[create-cloudflare] Quarantine Next.js experimental e2e test

### DIFF
--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -1,6 +1,5 @@
 import { detectPackageManager } from "../../../src/helpers/packageManagers";
 import {
-	CLOUDFLARE_API_TOKEN,
 	frameworkToTestFilter,
 	isExperimental,
 	keys,


### PR DESCRIPTION
Quarantines the Next.js experimental (workers platform) e2e test while we investigate CI failures.

The test was previously only conditionally quarantined when no `CLOUDFLARE_API_TOKEN` was available (fork PRs). This change quarantines it unconditionally.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this change only quarantines (skips) an existing test
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal test infrastructure change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12842" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
