### PR TITLE
CC-7209: Deprecate and hide OpenSSH options from ssh command

### DIFF
--- a/.changeset/deprecate-ssh-passthrough-flags.md
+++ b/.changeset/deprecate-ssh-passthrough-flags.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Deprecate SSH passthrough flags in `wrangler containers ssh`
+
+The `--cipher`, `--log-file`, `--escape-char`, `--config-file`, `--pkcs11`, `--identity-file`, `--mac-spec`, `--option`, and `--tag` flags are now deprecated. These flags expose OpenSSH-specific options that are tied to the current implementation. A future release will replace the underlying SSH transport, at which point these flags will be removed. They still function for now.

--- a/packages/wrangler/src/__tests__/containers/ssh.test.ts
+++ b/packages/wrangler/src/__tests__/containers/ssh.test.ts
@@ -35,18 +35,7 @@ describe("containers ssh", () => {
 			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]
-
-			OPTIONS
-			      --cipher         Sets \`ssh -c\`: Select the cipher specification for encrypting the session  [string]
-			      --log-file       Sets \`ssh -E\`: Append debug logs to log_file instead of standard error  [string]
-			      --escape-char    Sets \`ssh -e\`: Set the escape character for sessions with a pty (default: '~')  [string]
-			  -F, --config-file    Sets \`ssh -F\`: Specify an alternative per-user ssh configuration file  [string]
-			      --pkcs11         Sets \`ssh -I\`: Specify the PKCS#11 shared library ssh should use to communicate with a PKCS#11 token providing keys for user authentication  [string]
-			  -i, --identity-file  Sets \`ssh -i\`: Select a file from which the identity (private key) for public key authentication is read  [string]
-			      --mac-spec       Sets \`ssh -m\`: A comma-separated list of MAC (message authentication code) algorithms, specified in order of preference  [string]
-			  -o, --option         Sets \`ssh -o\`: Set options in the format used in the ssh configuration file. May be repeated  [string]
-			      --tag            Sets \`ssh -P\`: Specify a tag name that may be used to select configuration in ssh_config  [string]"
+			  -v, --version   Show version number  [boolean]"
 		`);
 	});
 
@@ -65,12 +54,12 @@ describe("containers ssh", () => {
 		setWranglerConfig({});
 		msw.use(
 			http.get(`*/instances/:instanceId/ssh`, async () => {
-				return new HttpResponse(
-					`{"success": false, "errors": [{"code": 1000, "message": "something happened"}]}`,
+				return HttpResponse.json(
 					{
-						type: "applicaton/json",
-						status: 500,
-					}
+						success: false,
+						errors: [{ code: 1000, message: "something happened" }],
+					},
+					{ status: 500 }
 				);
 			})
 		);
@@ -95,12 +84,9 @@ describe("containers ssh", () => {
 		setWranglerConfig({});
 		msw.use(
 			http.get(`*/instances/:instanceId/ssh`, async () => {
-				return new HttpResponse(
-					`{"success": true, "result": {"url": "${wsUrl}", "token": "${sshJwt}"}}`,
-					{
-						type: "applicaton/json",
-						status: 200,
-					}
+				return HttpResponse.json(
+					{ success: true, result: { url: wsUrl, token: sshJwt } },
+					{ status: 200 }
 				);
 			})
 		);

--- a/packages/wrangler/src/containers/ssh.ts
+++ b/packages/wrangler/src/containers/ssh.ts
@@ -12,78 +12,90 @@ import {
 import { createCommand } from "../core/create-command";
 import { logger } from "../logger";
 import { containersScope } from "./index";
-import type {
-	CommonYargsArgv,
-	StrictYargsOptionsToInterface,
-} from "../yargs-types";
+import type { HandlerArgs, NamedArgDefinitions } from "../core/types";
 import type { WranglerSSHResponse } from "@cloudflare/containers-shared";
 import type { Config } from "@cloudflare/workers-utils";
 import type { Server } from "node:net";
 
-export function sshYargs(args: CommonYargsArgv) {
-	return (
-		args
-			.positional("ID", {
-				describe: "ID of the container instance",
-				type: "string",
-				demandOption: true,
-			})
-			// Following are SSH flags that should be directly passed in
-			.option("cipher", {
-				describe:
-					"Sets `ssh -c`: Select the cipher specification for encrypting the session",
-				type: "string",
-			})
-			.option("log-file", {
-				describe:
-					"Sets `ssh -E`: Append debug logs to log_file instead of standard error",
-				type: "string",
-			})
-			.option("escape-char", {
-				describe:
-					"Sets `ssh -e`: Set the escape character for sessions with a pty (default: ‘~’)",
-				type: "string",
-			})
-			.option("config-file", {
-				alias: "F",
-				describe:
-					"Sets `ssh -F`: Specify an alternative per-user ssh configuration file",
-				type: "string",
-			})
-			.option("pkcs11", {
-				describe:
-					"Sets `ssh -I`: Specify the PKCS#11 shared library ssh should use to communicate with a PKCS#11 token providing keys for user authentication",
-				type: "string",
-			})
-			.option("identity-file", {
-				alias: "i",
-				describe:
-					"Sets `ssh -i`: Select a file from which the identity (private key) for public key authentication is read",
-				type: "string",
-			})
-			.option("mac-spec", {
-				describe:
-					"Sets `ssh -m`: A comma-separated list of MAC (message authentication code) algorithms, specified in order of preference",
-				type: "string",
-			})
-			.option("option", {
-				alias: "o",
-				describe:
-					"Sets `ssh -o`: Set options in the format used in the ssh configuration file. May be repeated",
-				type: "string",
-			})
-			.option("tag", {
-				describe:
-					"Sets `ssh -P`: Specify a tag name that may be used to select configuration in ssh_config",
-				type: "string",
-			})
-	);
-}
+// Deprecated SSH flags are hidden because a future SSH implementation
+// will not use OpenSSH, at which point these options will not work.
+const sshArgDefs = {
+	ID: {
+		describe: "ID of the container instance",
+		type: "string",
+		demandOption: true,
+	},
+	cipher: {
+		describe:
+			"Sets `ssh -c`: Select the cipher specification for encrypting the session",
+		type: "string",
+		hidden: true,
+		deprecated: true,
+	},
+	"log-file": {
+		describe:
+			"Sets `ssh -E`: Append debug logs to log_file instead of standard error",
+		type: "string",
+		hidden: true,
+		deprecated: true,
+	},
+	"escape-char": {
+		describe:
+			"Sets `ssh -e`: Set the escape character for sessions with a pty (default: '~')",
+		type: "string",
+		hidden: true,
+		deprecated: true,
+	},
+	"config-file": {
+		alias: "F",
+		describe:
+			"Sets `ssh -F`: Specify an alternative per-user ssh configuration file",
+		type: "string",
+		hidden: true,
+		deprecated: true,
+	},
+	pkcs11: {
+		describe:
+			"Sets `ssh -I`: Specify the PKCS#11 shared library ssh should use to communicate with a PKCS#11 token providing keys for user authentication",
+		type: "string",
+		hidden: true,
+		deprecated: true,
+	},
+	"identity-file": {
+		alias: "i",
+		describe:
+			"Sets `ssh -i`: Select a file from which the identity (private key) for public key authentication is read",
+		type: "string",
+		hidden: true,
+		deprecated: true,
+	},
+	"mac-spec": {
+		describe:
+			"Sets `ssh -m`: A comma-separated list of MAC (message authentication code) algorithms, specified in order of preference",
+		type: "string",
+		hidden: true,
+		deprecated: true,
+	},
+	option: {
+		alias: "o",
+		describe:
+			"Sets `ssh -o`: Set options in the format used in the ssh configuration file. May be repeated",
+		type: "string",
+		hidden: true,
+		deprecated: true,
+	},
+	tag: {
+		describe:
+			"Sets `ssh -P`: Specify a tag name that may be used to select configuration in ssh_config",
+		type: "string",
+		hidden: true,
+		deprecated: true,
+	},
+} as const satisfies NamedArgDefinitions;
 
-export async function sshCommand(
-	sshArgs: StrictYargsOptionsToInterface<typeof sshYargs>,
-	_config: Config
-) {
+type SshArgs = HandlerArgs<typeof sshArgDefs>;
+
+async function sshCommand(sshArgs: SshArgs, _config: Config) {
 	if (sshArgs.ID.length !== 64) {
 		throw new UserError(`Expected an instance ID but got ${sshArgs.ID}`);
 	}
@@ -261,9 +273,7 @@ export function createSshTcpProxy(sshResponse: WranglerSSHResponse): Server {
 	return proxy;
 }
 
-function buildSshArgs(
-	sshArgs: StrictYargsOptionsToInterface<typeof sshYargs>
-): string[] {
+function buildSshArgs(sshArgs: SshArgs): string[] {
 	const flags = [
 		// Never use a control socket.
 		"-o",
@@ -334,61 +344,7 @@ export const containersSshCommand = createCommand({
 		owner: "Product: Cloudchamber",
 		hidden: true,
 	},
-	args: {
-		ID: {
-			describe: "ID of the container instance",
-			type: "string",
-			demandOption: true,
-		},
-		cipher: {
-			describe:
-				"Sets `ssh -c`: Select the cipher specification for encrypting the session",
-			type: "string",
-		},
-		"log-file": {
-			describe:
-				"Sets `ssh -E`: Append debug logs to log_file instead of standard error",
-			type: "string",
-		},
-		"escape-char": {
-			describe:
-				"Sets `ssh -e`: Set the escape character for sessions with a pty (default: '~')",
-			type: "string",
-		},
-		"config-file": {
-			alias: "F",
-			describe:
-				"Sets `ssh -F`: Specify an alternative per-user ssh configuration file",
-			type: "string",
-		},
-		pkcs11: {
-			describe:
-				"Sets `ssh -I`: Specify the PKCS#11 shared library ssh should use to communicate with a PKCS#11 token providing keys for user authentication",
-			type: "string",
-		},
-		"identity-file": {
-			alias: "i",
-			describe:
-				"Sets `ssh -i`: Select a file from which the identity (private key) for public key authentication is read",
-			type: "string",
-		},
-		"mac-spec": {
-			describe:
-				"Sets `ssh -m`: A comma-separated list of MAC (message authentication code) algorithms, specified in order of preference",
-			type: "string",
-		},
-		option: {
-			alias: "o",
-			describe:
-				"Sets `ssh -o`: Set options in the format used in the ssh configuration file. May be repeated",
-			type: "string",
-		},
-		tag: {
-			describe:
-				"Sets `ssh -P`: Specify a tag name that may be used to select configuration in ssh_config",
-			type: "string",
-		},
-	},
+	args: sshArgDefs,
 	positionalArgs: ["ID"],
 	async handler(args, { config }) {
 		await fillOpenAPIConfiguration(config, containersScope);


### PR DESCRIPTION
Fixes CC-7209.

Deprecate and hide OpenSSH-specific config flags for the `wrangler containers ssh` command.

Today we use OpenSSH to implement the SSH feature, but in the future we will not, at which point these flags will stop working. We are hiding and deprecating them now before the SSH feature is fully launched so that users do not come to depend on them.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/28923
  - [ ] Documentation not necessary because:
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12853" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
