### PR TITLE
Support local explorer `/cdn-cgi/` routes

### DIFF
--- a/.changeset/bumpy-suns-press.md
+++ b/.changeset/bumpy-suns-press.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": minor
+---
+
+Support local explorer `/cdn-cgi/` routes
+
+The local explorer UI can now be accessed at `/cdn-cgi/explorer`.

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -2,6 +2,7 @@ import { assertWranglerVersion } from "./assert-wrangler-version";
 import { PluginContext } from "./context";
 import { resolvePluginConfig } from "./plugin-config";
 import { additionalModulesPlugin } from "./plugins/additional-modules";
+import { cdnCgiPlugin } from "./plugins/cdn-cgi";
 import { configPlugin } from "./plugins/config";
 import { debugPlugin } from "./plugins/debug";
 import { devPlugin } from "./plugins/dev";
@@ -14,7 +15,6 @@ import { outputConfigPlugin } from "./plugins/output-config";
 import { previewPlugin } from "./plugins/preview";
 import { rscPlugin } from "./plugins/rsc";
 import { shortcutsPlugin } from "./plugins/shortcuts";
-import { triggerHandlersPlugin } from "./plugins/trigger-handlers";
 import {
 	virtualClientFallbackPlugin,
 	virtualModulesPlugin,
@@ -81,7 +81,7 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 		previewPlugin(ctx),
 		shortcutsPlugin(ctx),
 		debugPlugin(ctx),
-		triggerHandlersPlugin(ctx),
+		cdnCgiPlugin(ctx),
 		virtualModulesPlugin(ctx),
 		virtualClientFallbackPlugin(ctx),
 		outputConfigPlugin(ctx),

--- a/packages/vite-plugin-cloudflare/src/plugins/cdn-cgi.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/cdn-cgi.ts
@@ -3,6 +3,7 @@ import { createPlugin, createRequestHandler } from "../utils";
 
 /**
  * Plugin to forward `/cdn-cgi/` routes to Miniflare in development
+ * We handle specified routes rather than using a catch all so that users can add their own routes using Vite's proxy functionality
  */
 export const cdnCgiPlugin = createPlugin("cdn-cgi", (ctx) => {
 	return {
@@ -28,6 +29,7 @@ export const cdnCgiPlugin = createPlugin("cdn-cgi", (ctx) => {
 				if (
 					url === "/cdn-cgi/explorer" ||
 					url.startsWith("/cdn-cgi/explorer/") ||
+					url.startsWith("/cdn-cgi/explorer?") ||
 					url.startsWith("/cdn-cgi/handler/")
 				) {
 					await requestHandler(req, res, next);

--- a/packages/vite-plugin-cloudflare/src/plugins/cdn-cgi.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/cdn-cgi.ts
@@ -26,12 +26,13 @@ export const cdnCgiPlugin = createPlugin("cdn-cgi", (ctx) => {
 			viteDevServer.middlewares.use(async (req, res, next) => {
 				const url = req.originalUrl ?? "";
 
-				if (
+				const isLocalExplorer =
 					url === "/cdn-cgi/explorer" ||
 					url.startsWith("/cdn-cgi/explorer/") ||
-					url.startsWith("/cdn-cgi/explorer?") ||
-					url.startsWith("/cdn-cgi/handler/")
-				) {
+					url.startsWith("/cdn-cgi/explorer?");
+				const isTriggerHandler = url.startsWith("/cdn-cgi/handler/");
+
+				if (isLocalExplorer || isTriggerHandler) {
 					await requestHandler(req, res, next);
 				} else {
 					next();

--- a/packages/vite-plugin-cloudflare/src/plugins/cdn-cgi.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/cdn-cgi.ts
@@ -2,9 +2,9 @@ import { CoreHeaders } from "miniflare";
 import { createPlugin, createRequestHandler } from "../utils";
 
 /**
- * Plugin to forward `/cdn-cgi/handler/*` routes to trigger handlers in development
+ * Plugin to forward `/cdn-cgi/` routes to Miniflare in development
  */
-export const triggerHandlersPlugin = createPlugin("trigger-handlers", (ctx) => {
+export const cdnCgiPlugin = createPlugin("cdn-cgi", (ctx) => {
 	return {
 		enforce: "pre",
 		async configureServer(viteDevServer) {
@@ -22,7 +22,19 @@ export const triggerHandlersPlugin = createPlugin("trigger-handlers", (ctx) => {
 				});
 			});
 
-			viteDevServer.middlewares.use("/cdn-cgi/handler/", requestHandler);
+			viteDevServer.middlewares.use(async (req, res, next) => {
+				const url = req.originalUrl ?? "";
+
+				if (
+					url === "/cdn-cgi/explorer" ||
+					url.startsWith("/cdn-cgi/explorer/") ||
+					url.startsWith("/cdn-cgi/handler/")
+				) {
+					await requestHandler(req, res, next);
+				} else {
+					next();
+				}
+			});
 		},
 	};
 });


### PR DESCRIPTION
Support local explorer `/cdn-cgi/` routes

The local explorer UI can now be accessed at `/cdn-cgi/explorer`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: tested that it works with the `X_LOCAL_EXPLORER=true` environment variable
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: N/A

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
