### PR TITLE
[wrangler] Deduplicate unenv-preset e2e tests and bump beforeAll timeout

### DIFF
--- a/packages/wrangler/e2e/unenv-preset/preset.test.ts
+++ b/packages/wrangler/e2e/unenv-preset/preset.test.ts
@@ -981,10 +981,20 @@ function groupByWranglerConfig(configs: TestConfig[]): ConfigGroup[] {
 		const existing = groups.get(key);
 		if (existing) {
 			existing.name += `, ${config.name}`;
-			Object.assign(
-				existing.expectRuntimeFlags,
+			for (const [flag, value] of Object.entries(
 				config.expectRuntimeFlags ?? {}
-			);
+			)) {
+				if (
+					flag in existing.expectRuntimeFlags &&
+					existing.expectRuntimeFlags[flag] !== value
+				) {
+					throw new Error(
+						`Conflicting expectRuntimeFlags for "${flag}" in group "${existing.name}": ` +
+							`existing=${existing.expectRuntimeFlags[flag]}, new=${value} (from "${config.name}")`
+					);
+				}
+				existing.expectRuntimeFlags[flag] = value;
+			}
 		} else {
 			groups.set(key, {
 				name: config.name,


### PR DESCRIPTION
<!-- no issue -->

The unenv-preset e2e tests sometimes flake in CI with `Error: Hook timed out in 10000ms` because `wrangler dev --local` occasionally takes longer than 10s to start under load (see [example failure](https://github.com/cloudflare/workers-sdk/actions/runs/22956789940/job/66635671183)).

This PR addresses the flake in two ways:

**1. Bump `beforeAll` timeout from 10s to 30s**

The local `beforeAll` hook starts `wrangler dev --local` and waits for it to become ready. Under CI load, this can exceed the tight 10s timeout, causing the entire test file (3,500+ tests) to fail. Increasing to 30s provides adequate headroom.

**2. Deduplicate identical wrangler dev instances**

Many `localTestConfigs` share the same `(compatibilityDate, compatibilityFlags)` and therefore produce identical wrangler dev instances. For example, 18 "X disabled by date" configs all use `date: 2024-09-23` with no extra flags — each starting a separate, identical wrangler process.

A new `groupByWranglerConfig()` function groups configs by their effective wrangler settings at runtime, starting one instance per unique config and merging their `expectRuntimeFlags` assertions. The `localTestConfigs` array is preserved as-is for readability.

**Results (local run):**

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Wrangler dev instances | 84 | 58 | -31% |
| Test executions | ~3,526 | ~2,460 | -30% |
| Test duration | 131s | 49s | **-62%** |
| `beforeAll` timeout | 10s | 30s | 3x flake tolerance |

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Internal test-only change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
