### PR TITLE
[wrangler] Add ai search commands

### DIFF
--- a/.changeset/add-ai-search-commands.md
+++ b/.changeset/add-ai-search-commands.md
@@ -1,0 +1,13 @@
+---
+"wrangler": minor
+---
+
+Add `wrangler ai-search` command namespace for managing Cloudflare AI Search instances
+
+Introduces a CLI surface for the Cloudflare AI Search API (open beta), including:
+
+- Instance management: `ai-search list`, `create`, `get`, `update`, `delete`
+- Semantic search: `ai-search search` with repeatable `--filter key=value` flags
+- Instance stats: `ai-search stats`
+
+The `create` command uses an interactive wizard to guide configuration. All commands require authentication via `wrangler login`.

--- a/packages/wrangler/src/__tests__/ai-search.test.ts
+++ b/packages/wrangler/src/__tests__/ai-search.test.ts
@@ -1,0 +1,899 @@
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, it } from "vitest";
+import { endEventLoop } from "./helpers/end-event-loop";
+import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import {
+	clearDialogs,
+	mockConfirm,
+	mockPrompt,
+	mockSelect,
+} from "./helpers/mock-dialogs";
+import { useMockIsTTY } from "./helpers/mock-istty";
+import { createFetchResult, msw } from "./helpers/msw";
+import { runInTempDir } from "./helpers/run-in-tmp";
+import { runWrangler } from "./helpers/run-wrangler";
+
+// ── Shared test data ──────────────────────────────────────────────────────────
+
+const MOCK_INSTANCE = {
+	id: "my-instance",
+	created_at: "2025-01-01T00:00:00Z",
+	modified_at: "2025-01-02T00:00:00Z",
+	source: "my-bucket",
+	type: "r2",
+	status: "active",
+	ai_search_model: "@cf/meta/llama-3-8b",
+	embedding_model: "@cf/bge-base-en-v1.5",
+};
+
+const MOCK_INSTANCE_2 = {
+	id: "other-instance",
+	created_at: "2025-02-01T00:00:00Z",
+	modified_at: "2025-02-02T00:00:00Z",
+	source: "https://example.com",
+	type: "web-crawler",
+	status: "active",
+};
+
+const MOCK_CHUNK = {
+	id: "chunk-001",
+	score: 0.9512,
+	text: "This is a relevant text chunk from the indexed document.",
+	type: "text",
+	item: {
+		key: "docs/readme.md",
+		metadata: {},
+		timestamp: 1700000000,
+	},
+};
+
+const MOCK_CHUNK_LONG_TEXT = {
+	id: "chunk-002",
+	score: 0.8234,
+	text: "This is a very long text chunk that exceeds eighty characters and should be truncated in the table output display.",
+	type: "text",
+	item: {
+		key: "docs/guide.md",
+	},
+};
+
+const MOCK_CHUNK_NO_ITEM = {
+	id: "chunk-003",
+	score: 0.7001,
+	text: "Orphan chunk with no item reference.",
+	type: "text",
+};
+
+const MOCK_TOKEN = {
+	id: "tok-1",
+	name: "test",
+	status: "active",
+	created_at: "2025-01-01T00:00:00Z",
+	modified_at: "2025-01-01T00:00:00Z",
+};
+
+const MOCK_STATS = {
+	queued: 0,
+	running: 0,
+	completed: 3464,
+	skipped: 1744,
+	outdated: 1,
+	error: 2,
+};
+
+// ── Help / Namespace ──────────────────────────────────────────────────────────
+
+describe("ai-search help", () => {
+	const std = mockConsoleMethods();
+	runInTempDir();
+
+	it("should show help when no argument is passed", async ({ expect }) => {
+		await runWrangler("ai-search");
+		await endEventLoop();
+
+		expect(std.out).toContain("wrangler ai-search");
+		expect(std.out).toContain("Manage AI Search instances");
+		expect(std.out).toContain("wrangler ai-search list");
+		expect(std.out).toContain("wrangler ai-search create");
+		expect(std.out).toContain("wrangler ai-search get");
+		expect(std.out).toContain("wrangler ai-search update");
+		expect(std.out).toContain("wrangler ai-search delete");
+		expect(std.out).toContain("wrangler ai-search stats");
+		expect(std.out).toContain("wrangler ai-search search");
+	});
+
+	it("should show help when an invalid argument is passed", async ({
+		expect,
+	}) => {
+		await expect(() => runWrangler("ai-search foobar")).rejects.toThrow(
+			"Unknown argument: foobar"
+		);
+
+		expect(std.err).toContain("Unknown argument: foobar");
+		expect(std.out).toContain("wrangler ai-search");
+		expect(std.out).toContain("Manage AI Search instances");
+	});
+});
+
+// ── Command tests ─────────────────────────────────────────────────────────────
+
+describe("ai-search commands", () => {
+	mockAccountId();
+	mockApiToken();
+	runInTempDir();
+	const { setIsTTY } = useMockIsTTY();
+	const std = mockConsoleMethods();
+
+	beforeEach(() => {
+		setIsTTY(true);
+	});
+
+	afterEach(() => {
+		clearDialogs();
+	});
+
+	// ── list ────────────────────────────────────────────────────────────────────
+
+	describe("list", () => {
+		it("should list instances", async ({ expect }) => {
+			mockListInstances([MOCK_INSTANCE, MOCK_INSTANCE_2]);
+			await runWrangler("ai-search list");
+			expect(std.out).toContain(MOCK_INSTANCE.id);
+			expect(std.out).toContain(MOCK_INSTANCE_2.id);
+			expect(std.out).toContain(MOCK_INSTANCE.type);
+			expect(std.out).toContain(MOCK_INSTANCE_2.type);
+		});
+
+		it("should list instances as JSON", async ({ expect }) => {
+			mockListInstances([MOCK_INSTANCE]);
+			await runWrangler("ai-search list --json");
+			const parsed = JSON.parse(std.out);
+			expect(parsed).toEqual([MOCK_INSTANCE]);
+		});
+
+		it("should output empty JSON array when no instances exist with --json", async ({
+			expect,
+		}) => {
+			mockListInstances([]);
+			await runWrangler("ai-search list --json");
+			const parsed = JSON.parse(std.out);
+			expect(parsed).toEqual([]);
+		});
+
+		it("should warn when no instances exist", async ({ expect }) => {
+			mockListInstances([]);
+			await runWrangler("ai-search list");
+			expect(std.warn).toContain(
+				"You haven't created any AI Search instances on this account."
+			);
+		});
+
+		it("should warn when page is out of range", async ({ expect }) => {
+			mockListInstances([]);
+			await runWrangler("ai-search list --page 99");
+			expect(std.warn).toContain(
+				"No instances found on page 99. Please try a smaller page number."
+			);
+		});
+
+		it("should pass pagination params", async ({ expect }) => {
+			let capturedUrl: URL | undefined;
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/ai-search/instances",
+					({ request }) => {
+						capturedUrl = new URL(request.url);
+						return HttpResponse.json(
+							createFetchResult([], true, [], [], {
+								page: 2,
+								per_page: 5,
+								count: 0,
+								total_count: 0,
+							})
+						);
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler("ai-search list --page 2 --per-page 5");
+			expect(capturedUrl?.searchParams.get("page")).toBe("2");
+			expect(capturedUrl?.searchParams.get("per_page")).toBe("5");
+		});
+	});
+
+	// ── create ──────────────────────────────────────────────────────────────────
+
+	describe("create", () => {
+		it("should create an R2 instance with all flags", async ({ expect }) => {
+			let capturedBody: Record<string, unknown> | undefined;
+			mockListTokens([MOCK_TOKEN]);
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/instances",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(createFetchResult(MOCK_INSTANCE, true));
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(
+				"ai-search create my-instance --type r2 --source my-bucket --embedding-model @cf/bge-base-en-v1.5 --generation-model @cf/meta/llama-3-8b --chunk-size 512 --chunk-overlap 64 --max-num-results 10 --reranking --hybrid-search --cache --score-threshold 0.5"
+			);
+			expect(capturedBody).toMatchObject({
+				id: "my-instance",
+				source: "my-bucket",
+				type: "r2",
+				embedding_model: "@cf/bge-base-en-v1.5",
+				ai_search_model: "@cf/meta/llama-3-8b",
+				chunk_size: 512,
+				chunk_overlap: 64,
+				max_num_results: 10,
+				reranking: true,
+				hybrid_search_enabled: true,
+				cache: true,
+				score_threshold: 0.5,
+			});
+		});
+
+		it("should create instance and print details", async ({ expect }) => {
+			mockListTokens([MOCK_TOKEN]);
+			mockCreateInstance(MOCK_INSTANCE);
+			await runWrangler(
+				"ai-search create my-instance --type r2 --source my-bucket"
+			);
+			expect(std.out).toContain(
+				'Successfully created AI Search instance "my-instance"'
+			);
+			expect(std.out).toContain("Type:       r2");
+			expect(std.out).toContain("Source:     my-bucket");
+		});
+
+		it("should create instance as JSON", async ({ expect }) => {
+			mockListTokens([MOCK_TOKEN]);
+			mockCreateInstance(MOCK_INSTANCE);
+			await runWrangler(
+				"ai-search create my-instance --type r2 --source my-bucket --json"
+			);
+			const parsed = JSON.parse(std.out);
+			expect(parsed.id).toBe("my-instance");
+			expect(parsed.type).toBe("r2");
+		});
+
+		it("should send source_params with prefix and include/exclude items", async ({
+			expect,
+		}) => {
+			let capturedBody: Record<string, unknown> | undefined;
+			mockListTokens([MOCK_TOKEN]);
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/instances",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(createFetchResult(MOCK_INSTANCE, true));
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(
+				'ai-search create my-instance --type r2 --source my-bucket --prefix docs/ --include-items "*.md" --exclude-items "*.tmp"'
+			);
+			expect(capturedBody).toMatchObject({
+				source_params: {
+					prefix: "docs/",
+					include_items: ["*.md"],
+					exclude_items: ["*.tmp"],
+				},
+			});
+		});
+
+		it("should error in non-interactive mode when no tokens exist", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			mockListTokens([]);
+			await expect(
+				runWrangler("ai-search create my-instance --type r2 --source my-bucket")
+			).rejects.toThrowError(/No AI Search API token found/);
+		});
+
+		it("should abort when user declines to create a token", async ({
+			expect,
+		}) => {
+			mockListTokens([]);
+			mockConfirm({
+				text: "Have you created a token?",
+				result: false,
+			});
+			await expect(
+				runWrangler("ai-search create my-instance --type r2 --source my-bucket")
+			).rejects.toThrowError(/AI Search instance creation cancelled/);
+		});
+
+		it("should proceed after user creates a token on retry", async ({
+			expect,
+		}) => {
+			// MSW prepends once-handlers (LIFO), so register in reverse order:
+			// second call (with token) first, then first call (empty) on top.
+			mockListTokens([MOCK_TOKEN]);
+			mockListTokens([]);
+			mockConfirm({
+				text: "Have you created a token?",
+				result: true,
+			});
+			mockCreateInstance(MOCK_INSTANCE);
+			await runWrangler(
+				"ai-search create my-instance --type r2 --source my-bucket"
+			);
+			expect(std.out).toContain(
+				'Successfully created AI Search instance "my-instance"'
+			);
+		});
+
+		it("should interactively select r2 type and existing bucket", async ({
+			expect,
+		}) => {
+			mockListTokens([MOCK_TOKEN]);
+			// 1. Select source type
+			mockSelect({
+				text: "Select the source type:",
+				result: "r2",
+			});
+			// 2. Select an existing R2 bucket from the list
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/r2/buckets",
+					() =>
+						HttpResponse.json(
+							createFetchResult({
+								buckets: [{ name: "my-bucket", creation_date: "01-01-2001" }],
+							})
+						),
+					{ once: true }
+				)
+			);
+			mockSelect({
+				text: "Select an R2 bucket:",
+				result: "my-bucket",
+			});
+			mockCreateInstance(MOCK_INSTANCE);
+			await runWrangler("ai-search create my-instance");
+			expect(std.out).toContain(
+				'Successfully created AI Search instance "my-instance"'
+			);
+			expect(std.out).toContain("Source:     my-bucket");
+		});
+
+		it("should interactively create a new r2 bucket when selected", async ({
+			expect,
+		}) => {
+			mockListTokens([MOCK_TOKEN]);
+			mockSelect({ text: "Select the source type:", result: "r2" });
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/r2/buckets",
+					() => HttpResponse.json(createFetchResult({ buckets: [] })),
+					{ once: true }
+				)
+			);
+			mockSelect({
+				text: "Select an R2 bucket:",
+				result: "__create_new__",
+			});
+			mockPrompt({
+				text: "Enter a name for the new R2 bucket:",
+				result: "new-bucket",
+			});
+			// POST to create the R2 bucket
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/r2/buckets",
+					() => HttpResponse.json(createFetchResult({})),
+					{ once: true }
+				)
+			);
+			mockCreateInstance({
+				...MOCK_INSTANCE,
+				source: "new-bucket",
+			});
+			await runWrangler("ai-search create my-instance");
+			expect(std.out).toContain('Creating R2 bucket "new-bucket"...');
+			expect(std.out).toContain('Successfully created R2 bucket "new-bucket".');
+			expect(std.out).toContain(
+				'Successfully created AI Search instance "my-instance"'
+			);
+		});
+
+		it("should interactively select web-crawler type and zone", async ({
+			expect,
+		}) => {
+			mockListTokens([MOCK_TOKEN]);
+			mockSelect({ text: "Select the source type:", result: "web-crawler" });
+			// Select sitemap parse type
+			mockSelect({
+				text: "Select the web source type:",
+				result: "sitemap",
+			});
+			// Return a zone list for the account
+			msw.use(
+				http.get(
+					"*/zones",
+					() =>
+						HttpResponse.json(
+							createFetchResult([{ id: "zone-1", name: "example.com" }])
+						),
+					{ once: true }
+				)
+			);
+			mockSelect({
+				text: "Select a zone:",
+				result: "example.com",
+			});
+			mockCreateInstance({
+				...MOCK_INSTANCE,
+				type: "web-crawler",
+				source: "https://example.com",
+			});
+			await runWrangler("ai-search create my-instance");
+			expect(std.out).toContain(
+				'Successfully created AI Search instance "my-instance"'
+			);
+		});
+
+		it("should prompt for URL when no zones exist in web-crawler interactive mode", async ({
+			expect,
+		}) => {
+			mockListTokens([MOCK_TOKEN]);
+			mockSelect({ text: "Select the source type:", result: "web-crawler" });
+			mockSelect({
+				text: "Select the web source type:",
+				result: "sitemap",
+			});
+			// No zones found
+			msw.use(
+				http.get("*/zones", () => HttpResponse.json(createFetchResult([])), {
+					once: true,
+				})
+			);
+			mockPrompt({
+				text: "Enter the website URL to index:",
+				result: "https://my-site.com",
+			});
+			mockCreateInstance({
+				...MOCK_INSTANCE,
+				type: "web-crawler",
+				source: "https://my-site.com",
+			});
+			await runWrangler("ai-search create my-instance");
+			expect(std.out).toContain(
+				'Successfully created AI Search instance "my-instance"'
+			);
+		});
+
+		it("should error when name is missing", async ({ expect }) => {
+			await expect(() => runWrangler("ai-search create")).rejects.toThrow(
+				"Not enough non-option arguments"
+			);
+		});
+
+		it("should error in non-interactive mode when --type is missing", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			mockListTokens([MOCK_TOKEN]);
+			await expect(
+				runWrangler("ai-search create my-instance --source my-bucket")
+			).rejects.toThrowError(/Missing required flag.*--type/);
+		});
+
+		it("should error in non-interactive mode when --source is missing for r2", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			mockListTokens([MOCK_TOKEN]);
+			await expect(
+				runWrangler("ai-search create my-instance --type r2")
+			).rejects.toThrowError(/Missing required flag.*--source/);
+		});
+
+		it("should error in non-interactive mode when --source is missing for web-crawler", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			mockListTokens([MOCK_TOKEN]);
+			await expect(
+				runWrangler("ai-search create my-instance --type web-crawler")
+			).rejects.toThrowError(/Missing required flag.*--source/);
+		});
+	});
+
+	// ── get ──────────────────────────────────────────────────────────────────────
+
+	describe("get", () => {
+		it("should get instance details", async ({ expect }) => {
+			mockGetInstance(MOCK_INSTANCE);
+			await runWrangler("ai-search get my-instance");
+			expect(std.out).toContain("my-instance");
+			expect(std.out).toContain("r2");
+			expect(std.out).toContain("active");
+			expect(std.out).toContain("my-bucket");
+		});
+
+		it("should get instance as JSON", async ({ expect }) => {
+			mockGetInstance(MOCK_INSTANCE);
+			await runWrangler("ai-search get my-instance --json");
+			const parsed = JSON.parse(std.out);
+			expect(parsed.id).toBe("my-instance");
+			expect(parsed.type).toBe("r2");
+			expect(parsed.source).toBe("my-bucket");
+		});
+
+		it("should error when name is missing", async ({ expect }) => {
+			await expect(() => runWrangler("ai-search get")).rejects.toThrow(
+				"Not enough non-option arguments"
+			);
+		});
+	});
+
+	// ── update ──────────────────────────────────────────────────────────────────
+
+	describe("update", () => {
+		it("should update instance with flags", async ({ expect }) => {
+			let capturedBody: Record<string, unknown> | undefined;
+			msw.use(
+				http.put(
+					"*/accounts/:accountId/ai-search/instances/:name",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(createFetchResult(MOCK_INSTANCE, true));
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(
+				"ai-search update my-instance --embedding-model @cf/bge-base-en-v1.5 --chunk-size 256 --reranking --paused"
+			);
+			expect(capturedBody).toMatchObject({
+				embedding_model: "@cf/bge-base-en-v1.5",
+				chunk_size: 256,
+				reranking: true,
+				paused: true,
+			});
+			expect(std.out).toContain(
+				'Successfully updated AI Search instance "my-instance"'
+			);
+		});
+
+		it("should update instance as JSON", async ({ expect }) => {
+			mockUpdateInstance(MOCK_INSTANCE);
+			await runWrangler("ai-search update my-instance --paused --json");
+			const parsed = JSON.parse(std.out);
+			expect(parsed.id).toBe("my-instance");
+		});
+
+		it("should error when no fields are provided", async ({ expect }) => {
+			await expect(() =>
+				runWrangler("ai-search update my-instance")
+			).rejects.toThrow(
+				"No fields to update. Provide at least one flag (e.g. --paused, --cache)."
+			);
+		});
+
+		it("should only send provided fields", async ({ expect }) => {
+			let capturedBody: Record<string, unknown> | undefined;
+			msw.use(
+				http.put(
+					"*/accounts/:accountId/ai-search/instances/:name",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(createFetchResult(MOCK_INSTANCE, true));
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler("ai-search update my-instance --cache");
+			expect(capturedBody).toEqual({ cache: true });
+		});
+	});
+
+	// ── delete ──────────────────────────────────────────────────────────────────
+
+	describe("delete", () => {
+		it("should delete with confirmation", async ({ expect }) => {
+			mockConfirm({
+				text: 'OK to delete the AI Search instance "my-instance"?',
+				result: true,
+			});
+			mockDeleteInstance();
+			await runWrangler("ai-search delete my-instance");
+			expect(std.out).toContain(
+				'Successfully deleted AI Search instance "my-instance"'
+			);
+		});
+
+		it("should cancel deletion when not confirmed", async ({ expect }) => {
+			mockConfirm({
+				text: 'OK to delete the AI Search instance "my-instance"?',
+				result: false,
+			});
+			const requests = mockDeleteInstance();
+			await runWrangler("ai-search delete my-instance");
+			expect(std.out).toContain("Deletion cancelled.");
+			expect(requests.count).toBe(0);
+		});
+
+		it("should delete with --force flag", async ({ expect }) => {
+			mockDeleteInstance();
+			await runWrangler("ai-search delete my-instance --force");
+			expect(std.out).toContain(
+				'Successfully deleted AI Search instance "my-instance"'
+			);
+		});
+	});
+
+	// ── stats ───────────────────────────────────────────────────────────────────
+
+	describe("stats", () => {
+		it("should display stats in table", async ({ expect }) => {
+			mockGetStats(MOCK_STATS);
+			await runWrangler("ai-search stats my-instance");
+			expect(std.out).toContain("Queued");
+			expect(std.out).toContain("Processing");
+			expect(std.out).toContain("Indexed");
+			expect(std.out).toContain("Skipped");
+			expect(std.out).toContain("Outdated");
+			expect(std.out).toContain("Errors");
+			expect(std.out).toContain("3464");
+			expect(std.out).toContain("1744");
+		});
+
+		it("should display stats as JSON", async ({ expect }) => {
+			mockGetStats(MOCK_STATS);
+			await runWrangler("ai-search stats my-instance --json");
+			const parsed = JSON.parse(std.out);
+			expect(parsed.queued).toBe(0);
+			expect(parsed.running).toBe(0);
+			expect(parsed.completed).toBe(3464);
+			expect(parsed.skipped).toBe(1744);
+			expect(parsed.outdated).toBe(1);
+			expect(parsed.error).toBe(2);
+		});
+	});
+
+	// ── search ──────────────────────────────────────────────────────────────────
+
+	describe("search", () => {
+		it("should perform a search query", async ({ expect }) => {
+			mockSearchInstance({
+				chunks: [MOCK_CHUNK],
+				search_query: "test query",
+			});
+			await runWrangler('ai-search search my-instance --query "test query"');
+			expect(std.out).toContain('Search query: "test query"  (1 results)');
+			expect(std.out).toContain("0.9512");
+			expect(std.out).toContain("docs/readme.md");
+		});
+
+		it("should output search results as JSON", async ({ expect }) => {
+			const response = {
+				chunks: [MOCK_CHUNK],
+				search_query: "test query",
+			};
+			mockSearchInstance(response);
+			await runWrangler(
+				'ai-search search my-instance --query "test query" --json'
+			);
+			const parsed = JSON.parse(std.out);
+			expect(parsed.search_query).toBe("test query");
+			expect(parsed.chunks).toHaveLength(1);
+			expect(parsed.chunks[0].score).toBe(0.9512);
+		});
+
+		it("should handle empty results", async ({ expect }) => {
+			mockSearchInstance({
+				chunks: [],
+				search_query: "no matches",
+			});
+			await runWrangler('ai-search search my-instance --query "no matches"');
+			expect(std.out).toContain('Search query: "no matches"  (0 results)');
+			expect(std.out).toContain("No results found.");
+		});
+
+		it("should truncate long text at 80 chars", async ({ expect }) => {
+			mockSearchInstance({
+				chunks: [MOCK_CHUNK_LONG_TEXT],
+				search_query: "test",
+			});
+			await runWrangler('ai-search search my-instance --query "test"');
+			// The original text is > 80 chars, so it should be truncated with "..."
+			expect(std.out).toContain("...");
+			// Should NOT contain the full text
+			expect(std.out).not.toContain(MOCK_CHUNK_LONG_TEXT.text);
+		});
+
+		it("should parse --filter flags", async ({ expect }) => {
+			let capturedBody: Record<string, unknown> | undefined;
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/instances/:name/search",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(
+							createFetchResult({ chunks: [], search_query: "test" }, true)
+						);
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(
+				'ai-search search my-instance --query "test" --filter type=docs --filter lang=en'
+			);
+			expect(capturedBody).toMatchObject({
+				messages: [{ role: "user", content: "test" }],
+				filters: { type: "docs", lang: "en" },
+			});
+		});
+
+		it("should warn on malformed filters", async ({ expect }) => {
+			mockSearchInstance({
+				chunks: [],
+				search_query: "test",
+			});
+			await runWrangler(
+				'ai-search search my-instance --query "test" --filter badformat'
+			);
+			expect(std.warn).toContain(
+				'Ignoring malformed filter "badformat" (expected key=value)'
+			);
+		});
+
+		it("should handle chunk with missing item key", async ({ expect }) => {
+			mockSearchInstance({
+				chunks: [MOCK_CHUNK_NO_ITEM],
+				search_query: "test",
+			});
+			await runWrangler('ai-search search my-instance --query "test"');
+			expect(std.out).toContain("0.7001");
+			expect(std.out).toContain("Orphan chunk with no item reference.");
+		});
+
+		it("should send messages in correct format", async ({ expect }) => {
+			let capturedBody: Record<string, unknown> | undefined;
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/instances/:name/search",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(
+							createFetchResult(
+								{ chunks: [], search_query: "hello world" },
+								true
+							)
+						);
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler('ai-search search my-instance --query "hello world"');
+			expect(capturedBody).toEqual({
+				messages: [{ role: "user", content: "hello world" }],
+			});
+		});
+	});
+});
+
+// ── MSW Mock Handlers ─────────────────────────────────────────────────────────
+
+function mockListInstances(instances: unknown[]) {
+	msw.use(
+		http.get(
+			"*/accounts/:accountId/ai-search/instances",
+			() => {
+				return HttpResponse.json(
+					createFetchResult(instances, true, [], [], {
+						page: 1,
+						per_page: 20,
+						count: instances.length,
+						total_count: instances.length,
+					})
+				);
+			},
+			{ once: true }
+		)
+	);
+}
+
+function mockCreateInstance(instance: unknown) {
+	msw.use(
+		http.post(
+			"*/accounts/:accountId/ai-search/instances",
+			() => {
+				return HttpResponse.json(createFetchResult(instance, true));
+			},
+			{ once: true }
+		)
+	);
+}
+
+function mockGetInstance(instance: unknown) {
+	msw.use(
+		http.get(
+			"*/accounts/:accountId/ai-search/instances/:name",
+			() => {
+				return HttpResponse.json(createFetchResult(instance, true));
+			},
+			{ once: true }
+		)
+	);
+}
+
+function mockUpdateInstance(instance: unknown) {
+	msw.use(
+		http.put(
+			"*/accounts/:accountId/ai-search/instances/:name",
+			() => {
+				return HttpResponse.json(createFetchResult(instance, true));
+			},
+			{ once: true }
+		)
+	);
+}
+
+function mockDeleteInstance() {
+	const requests = { count: 0 };
+	msw.use(
+		http.delete(
+			"*/accounts/:accountId/ai-search/instances/:name",
+			() => {
+				requests.count++;
+				return HttpResponse.json(createFetchResult(null, true));
+			},
+			{ once: true }
+		)
+	);
+	return requests;
+}
+
+function mockGetStats(stats: unknown) {
+	msw.use(
+		http.get(
+			"*/accounts/:accountId/ai-search/instances/:name/stats",
+			() => {
+				return HttpResponse.json(createFetchResult(stats, true));
+			},
+			{ once: true }
+		)
+	);
+}
+
+function mockSearchInstance(response: unknown) {
+	msw.use(
+		http.post(
+			"*/accounts/:accountId/ai-search/instances/:name/search",
+			() => {
+				return HttpResponse.json(createFetchResult(response, true));
+			},
+			{ once: true }
+		)
+	);
+}
+
+function mockListTokens(tokens: unknown[]) {
+	msw.use(
+		http.get(
+			"*/accounts/:accountId/ai-search/tokens",
+			() => {
+				return HttpResponse.json(
+					createFetchResult(tokens, true, [], [], {
+						page: 1,
+						per_page: 20,
+						count: tokens.length,
+						total_count: tokens.length,
+					})
+				);
+			},
+			{ once: true }
+		)
+	);
+}

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -47,6 +47,7 @@ describe("wrangler", () => {
 
 				COMPUTE & AI
 				  wrangler ai                     🤖 Manage AI models
+				  wrangler ai-search              🔍 Manage AI Search instances [open beta]
 				  wrangler containers             📦 Manage Containers [open beta]
 				  wrangler delete [name]          🗑️ Delete a Worker from Cloudflare
 				  wrangler deploy [script]        🆙 Deploy a Worker to Cloudflare
@@ -119,6 +120,7 @@ describe("wrangler", () => {
 
 				COMPUTE & AI
 				  wrangler ai                     🤖 Manage AI models
+				  wrangler ai-search              🔍 Manage AI Search instances [open beta]
 				  wrangler containers             📦 Manage Containers [open beta]
 				  wrangler delete [name]          🗑️ Delete a Worker from Cloudflare
 				  wrangler deploy [script]        🆙 Deploy a Worker to Cloudflare

--- a/packages/wrangler/src/ai-search/client.ts
+++ b/packages/wrangler/src/ai-search/client.ts
@@ -1,0 +1,138 @@
+import { fetchListResult, fetchResult } from "../cfetch";
+import { requireAuth } from "../user";
+import type {
+	AiSearchInstance,
+	AiSearchMessage,
+	AiSearchSearchResponse,
+	AiSearchStats,
+	AiSearchToken,
+} from "./types";
+import type { Config } from "@cloudflare/workers-utils";
+
+const jsonContentType = "application/json; charset=utf-8;";
+
+function baseInstanceUrl(accountId: string): string {
+	return `/accounts/${accountId}/ai-search/instances`;
+}
+
+function baseTokenUrl(accountId: string): string {
+	return `/accounts/${accountId}/ai-search/tokens`;
+}
+
+// ── Instances ──────────────────────────────────────────────────────────────────
+
+export async function listInstances(
+	config: Config,
+	queryParams?: URLSearchParams
+): Promise<AiSearchInstance[]> {
+	const accountId = await requireAuth(config);
+	return await fetchResult<AiSearchInstance[]>(
+		config,
+		baseInstanceUrl(accountId),
+		{ method: "GET" },
+		queryParams
+	);
+}
+
+export async function createInstance(
+	config: Config,
+	accountId: string,
+	body: Record<string, unknown>
+): Promise<AiSearchInstance> {
+	return await fetchResult<AiSearchInstance>(
+		config,
+		baseInstanceUrl(accountId),
+		{
+			method: "POST",
+			headers: { "content-type": jsonContentType },
+			body: JSON.stringify(body),
+		}
+	);
+}
+
+export async function getInstance(
+	config: Config,
+	name: string
+): Promise<AiSearchInstance> {
+	const accountId = await requireAuth(config);
+	return await fetchResult<AiSearchInstance>(
+		config,
+		`${baseInstanceUrl(accountId)}/${name}`,
+		{ method: "GET" }
+	);
+}
+
+export async function updateInstance(
+	config: Config,
+	name: string,
+	body: Record<string, unknown>
+): Promise<AiSearchInstance> {
+	const accountId = await requireAuth(config);
+	return await fetchResult<AiSearchInstance>(
+		config,
+		`${baseInstanceUrl(accountId)}/${name}`,
+		{
+			method: "PUT",
+			headers: { "content-type": jsonContentType },
+			body: JSON.stringify(body),
+		}
+	);
+}
+
+export async function deleteInstance(
+	config: Config,
+	name: string
+): Promise<AiSearchInstance> {
+	const accountId = await requireAuth(config);
+	return await fetchResult<AiSearchInstance>(
+		config,
+		`${baseInstanceUrl(accountId)}/${name}`,
+		{ method: "DELETE" }
+	);
+}
+
+export async function getInstanceStats(
+	config: Config,
+	name: string
+): Promise<AiSearchStats> {
+	const accountId = await requireAuth(config);
+	return await fetchResult<AiSearchStats>(
+		config,
+		`${baseInstanceUrl(accountId)}/${name}/stats`,
+		{ method: "GET" }
+	);
+}
+
+export async function searchInstance(
+	config: Config,
+	name: string,
+	body: {
+		messages: AiSearchMessage[];
+		filters?: Record<string, string>;
+		max_num_results?: number;
+		score_threshold?: number;
+		reranking?: boolean;
+	}
+): Promise<AiSearchSearchResponse> {
+	const accountId = await requireAuth(config);
+	return await fetchResult<AiSearchSearchResponse>(
+		config,
+		`${baseInstanceUrl(accountId)}/${name}/search`,
+		{
+			method: "POST",
+			headers: { "content-type": jsonContentType },
+			body: JSON.stringify(body),
+		}
+	);
+}
+
+// ── Tokens ─────────────────────────────────────────────────────────────────────
+
+export async function listTokens(
+	config: Config,
+	accountId: string
+): Promise<AiSearchToken[]> {
+	return await fetchListResult<AiSearchToken>(config, baseTokenUrl(accountId), {
+		method: "GET",
+	});
+}

--- a/packages/wrangler/src/ai-search/create.ts
+++ b/packages/wrangler/src/ai-search/create.ts
@@ -1,0 +1,343 @@
+import { UserError } from "@cloudflare/workers-utils";
+import { fetchPagedListResult } from "../cfetch";
+import { createCommand } from "../core/create-command";
+import { confirm, prompt, select } from "../dialogs";
+import { isNonInteractiveOrCI } from "../is-interactive";
+import { logger } from "../logger";
+import { createR2Bucket, listR2Buckets } from "../r2/helpers/bucket";
+import { requireAuth } from "../user";
+import { createInstance, listTokens } from "./client";
+
+const CREATE_NEW_BUCKET = "__create_new__";
+
+export const aiSearchCreateCommand = createCommand({
+	metadata: {
+		description: "Create a new AI Search instance",
+		status: "open beta",
+		owner: "Product: AI Search",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		name: {
+			type: "string",
+			demandOption: true,
+			description:
+				"The name of the AI Search instance to create (must be unique).",
+		},
+		source: {
+			type: "string",
+			description: "Data source identifier (R2 bucket name or web URL).",
+		},
+		type: {
+			type: "string",
+			choices: ["r2", "web-crawler"],
+			description: "The source type for the instance.",
+		},
+		"embedding-model": {
+			type: "string",
+			description: "Embedding model to use.",
+		},
+		"generation-model": {
+			type: "string",
+			description: "LLM model for chat completions.",
+		},
+		"chunk-size": {
+			type: "number",
+			description: "Chunk size for document splitting (min: 64).",
+		},
+		"chunk-overlap": {
+			type: "number",
+			description: "Overlap between document chunks.",
+		},
+		"max-num-results": {
+			type: "number",
+			description: "Maximum search results per query.",
+		},
+		reranking: {
+			type: "boolean",
+			description: "Enable reranking of search results.",
+		},
+		"reranking-model": {
+			type: "string",
+			description: "Model to use for reranking.",
+		},
+		"hybrid-search": {
+			type: "boolean",
+			description: "Enable hybrid (keyword + vector) search.",
+		},
+		cache: {
+			type: "boolean",
+			description: "Enable response caching.",
+		},
+		"score-threshold": {
+			type: "number",
+			description: "Minimum relevance score threshold (0-1).",
+		},
+		prefix: {
+			type: "string",
+			description: "R2 key prefix to scope indexing.",
+		},
+		"include-items": {
+			type: "array",
+			string: true,
+			description: "Glob patterns for items to include.",
+		},
+		"exclude-items": {
+			type: "array",
+			string: true,
+			description: "Glob patterns for items to exclude.",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as clean JSON",
+		},
+	},
+	positionalArgs: ["name"],
+	async handler(args, { config }) {
+		// Get accountId early — needed for listing R2 buckets and zones
+		const accountId = await requireAuth(config);
+
+		// Check for AI Search API tokens before proceeding
+		const existingTokens = await listTokens(config, accountId);
+		if (existingTokens.length === 0) {
+			if (isNonInteractiveOrCI()) {
+				throw new UserError(
+					`No AI Search API token found. Create one at:\n` +
+						`  https://dash.cloudflare.com/${accountId}/ai/ai-search/tokens\n` +
+						`Then re-run this command.`
+				);
+			}
+			logger.log(
+				`No AI Search API token found. Create one at:\n` +
+					`  https://dash.cloudflare.com/${accountId}/ai/ai-search/tokens`
+			);
+			let hasToken = false;
+			while (!hasToken) {
+				const ready = await confirm("Have you created a token?");
+				if (!ready) {
+					throw new UserError("AI Search instance creation cancelled.");
+				}
+				const tokens = await listTokens(config, accountId);
+				if (tokens.length > 0) {
+					hasToken = true;
+				} else {
+					logger.log(
+						"No token found yet. Please create one before continuing."
+					);
+				}
+			}
+		}
+
+		// Interactive wizard: prompt for missing required fields
+		const instanceName = args.name;
+
+		// 1. Source type
+		let instanceType = args.type;
+		if (!instanceType) {
+			if (isNonInteractiveOrCI()) {
+				throw new UserError(
+					"Missing required flag in non-interactive mode: --type\n" +
+						"  Pass --type r2 or --type web-crawler."
+				);
+			}
+			instanceType = await select("Select the source type:", {
+				choices: [
+					{
+						title: "R2",
+						description: "Index files from an R2 bucket",
+						value: "r2" as const,
+					},
+					{
+						title: "Web",
+						description: "Index content from a website",
+						value: "web-crawler" as const,
+					},
+				],
+				defaultOption: 0,
+			});
+		}
+
+		// 2. Source selection — depends on the type
+		let instanceSource = args.source;
+		// Track whether the user went through the web/sitemap interactive flow
+		let webParseType: string | undefined;
+
+		if (instanceType === "r2" && !instanceSource) {
+			if (isNonInteractiveOrCI()) {
+				throw new UserError(
+					"Missing required flag in non-interactive mode: --source\n" +
+						"  Pass --source <r2-bucket-name>."
+				);
+			}
+			// 2.1 R2: list buckets and let user pick, with "Create new" option
+			const buckets = await listR2Buckets(config, accountId);
+			const bucketChoices = [
+				...buckets.map((b) => ({
+					title: b.name,
+					value: b.name,
+				})),
+				{
+					title: "Create new bucket",
+					description: "Create a new R2 bucket for this instance",
+					value: CREATE_NEW_BUCKET,
+				},
+			];
+
+			const selectedBucket = await select("Select an R2 bucket:", {
+				choices: bucketChoices,
+				defaultOption: 0,
+			});
+
+			if (selectedBucket === CREATE_NEW_BUCKET) {
+				const newBucketName = await prompt(
+					"Enter a name for the new R2 bucket:",
+					{
+						validate: (value: string) =>
+							value.length > 0 || "Bucket name is required.",
+					}
+				);
+				logger.log(`Creating R2 bucket "${newBucketName}"...`);
+				await createR2Bucket(config, accountId, newBucketName);
+				logger.log(`Successfully created R2 bucket "${newBucketName}".`);
+				instanceSource = newBucketName;
+			} else {
+				instanceSource = selectedBucket;
+			}
+		} else if (instanceType === "web-crawler" && !instanceSource) {
+			if (isNonInteractiveOrCI()) {
+				throw new UserError(
+					"Missing required flag in non-interactive mode: --source\n" +
+						"  Pass --source <url> (e.g. --source https://example.com)."
+				);
+			}
+			// 2.2 Web: select source type (sitemap only for now), then list zones
+			// fallbackOption: 0 is safe — sitemap is the only available option
+			webParseType = await select("Select the web source type:", {
+				choices: [
+					{
+						title: "Sitemap",
+						description: "Crawl and index pages from a sitemap",
+						value: "sitemap" as const,
+					},
+				],
+				defaultOption: 0,
+				fallbackOption: 0,
+			});
+
+			// List all zones for the account
+			const zones = await fetchPagedListResult<{
+				id: string;
+				name: string;
+			}>(
+				config,
+				"/zones",
+				{},
+				new URLSearchParams({ "account.id": accountId })
+			);
+
+			if (zones.length === 0) {
+				// Fallback to manual URL entry if no zones found
+				instanceSource = await prompt("Enter the website URL to index:", {
+					validate: (value: string) => {
+						if (value.length === 0) {
+							return "Source is required.";
+						}
+						try {
+							new URL(value);
+							return true;
+						} catch {
+							return "Please enter a valid URL (e.g. https://example.com).";
+						}
+					},
+				});
+			} else {
+				const selectedZone = await select("Select a zone:", {
+					choices: zones.map((z) => ({
+						title: z.name,
+						description: z.id,
+						value: z.name,
+					})),
+					defaultOption: 0,
+				});
+				instanceSource = `https://${selectedZone}`;
+			}
+		}
+
+		const body: Record<string, unknown> = {
+			id: instanceName,
+			source: instanceSource,
+			type: instanceType,
+		};
+
+		if (args.embeddingModel !== undefined) {
+			body.embedding_model = args.embeddingModel;
+		}
+		if (args.generationModel !== undefined) {
+			body.ai_search_model = args.generationModel;
+		}
+		if (args.chunkSize !== undefined) {
+			body.chunk_size = args.chunkSize;
+		}
+		if (args.chunkOverlap !== undefined) {
+			body.chunk_overlap = args.chunkOverlap;
+		}
+		if (args.maxNumResults !== undefined) {
+			body.max_num_results = args.maxNumResults;
+		}
+		if (args.reranking !== undefined) {
+			body.reranking = args.reranking;
+		}
+		if (args.rerankingModel !== undefined) {
+			body.reranking_model = args.rerankingModel;
+		}
+		if (args.hybridSearch !== undefined) {
+			body.hybrid_search_enabled = args.hybridSearch;
+		}
+		if (args.cache !== undefined) {
+			body.cache = args.cache;
+		}
+		if (args.scoreThreshold !== undefined) {
+			body.score_threshold = args.scoreThreshold;
+		}
+
+		const sourceParams: Record<string, unknown> = {};
+		if (args.prefix) {
+			sourceParams.prefix = args.prefix;
+		}
+		if (args.includeItems) {
+			sourceParams.include_items = args.includeItems;
+		}
+		if (args.excludeItems) {
+			sourceParams.exclude_items = args.excludeItems;
+		}
+		if (webParseType) {
+			sourceParams.web_crawler = {
+				parse_type: webParseType,
+			};
+		}
+		if (Object.keys(sourceParams).length > 0) {
+			body.source_params = sourceParams;
+		}
+
+		if (!args.json) {
+			logger.log(`Creating AI Search instance "${instanceName}"...`);
+		}
+		const instance = await createInstance(config, accountId, body);
+
+		if (args.json) {
+			logger.log(JSON.stringify(instance, null, 2));
+		} else {
+			logger.log(
+				`Successfully created AI Search instance "${instance.id}"\n` +
+					`  Name:       ${instance.id}\n` +
+					`  Type:       ${instance.type}\n` +
+					`  Source:     ${instance.source}\n` +
+					`  Model:      ${instance.ai_search_model ?? "default"}\n` +
+					`  Embedding:  ${instance.embedding_model ?? "default"}`
+			);
+		}
+	},
+});

--- a/packages/wrangler/src/ai-search/delete.ts
+++ b/packages/wrangler/src/ai-search/delete.ts
@@ -1,0 +1,41 @@
+import { createCommand } from "../core/create-command";
+import { confirm } from "../dialogs";
+import { logger } from "../logger";
+import { deleteInstance } from "./client";
+
+export const aiSearchDeleteCommand = createCommand({
+	metadata: {
+		description: "Delete an AI Search instance",
+		status: "open beta",
+		owner: "Product: AI Search",
+	},
+	args: {
+		name: {
+			type: "string",
+			demandOption: true,
+			description: "The name of the AI Search instance to delete.",
+		},
+		force: {
+			type: "boolean",
+			alias: "y",
+			default: false,
+			description: "Skip confirmation",
+		},
+	},
+	positionalArgs: ["name"],
+	async handler({ name, force }, { config }) {
+		if (!force) {
+			const confirmedDeletion = await confirm(
+				`OK to delete the AI Search instance "${name}"?`
+			);
+			if (!confirmedDeletion) {
+				logger.log("Deletion cancelled.");
+				return;
+			}
+		}
+
+		logger.log(`Deleting AI Search instance "${name}"...`);
+		await deleteInstance(config, name);
+		logger.log(`Successfully deleted AI Search instance "${name}"`);
+	},
+});

--- a/packages/wrangler/src/ai-search/get.ts
+++ b/packages/wrangler/src/ai-search/get.ts
@@ -1,0 +1,48 @@
+import { createCommand } from "../core/create-command";
+import { logger } from "../logger";
+import { getInstance } from "./client";
+
+export const aiSearchGetCommand = createCommand({
+	metadata: {
+		description: "Get details of an AI Search instance",
+		status: "open beta",
+		owner: "Product: AI Search",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		name: {
+			type: "string",
+			demandOption: true,
+			description: "The name of the AI Search instance.",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as clean JSON",
+		},
+	},
+	positionalArgs: ["name"],
+	async handler({ name, json }, { config }) {
+		const instance = await getInstance(config, name);
+
+		if (json) {
+			logger.log(JSON.stringify(instance, null, 2));
+			return;
+		}
+
+		logger.table([
+			{
+				name: instance.id,
+				type: instance.type,
+				status: instance.status ?? "",
+				source: instance.source,
+				model: instance.ai_search_model ?? "",
+				embedding: instance.embedding_model ?? "",
+				created: instance.created_at,
+				modified: instance.modified_at,
+			},
+		]);
+	},
+});

--- a/packages/wrangler/src/ai-search/index.ts
+++ b/packages/wrangler/src/ai-search/index.ts
@@ -1,0 +1,10 @@
+import { createNamespace } from "../core/create-command";
+
+export const aiSearchNamespace = createNamespace({
+	metadata: {
+		description: "🔍 Manage AI Search instances",
+		status: "open beta",
+		owner: "Product: AI Search",
+		category: "Compute & AI",
+	},
+});

--- a/packages/wrangler/src/ai-search/list.ts
+++ b/packages/wrangler/src/ai-search/list.ts
@@ -1,0 +1,74 @@
+import { createCommand } from "../core/create-command";
+import { logger } from "../logger";
+import { listInstances } from "./client";
+
+export const aiSearchListCommand = createCommand({
+	metadata: {
+		description: "List all AI Search instances",
+		status: "open beta",
+		owner: "Product: AI Search",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as clean JSON",
+		},
+		page: {
+			describe:
+				'Page number of the results, can configure page size using "per-page"',
+			type: "number",
+			default: 1,
+		},
+		"per-page": {
+			describe: "Number of instances to show per page",
+			type: "number",
+		},
+	},
+	async handler(args, { config }) {
+		const urlParams = new URLSearchParams();
+		urlParams.set("page", args.page.toString());
+		if (args.perPage !== undefined) {
+			urlParams.set("per_page", args.perPage.toString());
+		}
+
+		const instances = await listInstances(config, urlParams);
+
+		if (args.json) {
+			logger.log(JSON.stringify(instances, null, 2));
+			return;
+		}
+
+		if (instances.length === 0 && args.page === 1) {
+			logger.warn(`You haven't created any AI Search instances on this account.
+
+Use 'wrangler ai-search create <name>' to create one, or visit
+https://developers.cloudflare.com/ai-search/ to get started.`);
+			return;
+		}
+
+		if (instances.length === 0 && args.page > 1) {
+			logger.warn(
+				`No instances found on page ${args.page}. Please try a smaller page number.`
+			);
+			return;
+		}
+
+		logger.info(
+			`Showing ${instances.length} instance${instances.length !== 1 ? "s" : ""} from page ${args.page}:`
+		);
+
+		logger.table(
+			instances.map((instance) => ({
+				name: instance.id,
+				type: instance.type,
+				status: instance.status ?? "",
+				source: instance.source,
+				created: instance.created_at,
+			}))
+		);
+	},
+});

--- a/packages/wrangler/src/ai-search/search.ts
+++ b/packages/wrangler/src/ai-search/search.ts
@@ -1,0 +1,102 @@
+import { createCommand } from "../core/create-command";
+import { logger } from "../logger";
+import { searchInstance } from "./client";
+import { parseFilters } from "./utils";
+import type { AiSearchMessage } from "./types";
+
+export const aiSearchSearchCommand = createCommand({
+	metadata: {
+		description:
+			"Execute a semantic search query against an AI Search instance",
+		status: "open beta",
+		owner: "Product: AI Search",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		name: {
+			type: "string",
+			demandOption: true,
+			description: "The name of the AI Search instance.",
+		},
+		query: {
+			type: "string",
+			demandOption: true,
+			description: "The search query text.",
+		},
+		"max-num-results": {
+			type: "number",
+			description: "Override maximum number of results.",
+		},
+		"score-threshold": {
+			type: "number",
+			description: "Override minimum relevance score (0-1).",
+		},
+		reranking: {
+			type: "boolean",
+			description: "Override reranking setting.",
+		},
+		filter: {
+			type: "array",
+			string: true,
+			description:
+				"Metadata filter as key=value (repeatable, e.g. --filter type=docs --filter lang=en).",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as clean JSON",
+		},
+	},
+	positionalArgs: ["name"],
+	async handler(args, { config }) {
+		const messages: AiSearchMessage[] = [{ role: "user", content: args.query }];
+
+		const filterStrings = args.filter?.map(String);
+		const filters = parseFilters(filterStrings);
+
+		const body: {
+			messages: AiSearchMessage[];
+			filters?: Record<string, string>;
+			max_num_results?: number;
+			score_threshold?: number;
+			reranking?: boolean;
+		} = { messages, filters };
+		if (args.maxNumResults !== undefined) {
+			body.max_num_results = args.maxNumResults;
+		}
+		if (args.scoreThreshold !== undefined) {
+			body.score_threshold = args.scoreThreshold;
+		}
+		if (args.reranking !== undefined) {
+			body.reranking = args.reranking;
+		}
+		const result = await searchInstance(config, args.name, body);
+
+		if (args.json) {
+			logger.log(JSON.stringify(result, null, 2));
+			return;
+		}
+
+		logger.log(
+			`Search query: "${result.search_query}"  (${result.chunks.length} results)\n`
+		);
+
+		if (result.chunks.length === 0) {
+			logger.log("No results found.");
+			return;
+		}
+
+		logger.table(
+			result.chunks.map((chunk, i) => ({
+				"#": String(i + 1),
+				score: chunk.score.toFixed(4),
+				key: chunk.item?.key ?? "",
+				text:
+					chunk.text.length > 80 ? chunk.text.slice(0, 80) + "..." : chunk.text,
+				type: chunk.type,
+			}))
+		);
+	},
+});

--- a/packages/wrangler/src/ai-search/stats.ts
+++ b/packages/wrangler/src/ai-search/stats.ts
@@ -1,0 +1,46 @@
+import { createCommand } from "../core/create-command";
+import { logger } from "../logger";
+import { getInstanceStats } from "./client";
+
+export const aiSearchStatsCommand = createCommand({
+	metadata: {
+		description: "Get usage statistics for an AI Search instance",
+		status: "open beta",
+		owner: "Product: AI Search",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		name: {
+			type: "string",
+			demandOption: true,
+			description: "The name of the AI Search instance.",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as clean JSON",
+		},
+	},
+	positionalArgs: ["name"],
+	async handler({ name, json }, { config }) {
+		const stats = await getInstanceStats(config, name);
+
+		if (json) {
+			logger.log(JSON.stringify(stats, null, 2));
+			return;
+		}
+
+		logger.table([
+			{
+				Queued: String(stats.queued),
+				Processing: String(stats.running),
+				Indexed: String(stats.completed),
+				Skipped: String(stats.skipped),
+				Outdated: String(stats.outdated),
+				Errors: String(stats.error),
+			},
+		]);
+	},
+});

--- a/packages/wrangler/src/ai-search/types.ts
+++ b/packages/wrangler/src/ai-search/types.ts
@@ -1,0 +1,149 @@
+/**
+ * Represents an AI Search instance.
+ */
+export interface AiSearchInstance {
+	id: string;
+	created_at: string;
+	modified_at: string;
+	source: string;
+	type: "r2" | "web-crawler";
+	vectorize_name?: string;
+	ai_gateway_id?: string;
+	ai_search_model?: string;
+	cache?: boolean;
+	cache_threshold?: string;
+	chunk_overlap?: number;
+	chunk_size?: number;
+	created_by?: string;
+	custom_metadata?: AiSearchCustomMetadata[];
+	embedding_model?: string;
+	enable?: boolean;
+	fusion_method?: string;
+	hybrid_search_enabled?: boolean;
+	last_activity?: string;
+	max_num_results?: number;
+	metadata?: {
+		created_from_aisearch_wizard?: boolean;
+		worker_domain?: string;
+	};
+	modified_by?: string;
+	paused?: boolean;
+	public_endpoint_id?: string;
+	public_endpoint_params?: AiSearchPublicEndpointParams;
+	reranking?: boolean;
+	reranking_model?: string;
+	retrieval_options?: {
+		keyword_match_mode?: string;
+	};
+	rewrite_model?: string;
+	rewrite_query?: boolean;
+	score_threshold?: number;
+	source_params?: AiSearchSourceParams;
+	status?: string;
+	token_id?: string;
+}
+
+export interface AiSearchCustomMetadata {
+	data_type: string;
+	field_name: string;
+}
+
+export interface AiSearchPublicEndpointParams {
+	authorized_hosts?: string[];
+	chat_completions_endpoint?: { disabled?: boolean };
+	enabled?: boolean;
+	mcp?: { description?: string; disabled?: boolean };
+	rate_limit?: { period_ms?: number; requests?: number; technique?: string };
+	search_endpoint?: { disabled?: boolean };
+}
+
+export interface AiSearchSourceParams {
+	exclude_items?: string[];
+	include_items?: string[];
+	prefix?: string;
+	r2_jurisdiction?: string;
+	web_crawler?: {
+		parse_options?: {
+			include_headers?: Record<string, string>;
+			include_images?: boolean;
+			specific_sitemaps?: string[];
+			use_browser_rendering?: boolean;
+		};
+		parse_type?: string;
+		store_options?: {
+			storage_id?: string;
+			r2_jurisdiction?: string;
+			storage_type?: string;
+		};
+	};
+}
+
+/**
+ * Stats for an AI Search instance.
+ */
+export interface AiSearchStats {
+	/** Items queued but not yet started. */
+	queued: number;
+	/** Items actively being processed. */
+	running: number;
+	/** Items successfully indexed. */
+	completed: number;
+	/** Items skipped during indexing. */
+	skipped: number;
+	/** Items that are outdated and need re-indexing. */
+	outdated: number;
+	/** Items that errored during indexing. */
+	error: number;
+}
+
+/**
+ * A chunk returned from a search.
+ */
+export interface AiSearchChunk {
+	id: string;
+	score: number;
+	text: string;
+	type: string;
+	item?: {
+		key: string;
+		metadata?: Record<string, unknown>;
+		timestamp?: number;
+	};
+	scoring_details?: {
+		keyword_rank?: number;
+		keyword_score?: number;
+		reranking_score?: number;
+		vector_rank?: number;
+		vector_score?: number;
+	};
+}
+
+/**
+ * Response from a search query.
+ */
+export interface AiSearchSearchResponse {
+	chunks: AiSearchChunk[];
+	search_query: string;
+}
+
+/**
+ * An AI Search API token.
+ */
+export interface AiSearchToken {
+	id: string;
+	cf_api_id?: string;
+	created_at: string;
+	expires_at?: string;
+	modified_at: string;
+	name: string;
+	status: string;
+	value?: string;
+}
+
+/**
+ * Messages for search.
+ */
+export interface AiSearchMessage {
+	role: "system" | "user" | "assistant";
+	content: string;
+}

--- a/packages/wrangler/src/ai-search/update.ts
+++ b/packages/wrangler/src/ai-search/update.ts
@@ -1,0 +1,127 @@
+import { UserError } from "@cloudflare/workers-utils";
+import { createCommand } from "../core/create-command";
+import { logger } from "../logger";
+import { updateInstance } from "./client";
+
+export const aiSearchUpdateCommand = createCommand({
+	metadata: {
+		description: "Update an AI Search instance configuration",
+		status: "open beta",
+		owner: "Product: AI Search",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		name: {
+			type: "string",
+			demandOption: true,
+			description: "The name of the AI Search instance to update.",
+		},
+		"embedding-model": {
+			type: "string",
+			description: "Update the embedding model.",
+		},
+		"generation-model": {
+			type: "string",
+			description: "Update the LLM model for chat completions.",
+		},
+		"chunk-size": {
+			type: "number",
+			description: "Update the chunk size.",
+		},
+		"chunk-overlap": {
+			type: "number",
+			description: "Update the chunk overlap.",
+		},
+		"max-num-results": {
+			type: "number",
+			description: "Update max search results per query.",
+		},
+		reranking: {
+			type: "boolean",
+			description: "Enable or disable reranking.",
+		},
+		"reranking-model": {
+			type: "string",
+			description: "Update the reranking model.",
+		},
+		"hybrid-search": {
+			type: "boolean",
+			description: "Enable or disable hybrid search.",
+		},
+		cache: {
+			type: "boolean",
+			description: "Enable or disable caching.",
+		},
+		"score-threshold": {
+			type: "number",
+			description: "Update the minimum relevance score threshold (0-1).",
+		},
+		paused: {
+			type: "boolean",
+			description: "Pause or resume the instance.",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as clean JSON",
+		},
+	},
+	positionalArgs: ["name"],
+	async handler(args, { config }) {
+		const body: Record<string, unknown> = {};
+
+		if (args.embeddingModel !== undefined) {
+			body.embedding_model = args.embeddingModel;
+		}
+		if (args.generationModel !== undefined) {
+			body.ai_search_model = args.generationModel;
+		}
+		if (args.chunkSize !== undefined) {
+			body.chunk_size = args.chunkSize;
+		}
+		if (args.chunkOverlap !== undefined) {
+			body.chunk_overlap = args.chunkOverlap;
+		}
+		if (args.maxNumResults !== undefined) {
+			body.max_num_results = args.maxNumResults;
+		}
+		if (args.reranking !== undefined) {
+			body.reranking = args.reranking;
+		}
+		if (args.rerankingModel !== undefined) {
+			body.reranking_model = args.rerankingModel;
+		}
+		if (args.hybridSearch !== undefined) {
+			body.hybrid_search_enabled = args.hybridSearch;
+		}
+		if (args.cache !== undefined) {
+			body.cache = args.cache;
+		}
+		if (args.scoreThreshold !== undefined) {
+			body.score_threshold = args.scoreThreshold;
+		}
+		if (args.paused !== undefined) {
+			body.paused = args.paused;
+		}
+
+		if (Object.keys(body).length === 0) {
+			throw new UserError(
+				"No fields to update. Provide at least one flag (e.g. --paused, --cache)."
+			);
+		}
+
+		if (!args.json) {
+			logger.log(`Updating AI Search instance "${args.name}"...`);
+		}
+		const instance = await updateInstance(config, args.name, body);
+
+		if (args.json) {
+			logger.log(JSON.stringify(instance, null, 2));
+			return;
+		}
+
+		logger.log(`Successfully updated AI Search instance "${instance.id}"`);
+	},
+});

--- a/packages/wrangler/src/ai-search/utils.ts
+++ b/packages/wrangler/src/ai-search/utils.ts
@@ -1,0 +1,24 @@
+import { logger } from "../logger";
+
+/**
+ * Parse repeatable --filter key=value flags into a filter object.
+ */
+export function parseFilters(
+	filters: string[] | undefined
+): Record<string, string> | undefined {
+	if (!filters || filters.length === 0) {
+		return undefined;
+	}
+	const result: Record<string, string> = {};
+	for (const f of filters) {
+		const eqIndex = f.indexOf("=");
+		if (eqIndex === -1) {
+			logger.warn(`Ignoring malformed filter "${f}" (expected key=value)`);
+			continue;
+		}
+		const key = f.slice(0, eqIndex);
+		const value = f.slice(eqIndex + 1);
+		result[key] = value;
+	}
+	return Object.keys(result).length > 0 ? result : undefined;
+}

--- a/packages/wrangler/src/core/teams.d.ts
+++ b/packages/wrangler/src/core/teams.d.ts
@@ -14,6 +14,7 @@ export type Teams =
 	| "Product: D1"
 	| "Product: Queues"
 	| "Product: AI"
+	| "Product: AI Search"
 	| "Product: Hyperdrive"
 	| "Product: Pipelines"
 	| "Product: Vectorize"

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -10,6 +10,14 @@ import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 import makeCLI from "yargs";
 import { version as wranglerVersion } from "../package.json";
 import { aiFineTuneNamespace, aiNamespace } from "./ai";
+import { aiSearchCreateCommand } from "./ai-search/create";
+import { aiSearchDeleteCommand } from "./ai-search/delete";
+import { aiSearchGetCommand } from "./ai-search/get";
+import { aiSearchNamespace } from "./ai-search/index";
+import { aiSearchListCommand } from "./ai-search/list";
+import { aiSearchSearchCommand } from "./ai-search/search";
+import { aiSearchStatsCommand } from "./ai-search/stats";
+import { aiSearchUpdateCommand } from "./ai-search/update";
 import { aiFineTuneCreateCommand } from "./ai/createFinetune";
 import { aiModelsCommand } from "./ai/listCatalog";
 import { aiFineTuneListCommand } from "./ai/listFinetune";
@@ -1330,6 +1338,30 @@ export function createCLIParser(argv: string[]) {
 		},
 	]);
 	registry.registerNamespace("tunnel");
+	// ai-search
+	registry.define([
+		{ command: "wrangler ai-search", definition: aiSearchNamespace },
+		{ command: "wrangler ai-search list", definition: aiSearchListCommand },
+		{
+			command: "wrangler ai-search create",
+			definition: aiSearchCreateCommand,
+		},
+		{ command: "wrangler ai-search get", definition: aiSearchGetCommand },
+		{
+			command: "wrangler ai-search update",
+			definition: aiSearchUpdateCommand,
+		},
+		{
+			command: "wrangler ai-search delete",
+			definition: aiSearchDeleteCommand,
+		},
+		{ command: "wrangler ai-search stats", definition: aiSearchStatsCommand },
+		{
+			command: "wrangler ai-search search",
+			definition: aiSearchSearchCommand,
+		},
+	]);
+	registry.registerNamespace("ai-search");
 
 	// cert - includes mtls-certificates and CA cert management
 	registry.define([


### PR DESCRIPTION
Fixes #[insert GH or internal issue link(s)].

Add `wrangler ai-search` command namespace for managing Cloudflare AI Search instances

Introduces a full CLI surface for the Cloudflare AI Search API (open beta), including:

- Instance management: `ai-search list`, `create`, `get`, `update`, `delete`
- Semantic search: `ai-search search` with repeatable `--filter key=value` flags
- Instance stats: `ai-search stats`

The `create` command uses an interactive wizard to guide configuration. All commands require authentication via `wrangler login`.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/29357
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12868" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
