### PR TITLE
Add `bundle.external` configuration option for marking modules as external during bundling

### DIFF
--- a/.changeset/large-coins-open.md
+++ b/.changeset/large-coins-open.md
@@ -1,0 +1,18 @@
+---
+"@cloudflare/workers-utils": minor
+"wrangler": minor
+---
+
+Add `bundling_external` configuration option for marking modules as external during bundling
+
+You can now configure modules to be excluded from bundling using the `bundling_external` option in your Wrangler configuration:
+
+```json
+{
+	"bundling_external": ["external-module", "another-external-module"]
+}
+```
+
+This corresponds to esbuild's `external` option and is useful when you have modules that should be resolved at runtime rather than bundled. The option is inheritable, so it can be set at the top level or per-environment.
+
+Additionally, when a module cannot be resolved during bundling, Wrangler now suggests using `bundling_external` or `alias` to fix the issue.

--- a/.changeset/large-coins-open.md
+++ b/.changeset/large-coins-open.md
@@ -3,16 +3,18 @@
 "wrangler": minor
 ---
 
-Add `bundling_external` configuration option for marking modules as external during bundling
+Add `bundle.external` configuration option for marking modules as external during bundling
 
-You can now configure modules to be excluded from bundling using the `bundling_external` option in your Wrangler configuration:
+You can now configure modules to be excluded from bundling using the `bundle.external` option in your Wrangler configuration:
 
 ```json
 {
-	"bundling_external": ["external-module", "another-external-module"]
+	"bundle": {
+		"external": ["external-module", "another-external-module"]
+	}
 }
 ```
 
 This corresponds to esbuild's `external` option and is useful when you have modules that should be resolved at runtime rather than bundled. The option is inheritable, so it can be set at the top level or per-environment.
 
-Additionally, when a module cannot be resolved during bundling, Wrangler now suggests using `bundling_external` or `alias` to fix the issue.
+Additionally, when a module cannot be resolved during bundling, Wrangler now suggests using `bundle.external` or `alias` to fix the issue.

--- a/packages/workers-utils/src/config/config.ts
+++ b/packages/workers-utils/src/config/config.ts
@@ -381,6 +381,7 @@ export const defaultWranglerConfig: Config = {
 	no_bundle: undefined,
 	minify: undefined,
 	keep_names: undefined,
+	bundling_external: undefined,
 	dispatch_namespaces: [],
 	first_party_worker: undefined,
 	logfwdr: { bindings: [] },

--- a/packages/workers-utils/src/config/config.ts
+++ b/packages/workers-utils/src/config/config.ts
@@ -381,7 +381,7 @@ export const defaultWranglerConfig: Config = {
 	no_bundle: undefined,
 	minify: undefined,
 	keep_names: undefined,
-	bundling_external: undefined,
+	bundle: {},
 	dispatch_namespaces: [],
 	first_party_worker: undefined,
 	logfwdr: { bindings: [] },

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -528,12 +528,17 @@ interface EnvironmentInheritable {
 	no_bundle: boolean | undefined;
 
 	/**
-	 * A list of modules to be considered external during bundling (not applicable when bundling is disabled).
-	 * Corresponds with esbuild's `external` config (https://esbuild.github.io/api/#external).
+	 * Configuration for Wrangler's bundling.
 	 *
 	 * @inheritable
 	 */
-	bundling_external: string[] | undefined;
+	bundle?: {
+		/**
+		 * A list of modules to be considered external during bundling (not applicable when bundling is disabled).
+		 * Corresponds with esbuild's `external` config (https://esbuild.github.io/api/#external).
+		 */
+		external?: string[];
+	};
 
 	/**
 	 * Minify the script before uploading.

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -528,6 +528,14 @@ interface EnvironmentInheritable {
 	no_bundle: boolean | undefined;
 
 	/**
+	 * A list of modules to be considered external during bundling (not applicable when bundling is disabled).
+	 * Corresponds with esbuild's `external` config (https://esbuild.github.io/api/#external).
+	 *
+	 * @inheritable
+	 */
+	bundling_external: string[] | undefined;
+
+	/**
 	 * Minify the script before uploading.
 	 * @inheritable
 	 */

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -1916,13 +1916,13 @@ function normalizeAndValidateEnvironment(
 			isBoolean,
 			undefined
 		),
-		bundling_external: inheritable(
+		bundle: inheritable(
 			diagnostics,
 			topLevelEnv,
 			rawEnv,
-			"bundling_external",
-			isStringArray,
-			undefined
+			"bundle",
+			validateBundle,
+			{}
 		),
 		first_party_worker: inheritable(
 			diagnostics,
@@ -5052,6 +5052,37 @@ const validateCache: ValidatorFn = (diagnostics, field, value) => {
 	isValid =
 		validateAdditionalProperties(diagnostics, field, Object.keys(val), [
 			"enabled",
+		]) && isValid;
+
+	return isValid;
+};
+
+const validateBundle: ValidatorFn = (diagnostics, field, value) => {
+	if (value === undefined) {
+		return true;
+	}
+
+	if (typeof value !== "object" || value === null) {
+		diagnostics.errors.push(
+			`"${field}" should be an object but got ${JSON.stringify(value)}.`
+		);
+		return false;
+	}
+
+	const val = value as NonNullable<Environment["bundle"]>;
+	let isValid = true;
+
+	isValid =
+		validateOptionalTypedArray(
+			diagnostics,
+			`${field}.external`,
+			val.external,
+			"string"
+		) && isValid;
+
+	isValid =
+		validateAdditionalProperties(diagnostics, field, Object.keys(val), [
+			"external",
 		]) && isValid;
 
 	return isValid;

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -1916,6 +1916,14 @@ function normalizeAndValidateEnvironment(
 			isBoolean,
 			undefined
 		),
+		bundling_external: inheritable(
+			diagnostics,
+			topLevelEnv,
+			rawEnv,
+			"bundling_external",
+			isStringArray,
+			undefined
+		),
 		first_party_worker: inheritable(
 			diagnostics,
 			topLevelEnv,

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -123,7 +123,7 @@ describe("normalizeAndValidateConfig()", () => {
 			base_dir: undefined,
 			limits: undefined,
 			keep_names: undefined,
-			bundling_external: undefined,
+			bundle: undefined,
 			assets: undefined,
 			observability: undefined,
 			cache: undefined,
@@ -1028,7 +1028,7 @@ describe("normalizeAndValidateConfig()", () => {
 				},
 				no_bundle: true,
 				minify: true,
-				bundling_external: ["external-a", "external-b"],
+				bundle: { external: ["external-a", "external-b"] },
 				first_party_worker: true,
 				logpush: true,
 				upload_source_maps: true,
@@ -1129,7 +1129,7 @@ describe("normalizeAndValidateConfig()", () => {
 				},
 				no_bundle: "INVALID",
 				minify: "INVALID",
-				bundling_external: "INVALID",
+				bundle: "INVALID",
 				first_party_worker: "INVALID",
 				logpush: "INVALID",
 				upload_source_maps: "INVALID",
@@ -1220,7 +1220,7 @@ describe("normalizeAndValidateConfig()", () => {
 				  - The field "define.DEF1" should be a string but got 1777.
 				  - Expected "no_bundle" to be of type boolean but got "INVALID".
 				  - Expected "minify" to be of type boolean but got "INVALID".
-				  - Expected "bundling_external" to be of type string array but got "INVALID".
+				  - "bundle" should be an object but got "INVALID".
 				  - Expected "first_party_worker" to be of type boolean but got "INVALID".
 				  - Expected "logpush" to be of type boolean but got "INVALID".
 				  - Expected "upload_source_maps" to be of type boolean but got "INVALID".
@@ -5355,7 +5355,7 @@ describe("normalizeAndValidateConfig()", () => {
 				},
 				no_bundle: true,
 				minify: true,
-				bundling_external: ["top-level-external"],
+				bundle: { external: ["top-level-external"] },
 				first_party_worker: true,
 				logpush: true,
 				upload_source_maps: true,
@@ -5408,7 +5408,7 @@ describe("normalizeAndValidateConfig()", () => {
 				},
 				no_bundle: false,
 				minify: false,
-				bundling_external: ["env-external"],
+				bundle: { external: ["env-external"] },
 				first_party_worker: false,
 				logpush: false,
 				upload_source_maps: false,
@@ -5435,7 +5435,7 @@ describe("normalizeAndValidateConfig()", () => {
 				},
 				no_bundle: true,
 				minify: true,
-				bundling_external: ["top-level-external"],
+				bundle: { external: ["top-level-external"] },
 				first_party_worker: true,
 				logpush: true,
 				upload_source_maps: true,
@@ -5797,7 +5797,7 @@ describe("normalizeAndValidateConfig()", () => {
 				},
 				no_bundle: "INVALID",
 				minify: "INVALID",
-				bundling_external: "INVALID",
+				bundle: "INVALID",
 				first_party_worker: "INVALID",
 				logpush: "INVALID",
 				upload_source_maps: "INVALID",
@@ -5836,7 +5836,7 @@ describe("normalizeAndValidateConfig()", () => {
 				    - Expected "main" to be of type string but got 1333.
 				    - Expected "no_bundle" to be of type boolean but got "INVALID".
 				    - Expected "minify" to be of type boolean but got "INVALID".
-				    - Expected "bundling_external" to be of type string array but got "INVALID".
+				    - "bundle" should be an object but got "INVALID".
 				    - Expected "first_party_worker" to be of type boolean but got "INVALID".
 				    - Expected "logpush" to be of type boolean but got "INVALID".
 				    - Expected "upload_source_maps" to be of type boolean but got "INVALID"."

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -123,6 +123,7 @@ describe("normalizeAndValidateConfig()", () => {
 			base_dir: undefined,
 			limits: undefined,
 			keep_names: undefined,
+			bundling_external: undefined,
 			assets: undefined,
 			observability: undefined,
 			cache: undefined,
@@ -1027,6 +1028,7 @@ describe("normalizeAndValidateConfig()", () => {
 				},
 				no_bundle: true,
 				minify: true,
+				bundling_external: ["external-a", "external-b"],
 				first_party_worker: true,
 				logpush: true,
 				upload_source_maps: true,
@@ -1127,6 +1129,7 @@ describe("normalizeAndValidateConfig()", () => {
 				},
 				no_bundle: "INVALID",
 				minify: "INVALID",
+				bundling_external: "INVALID",
 				first_party_worker: "INVALID",
 				logpush: "INVALID",
 				upload_source_maps: "INVALID",
@@ -1217,6 +1220,7 @@ describe("normalizeAndValidateConfig()", () => {
 				  - The field "define.DEF1" should be a string but got 1777.
 				  - Expected "no_bundle" to be of type boolean but got "INVALID".
 				  - Expected "minify" to be of type boolean but got "INVALID".
+				  - Expected "bundling_external" to be of type string array but got "INVALID".
 				  - Expected "first_party_worker" to be of type boolean but got "INVALID".
 				  - Expected "logpush" to be of type boolean but got "INVALID".
 				  - Expected "upload_source_maps" to be of type boolean but got "INVALID".
@@ -5351,6 +5355,7 @@ describe("normalizeAndValidateConfig()", () => {
 				},
 				no_bundle: true,
 				minify: true,
+				bundling_external: ["top-level-external"],
 				first_party_worker: true,
 				logpush: true,
 				upload_source_maps: true,
@@ -5403,6 +5408,7 @@ describe("normalizeAndValidateConfig()", () => {
 				},
 				no_bundle: false,
 				minify: false,
+				bundling_external: ["env-external"],
 				first_party_worker: false,
 				logpush: false,
 				upload_source_maps: false,
@@ -5429,6 +5435,7 @@ describe("normalizeAndValidateConfig()", () => {
 				},
 				no_bundle: true,
 				minify: true,
+				bundling_external: ["top-level-external"],
 				first_party_worker: true,
 				logpush: true,
 				upload_source_maps: true,
@@ -5790,6 +5797,7 @@ describe("normalizeAndValidateConfig()", () => {
 				},
 				no_bundle: "INVALID",
 				minify: "INVALID",
+				bundling_external: "INVALID",
 				first_party_worker: "INVALID",
 				logpush: "INVALID",
 				upload_source_maps: "INVALID",
@@ -5828,6 +5836,7 @@ describe("normalizeAndValidateConfig()", () => {
 				    - Expected "main" to be of type string but got 1333.
 				    - Expected "no_bundle" to be of type boolean but got "INVALID".
 				    - Expected "minify" to be of type boolean but got "INVALID".
+				    - Expected "bundling_external" to be of type string array but got "INVALID".
 				    - Expected "first_party_worker" to be of type boolean but got "INVALID".
 				    - Expected "logpush" to be of type boolean but got "INVALID".
 				    - Expected "upload_source_maps" to be of type boolean but got "INVALID"."

--- a/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
@@ -183,6 +183,32 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 				`);
 		});
 
+		test("external modules via build.external", async () => {
+			await seed({
+				"src/index.ts": dedent/* javascript */ `
+				import foo from 'external-module';
+				export default {
+					fetch(request, env, ctx) {
+						return new Response(foo)
+					}
+				} satisfies ExportedHandler
+			`,
+			});
+			const config = configDefaults({
+				entrypoint: path.resolve("src/index.ts"),
+				projectRoot: path.resolve("src"),
+				build: {
+					external: ["external-module"],
+				},
+			});
+			const ev = bus.waitFor("bundleComplete");
+			controller.onConfigUpdate({ type: "configUpdate", config });
+			const bundleSource = (await ev).bundle.entrypointSource;
+
+			// External import should be preserved, not bundled
+			expect(bundleSource).toMatch(/from\s*["']external-module["']/);
+		});
+
 		test("custom build", async () => {
 			await seed({
 				"custom_build_dir/index.ts": dedent/* javascript */ `

--- a/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
@@ -310,4 +310,40 @@ describe("ConfigController", () => {
 
 		expect(warningCount).toBe(1);
 	});
+
+	it("should error when using bundling_external with service-worker format", async () => {
+		await seed({
+			"src/index.js": dedent/* javascript */ `
+				addEventListener('fetch', event => {
+					event.respondWith(new Response('hello world'))
+				})
+			`,
+			"wrangler.toml": dedent/* toml */ `
+				name = "my-worker"
+				main = "src/index.js"
+				compatibility_date = "2024-06-01"
+				bundling_external = ["external-module"]
+			`,
+		});
+
+		const event = bus.waitFor("error");
+		await controller.set({
+			config: "./wrangler.toml",
+		});
+		const error = await event;
+
+		expect(error.reason).toBe("Error resolving config");
+		expect((error.cause as Error).message).toMatchInlineSnapshot(
+			`"You cannot configure \`bundling_external\` with a service-worker format worker. Instead, configure \`alias\` to substitute modules with alternative implementations.
+
+For example:
+{
+  "alias": {
+    "external-module": "./my-local-implementation.js"
+  }
+}
+
+See https://developers.cloudflare.com/workers/wrangler/configuration/#module-aliasing"`
+		);
+	});
 });

--- a/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
@@ -311,7 +311,7 @@ describe("ConfigController", () => {
 		expect(warningCount).toBe(1);
 	});
 
-	it("should error when using bundling_external with service-worker format", async () => {
+	it("should error when using bundle.external with service-worker format", async () => {
 		await seed({
 			"src/index.js": dedent/* javascript */ `
 				addEventListener('fetch', event => {
@@ -322,7 +322,8 @@ describe("ConfigController", () => {
 				name = "my-worker"
 				main = "src/index.js"
 				compatibility_date = "2024-06-01"
-				bundling_external = ["external-module"]
+				[bundle]
+				external = ["external-module"]
 			`,
 		});
 
@@ -334,7 +335,7 @@ describe("ConfigController", () => {
 
 		expect(error.reason).toBe("Error resolving config");
 		expect((error.cause as Error).message).toMatchInlineSnapshot(
-			`"You cannot configure \`bundling_external\` with a service-worker format worker. Instead, configure \`alias\` to substitute modules with alternative implementations.
+			`"You cannot configure \`bundle.external\` with a service-worker format worker. Instead, configure \`alias\` to substitute modules with alternative implementations.
 
 For example:
 {

--- a/packages/wrangler/src/__tests__/deploy/build.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/build.test.ts
@@ -658,6 +658,28 @@ describe("deploy", () => {
 				  - Add the "nodejs_compat" compatibility flag to your project."
 			`);
 		});
+
+		it("should error when using bundling_external with service-worker format", async () => {
+			writeWranglerConfig({
+				bundling_external: ["external-module"],
+			});
+			writeWorkerSource({ type: "sw" });
+
+			await expect(
+				runWrangler("deploy index.js")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: You cannot configure \`bundling_external\` with a service-worker format worker. Instead, configure \`alias\` to substitute modules with alternative implementations.
+
+For example:
+{
+  "alias": {
+    "external-module": "./my-local-implementation.js"
+  }
+}
+
+See https://developers.cloudflare.com/workers/wrangler/configuration/#module-aliasing]`
+			);
+		});
 	});
 	describe("--node-compat", () => {
 		it("should error when using node compatibility mode", async () => {

--- a/packages/wrangler/src/__tests__/deploy/build.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/build.test.ts
@@ -513,11 +513,11 @@ describe("deploy", () => {
 			await runWrangler("deploy -e testEnv index.js");
 		});
 	});
-	describe("bundling_external", () => {
-		it("should mark modules as external when `bundling_external` is configured", async () => {
+	describe("bundle.external", () => {
+		it("should mark modules as external when `bundle.external` is configured", async () => {
 			writeWranglerConfig({
 				main: "./index.js",
-				bundling_external: ["external-module"],
+				bundle: { external: ["external-module"] },
 			});
 			fs.writeFileSync(
 				"./index.js",
@@ -555,13 +555,13 @@ describe("deploy", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should mark modules as external when `bundling_external` is configured in environment", async () => {
+		it("should mark modules as external when `bundle.external` is configured in environment", async () => {
 			writeWranglerConfig({
 				main: "./index.js",
 				legacy_env: false,
 				env: {
 					testEnv: {
-						bundling_external: ["env-external-module"],
+						bundle: { external: ["env-external-module"] },
 					},
 				},
 			});
@@ -602,7 +602,7 @@ describe("deploy", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should recommend bundling_external when a non-Node module cannot be resolved", async () => {
+		it("should recommend bundle.external when a non-Node module cannot be resolved", async () => {
 			writeWranglerConfig();
 			fs.writeFileSync(
 				"index.js",
@@ -629,12 +629,12 @@ describe("deploy", () => {
 				        ╵                 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 				  To fix this, you can:
-				  - Add "some-nonexistent-module" to "bundling_external" in your Wrangler configuration to exclude it from the bundle
+				  - Add "some-nonexistent-module" to "bundle.external" in your Wrangler configuration to exclude it from the bundle
 				  - Add an entry to "alias" in your Wrangler configuration to map it to a different module (see https://developers.cloudflare.com/workers/wrangler/configuration/#module-aliasing)"
 			`);
 		});
 
-		it("should NOT recommend bundling_external for Node built-in modules", async () => {
+		it("should NOT recommend bundle.external for Node built-in modules", async () => {
 			writeWranglerConfig();
 			fs.writeFileSync("index.js", "import fs from 'fs';");
 
@@ -659,16 +659,16 @@ describe("deploy", () => {
 			`);
 		});
 
-		it("should error when using bundling_external with service-worker format", async () => {
+		it("should error when using bundle.external with service-worker format", async () => {
 			writeWranglerConfig({
-				bundling_external: ["external-module"],
+				bundle: { external: ["external-module"] },
 			});
 			writeWorkerSource({ type: "sw" });
 
 			await expect(
 				runWrangler("deploy index.js")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: You cannot configure \`bundling_external\` with a service-worker format worker. Instead, configure \`alias\` to substitute modules with alternative implementations.
+				`[Error: You cannot configure \`bundle.external\` with a service-worker format worker. Instead, configure \`alias\` to substitute modules with alternative implementations.
 
 For example:
 {
@@ -1292,10 +1292,13 @@ See https://developers.cloudflare.com/workers/wrangler/configuration/#module-ali
 				"deploy index.js --no-bundle --minify --dry-run --outdir dist"
 			);
 			expect(std.warn).toMatchInlineSnapshot(`
-			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m\`--minify\` and \`--no-bundle\` can't be used together. If you want to minify your Worker and disable Wrangler's bundling, please minify as part of your own bundling process.[0m
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m\`--minify\` and \`--no-bundle\` can't be used together. If you want to minify your Worker and disable Wrangler's bundling, please minify as part of your own bundling process.[0m
 
-			"
-		`);
+
+				[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m\`bundle\` and \`--no-bundle\` can't be used together. Please choose the one that is most appropriate for your use case.[0m
+
+				"
+			`);
 		});
 
 		it("should warn that no-bundle and minify can't be used together", async () => {
@@ -1311,14 +1314,17 @@ See https://developers.cloudflare.com/workers/wrangler/configuration/#module-ali
 			expect(std.warn).toMatchInlineSnapshot(`
 				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m\`--minify\` and \`--no-bundle\` can't be used together. If you want to minify your Worker and disable Wrangler's bundling, please minify as part of your own bundling process.[0m
 
+
+				[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m\`bundle\` and \`--no-bundle\` can't be used together. Please choose the one that is most appropriate for your use case.[0m
+
 				"
 			`);
 		});
 	});
-	describe("--no-bundle bundling_external", () => {
-		it("should warn that no-bundle and bundling_external can't be used together (CLI flag)", async () => {
+	describe("--no-bundle bundle.external", () => {
+		it("should warn that no-bundle and bundle.external can't be used together (CLI flag)", async () => {
 			writeWranglerConfig({
-				bundling_external: ["external-module"],
+				bundle: { external: ["external-module"] },
 			});
 			const scriptContent = `
 				import foo from 'external-module';
@@ -1327,16 +1333,16 @@ See https://developers.cloudflare.com/workers/wrangler/configuration/#module-ali
 			fs.writeFileSync("index.js", scriptContent);
 			await runWrangler("deploy index.js --no-bundle --dry-run --outdir dist");
 			expect(std.warn).toMatchInlineSnapshot(`
-				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m\`bundling_external\` and \`--no-bundle\` can't be used together. If you want to exclude modules from your bundle and disable Wrangler's bundling, please handle external modules as part of your own bundling process.[0m
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m\`bundle\` and \`--no-bundle\` can't be used together. Please choose the one that is most appropriate for your use case.[0m
 
 				"
 			`);
 		});
 
-		it("should warn that no-bundle and bundling_external can't be used together (config)", async () => {
+		it("should warn that no-bundle and bundle.external can't be used together (config)", async () => {
 			writeWranglerConfig({
 				no_bundle: true,
-				bundling_external: ["external-module"],
+				bundle: { external: ["external-module"] },
 			});
 			const scriptContent = `
 				import foo from 'external-module';
@@ -1345,7 +1351,7 @@ See https://developers.cloudflare.com/workers/wrangler/configuration/#module-ali
 			fs.writeFileSync("index.js", scriptContent);
 			await runWrangler("deploy index.js --dry-run --outdir dist");
 			expect(std.warn).toMatchInlineSnapshot(`
-				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m\`bundling_external\` and \`--no-bundle\` can't be used together. If you want to exclude modules from your bundle and disable Wrangler's bundling, please handle external modules as part of your own bundling process.[0m
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m\`bundle\` and \`--no-bundle\` can't be used together. Please choose the one that is most appropriate for your use case.[0m
 
 				"
 			`);

--- a/packages/wrangler/src/__tests__/deploy/build.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/build.test.ts
@@ -10,6 +10,7 @@ import {
 } from "@cloudflare/workers-utils/test-helpers";
 import * as esbuild from "esbuild";
 import { http, HttpResponse } from "msw";
+import dedent from "ts-dedent";
 import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
 import { getInstalledPackageVersion } from "../../autoconfig/frameworks/utils/packages";
 import { printBundleSize } from "../../deployment-bundle/bundle-reporter";
@@ -510,6 +511,152 @@ describe("deploy", () => {
 
 			mockSubDomainRequest();
 			await runWrangler("deploy -e testEnv index.js");
+		});
+	});
+	describe("bundling_external", () => {
+		it("should mark modules as external when `bundling_external` is configured", async () => {
+			writeWranglerConfig({
+				main: "./index.js",
+				bundling_external: ["external-module"],
+			});
+			fs.writeFileSync(
+				"./index.js",
+				`
+				import foo from 'external-module';
+				export default {
+					fetch() {
+						return new Response(foo);
+					}
+				}
+				`
+			);
+
+			mockUploadWorkerRequest({
+				expectedType: "esm",
+				expectedEntry: (str) => {
+					// External import should be preserved as an import statement
+					expect(str).toMatch(/from\s*["']external-module["']/);
+				},
+			});
+
+			mockSubDomainRequest();
+			await runWrangler("deploy index.js");
+			expect(std.out).toMatchInlineSnapshot(`
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				Total Upload: xx KiB / gzip: xx KiB
+				Worker Startup Time: 100 ms
+				Uploaded test-name (TIMINGS)
+				Deployed test-name triggers (TIMINGS)
+				  https://test-name.test-sub-domain.workers.dev
+				Current Version ID: Galaxy-Class"
+			`);
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
+		it("should mark modules as external when `bundling_external` is configured in environment", async () => {
+			writeWranglerConfig({
+				main: "./index.js",
+				legacy_env: false,
+				env: {
+					testEnv: {
+						bundling_external: ["env-external-module"],
+					},
+				},
+			});
+			fs.writeFileSync(
+				"./index.js",
+				`
+				import bar from 'env-external-module';
+				export default {
+					fetch() {
+						return new Response(bar);
+					}
+				}`
+			);
+
+			mockUploadWorkerRequest({
+				env: "testEnv",
+				expectedType: "esm",
+				useServiceEnvironments: true,
+				expectedEntry: (str) => {
+					// External import should be preserved
+					expect(str).toMatch(/from\s*["']env-external-module["']/);
+				},
+			});
+
+			mockSubDomainRequest();
+			await runWrangler("deploy -e testEnv index.js");
+			expect(std.out).toMatchInlineSnapshot(`
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				Total Upload: xx KiB / gzip: xx KiB
+				Worker Startup Time: 100 ms
+				Uploaded test-name (testEnv) (TIMINGS)
+				Deployed test-name (testEnv) triggers (TIMINGS)
+				  https://testEnv.test-name.test-sub-domain.workers.dev
+				Current Version ID: undefined"
+			`);
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
+		it("should recommend bundling_external when a non-Node module cannot be resolved", async () => {
+			writeWranglerConfig();
+			fs.writeFileSync(
+				"index.js",
+				dedent/* javascript */ `
+					import foo from 'some-nonexistent-module';
+					export default { fetch() { return new Response(foo); } }
+				`
+			);
+
+			await expect(
+				runWrangler("deploy index.js --dry-run").catch((e) =>
+					normalizeString(
+						esbuild
+							.formatMessagesSync(e?.errors ?? [], { kind: "error" })
+							.join()
+							.trim()
+					)
+				)
+			).resolves.toMatchInlineSnapshot(`
+				"X [ERROR] Could not resolve "some-nonexistent-module"
+
+				    index.js:1:16:
+				      1 │ import foo from 'some-nonexistent-module';
+				        ╵                 ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+				  To fix this, you can:
+				  - Add "some-nonexistent-module" to "bundling_external" in your Wrangler configuration to exclude it from the bundle
+				  - Add an entry to "alias" in your Wrangler configuration to map it to a different module (see https://developers.cloudflare.com/workers/wrangler/configuration/#module-aliasing)"
+			`);
+		});
+
+		it("should NOT recommend bundling_external for Node built-in modules", async () => {
+			writeWranglerConfig();
+			fs.writeFileSync("index.js", "import fs from 'fs';");
+
+			await expect(
+				runWrangler("deploy index.js --dry-run").catch((e) =>
+					normalizeString(
+						esbuild
+							.formatMessagesSync(e?.errors ?? [], { kind: "error" })
+							.join()
+							.trim()
+					)
+				)
+			).resolves.toMatchInlineSnapshot(`
+				"X [ERROR] Could not resolve "fs"
+
+				    index.js:1:15:
+				      1 │ import fs from 'fs';
+				        ╵                ~~~~
+
+				  The package "fs" wasn't found on the file system but is built into node.
+				  - Add the "nodejs_compat" compatibility flag to your project."
+			`);
 		});
 	});
 	describe("--node-compat", () => {
@@ -1140,10 +1287,46 @@ describe("deploy", () => {
 			fs.writeFileSync("index.js", scriptContent);
 			await runWrangler("deploy index.js --dry-run --outdir dist");
 			expect(std.warn).toMatchInlineSnapshot(`
-			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m\`--minify\` and \`--no-bundle\` can't be used together. If you want to minify your Worker and disable Wrangler's bundling, please minify as part of your own bundling process.[0m
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m\`--minify\` and \`--no-bundle\` can't be used together. If you want to minify your Worker and disable Wrangler's bundling, please minify as part of your own bundling process.[0m
 
-			"
-		`);
+				"
+			`);
+		});
+	});
+	describe("--no-bundle bundling_external", () => {
+		it("should warn that no-bundle and bundling_external can't be used together (CLI flag)", async () => {
+			writeWranglerConfig({
+				bundling_external: ["external-module"],
+			});
+			const scriptContent = `
+				import foo from 'external-module';
+				export default { fetch() { return new Response(foo); } }
+			`;
+			fs.writeFileSync("index.js", scriptContent);
+			await runWrangler("deploy index.js --no-bundle --dry-run --outdir dist");
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m\`bundling_external\` and \`--no-bundle\` can't be used together. If you want to exclude modules from your bundle and disable Wrangler's bundling, please handle external modules as part of your own bundling process.[0m
+
+				"
+			`);
+		});
+
+		it("should warn that no-bundle and bundling_external can't be used together (config)", async () => {
+			writeWranglerConfig({
+				no_bundle: true,
+				bundling_external: ["external-module"],
+			});
+			const scriptContent = `
+				import foo from 'external-module';
+				export default { fetch() { return new Response(foo); } }
+			`;
+			fs.writeFileSync("index.js", scriptContent);
+			await runWrangler("deploy index.js --dry-run --outdir dist");
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m\`bundling_external\` and \`--no-bundle\` can't be used together. If you want to exclude modules from your bundle and disable Wrangler's bundling, please handle external modules as part of your own bundling process.[0m
+
+				"
+			`);
 		});
 	});
 	describe("source maps", () => {

--- a/packages/wrangler/src/api/startDevWorker/BundlerController.ts
+++ b/packages/wrangler/src/api/startDevWorker/BundlerController.ts
@@ -142,7 +142,7 @@ export class BundlerController extends Controller {
 						entryName: undefined,
 						inject: undefined,
 						isOutfile: undefined,
-						external: undefined,
+						external: config.build.external,
 
 						// We don't use esbuild watching for custom builds
 						watch: undefined,
@@ -284,6 +284,7 @@ export class BundlerController extends Controller {
 					config.compatibilityFlags
 				),
 				pythonModulesExcludes: config.pythonModules?.exclude ?? [],
+				external: config.build.external,
 			},
 			(cb) => {
 				const newBundle = cb(this.#currentBundle);

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -344,6 +344,7 @@ async function resolveConfig(
 
 			minify: input.build?.minify ?? config.minify,
 			keepNames: input.build?.keepNames ?? config.keep_names,
+			external: input.build?.external ?? config.bundling_external,
 			define: { ...config.define, ...input.build?.define },
 			custom: {
 				command: input.build?.custom?.command ?? config.build?.command,

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -386,6 +386,24 @@ async function resolveConfig(
 		);
 	}
 
+	if (
+		resolved.build.external?.length &&
+		resolved.build.format === "service-worker"
+	) {
+		throw new UserError(
+			`You cannot configure \`bundling_external\` with a service-worker format worker. Instead, configure \`alias\` to substitute modules with alternative implementations.
+
+For example:
+{
+  "alias": {
+    "${resolved.build.external[0]}": "./my-local-implementation.js"
+  }
+}
+
+See https://developers.cloudflare.com/workers/wrangler/configuration/#module-aliasing`
+		);
+	}
+
 	validateAssetsArgsAndConfig(resolved);
 
 	const services = extractBindingsOfType("service", resolved.bindings);

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -344,7 +344,7 @@ async function resolveConfig(
 
 			minify: input.build?.minify ?? config.minify,
 			keepNames: input.build?.keepNames ?? config.keep_names,
-			external: input.build?.external ?? config.bundling_external,
+			external: input.build?.external ?? config.bundle?.external,
 			define: { ...config.define, ...input.build?.define },
 			custom: {
 				command: input.build?.custom?.command ?? config.build?.command,
@@ -391,7 +391,7 @@ async function resolveConfig(
 		resolved.build.format === "service-worker"
 	) {
 		throw new UserError(
-			`You cannot configure \`bundling_external\` with a service-worker format worker. Instead, configure \`alias\` to substitute modules with alternative implementations.
+			`You cannot configure \`bundle.external\` with a service-worker format worker. Instead, configure \`alias\` to substitute modules with alternative implementations.
 
 For example:
 {

--- a/packages/wrangler/src/api/startDevWorker/types.ts
+++ b/packages/wrangler/src/api/startDevWorker/types.ts
@@ -115,6 +115,8 @@ export interface StartDevWorkerInput {
 		minify?: boolean;
 		/** Whether to keep function names after JavaScript transpilations. */
 		keepNames?: boolean;
+		/** Modules to mark as external during bundling. Only takes effect if bundle: true. */
+		external?: string[];
 		/** Options controlling a custom build step. */
 		custom?: {
 			/** Custom shell command to run before bundling. Runs even if bundle. */

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -675,6 +675,22 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		);
 	}
 
+	if (config.bundling_external?.length && format === "service-worker") {
+		throw new UserError(
+			`You cannot configure \`bundling_external\` with a service-worker format worker. Instead, configure \`alias\` to substitute modules with alternative implementations.
+
+For example:
+{
+  "alias": {
+    "${config.bundling_external[0]}": "./my-local-implementation.js"
+  }
+}
+
+See https://developers.cloudflare.com/workers/wrangler/configuration/#module-aliasing`,
+			{ telemetryMessage: "[bundling_external] with service-worker format" }
+		);
+	}
+
 	let sourceMapSize;
 	const normalisedContainerConfig = await getNormalizedContainerOptions(
 		config,

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -580,9 +580,9 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			);
 		}
 
-		if (config.bundling_external?.length) {
+		if (config.bundle) {
 			logger.warn(
-				"`bundling_external` and `--no-bundle` can't be used together. If you want to exclude modules from your bundle and disable Wrangler's bundling, please handle external modules as part of your own bundling process."
+				"`bundle` and `--no-bundle` can't be used together. Please choose the one that is most appropriate for your use case."
 			);
 		}
 	}
@@ -675,19 +675,19 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		);
 	}
 
-	if (config.bundling_external?.length && format === "service-worker") {
+	if (config.bundle?.external?.length && format === "service-worker") {
 		throw new UserError(
-			`You cannot configure \`bundling_external\` with a service-worker format worker. Instead, configure \`alias\` to substitute modules with alternative implementations.
+			`You cannot configure \`bundle.external\` with a service-worker format worker. Instead, configure \`alias\` to substitute modules with alternative implementations.
 
 For example:
 {
   "alias": {
-    "${config.bundling_external[0]}": "./my-local-implementation.js"
+    "${config.bundle.external[0]}": "./my-local-implementation.js"
   }
 }
 
 See https://developers.cloudflare.com/workers/wrangler/configuration/#module-aliasing`,
-			{ telemetryMessage: "[bundling_external] with service-worker format" }
+			{ telemetryMessage: "[bundle.external] with service-worker format" }
 		);
 	}
 
@@ -774,7 +774,7 @@ See https://developers.cloudflare.com/workers/wrangler/configuration/#module-ali
 						entryName: undefined,
 						inject: undefined,
 						isOutfile: undefined,
-						external: config.bundling_external,
+						external: config.bundle?.external,
 
 						// These options are dev-only
 						testScheduled: undefined,

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -573,11 +573,18 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		}
 	);
 
-	// Warn if user tries minify with no-bundle
-	if (props.noBundle && minify) {
-		logger.warn(
-			"`--minify` and `--no-bundle` can't be used together. If you want to minify your Worker and disable Wrangler's bundling, please minify as part of your own bundling process."
-		);
+	if (props.noBundle) {
+		if (minify) {
+			logger.warn(
+				"`--minify` and `--no-bundle` can't be used together. If you want to minify your Worker and disable Wrangler's bundling, please minify as part of your own bundling process."
+			);
+		}
+
+		if (config.bundling_external?.length) {
+			logger.warn(
+				"`bundling_external` and `--no-bundle` can't be used together. If you want to exclude modules from your bundle and disable Wrangler's bundling, please handle external modules as part of your own bundling process."
+			);
+		}
 	}
 
 	const scriptName = props.name;
@@ -751,7 +758,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 						entryName: undefined,
 						inject: undefined,
 						isOutfile: undefined,
-						external: undefined,
+						external: config.bundling_external,
 
 						// These options are dev-only
 						testScheduled: undefined,

--- a/packages/wrangler/src/deployment-bundle/build-failures.ts
+++ b/packages/wrangler/src/deployment-bundle/build-failures.ts
@@ -45,7 +45,7 @@ export function rewriteNodeCompatBuildFailure(
 
 /**
  * RegExp matching against esbuild's error text when it is unable to resolve
- * a module. Used to detect when we should suggest the `bundling_external` config.
+ * a module. Used to detect when we should suggest the `bundle.external` config.
  */
 const couldNotResolveErrorText = /^Could not resolve "(.+)"$/;
 
@@ -56,7 +56,7 @@ const markAsExternalNoteText = "as external to exclude it from the bundle";
 
 /**
  * Rewrites esbuild BuildFailures for failing to resolve modules to suggest
- * using the `bundling_external` or `alias` config options in wrangler.json.
+ * using the `bundle.external` or `alias` config options in wrangler.json.
  */
 export function rewriteBundlingExternalBuildFailure(errors: esbuild.Message[]) {
 	for (const error of errors) {
@@ -76,10 +76,10 @@ export function rewriteBundlingExternalBuildFailure(errors: esbuild.Message[]) {
 					),
 					{
 						location: null,
-						// TODO: Add documentation link for bundling_external once available
+						// TODO: Add documentation link for bundle.external once available
 						text:
 							`To fix this, you can:\n` +
-							`- Add "${moduleName}" to "bundling_external" in your Wrangler configuration to exclude it from the bundle\n` +
+							`- Add "${moduleName}" to "bundle.external" in your Wrangler configuration to exclude it from the bundle\n` +
 							`- Add an entry to "alias" in your Wrangler configuration to map it to a different module (see https://developers.cloudflare.com/workers/wrangler/configuration/#module-aliasing)`,
 					},
 				];

--- a/packages/wrangler/src/deployment-bundle/build-failures.ts
+++ b/packages/wrangler/src/deployment-bundle/build-failures.ts
@@ -42,6 +42,52 @@ export function rewriteNodeCompatBuildFailure(
 		}
 	}
 }
+
+/**
+ * RegExp matching against esbuild's error text when it is unable to resolve
+ * a module. Used to detect when we should suggest the `bundling_external` config.
+ */
+const couldNotResolveErrorText = /^Could not resolve "(.+)"$/;
+
+/**
+ * Text that appears in esbuild's notes when it suggests marking a module as external.
+ */
+const markAsExternalNoteText = "as external to exclude it from the bundle";
+
+/**
+ * Rewrites esbuild BuildFailures for failing to resolve modules to suggest
+ * using the `bundling_external` or `alias` config options in wrangler.json.
+ */
+export function rewriteBundlingExternalBuildFailure(errors: esbuild.Message[]) {
+	for (const error of errors) {
+		const match = couldNotResolveErrorText.exec(error.text);
+		// Note: we skip the node built-in modules since these are handled by rewriteNodeCompatBuildFailure
+		if (match !== null && !nodeBuiltinResolveErrorText.test(error.text)) {
+			const moduleName = match[1];
+			// Check if esbuild's notes mention marking as external
+			const hasExternalSuggestion = error.notes?.some((note) =>
+				note.text?.includes(markAsExternalNoteText)
+			);
+			if (hasExternalSuggestion) {
+				// Filter out esbuild's "mark as external" suggestion since we provide our own
+				error.notes = [
+					...(error.notes ?? []).filter(
+						(note) => !note.text?.includes(markAsExternalNoteText)
+					),
+					{
+						location: null,
+						// TODO: Add documentation link for bundling_external once available
+						text:
+							`To fix this, you can:\n` +
+							`- Add "${moduleName}" to "bundling_external" in your Wrangler configuration to exclude it from the bundle\n` +
+							`- Add an entry to "alias" in your Wrangler configuration to map it to a different module (see https://developers.cloudflare.com/workers/wrangler/configuration/#module-aliasing)`,
+					},
+				];
+			}
+		}
+	}
+}
+
 /**
  * Returns true if the passed value looks like an esbuild BuildFailure object
  */

--- a/packages/wrangler/src/deployment-bundle/bundle.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle.ts
@@ -12,6 +12,7 @@ import { getBasePath, getWranglerTmpDir } from "../paths";
 import { applyMiddlewareLoaderFacade } from "./apply-middleware";
 import {
 	isBuildFailure,
+	rewriteBundlingExternalBuildFailure,
 	rewriteNodeCompatBuildFailure,
 } from "./build-failures";
 import { dedupeModulesByName } from "./dedupe-modules";
@@ -477,6 +478,7 @@ export async function bundleWorker(
 	} catch (e) {
 		if (isBuildFailure(e)) {
 			rewriteNodeCompatBuildFailure(e.errors, nodejsCompatMode);
+			rewriteBundlingExternalBuildFailure(e.errors);
 		}
 		throw e;
 	}

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -59,6 +59,7 @@ export function runBuild(
 		defineNavigatorUserAgent,
 		checkFetch,
 		pythonModulesExcludes,
+		external,
 	}: {
 		entry: Entry;
 		destination: string | undefined;
@@ -87,6 +88,7 @@ export function runBuild(
 		defineNavigatorUserAgent: boolean;
 		checkFetch: boolean;
 		pythonModulesExcludes?: string[];
+		external?: string[];
 	},
 	setBundle: (
 		cb: (previous: EsbuildBundle | undefined) => EsbuildBundle
@@ -179,7 +181,7 @@ export function runBuild(
 						entryName: undefined,
 						inject: undefined,
 						isOutfile: undefined,
-						external: undefined,
+						external,
 
 						// sourcemap defaults to true in dev
 						sourcemap: undefined,

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -557,6 +557,21 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		);
 	}
 
+	if (config.bundling_external?.length && format === "service-worker") {
+		throw new UserError(
+			`You cannot configure \`bundling_external\` with a service-worker format worker. Instead, configure \`alias\` to substitute modules with alternative implementations.
+
+For example:
+{
+  "alias": {
+    "${config.bundling_external[0]}": "./my-local-implementation.js"
+  }
+}
+
+See https://developers.cloudflare.com/workers/wrangler/configuration/#module-aliasing`
+		);
+	}
+
 	let hasPreview = false;
 
 	try {

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -503,9 +503,9 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			);
 		}
 
-		if (props.noBundle && config.bundling_external?.length) {
+		if (props.noBundle && config.bundle?.external?.length) {
 			logger.warn(
-				"`bundling_external` and `--no-bundle` can't be used together. If you want to exclude modules from your bundle and disable Wrangler's bundling, please handle external modules as part of your own bundling process."
+				"`bundle.external` and `--no-bundle` can't be used together. If you want to exclude modules from your bundle and disable Wrangler's bundling, please handle external modules as part of your own bundling process."
 			);
 		}
 	}
@@ -557,14 +557,14 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		);
 	}
 
-	if (config.bundling_external?.length && format === "service-worker") {
+	if (config.bundle?.external?.length && format === "service-worker") {
 		throw new UserError(
-			`You cannot configure \`bundling_external\` with a service-worker format worker. Instead, configure \`alias\` to substitute modules with alternative implementations.
+			`You cannot configure \`bundle.external\` with a service-worker format worker. Instead, configure \`alias\` to substitute modules with alternative implementations.
 
 For example:
 {
   "alias": {
-    "${config.bundling_external[0]}": "./my-local-implementation.js"
+    "${config.bundle.external[0]}": "./my-local-implementation.js"
   }
 }
 
@@ -661,7 +661,7 @@ See https://developers.cloudflare.com/workers/wrangler/configuration/#module-ali
 						entryName: undefined,
 						inject: undefined,
 						isOutfile: undefined,
-						external: config.bundling_external,
+						external: config.bundle?.external,
 
 						// These options are dev-only
 						testScheduled: undefined,

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -496,11 +496,18 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		}
 	);
 
-	// Warn if user tries minify or node-compat with no-bundle
-	if (props.noBundle && minify) {
-		logger.warn(
-			"`--minify` and `--no-bundle` can't be used together. If you want to minify your Worker and disable Wrangler's bundling, please minify as part of your own bundling process."
-		);
+	if (props.noBundle) {
+		if (props.noBundle && minify) {
+			logger.warn(
+				"`--minify` and `--no-bundle` can't be used together. If you want to minify your Worker and disable Wrangler's bundling, please minify as part of your own bundling process."
+			);
+		}
+
+		if (props.noBundle && config.bundling_external?.length) {
+			logger.warn(
+				"`bundling_external` and `--no-bundle` can't be used together. If you want to exclude modules from your bundle and disable Wrangler's bundling, please handle external modules as part of your own bundling process."
+			);
+		}
 	}
 
 	const scriptName = props.name;
@@ -639,7 +646,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 						entryName: undefined,
 						inject: undefined,
 						isOutfile: undefined,
-						external: undefined,
+						external: config.bundling_external,
 
 						// These options are dev-only
 						testScheduled: undefined,


### PR DESCRIPTION
Fixes #7095

This PR adds a `bundle.external` wrangler option to make packages as external. It also improves the esbuild error message to mention this new option or `alias` as a way to fix imports that failed to be resolved.

| Error message before | Error message after |
|--------|--------|
| <img width="834" height="513" alt="Screenshot of error message before changes" src="https://github.com/user-attachments/assets/1ba81c56-d551-40f4-aa1e-f9be7b93845a" /> | <img width="874" height="548" alt="Screenshot of error message after changes" src="https://github.com/user-attachments/assets/0f3de42e-d778-4076-b30f-373703ad7aad" /> | 

(Note: the screenshot is slightly outdated, `bundling_external` has been updated to `bundle.external`)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): __TODO__
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
