### PR TITLE
feat(vite-plugin-cloudflare): add Vite 8 to the supported peer dependency range

### DIFF
--- a/.changeset/green-buses-melt.md
+++ b/.changeset/green-buses-melt.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": minor
+---
+
+Add Vite 8 to the supported peer dependency range
+
+The package now lists Vite 8 in its peer dependency range, so installs with Vite 8 no longer show a peer dependency warning.

--- a/.github/workflows/vite-plugin-playgrounds.yml
+++ b/.github/workflows/vite-plugin-playgrounds.yml
@@ -28,7 +28,7 @@ jobs:
           - os: ubuntu-latest
             vite: "vite-6"
           - os: ubuntu-latest
-            vite: vite-8-beta
+            vite: vite-8
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo
@@ -60,10 +60,10 @@ jobs:
         if: steps.changes.outputs.everything_but_markdown == 'true' && matrix.vite == 'vite-6'
         run: |
           pnpm update -r --no-save vite@6.4.1
-      - name: Upgrade to Vite 8 beta
-        if: steps.changes.outputs.everything_but_markdown == 'true' && matrix.vite == 'vite-8-beta'
+      - name: Upgrade to Vite 8
+        if: steps.changes.outputs.everything_but_markdown == 'true' && matrix.vite == 'vite-8'
         run: |
-          pnpm update -r --no-save vite@beta
+          pnpm update -r --no-save vite@^8.0.0
       - name: Run dev playground tests
         if: steps.changes.outputs.everything_but_markdown == 'true'
         # We use `--only` to prevent TurboRepo from rebuilding dependencies

--- a/packages/vite-plugin-cloudflare/AGENTS.md
+++ b/packages/vite-plugin-cloudflare/AGENTS.md
@@ -29,4 +29,4 @@ Vite plugin for Cloudflare Workers development. Exports `cloudflare()` plugin fa
 
 - Unit tests: `.spec.ts` in `__tests__/`
 - E2E tests: `.test.ts` in `e2e/`, own vitest config
-- Playground tests: Playwright-based, tested across Vite 6/7/8-beta in CI
+- Playground tests: Playwright-based, tested across Vite 6/7/8 in CI

--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -74,7 +74,7 @@
 		"vitest": "catalog:vitest-3"
 	},
 	"peerDependencies": {
-		"vite": "^6.1.0 || ^7.0.0",
+		"vite": "^6.1.0 || ^7.0.0 || ^8.0.0",
 		"wrangler": "workspace:^"
 	},
 	"publishConfig": {


### PR DESCRIPTION
Fixes n/a.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: We didn't mention the supported vite version in the docs.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
