### PR TITLE
[vite-plugin] Fix dev crashes when Worker entries use standard decorators

### DIFF
--- a/.changeset/tiny-buses-thank.md
+++ b/.changeset/tiny-buses-thank.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Fix `vite dev` crashing when Worker entry files use standard decorators
+
+The Vite plugin now forces decorator lowering in Vite's esbuild transform before worker modules are evaluated in development. Previously, TypeScript configs such as `target: "ES2022"` could leave `@decorator` syntax in dev output, which caused `Invalid or unexpected token` when workerd evaluated the module.

--- a/packages/vite-plugin-cloudflare/e2e/decorators.test.ts
+++ b/packages/vite-plugin-cloudflare/e2e/decorators.test.ts
@@ -1,0 +1,27 @@
+import { describe, test } from "vitest";
+import {
+	fetchJson,
+	isBuildAndPreviewOnWindows,
+	runLongLived,
+	seed,
+	waitForReady,
+} from "./helpers.js";
+
+const commands = ["dev", "buildAndPreview"] as const;
+
+describe("decorated worker entry modules", () => {
+	const projectPath = seed("decorators", { pm: "pnpm" });
+
+	describe.each(commands)('with "%s" command', (command) => {
+		test.skipIf(isBuildAndPreviewOnWindows(command))(
+			"can serve a Worker that uses standard decorators",
+			async ({ expect }) => {
+				const proc = await runLongLived("pnpm", command, projectPath);
+				const url = await waitForReady(proc);
+
+				expect(await fetchJson(url)).toEqual({ message: "ok" });
+				expect(proc.stderr).not.toContain("Invalid or unexpected token");
+			}
+		);
+	});
+});

--- a/packages/vite-plugin-cloudflare/e2e/fixtures/decorators/package.json
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/decorators/package.json
@@ -1,0 +1,18 @@
+{
+	"name": "@cloudflare/vite-plugin-e2e-decorators",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"build": "vite build",
+		"buildAndPreview": "vite build && vite preview",
+		"dev": "vite dev",
+		"preview": "vite preview"
+	},
+	"devDependencies": {
+		"@cloudflare/vite-plugin": "*",
+		"@cloudflare/workers-types": "^4.20250204.0",
+		"typescript": "~5.7.2",
+		"vite": "^7.0.0",
+		"wrangler": "*"
+	}
+}

--- a/packages/vite-plugin-cloudflare/e2e/fixtures/decorators/src/index.ts
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/decorators/src/index.ts
@@ -1,0 +1,23 @@
+function callable() {
+	return function <
+		This,
+		Value extends (this: This, ...args: Array<unknown>) => unknown,
+	>(value: Value, _context: ClassMethodDecoratorContext<This, Value>) {
+		return value;
+	};
+}
+
+class DecoratedWorker {
+	@callable()
+	async message() {
+		return { message: "ok" };
+	}
+}
+
+const worker = new DecoratedWorker();
+
+export default {
+	async fetch() {
+		return Response.json(await worker.message());
+	},
+} satisfies ExportedHandler;

--- a/packages/vite-plugin-cloudflare/e2e/fixtures/decorators/tsconfig.json
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/decorators/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"useDefineForClassFields": true,
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"noEmit": true,
+		"isolatedModules": true,
+		"types": ["@cloudflare/workers-types", "vite/client"]
+	},
+	"include": ["src"]
+}

--- a/packages/vite-plugin-cloudflare/e2e/fixtures/decorators/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/decorators/vite.config.ts
@@ -1,0 +1,6 @@
+import { cloudflare } from "@cloudflare/vite-plugin";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+});

--- a/packages/vite-plugin-cloudflare/e2e/fixtures/decorators/wrangler.jsonc
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/decorators/wrangler.jsonc
@@ -1,0 +1,5 @@
+{
+	"name": "cloudflare-vite-e2e-decorators",
+	"main": "./src/index.ts",
+	"compatibility_date": "2026-03-01",
+}

--- a/packages/vite-plugin-cloudflare/src/__tests__/config.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/config.spec.ts
@@ -1,0 +1,38 @@
+import { describe, test } from "vitest";
+import { getEsbuildOptions } from "../plugins/config";
+
+describe("getEsbuildOptions", () => {
+	test("forces decorator lowering by default", ({ expect }) => {
+		expect(getEsbuildOptions({})).toEqual({
+			supported: {
+				decorators: false,
+			},
+		});
+	});
+
+	test("preserves user esbuild options while forcing decorator lowering", ({
+		expect,
+	}) => {
+		expect(
+			getEsbuildOptions({
+				esbuild: {
+					jsx: "automatic",
+					supported: {
+						bigint: true,
+						decorators: true,
+					},
+				},
+			})
+		).toEqual({
+			jsx: "automatic",
+			supported: {
+				bigint: true,
+				decorators: false,
+			},
+		});
+	});
+
+	test("respects explicitly disabled esbuild transforms", ({ expect }) => {
+		expect(getEsbuildOptions({ esbuild: false })).toBe(false);
+	});
+});

--- a/packages/vite-plugin-cloudflare/src/plugins/config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/config.ts
@@ -48,6 +48,7 @@ export const configPlugin = createPlugin("config", (ctx) => {
 
 			return {
 				appType: "custom",
+				esbuild: getEsbuildOptions(userConfig),
 				server: {
 					fs: {
 						deny: [
@@ -148,6 +149,24 @@ export const configPlugin = createPlugin("config", (ctx) => {
 		},
 	};
 });
+
+export function getEsbuildOptions(
+	userConfig: UserConfig
+): UserConfig["esbuild"] {
+	if (userConfig.esbuild === false) {
+		return false;
+	}
+
+	return {
+		...userConfig.esbuild,
+		supported: {
+			...userConfig.esbuild?.supported,
+			// Force esbuild to lower TC39 decorators — workerd does not support
+			// native decorator syntax. See https://github.com/cloudflare/workers-sdk/issues/12626
+			decorators: false,
+		},
+	};
+}
 
 /**
  * Generates the environment configuration for all Worker environments.


### PR DESCRIPTION
Fixes #12626.

Lower standard decorators before Vite's dev module runner evaluates Worker entry modules.

This forces `esbuild.supported.decorators = false` so decorators are lowered consistently in development, and adds unit and e2e regression coverage for the reported crash.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is a bug fix for internal dev-time transformation behavior.

*A picture of a cute animal (not mandatory, but encouraged)*

🦦
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
