### PR TITLE
[vitest-pool-workers] Resolve CJS alternatives when require() picks up ESM via "import" condition

### DIFF
--- a/.changeset/giant-places-cry.md
+++ b/.changeset/giant-places-cry.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+fix: resolve CJS alternatives when `require()` picks up an ESM file via the "import" export condition
+
+workerd always uses the "import" condition even for `require()` calls, which can cause it to resolve to an ESM file instead of the intended CJS entry. The module fallback service now inspects the package's `exports` map to find a matching "require" or "default" entry and redirects to the CJS file when one exists. This also handles packages that expose `workerd` or `worker` conditions with CJS-compatible entries (e.g. `pg-cloudflare`).

--- a/packages/vitest-pool-workers/src/pool/module-fallback.ts
+++ b/packages/vitest-pool-workers/src/pool/module-fallback.ts
@@ -295,6 +295,116 @@ async function viteResolve(
 	return trimViteVersionHash(resolved.id);
 }
 
+/**
+ * When require() resolves to an ESM file (via the "import" export condition),
+ * find the CJS alternative from the package's exports map.
+ * workerd always uses the "import" condition even for require() calls,
+ * so we need to look up the "require" or "default" entry instead.
+ */
+export function findCjsExportAlternative(esmFilePath: string): string | undefined {
+	const cleanPath = esmFilePath.replace(/\?.*$/, "");
+	let dir = posixPath.dirname(cleanPath);
+	while (dir !== posixPath.dirname(dir)) {
+		const pkgPath = posixPath.join(dir, "package.json");
+		try {
+			const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+			if (pkg.exports) {
+				const relPath =
+					"./" + posixPath.relative(dir, cleanPath).replace(/\\/g, "/");
+				const cjsEntry = findCjsEntryInExports(pkg.exports, relPath);
+				if (cjsEntry) {
+					const cjsPath = posixPath.join(dir, cjsEntry);
+					if (isFile(cjsPath)) {
+						return cjsPath;
+					}
+				}
+			}
+			if (pkg.name) {
+				break;
+			}
+		} catch (e: unknown) {
+			if (!isFileNotFoundError(e)) {
+				throw e;
+			}
+		}
+		dir = posixPath.dirname(dir);
+	}
+}
+
+export function findCjsEntryInExports(
+	exports: Record<string, unknown>,
+	esmRelPath: string
+): string | undefined {
+	for (const value of Object.values(exports)) {
+		if (typeof value !== "object" || value === null) {
+			continue;
+		}
+		const result = findCjsEntryInConditions(
+			value as Record<string, unknown>,
+			esmRelPath
+		);
+		if (result) {
+			return result;
+		}
+	}
+}
+
+export function findCjsEntryInConditions(
+	conditions: Record<string, unknown>,
+	resolvedRelPath: string
+): string | undefined {
+	// Case 1: resolved file came from "import", find CJS alternative
+	const importEntry = conditions.import;
+	const requireEntry = conditions.require || conditions.default;
+	if (
+		typeof importEntry === "string" &&
+		importEntry === resolvedRelPath &&
+		typeof requireEntry === "string" &&
+		requireEntry !== importEntry
+	) {
+		return requireEntry;
+	}
+
+	// Case 2: resolved file came from "default", but a "workerd"/"worker" condition
+	// exists at the same level with a better entry (e.g. pg-cloudflare)
+	const defaultEntry = conditions.default;
+	if (typeof defaultEntry === "string" && defaultEntry === resolvedRelPath) {
+		for (const condName of ["workerd", "worker"]) {
+			const condValue = conditions[condName];
+			if (condValue == null) {
+				continue;
+			}
+			if (typeof condValue === "string") {
+				if (condValue !== resolvedRelPath) {
+					return condValue;
+				}
+			} else if (typeof condValue === "object") {
+				const condObj = condValue as Record<string, unknown>;
+				const entry = condObj.require || condObj.default || condObj.import;
+				if (typeof entry === "string" && entry !== resolvedRelPath) {
+					return entry;
+				}
+			}
+		}
+	}
+
+	// Recurse into nested conditions
+	for (const [key, value] of Object.entries(conditions)) {
+		if (key === "import" || key === "require" || key === "default") {
+			continue;
+		}
+		if (typeof value === "object" && value !== null) {
+			const result = findCjsEntryInConditions(
+				value as Record<string, unknown>,
+				resolvedRelPath
+			);
+			if (result) {
+				return result;
+			}
+		}
+	}
+}
+
 type ResolveMethod = "import" | "require";
 async function resolve(
 	vite: Vite.ViteDevServer,
@@ -307,6 +417,12 @@ async function resolve(
 
 	let filePath = maybeGetTargetFilePath(target);
 	if (filePath !== undefined) {
+		if (method === "require" && !specifier.startsWith("node:")) {
+			const cjsAlt = findCjsExportAlternative(filePath);
+			if (cjsAlt) {
+				return cjsAlt;
+			}
+		}
 		return filePath;
 	}
 
@@ -331,7 +447,19 @@ async function resolve(
 		return filePath;
 	}
 
-	return viteResolve(vite, specifier, referrer, method === "require");
+	const resolved = await viteResolve(
+		vite,
+		specifier,
+		referrer,
+		method === "require"
+	);
+	if (method === "require" && !specifier.startsWith("node:")) {
+		const cjsAlt = findCjsExportAlternative(resolved);
+		if (cjsAlt) {
+			return cjsAlt;
+		}
+	}
+	return resolved;
 }
 
 function buildRedirectResponse(filePath: string) {

--- a/packages/vitest-pool-workers/test/module-fallback.test.ts
+++ b/packages/vitest-pool-workers/test/module-fallback.test.ts
@@ -1,0 +1,547 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path/posix";
+import { removeDirSync } from "@cloudflare/workers-utils";
+import { afterEach, describe, it, vi } from "vitest";
+
+vi.mock("../src/shared/builtin-modules", () => ({
+	workerdBuiltinModules: new Set(),
+}));
+
+import {
+	findCjsEntryInConditions,
+	findCjsEntryInExports,
+	findCjsExportAlternative,
+} from "../src/pool/module-fallback";
+
+describe("findCjsEntryInConditions", () => {
+	describe("case 1: import condition matches", () => {
+		it("returns require entry when import matches resolvedRelPath", ({
+			expect,
+		}) => {
+			const result = findCjsEntryInConditions(
+				{ import: "./esm/index.mjs", require: "./cjs/index.cjs" },
+				"./esm/index.mjs"
+			);
+			expect(result).toBe("./cjs/index.cjs");
+		});
+
+		it("falls back to default when no require", ({ expect }) => {
+			const result = findCjsEntryInConditions(
+				{ import: "./esm/index.mjs", default: "./cjs/index.cjs" },
+				"./esm/index.mjs"
+			);
+			expect(result).toBe("./cjs/index.cjs");
+		});
+
+		it("prefers require over default", ({ expect }) => {
+			const result = findCjsEntryInConditions(
+				{
+					import: "./esm/index.mjs",
+					require: "./cjs/index.cjs",
+					default: "./default/index.js",
+				},
+				"./esm/index.mjs"
+			);
+			expect(result).toBe("./cjs/index.cjs");
+		});
+
+		it("returns undefined when require === import (same file)", ({
+			expect,
+		}) => {
+			const result = findCjsEntryInConditions(
+				{ import: "./index.js", require: "./index.js" },
+				"./index.js"
+			);
+			expect(result).toBeUndefined();
+		});
+
+		it("returns undefined when import doesn't match", ({ expect }) => {
+			const result = findCjsEntryInConditions(
+				{ import: "./esm/index.mjs", require: "./cjs/index.cjs" },
+				"./other/file.mjs"
+			);
+			expect(result).toBeUndefined();
+		});
+
+		it("returns undefined when import is not a string (nested object)", ({
+			expect,
+		}) => {
+			const result = findCjsEntryInConditions(
+				{
+					import: { node: "./esm/index.mjs" },
+					require: "./cjs/index.cjs",
+				},
+				"./esm/index.mjs"
+			);
+			expect(result).toBeUndefined();
+		});
+
+		it("returns undefined when require/default are not strings", ({
+			expect,
+		}) => {
+			const result = findCjsEntryInConditions(
+				{
+					import: "./esm/index.mjs",
+					require: { node: "./cjs/index.cjs" },
+				},
+				"./esm/index.mjs"
+			);
+			expect(result).toBeUndefined();
+		});
+	});
+
+	describe("case 2: default condition with workerd/worker", () => {
+		it("returns workerd string condition", ({ expect }) => {
+			const result = findCjsEntryInConditions(
+				{ default: "./index.js", workerd: "./workerd.js" },
+				"./index.js"
+			);
+			expect(result).toBe("./workerd.js");
+		});
+
+		it("returns worker string condition", ({ expect }) => {
+			const result = findCjsEntryInConditions(
+				{ default: "./index.js", worker: "./worker.js" },
+				"./index.js"
+			);
+			expect(result).toBe("./worker.js");
+		});
+
+		it("workerd takes priority over worker", ({ expect }) => {
+			const result = findCjsEntryInConditions(
+				{
+					default: "./index.js",
+					workerd: "./workerd.js",
+					worker: "./worker.js",
+				},
+				"./index.js"
+			);
+			expect(result).toBe("./workerd.js");
+		});
+
+		it("handles workerd as object with require field", ({ expect }) => {
+			const result = findCjsEntryInConditions(
+				{
+					default: "./index.js",
+					workerd: { require: "./workerd-cjs.js" },
+				},
+				"./index.js"
+			);
+			expect(result).toBe("./workerd-cjs.js");
+		});
+
+		it("handles workerd as object with default field", ({ expect }) => {
+			const result = findCjsEntryInConditions(
+				{
+					default: "./index.js",
+					workerd: { default: "./workerd-default.js" },
+				},
+				"./index.js"
+			);
+			expect(result).toBe("./workerd-default.js");
+		});
+
+		it("handles workerd as object with import field", ({ expect }) => {
+			const result = findCjsEntryInConditions(
+				{
+					default: "./index.js",
+					workerd: { import: "./workerd-esm.js" },
+				},
+				"./index.js"
+			);
+			expect(result).toBe("./workerd-esm.js");
+		});
+
+		it("object prefers require > default > import", ({ expect }) => {
+			const result = findCjsEntryInConditions(
+				{
+					default: "./index.js",
+					workerd: {
+						require: "./workerd-cjs.js",
+						default: "./workerd-default.js",
+						import: "./workerd-esm.js",
+					},
+				},
+				"./index.js"
+			);
+			expect(result).toBe("./workerd-cjs.js");
+		});
+
+		it("skips workerd when it resolves to same path, tries worker", ({
+			expect,
+		}) => {
+			const result = findCjsEntryInConditions(
+				{
+					default: "./index.js",
+					workerd: "./index.js",
+					worker: "./worker.js",
+				},
+				"./index.js"
+			);
+			expect(result).toBe("./worker.js");
+		});
+
+		it("returns undefined when no workerd/worker conditions", ({
+			expect,
+		}) => {
+			const result = findCjsEntryInConditions(
+				{ default: "./index.js", node: "./node.js" },
+				"./index.js"
+			);
+			// "node" is not "workerd" or "worker", so case 2 doesn't match,
+			// but it will recurse into "node" (case 3) and not find a match there
+			expect(result).toBeUndefined();
+		});
+
+		it("handles null workerd gracefully", ({ expect }) => {
+			const result = findCjsEntryInConditions(
+				{ default: "./index.js", workerd: null, worker: "./worker.js" },
+				"./index.js"
+			);
+			expect(result).toBe("./worker.js");
+		});
+	});
+
+	describe("case 3: recursion into nested conditions", () => {
+		it("recurses into custom condition keys", ({ expect }) => {
+			const result = findCjsEntryInConditions(
+				{
+					node: {
+						import: "./esm/index.mjs",
+						require: "./cjs/index.cjs",
+					},
+				},
+				"./esm/index.mjs"
+			);
+			expect(result).toBe("./cjs/index.cjs");
+		});
+
+		it("skips import/require/default keys for recursion", ({ expect }) => {
+			// When import is a string (not object), it won't recurse into it
+			const result = findCjsEntryInConditions(
+				{
+					import: "./esm/index.mjs",
+					require: "./cjs/index.cjs",
+				},
+				"./other/file.mjs"
+			);
+			expect(result).toBeUndefined();
+		});
+
+		it("handles deeply nested conditions", ({ expect }) => {
+			const result = findCjsEntryInConditions(
+				{
+					node: {
+						production: {
+							import: "./esm/prod.mjs",
+							require: "./cjs/prod.cjs",
+						},
+					},
+				},
+				"./esm/prod.mjs"
+			);
+			expect(result).toBe("./cjs/prod.cjs");
+		});
+
+		it("returns first match found", ({ expect }) => {
+			const result = findCjsEntryInConditions(
+				{
+					node: {
+						import: "./esm/index.mjs",
+						require: "./cjs/node.cjs",
+					},
+					browser: {
+						import: "./esm/index.mjs",
+						require: "./cjs/browser.cjs",
+					},
+				},
+				"./esm/index.mjs"
+			);
+			// Should return the first match (node)
+			expect(result).toBe("./cjs/node.cjs");
+		});
+
+		it("skips non-object/null values during recursion", ({ expect }) => {
+			const result = findCjsEntryInConditions(
+				{
+					types: "./index.d.ts",
+					node: null,
+					browser: {
+						import: "./esm/index.mjs",
+						require: "./cjs/index.cjs",
+					},
+				},
+				"./esm/index.mjs"
+			);
+			expect(result).toBe("./cjs/index.cjs");
+		});
+
+		it("returns undefined for empty conditions", ({ expect }) => {
+			const result = findCjsEntryInConditions({}, "./esm/index.mjs");
+			expect(result).toBeUndefined();
+		});
+	});
+});
+
+describe("findCjsEntryInExports", () => {
+	it("finds entry in standard exports map with '.' entry", ({ expect }) => {
+		const result = findCjsEntryInExports(
+			{
+				".": {
+					import: "./esm/index.mjs",
+					require: "./cjs/index.cjs",
+				},
+			},
+			"./esm/index.mjs"
+		);
+		expect(result).toBe("./cjs/index.cjs");
+	});
+
+	it("finds match in second export entry", ({ expect }) => {
+		const result = findCjsEntryInExports(
+			{
+				".": {
+					import: "./esm/main.mjs",
+					require: "./cjs/main.cjs",
+				},
+				"./utils": {
+					import: "./esm/utils.mjs",
+					require: "./cjs/utils.cjs",
+				},
+			},
+			"./esm/utils.mjs"
+		);
+		expect(result).toBe("./cjs/utils.cjs");
+	});
+
+	it("skips string values (not objects)", ({ expect }) => {
+		const result = findCjsEntryInExports(
+			{
+				".": "./index.js",
+				"./utils": {
+					import: "./esm/utils.mjs",
+					require: "./cjs/utils.cjs",
+				},
+			},
+			"./esm/utils.mjs"
+		);
+		expect(result).toBe("./cjs/utils.cjs");
+	});
+
+	it("skips null values", ({ expect }) => {
+		const result = findCjsEntryInExports(
+			{
+				"./internal": null,
+				".": {
+					import: "./esm/index.mjs",
+					require: "./cjs/index.cjs",
+				},
+			},
+			"./esm/index.mjs"
+		);
+		expect(result).toBe("./cjs/index.cjs");
+	});
+
+	it("returns undefined when no match", ({ expect }) => {
+		const result = findCjsEntryInExports(
+			{
+				".": {
+					import: "./esm/index.mjs",
+					require: "./cjs/index.cjs",
+				},
+			},
+			"./other/file.mjs"
+		);
+		expect(result).toBeUndefined();
+	});
+
+	it("returns undefined for empty exports", ({ expect }) => {
+		const result = findCjsEntryInExports({}, "./esm/index.mjs");
+		expect(result).toBeUndefined();
+	});
+});
+
+describe("findCjsExportAlternative", () => {
+	let tmpDir: string;
+
+	function createTmpDir(): string {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "module-fallback-test-"));
+		return tmpDir;
+	}
+
+	afterEach(() => {
+		if (tmpDir) {
+			removeDirSync(tmpDir);
+		}
+	});
+
+	it("finds CJS alternative from package.json exports", ({ expect }) => {
+		const dir = createTmpDir();
+		const pkgJson = {
+			name: "test-pkg",
+			exports: {
+				".": {
+					import: "./esm/index.mjs",
+					require: "./cjs/index.cjs",
+				},
+			},
+		};
+		fs.writeFileSync(
+			path.join(dir, "package.json"),
+			JSON.stringify(pkgJson)
+		);
+		fs.mkdirSync(path.join(dir, "esm"), { recursive: true });
+		fs.mkdirSync(path.join(dir, "cjs"), { recursive: true });
+		fs.writeFileSync(path.join(dir, "esm/index.mjs"), "");
+		fs.writeFileSync(path.join(dir, "cjs/index.cjs"), "");
+
+		const result = findCjsExportAlternative(
+			path.join(dir, "esm/index.mjs")
+		);
+		expect(result).toBe(path.join(dir, "cjs/index.cjs"));
+	});
+
+	it("strips query strings from path", ({ expect }) => {
+		const dir = createTmpDir();
+		const pkgJson = {
+			name: "test-pkg",
+			exports: {
+				".": {
+					import: "./esm/index.mjs",
+					require: "./cjs/index.cjs",
+				},
+			},
+		};
+		fs.writeFileSync(
+			path.join(dir, "package.json"),
+			JSON.stringify(pkgJson)
+		);
+		fs.mkdirSync(path.join(dir, "esm"), { recursive: true });
+		fs.mkdirSync(path.join(dir, "cjs"), { recursive: true });
+		fs.writeFileSync(path.join(dir, "esm/index.mjs"), "");
+		fs.writeFileSync(path.join(dir, "cjs/index.cjs"), "");
+
+		const result = findCjsExportAlternative(
+			path.join(dir, "esm/index.mjs") + "?v=abc123"
+		);
+		expect(result).toBe(path.join(dir, "cjs/index.cjs"));
+	});
+
+	it("returns undefined when CJS file doesn't exist on disk", ({
+		expect,
+	}) => {
+		const dir = createTmpDir();
+		const pkgJson = {
+			name: "test-pkg",
+			exports: {
+				".": {
+					import: "./esm/index.mjs",
+					require: "./cjs/index.cjs",
+				},
+			},
+		};
+		fs.writeFileSync(
+			path.join(dir, "package.json"),
+			JSON.stringify(pkgJson)
+		);
+		fs.mkdirSync(path.join(dir, "esm"), { recursive: true });
+		fs.writeFileSync(path.join(dir, "esm/index.mjs"), "");
+		// Note: cjs/index.cjs does NOT exist
+
+		const result = findCjsExportAlternative(
+			path.join(dir, "esm/index.mjs")
+		);
+		expect(result).toBeUndefined();
+	});
+
+	it("returns undefined when package.json has no exports field", ({
+		expect,
+	}) => {
+		const dir = createTmpDir();
+		const pkgJson = { name: "test-pkg", main: "./index.js" };
+		fs.writeFileSync(
+			path.join(dir, "package.json"),
+			JSON.stringify(pkgJson)
+		);
+		fs.mkdirSync(path.join(dir, "esm"), { recursive: true });
+		fs.writeFileSync(path.join(dir, "esm/index.mjs"), "");
+
+		const result = findCjsExportAlternative(
+			path.join(dir, "esm/index.mjs")
+		);
+		expect(result).toBeUndefined();
+	});
+
+	it("stops walking at package.json with name field", ({ expect }) => {
+		const dir = createTmpDir();
+		// Inner package with name but no matching exports
+		const innerDir = path.join(dir, "inner");
+		fs.mkdirSync(innerDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(innerDir, "package.json"),
+			JSON.stringify({ name: "inner-pkg" })
+		);
+
+		// Outer package with matching exports (should NOT be reached)
+		fs.writeFileSync(
+			path.join(dir, "package.json"),
+			JSON.stringify({
+				name: "outer-pkg",
+				exports: {
+					".": {
+						import: "./inner/esm/index.mjs",
+						require: "./inner/cjs/index.cjs",
+					},
+				},
+			})
+		);
+
+		fs.mkdirSync(path.join(innerDir, "esm"), { recursive: true });
+		fs.writeFileSync(path.join(innerDir, "esm/index.mjs"), "");
+
+		const result = findCjsExportAlternative(
+			path.join(innerDir, "esm/index.mjs")
+		);
+		// Should stop at inner package.json (which has name but no exports)
+		expect(result).toBeUndefined();
+	});
+
+	it("walks up directories to find package.json", ({ expect }) => {
+		const dir = createTmpDir();
+		const pkgJson = {
+			name: "test-pkg",
+			exports: {
+				"./sub": {
+					import: "./src/sub/index.mjs",
+					require: "./lib/sub/index.cjs",
+				},
+			},
+		};
+		fs.writeFileSync(
+			path.join(dir, "package.json"),
+			JSON.stringify(pkgJson)
+		);
+		fs.mkdirSync(path.join(dir, "src/sub"), { recursive: true });
+		fs.mkdirSync(path.join(dir, "lib/sub"), { recursive: true });
+		fs.writeFileSync(path.join(dir, "src/sub/index.mjs"), "");
+		fs.writeFileSync(path.join(dir, "lib/sub/index.cjs"), "");
+
+		const result = findCjsExportAlternative(
+			path.join(dir, "src/sub/index.mjs")
+		);
+		expect(result).toBe(path.join(dir, "lib/sub/index.cjs"));
+	});
+
+	it("handles missing package.json (ENOENT) gracefully", ({ expect }) => {
+		const dir = createTmpDir();
+		fs.mkdirSync(path.join(dir, "esm"), { recursive: true });
+		fs.writeFileSync(path.join(dir, "esm/index.mjs"), "");
+		// No package.json at all
+
+		const result = findCjsExportAlternative(
+			path.join(dir, "esm/index.mjs")
+		);
+		expect(result).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/12899.

workerd always uses the `"import"` export condition even for `require()` calls, which can cause it to resolve to an ESM file instead of the intended CJS entry. This causes failures when a package has dual ESM/CJS exports and the wrong format is loaded.

This PR adds logic to the module fallback service in `vitest-pool-workers` to detect when `require()` has resolved to an ESM file and find the CJS alternative by inspecting the package's `exports` map. It looks for a matching `"require"` or `"default"` entry and redirects accordingly.

It also handles packages that expose `workerd` or `worker` conditions with CJS-compatible entries (e.g. `pg-cloudflare`).

**Changes:**
- Added `findCjsExportAlternative()` — walks up from a resolved ESM file path to find the nearest `package.json`, then searches its `exports` map for a CJS alternative
- Added `findCjsEntryInExports()` and `findCjsEntryInConditions()` — helpers that traverse the exports/conditions tree to find CJS entries
- Integrated the CJS fallback into the `resolve()` function at both the direct file path and Vite resolution stages
- Added comprehensive unit tests (~550 lines) covering all condition matching cases, directory walking, edge cases

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal behavior change with no user-facing API changes

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
