### PR TITLE
Update README to remove Wrangler v2 warning

### DIFF
--- a/packages/wrangler/README.md
+++ b/packages/wrangler/README.md
@@ -8,10 +8,6 @@
 
 `wrangler` is a command line tool for building [Cloudflare Workers](https://workers.cloudflare.com/).
 
-> [!WARNING]
->
-> Wrangler v2 is **only receiving critical security updates.** We recommend you [migrate to Wrangler v3](https://developers.cloudflare.com/workers/wrangler/migration/update-v2-to-v3/) if you can.
-
 ## Quick Start
 
 To get started quickly with a Hello World worker, run the command below:


### PR DESCRIPTION
Fix https://github.com/cloudflare/workers-sdk/issues/12721 

Removed warning about Wrangler v2 and migration to v3.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
