### PR TITLE
[wrangler] Add type-to-search filtering to `wrangler versions deploy` interactive prompt

### DIFF
--- a/.changeset/versions-deploy-search-ux.md
+++ b/.changeset/versions-deploy-search-ux.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add type-to-search filtering to `wrangler versions deploy` interactive prompt
+
+The version selection prompt in `wrangler versions deploy` was difficult to use when many versions existed — the list could be 20+ items long, each with multi-line details, making it hard to navigate and select. The prompt now supports type-to-search filtering: you can type part of a version ID, tag, message, or creation date to instantly narrow the list. The viewport also now shows 3 versions at a time with scrolling instead of dumping the entire list at once.

--- a/packages/cli/__tests__/multiselect-search.test.ts
+++ b/packages/cli/__tests__/multiselect-search.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from "vitest";
-
 import { stripAnsi } from "..";
 import { getRenderers } from "../interactive";
 import MultiSelectSearchPrompt from "../multiselect-search";
@@ -10,7 +9,9 @@ type PromptInternals = {
 	close: () => void;
 };
 
-function createPrompt(options: ConstructorParameters<typeof MultiSelectSearchPrompt>[0]["options"]) {
+function createPrompt(
+	options: ConstructorParameters<typeof MultiSelectSearchPrompt>[0]["options"]
+) {
 	const prompt = new MultiSelectSearchPrompt({
 		options,
 		render() {
@@ -135,7 +136,11 @@ describe("MultiSelectSearchPrompt", () => {
 
 	test("ranks exact and prefix matches ahead of weaker matches", () => {
 		const { prompt } = createPrompt([
-			{ label: "Later substring", value: "later", sublabel: "contains abc later" },
+			{
+				label: "Later substring",
+				value: "later",
+				sublabel: "contains abc later",
+			},
 			{ label: "Prefix match", value: "prefix-1", sublabel: "abc release" },
 			{ label: "Metadata only", value: "metadata-1", sublabel: "release abc" },
 			{ label: "Other", value: "abc" },
@@ -145,7 +150,7 @@ describe("MultiSelectSearchPrompt", () => {
 		prompt.emit("key", "b");
 		prompt.emit("key", "c");
 
-			expect(prompt.filteredOptions.map((option) => option.value)).toEqual([
+		expect(prompt.filteredOptions.map((option) => option.value)).toEqual([
 			"abc",
 			"prefix-1",
 			"later",
@@ -155,7 +160,11 @@ describe("MultiSelectSearchPrompt", () => {
 
 	test("resets focus to the top ranked match when search results reorder", () => {
 		const { prompt } = createPrompt([
-			{ label: "Later substring", value: "later", sublabel: "contains abc later" },
+			{
+				label: "Later substring",
+				value: "later",
+				sublabel: "contains abc later",
+			},
 			{ label: "Prefix match", value: "prefix-1", sublabel: "abc release" },
 			{ label: "Metadata only", value: "metadata-1", sublabel: "release abc" },
 			{ label: "Other", value: "abc" },
@@ -184,7 +193,8 @@ describe("MultiSelectSearchPrompt", () => {
 			{
 				label: "Version two",
 				value: "id-2",
-				sublabel: "\u001B[90mMessage: release-candidate follows later\u001B[39m",
+				sublabel:
+					"\u001B[90mMessage: release-candidate follows later\u001B[39m",
 				searchText: ["release-candidate follows later"],
 			},
 		]);
@@ -228,6 +238,8 @@ describe("MultiSelectSearchPrompt", () => {
 		const rendered = stripAnsi(lines.join("\n"));
 		expect(rendered).toContain("Search: zzz");
 		expect(rendered).toContain("0 matches • 1 selected");
-		expect(rendered).toContain("No matching options. Backspace to edit search.");
+		expect(rendered).toContain(
+			"No matching options. Backspace to edit search."
+		);
 	});
 });

--- a/packages/cli/__tests__/multiselect-search.test.ts
+++ b/packages/cli/__tests__/multiselect-search.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, test } from "vitest";
+
+import { stripAnsi } from "..";
+import { getRenderers } from "../interactive";
+import MultiSelectSearchPrompt from "../multiselect-search";
+
+type PromptInternals = {
+	onKeypress: (char?: string, key?: { name?: string }) => void;
+	render: () => void;
+	close: () => void;
+};
+
+function createPrompt(options: ConstructorParameters<typeof MultiSelectSearchPrompt>[0]["options"]) {
+	const prompt = new MultiSelectSearchPrompt({
+		options,
+		render() {
+			return "";
+		},
+	});
+
+	const internals = prompt as unknown as PromptInternals;
+	internals.render = () => {};
+	internals.close = () => {};
+
+	return { prompt, internals };
+}
+
+describe("MultiSelectSearchPrompt", () => {
+	test.each(["h", "j", "k", "l"])(
+		"allows vim key character %s to be typed into search",
+		(char) => {
+			const { prompt, internals } = createPrompt([
+				{ label: "hijkl", value: "first" },
+				{ label: "shufflejklh", value: "second" },
+			]);
+
+			prompt.cursor = 1;
+			internals.onKeypress(char, { name: char });
+
+			expect(prompt.search).toBe(char);
+			expect(prompt.cursor).toBe(0);
+			expect(prompt.filteredOptions.map((option) => option.value)).toEqual([
+				"first",
+				"second",
+			]);
+		}
+	);
+
+	test("keeps arrow key navigation working", () => {
+		const { prompt, internals } = createPrompt([
+			{ label: "first", value: "first" },
+			{ label: "second", value: "second" },
+		]);
+
+		internals.onKeypress(undefined, { name: "down" });
+
+		expect(prompt.cursor).toBe(1);
+		expect(prompt.search).toBe("");
+	});
+
+	test("supports escape to cancel", () => {
+		const { prompt, internals } = createPrompt([
+			{ label: "first", value: "first" },
+		]);
+
+		internals.onKeypress(undefined, { name: "escape" });
+
+		expect(prompt.state).toBe("cancel");
+	});
+
+	test("preserves submit handling in the custom keypress override", () => {
+		const { prompt, internals } = createPrompt([
+			{ label: "first", value: "first" },
+		]);
+
+		internals.onKeypress(undefined, { name: "return" });
+
+		expect(prompt.state).toBe("submit");
+	});
+
+	test("preserves validation errors in the custom keypress override", () => {
+		const prompt = new MultiSelectSearchPrompt({
+			options: [{ label: "first", value: "first" }],
+			render() {
+				return "";
+			},
+			validate() {
+				return "Pick something";
+			},
+		});
+
+		const internals = prompt as unknown as PromptInternals;
+		internals.render = () => {};
+		internals.close = () => {};
+
+		internals.onKeypress(undefined, { name: "return" });
+
+		expect(prompt.state).toBe("error");
+		expect(prompt.error).toBe("Pick something");
+	});
+
+	test("does not move cursor out of bounds when no options match", () => {
+		const { prompt } = createPrompt([{ label: "apple", value: "apple" }]);
+
+		prompt.emit("key", "z");
+
+		expect(prompt.filteredOptions).toEqual([]);
+		prompt.emit("cursor", "up");
+		expect(prompt.cursor).toBe(0);
+		prompt.emit("cursor", "down");
+		expect(prompt.cursor).toBe(0);
+	});
+
+	test("restores cursor to the toggled option after clearing search", () => {
+		const { prompt } = createPrompt([
+			{ label: "apple", value: "apple" },
+			{ label: "banana", value: "banana" },
+			{ label: "carrot", value: "carrot" },
+		]);
+
+		prompt.emit("key", "b");
+		prompt.emit("key", "a");
+		prompt.emit("key", "n");
+		prompt.emit("cursor", "space");
+
+		expect(prompt.search).toBe("");
+		expect(prompt.filteredOptions.map((option) => option.value)).toEqual([
+			"apple",
+			"banana",
+			"carrot",
+		]);
+		expect(prompt.cursor).toBe(1);
+		expect(prompt.selectedValues).toEqual(["banana"]);
+	});
+
+	test("ranks exact and prefix matches ahead of weaker matches", () => {
+		const { prompt } = createPrompt([
+			{ label: "Later substring", value: "later", sublabel: "contains abc later" },
+			{ label: "Prefix match", value: "prefix-1", sublabel: "abc release" },
+			{ label: "Metadata only", value: "metadata-1", sublabel: "release abc" },
+			{ label: "Other", value: "abc" },
+		]);
+
+		prompt.emit("key", "a");
+		prompt.emit("key", "b");
+		prompt.emit("key", "c");
+
+			expect(prompt.filteredOptions.map((option) => option.value)).toEqual([
+			"abc",
+			"prefix-1",
+			"later",
+			"metadata-1",
+		]);
+	});
+
+	test("resets focus to the top ranked match when search results reorder", () => {
+		const { prompt } = createPrompt([
+			{ label: "Later substring", value: "later", sublabel: "contains abc later" },
+			{ label: "Prefix match", value: "prefix-1", sublabel: "abc release" },
+			{ label: "Metadata only", value: "metadata-1", sublabel: "release abc" },
+			{ label: "Other", value: "abc" },
+		]);
+
+		prompt.cursor = 3;
+		prompt.windowStart = 2;
+		prompt.emit("key", "a");
+		prompt.emit("key", "b");
+		prompt.emit("key", "c");
+
+		expect(prompt.cursor).toBe(0);
+		expect(prompt.windowStart).toBe(0);
+		prompt.emit("cursor", "space");
+		expect(prompt.selectedValues).toEqual(["abc"]);
+	});
+
+	test("ranks clean metadata search text ahead of formatted sublabel content", () => {
+		const { prompt } = createPrompt([
+			{
+				label: "Version one",
+				value: "id-1",
+				sublabel: "\u001B[90mTag: release-candidate\u001B[39m",
+				searchText: ["release-candidate"],
+			},
+			{
+				label: "Version two",
+				value: "id-2",
+				sublabel: "\u001B[90mMessage: release-candidate follows later\u001B[39m",
+				searchText: ["release-candidate follows later"],
+			},
+		]);
+
+		for (const char of "release-candidate") {
+			prompt.emit("key", char);
+		}
+
+		expect(prompt.filteredOptions.map((option) => option.value)).toEqual([
+			"id-1",
+			"id-2",
+		]);
+	});
+
+	test("does not clear search when space is pressed with no matches", () => {
+		const { prompt } = createPrompt([{ label: "apple", value: "apple" }]);
+
+		prompt.emit("key", "z");
+		prompt.emit("cursor", "space");
+
+		expect(prompt.search).toBe("z");
+		expect(prompt.filteredOptions).toEqual([]);
+		expect(prompt.selectedValues).toEqual([]);
+	});
+
+	test("renders match counts and a clearer empty state", () => {
+		const renderers = getRenderers({
+			type: "multiselect-search",
+			question: "Pick versions",
+			label: "",
+			helpText: "",
+			options: [{ label: "Alpha", value: "alpha" }],
+			maxItemsPerPage: 5,
+		});
+
+		const lines = renderers.active(
+			{ cursor: 0, value: ["alpha"] } as never,
+			{ search: "zzz", filteredOptions: [], windowStart: 0 } as never
+		);
+
+		const rendered = stripAnsi(lines.join("\n"));
+		expect(rendered).toContain("Search: zzz");
+		expect(rendered).toContain("0 matches • 1 selected");
+		expect(rendered).toContain("No matching options. Backspace to edit search.");
+	});
+});

--- a/packages/cli/interactive.ts
+++ b/packages/cli/interactive.ts
@@ -8,6 +8,7 @@ import {
 import { createLogUpdate } from "log-update";
 import { blue, bold, brandColor, dim, gray, white } from "./colors";
 import { CancelError } from "./error";
+import MultiSelectSearchPrompt from "./multiselect-search";
 import SelectRefreshablePrompt from "./select-list";
 import { stdout } from "./streams";
 import {
@@ -83,6 +84,10 @@ export type MultiSelectPromptConfig = BaseSelectPromptConfig & {
 	type: "multiselect";
 };
 
+export type MultiSelectSearchPromptConfig = BaseSelectPromptConfig & {
+	type: "multiselect-search";
+};
+
 export type ConfirmPromptConfig = BasePromptConfig & {
 	type: "confirm";
 	activeText?: string;
@@ -100,11 +105,13 @@ export type PromptConfig =
 	| ConfirmPromptConfig
 	| SelectPromptConfig
 	| MultiSelectPromptConfig
+	| MultiSelectSearchPromptConfig
 	| ListPromptConfig;
 
 type RenderProps =
 	| Omit<SelectPrompt<Option>, "prompt">
 	| Omit<MultiSelectPrompt<Option>, "prompt">
+	| Omit<MultiSelectSearchPrompt, "prompt">
 	| Omit<TextPrompt, "prompt">
 	| Omit<ConfirmPrompt, "prompt">
 	| Omit<SelectRefreshablePrompt, "prompt">;
@@ -142,6 +149,7 @@ export const inputPrompt = async <T = string>(
 		| TextPrompt
 		| ConfirmPrompt
 		| MultiSelectPrompt<Option>
+		| MultiSelectSearchPrompt
 		| SelectRefreshablePrompt;
 
 	// Looks up the needed renderer by the current state ('initial', 'submitted', etc.)
@@ -201,6 +209,26 @@ export const inputPrompt = async <T = string>(
 		}
 
 		prompt = new MultiSelectPrompt({
+			...promptConfig,
+			options: promptConfig.options,
+			initialValues: initialValues,
+			render() {
+				return dispatchRender(this, prompt);
+			},
+		});
+	} else if (promptConfig.type === "multiselect-search") {
+		let initialValues: string[] | undefined;
+		if (Array.isArray(promptConfig.defaultValue)) {
+			initialValues = promptConfig.defaultValue;
+		} else if (promptConfig.defaultValue !== undefined) {
+			initialValues = [String(promptConfig.defaultValue)];
+		}
+
+		if (promptConfig.acceptDefault) {
+			return acceptDefault<T>(promptConfig, renderers, initialValues as T);
+		}
+
+		prompt = new MultiSelectSearchPrompt({
 			...promptConfig,
 			options: promptConfig.options,
 			initialValues: initialValues,
@@ -291,6 +319,8 @@ export const getRenderers = (config: PromptConfig) => {
 			return getTextRenderers(config);
 		case "multiselect":
 			return getSelectRenderers(config);
+		case "multiselect-search":
+			return getMultiSelectSearchRenderers(config);
 		case "list":
 			return getSelectListRenderers(config);
 	}
@@ -426,6 +456,126 @@ const getSelectRenderers = (
 				``
 			);
 		}
+
+		return lines;
+	};
+
+	return {
+		initial: defaultRenderer,
+		active: defaultRenderer,
+		confirm: defaultRenderer,
+		error: (opts: { value: Arg; error: string }, prompt: Prompt) => {
+			return [
+				`${leftT} ${status.error} ${dim(opts.error)}`,
+				`${grayBar}`,
+				...defaultRenderer(opts, prompt),
+			];
+		},
+		submit: ({ value }: { value: Arg }) => {
+			if (Array.isArray(value)) {
+				return renderSubmit(
+					config,
+					options
+						.filter((o) => value.includes(o.value))
+						.map((o) => o.label)
+						.join(", ")
+				);
+			}
+
+			return renderSubmit(
+				config,
+				options.find((o) => o.value === value)?.label as string
+			);
+		},
+		cancel: defaultRenderer,
+	};
+};
+
+const getMultiSelectSearchRenderers = (
+	config: MultiSelectSearchPromptConfig
+) => {
+	const { options, question, helpText: _helpText } = config;
+	const helpText = _helpText ?? "";
+	const maxItemsPerPage = config.maxItemsPerPage ?? 5;
+
+	const defaultRenderer: Renderer = (props, prompt: Prompt) => {
+		const { cursor = 0, value } = props;
+		const searchPrompt = prompt as unknown as MultiSelectSearchPrompt;
+		const searchText = searchPrompt.search ?? "";
+		const filtered = searchPrompt.filteredOptions ?? options;
+
+		const selectedCount = Array.isArray(value) ? value.length : 0;
+
+		const renderOption = (opt: Option, i: number) => {
+			const { label: optionLabel, value: optionValue } = opt;
+			const active = i === cursor;
+			const isSelected = Array.isArray(value) && value.includes(optionValue);
+
+			// Use a clear checkmark for selected items, empty box for unselected
+			let indicator: string;
+			let text: string;
+			let sublabel: string;
+			if (isSelected) {
+				indicator = brandColor("✔");
+				text = active
+					? brandColor.underline(optionLabel)
+					: brandColor(optionLabel);
+				sublabel = opt.sublabel ? brandColor.grey(opt.sublabel) : "";
+			} else {
+				const color = active ? blue : white;
+				indicator = dim("○");
+				text = active ? color.underline(optionLabel) : color(optionLabel);
+				sublabel = opt.sublabel ? color.grey(opt.sublabel) : "";
+			}
+
+			const pointer = active ? blue("❯ ") : "  ";
+
+			return `${space(2)}${pointer}${indicator} ${text} ${sublabel}`;
+		};
+
+		// Sliding window: only scroll when cursor reaches the edge of the viewport
+		let windowStart = 0;
+		if (filtered.length > maxItemsPerPage) {
+			// Keep the cursor visible within the window
+			if (cursor >= windowStart + maxItemsPerPage) {
+				windowStart = cursor - maxItemsPerPage + 1;
+			}
+			if (cursor < windowStart) {
+				windowStart = cursor;
+			}
+			// Clamp to valid range
+			windowStart = Math.max(
+				0,
+				Math.min(windowStart, filtered.length - maxItemsPerPage)
+			);
+		}
+		const windowEnd = Math.min(windowStart + maxItemsPerPage, filtered.length);
+		const windowedOptions = filtered.slice(windowStart, windowEnd);
+		const hasMoreAbove = windowStart > 0;
+		const hasMoreBelow = windowEnd < filtered.length;
+
+		const searchLine = searchText
+			? `${space(2)}${dim("Search:")} ${white(searchText)}${dim("▏")}`
+			: `${space(2)}${dim("Type to search, SPACE to select, ENTER to submit")}`;
+
+		const selectedLine =
+			selectedCount > 0
+				? `${space(2)}${brandColor(`${selectedCount} selected`)}`
+				: "";
+
+		const lines = [
+			`${blCorner} ${bold(question)} ${dim(helpText)}`,
+			searchLine,
+			...(selectedLine ? [selectedLine] : []),
+			`${hasMoreAbove ? `${space(2)}${dim("...")}\n` : ""}${
+				filtered.length > 0
+					? windowedOptions
+							.map((opt, i) => renderOption(opt, windowStart + i))
+							.join(`\n`)
+					: `${space(2)}${dim("No matching versions")}`
+			}${hasMoreBelow ? `\n${space(2)}${dim("...")}` : ""}`,
+			``, // extra line for readability
+		];
 
 		return lines;
 	};

--- a/packages/cli/interactive.ts
+++ b/packages/cli/interactive.ts
@@ -533,8 +533,9 @@ const getMultiSelectSearchRenderers = (
 			return `${space(2)}${pointer}${indicator} ${text} ${sublabel}`;
 		};
 
-		// Sliding window: only scroll when cursor reaches the edge of the viewport
-		let windowStart = 0;
+		// Sliding window: persist scroll position on the prompt instance so it
+		// survives across renders. Only scroll when cursor reaches the edge.
+		let windowStart = searchPrompt.windowStart ?? 0;
 		if (filtered.length > maxItemsPerPage) {
 			// Keep the cursor visible within the window
 			if (cursor >= windowStart + maxItemsPerPage) {
@@ -548,7 +549,10 @@ const getMultiSelectSearchRenderers = (
 				0,
 				Math.min(windowStart, filtered.length - maxItemsPerPage)
 			);
+		} else {
+			windowStart = 0;
 		}
+		searchPrompt.windowStart = windowStart;
 		const windowEnd = Math.min(windowStart + maxItemsPerPage, filtered.length);
 		const windowedOptions = filtered.slice(windowStart, windowEnd);
 		const hasMoreAbove = windowStart > 0;
@@ -572,7 +576,7 @@ const getMultiSelectSearchRenderers = (
 					? windowedOptions
 							.map((opt, i) => renderOption(opt, windowStart + i))
 							.join(`\n`)
-					: `${space(2)}${dim("No matching versions")}`
+					: `${space(2)}${dim("No matching options")}`
 			}${hasMoreBelow ? `\n${space(2)}${dim("...")}` : ""}`,
 			``, // extra line for readability
 		];

--- a/packages/cli/interactive.ts
+++ b/packages/cli/interactive.ts
@@ -562,21 +562,32 @@ const getMultiSelectSearchRenderers = (
 			? `${space(2)}${dim("Search:")} ${white(searchText)}${dim("▏")}`
 			: `${space(2)}${dim("Type to search, SPACE to select, ENTER to submit")}`;
 
-		const selectedLine =
-			selectedCount > 0
-				? `${space(2)}${brandColor(`${selectedCount} selected`)}`
+		const statusParts = [];
+		if (searchText) {
+			statusParts.push(dim(`${filtered.length} match${filtered.length === 1 ? "" : "es"}`));
+		}
+		if (selectedCount > 0) {
+			statusParts.push(brandColor(`${selectedCount} selected`));
+		}
+		const statusLine =
+			statusParts.length > 0
+				? `${space(2)}${statusParts.join(dim(" • "))}`
 				: "";
+
+		const emptyState = searchText
+			? `${space(2)}${dim("No matching options. Backspace to edit search.")}`
+			: `${space(2)}${dim("No options available.")}`;
 
 		const lines = [
 			`${blCorner} ${bold(question)} ${dim(helpText)}`,
 			searchLine,
-			...(selectedLine ? [selectedLine] : []),
+			...(statusLine ? [statusLine] : []),
 			`${hasMoreAbove ? `${space(2)}${dim("...")}\n` : ""}${
 				filtered.length > 0
 					? windowedOptions
 							.map((opt, i) => renderOption(opt, windowStart + i))
 							.join(`\n`)
-					: `${space(2)}${dim("No matching options")}`
+					: emptyState
 			}${hasMoreBelow ? `\n${space(2)}${dim("...")}` : ""}`,
 			``, // extra line for readability
 		];

--- a/packages/cli/interactive.ts
+++ b/packages/cli/interactive.ts
@@ -564,7 +564,9 @@ const getMultiSelectSearchRenderers = (
 
 		const statusParts = [];
 		if (searchText) {
-			statusParts.push(dim(`${filtered.length} match${filtered.length === 1 ? "" : "es"}`));
+			statusParts.push(
+				dim(`${filtered.length} match${filtered.length === 1 ? "" : "es"}`)
+			);
 		}
 		if (selectedCount > 0) {
 			statusParts.push(brandColor(`${selectedCount} selected`));

--- a/packages/cli/multiselect-search.ts
+++ b/packages/cli/multiselect-search.ts
@@ -42,7 +42,10 @@ const normalizeSearchText = (text: string | undefined): string | undefined => {
 	return normalized.length > 0 ? normalized : undefined;
 };
 
-const getMatchPriority = (text: string | undefined, query: string): number | null => {
+const getMatchPriority = (
+	text: string | undefined,
+	query: string
+): number | null => {
 	if (!text) {
 		return null;
 	}
@@ -63,7 +66,10 @@ const getMatchPriority = (text: string | undefined, query: string): number | nul
 	return null;
 };
 
-const getOptionPriority = (option: SearchableOption, query: string): number | null => {
+const getOptionPriority = (
+	option: SearchableOption,
+	query: string
+): number | null => {
 	const priorities = [
 		getMatchPriority(option.value, query),
 		getMatchPriority(option.label, query),
@@ -236,13 +242,13 @@ export default class MultiSelectSearchPrompt extends Prompt {
 		if (idx === -1) {
 			this.selectedValues = [...this.selectedValues, opt.value];
 		} else {
-			this.selectedValues = this.selectedValues.filter(
-				(v) => v !== opt.value
-			);
+			this.selectedValues = this.selectedValues.filter((v) => v !== opt.value);
 		}
 	}
 
-	private applyFilter({ resetFocus = false }: { resetFocus?: boolean } = {}): void {
+	private applyFilter({
+		resetFocus = false,
+	}: { resetFocus?: boolean } = {}): void {
 		const query = this.search.toLowerCase();
 
 		if (query === "") {
@@ -255,12 +261,15 @@ export default class MultiSelectSearchPrompt extends Prompt {
 					priority: getOptionPriority(option, query),
 				}))
 				.filter(
-					(result): result is { option: SearchableOption; index: number; priority: number } =>
-						result.priority !== null
+					(
+						result
+					): result is {
+						option: SearchableOption;
+						index: number;
+						priority: number;
+					} => result.priority !== null
 				)
-				.sort(
-					(a, b) => a.priority - b.priority || a.index - b.index
-				)
+				.sort((a, b) => a.priority - b.priority || a.index - b.index)
 				.map(({ option }) => option);
 		}
 

--- a/packages/cli/multiselect-search.ts
+++ b/packages/cli/multiselect-search.ts
@@ -13,6 +13,11 @@ export type MultiSelectSearchOptions = {
 	validate?: (value: string[] | undefined) => string | void;
 };
 
+// Keys that @clack/core maps to cursor events when trackValue is false.
+// These are emitted as both "cursor" and "key" events, so we must ignore
+// them in the "key" handler to avoid double-handling (navigate + search append).
+const VIM_NAV_KEYS = new Set(["h", "j", "k", "l"]);
+
 /**
  * A multiselect prompt with type-to-search filtering.
  *
@@ -24,20 +29,30 @@ export type MultiSelectSearchOptions = {
  *
  * `this.search` contains the current search text.
  * `this.filteredOptions` contains the options matching the search.
- * `this.value` is the array of selected option values.
+ * `this.selectedValues` is the array of selected option values.
  * `this.cursor` is the index into `filteredOptions`.
+ * `this.windowStart` tracks the scroll position for the sliding window.
  */
 export default class MultiSelectSearchPrompt extends Prompt {
 	options: SearchableOption[];
 	filteredOptions: SearchableOption[];
 	cursor = 0;
 	search = "";
+	windowStart = 0;
+
+	get selectedValues(): string[] {
+		return this.value as string[];
+	}
+
+	set selectedValues(v: string[]) {
+		this.value = v;
+	}
 
 	constructor(opts: MultiSelectSearchOptions) {
 		super(opts, false);
 
 		this.options = opts.options;
-		this.value = [...(opts.initialValues ?? [])];
+		this.selectedValues = [...(opts.initialValues ?? [])];
 		this.filteredOptions = [...this.options];
 		this.cursor = 0;
 
@@ -78,10 +93,9 @@ export default class MultiSelectSearchPrompt extends Prompt {
 				return;
 			}
 
-			if (char === "a" && this.search === "") {
-				// Toggle all only when not searching (consistent with base MultiSelectPrompt)
-				this.toggleAll();
-				this.rerender();
+			// Ignore vim navigation keys (h/j/k/l) — they are already handled
+			// by the "cursor" event and would otherwise be appended to search.
+			if (VIM_NAV_KEYS.has(char)) {
 				return;
 			}
 
@@ -101,30 +115,13 @@ export default class MultiSelectSearchPrompt extends Prompt {
 		}
 
 		const opt = this.filteredOptions[this.cursor];
-		const idx = (this.value as string[]).indexOf(opt.value);
+		const idx = this.selectedValues.indexOf(opt.value);
 
 		if (idx === -1) {
-			this.value = [...(this.value as string[]), opt.value];
+			this.selectedValues = [...this.selectedValues, opt.value];
 		} else {
-			this.value = (this.value as string[]).filter(
-				(v: string) => v !== opt.value
-			);
-		}
-	}
-
-	private toggleAll(): void {
-		const allValues = this.filteredOptions.map((o) => o.value);
-		const allSelected = allValues.every((v) =>
-			(this.value as string[]).includes(v)
-		);
-
-		if (allSelected) {
-			this.value = (this.value as string[]).filter(
-				(v: string) => !allValues.includes(v)
-			);
-		} else {
-			this.value = Array.from(
-				new Set([...(this.value as string[]), ...allValues])
+			this.selectedValues = this.selectedValues.filter(
+				(v) => v !== opt.value
 			);
 		}
 	}

--- a/packages/cli/multiselect-search.ts
+++ b/packages/cli/multiselect-search.ts
@@ -1,9 +1,11 @@
 import { Prompt } from "@clack/core";
+import { stripAnsi } from ".";
 
 export type SearchableOption = {
 	label: string;
 	value: string;
 	sublabel?: string;
+	searchText?: string[];
 };
 
 export type MultiSelectSearchOptions = {
@@ -13,10 +15,68 @@ export type MultiSelectSearchOptions = {
 	validate?: (value: string[] | undefined) => string | void;
 };
 
-// Keys that @clack/core maps to cursor events when trackValue is false.
-// These are emitted as both "cursor" and "key" events, so we must ignore
-// them in the "key" handler to avoid double-handling (navigate + search append).
-const VIM_NAV_KEYS = new Set(["h", "j", "k", "l"]);
+type PromptInternals = {
+	onKeypress: (char?: string, key?: { name?: string }) => void;
+	render: () => void;
+	close: () => void;
+	opts: {
+		validate?: (value: string[] | undefined) => string | void;
+	};
+	rl?: {
+		write: (value: string[]) => void;
+	};
+};
+
+const CURSOR_KEYS = new Set(["up", "down", "left", "right", "space", "enter"]);
+
+const normalizeSearchText = (text: string | undefined): string | undefined => {
+	if (!text) {
+		return undefined;
+	}
+
+	const normalized = stripAnsi(text)
+		.replace(/[\u200A\u200B]/g, "")
+		.replace(/\s+/g, " ")
+		.trim();
+
+	return normalized.length > 0 ? normalized : undefined;
+};
+
+const getMatchPriority = (text: string | undefined, query: string): number | null => {
+	if (!text) {
+		return null;
+	}
+
+	const normalized = text.toLowerCase();
+	if (normalized === query) {
+		return 0;
+	}
+
+	if (normalized.startsWith(query)) {
+		return 1;
+	}
+
+	if (normalized.includes(query)) {
+		return 2;
+	}
+
+	return null;
+};
+
+const getOptionPriority = (option: SearchableOption, query: string): number | null => {
+	const priorities = [
+		getMatchPriority(option.value, query),
+		getMatchPriority(option.label, query),
+		...(option.searchText ?? []).map((text) => getMatchPriority(text, query)),
+		getMatchPriority(normalizeSearchText(option.sublabel), query),
+	].filter((priority): priority is number => priority !== null);
+
+	if (priorities.length === 0) {
+		return null;
+	}
+
+	return Math.min(...priorities);
+};
 
 /**
  * A multiselect prompt with type-to-search filtering.
@@ -51,6 +111,50 @@ export default class MultiSelectSearchPrompt extends Prompt {
 	constructor(opts: MultiSelectSearchOptions) {
 		super(opts, false);
 
+		const prompt = this as unknown as PromptInternals;
+		prompt.onKeypress = (char: string | undefined, key?: { name?: string }) => {
+			if (this.state === "error") {
+				this.state = "active";
+			}
+
+			if (key?.name && CURSOR_KEYS.has(key.name)) {
+				this.emit("cursor", key.name);
+			}
+
+			if (char) {
+				this.emit("key", char.toLowerCase());
+			}
+
+			if (key?.name === "return") {
+				if (prompt.opts.validate) {
+					const error = prompt.opts.validate(this.value);
+					if (error) {
+						this.error = error;
+						this.state = "error";
+						prompt.rl?.write(this.value);
+					}
+				}
+
+				if (this.state !== "error") {
+					this.state = "submit";
+				}
+			}
+
+			if (char === "\u0003" || key?.name === "escape") {
+				this.state = "cancel";
+			}
+
+			if (this.state === "submit" || this.state === "cancel") {
+				this.emit("finalize");
+			}
+
+			prompt.render();
+
+			if (this.state === "submit" || this.state === "cancel") {
+				prompt.close();
+			}
+		};
+
 		this.options = opts.options;
 		this.selectedValues = [...(opts.initialValues ?? [])];
 		this.filteredOptions = [...this.options];
@@ -60,6 +164,9 @@ export default class MultiSelectSearchPrompt extends Prompt {
 			switch (key) {
 				case "left":
 				case "up":
+					if (this.filteredOptions.length === 0) {
+						break;
+					}
 					this.cursor =
 						this.cursor === 0
 							? this.filteredOptions.length - 1
@@ -67,18 +174,33 @@ export default class MultiSelectSearchPrompt extends Prompt {
 					break;
 				case "down":
 				case "right":
+					if (this.filteredOptions.length === 0) {
+						break;
+					}
 					this.cursor =
 						this.cursor === this.filteredOptions.length - 1
 							? 0
 							: this.cursor + 1;
 					break;
-				case "space":
+				case "space": {
+					if (this.filteredOptions.length === 0) {
+						break;
+					}
+
+					const toggledValue = this.filteredOptions[this.cursor]?.value;
 					this.toggleValue();
 					// Clear search after toggling so the full list reappears
 					// and the user can immediately search for the next version
 					this.search = "";
 					this.applyFilter();
+					if (toggledValue !== undefined) {
+						const nextCursor = this.filteredOptions.findIndex(
+							(option) => option.value === toggledValue
+						);
+						this.cursor = nextCursor === -1 ? 0 : nextCursor;
+					}
 					break;
+				}
 			}
 		});
 
@@ -87,23 +209,17 @@ export default class MultiSelectSearchPrompt extends Prompt {
 			if (char === "\x7F" || char === "\b") {
 				if (this.search.length > 0) {
 					this.search = this.search.slice(0, -1);
-					this.applyFilter();
+					this.applyFilter({ resetFocus: true });
 					this.rerender();
 				}
 				return;
 			}
 
-			// Ignore vim navigation keys (h/j/k/l) — they are already handled
-			// by the "cursor" event and would otherwise be appended to search.
-			if (VIM_NAV_KEYS.has(char)) {
-				return;
-			}
-
-			// Printable character — append to search
+			// Printable character - append to search
 			// Exclude space (used for toggling) and control characters
 			if (char.length === 1 && char >= " " && char !== " ") {
 				this.search += char;
-				this.applyFilter();
+				this.applyFilter({ resetFocus: true });
 				this.rerender();
 			}
 		});
@@ -126,19 +242,32 @@ export default class MultiSelectSearchPrompt extends Prompt {
 		}
 	}
 
-	private applyFilter(): void {
+	private applyFilter({ resetFocus = false }: { resetFocus?: boolean } = {}): void {
 		const query = this.search.toLowerCase();
 
 		if (query === "") {
 			this.filteredOptions = [...this.options];
 		} else {
-			this.filteredOptions = this.options.filter((opt) => {
-				return (
-					opt.label.toLowerCase().includes(query) ||
-					opt.value.toLowerCase().includes(query) ||
-					(opt.sublabel?.toLowerCase().includes(query) ?? false)
-				);
-			});
+			this.filteredOptions = this.options
+				.map((option, index) => ({
+					option,
+					index,
+					priority: getOptionPriority(option, query),
+				}))
+				.filter(
+					(result): result is { option: SearchableOption; index: number; priority: number } =>
+						result.priority !== null
+				)
+				.sort(
+					(a, b) => a.priority - b.priority || a.index - b.index
+				)
+				.map(({ option }) => option);
+		}
+
+		if (resetFocus) {
+			this.cursor = 0;
+			this.windowStart = 0;
+			return;
 		}
 
 		// Keep cursor in bounds

--- a/packages/cli/multiselect-search.ts
+++ b/packages/cli/multiselect-search.ts
@@ -1,0 +1,160 @@
+import { Prompt } from "@clack/core";
+
+export type SearchableOption = {
+	label: string;
+	value: string;
+	sublabel?: string;
+};
+
+export type MultiSelectSearchOptions = {
+	options: SearchableOption[];
+	initialValues?: string[];
+	render(this: Omit<MultiSelectSearchPrompt, "prompt">): string | void;
+	validate?: (value: string[] | undefined) => string | void;
+};
+
+/**
+ * A multiselect prompt with type-to-search filtering.
+ *
+ * - Arrow keys navigate the filtered list
+ * - SPACE toggles selection on the focused item
+ * - Typing narrows the visible options (matches against label, value, and sublabel)
+ * - Backspace removes the last character from the search query
+ * - ENTER submits
+ *
+ * `this.search` contains the current search text.
+ * `this.filteredOptions` contains the options matching the search.
+ * `this.value` is the array of selected option values.
+ * `this.cursor` is the index into `filteredOptions`.
+ */
+export default class MultiSelectSearchPrompt extends Prompt {
+	options: SearchableOption[];
+	filteredOptions: SearchableOption[];
+	cursor = 0;
+	search = "";
+
+	constructor(opts: MultiSelectSearchOptions) {
+		super(opts, false);
+
+		this.options = opts.options;
+		this.value = [...(opts.initialValues ?? [])];
+		this.filteredOptions = [...this.options];
+		this.cursor = 0;
+
+		this.on("cursor", (key: string) => {
+			switch (key) {
+				case "left":
+				case "up":
+					this.cursor =
+						this.cursor === 0
+							? this.filteredOptions.length - 1
+							: this.cursor - 1;
+					break;
+				case "down":
+				case "right":
+					this.cursor =
+						this.cursor === this.filteredOptions.length - 1
+							? 0
+							: this.cursor + 1;
+					break;
+				case "space":
+					this.toggleValue();
+					// Clear search after toggling so the full list reappears
+					// and the user can immediately search for the next version
+					this.search = "";
+					this.applyFilter();
+					break;
+			}
+		});
+
+		this.on("key", (char: string) => {
+			// Backspace / DEL — remove last search character
+			if (char === "\x7F" || char === "\b") {
+				if (this.search.length > 0) {
+					this.search = this.search.slice(0, -1);
+					this.applyFilter();
+					this.rerender();
+				}
+				return;
+			}
+
+			if (char === "a" && this.search === "") {
+				// Toggle all only when not searching (consistent with base MultiSelectPrompt)
+				this.toggleAll();
+				this.rerender();
+				return;
+			}
+
+			// Printable character — append to search
+			// Exclude space (used for toggling) and control characters
+			if (char.length === 1 && char >= " " && char !== " ") {
+				this.search += char;
+				this.applyFilter();
+				this.rerender();
+			}
+		});
+	}
+
+	private toggleValue(): void {
+		if (this.filteredOptions.length === 0) {
+			return;
+		}
+
+		const opt = this.filteredOptions[this.cursor];
+		const idx = (this.value as string[]).indexOf(opt.value);
+
+		if (idx === -1) {
+			this.value = [...(this.value as string[]), opt.value];
+		} else {
+			this.value = (this.value as string[]).filter(
+				(v: string) => v !== opt.value
+			);
+		}
+	}
+
+	private toggleAll(): void {
+		const allValues = this.filteredOptions.map((o) => o.value);
+		const allSelected = allValues.every((v) =>
+			(this.value as string[]).includes(v)
+		);
+
+		if (allSelected) {
+			this.value = (this.value as string[]).filter(
+				(v: string) => !allValues.includes(v)
+			);
+		} else {
+			this.value = Array.from(
+				new Set([...(this.value as string[]), ...allValues])
+			);
+		}
+	}
+
+	private applyFilter(): void {
+		const query = this.search.toLowerCase();
+
+		if (query === "") {
+			this.filteredOptions = [...this.options];
+		} else {
+			this.filteredOptions = this.options.filter((opt) => {
+				return (
+					opt.label.toLowerCase().includes(query) ||
+					opt.value.toLowerCase().includes(query) ||
+					(opt.sublabel?.toLowerCase().includes(query) ?? false)
+				);
+			});
+		}
+
+		// Keep cursor in bounds
+		if (this.cursor >= this.filteredOptions.length) {
+			this.cursor = Math.max(0, this.filteredOptions.length - 1);
+		}
+	}
+
+	private rerender(): void {
+		// Workaround: render is private in Prompt, but we need to trigger a re-render
+		const self = this as Record<string, unknown>;
+		if ("render" in self && typeof self.render === "function") {
+			self.render();
+		}
+	}
+}

--- a/packages/workers-editor-shared/lib/Frame.tsx
+++ b/packages/workers-editor-shared/lib/Frame.tsx
@@ -1,6 +1,11 @@
 import { createComponent } from "@cloudflare/style-container";
+import type { ComponentPropsWithoutRef, ComponentType, Ref } from "react";
 
-const Frame = createComponent<"iframe">(
+type FrameProps = ComponentPropsWithoutRef<"iframe"> & {
+	innerRef?: Ref<HTMLIFrameElement>;
+};
+
+const Frame: ComponentType<FrameProps> = createComponent<"iframe">(
 	() => ({
 		position: "absolute",
 		top: 0,

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -344,9 +344,8 @@ function formatVersions(
  * The list of possible versions will include all deployable versions.
  *
  * Versions are sorted by upload date (latest first). The interactive
- * Versions are sorted by upload date (latest first). The interactive
  * prompt displays 5 versions at a time with scrolling, and supports
- * tag, message, or creation date.
+ * type-to-search filtering by version ID, tag, message, or creation date.
  *
  * @param accountId
  * @param workerName
@@ -402,6 +401,11 @@ async function promptVersionsToDeploy(
 		options: selectableVersions.map((version) => ({
 			value: version.id,
 			label: version.id,
+			searchText: [
+				version.metadata.created_on,
+				version.annotations?.["workers/tag"] ?? "",
+				version.annotations?.["workers/message"] ?? "",
+			].filter((text): text is string => text.length > 0),
 			sublabel: gray(`
 ${ZERO_WIDTH_SPACE}       Created:  ${version.metadata.created_on}
 ${ZERO_WIDTH_SPACE}           Tag:  ${

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -341,12 +341,12 @@ function formatVersions(
 
 /**
  * Prompts the user to select which versions they want to deploy.
- * The list of possible versions will include:
- * - versions within the latest deployment
- * - the latest 10 uploaded versions
- * - the versions the user provided as args (if any)
+ * The list of possible versions will include all deployable versions.
  *
- * sorted by upload date (latest first)
+ * Versions are sorted by upload date (latest first). The interactive
+ * prompt displays 3 versions at a time with scrolling, and supports
+ * type-to-search filtering to quickly find a specific version by ID,
+ * tag, message, or creation date.
  *
  * @param accountId
  * @param workerName
@@ -396,8 +396,9 @@ async function promptVersionsToDeploy(
 	const question = "Which version(s) do you want to deploy?";
 
 	const result = await inputPrompt<string[]>({
-		type: "multiselect",
+		type: "multiselect-search",
 		question,
+		maxItemsPerPage: 5,
 		options: selectableVersions.map((version) => ({
 			value: version.id,
 			label: version.id,
@@ -412,7 +413,7 @@ ${ZERO_WIDTH_SPACE}       Message:  ${
             `),
 		})),
 		label: "",
-		helpText: "Use SPACE to select/unselect version(s) and ENTER to submit.",
+		helpText: "Type to search, SPACE to select, ENTER to submit.",
 		defaultValue: defaultSelectedVersionIds,
 		acceptDefault: yesFlag,
 		validate(versionIds) {

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -417,7 +417,10 @@ ${ZERO_WIDTH_SPACE}       Message:  ${
 		defaultValue: defaultSelectedVersionIds,
 		acceptDefault: yesFlag,
 		validate(versionIds) {
-			if (versionIds === undefined) {
+			if (
+				versionIds === undefined ||
+				(Array.isArray(versionIds) && versionIds.length === 0)
+			) {
 				return `You must select at least 1 version to deploy.`;
 			}
 		},

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -344,8 +344,8 @@ function formatVersions(
  * The list of possible versions will include all deployable versions.
  *
  * Versions are sorted by upload date (latest first). The interactive
- * prompt displays 3 versions at a time with scrolling, and supports
- * type-to-search filtering to quickly find a specific version by ID,
+ * Versions are sorted by upload date (latest first). The interactive
+ * prompt displays 5 versions at a time with scrolling, and supports
  * tag, message, or creation date.
  *
  * @param accountId


### PR DESCRIPTION
## Summary
- Add a reusable `multiselect-search` prompt to `@cloudflare/cli` and use it for `wrangler versions deploy`.
- Make large version lists easier to work with through type-to-search filtering by version ID, tag, message, and creation date.
- Polish the interaction so selection, ranking, scrolling, and empty states behave predictably in real terminal usage.

## What It Does
- Lets you start typing immediately to filter deployable versions.
- Ranks results so exact matches appear first, then prefix matches, then broader substring matches.
- Shows clearer selection state with a `✔` checkmark, active-row pointer, match count, and selected count.
- Keeps the viewport stable with a sliding window instead of reflowing the whole list on every movement.
- Clears search after a successful selection so you can quickly search for the next version.
- Preserves the selected item after clearing search, resets focus to the top result when search results reorder, and ignores `SPACE` when there are no matches.
- Supports searching real version metadata using raw created date, tag, and message values rather than only the formatted terminal sublabel.

## Files Changed
- `packages/cli/multiselect-search.ts` - implements the custom search-enabled multiselect prompt, ranking logic, focus handling, and key handling.
- `packages/cli/interactive.ts` - adds the renderer for the new prompt type, including search/status lines, empty states, and sliding-window rendering.
- `packages/wrangler/src/versions/deploy.ts` - switches version selection to the new prompt and passes searchable metadata.
- `packages/cli/__tests__/multiselect-search.test.ts` - adds coverage for key handling, ranking, focus reset, empty-result behavior, renderer output, and validation/cancel flows.

## Validation
- `pnpm --filter @cloudflare/cli check:type`
- `pnpm --filter @cloudflare/cli test:ci -- multiselect-search`
- `pnpm --filter @cloudflare/workers-editor-shared build`
- `pnpm dlx oxfmt@0.41.0 --check packages/cli/__tests__/multiselect-search.test.ts packages/cli/interactive.ts packages/cli/multiselect-search.ts packages/workers-editor-shared/lib/Frame.tsx packages/wrangler/src/versions/deploy.ts`

- [x] Tests included/updated
- [x] Documentation not necessary because: this changes terminal interaction for an existing command but does not add new flags, config, or public API surface.