### PR TITLE
Update prettier to 3.8.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,7 +176,6 @@ For TypeScript to work properly in the Monorepo the version used in VSCode must 
 3. In the command palette, type "Select TypeScript Version" and select the command with the same name that appears in the list.
 
 4. A submenu will appear with a list of available TypeScript versions. Choose the desired version you want to use for this project. If you have multiple versions installed, they will be listed here.
-
    - Selecting "Use Workspace Version" will use the version of TypeScript installed in the project's `node_modules` directory.
 
 5. After selecting the TypeScript version, VSCode will reload the workspace using the chosen version.
@@ -272,7 +271,6 @@ Changes should be committed to a new local branch, which then gets pushed to you
   ```
 
 - Stage files to include in a commit
-
   - Use [VS Code](https://code.visualstudio.com/docs/editor/versioncontrol#_git-support)
   - Or add and commit files via the command line
 

--- a/fixtures/vitest-pool-workers-examples/README.md
+++ b/fixtures/vitest-pool-workers-examples/README.md
@@ -2,22 +2,22 @@
 
 This directory contains example projects tested with `@cloudflare/vitest-pool-workers`. It aims to provide the building blocks for you to write tests for your own Workers. Note the examples in this directory define `singleWorker: true` options. We recommend you enable this option if you have lots of small test files. Isolated storage is enabled by default meaning writes performed in each test are automatically undone when the test finishes.
 
-| Directory                                                                          | Overview                                                  |
-| ---------------------------------------------------------------------------------- | --------------------------------------------------------- |
-| [✅ basics-unit-integration-self](basics-unit-integration-self)                    | Basic unit tests and integration tests using `SELF`       |
-| [⚠️ basics-integration-auxiliary](basics-integration-auxiliary)                    | Basic integration tests using an auxiliary worker[^1]     |
+| Directory                                                                         | Overview                                                  |
+| --------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| [✅ basics-unit-integration-self](basics-unit-integration-self)                   | Basic unit tests and integration tests using `SELF`       |
+| [⚠️ basics-integration-auxiliary](basics-integration-auxiliary)                   | Basic integration tests using an auxiliary worker[^1]     |
 | [⚡️ pages-functions-unit-integration-self](pages-functions-unit-integration-self) | Functions unit tests and integration tests using `SELF`   |
-| [📦 kv-r2-caches](kv-r2-caches)                                                    | Isolated tests using KV, R2 and the Cache API             |
-| [📚 d1](d1)                                                                        | Isolated tests using D1 with migrations                   |
-| [📌 durable-objects](durable-objects)                                              | Isolated tests using Durable Objects with direct access   |
-| [🔁 workflows](workflows)                                                          | Tests using Workflows                                     |
-| [🚥 queues](queues)                                                                | Tests using Queue producers and consumers                 |
-| [🚰 pipelines](pipelines)                                                          | Tests using Pipelines                                     |
-| [🚀 hyperdrive](hyperdrive)                                                        | Tests using Hyperdrive with a Vitest managed TCP server   |
-| [🤹 request-mocking](request-mocking)                                              | Tests using declarative/imperative outbound request mocks |
-| [🔌 multiple-workers](multiple-workers)                                            | Tests using multiple auxiliary workers and request mocks  |
-| [⚙️ web-assembly](web-assembly)                                                    | Tests importing WebAssembly modules                       |
-| [🤯 rpc](rpc)                                                                      | Tests using named entrypoints, Durable Objects and RPC    |
-| [🤷 misc](misc)                                                                    | Tests for other assorted Vitest features                  |
+| [📦 kv-r2-caches](kv-r2-caches)                                                   | Isolated tests using KV, R2 and the Cache API             |
+| [📚 d1](d1)                                                                       | Isolated tests using D1 with migrations                   |
+| [📌 durable-objects](durable-objects)                                             | Isolated tests using Durable Objects with direct access   |
+| [🔁 workflows](workflows)                                                         | Tests using Workflows                                     |
+| [🚥 queues](queues)                                                               | Tests using Queue producers and consumers                 |
+| [🚰 pipelines](pipelines)                                                         | Tests using Pipelines                                     |
+| [🚀 hyperdrive](hyperdrive)                                                       | Tests using Hyperdrive with a Vitest managed TCP server   |
+| [🤹 request-mocking](request-mocking)                                             | Tests using declarative/imperative outbound request mocks |
+| [🔌 multiple-workers](multiple-workers)                                           | Tests using multiple auxiliary workers and request mocks  |
+| [⚙️ web-assembly](web-assembly)                                                   | Tests importing WebAssembly modules                       |
+| [🤯 rpc](rpc)                                                                     | Tests using named entrypoints, Durable Objects and RPC    |
+| [🤷 misc](misc)                                                                   | Tests for other assorted Vitest features                  |
 
 [^1]: When using `SELF` for integration tests, your worker code runs in the same context as the test runner. This means you can use global mocks to control your worker, but also means your worker uses the same subtly different module resolution behaviour provided by Vite. Usually this isn't a problem, but if you'd like to run your worker in a fresh environment that's as close to production as possible, using an auxiliary worker may be a good idea. Note this prevents global mocks from controlling your worker, and requires you to build your worker ahead-of-time. This means your tests won't re-run automatically if you change your worker's source code, but could be useful if you have a complicated build process (e.g. full-stack framework).

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"esbuild": "catalog:default",
 		"esbuild-register": "^3.5.0",
 		"jsonc-parser": "catalog:default",
-		"prettier": "^3.2.5",
+		"prettier": "^3.8.1",
 		"prettier-plugin-packagejson": "^2.2.18",
 		"prettier-plugin-tailwindcss": "^0.7.2",
 		"tree-kill": "^1.2.2",

--- a/packages/containers-shared/src/utils.ts
+++ b/packages/containers-shared/src/utils.ts
@@ -267,7 +267,7 @@ export function resolveDockerHost(dockerPath: string): string {
 export const getDockerHostFromEnv = (): string => {
 	const fromEnv = process.env.WRANGLER_DOCKER_HOST ?? process.env.DOCKER_HOST;
 
-	return fromEnv ?? process.platform === "win32"
+	return (fromEnv ?? process.platform === "win32")
 		? "//./pipe/docker_engine"
 		: "unix:///var/run/docker.sock";
 };

--- a/packages/local-explorer-ui/src/components/studio/SQLWhereEditor.tsx
+++ b/packages/local-explorer-ui/src/components/studio/SQLWhereEditor.tsx
@@ -12,8 +12,10 @@ import type {
 } from "./Code/Mirror";
 import type { Extension } from "@codemirror/state";
 
-interface SutdioSQLWhereEditor
-	extends Omit<StudioCodeMirrorProps, "extensions"> {
+interface SutdioSQLWhereEditor extends Omit<
+	StudioCodeMirrorProps,
+	"extensions"
+> {
 	columnNames?: string[];
 	functionNames?: string[];
 	onEnterPressed?: () => void;

--- a/packages/local-explorer-ui/src/components/studio/Table/BaseTable.tsx
+++ b/packages/local-explorer-ui/src/components/studio/Table/BaseTable.tsx
@@ -147,8 +147,9 @@ export function StudioBaseTable<HeaderMetadata = unknown>({
 	);
 }
 
-export interface StudioTableHeaderProps<MetadataType = unknown>
-	extends StudioTableHeaderInput<MetadataType> {
+export interface StudioTableHeaderProps<
+	MetadataType = unknown,
+> extends StudioTableHeaderInput<MetadataType> {
 	index: number;
 	sticky: boolean;
 }
@@ -185,15 +186,17 @@ interface TableCellListCommonProps<MetadataType = unknown> {
 	state: StudioTableState<MetadataType>;
 }
 
-export interface StudioTableProps<HeaderMetadata = unknown>
-	extends TableCellListCommonProps<HeaderMetadata> {
+export interface StudioTableProps<
+	HeaderMetadata = unknown,
+> extends TableCellListCommonProps<HeaderMetadata> {
 	arrangeHeaderIndex: number[];
 	renderAhead: number;
 	stickyHeaderIndex?: number;
 }
 
-interface RenderCellListProps<HeaderMetadata = unknown>
-	extends TableCellListCommonProps<HeaderMetadata> {
+interface RenderCellListProps<
+	HeaderMetadata = unknown,
+> extends TableCellListCommonProps<HeaderMetadata> {
 	colEnd: number;
 	colStart: number;
 	customStyles?: React.CSSProperties;

--- a/packages/local-explorer-ui/src/components/studio/index.tsx
+++ b/packages/local-explorer-ui/src/components/studio/index.tsx
@@ -414,7 +414,7 @@ export const Studio = forwardRef<StudioRef, StudioProps>(function Studio(
 		const tableMatch = selectedTab.identifier.match(
 			/^(?:table|edit-table)\/[^.]+\.(.+)$/
 		);
-		lastOpenedTable.current = tableMatch ? tableMatch[1] ?? null : null;
+		lastOpenedTable.current = tableMatch ? (tableMatch[1] ?? null) : null;
 		onTableChange(tableMatch?.[1]);
 	}, [initialTable, loadingSchema, onTableChange, selectedTabKey, tabs]);
 

--- a/packages/local-explorer-ui/src/styles/tailwind.css
+++ b/packages/local-explorer-ui/src/styles/tailwind.css
@@ -139,8 +139,9 @@
 
 @layer base {
 	body {
-		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
-			Ubuntu, sans-serif;
+		font-family:
+			-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+			sans-serif;
 		@apply text-text bg-bg-secondary text-sm leading-normal;
 	}
 }

--- a/packages/miniflare/README.md
+++ b/packages/miniflare/README.md
@@ -260,7 +260,6 @@ parameter in module format Workers.
   have any _npm_ imports, and `modules: true` must be set.
 
 - `modules?: boolean | ModuleDefinition[]`
-
   - If `true`, Miniflare will treat `script`/`scriptPath` as an ES Module and
     automatically locate transitive module dependencies according to
     `modulesRules`. Note that automatic location is not perfect: if the
@@ -335,7 +334,6 @@ parameter in module format Workers.
   `{ fetch: typeof fetch }`
   [service bindings](https://developers.cloudflare.com/workers/platform/bindings/about-service-bindings/)
   into this Worker.
-
   - If the designator is a `string`, requests will be dispatched to the Worker
     with that `name`.
   - If the designator is `(await import("miniflare")).kCurrentWorker`, requests
@@ -535,7 +533,6 @@ parameter in module format Workers.
 
   Record mapping binding name to Durable Object class designators to inject as
   `DurableObjectNamespace` bindings into this Worker.
-
   - If the designator is a `string`, it should be the name of a `class` exported
     by this Worker.
   - If the designator is an object, and `scriptName` is `undefined`, `className`
@@ -569,11 +566,9 @@ parameter in module format Workers.
 
   If set, only files with paths _not_ matching these glob patterns will be
   served.
-
   - `assetsPath?: string`
 
   Path to serve Workers assets from.
-
   - `assetsKVBindingName?: string`
     Name of the binding to the KV namespace that the assets are in. If `assetsPath` is set, this binding will be injected into this Worker.
 
@@ -763,7 +758,6 @@ Options shared between all Workers/"nanoservices".
 - `cf?: boolean | string | Record<string, any>`
 
   Controls the object returned from incoming `Request`'s `cf` property.
-
   - If set to a falsy value, an object with default placeholder values will be
     used
   - If set to an object, that object will be used

--- a/packages/miniflare/src/workers/local-explorer/resources/kv.ts
+++ b/packages/miniflare/src/workers/local-explorer/resources/kv.ts
@@ -183,7 +183,7 @@ async function executeListKeys(
 	options: { cursor?: string; limit?: number; prefix?: string }
 ) {
 	const listResult = await kv.list(options);
-	const resultCursor = "cursor" in listResult ? listResult.cursor ?? "" : "";
+	const resultCursor = "cursor" in listResult ? (listResult.cursor ?? "") : "";
 
 	return c.json({
 		...wrapResponse(

--- a/packages/miniflare/src/workers/shared/keyvalue.worker.ts
+++ b/packages/miniflare/src/workers/shared/keyvalue.worker.ts
@@ -20,8 +20,9 @@ export interface KeyEntry<Metadata = unknown> {
 export interface KeyValueEntry<Metadata = unknown> extends KeyEntry<Metadata> {
 	value: ReadableStream<Uint8Array>;
 }
-export interface KeyMultipartValueEntry<Metadata = unknown>
-	extends KeyEntry<Metadata> {
+export interface KeyMultipartValueEntry<
+	Metadata = unknown,
+> extends KeyEntry<Metadata> {
 	value: MultipartReadableStream;
 }
 

--- a/packages/miniflare/test/plugins/email/index.spec.ts
+++ b/packages/miniflare/test/plugins/email/index.spec.ts
@@ -4,7 +4,7 @@ import dedent from "ts-dedent";
 import { test, vi } from "vitest";
 import { TestLog, useDispose } from "../../test-shared";
 
-const SEND_EMAIL_WORKER = dedent/* javascript */ `
+const SEND_EMAIL_WORKER = dedent /* javascript */ `
 	import { EmailMessage } from "cloudflare:email";
 
 	export default {
@@ -23,7 +23,7 @@ const SEND_EMAIL_WORKER = dedent/* javascript */ `
 	};
 `;
 
-const REPLY_EMAIL_WORKER = (email = "message.raw") => dedent/* javascript */ `
+const REPLY_EMAIL_WORKER = (email = "message.raw") => dedent /* javascript */ `
 	import { EmailMessage } from "cloudflare:email";
 
 	export default {
@@ -984,7 +984,7 @@ test("reply: references generated correctly", async ({ expect }) => {
 	).toBe(true);
 });
 
-const MESSAGE_BUILDER_WORKER = dedent/* javascript */ `
+const MESSAGE_BUILDER_WORKER = dedent /* javascript */ `
 	export default {
 		async fetch(request, env) {
 			const builder = await request.json();

--- a/packages/pages-shared/environment-polyfills/html-rewriter.ts
+++ b/packages/pages-shared/environment-polyfills/html-rewriter.ts
@@ -49,9 +49,8 @@ export class HTMLRewriter {
 				const {
 					HTMLRewriter: BaseHTMLRewriter,
 					// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-				}: typeof import("html-rewriter-wasm") = await import(
-					"html-rewriter-wasm"
-				);
+				}: typeof import("html-rewriter-wasm") =
+					await import("html-rewriter-wasm");
 				rewriter = new BaseHTMLRewriter((output) => {
 					// enqueue will throw on empty chunks
 					if (output.length !== 0) {

--- a/packages/playground-preview-worker/src/realish.ts
+++ b/packages/playground-preview-worker/src/realish.ts
@@ -96,8 +96,8 @@ export async function setupTokens(
 ): Promise<RealishPreviewConfig> {
 	const previewSession = await initialiseSubdomainPreview(accountId, apiToken);
 	const uploadConfigToken = previewSession.exchange_url
-		? (await tryExpandToken(previewSession.exchange_url)) ??
-			previewSession.token
+		? ((await tryExpandToken(previewSession.exchange_url)) ??
+			previewSession.token)
 		: previewSession.token;
 
 	return {

--- a/packages/vite-plugin-cloudflare/playground/module-resolution/__tests__/base-tests.ts
+++ b/packages/vite-plugin-cloudflare/playground/module-resolution/__tests__/base-tests.ts
@@ -105,8 +105,7 @@ describe("module resolution", async () => {
 			expect(result).toEqual({
 				"(slash-create/web) VERSION": "6.2.1",
 				"(slash-create/web) myCollection.random()": 54321,
-				"(slash-create/web) slashCreatorInstance is instance of SlashCreator":
-					true,
+				"(slash-create/web) slashCreatorInstance is instance of SlashCreator": true,
 			});
 		});
 	});

--- a/packages/vite-plugin-cloudflare/src/context.ts
+++ b/packages/vite-plugin-cloudflare/src/context.ts
@@ -214,8 +214,9 @@ export class PluginContext {
 	}
 }
 
-interface NarrowedPluginContext<T extends ResolvedPluginConfig>
-	extends PluginContext {
+interface NarrowedPluginContext<
+	T extends ResolvedPluginConfig,
+> extends PluginContext {
 	readonly resolvedPluginConfig: T;
 }
 

--- a/packages/vite-plugin-cloudflare/src/workers-configs.ts
+++ b/packages/vite-plugin-cloudflare/src/workers-configs.ts
@@ -12,14 +12,12 @@ export type WorkerResolvedConfig =
 	| AssetsOnlyWorkerResolvedConfig
 	| WorkerWithServerLogicResolvedConfig;
 
-export interface AssetsOnlyWorkerResolvedConfig
-	extends WorkerBaseResolvedConfig {
+export interface AssetsOnlyWorkerResolvedConfig extends WorkerBaseResolvedConfig {
 	type: "assets-only";
 	config: ResolvedAssetsOnlyConfig;
 }
 
-export interface WorkerWithServerLogicResolvedConfig
-	extends WorkerBaseResolvedConfig {
+export interface WorkerWithServerLogicResolvedConfig extends WorkerBaseResolvedConfig {
 	type: "worker";
 	config: ResolvedWorkerConfig;
 }

--- a/packages/vite-plugin-cloudflare/src/workers/runner-worker/module-runner.ts
+++ b/packages/vite-plugin-cloudflare/src/workers/runner-worker/module-runner.ts
@@ -267,9 +267,8 @@ async function createModuleRunner(
 			},
 			async runExternalModule(filepath) {
 				if (filepath === "cloudflare:workers") {
-					const originalCloudflareWorkersModule = await import(
-						"cloudflare:workers"
-					);
+					const originalCloudflareWorkersModule =
+						await import("cloudflare:workers");
 
 					return Object.seal({
 						...originalCloudflareWorkersModule,

--- a/packages/vitest-pool-workers/src/worker/index.ts
+++ b/packages/vitest-pool-workers/src/worker/index.ts
@@ -189,9 +189,8 @@ export class __VITEST_POOL_WORKERS_RUNNER_DURABLE_OBJECT__ extends DurableObject
 
 		cwd = wd.cwd;
 
-		const { init, runBaseTests, setupEnvironment } = await import(
-			"vitest/worker"
-		);
+		const { init, runBaseTests, setupEnvironment } =
+			await import("vitest/worker");
 
 		poolSocket.accept();
 

--- a/packages/vitest-pool-workers/src/worker/node/console.ts
+++ b/packages/vitest-pool-workers/src/worker/node/console.ts
@@ -31,7 +31,7 @@ export class Console {
 		this.#stdout = opts.stdout;
 		this.#stderr = opts.stderr ?? this.#stdout;
 		const colors =
-			typeof opts.colorMode === "string" ? false : opts.colorMode ?? false;
+			typeof opts.colorMode === "string" ? false : (opts.colorMode ?? false);
 		this.#inspectOptions = opts.inspectOptions ?? { colors };
 
 		// Ensure methods are bound to the instance

--- a/packages/vitest-pool-workers/src/worker/workflows.ts
+++ b/packages/vitest-pool-workers/src/worker/workflows.ts
@@ -40,9 +40,7 @@ export async function introspectWorkflowInstance(
 	return new WorkflowInstanceIntrospectorHandle(workflow, instanceId);
 }
 
-class WorkflowInstanceIntrospectorHandle
-	implements WorkflowInstanceIntrospector
-{
+class WorkflowInstanceIntrospectorHandle implements WorkflowInstanceIntrospector {
 	#workflow: WorkflowBinding;
 	#instanceId: string;
 	#instanceModifier: WorkflowInstanceModifier | undefined;

--- a/packages/vitest-pool-workers/test/helpers.ts
+++ b/packages/vitest-pool-workers/test/helpers.ts
@@ -15,7 +15,7 @@ const debuglog = util.debuglog("vitest-pool-workers:test");
 export const vitestConfig = (
 	cfOptions: Record<string, unknown> = {},
 	testOptions: Record<string, unknown> = {}
-) => dedent/* javascript */ `
+) => dedent /* javascript */ `
 	import { cloudflareTest } from "@cloudflare/vitest-pool-workers"
 
 	import { BaseSequencer } from "vitest/node";

--- a/packages/vitest-pool-workers/test/isolation.test.ts
+++ b/packages/vitest-pool-workers/test/isolation.test.ts
@@ -8,7 +8,7 @@ test(
 		// Check unique global scopes, storage isolated, and unique auxiliaries:
 		// https://developers.cloudflare.com/workers/testing/vitest-integration/isolation-and-concurrency/#isolatedstorage-true-singleworker-false-default
 		await seed({
-			"auxiliary.mjs": dedent/* javascript */ `
+			"auxiliary.mjs": dedent /* javascript */ `
 				let count = 0;
 				export default {
 					fetch() {
@@ -31,7 +31,7 @@ test(
 					],
 				},
 			}),
-			"a.test.ts": dedent/* javascript */ `
+			"a.test.ts": dedent /* javascript */ `
 				import { env } from "cloudflare:test";
 				import { it, expect } from "vitest";
 				it("does something", async () => {
@@ -45,7 +45,7 @@ test(
 					expect(await response.text()).toBe("1");
 				});
 			`,
-			"b.test.ts": dedent/* javascript */ `
+			"b.test.ts": dedent /* javascript */ `
 				import { env } from "cloudflare:test";
 				import { it, expect } from "vitest";
 				it("does something else", async () => {
@@ -95,7 +95,7 @@ test(
 					],
 				},
 			}),
-			"a.test.ts": dedent/* javascript */ `
+			"a.test.ts": dedent /* javascript */ `
 				import { env } from "cloudflare:test";
 				import { it, expect } from "vitest";
 				it("does something", async () => {
@@ -106,7 +106,7 @@ test(
 					expect(await response.text()).toBe("1");
 				});
 			`,
-			"b.test.ts": dedent/* javascript */ `
+			"b.test.ts": dedent /* javascript */ `
 				import { env } from "cloudflare:test";
 				import { it, expect } from "vitest";
 				it("does something else", async () => {
@@ -130,7 +130,7 @@ test(
 	async ({ expect, seed, vitestRun }) => {
 		// With --no-isolate --max-workers=1, test files share globals, storage, and auxiliaries
 		await seed({
-			"auxiliary.mjs": dedent/* javascript */ `
+			"auxiliary.mjs": dedent /* javascript */ `
 				let count = 0;
 				export default {
 					fetch() {
@@ -153,7 +153,7 @@ test(
 					],
 				},
 			}),
-			"a.test.ts": dedent/* javascript */ `
+			"a.test.ts": dedent /* javascript */ `
 				import { env } from "cloudflare:test";
 				import { it, expect } from "vitest";
 				it("does something", async () => {
@@ -167,7 +167,7 @@ test(
 					expect(await response.text()).toBe("1");
 				});
 			`,
-			"b.test.ts": dedent/* javascript */ `
+			"b.test.ts": dedent /* javascript */ `
 				import { env } from "cloudflare:test";
 				import { it, expect } from "vitest";
 				it("does something else", async () => {

--- a/packages/vitest-pool-workers/test/validation.test.ts
+++ b/packages/vitest-pool-workers/test/validation.test.ts
@@ -67,7 +67,7 @@ test(
 					compatibilityFlags: ["nodejs_compat"],
 				},
 			}),
-			"index.test.ts": dedent/* javascript */ `
+			"index.test.ts": dedent /* javascript */ `
 				import { SELF } from "cloudflare:test";
 				import { it, expect } from "vitest";
 				it("sends request", async () => {
@@ -92,7 +92,7 @@ test(
 					compatibilityFlags: ["nodejs_compat"],
 				},
 			}),
-			"index.ts": dedent/* javascript */ `
+			"index.ts": dedent /* javascript */ `
 				addEventListener("fetch", (event) => {
 					event.respondWith(new Response("body"));
 				});

--- a/packages/vitest-pool-workers/test/watch.test.ts
+++ b/packages/vitest-pool-workers/test/watch.test.ts
@@ -11,14 +11,14 @@ test("automatically re-runs unit tests", async ({
 }) => {
 	await seed({
 		"vitest.config.mts": vitestConfig(),
-		"index.ts": dedent/* javascript */ `
+		"index.ts": dedent /* javascript */ `
 			export default {
 				async fetch(request, env, ctx) {
 					return new Response("wrong");
 				}
 			}
 		`,
-		"index.test.ts": dedent/* javascript */ `
+		"index.test.ts": dedent /* javascript */ `
 			import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
 			import { it, expect } from "vitest";
 			import worker from "./index";
@@ -38,7 +38,7 @@ test("automatically re-runs unit tests", async ({
 	});
 
 	await seed({
-		"index.ts": dedent/* javascript */ `
+		"index.ts": dedent /* javascript */ `
 			export default {
 				async fetch(request, env, ctx) {
 					return new Response("correct");
@@ -64,14 +64,14 @@ test("automatically re-runs integration tests", async ({
 				compatibilityFlags: ["nodejs_compat"],
 			},
 		}),
-		"index.ts": dedent/* javascript */ `
+		"index.ts": dedent /* javascript */ `
 			export default {
 				async fetch(request, env, ctx) {
 					return new Response("wrong");
 				}
 			}
 		`,
-		"index.test.ts": dedent/* javascript */ `
+		"index.test.ts": dedent /* javascript */ `
 			import { SELF } from "cloudflare:test";
 			import { it, expect } from "vitest";
 			it("sends request", async () => {
@@ -87,7 +87,7 @@ test("automatically re-runs integration tests", async ({
 	});
 
 	await seed({
-		"index.ts": dedent/* javascript */ `
+		"index.ts": dedent /* javascript */ `
 			export default {
 				async fetch(request, env, ctx) {
 					return new Response("correct");
@@ -113,12 +113,12 @@ test("automatically reset module graph", async ({
 				compatibilityFlags: ["nodejs_compat"],
 			},
 		}),
-		"answer.ts": dedent/* javascript */ `
+		"answer.ts": dedent /* javascript */ `
 			export function getAnswer() {
 				return "wrong";
 			}
 		`,
-		"index.ts": dedent/* javascript */ `
+		"index.ts": dedent /* javascript */ `
 			import { getAnswer } from "./answer";
 
 			export default {
@@ -128,7 +128,7 @@ test("automatically reset module graph", async ({
 				}
 			}
 		`,
-		"index.test.ts": dedent/* javascript */ `
+		"index.test.ts": dedent /* javascript */ `
 			import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
 			import { it, expect, vi } from "vitest";
 			import worker from "./index";
@@ -155,7 +155,7 @@ test("automatically reset module graph", async ({
 
 	// Trigger a re-run by updating the test file with an extra test.
 	await seed({
-		"index.test.ts": dedent/* javascript */ `
+		"index.test.ts": dedent /* javascript */ `
 			import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
 			import { it, expect, vi } from "vitest";
 			import worker from "./index";

--- a/packages/workers-playground/src/index.css
+++ b/packages/workers-playground/src/index.css
@@ -1,8 +1,8 @@
 :root {
 	/* Font stack taken from workers.cloudflare.com */
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-		"Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-		sans-serif;
+	font-family:
+		-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
+		"Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	line-height: 1.5;
 	font-weight: 400;
 

--- a/packages/workers-shared/asset-worker/src/handler.ts
+++ b/packages/workers-shared/asset-worker/src/handler.ts
@@ -109,7 +109,7 @@ const getResponseOrAssetIntent = async (
 				location:
 					encodedDestination !== pathname
 						? encodedDestination
-						: intent.redirect ?? "<unknown>",
+						: (intent.redirect ?? "<unknown>"),
 				status: TemporaryRedirectResponse.status,
 			});
 

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -7,8 +7,7 @@ import type { Json } from "../types";
  * This could be the top-level default environment, or a specific named environment.
  */
 export interface Environment
-	extends EnvironmentInheritable,
-		EnvironmentNonInheritable {}
+	extends EnvironmentInheritable, EnvironmentNonInheritable {}
 
 type SimpleRoute = string;
 export type ZoneIdRoute = {

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -699,7 +699,7 @@ function normalizeAndValidateDev(
 		inspector_ip,
 		local_protocol = localProtocolArg ?? "http",
 		// In remote mode upstream_protocol must be https, otherwise it defaults to local_protocol.
-		upstream_protocol = upstreamProtocolArg ?? remoteArg
+		upstream_protocol = (upstreamProtocolArg ?? remoteArg)
 			? "https"
 			: local_protocol,
 		host,

--- a/packages/wrangler/e2e/assets-multiworker.test.ts
+++ b/packages/wrangler/e2e/assets-multiworker.test.ts
@@ -129,7 +129,7 @@ describe.each(
 					`,
 				"public/asset-binding.html": "<p>have an asset via a binding</p>",
 				"public/asset.html": "<p>have an asset directly</p>",
-				"src/index.ts": dedent/* javascript */ `
+				"src/index.ts": dedent /* javascript */ `
 						export default {
 							async fetch(req, env) {
 								const url = new URL(req.url)
@@ -176,7 +176,7 @@ describe.each(
 					main = "src/index.ts"
 					compatibility_date = "2024-11-01"
 			`,
-				"src/index.ts": dedent/* javascript */ `
+				"src/index.ts": dedent /* javascript */ `
 					import { DurableObject, WorkerEntrypoint, RpcTarget } from "cloudflare:workers";
 					export default{
 						async fetch(req, env) {
@@ -308,7 +308,7 @@ describe.each(
 						binding = "AW"
 						service = '${assetWorkerName}'
 				`,
-					"src/index.ts": dedent/* javascript */ `
+					"src/index.ts": dedent /* javascript */ `
 						export default {
 							async fetch(req, env) {
 								const url = new URL(req.url)
@@ -392,7 +392,7 @@ describe.each(
 							binding = "AW"
 							service = '${assetWorkerName}'
 					`,
-					"src/index.ts": dedent/* javascript */ `
+					"src/index.ts": dedent /* javascript */ `
 							export default {
 								async fetch(req, env) {
 									const url = new URL(req.url)
@@ -413,7 +413,7 @@ describe.each(
 								directory = "public"
 								binding = "ASSETS"
 						`,
-					"src/index.ts": dedent/* javascript */ `
+					"src/index.ts": dedent /* javascript */ `
 							import { WorkerEntrypoint } from "cloudflare:workers"
 
 							export default {
@@ -444,7 +444,7 @@ describe.each(
 			describe("default export object", () => {
 				beforeEach(async () => {
 					await baseSeed(assetWorker, {
-						"src/index.ts": dedent/* javascript */ `
+						"src/index.ts": dedent /* javascript */ `
 									import { WorkerEntrypoint } from "cloudflare:workers"
 
 									export default {
@@ -526,7 +526,7 @@ describe.each(
 			describe("default export WorkerEntrypoint class", () => {
 				beforeEach(async () => {
 					await baseSeed(assetWorker, {
-						"src/index.ts": dedent/* javascript */ `
+						"src/index.ts": dedent /* javascript */ `
 									import { WorkerEntrypoint } from "cloudflare:workers"
 
 									export default class Worker extends WorkerEntrypoint {
@@ -608,7 +608,7 @@ describe.each(
 			describe("named export WorkerEntrypoint class", () => {
 				beforeEach(async () => {
 					await baseSeed(assetWorker, {
-						"src/index.ts": dedent/* javascript */ `
+						"src/index.ts": dedent /* javascript */ `
 									import { WorkerEntrypoint } from "cloudflare:workers"
 
 									export default {fetch() {}}

--- a/packages/wrangler/e2e/dev-env.test.ts
+++ b/packages/wrangler/e2e/dev-env.test.ts
@@ -16,7 +16,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("switching runtimes", () => {
 					account_id = "${CLOUDFLARE_ACCOUNT_ID}"
 					compatibility_date = "2023-01-01"
 			`,
-			"index.ts": dedent/*javascript*/ `
+			"index.ts": dedent /*javascript*/ `
 				export default {
 					async fetch(request, env) {
 						return new Response(
@@ -25,7 +25,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("switching runtimes", () => {
 					},
 				};
 			`,
-			"index.mjs": dedent/*javascript*/ `
+			"index.mjs": dedent /*javascript*/ `
 				import { setTimeout } from "timers/promises";
 				import { unstable_startWorker as startWorker } from "${WRANGLER_IMPORT}";
 

--- a/packages/wrangler/e2e/dev-registry.test.ts
+++ b/packages/wrangler/e2e/dev-registry.test.ts
@@ -53,7 +53,7 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 					main = "src/index.ts"
 					compatibility_date = "2023-01-01"
 			`,
-			"src/index.ts": dedent/* javascript */ `
+			"src/index.ts": dedent /* javascript */ `
 				export default {
 					fetch(req, env) {
                         const url = new URL(req.url)
@@ -104,7 +104,7 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
                         { name = "REFERENCED_DO", class_name = "MyDurableObject", script_name = "${workerName}" }
                     ]
 			`,
-			"src/index.ts": dedent/* javascript */ `
+			"src/index.ts": dedent /* javascript */ `
 				export default{
 					fetch(req, env) {
                         const url = new URL(req.url)
@@ -132,7 +132,7 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 					name = "${workerName3}"
 					main = "src/index.ts"
 			`,
-			"src/index.ts": dedent/* javascript */ `
+			"src/index.ts": dedent /* javascript */ `
                 addEventListener("fetch", (event) => {
                     event.respondWith(new Response("Hello from service worker"));
                 });
@@ -269,7 +269,7 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 							[[tail_consumers]]
 							service = "${workerName2}"
 					`,
-				"src/index.ts": dedent/* javascript */ `
+				"src/index.ts": dedent /* javascript */ `
 						export default {
 							async fetch(req, env) {
 								console.log("log something")
@@ -286,7 +286,7 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 							main = "src/index.ts"
 							compatibility_date = "2025-04-28"
 					`,
-				"src/index.ts": dedent/* javascript */ `
+				"src/index.ts": dedent /* javascript */ `
 						export default {
 							async tail(event) {
 								console.log("received tail event", event)
@@ -418,7 +418,7 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 						binding = "BEE"
 						service = '${workerName2}'
 				`,
-				"dist/_worker.js": dedent/* javascript */ `export default {
+				"dist/_worker.js": dedent /* javascript */ `export default {
 					fetch(req, env) {
                         const url = new URL(req.url)
                         if (url.pathname === "/service") {

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -1034,7 +1034,7 @@ describe("writes debug logs to hidden file", () => {
 					main = "src/index.ts"
 					compatibility_date = "2023-01-01"
 				`,
-			"src/index.ts": dedent/* javascript */ `
+			"src/index.ts": dedent /* javascript */ `
 					export default {
 						fetch(req, env) {
 							return new Response('A' + req.url);
@@ -1071,7 +1071,7 @@ describe("writes debug logs to hidden file", () => {
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
 			`,
-			"src/index.ts": dedent/* javascript */ `
+			"src/index.ts": dedent /* javascript */ `
 				export default {
 					fetch(req, env) {
 						return new Response('A' + req.url);

--- a/packages/wrangler/e2e/get-platform-proxy.test.ts
+++ b/packages/wrangler/e2e/get-platform-proxy.test.ts
@@ -37,7 +37,7 @@ describe("getPlatformProxy()", () => {
 						[ai]
 						binding = "AI"
 				`,
-				"index.mjs": dedent/*javascript*/ `
+				"index.mjs": dedent /*javascript*/ `
 						import { getPlatformProxy } from "${WRANGLER_IMPORT}"
 
 						const { env } = await getPlatformProxy();
@@ -114,7 +114,7 @@ describe("getPlatformProxy()", () => {
 							main = "src/index.ts"
 							compatibility_date = "2023-01-01"
 					`,
-				"src/index.ts": dedent/* javascript */ `
+				"src/index.ts": dedent /* javascript */ `
 						export default {
 							fetch(req, env) {
 								return new Response("Hello from Worker!")
@@ -139,7 +139,7 @@ describe("getPlatformProxy()", () => {
 			await w.waitForReady();
 
 			await seed(app, {
-				"index.mjs": dedent/*javascript*/ `
+				"index.mjs": dedent /*javascript*/ `
 						import { getPlatformProxy } from "${WRANGLER_IMPORT}"
 
 						const { env } = await getPlatformProxy();
@@ -181,7 +181,7 @@ describe("getPlatformProxy()", () => {
 				`,
 			});
 			await seed(worker, {
-				"src/index.ts": dedent/* javascript */ `
+				"src/index.ts": dedent /* javascript */ `
 					import { DurableObject } from "cloudflare:workers";
 					export default {
 						async fetch(): Promise<Response> {
@@ -220,7 +220,7 @@ describe("getPlatformProxy()", () => {
 		describe("provides rpc service bindings to external local workers", () => {
 			beforeEach(async () => {
 				await seed(worker, {
-					"src/index.ts": dedent/* javascript */ `
+					"src/index.ts": dedent /* javascript */ `
 							import { RpcTarget, WorkerEntrypoint } from "cloudflare:workers";
 
 							export default {
@@ -481,7 +481,7 @@ describe("getPlatformProxy()", () => {
 							id = "hyperdrive_id"
 							localConnectionString = "${scheme}://user:%21pass@127.0.0.1:${port}/some_db"
 					`,
-					"index.mjs": dedent/*javascript*/ `
+					"index.mjs": dedent /*javascript*/ `
 							// Windows socket cleanup error handler
 							if (process.platform === 'win32') {
 								process.on('uncaughtException', (err) => {
@@ -538,7 +538,7 @@ describe("getPlatformProxy()", () => {
 							id = "hyperdrive_id"
 							localConnectionString = "postgresql://user:%21pass@127.0.0.1:${port}/some_db?sslmode=prefer"
 					`,
-						"index.mjs": dedent/*javascript*/ `
+						"index.mjs": dedent /*javascript*/ `
 							// Windows socket cleanup error handler
 							if (process.platform === 'win32') {
 								process.on('uncaughtException', (err) => {
@@ -594,7 +594,7 @@ describe("getPlatformProxy()", () => {
 						id = "hyperdrive_id"
 						localConnectionString = "postgresql://user:%21pass@127.0.0.1:${port}/some_db?sslmode=require"
 					`,
-						"index.mjs": dedent/*javascript*/ `
+						"index.mjs": dedent /*javascript*/ `
 						// Windows socket cleanup error handler
 						if (process.platform === 'win32') {
 							process.on('uncaughtException', (err) => {

--- a/packages/wrangler/e2e/multiworker-dev.test.ts
+++ b/packages/wrangler/e2e/multiworker-dev.test.ts
@@ -47,7 +47,7 @@ describe("multiworker", () => {
 					main = "src/index.ts"
 					compatibility_date = "2024-11-01"
 			`,
-			"src/index.ts": dedent/* javascript */ `
+			"src/index.ts": dedent /* javascript */ `
 				import { DurableObject } from "cloudflare:workers";
 
 				export default {
@@ -113,7 +113,7 @@ describe("multiworker", () => {
                         { name = "REFERENCED_DO", class_name = "MyDurableObject", script_name = "${workerName}" }
                     ]
 			`,
-			"src/index.ts": dedent/* javascript */ `
+			"src/index.ts": dedent /* javascript */ `
 				import { WorkerEntrypoint, RpcTarget } from "cloudflare:workers";
 
 				class Counter extends RpcTarget {
@@ -169,7 +169,7 @@ describe("multiworker", () => {
 					name = "${workerName3}"
 					main = "src/index.ts"
 			`,
-			"src/index.ts": dedent/* javascript */ `
+			"src/index.ts": dedent /* javascript */ `
                 addEventListener("fetch", (event) => {
                     event.respondWith(new Response("Hello from service worker"));
                 });
@@ -408,7 +408,7 @@ describe("multiworker", () => {
 						[[tail_consumers]]
 						service = "${workerName2}"
 				`,
-				"src/index.ts": dedent/* javascript */ `
+				"src/index.ts": dedent /* javascript */ `
 					export default {
 						async fetch(req, env) {
 							console.log("log something")
@@ -425,7 +425,7 @@ describe("multiworker", () => {
 						main = "src/index.ts"
 						compatibility_date = "2025-04-28"
 				`,
-				"src/index.ts": dedent/* javascript */ `
+				"src/index.ts": dedent /* javascript */ `
 					export default {
 						async tail(event) {
 							console.log("received tail event", event)
@@ -475,7 +475,7 @@ describe("multiworker", () => {
 						[[streaming_tail_consumers]]
 						service = "${workerName2}"
 				`,
-				"src/index.ts": dedent/* javascript */ `
+				"src/index.ts": dedent /* javascript */ `
 					export default {
 						async fetch(req, env) {
 							console.log("log something")
@@ -492,7 +492,7 @@ describe("multiworker", () => {
 						main = "src/index.ts"
 						compatibility_date = "2025-04-28"
 				`,
-				"src/index.ts": dedent/* javascript */ `
+				"src/index.ts": dedent /* javascript */ `
 					export default {
 						async tail(event) {
 							console.log("received tail event", event)
@@ -538,11 +538,11 @@ describe("multiworker", () => {
 					binding = "BEE"
 					service = '${workerName2}'
 				`,
-				"functions/cee.ts": dedent/* javascript */ `
+				"functions/cee.ts": dedent /* javascript */ `
 				export async function onRequest(context) {
 					return context.env.CEE.fetch("https://example.com");
 				}`,
-				"functions/bee.ts": dedent/* javascript */ `
+				"functions/bee.ts": dedent /* javascript */ `
 				export async function onRequest(context) {
 					return context.env.BEE.fetch("https://example.com");
 				}`,
@@ -622,7 +622,7 @@ describe("multiworker", () => {
 						binding = "BEE"
 						service = '${workerName2}'
 				`,
-				"src/index.ts": dedent/* javascript */ `
+				"src/index.ts": dedent /* javascript */ `
 					export default {
 						async fetch(req, env) {
 							return env.BEE.fetch(req);
@@ -643,7 +643,7 @@ describe("multiworker", () => {
 						[triggers]
 						crons = ["0 * * * *"]
 				`,
-				"src/index.ts": dedent/* javascript */ `
+				"src/index.ts": dedent /* javascript */ `
 					export default {
 						async fetch(req, env) {
 							return new Response("hello world");

--- a/packages/wrangler/e2e/remote-binding/miniflare-remote-resources.test.ts
+++ b/packages/wrangler/e2e/remote-binding/miniflare-remote-resources.test.ts
@@ -127,7 +127,7 @@ const testCases: TestCase[] = [
 		setup: async (helper) => {
 			const targetWorkerName = generateResourceName();
 			await helper.seed({
-				"target-worker.js": dedent/* javascript */ `
+				"target-worker.js": dedent /* javascript */ `
 					import { WorkerEntrypoint } from "cloudflare:workers"
 					export default {
 						fetch(request) {
@@ -374,7 +374,7 @@ const testCases: TestCase[] = [
 
 			const customerWorkerName = "remote-bindings-test-customer-worker";
 			await helper.seed({
-				"customer-worker.js": dedent/* javascript */ `
+				"customer-worker.js": dedent /* javascript */ `
 					import {WorkerEntrypoint} from "cloudflare:workers"
 					export default class W extends WorkerEntrypoint {
 						fetch(request) {
@@ -616,7 +616,7 @@ if (!CLOUDFLARE_ACCOUNT_ID) {
 					],
 				};
 				await helper.seed({
-					"worker.js": dedent/* javascript */ `
+					"worker.js": dedent /* javascript */ `
 						export default {
 							fetch(request) { return new Response("Hello"); }
 						}

--- a/packages/wrangler/e2e/unenv-preset/worker/index.ts
+++ b/packages/wrangler/e2e/unenv-preset/worker/index.ts
@@ -15,7 +15,7 @@ export default {
 
 				return Response.json(
 					flagName
-						? getRuntimeFlagValue(flagName) ?? "undefined"
+						? (getRuntimeFlagValue(flagName) ?? "undefined")
 						: "The request is missing the `name` query parameter"
 				);
 			}

--- a/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
@@ -72,7 +72,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 	describe("happy path bundle + watch", () => {
 		test("single ts source file", async () => {
 			await seed({
-				"src/index.ts": dedent/* javascript */ `
+				"src/index.ts": dedent /* javascript */ `
 				export default {
 					fetch(request, env, ctx) {
 						//comment
@@ -105,7 +105,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 			// Now update the source file and see that we re-bundle
 			const ev2 = bus.waitFor("bundleComplete");
 			await seed({
-				"src/index.ts": dedent/* javascript */ `
+				"src/index.ts": dedent /* javascript */ `
 					export default {
 						fetch(request, env, ctx) {
 							//comment
@@ -132,7 +132,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 
 		test("multiple ts source files", async () => {
 			await seed({
-				"src/index.ts": dedent/* javascript */ `
+				"src/index.ts": dedent /* javascript */ `
 				import name from "./other"
 				export default {
 					fetch(request, env, ctx) {
@@ -141,7 +141,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 					}
 				} satisfies ExportedHandler
 			`,
-				"src/other.ts": dedent/* javascript */ `
+				"src/other.ts": dedent /* javascript */ `
 				export default "someone"
 			`,
 			});
@@ -171,7 +171,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 			// Now update the secondary source file and see that we re-bundle
 			ev = bus.waitFor("bundleComplete");
 			await seed({
-				"src/other.ts": dedent/* javascript */ `
+				"src/other.ts": dedent /* javascript */ `
 					export default "someone else"
 				`,
 			});
@@ -185,7 +185,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 
 		test("custom build", async () => {
 			await seed({
-				"custom_build_dir/index.ts": dedent/* javascript */ `
+				"custom_build_dir/index.ts": dedent /* javascript */ `
 				export default {
 					fetch(request, env, ctx) {
 						//comment
@@ -227,7 +227,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 				async () => {
 					ev = bus.waitFor("bundleComplete");
 					await seed({
-						"custom_build_dir/index.ts": dedent/* javascript */ `
+						"custom_build_dir/index.ts": dedent /* javascript */ `
 						export default {
 							fetch(request, env, ctx) {
 								//comment
@@ -259,7 +259,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 
 	test("module aliasing", async () => {
 		await seed({
-			"src/index.ts": dedent/* javascript */ `
+			"src/index.ts": dedent /* javascript */ `
 				import name from "foo"
 				export default {
 					fetch(request, env, ctx) {
@@ -268,10 +268,10 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 					}
 				} satisfies ExportedHandler
 			`,
-			"node_modules/foo": dedent/* javascript */ `
+			"node_modules/foo": dedent /* javascript */ `
 				export default "foo"
 			`,
-			"node_modules/bar": dedent/* javascript */ `
+			"node_modules/bar": dedent /* javascript */ `
 				export default "bar"
 			`,
 		});
@@ -283,7 +283,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 		controller.onConfigUpdate({ type: "configUpdate", config });
 
 		expect((await ev).bundle.entrypointSource)
-			.toContain(dedent/* javascript */ `
+			.toContain(dedent /* javascript */ `
             // ../node_modules/foo
             var foo_default = "foo"
         `);
@@ -302,7 +302,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 			},
 		});
 		expect((await ev).bundle.entrypointSource)
-			.toContain(dedent/* javascript */ `
+			.toContain(dedent /* javascript */ `
             // ../node_modules/bar
             var bar_default = "bar"
         `);
@@ -311,7 +311,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 	describe("switching", () => {
 		test("esbuild -> custom builds", { timeout: 500000 }, async () => {
 			await seed({
-				"src/index.ts": dedent/* javascript */ `
+				"src/index.ts": dedent /* javascript */ `
 				export default {
 					fetch(request, env, ctx) {
 						//comment
@@ -347,7 +347,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 
 			// Now switch to custom builds and see that it rebundles
 			await seed({
-				"custom_build_dir/index.ts": dedent/* javascript */ `
+				"custom_build_dir/index.ts": dedent /* javascript */ `
 					export default {
 						fetch(request, env, ctx) {
 							//comment
@@ -397,7 +397,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 						500000
 					);
 					await seed({
-						"custom_build_dir/index.ts": dedent/* javascript */ `
+						"custom_build_dir/index.ts": dedent /* javascript */ `
 						export default {
 							fetch(request, env, ctx) {
 								//comment
@@ -431,7 +431,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 
 		test("custom builds -> esbuild", async () => {
 			await seed({
-				"custom_build_dir/index.ts": dedent/* javascript */ `
+				"custom_build_dir/index.ts": dedent /* javascript */ `
 					export default {
 						fetch(request, env, ctx) {
 							//comment
@@ -473,7 +473,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 					"
 				`);
 			await seed({
-				"src/index.ts": dedent/* javascript */ `
+				"src/index.ts": dedent /* javascript */ `
 						export default {
 							fetch(request, env, ctx) {
 								//comment
@@ -512,7 +512,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 			// Now change the source file and see that we still rebundle
 			ev = bus.waitFor("bundleComplete");
 			await seed({
-				"src/index.ts": dedent/* javascript */ `
+				"src/index.ts": dedent /* javascript */ `
 						export default {
 							fetch(request, env, ctx) {
 								//comment

--- a/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
@@ -43,10 +43,10 @@ describe("ConfigController", () => {
 
 	it("should prompt user to update types if they're out of date", async () => {
 		await seed({
-			"src/index.ts": dedent/* javascript */ `
+			"src/index.ts": dedent /* javascript */ `
 				export default {}
 			`,
-			"wrangler.toml": dedent/* toml */ `
+			"wrangler.toml": dedent /* toml */ `
 				name = "my-worker"
 				main = "src/index.ts"
 				compatibility_date = \"2024-06-01\"
@@ -56,7 +56,7 @@ describe("ConfigController", () => {
 		await controller.set({ config: "./wrangler.toml" });
 
 		await seed({
-			"wrangler.toml": dedent/* toml */ `
+			"wrangler.toml": dedent /* toml */ `
 				name = "my-worker"
 				main = "src/index.ts"
 				compatibility_date = \"2025-06-01\"
@@ -71,10 +71,10 @@ describe("ConfigController", () => {
 
 	it("should use account_id from config file before env var", async () => {
 		await seed({
-			"src/index.ts": dedent/* javascript */ `
+			"src/index.ts": dedent /* javascript */ `
                 export default {}
             `,
-			"wrangler.toml": dedent/* toml */ `
+			"wrangler.toml": dedent /* toml */ `
                 name = "my-worker"
                 main = "src/index.ts"
 				compatibility_date = \"2024-06-01\"
@@ -90,7 +90,7 @@ describe("ConfigController", () => {
 		});
 
 		await seed({
-			"wrangler.toml": dedent/* toml */ `
+			"wrangler.toml": dedent /* toml */ `
                 name = "my-worker"
                 main = "src/index.ts"
 								compatibility_date = \"2024-06-01\"
@@ -109,7 +109,7 @@ describe("ConfigController", () => {
 	it("should emit configUpdate events with defaults applied", async () => {
 		const event = bus.waitFor("configUpdate");
 		await seed({
-			"src/index.ts": dedent/* javascript */ `
+			"src/index.ts": dedent /* javascript */ `
 				export default {
 					fetch(request, env, ctx) {
 						return new Response("hello world")
@@ -141,7 +141,7 @@ describe("ConfigController", () => {
 	it("should apply module root to parent if main is nested from base_dir", async () => {
 		const event = bus.waitFor("configUpdate");
 		await seed({
-			"some/base_dir/nested/index.js": dedent/* javascript */ `
+			"some/base_dir/nested/index.js": dedent /* javascript */ `
 				export default {
 					fetch(request, env, ctx) {
 						return new Response("hello world")
@@ -175,7 +175,7 @@ describe("ConfigController", () => {
 	it("should shallow merge patched config", async () => {
 		const event1 = bus.waitFor("configUpdate");
 		await seed({
-			"src/index.ts": dedent/* javascript */ `
+			"src/index.ts": dedent /* javascript */ `
 				export default {
 					fetch(request, env, ctx) {
 						return new Response("hello world")
@@ -266,12 +266,12 @@ describe("ConfigController", () => {
 
 	it("should only log warnings once even with multiple config updates", async () => {
 		await seed({
-			"src/index.js": dedent/* javascript */ `
+			"src/index.js": dedent /* javascript */ `
 				addEventListener('fetch', event => {
 					event.respondWith(new Response('hello world'))
 				})
 			`,
-			"wrangler.toml": dedent/* toml */ `
+			"wrangler.toml": dedent /* toml */ `
 				name = "my-worker"
 				main = "src/index.js"
 				compatibility_date = "2024-06-01"

--- a/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
@@ -205,7 +205,7 @@ describe("LocalRuntimeController", () => {
 				],
 				id: 0,
 				path: "/virtual/esm/index.mjs",
-				entrypointSource: dedent/*javascript*/ `
+				entrypointSource: dedent /*javascript*/ `
 				import add from "./add.cjs";
 				import base64 from "./base64.cjs";
 				import wave1 from "./data/wave.txt";
@@ -305,7 +305,7 @@ describe("LocalRuntimeController", () => {
 			};
 			const bundle: Bundle = {
 				type: "commonjs",
-				entrypointSource: dedent/*javascript*/ `
+				entrypointSource: dedent /*javascript*/ `
 				addEventListener("fetch", (event) => {
 					const { pathname } = new URL(event.request.url);
 					if (pathname === "/") {
@@ -403,7 +403,7 @@ describe("LocalRuntimeController", () => {
 						VERSION: { type: "json", value: version },
 					},
 				} satisfies Partial<StartDevWorkerOptions>;
-				const bundle = makeEsbuildBundle(dedent/*javascript*/ `
+				const bundle = makeEsbuildBundle(dedent /*javascript*/ `
 					export default {
 						fetch(request, env, ctx) {
 							return Response.json({ binding: env.VERSION, bundle: ${version} });
@@ -457,7 +457,7 @@ describe("LocalRuntimeController", () => {
 				entrypoint: "NOT_REAL",
 				compatibilityDate: disabledDate,
 			};
-			const bundle = makeEsbuildBundle(dedent/*javascript*/ `
+			const bundle = makeEsbuildBundle(dedent /*javascript*/ `
 				export default {
 					fetch(request, env, ctx) { return new Response(typeof navigator); }
 				}
@@ -516,7 +516,7 @@ describe("LocalRuntimeController", () => {
 				name: "worker",
 				entrypoint: "NOT_REAL",
 			};
-			const bundle = makeEsbuildBundle(dedent/*javascript*/ `
+			const bundle = makeEsbuildBundle(dedent /*javascript*/ `
 				export default {
 					fetch(request, env, ctx) {
 						debugger;
@@ -594,7 +594,7 @@ describe("LocalRuntimeController", () => {
 					},
 				},
 			};
-			const bundle = makeEsbuildBundle(dedent/*javascript*/ `
+			const bundle = makeEsbuildBundle(dedent /*javascript*/ `
 			export default {
 				fetch(request, env, ctx) {
 					const body = JSON.stringify(env, (key, value) => {
@@ -672,7 +672,7 @@ describe("LocalRuntimeController", () => {
 				dev: { persist: "./persist" },
 			};
 
-			const bundle = makeEsbuildBundle(dedent/*javascript*/ `
+			const bundle = makeEsbuildBundle(dedent /*javascript*/ `
 				export default {
 					async fetch(request, env, ctx) {
 						const key = "http://localhost/";
@@ -746,7 +746,7 @@ describe("LocalRuntimeController", () => {
 				name: "worker",
 			} satisfies Partial<StartDevWorkerOptions>;
 
-			const bundle = makeEsbuildBundle(dedent/*javascript*/ `
+			const bundle = makeEsbuildBundle(dedent /*javascript*/ `
 				export default {
 					async fetch(request, env, ctx) {
 						const key = "http://localhost/";
@@ -812,7 +812,7 @@ describe("LocalRuntimeController", () => {
 				bindings: { NAMESPACE: { type: "kv_namespace", id: "ns" } },
 				dev: { persist: "./persist" },
 			};
-			const bundle = makeEsbuildBundle(dedent/*javascript*/ `
+			const bundle = makeEsbuildBundle(dedent /*javascript*/ `
 				export default {
 					async fetch(request, env, ctx) {
 						if (request.method === "POST") await env.NAMESPACE.put("key", "value");
@@ -881,7 +881,7 @@ describe("LocalRuntimeController", () => {
 				(api) => api.create(secretValue)
 			);
 
-			const bundle = makeEsbuildBundle(dedent/*javascript*/ `
+			const bundle = makeEsbuildBundle(dedent /*javascript*/ `
 				export default {
 					async fetch(request, env, ctx) {
 						return new Response(await env.SECRET.get());
@@ -916,7 +916,7 @@ describe("LocalRuntimeController", () => {
 			const controller = new LocalRuntimeController(bus);
 			teardown(() => controller.teardown());
 
-			const bundle = makeEsbuildBundle(dedent/*javascript*/ `
+			const bundle = makeEsbuildBundle(dedent /*javascript*/ `
 				export default {
 					async fetch(request, env, ctx) {
 						if (request.method === "POST") {
@@ -988,7 +988,7 @@ describe("LocalRuntimeController", () => {
 				entrypoint: "NOT_REAL",
 				legacy: { site: { bucket: ".", include: ["*.txt"] } },
 			};
-			const bundle = makeEsbuildBundle(dedent/*javascript*/ `
+			const bundle = makeEsbuildBundle(dedent /*javascript*/ `
 				import manifestJSON from "__STATIC_CONTENT_MANIFEST";
 				const manifest = JSON.parse(manifestJSON);
 				export default {
@@ -1057,7 +1057,7 @@ describe("LocalRuntimeController", () => {
 				bindings: { BUCKET: { type: "r2_bucket", bucket_name: "bucket" } },
 				dev: { persist: "./persist" },
 			};
-			const bundle = makeEsbuildBundle(dedent/*javascript*/ `
+			const bundle = makeEsbuildBundle(dedent /*javascript*/ `
 				export default {
 					async fetch(request, env, ctx) {
 						if (request.method === "POST") await env.BUCKET.put("key", "value");
@@ -1124,7 +1124,7 @@ describe("LocalRuntimeController", () => {
 				},
 				dev: { persist: "./persist" },
 			};
-			const bundle = makeEsbuildBundle(dedent/*javascript*/ `
+			const bundle = makeEsbuildBundle(dedent /*javascript*/ `
 				export default {
 					async fetch(request, env, ctx) {
 						await env.DB.exec("CREATE TABLE IF NOT EXISTS entries (key text PRIMARY KEY, value text)");
@@ -1205,7 +1205,7 @@ describe("LocalRuntimeController", () => {
 				],
 				dev: { persist: "./persist" },
 			};
-			const bundle = makeEsbuildBundle(dedent/*javascript*/ `
+			const bundle = makeEsbuildBundle(dedent /*javascript*/ `
 				export default {
 					async fetch(request, env, ctx) {
 						await env.QUEUE.send("message");
@@ -1261,7 +1261,7 @@ describe("LocalRuntimeController", () => {
 					DB: { type: "hyperdrive", id: "db", localConnectionString },
 				},
 			};
-			const bundle = makeEsbuildBundle(dedent/*javascript*/ `
+			const bundle = makeEsbuildBundle(dedent /*javascript*/ `
 				export default {
 					async fetch(request, env, ctx) {
 						const socket = env.DB.connect();
@@ -1413,7 +1413,7 @@ describe("LocalRuntimeController", () => {
 			const controller = new LocalRuntimeController(bus);
 			teardown(() => controller.teardown());
 
-			const bundle = makeEsbuildBundle(dedent/*javascript*/ `
+			const bundle = makeEsbuildBundle(dedent /*javascript*/ `
 				export default {
 					async fetch(request, env, ctx) {
 						let log = {
@@ -1454,7 +1454,7 @@ describe("LocalRuntimeController", () => {
 			const controller = new LocalRuntimeController(bus);
 			teardown(() => controller.teardown());
 
-			const bundle = makeEsbuildBundle(dedent/*javascript*/ `
+			const bundle = makeEsbuildBundle(dedent /*javascript*/ `
 				export default {
 					async fetch(request, env, ctx) {
 						return new Response("env.IMAGES is " + (env.IMAGES === undefined ? "not available" : "available"));

--- a/packages/wrangler/src/__tests__/deploy/core.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/core.test.ts
@@ -1020,7 +1020,7 @@ describe("deploy", () => {
 			writeWranglerConfig();
 			fs.writeFileSync(
 				"index.js",
-				dedent/* javascript */ `
+				dedent /* javascript */ `
 					export default {
 						fetch() {
 							return

--- a/packages/wrangler/src/__tests__/find-additional-modules.test.ts
+++ b/packages/wrangler/src/__tests__/find-additional-modules.test.ts
@@ -21,7 +21,7 @@ describe("traverse module graph", () => {
 	it("should not detect JS without module rules", async ({ expect }) => {
 		await writeFile(
 			"./index.js",
-			dedent/* javascript */ `
+			dedent /* javascript */ `
 			import { HELLO } from "./other.js"
 			export default {
 				async fetch(request) {
@@ -32,7 +32,7 @@ describe("traverse module graph", () => {
 		);
 		await writeFile(
 			"./other.js",
-			dedent/* javascript */ `
+			dedent /* javascript */ `
 			export const HELLO = "WORLD"
 			`
 		);
@@ -58,7 +58,7 @@ describe("traverse module graph", () => {
 	])("should detect JS as %s", async ([type, format], { expect }) => {
 		await writeFile(
 			"./index.js",
-			dedent/* javascript */ `
+			dedent /* javascript */ `
 			import { HELLO } from "./other.js"
 			export default {
 				async fetch(request) {
@@ -69,7 +69,7 @@ describe("traverse module graph", () => {
 		);
 		await writeFile(
 			"./other.js",
-			dedent/* javascript */ `
+			dedent /* javascript */ `
 			export const HELLO = "WORLD"
 			`
 		);
@@ -93,7 +93,7 @@ describe("traverse module graph", () => {
 		await mkdir("./src/nested", { recursive: true });
 		await writeFile(
 			"./src/nested/index.js",
-			dedent/* javascript */ `
+			dedent /* javascript */ `
 			import { HELLO } from "../other.js"
 			export default {
 				async fetch(request) {
@@ -104,7 +104,7 @@ describe("traverse module graph", () => {
 		);
 		await writeFile(
 			"./src/other.js",
-			dedent/* javascript */ `
+			dedent /* javascript */ `
 			export const HELLO = "WORLD"
 			`
 		);
@@ -129,7 +129,7 @@ describe("traverse module graph", () => {
 		await mkdir("./src/nested", { recursive: true });
 		await writeFile(
 			"./src/nested/index.js",
-			dedent/* javascript */ `
+			dedent /* javascript */ `
 			import { HELLO } from "../other.js"
 			export default {
 				async fetch(request) {
@@ -140,7 +140,7 @@ describe("traverse module graph", () => {
 		);
 		await writeFile(
 			"./src/other.js",
-			dedent/* javascript */ `
+			dedent /* javascript */ `
 			export const HELLO = "WORLD"
 			`
 		);
@@ -165,7 +165,7 @@ describe("traverse module graph", () => {
 		await mkdir("./src/nested", { recursive: true });
 		await writeFile(
 			"./src/nested/index.js",
-			dedent/* javascript */ `
+			dedent /* javascript */ `
 			import { HELLO } from "../other.js"
 			export default {
 				async fetch(request) {
@@ -176,7 +176,7 @@ describe("traverse module graph", () => {
 		);
 		await writeFile(
 			"./src/other.js",
-			dedent/* javascript */ `
+			dedent /* javascript */ `
 			export const HELLO = "WORLD"
 			`
 		);
@@ -201,7 +201,7 @@ describe("traverse module graph", () => {
 		await mkdir("./src", { recursive: true });
 		await writeFile(
 			"./src/index.js",
-			dedent/* javascript */ `
+			dedent /* javascript */ `
 			import { HELLO } from "./other.js"
 			export default {
 				async fetch(request) {
@@ -212,7 +212,7 @@ describe("traverse module graph", () => {
 		);
 		await writeFile(
 			"./src/wrangler.jsonc",
-			dedent/* jsonc */ `
+			dedent /* jsonc */ `
 			{
 				"compatibility_date": "2025/01/01"
 			}
@@ -252,7 +252,7 @@ describe("traverse module graph", () => {
 		await mkdir("./src", { recursive: true });
 		await writeFile(
 			"./src/index.js",
-			dedent/* javascript */ `
+			dedent /* javascript */ `
 			import HELLO from "../other.txt"
 			export default {
 				async fetch(request) {
@@ -263,7 +263,7 @@ describe("traverse module graph", () => {
 		);
 		await writeFile(
 			"./src/other.txt",
-			dedent/* javascript */ `
+			dedent /* javascript */ `
 			export const HELLO = "WORLD"
 			`
 		);
@@ -290,7 +290,7 @@ describe("traverse module graph", () => {
 		await mkdir("./src", { recursive: true });
 		await writeFile(
 			"./src/index.js",
-			dedent/* javascript */ `
+			dedent /* javascript */ `
 			export default {
 				async fetch(request) {
 					return new Response(HELLO)
@@ -300,7 +300,7 @@ describe("traverse module graph", () => {
 		);
 		await writeFile(
 			"./src/other.txt",
-			dedent/* javascript */ `
+			dedent /* javascript */ `
 			export const HELLO = "WORLD"
 			`
 		);

--- a/packages/wrangler/src/__tests__/get-entry.test.ts
+++ b/packages/wrangler/src/__tests__/get-entry.test.ts
@@ -32,7 +32,7 @@ describe("getEntry()", () => {
 
 	it("--script index.ts", async () => {
 		await seed({
-			"index.ts": dedent/* javascript */ `
+			"index.ts": dedent /* javascript */ `
 							export default {
 								fetch() {
 
@@ -54,7 +54,7 @@ describe("getEntry()", () => {
 
 	it("--script src/index.ts", async () => {
 		await seed({
-			"src/index.ts": dedent/* javascript */ `
+			"src/index.ts": dedent /* javascript */ `
 							export default {
 								fetch() {
 
@@ -76,7 +76,7 @@ describe("getEntry()", () => {
 
 	it("main = index.ts", async () => {
 		await seed({
-			"index.ts": dedent/* javascript */ `
+			"index.ts": dedent /* javascript */ `
 							export default {
 								fetch() {
 
@@ -98,7 +98,7 @@ describe("getEntry()", () => {
 
 	it("main = src/index.ts", async () => {
 		await seed({
-			"src/index.ts": dedent/* javascript */ `
+			"src/index.ts": dedent /* javascript */ `
 							export default {
 								fetch() {
 
@@ -120,7 +120,7 @@ describe("getEntry()", () => {
 
 	it("main = src/index.ts w/ configPath", async () => {
 		await seed({
-			"other-worker/src/index.ts": dedent/* javascript */ `
+			"other-worker/src/index.ts": dedent /* javascript */ `
 							export default {
 								fetch() {
 

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -216,7 +216,7 @@ describe("init", () => {
 			usage_model = "bundled",
 			tags = [],
 			compatibility_date = "1987-09-27",
-			content = dedent/*javascript*/ `
+			content = dedent /*javascript*/ `
 							export default {
 								async fetch(request, env, ctx) {
 									return new Response("Hello World!");
@@ -1327,7 +1327,7 @@ describe("init", () => {
 				"index.js",
 				new File(
 					[
-						dedent/*javascript*/ `
+						dedent /*javascript*/ `
 								import handleRequest from './other.js';
 
 								export default {
@@ -1345,7 +1345,7 @@ describe("init", () => {
 				"other.js",
 				new File(
 					[
-						dedent/*javascript*/ `
+						dedent /*javascript*/ `
 								export default function (request, env, ctx) {
 									return new Response("Hello World!");
 								}

--- a/packages/wrangler/src/__tests__/middleware.test.ts
+++ b/packages/wrangler/src/__tests__/middleware.test.ts
@@ -827,7 +827,7 @@ describe("middleware", () => {
 
 		it("should build multiple middleware as expected", async () => {
 			await seedFs({
-				"src/index.js": dedent/* javascript */ `
+				"src/index.js": dedent /* javascript */ `
 				export default {
 					async fetch(request, env) {
 						return Response.json(env);
@@ -841,7 +841,7 @@ describe("middleware", () => {
 					}
 				}
 			`,
-				"wrangler.toml": dedent/*toml*/ `
+				"wrangler.toml": dedent /*toml*/ `
 				name = "worker-app"
 				main = "src/index.js"
 				compatibility_date = "2022-03-31"

--- a/packages/wrangler/src/__tests__/navigator-user-agent.test.ts
+++ b/packages/wrangler/src/__tests__/navigator-user-agent.test.ts
@@ -105,7 +105,7 @@ describe("defineNavigatorUserAgent is respected", () => {
 		expect,
 	}) => {
 		await seedFs({
-			"src/index.js": dedent/* javascript */ `
+			"src/index.js": dedent /* javascript */ `
 			function randomBytes(length) {
 				if (navigator.userAgent !== "Cloudflare-Workers") {
 					return new Uint8Array(require("node:crypto").randomBytes(length));
@@ -159,7 +159,7 @@ describe("defineNavigatorUserAgent is respected", () => {
 		expect,
 	}) => {
 		await seedFs({
-			"src/index.js": dedent/* javascript */ `
+			"src/index.js": dedent /* javascript */ `
 			function randomBytes(length) {
 				if (navigator.userAgent !== "Cloudflare-Workers") {
 					return new Uint8Array(require("node:crypto").randomBytes(length));
@@ -205,7 +205,7 @@ describe("defineNavigatorUserAgent is respected", () => {
 		expect,
 	}) => {
 		await seedFs({
-			"src/index.js": dedent/* javascript */ `
+			"src/index.js": dedent /* javascript */ `
 			function randomBytes(length) {
 				if (navigator.userAgent !== "Cloudflare-Workers") {
 					return new Uint8Array(require("node:crypto").randomBytes(length));

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -515,7 +515,7 @@ export function unstable_getMiniflareWorkerOptions(
 		compatibilityFlags: config.compatibility_flags,
 		modulesRules,
 		containerEngine: useContainers
-			? config.dev.container_engine ?? resolveDockerHost(getDockerPath())
+			? (config.dev.container_engine ?? resolveDockerHost(getDockerPath()))
 			: undefined,
 
 		...bindingOptions,

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -159,9 +159,9 @@ async function resolveDevConfig(
 			input.dev?.enableContainers ?? config.dev.enable_containers,
 		dockerPath: input.dev?.dockerPath ?? getDockerPath(),
 		containerEngine: useContainers
-			? input.dev?.containerEngine ??
+			? (input.dev?.containerEngine ??
 				config.dev.container_engine ??
-				resolveDockerHost(input.dev?.dockerPath ?? getDockerPath())
+				resolveDockerHost(input.dev?.dockerPath ?? getDockerPath()))
 			: undefined,
 		containerBuildId: input.dev?.containerBuildId,
 		generateTypes: input.dev?.generateTypes ?? config.dev.generate_types,

--- a/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
@@ -118,9 +118,8 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 			if (data.config.dev?.remote !== false) {
 				// note: remote bindings use (transitively) LocalRuntimeController, so we need to import
 				// from the module lazily in order to avoid circular dependency issues
-				const { maybeStartOrUpdateRemoteProxySession } = await import(
-					"../remoteBindings"
-				);
+				const { maybeStartOrUpdateRemoteProxySession } =
+					await import("../remoteBindings");
 				const remoteProxySession = await maybeStartOrUpdateRemoteProxySession(
 					{
 						name: configBundle.name,

--- a/packages/wrangler/src/api/startDevWorker/utils.ts
+++ b/packages/wrangler/src/api/startDevWorker/utils.ts
@@ -133,7 +133,7 @@ export function convertConfigToBindings(
 					output[binding] = {
 						type: "kv_namespace",
 						...x,
-						id: usePreviewIds ? x.preview_id ?? x.id : x.id,
+						id: usePreviewIds ? (x.preview_id ?? x.id) : x.id,
 					};
 				}
 				break;
@@ -215,7 +215,7 @@ export function convertConfigToBindings(
 						type: "r2_bucket",
 						...x,
 						bucket_name: usePreviewIds
-							? x.preview_bucket_name ?? x.bucket_name
+							? (x.preview_bucket_name ?? x.bucket_name)
 							: x.bucket_name,
 					};
 				}
@@ -227,7 +227,7 @@ export function convertConfigToBindings(
 						type: "d1",
 						...x,
 						database_id: usePreviewIds
-							? x.preview_database_id ?? x.database_id
+							? (x.preview_database_id ?? x.database_id)
 							: x.database_id,
 					};
 				}

--- a/packages/wrangler/src/autoconfig/frameworks/react-router.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/react-router.ts
@@ -162,7 +162,7 @@ export class ReactRouter extends Framework {
 
 			writeFileSync(
 				"workers/app.ts",
-				dedent/* javascript */ `
+				dedent /* javascript */ `
 					import { createRequestHandler } from "react-router";
 
 					declare module "react-router" {
@@ -199,7 +199,7 @@ export class ReactRouter extends Framework {
 			if (!existsSync("app/entry.server.tsx")) {
 				writeFileSync(
 					`app/entry.server.tsx`,
-					dedent/* javascript */ `
+					dedent /* javascript */ `
 					import type { AppLoadContext, EntryContext } from "react-router";
 					import { ServerRouter } from "react-router";
 					import { isbot } from "isbot";

--- a/packages/wrangler/src/cfetch/index.ts
+++ b/packages/wrangler/src/cfetch/index.ts
@@ -254,12 +254,12 @@ export function renderError(err: FetchError | ErrorData, level = 0): string {
 	const indent = "  ".repeat(level);
 	const chainedMessages =
 		"error_chain" in err
-			? err.error_chain
+			? (err.error_chain
 					?.map(
 						(chainedError) =>
 							`\n\n${indent}- ${renderError(chainedError, level + 1)}`
 					)
-					.join("\n") ?? ""
+					.join("\n") ?? "")
 			: "";
 	return (
 		(err.code ? `${err.message} [code: ${err.code}]` : err.message) +

--- a/packages/wrangler/src/cloudchamber/apply.ts
+++ b/packages/wrangler/src/cloudchamber/apply.ts
@@ -453,7 +453,7 @@ export async function apply(
 					name: application.name,
 					rollout_step_percentage:
 						application.durable_objects !== undefined
-							? appConfigNoDefaults.rollout_step_percentage ?? 25
+							? (appConfigNoDefaults.rollout_step_percentage ?? 25)
 							: appConfigNoDefaults.rollout_step_percentage,
 					rollout_kind:
 						appConfigNoDefaults.rollout_kind == "full_manual"

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -131,9 +131,7 @@ export function readPagesConfig(
 		throw new UserError(diagnostics.renderErrors());
 	}
 
-	logger.debug(
-		`Configuration file belonging to ⚡️ Pages ⚡️ project detected.`
-	);
+	logger.debug(`Configuration file belonging to ⚡️ Pages ⚡️ project detected.`);
 
 	const envNames = rawConfig.env ? Object.keys(rawConfig.env) : [];
 	const projectName = rawConfig?.name;

--- a/packages/wrangler/src/containers/config.ts
+++ b/packages/wrangler/src/containers/config.ts
@@ -123,7 +123,8 @@ export const getNormalizedContainerOptions = async (
 			rollout_step_percentage:
 				args?.containersRollout === "immediate"
 					? 100
-					: container.rollout_step_percentage ?? rolloutStepPercentageFallback,
+					: (container.rollout_step_percentage ??
+						rolloutStepPercentageFallback),
 			rollout_kind: container.rollout_kind ?? "full_auto",
 			rollout_active_grace_period: container.rollout_active_grace_period ?? 0,
 			observability: {

--- a/packages/wrangler/src/containers/deploy.ts
+++ b/packages/wrangler/src/containers/deploy.ts
@@ -347,7 +347,7 @@ export async function apply(
 	// however deployments that fail after push may result in no previous app but the image still existing
 	const imageRef =
 		"remoteDigest" in args.imageRef
-			? prevApp?.configuration.image ?? args.imageRef.remoteDigest
+			? (prevApp?.configuration.image ?? args.imageRef.remoteDigest)
 			: args.imageRef.newTag;
 	log(dim("Container application changes\n"));
 

--- a/packages/wrangler/src/core/CommandRegistry.ts
+++ b/packages/wrangler/src/core/CommandRegistry.ts
@@ -463,7 +463,7 @@ export class CommandRegistry {
 		const { subtree } =
 			node.definition.type !== "alias"
 				? node
-				: this.#findNodeFor(resolvedDef.command) ?? node;
+				: (this.#findNodeFor(resolvedDef.command) ?? node);
 
 		const definition: InternalDefinition = {
 			// take all properties from the resolved alias

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -183,7 +183,7 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 
 			await run(experimentalFlags, async () => {
 				const config =
-					def.behaviour?.provideConfig ?? true
+					(def.behaviour?.provideConfig ?? true)
 						? readConfig(args, {
 								hideWarnings: !(def.behaviour?.printConfigWarnings ?? true),
 								useRedirectIfAvailable:

--- a/packages/wrangler/src/d1/execute.ts
+++ b/packages/wrangler/src/d1/execute.ts
@@ -610,7 +610,7 @@ function logResult(r: QueryResult | QueryResult[]) {
 		? r
 				.map((d: QueryResult) => d.meta?.duration || 0)
 				.reduce((a, b) => a + b, 0)
-		: r.meta?.duration ?? 0;
+		: (r.meta?.duration ?? 0);
 
 	logger.log(`🚣 Executed ${commandsCount} in ${durationMs.toFixed(2)}ms`);
 }

--- a/packages/wrangler/src/deployment-bundle/apply-middleware.ts
+++ b/packages/wrangler/src/deployment-bundle/apply-middleware.ts
@@ -61,7 +61,7 @@ export async function applyMiddlewareLoaderFacade(
 	if (entry.format === "modules") {
 		await fs.promises.writeFile(
 			dynamicFacadePath,
-			dedent/*javascript*/ `
+			dedent /*javascript*/ `
 				import worker, * as OTHER_EXPORTS from "${prepareFilePath(entry.file)}";
 				${imports}
 
@@ -110,7 +110,7 @@ export async function applyMiddlewareLoaderFacade(
 
 		await fs.promises.writeFile(
 			dynamicFacadePath,
-			dedent/*javascript*/ `
+			dedent /*javascript*/ `
 				import { __facade_registerInternal__ } from "${prepareFilePath(loaderSwPath)}";
 				${imports}
 				__facade_registerInternal__([${middlewareFns}])

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -456,7 +456,7 @@ export function createWorkerUploadForm(
 						? source.contents
 						: readFileSync(source.path as string),
 				],
-				"path" in source ? source.path ?? name : name,
+				"path" in source ? (source.path ?? name) : name,
 				{ type: "application/wasm" }
 			)
 		);
@@ -549,7 +549,7 @@ export function createWorkerUploadForm(
 						? source.contents
 						: readFileSync(source.path as string),
 				],
-				"path" in source ? source.path ?? name : name,
+				"path" in source ? (source.path ?? name) : name,
 				{ type: "application/octet-stream" }
 			)
 		);

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
@@ -24,9 +24,8 @@ export function nodejsHybridPlugin({
 		async setup(build) {
 			// `unenv` and `@cloudflare/unenv-preset` only publish esm
 			const { defineEnv } = await import("unenv");
-			const { getCloudflarePreset, nonPrefixedNodeModules } = await import(
-				"@cloudflare/unenv-preset"
-			);
+			const { getCloudflarePreset, nonPrefixedNodeModules } =
+				await import("@cloudflare/unenv-preset");
 			const { alias, inject, external, polyfill } = defineEnv({
 				presets: [
 					getCloudflarePreset({

--- a/packages/wrangler/src/dev/create-worker-preview.ts
+++ b/packages/wrangler/src/dev/create-worker-preview.ts
@@ -106,7 +106,7 @@ function switchHost(
 	zonePreview: boolean
 ): URL {
 	const url = new URL(originalUrl);
-	url.hostname = zonePreview ? host ?? url.hostname : url.hostname;
+	url.hostname = zonePreview ? (host ?? url.hostname) : url.hostname;
 	return url;
 }
 
@@ -190,7 +190,7 @@ export async function createPreviewSession(
 	}>(complianceConfig, initUrl, undefined, undefined, abortSignal, apiToken);
 
 	const previewSessionToken = exchange_url
-		? (await tryExpandToken(exchange_url, ctx, abortSignal)) ?? token
+		? ((await tryExpandToken(exchange_url, ctx, abortSignal)) ?? token)
 		: token;
 
 	try {

--- a/packages/wrangler/src/dev/inspect.ts
+++ b/packages/wrangler/src/dev/inspect.ts
@@ -70,7 +70,7 @@ export function logConsoleMessage(
 					args.push(
 						ro.subtype === "null"
 							? "null"
-							: ro.description ?? "<no-description>"
+							: (ro.description ?? "<no-description>")
 					);
 				} else {
 					args.push(ro.preview.description ?? "<no-description>");

--- a/packages/wrangler/src/miniflare-cli/assets.ts
+++ b/packages/wrangler/src/miniflare-cli/assets.ts
@@ -148,9 +148,8 @@ async function generateAssetsFetch(
 	).default;
 	await polyfill();
 
-	const { generateHandler, parseQualityWeightedList } = await import(
-		"@cloudflare/pages-shared/asset-server/handler"
-	);
+	const { generateHandler, parseQualityWeightedList } =
+		await import("@cloudflare/pages-shared/asset-server/handler");
 
 	const headersFile = join(directory, "_headers");
 	const redirectsFile = join(directory, "_redirects");

--- a/packages/wrangler/src/output.ts
+++ b/packages/wrangler/src/output.ts
@@ -120,8 +120,7 @@ interface OutputEntryPagesDeployment extends OutputEntryBase<"pages-deploy"> {
 	url: string | undefined;
 }
 
-interface OutputEntryPagesDeploymentDetailed
-	extends OutputEntryBase<"pages-deploy-detailed"> {
+interface OutputEntryPagesDeploymentDetailed extends OutputEntryBase<"pages-deploy-detailed"> {
 	version: 1;
 	/** The name of the Pages project. */
 	pages_project: string | null;
@@ -161,8 +160,7 @@ interface OutputEntryVersionUpload extends OutputEntryBase<"version-upload"> {
 	wrangler_environment: string | undefined;
 }
 
-interface OutputEntryVersionDeployment
-	extends OutputEntryBase<"version-deploy"> {
+interface OutputEntryVersionDeployment extends OutputEntryBase<"version-deploy"> {
 	version: 1;
 	/** The name of the Worker. */
 	worker_name: string | null;

--- a/packages/wrangler/src/pipelines/types.ts
+++ b/packages/wrangler/src/pipelines/types.ts
@@ -31,8 +31,9 @@ export interface CloudflareAPIResponse<T> {
 	result: T;
 }
 
-export interface PipelineListResponse
-	extends CloudflareAPIResponse<Pipeline[]> {
+export interface PipelineListResponse extends CloudflareAPIResponse<
+	Pipeline[]
+> {
 	result_info: PaginationInfo;
 }
 

--- a/packages/wrangler/src/utils/getLegacyScriptName.ts
+++ b/packages/wrangler/src/utils/getLegacyScriptName.ts
@@ -11,5 +11,5 @@ export function getLegacyScriptName(
 ) {
 	return args.name && args.env && !useServiceEnvironments(config)
 		? `${args.name}-${args.env}`
-		: args.name ?? config.name;
+		: (args.name ?? config.name);
 }

--- a/packages/wrangler/src/utils/print-bindings.ts
+++ b/packages/wrangler/src/utils/print-bindings.ts
@@ -292,7 +292,7 @@ export function printBindings(
 					const value =
 						typeof database_id == "symbol"
 							? database_id
-							: preview_database_id ?? database_name ?? database_id;
+							: (preview_database_id ?? database_name ?? database_id);
 
 					return {
 						name: binding,
@@ -718,7 +718,9 @@ export function printBindings(
 
 		const maxValueLength = Math.max(
 			...output.map((b) =>
-				typeof b.value === "symbol" ? "inherited".length : b.value?.length ?? 0
+				typeof b.value === "symbol"
+					? "inherited".length
+					: (b.value?.length ?? 0)
 			)
 		);
 		const maxNameLength = Math.max(...output.map((b) => b.name.length));
@@ -765,7 +767,7 @@ export function printBindings(
 			const bindingValue = dim(
 				typeof binding.value === "symbol"
 					? chalk.italic("inherited")
-					: binding.value ?? ""
+					: (binding.value ?? "")
 			);
 			const bindingString = padEndAnsi(
 				`${white(`env.${binding.name}`)}${binding.value && !shouldWrap ? ` (${bindingValue})` : ""}`,

--- a/packages/wrangler/src/vectorize/types.ts
+++ b/packages/wrangler/src/vectorize/types.ts
@@ -174,8 +174,7 @@ export type VectorizeIndexDetails = {
 	processedUpToMutation: string;
 };
 
-export interface VectorizeMetadataIndexProperty
-	extends VectorizeMetadataIndexPropertyName {
+export interface VectorizeMetadataIndexProperty extends VectorizeMetadataIndexPropertyName {
 	/** Specifies the type of metadata property to index. */
 	indexType: VectorizeVectorMetadataValueString;
 }

--- a/packages/wrangler/templates/checked-fetch.js
+++ b/packages/wrangler/templates/checked-fetch.js
@@ -5,10 +5,8 @@ function checkURL(request, init) {
 		request instanceof URL
 			? request
 			: new URL(
-					(typeof request === "string"
-						? new Request(request, init)
-						: request
-					).url
+					(typeof request === "string" ? new Request(request, init) : request)
+						.url
 				);
 	if (url.port && url.port !== "443" && url.protocol === "https:") {
 		if (!urls.has(url.toString())) {

--- a/packages/wrangler/vitest.config.mts
+++ b/packages/wrangler/vitest.config.mts
@@ -49,7 +49,7 @@ function embedWorkersPlugin() {
 				this.addWatchFile(file);
 			}
 
-			return dedent/*javascript*/ `
+			return dedent /*javascript*/ `
 				export default ${absoluteScriptPath};
 			`;
 		},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,7 +139,7 @@ importers:
         version: 0.4.1
       '@ianvs/prettier-plugin-sort-imports':
         specifier: 4.2.1
-        version: 4.2.1(@vue/compiler-sfc@3.3.4)(prettier@3.2.5)
+        version: 4.2.1(@vue/compiler-sfc@3.3.4)(prettier@3.8.1)
       '@manypkg/cli':
         specifier: ^0.23.0
         version: 0.23.0
@@ -165,14 +165,14 @@ importers:
         specifier: catalog:default
         version: 3.2.0
       prettier:
-        specifier: ^3.2.5
-        version: 3.2.5
+        specifier: ^3.8.1
+        version: 3.8.1
       prettier-plugin-packagejson:
         specifier: ^2.2.18
-        version: 2.2.18(prettier@3.2.5)
+        version: 2.2.18(prettier@3.8.1)
       prettier-plugin-tailwindcss:
         specifier: ^0.7.2
-        version: 0.7.2(@ianvs/prettier-plugin-sort-imports@4.2.1(@vue/compiler-sfc@3.3.4)(prettier@3.2.5))(prettier@3.2.5)
+        version: 0.7.2(@ianvs/prettier-plugin-sort-imports@4.2.1(@vue/compiler-sfc@3.3.4)(prettier@3.8.1))(prettier@3.8.1)
       tree-kill:
         specifier: ^1.2.2
         version: 1.2.2
@@ -14138,19 +14138,9 @@ packages:
       prettier-plugin-svelte:
         optional: true
 
-  prettier@2.7.1:
-    resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
-    hasBin: true
-
-  prettier@3.2.5:
-    resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
-    engines: {node: '>=14'}
     hasBin: true
 
   prettier@3.8.1:
@@ -17530,7 +17520,7 @@ snapshots:
       '@changesets/types': 6.1.0
       fs-extra: 7.0.1
       human-id: 4.1.1
-      prettier: 2.7.1
+      prettier: 2.8.8
 
   '@chevrotain/cst-dts-gen@10.5.0':
     dependencies:
@@ -18767,14 +18757,14 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@ianvs/prettier-plugin-sort-imports@4.2.1(@vue/compiler-sfc@3.3.4)(prettier@3.2.5)':
+  '@ianvs/prettier-plugin-sort-imports@4.2.1(@vue/compiler-sfc@3.3.4)(prettier@3.8.1)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/generator': 7.26.3
       '@babel/parser': 7.26.3
       '@babel/traverse': 7.25.9
       '@babel/types': 7.26.3
-      prettier: 3.2.5
+      prettier: 3.8.1
       semver: 7.7.3
     optionalDependencies:
       '@vue/compiler-sfc': 3.3.4
@@ -26422,22 +26412,18 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-packagejson@2.2.18(prettier@3.2.5):
+  prettier-plugin-packagejson@2.2.18(prettier@3.8.1):
     dependencies:
-      prettier: 3.2.5
+      prettier: 3.8.1
       sort-package-json: 1.57.0
 
-  prettier-plugin-tailwindcss@0.7.2(@ianvs/prettier-plugin-sort-imports@4.2.1(@vue/compiler-sfc@3.3.4)(prettier@3.2.5))(prettier@3.2.5):
+  prettier-plugin-tailwindcss@0.7.2(@ianvs/prettier-plugin-sort-imports@4.2.1(@vue/compiler-sfc@3.3.4)(prettier@3.8.1))(prettier@3.8.1):
     dependencies:
-      prettier: 3.2.5
+      prettier: 3.8.1
     optionalDependencies:
-      '@ianvs/prettier-plugin-sort-imports': 4.2.1(@vue/compiler-sfc@3.3.4)(prettier@3.2.5)
-
-  prettier@2.7.1: {}
+      '@ianvs/prettier-plugin-sort-imports': 4.2.1(@vue/compiler-sfc@3.3.4)(prettier@3.8.1)
 
   prettier@2.8.8: {}
-
-  prettier@3.2.5: {}
 
   prettier@3.8.1: {}
 


### PR DESCRIPTION
Updates prettier from 3.2.5 to 3.8.1 and reformats the codebase.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: formatting-only change
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal tooling update
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
