### PR TITLE
Increase timeout for triage issue workflow to 60 minutes

### DIFF
--- a/.github/workflows/triage-issue.yml
+++ b/.github/workflows/triage-issue.yml
@@ -27,7 +27,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (!github.event.issue.pull_request &&
       github.event.issue.user.type != 'Bot')
-    timeout-minutes: 15
+    timeout-minutes: 60
     steps:
       - name: Resolve issue number
         id: issue


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
