### PR TITLE
[create-cloudflare] Updated C3 Hello World!/openapi dependencies to Chanfana 3 and Zod 4

### DIFF
--- a/.changeset/six-badgers-repair.md
+++ b/.changeset/six-badgers-repair.md
@@ -1,0 +1,8 @@
+---
+"create-cloudflare": major
+---
+
+C3 OpenAPI template zod dependency bumped to v4 and chanfana bumped to v3, with respective breaking changes fixed
+WHAT: Chanfana was updated and added Zodv4 support so why not just using that on the template
+WHY: Because the template used old deprecated syntax and anyone using it would need to migrate to Chanfana V3
+HOW: Not a dependency, just a template

--- a/packages/create-cloudflare/templates/openapi/ts/package.json
+++ b/packages/create-cloudflare/templates/openapi/ts/package.json
@@ -6,12 +6,13 @@
 		"deploy": "wrangler deploy",
 		"dev": "wrangler dev",
 		"start": "wrangler dev",
-		"cf-typegen": "wrangler types"
+		"cf-typegen": "wrangler types",
+		"openapi": "chanfana"
 	},
 	"dependencies": {
-		"chanfana": "^2.6.3",
+		"chanfana": "^3.3.0",
 		"hono": "^4.6.20",
-		"zod": "^3.24.1"
+		"zod": "^4.3.6"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20250129.0",

--- a/packages/create-cloudflare/templates/openapi/ts/src/endpoints/taskCreate.ts
+++ b/packages/create-cloudflare/templates/openapi/ts/src/endpoints/taskCreate.ts
@@ -1,4 +1,4 @@
-import { Bool, OpenAPIRoute } from "chanfana";
+import { OpenAPIRoute } from "chanfana";
 import { z } from "zod";
 import { type AppContext, Task } from "../types";
 
@@ -22,7 +22,7 @@ export class TaskCreate extends OpenAPIRoute {
 					"application/json": {
 						schema: z.object({
 							series: z.object({
-								success: Bool(),
+								success: z.boolean(),
 								result: z.object({
 									task: Task,
 								}),

--- a/packages/create-cloudflare/templates/openapi/ts/src/endpoints/taskDelete.ts
+++ b/packages/create-cloudflare/templates/openapi/ts/src/endpoints/taskDelete.ts
@@ -1,4 +1,4 @@
-import { Bool, OpenAPIRoute, Str } from "chanfana";
+import { OpenAPIRoute } from "chanfana";
 import { z } from "zod";
 import { type AppContext, Task } from "../types";
 
@@ -8,7 +8,7 @@ export class TaskDelete extends OpenAPIRoute {
 		summary: "Delete a Task",
 		request: {
 			params: z.object({
-				taskSlug: Str({ description: "Task slug" }),
+				taskSlug: z.string().describe("Task slug"),
 			}),
 		},
 		responses: {
@@ -18,7 +18,7 @@ export class TaskDelete extends OpenAPIRoute {
 					"application/json": {
 						schema: z.object({
 							series: z.object({
-								success: Bool(),
+								success: z.boolean(),
 								result: z.object({
 									task: Task,
 								}),

--- a/packages/create-cloudflare/templates/openapi/ts/src/endpoints/taskFetch.ts
+++ b/packages/create-cloudflare/templates/openapi/ts/src/endpoints/taskFetch.ts
@@ -1,4 +1,4 @@
-import { Bool, OpenAPIRoute, Str } from "chanfana";
+import { OpenAPIRoute } from "chanfana";
 import { z } from "zod";
 import { type AppContext, Task } from "../types";
 
@@ -8,7 +8,7 @@ export class TaskFetch extends OpenAPIRoute {
 		summary: "Get a single Task by slug",
 		request: {
 			params: z.object({
-				taskSlug: Str({ description: "Task slug" }),
+				taskSlug: z.string().describe("Task slug"),
 			}),
 		},
 		responses: {
@@ -18,7 +18,7 @@ export class TaskFetch extends OpenAPIRoute {
 					"application/json": {
 						schema: z.object({
 							series: z.object({
-								success: Bool(),
+								success: z.boolean(),
 								result: z.object({
 									task: Task,
 								}),
@@ -33,8 +33,8 @@ export class TaskFetch extends OpenAPIRoute {
 					"application/json": {
 						schema: z.object({
 							series: z.object({
-								success: Bool(),
-								error: Str(),
+								success: z.boolean(),
+								error: z.string(),
 							}),
 						}),
 					},

--- a/packages/create-cloudflare/templates/openapi/ts/src/endpoints/taskList.ts
+++ b/packages/create-cloudflare/templates/openapi/ts/src/endpoints/taskList.ts
@@ -1,4 +1,4 @@
-import { Bool, Num, OpenAPIRoute } from "chanfana";
+import { OpenAPIRoute } from "chanfana";
 import { z } from "zod";
 import { type AppContext, Task } from "../types";
 
@@ -8,14 +8,8 @@ export class TaskList extends OpenAPIRoute {
 		summary: "List Tasks",
 		request: {
 			query: z.object({
-				page: Num({
-					description: "Page number",
-					default: 0,
-				}),
-				isCompleted: Bool({
-					description: "Filter by completed flag",
-					required: false,
-				}),
+				page: z.number().int().default(0).describe("Page number"),
+				isCompleted: z.boolean().optional().describe("Filter by completed flag"),
 			}),
 		},
 		responses: {
@@ -25,7 +19,7 @@ export class TaskList extends OpenAPIRoute {
 					"application/json": {
 						schema: z.object({
 							series: z.object({
-								success: Bool(),
+								success: z.boolean(),
 								result: z.object({
 									tasks: Task.array(),
 								}),

--- a/packages/create-cloudflare/templates/openapi/ts/src/types.ts
+++ b/packages/create-cloudflare/templates/openapi/ts/src/types.ts
@@ -1,13 +1,12 @@
-import { DateTime, Str } from "chanfana";
 import type { Context } from "hono";
 import { z } from "zod";
 
 export type AppContext = Context<{ Bindings: Env }>;
 
 export const Task = z.object({
-	name: Str({ example: "lorem" }),
-	slug: Str(),
-	description: Str({ required: false }),
+	name: z.string().openapi({ example: "lorem" }),
+	slug: z.string(),
+	description: z.string().optional(),
 	completed: z.boolean().default(false),
-	due_date: DateTime(),
+	due_date: z.iso.datetime(),
 });


### PR DESCRIPTION
Fixes #[insert GH or internal issue link(s)].

_Describe your change..._

I've been doing some deployments using wrangler and i noticed the template used old Chanfana dependencies which does not reflect new advancements on the libraries, which both have deprecated symbols and newer Zod support, which i upped to v4. Also i restrained myself from upping Hono tho

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: Version bump
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: It's just a version bump

*A picture of a cute animal (not mandatory, but encouraged)*

![Ur8qw9UJEhNuw](https://github.com/user-attachments/assets/836a2fa6-74d8-4dde-aa0b-7dab6fec712c)

Im not a PR guy btw so sorry beforehand, **im clueless about changesets but i included the required one just in case, albeit it might not be necessary since it does not really impact ANY of the behaviour of the workers-sdk**
<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
