### PR TITLE
[wrangler] Fix e2e flakes in startWorker, deployments, and containers tests

### DIFF
--- a/packages/wrangler/e2e/deployments.test.ts
+++ b/packages/wrangler/e2e/deployments.test.ts
@@ -388,7 +388,10 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("Workers + Assets deployment", () => {
 			// note that with a user worker, the request must be passed back to the asset worker via the ASSET binding
 			// in order to return the 404 page
 			const { text } = await retry(
-				(s) => s.status !== 404,
+				// Retry while the status isn't 404 OR the content hasn't propagated yet.
+				// Before assets are live the platform may return its own 404 page (status 200)
+				// instead of the user's 404.html asset.
+				(s) => s.status !== 404 || !s.text.includes("<h1>404.html</h1>"),
 				async () => {
 					const r = await fetch(new URL("/try-404", deployedUrl));
 					const temp = { text: await r.text(), status: r.status };
@@ -771,7 +774,10 @@ Current Version ID: 00000000-0000-0000-0000-000000000000`);
 			// the asset worker via the ASSET binding in order to return the 404
 			// page
 			const { text } = await retry(
-				(s) => s.status !== 404,
+				// Retry while the status isn't 404 OR the content hasn't propagated yet.
+				// Before assets are live the platform may return its own 404 page (status 200)
+				// instead of the user's 404.html asset.
+				(s) => s.status !== 404 || !s.text.includes("<h1>404.html</h1>"),
 				async () => {
 					const r = await fetch(new URL("/try-404", deployedUrl));
 					const temp = { text: await r.text(), status: r.status };
@@ -959,7 +965,7 @@ describe.skipIf(skipContainersTest)("containers", () => {
 			`wrangler containers delete ${applicationId}`
 		);
 		await Promise.allSettled([deleteWorker, deleteContainer]);
-	});
+	}, 30_000);
 
 	it(
 		"won't rebuild unchanged containers",

--- a/packages/wrangler/e2e/startWorker.test.ts
+++ b/packages/wrangler/e2e/startWorker.test.ts
@@ -398,7 +398,9 @@ describe("DevEnv", { sequential: true }, () => {
 			`,
 			});
 
-			await waitFor(async () => {
+			// In remote mode the edge needs time to propagate the new bundle,
+			// so use the longer polling timeout.
+			await waitForLong(async () => {
 				// test liveReload does nothing when the response Content-Type is not html
 				res = await worker.fetch("http://dummy");
 				resText = await res.text();
@@ -423,7 +425,7 @@ describe("DevEnv", { sequential: true }, () => {
 				},
 			});
 
-			await waitFor(async () => {
+			await waitForLong(async () => {
 				// test liveReload: false does nothing even when the response Content-Type is html
 				res = await worker.fetch("http://dummy");
 				resText = await res.text();


### PR DESCRIPTION
## Summary

Four targeted fixes for recurring e2e test flakes:

### 1. `startWorker.test.ts > liveReload (remote: true)` — stale response body

After seeding new code the test polls `worker.fetch()` via `waitFor` (5s). In remote mode the edge preview needs more time to propagate. Switched both post-reload assertions to `waitForLong` (10s), matching the convention for remote reload assertions.

### 2. `deployments.test.ts > Workers+Assets > deploys a Worker with static assets and user Worker` (and Workers for Platforms variant) — wrong 404 page content

Both tests use `retry(s => s.status !== 404, ...)` to wait for the `/try-404` path to serve the user's `404.html` asset. Before assets propagate the platform returns its own 404 HTML page with a **200** status — so `retry` exits immediately with the wrong content. Expanded the retry condition to also check the response body:

```ts
(s) => s.status !== 404 || !s.text.includes("<h1>404.html</h1>")
```

### 3. `deployments.test.ts > containers` — `afterAll` hook timed out in 10000ms

The `afterAll` runs `wrangler delete` and `wrangler containers delete` concurrently. On slow CI runners the 10s default vitest `hookTimeout` isn't enough. Increased to 30s via `afterAll(fn, 30_000)`.

### 4. `pages-dev.test.ts` — port conflicts and bare fetch calls

- **Removed module-level `getPort()`**: two ports were allocated once and reused across all 20+ sequential tests. On Linux, TCP TIME_WAIT (up to 60s) caused `EADDRINUSE` when test N's worker was still dying as test N+1 tried to bind the same port. The `getWranglerCommand` helper already auto-appends `--port 0 --inspector-port 0` for `wrangler pages dev` (OS assigns port at bind time, no race).
- **Wrapped all bare `fetchText`/`fetch` calls** after `waitForReady` and `waitForReload` in `waitForLong` (10s, 500ms poll). The port being open doesn't guarantee the first request will succeed; the reload log appearing doesn't guarantee the new handler is live.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: test infrastructure only