### PR TITLE
[miniflare] Fix mixed kvNamespaces and d1Databases records

### DIFF
--- a/.changeset/fix-mixed-d1-databases.md
+++ b/.changeset/fix-mixed-d1-databases.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+fix: allow mixed `d1Databases` records containing both string and object entries
+
+Previously, passing a `d1Databases` config that mixed plain string values and object entries (e.g. `{ MY_DB: "db-name", OTHER_DB: { id: "...", remoteProxyConnectionString: ... } }`) would cause Miniflare to throw an error. Both forms are now accepted and normalised correctly.

--- a/.changeset/fix-mixed-kv-namespaces.md
+++ b/.changeset/fix-mixed-kv-namespaces.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+fix: allow mixed `kvNamespaces` records containing both string and object entries
+
+Previously, passing a `kvNamespaces` config that mixed plain string values and object entries (e.g. `{ MY_NS: "ns-name", OTHER_NS: { id: "...", remoteProxyConnectionString: ... } }`) would cause Miniflare to throw an error. Both forms are now accepted and normalised correctly.

--- a/packages/miniflare/src/plugins/d1/index.ts
+++ b/packages/miniflare/src/plugins/d1/index.ts
@@ -27,14 +27,16 @@ import {
 export const D1OptionsSchema = z.object({
 	d1Databases: z
 		.union([
-			z.record(z.string()),
 			z.record(
-				z.object({
-					id: z.string(),
-					remoteProxyConnectionString: z
-						.custom<RemoteProxyConnectionString>()
-						.optional(),
-				})
+				z.union([
+					z.string(),
+					z.object({
+						id: z.string(),
+						remoteProxyConnectionString: z
+							.custom<RemoteProxyConnectionString>()
+							.optional(),
+					}),
+				])
 			),
 			z.string().array(),
 		])

--- a/packages/miniflare/src/plugins/kv/index.ts
+++ b/packages/miniflare/src/plugins/kv/index.ts
@@ -34,14 +34,16 @@ import {
 export const KVOptionsSchema = z.object({
 	kvNamespaces: z
 		.union([
-			z.record(z.string()),
 			z.record(
-				z.object({
-					id: z.string(),
-					remoteProxyConnectionString: z
-						.custom<RemoteProxyConnectionString>()
-						.optional(),
-				})
+				z.union([
+					z.string(),
+					z.object({
+						id: z.string(),
+						remoteProxyConnectionString: z
+							.custom<RemoteProxyConnectionString>()
+							.optional(),
+					}),
+				])
 			),
 			z.string().array(),
 		])

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -149,6 +149,29 @@ test("Miniflare: accepts mixed r2Buckets record", () => {
 	useDispose(mf);
 });
 
+test("Miniflare: accepts mixed kvNamespaces record", () => {
+	const mf = new Miniflare({
+		modules: true,
+		script: "",
+		kvNamespaces: {
+			LOCAL_NS: "local-ns",
+			REMOTE_NS: { id: "remote-ns" },
+		},
+	});
+	useDispose(mf);
+});
+
+test("Miniflare: accepts mixed d1Databases record", () => {
+	const mf = new Miniflare({
+		modules: true,
+		script: "",
+		d1Databases: {
+			LOCAL_DB: "local-db",
+			REMOTE_DB: { id: "remote-db" },
+		},
+	});
+	useDispose(mf);
+});
 test("Miniflare: ready returns copy of entry URL", async ({ expect }) => {
 	const mf = new Miniflare({
 		port: 0,


### PR DESCRIPTION
Fixes the same schema validation bug as was fixed for `r2Buckets` — `kvNamespaces` and `d1Databases` bindings could not mix plain string values and object values in the same record.

Previously, passing a config like:

```ts
new Miniflare({
  kvNamespaces: {
    LOCAL_NS: "local-ns",
    REMOTE_NS: { id: "remote-ns", remoteProxyConnectionString: ... },
  },
})
```

would throw a Zod validation error because the schema used two separate `z.record(...)` union branches — one accepting only strings, one accepting only objects. Zod would fail both branches when the values were mixed.

The fix collapses the two `z.record(...)` branches into a single `z.record(z.union([z.string(), z.object({...})]))`, matching the pattern already applied to `r2Buckets`. The `namespaceEntries()` helper in `plugins/shared` already handled mixed values correctly at runtime — only the schema validation was too restrictive.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is a bug fix for an internal schema validation constraint; no public API surface changed

*A picture of a cute animal (not mandatory, but encouraged)*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
