### PR TITLE
[miniflare] Fix mixed pipelines records

### DIFF
--- a/.changeset/fix-mixed-pipelines.md
+++ b/.changeset/fix-mixed-pipelines.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+fix: allow mixed `pipelines` records containing both string and object entries
+
+Previously, passing a `pipelines` config that mixed plain string values and object entries (e.g. `{ MY_PIPELINE: "pipeline-name", OTHER_PIPELINE: { pipeline: "...", remoteProxyConnectionString: ... } }`) would cause Miniflare to throw an error. Both forms are now accepted and normalised correctly.

--- a/packages/miniflare/src/plugins/pipelines/index.ts
+++ b/packages/miniflare/src/plugins/pipelines/index.ts
@@ -12,16 +12,18 @@ import {
 export const PipelineOptionsSchema = z.object({
 	pipelines: z
 		.union([
-			z.record(z.string()),
-			z.string().array(),
 			z.record(
-				z.object({
-					pipeline: z.string(),
-					remoteProxyConnectionString: z
-						.custom<RemoteProxyConnectionString>()
-						.optional(),
-				})
+				z.union([
+					z.string(),
+					z.object({
+						pipeline: z.string(),
+						remoteProxyConnectionString: z
+							.custom<RemoteProxyConnectionString>()
+							.optional(),
+					}),
+				])
 			),
+			z.string().array(),
 		])
 		.optional(),
 });
@@ -76,13 +78,13 @@ function bindingEntries(
 	namespaces?:
 		| Record<
 				string,
-				{
-					pipeline: string;
-					remoteProxyConnectionString?: RemoteProxyConnectionString;
-				}
+				| string
+				| {
+						pipeline: string;
+						remoteProxyConnectionString?: RemoteProxyConnectionString;
+				  }
 		  >
 		| string[]
-		| Record<string, string>
 ): [
 	bindingName: string,
 	{ id: string; remoteProxyConnectionString?: RemoteProxyConnectionString },

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -172,6 +172,18 @@ test("Miniflare: accepts mixed d1Databases record", () => {
 	});
 	useDispose(mf);
 });
+
+test("Miniflare: accepts mixed pipelines record", () => {
+	const mf = new Miniflare({
+		modules: true,
+		script: "",
+		pipelines: {
+			LOCAL_PIPELINE: "local-pipeline",
+			REMOTE_PIPELINE: { pipeline: "remote-pipeline" },
+		},
+	});
+	useDispose(mf);
+});
 test("Miniflare: ready returns copy of entry URL", async ({ expect }) => {
 	const mf = new Miniflare({
 		port: 0,


### PR DESCRIPTION
Fixes the same schema validation bug as was fixed for `r2Buckets`, `kvNamespaces`, and `d1Databases` — `pipelines` bindings could not mix plain string values and object values in the same record.

Previously, passing a config like:

```ts
new Miniflare({
  pipelines: {
    LOCAL_PIPELINE: "local-pipeline",
    REMOTE_PIPELINE: { pipeline: "remote-pipeline", remoteProxyConnectionString: ... },
  },
})
```

would throw a Zod validation error because the schema used two separate `z.record(...)` union branches — one accepting only strings, one accepting only objects. Zod would fail both branches when the values were mixed.

The fix collapses the two `z.record(...)` branches into a single `z.record(z.union([z.string(), z.object({...})]))`, matching the pattern already applied to `r2Buckets`. The `bindingEntries()` local helper already handled mixed values correctly at runtime (`typeof opts === "string"`) — only the schema validation was too restrictive. The helper's TypeScript parameter type has also been updated to reflect the new union.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is a bug fix for an internal schema validation constraint; no public API surface changed

*A picture of a cute animal (not mandatory, but encouraged)*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/12987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
