### PR TITLE
[miniflare] Fix requests failing after 5 minutes due to undici Pool default timeouts

### DIFF
--- a/.changeset/miniflare-disable-pool-timeouts.md
+++ b/.changeset/miniflare-disable-pool-timeouts.md
@@ -1,0 +1,9 @@
+---
+"miniflare": patch
+---
+
+fix: disable undici Pool request timeouts for local dev
+
+Miniflare's undici `Pool` instances were using the default `headersTimeout` and `bodyTimeout` of 300 seconds (5 minutes). Any request taking longer than that — streaming responses, large uploads, long-polling, or compute-heavy Workers — would be silently killed with a "request failed" error.
+
+Setting both timeouts to `0` disables them entirely, which is the correct behaviour for a local development tool where there is no reason to enforce request timeouts.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -2143,6 +2143,10 @@ export class Miniflare {
 		if (previousEntryURL?.toString() !== this.#runtimeEntryURL.toString()) {
 			this.#runtimeDispatcher = new Pool(this.#runtimeEntryURL, {
 				connect: { rejectUnauthorized: false },
+				// Disable timeouts for local dev — long-running responses (streaming,
+				// slow uploads, long-polling) should not be killed by undici defaults.
+				headersTimeout: 0,
+				bodyTimeout: 0,
 			});
 		}
 		if (this.#proxyClient === undefined) {

--- a/packages/miniflare/src/plugins/core/proxy/fetch-sync.ts
+++ b/packages/miniflare/src/plugins/core/proxy/fetch-sync.ts
@@ -54,6 +54,10 @@ port.addEventListener("message", async (event) => {
     dispatcherUrl = url;
     dispatcher = new Pool(url, {
       connect: { rejectUnauthorized: false },
+      // Disable timeouts for local dev — long-running responses (streaming,
+      // slow uploads, long-polling) should not be killed by undici defaults.
+      headersTimeout: 0,
+      bodyTimeout: 0,
     });
   }
   headers["${CoreHeaders.OP_SYNC}"] = "true";


### PR DESCRIPTION
Fixes #12949.

Miniflare's two `undici` `Pool` instances (the main runtime dispatcher in `index.ts` and the sync proxy dispatcher in `fetch-sync.ts`) were created without any timeout configuration, causing them to silently inherit undici's default `headersTimeout` and `bodyTimeout` of 300,000 ms (5 minutes).

Any request taking longer than 5 minutes — streaming responses, large uploads, long-polling, or compute-heavy Workers — would be killed by undici with a "request failed" error.

Setting both timeouts to `0` disables them entirely. This is the correct behaviour for a local development tool, and is consistent with the existing pattern in `dev-registry.worker.ts` where Node.js HTTP server timeouts are explicitly disabled for the same reason (long-lived WebSocket connections).

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this changes timeout defaults that are not exercised by the existing test suite (no test runs for >5 minutes), and the fix is a straightforward configuration change consistent with existing patterns in the codebase.
- Public documentation
  - [x] Documentation not necessary because: internal implementation detail, no user-facing API change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
