### PR TITLE
[containers-shared] Fix Docker spawn opening console windows on Windows

### DIFF
--- a/.changeset/fix-windows-docker-console-windows.md
+++ b/.changeset/fix-windows-docker-console-windows.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: prevent Docker container builds from spawning console windows on Windows
+
+On Windows, `detached: true` in `child_process.spawn()` gives each child process its own visible console window, causing many windows to flash open during `wrangler deploy` with `[[containers]]`. The `detached` option is now only set on non-Windows platforms (where it is needed for process group cleanup), and `windowsHide: true` is added to further suppress console windows on Windows.

--- a/packages/containers-shared/src/build.ts
+++ b/packages/containers-shared/src/build.ts
@@ -58,9 +58,14 @@ export function dockerBuild(
 	const child = spawn(dockerPath, options.buildCmd, {
 		stdio: ["pipe", "inherit", "inherit"],
 		// We need to set detached to true so that the child process
-		// will control all of its child processed and we can kill
-		// all of them in case we need to abort the build process
-		detached: true,
+		// will control all of its child processes and we can kill
+		// all of them in case we need to abort the build process.
+		// On Windows, detached: true opens a new console window per child
+		// process, so we only set it on non-Windows platforms.
+		detached: process.platform !== "win32",
+		// Prevent child processes from opening visible console windows on Windows.
+		// This is a no-op on non-Windows platforms.
+		windowsHide: true,
 	});
 	if (child.stdin !== null) {
 		child.stdin.write(options.dockerfile);
@@ -85,8 +90,15 @@ export function dockerBuild(
 		abort: () => {
 			child.unref();
 			if (child.pid !== undefined) {
-				// kill run on the negative PID kills the whole group controlled by the child process
-				process.kill(-child.pid);
+				if (process.platform === "win32") {
+					// On Windows, negative-PID process group kill is not supported.
+					// Kill the child process directly instead.
+					child.kill();
+				} else {
+					// Kill using the negative PID to terminate the whole process group
+					// controlled by the child process.
+					process.kill(-child.pid);
+				}
 			}
 		},
 		ready,

--- a/packages/containers-shared/src/utils.ts
+++ b/packages/containers-shared/src/utils.ts
@@ -26,9 +26,14 @@ export const runDockerCmd = (
 	const child = spawn(dockerPath, args, {
 		stdio: stdio ?? "inherit",
 		// We need to set detached to true so that the child process
-		// will control all of its child processed and we can kill
-		// all of them in case we need to abort the build process
-		detached: true,
+		// will control all of its child processes and we can kill
+		// all of them in case we need to abort the build process.
+		// On Windows, detached: true opens a new console window per child
+		// process, so we only set it on non-Windows platforms.
+		detached: process.platform !== "win32",
+		// Prevent child processes from opening visible console windows on Windows.
+		// This is a no-op on non-Windows platforms.
+		windowsHide: true,
 	});
 	let errorHandled = false;
 
@@ -51,8 +56,15 @@ export const runDockerCmd = (
 			aborted = true;
 			child.unref();
 			if (child.pid !== undefined) {
-				// kill run on the negative PID kills the whole group controlled by the child process
-				process.kill(-child.pid);
+				if (process.platform === "win32") {
+					// On Windows, negative-PID process group kill is not supported.
+					// Kill the child process directly instead.
+					child.kill();
+				} else {
+					// Kill using the negative PID to terminate the whole process group
+					// controlled by the child process.
+					process.kill(-child.pid);
+				}
 			}
 		},
 		ready,


### PR DESCRIPTION
Fixes #12963.

When running `wrangler deploy` on Windows with `[[containers]]` configured, the Docker build step spawns numerous console windows that flash open during the build process.

This is caused by `detached: true` in `child_process.spawn()` calls — on Windows, `detached: true` gives each child process its own visible console window ([Node.js docs](https://nodejs.org/api/child_process.html#optionsdetached)).

The fix:
- Sets `detached` conditionally: `true` on Unix/macOS (needed for process group cleanup via `process.kill(-pid)`), `false` on Windows
- Adds `windowsHide: true` to further suppress console windows on Windows (no-op on other platforms)
- Guards the `process.kill(-child.pid)` abort logic with a platform check: uses `child.kill()` on Windows since negative-PID process group kill is a Unix-only concept

Both `dockerBuild()` in `build.ts` and `runDockerCmd()` in `utils.ts` are updated.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: This is a platform-specific behavior change (Windows `detached` and `windowsHide` options). Existing tests pass. The behavior difference is only observable on Windows with Docker Desktop, which cannot be tested in CI. The logic change is minimal and well-documented in Node.js docs.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is a bug fix with no user-facing API changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
