### PR TITLE
[ci] Run fixture tests in parallel with package tests

### DIFF
--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -75,13 +75,20 @@ jobs:
   test:
     timeout-minutes: 60
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-test
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.suite }}-test
       cancel-in-progress: true
 
-    name: ${{ format('Tests ({0})', matrix.description) }}
+    name: ${{ format('Tests ({0}, {1})', matrix.description, matrix.suite) }}
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+        suite:
+          - packages-and-tools
+          - fixtures
         include:
           - os: macos-latest
             description: macOS
@@ -122,7 +129,7 @@ jobs:
 
       - name: Run tests (tools only)
         # tools _only_ needs to be tested on Linux because they're only intended to run in CI
-        if: steps.changes.outputs.everything_but_markdown == 'true' && matrix.os == 'ubuntu-latest'
+        if: steps.changes.outputs.everything_but_markdown == 'true' && matrix.suite == 'packages-and-tools' && matrix.os == 'ubuntu-latest'
         run: pnpm run test:ci --log-order=stream --filter="@cloudflare/tools"
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
@@ -130,9 +137,7 @@ jobs:
           CI_OS: ${{ matrix.description }}
 
       - name: Run tests (packages)
-        # We are running the package tests first be able to get early feedback on changes.
-        # There is no point in running the fixtures if a package is broken.
-        if: steps.changes.outputs.everything_but_markdown == 'true'
+        if: steps.changes.outputs.everything_but_markdown == 'true' && matrix.suite == 'packages-and-tools'
         # We skip @cloudflare/vitest-pool-workers tests in CI on Windows because they're very flaky. We still run the vitest-pool-workers-examples fixture, which is a comprehensive set of example tests and gives us a lot of confidence.
         # The @cloudflare/vitest-pool-workers tests skipped are things like watch mode, which constantly times out probably due to the github runners in use.
         run: pnpm run test:ci --log-order=stream --concurrency=1 --filter="./packages/*" ${{ matrix.os == 'windows-latest' && '--filter="!./packages/vitest-pool-workers"' || '' }}
@@ -143,7 +148,7 @@ jobs:
           CI_OS: ${{ matrix.description }}
 
       - name: Run tests (fixtures)
-        if: steps.changes.outputs.everything_but_markdown == 'true'
+        if: steps.changes.outputs.everything_but_markdown == 'true' && matrix.suite == 'fixtures'
         # Browser rendering is disabled on Ubuntu because of https://pptr.dev/troubleshooting#issues-with-apparmor-on-ubuntu
         run: pnpm run test:ci --concurrency 1 --log-order=stream --filter="./fixtures/*" ${{ matrix.os == 'ubuntu-latest' && '--filter="!./fixtures/browser-rendering"' || '' }}
         env:
@@ -156,5 +161,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: turbo-runs-${{ matrix.os }}
+          name: turbo-runs-${{ matrix.os }}-${{ matrix.suite }}
           path: .turbo/runs


### PR DESCRIPTION
_Expand the `test` job's matrix with a `suite` dimension so fixture tests run concurrently with package/tools tests, rather than sequentially after them._

Previously the `test` job ran three steps in sequence on each of the 3 OS runners:
1. tools tests (Linux only)
2. packages tests
3. fixtures tests

This meant fixtures couldn't start until all package tests had finished. By adding a `suite` dimension (`packages-and-tools` | `fixtures`) to the existing OS matrix, the workflow now spawns **6 runners** (3 OS × 2 suites) all running concurrently, cutting the critical path roughly in half for fixture-heavy runs.

Changes:
- Added `suite` matrix dimension alongside the existing `os` dimension
- Scoped each test step's `if` condition to the relevant suite
- Updated the concurrency group key and artifact name to include `matrix.suite` to avoid collisions between the two suites on the same OS

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this is a CI workflow restructuring with no code changes — correctness is verified by the workflow itself running

- Public documentation
  - [x] Documentation not necessary because: internal CI change only

*A picture of a cute animal (not mandatory, but encouraged)*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
