### PR TITLE
BRAPI-1018: Add missing browser rendering endpoints (devtools, history, limits)

### DIFF
--- a/.changeset/browser-rendering-devtools-endpoints.md
+++ b/.changeset/browser-rendering-devtools-endpoints.md
@@ -1,0 +1,24 @@
+---
+"miniflare": minor
+---
+
+Add missing devtools endpoints to browser rendering local binding.
+
+The local browser rendering binding now implements the full set of devtools endpoints, matching the remote Browser Rendering API:
+
+- `GET /v1/limits` — returns local concurrency defaults
+- `GET /v1/history` — returns empty array (no persistence in local dev)
+- `GET /v1/devtools/session` - list and inspect active sessions
+- `GET /v1/devtools/session/:id` — list and inspect active session
+- `GET /v1/devtools/browser/:id/json/version` — Browser version metadata, includes webSocketDebuggerUrl
+- `GET /v1/devtools/browser/:id/json/list` — A list of all available websocket targets
+- `GET /v1/devtools/browser/:id/json` — Alias for `GET /v1/devtools/browser/:id/json`
+- `GET /v1/devtools/browser/:id/json/protocol` — The current devtools protocol, as JSON. Includes webSocketDebuggerUrl and devtoolsFrontendUrl
+- `PUT /v1/devtools/browser/:id/json/new` — Opens a new tab. Responds with the websocket target data for the new tab
+- `GET /v1/devtools/browser/:id/json/activate/:target` — Brings a page into the foreground (activate a tab)
+- `GET /v1/devtools/browser/:id/json/close/:target` — Closes the target page identified by targetId
+- `GET /v1/devtools/browser/:id/page/:target` — WebSocket connection to a page target
+- `GET /v1/devtools/browser/:id` — WebSocket connection to a previously acquired browser session
+- `DELETE /v1/devtools/browser/:id` — Closes a browser session
+- `POST /v1/devtools/browser` — Acquires a new session
+- `GET /v1/devtools/browser` — Acquire a new session and connect via WebSocket in one step, returning `cf-browser-session-id` header

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1334,6 +1334,19 @@ export class Miniflare {
 				assert(sessionId !== null, "Missing sessionId query parameter");
 				const process = this.#browserProcesses.get(sessionId);
 				response = new Response(null, { status: process ? 200 : 410 });
+			} else if (url.pathname === "/browser/close") {
+				const sessionId = url.searchParams.get("sessionId");
+				assert(sessionId !== null, "Missing sessionId query parameter");
+				const browserProcess = this.#browserProcesses.get(sessionId);
+				if (!browserProcess) {
+					response = new Response("Session not found", { status: 404 });
+				} else {
+					this.#browserProcesses.delete(sessionId);
+					await browserProcess.close().catch(() => {
+						// oh well, process might already be dead
+					});
+					response = new Response(null, { status: 200 });
+				}
 			} else if (url.pathname === "/browser/sessionIds") {
 				const sessionIds = this.#browserProcesses.keys();
 				response = Response.json(Array.from(sessionIds));

--- a/packages/miniflare/src/workers/browser-rendering/binding.worker.ts
+++ b/packages/miniflare/src/workers/browser-rendering/binding.worker.ts
@@ -1,15 +1,27 @@
 import assert from "node:assert";
-import { DurableObject } from "cloudflare:workers";
-import { CoreBindings } from "../core/constants";
+import {
+	DELETE,
+	GET,
+	HttpError,
+	MiniflareDurableObject,
+	MiniflareDurableObjectCf,
+	MiniflareDurableObjectEnv,
+	POST,
+	PUT,
+	RouteHandler,
+	Router,
+	SharedBindings,
+	TimerHandle,
+} from "miniflare:shared";
 import type { Fetcher } from "@cloudflare/workers-types/experimental";
 
-interface Env {
-	[CoreBindings.SERVICE_LOOPBACK]: Fetcher;
-	BrowserSession: DurableObjectNamespace<BrowserSession>;
+interface BrowserSessionEnv extends MiniflareDurableObjectEnv {
+	[SharedBindings.MAYBE_SERVICE_LOOPBACK]: Fetcher;
 }
 
-function isClosed(ws: WebSocket | undefined): boolean {
-	return !ws || ws.readyState === WebSocket.CLOSED;
+interface Env {
+	[SharedBindings.MAYBE_SERVICE_LOOPBACK]: Fetcher;
+	BrowserSession: DurableObjectNamespace;
 }
 
 export type SessionInfo = {
@@ -20,22 +32,91 @@ export type SessionInfo = {
 	connectionStartTime?: number;
 };
 
-export class BrowserSession extends DurableObject<Env> {
-	sessionInfo?: SessionInfo;
-	ws?: WebSocket;
-	server?: WebSocket;
+function isClosed(ws: WebSocket | undefined): boolean {
+	return !ws || ws.readyState === WebSocket.CLOSED;
+}
 
-	async fetch(_request: Request) {
+function chromeBaseUrl(wsEndpoint: string): string {
+	const u = new URL(wsEndpoint.replace("ws://", "http://"));
+	return `http://${u.host}`;
+}
+
+// Reserved codes 1005 (No Status Received) and 1006 (Abnormal Closure) are
+// valid in CloseEvent but throw InvalidAccessError when passed to .close().
+function forwardClose(target?: WebSocket, e?: CloseEvent) {
+	if (!target) {
+		return;
+	}
+	if (!e?.code || e?.code === 1005 || e?.code === 1006) {
+		target.close();
+	} else {
+		target.close(e.code, e.reason);
+	}
+}
+
+export class BrowserSession extends MiniflareDurableObject<BrowserSessionEnv> {
+	sessionInfo?: SessionInfo;
+	chromeWs?: WebSocket;
+	legacyServerWs?: WebSocket;
+	wss: Array<{ chrome: WebSocket; server: WebSocket }> = [];
+	#statusTimeout: TimerHandle | undefined;
+
+	// --- Internal routes (called by module handler, not user-facing) ---
+
+	@POST("/session-info")
+	setSessionInfoRoute: RouteHandler = async (req) => {
+		this.sessionInfo = await req.json();
+		// Establish a persistent WebSocket to Chrome's DevTools endpoint.
+		// This serves as the health indicator for the session and is reused
+		// by the legacy chunked-framing client (/v1/connectDevtools).
+		const wsUrl = this.sessionInfo.wsEndpoint.replace("ws://", "http://");
+		const resp = await fetch(wsUrl, { headers: { Upgrade: "websocket" } });
+		assert(resp.webSocket !== null, "Expected a WebSocket response");
+		this.chromeWs = resp.webSocket;
+		this.chromeWs.accept();
+		// Forward Chrome messages to whatever legacyServerWs is currently connected.
+		// Set up once here so reconnects don't accumulate duplicate listeners.
+		this.chromeWs.addEventListener("message", (m) => {
+			if (!this.legacyServerWs) {
+				return;
+			}
+			const string = new TextEncoder().encode(m.data as string);
+			const data = new Uint8Array(string.length + 4);
+			const view = new DataView(data.buffer);
+			view.setUint32(0, string.length, true);
+			data.set(string, 4);
+			this.legacyServerWs.send(data);
+		});
+		this.chromeWs.addEventListener("close", (e) => {
+			this.closeSession(e);
+		});
+		this.#scheduleStatusCheck();
+		return new Response(null, { status: 204 });
+	};
+
+	@GET("/session-info")
+	getSessionInfoRoute: RouteHandler = async () => {
+		if (isClosed(this.chromeWs)) {
+			this.closeSession();
+		}
+		if (!this.sessionInfo) {
+			return new Response(null, { status: 204 });
+		}
+		return Response.json(this.sessionInfo);
+	};
+
+	@GET("/v1/connectDevtools")
+	connectDevtools: RouteHandler = async () => {
 		assert(
 			this.sessionInfo !== undefined,
 			"sessionInfo must be set before connecting"
 		);
-
-		// sometimes the websocket doesn't get the close event, so we need to close them explicitly if needed
-		if (isClosed(this.ws) || isClosed(this.server)) {
-			this.closeWebSockets();
-		} else {
-			assert.fail("WebSocket already initialized");
+		assert(
+			this.chromeWs !== undefined,
+			"chromeWs must be established before connecting"
+		);
+		if (this.legacyServerWs !== undefined) {
+			throw new HttpError(409, "WebSocket already initialized");
 		}
 
 		const webSocketPair = new WebSocketPair();
@@ -43,151 +124,453 @@ export class BrowserSession extends DurableObject<Env> {
 
 		server.accept();
 
-		const wsEndpoint = this.sessionInfo.wsEndpoint.replace("ws://", "http://");
-
-		const response = await fetch(wsEndpoint, {
-			headers: {
-				Upgrade: "websocket",
-			},
-		});
-
-		assert(response.webSocket !== null, "Expected a WebSocket response");
-		const ws = response.webSocket;
-
-		ws.accept();
-
-		ws.addEventListener("message", (m) => {
-			// HACK: TODO: Figure out what the chunking mechanism is in @cloudflare/puppeteer and re-chunk the messages here, rather than just naively slicing off the header. This Worker should probably have the increase_websocket_message_size compat flag added
-			const string = new TextEncoder().encode(m.data as string);
-			const data = new Uint8Array(string.length + 4);
-
-			const view = new DataView(data.buffer);
-			view.setUint32(0, string.length, true);
-			data.set(string, 4);
-
-			server.send(data);
-		});
-
 		server.addEventListener("message", (m) => {
-			// both @cloudflare/puppeteer and @cloudflare/playwright send ping messages each second,
-			// so we use them to check the status of the browser
 			if (m.data === "ping") {
-				this.#checkStatus().catch((err) => {
-					console.error("Error checking browser status:", err);
-				});
 				return;
 			}
-
-			// HACK: TODO: Figure out what the chunking mechanism is in @cloudflare/puppeteer and unchunk the messages here, rather than just naively slicing off the header. This Worker should probably have the increase_websocket_message_size compat flag added
-			ws.send(new TextDecoder().decode((m.data as ArrayBuffer).slice(4)));
+			this.chromeWs?.send(
+				new TextDecoder().decode((m.data as ArrayBuffer).slice(4))
+			);
 		});
-		const forwardClose = (ws: WebSocket, e: CloseEvent) => {
-			// Reserved codes 1005 (No Status Received) and 1006 (Abnormal Closure) are
-			// valid in CloseEvent but throw InvalidAccessError when passed to .close().
-			if (e.code === 1005 || e.code === 1006) {
-				ws.close();
-			} else {
-				ws.close(e.code, e.reason);
-			}
-		};
 		server.addEventListener("close", (e) => {
-			forwardClose(ws, e);
-			this.ws = undefined;
+			this.closeWebSockets(e);
 		});
-		ws.addEventListener("close", (e) => {
-			forwardClose(server, e);
-			this.server = undefined;
-		});
-		this.ws = ws;
-		this.server = server;
+		this.legacyServerWs = server;
 		this.sessionInfo.connectionId = crypto.randomUUID();
 		this.sessionInfo.connectionStartTime = Date.now();
 
 		return new Response(null, {
 			status: 101,
 			webSocket: client,
+			headers: { "cf-browser-session-id": this.name },
 		});
-	}
+	};
 
-	async setSessionInfo(sessionInfo: SessionInfo) {
-		this.sessionInfo = sessionInfo;
-	}
+	@GET("/v1/devtools/browser/:sessionId/json/version")
+	jsonVersion: RouteHandler = async () => {
+		return this.#proxyJsonRequest("/json/version");
+	};
 
-	async getSessionInfo(): Promise<SessionInfo | undefined> {
-		if (isClosed(this.ws) || isClosed(this.server)) {
-			this.closeWebSockets();
+	@GET("/v1/devtools/browser/:sessionId/json/list")
+	jsonList: RouteHandler = async () => {
+		return this.#proxyJsonRequest("/json/list");
+	};
+
+	@GET("/v1/devtools/browser/:sessionId/json")
+	jsonAlias: RouteHandler = async () => {
+		return this.#proxyJsonRequest("/json/list");
+	};
+
+	@GET("/v1/devtools/browser/:sessionId/json/protocol")
+	jsonProtocol: RouteHandler = async () => {
+		return this.#proxyJsonRequest("/json/protocol");
+	};
+
+	@PUT("/v1/devtools/browser/:sessionId/json/new")
+	jsonNew: RouteHandler = async (_req, _params, url) => {
+		return this.#proxyJsonRequest(
+			`/json/new?${new URLSearchParams({ url: url.searchParams.get("url") ?? "" })}`,
+			"PUT"
+		);
+	};
+
+	@GET("/v1/devtools/browser/:sessionId/json/activate/:targetId")
+	jsonActivate: RouteHandler<{ targetId: string }> = async (_req, params) => {
+		return this.#proxyJsonRequest(`/json/activate/${params?.targetId}`);
+	};
+
+	@GET("/v1/devtools/browser/:sessionId/json/close/:targetId")
+	jsonClose: RouteHandler<{ targetId: string }> = async (_req, params) => {
+		return this.#proxyJsonRequest(`/json/close/${params?.targetId}`);
+	};
+
+	@GET("/v1/devtools/browser/:sessionId/page/:pageId")
+	pageWebSocket: RouteHandler<{ pageId: string }> = async (_req, params) => {
+		if (!this.sessionInfo) {
+			return Response.json({ error: "Browser not found" }, { status: 404 });
 		}
-		return this.sessionInfo;
-	}
+		return this.#proxyRawWebSocket(
+			`${chromeBaseUrl(this.sessionInfo.wsEndpoint).replace("http://", "ws://")}/devtools/page/${params?.pageId}`
+		);
+	};
 
-	async #checkStatus() {
+	@DELETE("/v1/devtools/browser/:sessionId")
+	closeBrowser: RouteHandler = async () => {
+		// Browser.close CDP doesn't reliably kill Chrome, so we kill via loopback
+		// instead. The DO returns immediately so it stays idle while the
+		// module-level binding worker waits for Chrome to fully exit.
 		if (this.sessionInfo) {
-			const url = new URL("http://example.com/browser/status");
-			url.searchParams.set("sessionId", this.sessionInfo.sessionId);
-			const resp = await this.env[CoreBindings.SERVICE_LOOPBACK].fetch(url);
-
-			if (!resp.ok) {
-				// Browser process has exited, close the WebSockets
-				this.closeWebSockets();
-			}
+			const closeUrl = new URL("http://localhost/browser/close");
+			closeUrl.searchParams.set("sessionId", this.sessionInfo.sessionId);
+			void this.env[SharedBindings.MAYBE_SERVICE_LOOPBACK].fetch(closeUrl, {
+				method: "POST",
+			});
 		}
-	}
+		return Response.json({ status: "closed" });
+	};
 
-	closeWebSockets() {
-		this.ws?.close();
-		this.server?.close();
-		this.ws = undefined;
-		this.server = undefined;
+	@GET("/v1/devtools/session/:sessionId")
+	sessionDetail: RouteHandler = async () => {
+		if (!this.sessionInfo) {
+			return Response.json({ error: "Session not found" }, { status: 404 });
+		}
+		return Response.json({
+			sessionId: this.sessionInfo.sessionId,
+			startTime: this.sessionInfo.startTime,
+			connectionId: this.sessionInfo.connectionId,
+			connectionStartTime: this.sessionInfo.connectionStartTime,
+		});
+	};
+
+	@GET("/v1/devtools/browser/:sessionId")
+	connect: RouteHandler = async (req) => {
+		assert(
+			this.sessionInfo !== undefined,
+			"sessionInfo must be set before connecting"
+		);
+
+		const wsUrl = this.sessionInfo.wsEndpoint.replace("ws://", "http://");
+		const resp = await this.#proxyRawWebSocket(wsUrl);
+
+		this.sessionInfo.connectionId = crypto.randomUUID();
+		this.sessionInfo.connectionStartTime = Date.now();
+
+		return new Response(null, {
+			status: resp.status,
+			webSocket: resp.webSocket,
+			headers: { "cf-browser-session-id": this.name },
+		});
+	};
+
+	closeWebSockets(e?: CloseEvent) {
+		forwardClose(this.legacyServerWs, e);
+		for (const { chrome, server } of this.wss) {
+			forwardClose(chrome, e);
+			forwardClose(server, e);
+		}
+		this.legacyServerWs = undefined;
+		this.wss = [];
 		if (this.sessionInfo) {
 			this.sessionInfo.connectionId = undefined;
 			this.sessionInfo.connectionStartTime = undefined;
 		}
 	}
+
+	closeSession(e?: CloseEvent) {
+		if (this.#statusTimeout !== undefined) {
+			this.timers.clearTimeout(this.#statusTimeout);
+			this.#statusTimeout = undefined;
+		}
+		this.closeWebSockets(e);
+		forwardClose(this.chromeWs, e);
+		this.chromeWs = undefined;
+		this.sessionInfo = undefined;
+	}
+
+	async #proxyRawWebSocket(targetWsUrl: string): Promise<Response> {
+		const webSocketPair = new WebSocketPair();
+		const [client, server] = Object.values(webSocketPair);
+
+		server.accept();
+
+		const response = await fetch(targetWsUrl.replace("ws://", "http://"), {
+			headers: { Upgrade: "websocket" },
+		});
+
+		assert(response.webSocket !== null, "Expected a WebSocket response");
+		const chrome = response.webSocket;
+		chrome.accept();
+
+		const pair = { chrome, server };
+		this.wss.push(pair);
+
+		chrome.addEventListener("message", (m) => server.send(m.data as string));
+		server.addEventListener("message", (m) => chrome.send(m.data as string));
+		server.addEventListener("close", (e) => {
+			forwardClose(chrome, e);
+			forwardClose(server, e);
+			this.wss = this.wss.filter((p) => p !== pair);
+		});
+		chrome.addEventListener("close", (e) => {
+			forwardClose(server, e);
+			forwardClose(chrome, e);
+			this.wss = this.wss.filter((p) => p !== pair);
+		});
+
+		return new Response(null, { status: 101, webSocket: client });
+	}
+
+	async #proxyJsonRequest(
+		chromePath: string,
+		method = "GET"
+	): Promise<Response> {
+		if (!this.sessionInfo) {
+			return Response.json({ error: "Browser not found" }, { status: 404 });
+		}
+		const resp = await fetch(
+			`${chromeBaseUrl(this.sessionInfo.wsEndpoint)}${chromePath}`,
+			{ method }
+		);
+		return new Response(await resp.text(), {
+			status: resp.status,
+			headers: { "Content-Type": "application/json" },
+		});
+	}
+
+	async #checkStatus() {
+		if (this.sessionInfo) {
+			const url = new URL("http://localhost/browser/status");
+			url.searchParams.set("sessionId", this.sessionInfo.sessionId);
+			const resp =
+				await this.env[SharedBindings.MAYBE_SERVICE_LOOPBACK].fetch(url);
+			if (!resp.ok) {
+				this.closeSession();
+			}
+		}
+	}
+
+	#scheduleStatusCheck() {
+		if (this.#statusTimeout !== undefined) {
+			return;
+		}
+		this.#statusTimeout = this.timers.setTimeout(async () => {
+			this.#statusTimeout = undefined;
+			await this.#checkStatus();
+			if (this.chromeWs) {
+				this.#scheduleStatusCheck();
+			}
+		}, 1000);
+	}
+}
+
+class BrowserRenderingRouter extends Router {
+	constructor(private readonly env: Env) {
+		super();
+	}
+
+	#callSession(
+		sessionId: string,
+		request: Request<unknown, unknown>
+	): Promise<Response> {
+		const cf: MiniflareDurableObjectCf = { miniflare: { name: sessionId } };
+		const stub = this.env.BrowserSession.get(
+			this.env.BrowserSession.idFromName(sessionId)
+		);
+		return stub.fetch(request as Request, {
+			cf: cf as Record<string, unknown>,
+		});
+	}
+
+	#fetchSession(
+		sessionId: string,
+		path: string,
+		init?: RequestInit
+	): Promise<Response> {
+		const cf: MiniflareDurableObjectCf = { miniflare: { name: sessionId } };
+		const stub = this.env.BrowserSession.get(
+			this.env.BrowserSession.idFromName(sessionId)
+		);
+		return stub.fetch(`http://placeholder${path}`, {
+			...init,
+			cf: cf as Record<string, unknown>,
+		});
+	}
+
+	async #acquireSession(): Promise<SessionInfo> {
+		const sessionInfo: SessionInfo = await this.env[
+			SharedBindings.MAYBE_SERVICE_LOOPBACK
+		]
+			.fetch("http://localhost/browser/launch")
+			.then((r) => r.json());
+		await this.#fetchSession(sessionInfo.sessionId, "/session-info", {
+			method: "POST",
+			body: JSON.stringify(sessionInfo),
+		});
+		return sessionInfo;
+	}
+
+	async #getActiveSessions() {
+		const sessionIds = (await this.env[SharedBindings.MAYBE_SERVICE_LOOPBACK]
+			.fetch("http://localhost/browser/sessionIds")
+			.then((r) => r.json())) as string[];
+
+		const sessions = await Promise.all(
+			sessionIds.map(async (sessionId) => {
+				const resp = await this.#fetchSession(sessionId, "/session-info");
+				if (resp.status === 204) {
+					return null;
+				}
+				const sessionInfo: SessionInfo = await resp.json();
+				return {
+					sessionId: sessionInfo.sessionId,
+					startTime: sessionInfo.startTime,
+					connectionId: sessionInfo.connectionId,
+					connectionStartTime: sessionInfo.connectionStartTime,
+				};
+			})
+		);
+
+		return sessions.filter(Boolean);
+	}
+
+	@GET("/v1/acquire")
+	acquireRoute: RouteHandler = async () => {
+		const sessionInfo = await this.#acquireSession();
+		return Response.json({ sessionId: sessionInfo.sessionId });
+	};
+
+	@GET("/v1/sessions")
+	sessionsRoute: RouteHandler = async () => {
+		return Response.json({ sessions: await this.#getActiveSessions() });
+	};
+
+	@GET("/v1/limits")
+	limitsRoute: RouteHandler = async () => {
+		return Response.json({
+			maxConcurrentSessions: 6,
+			allowedBrowserAcquisitions: 6,
+			timeUntilNextAllowedBrowserAcquisition: 0,
+		});
+	};
+
+	@GET("/v1/history")
+	historyRoute: RouteHandler = async () => {
+		return Response.json([]);
+	};
+
+	@GET("/v1/devtools/session")
+	sessionListRoute: RouteHandler = async () => {
+		return Response.json(await this.#getActiveSessions());
+	};
+
+	@GET("/v1/connectDevtools")
+	connectDevtoolsRoute: RouteHandler = async (req, _params, url) => {
+		const sessionId = url.searchParams.get("browser_session");
+		if (!sessionId) {
+			return new Response("browser_session must be set", { status: 400 });
+		}
+		return this.#callSession(sessionId, req);
+	};
+
+	@POST("/v1/devtools/browser")
+	acquireBrowserRoute: RouteHandler = async () => {
+		const sessionInfo = await this.#acquireSession();
+		return Response.json({ sessionId: sessionInfo.sessionId });
+	};
+
+	@GET("/v1/devtools/browser")
+	connectBrowserRoute: RouteHandler = async (req) => {
+		const sessionInfo = await this.#acquireSession();
+		const doUrl = new URL(req.url);
+		doUrl.pathname = `/v1/devtools/browser/${sessionInfo.sessionId}`;
+		return this.#callSession(
+			sessionInfo.sessionId,
+			new Request(doUrl, {
+				method: req.method,
+				headers: {
+					...Object.fromEntries(req.headers),
+					"x-session-id": sessionInfo.sessionId,
+				},
+			})
+		);
+	};
+
+	@GET("/v1/devtools/session/:sessionId")
+	sessionDetailRoute: RouteHandler<{ sessionId: string }> = async (
+		req,
+		params
+	) => {
+		return this.#callSession(params.sessionId, req);
+	};
+
+	@DELETE("/v1/devtools/browser/:sessionId")
+	closeBrowserRoute: RouteHandler<{ sessionId: string }> = async (
+		req,
+		params
+	) => {
+		const { sessionId } = params;
+		// The DO sends the kill signal and returns immediately, keeping
+		// it idle so WebSocket close events can propagate to the user.
+		await this.#callSession(sessionId, req);
+		// Poll until Chrome has exited so the session list is clean
+		for (let i = 0; i < 50; i++) {
+			const statusUrl = new URL("http://localhost/browser/status");
+			statusUrl.searchParams.set("sessionId", sessionId);
+			const statusResp =
+				await this.env[SharedBindings.MAYBE_SERVICE_LOOPBACK].fetch(statusUrl);
+			if (statusResp.status === 410) {
+				break;
+			}
+			await new Promise((r) => setTimeout(r, 100));
+		}
+		return Response.json({ status: "closed" });
+	};
+
+	@GET("/v1/devtools/browser/:sessionId")
+	connectBrowserSessionRoute: RouteHandler<{ sessionId: string }> = async (
+		req,
+		params,
+		_url
+	) => {
+		const doUrl = new URL(req.url);
+		return this.#callSession(params.sessionId, new Request(doUrl, req));
+	};
+
+	@GET("/v1/devtools/browser/:sessionId/json/version")
+	jsonVersionRoute: RouteHandler<{ sessionId: string }> = async (
+		req,
+		params
+	) => {
+		return this.#callSession(params.sessionId, req);
+	};
+
+	@GET("/v1/devtools/browser/:sessionId/json/list")
+	jsonListRoute: RouteHandler<{ sessionId: string }> = async (req, params) => {
+		return this.#callSession(params.sessionId, req);
+	};
+
+	@GET("/v1/devtools/browser/:sessionId/json")
+	jsonAliasRoute: RouteHandler<{ sessionId: string }> = async (req, params) => {
+		return this.#callSession(params.sessionId, req);
+	};
+
+	@GET("/v1/devtools/browser/:sessionId/json/protocol")
+	jsonProtocolRoute: RouteHandler<{ sessionId: string }> = async (
+		req,
+		params
+	) => {
+		return this.#callSession(params.sessionId, req);
+	};
+
+	@PUT("/v1/devtools/browser/:sessionId/json/new")
+	jsonNewRoute: RouteHandler<{ sessionId: string }> = async (req, params) => {
+		return this.#callSession(params.sessionId, req);
+	};
+
+	@GET("/v1/devtools/browser/:sessionId/json/activate/:targetId")
+	jsonActivateRoute: RouteHandler<{ sessionId: string }> = async (
+		req,
+		params
+	) => {
+		return this.#callSession(params.sessionId, req);
+	};
+
+	@GET("/v1/devtools/browser/:sessionId/json/close/:targetId")
+	jsonCloseRoute: RouteHandler<{ sessionId: string }> = async (req, params) => {
+		return this.#callSession(params.sessionId, req);
+	};
+
+	@GET("/v1/devtools/browser/:sessionId/page/:pageId")
+	pageWebSocketRoute: RouteHandler<{ sessionId: string }> = async (
+		req,
+		params
+	) => {
+		return this.#callSession(params.sessionId, req);
+	};
 }
 
 export default {
-	async fetch(request: Request, env: Env) {
-		const url = new URL(request.url);
-		switch (url.pathname) {
-			case "/v1/acquire": {
-				const resp = await env[CoreBindings.SERVICE_LOOPBACK].fetch(
-					"http://example.com/browser/launch"
-				);
-				const sessionInfo: SessionInfo = await resp.json();
-				const id = env.BrowserSession.idFromName(sessionInfo.sessionId);
-				await env.BrowserSession.get(id).setSessionInfo(sessionInfo);
-				return Response.json({ sessionId: sessionInfo.sessionId });
-			}
-			case "/v1/connectDevtools": {
-				const sessionId = url.searchParams.get("browser_session");
-				assert(sessionId !== null, "browser_session must be set");
-				const id = env.BrowserSession.idFromName(sessionId);
-				return env.BrowserSession.get(id).fetch(request);
-			}
-			case "/v1/sessions": {
-				const sessionIds = (await env[CoreBindings.SERVICE_LOOPBACK]
-					.fetch("http://example.com/browser/sessionIds")
-					.then((resp) => resp.json())) as string[];
-				const sessions = await Promise.all(
-					sessionIds.map(async (sessionId) => {
-						const id = env.BrowserSession.idFromName(sessionId);
-						return env.BrowserSession.get(id)
-							.getSessionInfo()
-							.then((sessionInfo) => {
-								if (!sessionInfo) return null;
-								return {
-									sessionId: sessionInfo.sessionId,
-									startTime: sessionInfo.startTime,
-									connectionId: sessionInfo.connectionId,
-									connectionStartTime: sessionInfo.connectionStartTime,
-								};
-							});
-					})
-				).then((results) => results.filter(Boolean));
-				return Response.json({ sessions });
-			}
-			default:
-				return new Response("Not implemented", { status: 405 });
-		}
+	fetch(request: Request, env: Env) {
+		return new BrowserRenderingRouter(env).fetch(request);
 	},
 };

--- a/packages/miniflare/test/plugins/browser/index.spec.ts
+++ b/packages/miniflare/test/plugins/browser/index.spec.ts
@@ -1,9 +1,8 @@
 import { Miniflare, MiniflareOptions } from "miniflare";
 import { afterEach, beforeEach, describe, test, vi } from "vitest";
 import { useDispose } from "../../test-shared";
-import type { WebSocket } from "undici";
 
-async function sendMessage(ws: WebSocket, message: any) {
+async function sendMessage(ws: WebSocket, message: unknown) {
 	// adapted from https://github.com/cloudflare/puppeteer/blob/b4984452165437e26dd1c8e516581cec2a02b4cd/packages/puppeteer-core/src/cloudflare/chunking.ts#L6-L30
 	const messageToChunks = (data: string): Uint8Array[] => {
 		const HEADER_SIZE = 4; // Uint32
@@ -45,11 +44,12 @@ async function waitForClosedConnection(ws: WebSocket): Promise<void> {
 	if (ws.readyState === ws.CLOSED) {
 		return;
 	}
-	// local dev browser rendering relies on a ping message to check browser process status
-	const timeoutId = setInterval(() => ws.send("ping"), 500);
-	await new Promise((resolve) => ws.addEventListener("close", resolve));
-	// clear the interval, no longer need to ping
-	if (timeoutId) clearInterval(timeoutId);
+	await new Promise<void>((resolve) => {
+		ws.addEventListener("close", () => {
+			ws.close();
+			resolve();
+		});
+	});
 }
 
 const BROWSER_WORKER_SCRIPT = () => `
@@ -169,6 +169,97 @@ export default {
 		expect(await res.text()).toBe("Browser session reused");
 	});
 
+	const BROWSER_WORKER_RECONNECT_SCRIPT = `
+${sendMessage.toString()}
+${waitForClosedConnection.toString()}
+
+async function waitForMessage(ws) {
+	const chunks = [];
+	return new Promise((resolve) => {
+		ws.addEventListener("message", function handler(event) {
+			const data = new Uint8Array(event.data);
+			if (chunks.length === 0) {
+				// First chunk contains a 4-byte little-endian length header
+				const view = new DataView(data.buffer);
+				const totalLength = view.getUint32(0, true);
+				chunks.push({ data: data.slice(4), totalLength });
+			} else {
+				chunks[0].data = new Uint8Array([...chunks[0].data, ...data]);
+			}
+			const accumulated = chunks[0];
+			if (accumulated.data.length >= accumulated.totalLength) {
+				ws.removeEventListener("message", handler);
+				const text = new TextDecoder().decode(accumulated.data.slice(0, accumulated.totalLength));
+				resolve(JSON.parse(text));
+			}
+		});
+	});
+}
+
+export default {
+	async fetch(request, env) {
+		const acquireResponse = await env.MYBROWSER.fetch("https://localhost/v1/acquire");
+		const { sessionId } = await acquireResponse.json();
+
+		// First connection
+		const { webSocket: ws } = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
+			headers: { "Upgrade": "websocket" },
+		});
+		ws.accept();
+
+		// Send a CDP command and verify we get a response
+		sendMessage(ws, { method: "Target.getTargets", id: 1 });
+		const msg1 = await waitForMessage(ws);
+		if (!msg1 || !msg1.result) {
+			return new Response("First CDP command failed: " + JSON.stringify(msg1));
+		}
+
+		// Disconnect
+		ws.close();
+		await waitForClosedConnection(ws);
+
+		// Reconnect with the same sessionId
+		const resp2 = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
+			headers: { "Upgrade": "websocket" },
+		});
+		if (!resp2.webSocket) {
+			return new Response("Reconnect failed with status: " + resp2.status);
+		}
+		const ws2 = resp2.webSocket;
+		ws2.accept();
+
+		// Send a CDP command on the reconnected socket
+		sendMessage(ws2, { method: "Target.getTargets", id: 2 });
+		const msg2 = await waitForMessage(ws2);
+		if (!msg2 || !msg2.result) {
+			return new Response("Second CDP command failed: " + JSON.stringify(msg2));
+		}
+
+		ws2.close();
+		return new Response("Reconnect successful");
+	}
+};
+`;
+
+	test(
+		"it reconnects and sends CDP commands after disconnect",
+		{ retry: 3 },
+		async ({ expect }) => {
+			const opts: MiniflareOptions = {
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: BROWSER_WORKER_RECONNECT_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			};
+			const mf = new Miniflare(opts);
+			useDispose(mf);
+
+			const res = await mf.dispatchFetch("https://localhost");
+			expect(await res.text()).toBe("Reconnect successful");
+		}
+	);
+
 	const BROWSER_WORKER_ALREADY_USED_SCRIPT = `
 export default {
 	async fetch(request, env) {
@@ -181,12 +272,11 @@ export default {
 
 		await new Promise(resolve => setTimeout(resolve, 100));
 
-		try {
-			// try to open new connection for the same session
-			const { webSocket: ws2 } = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
-				headers: { "Upgrade": "websocket" },
-			});
-		} catch (error) {
+		// try to open new connection for the same session
+		const resp2 = await env.MYBROWSER.fetch(\`https://localhost/v1/connectDevtools?browser_session=\${sessionId}\`, {
+			headers: { "Upgrade": "websocket" },
+		});
+		if (resp2.status === 409) {
 			return new Response("Failed to connect to browser session");
 		}
 
@@ -320,6 +410,576 @@ export default {
 				!disconnectedSession.connectionId &&
 					!disconnectedSession.connectionStartTime
 			).toBe(true);
+		}
+	);
+
+	test("returns limits", async ({ expect }) => {
+		const mf = new Miniflare({
+			name: "worker",
+			compatibilityDate: "2024-11-20",
+			modules: true,
+			script: `export default { async fetch(req, env) {
+				return env.MYBROWSER.fetch("https://localhost/v1/limits");
+			} }`,
+			browserRendering: { binding: "MYBROWSER" },
+		});
+		useDispose(mf);
+
+		const res = await mf.dispatchFetch("https://localhost");
+		const body = (await res.json()) as any;
+		expect(res.status).toBe(200);
+		expect(typeof body.maxConcurrentSessions).toBe("number");
+		expect(typeof body.allowedBrowserAcquisitions).toBe("number");
+		expect(typeof body.timeUntilNextAllowedBrowserAcquisition).toBe("number");
+	});
+
+	test("returns empty history", async ({ expect }) => {
+		const mf = new Miniflare({
+			name: "worker",
+			compatibilityDate: "2024-11-20",
+			modules: true,
+			script: `export default { async fetch(req, env) {
+				return env.MYBROWSER.fetch("https://localhost/v1/history");
+			} }`,
+			browserRendering: { binding: "MYBROWSER" },
+		});
+		useDispose(mf);
+
+		const res = await mf.dispatchFetch("https://localhost");
+		const body = await res.json();
+		expect(res.status).toBe(200);
+		expect(body).toEqual([]);
+	});
+
+	const DEVTOOLS_SESSION_SCRIPT = `
+export default {
+	async fetch(request, env) {
+		const emptyList = await env.MYBROWSER.fetch("https://localhost/v1/devtools/session").then(r => r.json());
+		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+		const list = await env.MYBROWSER.fetch("https://localhost/v1/devtools/session").then(r => r.json());
+		const detail = await env.MYBROWSER.fetch(\`https://localhost/v1/devtools/session/\${sessionId}\`).then(r => r.json());
+		const missing = await env.MYBROWSER.fetch("https://localhost/v1/devtools/session/does-not-exist");
+		return Response.json({ emptyList, list, detail, missingStatus: missing.status });
+	}
+};
+`;
+
+	test(
+		"devtools session list and detail endpoints",
+		{ retry: 3 },
+		async ({ expect }) => {
+			const mf = new Miniflare({
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: DEVTOOLS_SESSION_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			});
+			useDispose(mf);
+
+			const { emptyList, list, detail, missingStatus } = (await mf
+				.dispatchFetch("https://localhost")
+				.then((r) => r.json())) as any;
+
+			expect(emptyList).toEqual([]);
+			expect(list.length).toBe(1);
+			expect(typeof list[0].sessionId).toBe("string");
+			expect(detail.sessionId).toBe(list[0].sessionId);
+			expect(missingStatus).toBe(404);
+		}
+	);
+
+	const DEVTOOLS_JSON_SCRIPT = `
+export default {
+	async fetch(request, env) {
+		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+
+		const version = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}/json/version\`
+		).then(r => r.json());
+
+		const list = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}/json/list\`
+		).then(r => r.json());
+
+		const listAlias = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}/json\`
+		).then(r => r.json());
+
+		return Response.json({ version, list, listAlias });
+	}
+};
+`;
+
+	test(
+		"devtools json/version, json/list, json endpoints",
+		{ retry: 3 },
+		async ({ expect }) => {
+			const mf = new Miniflare({
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: DEVTOOLS_JSON_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			});
+			useDispose(mf);
+
+			const { version, list, listAlias } = (await mf
+				.dispatchFetch("https://localhost")
+				.then((r) => r.json())) as any;
+
+			expect(typeof version.Browser).toBe("string");
+			expect(typeof version["Protocol-Version"]).toBe("string");
+			expect(Array.isArray(list)).toBe(true);
+			expect(list).toEqual(listAlias);
+		}
+	);
+
+	const DEVTOOLS_DELETE_SCRIPT = `
+${waitForClosedConnection.toString()}
+
+export default {
+	async fetch(request, env) {
+		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+		const { webSocket: ws } = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+			{ headers: { Upgrade: "websocket" } }
+		);
+		ws.accept();
+		const deleteResp = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+			{ method: "DELETE" }
+		);
+		const deleteBody = await deleteResp.json();
+		// Verify the session is gone after DELETE
+		const { sessions } = await env.MYBROWSER.fetch(\`https://localhost/v1/sessions?sessionId=\${sessionId}\`).then(r => r.json());
+		const sessionGone = sessions.length === 0;
+		await waitForClosedConnection(ws);
+		const wsClosed = ws.readyState === WebSocket.CLOSED;
+		return Response.json({
+			deleteStatus: deleteResp.status,
+			deleteBody,
+			sessionGone,
+			wsClosed,
+		});
+	}
+};
+`;
+
+	test(
+		"DELETE /v1/devtools/browser/:session_id closes browser",
+		{ retry: 3 },
+		async ({ expect }) => {
+			const mf = new Miniflare({
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: DEVTOOLS_DELETE_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			});
+			useDispose(mf);
+
+			const { deleteStatus, deleteBody, sessionGone, wsClosed } = (await mf
+				.dispatchFetch("https://localhost")
+				.then((r) => r.json())) as any;
+
+			expect(deleteStatus).toBe(200);
+			expect(deleteBody.status).toBe("closed");
+			expect(sessionGone).toBe(true);
+			expect(wsClosed).toBe(true);
+		}
+	);
+
+	const DEVTOOLS_BROWSER_WS_SCRIPT = `
+export default {
+	async fetch(request, env) {
+		const postResp = await env.MYBROWSER.fetch("https://localhost/v1/devtools/browser", {
+			method: "POST",
+		});
+		const { sessionId } = await postResp.json();
+
+		await new Promise(resolve => setTimeout(resolve, 200));
+
+		const getResp = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+			{ headers: { Upgrade: "websocket" } }
+		);
+		const sessionIdFromGet = getResp.headers.get("cf-browser-session-id");
+		const ws = getResp.webSocket;
+		ws.accept();
+		const browserVersion = await new Promise((resolve) => {
+			ws.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
+			ws.send(JSON.stringify({ id: 1, method: "Browser.getVersion" }));
+		});
+		ws.close();
+
+		return Response.json({
+			postStatus: postResp.status,
+			sessionId,
+			getStatus: getResp.status,
+			sessionIdFromGet,
+			browserProduct: browserVersion.result?.product,
+		});
+	}
+};
+`;
+
+	test(
+		"POST /v1/devtools/browser acquires session, GET /v1/devtools/browser/:id connects and returns cf-browser-session-id",
+		{ retry: 3 },
+		async ({ expect }) => {
+			const mf = new Miniflare({
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: DEVTOOLS_BROWSER_WS_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			});
+			useDispose(mf);
+
+			const {
+				postStatus,
+				sessionId,
+				getStatus,
+				sessionIdFromGet,
+				browserProduct,
+			} = (await mf
+				.dispatchFetch("https://localhost")
+				.then((r) => r.json())) as any;
+
+			expect(postStatus).toBe(200);
+			expect(typeof sessionId).toBe("string");
+			expect(getStatus).toBe(101);
+			expect(sessionIdFromGet).toBe(sessionId);
+			expect(typeof browserProduct).toBe("string");
+			expect(browserProduct).toContain("Chrome");
+		}
+	);
+
+	test(
+		"GET /v1/devtools/browser acquires and connects",
+		{ retry: 3 },
+		async ({ expect }) => {
+			const mf = new Miniflare({
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: `export default {
+	async fetch(request, env) {
+		const resp = await env.MYBROWSER.fetch("https://localhost/v1/devtools/browser", {
+			headers: { Upgrade: "websocket" },
+		});
+		const sessionId = resp.headers.get("cf-browser-session-id");
+		const ws = resp.webSocket;
+		ws.accept();
+		const browserVersion = await new Promise((resolve) => {
+			ws.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
+			ws.send(JSON.stringify({ id: 1, method: "Browser.getVersion" }));
+		});
+		ws.close();
+		return Response.json({ status: resp.status, sessionId, browserProduct: browserVersion.result?.product });
+	}
+};`,
+				browserRendering: { binding: "MYBROWSER" },
+			});
+			useDispose(mf);
+
+			const { status, sessionId, browserProduct } = (await mf
+				.dispatchFetch("https://localhost")
+				.then((r) => r.json())) as any;
+
+			expect(status).toBe(101);
+			expect(typeof sessionId).toBe("string");
+			expect(typeof browserProduct).toBe("string");
+			expect(browserProduct).toContain("Chrome");
+		}
+	);
+
+	const DEVTOOLS_JSON_PROTOCOL_SCRIPT = `
+export default {
+	async fetch(request, env) {
+		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+		const protocol = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}/json/protocol\`
+		).then(r => r.json());
+		return Response.json({ hasDomains: Array.isArray(protocol.domains) });
+	}
+};
+`;
+
+	test("devtools json/protocol endpoint", { retry: 3 }, async ({ expect }) => {
+		const mf = new Miniflare({
+			name: "worker",
+			compatibilityDate: "2024-11-20",
+			modules: true,
+			script: DEVTOOLS_JSON_PROTOCOL_SCRIPT,
+			browserRendering: { binding: "MYBROWSER" },
+		});
+		useDispose(mf);
+
+		const { hasDomains } = (await mf
+			.dispatchFetch("https://localhost")
+			.then((r) => r.json())) as any;
+
+		expect(hasDomains).toBe(true);
+	});
+
+	const DEVTOOLS_JSON_NEW_ACTIVATE_CLOSE_SCRIPT = `
+export default {
+	async fetch(request, env) {
+		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+		const newTarget = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}/json/new?url=about:blank\`,
+			{ method: "PUT" }
+		).then(r => r.json());
+		const activateResp = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}/json/activate/\${newTarget.id}\`
+		);
+		const closeResp = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}/json/close/\${newTarget.id}\`
+		);
+		return Response.json({
+			targetType: newTarget.type,
+			activateStatus: activateResp.status,
+			closeStatus: closeResp.status,
+		});
+	}
+};
+`;
+
+	test(
+		"devtools json/new, json/activate, json/close endpoints",
+		{ retry: 3 },
+		async ({ expect }) => {
+			const mf = new Miniflare({
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: DEVTOOLS_JSON_NEW_ACTIVATE_CLOSE_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			});
+			useDispose(mf);
+
+			const { targetType, activateStatus, closeStatus } = (await mf
+				.dispatchFetch("https://localhost")
+				.then((r) => r.json())) as any;
+
+			expect(targetType).toBe("page");
+			expect(activateStatus).toBe(200);
+			expect(closeStatus).toBe(200);
+		}
+	);
+
+	const DEVTOOLS_PAGE_WS_SCRIPT = `
+export default {
+	async fetch(request, env) {
+		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+		const targets = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}/json/list\`
+		).then(r => r.json());
+		const targetId = targets[0].id;
+		const { webSocket: ws } = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}/page/\${targetId}\`,
+			{ headers: { Upgrade: "websocket" } }
+		);
+		ws.accept();
+		const result = await new Promise((resolve) => {
+			ws.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
+			ws.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "1+1" } }));
+		});
+		ws.close();
+		return Response.json({ resultValue: result.result?.result?.value });
+	}
+};
+`;
+
+	test(
+		"devtools page/:target_id WebSocket endpoint",
+		{ retry: 3 },
+		async ({ expect }) => {
+			const mf = new Miniflare({
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: DEVTOOLS_PAGE_WS_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			});
+			useDispose(mf);
+
+			const { resultValue } = (await mf
+				.dispatchFetch("https://localhost")
+				.then((r) => r.json())) as any;
+
+			expect(resultValue).toBe(2);
+		}
+	);
+
+	test(
+		"DELETE without prior WebSocket connection",
+		{ retry: 3 },
+		async ({ expect }) => {
+			const mf = new Miniflare({
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: `export default {
+	async fetch(request, env) {
+		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+		const deleteResp = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+			{ method: "DELETE" }
+		);
+		const deleteBody = await deleteResp.json();
+		const { sessions } = await env.MYBROWSER.fetch("https://localhost/v1/sessions").then(r => r.json());
+		return Response.json({
+			deleteStatus: deleteResp.status,
+			deleteBody,
+			sessionGone: sessions.length === 0,
+		});
+	}
+};`,
+				browserRendering: { binding: "MYBROWSER" },
+			});
+			useDispose(mf);
+
+			const { deleteStatus, deleteBody, sessionGone } = (await mf
+				.dispatchFetch("https://localhost")
+				.then((r) => r.json())) as any;
+
+			expect(deleteStatus).toBe(200);
+			expect(deleteBody.status).toBe("closed");
+			expect(sessionGone).toBe(true);
+		}
+	);
+
+	const DEVTOOLS_DELETE_ALL_WS_SCRIPT = `
+${waitForClosedConnection.toString()}
+
+export default {
+	async fetch(request, env) {
+		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+
+		// Connect browser-level WebSocket
+		const { webSocket: browserWs } = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+			{ headers: { Upgrade: "websocket" } }
+		);
+		browserWs.accept();
+
+		// Connect page-level WebSocket
+		const targets = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}/json/list\`
+		).then(r => r.json());
+		const { webSocket: pageWs } = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}/page/\${targets[0].id}\`,
+			{ headers: { Upgrade: "websocket" } }
+		);
+		pageWs.accept();
+
+		// DELETE should close everything
+		const deleteResp = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+			{ method: "DELETE" }
+		);
+		const deleteBody = await deleteResp.json();
+
+		await Promise.all([
+			waitForClosedConnection(browserWs),
+			waitForClosedConnection(pageWs),
+		]);
+
+		return Response.json({
+			deleteStatus: deleteResp.status,
+			deleteBody,
+			browserWsClosed: browserWs.readyState === WebSocket.CLOSED,
+			pageWsClosed: pageWs.readyState === WebSocket.CLOSED,
+		});
+	}
+};
+`;
+
+	test(
+		"DELETE closes all WebSocket connections (browser + page)",
+		{ retry: 3 },
+		async ({ expect }) => {
+			const mf = new Miniflare({
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: DEVTOOLS_DELETE_ALL_WS_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			});
+			useDispose(mf);
+
+			const { deleteStatus, deleteBody, browserWsClosed, pageWsClosed } =
+				(await mf
+					.dispatchFetch("https://localhost")
+					.then((r) => r.json())) as any;
+
+			expect(deleteStatus).toBe(200);
+			expect(deleteBody.status).toBe("closed");
+			expect(browserWsClosed).toBe(true);
+			expect(pageWsClosed).toBe(true);
+		}
+	);
+
+	test(
+		"multiple concurrent raw WebSocket connections to same session",
+		{ retry: 3 },
+		async ({ expect }) => {
+			const mf = new Miniflare({
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: `export default {
+	async fetch(request, env) {
+		const { sessionId } = await env.MYBROWSER.fetch("https://localhost/v1/acquire").then(r => r.json());
+
+		// Open two raw WebSocket connections to the same browser session
+		const { webSocket: ws1 } = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+			{ headers: { Upgrade: "websocket" } }
+		);
+		ws1.accept();
+
+		const { webSocket: ws2 } = await env.MYBROWSER.fetch(
+			\`https://localhost/v1/devtools/browser/\${sessionId}\`,
+			{ headers: { Upgrade: "websocket" } }
+		);
+		ws2.accept();
+
+		// Send Browser.getVersion on both and verify responses
+		const v1 = new Promise((resolve) => {
+			ws1.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
+			ws1.send(JSON.stringify({ id: 1, method: "Browser.getVersion" }));
+		});
+		const v2 = new Promise((resolve) => {
+			ws2.addEventListener("message", (m) => resolve(JSON.parse(m.data)));
+			ws2.send(JSON.stringify({ id: 2, method: "Browser.getVersion" }));
+		});
+
+		const [r1, r2] = await Promise.all([v1, v2]);
+		ws1.close();
+		ws2.close();
+
+		return Response.json({
+			product1: r1.result?.product,
+			product2: r2.result?.product,
+		});
+	}
+};`,
+				browserRendering: { binding: "MYBROWSER" },
+			});
+			useDispose(mf);
+
+			const { product1, product2 } = (await mf
+				.dispatchFetch("https://localhost")
+				.then((r) => r.json())) as any;
+
+			expect(typeof product1).toBe("string");
+			expect(product1).toContain("Chrome");
+			expect(typeof product2).toBe("string");
+			expect(product2).toContain("Chrome");
 		}
 	);
 });


### PR DESCRIPTION
Fixes BRAPI-1018

Adds missing devtools endpoints to browser rendering local binding.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal only for now

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
