### PR TITLE
Post changeset review issues as inline file comments

### DIFF
--- a/.changeset/test-bad-changeset.md
+++ b/.changeset/test-bad-changeset.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+# fix bug
+
+update stuff

--- a/.changeset/test-good-changeset.md
+++ b/.changeset/test-good-changeset.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler dev` failing when configuration file contains trailing commas
+
+Previously, `wrangler dev` would crash with a JSON parse error if `wrangler.json` contained trailing commas in arrays or objects. Since JSONC supports trailing commas, this is now handled correctly by using a JSONC-aware parser.

--- a/.github/workflows/changeset-review.yml
+++ b/.github/workflows/changeset-review.yml
@@ -44,6 +44,34 @@ jobs:
           # Recover deleted files so Claude can read them (needed for Version Packages PRs)
           recover_deleted_files: ${{ github.event.pull_request.title == 'Version Packages' }}
 
+      - name: Clean up prior changeset reviews
+        if: github.event.pull_request.title == 'Version Packages' || steps.changed-changesets.outputs.added_files_count > 0
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          COMMENTS=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate | jq -s 'add')
+
+          # Delete sticky OK comments (identified by embedded HTML marker)
+          echo "$COMMENTS" | jq -r '.[] | select(.body | contains("<!-- changeset-review -->")) | .id' | while read -r COMMENT_ID; do
+            echo "Deleting sticky OK comment ${COMMENT_ID}"
+            gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" -X DELETE
+          done
+
+          # Find marker comments from prior issue-review runs, delete the associated review and the marker
+          echo "$COMMENTS" | jq -c '.[] | select(.body | contains("<!-- changeset-review-marker"))' | while read -r ITEM; do
+            COMMENT_ID=$(echo "$ITEM" | jq -r '.id')
+            BODY=$(echo "$ITEM" | jq -r '.body')
+            REVIEW_ID=$(echo "$BODY" | grep -oP '(?<=review-id:)\d+')
+            if [ -n "$REVIEW_ID" ]; then
+              echo "Deleting prior review ${REVIEW_ID}"
+              gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews/${REVIEW_ID}" -X DELETE || true
+            fi
+            echo "Deleting marker comment ${COMMENT_ID}"
+            gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" -X DELETE
+          done
+
       - name: Review Changesets with OpenCode
         id: opencode-review
         # Run for Version Packages PRs (which delete changesets) or regular PRs with new changesets
@@ -69,20 +97,66 @@ jobs:
             5. **Dependabot**: Do not validate dependency update changesets for create-cloudflare
             6. **Experimental features**: Changesets for experimental features should include note on how users can opt in.
 
-            If all changesets pass, just output \"✅ All changesets look good\" - no need for a detailed checklist.
+            Write your review as JSON to \`changeset-review.json\` in this exact format (no other output):
+            {
+              \"status\": \"ok\",
+              \"summary\": \"✅ All changesets look good.\",
+              \"files\": []
+            }
+            or when there are issues:
+            {
+              \"status\": \"issues\",
+              \"summary\": \"⚠️ Issues found in N of M changesets.\",
+              \"files\": [
+                {
+                  \"path\": \".changeset/foo.md\",
+                  \"status\": \"issues\",
+                  \"comment\": \"<specific problems with this file>\"
+                }
+              ]
+            }
 
-            Do not review other files, only the changesets. This is specifically a changeset review action.
+            Only include files in the array when they have status \"issues\".
+            The top-level status must be \"issues\" if ANY file has issues, otherwise \"ok\".
+            Do not review other files, only the changesets. This is specifically a changeset review action."
 
-            If there are issues, output \"⚠️ Issues found\" followed by the specific problems.
-
-            Write your review to changeset-review.md."
-
-      - name: Post review comment
+      - name: Post review results
         if: steps.opencode-review.outcome == 'success'
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
-        with:
-          header: changeset-review
-          path: changeset-review.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          STATUS=$(jq -r '.status' changeset-review.json)
+          SUMMARY=$(jq -r '.summary' changeset-review.json)
+
+          if [ "$STATUS" = "issues" ]; then
+            # Build the comments array: one entry per file with issues, anchored to line 1
+            COMMENTS=$(jq '[.files[] | select(.status == "issues") | {path: .path, position: 1, body: .comment}]' changeset-review.json)
+
+            # Post a pull request review with inline file-level comments
+            REVIEW_RESPONSE=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+              -X POST \
+              -f "commit_id=${HEAD_SHA}" \
+              -f "event=COMMENT" \
+              -f "body=" \
+              --field "comments=${COMMENTS}")
+
+            REVIEW_ID=$(echo "$REVIEW_RESPONSE" | jq -r '.id')
+            echo "Posted review ${REVIEW_ID}"
+
+            # Post a hidden marker comment so the next run can find and delete this review
+            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+              -X POST \
+              -f "body=<!-- changeset-review-marker review-id:${REVIEW_ID} -->"
+          else
+            # Post a normal (non-resolvable) PR comment with a hidden marker for cleanup
+            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+              -X POST \
+              -f "body=<!-- changeset-review -->
+          ${SUMMARY}"
+          fi
 
       - name: Skip notice
         if: github.event.pull_request.title != 'Version Packages' && steps.changed-changesets.outputs.added_files_count == 0

--- a/.github/workflows/changeset-review.yml
+++ b/.github/workflows/changeset-review.yml
@@ -56,20 +56,24 @@ jobs:
           # Delete sticky OK comments (identified by embedded HTML marker)
           echo "$COMMENTS" | jq -r '.[] | select(.body | contains("<!-- changeset-review -->")) | .id' | while read -r COMMENT_ID; do
             echo "Deleting sticky OK comment ${COMMENT_ID}"
-            gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" -X DELETE
+            gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" -X DELETE || true
           done
 
-          # Find marker comments from prior issue-review runs, delete the associated review and the marker
+          # Find marker comments from prior issue-review runs, delete the associated review comments and the marker
           echo "$COMMENTS" | jq -c '.[] | select(.body | contains("<!-- changeset-review-marker"))' | while read -r ITEM; do
             COMMENT_ID=$(echo "$ITEM" | jq -r '.id')
             BODY=$(echo "$ITEM" | jq -r '.body')
             REVIEW_ID=$(echo "$BODY" | grep -oP '(?<=review-id:)\d+')
             if [ -n "$REVIEW_ID" ]; then
-              echo "Deleting prior review ${REVIEW_ID}"
-              gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews/${REVIEW_ID}" -X DELETE || true
+              echo "Deleting comments on prior review ${REVIEW_ID}"
+              # Submitted reviews cannot be deleted via the API; delete each review comment individually instead
+              gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews/${REVIEW_ID}/comments" \
+                | jq -r '.[].id' | while read -r RC_ID; do
+                  gh api "repos/${REPO}/pulls/comments/${RC_ID}" -X DELETE || true
+                done
             fi
             echo "Deleting marker comment ${COMMENT_ID}"
-            gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" -X DELETE
+            gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" -X DELETE || true
           done
 
       - name: Review Changesets with OpenCode
@@ -132,16 +136,16 @@ jobs:
           SUMMARY=$(jq -r '.summary' changeset-review.json)
 
           if [ "$STATUS" = "issues" ]; then
-            # Build the comments array: one entry per file with issues, anchored to line 1
-            COMMENTS=$(jq '[.files[] | select(.status == "issues") | {path: .path, position: 1, body: .comment}]' changeset-review.json)
+            # Build the request body: file-level comments (subject_type: "file") for each problematic changeset
+            REQUEST_BODY=$(jq -n \
+              --arg commit_id "$HEAD_SHA" \
+              --argjson comments "$(jq '[.files[] | select(.status == "issues") | {path: .path, subject_type: "file", body: .comment}]' changeset-review.json)" \
+              '{commit_id: $commit_id, event: "COMMENT", body: "", comments: $comments}')
 
             # Post a pull request review with inline file-level comments
-            REVIEW_RESPONSE=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+            REVIEW_RESPONSE=$(echo "$REQUEST_BODY" | gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
               -X POST \
-              -f "commit_id=${HEAD_SHA}" \
-              -f "event=COMMENT" \
-              -f "body=" \
-              --field "comments=${COMMENTS}")
+              --input -)
 
             REVIEW_ID=$(echo "$REVIEW_RESPONSE" | jq -r '.id')
             echo "Posted review ${REVIEW_ID}"


### PR DESCRIPTION
Fixes #[N/A - internal workflow improvement].

When the changeset review AI finds issues, post feedback as PR review comments attached to the specific changeset file(s). This creates resolvable conversation threads that must be addressed before merging. When changesets are fine, post a normal non-resolvable PR comment instead.

#### Changes

- **Cleanup step**: On each run, find and delete any prior review (via hidden marker comments) so stale threads don't accumulate across pushes
- **Structured AI output**: Updated the OpenCode prompt to write `changeset-review.json` with per-file status/comments instead of free-form markdown
- **Inline file comments** (issues path): Uses `gh api` to create a PR review with `event: COMMENT` and one inline comment per problematic changeset file
- **Normal PR comment** (ok path): Posts a plain non-resolvable comment with the summary

#### Testing

The second commit adds a good and a bad test changeset to exercise both paths. **Remove that commit before merging.**

- `test-good-changeset.md`: well-formed patch changeset (should get ✅)
- `test-bad-changeset.md`: has an h1 header, vague description, questionable version type (should get inline review comment)

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: CI workflow change — validated by triggering the workflow with test changesets in this PR
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Internal CI workflow change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13026" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
