### PR TITLE
fix(wrangler): run asset directory validation during --dry-run

### DIFF
--- a/.changeset/dry-run-asset-validation.md
+++ b/.changeset/dry-run-asset-validation.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler deploy --dry-run` skipping asset build-artifact validation checks
+
+Previously, `--dry-run` skipped the entire asset sync step, which meant it also skipped validation that runs during asset manifest building. This included the check that errors when a `_worker.js` file or directory would be uploaded as a public static asset (which can expose private server-side code), as well as the per-file size limit check.
+
+With this fix, `--dry-run` now runs `buildAssetManifest` against the asset directory when assets are configured, performing the same file-system validation as a real deploy without uploading anything or making any API calls.

--- a/packages/wrangler/src/__tests__/deploy/assets.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/assets.test.ts
@@ -759,6 +759,30 @@ describe("deploy", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
+		it("should error on --dry-run if it is going to upload a _worker.js file as an asset", async ({
+			expect,
+		}) => {
+			const assets = [
+				{ filePath: "_worker.js", content: "// some secret server-side code." },
+			];
+			writeAssets(assets, "some/path/assets");
+			writeWranglerConfig(
+				{
+					assets: { directory: "assets" },
+				},
+				"some/path/wrangler.toml"
+			);
+			writeWorkerSource({ basePath: "some/path" });
+			await expect(
+				runWrangler("deploy --dry-run --config some/path/wrangler.toml")
+			).rejects.toThrowErrorMatchingInlineSnapshot(`
+				[Error: Uploading a Pages _worker.js file as an asset.
+				This could expose your private server-side code to the public Internet. Is this intended?
+				If you do not want to upload this file, either remove it or add an ".assetsignore" file, to the root of your asset directory, containing "_worker.js" to avoid uploading.
+				If you do want to upload this file, you can add an empty ".assetsignore" file, to the root of your asset directory, to hide this error.]
+			`);
+		});
+
 		it("should upload _redirects and _headers", async ({ expect }) => {
 			const redirectsContent = "/foo /bar";
 			const headersContent = "/some-path\nX-Header: Custom-Value";

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -264,7 +264,7 @@ export const syncAssets = async (
 	return completionJwt;
 };
 
-const buildAssetManifest = async (dir: string) => {
+export const buildAssetManifest = async (dir: string) => {
 	const files = await readdir(dir, { recursive: true });
 	logReadFilesFromDirectory(dir, files);
 

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -16,7 +16,7 @@ import {
 } from "@cloudflare/workers-utils";
 import PQueue from "p-queue";
 import { Response } from "undici";
-import { syncAssets } from "../assets";
+import { buildAssetManifest, syncAssets } from "../assets";
 import { fetchListResult, fetchResult } from "../cfetch";
 import { buildContainer } from "../containers/build";
 import { getNormalizedContainerOptions } from "../containers/config";
@@ -801,6 +801,11 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 						props.dispatchNamespace
 					)
 				: undefined;
+
+		// validate asset directory
+		if (props.assetsOptions && props.dryRun) {
+			await buildAssetManifest(props.assetsOptions.directory);
+		}
 
 		const workersSitesAssets = await syncWorkersSite(
 			config,


### PR DESCRIPTION
## Summary
`wrangler deploy --dry-run` currently skips the entire `syncAssets()` call, which means asset directory validation checks (`_worker.js` exposure detection, file size limits) are also skipped. A real deploy fails with a clear error, but `--dry-run` silently passes.

This fix exports `buildAssetManifest()` from `assets.ts` and calls it during `--dry-run` when assets are configured. This runs the same filesystem validation as a real deploy without deploying anything, making API calls, or altering the behavior or `--dry-run`.

### Testing

One new test in `assets.test.ts` verifies that `--dry-run` catches a `_worker.js` file in the asset directory.

### Note
The same gap exists in the `wrangler versions upload --dry-run` path. This PR scopes the fix to `wrangler deploy`, but `buildAssetManifest` is now exported and available if maintainers want to apply the same check there (either here or in a separate PR).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix

*A picture of a cute animal (not mandatory, but encouraged)*

<img width="1800" height="1200" alt="image" src="https://github.com/user-attachments/assets/df26bc66-4f96-43b5-8e14-741695ca944e" />

*Lihn Mai from the [National Zoo](https://nationalzoo.si.edu/elephants) with her aunt Swarna*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
