### PR TITLE
In the changesets validation, allow private packages to have major bumps

### DIFF
--- a/tools/deployments/__tests__/validate-changesets.test.ts
+++ b/tools/deployments/__tests__/validate-changesets.test.ts
@@ -169,6 +169,26 @@ describe("validateChangesets()", () => {
 		`);
 	});
 
+	it("should allow major bumps for private packages", ({ expect }) => {
+		const errors = validateChangesets(
+			new Map<string, PackageJSON>([
+				["package-b", { name: "package-b", private: true }],
+			]),
+			[
+				{
+					file: "major-private.md",
+					contents: dedent`
+					---
+					"package-b": major
+					---
+
+					breaking change for private pkg!`,
+				},
+			]
+		);
+		expect(errors).toMatchInlineSnapshot(`[]`);
+	});
+
 	it("should report errors for major bump changesets", ({ expect }) => {
 		const errors = validateChangesets(
 			new Map<string, PackageJSON>([
@@ -208,7 +228,6 @@ describe("validateChangesets()", () => {
 		expect(errors).toMatchInlineSnapshot(`
 			[
 			  "Major version bumps are not allowed for package "package-c" in changeset at "major-three.md".",
-			  "Invalid type "major" for package "package-c" in changeset at "major-three.md".",
 			]
 		`);
 	});

--- a/tools/deployments/validate-changesets.ts
+++ b/tools/deployments/validate-changesets.ts
@@ -24,18 +24,19 @@ export function validateChangesets(
 		try {
 			const changeset = parseChangeset(contents);
 			for (const release of changeset.releases) {
-				if (!packages.has(release.name)) {
+				const targetPackage = packages.get(release.name);
+				if (!targetPackage) {
 					errors.push(
 						`Unknown package name "${release.name}" in changeset at "${file}".`
 					);
 				}
 
-				if (release.type === "major") {
+				if (release.type === "major" && targetPackage?.private !== true) {
 					errors.push(
 						`Major version bumps are not allowed for package "${release.name}" in changeset at "${file}".`
 					);
 				}
-				if (!["minor", "patch", "none"].includes(release.type)) {
+				if (!["major", "minor", "patch", "none"].includes(release.type)) {
 					errors.push(
 						`Invalid type "${release.type}" for package "${release.name}" in changeset at "${file}".`
 					);


### PR DESCRIPTION
<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal infra change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
