### PR TITLE
Fixing bug when two containers share same image

### DIFF
--- a/.changeset/container-shared-image-cleanup.md
+++ b/.changeset/container-shared-image-cleanup.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+"@cloudflare/vite-plugin": patch
+---
+
+Fix local dev incorrectly removing image tags for other container classes that share the same Docker image
+
+When multiple container classes were built from the same Dockerfile, starting a dev session would remove image tags belonging to sibling classes that were still in use. Tag cleanup now only removes stale tags from the same repository (class name) as the one being rebuilt.

--- a/packages/containers-shared/src/utils.ts
+++ b/packages/containers-shared/src/utils.ts
@@ -305,6 +305,11 @@ export async function getImageRepoTags(
 /**
  * Checks if the given image has any duplicate tags from previous dev sessions,
  * and remove them if so.
+ *
+ * Only removes tags that share the same repository name (e.g. cloudflare-dev/orchestrator)
+ * but have a different tag (build ID). This prevents removing tags for other container
+ * classes that happen to share the same underlying Docker image (e.g. when multiple
+ * containers are built from the same Dockerfile).
  */
 export async function cleanupDuplicateImageTags(
 	dockerPath: string,
@@ -312,9 +317,12 @@ export async function cleanupDuplicateImageTags(
 ): Promise<void> {
 	try {
 		const repoTags = await getImageRepoTags(dockerPath, imageTag);
-		// Remove all cloudflare-dev tags from previous sessions except the current one
+		// Extract the repository name (everything before the last colon)
+		const lastColon = imageTag.lastIndexOf(":");
+		const repo = lastColon !== -1 ? imageTag.slice(0, lastColon) : imageTag;
+		// Only remove tags from the same repository (class name) with a different build ID
 		const tagsToRemove = repoTags.filter(
-			(tag) => tag !== imageTag && tag.startsWith("cloudflare-dev")
+			(tag) => tag !== imageTag && tag.startsWith(repo + ":")
 		);
 		if (tagsToRemove.length > 0) {
 			runDockerCmdWithOutput(dockerPath, ["rmi", ...tagsToRemove]);

--- a/packages/containers-shared/tests/utils.test.ts
+++ b/packages/containers-shared/tests/utils.test.ts
@@ -1,5 +1,6 @@
+import { execFileSync } from "node:child_process";
 import { beforeEach, describe, it, vi } from "vitest";
-import { checkExposedPorts } from "./../src/utils";
+import { checkExposedPorts, cleanupDuplicateImageTags } from "./../src/utils";
 import type { ContainerDevOptions } from "../src/types";
 
 let docketImageInspectResult = "0";
@@ -11,6 +12,8 @@ vi.mock("../src/inspect", async (importOriginal) => {
 		dockerImageInspect: () => docketImageInspectResult,
 	};
 });
+
+vi.mock("node:child_process");
 
 const containerConfig = {
 	dockerfile: "",
@@ -38,5 +41,51 @@ describe("checkExposedPorts", () => {
 				For additional information please see: https://developers.cloudflare.com/containers/local-dev/#exposing-ports.
 				]
 			`);
+	});
+});
+
+// Regression test for a bug where cleaning up stale image tags from a previous
+// dev session would also remove tags belonging to other, still-active container
+// classes. This happens when multiple container classes share the same underlying
+// Docker image (e.g. built from the same Dockerfile) and therefore all live under
+// the "cloudflare-dev/*" namespace on the same image.
+//
+// The original filter matched any tag starting with "cloudflare-dev", so cleaning
+// up class `foo` would wipe out `bar`'s tags too. The fix narrows the filter to
+// the exact repository (class name), so only stale tags for the same class are
+// removed.
+describe("cleanupDuplicateImageTags", () => {
+	beforeEach(() => {
+		vi.mocked(execFileSync).mockReset();
+	});
+
+	it("only removes stale tags from the same repository, leaving sibling classes alone", async ({
+		expect,
+	}) => {
+		// Simulate the RepoTags that `docker image inspect` would return for an
+		// image shared between two classes (`foo` and `bar`). Each class has a
+		// current tag and a stale tag from a previous dev session.
+		docketImageInspectResult = [
+			"cloudflare-dev/foo:build-current",
+			"cloudflare-dev/foo:build-old",
+			"cloudflare-dev/bar:build-current",
+			"cloudflare-dev/bar:build-old",
+		].join("\n");
+
+		// Run cleanup as if we just (re)built `foo`. Only `foo:build-old` should
+		// be removed; `bar`'s tags must be untouched because `bar` is still in
+		// use and will manage its own cleanup.
+		await cleanupDuplicateImageTags(
+			"docker",
+			"cloudflare-dev/foo:build-current"
+		);
+
+		// Asserting on the exact args passed to `docker rmi` guards against the
+		// original bug: if the filter ever regresses to matching the whole
+		// `cloudflare-dev` prefix, this call would include the `bar` tags and
+		// the assertion would fail.
+		expect(vi.mocked(execFileSync)).toHaveBeenCalledOnce();
+		const [, args] = vi.mocked(execFileSync).mock.calls[0];
+		expect(args).toEqual(["rmi", "cloudflare-dev/foo:build-old"]);
 	});
 });


### PR DESCRIPTION
Fixes issue when two container apps share the same image one is not found.

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
