### PR TITLE
[miniflare] Restart workerd process on crash after successful startup

### DIFF
--- a/.changeset/rude-lands-hug.md
+++ b/.changeset/rude-lands-hug.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+Miniflare now restarts workerd if it crashes in a handler (but not if it crashes at startup)

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -2286,6 +2286,21 @@ export class Miniflare {
 			verbose: this.#sharedOpts.core.verbose,
 			handleRuntimeStdio: this.#sharedOpts.core.handleRuntimeStdio,
 			handleStructuredLogs: this.#sharedOpts.core.handleStructuredLogs,
+			onWorkerdCrashRestart: () => {
+				// workerd crashed after successful startup. Try to restart
+				// workerd. I copied this from the constructor.
+				// TODO(NOW): What do we do when it fails??
+				void this.#runtimeMutex
+					.runWith(() => this.#assembleAndUpdateConfig())
+					.catch((e) => {
+						// If initialisation failed, attempting to `dispose()` this instance
+						// will too. Therefore, remove from the instance registry now, so we
+						// can still test async initialisation failures, without test failures
+						// telling us to `dispose()` the instance.
+						maybeInstanceRegistry?.delete(this);
+						throw e;
+					});
+			},
 		};
 		const maybeSocketPorts = await this.#runtime.updateConfig(
 			configBuffer,

--- a/packages/miniflare/src/runtime/index.ts
+++ b/packages/miniflare/src/runtime/index.ts
@@ -318,7 +318,7 @@ export class Runtime {
 			const currentProcess = this.#process;
 			currentProcess?.once("exit", () => {
 				if (this.#process !== currentProcess) {
-					// We goit here because dispose() set this.#process to
+					// We got here because dispose() set this.#process to
 					// undefined before sending SIGKILL
 					return;
 				}

--- a/packages/miniflare/src/runtime/index.ts
+++ b/packages/miniflare/src/runtime/index.ts
@@ -44,6 +44,8 @@ export interface RuntimeOptions {
 	verbose?: boolean;
 	handleRuntimeStdio?: (stdout: Readable, stderr: Readable) => void;
 	handleStructuredLogs?: StructuredLogsHandler;
+	// Called when workerd crashes after the initial ready signal
+	onWorkerdCrashRestart?: () => void;
 }
 
 async function waitForPorts(
@@ -217,7 +219,6 @@ export class Runtime {
 	): Promise<SocketPorts | undefined> {
 		// 1. Stop existing process (if any) and wait for exit
 		await this.dispose();
-		// TODO: what happens if runtime crashes?
 
 		// 2. Start new process
 		const command = getRuntimeCommand();
@@ -311,6 +312,23 @@ export class Runtime {
 
 		if (ports === undefined && !abortSignal.aborted) {
 			startupLogBuffer.handleStartupFailure();
+		} else {
+			// workerd is now listening. Watch for unexpected exits so we can
+			// restart.
+			const currentProcess = this.#process;
+			currentProcess?.once("exit", () => {
+				if (this.#process !== currentProcess) {
+					// We goit here because dispose() set this.#process to
+					// undefined before sending SIGKILL
+					return;
+				}
+				if (abortSignal.aborted) {
+					return;
+				}
+				// Crash: clear stale #process and notify the caller.
+				this.#process = undefined;
+				options.onWorkerdCrashRestart?.();
+			});
 		}
 
 		return ports;

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -2584,6 +2584,72 @@ unixSerialTest(
 	}
 );
 
+test("Miniflare: workerd crash during startup => ERR_RUNTIME_FAILURE", async ({
+	expect,
+}) => {
+	const mf = new Miniflare({
+		modules: true,
+		script: `
+			import { abortIsolate } from "cloudflare:workers";
+			abortIsolate("crash!");
+			export default {
+				fetch(request) {
+					return new Response("ok");
+				},
+			}
+		`,
+	});
+	// dispose() on a startup-failed instance propagates the same
+	// ERR_RUNTIME_FAILURE
+	onTestFinished(() => mf.dispose().catch(() => {}));
+
+	await expect(mf.ready).rejects.toThrow(
+		new MiniflareCoreError(
+			"ERR_RUNTIME_FAILURE",
+			"The Workers runtime failed to start. " +
+				"There is likely additional logging output above."
+		)
+	);
+});
+
+test("Miniflare: workerd crash in handler => restart", async ({ expect }) => {
+	const mf = new Miniflare({
+		modules: true,
+		script: `
+			import { abortIsolate } from "cloudflare:workers";
+			let counter = 1;
+			export default {
+				fetch(request) {
+					if (new URL(request.url).searchParams.get("crash")) {
+						abortIsolate("test crash");
+					}
+					return new Response(\`ok \${counter++}\`);
+				},
+			}
+		`,
+	});
+	useDispose(mf);
+
+	await mf.ready;
+	const r1 = await mf.dispatchFetch("http://placeholder/");
+	expect(await r1.text()).toBe("ok 1");
+
+	const r2 = await mf.dispatchFetch("http://placeholder/");
+	expect(await r2.text()).toBe("ok 2");
+
+	// Trigger crash
+	await expect(
+		mf.dispatchFetch("http://placeholder/?crash=1")
+	).rejects.toThrow();
+
+	// Wait for workerd to reset
+	await new Promise((resolve) => setTimeout(resolve, 0));
+
+	// Starts over with counter = 1 again
+	const r3 = await mf.dispatchFetch("http://placeholder/");
+	expect(await r3.text()).toBe("ok 1");
+});
+
 test("Miniflare: exits cleanly", async ({ expect }) => {
 	const miniflarePath = require.resolve("miniflare");
 	const result = childProcess.spawn(


### PR DESCRIPTION
If workerd crashes while starting up, exit as before. If workerd crash happens in a handler, try to restart workerd.
I'm not really sure whether the added logic is correct if restarting workerd fails. On the other hand, starting it the first time worked so hopefully restarting it will work?
The added tests require cloudflare/workerd#6382 for abortIsolate().

cc @penalosa

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: I don't think it's necessary?

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
