### PR TITLE
Add `localhost:7445` to Quick Edit allowed parent origins

### DIFF
--- a/packages/quick-edit/src/index.ts
+++ b/packages/quick-edit/src/index.ts
@@ -14,6 +14,7 @@ const ALLOWED_PARENT_ORIGINS = [
 const ALLOWED_PARENT_ORIGIN_WILDCARDS = [
 	"https://*.workers-playground.pages.dev",
 	"https://*.workers-playground.workers.dev",
+	"http://localhost:*",
 ];
 
 // During local development (wrangler dev), the playground runs on localhost.

--- a/packages/quick-edit/src/index.ts
+++ b/packages/quick-edit/src/index.ts
@@ -7,7 +7,7 @@ const ALLOWED_PARENT_ORIGINS = [
 	"https://workers.cloudflare.com",
 	"https://workers-playground.pages.dev",
 	"https://workers-playground.workers.dev",
-	"http://localhost:8445",
+	"http://localhost:7445",
 ];
 
 // Origin patterns using wildcards, for preview deployments etc.
@@ -16,6 +16,12 @@ const ALLOWED_PARENT_ORIGIN_WILDCARDS = [
 	"https://*.workers-playground.pages.dev",
 	"https://*.workers-playground.workers.dev",
 ];
+
+// During local development (wrangler dev), the playground runs on localhost.
+// We detect this from the request URL and add localhost origins dynamically.
+// The wildcard port "http://localhost:*" allows any port in CSP frame-ancestors,
+// and "http://localhost" is matched as a prefix in the client-side origin check.
+const LOCALHOST_ORIGIN_WILDCARDS = ["http://localhost:*"];
 
 export default {
 	async fetch(request: Request, env: Env) {
@@ -31,8 +37,13 @@ export default {
 			forwardedHost?.endsWith(".devprod.cloudflare.dev") ?? false;
 		const authority = isValidForwardedHost ? forwardedHost : url.host;
 
+		const isLocalDev = url.hostname === "localhost";
+
 		const allOrigins = [...ALLOWED_PARENT_ORIGINS];
 		const allWildcards = [...ALLOWED_PARENT_ORIGIN_WILDCARDS];
+		if (isLocalDev) {
+			allWildcards.push(...LOCALHOST_ORIGIN_WILDCARDS);
+		}
 
 		const configValues = {
 			// Allowed parent origins are injected into the HTML so the client-side

--- a/packages/quick-edit/src/index.ts
+++ b/packages/quick-edit/src/index.ts
@@ -7,6 +7,7 @@ const ALLOWED_PARENT_ORIGINS = [
 	"https://workers.cloudflare.com",
 	"https://workers-playground.pages.dev",
 	"https://workers-playground.workers.dev",
+	"http://localhost:8445",
 ];
 
 // Origin patterns using wildcards, for preview deployments etc.
@@ -14,14 +15,7 @@ const ALLOWED_PARENT_ORIGINS = [
 const ALLOWED_PARENT_ORIGIN_WILDCARDS = [
 	"https://*.workers-playground.pages.dev",
 	"https://*.workers-playground.workers.dev",
-	"http://localhost:*",
 ];
-
-// During local development (wrangler dev), the playground runs on localhost.
-// We detect this from the request URL and add localhost origins dynamically.
-// The wildcard port "http://localhost:*" allows any port in CSP frame-ancestors,
-// and "http://localhost" is matched as a prefix in the client-side origin check.
-const LOCALHOST_ORIGIN_WILDCARDS = ["http://localhost:*"];
 
 export default {
 	async fetch(request: Request, env: Env) {
@@ -37,13 +31,8 @@ export default {
 			forwardedHost?.endsWith(".devprod.cloudflare.dev") ?? false;
 		const authority = isValidForwardedHost ? forwardedHost : url.host;
 
-		const isLocalDev = url.hostname === "localhost";
-
 		const allOrigins = [...ALLOWED_PARENT_ORIGINS];
 		const allWildcards = [...ALLOWED_PARENT_ORIGIN_WILDCARDS];
-		if (isLocalDev) {
-			allWildcards.push(...LOCALHOST_ORIGIN_WILDCARDS);
-		}
 
 		const configValues = {
 			// Allowed parent origins are injected into the HTML so the client-side


### PR DESCRIPTION
This allows the production editor to be embedded in apps running locally.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
