### PR TITLE
Update AGENTS.md to mention oxfmt since we no longer use prettier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,14 +96,14 @@ This is the **Cloudflare Workers SDK** monorepo containing tools and libraries f
 - Use `node:` prefix for Node.js imports (`import/enforce-node-protocol-usage`)
 - Prefix unused variables with `_`
 - No `.only()` in tests (`no-only-tests/no-only-tests`)
-- Format with Prettier - run `pnpm prettify` in the workspace root before committing
+- Format with oxfmt - run `pnpm prettify` in the workspace root before committing
 - All changes to published packages require a changeset (see below)
 
-**Formatting (Prettier):**
+**Formatting (oxfmt):**
 
 - Tabs (not spaces), double quotes, semicolons, trailing commas (es5)
 - Import order enforced: builtins → third-party → parent → sibling → index → types
-- `prettier-plugin-packagejson` sorts package.json keys
+- `sortPackageJson` option sorts package.json keys
 
 **Security:**
 

--- a/packages/create-cloudflare/AGENTS.md
+++ b/packages/create-cloudflare/AGENTS.md
@@ -19,7 +19,6 @@ Project scaffolding CLI for Cloudflare Workers. Single entry: `src/cli.ts` serve
 ## CONVENTIONS
 
 - `no-console: error` — use project's logging utilities
-- Own `.prettierrc` — same settings as root but without `prettier-plugin-packagejson`
 - Templates excluded from linting (except `c3.ts` files within templates)
 - Templates excluded from formatting (except hello-world templates)
 


### PR DESCRIPTION
Minimal update to the AGENTS.md since we no longer use prettier

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: I don't think this is testable
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: minimal infra change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
