### PR TITLE
Unhide `cache` config

### DIFF
--- a/.changeset/twenty-spies-rest.md
+++ b/.changeset/twenty-spies-rest.md
@@ -5,4 +5,4 @@
 
 Introducing the `cache` configuration option for Workers.
 
-You can now set `{ cache: { enabled: true } }` in your Wrangler configuration file to enable a HTTP cache in front of your Worker's `fetch` handler. More information can be found in [our documentation](https://developers.cloudflare.com/workers/cache/configuration/).
+You can now set `{ cache: { enabled: true } }` in your Wrangler configuration file to enable a HTTP cache in front of your Worker's `fetch` handler. This is also supported in `[previews]` configuration — `previews.cache` overrides the top-level `cache` setting for preview deployments, and falls back to the top-level value when absent. More information can be found in [our documentation](https://developers.cloudflare.com/workers/cache/configuration/).

--- a/.changeset/twenty-spies-rest.md
+++ b/.changeset/twenty-spies-rest.md
@@ -5,4 +5,4 @@
 
 Introducing the `cache` configuration option for Workers.
 
-You can now set `{ cache: { enabled: true } }` in your Wrangler configuration file to enable a HTTP cache in front of your Worker's `fetch` handler. More information can be found in [our documentation](TODO).
+You can now set `{ cache: { enabled: true } }` in your Wrangler configuration file to enable a HTTP cache in front of your Worker's `fetch` handler. More information can be found in [our documentation](https://developers.cloudflare.com/workers/cache/configuration/).

--- a/.changeset/twenty-spies-rest.md
+++ b/.changeset/twenty-spies-rest.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/workers-utils": minor
+"wrangler": minor
+---
+
+Introducing the `cache` configuration option for Workers.
+
+You can now set `{ cache: { enabled: true } }` in your Wrangler configuration file to enable a HTTP cache in front of your Worker's `fetch` handler. More information can be found in [our documentation](TODO).

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -1658,7 +1658,7 @@ export type ContainerEngine =
  *
  * The `previews` block contains any intentionally divergent configuration intended solely for Previews, including:
  * - All non-inheritable properties (environment variables and bindings like KV, D1, R2, etc.)
- * - Select inheritable properties: `logpush`, `observability`, `limits`
+ * - Select inheritable properties: `logpush`, `observability`, `limits`, `cache`
  *
  * @inheritable
  */
@@ -1666,5 +1666,8 @@ export interface PreviewsConfig
 	extends
 		Partial<EnvironmentNonInheritable>,
 		Partial<
-			Pick<EnvironmentInheritable, "logpush" | "observability" | "limits">
+			Pick<
+				EnvironmentInheritable,
+				"logpush" | "observability" | "limits" | "cache"
+			>
 		> {}

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -660,7 +660,6 @@ interface EnvironmentInheritable {
 	 * Specify the cache behavior of the Worker.
 	 *
 	 * @inheritable
-	 * @hidden
 	 */
 	cache: CacheOptions | undefined;
 

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -1660,7 +1660,7 @@ export type ContainerEngine =
  *
  * The `previews` block contains any intentionally divergent configuration intended solely for Previews, including:
  * - All non-inheritable properties (environment variables and bindings like KV, D1, R2, etc.)
- * - Select inheritable properties: `logpush`, `observability`, `limits`
+ * - Select inheritable properties: `logpush`, `observability`, `limits`, `cache`
  *
  * @inheritable
  */
@@ -1668,5 +1668,8 @@ export interface PreviewsConfig
 	extends
 		Partial<EnvironmentNonInheritable>,
 		Partial<
-			Pick<EnvironmentInheritable, "logpush" | "observability" | "limits">
+			Pick<
+				EnvironmentInheritable,
+				"logpush" | "observability" | "limits" | "cache"
+			>
 		> {}

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -5168,6 +5168,7 @@ const validatePreviewsConfig =
 				"logpush",
 				"observability",
 				"limits",
+				"cache",
 			]) && isValid;
 
 		isValid =
@@ -5473,6 +5474,10 @@ const validatePreviewsConfig =
 					"number"
 				) && isValid;
 		}
+
+		isValid =
+			validateCache(diagnostics, `${field}.cache`, previews.cache, undefined) &&
+			isValid;
 
 		return isValid;
 	};

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -5168,6 +5168,7 @@ const validatePreviewsConfig =
 				"logpush",
 				"observability",
 				"limits",
+				"cache",
 			]) && isValid;
 
 		isValid =
@@ -5465,6 +5466,10 @@ const validatePreviewsConfig =
 					"number"
 				) && isValid;
 		}
+
+		isValid =
+			validateCache(diagnostics, `${field}.cache`, previews.cache, undefined) &&
+			isValid;
 
 		return isValid;
 	};

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -9554,6 +9554,83 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
+			it("should accept previews.cache with enabled: true", ({ expect }) => {
+				const rawConfig = {
+					previews: {
+						cache: {
+							enabled: true,
+						},
+					},
+				} as unknown as RawConfig;
+
+				const { diagnostics } = normalizeAndValidateConfig(
+					rawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(false);
+			});
+
+			it("should accept previews.cache with enabled: false", ({ expect }) => {
+				const rawConfig = {
+					previews: {
+						cache: {
+							enabled: false,
+						},
+					},
+				} as unknown as RawConfig;
+
+				const { diagnostics } = normalizeAndValidateConfig(
+					rawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(false);
+			});
+
+			it("should reject previews.cache when missing enabled", ({ expect }) => {
+				const rawConfig = {
+					previews: {
+						cache: {},
+					},
+				} as unknown as RawConfig;
+
+				const { diagnostics } = normalizeAndValidateConfig(
+					rawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toContain("enabled");
+			});
+
+			it("should reject previews.cache when enabled is not a boolean", ({
+				expect,
+			}) => {
+				const rawConfig = {
+					previews: {
+						cache: {
+							enabled: "yes",
+						},
+					},
+				} as unknown as RawConfig;
+
+				const { diagnostics } = normalizeAndValidateConfig(
+					rawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+			});
+
 			it("should reject previews.queues when passed as a flat array", ({
 				expect,
 			}) => {

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -9551,6 +9551,83 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
+			it("should accept previews.cache with enabled: true", ({ expect }) => {
+				const rawConfig = {
+					previews: {
+						cache: {
+							enabled: true,
+						},
+					},
+				} as unknown as RawConfig;
+
+				const { diagnostics } = normalizeAndValidateConfig(
+					rawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(false);
+			});
+
+			it("should accept previews.cache with enabled: false", ({ expect }) => {
+				const rawConfig = {
+					previews: {
+						cache: {
+							enabled: false,
+						},
+					},
+				} as unknown as RawConfig;
+
+				const { diagnostics } = normalizeAndValidateConfig(
+					rawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(false);
+			});
+
+			it("should reject previews.cache when missing enabled", ({ expect }) => {
+				const rawConfig = {
+					previews: {
+						cache: {},
+					},
+				} as unknown as RawConfig;
+
+				const { diagnostics } = normalizeAndValidateConfig(
+					rawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toContain("enabled");
+			});
+
+			it("should reject previews.cache when enabled is not a boolean", ({
+				expect,
+			}) => {
+				const rawConfig = {
+					previews: {
+						cache: {
+							enabled: "yes",
+						},
+					},
+				} as unknown as RawConfig;
+
+				const { diagnostics } = normalizeAndValidateConfig(
+					rawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+			});
+
 			it("should reject previews.queues when passed as a flat array", ({
 				expect,
 			}) => {

--- a/packages/wrangler/src/__tests__/preview.settings.test.ts
+++ b/packages/wrangler/src/__tests__/preview.settings.test.ts
@@ -91,6 +91,27 @@ describe("wrangler preview", () => {
 			expect(std.out).toContain("╭");
 		});
 
+		test("should display cache setting in pretty format", async ({
+			expect,
+		}) => {
+			msw.use(
+				http.get(`*/accounts/:accountId/workers/workers/:workerId`, () =>
+					HttpResponse.json({
+						success: true,
+						result: {
+							preview_defaults: {
+								cache: { enabled: true },
+								env: {},
+							},
+						},
+					})
+				)
+			);
+			await runWrangler("preview settings --worker-name override-worker");
+			expect(std.out).toContain("cache");
+			expect(std.out).toContain("enabled");
+		});
+
 		test("should show empty bindings in pretty format", async ({ expect }) => {
 			msw.use(
 				http.get(`*/accounts/:accountId/workers/workers/:workerId`, () =>
@@ -393,6 +414,94 @@ describe("wrangler preview", () => {
 			);
 			expect(patchRequestBody?.preview_defaults?.limits).toEqual({
 				subrequests: 50,
+			});
+		});
+
+		test("should prefer previews cache over top-level cache", async ({
+			expect,
+		}) => {
+			writeFileSync(
+				"wrangler.json",
+				JSON.stringify({
+					name: "test-worker",
+					main: "src/index.ts",
+					compatibility_date: "2025-01-01",
+					cache: { enabled: true },
+					previews: { cache: { enabled: false } },
+				})
+			);
+			let patchRequestBody:
+				| {
+						preview_defaults?: {
+							cache?: { enabled?: boolean };
+						};
+				  }
+				| undefined;
+			msw.use(
+				http.get(`*/accounts/:accountId/workers/workers/:workerId`, () =>
+					HttpResponse.json({
+						success: true,
+						result: { preview_defaults: {} },
+					})
+				),
+				http.patch(
+					`*/accounts/:accountId/workers/workers/:workerId`,
+					async ({ request }) => {
+						patchRequestBody =
+							(await request.json()) as typeof patchRequestBody;
+						return HttpResponse.json({ success: true, result: {} });
+					}
+				)
+			);
+			await runWrangler(
+				"preview settings update --worker-name override-worker --skip-confirmation"
+			);
+			expect(patchRequestBody?.preview_defaults?.cache).toEqual({
+				enabled: false,
+			});
+		});
+
+		test("should fall back to top-level cache when previews.cache is absent", async ({
+			expect,
+		}) => {
+			writeFileSync(
+				"wrangler.json",
+				JSON.stringify({
+					name: "test-worker",
+					main: "src/index.ts",
+					compatibility_date: "2025-01-01",
+					cache: { enabled: true },
+					previews: {},
+				})
+			);
+			let patchRequestBody:
+				| {
+						preview_defaults?: {
+							cache?: { enabled?: boolean };
+						};
+				  }
+				| undefined;
+			msw.use(
+				http.get(`*/accounts/:accountId/workers/workers/:workerId`, () =>
+					HttpResponse.json({
+						success: true,
+						result: { preview_defaults: {} },
+					})
+				),
+				http.patch(
+					`*/accounts/:accountId/workers/workers/:workerId`,
+					async ({ request }) => {
+						patchRequestBody =
+							(await request.json()) as typeof patchRequestBody;
+						return HttpResponse.json({ success: true, result: {} });
+					}
+				)
+			);
+			await runWrangler(
+				"preview settings update --worker-name override-worker --skip-confirmation"
+			);
+			expect(patchRequestBody?.preview_defaults?.cache).toEqual({
+				enabled: true,
 			});
 		});
 

--- a/packages/wrangler/src/__tests__/preview.test.ts
+++ b/packages/wrangler/src/__tests__/preview.test.ts
@@ -2506,6 +2506,174 @@ describe("wrangler preview", () => {
 			expect(deploymentRequestBody?.env).not.toHaveProperty("TOP_KV");
 		});
 
+		test("should include previews.cache in deployment request, falling back to top-level cache", async ({
+			expect,
+		}) => {
+			writeFileSync(
+				"wrangler.json",
+				JSON.stringify({
+					name: "test-worker",
+					main: "src/index.ts",
+					compatibility_date: "2025-01-01",
+					cache: { enabled: true },
+					previews: {
+						vars: { ENVIRONMENT: "preview" },
+					},
+				})
+			);
+
+			let deploymentRequestBody:
+				| {
+						cache?: { enabled?: boolean };
+				  }
+				| undefined;
+
+			msw.use(
+				http.get(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId`,
+					() =>
+						HttpResponse.json(
+							{
+								success: false,
+								result: null,
+								errors: [{ code: 10025, message: "Preview not found" }],
+							},
+							{ status: 404 }
+						)
+				),
+				http.post(
+					`*/accounts/:accountId/workers/workers/:workerId/previews`,
+					async () => {
+						return HttpResponse.json(
+							{
+								success: true,
+								result: {
+									id: "preview-id-cache",
+									name: "test-preview",
+									slug: "test-preview",
+									urls: ["https://test-preview.test-worker.cloudflare.app"],
+									worker_name: "test-worker",
+									created_on: new Date().toISOString(),
+								},
+							},
+							{ status: 201 }
+						);
+					}
+				),
+				http.post(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId/deployments`,
+					async ({ request }) => {
+						deploymentRequestBody =
+							(await request.json()) as typeof deploymentRequestBody;
+						return HttpResponse.json(
+							{
+								success: true,
+								result: {
+									id: "deployment-id-cache",
+									preview_id: "preview-id-cache",
+									preview_name: "test-preview",
+									urls: ["https://cache.test-worker.cloudflare.app"],
+									compatibility_date: "2025-01-01",
+									cache: deploymentRequestBody?.cache,
+									env: {},
+									created_on: new Date().toISOString(),
+								},
+							},
+							{ status: 201 }
+						);
+					}
+				)
+			);
+
+			await runWrangler("preview --name test-preview");
+
+			expect(deploymentRequestBody?.cache).toEqual({ enabled: true });
+		});
+
+		test("should prefer previews.cache over top-level cache in deployment request", async ({
+			expect,
+		}) => {
+			writeFileSync(
+				"wrangler.json",
+				JSON.stringify({
+					name: "test-worker",
+					main: "src/index.ts",
+					compatibility_date: "2025-01-01",
+					cache: { enabled: true },
+					previews: {
+						cache: { enabled: false },
+					},
+				})
+			);
+
+			let deploymentRequestBody:
+				| {
+						cache?: { enabled?: boolean };
+				  }
+				| undefined;
+
+			msw.use(
+				http.get(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId`,
+					() =>
+						HttpResponse.json(
+							{
+								success: false,
+								result: null,
+								errors: [{ code: 10025, message: "Preview not found" }],
+							},
+							{ status: 404 }
+						)
+				),
+				http.post(
+					`*/accounts/:accountId/workers/workers/:workerId/previews`,
+					async () => {
+						return HttpResponse.json(
+							{
+								success: true,
+								result: {
+									id: "preview-id-cache-override",
+									name: "test-preview",
+									slug: "test-preview",
+									urls: ["https://test-preview.test-worker.cloudflare.app"],
+									worker_name: "test-worker",
+									created_on: new Date().toISOString(),
+								},
+							},
+							{ status: 201 }
+						);
+					}
+				),
+				http.post(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId/deployments`,
+					async ({ request }) => {
+						deploymentRequestBody =
+							(await request.json()) as typeof deploymentRequestBody;
+						return HttpResponse.json(
+							{
+								success: true,
+								result: {
+									id: "deployment-id-cache-override",
+									preview_id: "preview-id-cache-override",
+									preview_name: "test-preview",
+									urls: ["https://cache-override.test-worker.cloudflare.app"],
+									compatibility_date: "2025-01-01",
+									cache: deploymentRequestBody?.cache,
+									env: {},
+									created_on: new Date().toISOString(),
+								},
+							},
+							{ status: 201 }
+						);
+					}
+				)
+			);
+
+			await runWrangler("preview --name test-preview");
+
+			expect(deploymentRequestBody?.cache).toEqual({ enabled: false });
+		});
+
 		test("should respect env-specific worker name for preview and deployment requests", async ({
 			expect,
 		}) => {

--- a/packages/wrangler/src/__tests__/preview.test.ts
+++ b/packages/wrangler/src/__tests__/preview.test.ts
@@ -2592,6 +2592,174 @@ describe("wrangler preview", () => {
 			expect(deploymentRequestBody?.env).not.toHaveProperty("TOP_KV");
 		});
 
+		test("should include previews.cache in deployment request, falling back to top-level cache", async ({
+			expect,
+		}) => {
+			writeFileSync(
+				"wrangler.json",
+				JSON.stringify({
+					name: "test-worker",
+					main: "src/index.ts",
+					compatibility_date: "2025-01-01",
+					cache: { enabled: true },
+					previews: {
+						vars: { ENVIRONMENT: "preview" },
+					},
+				})
+			);
+
+			let deploymentRequestBody:
+				| {
+						cache?: { enabled?: boolean };
+				  }
+				| undefined;
+
+			msw.use(
+				http.get(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId`,
+					() =>
+						HttpResponse.json(
+							{
+								success: false,
+								result: null,
+								errors: [{ code: 10025, message: "Preview not found" }],
+							},
+							{ status: 404 }
+						)
+				),
+				http.post(
+					`*/accounts/:accountId/workers/workers/:workerId/previews`,
+					async () => {
+						return HttpResponse.json(
+							{
+								success: true,
+								result: {
+									id: "preview-id-cache",
+									name: "test-preview",
+									slug: "test-preview",
+									urls: ["https://test-preview.test-worker.cloudflare.app"],
+									worker_name: "test-worker",
+									created_on: new Date().toISOString(),
+								},
+							},
+							{ status: 201 }
+						);
+					}
+				),
+				http.post(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId/deployments`,
+					async ({ request }) => {
+						deploymentRequestBody =
+							(await request.json()) as typeof deploymentRequestBody;
+						return HttpResponse.json(
+							{
+								success: true,
+								result: {
+									id: "deployment-id-cache",
+									preview_id: "preview-id-cache",
+									preview_name: "test-preview",
+									urls: ["https://cache.test-worker.cloudflare.app"],
+									compatibility_date: "2025-01-01",
+									cache: deploymentRequestBody?.cache,
+									env: {},
+									created_on: new Date().toISOString(),
+								},
+							},
+							{ status: 201 }
+						);
+					}
+				)
+			);
+
+			await runWrangler("preview --name test-preview");
+
+			expect(deploymentRequestBody?.cache).toEqual({ enabled: true });
+		});
+
+		test("should prefer previews.cache over top-level cache in deployment request", async ({
+			expect,
+		}) => {
+			writeFileSync(
+				"wrangler.json",
+				JSON.stringify({
+					name: "test-worker",
+					main: "src/index.ts",
+					compatibility_date: "2025-01-01",
+					cache: { enabled: true },
+					previews: {
+						cache: { enabled: false },
+					},
+				})
+			);
+
+			let deploymentRequestBody:
+				| {
+						cache?: { enabled?: boolean };
+				  }
+				| undefined;
+
+			msw.use(
+				http.get(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId`,
+					() =>
+						HttpResponse.json(
+							{
+								success: false,
+								result: null,
+								errors: [{ code: 10025, message: "Preview not found" }],
+							},
+							{ status: 404 }
+						)
+				),
+				http.post(
+					`*/accounts/:accountId/workers/workers/:workerId/previews`,
+					async () => {
+						return HttpResponse.json(
+							{
+								success: true,
+								result: {
+									id: "preview-id-cache-override",
+									name: "test-preview",
+									slug: "test-preview",
+									urls: ["https://test-preview.test-worker.cloudflare.app"],
+									worker_name: "test-worker",
+									created_on: new Date().toISOString(),
+								},
+							},
+							{ status: 201 }
+						);
+					}
+				),
+				http.post(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId/deployments`,
+					async ({ request }) => {
+						deploymentRequestBody =
+							(await request.json()) as typeof deploymentRequestBody;
+						return HttpResponse.json(
+							{
+								success: true,
+								result: {
+									id: "deployment-id-cache-override",
+									preview_id: "preview-id-cache-override",
+									preview_name: "test-preview",
+									urls: ["https://cache-override.test-worker.cloudflare.app"],
+									compatibility_date: "2025-01-01",
+									cache: deploymentRequestBody?.cache,
+									env: {},
+									created_on: new Date().toISOString(),
+								},
+							},
+							{ status: 201 }
+						);
+					}
+				)
+			);
+
+			await runWrangler("preview --name test-preview");
+
+			expect(deploymentRequestBody?.cache).toEqual({ enabled: false });
+		});
+
 		test("should respect env-specific worker name for preview and deployment requests", async ({
 			expect,
 		}) => {

--- a/packages/wrangler/src/preview/api.ts
+++ b/packages/wrangler/src/preview/api.ts
@@ -2,6 +2,7 @@ import { fetchResult } from "../cfetch";
 import type {
 	CfWorkerInit,
 	Config,
+	CacheOptions,
 	CfPlacement,
 	CfUserLimits,
 	Observability,
@@ -74,6 +75,7 @@ export interface DeploymentResource {
 	compatibility_flags?: string[];
 	limits?: CfUserLimits;
 	placement?: CfPlacement;
+	cache?: CacheOptions;
 	env?: EnvBindings;
 	created_on: string;
 }
@@ -102,6 +104,7 @@ export type CreatePreviewDeploymentRequestParams = {
 	migrations?: CfWorkerInit["migrations"];
 	limits?: CfUserLimits;
 	placement?: CfPlacement;
+	cache?: CacheOptions;
 	env?: EnvBindings;
 };
 
@@ -126,6 +129,7 @@ export type PreviewDefaults = {
 	logpush?: boolean;
 	limits?: CfUserLimits;
 	placement?: CfPlacement;
+	cache?: CacheOptions;
 	tail_consumers?: Array<{ name: string }>;
 	env?: EnvBindings;
 };

--- a/packages/wrangler/src/preview/api.ts
+++ b/packages/wrangler/src/preview/api.ts
@@ -2,6 +2,7 @@ import { fetchResult } from "../cfetch";
 import type {
 	CfWorkerInit,
 	Config,
+	CacheOptions,
 	CfPlacement,
 	CfUserLimits,
 	Observability,
@@ -75,6 +76,7 @@ export interface DeploymentResource {
 	compatibility_flags?: string[];
 	limits?: CfUserLimits;
 	placement?: CfPlacement;
+	cache?: CacheOptions;
 	env?: EnvBindings;
 	created_on: string;
 }
@@ -103,6 +105,7 @@ export type CreatePreviewDeploymentRequestParams = {
 	migrations?: CfWorkerInit["migrations"];
 	limits?: CfUserLimits;
 	placement?: CfPlacement;
+	cache?: CacheOptions;
 	env?: EnvBindings;
 };
 
@@ -127,6 +130,7 @@ export type PreviewDefaults = {
 	logpush?: boolean;
 	limits?: CfUserLimits;
 	placement?: CfPlacement;
+	cache?: CacheOptions;
 	tail_consumers?: Array<{ name: string }>;
 	env?: EnvBindings;
 };

--- a/packages/wrangler/src/preview/preview.ts
+++ b/packages/wrangler/src/preview/preview.ts
@@ -103,6 +103,10 @@ type MergedVersionLevel = {
 		value: { mode: string };
 		fromConfig: boolean;
 	};
+	cache?: {
+		value: Config["cache"];
+		fromConfig: boolean;
+	};
 	assets?: {
 		value: {
 			directory?: string;
@@ -381,6 +385,11 @@ async function assemblePreviewDeploymentSettings(
 	} else if (config.limits !== undefined) {
 		request.limits = config.limits;
 	}
+	if (previews?.cache !== undefined) {
+		request.cache = previews.cache;
+	} else if (config.cache !== undefined) {
+		request.cache = config.cache;
+	}
 	if (config.placement) {
 		request.placement = parseConfigPlacement(config);
 	}
@@ -475,6 +484,14 @@ function buildMergedVersionLevel(
 		result.placement = {
 			value: { mode: deployment.placement.mode },
 			fromConfig: !!config.placement?.mode,
+		};
+	}
+	if (deployment.cache !== undefined) {
+		result.cache = {
+			value: deployment.cache,
+			fromConfig: !!(
+				previews?.cache !== undefined || config.cache !== undefined
+			),
 		};
 	}
 	if (config.assets) {
@@ -667,6 +684,13 @@ function formatDeploymentResource(
 			"placement",
 			versionLevel.placement.value.mode,
 			versionLevel.placement.fromConfig,
+		]);
+	}
+	if (versionLevel.cache) {
+		settingsRows.push([
+			"cache",
+			versionLevel.cache.value?.enabled ? "enabled" : "disabled",
+			versionLevel.cache.fromConfig,
 		]);
 	}
 	if (settingsRows.length > 0) {

--- a/packages/wrangler/src/preview/preview.ts
+++ b/packages/wrangler/src/preview/preview.ts
@@ -103,6 +103,10 @@ type MergedVersionLevel = {
 		value: { mode: string };
 		fromConfig: boolean;
 	};
+	cache?: {
+		value: Config["cache"];
+		fromConfig: boolean;
+	};
 	assets?: {
 		value: {
 			directory?: string;
@@ -381,6 +385,11 @@ async function assemblePreviewDeploymentSettings(
 	} else if (config.limits !== undefined) {
 		request.limits = config.limits;
 	}
+	if (previews?.cache !== undefined) {
+		request.cache = previews.cache;
+	} else if (config.cache !== undefined) {
+		request.cache = config.cache;
+	}
 	if (config.placement) {
 		request.placement = parseConfigPlacement(config);
 	}
@@ -475,6 +484,12 @@ function buildMergedVersionLevel(
 		result.placement = {
 			value: { mode: deployment.placement.mode },
 			fromConfig: !!config.placement?.mode,
+		};
+	}
+	if (deployment.cache !== undefined) {
+		result.cache = {
+			value: deployment.cache,
+			fromConfig: previews?.cache !== undefined || config.cache !== undefined,
 		};
 	}
 	if (config.assets) {
@@ -667,6 +682,13 @@ function formatDeploymentResource(
 			"placement",
 			versionLevel.placement.value.mode,
 			versionLevel.placement.fromConfig,
+		]);
+	}
+	if (versionLevel.cache !== undefined) {
+		settingsRows.push([
+			"cache",
+			versionLevel.cache.value?.enabled ? "enabled" : "disabled",
+			versionLevel.cache.fromConfig,
 		]);
 	}
 	if (settingsRows.length > 0) {

--- a/packages/wrangler/src/preview/settings.ts
+++ b/packages/wrangler/src/preview/settings.ts
@@ -97,6 +97,12 @@ export function formatPreviewsSettings(
 	if (typeof previewDefaults.placement?.mode === "string") {
 		settingsRows.push(["placement", previewDefaults.placement.mode]);
 	}
+	if (previewDefaults.cache !== undefined) {
+		settingsRows.push([
+			"cache",
+			previewDefaults.cache.enabled ? "enabled" : "disabled",
+		]);
+	}
 
 	if (settingsRows.length > 0) {
 		const labelWidth = Math.max(...settingsRows.map(([label]) => label.length));

--- a/packages/wrangler/src/preview/shared.ts
+++ b/packages/wrangler/src/preview/shared.ts
@@ -351,6 +351,10 @@ export function assemblePreviewDefaults(config: Config): PreviewDefaults {
 		previewDefaults.limits = previews?.limits ?? config.limits;
 	}
 
+	if (previews?.cache !== undefined || config.cache !== undefined) {
+		previewDefaults.cache = previews?.cache ?? config.cache;
+	}
+
 	if (config.placement) {
 		previewDefaults.placement = parseConfigPlacement(config);
 	}

--- a/packages/wrangler/src/preview/shared.ts
+++ b/packages/wrangler/src/preview/shared.ts
@@ -342,6 +342,10 @@ export function assemblePreviewDefaults(config: Config): PreviewDefaults {
 		previewDefaults.limits = previews?.limits ?? config.limits;
 	}
 
+	if (previews?.cache || config.cache) {
+		previewDefaults.cache = previews?.cache ?? config.cache;
+	}
+
 	if (config.placement) {
 		previewDefaults.placement = parseConfigPlacement(config);
 	}


### PR DESCRIPTION
Fixes WC-4623.

Unhides the `cache` configuration option for Workers.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: no tests for schema changes
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/30018
  - [ ] Documentation not necessary because: 

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
