### PR TITLE
[wrangler] fix e2e flakiness: use waitForLong to verify response body after deploy

### DIFF
--- a/packages/wrangler/e2e/assets-multiworker.test.ts
+++ b/packages/wrangler/e2e/assets-multiworker.test.ts
@@ -211,15 +211,21 @@ describe.each(
 					false
 				);
 
-				await expect(fetchText(`${url}/asset`)).resolves.toBe(
-					"<p>have an asset directly</p>"
+				await waitForLong(() =>
+					expect(fetchText(`${url}/asset`)).resolves.toBe(
+						"<p>have an asset directly</p>"
+					)
 				);
-				await expect(fetchText(`${url}/asset-via-binding`)).resolves.toBe(
-					"<p>have an asset via a binding</p>"
+				await waitForLong(() =>
+					expect(fetchText(`${url}/asset-via-binding`)).resolves.toBe(
+						"<p>have an asset via a binding</p>"
+					)
 				);
-				await expect(
-					fetch(`${url}/worker`).then((r) => r.text())
-				).resolves.toBe("hello world from a worker with assets");
+				await waitForLong(() =>
+					expect(fetch(`${url}/worker`).then((r) => r.text())).resolves.toBe(
+						"hello world from a worker with assets"
+					)
+				);
 			});
 
 			it("can fetch a regular worker through a worker with assets, including with rpc", async ({

--- a/packages/wrangler/e2e/deployments.test.ts
+++ b/packages/wrangler/e2e/deployments.test.ts
@@ -63,11 +63,13 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 
 			const deployedUrl = getDeployedUrl(output);
 
-			const response = await retry(
-				(resp) => !resp.ok,
-				async () => await fetch(deployedUrl)
+			await waitForLong(
+				async () => {
+					const response = await fetch(deployedUrl);
+					expect(await response.text()).toEqual("Hello World!");
+				},
+				{ timeout: 30_000 }
 			);
-			await expect(response.text()).resolves.toEqual("Hello World!");
 		});
 
 		it("lists 1 deployment", async ({ expect }) => {
@@ -98,11 +100,13 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 
 			const deployedUrl = getDeployedUrl(output);
 
-			const response = await retry(
-				(resp) => !resp.ok,
-				async () => await fetch(deployedUrl)
+			await waitForLong(
+				async () => {
+					const response = await fetch(deployedUrl);
+					expect(await response.text()).toEqual("Updated Worker!");
+				},
+				{ timeout: 30_000 }
 			);
-			await expect(response.text()).resolves.toEqual("Updated Worker!");
 		});
 
 		it("lists 2 deployments", async ({ expect }) => {

--- a/packages/wrangler/e2e/provision.test.ts
+++ b/packages/wrangler/e2e/provision.test.ts
@@ -6,7 +6,7 @@ import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { fetchText } from "./helpers/fetch-text";
 import { generateResourceName } from "./helpers/generate-resource-name";
 import { normalizeOutput } from "./helpers/normalize";
-import { retry } from "./helpers/retry";
+import { waitForLong } from "./helpers/wait-for";
 
 const TIMEOUT = 500_000;
 const normalize = (str: string) => {
@@ -122,11 +122,13 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 			assert(d1Match?.groups);
 			d1Id = d1Match.groups.d1;
 
-			const response = await retry(
-				(resp) => !resp.ok,
-				async () => await fetch(deployedUrl)
+			await waitForLong(
+				async () => {
+					const response = await fetch(deployedUrl);
+					expect(await response.text()).toEqual("Hello World!");
+				},
+				{ timeout: 30_000 }
 			);
-			await expect(response.text()).resolves.toEqual("Hello World!");
 		});
 
 		it("can inherit bindings on re-deploy and won't re-provision", async ({
@@ -149,11 +151,13 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 				Current Version ID: 00000000-0000-0000-0000-000000000000"
 			`);
 
-			const response = await retry(
-				(resp) => !resp.ok,
-				async () => await fetch(deployedUrl)
+			await waitForLong(
+				async () => {
+					const response = await fetch(deployedUrl);
+					expect(await response.text()).toEqual("Hello World!");
+				},
+				{ timeout: 30_000 }
 			);
-			await expect(response.text()).resolves.toEqual("Hello World!");
 		});
 		it("can inspect current bindings", async ({ expect }) => {
 			const versionsRaw = await helper.run(`wrangler versions list --json`);


### PR DESCRIPTION
Fixes a flaky test pattern in e2e tests where `retry()` only checked `resp.ok` but not the response body content. After a `wrangler deploy`, the CDN may still serve the old worker version with a `200 OK`, causing the body assertion immediately after the retry loop to pass with stale content (or fail non-deterministically).

The fix replaces `retry((resp) => !resp.ok, ...)` followed by an out-of-loop `.text()` assertion with `waitForLong()` that fetches and checks the expected body content inside the retry callback — so the loop keeps retrying until the new version is actually live.

Affected tests:
- `deployments.test.ts`: "deploys a Worker" and "modifies & deploys a Worker"
- `provision.test.ts`: "can provision resources and deploy worker" and "can inherit bindings on re-deploy and won't re-provision"
- `assets-multiworker.test.ts`: "can fetch a worker with assets" (three assertions, consistent with the adjacent test which already used `waitForLong`)

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test-only change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
