### PR TITLE
[wrangler] Fix R2 e2e snapshot for data catalog confirmation prompt

### DIFF
--- a/packages/wrangler/e2e/r2.test.ts
+++ b/packages/wrangler/e2e/r2.test.ts
@@ -63,6 +63,8 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("r2", () => {
 		expect(normalize(output.stdout)).toMatchInlineSnapshot(`
 			"Resource location: remote
 			Starting bulk upload of 2 objects to bucket tmp-e2e-r2-00000000-0000-0000-0000-000000000000 using a concurrency of 20
+			? Bulk upload may overwrite existing objects. If this bucket has data catalog enabled, this operation could leave the catalog in an invalid state. Continue?
+			🤖 Using fallback value in non-interactive context: yes
 			Uploaded 100% (2 out of 2)"
 		`);
 	});


### PR DESCRIPTION
Fixes the R2 e2e test broken by #12852.

#12852 added a confirmation prompt to `r2 bulk put` for operations that could affect data catalog state. In non-interactive contexts (like e2e tests), this prompt auto-confirms with a fallback "yes". The `batch create objects` e2e test snapshot was not updated to include this new output, causing the test to fail.

This updates the inline snapshot to expect the new confirmation prompt lines.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: test-only change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13059" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
