### PR TITLE
[vitest-pool-workers] Fix require() resolving to ESM via "import" export condition

### DIFF
--- a/.changeset/fix-vpw-require-cjs-resolution.md
+++ b/.changeset/fix-vpw-require-cjs-resolution.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+fix: resolve CJS alternatives when require() resolves to an ESM file via the "import" export condition
+
+Vite 8 switched to a rolldown-based module resolver that, when resolving a `require()` call, can select the `"import"` export condition from a dual-format package instead of the `"require"` or `"default"` condition. This caused workerd to receive an ESM file (`import` statements) where it expected a CommonJS module, producing `SyntaxError: Cannot use import statement outside a module`. Packages affected include `pg-protocol`, `pg-connection-string`, and any package with dual CJS/ESM exports that is transitively required by a worker under test.
+
+The module-fallback service now checks whether a path resolved for a `require()` call appears in the package's exports map under the `"import"` condition. If so, it finds and returns the `"require"` or `"default"` CJS alternative instead.

--- a/.changeset/fix-vpw-require-cjs-resolution.md
+++ b/.changeset/fix-vpw-require-cjs-resolution.md
@@ -2,8 +2,8 @@
 "@cloudflare/vitest-pool-workers": patch
 ---
 
-fix: resolve CJS alternatives when require() resolves to an ESM file via the "import" export condition
+fix: resolve CJS alternatives when require() resolves to an ESM file via the "import" export condition in Vite 8
 
-Vite 8 switched to a rolldown-based module resolver that, when resolving a `require()` call, can select the `"import"` export condition from a dual-format package instead of the `"require"` or `"default"` condition. This caused workerd to receive an ESM file (`import` statements) where it expected a CommonJS module, producing `SyntaxError: Cannot use import statement outside a module`. Packages affected include `pg-protocol`, `pg-connection-string`, and any package with dual CJS/ESM exports that is transitively required by a worker under test.
+When Vite 8 switched to a rolldown-based resolver, `require()` calls in the module-fallback service started resolving to the `"import"` export condition of dual-format packages instead of `"require"`/`"default"`. This caused workerd to receive an ESM file where it expected CommonJS, producing `SyntaxError: Cannot use import statement outside a module`. Packages affected include `pg-protocol`, `pg-connection-string`, and any package with dual CJS/ESM exports that is transitively `require()`d by a worker under test.
 
-The module-fallback service now checks whether a path resolved for a `require()` call appears in the package's exports map under the `"import"` condition. If so, it finds and returns the `"require"` or `"default"` CJS alternative instead.
+In Vite 8 the main resolve plugin (`vite:resolve-builtin`) does not read the `kind` field from hook options per-request — its `isRequire` is a static value set at plugin-construction time. The `custom["node-resolve"].isRequire` convention used for Vite 7 is also silently ignored in Vite 8. Both hints are now passed to `pluginContainer.resolveId()` for forward and backward compatibility, but as a reliable fallback the module-fallback service also checks the package `exports` map: if the resolved path matches the `"import"` condition, the `"require"` or `"default"` CJS entry is returned instead.

--- a/packages/vitest-pool-workers/src/pool/module-fallback.ts
+++ b/packages/vitest-pool-workers/src/pool/module-fallback.ts
@@ -369,13 +369,23 @@ export function findCjsAlternative(resolvedPath: string): string | undefined {
  * resolved via the `"import"` condition, find the `"require"` or `"default"`
  * entry that points to a different (CJS) file.
  *
- * Handles both flat maps (`{ ".": { "import": "...", "require": "..." } }`) and
- * subpath maps (`{ "./esm/index.js": { "require": "..." } }`).
+ * Handles:
+ * - Sugar conditional exports (`{ "import": "...", "require": "..." }`)
+ * - Subpath maps (`{ ".": { "import": "...", "require": "..." } }`)
  */
 export function findCjsEntryInExports(
 	exports: Record<string, unknown>,
 	esmRelPath: string
 ): string | undefined {
+	// Handle sugar conditional exports (no subpath keys like ".")
+	// e.g. { "import": "./esm/index.js", "require": "./cjs/index.js" }
+	const directResult = findCjsEntryInConditions(exports, esmRelPath);
+	if (directResult !== undefined) {
+		return directResult;
+	}
+
+	// Handle subpath exports maps
+	// e.g. { ".": { "import": "...", "require": "..." } }
 	for (const value of Object.values(exports)) {
 		if (typeof value !== "object" || value === null) {
 			continue;
@@ -392,11 +402,36 @@ export function findCjsEntryInExports(
 }
 
 /**
+ * Collect all terminal string values from a (potentially nested) conditions
+ * object. Used to check whether a resolved path appears anywhere inside a
+ * nested `"import"` condition (e.g. `{ "types": "...", "default": "./esm/index.mjs" }`).
+ */
+function collectTerminalStrings(
+	obj: Record<string, unknown>
+): string[] {
+	const result: string[] = [];
+	for (const value of Object.values(obj)) {
+		if (typeof value === "string") {
+			result.push(value);
+		} else if (typeof value === "object" && value !== null) {
+			result.push(
+				...collectTerminalStrings(value as Record<string, unknown>)
+			);
+		}
+	}
+	return result;
+}
+
+/**
  * Given a single conditions object from a package exports map and the relative
  * path of the file that was resolved via `"import"`, return the path from the
  * `"require"` or `"default"` condition if it points to a different file.
  *
- * Recurses into nested conditions.
+ * Handles:
+ * - Flat `"import"` strings: `{ "import": "./esm/index.js", "require": "..." }`
+ * - Nested `"import"` objects: `{ "import": { "types": "...", "default": "./esm/index.mjs" }, "require": "..." }`
+ *
+ * Recurses into other nested condition objects (e.g. `"node"`, `"browser"`).
  */
 export function findCjsEntryInConditions(
 	conditions: Record<string, unknown>,
@@ -405,17 +440,27 @@ export function findCjsEntryInConditions(
 	const importEntry = conditions["import"];
 	const requireEntry = conditions["require"] ?? conditions["default"];
 
-	// The "import" entry matches our resolved path → prefer "require"/"default"
-	if (
-		typeof importEntry === "string" &&
-		importEntry === esmRelPath &&
-		typeof requireEntry === "string" &&
-		requireEntry !== importEntry
-	) {
-		return requireEntry;
+	if (typeof requireEntry === "string" && requireEntry !== esmRelPath) {
+		// Case 1: "import" is a plain string that matches the resolved path
+		if (typeof importEntry === "string" && importEntry === esmRelPath) {
+			return requireEntry;
+		}
+
+		// Case 2: "import" is a nested conditions object (common in TypeScript
+		// packages, e.g. { "types": "...", "default": "./esm/index.mjs" }).
+		// Check whether any terminal string inside it matches esmRelPath.
+		if (typeof importEntry === "object" && importEntry !== null) {
+			const importPaths = collectTerminalStrings(
+				importEntry as Record<string, unknown>
+			);
+			if (importPaths.includes(esmRelPath)) {
+				return requireEntry;
+			}
+		}
 	}
 
-	// Recurse into nested condition objects (skip terminal string conditions)
+	// Recurse into nested condition objects (skip terminal string conditions
+	// and "import"/"require"/"default" which we already handled above)
 	for (const [key, value] of Object.entries(conditions)) {
 		if (key === "import" || key === "require" || key === "default") {
 			continue;

--- a/packages/vitest-pool-workers/src/pool/module-fallback.ts
+++ b/packages/vitest-pool-workers/src/pool/module-fallback.ts
@@ -295,6 +295,145 @@ async function viteResolve(
 	return trimViteVersionHash(resolved.id);
 }
 
+/**
+ * When a `require()` call resolves to an ESM file (e.g. because Vite 8's
+ * rolldown-based resolver selected the `"import"` export condition), walk up
+ * the directory tree to find the nearest `package.json` that owns the file
+ * and look for a CJS-compatible alternative via the `"require"` or `"default"`
+ * export condition.
+ *
+ * This handles the Vite 8 regression where `pluginContainer.resolveId()` with
+ * `{ custom: { "node-resolve": { isRequire: true } } }` still picks the
+ * `"import"` entry instead of `"require"` for packages with dual CJS/ESM
+ * exports (e.g. `pg-protocol`, `pg-connection-string`, `mimetext`).
+ */
+export function findCjsAlternative(resolvedPath: string): string | undefined {
+	// Strip any query suffix (e.g. ?mf_vitest_no_cjs_esm_shim, ?v=hash)
+	const cleanPath = resolvedPath.replace(/\?.*$/, "");
+
+	// Only .js, .mjs, and .cjs files can be module entry points.
+	// Bail out early for non-JS extensions (wasm, json, etc.) to avoid
+	// unnecessary filesystem walks.
+	if (!/\.[mc]?js$/.test(cleanPath)) {
+		return undefined;
+	}
+
+	// Walk up looking for the package.json that owns this file
+	let dir = posixPath.dirname(cleanPath);
+	while (dir !== posixPath.dirname(dir)) {
+		const pkgJsonPath = posixPath.join(dir, "package.json");
+		let pkg: Record<string, unknown>;
+		try {
+			pkg = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8")) as Record<
+				string,
+				unknown
+			>;
+		} catch (e) {
+			if (!isFileNotFoundError(e)) {
+				throw e;
+			}
+			dir = posixPath.dirname(dir);
+			continue;
+		}
+
+		if (pkg.exports && typeof pkg.exports === "object") {
+			// Build a relative path from the package root to the resolved file
+			// e.g. "./esm/index.js" or "./esm/index.mjs"
+			const relPath =
+				"./" + posixPath.relative(dir, cleanPath).replaceAll("\\", "/");
+
+			const cjsEntry = findCjsEntryInExports(
+				pkg.exports as Record<string, unknown>,
+				relPath
+			);
+			if (cjsEntry) {
+				const cjsAbsPath = posixPath.join(dir, cjsEntry);
+				if (isFile(cjsAbsPath)) {
+					return cjsAbsPath;
+				}
+			}
+		}
+
+		// Stop at package boundary — don't cross into a parent package
+		if (pkg.name) {
+			break;
+		}
+		dir = posixPath.dirname(dir);
+	}
+
+	return undefined;
+}
+
+/**
+ * Given a package `exports` map and the relative path of a file that was
+ * resolved via the `"import"` condition, find the `"require"` or `"default"`
+ * entry that points to a different (CJS) file.
+ *
+ * Handles both flat maps (`{ ".": { "import": "...", "require": "..." } }`) and
+ * subpath maps (`{ "./esm/index.js": { "require": "..." } }`).
+ */
+export function findCjsEntryInExports(
+	exports: Record<string, unknown>,
+	esmRelPath: string
+): string | undefined {
+	for (const value of Object.values(exports)) {
+		if (typeof value !== "object" || value === null) {
+			continue;
+		}
+		const result = findCjsEntryInConditions(
+			value as Record<string, unknown>,
+			esmRelPath
+		);
+		if (result !== undefined) {
+			return result;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Given a single conditions object from a package exports map and the relative
+ * path of the file that was resolved via `"import"`, return the path from the
+ * `"require"` or `"default"` condition if it points to a different file.
+ *
+ * Recurses into nested conditions.
+ */
+export function findCjsEntryInConditions(
+	conditions: Record<string, unknown>,
+	esmRelPath: string
+): string | undefined {
+	const importEntry = conditions["import"];
+	const requireEntry = conditions["require"] ?? conditions["default"];
+
+	// The "import" entry matches our resolved path → prefer "require"/"default"
+	if (
+		typeof importEntry === "string" &&
+		importEntry === esmRelPath &&
+		typeof requireEntry === "string" &&
+		requireEntry !== importEntry
+	) {
+		return requireEntry;
+	}
+
+	// Recurse into nested condition objects (skip terminal string conditions)
+	for (const [key, value] of Object.entries(conditions)) {
+		if (key === "import" || key === "require" || key === "default") {
+			continue;
+		}
+		if (typeof value === "object" && value !== null) {
+			const result = findCjsEntryInConditions(
+				value as Record<string, unknown>,
+				esmRelPath
+			);
+			if (result !== undefined) {
+				return result;
+			}
+		}
+	}
+
+	return undefined;
+}
+
 type ResolveMethod = "import" | "require";
 async function resolve(
 	vite: Vite.ViteDevServer,
@@ -331,7 +470,27 @@ async function resolve(
 		return filePath;
 	}
 
-	return viteResolve(vite, specifier, referrer, method === "require");
+	const resolved = await viteResolve(
+		vite,
+		specifier,
+		referrer,
+		method === "require"
+	);
+
+	// Vite 8 (rolldown resolver) may resolve a require() call to the ESM
+	// "import" export condition instead of "require"/"default". Detect this and
+	// redirect to the CJS alternative so workerd doesn't choke on `import`
+	// statements inside a commonJsModule. See:
+	// https://github.com/cloudflare/workers-sdk/issues/12984
+	// https://github.com/cloudflare/workers-sdk/issues/13037
+	if (method === "require" && !specifier.startsWith("node:")) {
+		const cjsAlt = findCjsAlternative(resolved);
+		if (cjsAlt !== undefined) {
+			return cjsAlt;
+		}
+	}
+
+	return resolved;
 }
 
 function buildRedirectResponse(filePath: string) {

--- a/packages/vitest-pool-workers/src/pool/module-fallback.ts
+++ b/packages/vitest-pool-workers/src/pool/module-fallback.ts
@@ -246,8 +246,29 @@ async function viteResolve(
 ): Promise<string> {
 	const resolved = await vite.pluginContainer.resolveId(specifier, referrer, {
 		ssr: true,
+		// Vite ≤7: the rollup-based resolve plugin reads `isRequire` from this
+		// private `custom["node-resolve"]` bag to select the correct conditional
+		// export (`"require"` vs `"import"`).
 		// https://github.com/vitejs/vite/blob/v5.1.4/packages/vite/src/node/plugins/resolve.ts#L178-L179
 		custom: { "node-resolve": { isRequire } },
+		// Vite 8+: the resolver was rewritten to use rolldown and no longer reads
+		// `custom["node-resolve"]`. The `kind` field is read by the
+		// `vite:resolve-dev` plugin, which uses `kind === "require-call"` to
+		// set `isRequire: true` when resolving pre-bundled (optimized) deps.
+		// For deps that are NOT pre-bundled the `vite:resolve-builtin` native
+		// Rust plugin handles resolution — but its `isRequire` flag is a static
+		// value set at construction time and it does NOT read `kind` per-call.
+		// So `kind` alone is insufficient for the general case; `findCjsAlternative`
+		// below provides the fallback. We still pass `kind` so that pre-bundled
+		// deps resolve correctly and so future Vite versions that fix
+		// `vite:resolve-builtin` work without any change here.
+		// The `kind` field is not declared on the legacy `PluginContainer` type,
+		// so we cast it through `unknown`.
+		// https://github.com/cloudflare/workers-sdk/issues/12984
+		// https://github.com/cloudflare/workers-sdk/issues/13037
+		...(isRequire
+			? ({ kind: "require-call" } as unknown as object)
+			: undefined),
 	});
 	if (resolved === null) {
 		// Vite's resolution algorithm doesn't apply Node resolution to specifiers
@@ -296,16 +317,25 @@ async function viteResolve(
 }
 
 /**
- * When a `require()` call resolves to an ESM file (e.g. because Vite 8's
- * rolldown-based resolver selected the `"import"` export condition), walk up
- * the directory tree to find the nearest `package.json` that owns the file
- * and look for a CJS-compatible alternative via the `"require"` or `"default"`
- * export condition.
+ * When a `require()` call resolves to an ESM file, walk up the directory tree
+ * to find the nearest `package.json` that owns the file and look for a
+ * CJS-compatible alternative via the `"require"` or `"default"` export
+ * condition.
  *
- * This handles the Vite 8 regression where `pluginContainer.resolveId()` with
- * `{ custom: { "node-resolve": { isRequire: true } } }` still picks the
- * `"import"` entry instead of `"require"` for packages with dual CJS/ESM
- * exports (e.g. `pg-protocol`, `pg-connection-string`, `mimetext`).
+ * In Vite 8 the main resolve plugin (`vite:resolve-builtin`, backed by
+ * `viteResolvePlugin` from `rolldown/experimental`) does NOT dynamically read
+ * the `kind` field from the hook options to pick `"require"` vs `"import"`.
+ * Its `isRequire` flag is a static value set at plugin-construction time, so
+ * passing `kind: "require-call"` on the `pluginContainer.resolveId()` call is
+ * not sufficient. As a result, `require()` calls can still resolve to the
+ * `"import"` export condition entry (e.g. `pg-protocol/esm/index.js`) instead
+ * of `"require"`/`"default"` (e.g. `pg-protocol/dist/index.js`), causing
+ * workerd to choke on `import` statements inside a `commonJsModule`.
+ *
+ * This function detects the mismatch and redirects to the CJS alternative.
+ *
+ * See: https://github.com/cloudflare/workers-sdk/issues/12984
+ *      https://github.com/cloudflare/workers-sdk/issues/13037
  */
 export function findCjsAlternative(resolvedPath: string): string | undefined {
 	// Strip any query suffix (e.g. ?mf_vitest_no_cjs_esm_shim, ?v=hash)
@@ -406,17 +436,13 @@ export function findCjsEntryInExports(
  * object. Used to check whether a resolved path appears anywhere inside a
  * nested `"import"` condition (e.g. `{ "types": "...", "default": "./esm/index.mjs" }`).
  */
-function collectTerminalStrings(
-	obj: Record<string, unknown>
-): string[] {
+function collectTerminalStrings(obj: Record<string, unknown>): string[] {
 	const result: string[] = [];
 	for (const value of Object.values(obj)) {
 		if (typeof value === "string") {
 			result.push(value);
 		} else if (typeof value === "object" && value !== null) {
-			result.push(
-				...collectTerminalStrings(value as Record<string, unknown>)
-			);
+			result.push(...collectTerminalStrings(value as Record<string, unknown>));
 		}
 	}
 	return result;
@@ -430,6 +456,7 @@ function collectTerminalStrings(
  * Handles:
  * - Flat `"import"` strings: `{ "import": "./esm/index.js", "require": "..." }`
  * - Nested `"import"` objects: `{ "import": { "types": "...", "default": "./esm/index.mjs" }, "require": "..." }`
+ *   (common in TypeScript packages)
  *
  * Recurses into other nested condition objects (e.g. `"node"`, `"browser"`).
  */
@@ -522,12 +549,13 @@ async function resolve(
 		method === "require"
 	);
 
-	// Vite 8 (rolldown resolver) may resolve a require() call to the ESM
-	// "import" export condition instead of "require"/"default". Detect this and
-	// redirect to the CJS alternative so workerd doesn't choke on `import`
-	// statements inside a commonJsModule. See:
-	// https://github.com/cloudflare/workers-sdk/issues/12984
-	// https://github.com/cloudflare/workers-sdk/issues/13037
+	// In Vite 8, the main `vite:resolve-builtin` plugin does not read the
+	// `kind` field from hook options to pick `"require"` vs `"import"` export
+	// conditions. Its `isRequire` is fixed at construction time, so `require()`
+	// calls can still resolve to the `"import"` condition (e.g. an ESM wrapper
+	// file). Detect and redirect to the CJS alternative.
+	// See: https://github.com/cloudflare/workers-sdk/issues/12984
+	//      https://github.com/cloudflare/workers-sdk/issues/13037
 	if (method === "require" && !specifier.startsWith("node:")) {
 		const cjsAlt = findCjsAlternative(resolved);
 		if (cjsAlt !== undefined) {

--- a/packages/vitest-pool-workers/test/module-fallback.test.ts
+++ b/packages/vitest-pool-workers/test/module-fallback.test.ts
@@ -1,0 +1,343 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { removeDir } from "@cloudflare/workers-utils";
+import { afterEach, beforeEach, describe, it } from "vitest";
+import {
+	findCjsAlternative,
+	findCjsEntryInConditions,
+	findCjsEntryInExports,
+} from "../src/pool/module-fallback";
+
+// ---------------------------------------------------------------------------
+// Pure unit tests for findCjsEntryInConditions / findCjsEntryInExports
+// ---------------------------------------------------------------------------
+
+describe("findCjsEntryInConditions", () => {
+	it("returns require entry when import condition matches", ({ expect }) => {
+		const result = findCjsEntryInConditions(
+			{
+				import: "./esm/index.js",
+				require: "./dist/index.js",
+				default: "./dist/index.js",
+			},
+			"./esm/index.js"
+		);
+		expect(result).toBe("./dist/index.js");
+	});
+
+	it("returns default entry when require is absent but default differs", ({
+		expect,
+	}) => {
+		const result = findCjsEntryInConditions(
+			{
+				import: "./esm/index.mjs",
+				default: "./lib/index.js",
+			},
+			"./esm/index.mjs"
+		);
+		expect(result).toBe("./lib/index.js");
+	});
+
+	it("returns undefined when import entry does not match resolved path", ({
+		expect,
+	}) => {
+		const result = findCjsEntryInConditions(
+			{
+				import: "./esm/index.js",
+				require: "./dist/index.js",
+			},
+			"./other/file.js"
+		);
+		expect(result).toBeUndefined();
+	});
+
+	it("returns undefined when import and require point to the same file", ({
+		expect,
+	}) => {
+		const result = findCjsEntryInConditions(
+			{
+				import: "./dist/index.js",
+				require: "./dist/index.js",
+			},
+			"./dist/index.js"
+		);
+		expect(result).toBeUndefined();
+	});
+
+	it("recurses into nested condition objects", ({ expect }) => {
+		const result = findCjsEntryInConditions(
+			{
+				node: {
+					import: "./esm/node.js",
+					require: "./cjs/node.js",
+				},
+			},
+			"./esm/node.js"
+		);
+		expect(result).toBe("./cjs/node.js");
+	});
+
+	it("does not recurse into import/require/default string entries", ({
+		expect,
+	}) => {
+		// Strings under "import"/"require"/"default" are terminal, not nested maps
+		const result = findCjsEntryInConditions(
+			{
+				import: "./esm/index.js",
+				require: "./cjs/index.js",
+			},
+			"./cjs/index.js"
+		);
+		// require entry IS NOT the esm path, so no match from import condition
+		expect(result).toBeUndefined();
+	});
+});
+
+describe("findCjsEntryInExports", () => {
+	it("finds cjs entry from a standard dual-format exports map", ({
+		expect,
+	}) => {
+		const result = findCjsEntryInExports(
+			{
+				".": {
+					import: "./esm/index.mjs",
+					require: "./lib/index.js",
+					default: "./lib/index.js",
+				},
+			},
+			"./esm/index.mjs"
+		);
+		expect(result).toBe("./lib/index.js");
+	});
+
+	it("returns undefined when no matching entry exists", ({ expect }) => {
+		const result = findCjsEntryInExports(
+			{
+				".": {
+					import: "./esm/index.js",
+					require: "./dist/index.js",
+				},
+			},
+			"./totally/different/path.js"
+		);
+		expect(result).toBeUndefined();
+	});
+
+	it("searches across multiple export subpaths", ({ expect }) => {
+		const result = findCjsEntryInExports(
+			{
+				".": {
+					import: "./esm/index.js",
+					require: "./dist/index.js",
+				},
+				"./sub": {
+					import: "./esm/sub.js",
+					require: "./dist/sub.js",
+				},
+			},
+			"./esm/sub.js"
+		);
+		expect(result).toBe("./dist/sub.js");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests for findCjsAlternative (needs real filesystem fixtures)
+// ---------------------------------------------------------------------------
+
+describe("findCjsAlternative", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mf-test-"));
+	});
+
+	afterEach(async () => {
+		await removeDir(tmpDir);
+	});
+
+	/**
+	 * Creates files under tmpDir.  `files` is a map of relative path → content.
+	 */
+	function scaffold(files: Record<string, string>) {
+		for (const [relPath, content] of Object.entries(files)) {
+			const abs = path.join(tmpDir, relPath);
+			fs.mkdirSync(path.dirname(abs), { recursive: true });
+			fs.writeFileSync(abs, content);
+		}
+	}
+
+	/**
+	 * Returns a POSIX-style absolute path inside tmpDir.
+	 */
+	function p(...parts: string[]): string {
+		// On Windows posixPath.join would use forward slashes; on POSIX it's the same
+		return path.posix.join(tmpDir.replaceAll("\\", "/"), ...parts);
+	}
+
+	it("returns CJS alternative for .mjs file with require condition", ({
+		expect,
+	}) => {
+		scaffold({
+			"package.json": JSON.stringify({
+				name: "my-pkg",
+				exports: {
+					".": {
+						import: "./esm/index.mjs",
+						require: "./lib/index.js",
+					},
+				},
+			}),
+			"esm/index.mjs": "export default 42;",
+			"lib/index.js": "module.exports = 42;",
+		});
+
+		const result = findCjsAlternative(p("esm/index.mjs"));
+		expect(result).toBe(p("lib/index.js"));
+	});
+
+	it("returns CJS alternative for .js file in type:module package", ({
+		expect,
+	}) => {
+		scaffold({
+			"package.json": JSON.stringify({
+				name: "my-pkg",
+				type: "module",
+				exports: {
+					".": {
+						import: "./esm/index.js",
+						require: "./dist/index.cjs",
+					},
+				},
+			}),
+			"esm/index.js": "export default 42;",
+			"dist/index.cjs": "module.exports = 42;",
+		});
+
+		const result = findCjsAlternative(p("esm/index.js"));
+		expect(result).toBe(p("dist/index.cjs"));
+	});
+
+	it("returns undefined for a plain CJS .js file (not in type:module pkg)", ({
+		expect,
+	}) => {
+		scaffold({
+			"package.json": JSON.stringify({ name: "my-pkg" }),
+			"lib/index.js": "module.exports = 42;",
+		});
+
+		const result = findCjsAlternative(p("lib/index.js"));
+		expect(result).toBeUndefined();
+	});
+
+	it("returns undefined when package has no exports map", ({ expect }) => {
+		scaffold({
+			"package.json": JSON.stringify({
+				name: "my-pkg",
+				type: "module",
+				main: "./index.js",
+			}),
+			"index.js": "export default 42;",
+		});
+
+		const result = findCjsAlternative(p("index.js"));
+		expect(result).toBeUndefined();
+	});
+
+	it("returns undefined when the CJS candidate file does not exist on disk", ({
+		expect,
+	}) => {
+		scaffold({
+			"package.json": JSON.stringify({
+				name: "my-pkg",
+				exports: {
+					".": {
+						import: "./esm/index.mjs",
+						require: "./lib/index.js",
+						// lib/index.js is NOT created
+					},
+				},
+			}),
+			"esm/index.mjs": "export default 42;",
+		});
+
+		const result = findCjsAlternative(p("esm/index.mjs"));
+		expect(result).toBeUndefined();
+	});
+
+	it("works for pg-protocol-style layout", ({ expect }) => {
+		scaffold({
+			"package.json": JSON.stringify({
+				name: "pg-protocol",
+				exports: {
+					".": {
+						import: "./esm/index.js",
+						require: "./dist/index.js",
+						default: "./dist/index.js",
+					},
+					"./dist/*": "./dist/*.js",
+					"./dist/*.js": "./dist/*.js",
+				},
+			}),
+			"esm/index.js":
+				"import * as p from '../dist/index.js'; export default p;",
+			"dist/index.js": '"use strict"; module.exports = {};',
+		});
+
+		const result = findCjsAlternative(p("esm/index.js"));
+		expect(result).toBe(p("dist/index.js"));
+	});
+
+	it("works for pg-connection-string .mjs layout", ({ expect }) => {
+		scaffold({
+			"package.json": JSON.stringify({
+				name: "pg-connection-string",
+				exports: {
+					".": {
+						import: "./esm/index.mjs",
+						require: "./index.js",
+						default: "./index.js",
+					},
+				},
+			}),
+			"esm/index.mjs": "export default {};",
+			"index.js": "module.exports = {};",
+		});
+
+		const result = findCjsAlternative(p("esm/index.mjs"));
+		expect(result).toBe(p("index.js"));
+	});
+
+	it("strips query suffix before checking ESM nature", ({ expect }) => {
+		scaffold({
+			"package.json": JSON.stringify({
+				name: "my-pkg",
+				exports: {
+					".": {
+						import: "./esm/index.mjs",
+						require: "./lib/index.js",
+					},
+				},
+			}),
+			"esm/index.mjs": "export default 42;",
+			"lib/index.js": "module.exports = 42;",
+		});
+
+		// The module-fallback passes paths with ?mf_vitest_no_cjs_esm_shim suffix
+		const result = findCjsAlternative(
+			p("esm/index.mjs") + "?mf_vitest_no_cjs_esm_shim"
+		);
+		expect(result).toBe(p("lib/index.js"));
+	});
+
+	it("returns undefined for non-ESM .cjs file", ({ expect }) => {
+		scaffold({
+			"package.json": JSON.stringify({ name: "my-pkg" }),
+			"lib/index.cjs": "module.exports = 42;",
+		});
+
+		const result = findCjsAlternative(p("lib/index.cjs"));
+		expect(result).toBeUndefined();
+	});
+});

--- a/packages/vitest-pool-workers/test/module-fallback.test.ts
+++ b/packages/vitest-pool-workers/test/module-fallback.test.ts
@@ -65,7 +65,9 @@ describe("findCjsEntryInConditions", () => {
 		expect(result).toBeUndefined();
 	});
 
-	it("recurses into nested condition objects", ({ expect }) => {
+	it("recurses into nested condition objects (e.g. 'node' key)", ({
+		expect,
+	}) => {
 		const result = findCjsEntryInConditions(
 			{
 				node: {
@@ -78,26 +80,41 @@ describe("findCjsEntryInConditions", () => {
 		expect(result).toBe("./cjs/node.js");
 	});
 
-	it("does not recurse into import/require/default string entries", ({
+	it("handles nested conditions under 'import' (TypeScript-style)", ({
 		expect,
 	}) => {
-		// Strings under "import"/"require"/"default" are terminal, not nested maps
+		// Common pattern: { "import": { "types": "...", "default": "./esm/index.mjs" }, "require": "./cjs/index.js" }
 		const result = findCjsEntryInConditions(
 			{
-				import: "./esm/index.js",
+				import: {
+					types: "./esm/index.d.ts",
+					default: "./esm/index.mjs",
+				},
 				require: "./cjs/index.js",
 			},
-			"./cjs/index.js"
+			"./esm/index.mjs"
 		);
-		// require entry IS NOT the esm path, so no match from import condition
-		expect(result).toBeUndefined();
+		expect(result).toBe("./cjs/index.js");
+	});
+
+	it("handles deeply nested import conditions", ({ expect }) => {
+		const result = findCjsEntryInConditions(
+			{
+				import: {
+					node: {
+						default: "./esm/node.mjs",
+					},
+				},
+				require: "./cjs/index.js",
+			},
+			"./esm/node.mjs"
+		);
+		expect(result).toBe("./cjs/index.js");
 	});
 });
 
 describe("findCjsEntryInExports", () => {
-	it("finds cjs entry from a standard dual-format exports map", ({
-		expect,
-	}) => {
+	it("finds cjs entry from a standard subpath exports map", ({ expect }) => {
 		const result = findCjsEntryInExports(
 			{
 				".": {
@@ -109,6 +126,19 @@ describe("findCjsEntryInExports", () => {
 			"./esm/index.mjs"
 		);
 		expect(result).toBe("./lib/index.js");
+	});
+
+	it("handles sugar conditional exports (no subpath keys)", ({ expect }) => {
+		// Package uses: { "exports": { "import": "...", "require": "..." } }
+		// instead of:  { "exports": { ".": { "import": "...", "require": "..." } } }
+		const result = findCjsEntryInExports(
+			{
+				import: "./esm/index.js",
+				require: "./cjs/index.js",
+			},
+			"./esm/index.js"
+		);
+		expect(result).toBe("./cjs/index.js");
 	});
 
 	it("returns undefined when no matching entry exists", ({ expect }) => {
@@ -157,9 +187,6 @@ describe("findCjsAlternative", () => {
 		await removeDir(tmpDir);
 	});
 
-	/**
-	 * Creates files under tmpDir.  `files` is a map of relative path → content.
-	 */
 	function scaffold(files: Record<string, string>) {
 		for (const [relPath, content] of Object.entries(files)) {
 			const abs = path.join(tmpDir, relPath);
@@ -168,11 +195,7 @@ describe("findCjsAlternative", () => {
 		}
 	}
 
-	/**
-	 * Returns a POSIX-style absolute path inside tmpDir.
-	 */
 	function p(...parts: string[]): string {
-		// On Windows posixPath.join would use forward slashes; on POSIX it's the same
 		return path.posix.join(tmpDir.replaceAll("\\", "/"), ...parts);
 	}
 
@@ -219,7 +242,7 @@ describe("findCjsAlternative", () => {
 		expect(result).toBe(p("dist/index.cjs"));
 	});
 
-	it("returns undefined for a plain CJS .js file (not in type:module pkg)", ({
+	it("returns undefined for a plain CJS .js file (not in exports as import)", ({
 		expect,
 	}) => {
 		scaffold({
@@ -255,11 +278,11 @@ describe("findCjsAlternative", () => {
 					".": {
 						import: "./esm/index.mjs",
 						require: "./lib/index.js",
-						// lib/index.js is NOT created
 					},
 				},
 			}),
 			"esm/index.mjs": "export default 42;",
+			// lib/index.js intentionally not created
 		});
 
 		const result = findCjsAlternative(p("esm/index.mjs"));
@@ -309,7 +332,46 @@ describe("findCjsAlternative", () => {
 		expect(result).toBe(p("index.js"));
 	});
 
-	it("strips query suffix before checking ESM nature", ({ expect }) => {
+	it("works for sugar conditional exports (no subpath keys)", ({ expect }) => {
+		scaffold({
+			"package.json": JSON.stringify({
+				name: "my-pkg",
+				exports: {
+					import: "./esm/index.mjs",
+					require: "./lib/index.js",
+				},
+			}),
+			"esm/index.mjs": "export default 42;",
+			"lib/index.js": "module.exports = 42;",
+		});
+
+		const result = findCjsAlternative(p("esm/index.mjs"));
+		expect(result).toBe(p("lib/index.js"));
+	});
+
+	it("works for TypeScript-style nested import conditions", ({ expect }) => {
+		scaffold({
+			"package.json": JSON.stringify({
+				name: "my-ts-pkg",
+				exports: {
+					".": {
+						import: {
+							types: "./esm/index.d.ts",
+							default: "./esm/index.mjs",
+						},
+						require: "./cjs/index.js",
+					},
+				},
+			}),
+			"esm/index.mjs": "export default 42;",
+			"cjs/index.js": "module.exports = 42;",
+		});
+
+		const result = findCjsAlternative(p("esm/index.mjs"));
+		expect(result).toBe(p("cjs/index.js"));
+	});
+
+	it("strips query suffix before checking", ({ expect }) => {
 		scaffold({
 			"package.json": JSON.stringify({
 				name: "my-pkg",
@@ -324,20 +386,19 @@ describe("findCjsAlternative", () => {
 			"lib/index.js": "module.exports = 42;",
 		});
 
-		// The module-fallback passes paths with ?mf_vitest_no_cjs_esm_shim suffix
 		const result = findCjsAlternative(
 			p("esm/index.mjs") + "?mf_vitest_no_cjs_esm_shim"
 		);
 		expect(result).toBe(p("lib/index.js"));
 	});
 
-	it("returns undefined for non-ESM .cjs file", ({ expect }) => {
+	it("returns undefined for non-JS extensions", ({ expect }) => {
 		scaffold({
 			"package.json": JSON.stringify({ name: "my-pkg" }),
-			"lib/index.cjs": "module.exports = 42;",
+			"lib/index.wasm": "",
 		});
 
-		const result = findCjsAlternative(p("lib/index.cjs"));
+		const result = findCjsAlternative(p("lib/index.wasm"));
 		expect(result).toBeUndefined();
 	});
 });

--- a/packages/vitest-pool-workers/vitest.config.mts
+++ b/packages/vitest-pool-workers/vitest.config.mts
@@ -1,6 +1,11 @@
 import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
+	// Provide the build-time define required by src/shared/builtin-modules.ts
+	// when running unit tests directly against source (without a tsdown build).
+	define: {
+		VITEST_POOL_WORKERS_DEFINE_BUILTIN_MODULES: "[]",
+	},
 	test: {
 		globalSetup: ["./test/global-setup.ts"],
 		exclude: [...configDefaults.exclude, "**/*.worker.test.ts"],


### PR DESCRIPTION
Fixes #12984, #13037.

When Vite 8 switched to a rolldown-based resolver, `require()` calls in the module-fallback service started resolving to the `"import"` export condition of dual-format packages (e.g. `pg-protocol`, `pg-connection-string`, `mimetext`) instead of `"require"`/`"default"`. This caused workerd to receive an ESM file as a CommonJS module, producing `SyntaxError: Cannot use import statement outside a module`.

#### Root Cause (Vite 8 architecture)

Vite 8's main resolve plugin is `vite:resolve-builtin` — a native Rust builtin backed by `viteResolvePlugin` from `rolldown/experimental`. Its `isRequire` flag is a **static value set at construction time** (`undefined` in all normal configurations), so it always appends `"import"` to the conditions list regardless of what `kind` is passed to the `resolveId` hook.

- **Vite ≤7**: the rollup-based resolve plugin read `isRequire` from `custom["node-resolve"]` (a private internal convention we were relying on).
- **Vite 8**: `custom["node-resolve"]` is silently ignored. The `kind: "require-call"` field is read by `vite:resolve-dev` (the optimizer-path plugin) and sets `isRequire` dynamically — but only for packages that have been pre-bundled by the dep optimizer. For non-pre-bundled packages, `vite:resolve-dev` falls through to `vite:resolve-builtin`, which ignores `kind`. This appears to be a current limitation of the architecture rather than an intentional API, since the native plugin's interface (`BindingViteResolvePluginResolveOptions`) has `isRequire` as a static field with no per-call override.

#### Fix

Three complementary layers:

1. **`custom["node-resolve"].isRequire`** — kept for Vite ≤7 compatibility (rollup-based resolver reads this).

2. **`kind: "require-call"`** — added for Vite 8+ as a forward-looking hint. Works today for pre-bundled deps via `vite:resolve-dev`. If Vite fixes `vite:resolve-builtin` to read `kind` per-call, this will start working for the general case automatically.

3. **`findCjsAlternative()`** — the reliable fallback for the general case in Vite 8. After `pluginContainer.resolveId()` returns, if the resolved path appears as an `"import"` condition value in the package's `exports` map, the `"require"`/`"default"` CJS alternative is returned instead. This is an explicit post-resolution fixup rather than a resolver-level fix, but it is correct and necessary given the current Vite 8 architecture.

The exports-map walk handles:
- Standard subpath exports (`{ ".": { "import": "...", "require": "..." } }`)
- Sugar conditional exports (`{ "import": "...", "require": "..." }`)
- Nested `"import"` conditions (TypeScript-style: `{ "import": { "types": "...", "default": "..." }, "require": "..." }`)

#### Verified against both issues
- **#12984** (`pg`/`pg-protocol`/`pg-connection-string`): no longer throws `SyntaxError`; reaches `ECONNREFUSED` (expected — no DB running)
- **#13037** (`mimetext` via `agents`): same class of failure, same fix applies

---

#### Why the module-fallback approach is the right one

A reviewer might ask: *"Can't we just do what `vite-plugin-cloudflare` does and avoid the module-fallback service altogether?"*

`vite-plugin-cloudflare` uses the **Vite Module Runner pattern**: all deps pass through Vite's pre-bundler with `noExternal: true`, CJS packages are interop-wrapped into ESM at that stage, and workerd executes Vite-*transformed* code strings via an `UnsafeEval` binding (`runInlinedModule`). The `unsafeModuleFallbackService` is only used there for binary module types (Wasm, Data, Text) — never for JavaScript.

`vitest-pool-workers` intentionally takes the opposite approach, and for good reason: **the entire point of this package is to run tests in the actual workerd runtime with production-equivalent module semantics.**

The Module Runner (`runInlinedModule`) wraps each module's code in an `async function` body, not a real ES module. This changes semantics in ways that matter for test correctness: `import.meta`, live bindings, TDZ, module caching, and circular dependency handling all behave differently from how workerd's native ESM loader would handle them. A test suite that passes under `runInlinedModule` may not accurately reflect what happens in production.

By contrast, `vitest-pool-workers`' module-fallback approach lets workerd use its own native ESM loader for all user code. Files are served lazily from disk one at a time, with only minimal shimming (CJS→ESM name-export wrapping via `cjs-module-lexer`). workerd then loads them exactly as it would in production.

Pre-bundling everything upfront isn't a practical alternative either: test files are discovered dynamically at runtime (you can't know at startup which files will be run), Vitest's own internals are CJS-heavy and would require substantial interop work, and lazy per-file loading preserves module identity (two packages that both `require('lodash')` share a single copy, as in production).

So: the `findCjsAlternative` workaround added in this PR is the correct narrow fix for the Vite 8 regression. The right place to fix the symptom is in `viteResolve()`, precisely because `module-fallback.ts` is the component responsible for bridging Vite's resolver into workerd's native module system — and that bridge needs to correctly honour `require()` vs `import` semantics across Vite versions.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: bug fix restoring previously-working behaviour