### PR TITLE
[vitest-pool-workers] Allow `main: false` to disable automatic entrypoint import

### DIFF
--- a/.changeset/disable-main-import.md
+++ b/.changeset/disable-main-import.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-pool-workers": minor
+---
+
+Allow `main: false` to disable automatic entrypoint import
+
+Setting `main: false` in pool options explicitly opts out of importing the worker entrypoint, even when a wrangler config provides one. This is useful for pure unit testing scenarios where `SELF` and Durable Object bindings to the current worker are not needed, avoiding unnecessary setup overhead.

--- a/packages/vitest-pool-workers/src/pool/cloudflare-pool-worker.ts
+++ b/packages/vitest-pool-workers/src/pool/cloudflare-pool-worker.ts
@@ -17,9 +17,9 @@ import {
 	structuredSerializableStringify,
 } from ".";
 import type {
+	ParsedWorkerPoolOptions,
 	WorkersConfigPluginAPI,
 	WorkersPoolOptions,
-	WorkersPoolOptionsWithDefines,
 } from "./config";
 import type {
 	Miniflare,
@@ -37,7 +37,7 @@ export class CloudflarePoolWorker implements PoolWorker {
 	name = "cloudflare-pool";
 	private mf: Miniflare | undefined;
 	private socket: WebSocket | undefined;
-	private parsedPoolOptions: WorkersPoolOptionsWithDefines | undefined;
+	private parsedPoolOptions: ParsedWorkerPoolOptions | undefined;
 	private main: string | undefined;
 	// Store wrapped listeners so off() can remove them correctly.
 	// Vitest registers at most one listener per event type.

--- a/packages/vitest-pool-workers/src/pool/config.ts
+++ b/packages/vitest-pool-workers/src/pool/config.ts
@@ -339,9 +339,7 @@ async function parseCustomPoolOptions(
 		// (Used to set the SELF binding to point to the router worker instead)
 		parsed.miniflare.hasAssetsAndIsVitest = true;
 		parsed.miniflare.assets.routerConfig ??= {};
-		parsed.miniflare.assets.routerConfig.has_user_worker = Boolean(
-			parsed.main
-		);
+		parsed.miniflare.assets.routerConfig.has_user_worker = Boolean(parsed.main);
 	}
 
 	return parsed;

--- a/packages/vitest-pool-workers/src/pool/config.ts
+++ b/packages/vitest-pool-workers/src/pool/config.ts
@@ -304,7 +304,6 @@ async function parseCustomPoolOptions(
 			);
 
 		// If `main` wasn't explicitly configured, fall back to Wrangler config's.
-		// `main: false` is not nullish, so `??=` preserves it (skips fallback).
 		options.main ??= main;
 
 		options.miniflare.workers = [

--- a/packages/vitest-pool-workers/src/pool/config.ts
+++ b/packages/vitest-pool-workers/src/pool/config.ts
@@ -94,6 +94,14 @@ export type WorkersPoolOptionsWithDefines = WorkersPoolOptions & {
 	defines?: Record<string, string>;
 };
 
+/** Post-parse type where `main: false` has been normalised to `undefined`. */
+export type ParsedWorkerPoolOptions = Omit<
+	WorkersPoolOptionsWithDefines,
+	"main"
+> & {
+	main?: string;
+};
+
 type PathParseParams = Pick<ParseParams, "path">;
 
 function isZodErrorLike(value: unknown): value is ZodError {
@@ -200,7 +208,7 @@ export const remoteProxySessionsDataMap = new Map<
 async function parseCustomPoolOptions(
 	rootPath: string,
 	value: unknown
-): Promise<WorkersPoolOptionsWithDefines> {
+): Promise<ParsedWorkerPoolOptions> {
 	// Try to parse pool specific options
 	const options = WorkersPoolOptionsSchema.parse(
 		value
@@ -320,28 +328,30 @@ async function parseCustomPoolOptions(
 	}
 
 	// Convert `main: false` to `undefined` so downstream code only ever sees
-	// `string | undefined`.
+	// `string | undefined`. After this point the object satisfies
+	// `ParsedWorkerPoolOptions`.
 	if (options.main === false) {
 		options.main = undefined;
 	}
+	const parsed = options as ParsedWorkerPoolOptions;
 
 	// Some assets plumbing that should be hidden from the end user
-	if (options.miniflare?.assets) {
+	if (parsed.miniflare?.assets) {
 		// (Used to set the SELF binding to point to the router worker instead)
-		options.miniflare.hasAssetsAndIsVitest = true;
-		options.miniflare.assets.routerConfig ??= {};
-		options.miniflare.assets.routerConfig.has_user_worker = Boolean(
-			options.main
+		parsed.miniflare.hasAssetsAndIsVitest = true;
+		parsed.miniflare.assets.routerConfig ??= {};
+		parsed.miniflare.assets.routerConfig.has_user_worker = Boolean(
+			parsed.main
 		);
 	}
 
-	return options;
+	return parsed;
 }
 
 export async function parseProjectOptions(
 	project: TestProject,
 	poolOptions: unknown
-): Promise<WorkersPoolOptionsWithDefines> {
+): Promise<ParsedWorkerPoolOptions> {
 	// Make sure the user hasn't specified a custom environment. This was how
 	// users enabled Miniflare 2's Vitest environment, so it's likely users will
 	// hit this case.

--- a/packages/vitest-pool-workers/src/pool/config.ts
+++ b/packages/vitest-pool-workers/src/pool/config.ts
@@ -299,12 +299,6 @@ async function parseCustomPoolOptions(
 		// `main: false` is not nullish, so `??=` preserves it (skips fallback).
 		options.main ??= main;
 
-		// Now that the fallback has been resolved, convert `false` to `undefined`
-		// so downstream code only ever sees `string | undefined`.
-		if (options.main === false) {
-			options.main = undefined;
-		}
-
 		options.miniflare.workers = [
 			...options.miniflare.workers,
 			...externalWorkers,
@@ -323,6 +317,12 @@ async function parseCustomPoolOptions(
 
 		// Record any Wrangler `define`s
 		options.defines = define;
+	}
+
+	// Convert `main: false` to `undefined` so downstream code only ever sees
+	// `string | undefined`.
+	if (options.main === false) {
+		options.main = undefined;
 	}
 
 	// Some assets plumbing that should be hidden from the end user

--- a/packages/vitest-pool-workers/src/pool/config.ts
+++ b/packages/vitest-pool-workers/src/pool/config.ts
@@ -34,8 +34,13 @@ const WorkersPoolOptionsSchema = z.object({
 	 * `import module from "<path-to-main>"` inside tests gives exactly the same
 	 * `module` instance as is used internally for the `SELF` and Durable Object
 	 * bindings.
+	 *
+	 * Set to `false` to explicitly disable automatic entrypoint import, even
+	 * when a wrangler config provides one. This is useful for pure unit testing
+	 * where `SELF` and Durable Object bindings to the current worker are not
+	 * needed.
 	 */
-	main: z.ostring(),
+	main: z.union([z.string(), z.literal(false)]).optional(),
 	/**
 	 * Enables remote bindings to access remote resources configured
 	 * with `remote: true` in the wrangler configuration file.
@@ -290,8 +295,15 @@ async function parseCustomPoolOptions(
 				}
 			);
 
-		// If `main` wasn't explicitly configured, fall back to Wrangler config's
+		// If `main` wasn't explicitly configured, fall back to Wrangler config's.
+		// `main: false` is not nullish, so `??=` preserves it (skips fallback).
 		options.main ??= main;
+
+		// Now that the fallback has been resolved, convert `false` to `undefined`
+		// so downstream code only ever sees `string | undefined`.
+		if (options.main === false) {
+			options.main = undefined;
+		}
 
 		options.miniflare.workers = [
 			...options.miniflare.workers,

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -659,7 +659,7 @@ export function maybeGetResolvedMainPath(
 ): string | undefined {
 	const projectPath = getProjectPath(project);
 	const main = options.main;
-	if (main === undefined) {
+	if (main === undefined || main === false) {
 		return;
 	}
 	if (typeof projectPath === "string") {

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -30,9 +30,9 @@ import {
 import { handleLoopbackRequest } from "./loopback";
 import { handleModuleFallbackRequest } from "./module-fallback";
 import type {
+	ParsedWorkerPoolOptions,
 	SourcelessWorkerOptions,
 	WorkersPoolOptions,
-	WorkersPoolOptionsWithDefines,
 } from "./config";
 import type { MiniflareOptions, SharedOptions, WorkerOptions } from "miniflare";
 import type { Readable } from "node:stream";
@@ -273,7 +273,7 @@ const RUNNER_OBJECT_BINDING = "__VITEST_POOL_WORKERS_RUNNER_OBJECT";
 
 async function buildProjectWorkerOptions(
 	project: TestProject,
-	customOptions: WorkersPoolOptionsWithDefines,
+	customOptions: ParsedWorkerPoolOptions,
 	main: string | undefined
 ): Promise<ProjectWorkers> {
 	const relativeWranglerConfigPath = maybeApply(
@@ -589,7 +589,7 @@ function getModuleFallbackService(ctx: Vitest): ModuleFallbackService {
 async function buildProjectMiniflareOptions(
 	ctx: Vitest,
 	project: TestProject,
-	customOptions: WorkersPoolOptions,
+	customOptions: ParsedWorkerPoolOptions,
 	main: string | undefined
 ): Promise<MiniflareOptions> {
 	const moduleFallbackService = getModuleFallbackService(ctx);
@@ -634,7 +634,7 @@ async function buildProjectMiniflareOptions(
 export async function getProjectMiniflare(
 	ctx: Vitest,
 	project: TestProject,
-	poolOptions: WorkersPoolOptionsWithDefines,
+	poolOptions: ParsedWorkerPoolOptions,
 	main: string | undefined
 ): Promise<Miniflare> {
 	const mfOptions = await buildProjectMiniflareOptions(
@@ -655,11 +655,11 @@ export async function getProjectMiniflare(
 
 export function maybeGetResolvedMainPath(
 	project: TestProject,
-	options: WorkersPoolOptionsWithDefines
+	options: ParsedWorkerPoolOptions
 ): string | undefined {
 	const projectPath = getProjectPath(project);
 	const main = options.main;
-	if (main === undefined || main === false) {
+	if (main === undefined) {
 		return;
 	}
 	if (typeof projectPath === "string") {


### PR DESCRIPTION
Fixes #9710.

Allows setting `main: false` in pool options to explicitly opt out of the automatic worker entrypoint import, even when a wrangler config provides one. This is useful for pure unit testing scenarios where `SELF` and Durable Object bindings to the current worker are not needed.

`false` is not nullish, so the existing `options.main ??= main` fallback from the wrangler config is skipped naturally. After the fallback gate, `false` is converted to `undefined` so all downstream code continues to see `string | undefined`.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: existing tests verify the unchanged behaviour; `main: false` follows the same code path as `main: undefined` after normalisation
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: the JSDoc on the `main` option covers the new `false` value
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
