### PR TITLE
[vitest-pool-workers] Only probe extensions in module fallback for `require()`, not `import`

### DIFF
--- a/.changeset/vitest-pool-workers-esm-import-fallback.md
+++ b/.changeset/vitest-pool-workers-esm-import-fallback.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+fix: only apply module fallback extension probing for `require()`, not `import`
+
+The module fallback service previously tried adding `.js`, `.mjs`, `.cjs`, and `.json` suffixes to extensionless specifiers unconditionally. Per the Node.js spec, this extension-probing behaviour is specific to CommonJS `require()`. ESM `import` statements must include explicit file extensions.
+
+Extension-less TypeScript `import` specifiers continue to work correctly — they are resolved by Vite's resolver rather than the fallback's extension loop.

--- a/fixtures/vitest-pool-workers-examples/module-resolution/test/index.spec.ts
+++ b/fixtures/vitest-pool-workers-examples/module-resolution/test/index.spec.ts
@@ -1,6 +1,7 @@
 import { instrument } from "@microlabs/otel-cf-workers";
 import { SELF } from "cloudflare:test";
 import { Utils } from "discord-api-types/v10";
+import { value as esmDepValue } from "esm-dep";
 import dep from "ext-dep";
 import mime from "mime-types";
 import { assert, describe, expect, test } from "vitest";
@@ -39,5 +40,12 @@ describe("test", () => {
 	// Verify CommonJS require() of JSON files works
 	test("resolves dependency that requires JSON files", async () => {
 		assert.equal(mime.lookup("test.html"), "text/html");
+	});
+
+	// Regression test for https://github.com/cloudflare/workers-sdk/issues/12022
+	// ESM imports with extensionless specifiers should be resolved by Vite, not
+	// by the module fallback's extension-probing loop (which is only for require()).
+	test("resolves ESM dependency with extensionless internal import", async () => {
+		assert.equal(esmDepValue, 456);
 	});
 });

--- a/fixtures/vitest-pool-workers-examples/module-resolution/vendor/esm-dep/index.d.mts
+++ b/fixtures/vitest-pool-workers-examples/module-resolution/vendor/esm-dep/index.d.mts
@@ -1,0 +1,1 @@
+export declare const value: number;

--- a/fixtures/vitest-pool-workers-examples/module-resolution/vendor/esm-dep/index.mjs
+++ b/fixtures/vitest-pool-workers-examples/module-resolution/vendor/esm-dep/index.mjs
@@ -1,0 +1,5 @@
+// Intentionally extensionless — valid in bundler/Vite contexts but technically
+// requires explicit extensions in strict ESM. The module fallback service must
+// NOT add extensions for `import` (only for `require()`); it should defer to
+// Vite's resolver for this.
+export { value } from "./value";

--- a/fixtures/vitest-pool-workers-examples/module-resolution/vendor/esm-dep/package.json
+++ b/fixtures/vitest-pool-workers-examples/module-resolution/vendor/esm-dep/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "esm-dep",
+	"type": "module",
+	"main": "index.mjs"
+}

--- a/fixtures/vitest-pool-workers-examples/module-resolution/vendor/esm-dep/value.mjs
+++ b/fixtures/vitest-pool-workers-examples/module-resolution/vendor/esm-dep/value.mjs
@@ -1,0 +1,1 @@
+export const value = 456;

--- a/fixtures/vitest-pool-workers-examples/package.json
+++ b/fixtures/vitest-pool-workers-examples/package.json
@@ -19,6 +19,7 @@
 		"@types/nunjucks": "^3.2.6",
 		"better-auth": "^1.4.6",
 		"discord-api-types": "0.37.98",
+		"esm-dep": "file:./module-resolution/vendor/esm-dep",
 		"ext-dep": "file:./module-resolution/vendor/ext-dep",
 		"jose": "^5.9.3",
 		"mime-types": "^2.1.35",

--- a/packages/vitest-pool-workers/src/pool/module-fallback.ts
+++ b/packages/vitest-pool-workers/src/pool/module-fallback.ts
@@ -187,26 +187,31 @@ function withImportMetaUrl(contents: string, url: string | URL): string {
 	return contents.replaceAll("import.meta.url", JSON.stringify(url.toString()));
 }
 
-// Extensions `workerd` won't resolve automatically, but Node.js will.
-// Note: `.json` is especially important for CommonJS `require()` chains.
-const moduleExtensions = [".js", ".mjs", ".cjs", ".json"];
-function maybeGetTargetFilePath(target: string): string | undefined {
+// Extensions that Node's `require()` probes automatically but `workerd` won't.
+// ESM `import` requires explicit extensions; Vite's resolver handles those.
+const requireExtensions = [".js", ".mjs", ".cjs", ".json"];
+function maybeGetTargetFilePath(
+	target: string,
+	isRequire: boolean
+): string | undefined {
 	// Can't use `fs.existsSync()` here as `target` could be a directory
 	// (e.g. `node:fs` and `node:fs/promises`)
 	if (isFile(target)) {
 		return target;
 	}
-	for (const extension of moduleExtensions) {
-		const targetWithExtension = target + extension;
-		if (fs.existsSync(targetWithExtension)) {
-			return targetWithExtension;
+	if (isRequire) {
+		for (const extension of requireExtensions) {
+			const targetWithExtension = target + extension;
+			if (fs.existsSync(targetWithExtension)) {
+				return targetWithExtension;
+			}
 		}
 	}
 	if (target.endsWith(disableCjsEsmShimSuffix)) {
 		return target;
 	}
 	if (isDirectory(target)) {
-		return maybeGetTargetFilePath(target + "/index");
+		return maybeGetTargetFilePath(target + "/index", isRequire);
 	}
 }
 
@@ -305,7 +310,8 @@ async function resolve(
 ): Promise<string /* filePath */> {
 	const referrerDir = posixPath.dirname(referrer);
 
-	let filePath = maybeGetTargetFilePath(target);
+	const isRequire = method === "require";
+	let filePath = maybeGetTargetFilePath(target, isRequire);
 	if (filePath !== undefined) {
 		return filePath;
 	}
@@ -326,7 +332,8 @@ async function resolve(
 		libPath,
 		specifier.replaceAll(":", "/")
 	);
-	filePath = maybeGetTargetFilePath(specifierLibPath);
+	// Always probe extensions for pool-internal lib modules
+	filePath = maybeGetTargetFilePath(specifierLibPath, /* isRequire */ true);
 	if (filePath !== undefined) {
 		return filePath;
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1199,6 +1199,9 @@ importers:
       discord-api-types:
         specifier: 0.37.98
         version: 0.37.98
+      esm-dep:
+        specifier: file:./module-resolution/vendor/esm-dep
+        version: file:fixtures/vitest-pool-workers-examples/module-resolution/vendor/esm-dep
       ext-dep:
         specifier: file:./module-resolution/vendor/ext-dep
         version: file:fixtures/vitest-pool-workers-examples/module-resolution/vendor/ext-dep
@@ -10339,6 +10342,9 @@ packages:
     peerDependenciesMeta:
       jiti:
         optional: true
+
+  esm-dep@file:fixtures/vitest-pool-workers-examples/module-resolution/vendor/esm-dep:
+    resolution: {directory: fixtures/vitest-pool-workers-examples/module-resolution/vendor/esm-dep, type: directory}
 
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
@@ -21213,6 +21219,8 @@ snapshots:
       jiti: 2.6.1
     transitivePeerDependencies:
       - supports-color
+
+  esm-dep@file:fixtures/vitest-pool-workers-examples/module-resolution/vendor/esm-dep: {}
 
   espree@10.4.0:
     dependencies:


### PR DESCRIPTION
Fixes #12022.

The module fallback's `maybeGetTargetFilePath` unconditionally tried adding `.js`/`.mjs`/`.cjs`/`.json` extensions to extensionless specifiers for both `require()` and `import`. Per the Node.js spec, this extension-probing is specific to CommonJS `require()` — ESM `import` requires explicit extensions. Extensionless TypeScript imports continue to work correctly via Vite's resolver.

The extension loop is now gated behind an `isRequire` flag for user module paths. Internal lib paths (e.g. `cloudflare:test-internal` → `test-internal.mjs`) still always probe extensions since these are pool-owned files with known extensionless paths.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal module fallback behavior, no user-facing docs change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
