### PR TITLE
[vitest-pool-workers] Add regression tests for `onUnhandledError` callback

### DIFF
--- a/packages/vitest-pool-workers/test/unhandled-rejection.test.ts
+++ b/packages/vitest-pool-workers/test/unhandled-rejection.test.ts
@@ -1,0 +1,61 @@
+import dedent from "ts-dedent";
+import { test } from "./helpers";
+
+const unhandledRejectionTest = dedent`
+	import { it } from "vitest";
+	it("triggers unhandled rejection", async () => {
+		// Start a promise that will be rejected; don't chain a rejection handler
+		// before yielding so it becomes "unhandled" from workerd's perspective.
+		Promise.reject(new Error("expected-unhandled-error"));
+		await new Promise<void>((resolve) => setTimeout(resolve, 50));
+	});
+`;
+
+test(
+	"unhandled rejection fails the run by default",
+	{ timeout: 45_000 },
+	async ({ expect, seed, vitestRun }) => {
+		await seed({
+			"vitest.config.mts": dedent`
+				import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+				export default {
+					plugins: [cloudflareTest({ miniflare: { compatibilityDate: "2025-12-02", compatibilityFlags: ["nodejs_compat"] } })],
+					test: { testTimeout: 30_000 }
+				};
+			`,
+			"index.test.ts": unhandledRejectionTest,
+		});
+		const result = await vitestRun();
+		expect(await result.exitCode).not.toBe(0);
+		// The unhandled error is printed to stderr by Vitest
+		expect(result.stderr).toMatch("expected-unhandled-error");
+	}
+);
+
+test(
+	"onUnhandledError callback is invoked and can suppress unhandled rejections",
+	{ timeout: 45_000 },
+	async ({ expect, seed, vitestRun }) => {
+		await seed({
+			"vitest.config.mts": dedent`
+				import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+				export default {
+					plugins: [cloudflareTest({ miniflare: { compatibilityDate: "2025-12-02", compatibilityFlags: ["nodejs_compat"] } })],
+					test: {
+						testTimeout: 30_000,
+						onUnhandledError(err) {
+							// Errors from workers are serialised plain objects (not Error
+							// instances) — match on .message, consistent with standard pools.
+							if (err?.message === "expected-unhandled-error") {
+								return false;
+							}
+						},
+					},
+				};
+			`,
+			"index.test.ts": unhandledRejectionTest,
+		});
+		const result = await vitestRun();
+		expect(await result.exitCode).toBe(0);
+	}
+);


### PR DESCRIPTION
Fixes #11532.

The `onUnhandledError` callback was not being invoked with `@cloudflare/vitest-pool-workers` on versions prior to 0.13.0. This was fixed by the `nodejs_process_v2` compatibility flag enforcement added in the Vitest 4 support rewrite (#11632) — workerd's native `process.on('unhandledRejection')` support is what Vitest's internal `listenForErrors()` relies on.

This PR adds regression tests to ensure the callback continues to work:

1. **Unhandled rejection fails the run by default** — verifies that an unhandled `Promise.reject()` causes the test run to exit non-zero
2. **`onUnhandledError` can suppress specific errors** — verifies that returning `false` from the callback prevents the error from failing the run

Note: errors from workers are serialised plain objects (via Vitest's `serializeValue`), not `Error` instances — this is consistent with standard Vitest pools (threads/forks). The test uses `.message` property access rather than `instanceof Error`, matching the [Vitest docs example](https://vitest.dev/config/onunhandlederror).

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: regression test only, no user-facing change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
