### PR TITLE
[wrangler] Fix vitest-pool-workers crashing when assets configured without directory

### DIFF
--- a/.changeset/fix-vitest-pool-workers-assets-no-dir.md
+++ b/.changeset/fix-vitest-pool-workers-assets-no-dir.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix `getPlatformProxy` and `unstable_getMiniflareWorkerOptions` crashing when `assets` is configured without a `directory`
+
+`getPlatformProxy` and `unstable_getMiniflareWorkerOptions` now skip asset setup when the config has an `assets` block but no `directory` — instead of throwing "missing required `directory` property". This happens when an external tool like `@cloudflare/vite-plugin` handles asset serving independently.

--- a/fixtures/vitest-pool-workers-examples/workers-assets-no-dir/src/env.d.ts
+++ b/fixtures/vitest-pool-workers-examples/workers-assets-no-dir/src/env.d.ts
@@ -1,0 +1,3 @@
+interface Env {
+	ASSETS: Fetcher;
+}

--- a/fixtures/vitest-pool-workers-examples/workers-assets-no-dir/src/index.ts
+++ b/fixtures/vitest-pool-workers-examples/workers-assets-no-dir/src/index.ts
@@ -1,0 +1,5 @@
+export default {
+	async fetch(request): Promise<Response> {
+		return new Response("Hello from worker!");
+	},
+} satisfies ExportedHandler<Env>;

--- a/fixtures/vitest-pool-workers-examples/workers-assets-no-dir/src/tsconfig.json
+++ b/fixtures/vitest-pool-workers-examples/workers-assets-no-dir/src/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.workerd.json",
+	"include": ["./**/*.ts"]
+}

--- a/fixtures/vitest-pool-workers-examples/workers-assets-no-dir/test/assets-no-dir.test.ts
+++ b/fixtures/vitest-pool-workers-examples/workers-assets-no-dir/test/assets-no-dir.test.ts
@@ -1,0 +1,19 @@
+import { SELF } from "cloudflare:test";
+import { describe, it } from "vitest";
+
+// Regression test for https://github.com/cloudflare/workers-sdk/issues/9381
+//
+// When a wrangler config has `assets: { binding: "ASSETS" }` but no `directory`
+// (as is common when using @cloudflare/vite-plugin, which handles asset serving
+// independently via its dev server), vitest-pool-workers must not throw:
+//   "The `assets` property in your configuration is missing the required `directory` property."
+
+describe("workers-assets-no-dir", () => {
+	it("worker starts and responds when assets binding has no directory configured", async ({
+		expect,
+	}) => {
+		const response = await SELF.fetch("http://example.com/");
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("Hello from worker!");
+	});
+});

--- a/fixtures/vitest-pool-workers-examples/workers-assets-no-dir/test/tsconfig.json
+++ b/fixtures/vitest-pool-workers-examples/workers-assets-no-dir/test/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.workerd-test.json",
+	"include": ["./**/*.ts", "../src/env.d.ts"]
+}

--- a/fixtures/vitest-pool-workers-examples/workers-assets-no-dir/tsconfig.json
+++ b/fixtures/vitest-pool-workers-examples/workers-assets-no-dir/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../tsconfig.node.json",
+	"include": ["./*.ts"]
+}

--- a/fixtures/vitest-pool-workers-examples/workers-assets-no-dir/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/workers-assets-no-dir/vitest.config.ts
@@ -1,0 +1,10 @@
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	plugins: [
+		cloudflareTest({
+			wrangler: { configPath: "./wrangler.jsonc" },
+		}),
+	],
+});

--- a/fixtures/vitest-pool-workers-examples/workers-assets-no-dir/wrangler.jsonc
+++ b/fixtures/vitest-pool-workers-examples/workers-assets-no-dir/wrangler.jsonc
@@ -1,0 +1,10 @@
+{
+	"name": "workers-assets-no-directory",
+	"main": "src/index.ts",
+	// Simulate a project using @cloudflare/vite-plugin where assets are configured
+	// with a binding but no directory (vite-plugin serves them via its dev server).
+	// vitest-pool-workers must not throw "missing required `directory` property" here.
+	"assets": {
+		"binding": "ASSETS",
+	},
+}

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -267,15 +267,19 @@ async function getMiniflareOptionsFromConfig(args: {
 
 	let processedAssetOptions: AssetsOptions | undefined;
 
-	try {
-		processedAssetOptions = getAssetsOptions({ assets: undefined }, config);
-	} catch (e) {
-		const isNonExistentError = e instanceof NonExistentAssetsDirError;
-		// we want to loosen up the assets directory existence restriction here,
-		// since `getPlatformProxy` can be run when the assets directory doesn't actual
-		// exist, but all other exceptions should still be thrown
-		if (!isNonExistentError) {
-			throw e;
+	// Only resolve assets if a directory is configured. When assets are configured
+	// without a directory (e.g. via @cloudflare/vite-plugin), skip asset setup.
+	if (config.assets?.directory) {
+		try {
+			processedAssetOptions = getAssetsOptions({ assets: undefined }, config);
+		} catch (e) {
+			const isNonExistentError = e instanceof NonExistentAssetsDirError;
+			// we want to loosen up the assets directory existence restriction here,
+			// since `getPlatformProxy` can be run when the assets directory doesn't
+			// actually exist, but all other exceptions should still be thrown
+			if (!isNonExistentError) {
+				throw e;
+			}
 		}
 	}
 
@@ -499,11 +503,19 @@ export function unstable_getMiniflareWorkerOptions(
 
 	const sitesAssetPaths = getSiteAssetPaths(config);
 	const sitesOptions = buildSitesOptions({ legacyAssetPaths: sitesAssetPaths });
-	const processedAssetOptions = getAssetsOptions(
-		{ assets: undefined },
-		config,
-		options?.overrides?.assets
-	);
+	// Only resolve assets if a directory is available (from config or overrides).
+	// When assets are configured without a directory (e.g. when using
+	// @cloudflare/vite-plugin, which handles asset serving independently),
+	// there's nothing for Miniflare to serve, so skip asset setup entirely.
+	const hasAssetsDirectory =
+		config.assets?.directory || options?.overrides?.assets?.directory;
+	const processedAssetOptions = hasAssetsDirectory
+		? getAssetsOptions(
+				{ assets: undefined },
+				config,
+				options?.overrides?.assets
+			)
+		: undefined;
 	const assetOptions = processedAssetOptions
 		? buildAssetOptions({ assets: processedAssetOptions })
 		: {};


### PR DESCRIPTION
Fixes #9381.

When using `@cloudflare/vite-plugin`, the wrangler config typically has `assets: { binding: "ASSETS" }` without a `directory` — the Vite dev server handles asset serving independently. `vitest-pool-workers` passes the config path to `unstable_getMiniflareWorkerOptions`, which reads the raw config and calls `getAssetsOptions()`. That function unconditionally requires `directory`, so it throws "missing required `directory` property".

The fix guards the `getAssetsOptions()` call in both programmatic API callsites (`unstable_getMiniflareWorkerOptions` and `getPlatformProxy`) — when no directory is available from either the config or overrides, asset setup is skipped entirely rather than crashing.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Bug fix, no new user-facing API
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
