### PR TITLE
[vitest-pool-workers] Add regression test for Istanbul coverage across multiple test files

### DIFF
--- a/packages/vitest-pool-workers/test/coverage.test.ts
+++ b/packages/vitest-pool-workers/test/coverage.test.ts
@@ -1,0 +1,120 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import dedent from "ts-dedent";
+import { test } from "./helpers";
+
+// Regression test for https://github.com/cloudflare/workers-sdk/issues/5825
+// Istanbul coverage was reporting 0% for source files exercised by test files
+// that ran after the first one. The root cause was that in vitest v1, module
+// re-evaluation after `resetModules()` replaced Istanbul's coverage counter
+// objects, losing data from earlier test files. This was fixed by the vitest v4
+// module runner architecture which correctly preserves counter objects across
+// module re-evaluations via hash-based reuse in istanbul-lib-instrument.
+test(
+	"istanbul coverage reports correctly across multiple test files (#5825)",
+	{ timeout: 60_000 },
+	async ({ expect, seed, vitestRun, tmpPath }) => {
+		await seed({
+			"wrangler.jsonc": JSON.stringify({
+				name: "coverage-test",
+				main: "src/index.ts",
+			}),
+			"vitest.config.mts": dedent /* javascript */ `
+				import { cloudflareTest } from "@cloudflare/vitest-pool-workers"
+				import { BaseSequencer } from "vitest/node";
+
+				class DeterministicSequencer extends BaseSequencer {
+					sort(files) {
+						return [...files].sort((a, b) => a.moduleId.localeCompare(b.moduleId));
+					}
+				}
+
+				export default {
+					plugins: [
+						cloudflareTest({
+							miniflare: {
+								compatibilityDate: "2025-12-02",
+								compatibilityFlags: ["nodejs_compat"],
+							},
+							wrangler: {
+								configPath: "./wrangler.jsonc",
+							},
+						})
+					],
+					test: {
+						sequence: { sequencer: DeterministicSequencer },
+						testTimeout: 90_000,
+						coverage: {
+							provider: "istanbul",
+							reporter: ["json-summary"],
+							include: ["src/**"],
+						},
+					},
+				};
+			`,
+			// Worker with two routes dispatching to separate source files
+			"src/index.ts": dedent /* javascript */ `
+				import { greetA } from "./a";
+				import { greetB } from "./b";
+
+				export default {
+					async fetch(request, env, ctx) {
+						if (request.url.endsWith("/a")) {
+							return new Response(greetA(request));
+						}
+						return new Response(greetB(request));
+					},
+				} satisfies ExportedHandler;
+			`,
+			"src/a.ts": dedent /* javascript */ `
+				export function greetA(request: Request): string {
+					return "A: " + request.url;
+				}
+			`,
+			"src/b.ts": dedent /* javascript */ `
+				export function greetB(request: Request): string {
+					return "B: " + request.url;
+				}
+			`,
+			// Two test files exercising different routes — a.test.ts runs first
+			"a.test.ts": dedent /* javascript */ `
+				import { SELF } from "cloudflare:test";
+				import { it, expect } from "vitest";
+
+				it("routes to a", async () => {
+					const response = await SELF.fetch("http://example.com/a");
+					expect(await response.text()).toBe("A: http://example.com/a");
+				});
+			`,
+			"b.test.ts": dedent /* javascript */ `
+				import { SELF } from "cloudflare:test";
+				import { it, expect } from "vitest";
+
+				it("routes to b", async () => {
+					const response = await SELF.fetch("http://example.com/b");
+					expect(await response.text()).toBe("B: http://example.com/b");
+				});
+			`,
+		});
+		const result = await vitestRun({ flags: ["--coverage"] });
+		expect(await result.exitCode).toBe(0);
+
+		// Read the JSON coverage summary to verify actual coverage values
+		const summaryPath = path.join(tmpPath, "coverage", "coverage-summary.json");
+		const summaryJson = JSON.parse(await fs.readFile(summaryPath, "utf8"));
+
+		// Find coverage for a.ts and b.ts (keys are absolute paths)
+		const entries = Object.entries(summaryJson) as [
+			string,
+			{ functions: { pct: number } },
+		][];
+		const aCoverage = entries.find(([k]) => k.endsWith("/src/a.ts"))?.[1];
+		const bCoverage = entries.find(([k]) => k.endsWith("/src/b.ts"))?.[1];
+
+		// The bug: b.ts showed 0% coverage when both files ran together,
+		// because its counters were lost during module re-evaluation.
+		// Both files should now report non-zero function coverage.
+		expect(aCoverage?.functions.pct).toBeGreaterThan(0);
+		expect(bCoverage?.functions.pct).toBeGreaterThan(0);
+	}
+);

--- a/packages/vitest-pool-workers/test/global-setup.ts
+++ b/packages/vitest-pool-workers/test/global-setup.ts
@@ -42,6 +42,7 @@ async function createTestProject() {
 		await fs.mkdtemp(path.join(os.tmpdir(), "vitest-pool-workers temp-"))
 	);
 	const packageJsonPath = path.join(projectPath, "package.json");
+	const vitestPeerDep = await getVitestPeerDep();
 	const packageJson = {
 		name: "vitest-pool-workers-e2e-tests",
 		private: true,
@@ -49,7 +50,8 @@ async function createTestProject() {
 		devDependencies: {
 			// Ensure we use the local version of vitest-pool-workers
 			"@cloudflare/vitest-pool-workers": version,
-			vitest: await getVitestPeerDep(),
+			"@vitest/coverage-istanbul": vitestPeerDep,
+			vitest: vitestPeerDep,
 		},
 	};
 	await fs.writeFile(packageJsonPath, JSON.stringify(packageJson));


### PR DESCRIPTION
Fixes #5825.

The bug reported in #5825 — Istanbul coverage reporting 0% for source files exercised by the 2nd+ test file — was fixed by the vitest v4 module runner migration. This PR adds a regression test to prevent it from recurring.

**Root cause (vitest v1):** When `resetModules()` cleared the module cache between test files and modules were re-evaluated, Istanbul's instrumentation created new counter objects that replaced the ones accumulating coverage from earlier files.

**Why it's fixed (vitest v4):** `istanbul-lib-instrument` uses a hash-based check (`coverage[path].hash !== hash`) to reuse existing counter objects when module source hasn't changed. Vitest v4's `VitestModuleRunner` correctly triggers this path, so coverage counters survive across module re-evaluations.

**Changes:**
- `test/global-setup.ts`: Add `@vitest/coverage-istanbul` to the test project so coverage tests can run
- `test/coverage.test.ts`: New test reproducing the exact issue scenario — two test files each exercising a different route via `SELF.fetch()`, verifying both source files report non-zero Istanbul function coverage

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: test-only change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
