### PR TITLE
[vitest-pool-workers] Add regression test for WorkerEntrypoint env mocking

### DIFF
--- a/fixtures/vitest-pool-workers-examples/rpc/test/unit.test.ts
+++ b/fixtures/vitest-pool-workers-examples/rpc/test/unit.test.ts
@@ -1,4 +1,5 @@
 import {
+	createExecutionContext,
 	env,
 	runDurableObjectAlarm,
 	runInDurableObject,
@@ -6,7 +7,7 @@ import {
 } from "cloudflare:test";
 import { RpcStub } from "cloudflare:workers";
 import { describe, it, onTestFinished } from "vitest";
-import { Counter, TestObject } from "../src";
+import TestDefaultEntrypoint, { Counter, TestObject } from "../src";
 
 describe("named entrypoints", () => {
 	it("dispatches fetch request to named ExportedHandler", async ({
@@ -152,6 +153,25 @@ describe("Durable Object", () => {
 		using result = await stub.getObject();
 		expect(result).toMatchObject({ hello: "world" });
 	});
+});
+
+// Regression: https://github.com/cloudflare/workers-sdk/issues/7077
+// Fixed in workerd by https://github.com/cloudflare/workerd/pull/3782
+it("can construct a WorkerEntrypoint with mocked env", async ({ expect }) => {
+	const data = new Map<string, string>([["mocked-key", "mocked-value"]]);
+	const mockedKv = new Proxy(env.KV_NAMESPACE, {
+		get: (target, prop, receiver) =>
+			prop === "get"
+				? async (key: string) => data.get(key) ?? null
+				: Reflect.get(target, prop, receiver),
+	});
+
+	const ctx = createExecutionContext();
+	const worker = new TestDefaultEntrypoint(ctx, {
+		...env,
+		KV_NAMESPACE: mockedKv,
+	});
+	expect(await worker.read("mocked-key")).toBe("mocked-value");
 });
 
 describe("counter", () => {


### PR DESCRIPTION
Fixes #7077.

The underlying issue — `WorkerEntrypoint`'s native constructor rejecting a user-provided `ctx` object — was fixed in workerd via https://github.com/cloudflare/workerd/pull/3782, which relaxed the constructor parameter from `jsg::Ref<ExecutionContext>` to `jsg::JsObject`. This has been shipping since `workerd@1.20250324.0`.

This PR adds a regression test that constructs a `WorkerEntrypoint` subclass with `createExecutionContext()` and a mocked `KVNamespace`, confirming the pattern works.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: no user-facing change, the fix already shipped in workerd
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
