### PR TITLE
[vitest-pool-workers] Support `__mocks__` directories for `vi.mock()` without a factory

### DIFF
--- a/.changeset/fix-mocks-directory.md
+++ b/.changeset/fix-mocks-directory.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Support `__mocks__` directories for `vi.mock()` without a factory
+
+When calling `vi.mock("some-module")` without providing a factory function, Vitest looks for a corresponding file in a `__mocks__` directory. This was not working in `@cloudflare/vitest-pool-workers` because the mock resolution uses `node:fs` filesystem operations (`existsSync`, `readdirSync`) that don't have access to the host filesystem inside workerd.
+
+The fix routes `__mocks__` directory lookups through the existing loopback service binding, which runs on the Node.js pool side where filesystem access works. This is done by overriding the mocker's `resolveMocks()` method via the `onModuleRunner` hook to pre-fetch redirect paths asynchronously before the synchronous `findMockRedirect()` is called.

--- a/fixtures/vitest-pool-workers-examples/mock-directory/__mocks__/mime-types.ts
+++ b/fixtures/vitest-pool-workers-examples/mock-directory/__mocks__/mime-types.ts
@@ -1,0 +1,6 @@
+// Manual mock for the "mime-types" package via __mocks__ directory.
+// When vi.mock("mime-types") is called without a factory, Vitest should
+// pick up this file instead of auto-mocking the real module.
+export function lookup(_path: string): string {
+	return "text/mock";
+}

--- a/fixtures/vitest-pool-workers-examples/mock-directory/src/__mocks__/dep.ts
+++ b/fixtures/vitest-pool-workers-examples/mock-directory/src/__mocks__/dep.ts
@@ -1,0 +1,6 @@
+// Manual mock for the local "./dep" module via __mocks__ directory.
+// When vi.mock("./dep") is called without a factory, Vitest should
+// pick up this file instead of auto-mocking the real module.
+export function getValue(): string {
+	return "mocked";
+}

--- a/fixtures/vitest-pool-workers-examples/mock-directory/src/dep.ts
+++ b/fixtures/vitest-pool-workers-examples/mock-directory/src/dep.ts
@@ -1,0 +1,3 @@
+export function getValue(): string {
+	return "real";
+}

--- a/fixtures/vitest-pool-workers-examples/mock-directory/src/index.ts
+++ b/fixtures/vitest-pool-workers-examples/mock-directory/src/index.ts
@@ -1,0 +1,11 @@
+import { getValue } from "./dep";
+
+export function greet(): string {
+	return `Hello, ${getValue()}!`;
+}
+
+export default {
+	async fetch() {
+		return new Response(greet());
+	},
+} satisfies ExportedHandler;

--- a/fixtures/vitest-pool-workers-examples/mock-directory/test/mock-directory.test.ts
+++ b/fixtures/vitest-pool-workers-examples/mock-directory/test/mock-directory.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Test __mocks__ directory support for external packages.
+// The __mocks__/mime-types.ts file should be loaded instead of auto-mocking.
+vi.mock("mime-types");
+
+// Test __mocks__ directory support for local modules.
+// The src/__mocks__/dep.ts file should be loaded instead of auto-mocking.
+vi.mock("../src/dep");
+
+describe("__mocks__ directory", () => {
+	it("uses __mocks__/mime-types.ts for external package mock", async () => {
+		const { lookup } = await import("mime-types");
+		expect(lookup("test.html")).toBe("text/mock");
+	});
+
+	it("uses src/__mocks__/dep.ts for local module mock", async () => {
+		const { getValue } = await import("../src/dep");
+		expect(getValue()).toBe("mocked");
+	});
+
+	it("greet() uses the mocked dep", async () => {
+		const { greet } = await import("../src/index");
+		expect(greet()).toBe("Hello, mocked!");
+	});
+});

--- a/fixtures/vitest-pool-workers-examples/mock-directory/tsconfig.json
+++ b/fixtures/vitest-pool-workers-examples/mock-directory/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../tsconfig.workerd-test.json",
+	"include": ["src/**/*.ts", "test/**/*.ts", "__mocks__/**/*.ts"],
+	"compilerOptions": {
+		"paths": {
+			"mime-types": ["../node_modules/@types/mime-types"]
+		}
+	}
+}

--- a/fixtures/vitest-pool-workers-examples/mock-directory/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/mock-directory/vitest.config.ts
@@ -1,0 +1,13 @@
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	plugins: [
+		cloudflareTest({
+			wrangler: {
+				configPath: "./wrangler.jsonc",
+			},
+		}),
+	],
+	test: {},
+});

--- a/fixtures/vitest-pool-workers-examples/mock-directory/wrangler.jsonc
+++ b/fixtures/vitest-pool-workers-examples/mock-directory/wrangler.jsonc
@@ -1,0 +1,4 @@
+{
+	"name": "mock-directory",
+	"main": "src/index.ts"
+}

--- a/packages/vitest-pool-workers/src/pool/loopback.ts
+++ b/packages/vitest-pool-workers/src/pool/loopback.ts
@@ -1,9 +1,54 @@
 import assert from "node:assert";
+import nodeFs from "node:fs";
 import fs from "node:fs/promises";
+import nodeModule from "node:module";
 import path from "node:path";
 import { Response } from "miniflare";
 import { isFileNotFoundError } from "./helpers";
 import type { Awaitable, Miniflare, Request } from "miniflare";
+
+// Inlined from @vitest/mocker/redirect — we can't import it because pnpm
+// doesn't hoist it to a location resolvable from our dist output.
+function findMockRedirect(
+	root: string,
+	mockPath: string,
+	external: string | null
+): string | null {
+	const p = external || mockPath;
+
+	if (external || nodeModule.isBuiltin(mockPath) || !nodeFs.existsSync(mockPath)) {
+		const mockDirname = path.dirname(p);
+		const mockFolder = path.join(root, "__mocks__", mockDirname);
+		if (!nodeFs.existsSync(mockFolder)) {
+			return null;
+		}
+		const baseOriginal = path.basename(p);
+		return findFile(mockFolder, baseOriginal);
+	}
+
+	const dir = path.dirname(p);
+	const baseId = path.basename(p);
+	const fullPath = path.resolve(dir, "__mocks__", baseId);
+	return nodeFs.existsSync(fullPath) ? fullPath : null;
+}
+
+function findFile(mockFolder: string, baseOriginal: string): string | null {
+	const files = nodeFs.readdirSync(mockFolder);
+	for (const file of files) {
+		const baseFile = path.basename(file, path.extname(file));
+		if (baseFile === baseOriginal) {
+			const filePath = path.resolve(mockFolder, file);
+			if (nodeFs.statSync(filePath).isFile()) {
+				return filePath;
+			}
+			const indexFile = findFile(filePath, "index");
+			if (indexFile) {
+				return indexFile;
+			}
+		}
+	}
+	return null;
+}
 
 // Based on https://github.com/vitest-dev/vitest/blob/v4.0.18/packages/snapshot/src/env/node.ts
 async function handleSnapshotRequest(
@@ -89,6 +134,20 @@ export async function listDurableObjectIds(
 	return Response.json(ids);
 }
 
+function handleMockRedirectRequest(url: URL): Response {
+	const root = url.searchParams.get("root");
+	const mockPath = url.searchParams.get("mockPath");
+	const external = url.searchParams.get("external");
+	if (root === null || mockPath === null) {
+		return new Response(null, { status: 400 });
+	}
+	const redirect = findMockRedirect(root, mockPath, external);
+	if (redirect === null) {
+		return new Response(null, { status: 404 });
+	}
+	return new Response(redirect, { status: 200 });
+}
+
 export function handleLoopbackRequest(
 	request: Request,
 	mf: Miniflare
@@ -99,6 +158,9 @@ export function handleLoopbackRequest(
 	}
 	if (url.pathname === "/durable-objects") {
 		return listDurableObjectIds(request, mf, url);
+	}
+	if (url.pathname === "/mock-redirect") {
+		return handleMockRedirectRequest(url);
 	}
 	return new Response(null, { status: 404 });
 }

--- a/packages/vitest-pool-workers/src/worker/index.ts
+++ b/packages/vitest-pool-workers/src/worker/index.ts
@@ -7,13 +7,35 @@ import {
 	registerHandlerAndGlobalWaitUntil,
 	runInRunnerObject,
 } from "cloudflare:test-internal";
-import { DurableObject } from "cloudflare:workers";
+import { DurableObject, env } from "cloudflare:workers";
 import * as devalue from "devalue";
 // Using relative path here to ensure `esbuild` bundles it
 import {
 	structuredSerializableReducers,
 	structuredSerializableRevivers,
 } from "../../../miniflare/src/workers/core/devalue";
+
+// Minimal type declarations for the VitestMocker methods we override.
+// These are internal Vitest types not publicly exported.
+interface PendingSuiteMock {
+	action: "mock" | "unmock";
+	id: string;
+	importer: string;
+	factory?: unknown;
+}
+interface Mocker {
+	resolveMocks: () => Promise<void>;
+	findMockRedirect: (mockPath: string, external: string | null) => string | null;
+	resolveId: (
+		id: string,
+		importer?: string
+	) => Promise<{ id: string; url: string; external: string | null }>;
+	root: string;
+	constructor: unknown;
+}
+interface PendingIds {
+	pendingIds: PendingSuiteMock[];
+}
 
 function structuredSerializableStringify(value: unknown): string {
 	return devalue.stringify(value, structuredSerializableReducers);
@@ -133,6 +155,28 @@ function isDifferentIOContextError(e: unknown) {
 	);
 }
 
+// Fetch the __mocks__ redirect for a given module from the pool-side loopback
+// service, which has host filesystem access. Returns the absolute path to the
+// __mocks__ file, or null if none exists.
+async function fetchMockRedirect(
+	root: string,
+	mockPath: string,
+	external: string | null
+): Promise<string | null> {
+	const params = new URLSearchParams({ root, mockPath });
+	if (external !== null) {
+		params.set("external", external);
+	}
+	const res =
+		await env.__VITEST_POOL_WORKERS_LOOPBACK_SERVICE.fetch(
+			`http://placeholder/mock-redirect?${params}`
+		);
+	if (res.status === 404) {
+		return null;
+	}
+	return res.text();
+}
+
 let patchedFunction = false;
 function ensurePatchedFunction(unsafeEval: UnsafeEval) {
 	if (patchedFunction) {
@@ -195,6 +239,53 @@ export class __VITEST_POOL_WORKERS_RUNNER_DURABLE_OBJECT__ extends DurableObject
 		poolSocket.accept();
 
 		init({
+			onModuleRunner: (runner) => {
+				// Override the mocker's __mocks__ directory resolution to work inside
+				// workerd. The default implementation uses node:fs (existsSync, etc.)
+				// which doesn't have host filesystem access inside workerd. Instead,
+				// we pre-fetch redirects from the loopback service (which runs on the
+				// Node.js pool side) in the async resolveMocks(), then let the sync
+				// findMockRedirect() do a simple map lookup.
+				const mocker = (runner as { mocker: Mocker }).mocker;
+				const redirectCache = new Map<string, string>();
+
+				const originalResolveMocks = mocker.resolveMocks.bind(mocker);
+				mocker.resolveMocks = async () => {
+					// Access pending mock registrations from the static property
+					const pendingIds = (mocker.constructor as PendingIds).pendingIds;
+					if (pendingIds?.length) {
+						await Promise.all(
+							pendingIds
+								.filter(
+									(m) => m.action === "mock" && !m.factory
+								)
+								.map(async (m) => {
+									const resolved = await mocker.resolveId(
+										m.id,
+										m.importer
+									);
+									const redirect = await fetchMockRedirect(
+										(mocker as { root: string }).root,
+										resolved.id,
+										resolved.external
+									);
+									if (redirect !== null) {
+										redirectCache.set(resolved.id, redirect);
+									}
+								})
+						);
+					}
+					try {
+						await originalResolveMocks();
+					} finally {
+						redirectCache.clear();
+					}
+				};
+
+				mocker.findMockRedirect = (mockPath: string) => {
+					return redirectCache.get(mockPath) ?? null;
+				};
+			},
 			post: (response) => {
 				try {
 					poolSocket.send(structuredSerializableStringify(response));


### PR DESCRIPTION
Fixes #7679.

When calling `vi.mock("some-module")` without providing a factory function, Vitest looks for a corresponding file in a `__mocks__` directory. This was not working in `@cloudflare/vitest-pool-workers` because the mock resolution (`findMockRedirect` from `@vitest/mocker`) uses `node:fs` operations (`existsSync`, `readdirSync`, `statSync`) that don't have access to the host filesystem inside workerd.

## Approach

The fix routes `__mocks__` directory lookups through the existing loopback service binding — which runs on the Node.js pool side where filesystem access works.

- **`loopback.ts`** — new `/mock-redirect` endpoint that runs `findMockRedirect` logic on the pool side (inlined from `@vitest/mocker/redirect` since pnpm doesn't hoist it to a resolvable location)
- **`worker/index.ts`** — uses the `onModuleRunner` hook to override two methods on the mocker instance:
  - `resolveMocks()` — before calling the original, pre-fetches `__mocks__` redirects for pending auto-mocks via the loopback service binding. Stores results in a `Map`.
  - `findMockRedirect()` — returns from the pre-fetched `Map` instead of calling `existsSync`. The cache is populated by `resolveMocks()` (which is async, avoiding the sync/async bridging problem) and cleared after each call.

This mirrors the pattern used by Vitest's browser pool, which also resolves mocks server-side since the browser doesn't have filesystem access.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this enables existing Vitest functionality that was previously broken