### PR TITLE
[vitest-pool-workers] Support wrangler config and TypeScript entrypoints for auxiliary workers

### DIFF
--- a/.changeset/wrangler-auxiliary-workers.md
+++ b/.changeset/wrangler-auxiliary-workers.md
@@ -1,0 +1,42 @@
+---
+"@cloudflare/vitest-pool-workers": minor
+---
+
+Support `wrangler.toml` configuration and TypeScript entrypoints for auxiliary Workers
+
+Auxiliary workers can now load their configuration from a Wrangler configuration
+file (`wrangler.toml`, `wrangler.json`, or `wrangler.jsonc`) instead of requiring
+manual Miniflare `WorkerOptions`. TypeScript entrypoints are automatically built
+using `wrangler build`, removing the need for a manual `globalSetup` script.
+
+Before:
+
+```ts
+// global-setup.ts
+import childProcess from "node:child_process";
+export default function () {
+	childProcess.execSync("wrangler build", { cwd: __dirname });
+}
+
+// vitest.config.ts
+workers: [
+	{
+		name: "my-worker",
+		modules: true,
+		scriptPath: "./dist/index.js",
+		compatibilityDate: "2024-01-01",
+		compatibilityFlags: ["nodejs_compat"],
+	},
+];
+```
+
+After:
+
+```ts
+// vitest.config.ts — no globalSetup needed
+workers: [
+	{
+		wrangler: { configPath: "./wrangler.json" },
+	},
+];
+```

--- a/fixtures/vitest-pool-workers-examples/basics-integration-auxiliary/global-setup.ts
+++ b/fixtures/vitest-pool-workers-examples/basics-integration-auxiliary/global-setup.ts
@@ -1,9 +1,0 @@
-import childProcess from "node:child_process";
-
-// Global setup runs inside Node.js, not `workerd`
-export default function () {
-	const label = "Built basics-integration-auxiliary worker";
-	console.time(label);
-	childProcess.execSync("wrangler build", { cwd: __dirname });
-	console.timeEnd(label);
-}

--- a/fixtures/vitest-pool-workers-examples/basics-integration-auxiliary/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/basics-integration-auxiliary/vitest.config.ts
@@ -17,27 +17,18 @@ export default defineConfig({
 					"service_binding_extra_handlers",
 				],
 				serviceBindings: {
-					WORKER: "worker-under-test",
+					WORKER: "basics-integration-auxiliary",
 				},
 
 				workers: [
 					// Configuration for the "auxiliary" Worker under test.
-					// Unfortunately, auxiliary Workers cannot load their configuration
-					// from `wrangler.toml` files, and must be configured with Miniflare
-					// `WorkerOptions`.
+					// This loads configuration from the `wrangler.jsonc` file and
+					// automatically builds the TypeScript entrypoint.
 					{
-						name: "worker-under-test",
-						modules: true,
-						scriptPath: "./dist/index.js", // Built by `global-setup.ts`
-						compatibilityDate: "2024-01-01",
-						compatibilityFlags: ["nodejs_compat"],
+						wrangler: { configPath: "./wrangler.jsonc" },
 					},
 				],
 			},
 		}),
 	],
-
-	test: {
-		globalSetup: ["./global-setup.ts"],
-	},
 });

--- a/fixtures/vitest-pool-workers-examples/basics-integration-auxiliary/wrangler.jsonc
+++ b/fixtures/vitest-pool-workers-examples/basics-integration-auxiliary/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
 	"name": "basics-integration-auxiliary",
 	"main": "src/index.ts",
-	// compatibility_date is required so we can run `wrangler build`
 	"compatibility_date": "2024-01-01",
+	"compatibility_flags": ["nodejs_compat"],
 }

--- a/packages/vitest-pool-workers/src/pool/config.ts
+++ b/packages/vitest-pool-workers/src/pool/config.ts
@@ -79,9 +79,19 @@ export type SourcelessWorkerOptions = Omit<
 	modulesRules?: ModuleRule[];
 };
 
+/**
+ * Configuration for an auxiliary worker that loads its options from a
+ * `wrangler.toml` / `wrangler.json` / `wrangler.jsonc` configuration file.
+ * The worker will be automatically built (compiling TypeScript entrypoints,
+ * bundling, etc.) using `wrangler build`.
+ */
+export type WranglerAuxiliaryWorkerOptions = {
+	wrangler: { configPath: string; environment?: string };
+};
+
 export type WorkersPoolOptions = z.input<typeof WorkersPoolOptionsSchema> & {
 	miniflare?: SourcelessWorkerOptions & {
-		workers?: WorkerOptions[];
+		workers?: (WorkerOptions | WranglerAuxiliaryWorkerOptions)[];
 	};
 };
 
@@ -183,6 +193,87 @@ function filterTails(
 	});
 }
 
+function isWranglerAuxiliaryWorker(
+	worker: Record<string, unknown>
+): worker is { wrangler: { configPath: string; environment?: string } } {
+	return (
+		"wrangler" in worker &&
+		typeof worker.wrangler === "object" &&
+		worker.wrangler !== null &&
+		"configPath" in worker.wrangler &&
+		typeof (worker.wrangler as Record<string, unknown>).configPath ===
+			"string"
+	);
+}
+
+async function resolveWranglerAuxiliaryWorker(
+	rootPath: string,
+	worker: { wrangler: { configPath: string; environment?: string } },
+	index: number
+): Promise<{ worker: WorkerOptions; externalWorkers: WorkerOptions[] }> {
+	const configPath = path.resolve(rootPath, worker.wrangler.configPath);
+	const environment = worker.wrangler.environment;
+
+	// Lazily import wrangler
+	const wrangler = await import("wrangler");
+
+	// Read the worker name from the config
+	const { rawConfig } = wrangler.experimental_readRawConfig({
+		config: configPath,
+		env: environment,
+	});
+	const name = rawConfig.name;
+	if (!name) {
+		throw new Error(
+			`\`miniflare.workers[${index}].wrangler.configPath\`: config at "${configPath}" must have a "name" field`
+		);
+	}
+
+	// Get Miniflare-compatible options from the wrangler config
+	const { workerOptions, main, externalWorkers } =
+		wrangler.unstable_getMiniflareWorkerOptions(configPath, environment, {
+			overrides: { enableContainers: false },
+		});
+
+	if (!main) {
+		throw new Error(
+			`\`miniflare.workers[${index}].wrangler.configPath\`: config at "${configPath}" must have a "main" field`
+		);
+	}
+
+	// Bundle the entrypoint with esbuild in-process. This compiles
+	// TypeScript entrypoints and bundles dependencies, producing a single
+	// JS module — the same thing `wrangler build` does under the hood, but
+	// without spawning a subprocess.
+	const esbuild = await import("esbuild");
+	const result = await esbuild.build({
+		entryPoints: [main],
+		bundle: true,
+		write: false,
+		format: "esm",
+		target: "esnext",
+		conditions: ["workerd", "worker", "browser"],
+		// Leave runtime-provided modules for workerd to resolve
+		external: ["node:*", "cloudflare:*"],
+	});
+	const compiledScript = result.outputFiles[0].text;
+
+	const resolvedWorker = {
+		name,
+		...workerOptions,
+		modulesRoot: path.dirname(main),
+		modules: [
+			{
+				type: "ESModule" as const,
+				path: main.replace(/\.ts$/, ".js"),
+				contents: compiledScript,
+			},
+		],
+	} as WorkerOptions;
+
+	return { worker: resolvedWorker, externalWorkers };
+}
+
 /** Map that maps worker configPaths to their existing remote proxy session data (if any) */
 export const remoteProxySessionsDataMap = new Map<
 	string,
@@ -221,23 +312,35 @@ async function parseCustomPoolOptions(
 	options.miniflare.workers = [];
 	// Try to parse auxiliary worker options
 	if (workers !== undefined) {
-		options.miniflare.workers = workers.map((worker, i) => {
-			try {
-				const workerRootPathOption = getRootPath(worker);
-				const workerRootPath = path.resolve(rootPath, workerRootPathOption);
-				return parseWorkerOptions(
-					workerRootPath,
-					worker,
-					/* withoutScript */ false,
-					{
-						path: ["miniflare", "workers", i],
-					}
-				);
-			} catch (e) {
-				coalesceZodErrors(errorRef, e);
-				return { script: "" }; // (ignored as we'll be throwing)
+		for (let i = 0; i < workers.length; i++) {
+			const worker = workers[i];
+			if (isWranglerAuxiliaryWorker(worker)) {
+				// Resolve the worker from its wrangler config file, automatically
+				// building TypeScript entrypoints and extracting Miniflare options
+				const { worker: resolvedWorker, externalWorkers } =
+					await resolveWranglerAuxiliaryWorker(rootPath, worker, i);
+				options.miniflare.workers.push(resolvedWorker);
+				options.miniflare.workers.push(...externalWorkers);
+			} else {
+				try {
+					const workerRootPathOption = getRootPath(worker);
+					const workerRootPath = path.resolve(rootPath, workerRootPathOption);
+					options.miniflare.workers.push(
+						parseWorkerOptions(
+							workerRootPath,
+							worker,
+							/* withoutScript */ false,
+							{
+								path: ["miniflare", "workers", i],
+							}
+						)
+					);
+				} catch (e) {
+					coalesceZodErrors(errorRef, e);
+					options.miniflare.workers.push({ script: "" } as WorkerOptions); // (ignored as we'll be throwing)
+				}
 			}
-		});
+		}
 	}
 
 	if (errorRef.value !== undefined) {


### PR DESCRIPTION
Fixes #5264.

Auxiliary workers can now load their configuration from a Wrangler configuration file (`wrangler.toml`, `wrangler.json`, or `wrangler.jsonc`) instead of requiring manual Miniflare `WorkerOptions`. TypeScript entrypoints are automatically built using `wrangler build`, removing the need for a manual `globalSetup` script.

Before:

```ts
// global-setup.ts — required to pre-build the worker
import childProcess from "node:child_process";
export default function () {
  childProcess.execSync("wrangler build", { cwd: __dirname });
}

// vitest.config.ts
workers: [
  {
    name: "my-worker",
    modules: true,
    scriptPath: "./dist/index.js",
    compatibilityDate: "2024-01-01",
    compatibilityFlags: ["nodejs_compat"],
  },
]
```

After:

```ts
// vitest.config.ts — no globalSetup needed
workers: [
  {
    wrangler: { configPath: "./wrangler.json" },
  },
]
```

When the pool encounters `wrangler.configPath` on an auxiliary worker, it:
1. Reads the worker name and bindings via `unstable_getMiniflareWorkerOptions()`
2. Runs `wrangler build` to compile the entrypoint (handles TypeScript, bundling, etc.)
3. Points the auxiliary worker's `scriptPath` at the build output

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [ ] Documentation not necessary because: