### PR TITLE
fix(vite-plugin): route websocket service bindings to entry worker

### DIFF
--- a/.changeset/fix-vite-plugin-websocket-service-bindings.md
+++ b/.changeset/fix-vite-plugin-websocket-service-bindings.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Route dev-mode WebSocket service bindings to the entry worker
+
+WebSocket upgrade requests sent to another local worker via a service binding now bypass the Vite middleware proxy and go straight to that worker's entrypoint in dev mode. This fixes multi-worker setups where the upgrade was incorrectly forwarded into the Node middleware service and the connection failed before the target worker could accept it.

--- a/packages/vite-plugin-cloudflare/playground/multi-worker/__tests__/multi-worker.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/multi-worker/__tests__/multi-worker.spec.ts
@@ -2,7 +2,13 @@ import { execSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, test } from "vitest";
-import { getJsonResponse, isBuild, rootDir } from "../../__test-utils__";
+import {
+	getJsonResponse,
+	isBuild,
+	page,
+	rootDir,
+	viteTestUrl,
+} from "../../__test-utils__";
 
 describe.runIf(isBuild)("output directories", () => {
 	test("creates the correct output directories", ({ expect }) => {
@@ -34,6 +40,60 @@ describe("multi-worker service bindings", async () => {
 		const result = await getJsonResponse("/fetch");
 		expect(result).toEqual({ result: { name: "Worker B" } });
 	});
+
+	test.runIf(!isBuild)(
+		"proxies WebSocket upgrades through another worker service binding in dev",
+		async ({ expect }) => {
+			await page.goto(viteTestUrl);
+			const message = await page.evaluate(async () => {
+				const url = new URL("/websocket-proxy", window.location.href);
+				url.protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+
+				return await new Promise<string>((resolve, reject) => {
+					const websocket = new WebSocket(url);
+					let settled = false;
+					const timer = window.setTimeout(() => {
+						if (settled) return;
+						settled = true;
+						websocket.close();
+						reject(new Error("Timed out waiting for proxied WebSocket message"));
+					}, 10_000);
+
+					const finish = (fn: () => void) => {
+						if (settled) return;
+						settled = true;
+						window.clearTimeout(timer);
+						fn();
+					};
+
+					websocket.addEventListener("open", () => {
+						websocket.send("ping");
+					});
+					websocket.addEventListener("message", (event) => {
+						finish(() => {
+							websocket.close();
+							resolve(String(event.data));
+						});
+					});
+					websocket.addEventListener("error", () => {
+						finish(() => reject(new Error("WebSocket error")));
+					});
+					websocket.addEventListener("close", (event) => {
+						if (event.wasClean || settled) return;
+						finish(() =>
+							reject(
+								new Error(
+									`WebSocket closed before message (${event.code}: ${event.reason})`
+								)
+							)
+						);
+					});
+				});
+			});
+
+			expect(message).toBe("pong from worker-b");
+		}
+	);
 
 	test("calls an RPC method on another worker", async ({ expect }) => {
 		const result = await getJsonResponse("/rpc-method");

--- a/packages/vite-plugin-cloudflare/playground/multi-worker/worker-a/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/multi-worker/worker-a/index.ts
@@ -19,6 +19,10 @@ export default {
 					result,
 				});
 			}
+			case "/websocket-proxy": {
+				const upstreamUrl = new URL("/websocket", request.url);
+				return env.WORKER_B.fetch(new Request(upstreamUrl, request));
+			}
 			case "/rpc-method": {
 				const result = await env.WORKER_B.add(4, 5);
 				return Response.json({

--- a/packages/vite-plugin-cloudflare/playground/multi-worker/worker-b/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/multi-worker/worker-b/index.ts
@@ -7,6 +7,20 @@ interface Env {
 export default class extends WorkerEntrypoint<Env> {
 	override fetch(request: Request) {
 		const url = new URL(request.url);
+		if (url.pathname === "/websocket") {
+			if (request.headers.get("Upgrade") !== "websocket") {
+				return new Response("Expected Upgrade: websocket", { status: 426 });
+			}
+
+			const { 0: client, 1: server } = new WebSocketPair();
+			server.accept();
+			server.addEventListener("message", (event) => {
+				if (event.data === "ping") {
+					server.send("pong from worker-b");
+				}
+			});
+			return new Response(null, { status: 101, webSocket: client });
+		}
 		if (url.pathname === "/config-test") {
 			return Response.json({
 				configuredVar: this.env.CONFIGURED_VAR,

--- a/packages/vite-plugin-cloudflare/src/__tests__/vite-proxy-worker.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/vite-proxy-worker.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("cloudflare:workers", () => ({
+	WorkerEntrypoint: class WorkerEntrypoint<Env> {
+		constructor(
+			protected readonly ctx: ExecutionContext,
+			protected readonly env: Env
+		) {}
+	},
+}));
+
+describe("ViteProxyWorker", () => {
+	test("forwards WebSocket upgrades to the entry worker", async () => {
+		const { default: ViteProxyWorker } = await import(
+			"../workers/vite-proxy-worker/index"
+		);
+		const entryResponse = new Response(null);
+		const env = {
+			ENTRY_USER_WORKER: {
+				fetch: vi.fn().mockResolvedValue(entryResponse),
+				tail: vi.fn(),
+			},
+			__VITE_MIDDLEWARE__: {
+				fetch: vi.fn(),
+			},
+		};
+		const worker = new ViteProxyWorker(
+			{} as ExecutionContext,
+			env as ConstructorParameters<typeof ViteProxyWorker>[1]
+		);
+		const request = new Request("http://example.com/websocket", {
+			headers: { Upgrade: "websocket" },
+		});
+
+		const response = await worker.fetch(request);
+
+		expect(env.ENTRY_USER_WORKER.fetch).toHaveBeenCalledWith(request);
+		expect(env.__VITE_MIDDLEWARE__.fetch).not.toHaveBeenCalled();
+		expect(response).toBe(entryResponse);
+	});
+
+	test("forwards non-WebSocket requests to Vite middleware", async () => {
+		const { default: ViteProxyWorker } = await import(
+			"../workers/vite-proxy-worker/index"
+		);
+		const middlewareResponse = new Response("ok");
+		const env = {
+			ENTRY_USER_WORKER: {
+				fetch: vi.fn(),
+				tail: vi.fn(),
+			},
+			__VITE_MIDDLEWARE__: {
+				fetch: vi.fn().mockResolvedValue(middlewareResponse),
+			},
+		};
+		const worker = new ViteProxyWorker(
+			{} as ExecutionContext,
+			env as ConstructorParameters<typeof ViteProxyWorker>[1]
+		);
+		const request = new Request("http://example.com/");
+
+		const response = await worker.fetch(request);
+
+		expect(env.__VITE_MIDDLEWARE__.fetch).toHaveBeenCalledWith(request);
+		expect(env.ENTRY_USER_WORKER.fetch).not.toHaveBeenCalled();
+		expect(response).toBe(middlewareResponse);
+	});
+});

--- a/packages/vite-plugin-cloudflare/src/workers/vite-proxy-worker/index.ts
+++ b/packages/vite-plugin-cloudflare/src/workers/vite-proxy-worker/index.ts
@@ -20,6 +20,10 @@ export default class ViteProxyWorker extends WorkerEntrypoint<Env> {
 	}
 
 	override async fetch(request: Request) {
+		if (request.headers.get("Upgrade")?.toLowerCase() === "websocket") {
+			return this.env.ENTRY_USER_WORKER.fetch(request);
+		}
+
 		return this.env.__VITE_MIDDLEWARE__.fetch(request);
 	}
 


### PR DESCRIPTION
Fixes #13054.

## Summary

- route dev-mode WebSocket upgrade requests through the target worker entrypoint instead of the Vite middleware proxy
- add direct unit coverage for the `vite-proxy-worker` upgrade path
- add a multi-worker playground regression that exercises a worker-to-worker WebSocket service binding in dev

## Testing

- `node node_modules\\vitest\\vitest.mjs run src\\__tests__\\vite-proxy-worker.spec.ts`

## Notes

- I could not run the multi-worker playground e2e locally because the workspace install on this Windows host remained incomplete enough for the playground harness to fail resolving `@cloudflare/workers-utils` during setup.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
