### PR TITLE
[workers-playground] Fix Vite 8 / rolldown crash: TypeError: createRenderer is not a function

### DIFF
--- a/.changeset/workers-playground-fix-vite8-createrenderer.md
+++ b/.changeset/workers-playground-fix-vite8-createrenderer.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/workers-playground": patch
+---
+
+fix: resolve TypeError: createRenderer is not a function when built with Vite 8
+
+Vite 8 switched its bundler from Rollup to rolldown. The `@cloudflare/style-provider` package ships a hybrid ESM+CJS build (its `es/` directory uses `require()` internally), which rolldown mishandles by generating an anonymous, unreachable module initializer — leaving `createRenderer` as `undefined` at runtime.
+
+Fixed by aliasing `@cloudflare/style-provider` to its CJS entry (`lib/index.js`) in `vite.config.ts`. Rolldown handles plain CJS correctly via its interop layer.

--- a/packages/workers-playground/vite.config.ts
+++ b/packages/workers-playground/vite.config.ts
@@ -13,14 +13,26 @@ export default defineConfig(({ mode }) => {
 		],
 		resolve: {
 			alias: {
+				// @cloudflare/style-provider ships a hybrid ESM+CJS package: its es/ directory
+				// contains files that are nominally ESM but internally use require(). Vite 8's
+				// bundler (rolldown) mishandles this pattern and generates an anonymous,
+				// unreachable module initializer, leaving `createRenderer` as undefined at
+				// runtime (TypeError: createRenderer is not a function).
+				// Aliasing to the CJS build (lib/) avoids this — rolldown handles plain CJS
+				// correctly via its interop layer.
+				"@cloudflare/style-provider": "@cloudflare/style-provider/lib/index.js",
 				"react/jsx-runtime.js": "react/jsx-runtime",
 			},
 		},
 
 		appType: "spa",
-		base: "/playground",
 		build: {
 			chunkSizeWarningLimit: 1000,
+			// The application is actually hosted at `playground/`, but we can't use the `base` option.
+			// That would  cause Vite to put the assets directly in `dist/assets` and to refer to them via `/playground/assets/` in the generated HTML.
+			// But Wrangler will upload the assets as though they were in `/assets` and so the links in the HTML would be broken.
+			// By keeping the assets in `dist/playground/assets`, the links in the HTML will match the actual location of the assets when deployed.
+			assetsDir: "playground/assets",
 		},
 	};
 });


### PR DESCRIPTION
Fixes #[insert GH or internal issue link(s)].

`@cloudflare/style-provider` ships a hybrid ESM+CJS package: its `es/` directory contains files that are nominally ESM but internally use `require()`. Vite 8's new bundler (rolldown) mishandles this pattern and generates an anonymous, unreachable module initializer, leaving `createRenderer` as `undefined` at runtime:

```
Uncaught TypeError: createRenderer is not a function
    at getRenderer (index-B9Sbpvoo.js:42950:28)
```

Rolldown wraps the module in a lazy `__esmMin` thunk but discards the return value (assigns it to no variable), so `init_createRenderer()` is never called and the `createRenderer` variable stays `undefined`.

The fix aliases `@cloudflare/style-provider` to its CJS build (`lib/index.js`) in `vite.config.ts`. Rolldown handles plain CJS correctly via its interop layer, avoiding the broken initializer entirely.

Also replaces `base: '/playground'` with `assetsDir: 'playground/assets'`: using `base` causes Vite to write assets to `dist/assets/` but reference them as `/playground/assets/` in the HTML, which breaks after Wrangler uploads them. Keeping assets under `dist/playground/assets/` means the paths in the HTML match their actual deployed location.

---

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: ran `pnpm vite build && pnpm vite preview` and confirmed the TypeError is gone
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal build config change only

*A picture of a cute animal (not mandatory, but encouraged)*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
