### PR TITLE
Fix autoconfig failing on `waku` projects that use `hono`

### DIFF
--- a/.changeset/quiet-bats-push.md
+++ b/.changeset/quiet-bats-push.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix autoconfig failing on `waku` projects that use `hono`
+
+Waku has a tight integration with Hono, causing both to be detected simultaneously and triggering a "multiple frameworks found" error. Hono is now filtered out when Waku is also detected.

--- a/packages/wrangler/src/autoconfig/details.ts
+++ b/packages/wrangler/src/autoconfig/details.ts
@@ -90,7 +90,9 @@ export function assertNonConfigured(
 class MultipleFrameworksCIError extends FatalError {
 	constructor(frameworks: string[]) {
 		super(
-			dedent`Wrangler was unable to automatically configure your project to work with Cloudflare, since multiple frameworks were found: ${frameworks.join(", ")}.
+			dedent`Wrangler was unable to automatically configure your project to work with Cloudflare, since multiple frameworks were found: ${frameworks.join(
+				", "
+			)}.
 
 				To fix this issue either:
 				  - check your project's configuration to make sure that the target framework
@@ -336,6 +338,14 @@ function findDetectedFramework(
 				// or as part of a Vitest installation, so it's pretty safe to ignore it in this case
 				return knownNonViteSettings;
 			}
+		}
+
+		if (frameworkIdsFound.has("waku") && frameworkIdsFound.has("hono")) {
+			// The waku framework has a tight integration with hono, so it's likely that hono can also
+			// be detected in waku projects, if that's the case let's filter hono out
+			return settingsForOnlyKnownFrameworks.find(
+				({ framework }) => framework.id === "waku"
+			);
 		}
 	}
 


### PR DESCRIPTION
Waku has a tight integration with Hono, causing both to be detected simultaneously and triggering a "multiple frameworks found" error. Hono is now filtered out when Waku is also detected.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: already being tested by the (currently failing) C3 e2es
 > [!note]
 > https://github.com/cloudflare/workers-sdk/pull/13113 also adds a unit test for the changes in this PR
 > (see: https://github.com/cloudflare/workers-sdk/pull/13113/changes#r3006383619)
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
