### PR TITLE
Improve error message when the assets directory path points to a file instead of a directory

### DIFF
--- a/.changeset/wrangler-assets-not-a-directory-error.md
+++ b/.changeset/wrangler-assets-not-a-directory-error.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Improve error message when the assets directory path points to a file instead of a directory
+
+Previously, if the path provided as the assets directory (via `--assets` flag or `assets.directory` config) pointed to an existing file rather than a directory, Wrangler would throw an unhelpful `ENOTDIR` system error when trying to read the `_redirects` file inside it. Now Wrangler detects this condition earlier and throws a clear user error.

--- a/packages/wrangler/src/__tests__/deploy/assets.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/assets.test.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import dedent from "ts-dedent";
@@ -244,6 +245,32 @@ describe("deploy", () => {
 					'^The directory specified by the "assets.directory" field in your configuration file does not exist:[Ss]*'
 				)
 			);
+		});
+
+		it("should error if path specified by flag --assets is a file, not a directory", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			fs.writeFileSync("abc", "");
+			await expect(runWrangler("deploy --assets abc")).rejects
+				.toThrowErrorMatchingInlineSnapshot(`
+				[Error: The path specified by the "--assets" command line argument doesn't point to a directory:
+				<cwd>/abc]
+			`);
+		});
+
+		it("should error if path specified by config assets.directory is a file, not a directory", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				assets: { directory: "abc" },
+			});
+			fs.writeFileSync("abc", "");
+			await expect(runWrangler("deploy")).rejects
+				.toThrowErrorMatchingInlineSnapshot(`
+				[Error: The path specified by the "assets.directory" field in your configuration file doesn't point to a directory:
+				<cwd>/abc]
+			`);
 		});
 
 		it("should error if an ASSET binding is provided without a user Worker", async ({

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -2274,6 +2274,35 @@ describe.sequential("wrangler dev", () => {
 				)
 			);
 		});
+
+		it("should error with a clear error message if the path specified by '--assets' command line argument is a file, not a directory", async () => {
+			writeWranglerConfig({
+				main: "./index.js",
+			});
+			fs.writeFileSync("index.js", `export default {};`);
+			fs.writeFileSync("abc", "");
+			await expect(runWrangler("dev --assets abc")).rejects
+				.toThrowErrorMatchingInlineSnapshot(`
+				[Error: The path specified by the "--assets" command line argument doesn't point to a directory:
+				<cwd>/abc]
+			`);
+		});
+
+		it("should error with a clear error message if the path specified by '[assets]' configuration key is a file, not a directory", async () => {
+			writeWranglerConfig({
+				main: "./index.js",
+				assets: {
+					directory: "abc",
+				},
+			});
+			fs.writeFileSync("index.js", `export default {};`);
+			fs.writeFileSync("abc", "");
+			await expect(runWrangler("dev")).rejects
+				.toThrowErrorMatchingInlineSnapshot(`
+				[Error: The path specified by the "assets.directory" field in your configuration file doesn't point to a directory:
+				<cwd>/abc]
+			`);
+		});
 	});
 
 	describe("service bindings", () => {

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import { existsSync } from "node:fs";
+import { statSync } from "node:fs";
 import { readdir, readFile, stat } from "node:fs/promises";
 import * as path from "node:path";
 import { parseStaticRouting } from "@cloudflare/workers-shared/utils/configuration/parseStaticRouting";
@@ -108,7 +108,9 @@ export const syncAssets = async (
 	// 3. fill buckets and upload assets
 	const numberFilesToUpload = initializeAssetsResponse.buckets.flat().length;
 	logger.info(
-		`🌀 Found ${numberFilesToUpload} new or modified static asset${numberFilesToUpload > 1 ? "s" : ""} to upload. Proceeding with upload...`
+		`🌀 Found ${numberFilesToUpload} new or modified static asset${
+			numberFilesToUpload > 1 ? "s" : ""
+		} to upload. Proceeding with upload...`
 	);
 
 	// Create the buckets outside of doUpload so we can retry without losing track of potential duplicate files
@@ -216,7 +218,9 @@ export const syncAssets = async (
 				} else if (isJwtExpired(initializeAssetsResponse.jwt)) {
 					throw new FatalError(
 						`Upload took too long.\n` +
-							`Asset upload took too long on bucket ${bucketIndex + 1}/${initializeAssetsResponse.buckets.length}. Please try again.\n` +
+							`Asset upload took too long on bucket ${bucketIndex + 1}/${
+								initializeAssetsResponse.buckets.length
+							}. Please try again.\n` +
 							`Assets already uploaded have been saved, so the next attempt will automatically resume from this point.`,
 						undefined,
 						{ telemetryMessage: "Asset upload took too long" }
@@ -258,7 +262,9 @@ export const syncAssets = async (
 	const skippedMessage = skipped > 0 ? `(${skipped} already uploaded) ` : "";
 
 	logger.log(
-		`✨ Success! Uploaded ${numberFilesToUpload} file${numberFilesToUpload > 1 ? "s" : ""} ${skippedMessage}${formatTime(uploadMs)}\n`
+		`✨ Success! Uploaded ${numberFilesToUpload} file${
+			numberFilesToUpload > 1 ? "s" : ""
+		} ${skippedMessage}${formatTime(uploadMs)}\n`
 	);
 
 	return completionJwt;
@@ -348,7 +354,9 @@ function logAssetsUploadStatus(
 	uploadedAssetFiles: string[]
 ) {
 	logger.info(
-		`Uploaded ${uploadedAssetsCount} of ${numberFilesToUpload} asset${numberFilesToUpload === 1 ? "" : "s"}`
+		`Uploaded ${uploadedAssetsCount} of ${numberFilesToUpload} asset${
+			numberFilesToUpload === 1 ? "" : "s"
+		}`
 	);
 	uploadedAssetFiles.forEach((file) => logger.debug(`✨ ${file}`));
 }
@@ -360,7 +368,9 @@ function logAssetsUploadStatus(
  */
 function logReadFilesFromDirectory(directory: string, assetFiles: string[]) {
 	logger.info(
-		`✨ Read ${assetFiles.length} file${assetFiles.length === 1 ? "" : "s"} from the assets directory ${directory}`
+		`✨ Read ${assetFiles.length} file${
+			assetFiles.length === 1 ? "" : "s"
+		} from the assets directory ${directory}`
 	);
 	assetFiles.forEach((file) => logger.debug(`/${file}`));
 }
@@ -389,6 +399,8 @@ export type AssetsOptions = {
 };
 
 export class NonExistentAssetsDirError extends UserError {}
+
+export class NonDirectoryAssetsDirError extends UserError {}
 
 export function getAssetsOptions(
 	args: { assets: string | undefined; script?: string },
@@ -421,17 +433,30 @@ export function getAssetsOptions(
 	const assetsBasePath = getAssetsBasePath(config, args.assets);
 	const directory = path.resolve(assetsBasePath, assets.directory);
 
-	if (!existsSync(directory)) {
-		const sourceOfTruthMessage = args.assets
-			? '"--assets" command line argument'
-			: '"assets.directory" field in your configuration file';
+	const directoryStat = statSync(directory, { throwIfNoEntry: false });
 
+	const sourceOfTruthMessage = args.assets
+		? '"--assets" command line argument'
+		: '"assets.directory" field in your configuration file';
+
+	if (!directoryStat) {
 		throw new NonExistentAssetsDirError(
 			`The directory specified by the ${sourceOfTruthMessage} does not exist:\n` +
 				`${directory}`,
 
 			{
 				telemetryMessage: `The assets directory specified does not exist`,
+			}
+		);
+	}
+
+	if (!directoryStat.isDirectory()) {
+		throw new NonDirectoryAssetsDirError(
+			`The path specified by the ${sourceOfTruthMessage} doesn't point to a directory:\n` +
+				`${directory}`,
+
+			{
+				telemetryMessage: `The assets directory path specified is not a directory`,
 			}
 		);
 	}


### PR DESCRIPTION
If users mistakenly specify a path pointing to a file for assets they receive an unpolished/slightly confusing error message like so:
```
ENOTDIR: not a directory, open '<path>/_redirects'
```

This PR simply improves this error message so that we clearly tell the user what the issue is:
```
The directory specified by the "assets.directory" field in your configuration file is not a directory:
  <path>
```

Example:
| Before | After |
|--------|--------|
| <img width="1426" height="277" alt="Screenshot of error message before" src="https://github.com/user-attachments/assets/43477cca-9ba0-4017-9531-db2d9d3464a0" />  |  <img width="922" height="266" alt="Screenshot of error message after" src="https://github.com/user-attachments/assets/e881ccd4-70a9-4bfa-98f9-217ecea953e3" /> | 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: self-documenting UX improvement

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
