### PR TITLE
Allow users to run `getPlatformProxy` on static asset workers when the assets dir doesn't exist

### DIFF
--- a/.changeset/miniflare-assets-missing-dir.md
+++ b/.changeset/miniflare-assets-missing-dir.md
@@ -1,0 +1,9 @@
+---
+"miniflare": patch
+---
+
+Gracefully handle a missing assets directory by starting with zero assets
+
+Previously, configuring Miniflare with an `assets.directory` that did not exist on disk would cause the asset services to fail to start. This is a common situation during `wrangler dev` when the assets directory is a build output that hasn't been generated yet.
+
+Now, when the configured assets directory does not exist, Miniflare creates an empty temporary directory and starts the asset services with zero assets. Once the real directory is created and `setOptions()` is called (e.g. triggered by the file watcher), Miniflare reloads and begins serving the actual assets.

--- a/.changeset/wrangler-assets-missing-dir-local-dev.md
+++ b/.changeset/wrangler-assets-missing-dir-local-dev.md
@@ -2,8 +2,8 @@
 "wrangler": patch
 ---
 
-Allow `wrangler dev` to start when the assets directory does not exist yet
+Allow `getPlatformProxy` and `unstable_getMiniflareWorkerOptions` to start when the assets directory does not exist yet
 
-Previously, `wrangler dev` would throw a `NonExistentAssetsDirError` and refuse to start if the configured assets directory was absent on disk. This was a problem for projects where the assets directory is a build output (e.g. `dist/`) that hasn't been generated yet when the dev server first starts.
+Previously, `getPlatformProxy` would catch and swallow `NonExistentAssetsDirError` internally when the configured assets directory was absent on disk. This has been refactored so that the directory-existence check is skipped entirely for `getPlatformProxy` and `unstable_getMiniflareWorkerOptions`, since these APIs are typically used at dev time in frameworks where the assets directory is a build output that may not exist yet.
 
-Now, local dev commands (`wrangler dev`, `getPlatformProxy`, `unstable_getMiniflareWorkerOptions`) skip the directory-existence check and start up with zero assets. Once the build runs and populates the directory, the file watcher triggers a reload and assets are served normally. The existence check is still enforced for `wrangler deploy`, `wrangler versions upload`, and `wrangler triggers deploy`, where a missing directory is always an error.
+`wrangler dev`, `wrangler deploy`, `wrangler versions upload`, and `wrangler triggers deploy` continue to require the assets directory to exist when specified.

--- a/.changeset/wrangler-assets-missing-dir-local-dev.md
+++ b/.changeset/wrangler-assets-missing-dir-local-dev.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Allow `wrangler dev` to start when the assets directory does not exist yet
+
+Previously, `wrangler dev` would throw a `NonExistentAssetsDirError` and refuse to start if the configured assets directory was absent on disk. This was a problem for projects where the assets directory is a build output (e.g. `dist/`) that hasn't been generated yet when the dev server first starts.
+
+Now, local dev commands (`wrangler dev`, `getPlatformProxy`, `unstable_getMiniflareWorkerOptions`) skip the directory-existence check and start up with zero assets. Once the build runs and populates the directory, the file watcher triggers a reload and assets are served normally. The existence check is still enforced for `wrangler deploy`, `wrangler versions upload`, and `wrangler triggers deploy`, where a missing directory is always an error.

--- a/packages/miniflare/src/plugins/assets/index.ts
+++ b/packages/miniflare/src/plugins/assets/index.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path, { join } from "node:path";
 import {
 	CONTENT_HASH_OFFSET,
@@ -83,22 +84,32 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 			return [];
 		}
 
+		let assetDirectory = options.assets.directory;
+		const directoryStats = await fs.stat(assetDirectory).catch(() => undefined);
+		if (!directoryStats) {
+			// If the assets directory doesn't exist yet (e.g. the build output
+			// hasn't been generated), create an empty temp directory so that the
+			// asset services can still start up with zero assets.
+			assetDirectory = await fs.mkdtemp(
+				path.join(os.tmpdir(), "miniflare-assets-")
+			);
+		}
+
 		const storageServiceName = `${ASSETS_PLUGIN_NAME}:storage`;
 		const storageService: Service = {
 			name: storageServiceName,
 			disk: {
-				path: options.assets.directory,
+				path: assetDirectory,
 				writable: true,
 				allowDotfiles: true,
 			},
 		};
 
-		const { encodedAssetManifest, assetsReverseMap } = await buildAssetManifest(
-			options.assets.directory
-		);
+		const { encodedAssetManifest, assetsReverseMap } =
+			await buildAssetManifest(assetDirectory);
 
-		const redirectsFile = join(options.assets.directory, REDIRECTS_FILENAME);
-		const headersFile = join(options.assets.directory, HEADERS_FILENAME);
+		const redirectsFile = join(assetDirectory, REDIRECTS_FILENAME);
+		const headersFile = join(assetDirectory, HEADERS_FILENAME);
 
 		const redirectsContents = maybeGetFile(redirectsFile);
 		const headersContents = maybeGetFile(headersFile);

--- a/packages/miniflare/src/plugins/assets/index.ts
+++ b/packages/miniflare/src/plugins/assets/index.ts
@@ -54,8 +54,8 @@ import type { AssetConfig } from "@cloudflare/workers-shared/utils/types";
 import type { z } from "zod";
 
 // Cache of temp directories created for missing asset directories, keyed by
-// the configured assets directory path. Prevents accumulating orphaned temp
-// directories when getServices is called repeatedly
+// the Worker's name followed by the assets directory path. Prevents accumulating
+// orphaned temp directories when getServices is called repeatedly
 const tempDirCache = new Map<string, string>();
 
 export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
@@ -102,18 +102,18 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 			// asset services can still start up with zero assets.
 			// Reuse a previously created temp directory for this path to avoid
 			// accumulating orphaned temp directories on repeated calls.
-			const cached = tempDirCache.get(assetDirectory);
+			const cacheKey = `${options.assets.workerName}:${assetDirectory}`;
+			const cached = tempDirCache.get(cacheKey);
 			const cachedExists = cached
 				? await fs.stat(cached).catch(() => undefined)
 				: undefined;
 			if (cached && cachedExists) {
 				assetDirectory = cached;
 			} else {
-				const originalDir = assetDirectory;
 				assetDirectory = await fs.mkdtemp(
 					path.join(os.tmpdir(), "miniflare-assets-")
 				);
-				tempDirCache.set(originalDir, assetDirectory);
+				tempDirCache.set(cacheKey, assetDirectory);
 			}
 		}
 

--- a/packages/miniflare/src/plugins/assets/index.ts
+++ b/packages/miniflare/src/plugins/assets/index.ts
@@ -53,6 +53,11 @@ import type { Logger } from "@cloudflare/workers-shared";
 import type { AssetConfig } from "@cloudflare/workers-shared/utils/types";
 import type { z } from "zod";
 
+// Cache of temp directories created for missing asset directories, keyed by
+// the configured assets directory path. Prevents accumulating orphaned temp
+// directories when getServices is called repeatedly
+const tempDirCache = new Map<string, string>();
+
 export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 	options: AssetsOptionsSchema,
 	async getBindings(options: z.infer<typeof AssetsOptionsSchema>) {
@@ -95,9 +100,21 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 			// If the assets directory doesn't exist yet (e.g. the build output
 			// hasn't been generated), create an empty temp directory so that the
 			// asset services can still start up with zero assets.
-			assetDirectory = await fs.mkdtemp(
-				path.join(os.tmpdir(), "miniflare-assets-")
-			);
+			// Reuse a previously created temp directory for this path to avoid
+			// accumulating orphaned temp directories on repeated calls.
+			const cached = tempDirCache.get(assetDirectory);
+			const cachedExists = cached
+				? await fs.stat(cached).catch(() => undefined)
+				: undefined;
+			if (cached && cachedExists) {
+				assetDirectory = cached;
+			} else {
+				const originalDir = assetDirectory;
+				assetDirectory = await fs.mkdtemp(
+					path.join(os.tmpdir(), "miniflare-assets-")
+				);
+				tempDirCache.set(originalDir, assetDirectory);
+			}
 		}
 
 		const storageServiceName = `${ASSETS_PLUGIN_NAME}:storage`;

--- a/packages/miniflare/src/plugins/assets/index.ts
+++ b/packages/miniflare/src/plugins/assets/index.ts
@@ -85,7 +85,12 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 		}
 
 		let assetDirectory = options.assets.directory;
-		const directoryStats = await fs.stat(assetDirectory).catch(() => undefined);
+		const directoryStats = await fs.stat(assetDirectory).catch((err) => {
+			if (err?.code === "ENOENT") {
+				return undefined;
+			}
+			throw err;
+		});
 		if (!directoryStats) {
 			// If the assets directory doesn't exist yet (e.g. the build output
 			// hasn't been generated), create an empty temp directory so that the

--- a/packages/miniflare/test/plugins/assets/index.spec.ts
+++ b/packages/miniflare/test/plugins/assets/index.spec.ts
@@ -1,0 +1,101 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { Miniflare } from "miniflare";
+import { test } from "vitest";
+import { useDispose, useTmp } from "../../test-shared";
+
+// Minimal worker script. When assets are configured, all incoming `dispatchFetch`
+// requests are automatically routed through the assets router service, which
+// either serves a matched asset (200) or returns 404 (because `has_user_worker`
+// defaults to false, so unmatched paths go straight to the asset worker's 404).
+const WORKER_SCRIPT = `export default {
+	async fetch(request, env) {
+		return new Response("from user worker");
+	}
+}`;
+
+function makeOptions(directory: string) {
+	return {
+		modules: true,
+		script: WORKER_SCRIPT,
+		compatibilityDate: "2024-07-31",
+		assets: { directory },
+	};
+}
+
+test("starts without error when assets directory does not exist", async ({
+	expect,
+}) => {
+	const tmp = await useTmp();
+	// Create a path that does not exist on disk
+	const nonExistentDir = path.join(tmp, "does-not-exist");
+
+	// Should not throw even though the directory is absent
+	const mf = new Miniflare(makeOptions(nonExistentDir));
+	useDispose(mf);
+
+	// Empty manifest → asset not found → 404
+	const res = await mf.dispatchFetch("http://example.com/test.txt");
+	expect(res.status).toBe(404);
+	await res.arrayBuffer(); // consume body to avoid leaks
+});
+
+test("starts without error when assets directory is empty", async ({
+	expect,
+}) => {
+	// useTmp() creates the directory for us; we leave it empty
+	const tmp = await useTmp();
+
+	const mf = new Miniflare(makeOptions(tmp));
+	useDispose(mf);
+
+	const res = await mf.dispatchFetch("http://example.com/test.txt");
+	expect(res.status).toBe(404);
+	await res.arrayBuffer();
+});
+
+test("serves files from assets directory", async ({ expect }) => {
+	const tmp = await useTmp();
+	await fs.writeFile(path.join(tmp, "test.txt"), "hello from asset");
+
+	const mf = new Miniflare(makeOptions(tmp));
+	useDispose(mf);
+
+	const res = await mf.dispatchFetch("http://example.com/test.txt");
+	expect(res.status).toBe(200);
+	expect(await res.text()).toBe("hello from asset");
+});
+
+// ─── Watch / reload behaviour ────────────────────────────────────────────────
+
+// This test simulates what happens during `wrangler dev` when the assets
+// directory does not exist at startup but it is created afterwards
+test("serves new assets after setOptions() once the directory is created", async ({
+	expect,
+}) => {
+	const tmp = await useTmp();
+	// The assets directory does not exist yet (build hasn't run)
+	const assetsDir = path.join(tmp, "dist");
+
+	const mf = new Miniflare(makeOptions(assetsDir));
+	useDispose(mf);
+
+	// Initially no assets → 404
+	const res1 = await mf.dispatchFetch("http://example.com/index.html");
+	expect(res1.status).toBe(404);
+	await res1.arrayBuffer();
+
+	// Create assets directory
+	await fs.mkdir(assetsDir, { recursive: true });
+	await fs.writeFile(path.join(assetsDir, "index.html"), "<h1>Hello!</h1>");
+
+	// Simulate wrangler's reaction to chokidar detecting the new directory:
+	// it calls setOptions() which re-invokes getServices() on all plugins,
+	// re-walks the assets directory, and rebuilds the manifest.
+	await mf.setOptions(makeOptions(assetsDir));
+
+	// The asset should now be served
+	const res2 = await mf.dispatchFetch("http://example.com/index.html");
+	expect(res2.status).toBe(200);
+	expect(await res2.text()).toContain("<h1>Hello!</h1>");
+});

--- a/packages/miniflare/test/plugins/assets/index.spec.ts
+++ b/packages/miniflare/test/plugins/assets/index.spec.ts
@@ -43,7 +43,6 @@ test("starts without error when assets directory does not exist", async ({
 test("starts without error when assets directory is empty", async ({
 	expect,
 }) => {
-	// useTmp() creates the directory for us; we leave it empty
 	const tmp = await useTmp();
 
 	const mf = new Miniflare(makeOptions(tmp));

--- a/packages/miniflare/test/plugins/assets/index.spec.ts
+++ b/packages/miniflare/test/plugins/assets/index.spec.ts
@@ -18,7 +18,7 @@ function makeOptions(directory: string) {
 	return {
 		modules: true,
 		script: WORKER_SCRIPT,
-		compatibilityDate: "2024-07-31",
+		compatibilityDate: "2026-04-29",
 		assets: { directory },
 	};
 }

--- a/packages/wrangler/src/__tests__/assets.test.ts
+++ b/packages/wrangler/src/__tests__/assets.test.ts
@@ -88,7 +88,7 @@ describe("getAssetsOptions", () => {
 		});
 	});
 
-	describe("validateDirectoryExistence: false (local dev path)", () => {
+	describe("validateDirectoryExistence: false (getPlatformProxy / unstable_getMiniflareWorkerOptions path)", () => {
 		it("does NOT throw when the assets directory does not exist", ({
 			expect,
 		}) => {

--- a/packages/wrangler/src/__tests__/assets.test.ts
+++ b/packages/wrangler/src/__tests__/assets.test.ts
@@ -1,0 +1,172 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, it } from "vitest";
+import {
+	NonDirectoryAssetsDirError,
+	NonExistentAssetsDirError,
+	getAssetsOptions,
+} from "../assets";
+import { runInTempDir } from "./helpers/run-in-tmp";
+import type { Config } from "@cloudflare/workers-utils";
+
+/**
+ * Creates a minimal Config object sufficient for `getAssetsOptions`.
+ * Only the fields actually read by the function need to be populated.
+ */
+function makeConfig(
+	overrides: Partial<{
+		assets: { directory?: string; binding?: string };
+		main: string;
+		configPath: string;
+	}> = {}
+): Config {
+	return {
+		assets: undefined,
+		main: undefined,
+		configPath: undefined,
+		compatibility_date: "2024-01-01",
+		compatibility_flags: [],
+		...overrides,
+	} as unknown as Config;
+}
+
+describe("getAssetsOptions", () => {
+	runInTempDir();
+
+	describe("validateDirectoryExistence: true (default — deploy path)", () => {
+		it("throws NonExistentAssetsDirError when the --assets directory does not exist", ({
+			expect,
+		}) => {
+			expect(() =>
+				getAssetsOptions({
+					args: { assets: "dist" },
+					config: makeConfig(),
+					validateDirectoryExistence: true,
+				})
+			).toThrow(NonExistentAssetsDirError);
+		});
+
+		it("throws with a message referencing the CLI flag when --assets is used", ({
+			expect,
+		}) => {
+			expect(() =>
+				getAssetsOptions({
+					args: { assets: "dist" },
+					config: makeConfig(),
+					validateDirectoryExistence: true,
+				})
+			).toThrow(
+				/The directory specified by the "--assets" command line argument does not exist/
+			);
+		});
+
+		it("throws with a message referencing the config file when assets.directory is used", ({
+			expect,
+		}) => {
+			expect(() =>
+				getAssetsOptions({
+					args: { assets: undefined },
+					config: makeConfig({ assets: { directory: "dist" } }),
+					validateDirectoryExistence: true,
+				})
+			).toThrow(
+				/The directory specified by the "assets.directory" field in your configuration file does not exist/
+			);
+		});
+
+		it("throws NonDirectoryAssetsDirError when the path points to a file, not a directory", ({
+			expect,
+		}) => {
+			fs.writeFileSync("not-a-dir.txt", "");
+			expect(() =>
+				getAssetsOptions({
+					args: { assets: "not-a-dir.txt" },
+					config: makeConfig(),
+					validateDirectoryExistence: true,
+				})
+			).toThrow(NonDirectoryAssetsDirError);
+		});
+	});
+
+	describe("validateDirectoryExistence: false (local dev path)", () => {
+		it("does NOT throw when the assets directory does not exist", ({
+			expect,
+		}) => {
+			expect(() =>
+				getAssetsOptions({
+					args: { assets: "dist" },
+					config: makeConfig(),
+					validateDirectoryExistence: false,
+				})
+			).not.toThrow();
+		});
+
+		it("returns a valid AssetsOptions object even when the directory is absent", ({
+			expect,
+		}) => {
+			const result = getAssetsOptions({
+				args: { assets: "dist" },
+				config: makeConfig(),
+				validateDirectoryExistence: false,
+			});
+
+			expect(result).toBeDefined();
+			expect(result?.directory).toBe(path.resolve(process.cwd(), "dist"));
+			// No _redirects / _headers since the directory doesn't exist
+			expect(result?._redirects).toBeUndefined();
+			expect(result?._headers).toBeUndefined();
+		});
+
+		it("still throws NonDirectoryAssetsDirError when the path points to a file", ({
+			expect,
+		}) => {
+			fs.writeFileSync("not-a-dir.txt", "");
+			expect(() =>
+				getAssetsOptions({
+					args: { assets: "not-a-dir.txt" },
+					config: makeConfig(),
+					validateDirectoryExistence: false,
+				})
+			).toThrow(NonDirectoryAssetsDirError);
+		});
+
+		it("returns correct options when the directory exists and has files", ({
+			expect,
+		}) => {
+			fs.mkdirSync("dist");
+			fs.writeFileSync(path.join("dist", "_redirects"), "/old /new 301");
+
+			const result = getAssetsOptions({
+				args: { assets: "dist" },
+				config: makeConfig(),
+				validateDirectoryExistence: false,
+			});
+
+			expect(result?.directory).toBe(path.resolve(process.cwd(), "dist"));
+			expect(result?._redirects).toContain("/old /new 301");
+		});
+
+		it("works with assets from config rather than the CLI flag", ({
+			expect,
+		}) => {
+			const result = getAssetsOptions({
+				args: { assets: undefined },
+				config: makeConfig({ assets: { directory: "nonexistent-dir" } }),
+				validateDirectoryExistence: false,
+			});
+
+			expect(result).toBeDefined();
+			expect(result?.directory).toContain("nonexistent-dir");
+		});
+
+		it("returns undefined when no assets are configured", ({ expect }) => {
+			const result = getAssetsOptions({
+				args: { assets: undefined },
+				config: makeConfig(),
+				validateDirectoryExistence: false,
+			});
+
+			expect(result).toBeUndefined();
+		});
+	});
+});

--- a/packages/wrangler/src/__tests__/assets.test.ts
+++ b/packages/wrangler/src/__tests__/assets.test.ts
@@ -24,7 +24,7 @@ function makeConfig(
 		assets: undefined,
 		main: undefined,
 		configPath: undefined,
-		compatibility_date: "2024-01-01",
+		compatibility_date: "2026-04-29",
 		compatibility_flags: [],
 		...overrides,
 	} as unknown as Config;

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -2433,23 +2433,17 @@ describe.sequential("wrangler dev", () => {
 			);
 		});
 
-		it("should error if directory specified by '--assets' command line argument does not exist", async ({
-			expect,
-		}) => {
+		it("should not error if directory specified by '--assets' command line argument does not exist", async () => {
 			writeWranglerConfig({
 				main: "./index.js",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await expect(runWrangler("dev --assets abc")).rejects.toThrow(
-				new RegExp(
-					'^The directory specified by the "--assets" command line argument does not exist:[Ss]*'
-				)
-			);
+			// In local dev mode, a missing assets directory is tolerated — the dev
+			// server starts with zero assets so the build output can appear later.
+			await runWranglerUntilConfig("dev --assets abc");
 		});
 
-		it("should error if directory specified by '[assets]' configuration key does not exist", async ({
-			expect,
-		}) => {
+		it("should not error if directory specified by '[assets]' configuration key does not exist", async () => {
 			writeWranglerConfig({
 				main: "./index.js",
 				assets: {
@@ -2457,11 +2451,9 @@ describe.sequential("wrangler dev", () => {
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await expect(runWrangler("dev")).rejects.toThrow(
-				new RegExp(
-					'^The directory specified by the "assets.directory" field in your configuration file does not exist:[Ss]*'
-				)
-			);
+			// In local dev mode, a missing assets directory is tolerated — the dev
+			// server starts with zero assets so the build output can appear later.
+			await runWranglerUntilConfig("dev");
 		});
 
 		it("should error with a clear error message if the path specified by '--assets' command line argument is a file, not a directory", async ({

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -2433,17 +2433,23 @@ describe.sequential("wrangler dev", () => {
 			);
 		});
 
-		it("should not error if directory specified by '--assets' command line argument does not exist", async () => {
+		it("should error if directory specified by '--assets' command line argument does not exist", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "./index.js",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			// In local dev mode, a missing assets directory is tolerated — the dev
-			// server starts with zero assets so the build output can appear later.
-			await runWranglerUntilConfig("dev --assets abc");
+			await expect(runWrangler("dev --assets abc")).rejects.toThrow(
+				new RegExp(
+					'^The directory specified by the "--assets" command line argument does not exist:[Ss]*'
+				)
+			);
 		});
 
-		it("should not error if directory specified by '[assets]' configuration key does not exist", async () => {
+		it("should error if directory specified by '[assets]' configuration key does not exist", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "./index.js",
 				assets: {
@@ -2451,9 +2457,11 @@ describe.sequential("wrangler dev", () => {
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			// In local dev mode, a missing assets directory is tolerated — the dev
-			// server starts with zero assets so the build output can appear later.
-			await runWranglerUntilConfig("dev");
+			await expect(runWrangler("dev")).rejects.toThrow(
+				new RegExp(
+					'^The directory specified by the "assets.directory" field in your configuration file does not exist:[Ss]*'
+				)
+			);
 		});
 
 		it("should error with a clear error message if the path specified by '--assets' command line argument is a file, not a directory", async ({

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -5,7 +5,7 @@ import {
 	getTodaysCompatDate,
 } from "@cloudflare/workers-utils";
 import { kCurrentWorker, Miniflare } from "miniflare";
-import { getAssetsOptions, NonExistentAssetsDirError } from "../../../assets";
+import { getAssetsOptions } from "../../../assets";
 import { readConfig } from "../../../config";
 import { partitionDurableObjectBindings } from "../../../deployment-bundle/entry";
 import { DEFAULT_MODULE_RULES } from "../../../deployment-bundle/rules";
@@ -268,17 +268,14 @@ async function getMiniflareOptionsFromConfig(args: {
 	// Only resolve assets if a directory is configured. When assets are configured
 	// without a directory (e.g. via @cloudflare/vite-plugin), skip asset setup.
 	if (config.assets?.directory) {
-		try {
-			processedAssetOptions = getAssetsOptions({ assets: undefined }, config);
-		} catch (e) {
-			const isNonExistentError = e instanceof NonExistentAssetsDirError;
-			// we want to loosen up the assets directory existence restriction here,
-			// since `getPlatformProxy` can be run when the assets directory doesn't
-			// actually exist, but all other exceptions should still be thrown
-			if (!isNonExistentError) {
-				throw e;
-			}
-		}
+		processedAssetOptions = getAssetsOptions({
+			args: {
+				assets: undefined,
+			},
+			config,
+			// For getPlatformProxy/local dev we don't need to validate the directory's existence
+			validateDirectoryExistence: false,
+		});
 	}
 
 	const assetOptions = processedAssetOptions
@@ -507,11 +504,15 @@ export function unstable_getMiniflareWorkerOptions(
 	const hasAssetsDirectory =
 		config.assets?.directory || options?.overrides?.assets?.directory;
 	const processedAssetOptions = hasAssetsDirectory
-		? getAssetsOptions(
-				{ assets: undefined },
+		? getAssetsOptions({
+				args: {
+					assets: undefined,
+				},
 				config,
-				options?.overrides?.assets
-			)
+				// For getPlatformProxy we don't need to validate the directory's existence
+				validateDirectoryExistence: false,
+				overrides: options?.overrides?.assets,
+			})
 		: undefined;
 	const assetOptions = processedAssetOptions
 		? buildAssetOptions({ assets: processedAssetOptions })

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -302,13 +302,15 @@ async function resolveConfig(
 		input
 	);
 
-	const assetsOptions = getAssetsOptions(
-		{
+	const assetsOptions = getAssetsOptions({
+		args: {
 			assets: input?.assets,
 			script: input.entrypoint,
 		},
-		config
-	);
+		config,
+		// For local dev we don't need to validate the directory's existence
+		validateDirectoryExistence: false,
+	});
 
 	const resolved = {
 		name:

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -308,8 +308,6 @@ async function resolveConfig(
 			script: input.entrypoint,
 		},
 		config,
-		// For local dev we don't need to validate the directory's existence
-		validateDirectoryExistence: false,
 	});
 
 	const resolved = {

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -402,11 +402,17 @@ export class NonExistentAssetsDirError extends UserError {}
 
 export class NonDirectoryAssetsDirError extends UserError {}
 
-export function getAssetsOptions(
-	args: { assets: string | undefined; script?: string },
-	config: Config,
-	overrides?: Partial<AssetsOptions>
-): AssetsOptions | undefined {
+export function getAssetsOptions({
+	args,
+	config,
+	validateDirectoryExistence = true,
+	overrides,
+}: {
+	args: { assets: string | undefined; script?: string };
+	config: Config;
+	validateDirectoryExistence?: boolean;
+	overrides?: Partial<AssetsOptions>;
+}): AssetsOptions | undefined {
 	if (!overrides && !config.assets && !args.assets) {
 		return;
 	}
@@ -434,12 +440,13 @@ export function getAssetsOptions(
 	const directory = path.resolve(assetsBasePath, assets.directory);
 
 	const directoryStat = statSync(directory, { throwIfNoEntry: false });
+	const directoryExists = !!directoryStat;
 
 	const sourceOfTruthMessage = args.assets
 		? '"--assets" command line argument'
 		: '"assets.directory" field in your configuration file';
 
-	if (!directoryStat) {
+	if (validateDirectoryExistence && !directoryExists) {
 		throw new NonExistentAssetsDirError(
 			`The directory specified by the ${sourceOfTruthMessage} does not exist:\n` +
 				`${directory}`,
@@ -450,7 +457,7 @@ export function getAssetsOptions(
 		);
 	}
 
-	if (!directoryStat.isDirectory()) {
+	if (directoryExists && !directoryStat.isDirectory()) {
 		throw new NonDirectoryAssetsDirError(
 			`The path specified by the ${sourceOfTruthMessage} doesn't point to a directory:\n` +
 				`${directory}`,
@@ -500,8 +507,12 @@ export function getAssetsOptions(
 		);
 	}
 
-	const _redirects = maybeGetFile(path.join(directory, REDIRECTS_FILENAME));
-	const _headers = maybeGetFile(path.join(directory, HEADERS_FILENAME));
+	const _redirects = directoryExists
+		? maybeGetFile(path.join(directory, REDIRECTS_FILENAME))
+		: undefined;
+	const _headers = directoryExists
+		? maybeGetFile(path.join(directory, HEADERS_FILENAME))
+		: undefined;
 
 	// defaults are set in asset worker
 	const assetConfig: AssetConfig = {

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -413,7 +413,11 @@ export const deployCommand = createCommand({
 		const entry = await getEntry(args, config, "deploy");
 		validateAssetsArgsAndConfig(args, config);
 
-		const assetsOptions = getAssetsOptions(args, config);
+		const assetsOptions = getAssetsOptions({
+			args,
+			config,
+			validateDirectoryExistence: true,
+		});
 
 		if (args.latest) {
 			logger.warn(

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -416,7 +416,6 @@ export const deployCommand = createCommand({
 		const assetsOptions = getAssetsOptions({
 			args,
 			config,
-			validateDirectoryExistence: true,
 		});
 
 		if (args.latest) {

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -398,7 +398,14 @@ export async function getHostAndRoutes(
 		}
 	});
 	if (routes) {
-		const assetOptions = getAssetsOptions({ assets: args.assets }, config);
+		const assetOptions = getAssetsOptions({
+			args: {
+				assets: args.assets,
+			},
+			config,
+			// during local dev we don't care about validating the directory's existence
+			validateDirectoryExistence: false,
+		});
 		validateRoutes(routes, assetOptions);
 	}
 	return { host, routes };
@@ -417,7 +424,9 @@ export function getInferredHost(
 			throw new UserError(
 				`Cannot infer host from first route: ${JSON.stringify(
 					firstRoute
-				)}.\nYou can explicitly set the \`dev.host\` configuration in your ${configFileName(configPath)} file, for example:
+				)}.\nYou can explicitly set the \`dev.host\` configuration in your ${configFileName(
+					configPath
+				)} file, for example:
 
 	\`\`\`
 	${formatConfigSnippet(

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -403,8 +403,6 @@ export async function getHostAndRoutes(
 				assets: args.assets,
 			},
 			config,
-			// during local dev we don't care about validating the directory's existence
-			validateDirectoryExistence: false,
 		});
 		validateRoutes(routes, assetOptions);
 	}
@@ -424,9 +422,7 @@ export function getInferredHost(
 			throw new UserError(
 				`Cannot infer host from first route: ${JSON.stringify(
 					firstRoute
-				)}.\nYou can explicitly set the \`dev.host\` configuration in your ${configFileName(
-					configPath
-				)} file, for example:
+				)}.\nYou can explicitly set the \`dev.host\` configuration in your ${configFileName(configPath)} file, for example:
 
 	\`\`\`
 	${formatConfigSnippet(

--- a/packages/wrangler/src/preview/preview.ts
+++ b/packages/wrangler/src/preview/preview.ts
@@ -304,10 +304,10 @@ async function assemblePreviewDeploymentSettings(
 ): Promise<CreatePreviewDeploymentRequestParams> {
 	const previews = config.previews as PreviewsConfig | undefined;
 	const request: CreatePreviewDeploymentRequestParams = {};
-	const assetsOptions = getAssetsOptions(
-		{ assets: undefined, script: scriptPath },
-		config
-	);
+	const assetsOptions = getAssetsOptions({
+		args: { assets: undefined, script: scriptPath },
+		config,
+	});
 	const deploymentModules = await getDeploymentModules(config, scriptPath, {
 		_headers: assetsOptions?._headers,
 		_redirects: assetsOptions?._redirects,

--- a/packages/wrangler/src/triggers/index.ts
+++ b/packages/wrangler/src/triggers/index.ts
@@ -58,7 +58,6 @@ export const triggersDeployCommand = createCommand({
 		const assetsOptions = getAssetsOptions({
 			args: { assets: undefined },
 			config,
-			validateDirectoryExistence: true,
 		});
 		metrics.sendMetricsEvent("deploy worker triggers", {
 			sendMetrics: config.send_metrics,

--- a/packages/wrangler/src/triggers/index.ts
+++ b/packages/wrangler/src/triggers/index.ts
@@ -55,7 +55,11 @@ export const triggersDeployCommand = createCommand({
 		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
 	},
 	async handler(args, { config }) {
-		const assetsOptions = getAssetsOptions({ assets: undefined }, config);
+		const assetsOptions = getAssetsOptions({
+			args: { assets: undefined },
+			config,
+			validateDirectoryExistence: true,
+		});
 		metrics.sendMetricsEvent("deploy worker triggers", {
 			sendMetrics: config.send_metrics,
 		});

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -322,11 +322,17 @@ export const versionsUploadCommand = createCommand({
 			config
 		);
 
-		const assetsOptions = getAssetsOptions(args, config);
+		const assetsOptions = getAssetsOptions({
+			args,
+			config,
+			validateDirectoryExistence: true,
+		});
 
 		if (args.latest) {
 			logger.warn(
-				`Using the latest version of the Workers runtime. To silence this warning, please choose a specific version of the runtime with --compatibility-date, or add a compatibility_date to your ${configFileName(config.configPath)} file.\n`
+				`Using the latest version of the Workers runtime. To silence this warning, please choose a specific version of the runtime with --compatibility-date, or add a compatibility_date to your ${configFileName(
+					config.configPath
+				)} file.\n`
 			);
 		}
 
@@ -488,9 +494,17 @@ export default async function versionsUpload(props: Props): Promise<{
 	if (!compatibilityDate) {
 		const compatibilityDateStr = getTodaysCompatDate();
 
-		throw new UserError(`A compatibility_date is required when uploading a Worker Version. Add the following to your ${configFileName(config.configPath)} file:
+		throw new UserError(`A compatibility_date is required when uploading a Worker Version. Add the following to your ${configFileName(
+			config.configPath
+		)} file:
     \`\`\`
-	${(formatConfigSnippet({ compatibility_date: compatibilityDateStr }, config.configPath), false)}
+	${
+		(formatConfigSnippet(
+			{ compatibility_date: compatibilityDateStr },
+			config.configPath
+		),
+		false)
+	}
     \`\`\`
     Or you could pass it in your terminal as \`--compatibility-date ${compatibilityDateStr}\`
 See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`);
@@ -553,13 +567,17 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 	if (config.text_blobs && format === "modules") {
 		throw new UserError(
-			`You cannot configure [text_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure \`[rules]\` in your ${configFileName(config.configPath)} file`
+			`You cannot configure [text_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure \`[rules]\` in your ${configFileName(
+				config.configPath
+			)} file`
 		);
 	}
 
 	if (config.data_blobs && format === "modules") {
 		throw new UserError(
-			`You cannot configure [data_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure \`[rules]\` in your ${configFileName(config.configPath)} file`
+			`You cannot configure [data_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure \`[rules]\` in your ${configFileName(
+				config.configPath
+			)} file`
 		);
 	}
 

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -325,14 +325,11 @@ export const versionsUploadCommand = createCommand({
 		const assetsOptions = getAssetsOptions({
 			args,
 			config,
-			validateDirectoryExistence: true,
 		});
 
 		if (args.latest) {
 			logger.warn(
-				`Using the latest version of the Workers runtime. To silence this warning, please choose a specific version of the runtime with --compatibility-date, or add a compatibility_date to your ${configFileName(
-					config.configPath
-				)} file.\n`
+				`Using the latest version of the Workers runtime. To silence this warning, please choose a specific version of the runtime with --compatibility-date, or add a compatibility_date to your ${configFileName(config.configPath)} file.\n`
 			);
 		}
 
@@ -494,17 +491,9 @@ export default async function versionsUpload(props: Props): Promise<{
 	if (!compatibilityDate) {
 		const compatibilityDateStr = getTodaysCompatDate();
 
-		throw new UserError(`A compatibility_date is required when uploading a Worker Version. Add the following to your ${configFileName(
-			config.configPath
-		)} file:
+		throw new UserError(`A compatibility_date is required when uploading a Worker Version. Add the following to your ${configFileName(config.configPath)} file:
     \`\`\`
-	${
-		(formatConfigSnippet(
-			{ compatibility_date: compatibilityDateStr },
-			config.configPath
-		),
-		false)
-	}
+	${(formatConfigSnippet({ compatibility_date: compatibilityDateStr }, config.configPath), false)}
     \`\`\`
     Or you could pass it in your terminal as \`--compatibility-date ${compatibilityDateStr}\`
 See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`);
@@ -567,17 +556,13 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 	if (config.text_blobs && format === "modules") {
 		throw new UserError(
-			`You cannot configure [text_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure \`[rules]\` in your ${configFileName(
-				config.configPath
-			)} file`
+			`You cannot configure [text_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure \`[rules]\` in your ${configFileName(config.configPath)} file`
 		);
 	}
 
 	if (config.data_blobs && format === "modules") {
 		throw new UserError(
-			`You cannot configure [data_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure \`[rules]\` in your ${configFileName(
-				config.configPath
-			)} file`
+			`You cannot configure [data_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure \`[rules]\` in your ${configFileName(config.configPath)} file`
 		);
 	}
 


### PR DESCRIPTION
Users running `getPlatformProxy` might include in their config file an assets directory that not yet exists. The changes in this PR allow `getPlatformProxy` to work even if the assets directory doesn't exist yet.

All other commands like `wrangler dev` and `wrangler deploy` still fails if the directory doesn't exist at deploy time

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: self-documenting improvement

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
