### PR TITLE
[wrangler] Fix versions e2e test snapshots after #13072

### DIFF
--- a/packages/wrangler/e2e/versions.test.ts
+++ b/packages/wrangler/e2e/versions.test.ts
@@ -104,39 +104,39 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 			);
 
 			expect(normalize(deploy.stdout)).toMatchInlineSnapshot(`
-			"╭ Deploy Worker Versions by splitting traffic between multiple versions
-			│
-			├ Fetching latest deployment
-			│
-			├ Your current deployment has 1 version(s):
-			│
-			│ (100%) 00000000-0000-0000-0000-000000000000
-			│       Created:  TIMESTAMP
-			│           Tag:  -
-			│       Message:  -
-			│
-			├ Fetching deployable versions
-			│
-			├ Which version(s) do you want to deploy?
-			├ 1 Worker Version(s) selected
-			│
-			├     Worker Version 1:  00000000-0000-0000-0000-000000000000
-			│              Created:  TIMESTAMP
-			│                  Tag:  e2e-upload
-			│              Message:  Upload via e2e test
-			│
-			├ What percentage of traffic should Worker Version 1 receive?
-			├ 100% of traffic
-			├
-			├ Add a deployment message
-			│ Deployment message Deploy via e2e test
-			│
-			├ Deploying 1 version(s)
-			│
-			│ No non-versioned settings to sync. Skipping...
-			│
-			╰  SUCCESS  Deployed tmp-e2e-worker-00000000-0000-0000-0000-000000000000 version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
-		`);
+				"╭ Deploy Worker Versions by splitting traffic between multiple versions
+				│
+				├ Fetching latest deployment
+				│
+				├ Your current deployment has 1 version(s):
+				│
+				│ (100%) 00000000-0000-0000-0000-000000000000
+				│       Created:  TIMESTAMP
+				│           Tag:  -
+				│       Message:  -
+				│
+				├ Fetching versions
+				│
+				├ Which version(s) do you want to deploy?
+				├ 1 Worker Version(s) selected
+				│
+				├     Worker Version 1:  00000000-0000-0000-0000-000000000000
+				│              Created:  TIMESTAMP
+				│                  Tag:  e2e-upload
+				│              Message:  Upload via e2e test
+				│
+				├ What percentage of traffic should Worker Version 1 receive?
+				├ 100% of traffic
+				├
+				├ Add a deployment message
+				│ Deployment message Deploy via e2e test
+				│
+				├ Deploying 1 version(s)
+				│
+				│ No non-versioned settings to sync. Skipping...
+				│
+				╰  SUCCESS  Deployed tmp-e2e-worker-00000000-0000-0000-0000-000000000000 version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
+			`);
 		});
 
 		it("should list 1 deployment", async ({ expect }) => {
@@ -228,39 +228,39 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 			const deploymentsList = await helper.run(`wrangler deployments list`);
 
 			expect(normalize(deploy.stdout)).toMatchInlineSnapshot(`
-			"╭ Deploy Worker Versions by splitting traffic between multiple versions
-			│
-			├ Fetching latest deployment
-			│
-			├ Your current deployment has 1 version(s):
-			│
-			│ (100%) 00000000-0000-0000-0000-000000000000
-			│       Created:  TIMESTAMP
-			│           Tag:  e2e-upload
-			│       Message:  Upload via e2e test
-			│
-			├ Fetching deployable versions
-			│
-			├ Which version(s) do you want to deploy?
-			├ 1 Worker Version(s) selected
-			│
-			├     Worker Version 1:  00000000-0000-0000-0000-000000000000
-			│              Created:  TIMESTAMP
-			│                  Tag:  e2e-upload-AGAIN
-			│              Message:  Upload AGAIN via e2e test
-			│
-			├ What percentage of traffic should Worker Version 1 receive?
-			├ 100% of traffic
-			├
-			├ Add a deployment message
-			│ Deployment message Deploy AGAIN via e2e test
-			│
-			├ Deploying 1 version(s)
-			│
-			│ No non-versioned settings to sync. Skipping...
-			│
-			╰  SUCCESS  Deployed tmp-e2e-worker-00000000-0000-0000-0000-000000000000 version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
-		`);
+				"╭ Deploy Worker Versions by splitting traffic between multiple versions
+				│
+				├ Fetching latest deployment
+				│
+				├ Your current deployment has 1 version(s):
+				│
+				│ (100%) 00000000-0000-0000-0000-000000000000
+				│       Created:  TIMESTAMP
+				│           Tag:  e2e-upload
+				│       Message:  Upload via e2e test
+				│
+				├ Fetching versions
+				│
+				├ Which version(s) do you want to deploy?
+				├ 1 Worker Version(s) selected
+				│
+				├     Worker Version 1:  00000000-0000-0000-0000-000000000000
+				│              Created:  TIMESTAMP
+				│                  Tag:  e2e-upload-AGAIN
+				│              Message:  Upload AGAIN via e2e test
+				│
+				├ What percentage of traffic should Worker Version 1 receive?
+				├ 100% of traffic
+				├
+				├ Add a deployment message
+				│ Deployment message Deploy AGAIN via e2e test
+				│
+				├ Deploying 1 version(s)
+				│
+				│ No non-versioned settings to sync. Skipping...
+				│
+				╰  SUCCESS  Deployed tmp-e2e-worker-00000000-0000-0000-0000-000000000000 version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
+			`);
 
 			// list 2 deployments (+ old deployment)
 			expect(normalize(deploymentsList.stdout)).toMatchInlineSnapshot(`


### PR DESCRIPTION
Fixes the e2e test snapshots in `versions.test.ts` that were broken by #13072.

PR #13072 changed the status message from "Fetching deployable versions" to "Fetching versions" when no specific version IDs are provided, but the e2e test snapshots were not updated to match.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this PR only fixes existing test snapshots
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: test-only change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
