### PR TITLE
[miniflare] Remove unwanted images-skip-crud-tests changeset

### DIFF
--- a/.changeset/images-skip-crud-tests.md
+++ b/.changeset/images-skip-crud-tests.md
@@ -1,5 +1,0 @@
----
-"miniflare": patch
----
-
-Temporarily skip images hosted CRUD tests pending workerd API update (https://github.com/cloudflare/workerd/pull/6288)


### PR DESCRIPTION
Removes the `images-skip-crud-tests.md` changeset from `main` as it was not wanted.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this only removes a changeset file — no code or behavior changes
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: no user-facing changes

Link to Devin session: https://app.devin.ai/sessions/7d0be1ec96544529b5833b41fbe81be5
Requested by: @petebacondarwin
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
