### PR TITLE
Remove some of the `no-restricted-imports` eslint disabling comments

### DIFF
--- a/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
@@ -2,8 +2,7 @@ import path from "node:path";
 import { normalizeString, seed } from "@cloudflare/workers-utils/test-helpers";
 import * as esbuild from "esbuild";
 import dedent from "ts-dedent";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, test, vi } from "vitest";
 import { BundlerController } from "../../../api/startDevWorker/BundlerController";
 import { FakeBus } from "../../helpers/fake-bus";
 import { mockConsoleMethods } from "../../helpers/mock-console";
@@ -70,7 +69,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 	afterEach(() => controller.teardown());
 
 	describe("happy path bundle + watch", () => {
-		test("single ts source file", async () => {
+		test("single ts source file", async ({ expect }) => {
 			await seed({
 				"src/index.ts": dedent /* javascript */ `
 				export default {
@@ -130,7 +129,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 				`);
 		});
 
-		test("multiple ts source files", async () => {
+		test("multiple ts source files", async ({ expect }) => {
 			await seed({
 				"src/index.ts": dedent /* javascript */ `
 				import name from "./other"
@@ -183,7 +182,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 				`);
 		});
 
-		test("custom build", async () => {
+		test("custom build", async ({ expect }) => {
 			await seed({
 				"custom_build_dir/index.ts": dedent /* javascript */ `
 				export default {
@@ -257,7 +256,7 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 		});
 	});
 
-	test("module aliasing", async () => {
+	test("module aliasing", async ({ expect }) => {
 		await seed({
 			"src/index.ts": dedent /* javascript */ `
 				import name from "foo"
@@ -307,9 +306,12 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 	});
 
 	describe("switching", () => {
-		test("esbuild -> custom builds", { timeout: 500000 }, async () => {
-			await seed({
-				"src/index.ts": dedent /* javascript */ `
+		test(
+			"esbuild -> custom builds",
+			{ timeout: 500000 },
+			async ({ expect }) => {
+				await seed({
+					"src/index.ts": dedent /* javascript */ `
 				export default {
 					fetch(request, env, ctx) {
 						//comment
@@ -317,19 +319,19 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 					}
 				} satisfies ExportedHandler
 			`,
-			});
-			const config = configDefaults({
-				entrypoint: path.resolve("src/index.ts"),
-				projectRoot: path.resolve("src"),
-			});
+				});
+				const config = configDefaults({
+					entrypoint: path.resolve("src/index.ts"),
+					projectRoot: path.resolve("src"),
+				});
 
-			const ev = bus.waitFor("bundleComplete", undefined, 500000);
-			controller.onConfigUpdate({
-				type: "configUpdate",
-				config: configDefaults(config),
-			});
-			expect(findSourceFile((await ev).bundle.entrypointSource, "index.ts"))
-				.toMatchInlineSnapshot(`
+				const ev = bus.waitFor("bundleComplete", undefined, 500000);
+				controller.onConfigUpdate({
+					type: "configUpdate",
+					config: configDefaults(config),
+				});
+				expect(findSourceFile((await ev).bundle.entrypointSource, "index.ts"))
+					.toMatchInlineSnapshot(`
 					"// index.ts
 					var index_exports = {};
 					__export(index_exports, {
@@ -343,9 +345,9 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 					"
 				`);
 
-			// Now switch to custom builds and see that it rebundles
-			await seed({
-				"custom_build_dir/index.ts": dedent /* javascript */ `
+				// Now switch to custom builds and see that it rebundles
+				await seed({
+					"custom_build_dir/index.ts": dedent /* javascript */ `
 					export default {
 						fetch(request, env, ctx) {
 							//comment
@@ -353,26 +355,27 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 						}
 					} satisfies ExportedHandler
 				`,
-			});
-			const configCustom = configDefaults({
-				entrypoint: path.resolve("out.ts"),
-				projectRoot: path.resolve("."),
-				build: {
-					custom: {
-						command: `node -e "fs.cpSync('custom_build_dir/index.ts', 'out.ts')"`,
-						watch: "custom_build_dir",
+				});
+				const configCustom = configDefaults({
+					entrypoint: path.resolve("out.ts"),
+					projectRoot: path.resolve("."),
+					build: {
+						custom: {
+							command: `node -e "fs.cpSync('custom_build_dir/index.ts', 'out.ts')"`,
+							watch: "custom_build_dir",
+						},
+						moduleRoot: path.resolve("."),
 					},
-					moduleRoot: path.resolve("."),
-				},
-			});
+				});
 
-			const evCustom = bus.waitFor("bundleComplete", undefined, 500000);
-			controller.onConfigUpdate({
-				type: "configUpdate",
-				config: configCustom,
-			});
-			expect(findSourceFile((await evCustom).bundle.entrypointSource, "out.ts"))
-				.toMatchInlineSnapshot(`
+				const evCustom = bus.waitFor("bundleComplete", undefined, 500000);
+				controller.onConfigUpdate({
+					type: "configUpdate",
+					config: configCustom,
+				});
+				expect(
+					findSourceFile((await evCustom).bundle.entrypointSource, "out.ts")
+				).toMatchInlineSnapshot(`
 					"// out.ts
 					var out_exports = {};
 					__export(out_exports, {
@@ -386,16 +389,16 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 					"
 				`);
 
-			await vi.waitFor(
-				async () => {
-					// Make sure we are now watching and processing the custom builds after switching to them
-					const updatedSource = bus.waitFor(
-						"bundleComplete",
-						undefined,
-						500000
-					);
-					await seed({
-						"custom_build_dir/index.ts": dedent /* javascript */ `
+				await vi.waitFor(
+					async () => {
+						// Make sure we are now watching and processing the custom builds after switching to them
+						const updatedSource = bus.waitFor(
+							"bundleComplete",
+							undefined,
+							500000
+						);
+						await seed({
+							"custom_build_dir/index.ts": dedent /* javascript */ `
 						export default {
 							fetch(request, env, ctx) {
 								//comment
@@ -403,13 +406,13 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 							}
 						}
 					`,
-					});
-					expect(
-						findSourceFile(
-							(await updatedSource).bundle.entrypointSource,
-							"out.ts"
-						)
-					).toMatchInlineSnapshot(`
+						});
+						expect(
+							findSourceFile(
+								(await updatedSource).bundle.entrypointSource,
+								"out.ts"
+							)
+						).toMatchInlineSnapshot(`
 						"// out.ts
 						var out_exports = {};
 						__export(out_exports, {
@@ -422,12 +425,13 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 						};
 						"
 					`);
-				},
-				{ timeout: 5_000, interval: 500 }
-			);
-		});
+					},
+					{ timeout: 5_000, interval: 500 }
+				);
+			}
+		);
 
-		test("custom builds -> esbuild", async () => {
+		test("custom builds -> esbuild", async ({ expect }) => {
 			await seed({
 				"custom_build_dir/index.ts": dedent /* javascript */ `
 					export default {
@@ -537,7 +541,9 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 	});
 
 	describe("bundling error messages", () => {
-		test("should recommend alias when a non-Node module cannot be resolved", async () => {
+		test("should recommend alias when a non-Node module cannot be resolved", async ({
+			expect,
+		}) => {
 			await seed({
 				"src/index.ts": dedent /* javascript */ `
 					import foo from 'some-nonexistent-module';
@@ -576,7 +582,9 @@ describe("BundleController", { retry: 5, timeout: 10_000 }, () => {
 			`);
 		});
 
-		test("should NOT recommend alias for Node built-in modules", async () => {
+		test("should NOT recommend alias for Node built-in modules", async ({
+			expect,
+		}) => {
 			await seed({
 				"src/index.ts": dedent /* javascript */ `
 					import fs from 'fs';

--- a/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
@@ -1,8 +1,7 @@
 import path from "node:path";
 import { seed } from "@cloudflare/workers-utils/test-helpers";
 import dedent from "ts-dedent";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { ConfigController } from "../../../api/startDevWorker/ConfigController";
 import { unwrapHook } from "../../../api/startDevWorker/utils";
 import { logger } from "../../../logger";
@@ -40,7 +39,9 @@ describe("ConfigController", () => {
 		logger.resetLoggerLevel();
 	});
 
-	it("should prompt user to update types if they're out of date", async () => {
+	it("should prompt user to update types if they're out of date", async ({
+		expect,
+	}) => {
 		await seed({
 			"src/index.ts": dedent /* javascript */ `
 				export default {}
@@ -68,7 +69,9 @@ describe("ConfigController", () => {
 		});
 	});
 
-	it("should use account_id from config file before env var", async () => {
+	it("should use account_id from config file before env var", async ({
+		expect,
+	}) => {
 		await seed({
 			"src/index.ts": dedent /* javascript */ `
                 export default {}
@@ -105,7 +108,9 @@ describe("ConfigController", () => {
 		});
 	});
 
-	it("should emit configUpdate events with defaults applied", async () => {
+	it("should emit configUpdate events with defaults applied", async ({
+		expect,
+	}) => {
 		const event = bus.waitFor("configUpdate");
 		await seed({
 			"src/index.ts": dedent /* javascript */ `
@@ -137,7 +142,9 @@ describe("ConfigController", () => {
 		});
 	});
 
-	it("should apply module root to parent if main is nested from base_dir", async () => {
+	it("should apply module root to parent if main is nested from base_dir", async ({
+		expect,
+	}) => {
 		const event = bus.waitFor("configUpdate");
 		await seed({
 			"some/base_dir/nested/index.js": dedent /* javascript */ `
@@ -171,7 +178,7 @@ describe("ConfigController", () => {
 		});
 	});
 
-	it("should shallow merge patched config", async () => {
+	it("should shallow merge patched config", async ({ expect }) => {
 		const event1 = bus.waitFor("configUpdate");
 		await seed({
 			"src/index.ts": dedent /* javascript */ `
@@ -263,7 +270,9 @@ describe("ConfigController", () => {
 		});
 	});
 
-	it("should only log warnings once even with multiple config updates", async () => {
+	it("should only log warnings once even with multiple config updates", async ({
+		expect,
+	}) => {
 		await seed({
 			"src/index.js": dedent /* javascript */ `
 				addEventListener('fetch', event => {

--- a/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
@@ -7,8 +7,7 @@ import { removeDirSync } from "@cloudflare/workers-utils";
 import { DeferredPromise, Response } from "miniflare";
 import dedent from "ts-dedent";
 import { fetch } from "undici";
-// eslint-disable-next-line no-restricted-imports
-import { assert, describe, expect, it } from "vitest";
+import { assert, describe, it } from "vitest";
 import WebSocket from "ws";
 import { createPostgresEchoHandler } from "../../../../e2e/helpers/postgres-echo-handler";
 import { LocalRuntimeController } from "../../../api/startDevWorker/LocalRuntimeController";
@@ -138,7 +137,7 @@ describe("LocalRuntimeController", () => {
 	const teardown = useTeardown();
 
 	describe("Core", () => {
-		it("should start Miniflare with module worker", async () => {
+		it("should start Miniflare with module worker", async ({ expect }) => {
 			const bus = new FakeBus();
 			const controller = new LocalRuntimeController(bus);
 			teardown(() => controller.teardown());
@@ -293,7 +292,7 @@ describe("LocalRuntimeController", () => {
 			`);
 			}
 		});
-		it("should start Miniflare with service worker", async () => {
+		it("should start Miniflare with service worker", async ({ expect }) => {
 			const bus = new FakeBus();
 			const controller = new LocalRuntimeController(bus);
 			teardown(() => controller.teardown());
@@ -389,7 +388,7 @@ describe("LocalRuntimeController", () => {
 			`);
 			}
 		});
-		it("should update the running Miniflare instance", async () => {
+		it("should update the running Miniflare instance", async ({ expect }) => {
 			const bus = new FakeBus();
 			const controller = new LocalRuntimeController(bus);
 			teardown(() => controller.teardown());
@@ -441,7 +440,9 @@ describe("LocalRuntimeController", () => {
 			res = await fetch(urlFromParts(event.proxyData.userWorkerUrl));
 			expect(await res.json()).toEqual({ binding: 5, bundle: 5 });
 		});
-		it("should start Miniflare with configured compatibility settings", async () => {
+		it("should start Miniflare with configured compatibility settings", async ({
+			expect,
+		}) => {
 			const bus = new FakeBus();
 			const controller = new LocalRuntimeController(bus);
 			teardown(() => controller.teardown());
@@ -506,7 +507,9 @@ describe("LocalRuntimeController", () => {
 			res = await fetch(urlFromParts(event.proxyData.userWorkerUrl));
 			expect(await res.text()).toBe("object");
 		});
-		it("should start inspector on random port and allow debugging", async () => {
+		it("should start inspector on random port and allow debugging", async ({
+			expect,
+		}) => {
 			const bus = new FakeBus();
 			const controller = new LocalRuntimeController(bus);
 			teardown(() => controller.teardown());
@@ -576,7 +579,7 @@ describe("LocalRuntimeController", () => {
 	});
 
 	describe("Bindings", () => {
-		it("should expose basic bindings", async () => {
+		it("should expose basic bindings", async ({ expect }) => {
 			const bus = new FakeBus();
 			const controller = new LocalRuntimeController(bus);
 			teardown(() => controller.teardown());
@@ -624,7 +627,9 @@ describe("LocalRuntimeController", () => {
 				DATA: { $type: "ArrayBuffer", value: [1, 2, 3] },
 			});
 		});
-		it("should expose WebAssembly module bindings in service workers", async () => {
+		it("should expose WebAssembly module bindings in service workers", async ({
+			expect,
+		}) => {
 			const bus = new FakeBus();
 			const controller = new LocalRuntimeController(bus);
 			teardown(() => controller.teardown());
@@ -660,7 +665,7 @@ describe("LocalRuntimeController", () => {
 			const res = await fetch(urlFromParts(event.proxyData.userWorkerUrl));
 			expect(await res.text()).toBe("3");
 		});
-		it("should persist cached data", async () => {
+		it("should persist cached data", async ({ expect }) => {
 			const bus = new FakeBus();
 			const controller = new LocalRuntimeController(bus);
 			teardown(() => controller.teardown());
@@ -732,7 +737,7 @@ describe("LocalRuntimeController", () => {
 			res = await fetch(urlFromParts(event.proxyData.userWorkerUrl));
 			expect(await res.text()).toBe("miss");
 		});
-		it("should not persist data when persist is false", async () => {
+		it("should not persist data when persist is false", async ({ expect }) => {
 			const bus = new FakeBus();
 			const controller = new LocalRuntimeController(bus);
 			teardown(() => controller.teardown());
@@ -800,7 +805,7 @@ describe("LocalRuntimeController", () => {
 			// Data should be gone since persistence was disabled
 			expect(await res.text()).toBe("miss");
 		});
-		it("should expose KV namespace bindings", async () => {
+		it("should expose KV namespace bindings", async ({ expect }) => {
 			const bus = new FakeBus();
 			const controller = new LocalRuntimeController(bus);
 			teardown(() => controller.teardown());
@@ -864,7 +869,7 @@ describe("LocalRuntimeController", () => {
 			res = await fetch(urlFromParts(event.proxyData.userWorkerUrl));
 			expect(await res.text()).toBe("");
 		});
-		it("should support Secrets Store bindings", async () => {
+		it("should support Secrets Store bindings", async ({ expect }) => {
 			const bus = new FakeBus();
 			const controller = new LocalRuntimeController(bus);
 			teardown(() => controller.teardown());
@@ -910,7 +915,7 @@ describe("LocalRuntimeController", () => {
 			const res = await fetch(urlFromParts(event.proxyData.userWorkerUrl));
 			expect(await res.text()).toBe(secretValue);
 		});
-		it("should support Hello World bindings", async () => {
+		it("should support Hello World bindings", async ({ expect }) => {
 			const bus = new FakeBus();
 			const controller = new LocalRuntimeController(bus);
 			teardown(() => controller.teardown());
@@ -973,7 +978,7 @@ describe("LocalRuntimeController", () => {
 			expect(await res4.text()).toBe("Not found");
 			expect(res4.status).toBe(404);
 		});
-		it("should support Workers Sites bindings", async () => {
+		it("should support Workers Sites bindings", async ({ expect }) => {
 			const bus = new FakeBus();
 			const controller = new LocalRuntimeController(bus);
 			teardown(() => controller.teardown());
@@ -1045,7 +1050,7 @@ describe("LocalRuntimeController", () => {
 			res = await fetch(new URL("/secrets.txt", url));
 			expect(res.status).toBe(404);
 		});
-		it("should expose R2 bucket bindings", async () => {
+		it("should expose R2 bucket bindings", async ({ expect }) => {
 			const bus = new FakeBus();
 			const controller = new LocalRuntimeController(bus);
 			teardown(() => controller.teardown());
@@ -1110,7 +1115,7 @@ describe("LocalRuntimeController", () => {
 			res = await fetch(urlFromParts(event.proxyData.userWorkerUrl));
 			expect(await res.text()).toBe("");
 		});
-		it("should expose D1 database bindings", async () => {
+		it("should expose D1 database bindings", async ({ expect }) => {
 			const bus = new FakeBus();
 			const controller = new LocalRuntimeController(bus);
 			teardown(() => controller.teardown());
@@ -1180,7 +1185,9 @@ describe("LocalRuntimeController", () => {
 			res = await fetch(urlFromParts(event.proxyData.userWorkerUrl));
 			expect(await res.json()).toEqual([]);
 		});
-		it("should expose queue producer bindings and consume queue messages", async () => {
+		it("should expose queue producer bindings and consume queue messages", async ({
+			expect,
+		}) => {
 			const bus = new FakeBus();
 			const controller = new LocalRuntimeController(bus);
 			teardown(() => controller.teardown());
@@ -1234,7 +1241,7 @@ describe("LocalRuntimeController", () => {
 			expect(res.status).toBe(204);
 			expect(await reportPromise).toEqual(["message"]);
 		});
-		it("should expose hyperdrive bindings - default", async () => {
+		it("should expose hyperdrive bindings - default", async ({ expect }) => {
 			// Start TCP echo server
 			const server = net.createServer((socket) => {
 				socket.on("data", createPostgresEchoHandler(socket));
@@ -1290,7 +1297,9 @@ describe("LocalRuntimeController", () => {
 			expect(res.status).toBe(200);
 			expect(await res.text()).toBe("👋");
 		});
-		it("should expose hyperdrive bindings - sslmode 'prefer'", async () => {
+		it("should expose hyperdrive bindings - sslmode 'prefer'", async ({
+			expect,
+		}) => {
 			// Start TCP echo server
 			const server = net.createServer((socket) => {
 				socket.on("data", createPostgresEchoHandler(socket));
@@ -1345,7 +1354,9 @@ describe("LocalRuntimeController", () => {
 			expect(res.status).toBe(200);
 			expect(await res.text()).toBe("👋");
 		});
-		it("should expose hyperdrive bindings - sslmode 'require' fails", async () => {
+		it("should expose hyperdrive bindings - sslmode 'require' fails", async ({
+			expect,
+		}) => {
 			// Start TCP echo server
 			const server = net.createServer((socket) => {
 				socket.on("data", createPostgresEchoHandler(socket));
@@ -1407,7 +1418,7 @@ describe("LocalRuntimeController", () => {
 				"Error: Server does not support SSL, but client requires SSL"
 			);
 		});
-		it("should support Pipeline bindings", async () => {
+		it("should support Pipeline bindings", async ({ expect }) => {
 			const bus = new FakeBus();
 			const controller = new LocalRuntimeController(bus);
 			teardown(() => controller.teardown());
@@ -1448,7 +1459,7 @@ describe("LocalRuntimeController", () => {
 			const res = await fetch(url);
 			await expect(res.text()).resolves.toBe("Data sent to env.PIPELINE");
 		});
-		it("should support Images bindings", async () => {
+		it("should support Images bindings", async ({ expect }) => {
 			const bus = new FakeBus();
 			const controller = new LocalRuntimeController(bus);
 			teardown(() => controller.teardown());

--- a/packages/wrangler/src/__tests__/api/startDevWorker/RemoteRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/RemoteRuntimeController.test.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, it, vi } from "vitest";
 import { RemoteRuntimeController } from "../../../api/startDevWorker/RemoteRuntimeController";
 import { unwrapHook } from "../../../api/startDevWorker/utils";
 // Import the mocked functions so we can set their behavior
@@ -167,7 +166,7 @@ describe("RemoteRuntimeController", () => {
 	});
 
 	describe("preview token refresh", () => {
-		it("should handle missing state gracefully", async () => {
+		it("should handle missing state gracefully", async ({ expect }) => {
 			const { controller } = setup();
 
 			const expiredEvent: PreviewTokenExpiredEvent = {
@@ -195,7 +194,9 @@ describe("RemoteRuntimeController", () => {
 			});
 		});
 
-		it("should call API with stored config/bundle when refreshing", async () => {
+		it("should call API with stored config/bundle when refreshing", async ({
+			expect,
+		}) => {
 			const { controller, bus } = setup();
 			const config = makeConfig({ name: "my-worker" });
 			const bundle = makeBundle();
@@ -245,7 +246,9 @@ describe("RemoteRuntimeController", () => {
 			expect(createWorkerPreview).toHaveBeenCalledTimes(1);
 		});
 
-		it("should emit reloadComplete event with fresh token when refreshing", async () => {
+		it("should emit reloadComplete event with fresh token when refreshing", async ({
+			expect,
+		}) => {
 			const { controller, bus } = setup();
 			const config = makeConfig();
 			const bundle = makeBundle();

--- a/packages/wrangler/src/__tests__/cloudchamber/build.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/build.test.ts
@@ -8,8 +8,7 @@ import {
 	runDockerCmdWithOutput,
 } from "@cloudflare/containers-shared";
 import { UserError } from "@cloudflare/workers-utils";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runInTempDir } from "../helpers/run-in-tmp";
@@ -55,7 +54,9 @@ describe("buildAndMaybePush", () => {
 		vi.clearAllMocks();
 	});
 
-	it("should be able to build image and push with test-app:tag", async () => {
+	it("should be able to build image and push with test-app:tag", async ({
+		expect,
+	}) => {
 		await runWrangler(
 			"containers build ./container-context -t test-app:tag -p"
 		);
@@ -100,7 +101,9 @@ describe("buildAndMaybePush", () => {
 		expect(dockerLoginImageRegistry).toHaveBeenCalledOnce();
 	});
 
-	it("should be able to build image and push with registry.cloudflare.com/test-app:tag", async () => {
+	it("should be able to build image and push with registry.cloudflare.com/test-app:tag", async ({
+		expect,
+	}) => {
 		await runWrangler(
 			"containers build ./container-context -t registry.cloudflare.com/test-app:tag -p"
 		);
@@ -144,7 +147,9 @@ describe("buildAndMaybePush", () => {
 		expect(dockerLoginImageRegistry).toHaveBeenCalledOnce();
 	});
 
-	it("should be able to build image and push with registry.cloudflare.com/some-account-id/test-app:tag", async () => {
+	it("should be able to build image and push with registry.cloudflare.com/some-account-id/test-app:tag", async ({
+		expect,
+	}) => {
 		await runWrangler(
 			"containers build ./container-context -t registry.cloudflare.com/some-account-id/test-app:tag -p"
 		);
@@ -188,7 +193,7 @@ describe("buildAndMaybePush", () => {
 		expect(dockerLoginImageRegistry).toHaveBeenCalledOnce();
 	});
 
-	it("should use a custom docker path if provided", async () => {
+	it("should use a custom docker path if provided", async ({ expect }) => {
 		vi.stubEnv("WRANGLER_DOCKER_BIN", "/custom/docker/path");
 		await runWrangler(
 			"containers build ./container-context -t test-app:tag -p"
@@ -235,7 +240,7 @@ describe("buildAndMaybePush", () => {
 		);
 	});
 
-	it("should be able to build image and push", async () => {
+	it("should be able to build image and push", async ({ expect }) => {
 		await runWrangler(
 			"containers build ./container-context -t test-app:tag -p"
 		);
@@ -279,7 +284,9 @@ describe("buildAndMaybePush", () => {
 		expect(dockerLoginImageRegistry).toHaveBeenCalledOnce();
 	});
 
-	it("should be able to build image and not push if it already exists in remote if config sha and digest both match", async () => {
+	it("should be able to build image and not push if it already exists in remote if config sha and digest both match", async ({
+		expect,
+	}) => {
 		vi.mocked(runDockerCmd).mockResolvedValueOnce({
 			abort: () => {},
 			ready: Promise.resolve({ aborted: false }),
@@ -332,7 +339,9 @@ describe("buildAndMaybePush", () => {
 		expect(dockerLoginImageRegistry).toHaveBeenCalledOnce();
 	});
 
-	it("should match digests for images with registry ports", async () => {
+	it("should match digests for images with registry ports", async ({
+		expect,
+	}) => {
 		vi.mocked(runDockerCmd).mockResolvedValueOnce({
 			abort: () => {},
 			ready: Promise.resolve({ aborted: false }),
@@ -366,7 +375,7 @@ describe("buildAndMaybePush", () => {
 		expect(dockerLoginImageRegistry).toHaveBeenCalledOnce();
 	});
 
-	it("should be able to build image and not push", async () => {
+	it("should be able to build image and not push", async ({ expect }) => {
 		await runWrangler("containers build ./container-context -t test-app");
 		expect(dockerBuild).toHaveBeenCalledTimes(1);
 		expect(dockerBuild).toHaveBeenCalledWith("docker", {
@@ -388,7 +397,9 @@ describe("buildAndMaybePush", () => {
 		expect(dockerLoginImageRegistry).not.toHaveBeenCalled();
 	});
 
-	it("should add --network=host flag if WRANGLER_CI_OVERRIDE_NETWORK_MODE_HOST is set", async () => {
+	it("should add --network=host flag if WRANGLER_CI_OVERRIDE_NETWORK_MODE_HOST is set", async ({
+		expect,
+	}) => {
 		vi.stubEnv("WRANGLER_CI_OVERRIDE_NETWORK_MODE_HOST", "true");
 		await runWrangler("containers build ./container-context -t test-app");
 		expect(dockerBuild).toHaveBeenCalledTimes(1);
@@ -411,7 +422,9 @@ describe("buildAndMaybePush", () => {
 		});
 	});
 
-	it("should be able to build image with platform specified", async () => {
+	it("should be able to build image with platform specified", async ({
+		expect,
+	}) => {
 		await runWrangler(
 			"containers build ./container-context -t test-app:tag -p --platform linux/amd64"
 		);
@@ -432,7 +445,7 @@ describe("buildAndMaybePush", () => {
 		});
 	});
 
-	it("should fail with an invalid platform", async () => {
+	it("should fail with an invalid platform", async ({ expect }) => {
 		await expect(
 			runWrangler(
 				"containers build ./container-context -t test-app:tag -p --platform linux/arm64"
@@ -440,7 +453,7 @@ describe("buildAndMaybePush", () => {
 		).rejects.toThrow("Unsupported platform");
 	});
 
-	it("should throw UserError when docker build fails", async () => {
+	it("should throw UserError when docker build fails", async ({ expect }) => {
 		const errorMessage = "Docker build failed";
 		vi.mocked(dockerBuild).mockReturnValue({
 			abort: () => {},
@@ -451,7 +464,7 @@ describe("buildAndMaybePush", () => {
 		).rejects.toThrow(new UserError(errorMessage));
 	});
 
-	it("should throw UserError when docker login fails", async () => {
+	it("should throw UserError when docker login fails", async ({ expect }) => {
 		const errorMessage = "Docker login failed";
 		vi.mocked(dockerBuild).mockRejectedValue(new Error(errorMessage));
 		vi.mocked(dockerLoginImageRegistry).mockRejectedValue(

--- a/packages/wrangler/src/__tests__/cloudchamber/curl.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/curl.test.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, it } from "vitest";
 import { collectCLIOutput } from "../helpers/collect-cli-output";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { MOCK_DEPLOYMENTS_COMPLEX } from "../helpers/mock-cloudchamber";
@@ -27,7 +26,7 @@ describe("cloudchamber curl", () => {
 		msw.resetHandlers();
 	});
 
-	it("should help", async () => {
+	it("should help", async ({ expect }) => {
 		await runWrangler("cloudchamber curl --help");
 		expect(std.err).toMatchInlineSnapshot(`""`);
 		expect(helpStd.out).toMatchInlineSnapshot(`
@@ -56,7 +55,7 @@ describe("cloudchamber curl", () => {
 		`);
 	});
 
-	it("can send data with -d/--data", async () => {
+	it("can send data with -d/--data", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		msw.use(
@@ -132,7 +131,7 @@ describe("cloudchamber curl", () => {
 		`);
 	});
 
-	it("supports deprecated -D flag", async () => {
+	it("supports deprecated -D flag", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		msw.use(
@@ -208,7 +207,7 @@ describe("cloudchamber curl", () => {
 		`);
 	});
 
-	it("should set headers", async () => {
+	it("should set headers", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		msw.use(
@@ -231,7 +230,7 @@ describe("cloudchamber curl", () => {
 		`);
 	});
 
-	it("works", async () => {
+	it("works", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		msw.use(
@@ -355,7 +354,9 @@ describe("cloudchamber curl", () => {
 		]);
 	});
 
-	it("should give a response with headers and request-id when verbose flag is set", async () => {
+	it("should give a response with headers and request-id when verbose flag is set", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		msw.use(
@@ -378,7 +379,9 @@ describe("cloudchamber curl", () => {
 		expect(text).toContain("coordinator-request-id");
 	});
 
-	it("includes headers and request-id in JSON when used with --silent and --verbose", async () => {
+	it("includes headers and request-id in JSON when used with --silent and --verbose", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		msw.use(
@@ -400,7 +403,7 @@ describe("cloudchamber curl", () => {
 		expect(response.request_id.length).toBeGreaterThan(0);
 	});
 
-	it("should catch and report errors", async () => {
+	it("should catch and report errors", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		await runWrangler(

--- a/packages/wrangler/src/__tests__/cloudchamber/delete.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/delete.test.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { MOCK_DEPLOYMENTS_COMPLEX } from "../helpers/mock-cloudchamber";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -23,7 +22,7 @@ describe("cloudchamber delete", () => {
 		msw.resetHandlers();
 	});
 
-	it("should help", async () => {
+	it("should help", async ({ expect }) => {
 		await runWrangler("cloudchamber delete --help");
 		expect(std.err).toMatchInlineSnapshot(`""`);
 		expect(std.out).toMatchInlineSnapshot(`
@@ -44,7 +43,9 @@ describe("cloudchamber delete", () => {
 		`);
 	});
 
-	it("should delete deployment (detects no interactivity)", async () => {
+	it("should delete deployment (detects no interactivity)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		msw.use(
 			http.delete(
@@ -86,7 +87,7 @@ describe("cloudchamber delete", () => {
 		);
 	});
 
-	it("can't modify delete due to lack of fields", async () => {
+	it("can't modify delete due to lack of fields", async ({ expect }) => {
 		setIsTTY(false);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 		await expect(

--- a/packages/wrangler/src/__tests__/cloudchamber/images.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/images.test.ts
@@ -1,7 +1,6 @@
 import { getCloudflareContainerRegistry } from "@cloudflare/containers-shared";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
@@ -22,7 +21,7 @@ describe("cloudchamber image", () => {
 		msw.resetHandlers();
 	});
 
-	it("should help", async () => {
+	it("should help", async ({ expect }) => {
 		await runWrangler("cloudchamber registries --help");
 		expect(std.err).toMatchInlineSnapshot(`""`);
 		expect(std.out).toMatchInlineSnapshot(`
@@ -46,7 +45,9 @@ describe("cloudchamber image", () => {
 		`);
 	});
 
-	it("should create an image registry (no interactivity)", async () => {
+	it("should create an image registry (no interactivity)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		msw.use(
@@ -78,7 +79,9 @@ describe("cloudchamber image", () => {
 		`);
 	});
 
-	it("should create an image registry (no interactivity)", async () => {
+	it("should create an image registry (no interactivity)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		msw.use(
@@ -102,7 +105,9 @@ describe("cloudchamber image", () => {
 		expect(std.out).toMatchInlineSnapshot(`"jwt"`);
 	});
 
-	it("should remove an image registry (no interactivity)", async () => {
+	it("should remove an image registry (no interactivity)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		msw.use(
@@ -120,7 +125,7 @@ describe("cloudchamber image", () => {
 		expect(std.out).toMatchInlineSnapshot(`"{}"`);
 	});
 
-	it("should list registries (no interactivity)", async () => {
+	it("should list registries (no interactivity)", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		msw.use(
@@ -172,7 +177,7 @@ describe("cloudchamber image list", () => {
 		msw.resetHandlers();
 	});
 
-	it("should help", async () => {
+	it("should help", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		await runWrangler("cloudchamber images list --help");
@@ -196,7 +201,7 @@ describe("cloudchamber image list", () => {
 		`);
 	});
 
-	it("should list images", async () => {
+	it("should list images", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		const tags = {
@@ -232,7 +237,7 @@ describe("cloudchamber image list", () => {
 		`);
 	});
 
-	it("should list images with a filter", async () => {
+	it("should list images with a filter", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		const tags = {
@@ -264,7 +269,7 @@ describe("cloudchamber image list", () => {
 		`);
 	});
 
-	it("should filter out repos with no non-sha tags", async () => {
+	it("should filter out repos with no non-sha tags", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		const tags = {
@@ -302,7 +307,9 @@ describe("cloudchamber image list", () => {
 		`);
 	});
 
-	it("should list repos as valid json with json flag set", async () => {
+	it("should list repos as valid json with json flag set", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		const tags = {
@@ -354,7 +361,9 @@ describe("cloudchamber image list", () => {
 		`);
 	});
 
-	it("should filter out repos with no non-sha tags in valid json output", async () => {
+	it("should filter out repos with no non-sha tags in valid json output", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		const tags = {
@@ -423,7 +432,7 @@ describe("cloudchamber image delete", () => {
 		msw.resetHandlers();
 	});
 
-	it("should help", async () => {
+	it("should help", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		await runWrangler("cloudchamber images delete --help");
@@ -446,7 +455,7 @@ describe("cloudchamber image delete", () => {
 		`);
 	});
 
-	it("should delete images", async () => {
+	it("should delete images", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 
@@ -489,7 +498,7 @@ describe("cloudchamber image delete", () => {
 		);
 	});
 
-	it("should error when provided a repo without a tag", async () => {
+	it("should error when provided a repo without a tag", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 

--- a/packages/wrangler/src/__tests__/cloudchamber/limits.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/limits.test.ts
@@ -2,8 +2,7 @@ import {
 	dockerImageInspect,
 	InstanceType,
 } from "@cloudflare/containers-shared";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import {
 	ensureContainerLimits,
 	ensureImageFitsLimits,
@@ -40,7 +39,9 @@ describe("ensureContainerLimits", () => {
 	});
 
 	describe("instance type", async () => {
-		it("should throw error if vcpu is greater than limit", async () => {
+		it("should throw error if vcpu is greater than limit", async ({
+			expect,
+		}) => {
 			await expect(() =>
 				ensureContainerLimits({
 					pathToDocker: "path/to/docker",
@@ -60,7 +61,9 @@ describe("ensureContainerLimits", () => {
 			);
 		});
 
-		it("should throw error if memory is greater than limit", async () => {
+		it("should throw error if memory is greater than limit", async ({
+			expect,
+		}) => {
 			await expect(() =>
 				ensureContainerLimits({
 					pathToDocker: "path/to/docker",
@@ -80,7 +83,9 @@ describe("ensureContainerLimits", () => {
 			);
 		});
 
-		it("should throw error if disk is greater than limit", async () => {
+		it("should throw error if disk is greater than limit", async ({
+			expect,
+		}) => {
 			await expect(() =>
 				ensureContainerLimits({
 					pathToDocker: "path/to/docker",
@@ -100,7 +105,9 @@ describe("ensureContainerLimits", () => {
 			);
 		});
 
-		it("should succeed when instance type fits in limits", async () => {
+		it("should succeed when instance type fits in limits", async ({
+			expect,
+		}) => {
 			const result = await ensureContainerLimits({
 				pathToDocker: "path/to/docker",
 				imageTag: "docker.io/test-app:tag",
@@ -116,7 +123,9 @@ describe("ensureContainerLimits", () => {
 	});
 
 	describe("custom limits", async () => {
-		it("should throw error if vcpu is greater than limit", async () => {
+		it("should throw error if vcpu is greater than limit", async ({
+			expect,
+		}) => {
 			await expect(() =>
 				ensureContainerLimits({
 					pathToDocker: "path/to/docker",
@@ -135,7 +144,9 @@ describe("ensureContainerLimits", () => {
 			);
 		});
 
-		it("should throw error if memory is greater than limit", async () => {
+		it("should throw error if memory is greater than limit", async ({
+			expect,
+		}) => {
 			await expect(() =>
 				ensureContainerLimits({
 					pathToDocker: "path/to/docker",
@@ -154,7 +165,9 @@ describe("ensureContainerLimits", () => {
 			);
 		});
 
-		it("should throw error if disk is greater than limit", async () => {
+		it("should throw error if disk is greater than limit", async ({
+			expect,
+		}) => {
 			await expect(() =>
 				ensureContainerLimits({
 					pathToDocker: "path/to/docker",
@@ -173,7 +186,9 @@ describe("ensureContainerLimits", () => {
 			);
 		});
 
-		it("should succeed when configuration fits in limits", async () => {
+		it("should succeed when configuration fits in limits", async ({
+			expect,
+		}) => {
 			const result = await ensureContainerLimits({
 				pathToDocker: "path/to/docker",
 				imageTag: "docker.io/test-app:tag",
@@ -199,7 +214,9 @@ describe("ensureImageFitsLimits", () => {
 		vi.clearAllMocks();
 	});
 
-	it("should throw error if image size exceeds allowed size", async () => {
+	it("should throw error if image size exceeds allowed size", async ({
+		expect,
+	}) => {
 		// required size = 907387881 * 1.1 + 128 * 16 * MiB = 3146MB
 		vi.mocked(dockerImageInspect).mockResolvedValue("907387881 128");
 
@@ -222,7 +239,7 @@ describe("ensureImageFitsLimits", () => {
 		);
 	});
 
-	it("should not throw when disk size is within limits", async () => {
+	it("should not throw when disk size is within limits", async ({ expect }) => {
 		// required size = 53387881 * 1.1 + 2 * 16 * MiB = 93MB
 		vi.mocked(dockerImageInspect).mockResolvedValue("53387881 2");
 

--- a/packages/wrangler/src/__tests__/cloudchamber/list.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/list.test.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { MOCK_DEPLOYMENTS_COMPLEX } from "../helpers/mock-cloudchamber";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -23,7 +22,7 @@ describe("cloudchamber list", () => {
 		msw.resetHandlers();
 	});
 
-	it("should help", async () => {
+	it("should help", async ({ expect }) => {
 		await runWrangler("cloudchamber list --help");
 		expect(std.err).toMatchInlineSnapshot(`""`);
 		expect(std.out).toMatchInlineSnapshot(`
@@ -51,7 +50,7 @@ describe("cloudchamber list", () => {
 		`);
 	});
 
-	it("should list deployments (json)", async () => {
+	it("should list deployments (json)", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		msw.use(

--- a/packages/wrangler/src/__tests__/config-validation-pages.test.ts
+++ b/packages/wrangler/src/__tests__/config-validation-pages.test.ts
@@ -2,14 +2,15 @@ import {
 	defaultWranglerConfig,
 	validatePagesConfig,
 } from "@cloudflare/workers-utils";
-// eslint-disable-next-line no-restricted-imports
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import type { Config } from "@cloudflare/workers-utils";
 
 // TODO: Move these tests to the workers-utils package
 describe("validatePagesConfig()", () => {
 	describe("`main` field validation", () => {
-		it("should error if configuration contains both `pages_build_output_dir` and `main` config fields", () => {
+		it("should error if configuration contains both `pages_build_output_dir` and `main` config fields", ({
+			expect,
+		}) => {
 			const config = generateConfigurationWithDefaults();
 			config.pages_build_output_dir = "./public";
 			config.main = "./src/index.js";
@@ -28,7 +29,9 @@ describe("validatePagesConfig()", () => {
 	});
 
 	describe("`name` field validation", () => {
-		it('should error if "name" field is not specififed at the top-level', () => {
+		it('should error if "name" field is not specififed at the top-level', ({
+			expect,
+		}) => {
 			const config = generateConfigurationWithDefaults();
 			config.pages_build_output_dir = "./public";
 
@@ -44,7 +47,7 @@ describe("validatePagesConfig()", () => {
 	});
 
 	describe("named environments validation", () => {
-		it("should pass if no named environments are defined", () => {
+		it("should pass if no named environments are defined", ({ expect }) => {
 			const config = generateConfigurationWithDefaults();
 			config.pages_build_output_dir = "./public";
 			config.name = "pages-project";
@@ -54,7 +57,9 @@ describe("validatePagesConfig()", () => {
 			expect(diagnostics.hasErrors()).toBeFalsy();
 		});
 
-		it("should pass for environments named 'preview' and/or 'production'", () => {
+		it("should pass for environments named 'preview' and/or 'production'", ({
+			expect,
+		}) => {
 			const config = generateConfigurationWithDefaults();
 			config.pages_build_output_dir = "./public";
 			config.name = "pages-project";
@@ -84,7 +89,7 @@ describe("validatePagesConfig()", () => {
 			expect(diagnostics.hasErrors()).toBeFalsy();
 		});
 
-		it("should error for any other named environments", () => {
+		it("should error for any other named environments", ({ expect }) => {
 			const config = generateConfigurationWithDefaults();
 			config.pages_build_output_dir = "./assets";
 			config.name = "pages-project";
@@ -120,7 +125,9 @@ describe("validatePagesConfig()", () => {
 	});
 
 	describe("unsupported fields validation", () => {
-		it("should pass if configuration contains only Pages-supported configuration fields", () => {
+		it("should pass if configuration contains only Pages-supported configuration fields", ({
+			expect,
+		}) => {
 			let config = generateConfigurationWithDefaults();
 			config.pages_build_output_dir = "./dist";
 			config.name = "pages-project";
@@ -202,7 +209,9 @@ describe("validatePagesConfig()", () => {
 			expect(diagnostics.hasErrors()).toBeFalsy();
 		});
 
-		it("should fail if configuration contains any fields that are not supported by Pages projects", () => {
+		it("should fail if configuration contains any fields that are not supported by Pages projects", ({
+			expect,
+		}) => {
 			const defaultConfig = generateConfigurationWithDefaults();
 			defaultConfig.pages_build_output_dir = "./public";
 			defaultConfig.name = "pages-project";
@@ -283,7 +292,9 @@ describe("validatePagesConfig()", () => {
 	});
 
 	describe("DO bindings validation", () => {
-		it("should pass if all Durable Objects bindings specify 'script_name'", () => {
+		it("should pass if all Durable Objects bindings specify 'script_name'", ({
+			expect,
+		}) => {
 			const config = generateConfigurationWithDefaults();
 			config.pages_build_output_dir = "./public";
 			config.name = "pages-project";
@@ -305,7 +316,9 @@ describe("validatePagesConfig()", () => {
 			expect(diagnostics.hasErrors()).toBeFalsy();
 		});
 
-		it("should fail if any of the Durable Object bindings does not specify 'script_name'", () => {
+		it("should fail if any of the Durable Object bindings does not specify 'script_name'", ({
+			expect,
+		}) => {
 			const config = generateConfigurationWithDefaults();
 			config.pages_build_output_dir = "./public";
 			config.name = "pages-project";

--- a/packages/wrangler/src/__tests__/containers/config.test.ts
+++ b/packages/wrangler/src/__tests__/containers/config.test.ts
@@ -2,8 +2,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { getCloudflareContainerRegistry } from "@cloudflare/containers-shared";
 import { UserError } from "@cloudflare/workers-utils";
-// eslint-disable-next-line no-restricted-imports
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, it, vi } from "vitest";
 import { getNormalizedContainerOptions } from "../../containers/config";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { runInTempDir } from "../helpers/run-in-tmp";
@@ -18,7 +17,9 @@ describe("getNormalizedContainerOptions", () => {
 		vi.clearAllMocks();
 	});
 
-	it("should return empty array when no containers are configured", async () => {
+	it("should return empty array when no containers are configured", async ({
+		expect,
+	}) => {
 		const config = {
 			name: "test-worker",
 			configPath: "/test/wrangler.toml",
@@ -34,7 +35,9 @@ describe("getNormalizedContainerOptions", () => {
 		expect(result).toEqual([]);
 	});
 
-	it("should return empty array when containers is undefined", async () => {
+	it("should return empty array when containers is undefined", async ({
+		expect,
+	}) => {
 		const config = {
 			name: "test-worker",
 			configPath: "/test/wrangler.toml",
@@ -50,7 +53,9 @@ describe("getNormalizedContainerOptions", () => {
 		expect(result).toEqual([]);
 	});
 
-	it("should throw error when container class_name doesn't match any durable object", async () => {
+	it("should throw error when container class_name doesn't match any durable object", async ({
+		expect,
+	}) => {
 		const config = {
 			name: "test-worker",
 			configPath: "/test/wrangler.toml",
@@ -76,7 +81,9 @@ describe("getNormalizedContainerOptions", () => {
 		);
 	});
 
-	it("should throw error when durable object has script_name defined", async () => {
+	it("should throw error when durable object has script_name defined", async ({
+		expect,
+	}) => {
 		const config: Config = {
 			name: "test-worker",
 			configPath: "/test/wrangler.toml",
@@ -111,7 +118,9 @@ describe("getNormalizedContainerOptions", () => {
 		);
 	});
 
-	it("should normalize and set defaults for container with dockerfile", async () => {
+	it("should normalize and set defaults for container with dockerfile", async ({
+		expect,
+	}) => {
 		writeFileSync("Dockerfile", "FROM scratch");
 
 		const config: Config = {
@@ -158,7 +167,9 @@ describe("getNormalizedContainerOptions", () => {
 		});
 	});
 
-	it("should normalize and set defaults for container with registry image", async () => {
+	it("should normalize and set defaults for container with registry image", async ({
+		expect,
+	}) => {
 		const config: Config = {
 			name: "test-worker",
 			configPath: "/test/wrangler.toml",
@@ -201,7 +212,9 @@ describe("getNormalizedContainerOptions", () => {
 		});
 	});
 
-	it("should default max_instances and rollout_step_percentage accordingly", async () => {
+	it("should default max_instances and rollout_step_percentage accordingly", async ({
+		expect,
+	}) => {
 		writeFileSync("Dockerfile", "FROM scratch");
 
 		const config: Config = {
@@ -237,7 +250,7 @@ describe("getNormalizedContainerOptions", () => {
 		});
 	});
 
-	it("should handle custom limit configuration", async () => {
+	it("should handle custom limit configuration", async ({ expect }) => {
 		// deprecated path for setting custom limits
 		const config: Config = {
 			name: "test-worker",
@@ -285,7 +298,9 @@ describe("getNormalizedContainerOptions", () => {
 		});
 	});
 
-	it("should handle custom limit configuration through instance_type", async () => {
+	it("should handle custom limit configuration through instance_type", async ({
+		expect,
+	}) => {
 		// updated path for setting custom limits
 		const config: Config = {
 			name: "test-worker",
@@ -333,7 +348,9 @@ describe("getNormalizedContainerOptions", () => {
 		});
 	});
 
-	it("should normalize and set defaults for custom limits to dev instance type", async () => {
+	it("should normalize and set defaults for custom limits to dev instance type", async ({
+		expect,
+	}) => {
 		const config: Config = {
 			name: "test-worker",
 			configPath: "/test/wrangler.toml",
@@ -378,7 +395,7 @@ describe("getNormalizedContainerOptions", () => {
 		});
 	});
 
-	it("should handle instance type configuration", async () => {
+	it("should handle instance type configuration", async ({ expect }) => {
 		const config: Config = {
 			name: "test-worker",
 			configPath: "/test/wrangler.toml",
@@ -419,7 +436,7 @@ describe("getNormalizedContainerOptions", () => {
 		});
 	});
 
-	it("should handle all custom configuration options", async () => {
+	it("should handle all custom configuration options", async ({ expect }) => {
 		const config: Config = {
 			name: "test-worker",
 			configPath: "/test/wrangler.toml",
@@ -486,7 +503,9 @@ describe("getNormalizedContainerOptions", () => {
 		});
 	});
 
-	it("should handle dockerfile with default build context", async () => {
+	it("should handle dockerfile with default build context", async ({
+		expect,
+	}) => {
 		mkdirSync("nested", { recursive: true });
 		writeFileSync("nested/Dockerfile", "FROM scratch");
 
@@ -533,7 +552,7 @@ describe("getNormalizedContainerOptions", () => {
 		});
 	});
 
-	it("should handle multiple containers", async () => {
+	it("should handle multiple containers", async ({ expect }) => {
 		const config: Config = {
 			name: "test-worker",
 			configPath: "/test/wrangler.toml",
@@ -575,7 +594,7 @@ describe("getNormalizedContainerOptions", () => {
 		expect(result[1].class_name).toBe("Container2");
 	});
 
-	it("should handle config with no configPath", async () => {
+	it("should handle config with no configPath", async ({ expect }) => {
 		writeFileSync("Dockerfile", "FROM scratch");
 		const config: Config = {
 			name: "test-worker",
@@ -608,7 +627,7 @@ describe("getNormalizedContainerOptions", () => {
 		expect(result[0]).not.toHaveProperty("image_uri");
 	});
 
-	it("should be able to specify all tiers", async () => {
+	it("should be able to specify all tiers", async ({ expect }) => {
 		writeFileSync("Dockerfile", "FROM scratch");
 		const config: Config = {
 			name: "test-worker",
@@ -638,7 +657,7 @@ describe("getNormalizedContainerOptions", () => {
 		expect(result[0].constraints.tiers).toBeUndefined();
 	});
 
-	it("should convert deprecated tier to tiers array", async () => {
+	it("should convert deprecated tier to tiers array", async ({ expect }) => {
 		const config: Config = {
 			name: "test-worker",
 			containers: [
@@ -667,7 +686,9 @@ describe("getNormalizedContainerOptions", () => {
 		expect(result[0].constraints.tiers).toEqual([3]);
 	});
 
-	it("should default rollout_step_percentage to 100 when max_instances is 1", async () => {
+	it("should default rollout_step_percentage to 100 when max_instances is 1", async ({
+		expect,
+	}) => {
 		const config: Config = {
 			name: "test-worker",
 			configPath: "/test/wrangler.toml",
@@ -698,7 +719,7 @@ describe("getNormalizedContainerOptions", () => {
 	});
 
 	describe("image validation and resolution", async () => {
-		it("should allow any image registry", async () => {
+		it("should allow any image registry", async ({ expect }) => {
 			const config: Config = {
 				name: "test-worker",
 				configPath: "/test/wrangler.toml",
@@ -729,7 +750,9 @@ describe("getNormalizedContainerOptions", () => {
 				image_uri: "unsupported.domain/test:latest",
 			});
 		});
-		it("should not try and add an account id to non containers registry uris", async () => {
+		it("should not try and add an account id to non containers registry uris", async ({
+			expect,
+		}) => {
 			const config: Config = {
 				name: "test-worker",
 				configPath: "/test/wrangler.toml",
@@ -761,7 +784,9 @@ describe("getNormalizedContainerOptions", () => {
 			});
 			vi.unstubAllEnvs();
 		});
-		it("should not try and add an account id during a dry run", async () => {
+		it("should not try and add an account id during a dry run", async ({
+			expect,
+		}) => {
 			const config: Config = {
 				name: "test-worker",
 				configPath: "/test/wrangler.toml",
@@ -796,7 +821,9 @@ describe("getNormalizedContainerOptions", () => {
 		});
 	});
 
-	it("should handle valid ssh and authorized_keys config", async () => {
+	it("should handle valid ssh and authorized_keys config", async ({
+		expect,
+	}) => {
 		const config: Config = {
 			name: "test-worker",
 			configPath: "/test/wrangler.toml",

--- a/packages/wrangler/src/__tests__/containers/images.test.ts
+++ b/packages/wrangler/src/__tests__/containers/images.test.ts
@@ -1,7 +1,6 @@
 import { getCloudflareContainerRegistry } from "@cloudflare/containers-shared";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, it } from "vitest";
 import { mockAccount, setWranglerConfig } from "../cloudchamber/utils";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -29,7 +28,7 @@ describe("containers images list", () => {
 		msw.resetHandlers();
 	});
 
-	it("should help", async () => {
+	it("should help", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		await runWrangler("containers images list --help");
@@ -53,7 +52,7 @@ describe("containers images list", () => {
 		`);
 	});
 
-	it("should list images", async () => {
+	it("should list images", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		const tags = {
@@ -92,7 +91,7 @@ describe("containers images list", () => {
 		`);
 	});
 
-	it("should list images with a filter", async () => {
+	it("should list images with a filter", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		const tags = {
@@ -126,7 +125,9 @@ describe("containers images list", () => {
 		`);
 	});
 
-	it("should list repos as valid json with json flag set", async () => {
+	it("should list repos as valid json with json flag set", async ({
+		expect,
+	}) => {
 		setWranglerConfig({});
 		const tags = {
 			one: ["hundred", "ten", "sha256:239a0dfhasdfui235"],
@@ -194,7 +195,7 @@ describe("containers images delete", () => {
 		msw.resetHandlers();
 	});
 
-	it("should help", async () => {
+	it("should help", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		await runWrangler("containers images delete --help");
@@ -217,7 +218,7 @@ describe("containers images delete", () => {
 		`);
 	});
 
-	it("should delete images", async () => {
+	it("should delete images", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 
@@ -262,7 +263,7 @@ describe("containers images delete", () => {
 		);
 	});
 
-	it("should error when provided a repo without a tag", async () => {
+	it("should error when provided a repo without a tag", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 

--- a/packages/wrangler/src/__tests__/containers/info.test.ts
+++ b/packages/wrangler/src/__tests__/containers/info.test.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import * as user from "../../user";
 import { mockAccount, setWranglerConfig } from "../cloudchamber/utils";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
@@ -23,7 +22,7 @@ describe("containers info", () => {
 		msw.resetHandlers();
 	});
 
-	it("should help", async () => {
+	it("should help", async ({ expect }) => {
 		await runWrangler("containers info --help");
 		expect(std.err).toMatchInlineSnapshot(`""`);
 		expect(std.out).toMatchInlineSnapshot(`
@@ -44,7 +43,7 @@ describe("containers info", () => {
 		`);
 	});
 
-	it("should show the correct authentication error", async () => {
+	it("should show the correct authentication error", async ({ expect }) => {
 		const spy = vi.spyOn(user, "getScopes");
 		spy.mockReset();
 		spy.mockImplementationOnce(() => []);
@@ -57,7 +56,9 @@ describe("containers info", () => {
 		);
 	});
 
-	it("should show a single container when given an ID (json)", async () => {
+	it("should show a single container when given an ID (json)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		msw.use(
@@ -108,7 +109,7 @@ describe("containers info", () => {
 		`);
 	});
 
-	it("should error when not given an ID", async () => {
+	it("should error when not given an ID", async ({ expect }) => {
 		await expect(
 			runWrangler("containers info")
 		).rejects.toThrowErrorMatchingInlineSnapshot(

--- a/packages/wrangler/src/__tests__/containers/instances.test.ts
+++ b/packages/wrangler/src/__tests__/containers/instances.test.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import * as user from "../../user";
 import { mockAccount, setWranglerConfig } from "../cloudchamber/utils";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
@@ -95,7 +94,7 @@ describe("containers instances", () => {
 		msw.resetHandlers();
 	});
 
-	it("should help", async () => {
+	it("should help", async ({ expect }) => {
 		await runWrangler("containers instances --help");
 		expect(std.err).toMatchInlineSnapshot(`""`);
 		expect(std.out).toMatchInlineSnapshot(`
@@ -120,7 +119,7 @@ describe("containers instances", () => {
 		`);
 	});
 
-	it("should show the correct authentication error", async () => {
+	it("should show the correct authentication error", async ({ expect }) => {
 		const spy = vi.spyOn(user, "getScopes");
 		spy.mockReset();
 		spy.mockImplementationOnce(() => []);
@@ -133,7 +132,7 @@ describe("containers instances", () => {
 		);
 	});
 
-	it("should render a table (non-TTY)", async () => {
+	it("should render a table (non-TTY)", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		msw.use(
@@ -165,7 +164,7 @@ describe("containers instances", () => {
 		`);
 	});
 
-	it("should render DO instance table (non-TTY)", async () => {
+	it("should render DO instance table (non-TTY)", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		msw.use(
@@ -195,7 +194,7 @@ describe("containers instances", () => {
 		`);
 	});
 
-	it("should reject --per-page 0", async () => {
+	it("should reject --per-page 0", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		await expect(
@@ -203,7 +202,7 @@ describe("containers instances", () => {
 		).rejects.toThrowError(/--per-page must be at least 1/);
 	});
 
-	it("should reject --per-page with negative value", async () => {
+	it("should reject --per-page with negative value", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		await expect(
@@ -211,7 +210,7 @@ describe("containers instances", () => {
 		).rejects.toThrowError(/--per-page must be at least 1/);
 	});
 
-	it("should error on invalid ID format", async () => {
+	it("should error on invalid ID format", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		await expect(
@@ -221,7 +220,7 @@ describe("containers instances", () => {
 		);
 	});
 
-	it("should error on missing ID", async () => {
+	it("should error on missing ID", async ({ expect }) => {
 		await expect(
 			runWrangler("containers instances")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -234,7 +233,7 @@ describe("containers instances", () => {
 		`);
 	});
 
-	it("should handle empty instance list", async () => {
+	it("should handle empty instance list", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		msw.use(
@@ -256,7 +255,9 @@ describe("containers instances", () => {
 		expect(std.out).toContain("No instances found");
 	});
 
-	it("should fetch all results in a single unpaginated request (non-TTY)", async () => {
+	it("should fetch all results in a single unpaginated request (non-TTY)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		let requestCount = 0;
@@ -288,7 +289,9 @@ describe("containers instances", () => {
 	});
 
 	describe("--json", () => {
-		it("should output flat JSON matching table columns for non-DO apps", async () => {
+		it("should output flat JSON matching table columns for non-DO apps", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 			setWranglerConfig({});
 			msw.use(
@@ -326,7 +329,7 @@ describe("containers instances", () => {
 			});
 		});
 
-		it("should include name field for DO-backed apps", async () => {
+		it("should include name field for DO-backed apps", async ({ expect }) => {
 			setIsTTY(false);
 			setWranglerConfig({});
 			msw.use(
@@ -367,7 +370,7 @@ describe("containers instances", () => {
 			});
 		});
 
-		it("should output empty array for no instances", async () => {
+		it("should output empty array for no instances", async ({ expect }) => {
 			setIsTTY(false);
 			setWranglerConfig({});
 			msw.use(
@@ -390,7 +393,9 @@ describe("containers instances", () => {
 			expect(output).toEqual([]);
 		});
 
-		it("should fetch all results in a single unpaginated request", async () => {
+		it("should fetch all results in a single unpaginated request", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 			setWranglerConfig({});
 			let requestCount = 0;

--- a/packages/wrangler/src/__tests__/containers/list.test.ts
+++ b/packages/wrangler/src/__tests__/containers/list.test.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import * as user from "../../user";
 import { mockAccount, setWranglerConfig } from "../cloudchamber/utils";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
@@ -40,7 +39,7 @@ describe("containers list", () => {
 		msw.resetHandlers();
 	});
 
-	it("should help", async () => {
+	it("should help", async ({ expect }) => {
 		await runWrangler("containers list --help");
 		expect(std.err).toMatchInlineSnapshot(`""`);
 		expect(std.out).toMatchInlineSnapshot(`
@@ -62,7 +61,7 @@ describe("containers list", () => {
 		`);
 	});
 
-	it("should reject --per-page 0", async () => {
+	it("should reject --per-page 0", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		await expect(
@@ -70,7 +69,7 @@ describe("containers list", () => {
 		).rejects.toThrowError(/--per-page must be at least 1/);
 	});
 
-	it("should reject --per-page with negative value", async () => {
+	it("should reject --per-page with negative value", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		await expect(
@@ -78,7 +77,7 @@ describe("containers list", () => {
 		).rejects.toThrowError(/--per-page must be at least 1/);
 	});
 
-	it("should show the correct authentication error", async () => {
+	it("should show the correct authentication error", async ({ expect }) => {
 		const spy = vi.spyOn(user, "getScopes");
 		spy.mockReset();
 		spy.mockImplementationOnce(() => []);
@@ -91,7 +90,7 @@ describe("containers list", () => {
 		);
 	});
 
-	it("should throw UserError on 400 API response", async () => {
+	it("should throw UserError on 400 API response", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		msw.use(
@@ -117,7 +116,7 @@ describe("containers list", () => {
 		);
 	});
 
-	it("should throw on 500 API response", async () => {
+	it("should throw on 500 API response", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		msw.use(
@@ -142,7 +141,7 @@ describe("containers list", () => {
 		);
 	});
 
-	it("should render a table (non-TTY)", async () => {
+	it("should render a table (non-TTY)", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		msw.use(
@@ -171,7 +170,7 @@ describe("containers list", () => {
 		`);
 	});
 
-	it("should handle empty results (non-TTY)", async () => {
+	it("should handle empty results (non-TTY)", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		msw.use(
@@ -188,7 +187,9 @@ describe("containers list", () => {
 		expect(std.out).toContain("No containers found.");
 	});
 
-	it("should fetch all results in a single unpaginated request (non-TTY)", async () => {
+	it("should fetch all results in a single unpaginated request (non-TTY)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		let requestCount = 0;
@@ -224,7 +225,9 @@ describe("containers list", () => {
 	});
 
 	describe("state derivation", () => {
-		it("should derive 'active' when active > 0 and no failures", async () => {
+		it("should derive 'active' when active > 0 and no failures", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 			setWranglerConfig({});
 			const app: DashApplication = {
@@ -251,7 +254,9 @@ describe("containers list", () => {
 			expect(output[0].state).toBe("active");
 		});
 
-		it("should derive 'degraded' when failed > 0 (even with active)", async () => {
+		it("should derive 'degraded' when failed > 0 (even with active)", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 			setWranglerConfig({});
 			const app: DashApplication = {
@@ -278,7 +283,7 @@ describe("containers list", () => {
 			expect(output[0].state).toBe("degraded");
 		});
 
-		it("should derive 'provisioning' when starting > 0", async () => {
+		it("should derive 'provisioning' when starting > 0", async ({ expect }) => {
 			setIsTTY(false);
 			setWranglerConfig({});
 			const app: DashApplication = {
@@ -305,7 +310,9 @@ describe("containers list", () => {
 			expect(output[0].state).toBe("provisioning");
 		});
 
-		it("should derive 'provisioning' when scheduling > 0", async () => {
+		it("should derive 'provisioning' when scheduling > 0", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 			setWranglerConfig({});
 			const app: DashApplication = {
@@ -332,7 +339,9 @@ describe("containers list", () => {
 			expect(output[0].state).toBe("provisioning");
 		});
 
-		it("should derive 'ready' when all counters are zero", async () => {
+		it("should derive 'ready' when all counters are zero", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 			setWranglerConfig({});
 			const app: DashApplication = {
@@ -361,7 +370,7 @@ describe("containers list", () => {
 	});
 
 	describe("--json", () => {
-		it("should output JSON matching expected schema", async () => {
+		it("should output JSON matching expected schema", async ({ expect }) => {
 			setIsTTY(false);
 			setWranglerConfig({});
 			msw.use(
@@ -390,7 +399,7 @@ describe("containers list", () => {
 			}
 		});
 
-		it("should output empty array for no containers", async () => {
+		it("should output empty array for no containers", async ({ expect }) => {
 			setIsTTY(false);
 			setWranglerConfig({});
 			msw.use(
@@ -405,7 +414,9 @@ describe("containers list", () => {
 			expect(output).toEqual([]);
 		});
 
-		it("should fetch all results in a single unpaginated request", async () => {
+		it("should fetch all results in a single unpaginated request", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 			setWranglerConfig({});
 			let requestCount = 0;
@@ -428,7 +439,9 @@ describe("containers list", () => {
 			expect(output).toHaveLength(4);
 		});
 
-		it("should throw JsonFriendlyFatalError on unexpected API error", async () => {
+		it("should throw JsonFriendlyFatalError on unexpected API error", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 			setWranglerConfig({});
 			msw.use(
@@ -453,7 +466,9 @@ describe("containers list", () => {
 			);
 		});
 
-		it("should let UserError propagate through on 400 API response", async () => {
+		it("should let UserError propagate through on 400 API response", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 			setWranglerConfig({});
 			msw.use(

--- a/packages/wrangler/src/__tests__/deployments.test.ts
+++ b/packages/wrangler/src/__tests__/deployments.test.ts
@@ -1,8 +1,7 @@
 import fs from "node:fs";
 import { thrownIsDoesNotExistError } from "@cloudflare/workers-shared";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
-// eslint-disable-next-line no-restricted-imports
-import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs } from "./helpers/mock-dialogs";
@@ -50,7 +49,9 @@ describe("deployments", () => {
 		}
 	});
 
-	it("should log a help message for deployments command", async () => {
+	it("should log a help message for deployments command", async ({
+		expect,
+	}) => {
 		await runWrangler("deployments --help");
 		expect(std.out).toMatchInlineSnapshot(`
 			"wrangler deployments
@@ -73,7 +74,7 @@ describe("deployments", () => {
 
 	describe("deployments subcommands", () => {
 		describe("deployment view", () => {
-			it("should error with no flag", async () => {
+			it("should error with no flag", async ({ expect }) => {
 				writeWranglerConfig();
 
 				await expect(

--- a/packages/wrangler/src/__tests__/friendly-validator-errors.test.ts
+++ b/packages/wrangler/src/__tests__/friendly-validator-errors.test.ts
@@ -1,8 +1,7 @@
 import { ParseError } from "@cloudflare/workers-utils";
 import { normalizeString } from "@cloudflare/workers-utils/test-helpers";
 import { FormData } from "undici";
-// eslint-disable-next-line no-restricted-imports
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, it, vi } from "vitest";
 import * as checkCommands from "../check/commands";
 import { logger } from "../logger";
 import { helpIfErrorIsSizeOrScriptStartup } from "../utils/friendly-validator-errors";
@@ -24,7 +23,9 @@ describe("helpIfErrorIsSizeOrScriptStartup", () => {
 		return () => (logger.loggerLevel = loggerLevel); // Restore original logger level after test
 	});
 
-	it("cleanly reports a startup error even if bundle analysis fails", async () => {
+	it("cleanly reports a startup error even if bundle analysis fails", async ({
+		expect,
+	}) => {
 		mockAnalyseBundle.mockRejectedValue(new Error("workerd profiling failed"));
 
 		expect(
@@ -56,7 +57,9 @@ describe("helpIfErrorIsSizeOrScriptStartup", () => {
 		`);
 	});
 
-	it("reports size errors even if bundle analysis would fail", async () => {
+	it("reports size errors even if bundle analysis would fail", async ({
+		expect,
+	}) => {
 		mockAnalyseBundle.mockRejectedValue(new Error("workerd profiling failed"));
 
 		expect(
@@ -89,7 +92,9 @@ describe("helpIfErrorIsSizeOrScriptStartup", () => {
 		`);
 	});
 
-	it("includes profile information when bundle analysis succeeds", async () => {
+	it("includes profile information when bundle analysis succeeds", async ({
+		expect,
+	}) => {
 		mockAnalyseBundle.mockResolvedValue({ nodes: [], samples: [] });
 
 		const message = await helpIfErrorIsSizeOrScriptStartup(

--- a/packages/wrangler/src/__tests__/get-entry.test.ts
+++ b/packages/wrangler/src/__tests__/get-entry.test.ts
@@ -2,8 +2,7 @@ import path from "node:path";
 import { defaultWranglerConfig } from "@cloudflare/workers-utils";
 import { seed } from "@cloudflare/workers-utils/test-helpers";
 import dedent from "ts-dedent";
-// eslint-disable-next-line no-restricted-imports
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import { getEntry } from "../deployment-bundle/entry";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";
@@ -29,7 +28,7 @@ describe("getEntry()", () => {
 	runInTempDir();
 	mockConsoleMethods();
 
-	it("--script index.ts", async () => {
+	it("--script index.ts", async ({ expect }) => {
 		await seed({
 			"index.ts": dedent /* javascript */ `
 							export default {
@@ -51,7 +50,7 @@ describe("getEntry()", () => {
 		});
 	});
 
-	it("--script src/index.ts", async () => {
+	it("--script src/index.ts", async ({ expect }) => {
 		await seed({
 			"src/index.ts": dedent /* javascript */ `
 							export default {
@@ -73,7 +72,7 @@ describe("getEntry()", () => {
 		});
 	});
 
-	it("main = index.ts", async () => {
+	it("main = index.ts", async ({ expect }) => {
 		await seed({
 			"index.ts": dedent /* javascript */ `
 							export default {
@@ -95,7 +94,7 @@ describe("getEntry()", () => {
 		});
 	});
 
-	it("main = src/index.ts", async () => {
+	it("main = src/index.ts", async ({ expect }) => {
 		await seed({
 			"src/index.ts": dedent /* javascript */ `
 							export default {
@@ -117,7 +116,7 @@ describe("getEntry()", () => {
 		});
 	});
 
-	it("main = src/index.ts w/ configPath", async () => {
+	it("main = src/index.ts w/ configPath", async ({ expect }) => {
 		await seed({
 			"other-worker/src/index.ts": dedent /* javascript */ `
 							export default {

--- a/packages/wrangler/src/__tests__/middleware.test.ts
+++ b/packages/wrangler/src/__tests__/middleware.test.ts
@@ -2,8 +2,7 @@ import * as fs from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import dedent from "ts-dedent";
-// eslint-disable-next-line no-restricted-imports
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, it, vi } from "vitest";
 import { startWorker } from "../api/startDevWorker";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";
@@ -36,7 +35,7 @@ describe("middleware", () => {
 		});
 
 		describe("module workers", () => {
-			it("should register a middleware and intercept", async () => {
+			it("should register a middleware and intercept", async ({ expect }) => {
 				const scriptContent = `
 			const middleware = async (request, env, _ctx, middlewareCtx) => {
 				const response = await middlewareCtx.next(request, env);
@@ -70,7 +69,9 @@ describe("middleware", () => {
 				await worker.dispose();
 			});
 
-			it("should be able to access scheduled workers from middleware", async () => {
+			it("should be able to access scheduled workers from middleware", async ({
+				expect,
+			}) => {
 				const scriptContent = `
 			const middleware = async (request, env, _ctx, middlewareCtx) => {
 				await middlewareCtx.dispatch("scheduled", { cron: "* * * * *" });
@@ -104,7 +105,9 @@ describe("middleware", () => {
 				await worker.dispose();
 			});
 
-			it("should trigger an error in a scheduled work from middleware", async () => {
+			it("should trigger an error in a scheduled work from middleware", async ({
+				expect,
+			}) => {
 				const scriptContent = `
 			const middleware = async (request, env, _ctx, middlewareCtx) => {
 				try {
@@ -143,7 +146,9 @@ describe("middleware", () => {
 		});
 
 		describe("service workers", () => {
-			it("should register a middleware and intercept using addMiddleware", async () => {
+			it("should register a middleware and intercept using addMiddleware", async ({
+				expect,
+			}) => {
 				const scriptContent = `
 			const middleware = async (request, env, _ctx, middlewareCtx) => {
 				const response = await middlewareCtx.next(request, env);
@@ -174,7 +179,9 @@ describe("middleware", () => {
 				await worker.dispose();
 			});
 
-			it("should register a middleware and intercept using addMiddlewareInternal", async () => {
+			it("should register a middleware and intercept using addMiddlewareInternal", async ({
+				expect,
+			}) => {
 				const scriptContent = `
 			const middleware = async (request, env, _ctx, middlewareCtx) => {
 				const response = await middlewareCtx.next(request, env);
@@ -205,7 +212,9 @@ describe("middleware", () => {
 				await worker.dispose();
 			});
 
-			it("should be able to access scheduled workers from middleware", async () => {
+			it("should be able to access scheduled workers from middleware", async ({
+				expect,
+			}) => {
 				const scriptContent = `
 			const middleware = async (request, env, _ctx, middlewareCtx) => {
 				await middlewareCtx.dispatch("scheduled", { cron: "* * * * *" });
@@ -236,7 +245,9 @@ describe("middleware", () => {
 				await worker.dispose();
 			});
 
-			it("should trigger an error in a scheduled work from middleware", async () => {
+			it("should trigger an error in a scheduled work from middleware", async ({
+				expect,
+			}) => {
 				const scriptContent = `
 				const middleware = async (request, env, _ctx, middlewareCtx) => {
 					try {
@@ -280,7 +291,9 @@ describe("middleware", () => {
 		});
 
 		describe("module workers", () => {
-			it("should return Hello World with no middleware export", async () => {
+			it("should return Hello World with no middleware export", async ({
+				expect,
+			}) => {
 				const scriptContent = `
 			export default {
 				fetch(request, env, ctx) {
@@ -306,7 +319,9 @@ describe("middleware", () => {
 				await worker.dispose();
 			});
 
-			it("should return hello world with empty middleware array", async () => {
+			it("should return hello world with empty middleware array", async ({
+				expect,
+			}) => {
 				const scriptContent = `
 			export const __INJECT_FOR_TESTING_WRANGLER_MIDDLEWARE__ = []
 
@@ -335,7 +350,9 @@ describe("middleware", () => {
 				await worker.dispose();
 			});
 
-			it("should return hello world passing through middleware", async () => {
+			it("should return hello world passing through middleware", async ({
+				expect,
+			}) => {
 				const scriptContent = `
 			const middleware = async (request, env, _ctx, middlewareCtx) => {
 				return middlewareCtx.next(request, env);
@@ -366,7 +383,9 @@ describe("middleware", () => {
 				await worker.dispose();
 			});
 
-			it("should return hello world with multiple middleware in array", async () => {
+			it("should return hello world with multiple middleware in array", async ({
+				expect,
+			}) => {
 				const scriptContent = `
 			const middleware = async (request, env, _ctx, middlewareCtx) => {
 				return middlewareCtx.next(request, env);
@@ -401,7 +420,9 @@ describe("middleware", () => {
 				await worker.dispose();
 			});
 
-			it("should leave response headers unchanged with middleware", async () => {
+			it("should leave response headers unchanged with middleware", async ({
+				expect,
+			}) => {
 				const scriptContent = `
 			const middleware = async (request, env, _ctx, middlewareCtx) => {
 				return middlewareCtx.next(request, env);
@@ -437,7 +458,7 @@ describe("middleware", () => {
 				await worker.dispose();
 			});
 
-			it("waitUntil should not block responses", async () => {
+			it("waitUntil should not block responses", async ({ expect }) => {
 				const scriptContent = `
 			const middleware = async (request, env, _ctx, middlewareCtx) => {
 				return middlewareCtx.next(request, env);
@@ -480,7 +501,9 @@ describe("middleware", () => {
 		});
 
 		describe("service workers", () => {
-			it("should return Hello World with no middleware export", async () => {
+			it("should return Hello World with no middleware export", async ({
+				expect,
+			}) => {
 				const scriptContent = `
 			addEventListener("fetch", (event) => {
 				event.respondWith(new Response("Hello world"));
@@ -504,7 +527,9 @@ describe("middleware", () => {
 				await worker.dispose();
 			});
 
-			it("should return hello world with empty middleware array", async () => {
+			it("should return hello world with empty middleware array", async ({
+				expect,
+			}) => {
 				const scriptContent = `
 			addMiddleware([]);
 			addEventListener("fetch", (event) => {
@@ -530,7 +555,9 @@ describe("middleware", () => {
 				await worker.dispose();
 			});
 
-			it("should return hello world passing through middleware", async () => {
+			it("should return hello world passing through middleware", async ({
+				expect,
+			}) => {
 				const scriptContent = `
 			const middleware = async (request, env, _ctx, middlewareCtx) => {
 				return middlewareCtx.next(request, env);
@@ -558,7 +585,9 @@ describe("middleware", () => {
 				await worker.dispose();
 			});
 
-			it("should return hello world with addMiddleware function called multiple times", async () => {
+			it("should return hello world with addMiddleware function called multiple times", async ({
+				expect,
+			}) => {
 				const scriptContent = `
 			const middleware = async (request, env, _ctx, middlewareCtx) => {
 				return middlewareCtx.next(request, env);
@@ -591,7 +620,9 @@ describe("middleware", () => {
 				await worker.dispose();
 			});
 
-			it("should return hello world with addMiddleware function called with array of middleware", async () => {
+			it("should return hello world with addMiddleware function called with array of middleware", async ({
+				expect,
+			}) => {
 				const scriptContent = `
 			const middleware = async (request, env, _ctx, middlewareCtx) => {
 				return middlewareCtx.next(request, env);
@@ -623,7 +654,9 @@ describe("middleware", () => {
 				await worker.dispose();
 			});
 
-			it("should return hello world with addMiddlewareInternal function called multiple times", async () => {
+			it("should return hello world with addMiddlewareInternal function called multiple times", async ({
+				expect,
+			}) => {
 				const scriptContent = `
 			const middleware = async (request, env, _ctx, middlewareCtx) => {
 				return middlewareCtx.next(request, env);
@@ -656,7 +689,9 @@ describe("middleware", () => {
 				await worker.dispose();
 			});
 
-			it("should return hello world with addMiddlewareInternal function called with array of middleware", async () => {
+			it("should return hello world with addMiddlewareInternal function called with array of middleware", async ({
+				expect,
+			}) => {
 				const scriptContent = `
 			const middleware = async (request, env, _ctx, middlewareCtx) => {
 				return middlewareCtx.next(request, env);
@@ -688,7 +723,9 @@ describe("middleware", () => {
 				await worker.dispose();
 			});
 
-			it("should return hello world with both addMiddleware and addMiddlewareInternal called", async () => {
+			it("should return hello world with both addMiddleware and addMiddlewareInternal called", async ({
+				expect,
+			}) => {
 				const scriptContent = `
 			const middleware = async (request, env, _ctx, middlewareCtx) => {
 				return middlewareCtx.next(request, env);
@@ -721,7 +758,9 @@ describe("middleware", () => {
 				await worker.dispose();
 			});
 
-			it("should leave response headers unchanged with middleware", async () => {
+			it("should leave response headers unchanged with middleware", async ({
+				expect,
+			}) => {
 				const scriptContent = `
 			const middleware = async (request, env, _ctx, middlewareCtx) => {
 				return middlewareCtx.next(request, env);
@@ -753,7 +792,9 @@ describe("middleware", () => {
 				await worker.dispose();
 			});
 
-			it("should allow multiple addEventListeners for fetch", async () => {
+			it("should allow multiple addEventListeners for fetch", async ({
+				expect,
+			}) => {
 				const scriptContent = `
 			let count = 0;
 			addEventListener("fetch", (event) => {
@@ -782,7 +823,7 @@ describe("middleware", () => {
 				await worker.dispose();
 			});
 
-			it("waitUntil should not block responses", async () => {
+			it("waitUntil should not block responses", async ({ expect }) => {
 				const scriptContent = `
 			addEventListener("fetch", (event) => {
 				let count = 0;
@@ -824,7 +865,7 @@ describe("middleware", () => {
 			vi.stubEnv("EXPERIMENTAL_MIDDLEWARE", "true");
 		});
 
-		it("should build multiple middleware as expected", async () => {
+		it("should build multiple middleware as expected", async ({ expect }) => {
 			await seedFs({
 				"src/index.js": dedent /* javascript */ `
 				export default {
@@ -1036,7 +1077,9 @@ describe("middleware", () => {
 				//# sourceMappingURL=index.js.map"
 			`);
 		});
-		it("should respond correctly with D1 databases, scheduled testing, and formatted dev errors", async () => {
+		it("should respond correctly with D1 databases, scheduled testing, and formatted dev errors", async ({
+			expect,
+		}) => {
 			// Kitchen sink test to check interaction between multiple middlewares
 			const scriptContent = `
 			export default {

--- a/packages/wrangler/src/__tests__/package-manager.test.ts
+++ b/packages/wrangler/src/__tests__/package-manager.test.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { getPackageManager, getPackageManagerName } from "../package-manager";
 import { mockBinary } from "./helpers/mock-bin";
 import { mockConsoleMethods } from "./helpers/mock-console";
@@ -102,7 +101,7 @@ describe("getPackageManager()", () => {
 		mockPnpm(false);
 		mockBun(false);
 
-		it("should throw an error", async () => {
+		it("should throw an error", async ({ expect }) => {
 			await expect(() =>
 				getPackageManager()
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -118,7 +117,9 @@ describe("getPackageManager()", () => {
 			mockPnpm(pnpm);
 			mockBun(bun);
 
-			it(`should return the ${expectedPackageManager} package manager`, async () => {
+			it(`should return the ${expectedPackageManager} package manager`, async ({
+				expect,
+			}) => {
 				const actualPackageManager = await getPackageManager();
 				expect(getPackageManagerName(actualPackageManager)).toEqual(
 					expectedPackageManager

--- a/packages/wrangler/src/__tests__/r2/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/r2/bulk.test.ts
@@ -1,8 +1,7 @@
 import fs from "node:fs";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, it } from "vitest";
 import { MAX_UPLOAD_SIZE_BYTES } from "../../r2/constants";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
@@ -19,7 +18,9 @@ describe("r2", () => {
 	runInTempDir();
 
 	describe("bulk", () => {
-		it("should show help when the bulk command is passed", async () => {
+		it("should show help when the bulk command is passed", async ({
+			expect,
+		}) => {
 			await runWrangler("r2 bulk");
 			await endEventLoop();
 			expect(std.out).toMatchInlineSnapshot(`
@@ -40,7 +41,7 @@ describe("r2", () => {
 			mockAccountId();
 			mockApiToken();
 
-			it("should bulk upload R2 objects to bucket", async () => {
+			it("should bulk upload R2 objects to bucket", async ({ expect }) => {
 				fs.writeFileSync("wormhole-img.png", "passageway");
 				fs.writeFileSync("nebula-img.png", "cosmos");
 				fs.writeFileSync(
@@ -68,7 +69,9 @@ describe("r2", () => {
 				`);
 			});
 
-			it("should bulk upload R2 with storage class to bucket", async () => {
+			it("should bulk upload R2 with storage class to bucket", async ({
+				expect,
+			}) => {
 				fs.writeFileSync("wormhole-img.png", "passageway");
 				fs.writeFileSync("nebula-img.png", "cosmos");
 				fs.writeFileSync(
@@ -95,7 +98,9 @@ describe("r2", () => {
 				`);
 			});
 
-			it("should fail to bulk upload R2 objects if the list doesn't exist", async () => {
+			it("should fail to bulk upload R2 objects if the list doesn't exist", async ({
+				expect,
+			}) => {
 				await expect(
 					runWrangler(
 						`r2 bulk put bulk-bucket --filename no-list.json --remote`
@@ -105,7 +110,9 @@ describe("r2", () => {
 				);
 			});
 
-			it("should fail to bulk upload R2 objects if the list format is invalid", async () => {
+			it("should fail to bulk upload R2 objects if the list format is invalid", async ({
+				expect,
+			}) => {
 				fs.writeFileSync("bad-list.json", "[ invalid json }");
 				await expect(
 					runWrangler(
@@ -116,7 +123,9 @@ describe("r2", () => {
 				);
 			});
 
-			it("should fail to bulk upload R2 objects if the list contain invalid entries", async () => {
+			it("should fail to bulk upload R2 objects if the list contain invalid entries", async ({
+				expect,
+			}) => {
 				fs.writeFileSync(
 					"bad-list.json",
 					JSON.stringify([{ key: 123, file: [] }])
@@ -130,7 +139,9 @@ describe("r2", () => {
 				);
 			});
 
-			it("should fail to bulk upload R2 objects if the list contain a non existent file", async () => {
+			it("should fail to bulk upload R2 objects if the list contain a non existent file", async ({
+				expect,
+			}) => {
 				fs.writeFileSync(
 					"bad-list.json",
 					JSON.stringify([{ key: "key", file: "not/a/file" }])
@@ -148,7 +159,7 @@ describe("r2", () => {
 				"should fail to bulk upload R2 objects if too large",
 				// Writing a large file could timeout on CI
 				{ timeout: 30_000 },
-				async () => {
+				async ({ expect }) => {
 					const TOO_BIG_FILE_SIZE = MAX_UPLOAD_SIZE_BYTES + 1024 * 1024;
 					await createBigFile("big-img.png", TOO_BIG_FILE_SIZE);
 					fs.writeFileSync(
@@ -165,7 +176,9 @@ describe("r2", () => {
 				}
 			);
 
-			it("should fail to bulk upload R2 objects if the name is invalid", async () => {
+			it("should fail to bulk upload R2 objects if the name is invalid", async ({
+				expect,
+			}) => {
 				fs.writeFileSync("wormhole-img.png", "passageway");
 				fs.writeFileSync("nebula-img.png", "cosmos");
 				fs.writeFileSync(
@@ -183,7 +196,9 @@ describe("r2", () => {
 				);
 			});
 
-			it("should pass all fetch option flags into requestInit & check request inputs", async () => {
+			it("should pass all fetch option flags into requestInit & check request inputs", async ({
+				expect,
+			}) => {
 				msw.use(
 					http.put(
 						"*/accounts/:accountId/r2/buckets/bulk-bucket/objects/:objectName",
@@ -247,7 +262,9 @@ describe("r2", () => {
 				`);
 			});
 
-			it("should allow --env and --expires to be used together without conflict", async () => {
+			it("should allow --env and --expires to be used together without conflict", async ({
+				expect,
+			}) => {
 				fs.writeFileSync("wormhole-img.png", "passageway");
 				fs.writeFileSync("nebula-img.png", "cosmos");
 				fs.writeFileSync(

--- a/packages/wrangler/src/__tests__/r2/local-uploads.test.ts
+++ b/packages/wrangler/src/__tests__/r2/local-uploads.test.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -18,7 +17,9 @@ describe("r2 bucket local-uploads", () => {
 	mockApiToken();
 
 	describe("help", () => {
-		it("should show help when the local-uploads command is passed", async () => {
+		it("should show help when the local-uploads command is passed", async ({
+			expect,
+		}) => {
 			await runWrangler("r2 bucket local-uploads");
 			await endEventLoop();
 			expect(std.out).toMatchInlineSnapshot(`
@@ -43,7 +44,9 @@ describe("r2 bucket local-uploads", () => {
 	});
 
 	describe("get", () => {
-		it("should display enabled status when local uploads is enabled", async () => {
+		it("should display enabled status when local uploads is enabled", async ({
+			expect,
+		}) => {
 			msw.use(
 				http.get(
 					"*/accounts/:accountId/r2/buckets/:bucketName/local-uploads",
@@ -67,7 +70,9 @@ describe("r2 bucket local-uploads", () => {
 			`);
 		});
 
-		it("should display disabled status when local uploads is disabled", async () => {
+		it("should display disabled status when local uploads is disabled", async ({
+			expect,
+		}) => {
 			msw.use(
 				http.get(
 					"*/accounts/:accountId/r2/buckets/:bucketName/local-uploads",
@@ -91,7 +96,7 @@ describe("r2 bucket local-uploads", () => {
 			`);
 		});
 
-		it("should error if bucket name is not provided", async () => {
+		it("should error if bucket name is not provided", async ({ expect }) => {
 			await expect(() =>
 				runWrangler("r2 bucket local-uploads get")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -103,7 +108,7 @@ describe("r2 bucket local-uploads", () => {
 	describe("enable", () => {
 		const { setIsTTY } = useMockIsTTY();
 
-		it("should enable local uploads with confirmation", async () => {
+		it("should enable local uploads with confirmation", async ({ expect }) => {
 			setIsTTY(true);
 			mockConfirm({
 				text: `Are you sure you want to enable local uploads for bucket 'my-bucket'? Object data will be written to the nearest region first, then asynchronously replicated to the bucket's primary region.`,
@@ -136,7 +141,9 @@ describe("r2 bucket local-uploads", () => {
 			`);
 		});
 
-		it("should enable local uploads with --force flag without confirmation", async () => {
+		it("should enable local uploads with --force flag without confirmation", async ({
+			expect,
+		}) => {
 			msw.use(
 				http.put(
 					"*/accounts/:accountId/r2/buckets/:bucketName/local-uploads",
@@ -163,7 +170,9 @@ describe("r2 bucket local-uploads", () => {
 			`);
 		});
 
-		it("should enable local uploads with -y flag without confirmation", async () => {
+		it("should enable local uploads with -y flag without confirmation", async ({
+			expect,
+		}) => {
 			msw.use(
 				http.put(
 					"*/accounts/:accountId/r2/buckets/:bucketName/local-uploads",
@@ -190,7 +199,9 @@ describe("r2 bucket local-uploads", () => {
 			`);
 		});
 
-		it("should cancel enable when confirmation is declined", async () => {
+		it("should cancel enable when confirmation is declined", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 			mockConfirm({
 				text: `Are you sure you want to enable local uploads for bucket 'my-bucket'? Object data will be written to the nearest region first, then asynchronously replicated to the bucket's primary region.`,
@@ -207,7 +218,7 @@ describe("r2 bucket local-uploads", () => {
 			`);
 		});
 
-		it("should error if bucket name is not provided", async () => {
+		it("should error if bucket name is not provided", async ({ expect }) => {
 			await expect(() =>
 				runWrangler("r2 bucket local-uploads enable")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -219,7 +230,7 @@ describe("r2 bucket local-uploads", () => {
 	describe("disable", () => {
 		const { setIsTTY } = useMockIsTTY();
 
-		it("should disable local uploads with confirmation", async () => {
+		it("should disable local uploads with confirmation", async ({ expect }) => {
 			setIsTTY(true);
 			mockConfirm({
 				text: `Are you sure you want to disable local uploads for bucket 'my-bucket'? Object data will be written directly to the bucket's primary region.`,
@@ -252,7 +263,9 @@ describe("r2 bucket local-uploads", () => {
 			`);
 		});
 
-		it("should disable local uploads with --force flag without confirmation", async () => {
+		it("should disable local uploads with --force flag without confirmation", async ({
+			expect,
+		}) => {
 			msw.use(
 				http.put(
 					"*/accounts/:accountId/r2/buckets/:bucketName/local-uploads",
@@ -279,7 +292,9 @@ describe("r2 bucket local-uploads", () => {
 			`);
 		});
 
-		it("should disable local uploads with -y flag without confirmation", async () => {
+		it("should disable local uploads with -y flag without confirmation", async ({
+			expect,
+		}) => {
 			msw.use(
 				http.put(
 					"*/accounts/:accountId/r2/buckets/:bucketName/local-uploads",
@@ -306,7 +321,9 @@ describe("r2 bucket local-uploads", () => {
 			`);
 		});
 
-		it("should cancel disable when confirmation is declined", async () => {
+		it("should cancel disable when confirmation is declined", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 			mockConfirm({
 				text: `Are you sure you want to disable local uploads for bucket 'my-bucket'? Object data will be written directly to the bucket's primary region.`,
@@ -323,7 +340,7 @@ describe("r2 bucket local-uploads", () => {
 			`);
 		});
 
-		it("should error if bucket name is not provided", async () => {
+		it("should error if bucket name is not provided", async ({ expect }) => {
 			await expect(() =>
 				runWrangler("r2 bucket local-uploads disable")
 			).rejects.toThrowErrorMatchingInlineSnapshot(

--- a/packages/wrangler/src/__tests__/r2/object.test.ts
+++ b/packages/wrangler/src/__tests__/r2/object.test.ts
@@ -1,8 +1,7 @@
 import * as fs from "node:fs";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, it } from "vitest";
 import { MAX_UPLOAD_SIZE_BYTES } from "../../r2/constants";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
@@ -19,7 +18,9 @@ describe("r2", () => {
 	runInTempDir();
 
 	describe("object", () => {
-		it("should show help when the object command is passed", async () => {
+		it("should show help when the object command is passed", async ({
+			expect,
+		}) => {
 			await runWrangler("r2 object");
 			await endEventLoop();
 			expect(std.out).toMatchInlineSnapshot(`
@@ -46,7 +47,7 @@ describe("r2", () => {
 			mockAccountId();
 			mockApiToken();
 
-			it("should download R2 object from bucket", async () => {
+			it("should download R2 object from bucket", async ({ expect }) => {
 				await runWrangler(
 					`r2 object get --remote bucket-object-test/wormhole-img.png --file ./wormhole-img.png`
 				);
@@ -62,7 +63,9 @@ describe("r2", () => {
 				`);
 			});
 
-			it("should download R2 object from bucket into directory", async () => {
+			it("should download R2 object from bucket into directory", async ({
+				expect,
+			}) => {
 				await runWrangler(
 					`r2 object get --remote bucket-object-test/wormhole-img.png --file ./a/b/c/wormhole-img.png`
 				);
@@ -71,7 +74,7 @@ describe("r2", () => {
 				);
 			});
 
-			it("should upload R2 object to bucket", async () => {
+			it("should upload R2 object to bucket", async ({ expect }) => {
 				fs.writeFileSync("wormhole-img.png", "passageway");
 				await runWrangler(
 					`r2 object put --remote bucket-object-test/wormhole-img.png --file ./wormhole-img.png`
@@ -88,7 +91,9 @@ describe("r2", () => {
 				`);
 			});
 
-			it("should upload R2 object with storage class to bucket", async () => {
+			it("should upload R2 object with storage class to bucket", async ({
+				expect,
+			}) => {
 				fs.writeFileSync("wormhole-img.png", "passageway");
 				await runWrangler(
 					`r2 object put --remote bucket-object-test/wormhole-img.png --file ./wormhole-img.png -s InfrequentAccess`
@@ -109,7 +114,7 @@ describe("r2", () => {
 				"should fail to upload R2 object to bucket if too large",
 				// Writing a large file could timeout on CI
 				{ timeout: 30_000 },
-				async () => {
+				async ({ expect }) => {
 					const TOO_BIG_FILE_SIZE = MAX_UPLOAD_SIZE_BYTES + 1024 * 1024;
 					await createBigFile("wormhole-img.png", TOO_BIG_FILE_SIZE);
 					await expect(
@@ -123,7 +128,9 @@ describe("r2", () => {
 				}
 			);
 
-			it("should fail to upload R2 object to bucket if the name is invalid", async () => {
+			it("should fail to upload R2 object to bucket if the name is invalid", async ({
+				expect,
+			}) => {
 				fs.writeFileSync("wormhole-img.png", "passageway");
 				await expect(
 					runWrangler(
@@ -134,7 +141,9 @@ describe("r2", () => {
 				);
 			});
 
-			it("should pass all fetch option flags into requestInit & check request inputs", async () => {
+			it("should pass all fetch option flags into requestInit & check request inputs", async ({
+				expect,
+			}) => {
 				msw.use(
 					http.put(
 						"*/accounts/:accountId/r2/buckets/:bucketName/objects/:objectName",
@@ -191,7 +200,7 @@ describe("r2", () => {
 				`);
 			});
 
-			it("should delete R2 object from bucket", async () => {
+			it("should delete R2 object from bucket", async ({ expect }) => {
 				await runWrangler(
 					`r2 object delete --remote bucket-object-test/wormhole-img.png`
 				);
@@ -207,7 +216,9 @@ describe("r2", () => {
 				`);
 			});
 
-			it("should not allow `--pipe` & `--file` to run together", async () => {
+			it("should not allow `--pipe` & `--file` to run together", async ({
+				expect,
+			}) => {
 				fs.writeFileSync("wormhole-img.png", "passageway");
 				await expect(
 					runWrangler(
@@ -224,7 +235,9 @@ describe("r2", () => {
 		`);
 			});
 
-			it("should allow --env and --expires to be used together without conflict", async () => {
+			it("should allow --env and --expires to be used together without conflict", async ({
+				expect,
+			}) => {
 				writeWranglerConfig({
 					env: {
 						production: {},

--- a/packages/wrangler/src/__tests__/r2/sql.test.ts
+++ b/packages/wrangler/src/__tests__/r2/sql.test.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, it, vi } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -15,7 +14,7 @@ describe("r2 sql", () => {
 	runInTempDir();
 
 	describe("help", () => {
-		it("should show help when no subcommand is passed", async () => {
+		it("should show help when no subcommand is passed", async ({ expect }) => {
 			await runWrangler("r2 sql");
 			await endEventLoop();
 			expect(std.out).toContain("wrangler r2 sql");
@@ -23,7 +22,7 @@ describe("r2 sql", () => {
 			expect(std.out).toContain("wrangler r2 sql query <warehouse> <query>");
 		});
 
-		it("should show help for query command", async () => {
+		it("should show help for query command", async ({ expect }) => {
 			await runWrangler("r2 sql query --help");
 			await endEventLoop();
 			expect(std.out).toContain("Execute SQL query against R2 Data Catalog");
@@ -43,7 +42,7 @@ describe("r2 sql", () => {
 			vi.stubEnv("WRANGLER_R2_SQL_AUTH_TOKEN", mockToken);
 		});
 
-		it("should require warehouse and query arguments", async () => {
+		it("should require warehouse and query arguments", async ({ expect }) => {
 			await expect(runWrangler("r2 sql query")).rejects.toThrow(
 				"Not enough non-option arguments: got 0, need at least 2"
 			);
@@ -53,7 +52,9 @@ describe("r2 sql", () => {
 			);
 		});
 
-		it("should require WRANGLER_R2_SQL_AUTH_TOKEN environment variable", async () => {
+		it("should require WRANGLER_R2_SQL_AUTH_TOKEN environment variable", async ({
+			expect,
+		}) => {
 			// Use delete directly because vi.stubEnv(name, undefined) doesn't
 			// propagate through Vitest 4's env proxy deleteProperty handler.
 			delete process.env.WRANGLER_R2_SQL_AUTH_TOKEN;
@@ -66,13 +67,15 @@ describe("r2 sql", () => {
 			);
 		});
 
-		it("should validate warehouse name format", async () => {
+		it("should validate warehouse name format", async ({ expect }) => {
 			await expect(
 				runWrangler(`r2 sql query invalidwarehouse "${mockQuery}"`)
 			).rejects.toThrow("Warehouse name has invalid format");
 		});
 
-		it("should execute a successful query and display results", async () => {
+		it("should execute a successful query and display results", async ({
+			expect,
+		}) => {
 			const mockResponse = {
 				success: true,
 				errors: [],
@@ -133,7 +136,7 @@ describe("r2 sql", () => {
 			// Not checking MB/s speed as it depends on timing.
 		});
 
-		it("should handle queries with no results", async () => {
+		it("should handle queries with no results", async ({ expect }) => {
 			const mockResponse = {
 				success: true,
 				errors: [],
@@ -163,7 +166,7 @@ describe("r2 sql", () => {
 			expect(std.out).toContain("Query executed successfully with no results");
 		});
 
-		it("should handle query failures", async () => {
+		it("should handle query failures", async ({ expect }) => {
 			const mockResponse = {
 				success: false,
 				errors: [
@@ -192,7 +195,7 @@ describe("r2 sql", () => {
 			expect(std.err).toContain("1002: Table not found");
 		});
 
-		it("should handle API connection errors", async () => {
+		it("should handle API connection errors", async ({ expect }) => {
 			msw.use(
 				http.post(
 					"https://api.sql.cloudflarestorage.com/api/v1/accounts/:accountId/r2-sql/query/:bucketName",
@@ -208,7 +211,7 @@ describe("r2 sql", () => {
 			).rejects.toThrow("Failed to connect to R2 SQL API");
 		});
 
-		it("should handle invalid JSON responses", async () => {
+		it("should handle invalid JSON responses", async ({ expect }) => {
 			msw.use(
 				http.post(
 					"https://api.sql.cloudflarestorage.com/api/v1/accounts/:accountId/r2-sql/query/:bucketName",
@@ -224,7 +227,9 @@ describe("r2 sql", () => {
 			).rejects.toThrow("Received a malformed response from the API");
 		});
 
-		it("should handle nested objects (as JSON with null converted to '') in query results", async () => {
+		it("should handle nested objects (as JSON with null converted to '') in query results", async ({
+			expect,
+		}) => {
 			const mockResponse = {
 				success: true,
 				errors: [],
@@ -301,7 +306,7 @@ describe("r2 sql", () => {
 			`);
 		});
 
-		it("should handle null values in query results", async () => {
+		it("should handle null values in query results", async ({ expect }) => {
 			const mockResponse = {
 				success: true,
 				errors: [],

--- a/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
+++ b/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, it } from "vitest";
 import { validateQueryFilter } from "../../vectorize/query";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
@@ -16,7 +15,7 @@ describe("vectorize help", () => {
 	const std = mockConsoleMethods();
 	runInTempDir();
 
-	it("should show help when no argument is passed", async () => {
+	it("should show help when no argument is passed", async ({ expect }) => {
 		await runWrangler("vectorize");
 		await endEventLoop();
 
@@ -51,7 +50,9 @@ describe("vectorize help", () => {
 		`);
 	});
 
-	it("should show help when an invalid argument is passed", async () => {
+	it("should show help when an invalid argument is passed", async ({
+		expect,
+	}) => {
 		await expect(() => runWrangler("vectorize foobarfofum")).rejects.toThrow(
 			"Unknown argument: foobarfofum"
 		);
@@ -93,7 +94,9 @@ describe("vectorize help", () => {
 		`);
 	});
 
-	it("should show help when the get command is passed without an index", async () => {
+	it("should show help when the get command is passed without an index", async ({
+		expect,
+	}) => {
 		await expect(() => runWrangler("vectorize get")).rejects.toThrow(
 			"Not enough non-option arguments: got 0, need at least 1"
 		);
@@ -126,7 +129,9 @@ describe("vectorize help", () => {
 		`);
 	});
 
-	it("should show help when the query command is passed without an argument", async () => {
+	it("should show help when the query command is passed without an argument", async ({
+		expect,
+	}) => {
 		await expect(() => runWrangler("vectorize query")).rejects.toThrow(
 			"Not enough non-option arguments: got 0, need at least 1"
 		);
@@ -191,7 +196,7 @@ describe("vectorize commands", () => {
 		clearDialogs();
 	});
 
-	it("should handle creating a vectorize V1 index", async () => {
+	it("should handle creating a vectorize V1 index", async ({ expect }) => {
 		mockVectorizeRequest();
 		await runWrangler(
 			"vectorize create some-index --dimensions=768 --metric=cosine --deprecated-v1=true"
@@ -219,7 +224,7 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should handle creating a vectorize index", async () => {
+	it("should handle creating a vectorize index", async ({ expect }) => {
 		mockVectorizeV2Request();
 		await runWrangler(
 			"vectorize create test-index --dimensions=1536 --metric=euclidean"
@@ -242,7 +247,9 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should handle creating a vectorize index with preset", async () => {
+	it("should handle creating a vectorize index with preset", async ({
+		expect,
+	}) => {
 		mockVectorizeV2Request();
 		await runWrangler(
 			"vectorize create test-index --preset=openai/text-embedding-ada-002"
@@ -266,7 +273,7 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should fail index creation with invalid metric", async () => {
+	it("should fail index creation with invalid metric", async ({ expect }) => {
 		mockVectorizeV2Request();
 
 		await expect(() =>
@@ -287,7 +294,7 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should fail index creation with invalid preset", async () => {
+	it("should fail index creation with invalid preset", async ({ expect }) => {
 		mockVectorizeV2Request();
 
 		await expect(() =>
@@ -310,7 +317,7 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should fail index creation with invalid config", async () => {
+	it("should fail index creation with invalid config", async ({ expect }) => {
 		mockVectorizeV2Request();
 
 		await expect(
@@ -320,7 +327,7 @@ describe("vectorize commands", () => {
 		);
 	});
 
-	it("should handle listing vectorize V1 indexes", async () => {
+	it("should handle listing vectorize V1 indexes", async ({ expect }) => {
 		mockVectorizeRequest();
 		await runWrangler("vectorize list --deprecated-v1=true");
 		expect(std.out).toMatchInlineSnapshot(`
@@ -338,7 +345,7 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should handle listing vectorize indexes", async () => {
+	it("should handle listing vectorize indexes", async ({ expect }) => {
 		mockVectorizeV2Request();
 		await runWrangler("vectorize list");
 		expect(std.out).toMatchInlineSnapshot(`
@@ -356,7 +363,7 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should warn when there are no vectorize indexes", async () => {
+	it("should warn when there are no vectorize indexes", async ({ expect }) => {
 		mockVectorizeV2RequestError();
 		await runWrangler("vectorize list");
 		expect(std.out).toMatchInlineSnapshot(`
@@ -379,7 +386,9 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should return empty array JSON when there are no vectorize indexes with --json flag", async () => {
+	it("should return empty array JSON when there are no vectorize indexes with --json flag", async ({
+		expect,
+	}) => {
 		mockVectorizeV2RequestError();
 		await runWrangler("vectorize list --json");
 		expect(JSON.parse(std.out)).toMatchInlineSnapshot(`[]`);
@@ -387,7 +396,9 @@ describe("vectorize commands", () => {
 		expect(std.err).toBe("");
 	});
 
-	it("should handle listing vectorize indexes with valid JSON output", async () => {
+	it("should handle listing vectorize indexes with valid JSON output", async ({
+		expect,
+	}) => {
 		mockVectorizeV2Request();
 		await runWrangler("vectorize list --json");
 		expect(JSON.parse(std.out)).toMatchInlineSnapshot(`
@@ -418,7 +429,9 @@ describe("vectorize commands", () => {
 		expect(std.err).toBe("");
 	});
 
-	it("should handle creating a vectorize index with valid JSON output", async () => {
+	it("should handle creating a vectorize index with valid JSON output", async ({
+		expect,
+	}) => {
 		mockVectorizeV2Request();
 		await runWrangler(
 			"vectorize create test-index --dimensions=1536 --metric=euclidean --json"
@@ -439,7 +452,9 @@ describe("vectorize commands", () => {
 		expect(std.err).toBe("");
 	});
 
-	it("should handle get on a vectorize index with valid JSON output", async () => {
+	it("should handle get on a vectorize index with valid JSON output", async ({
+		expect,
+	}) => {
 		mockVectorizeV2Request();
 		await runWrangler("vectorize get test-index --json");
 		expect(JSON.parse(std.out)).toMatchInlineSnapshot(`
@@ -458,7 +473,9 @@ describe("vectorize commands", () => {
 		expect(std.err).toBe("");
 	});
 
-	it("should handle info on a vectorize index with valid JSON output", async () => {
+	it("should handle info on a vectorize index with valid JSON output", async ({
+		expect,
+	}) => {
 		mockVectorizeV2Request();
 		await runWrangler("vectorize info test-index --json");
 		expect(JSON.parse(std.out)).toMatchInlineSnapshot(`
@@ -473,7 +490,7 @@ describe("vectorize commands", () => {
 		expect(std.err).toBe("");
 	});
 
-	it("should handle a get on a vectorize V1 index", async () => {
+	it("should handle a get on a vectorize V1 index", async ({ expect }) => {
 		mockVectorizeRequest();
 		await runWrangler("vectorize get test-index --deprecated-v1=true");
 		expect(std.out).toMatchInlineSnapshot(`
@@ -488,7 +505,7 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should handle a get on a vectorize index", async () => {
+	it("should handle a get on a vectorize index", async ({ expect }) => {
 		mockVectorizeV2Request();
 		await runWrangler("vectorize get test-index");
 		expect(std.out).toMatchInlineSnapshot(`
@@ -503,7 +520,7 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should handle a delete on a vectorize V1 index", async () => {
+	it("should handle a delete on a vectorize V1 index", async ({ expect }) => {
 		mockVectorizeRequest();
 		mockConfirm({
 			text: "OK to delete the index 'test-index'?",
@@ -519,7 +536,7 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should handle a delete on a vectorize index", async () => {
+	it("should handle a delete on a vectorize index", async ({ expect }) => {
 		mockVectorizeV2Request();
 		mockConfirm({
 			text: "OK to delete the index 'test-index'?",
@@ -535,7 +552,7 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should handle a getByIds on a vectorize index", async () => {
+	it("should handle a getByIds on a vectorize index", async ({ expect }) => {
 		mockVectorizeV2Request();
 		await runWrangler("vectorize get-vectors test-index --ids a 'b'");
 		expect(std.out).toMatchInlineSnapshot(`
@@ -575,7 +592,9 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should warn when there are no vectors matching the getByIds identifiers", async () => {
+	it("should warn when there are no vectors matching the getByIds identifiers", async ({
+		expect,
+	}) => {
 		mockVectorizeV2RequestError();
 		await runWrangler("vectorize get-vectors test-index --ids a 'b'");
 		expect(std.out).toMatchInlineSnapshot(`
@@ -592,7 +611,9 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should log error when getByIds does not receive ids", async () => {
+	it("should log error when getByIds does not receive ids", async ({
+		expect,
+	}) => {
 		mockVectorizeV2Request();
 
 		await expect(
@@ -602,7 +623,7 @@ describe("vectorize commands", () => {
 		);
 	});
 
-	it("should handle a deleteByIds on a vectorize index", async () => {
+	it("should handle a deleteByIds on a vectorize index", async ({ expect }) => {
 		mockVectorizeV2Request();
 		await runWrangler("vectorize delete-vectors test-index --ids a 'b'");
 		expect(std.out).toMatchInlineSnapshot(`
@@ -614,7 +635,9 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should log error when deleteByIds does not receive ids", async () => {
+	it("should log error when deleteByIds does not receive ids", async ({
+		expect,
+	}) => {
 		mockVectorizeV2Request();
 
 		await expect(
@@ -624,7 +647,7 @@ describe("vectorize commands", () => {
 		);
 	});
 
-	it("should handle a query on a vectorize index", async () => {
+	it("should handle a query on a vectorize index", async ({ expect }) => {
 		mockVectorizeV2Request();
 		// Parses the vector as [1, 2, 3, 4, 1.5, 2.6, 7, 8]
 		await runWrangler(
@@ -672,7 +695,7 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should handle a query with a vector-id", async () => {
+	it("should handle a query with a vector-id", async ({ expect }) => {
 		mockVectorizeV2Request();
 		await runWrangler("vectorize query test-index --vector-id some-vector-id");
 		expect(std.out).toMatchInlineSnapshot(`
@@ -721,7 +744,9 @@ describe("vectorize commands", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	it("should handle a query on a vectorize index with all options", async () => {
+	it("should handle a query on a vectorize index with all options", async ({
+		expect,
+	}) => {
 		mockVectorizeV2Request();
 		await runWrangler(
 			`vectorize query test-index --vector 1 2 3 '4' --top-k=2 --return-values=true --return-metadata=indexed --namespace=abc --filter '{ "p1": "abc", "p2": { "$ne": true }, "p3": 10, "p4": false, "nested.p5": "abcd" }'`
@@ -771,7 +796,9 @@ describe("vectorize commands", () => {
 		expect(std.warn).toMatchInlineSnapshot(`""`);
 	});
 
-	it("should proceed with querying and log warning if the filter is invalid", async () => {
+	it("should proceed with querying and log warning if the filter is invalid", async ({
+		expect,
+	}) => {
 		mockVectorizeV2Request();
 		await runWrangler(
 			"vectorize query test-index --vector 1 2 3 '4' --filter='{ 'p1': [1,2,3] }'"
@@ -824,7 +851,7 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should warn when query returns no vectors", async () => {
+	it("should warn when query returns no vectors", async ({ expect }) => {
 		mockVectorizeV2RequestError();
 		await runWrangler("vectorize query test-index --vector 1 2 3 '4'");
 		expect(std.out).toMatchInlineSnapshot(`
@@ -841,7 +868,9 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should fail query when neither vector nor vector-id is provided", async () => {
+	it("should fail query when neither vector nor vector-id is provided", async ({
+		expect,
+	}) => {
 		mockVectorizeV2RequestError();
 		await expect(
 			runWrangler("vectorize query test-index --top-k=2 --return-values=true")
@@ -850,7 +879,9 @@ describe("vectorize commands", () => {
 		);
 	});
 
-	it("should fail query when both vector and vector-id are provided", async () => {
+	it("should fail query when both vector and vector-id are provided", async ({
+		expect,
+	}) => {
 		mockVectorizeV2RequestError();
 		await expect(
 			runWrangler(
@@ -861,7 +892,9 @@ describe("vectorize commands", () => {
 		);
 	});
 
-	it("should fail query with invalid return-metadata flag", async () => {
+	it("should fail query with invalid return-metadata flag", async ({
+		expect,
+	}) => {
 		mockVectorizeV2Request();
 
 		await expect(() =>
@@ -882,7 +915,7 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should handle info on a vectorize index", async () => {
+	it("should handle info on a vectorize index", async ({ expect }) => {
 		mockVectorizeV2Request();
 		await runWrangler("vectorize info test-index");
 		expect(std.out).toMatchInlineSnapshot(`
@@ -898,7 +931,7 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should handle create metadata index", async () => {
+	it("should handle create metadata index", async ({ expect }) => {
 		mockVectorizeV2Request();
 		await runWrangler(
 			`vectorize create-metadata-index test-index --property-name='some-prop' --type='string'`
@@ -912,7 +945,9 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should error if create metadata index type is invalid", async () => {
+	it("should error if create metadata index type is invalid", async ({
+		expect,
+	}) => {
 		mockVectorizeV2Request();
 		await expect(() =>
 			runWrangler(
@@ -930,7 +965,7 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should handle list metadata index", async () => {
+	it("should handle list metadata index", async ({ expect }) => {
 		mockVectorizeV2Request();
 		await runWrangler(`vectorize list-metadata-index test-index`);
 		expect(std.out).toMatchInlineSnapshot(`
@@ -950,7 +985,9 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should warn when list metadata indexes returns empty", async () => {
+	it("should warn when list metadata indexes returns empty", async ({
+		expect,
+	}) => {
 		mockVectorizeV2RequestError();
 		await runWrangler("vectorize list-metadata-index test-index");
 		expect(std.out).toMatchInlineSnapshot(`
@@ -973,7 +1010,9 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should return empty array JSON when list metadata indexes returns empty with --json flag", async () => {
+	it("should return empty array JSON when list metadata indexes returns empty with --json flag", async ({
+		expect,
+	}) => {
 		mockVectorizeV2RequestError();
 		await runWrangler("vectorize list-metadata-index test-index --json");
 		expect(JSON.parse(std.out)).toMatchInlineSnapshot(`[]`);
@@ -981,7 +1020,9 @@ describe("vectorize commands", () => {
 		expect(std.err).toBe("");
 	});
 
-	it("should handle list-metadata-index with valid JSON output", async () => {
+	it("should handle list-metadata-index with valid JSON output", async ({
+		expect,
+	}) => {
 		mockVectorizeV2Request();
 		await runWrangler("vectorize list-metadata-index test-index --json");
 		expect(JSON.parse(std.out)).toMatchInlineSnapshot(`
@@ -1004,7 +1045,7 @@ describe("vectorize commands", () => {
 		expect(std.err).toBe("");
 	});
 
-	it("should handle delete metadata index", async () => {
+	it("should handle delete metadata index", async ({ expect }) => {
 		mockVectorizeV2Request();
 		await runWrangler(
 			`vectorize delete-metadata-index test-index --property-name='some-prop'`
@@ -1018,7 +1059,9 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should show help when the list-vectors command is passed without an index", async () => {
+	it("should show help when the list-vectors command is passed without an index", async ({
+		expect,
+	}) => {
 		await expect(() => runWrangler("vectorize list-vectors")).rejects.toThrow(
 			"Not enough non-option arguments: got 0, need at least 1"
 		);
@@ -1057,7 +1100,7 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should handle list-vectors on a vectorize index", async () => {
+	it("should handle list-vectors on a vectorize index", async ({ expect }) => {
 		mockVectorizeV2Request();
 		await runWrangler("vectorize list-vectors test-index");
 		expect(std.out).toMatchInlineSnapshot(`
@@ -1082,7 +1125,9 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should handle list-vectors with custom count parameter", async () => {
+	it("should handle list-vectors with custom count parameter", async ({
+		expect,
+	}) => {
 		mockVectorizeV2Request();
 		await runWrangler("vectorize list-vectors test-index --count 2");
 		expect(std.out).toMatchInlineSnapshot(`
@@ -1105,7 +1150,9 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should handle list-vectors with cursor pagination", async () => {
+	it("should handle list-vectors with cursor pagination", async ({
+		expect,
+	}) => {
 		mockVectorizeV2Request();
 		await runWrangler(
 			"vectorize list-vectors test-index --cursor next-page-cursor"
@@ -1127,7 +1174,9 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should handle list-vectors with valid JSON output", async () => {
+	it("should handle list-vectors with valid JSON output", async ({
+		expect,
+	}) => {
 		mockVectorizeV2Request();
 		await runWrangler("vectorize list-vectors test-index --json");
 		expect(JSON.parse(std.out)).toMatchInlineSnapshot(`
@@ -1154,7 +1203,7 @@ describe("vectorize commands", () => {
 		expect(std.err).toBe("");
 	});
 
-	it("should warn when list-vectors returns no vectors", async () => {
+	it("should warn when list-vectors returns no vectors", async ({ expect }) => {
 		mockVectorizeV2RequestError();
 		await runWrangler("vectorize list-vectors test-index");
 		expect(std.out).toMatchInlineSnapshot(`
@@ -1171,7 +1220,9 @@ describe("vectorize commands", () => {
 		`);
 	});
 
-	it("should return valid JSON when list-vectors returns no vectors with --json flag", async () => {
+	it("should return valid JSON when list-vectors returns no vectors with --json flag", async ({
+		expect,
+	}) => {
 		mockVectorizeV2RequestError();
 		await runWrangler("vectorize list-vectors test-index --json");
 		expect(JSON.parse(std.out)).toMatchInlineSnapshot(`
@@ -1190,7 +1241,7 @@ describe("vectorize commands", () => {
 });
 
 describe("vectorize query filter", () => {
-	it("should parse correctly", async () => {
+	it("should parse correctly", async ({ expect }) => {
 		let jsonString =
 			'{ "p1": "abc", "p2": { "$ne": true }, "p3": 10, "p4": false, "nested.p5": "abcd", "p6": { "$in": ["a", 3, 4] }, "p7": {"$gt": 4, "$lte": "aaa"} }'; // Successful parse
 		expect(

--- a/packages/wrangler/src/__tests__/vectorize/vectorize.upsert.test.ts
+++ b/packages/wrangler/src/__tests__/vectorize/vectorize.upsert.test.ts
@@ -1,8 +1,7 @@
 import crypto from "node:crypto";
 import { writeFileSync } from "node:fs";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { msw } from "../helpers/msw";
@@ -53,7 +52,9 @@ describe("dataset upsert", () => {
 		},
 	];
 
-	it("should batch uploads in ndjson format for Vectorize v1", async () => {
+	it("should batch uploads in ndjson format for Vectorize v1", async ({
+		expect,
+	}) => {
 		writeFileSync(
 			"vectors.ndjson",
 			testVectors.map((v) => JSON.stringify(v)).join(`\n`)
@@ -112,7 +113,9 @@ describe("dataset upsert", () => {
 		`);
 	});
 
-	it("should batch uploads in ndjson format for Vectorize", async () => {
+	it("should batch uploads in ndjson format for Vectorize", async ({
+		expect,
+	}) => {
 		writeFileSync(
 			"vectors.ndjson",
 			testVectors.map((v) => JSON.stringify(v)).join(`\n`)
@@ -175,7 +178,9 @@ describe("dataset upsert", () => {
 		`);
 	});
 
-	it("should batch uploads for upsert in ndjson format for Vectorize", async () => {
+	it("should batch uploads for upsert in ndjson format for Vectorize", async ({
+		expect,
+	}) => {
 		writeFileSync(
 			"vectors.ndjson",
 			testVectors.map((v) => JSON.stringify(v)).join(`\n`)
@@ -238,7 +243,9 @@ describe("dataset upsert", () => {
 		`);
 	});
 
-	it("should output valid JSON for insert with --json flag", async () => {
+	it("should output valid JSON for insert with --json flag", async ({
+		expect,
+	}) => {
 		writeFileSync(
 			"vectors.ndjson",
 			testVectors.map((v) => JSON.stringify(v)).join(`\n`)
@@ -274,7 +281,9 @@ describe("dataset upsert", () => {
 		expect(std.err).toBe("");
 	});
 
-	it("should output valid JSON for upsert with --json flag", async () => {
+	it("should output valid JSON for upsert with --json flag", async ({
+		expect,
+	}) => {
 		writeFileSync(
 			"vectors.ndjson",
 			testVectors.map((v) => JSON.stringify(v)).join(`\n`)
@@ -310,7 +319,7 @@ describe("dataset upsert", () => {
 		expect(std.err).toBe("");
 	});
 
-	it("should reject an invalid file param", async () => {
+	it("should reject an invalid file param", async ({ expect }) => {
 		await expect(
 			runWrangler("vectorize upsert my-index --file invalid_vectors.ndjson")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -318,7 +327,7 @@ describe("dataset upsert", () => {
 		);
 	});
 
-	it("should reject an empty file param", async () => {
+	it("should reject an empty file param", async ({ expect }) => {
 		writeFileSync("empty_vectors.ndjson", "");
 
 		await expect(

--- a/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
@@ -1,8 +1,7 @@
 import { writeFile } from "node:fs/promises";
 import readline from "node:readline";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, describe, expect, it, test, vi } from "vitest";
+import { afterEach, describe, it, test, vi } from "vitest";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { clearDialogs } from "../../helpers/mock-dialogs";
@@ -20,7 +19,9 @@ describe("versions secret bulk", () => {
 		clearDialogs();
 	});
 
-	test("should fail secret bulk w/ no pipe or JSON input", async () => {
+	test("should fail secret bulk w/ no pipe or JSON input", async ({
+		expect,
+	}) => {
 		vi.spyOn(readline, "createInterface").mockImplementation(
 			() => null as unknown as Interface
 		);
@@ -41,7 +42,7 @@ describe("versions secret bulk", () => {
 		expect(std.warn).toMatchInlineSnapshot(`""`);
 	});
 
-	test("uploading secrets from json file", async () => {
+	test("uploading secrets from json file", async ({ expect }) => {
 		await writeFile(
 			"secrets.json",
 			JSON.stringify({
@@ -84,7 +85,7 @@ describe("versions secret bulk", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("uploading secrets from env file", async () => {
+	test("uploading secrets from env file", async ({ expect }) => {
 		await writeFile(
 			".env",
 			"SECRET_1=secret-1\nSECRET_2=secret-2\nSECRET_3=secret-3"
@@ -108,7 +109,7 @@ describe("versions secret bulk", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("no wrangler configuration warnings shown", async () => {
+	test("no wrangler configuration warnings shown", async ({ expect }) => {
 		await writeFile("secrets.json", JSON.stringify({ SECRET_1: "secret-1" }));
 		await writeFile("wrangler.json", JSON.stringify({ invalid_field: true }));
 		mockSetupApiCalls();
@@ -118,7 +119,7 @@ describe("versions secret bulk", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("uploading secrets from stdin", async () => {
+	test("uploading secrets from stdin", async ({ expect }) => {
 		vi.spyOn(readline, "createInterface").mockImplementation(
 			() =>
 				// `readline.Interface` is an async iterator: `[Symbol.asyncIterator](): AsyncIterableIterator<string>`
@@ -161,7 +162,7 @@ describe("versions secret bulk", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("should error on invalid json file", async () => {
+	test("should error on invalid json file", async ({ expect }) => {
 		await writeFile("secrets.json", "not valid json :(", { encoding: "utf8" });
 
 		await expect(
@@ -171,7 +172,7 @@ describe("versions secret bulk", () => {
 		);
 	});
 
-	test("should error on invalid json stdin", async () => {
+	test("should error on invalid json stdin", async ({ expect }) => {
 		vi.spyOn(readline, "createInterface").mockImplementation(
 			() =>
 				// `readline.Interface` is an async iterator: `[Symbol.asyncIterator](): AsyncIterableIterator<string>`
@@ -209,7 +210,7 @@ describe("versions secret bulk", () => {
 		`);
 	});
 
-	test("unsafe metadata is provided", async () => {
+	test("unsafe metadata is provided", async ({ expect }) => {
 		writeWranglerConfig({
 			name: "script-name",
 			unsafe: { metadata: { build_options: { stable_id: "foo/bar" } } },
@@ -258,7 +259,9 @@ describe("versions secret bulk", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("unsafe metadata not included if not in wrangler.toml", async () => {
+	test("unsafe metadata not included if not in wrangler.toml", async ({
+		expect,
+	}) => {
 		writeWranglerConfig({
 			name: "script-name",
 		});
@@ -307,7 +310,9 @@ describe("versions secret bulk", () => {
 	});
 
 	describe("multi-env warning", () => {
-		it("should warn if the wrangler config contains environments but none was specified in the command", async () => {
+		it("should warn if the wrangler config contains environments but none was specified in the command", async ({
+			expect,
+		}) => {
 			vi.spyOn(readline, "createInterface").mockImplementation(
 				() =>
 					// `readline.Interface` is an async iterator: `[Symbol.asyncIterator](): AsyncIterableIterator<string>`
@@ -333,7 +338,9 @@ describe("versions secret bulk", () => {
 			`);
 		});
 
-		it("should not warn if the wrangler config contains environments and one was specified in the command", async () => {
+		it("should not warn if the wrangler config contains environments and one was specified in the command", async ({
+			expect,
+		}) => {
 			vi.spyOn(readline, "createInterface").mockImplementation(
 				() =>
 					// `readline.Interface` is an async iterator: `[Symbol.asyncIterator](): AsyncIterableIterator<string>`
@@ -350,7 +357,9 @@ describe("versions secret bulk", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async () => {
+		it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async ({
+			expect,
+		}) => {
 			vi.spyOn(readline, "createInterface").mockImplementation(
 				() =>
 					// `readline.Interface` is an async iterator: `[Symbol.asyncIterator](): AsyncIterableIterator<string>`

--- a/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
@@ -1,7 +1,6 @@
 import { writeFile } from "node:fs/promises";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, describe, expect, it, test } from "vitest";
+import { afterEach, describe, it, test } from "vitest";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { clearDialogs, mockConfirm } from "../../helpers/mock-dialogs";
@@ -20,7 +19,7 @@ describe("versions secret delete", () => {
 		clearDialogs();
 	});
 
-	test("can delete a new secret (interactive)", async () => {
+	test("can delete a new secret (interactive)", async ({ expect }) => {
 		setIsTTY(true);
 
 		mockConfirm({
@@ -53,7 +52,7 @@ describe("versions secret delete", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("can delete a secret (non-interactive)", async () => {
+	test("can delete a secret (non-interactive)", async ({ expect }) => {
 		setIsTTY(false);
 
 		mockSetupApiCalls();
@@ -83,7 +82,9 @@ describe("versions secret delete", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("can delete a secret reading Worker name from wrangler.toml", async () => {
+	test("can delete a secret reading Worker name from wrangler.toml", async ({
+		expect,
+	}) => {
 		writeWranglerConfig({ name: "script-name" });
 		setIsTTY(false);
 
@@ -114,7 +115,7 @@ describe("versions secret delete", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("no wrangler configuration warnings shown", async () => {
+	test("no wrangler configuration warnings shown", async ({ expect }) => {
 		await writeFile("wrangler.json", JSON.stringify({ invalid_field: true }));
 		setIsTTY(false);
 
@@ -129,7 +130,9 @@ describe("versions secret delete", () => {
 	});
 
 	describe("multi-env warning", () => {
-		it("should warn if the wrangler config contains environments but none was specified in the command", async () => {
+		it("should warn if the wrangler config contains environments but none was specified in the command", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 
 			writeWranglerConfig({
@@ -153,7 +156,9 @@ describe("versions secret delete", () => {
 			`);
 		});
 
-		it("should not warn if the wrangler config contains environments and one was specified in the command", async () => {
+		it("should not warn if the wrangler config contains environments and one was specified in the command", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 
 			writeWranglerConfig({
@@ -170,7 +175,9 @@ describe("versions secret delete", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async () => {
+		it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 
 			writeWranglerConfig();

--- a/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
@@ -2,8 +2,7 @@ import { writeFile } from "node:fs/promises";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { FormData } from "undici";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, describe, expect, it, test } from "vitest";
+import { afterEach, describe, it, test } from "vitest";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { clearDialogs, mockPrompt } from "../../helpers/mock-dialogs";
@@ -24,7 +23,7 @@ describe("versions secret put", () => {
 		clearDialogs();
 	});
 
-	test("can add a new secret (interactive)", async () => {
+	test("can add a new secret (interactive)", async ({ expect }) => {
 		setIsTTY(true);
 
 		mockPrompt({
@@ -58,7 +57,7 @@ describe("versions secret put", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("unsafe metadata is provided", async () => {
+	test("unsafe metadata is provided", async ({ expect }) => {
 		writeWranglerConfig({
 			name: "script-name",
 			unsafe: { metadata: { build_options: { stable_id: "foo/bar" } } },
@@ -89,7 +88,9 @@ describe("versions secret put", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("unsafe metadata not included if not in wrangler.toml", async () => {
+	test("unsafe metadata not included if not in wrangler.toml", async ({
+		expect,
+	}) => {
 		writeWranglerConfig({
 			name: "script-name",
 		});
@@ -127,7 +128,7 @@ describe("versions secret put", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("no wrangler configuration warnings shown", async () => {
+	test("no wrangler configuration warnings shown", async ({ expect }) => {
 		await writeFile("wrangler.json", JSON.stringify({ invalid_field: true }));
 		setIsTTY(true);
 
@@ -146,7 +147,7 @@ describe("versions secret put", () => {
 
 	describe("(non-interactive)", () => {
 		const mockStdIn = useMockStdin({ isTTY: false });
-		test("can add a new secret (non-interactive)", async () => {
+		test("can add a new secret (non-interactive)", async ({ expect }) => {
 			mockSetupApiCalls();
 			mockPostVersion((metadata) => {
 				expect(metadata.bindings).toStrictEqual([
@@ -180,7 +181,9 @@ describe("versions secret put", () => {
 		});
 	});
 
-	test("can add a new secret, read Worker name from wrangler.toml", async () => {
+	test("can add a new secret, read Worker name from wrangler.toml", async ({
+		expect,
+	}) => {
 		writeWranglerConfig({ name: "script-name" });
 
 		setIsTTY(true);
@@ -216,7 +219,7 @@ describe("versions secret put", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("can add a new secret with message", async () => {
+	test("can add a new secret with message", async ({ expect }) => {
 		setIsTTY(true);
 
 		mockPrompt({
@@ -257,7 +260,7 @@ describe("versions secret put", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("can add a new secret with message + tag", async () => {
+	test("can add a new secret with message + tag", async ({ expect }) => {
 		setIsTTY(true);
 
 		mockPrompt({
@@ -301,7 +304,7 @@ describe("versions secret put", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("all non-secret bindings are inherited", async () => {
+	test("all non-secret bindings are inherited", async ({ expect }) => {
 		setIsTTY(true);
 
 		mockSetupApiCalls();
@@ -336,7 +339,7 @@ describe("versions secret put", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("can update an existing secret", async () => {
+	test("can update an existing secret", async ({ expect }) => {
 		setIsTTY(true);
 
 		mockPrompt({
@@ -377,7 +380,7 @@ describe("versions secret put", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("can add secret on wasm worker", async () => {
+	test("can add secret on wasm worker", async ({ expect }) => {
 		setIsTTY(true);
 
 		mockSetupApiCalls();
@@ -459,7 +462,9 @@ describe("versions secret put", () => {
 	describe("multi-env warning", () => {
 		const mockStdIn = useMockStdin({ isTTY: false });
 
-		it("should warn if the wrangler config contains environments but none was specified in the command", async () => {
+		it("should warn if the wrangler config contains environments but none was specified in the command", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				name: "script-name",
 				env: { test: {} },
@@ -487,7 +492,9 @@ describe("versions secret put", () => {
 			`);
 		});
 
-		it("should not warn if the wrangler config contains environments and one was specified in the command", async () => {
+		it("should not warn if the wrangler config contains environments and one was specified in the command", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				name: "script-name",
 				env: { test: {} },
@@ -506,7 +513,9 @@ describe("versions secret put", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async () => {
+		it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				name: "script-name",
 			});

--- a/packages/wrangler/src/__tests__/vpc.test.ts
+++ b/packages/wrangler/src/__tests__/vpc.test.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { ServiceType } from "../vpc/index";
 import {
 	extractPortFromHostname,
@@ -25,7 +24,9 @@ describe("vpc help", () => {
 	const std = mockConsoleMethods();
 	runInTempDir();
 
-	it("should show help text when no arguments are passed", async () => {
+	it("should show help text when no arguments are passed", async ({
+		expect,
+	}) => {
 		await runWrangler("vpc");
 		await endEventLoop();
 
@@ -48,7 +49,9 @@ describe("vpc help", () => {
 		`);
 	});
 
-	it("should show service help text when no service arguments are passed", async () => {
+	it("should show service help text when no service arguments are passed", async ({
+		expect,
+	}) => {
 		await runWrangler("vpc service");
 		await endEventLoop();
 
@@ -96,7 +99,7 @@ describe("vpc service commands", () => {
 		clearDialogs();
 	});
 
-	it("should handle creating an HTTP service with IPv4", async () => {
+	it("should handle creating an HTTP service with IPv4", async ({ expect }) => {
 		const reqProm = mockWvpcServiceCreate();
 		await runWrangler(
 			"vpc service create test-http-ipv4 --type http --ipv4 10.0.0.1 --tunnel-id 550e8400-e29b-41d4-a716-446655440000"
@@ -128,7 +131,9 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should handle creating a service with hostname and resolver network", async () => {
+	it("should handle creating a service with hostname and resolver network", async ({
+		expect,
+	}) => {
 		const reqProm = mockWvpcServiceCreate();
 		await runWrangler(
 			"vpc service create test-hostname --type http --http-port 80 --hostname db.example.com --tunnel-id 550e8400-e29b-41d4-a716-446655440002 --resolver-ips 8.8.8.8,8.8.4.4"
@@ -153,7 +158,9 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should reject service creation with both IP addresses and hostname", async () => {
+	it("should reject service creation with both IP addresses and hostname", async ({
+		expect,
+	}) => {
 		await expect(() =>
 			runWrangler(
 				"vpc service create test-invalid --type http --http-port 80 --ipv4 10.0.0.1 --hostname example.com --resolver-ips=1.1.1.1 --tunnel-id 550e8400-e29b-41d4-a716-446655440000"
@@ -166,7 +173,7 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should handle listing services", async () => {
+	it("should handle listing services", async ({ expect }) => {
 		mockWvpcServiceList();
 		await runWrangler("vpc service list");
 
@@ -183,7 +190,7 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should handle getting a service", async () => {
+	it("should handle getting a service", async ({ expect }) => {
 		mockWvpcServiceGetUpdateDelete();
 		await runWrangler("vpc service get service-uuid");
 
@@ -205,7 +212,7 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should handle deleting a service", async () => {
+	it("should handle deleting a service", async ({ expect }) => {
 		mockWvpcServiceGetUpdateDelete();
 		await runWrangler("vpc service delete service-uuid");
 
@@ -218,7 +225,7 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should handle updating a service", async () => {
+	it("should handle updating a service", async ({ expect }) => {
 		const reqProm = mockWvpcServiceUpdate();
 		await runWrangler(
 			"vpc service update service-uuid --name test-updated --type http --http-port 80 --ipv4 10.0.0.2 --tunnel-id 550e8400-e29b-41d4-a716-446655440001"
@@ -239,7 +246,9 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should handle getting a service without resolver_ips", async () => {
+	it("should handle getting a service without resolver_ips", async ({
+		expect,
+	}) => {
 		const serviceWithoutResolverIps: ConnectivityService = {
 			...mockService,
 			host: {
@@ -282,7 +291,9 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should handle creating a service and display without resolver_ips", async () => {
+	it("should handle creating a service and display without resolver_ips", async ({
+		expect,
+	}) => {
 		const serviceResponse = {
 			service_id: "service-uuid",
 			type: "http",
@@ -329,7 +340,7 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should handle creating a TCP service with IPv4", async () => {
+	it("should handle creating a TCP service with IPv4", async ({ expect }) => {
 		const reqProm = mockWvpcServiceCreate();
 		await runWrangler(
 			"vpc service create test-tcp-db --type tcp --tcp-port 5432 --ipv4 10.0.0.5 --tunnel-id 550e8400-e29b-41d4-a716-446655440000"
@@ -363,7 +374,9 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should handle creating a TCP service with hostname", async () => {
+	it("should handle creating a TCP service with hostname", async ({
+		expect,
+	}) => {
 		const reqProm = mockWvpcServiceCreate();
 		await runWrangler(
 			"vpc service create test-tcp-hostname --type tcp --tcp-port 3306 --hostname mysql.internal --tunnel-id 550e8400-e29b-41d4-a716-446655440001 --resolver-ips 10.0.0.1"
@@ -387,7 +400,9 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should reject TCP service creation without --tcp-port", async () => {
+	it("should reject TCP service creation without --tcp-port", async ({
+		expect,
+	}) => {
 		await expect(() =>
 			runWrangler(
 				"vpc service create test-tcp-no-port --type tcp --ipv4 10.0.0.1 --tunnel-id 550e8400-e29b-41d4-a716-446655440000"
@@ -395,7 +410,7 @@ describe("vpc service commands", () => {
 		).rejects.toThrow("TCP services require a --tcp-port to be specified");
 	});
 
-	it("should handle updating a TCP service", async () => {
+	it("should handle updating a TCP service", async ({ expect }) => {
 		const reqProm = mockWvpcServiceUpdate();
 		await runWrangler(
 			"vpc service update service-uuid --name test-tcp-updated --type tcp --tcp-port 5433 --ipv4 10.0.0.6 --tunnel-id 550e8400-e29b-41d4-a716-446655440001"
@@ -416,7 +431,7 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should handle getting a TCP service", async () => {
+	it("should handle getting a TCP service", async ({ expect }) => {
 		mockWvpcTcpServiceGet();
 		await runWrangler("vpc service get tcp-service-uuid");
 
@@ -437,7 +452,9 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should handle listing TCP services with port in table", async () => {
+	it("should handle listing TCP services with port in table", async ({
+		expect,
+	}) => {
 		mockWvpcTcpServiceList();
 		await runWrangler("vpc service list");
 
@@ -454,7 +471,9 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should handle creating a TCP service with --app-protocol postgresql", async () => {
+	it("should handle creating a TCP service with --app-protocol postgresql", async ({
+		expect,
+	}) => {
 		const reqProm = mockWvpcServiceCreate();
 		await runWrangler(
 			"vpc service create test-pg --type tcp --tcp-port 5432 --app-protocol postgresql --ipv4 10.0.0.5 --tunnel-id 550e8400-e29b-41d4-a716-446655440000"
@@ -490,7 +509,9 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should handle creating a TCP service with --app-protocol mysql", async () => {
+	it("should handle creating a TCP service with --app-protocol mysql", async ({
+		expect,
+	}) => {
 		const reqProm = mockWvpcServiceCreate();
 		await runWrangler(
 			"vpc service create test-mysql --type tcp --tcp-port 3306 --app-protocol mysql --ipv4 10.0.0.6 --tunnel-id 550e8400-e29b-41d4-a716-446655440000"
@@ -512,7 +533,7 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should reject --app-protocol with invalid value", async () => {
+	it("should reject --app-protocol with invalid value", async ({ expect }) => {
 		await expect(() =>
 			runWrangler(
 				"vpc service create test-bad-proto --type tcp --tcp-port 5432 --app-protocol redis --ipv4 10.0.0.1 --tunnel-id 550e8400-e29b-41d4-a716-446655440000"
@@ -524,7 +545,9 @@ describe("vpc service commands", () => {
 		);
 	});
 
-	it("should handle updating a TCP service with --app-protocol", async () => {
+	it("should handle updating a TCP service with --app-protocol", async ({
+		expect,
+	}) => {
 		const reqProm = mockWvpcServiceUpdate();
 		await runWrangler(
 			"vpc service update service-uuid --name test-pg-updated --type tcp --tcp-port 5432 --app-protocol postgresql --ipv4 10.0.0.5 --tunnel-id 550e8400-e29b-41d4-a716-446655440000"
@@ -546,7 +569,9 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should handle creating a TCP service with --cert-verification-mode verify_ca", async () => {
+	it("should handle creating a TCP service with --cert-verification-mode verify_ca", async ({
+		expect,
+	}) => {
 		const reqProm = mockWvpcServiceCreate();
 		await runWrangler(
 			"vpc service create test-tcp-tls --type tcp --tcp-port 5432 --ipv4 10.0.0.5 --tunnel-id 550e8400-e29b-41d4-a716-446655440000 --cert-verification-mode verify_ca"
@@ -584,7 +609,9 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should handle creating an HTTP service with --cert-verification-mode disabled", async () => {
+	it("should handle creating an HTTP service with --cert-verification-mode disabled", async ({
+		expect,
+	}) => {
 		const reqProm = mockWvpcServiceCreate();
 		await runWrangler(
 			"vpc service create test-http-tls --type http --http-port 80 --ipv4 10.0.0.1 --tunnel-id 550e8400-e29b-41d4-a716-446655440000 --cert-verification-mode disabled"
@@ -622,7 +649,9 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should not include tls_settings when --cert-verification-mode is not specified", async () => {
+	it("should not include tls_settings when --cert-verification-mode is not specified", async ({
+		expect,
+	}) => {
 		const reqProm = mockWvpcServiceCreate();
 		await runWrangler(
 			"vpc service create test-no-tls --type tcp --tcp-port 5432 --ipv4 10.0.0.5 --tunnel-id 550e8400-e29b-41d4-a716-446655440000"
@@ -632,7 +661,9 @@ describe("vpc service commands", () => {
 		expect(reqBody.tls_settings).toBeUndefined();
 	});
 
-	it("should handle getting a service with tls_settings", async () => {
+	it("should handle getting a service with tls_settings", async ({
+		expect,
+	}) => {
 		const serviceWithTls: ConnectivityService = {
 			...mockTcpService,
 			tls_settings: {
@@ -670,7 +701,9 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should handle updating a service with --cert-verification-mode", async () => {
+	it("should handle updating a service with --cert-verification-mode", async ({
+		expect,
+	}) => {
 		const reqProm = mockWvpcServiceUpdate();
 		await runWrangler(
 			"vpc service update service-uuid --name test-updated --type http --http-port 80 --ipv4 10.0.0.2 --tunnel-id 550e8400-e29b-41d4-a716-446655440001 --cert-verification-mode verify_full"
@@ -694,7 +727,9 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should reject --cert-verification-mode with invalid value", async () => {
+	it("should reject --cert-verification-mode with invalid value", async ({
+		expect,
+	}) => {
 		await expect(() =>
 			runWrangler(
 				"vpc service create test-bad-tls --type tcp --tcp-port 5432 --ipv4 10.0.0.1 --tunnel-id 550e8400-e29b-41d4-a716-446655440000 --cert-verification-mode invalid"
@@ -705,7 +740,9 @@ describe("vpc service commands", () => {
 		expect(std.err).toContain('"invalid"');
 	});
 
-	it("should extract port from hostname for TCP services", async () => {
+	it("should extract port from hostname for TCP services", async ({
+		expect,
+	}) => {
 		const reqProm = mockWvpcServiceCreate();
 		await runWrangler(
 			"vpc service create test-tcp-hostport --type tcp --hostname mysql.internal:3306 --tunnel-id 550e8400-e29b-41d4-a716-446655440001"
@@ -739,7 +776,9 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should accept matching --tcp-port when hostname also includes port", async () => {
+	it("should accept matching --tcp-port when hostname also includes port", async ({
+		expect,
+	}) => {
 		const reqProm = mockWvpcServiceCreate();
 		await runWrangler(
 			"vpc service create test-tcp-match --type tcp --tcp-port 5432 --hostname db.internal:5432 --tunnel-id 550e8400-e29b-41d4-a716-446655440001"
@@ -760,7 +799,9 @@ describe("vpc service commands", () => {
 		`);
 	});
 
-	it("should reject conflicting --tcp-port and hostname port", async () => {
+	it("should reject conflicting --tcp-port and hostname port", async ({
+		expect,
+	}) => {
 		await expect(() =>
 			runWrangler(
 				"vpc service create test-tcp-conflict --type tcp --tcp-port 5432 --hostname db.internal:3306 --tunnel-id 550e8400-e29b-41d4-a716-446655440001"
@@ -772,35 +813,35 @@ describe("vpc service commands", () => {
 });
 
 describe("extractPortFromHostname", () => {
-	it("should extract port from hostname:port", () => {
+	it("should extract port from hostname:port", ({ expect }) => {
 		expect(extractPortFromHostname("db.example.com:5432")).toEqual({
 			hostname: "db.example.com",
 			port: 5432,
 		});
 	});
 
-	it("should return undefined port for plain hostname", () => {
+	it("should return undefined port for plain hostname", ({ expect }) => {
 		expect(extractPortFromHostname("db.example.com")).toEqual({
 			hostname: "db.example.com",
 			port: undefined,
 		});
 	});
 
-	it("should not extract port from IPv6 addresses", () => {
+	it("should not extract port from IPv6 addresses", ({ expect }) => {
 		expect(extractPortFromHostname("2001:db8::1")).toEqual({
 			hostname: "2001:db8::1",
 			port: undefined,
 		});
 	});
 
-	it("should not extract port from bracketed IPv6 addresses", () => {
+	it("should not extract port from bracketed IPv6 addresses", ({ expect }) => {
 		expect(extractPortFromHostname("[::1]")).toEqual({
 			hostname: "[::1]",
 			port: undefined,
 		});
 	});
 
-	it("should handle port at boundary values", () => {
+	it("should handle port at boundary values", ({ expect }) => {
 		expect(extractPortFromHostname("host:1")).toEqual({
 			hostname: "host",
 			port: 1,
@@ -811,7 +852,7 @@ describe("extractPortFromHostname", () => {
 		});
 	});
 
-	it("should reject port 0 or above 65535", () => {
+	it("should reject port 0 or above 65535", ({ expect }) => {
 		expect(extractPortFromHostname("host:0")).toEqual({
 			hostname: "host:0",
 			port: undefined,
@@ -824,33 +865,33 @@ describe("extractPortFromHostname", () => {
 });
 
 describe("hostname validation", () => {
-	it("should accept valid hostnames", () => {
+	it("should accept valid hostnames", ({ expect }) => {
 		expect(() => validateHostname("api.example.com")).not.toThrow();
 		expect(() => validateHostname("localhost")).not.toThrow();
 		expect(() => validateHostname("my-service.internal.local")).not.toThrow();
 		expect(() => validateHostname("sub.domain.example.co.uk")).not.toThrow();
 	});
 
-	it("should reject empty hostname", () => {
+	it("should reject empty hostname", ({ expect }) => {
 		expect(() => validateHostname("")).toThrow("Hostname cannot be empty.");
 		expect(() => validateHostname("   ")).toThrow("Hostname cannot be empty.");
 	});
 
-	it("should reject hostname exceeding 253 characters", () => {
+	it("should reject hostname exceeding 253 characters", ({ expect }) => {
 		const longHostname = "a".repeat(254);
 		expect(() => validateHostname(longHostname)).toThrow(
 			"Hostname is too long. Maximum length is 253 characters."
 		);
 	});
 
-	it("should accept hostname at exactly 253 characters", () => {
+	it("should accept hostname at exactly 253 characters", ({ expect }) => {
 		const label = "a".repeat(63);
 		const hostname = `${label}.${label}.${label}.${label.slice(0, 61)}`;
 		expect(hostname.length).toBe(253);
 		expect(() => validateHostname(hostname)).not.toThrow();
 	});
 
-	it("should reject hostname with URL scheme", () => {
+	it("should reject hostname with URL scheme", ({ expect }) => {
 		expect(() => validateHostname("https://example.com")).toThrow(
 			"Hostname must not include a URL scheme"
 		);
@@ -859,13 +900,13 @@ describe("hostname validation", () => {
 		);
 	});
 
-	it("should reject hostname with path", () => {
+	it("should reject hostname with path", ({ expect }) => {
 		expect(() => validateHostname("example.com/path")).toThrow(
 			"Hostname must not include a path"
 		);
 	});
 
-	it("should reject bare IPv4 address", () => {
+	it("should reject bare IPv4 address", ({ expect }) => {
 		expect(() => validateHostname("192.168.1.1")).toThrow(
 			"Hostname must not be an IP address. Use --ipv4 or --ipv6 instead."
 		);
@@ -874,7 +915,7 @@ describe("hostname validation", () => {
 		);
 	});
 
-	it("should reject bare IPv6 address", () => {
+	it("should reject bare IPv6 address", ({ expect }) => {
 		expect(() => validateHostname("::1")).toThrow(
 			"Hostname must not be an IP address"
 		);
@@ -886,31 +927,33 @@ describe("hostname validation", () => {
 		);
 	});
 
-	it("should reject hostname with port", () => {
+	it("should reject hostname with port", ({ expect }) => {
 		expect(() => validateHostname("example.com:8080")).toThrow(
 			"Hostname must not include a port number"
 		);
 	});
 
-	it("should reject hostname with whitespace", () => {
+	it("should reject hostname with whitespace", ({ expect }) => {
 		expect(() => validateHostname("bad host.com")).toThrow(
 			"Hostname must not contain whitespace"
 		);
 	});
 
-	it("should accept hostnames with underscores", () => {
+	it("should accept hostnames with underscores", ({ expect }) => {
 		expect(() => validateHostname("_dmarc.example.com")).not.toThrow();
 		expect(() => validateHostname("my_service.internal")).not.toThrow();
 	});
 
-	it("should report all applicable errors at once", () => {
+	it("should report all applicable errors at once", ({ expect }) => {
 		// "https://example.com/path" has a scheme AND a path
 		expect(() => validateHostname("https://example.com/path")).toThrow(
 			/URL scheme.*\n.*path/s
 		);
 	});
 
-	it("should reject invalid hostname via wrangler service create", async () => {
+	it("should reject invalid hostname via wrangler service create", async ({
+		expect,
+	}) => {
 		await expect(() =>
 			runWrangler(
 				"vpc service create test-bad-hostname --type http --hostname https://example.com --tunnel-id 550e8400-e29b-41d4-a716-446655440000"
@@ -918,7 +961,9 @@ describe("hostname validation", () => {
 		).rejects.toThrow("Hostname must not include a URL scheme");
 	});
 
-	it("should reject IP address as hostname via wrangler service create", async () => {
+	it("should reject IP address as hostname via wrangler service create", async ({
+		expect,
+	}) => {
 		await expect(() =>
 			runWrangler(
 				"vpc service create test-ip-hostname --type http --hostname 192.168.1.1 --tunnel-id 550e8400-e29b-41d4-a716-446655440000"
@@ -934,7 +979,7 @@ describe("IP address validation", () => {
 		tunnelId: "550e8400-e29b-41d4-a716-446655440000",
 	};
 
-	it("should accept valid IPv4 addresses", () => {
+	it("should accept valid IPv4 addresses", ({ expect }) => {
 		expect(() =>
 			validateRequest({ ...baseArgs, ipv4: "192.168.1.1" })
 		).not.toThrow();
@@ -943,7 +988,7 @@ describe("IP address validation", () => {
 		).not.toThrow();
 	});
 
-	it("should reject invalid IPv4 addresses", () => {
+	it("should reject invalid IPv4 addresses", ({ expect }) => {
 		expect(() => validateRequest({ ...baseArgs, ipv4: "not-an-ip" })).toThrow(
 			"Invalid IPv4 address"
 		);
@@ -955,14 +1000,14 @@ describe("IP address validation", () => {
 		);
 	});
 
-	it("should accept valid IPv6 addresses", () => {
+	it("should accept valid IPv6 addresses", ({ expect }) => {
 		expect(() => validateRequest({ ...baseArgs, ipv6: "::1" })).not.toThrow();
 		expect(() =>
 			validateRequest({ ...baseArgs, ipv6: "2001:db8::1" })
 		).not.toThrow();
 	});
 
-	it("should reject invalid IPv6 addresses", () => {
+	it("should reject invalid IPv6 addresses", ({ expect }) => {
 		expect(() => validateRequest({ ...baseArgs, ipv6: "not-an-ip" })).toThrow(
 			"Invalid IPv6 address"
 		);
@@ -971,7 +1016,7 @@ describe("IP address validation", () => {
 		);
 	});
 
-	it("should accept valid resolver IPs", () => {
+	it("should accept valid resolver IPs", ({ expect }) => {
 		expect(() =>
 			validateRequest({
 				...baseArgs,
@@ -988,7 +1033,7 @@ describe("IP address validation", () => {
 		).not.toThrow();
 	});
 
-	it("should reject invalid resolver IPs", () => {
+	it("should reject invalid resolver IPs", ({ expect }) => {
 		expect(() =>
 			validateRequest({
 				...baseArgs,


### PR DESCRIPTION
We have a bunch of comments such as:
```
// eslint-disable-next-line no-restricted-imports
```

When AI creates new files it seems like it even adds this, I imagine to be consistent with the codebase

In this PR I'm just doing a bit of cleaning up and removing a bunch of these, mostly the simplest ones that require the less amount of changes 

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
