### PR TITLE
Fix entrypoints-rpc HTTPS test flakiness in CI

### DIFF
--- a/fixtures/entrypoints-rpc-tests/tests/entrypoints.spec.ts
+++ b/fixtures/entrypoints-rpc-tests/tests/entrypoints.spec.ts
@@ -11,9 +11,9 @@ import {
 } from "../../shared/src/run-wrangler-long-lived";
 
 const timeoutAgent = new Agent({
-	connectTimeout: 500,
-	bodyTimeout: 500,
-	headersTimeout: 500,
+	connectTimeout: 2_000,
+	bodyTimeout: 2_000,
+	headersTimeout: 2_000,
 });
 setGlobalDispatcher(timeoutAgent);
 
@@ -34,10 +34,13 @@ export async function seed(root: string, files: Record<string, string>) {
 	}
 }
 
-function waitFor<T>(callback: Parameters<typeof vi.waitFor<T>>[0]) {
+function waitFor<T>(
+	callback: Parameters<typeof vi.waitFor<T>>[0],
+	timeout = 5_000
+) {
 	// The default timeout of `vi.waitFor()` is only 1s, which is a little
 	// short for some of these tests, especially on Windows.
-	return vi.waitFor(callback, { timeout: 5_000, interval: 250 });
+	return vi.waitFor(callback, { timeout, interval: 250 });
 }
 
 const test = baseTest.extend<{
@@ -835,7 +838,7 @@ describe("entrypoints", () => {
 			const response = await fetch(url);
 			const text = await response.text();
 			expect(text).toBe("secure");
-		});
+		}, 10_000);
 	});
 
 	test("should support binding to version of wrangler without entrypoints support over HTTPS", async ({
@@ -887,7 +890,7 @@ describe("entrypoints", () => {
 		await waitFor(async () => {
 			let response = await fetch(url);
 			expect(await response.text()).toBe("Hello from bound!");
-		});
+		}, 10_000);
 	});
 
 	test("should throw if performing RPC with session that hasn't started", async ({


### PR DESCRIPTION
Fixes flaky CI failures in the `entrypoints-rpc` fixture tests that occur across unrelated PRs on all platforms (Windows, macOS, Linux).

The test "should support binding to wrangler session listening on HTTPS" fails intermittently with `HeadersTimeoutError` (UND_ERR_HEADERS_TIMEOUT) and/or `Couldn't find a local dev session for the "default" entrypoint of service "bound" to proxy to`.

**Root cause:** Three compounding timing issues:
1. The undici Agent's 500ms `headersTimeout` is too tight for HTTPS connections (TLS handshake overhead) on loaded CI runners
2. After `await dev(...)` returns, the bound worker's registry file may not yet be written or detected by the entry worker's chokidar watcher
3. The 5s `waitFor` budget (20 retries at 250ms) is consumed too quickly when each timeout failure takes ~750ms

**Changes:**
- Increase undici Agent timeouts from 500ms to 2000ms (connect, body, headers) — prevents premature timeout on HTTPS without slowing down passing tests
- Add optional `timeout` parameter to the `waitFor` helper
- Increase `waitFor` timeout to 10s for both HTTPS tests, giving more headroom for registry propagation + TLS overhead

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this change only adjusts timeouts in existing tests to reduce flakiness
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: test-only change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
