### PR TITLE
Remove all removable eslint disabling comments for `no-restricted-imports` in wrangler e2e

### DIFF
--- a/packages/wrangler/e2e/deployments.test.ts
+++ b/packages/wrangler/e2e/deployments.test.ts
@@ -1,7 +1,6 @@
 import ci from "ci-info";
 import dedent from "ts-dedent";
 import { fetch } from "undici";
-/* eslint-disable no-restricted-imports */
 import {
 	afterAll,
 	afterEach,
@@ -9,10 +8,9 @@ import {
 	beforeAll,
 	beforeEach,
 	describe,
-	expect,
+	type ExpectStatic,
 	it,
 } from "vitest";
-/* eslint-enable no-restricted-imports */
 import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
 import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { generateResourceName } from "./helpers/generate-resource-name";
@@ -225,7 +223,11 @@ function generateInitialAssets(workerName: string) {
 	};
 }
 
-async function checkAssets(testCases: AssetTestCase[], deployedUrl: string) {
+async function checkAssets(
+	expect: ExpectStatic,
+	testCases: AssetTestCase[],
+	deployedUrl: string
+) {
 	for (const testCase of testCases) {
 		await waitForLong(
 			async () => {
@@ -288,7 +290,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("Workers + Assets deployment", () => {
 
 			// deploy user Worker && verify output
 			const output = await helper.run(`wrangler deploy`);
-			validateAssetUploadLogs(output, [
+			validateAssetUploadLogs(expect, output, [
 				"/404.html",
 				"/index.html",
 				"/[boop].html",
@@ -313,7 +315,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("Workers + Assets deployment", () => {
 					redirect: "/%5Bboop%5D",
 				},
 			];
-			await checkAssets(testCases, deployedUrl);
+			await checkAssets(expect, testCases, deployedUrl);
 
 			// Test 404 handling:
 			// even though 404.html has been uploaded, because not_found_handling is set to "none"
@@ -360,7 +362,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("Workers + Assets deployment", () => {
 
 			// deploy user Worker && verify output
 			const output = await helper.run(`wrangler deploy`);
-			validateAssetUploadLogs(output, [
+			validateAssetUploadLogs(expect, output, [
 				"/404.html",
 				"/index.html",
 				"/[boop].html",
@@ -386,7 +388,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("Workers + Assets deployment", () => {
 					content: "Hello World!",
 				},
 			];
-			await checkAssets(testCases, deployedUrl);
+			await checkAssets(expect, testCases, deployedUrl);
 
 			// unlike before, not_found_handling has been set to "404-page" instead of the default "none"
 			// note that with a user worker, the request must be passed back to the asset worker via the ASSET binding
@@ -424,6 +426,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("Workers + Assets deployment", () => {
 			});
 
 			validateAssetUploadLogs(
+				expect,
 				output,
 				["/404.html", "/index.html", "/[boop].html"],
 				{ includeDebug: true }
@@ -448,7 +451,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("Workers + Assets deployment", () => {
 					redirect: "/%5Bboop%5D",
 				},
 			];
-			await checkAssets(testCases, deployedUrl);
+			await checkAssets(expect, testCases, deployedUrl);
 
 			// Test 404 handling:
 			// even though 404.html has been uploaded, because not_found_handling is set to "none"
@@ -490,7 +493,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("Workers + Assets deployment", () => {
 
 			// deploy user Worker && verify output
 			const output = await helper.run(`wrangler deploy`);
-			validateAssetUploadLogs(output, [
+			validateAssetUploadLogs(expect, output, [
 				"/404.html",
 				"/index.html",
 				"/[boop].html",
@@ -512,7 +515,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("Workers + Assets deployment", () => {
 					content: "Hello World from User Worker!",
 				},
 			];
-			await checkAssets(testCases, deployedUrl);
+			await checkAssets(expect, testCases, deployedUrl);
 		});
 
 		it("runs the user Worker ahead of matching assets for matching run_worker_first routes", async ({
@@ -544,7 +547,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("Workers + Assets deployment", () => {
 			// deploy user Worker && verify output
 			const output = await helper.run(`wrangler deploy`);
 
-			validateAssetUploadLogs(output, [
+			validateAssetUploadLogs(expect, output, [
 				"/404.html",
 				"/api/index.html",
 				"/index.html",
@@ -563,7 +566,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("Workers + Assets deployment", () => {
 				{ path: "/api/assets/test.html", content: "api/assets/test.html" },
 			];
 
-			await checkAssets(testCases, deployedUrl);
+			await checkAssets(expect, testCases, deployedUrl);
 		});
 	});
 
@@ -633,7 +636,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)("Workers + Assets deployment", () => {
 			output = await helper.run(
 				`wrangler deploy --dispatch-namespace ${dispatchNamespaceName}`
 			);
-			validateAssetUploadLogs(output, [
+			validateAssetUploadLogs(expect, output, [
 				"/404.html",
 				"/index.html",
 				"/[boop].html",
@@ -672,7 +675,7 @@ Current Version ID: 00000000-0000-0000-0000-000000000000`);
 					redirect: "/%5Bboop%5D",
 				},
 			];
-			await checkAssets(testCases, deployedUrl);
+			await checkAssets(expect, testCases, deployedUrl);
 
 			// Test 404 handling:
 			// even though 404.html has been uploaded, because not_found_handling is set to "none"
@@ -730,7 +733,7 @@ Current Version ID: 00000000-0000-0000-0000-000000000000`);
 			output = await helper.run(
 				`wrangler deploy --dispatch-namespace ${dispatchNamespaceName}`
 			);
-			validateAssetUploadLogs(output, [
+			validateAssetUploadLogs(expect, output, [
 				"/404.html",
 				"/index.html",
 				"/[boop].html",
@@ -770,7 +773,7 @@ Current Version ID: 00000000-0000-0000-0000-000000000000`);
 					content: "Hello World!",
 				},
 			];
-			await checkAssets(testCases, deployedUrl);
+			await checkAssets(expect, testCases, deployedUrl);
 
 			// unlike before, not_found_handling has been set to "404-page"
 			// instead of the default "none"
@@ -828,7 +831,7 @@ Current Version ID: 00000000-0000-0000-0000-000000000000`);
 			output = await helper.run(
 				`wrangler deploy --dispatch-namespace ${dispatchNamespaceName}`
 			);
-			validateAssetUploadLogs(output, [
+			validateAssetUploadLogs(expect, output, [
 				"/404.html",
 				"/index.html",
 				"/[boop].html",
@@ -864,7 +867,7 @@ Current Version ID: 00000000-0000-0000-0000-000000000000`);
 					content: "Hello World from User Worker!",
 				},
 			];
-			await checkAssets(testCases, deployedUrl);
+			await checkAssets(expect, testCases, deployedUrl);
 		});
 	});
 });

--- a/packages/wrangler/e2e/helpers/normalize.ts
+++ b/packages/wrangler/e2e/helpers/normalize.ts
@@ -1,7 +1,6 @@
 import { stripVTControlCharacters } from "node:util";
-// eslint-disable-next-line no-restricted-imports
-import { expect } from "vitest";
 import { CLOUDFLARE_ACCOUNT_ID } from "./account-id";
+import type { ExpectStatic } from "vitest";
 
 export function normalizeOutput(
 	stdout: string,
@@ -227,6 +226,7 @@ function normalizeAccountId(stdout: string) {
  * @param includeDebug Whether to check for debug logs as well. Default is false.
  */
 export function validateAssetUploadLogs(
+	expect: ExpectStatic,
 	output: { stdout: string },
 	files: string[],
 	{ includeDebug = false } = {}

--- a/packages/wrangler/e2e/remote-binding/miniflare-remote-resources.test.ts
+++ b/packages/wrangler/e2e/remote-binding/miniflare-remote-resources.test.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
 import dedent from "ts-dedent";
-// eslint-disable-next-line no-restricted-imports
-import { afterAll, assert, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, assert, beforeAll, describe, it } from "vitest";
 import { CLOUDFLARE_ACCOUNT_ID } from "../helpers/account-id";
 import {
 	importMiniflare,
@@ -47,7 +46,7 @@ interface TestCase {
 	/**
 	 * We do a fetch against the Worker defined by `scriptPath` and then check the response matches all these expectations.
 	 */
-	expectFetchToMatch: ExpectStatic[];
+	getExpectFetchToMatch: (expect: ExpectStatic) => ExpectStatic[];
 	/**
 	 * Setup the test case by creating any necessary resources and returning the configuration
 	 * for both the remote proxy session and Miniflare.
@@ -97,7 +96,7 @@ const testCases: TestCase[] = [
 				},
 			}),
 		}),
-		expectFetchToMatch: [
+		getExpectFetchToMatch: (expect) => [
 			expect.stringMatching(/This is a response from Workers AI/),
 		],
 	},
@@ -119,7 +118,7 @@ const testCases: TestCase[] = [
 				},
 			}),
 		}),
-		expectFetchToMatch: [expect.stringMatching(/sessionId/)],
+		getExpectFetchToMatch: (expect) => [expect.stringMatching(/sessionId/)],
 		worksWithoutRemoteBindings: true,
 	},
 	{
@@ -180,7 +179,7 @@ const testCases: TestCase[] = [
 				}),
 			};
 		},
-		expectFetchToMatch: [
+		getExpectFetchToMatch: (expect) => [
 			expect.stringMatching(
 				JSON.stringify({
 					default: "Hello from target worker",
@@ -217,7 +216,7 @@ const testCases: TestCase[] = [
 				}),
 			};
 		},
-		expectFetchToMatch: [
+		getExpectFetchToMatch: (expect) => [
 			expect.stringMatching("The pre-existing value is: existing-value"),
 		],
 	},
@@ -254,7 +253,7 @@ const testCases: TestCase[] = [
 				}),
 			};
 		},
-		expectFetchToMatch: [
+		getExpectFetchToMatch: (expect) => [
 			expect.stringMatching("The pre-existing value is: existing-value"),
 		],
 	},
@@ -291,7 +290,9 @@ const testCases: TestCase[] = [
 				}),
 			};
 		},
-		expectFetchToMatch: [expect.stringMatching("existing-value")],
+		getExpectFetchToMatch: (expect) => [
+			expect.stringMatching("existing-value"),
+		],
 	},
 	{
 		name: "Vectorize",
@@ -321,7 +322,7 @@ const testCases: TestCase[] = [
 				}),
 			};
 		},
-		expectFetchToMatch: [
+		getExpectFetchToMatch: (expect) => [
 			expect.stringContaining(
 				`[{"id":"a44706aa-a366-48bc-8cc1-3feffd87d548","namespace":null,"metadata":{"text":"Peter Piper picked a peck of pickled peppers"},"values":[0.2321,0.8121,0.6315,0.6151,0.4121,0.1512,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}]`
 			),
@@ -345,7 +346,7 @@ const testCases: TestCase[] = [
 				},
 			}),
 		}),
-		expectFetchToMatch: [expect.stringContaining(`image/avif`)],
+		getExpectFetchToMatch: (expect) => [expect.stringContaining(`image/avif`)],
 	},
 	{
 		name: "Media",
@@ -365,7 +366,7 @@ const testCases: TestCase[] = [
 				},
 			}),
 		}),
-		expectFetchToMatch: [expect.stringContaining(`image/jpeg`)],
+		getExpectFetchToMatch: (expect) => [expect.stringContaining(`image/jpeg`)],
 	},
 	{
 		name: "Dispatch Namespace",
@@ -411,7 +412,7 @@ const testCases: TestCase[] = [
 				}),
 			};
 		},
-		expectFetchToMatch: [
+		getExpectFetchToMatch: (expect) => [
 			expect.stringMatching(
 				JSON.stringify({
 					worker: "Hello from customer worker",
@@ -449,7 +450,7 @@ const testCases: TestCase[] = [
 				}),
 			};
 		},
-		expectFetchToMatch: [
+		getExpectFetchToMatch: (expect) => [
 			expect.stringContaining(`"created":true`),
 			expect.stringContaining(`"deleted":true`),
 		],
@@ -479,7 +480,7 @@ const testCases: TestCase[] = [
 				}),
 			};
 		},
-		expectFetchToMatch: [expect.stringContaining(`"id"`)],
+		getExpectFetchToMatch: (expect) => [expect.stringContaining(`"id"`)],
 	},
 	{
 		name: "Pipelines",
@@ -502,7 +503,9 @@ const testCases: TestCase[] = [
 				},
 			}),
 		}),
-		expectFetchToMatch: [expect.stringContaining(`Data sent to env.PIPELINE`)],
+		getExpectFetchToMatch: (expect) => [
+			expect.stringContaining(`Data sent to env.PIPELINE`),
+		],
 		worksWithoutRemoteBindings: true,
 	},
 	{
@@ -524,7 +527,7 @@ const testCases: TestCase[] = [
 				},
 			}),
 		}),
-		expectFetchToMatch: [
+		getExpectFetchToMatch: (expect) => [
 			// This error message comes from the production binding, and so indicates that the binding has been called
 			// successfully, which is all we care about. Full E2E testing of email sending would be _incredibly_ flaky
 			expect.stringContaining(
@@ -580,7 +583,7 @@ const testCases: TestCase[] = [
 				}),
 			};
 		},
-		expectFetchToMatch: [
+		getExpectFetchToMatch: (expect) => [
 			// Since we're using a real tunnel but no actual network connectivity, Iris will report back an error
 			// but this is considered an effective test for wrangler and vpc service bindings
 			expect.stringMatching(/CONNECT failed: 503 Service Unavailable/),
@@ -651,7 +654,7 @@ if (!CLOUDFLARE_ACCOUNT_ID) {
 					headers: { "x-test-module": testCase.scriptPath },
 				});
 				const respText = await resp.text();
-				testCase.expectFetchToMatch.forEach((match) => {
+				testCase.getExpectFetchToMatch(expect).forEach((match) => {
 					expect(respText).toEqual(match);
 				});
 			});
@@ -718,7 +721,7 @@ if (!CLOUDFLARE_ACCOUNT_ID) {
 					}),
 				};
 			},
-			expectFetchToMatch: [
+			getExpectFetchToMatch: (expect) => [
 				// Note: in this test we are making sure that TLS negotiation does work by checking that we get an SSL certificate error
 				expect.stringMatching(/The SSL certificate error/),
 				expect.not.stringMatching(/No required SSL certificate was sent/),
@@ -751,7 +754,7 @@ if (!CLOUDFLARE_ACCOUNT_ID) {
 			const mf = new Miniflare(miniflareConfig);
 			const resp = await mf.dispatchFetch("http://example.com/");
 			const respText = await resp.text();
-			mtlsTestCase.expectFetchToMatch.forEach((match) => {
+			mtlsTestCase.getExpectFetchToMatch(expect).forEach((match) => {
 				expect(respText).toEqual(match);
 			});
 		});
@@ -802,7 +805,7 @@ describe("Remote bindings (remote proxy session disabled)", () => {
 				headers: { "x-test-module": testCase.scriptPath },
 			});
 			const respText = await resp.text();
-			testCase.expectFetchToMatch.forEach((match) => {
+			testCase.getExpectFetchToMatch(expect).forEach((match) => {
 				expect(respText).toEqual(match);
 			});
 		});

--- a/packages/wrangler/e2e/start-worker-auth-opts.test.ts
+++ b/packages/wrangler/e2e/start-worker-auth-opts.test.ts
@@ -1,16 +1,6 @@
 import path from "node:path";
 import dedent from "ts-dedent";
-/* eslint-disable no-restricted-imports */
-import {
-	afterEach,
-	assert,
-	beforeEach,
-	describe,
-	expect,
-	test,
-	vi,
-} from "vitest";
-/* eslint-enable no-restricted-imports */
+import { afterEach, assert, beforeEach, describe, test, vi } from "vitest";
 import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
 import {
 	importWrangler,
@@ -18,7 +8,7 @@ import {
 } from "./helpers/e2e-wrangler-test";
 import { waitForLong } from "./helpers/wait-for";
 import type { Worker } from "../src/api/startDevWorker";
-import type { MockInstance } from "vitest";
+import type { ExpectStatic, MockInstance } from "vitest";
 
 const { unstable_startWorker: startWorker } = await importWrangler();
 
@@ -92,7 +82,7 @@ describe("startWorker - auth options", { sequential: true }, () => {
 				},
 			});
 
-			await assertValidWorkerAiResponse();
+			await assertValidWorkerAiResponse(expect);
 
 			expect(validAuth).toHaveBeenCalledOnce();
 
@@ -113,7 +103,7 @@ describe("startWorker - auth options", { sequential: true }, () => {
 				},
 			});
 
-			await assertInvalidWorkerAiResponse();
+			await assertInvalidWorkerAiResponse(expect);
 
 			expect(incorrectAuth).toHaveBeenCalledOnce();
 		});
@@ -147,7 +137,7 @@ describe("startWorker - auth options", { sequential: true }, () => {
 				},
 			});
 
-			await assertInvalidWorkerAiResponse();
+			await assertInvalidWorkerAiResponse(expect);
 
 			expect(incorrectAuth).toHaveBeenCalledOnce();
 
@@ -170,12 +160,12 @@ describe("startWorker - auth options", { sequential: true }, () => {
 				},
 			});
 
-			await assertValidWorkerAiResponse();
+			await assertValidWorkerAiResponse(expect);
 
 			expect(validAuth).toHaveBeenCalledOnce();
 		});
 
-		async function assertValidWorkerAiResponse() {
+		async function assertValidWorkerAiResponse(expect: ExpectStatic) {
 			assert(worker, "Worker is not defined");
 			const responseText = await fetchTimedTextFromWorker(worker);
 
@@ -192,7 +182,7 @@ describe("startWorker - auth options", { sequential: true }, () => {
 			);
 		}
 
-		async function assertInvalidWorkerAiResponse() {
+		async function assertInvalidWorkerAiResponse(expect: ExpectStatic) {
 			assert(worker, "Worker is not defined");
 			const responseText = await fetchTimedTextFromWorker(worker);
 

--- a/packages/wrangler/e2e/versions.test.ts
+++ b/packages/wrangler/e2e/versions.test.ts
@@ -581,7 +581,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 				`wrangler versions upload --message "Upload via e2e test" --tag "e2e-upload-assets"`
 			);
 
-			validateAssetUploadLogs(upload, ["/asset.txt"]);
+			validateAssetUploadLogs(expect, upload, ["/asset.txt"]);
 		});
 
 		it("should upload version of Worker with assets only", async ({
@@ -609,7 +609,7 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 				`wrangler versions upload --message "Upload via e2e test" --tag "e2e-upload-assets"`
 			);
 
-			validateAssetUploadLogs(upload, ["/asset.txt"]);
+			validateAssetUploadLogs(expect, upload, ["/asset.txt"]);
 
 			const versionsView = await helper.run(
 				`wrangler versions view ${matchVersionId(upload.stdout)}`

--- a/packages/wrangler/e2e/vitest.setup.ts
+++ b/packages/wrangler/e2e/vitest.setup.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-object-type */
-// eslint-disable-next-line no-restricted-imports
+// eslint-disable-next-line no-restricted-imports -- We need to import `expect` from "vitest" so that we can extend it
 import { expect } from "vitest";
 
 interface CustomMatchers {


### PR DESCRIPTION
Removal of comments such as:
```
// eslint-disable-next-line no-restricted-imports
```
In the wrangler e2es

Continuation from https://github.com/cloudflare/workers-sdk/pull/13140


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: refactoring

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
