### PR TITLE
[vitest-pool-workers-examples] Bump @cloudflare/containers to 0.2.2

### DIFF
--- a/fixtures/vitest-pool-workers-examples/package.json
+++ b/fixtures/vitest-pool-workers-examples/package.json
@@ -10,7 +10,7 @@
 	},
 	"devDependencies": {
 		"@better-auth/stripe": "^1.4.6",
-		"@cloudflare/containers": "^0.0.25",
+		"@cloudflare/containers": "^0.2.2",
 		"@cloudflare/vitest-pool-workers": "workspace:*",
 		"@cloudflare/workers-types": "catalog:default",
 		"@microlabs/otel-cf-workers": "1.0.0-rc.45",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1152,8 +1152,8 @@ importers:
         specifier: ^1.4.6
         version: 1.5.4(woqkghwnq7gb7clahla7g2e3zu)
       '@cloudflare/containers':
-        specifier: ^0.0.25
-        version: 0.0.25
+        specifier: ^0.2.2
+        version: 0.2.2
       '@cloudflare/vitest-pool-workers':
         specifier: workspace:*
         version: link:../../packages/vitest-pool-workers
@@ -4986,8 +4986,8 @@ packages:
       '@cloudflare/style-container': ^7.10.0
       react: ^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0
 
-  '@cloudflare/containers@0.0.25':
-    resolution: {integrity: sha512-41sCUwGPhMMQI/kwksEZXNWe/GZdQoIy8QlgO4NAF68M4y4NN41IXeQ4n2jn4iJ7tHaV4noe7RI75b7T6h2JGg==}
+  '@cloudflare/containers@0.2.2':
+    resolution: {integrity: sha512-cfTSd7M96Z9NeCiaN4i3FuMb+i2Nzi0HbMuxvMAnUmkXwtWIZCQ3XLqUWQkdCKWNJZ/3BLMInC6ntFvpbTWIpA==}
 
   '@cloudflare/elements@3.0.3':
     resolution: {integrity: sha512-s6Sjh+IWJD0xn+4iy6hk/FYwY1gAFLWvpiWUmfDZWrQ09ZOTto8aRwpoEN7jUV6dZCPlCkUqMj4xKwRzDQ72FQ==}
@@ -16054,7 +16054,7 @@ snapshots:
     transitivePeerDependencies:
       - regenerator-runtime
 
-  '@cloudflare/containers@0.0.25': {}
+  '@cloudflare/containers@0.2.2': {}
 
   '@cloudflare/elements@3.0.3(@cloudflare/style-const@5.7.3(react@18.3.1))(@cloudflare/style-container@7.12.2(@cloudflare/style-const@5.7.3(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
Bump `@cloudflare/containers` from `^0.0.25` to `^0.2.2` in the `vitest-pool-workers-examples` fixture.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: fixture dependency bump only
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: no user-facing change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
