### PR TITLE
[vite-plugin] Defer export type discovery to avoid TDZ on circular deps

### DIFF
--- a/.changeset/defer-export-types.md
+++ b/.changeset/defer-export-types.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+fix: defer worker export type discovery to avoid TDZ on circular deps
+
+Skip eager `getCurrentWorkerNameToExportTypesMap()` during dev server startup. Use config-derived export types instead, which reads DO/WEP/Workflow bindings from `wrangler.jsonc` without loading user code. The existing HMR handler corrects any discrepancy when the module first loads on request.
+
+This fixes dev startup for workers that import packages with circular internal imports (e.g. drizzle-orm) which cause TDZ errors under `noExternal: true`.

--- a/packages/vite-plugin-cloudflare/playground/circular-deps-do/__tests__/circular-deps-do.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/circular-deps-do/__tests__/circular-deps-do.spec.ts
@@ -1,0 +1,19 @@
+import { describe, test } from "vitest";
+import { getTextResponse } from "../../__test-utils__";
+
+describe("worker with circular-dep package and durable objects", () => {
+	test("worker starts and responds (circular dep does not crash startup)", async ({
+		expect,
+	}) => {
+		const text = await getTextResponse("/");
+		expect(text).toContain("sql type: function");
+		expect(text).toContain("greeting:");
+	});
+
+	test("durable object works through circular-dep import", async ({
+		expect,
+	}) => {
+		const text = await getTextResponse("/do");
+		expect(text).toContain("Hello DO from A");
+	});
+});

--- a/packages/vite-plugin-cloudflare/playground/circular-deps-do/node_modules/circular-pkg/a.js
+++ b/packages/vite-plugin-cloudflare/playground/circular-deps-do/node_modules/circular-pkg/a.js
@@ -1,0 +1,10 @@
+// a.js imports from b.js, b.js imports from a.js — circular
+import { greetFromB } from "./b.js";
+
+export function sql(strings, ...params) {
+	return strings.join("?");
+}
+
+export function greetFromA(name) {
+	return `Hello ${name} from A (via B: ${greetFromB("A")})`;
+}

--- a/packages/vite-plugin-cloudflare/playground/circular-deps-do/node_modules/circular-pkg/b.js
+++ b/packages/vite-plugin-cloudflare/playground/circular-deps-do/node_modules/circular-pkg/b.js
@@ -1,0 +1,8 @@
+// b.js imports sql from a.js — circular reference
+// In native ESM this works (live bindings). Under Vite's SSR transform
+// (which uses const), accessing `sql` before a.js finishes → TDZ.
+import { sql } from "./a.js";
+
+export function greetFromB(name) {
+	return `Hi ${name} from B (sql=${typeof sql})`;
+}

--- a/packages/vite-plugin-cloudflare/playground/circular-deps-do/node_modules/circular-pkg/index.js
+++ b/packages/vite-plugin-cloudflare/playground/circular-deps-do/node_modules/circular-pkg/index.js
@@ -1,0 +1,2 @@
+export { sql, greetFromA } from "./a.js";
+export { greetFromB } from "./b.js";

--- a/packages/vite-plugin-cloudflare/playground/circular-deps-do/node_modules/circular-pkg/package.json
+++ b/packages/vite-plugin-cloudflare/playground/circular-deps-do/node_modules/circular-pkg/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "circular-pkg",
+	"version": "1.0.0",
+	"type": "module",
+	"main": "./index.js",
+	"exports": {
+		".": "./index.js"
+	}
+}

--- a/packages/vite-plugin-cloudflare/playground/circular-deps-do/package.json
+++ b/packages/vite-plugin-cloudflare/playground/circular-deps-do/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "@playground/circular-deps-do",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vite dev"
+	},
+	"devDependencies": {
+		"@cloudflare/vite-plugin": "workspace:*",
+		"@cloudflare/workers-tsconfig": "workspace:*",
+		"@cloudflare/workers-types": "catalog:default",
+		"typescript": "catalog:default",
+		"vite": "catalog:default",
+		"wrangler": "workspace:*"
+	}
+}

--- a/packages/vite-plugin-cloudflare/playground/circular-deps-do/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/circular-deps-do/src/index.ts
@@ -1,0 +1,29 @@
+import { DurableObject } from "cloudflare:workers";
+// This import triggers a circular dep inside circular-pkg (a.js ↔ b.js).
+// In native ESM this works fine. Under Vite's SSR transform (noExternal: true),
+// the live bindings are converted to const, causing TDZ on circular references.
+import { sql, greetFromA } from "circular-pkg";
+
+interface Env {
+	MY_DO: DurableObjectNamespace<MyDurableObject>;
+}
+
+export class MyDurableObject extends DurableObject {
+	async fetch(request: Request) {
+		return new Response(greetFromA("DO"));
+	}
+}
+
+export default {
+	async fetch(request: Request, env: Env) {
+		const url = new URL(request.url);
+
+		if (url.pathname === "/do") {
+			const id = env.MY_DO.idFromName("test");
+			const stub = env.MY_DO.get(id);
+			return stub.fetch(request);
+		}
+
+		return new Response(`sql type: ${typeof sql}, greeting: ${greetFromA("worker")}`);
+	},
+} satisfies ExportedHandler<Env>;

--- a/packages/vite-plugin-cloudflare/playground/circular-deps-do/tsconfig.json
+++ b/packages/vite-plugin-cloudflare/playground/circular-deps-do/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"files": [],
+	"references": [
+		{ "path": "./tsconfig.node.json" },
+		{ "path": "./tsconfig.worker.json" }
+	]
+}

--- a/packages/vite-plugin-cloudflare/playground/circular-deps-do/tsconfig.node.json
+++ b/packages/vite-plugin-cloudflare/playground/circular-deps-do/tsconfig.node.json
@@ -1,0 +1,4 @@
+{
+	"extends": ["@cloudflare/workers-tsconfig/base.json"],
+	"include": ["vite.config.ts", "__tests__"]
+}

--- a/packages/vite-plugin-cloudflare/playground/circular-deps-do/tsconfig.worker.json
+++ b/packages/vite-plugin-cloudflare/playground/circular-deps-do/tsconfig.worker.json
@@ -1,0 +1,4 @@
+{
+	"extends": ["@cloudflare/workers-tsconfig/worker.json"],
+	"include": ["src"]
+}

--- a/packages/vite-plugin-cloudflare/playground/circular-deps-do/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/circular-deps-do/vite.config.ts
@@ -1,0 +1,6 @@
+import { cloudflare } from "@cloudflare/vite-plugin";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+});

--- a/packages/vite-plugin-cloudflare/playground/circular-deps-do/wrangler.jsonc
+++ b/packages/vite-plugin-cloudflare/playground/circular-deps-do/wrangler.jsonc
@@ -1,0 +1,19 @@
+{
+	"name": "worker",
+	"main": "./src/index.ts",
+	"compatibility_date": "2024-12-30",
+	"durable_objects": {
+		"bindings": [
+			{
+				"name": "MY_DO",
+				"class_name": "MyDurableObject"
+			}
+		]
+	},
+	"migrations": [
+		{
+			"tag": "v1",
+			"new_sqlite_classes": ["MyDurableObject"]
+		}
+	]
+}

--- a/packages/vite-plugin-cloudflare/src/plugins/dev.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/dev.ts
@@ -12,11 +12,7 @@ import {
 } from "../constants";
 import { getDockerPath } from "../containers";
 import { assertIsNotPreview } from "../context";
-import {
-	compareExportTypes,
-	compareWorkerNameToExportTypesMaps,
-	getCurrentWorkerNameToExportTypesMap,
-} from "../export-types";
+import { compareExportTypes } from "../export-types";
 import { getDevMiniflareOptions } from "../miniflare-options";
 import { UNKNOWN_HOST } from "../shared";
 import {
@@ -77,31 +73,17 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 					viteDevServer,
 					ctx.miniflare
 				);
-				const currentWorkerNameToExportTypesMap =
-					await getCurrentWorkerNameToExportTypesMap(
-						ctx.resolvedPluginConfig,
-						viteDevServer,
-						ctx.miniflare
-					);
-				const hasChanged = compareWorkerNameToExportTypesMaps(
-					ctx.workerNameToExportTypesMap,
-					currentWorkerNameToExportTypesMap
-				);
 
-				if (hasChanged) {
-					ctx.setWorkerNameToExportTypesMap(currentWorkerNameToExportTypesMap);
-					const updatedOptions = await getDevMiniflareOptions(
-						ctx,
-						viteDevServer
-					);
-					containerTagToOptionsMap = updatedOptions.containerTagToOptionsMap;
-					await ctx.startOrUpdateMiniflare(updatedOptions.miniflareOptions);
-					await initRunners(
-						ctx.resolvedPluginConfig,
-						viteDevServer,
-						ctx.miniflare
-					);
-				}
+				// Use config-derived export types for initial startup instead of
+				// eagerly loading the worker module graph. Loading the full module
+				// graph here can fail for packages with circular internal imports
+				// (e.g. drizzle-orm) because `noExternal: true` causes Vite's
+				// SSR transform to convert ESM live bindings to `const`, triggering
+				// TDZ errors on circular references.
+				//
+				// The HMR handler below will detect any discrepancy between the
+				// config-derived types and the actual exports when the module first
+				// loads (on first request), and restart the dev server if needed.
 
 				for (const environmentName of ctx.resolvedPluginConfig.environmentNameToWorkerMap.keys()) {
 					const environment = viteDevServer.environments[environmentName];


### PR DESCRIPTION
## Summary

- Skip eager `getCurrentWorkerNameToExportTypesMap()` call during dev server startup
- Use config-derived export types (`getInitialWorkerNameToExportTypesMap`) instead, which reads DO/WEP/Workflow bindings from `wrangler.jsonc` without loading any user code
- The existing HMR handler already corrects any discrepancy when the module first loads on request

## Problem

The dev plugin eagerly loads the entire worker module graph at startup to verify export types. This fails for packages with circular internal imports (e.g. `drizzle-orm`) because `noExternal: true` causes Vite's `runInlinedModule` to convert ESM live bindings to `const` assignments, triggering TDZ (`ReferenceError: Cannot access 'X' before initialization`).

The config-derived types are sufficient for initial startup — they already include all DurableObject, WorkerEntrypoint, and WorkflowEntrypoint exports declared in the wrangler config. The runtime check was a redundant verification step.

```
ReferenceError: Cannot access 'sql' before initialization
    at runInRunnerObject (workers/runner-worker/index.js:106:3)
    at getWorkerEntryExportTypes (workers/runner-worker/index.js:245:24)
```

This affects any worker that imports packages with internal circular imports alongside DO/WEP exports: drizzle-orm, prisma, and others. Production builds are unaffected (Rollup resolves circulars during bundling).

Related: #11695, #11825

## Test plan

- Added `playground/circular-deps-do` — worker with a DurableObject that imports a package containing circular internal imports (a.js ↔ b.js)
- Without the fix: `vite dev` crashes at startup with TDZ error
- With the fix: server starts, worker responds, DO works
- Existing `playground/durable-objects` test continues to pass (happy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
