### PR TITLE
Return more sensible user error

### DIFF
--- a/.changeset/ai-auth-error-message.md
+++ b/.changeset/ai-auth-error-message.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Log a helpful error message when AI binding requests fail with a 403 authentication error
+
+Previously, when the AI proxy token expired during a long session, users received an unhelpful 403 error. Now, wrangler detects error code 1031 and suggests running `wrangler login` to refresh the token.

--- a/packages/wrangler/src/__tests__/ai.local.test.ts
+++ b/packages/wrangler/src/__tests__/ai.local.test.ts
@@ -71,7 +71,9 @@ describe("ai", () => {
 		});
 
 		describe("403 auth error handling", () => {
-			it("should log error on 403 with auth error code 1031", async ({ expect }) => {
+			it("should log error on 403 with auth error code 1031", async ({
+				expect,
+			}) => {
 				vi.spyOn(user, "getAccountId").mockImplementation(async () => "123");
 				vi.spyOn(internal, "performApiFetch").mockImplementation(async () => {
 					return new Response(
@@ -93,7 +95,9 @@ describe("ai", () => {
 				);
 			});
 
-			it("should not log error on 403 without auth error code 1031", async ({ expect }) => {
+			it("should not log error on 403 without auth error code 1031", async ({
+				expect,
+			}) => {
 				vi.spyOn(user, "getAccountId").mockImplementation(async () => "123");
 				vi.spyOn(internal, "performApiFetch").mockImplementation(async () => {
 					return new Response(
@@ -113,7 +117,9 @@ describe("ai", () => {
 				expect(errorSpy).not.toHaveBeenCalled();
 			});
 
-			it("should not throw on 403 with unparseable body", async ({ expect }) => {
+			it("should not throw on 403 with unparseable body", async ({
+				expect,
+			}) => {
 				vi.spyOn(user, "getAccountId").mockImplementation(async () => "123");
 				vi.spyOn(internal, "performApiFetch").mockImplementation(async () => {
 					return new Response("not json", { status: 403 });

--- a/packages/wrangler/src/__tests__/ai.local.test.ts
+++ b/packages/wrangler/src/__tests__/ai.local.test.ts
@@ -4,6 +4,7 @@ import { Headers, Response } from "undici";
 import { afterEach, describe, it, vi } from "vitest";
 import { getAIFetcher } from "../ai/fetcher";
 import * as internal from "../cfetch/internal";
+import { logger } from "../logger";
 import * as user from "../user";
 
 const AIFetcher = getAIFetcher(COMPLIANCE_REGION_CONFIG_UNKNOWN);
@@ -66,6 +67,65 @@ describe("ai", () => {
 				expect(await resp.json()).toEqual({
 					resource: "/accounts/123/ai/run/proxy",
 				});
+			});
+		});
+
+		describe("403 auth error handling", () => {
+			it("should log error on 403 with auth error code 1031", async ({ expect }) => {
+				vi.spyOn(user, "getAccountId").mockImplementation(async () => "123");
+				vi.spyOn(internal, "performApiFetch").mockImplementation(async () => {
+					return new Response(
+						JSON.stringify({
+							errors: [{ code: 1031, message: "Forbidden" }],
+						}),
+						{ status: 403 }
+					);
+				});
+				const errorSpy = vi.spyOn(logger, "error");
+
+				const resp = await AIFetcher(
+					new Request("http://internal.ai/ai/test/path", { method: "POST" })
+				);
+
+				expect(resp.status).toBe(403);
+				expect(errorSpy).toHaveBeenCalledWith(
+					"Authentication error (code 1031): Your API token may have expired or lacks the required permissions. Please refresh your token by running `wrangler login`."
+				);
+			});
+
+			it("should not log error on 403 without auth error code 1031", async ({ expect }) => {
+				vi.spyOn(user, "getAccountId").mockImplementation(async () => "123");
+				vi.spyOn(internal, "performApiFetch").mockImplementation(async () => {
+					return new Response(
+						JSON.stringify({
+							errors: [{ code: 9999, message: "Other error" }],
+						}),
+						{ status: 403 }
+					);
+				});
+				const errorSpy = vi.spyOn(logger, "error");
+
+				const resp = await AIFetcher(
+					new Request("http://internal.ai/ai/test/path", { method: "POST" })
+				);
+
+				expect(resp.status).toBe(403);
+				expect(errorSpy).not.toHaveBeenCalled();
+			});
+
+			it("should not throw on 403 with unparseable body", async ({ expect }) => {
+				vi.spyOn(user, "getAccountId").mockImplementation(async () => "123");
+				vi.spyOn(internal, "performApiFetch").mockImplementation(async () => {
+					return new Response("not json", { status: 403 });
+				});
+				const errorSpy = vi.spyOn(logger, "error");
+
+				const resp = await AIFetcher(
+					new Request("http://internal.ai/ai/test/path", { method: "POST" })
+				);
+
+				expect(resp.status).toBe(403);
+				expect(errorSpy).not.toHaveBeenCalled();
 			});
 		});
 	});

--- a/packages/wrangler/src/ai/fetcher.ts
+++ b/packages/wrangler/src/ai/fetcher.ts
@@ -1,5 +1,6 @@
 import { Headers, Response } from "miniflare";
 import { performApiFetch } from "../cfetch";
+import { logger } from "../logger";
 import { getAccountId } from "../user";
 import type { ComplianceConfig } from "@cloudflare/workers-utils";
 import type { Request } from "miniflare";
@@ -33,6 +34,23 @@ export function getAIFetcher(complianceConfig: ComplianceConfig) {
 				duplex: "half",
 			}
 		);
+
+		if (res.status === 403) {
+			try {
+				const clonedRes = res.clone();
+				const body = (await clonedRes.json()) as {
+					errors?: Array<{ code?: number; message?: string }>;
+				};
+				const authError = body?.errors?.find((e) => e.code === 1031);
+				if (authError) {
+					logger.error(
+						"Authentication error (code 1031): Your API token may have expired or lacks the required permissions. Please refresh your token by running `wrangler login`."
+					);
+				}
+			} catch {
+				// If we can't parse the response body, fall through to return the original response
+			}
+		}
 
 		const respHeaders = new Headers(res.headers);
 		respHeaders.delete("Host");


### PR DESCRIPTION
Fixes #[insert GH or internal issue link(s)].

The AI binding uses a proxy for doing inference. if the session runs long, the token expires and the users gets a weird error message

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Minor error handling improvement.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
