### PR TITLE
ci: reuse external fork PRs and add remote test label

### DIFF
--- a/.github/workflows/run-ci-for-external-forks.yml
+++ b/.github/workflows/run-ci-for-external-forks.yml
@@ -69,7 +69,7 @@ jobs:
             --jq 'first(.[].number) // ""')
 
           if [ -n "$existing_pr" ]; then
-            gh pr edit "$existing_pr" 
+            gh pr edit "$existing_pr" \
               --add-label "e2e" \
               --add-label "run-remote-tests" \
               --title "$TITLE" \


### PR DESCRIPTION
Fixes n/a.

This updates the `Run CI on behalf of External Forks` workflow to reuse an existing draft PR by updating its title and body, and to always apply the `run-remote-tests` label.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
