### PR TITLE
[wrangler] Add enabled and previews_enabled options for custom domains

### DIFF
--- a/.changeset/angry-bears-count.md
+++ b/.changeset/angry-bears-count.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/workers-utils": minor
+"wrangler": minor
+---
+
+Add production_enabled and previews_enabled support for custom domain routes
+
+Custom domain routes can now include optional production_enabled and previews_enabled boolean fields to control whether a domain serves production and/or preview traffic. When omitted, the API defaults apply (production enabled, previews disabled).

--- a/.changeset/angry-bears-count.md
+++ b/.changeset/angry-bears-count.md
@@ -3,6 +3,6 @@
 "wrangler": minor
 ---
 
-Add production_enabled and previews_enabled support for custom domain routes
+Add enabled and previews_enabled support for custom domain routes
 
-Custom domain routes can now include optional production_enabled and previews_enabled boolean fields to control whether a domain serves production and/or preview traffic. When omitted, the API defaults apply (production enabled, previews disabled).
+Custom domain routes can now include optional `enabled` and `previews_enabled` boolean fields to control whether a custom domain serves production and/or preview traffic. When omitted, the API defaults apply (production enabled, previews disabled).

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -20,7 +20,22 @@ export type ZoneNameRoute = {
 	zone_name: string;
 	custom_domain?: boolean;
 };
-export type CustomDomainRoute = { pattern: string; custom_domain: boolean };
+export type CustomDomainRoute = {
+	pattern: string;
+	custom_domain: boolean;
+	/**
+	 * Whether this custom domain serves production traffic.
+	 *
+	 * @default true
+	 */
+	production_enabled?: boolean;
+	/**
+	 * Whether this custom domain serves preview traffic.
+	 *
+	 * @default false
+	 */
+	previews_enabled?: boolean;
+};
 export type Route =
 	| SimpleRoute
 	| ZoneIdRoute

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -23,17 +23,7 @@ export type ZoneNameRoute = {
 export type CustomDomainRoute = {
 	pattern: string;
 	custom_domain: boolean;
-	/**
-	 * Whether this custom domain serves production traffic.
-	 *
-	 * @default true
-	 */
-	production_enabled?: boolean;
-	/**
-	 * Whether this custom domain serves preview traffic.
-	 *
-	 * @default false
-	 */
+	enabled?: boolean;
 	previews_enabled?: boolean;
 };
 export type Route =

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -980,8 +980,6 @@ function isValidRouteValue(item: unknown): boolean {
 			return false;
 		}
 
-		const otherKeys = Object.keys(item).length - 1; // minus one to subtract "pattern"
-
 		const hasZoneId =
 			hasProperty(item, "zone_id") && typeof item.zone_id === "string";
 		const hasZoneName =
@@ -989,13 +987,34 @@ function isValidRouteValue(item: unknown): boolean {
 		const hasCustomDomainFlag =
 			hasProperty(item, "custom_domain") &&
 			typeof item.custom_domain === "boolean";
+		const hasProductionEnabled =
+			hasProperty(item, "production_enabled") &&
+			typeof item.production_enabled === "boolean";
+		const hasPreviewsEnabled =
+			hasProperty(item, "previews_enabled") &&
+			typeof item.previews_enabled === "boolean";
 
-		if (otherKeys === 2 && hasCustomDomainFlag && (hasZoneId || hasZoneName)) {
-			return true;
-		} else if (
-			otherKeys === 1 &&
-			(hasZoneId || hasZoneName || hasCustomDomainFlag)
-		) {
+		const recognizedKeys = [
+			hasZoneId,
+			hasZoneName,
+			hasCustomDomainFlag,
+			hasProductionEnabled,
+			hasPreviewsEnabled,
+		].filter(Boolean).length;
+		const otherKeys = Object.keys(item).length - 1; // minus one to subtract "pattern"
+
+		// All keys must be recognized
+		if (recognizedKeys !== otherKeys) {
+			return false;
+		}
+
+		// production_enabled and previews_enabled are only valid on custom domain routes
+		if ((hasProductionEnabled || hasPreviewsEnabled) && !hasCustomDomainFlag) {
+			return false;
+		}
+
+		// Must have at least one of: zone_id, zone_name, or custom_domain
+		if (hasZoneId || hasZoneName || hasCustomDomainFlag) {
 			return true;
 		}
 	}
@@ -1046,7 +1065,7 @@ function mutateEmptyStringRouteValue(
 const isRoute: ValidatorFn = (diagnostics, field, value) => {
 	if (value !== undefined && !isValidRouteValue(value)) {
 		diagnostics.errors.push(
-			`Expected "${field}" to be either a string, or an object with shape { pattern, custom_domain, zone_id | zone_name }, but got ${JSON.stringify(
+			`Expected "${field}" to be either a string, or an object with shape { pattern, custom_domain, zone_id | zone_name, production_enabled, previews_enabled }, but got ${JSON.stringify(
 				value
 			)}.`
 		);
@@ -1076,7 +1095,7 @@ const isRouteArray: ValidatorFn = (diagnostics, field, value) => {
 	}
 	if (invalidRoutes.length > 0) {
 		diagnostics.errors.push(
-			`Expected "${field}" to be an array of either strings or objects with the shape { pattern, custom_domain, zone_id | zone_name }, but these weren't valid: ${JSON.stringify(
+			`Expected "${field}" to be an array of either strings or objects with the shape { pattern, custom_domain, zone_id | zone_name, production_enabled, previews_enabled }, but these weren't valid: ${JSON.stringify(
 				invalidRoutes,
 				null,
 				2

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -987,9 +987,8 @@ function isValidRouteValue(item: unknown): boolean {
 		const hasCustomDomainFlag =
 			hasProperty(item, "custom_domain") &&
 			typeof item.custom_domain === "boolean";
-		const hasProductionEnabled =
-			hasProperty(item, "production_enabled") &&
-			typeof item.production_enabled === "boolean";
+		const hasEnabled =
+			hasProperty(item, "enabled") && typeof item.enabled === "boolean";
 		const hasPreviewsEnabled =
 			hasProperty(item, "previews_enabled") &&
 			typeof item.previews_enabled === "boolean";
@@ -998,7 +997,7 @@ function isValidRouteValue(item: unknown): boolean {
 			hasZoneId,
 			hasZoneName,
 			hasCustomDomainFlag,
-			hasProductionEnabled,
+			hasEnabled,
 			hasPreviewsEnabled,
 		].filter(Boolean).length;
 		const otherKeys = Object.keys(item).length - 1; // minus one to subtract "pattern"
@@ -1013,8 +1012,8 @@ function isValidRouteValue(item: unknown): boolean {
 			return false;
 		}
 
-		// production_enabled and previews_enabled are only valid on custom domain routes
-		if ((hasProductionEnabled || hasPreviewsEnabled) && !hasCustomDomainFlag) {
+		// enabled and previews_enabled are only valid on custom domain routes
+		if ((hasEnabled || hasPreviewsEnabled) && !hasCustomDomainFlag) {
 			return false;
 		}
 
@@ -1070,7 +1069,7 @@ function mutateEmptyStringRouteValue(
 const isRoute: ValidatorFn = (diagnostics, field, value) => {
 	if (value !== undefined && !isValidRouteValue(value)) {
 		diagnostics.errors.push(
-			`Expected "${field}" to be either a string, or an object with shape { pattern, custom_domain, zone_id | zone_name, production_enabled, previews_enabled }, but got ${JSON.stringify(
+			`Expected "${field}" to be either a string, or an object with shape { pattern, custom_domain, zone_id | zone_name, enabled, previews_enabled }, but got ${JSON.stringify(
 				value
 			)}.`
 		);
@@ -1100,7 +1099,7 @@ const isRouteArray: ValidatorFn = (diagnostics, field, value) => {
 	}
 	if (invalidRoutes.length > 0) {
 		diagnostics.errors.push(
-			`Expected "${field}" to be an array of either strings or objects with the shape { pattern, custom_domain, zone_id | zone_name, production_enabled, previews_enabled }, but these weren't valid: ${JSON.stringify(
+			`Expected "${field}" to be an array of either strings or objects with the shape { pattern, custom_domain, zone_id | zone_name, enabled, previews_enabled }, but these weren't valid: ${JSON.stringify(
 				invalidRoutes,
 				null,
 				2

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -1008,6 +1008,11 @@ function isValidRouteValue(item: unknown): boolean {
 			return false;
 		}
 
+		// zone_id and zone_name are mutually exclusive
+		if (hasZoneId && hasZoneName) {
+			return false;
+		}
+
 		// production_enabled and previews_enabled are only valid on custom domain routes
 		if ((hasProductionEnabled || hasPreviewsEnabled) && !hasCustomDomainFlag) {
 			return false;

--- a/packages/workers-utils/src/construct-wrangler-config.ts
+++ b/packages/workers-utils/src/construct-wrangler-config.ts
@@ -70,6 +70,10 @@ function convertWorkerToWranglerConfig(config: APIWorkerConfig): RawConfig {
 			pattern: c.hostname as string,
 			zone_name: c.zone_name,
 			custom_domain: true,
+			production_enabled: (c as typeof c & { production_enabled: boolean })
+				.production_enabled,
+			previews_enabled: (c as typeof c & { previews_enabled: boolean })
+				.previews_enabled,
 		})),
 	];
 

--- a/packages/workers-utils/src/construct-wrangler-config.ts
+++ b/packages/workers-utils/src/construct-wrangler-config.ts
@@ -70,8 +70,7 @@ function convertWorkerToWranglerConfig(config: APIWorkerConfig): RawConfig {
 			pattern: c.hostname as string,
 			zone_name: c.zone_name,
 			custom_domain: true,
-			production_enabled: (c as typeof c & { production_enabled: boolean })
-				.production_enabled,
+			enabled: (c as typeof c & { enabled: boolean }).enabled,
 			previews_enabled: (c as typeof c & { previews_enabled: boolean })
 				.previews_enabled,
 		})),

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -1170,9 +1170,9 @@ describe("normalizeAndValidateConfig()", () => {
 			expect(diagnostics.hasWarnings()).toBe(false);
 			expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 				"Processing wrangler configuration:
-				  - Expected "route" to be either a string, or an object with shape { pattern, custom_domain, zone_id | zone_name }, but got 888.
+				  - Expected "route" to be either a string, or an object with shape { pattern, custom_domain, zone_id | zone_name, production_enabled, previews_enabled }, but got 888.
 				  - Expected "account_id" to be of type string but got 222.
-				  - Expected "routes" to be an array of either strings or objects with the shape { pattern, custom_domain, zone_id | zone_name }, but these weren't valid: [
+				  - Expected "routes" to be an array of either strings or objects with the shape { pattern, custom_domain, zone_id | zone_name, production_enabled, previews_enabled }, but these weren't valid: [
 				      666,
 				      777,
 				      {
@@ -7125,9 +7125,9 @@ describe("normalizeAndValidateConfig()", () => {
 				"Processing wrangler configuration:
 
 				  - "env.ENV1" environment configuration
-				    - Expected "route" to be either a string, or an object with shape { pattern, custom_domain, zone_id | zone_name }, but got 888.
+				    - Expected "route" to be either a string, or an object with shape { pattern, custom_domain, zone_id | zone_name, production_enabled, previews_enabled }, but got 888.
 				    - Expected "account_id" to be of type string but got 222.
-				    - Expected "routes" to be an array of either strings or objects with the shape { pattern, custom_domain, zone_id | zone_name }, but these weren't valid: [
+				    - Expected "routes" to be an array of either strings or objects with the shape { pattern, custom_domain, zone_id | zone_name, production_enabled, previews_enabled }, but these weren't valid: [
 				        666,
 				        777
 				      ].

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -1170,9 +1170,9 @@ describe("normalizeAndValidateConfig()", () => {
 			expect(diagnostics.hasWarnings()).toBe(false);
 			expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 				"Processing wrangler configuration:
-				  - Expected "route" to be either a string, or an object with shape { pattern, custom_domain, zone_id | zone_name, production_enabled, previews_enabled }, but got 888.
+				  - Expected "route" to be either a string, or an object with shape { pattern, custom_domain, zone_id | zone_name, enabled, previews_enabled }, but got 888.
 				  - Expected "account_id" to be of type string but got 222.
-				  - Expected "routes" to be an array of either strings or objects with the shape { pattern, custom_domain, zone_id | zone_name, production_enabled, previews_enabled }, but these weren't valid: [
+				  - Expected "routes" to be an array of either strings or objects with the shape { pattern, custom_domain, zone_id | zone_name, enabled, previews_enabled }, but these weren't valid: [
 				      666,
 				      777,
 				      {
@@ -7125,9 +7125,9 @@ describe("normalizeAndValidateConfig()", () => {
 				"Processing wrangler configuration:
 
 				  - "env.ENV1" environment configuration
-				    - Expected "route" to be either a string, or an object with shape { pattern, custom_domain, zone_id | zone_name, production_enabled, previews_enabled }, but got 888.
+				    - Expected "route" to be either a string, or an object with shape { pattern, custom_domain, zone_id | zone_name, enabled, previews_enabled }, but got 888.
 				    - Expected "account_id" to be of type string but got 222.
-				    - Expected "routes" to be an array of either strings or objects with the shape { pattern, custom_domain, zone_id | zone_name, production_enabled, previews_enabled }, but these weren't valid: [
+				    - Expected "routes" to be an array of either strings or objects with the shape { pattern, custom_domain, zone_id | zone_name, enabled, previews_enabled }, but these weren't valid: [
 				        666,
 				        777
 				      ].

--- a/packages/wrangler/src/__tests__/deploy/helpers.ts
+++ b/packages/wrangler/src/__tests__/deploy/helpers.ts
@@ -215,6 +215,8 @@ export function mockCustomDomainsChangesetRequest({
 							environment: params.envName,
 							zone_name: "",
 							zone_id: "",
+							production_enabled: true,
+							previews_enabled: false,
 						};
 					}),
 					removed: [],
@@ -247,7 +249,11 @@ export function mockPublishCustomDomainsRequest({
 		override_existing_dns_record: boolean;
 	};
 	domains: Array<
-		{ hostname: string } & ({ zone_id?: string } | { zone_name?: string })
+		{
+			hostname: string;
+			production_enabled?: boolean;
+			previews_enabled?: boolean;
+		} & ({ zone_id?: string } | { zone_name?: string })
 	>;
 	env?: string | undefined;
 	useServiceEnvironments?: boolean | undefined;

--- a/packages/wrangler/src/__tests__/deploy/helpers.ts
+++ b/packages/wrangler/src/__tests__/deploy/helpers.ts
@@ -215,7 +215,7 @@ export function mockCustomDomainsChangesetRequest({
 							environment: params.envName,
 							zone_name: "",
 							zone_id: "",
-							production_enabled: true,
+							enabled: true,
 							previews_enabled: false,
 						};
 					}),
@@ -251,7 +251,7 @@ export function mockPublishCustomDomainsRequest({
 	domains: Array<
 		{
 			hostname: string;
-			production_enabled?: boolean;
+			enabled?: boolean;
 			previews_enabled?: boolean;
 		} & ({ zone_id?: string } | { zone_name?: string })
 	>;

--- a/packages/wrangler/src/__tests__/deploy/routes.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/routes.test.ts
@@ -674,8 +674,8 @@ describe("deploy", () => {
 				writeWorkerSource();
 				mockUpdateWorkerSubdomain({ enabled: false });
 				mockUploadWorkerRequest({ expectedType: "esm" });
-				mockGetZones("api.example.com", [{ id: "api-example-com-id" }]);
-				mockGetZoneWorkerRoutes("api-example-com-id", []);
+				mockGetZones(expect, "api.example.com", [{ id: "api-example-com-id" }]);
+				mockGetZoneWorkerRoutes(expect, "api-example-com-id", []);
 				mockCustomDomainsChangesetRequest({});
 				mockPublishCustomDomainsRequest({
 					publishFlags: {

--- a/packages/wrangler/src/__tests__/deploy/routes.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/routes.test.ts
@@ -658,6 +658,44 @@ describe("deploy", () => {
 				expect(std.out).toContain("api.example.com (custom domain)");
 			});
 
+			it("should pass production_enabled and previews_enabled to the custom domains API", async ({
+				expect,
+			}) => {
+				writeWranglerConfig({
+					routes: [
+						{
+							pattern: "api.example.com",
+							custom_domain: true,
+							production_enabled: true,
+							previews_enabled: true,
+						},
+					],
+				});
+				writeWorkerSource();
+				mockUpdateWorkerSubdomain({ enabled: false });
+				mockUploadWorkerRequest({ expectedType: "esm" });
+				mockGetZones("api.example.com", [{ id: "api-example-com-id" }]);
+				mockGetZoneWorkerRoutes("api-example-com-id", []);
+				mockCustomDomainsChangesetRequest({});
+				mockPublishCustomDomainsRequest({
+					publishFlags: {
+						override_scope: true,
+						override_existing_origin: false,
+						override_existing_dns_record: false,
+					},
+					domains: [
+						{
+							hostname: "api.example.com",
+							production_enabled: true,
+							previews_enabled: true,
+						},
+					],
+				});
+				await runWrangler("deploy ./index");
+				expect(std.out).toContain("api.example.com (custom domain)");
+				expect(std.out).toContain("[previews: on, production: on]");
+			});
+
 			it("should confirm override if custom domain deploy would override an existing domain", async ({
 				expect,
 			}) => {
@@ -681,6 +719,8 @@ describe("deploy", () => {
 							hostname: "api.example.com",
 							service: "test-name",
 							environment: "",
+							production_enabled: true,
+							previews_enabled: false,
 						},
 					],
 				});
@@ -691,6 +731,8 @@ describe("deploy", () => {
 					hostname: "api.example.com",
 					service: "other-script",
 					environment: "",
+					production_enabled: true,
+					previews_enabled: false,
 				});
 				mockPublishCustomDomainsRequest({
 					publishFlags: {
@@ -733,6 +775,8 @@ Update them to point to this script instead?`,
 							hostname: "api.example.com",
 							service: "test-name",
 							environment: "",
+							production_enabled: true,
+							previews_enabled: false,
 						},
 					],
 				});
@@ -777,6 +821,8 @@ Update them to point to this script instead?`,
 							hostname: "api.example.com",
 							service: "test-name",
 							environment: "",
+							production_enabled: true,
+							previews_enabled: false,
 						},
 					],
 					dnsRecordConflicts: [
@@ -787,6 +833,8 @@ Update them to point to this script instead?`,
 							hostname: "api.example.com",
 							service: "test-name",
 							environment: "",
+							production_enabled: true,
+							previews_enabled: false,
 						},
 					],
 				});
@@ -797,6 +845,8 @@ Update them to point to this script instead?`,
 					hostname: "api.example.com",
 					service: "other-script",
 					environment: "",
+					production_enabled: true,
+					previews_enabled: false,
 				});
 				mockPublishCustomDomainsRequest({
 					publishFlags: {
@@ -878,6 +928,8 @@ Update them to point to this script instead?`,
 							hostname: "api.example.com",
 							service: "test-name",
 							environment: "",
+							production_enabled: true,
+							previews_enabled: false,
 						},
 					],
 				});
@@ -888,6 +940,8 @@ Update them to point to this script instead?`,
 					hostname: "api.example.com",
 					service: "other-script",
 					environment: "",
+					production_enabled: true,
+					previews_enabled: false,
 				});
 				mockConfirm({
 					text: `Custom Domains already exist for these domains:

--- a/packages/wrangler/src/__tests__/deploy/routes.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/routes.test.ts
@@ -658,7 +658,7 @@ describe("deploy", () => {
 				expect(std.out).toContain("api.example.com (custom domain)");
 			});
 
-			it("should pass production_enabled and previews_enabled to the custom domains API", async ({
+			it("should pass enabled and previews_enabled to the custom domains API", async ({
 				expect,
 			}) => {
 				writeWranglerConfig({
@@ -666,7 +666,7 @@ describe("deploy", () => {
 						{
 							pattern: "api.example.com",
 							custom_domain: true,
-							production_enabled: true,
+							enabled: true,
 							previews_enabled: true,
 						},
 					],
@@ -686,14 +686,14 @@ describe("deploy", () => {
 					domains: [
 						{
 							hostname: "api.example.com",
-							production_enabled: true,
+							enabled: true,
 							previews_enabled: true,
 						},
 					],
 				});
 				await runWrangler("deploy ./index");
 				expect(std.out).toContain("api.example.com (custom domain)");
-				expect(std.out).toContain("[previews: on, production: on]");
+				expect(std.out).toContain("[enabled, previews: enabled]");
 			});
 
 			it("should confirm override if custom domain deploy would override an existing domain", async ({
@@ -719,7 +719,7 @@ describe("deploy", () => {
 							hostname: "api.example.com",
 							service: "test-name",
 							environment: "",
-							production_enabled: true,
+							enabled: true,
 							previews_enabled: false,
 						},
 					],
@@ -731,7 +731,7 @@ describe("deploy", () => {
 					hostname: "api.example.com",
 					service: "other-script",
 					environment: "",
-					production_enabled: true,
+					enabled: true,
 					previews_enabled: false,
 				});
 				mockPublishCustomDomainsRequest({
@@ -775,7 +775,7 @@ Update them to point to this script instead?`,
 							hostname: "api.example.com",
 							service: "test-name",
 							environment: "",
-							production_enabled: true,
+							enabled: true,
 							previews_enabled: false,
 						},
 					],
@@ -821,7 +821,7 @@ Update them to point to this script instead?`,
 							hostname: "api.example.com",
 							service: "test-name",
 							environment: "",
-							production_enabled: true,
+							enabled: true,
 							previews_enabled: false,
 						},
 					],
@@ -833,7 +833,7 @@ Update them to point to this script instead?`,
 							hostname: "api.example.com",
 							service: "test-name",
 							environment: "",
-							production_enabled: true,
+							enabled: true,
 							previews_enabled: false,
 						},
 					],
@@ -845,7 +845,7 @@ Update them to point to this script instead?`,
 					hostname: "api.example.com",
 					service: "other-script",
 					environment: "",
-					production_enabled: true,
+					enabled: true,
 					previews_enabled: false,
 				});
 				mockPublishCustomDomainsRequest({
@@ -928,7 +928,7 @@ Update them to point to this script instead?`,
 							hostname: "api.example.com",
 							service: "test-name",
 							environment: "",
-							production_enabled: true,
+							enabled: true,
 							previews_enabled: false,
 						},
 					],
@@ -940,7 +940,7 @@ Update them to point to this script instead?`,
 					hostname: "api.example.com",
 					service: "other-script",
 					environment: "",
-					production_enabled: true,
+					enabled: true,
 					previews_enabled: false,
 				});
 				mockConfirm({

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -152,6 +152,8 @@ export type CustomDomain = {
 	hostname: string;
 	service: string;
 	environment: string;
+	production_enabled: boolean;
+	previews_enabled: boolean;
 };
 type UpdatedCustomDomain = CustomDomain & { modified: boolean };
 type ConflictingCustomDomain = CustomDomain & {
@@ -248,6 +250,24 @@ export function renderRoute(route: Route): string {
 		} else if ("zone_name" in route) {
 			result += ` (zone name: ${route.zone_name})`;
 		}
+
+		if (isCustomDomain) {
+			const flags: string[] = [];
+			if ("previews_enabled" in route && route.previews_enabled !== undefined) {
+				flags.push(route.previews_enabled ? "previews: on" : "previews: off");
+			}
+			if (
+				"production_enabled" in route &&
+				route.production_enabled !== undefined
+			) {
+				flags.push(
+					route.production_enabled ? "production: on" : "production: off"
+				);
+			}
+			if (flags.length > 0) {
+				result += ` [${flags.join(", ")}]`;
+			}
+		}
 	}
 	return result;
 }
@@ -286,6 +306,14 @@ export async function publishCustomDomains(
 			hostname: domainRoute.pattern,
 			zone_id: "zone_id" in domainRoute ? domainRoute.zone_id : undefined,
 			zone_name: "zone_name" in domainRoute ? domainRoute.zone_name : undefined,
+			production_enabled:
+				"production_enabled" in domainRoute
+					? domainRoute.production_enabled
+					: undefined,
+			previews_enabled:
+				"previews_enabled" in domainRoute
+					? domainRoute.previews_enabled
+					: undefined,
 		};
 	});
 

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -152,7 +152,7 @@ export type CustomDomain = {
 	hostname: string;
 	service: string;
 	environment: string;
-	production_enabled: boolean;
+	enabled: boolean;
 	previews_enabled: boolean;
 };
 type UpdatedCustomDomain = CustomDomain & { modified: boolean };
@@ -253,15 +253,12 @@ export function renderRoute(route: Route): string {
 
 		if (isCustomDomain) {
 			const flags: string[] = [];
-			if ("previews_enabled" in route && route.previews_enabled !== undefined) {
-				flags.push(route.previews_enabled ? "previews: on" : "previews: off");
+			if ("enabled" in route && route.enabled !== undefined) {
+				flags.push(route.enabled ? "enabled" : "disabled");
 			}
-			if (
-				"production_enabled" in route &&
-				route.production_enabled !== undefined
-			) {
+			if ("previews_enabled" in route && route.previews_enabled !== undefined) {
 				flags.push(
-					route.production_enabled ? "production: on" : "production: off"
+					route.previews_enabled ? "previews: enabled" : "previews: disabled"
 				);
 			}
 			if (flags.length > 0) {
@@ -306,10 +303,7 @@ export async function publishCustomDomains(
 			hostname: domainRoute.pattern,
 			zone_id: "zone_id" in domainRoute ? domainRoute.zone_id : undefined,
 			zone_name: "zone_name" in domainRoute ? domainRoute.zone_name : undefined,
-			production_enabled:
-				"production_enabled" in domainRoute
-					? domainRoute.production_enabled
-					: undefined,
+			enabled: "enabled" in domainRoute ? domainRoute.enabled : undefined,
 			previews_enabled:
 				"previews_enabled" in domainRoute
 					? domainRoute.previews_enabled

--- a/packages/wrangler/src/utils/download-worker-config.ts
+++ b/packages/wrangler/src/utils/download-worker-config.ts
@@ -17,6 +17,8 @@ type CustomDomainsRes = {
 	service: string;
 	environment: string;
 	cert_id: string;
+	production_enabled: boolean;
+	previews_enabled: boolean;
 }[];
 
 type WorkerSubdomainRes = {

--- a/packages/wrangler/src/utils/download-worker-config.ts
+++ b/packages/wrangler/src/utils/download-worker-config.ts
@@ -17,7 +17,7 @@ type CustomDomainsRes = {
 	service: string;
 	environment: string;
 	cert_id: string;
-	production_enabled: boolean;
+	enabled: boolean;
 	previews_enabled: boolean;
 }[];
 


### PR DESCRIPTION
Fixes IAC-402

Add support for configuring enabled and previews_enabled on custom domain routes, allowing users to control whether a custom domain serves production and/or preview traffic. These optional boolean fields can be set on any route with `custom_domain: true` and are passed through to the custom domains API during deploy. When omitted, the API defaults to production-only for backwards compatibility. Users must explicitly opt-in to preview routing by setting `previews_enabled: true`.

## Examples

### Production-only

The default when both `enabled` and `previews_enabled` are omitted. Only requests to example.com will be routed to the Worker.

```jsonc
{ "pattern": "example.com", "custom_domain": true }
// OR
{ "pattern": "example.com", "custom_domain": true, "enabled": true }
// OR
{ "pattern": "example.com", "custom_domain": true, "previews_enabled": false }
// OR
{ "pattern": "example.com", "custom_domain": true, "enabled": true, "previews_enabled": false }
```

### Previews-only

Requests to example.com will not be routed to the Worker. Requests to subdomains of example.com (e.g. my-feature.example.com) will be routed to the corresponding preview if one exists.

```jsonc
{ "pattern": "example.com", "custom_domain": true, "enabled": false, "previews_enabled": true }
```

### Production and previews

Requests to example.com will be routed to the Worker. Requests to subdomains of example.com (e.g. my-feature.example.com) will be routed to the corresponding preview if one exists.

```jsonc
{ "pattern": "example.com", "custom_domain": true, "previews_enabled": true }
// OR
{ "pattern": "example.com", "custom_domain": true, "enabled": true, "previews_enabled": true }
```

### Invalid (API returns validation error)

At least one of production or previews must be enabled.

```jsonc
{ "pattern": "example.com", "custom_domain": true, "enabled": false }
// OR
{ "pattern": "example.com", "custom_domain": true, "enabled": false, "previews_enabled": false }
```
<img width="2569" height="325" alt="image" src="https://github.com/user-attachments/assets/cbca2002-6f17-41db-9076-136aea83b5f7" />

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): None
  - [x] Documentation not necessary because: This feature is in private beta and not available to the general public yet.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
