### PR TITLE
[wrangler] Improve error message for dynamic worker loaders on free plan

### DIFF
--- a/.changeset/friendly-worker-loader-error.md
+++ b/.changeset/friendly-worker-loader-error.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Improve error message when deploying dynamic worker loaders on a free plan
+
+Previously, deploying a Worker with a dynamic worker loader binding on a free account produced a generic validation error (`binding LOADER of type worker_loader is invalid [code: 10021]`), with a link to documentation about validation errors. This now shows a clear message explaining that dynamic worker loaders require a Workers Paid plan, with a link to upgrade.

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -1211,6 +1211,17 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 						);
 					}
 
+					if (
+						/binding .+ of type worker_loader is invalid/.test(
+							err.notes[0].text
+						)
+					) {
+						throw new UserError(
+							"Your Worker uses a dynamic worker loader binding, which is only available on the Workers Paid plan. To use dynamic worker loaders, upgrade your plan at https://dash.cloudflare.com/?to=/:account/workers/plans",
+							{ telemetryMessage: true }
+						);
+					}
+
 					const maybeNameToFilePath = (moduleName: string) => {
 						// If this is a service worker, always return the entrypoint path.
 						// Service workers can't have additional JavaScript modules.

--- a/packages/wrangler/src/dev/remote.ts
+++ b/packages/wrangler/src/dev/remote.ts
@@ -268,6 +268,18 @@ function handleUserFriendlyError(error: unknown, accountId?: string) {
 					return true;
 				}
 
+				if (
+					/binding .+ of type worker_loader is invalid/.test(
+						error.notes[0].text
+					)
+				) {
+					logger.error(
+						"Your Worker uses a dynamic worker loader binding, which is only available on the Workers Paid plan. To use dynamic worker loaders, upgrade your plan at https://dash.cloudflare.com/?to=/:account/workers/plans"
+					);
+
+					return true;
+				}
+
 				return false;
 			}
 

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -869,6 +869,17 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 					err.code === 10021 /* validation error */ &&
 					err.notes.length > 0
 				) {
+					if (
+						/binding .+ of type worker_loader is invalid/.test(
+							err.notes[0].text
+						)
+					) {
+						throw new UserError(
+							"Your Worker uses a dynamic worker loader binding, which is only available on the Workers Paid plan. To use dynamic worker loaders, upgrade your plan at https://dash.cloudflare.com/?to=/:account/workers/plans",
+							{ telemetryMessage: true }
+						);
+					}
+
 					const maybeNameToFilePath = (moduleName: string) => {
 						// If this is a service worker, always return the entrypoint path.
 						// Service workers can't have additional JavaScript modules.


### PR DESCRIPTION
Fixes #13235.

When a free account tries to deploy a Worker with a dynamic worker loader binding, the API returns a generic `binding LOADER of type worker_loader is invalid [code: 10021]` error with a link to validation error docs. This intercepts that specific error in the deploy, versions upload, and remote dev code paths to show a message explaining that dynamic worker loaders require a Workers Paid plan, with a direct link to upgrade.
<img width="755" height="255" alt="Screenshot 2026-04-01 at 23 14 52" src="https://github.com/user-attachments/assets/921f800b-96cf-4b2d-86c7-4ab6c22e7fc9" />

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: error interception follows existing patterns (D1 binding check) and only rewrites the message text
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this is a UX improvement to an error message
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
