### PR TITLE
[miniflare] Fix source phase imports parsing in module analysis

### DIFF
--- a/.changeset/source-phase-miniflare.md
+++ b/.changeset/source-phase-miniflare.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Fix source phase imports parsing in Miniflare
+
+Miniflare now uses the `acorn-import-phases` plugin to parse `import source` syntax when analyzing module dependencies. This fixes `ERR_MODULE_PARSE` errors when running Workers that use source phase imports for WebAssembly modules in local development.

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -77,6 +77,7 @@
 		"@types/which": "^2.0.1",
 		"@types/ws": "^8.5.7",
 		"acorn": "8.14.0",
+		"acorn-import-phases": "^1.0.4",
 		"acorn-walk": "8.3.2",
 		"capnp-es": "catalog:default",
 		"capnweb": "catalog:default",

--- a/packages/miniflare/src/plugins/core/modules.ts
+++ b/packages/miniflare/src/plugins/core/modules.ts
@@ -4,7 +4,8 @@ import { builtinModules } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { TextDecoder, TextEncoder } from "node:util";
-import { parse } from "acorn";
+import { Parser } from "acorn";
+import importPhases from "acorn-import-phases";
 import { simple } from "acorn-walk";
 import { dim } from "kleur/colors";
 import { z } from "zod";
@@ -13,6 +14,9 @@ import { globsToRegExps, MiniflareCoreError, PathSchema } from "../../shared";
 import { MatcherRegExps, testRegExps } from "../../workers";
 import { getNodeCompat, NodeJSCompatMode } from "./node-compat";
 import type estree from "estree";
+
+const ExtendedParser = Parser.extend(importPhases());
+const parse = ExtendedParser.parse.bind(ExtendedParser);
 
 const SUGGEST_BUNDLE =
 	"If you're trying to import an npm package, you'll need to bundle your Worker first.";

--- a/packages/miniflare/test/plugins/core/modules.spec.ts
+++ b/packages/miniflare/test/plugins/core/modules.spec.ts
@@ -339,3 +339,44 @@ If you're trying to import an npm package, you'll need to bundle your Worker fir
 		/^Unable to resolve "index\.mjs" dependency "node:assert": no matching module rules\.\nIf you're trying to import a Node\.js built-in module, or an npm package that uses Node\.js built-ins, you'll either need to:/
 	);
 });
+test("Miniflare: parses source phase imports without error", async ({
+	expect,
+}) => {
+	const tmp = await useTmp();
+	const wasmPath = path.join(tmp, "module.wasm");
+	const workerPath = path.join(tmp, "index.mjs");
+
+	// Create a minimal wasm file
+	await fs.writeFile(
+		wasmPath,
+		Buffer.from([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00])
+	);
+
+	// Create a worker that uses source phase import syntax
+	await fs.writeFile(
+		workerPath,
+		`import source wasmModule from "./module.wasm";
+export default {
+  async fetch() {
+    return new Response("source phase import parsed successfully");
+  }
+};`
+	);
+
+	// Verify the worker can be loaded without parse errors
+	// Note: workerd doesn't actually support source phase imports at runtime,
+	// but we need to ensure the parser doesn't fail on the syntax
+	const mf = new Miniflare({
+		modules: true,
+		modulesRoot: tmp,
+		modulesRules: [{ type: "CompiledWasm", include: ["**/*.wasm"] }],
+		compatibilityDate: "2023-08-01",
+		scriptPath: workerPath,
+	});
+	useDispose(mf);
+
+	// The worker should be able to load (even if the source phase import
+	// is not fully functional at runtime)
+	const res = await mf.dispatchFetch("http://localhost");
+	expect(await res.text()).toBe("source phase import parsed successfully");
+});

--- a/packages/wrangler/src/__tests__/deploy/formats.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/formats.test.ts
@@ -54,7 +54,7 @@ vi.mock("../../package-manager", async (importOriginal) => ({
 
 vi.mock("../../autoconfig/run");
 vi.mock("../../autoconfig/frameworks/utils/packages");
-vi.mock("../../autoconfig/c3-vendor/command");
+vi.mock("@cloudflare/cli/command");
 
 describe("deploy", () => {
 	mockAccountId();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2105,6 +2105,9 @@ importers:
       acorn:
         specifier: 8.14.0
         version: 8.14.0
+      acorn-import-phases:
+        specifier: ^1.0.4
+        version: 1.0.4(acorn@8.14.0)
       acorn-walk:
         specifier: 8.3.2
         version: 8.3.2
@@ -9051,6 +9054,12 @@ packages:
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
+
+  acorn-import-phases@1.0.4:
+    resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
+    engines: {node: '>=10.13.0'}
+    peerDependencies:
+      acorn: ^8.14.0
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -19905,6 +19914,10 @@ snapshots:
     dependencies:
       mime-types: 3.0.1
       negotiator: 1.0.0
+
+  acorn-import-phases@1.0.4(acorn@8.14.0):
+    dependencies:
+      acorn: 8.14.0
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:


### PR DESCRIPTION
Fixes module parsing to support the TC39 source phase imports proposal (`import source wasm from './module.wasm'`), which is required for WebAssembly ESM integration.

This is a follow-up to #12996 which added wrangler support for source phase imports. While that PR fixed wrangler's esbuild bundling and format detection, miniflare was still failing to parse Workers using this syntax with:

```
MiniflareCoreError [ERR_MODULE_PARSE]: Unable to parse \"build/index.js\": Unexpected token (37:14)
```

The issue was that miniflare uses acorn directly to analyze module dependencies, and acorn doesn't support the `import source` syntax by default. This PR adds the `acorn-import-phases` plugin to extend acorn's parser.

Part of #12995.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is a bug fix that enables existing documented functionality to work correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
