### PR TITLE
Remove all eslint comment disabling no-restricted-imports from the vite-plugin playground

### DIFF
--- a/packages/vite-plugin-cloudflare/playground/module-resolution/__tests__/base-tests.ts
+++ b/packages/vite-plugin-cloudflare/playground/module-resolution/__tests__/base-tests.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-restricted-imports -- expect used in afterAll which has no test context
-import { afterAll, describe, expect, test } from "vitest";
+import { afterAll, assert, describe, test } from "vitest";
 import {
 	getJsonResponse,
 	getTextResponse,
@@ -9,11 +8,18 @@ import {
 
 describe("module resolution", async () => {
 	afterAll(() => {
-		expect(serverLogs.errors).toEqual([]);
+		assert(
+			serverLogs.errors.length === 0,
+			`Unexpected server error logs remaining after tests:\n${serverLogs.errors
+				.map((error) => ` - ${error}`)
+				.join("\n")}\n`
+		);
 	});
 
 	describe("basic module resolution", () => {
-		test("`require` js/cjs files with specifying their file extension", async () => {
+		test("`require` js/cjs files with specifying their file extension", async ({
+			expect,
+		}) => {
 			const result = await getJsonResponse("/require-ext");
 			expect(result).toEqual({
 				"(requires/ext) hello.cjs (wrong-extension)": null,
@@ -22,14 +28,16 @@ describe("module resolution", async () => {
 			});
 		});
 
-		test("`require` js/cjs files without specifying their file extension", async () => {
+		test("`require` js/cjs files without specifying their file extension", async ({
+			expect,
+		}) => {
 			const result = await getJsonResponse("/require-no-ext");
 			expect(result).toEqual({
 				"(requires/no-ext) helloWorld": "hello (.js) world (.cjs)",
 			});
 		});
 
-		test("`require` json files", async () => {
+		test("`require` json files", async ({ expect }) => {
 			const result = await getJsonResponse("/require-json");
 			expect(result).toEqual({
 				"(requires/json) package name":
@@ -40,7 +48,7 @@ describe("module resolution", async () => {
 	});
 
 	describe("Cloudflare specific module resolution", () => {
-		test("internal imports from `cloudflare:*`", async () => {
+		test("internal imports from `cloudflare:*`", async ({ expect }) => {
 			const result = await getJsonResponse("/cloudflare-imports");
 
 			// Note: in some cases the DurableObject class name (erroneously) includes
@@ -54,7 +62,7 @@ describe("module resolution", async () => {
 			});
 		});
 
-		test("external imports from `cloudflare:*`", async () => {
+		test("external imports from `cloudflare:*`", async ({ expect }) => {
 			const result = await getJsonResponse("/external-cloudflare-imports");
 
 			// Note: in some cases the DurableObject class name (erroneously) includes
@@ -75,7 +83,7 @@ describe("module resolution", async () => {
 	 *  special meaning to us.
 	 */
 	describe("third party packages resolutions", () => {
-		test("react", async () => {
+		test("react", async ({ expect }) => {
 			const result = await getJsonResponse("/third-party/react");
 			expect(result).toEqual({
 				"(react) reactVersionsMatch": true,
@@ -84,7 +92,7 @@ describe("module resolution", async () => {
 			});
 		});
 
-		test("@remix-run/cloudflare", async () => {
+		test("@remix-run/cloudflare", async ({ expect }) => {
 			const result = await getJsonResponse("/third-party/remix");
 			expect(result).toEqual({
 				"(remix) remixRunCloudflareCookieName":
@@ -92,7 +100,7 @@ describe("module resolution", async () => {
 			});
 		});
 
-		test("discord-api-types/v10", async () => {
+		test("discord-api-types/v10", async ({ expect }) => {
 			const result = await getJsonResponse("/third-party/discord-api-types");
 			expect(result).toEqual({
 				"(discord-api-types/v10) RPCErrorCodes.InvalidUser": 4010,
@@ -100,7 +108,7 @@ describe("module resolution", async () => {
 			});
 		});
 
-		test("slash-create", async () => {
+		test("slash-create", async ({ expect }) => {
 			const result = await getJsonResponse("/third-party/slash-create");
 			expect(result).toEqual({
 				"(slash-create/web) VERSION": "6.2.1",
@@ -111,14 +119,16 @@ describe("module resolution", async () => {
 	});
 
 	describe("user aliases", () => {
-		test("imports from an aliased package", async () => {
+		test("imports from an aliased package", async ({ expect }) => {
 			const result = await getTextResponse("/@alias/test");
 			expect(result).toBe("OK!");
 		});
 	});
 
 	describe("optimizeDeps.exclude", () => {
-		test("supports excluded packages importing from virtual modules", async () => {
+		test("supports excluded packages importing from virtual modules", async ({
+			expect,
+		}) => {
 			const result = await getTextResponse("/optimize-deps/exclude");
 			expect(result).toBe("Export from virtual module");
 		});


### PR DESCRIPTION
Removal of the comment:
```
// eslint-disable-next-line no-restricted-imports
```
from the vite-plugin playground

Continuation from https://github.com/cloudflare/workers-sdk/pull/13140, https://github.com/cloudflare/workers-sdk/pull/13149 and https://github.com/cloudflare/workers-sdk/pull/13164


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal refactoring

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
