### PR TITLE
Add vscode `editor.defaultFormatter` settings specific for different files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-	"editor.defaultFormatter": "oxc.oxc-vscode",
 	"cSpell.words": [
 		"Abortable",
 		"assetsignore",
@@ -64,14 +63,14 @@
 		"websockets",
 		"workerd",
 		"xxhash",
-		"zjcompt",
+		"zjcompt"
 	],
 	"cSpell.ignoreWords": [
 		"TESTTEXTBLOBNAME",
 		"TESTWASMNAME",
 		"extensionless",
 		"webcontainer",
-		"yxxx",
+		"yxxx"
 	],
 	"files.trimTrailingWhitespace": true,
 	"typescript.tsdk": "node_modules/typescript/lib",
@@ -80,28 +79,32 @@
 		"api-extractor.json": "jsonc",
 		"CODEOWNERS": "plaintext",
 		"*.template": "javascript",
-		"wrangler.json": "jsonc",
+		"wrangler.json": "jsonc"
 	},
 
 	"[ignore]": {
-		"editor.defaultFormatter": "foxundermoon.shell-format",
+		"editor.defaultFormatter": "foxundermoon.shell-format"
 	},
 	"eslint.workingDirectories": [
 		{
-			"mode": "auto",
-		},
+			"mode": "auto"
+		}
 	],
 	"editor.formatOnSave": true,
+	"editor.defaultFormatter": "oxc.oxc-vscode",
 	"[javascript]": {
-		"editor.defaultFormatter": "oxc.oxc-vscode",
+		"editor.defaultFormatter": "oxc.oxc-vscode"
 	},
 	"[typescript]": {
-		"editor.defaultFormatter": "oxc.oxc-vscode",
+		"editor.defaultFormatter": "oxc.oxc-vscode"
 	},
 	"[typescriptreact]": {
-		"editor.defaultFormatter": "oxc.oxc-vscode",
+		"editor.defaultFormatter": "oxc.oxc-vscode"
 	},
 	"[javascriptreact]": {
-		"editor.defaultFormatter": "oxc.oxc-vscode",
+		"editor.defaultFormatter": "oxc.oxc-vscode"
 	},
+	"[json]": {
+		"editor.defaultFormatter": "oxc.oxc-vscode"
+	}
 }


### PR DESCRIPTION
In `.vscode/settings.json` there is a single global `editor.defaultFormatter`, however this workspace setting can easily be overritted by user settings for `editor.defaultFormatter` if they are specific to file types. So in order for the workspace setting to always take precendense let's target specific file types in `.vscode/settings.json`.

> [!Note]
> I kept getting format issues on my PRs, I then realized that the issue was my user settings overriding the workspace ones, I can fix things on my end by removing the problematic user settings, but we might as well just improve the workspace ones anyways (for external contributors etc...)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: vscode settings change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: vscode settings change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
