### PR TITLE
Remove lint `consistent-type-imports` override (to `off`) for miniflare

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -127,7 +127,6 @@
 				"curly": "off",
 				"@typescript-eslint/no-explicit-any": "off",
 				"@typescript-eslint/ban-ts-comment": "off",
-				"@typescript-eslint/consistent-type-imports": "off",
 				"@typescript-eslint/no-floating-promises": "off",
 				"no-shadow": "off",
 				"no-useless-escape": "off",

--- a/packages/miniflare/src/cf.ts
+++ b/packages/miniflare/src/cf.ts
@@ -4,8 +4,8 @@ import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { dim } from "kleur/colors";
 import { fetch } from "undici";
-import { Plugins } from "./plugins";
-import { Log, OptionalZodTypeOf } from "./shared";
+import type { Plugins } from "./plugins";
+import type { Log, OptionalZodTypeOf } from "./shared";
 import type { IncomingRequestCfProperties } from "@cloudflare/workers-types/experimental";
 
 /**

--- a/packages/miniflare/src/http/fetch.ts
+++ b/packages/miniflare/src/http/fetch.ts
@@ -1,13 +1,14 @@
 import assert from "node:assert";
-import http from "node:http";
-import { IncomingRequestCfProperties } from "@cloudflare/workers-types/experimental";
 import * as undici from "undici";
-import { UndiciHeaders } from "undici/types/dispatcher";
 import NodeWebSocket from "ws";
 import { CoreHeaders, DeferredPromise } from "../workers";
-import { Request, RequestInfo, RequestInit } from "./request";
+import { Request } from "./request";
 import { Response } from "./response";
 import { coupleWebSocket, WebSocketPair } from "./websocket";
+import type { RequestInfo, RequestInit } from "./request";
+import type { IncomingRequestCfProperties } from "@cloudflare/workers-types/experimental";
+import type http from "node:http";
+import type { UndiciHeaders } from "undici/types/dispatcher";
 
 const ignored = ["transfer-encoding", "connection", "keep-alive", "expect"];
 

--- a/packages/miniflare/src/http/request.ts
+++ b/packages/miniflare/src/http/request.ts
@@ -1,12 +1,12 @@
-import {
-	Request as BaseRequest,
-	RequestInfo as BaseRequestInfo,
-	RequestInit as BaseRequestInit,
-} from "undici";
+import { Request as BaseRequest } from "undici";
 import type {
 	IncomingRequestCfProperties,
 	RequestInitCfProperties,
 } from "@cloudflare/workers-types/experimental";
+import type {
+	RequestInfo as BaseRequestInfo,
+	RequestInit as BaseRequestInit,
+} from "undici";
 
 export type RequestInitCfType =
 	| Partial<IncomingRequestCfProperties>

--- a/packages/miniflare/src/http/response.ts
+++ b/packages/miniflare/src/http/response.ts
@@ -1,10 +1,10 @@
-import {
-	Response as BaseResponse,
+import { Response as BaseResponse } from "undici";
+import type { WebSocket } from "./websocket";
+import type {
 	ResponseInit as BaseResponseInit,
 	BodyInit,
 	ResponseRedirectStatus,
 } from "undici";
-import { WebSocket } from "./websocket";
 
 export interface ResponseInit extends BaseResponseInit {
 	webSocket?: WebSocket | null;

--- a/packages/miniflare/src/http/server.ts
+++ b/packages/miniflare/src/http/server.ts
@@ -1,9 +1,9 @@
 import fs from "node:fs/promises";
-import { z } from "zod";
-import { CORE_PLUGIN } from "../plugins";
-import { HttpOptions, Socket_Https } from "../runtime";
-import { Awaitable } from "../workers";
 import { CERT, KEY } from "./cert";
+import type { CORE_PLUGIN } from "../plugins";
+import type { HttpOptions, Socket_Https } from "../runtime";
+import type { Awaitable } from "../workers";
+import type { z } from "zod";
 
 export async function getEntrySocketHttpOptions(
 	coreOpts: z.infer<typeof CORE_PLUGIN.sharedOptions>

--- a/packages/miniflare/src/http/websocket.ts
+++ b/packages/miniflare/src/http/websocket.ts
@@ -2,7 +2,8 @@ import assert from "node:assert";
 import { once } from "node:events";
 import NodeWebSocket from "ws";
 import { TypedEventTarget } from "../shared";
-import { ValueOf, viewToBuffer } from "../workers";
+import { viewToBuffer } from "../workers";
+import type { ValueOf } from "../workers";
 
 export class MessageEvent extends Event {
 	readonly data: string | ArrayBuffer | Uint8Array<ArrayBuffer>;

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1,13 +1,11 @@
 import assert from "node:assert";
 import crypto from "node:crypto";
-import { Abortable } from "node:events";
 import fs from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import http from "node:http";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
-import { Duplex, Transform, Writable } from "node:stream";
 import { ReadableStream } from "node:stream/web";
 import util from "node:util";
 import zlib from "node:zlib";
@@ -16,12 +14,7 @@ import { removeDir, removeDirSync } from "@cloudflare/workers-utils";
 import exitHook from "exit-hook";
 import { $ as colors$, green } from "kleur/colors";
 import stoppable from "stoppable";
-import {
-	Dispatcher,
-	getGlobalDispatcher,
-	Pool,
-	Response as UndiciResponse,
-} from "undici";
+import { getGlobalDispatcher, Pool } from "undici";
 import SCRIPT_MINIFLARE_SHARED from "worker:shared/index";
 import SCRIPT_MINIFLARE_ZOD from "worker:shared/zod";
 import { WebSocketServer } from "ws";
@@ -29,21 +22,18 @@ import { z } from "zod";
 import { fallbackCf, setupCf } from "./cf";
 import {
 	coupleWebSocket,
-	DispatchFetch,
 	DispatchFetchDispatcher,
 	fetch,
 	getAccessibleHosts,
 	getEntrySocketHttpOptions,
 	Headers,
 	Request,
-	RequestInit,
 	Response,
 } from "./http";
 import {
 	BROWSER_RENDERING_PLUGIN_NAME,
 	D1_PLUGIN_NAME,
 	DURABLE_OBJECTS_PLUGIN_NAME,
-	DurableObjectClassNames,
 	getDirectSocketName,
 	getGlobalServices,
 	getPersistPath,
@@ -54,27 +44,18 @@ import {
 	launchBrowser,
 	loadExternalPlugins,
 	normaliseDurableObject,
-	Plugin,
 	PLUGIN_ENTRIES,
-	Plugins,
-	PluginServicesOptions,
 	ProxyClient,
 	ProxyNodeBinding,
-	QueueConsumers,
-	QueueProducers,
 	QUEUES_PLUGIN_NAME,
 	QueuesError,
 	R2_PLUGIN_NAME,
-	ReplaceWorkersTypes,
 	SECRET_STORE_PLUGIN_NAME,
 	SERVICE_ENTRY,
-	SharedOptions,
 	SOCKET_ENTRY,
 	SOCKET_ENTRY_LOCAL,
 	STREAM_PLUGIN_NAME,
-	WorkerOptions,
 	WORKFLOWS_PLUGIN_NAME,
-	WrappedBindingNames,
 } from "./plugins";
 import { RPC_PROXY_SERVICE_NAME } from "./plugins/assets/constants";
 import {
@@ -84,35 +65,22 @@ import {
 	handlePrettyErrorRequest,
 	JsonErrorSchema,
 	maybeWrappedModuleToWorkerName,
-	NameSourceOptions,
 	reviveError,
-	ServiceDesignatorSchema,
 } from "./plugins/core";
 import { InspectorProxyController } from "./plugins/core/inspector-proxy";
 import { HyperdriveProxyController } from "./plugins/hyperdrive/hyperdrive-proxy";
 import { imagesLocalFetcher } from "./plugins/images/fetcher";
 import {
-	Config,
-	Extension,
 	HttpOptions_Style,
 	kInspectorSocket,
 	Runtime,
-	RuntimeOptions,
 	serializeConfig,
-	Service,
-	Socket,
-	SocketIdentifier,
-	SocketPorts,
-	Worker_Binding,
-	Worker_Module,
 } from "./runtime";
 import {
 	_isCyclic,
 	isFileNotFoundError,
-	Log,
 	MiniflareCoreError,
 	NoOpLog,
-	OptionalZodTypeOf,
 	parseWithRootPath,
 	stripAnsi,
 } from "./shared";
@@ -143,6 +111,35 @@ import {
 } from "./workers";
 import { ADMIN_API } from "./workers/secrets-store/constants";
 import { formatZodError } from "./zod-format";
+import type { DispatchFetch, RequestInit } from "./http";
+import type {
+	DurableObjectClassNames,
+	Plugin,
+	Plugins,
+	PluginServicesOptions,
+	QueueConsumers,
+	QueueProducers,
+	ReplaceWorkersTypes,
+	SharedOptions,
+	WorkerOptions,
+	WrappedBindingNames,
+} from "./plugins";
+import type {
+	NameSourceOptions,
+	ServiceDesignatorSchema,
+} from "./plugins/core";
+import type {
+	Config,
+	Extension,
+	RuntimeOptions,
+	Service,
+	Socket,
+	SocketIdentifier,
+	SocketPorts,
+	Worker_Binding,
+	Worker_Module,
+} from "./runtime";
+import type { Log, OptionalZodTypeOf } from "./shared";
 import type { WorkerDefinition } from "./shared/dev-registry-types";
 import type {
 	CacheStorage,
@@ -157,6 +154,9 @@ import type {
 	StreamBinding,
 } from "@cloudflare/workers-types/experimental";
 import type { Process } from "@puppeteer/browsers";
+import type { Abortable } from "node:events";
+import type { Duplex, Transform, Writable } from "node:stream";
+import type { Dispatcher, Response as UndiciResponse } from "undici";
 
 const DEFAULT_HOST = "127.0.0.1";
 function getURLSafeHost(host: string) {

--- a/packages/miniflare/src/merge.ts
+++ b/packages/miniflare/src/merge.ts
@@ -1,4 +1,4 @@
-import { WorkerOptions } from "./plugins";
+import type { WorkerOptions } from "./plugins";
 
 // https://github.com/Rich-Harris/devalue/blob/50af63e2b2c648f6e6ea29904a14faac25a581fc/src/utils.js#L31-L51
 const objectProtoNames = Object.getOwnPropertyNames(Object.prototype)

--- a/packages/miniflare/src/plugins/ai-search/index.ts
+++ b/packages/miniflare/src/plugins/ai-search/index.ts
@@ -1,11 +1,10 @@
 import { z } from "zod";
 import {
 	getUserBindingServiceName,
-	Plugin,
 	ProxyNodeBinding,
 	remoteProxyClientWorker,
-	RemoteProxyConnectionString,
 } from "../shared";
+import type { Plugin, RemoteProxyConnectionString } from "../shared";
 
 const AISearchEntrySchema = z.object({
 	namespace: z.string().optional(),

--- a/packages/miniflare/src/plugins/ai/index.ts
+++ b/packages/miniflare/src/plugins/ai/index.ts
@@ -1,11 +1,10 @@
 import { z } from "zod";
 import {
 	getUserBindingServiceName,
-	Plugin,
 	ProxyNodeBinding,
 	remoteProxyClientWorker,
-	RemoteProxyConnectionString,
 } from "../shared";
+import type { Plugin, RemoteProxyConnectionString } from "../shared";
 
 const AISchema = z.object({
 	binding: z.string(),

--- a/packages/miniflare/src/plugins/analytics-engine/index.ts
+++ b/packages/miniflare/src/plugins/analytics-engine/index.ts
@@ -1,7 +1,8 @@
 import ANALYTICS_ENGINE from "worker:analytics-engine/analytics-engine";
 import { z } from "zod";
-import { Worker_Binding } from "../../runtime";
-import { PersistenceSchema, Plugin, ProxyNodeBinding } from "../shared";
+import { PersistenceSchema, ProxyNodeBinding } from "../shared";
+import type { Worker_Binding } from "../../runtime";
+import type { Plugin } from "../shared";
 
 const AnalyticsEngineSchema = z.record(
 	z.object({

--- a/packages/miniflare/src/plugins/assets/index.ts
+++ b/packages/miniflare/src/plugins/assets/index.ts
@@ -6,7 +6,6 @@ import {
 	ENTRY_SIZE,
 	getContentType,
 	HEADER_SIZE,
-	Logger,
 	MAX_ASSET_COUNT,
 	MAX_ASSET_SIZE,
 	normalizeFilePath,
@@ -28,7 +27,6 @@ import {
 	maybeGetFile,
 } from "@cloudflare/workers-shared/utils/helpers";
 import {
-	AssetConfig,
 	HeadersSchema,
 	RedirectsSchema,
 } from "@cloudflare/workers-shared/utils/types";
@@ -37,11 +35,9 @@ import SCRIPT_ASSETS from "worker:assets/assets";
 import SCRIPT_ASSETS_KV from "worker:assets/assets-kv";
 import SCRIPT_ROUTER from "worker:assets/router";
 import SCRIPT_RPC_PROXY from "worker:assets/rpc-proxy";
-import { z } from "zod";
-import { Service } from "../../runtime";
 import { SharedBindings } from "../../workers";
 import { getUserServiceName } from "../core";
-import { Plugin, ProxyNodeBinding } from "../shared";
+import { ProxyNodeBinding } from "../shared";
 import {
 	ASSETS_KV_SERVICE_NAME,
 	ASSETS_PLUGIN_NAME,
@@ -50,6 +46,11 @@ import {
 	RPC_PROXY_SERVICE_NAME,
 } from "./constants";
 import { AssetsOptionsSchema } from "./schema";
+import type { Service } from "../../runtime";
+import type { Plugin } from "../shared";
+import type { Logger } from "@cloudflare/workers-shared";
+import type { AssetConfig } from "@cloudflare/workers-shared/utils/types";
+import type { z } from "zod";
 
 export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 	options: AssetsOptionsSchema,

--- a/packages/miniflare/src/plugins/browser-rendering/index.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/index.ts
@@ -15,16 +15,15 @@ import { dim } from "kleur/colors";
 import BROWSER_RENDERING_WORKER from "worker:browser-rendering/binding";
 import { z } from "zod";
 import { kVoid } from "../../runtime";
-import { Log } from "../../shared";
 import { getGlobalWranglerCachePath } from "../../shared/wrangler";
 import {
 	getUserBindingServiceName,
-	Plugin,
 	ProxyNodeBinding,
 	remoteProxyClientWorker,
-	RemoteProxyConnectionString,
 	WORKER_BINDING_SERVICE_LOOPBACK,
 } from "../shared";
+import type { Log } from "../../shared";
+import type { Plugin, RemoteProxyConnectionString } from "../shared";
 
 const BrowserRenderingSchema = z.object({
 	binding: z.string(),

--- a/packages/miniflare/src/plugins/cache/index.ts
+++ b/packages/miniflare/src/plugins/cache/index.ts
@@ -3,19 +3,19 @@ import SCRIPT_CACHE_OBJECT from "worker:cache/cache";
 import SCRIPT_CACHE_ENTRY from "worker:cache/cache-entry";
 import SCRIPT_CACHE_ENTRY_NOOP from "worker:cache/cache-entry-noop";
 import { z } from "zod";
-import {
-	Service,
-	Worker,
-	Worker_Binding_DurableObjectNamespaceDesignator,
-} from "../../runtime";
 import { CacheBindings, SharedBindings } from "../../workers";
 import {
 	getMiniflareObjectBindings,
 	getPersistPath,
 	PersistenceSchema,
-	Plugin,
 	SERVICE_LOOPBACK,
 } from "../shared";
+import type {
+	Service,
+	Worker,
+	Worker_Binding_DurableObjectNamespaceDesignator,
+} from "../../runtime";
+import type { Plugin } from "../shared";
 
 export const CacheOptionsSchema = z.object({
 	cache: z.boolean().optional(),

--- a/packages/miniflare/src/plugins/core/errors/index.ts
+++ b/packages/miniflare/src/plugins/core/errors/index.ts
@@ -2,15 +2,14 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { z } from "zod";
-import { Request, Response } from "../../../http";
-import { Log, processStackTrace } from "../../../shared";
+import { Response } from "../../../http";
+import { processStackTrace } from "../../../shared";
 import { maybeParseURL } from "../../shared";
-import {
-	contentsToString,
-	maybeGetStringScriptPathIndex,
-	SourceOptions,
-} from "../modules";
+import { contentsToString, maybeGetStringScriptPathIndex } from "../modules";
 import { getSourceMapper } from "./sourcemap";
+import type { Request } from "../../../http";
+import type { Log } from "../../../shared";
+import type { SourceOptions } from "../modules";
 import type { RawSourceMap, UrlAndMap } from "@cspotcode/source-map-support";
 
 // Subset of core worker options that define Worker source code.
@@ -320,7 +319,7 @@ export async function handlePrettyErrorRequest(
 	}
 
 	// Lazily import `youch` when required
-	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	// eslint-disable-next-line typescript/consistent-type-imports, @typescript-eslint/no-require-imports
 	const { Youch }: typeof import("youch") = require("youch");
 	const youch = new Youch();
 

--- a/packages/miniflare/src/plugins/core/errors/sourcemap.ts
+++ b/packages/miniflare/src/plugins/core/errors/sourcemap.ts
@@ -12,6 +12,7 @@ import type { Options } from "@cspotcode/source-map-support";
 //
 // ...load a fresh copy, by resetting then restoring the `require` cache, and
 // overriding `Symbol.for()` to return a unique symbol.
+// eslint-disable-next-line typescript/consistent-type-imports
 export function getFreshSourceMapSupport(): typeof import("@cspotcode/source-map-support") {
 	const resolvedSupportPath = require.resolve("@cspotcode/source-map-support");
 

--- a/packages/miniflare/src/plugins/core/explorer.ts
+++ b/packages/miniflare/src/plugins/core/explorer.ts
@@ -1,19 +1,16 @@
 import assert from "node:assert";
 import SCRIPT_DO_WRAPPER from "worker:core/do-wrapper";
 import SCRIPT_LOCAL_EXPLORER from "worker:local-explorer/explorer";
-import { Service, Worker_Binding, Worker_Module } from "../../runtime";
 import { OUTBOUND_DO_PROXY_SERVICE_NAME } from "../../shared/external-service";
 import { CoreBindings } from "../../workers";
-import {
-	DurableObjectClassNames,
-	WorkflowOption,
-	WORKER_BINDING_SERVICE_LOOPBACK,
-} from "../shared";
+import { WORKER_BINDING_SERVICE_LOOPBACK } from "../shared";
 import {
 	getUserServiceName,
 	LOCAL_EXPLORER_DISK,
 	SERVICE_LOCAL_EXPLORER,
 } from "./constants";
+import type { Service, Worker_Binding, Worker_Module } from "../../runtime";
+import type { DurableObjectClassNames, WorkflowOption } from "../shared";
 import type { BindingIdMap, WorkflowBindingInfo } from "./types";
 
 export interface ExplorerServicesOptions {

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -12,37 +12,15 @@ import SCRIPT_ENTRY from "worker:core/entry";
 import STRIP_CF_CONNECTING_IP from "worker:core/strip-cf-connecting-ip";
 import { z } from "zod";
 import { fetch } from "../../http";
-import {
-	Extension,
-	kVoid,
-	Service,
-	ServiceDesignator,
-	Worker_Binding,
-	Worker_ContainerEngine,
-	Worker_DurableObjectNamespace,
-	Worker_Module,
-} from "../../runtime";
-import {
-	Json,
-	JsonSchema,
-	Log,
-	MiniflareCoreError,
-	PathSchema,
-} from "../../shared";
-import {
-	Awaitable,
-	CoreBindings,
-	CoreHeaders,
-	viewToBuffer,
-} from "../../workers";
+import { kVoid } from "../../runtime";
+import { JsonSchema, Log, MiniflareCoreError, PathSchema } from "../../shared";
+import { CoreBindings, CoreHeaders, viewToBuffer } from "../../workers";
 import { RPC_PROXY_SERVICE_NAME } from "../assets/constants";
 import { getCacheServiceName } from "../cache";
 import { DURABLE_OBJECTS_STORAGE_SERVICE_NAME } from "../do";
 import {
-	DurableObjectClassNames,
 	kUnsafeEphemeralUniqueKey,
 	parseRoutes,
-	Plugin,
 	ProxyNodeBinding,
 	remoteProxyClientWorker,
 	SERVICE_LOOPBACK,
@@ -67,7 +45,7 @@ import {
 	buildStringScriptPath,
 	convertModuleDefinition,
 	ModuleLocator,
-	SourceOptions,
+	type SourceOptions,
 	SourceOptionsSchema,
 	withSourceURL,
 } from "./modules";
@@ -77,8 +55,23 @@ import {
 	kCurrentWorker,
 	ServiceDesignatorSchema,
 } from "./services";
+import type {
+	Extension,
+	Service,
+	ServiceDesignator,
+	Worker_Binding,
+	Worker_ContainerEngine,
+	Worker_DurableObjectNamespace,
+	Worker_Module,
+} from "../../runtime";
+import type { Json } from "../../shared";
 import type { WorkerRegistry } from "../../shared/dev-registry-types";
-import type { WorkflowOption } from "../shared";
+import type { Awaitable } from "../../workers";
+import type {
+	WorkflowOption,
+	DurableObjectClassNames,
+	Plugin,
+} from "../shared";
 import type { BindingIdMap } from "./types";
 
 // `workerd`'s `trustBrowserCas` should probably be named `trustSystemCas`.

--- a/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
+++ b/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
@@ -1,10 +1,11 @@
 import crypto from "node:crypto";
-import { createServer, IncomingMessage, Server } from "node:http";
+import { createServer } from "node:http";
 import { DeferredPromise } from "miniflare:shared";
 import WebSocket, { WebSocketServer } from "ws";
 import { version as miniflareVersion } from "../../../../package.json";
-import { Log } from "../../../shared";
 import { InspectorProxy } from "./inspector-proxy";
+import type { Log } from "../../../shared";
+import type { IncomingMessage, Server } from "node:http";
 
 /**
  * An `InspectorProxyController` connects to the various runtime (/workerd) inspector servers and exposes through the user specified

--- a/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy.ts
+++ b/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import WebSocket from "ws";
-import { Log } from "../../../shared";
 import { isDevToolsEvent } from "./devtools";
+import type { Log } from "../../../shared";
 import type {
 	DevToolsCommandRequests,
 	DevToolsEvent,

--- a/packages/miniflare/src/plugins/core/modules.ts
+++ b/packages/miniflare/src/plugins/core/modules.ts
@@ -8,10 +8,12 @@ import { parse } from "acorn";
 import { simple } from "acorn-walk";
 import { dim } from "kleur/colors";
 import { z } from "zod";
-import { Worker_Module } from "../../runtime";
 import { globsToRegExps, MiniflareCoreError, PathSchema } from "../../shared";
-import { MatcherRegExps, testRegExps } from "../../workers";
-import { getNodeCompat, NodeJSCompatMode } from "./node-compat";
+import { testRegExps } from "../../workers";
+import { getNodeCompat } from "./node-compat";
+import type { Worker_Module } from "../../runtime";
+import type { MatcherRegExps } from "../../workers";
+import type { NodeJSCompatMode } from "./node-compat";
 import type estree from "estree";
 
 const SUGGEST_BUNDLE =

--- a/packages/miniflare/src/plugins/core/proxy/client.ts
+++ b/packages/miniflare/src/plugins/core/proxy/client.ts
@@ -5,10 +5,9 @@ import { ReadableStream, TransformStream } from "node:stream/web";
 import util from "node:util";
 import { stringify } from "devalue";
 import { Headers } from "undici";
-import { DispatchFetch, Request, Response } from "../../../http";
+import { Request } from "../../../http";
 import { prefixStream, readPrefix } from "../../../shared";
 import {
-	Awaitable,
 	CoreHeaders,
 	CorePaths,
 	createHTTPReducers,
@@ -19,14 +18,19 @@ import {
 	parseWithReadableStreams,
 	ProxyAddresses,
 	ProxyOps,
-	ReducersRevivers,
-	StringifiedWithStream,
 	stringifyWithStreams,
 	structuredSerializableReducers,
 	structuredSerializableRevivers,
 } from "../../../workers";
-import { DECODER, SynchronousFetcher, SynchronousResponse } from "./fetch-sync";
+import { DECODER, SynchronousFetcher } from "./fetch-sync";
 import { NODE_PLATFORM_IMPL } from "./types";
+import type { DispatchFetch, Response } from "../../../http";
+import type {
+	Awaitable,
+	ReducersRevivers,
+	StringifiedWithStream,
+} from "../../../workers";
+import type { SynchronousResponse } from "./fetch-sync";
 import type {
 	ImageDrawOptions,
 	ImageOutputOptions,

--- a/packages/miniflare/src/plugins/core/proxy/types.ts
+++ b/packages/miniflare/src/plugins/core/proxy/types.ts
@@ -2,8 +2,9 @@ import { Blob } from "node:buffer";
 import { arrayBuffer } from "node:stream/consumers";
 import { ReadableStream } from "node:stream/web";
 import { Headers } from "undici";
-import { Request, RequestInit, Response } from "../../../http";
-import { PlatformImpl } from "../../../workers";
+import { Request, Response } from "../../../http";
+import type { RequestInit } from "../../../http";
+import type { PlatformImpl } from "../../../workers";
 import type {
 	AbortSignal as WorkerAbortSignal,
 	Blob as WorkerBlob,

--- a/packages/miniflare/src/plugins/core/services.ts
+++ b/packages/miniflare/src/plugins/core/services.ts
@@ -1,15 +1,9 @@
 import { z } from "zod";
-import { Request, Response } from "../../http";
-import {
-	HOST_CAPNP_CONNECT,
-	Miniflare,
-	RemoteProxyConnectionString,
-} from "../../index";
-import {
-	ExternalServer,
-	HttpOptions_Style,
-	TlsOptions_Version,
-} from "../../runtime";
+import { HOST_CAPNP_CONNECT } from "../../index";
+import { HttpOptions_Style, TlsOptions_Version } from "../../runtime";
+import type { Request, Response } from "../../http";
+import type { Miniflare, RemoteProxyConnectionString } from "../../index";
+import type { ExternalServer } from "../../runtime";
 import type { Awaitable } from "../../workers";
 import type * as http from "node:http";
 

--- a/packages/miniflare/src/plugins/d1/index.ts
+++ b/packages/miniflare/src/plugins/d1/index.ts
@@ -2,11 +2,6 @@ import assert from "node:assert";
 import fs from "node:fs/promises";
 import SCRIPT_D1_DATABASE_OBJECT from "worker:d1/database";
 import { z } from "zod";
-import {
-	Service,
-	Worker_Binding,
-	Worker_Binding_DurableObjectNamespaceDesignator,
-} from "../../runtime";
 import { SharedBindings } from "../../workers";
 import {
 	getMiniflareObjectBindings,
@@ -17,12 +12,16 @@ import {
 	namespaceKeys,
 	objectEntryWorker,
 	PersistenceSchema,
-	Plugin,
 	ProxyNodeBinding,
 	remoteProxyClientWorker,
-	RemoteProxyConnectionString,
 	SERVICE_LOOPBACK,
 } from "../shared";
+import type {
+	Service,
+	Worker_Binding,
+	Worker_Binding_DurableObjectNamespaceDesignator,
+} from "../../runtime";
+import type { Plugin, RemoteProxyConnectionString } from "../shared";
 
 export const D1OptionsSchema = z.object({
 	d1Databases: z

--- a/packages/miniflare/src/plugins/dispatch-namespace/index.ts
+++ b/packages/miniflare/src/plugins/dispatch-namespace/index.ts
@@ -1,14 +1,13 @@
 import SCRIPT_DISPATCH_NAMESPACE from "worker:dispatch-namespace/dispatch-namespace";
 import SCRIPT_DISPATCH_NAMESPACE_PROXY from "worker:dispatch-namespace/dispatch-namespace-proxy";
 import { z } from "zod";
-import { Worker_Binding } from "../../runtime";
 import {
 	getUserBindingServiceName,
-	Plugin,
 	ProxyNodeBinding,
 	remoteProxyClientWorker,
-	RemoteProxyConnectionString,
 } from "../shared";
+import type { Worker_Binding } from "../../runtime";
+import type { Plugin, RemoteProxyConnectionString } from "../shared";
 
 export const DispatchNamespaceOptionsSchema = z.object({
 	dispatchNamespaces: z

--- a/packages/miniflare/src/plugins/do/index.ts
+++ b/packages/miniflare/src/plugins/do/index.ts
@@ -1,13 +1,15 @@
 import fs from "node:fs/promises";
 import { z } from "zod";
-import { Worker_Binding } from "../../runtime";
 import { getUserServiceName } from "../core";
 import {
 	getPersistPath,
 	kUnsafeEphemeralUniqueKey,
 	PersistenceSchema,
-	Plugin,
 	ProxyNodeBinding,
+} from "../shared";
+import type { Worker_Binding } from "../../runtime";
+import type {
+	Plugin,
 	RemoteProxyConnectionString,
 	UnsafeUniqueKey,
 } from "../shared";

--- a/packages/miniflare/src/plugins/email/index.ts
+++ b/packages/miniflare/src/plugins/email/index.ts
@@ -1,14 +1,13 @@
 import EMAIL_MESSAGE from "worker:email/email";
 import SEND_EMAIL_BINDING from "worker:email/send_email";
 import { z } from "zod";
-import { Service, Worker_Binding } from "../../runtime";
 import {
 	getUserBindingServiceName,
-	Plugin,
 	remoteProxyClientWorker,
-	RemoteProxyConnectionString,
 	WORKER_BINDING_SERVICE_LOOPBACK,
 } from "../shared";
+import type { Service, Worker_Binding } from "../../runtime";
+import type { Plugin, RemoteProxyConnectionString } from "../shared";
 
 // Define the mutually exclusive schema
 const EmailBindingOptionsSchema = z

--- a/packages/miniflare/src/plugins/hello-world/index.ts
+++ b/packages/miniflare/src/plugins/hello-world/index.ts
@@ -2,16 +2,16 @@ import fs from "node:fs/promises";
 import BINDING_SCRIPT from "worker:hello-world/binding";
 import OBJECT_SCRIPT from "worker:hello-world/object";
 import { z } from "zod";
-import { Service, Worker_Binding } from "../../runtime";
 import { SharedBindings } from "../../workers";
 import {
 	getMiniflareObjectBindings,
 	getPersistPath,
 	PersistenceSchema,
-	Plugin,
 	ProxyNodeBinding,
 	SERVICE_LOOPBACK,
 } from "../shared";
+import type { Service, Worker_Binding } from "../../runtime";
+import type { Plugin } from "../shared";
 
 export const HELLO_WORLD_PLUGIN_NAME = "hello-world";
 

--- a/packages/miniflare/src/plugins/hyperdrive/index.ts
+++ b/packages/miniflare/src/plugins/hyperdrive/index.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert";
 import { z } from "zod";
-import { Worker_Binding } from "../../runtime";
-import { Plugin, ProxyNodeBinding } from "../shared";
+import { ProxyNodeBinding } from "../shared";
+import type { Worker_Binding } from "../../runtime";
+import type { Plugin } from "../shared";
 
 export const HYPERDRIVE_PLUGIN_NAME = "hyperdrive";
 

--- a/packages/miniflare/src/plugins/images/fetcher.ts
+++ b/packages/miniflare/src/plugins/images/fetcher.ts
@@ -1,7 +1,7 @@
 import { File } from "node:buffer";
-import { Request } from "undici";
 import type { ImageInfoResponse } from "@cloudflare/workers-types/experimental";
 import type { Sharp } from "sharp";
+import type { Request } from "undici";
 
 type Transform = {
 	imageIndex?: number;

--- a/packages/miniflare/src/plugins/images/index.ts
+++ b/packages/miniflare/src/plugins/images/index.ts
@@ -2,7 +2,6 @@ import fs from "node:fs/promises";
 import SCRIPT_IMAGES_SERVICE from "worker:images/images";
 import SCRIPT_KV_NAMESPACE_OBJECT from "worker:kv/namespace";
 import { z } from "zod";
-import { Service } from "../../runtime";
 import { SharedBindings } from "../../workers";
 import { KV_NAMESPACE_OBJECT_CLASS_NAME } from "../kv";
 import {
@@ -11,13 +10,13 @@ import {
 	getUserBindingServiceName,
 	objectEntryWorker,
 	PersistenceSchema,
-	Plugin,
 	ProxyNodeBinding,
 	remoteProxyClientWorker,
-	RemoteProxyConnectionString,
 	SERVICE_LOOPBACK,
 	WORKER_BINDING_SERVICE_LOOPBACK,
 } from "../shared";
+import type { Service } from "../../runtime";
+import type { Plugin, RemoteProxyConnectionString } from "../shared";
 
 const ImagesSchema = z.object({
 	binding: z.string(),

--- a/packages/miniflare/src/plugins/index.ts
+++ b/packages/miniflare/src/plugins/index.ts
@@ -1,5 +1,3 @@
-import { z } from "zod";
-import { ValueOf } from "../workers";
 import { AI_PLUGIN, AI_PLUGIN_NAME } from "./ai";
 import { AI_SEARCH_PLUGIN, AI_SEARCH_PLUGIN_NAME } from "./ai-search";
 import {
@@ -45,6 +43,8 @@ import {
 	WORKER_LOADER_PLUGIN_NAME,
 } from "./worker-loader";
 import { WORKFLOWS_PLUGIN, WORKFLOWS_PLUGIN_NAME } from "./workflows";
+import type { ValueOf } from "../workers";
+import type { z } from "zod";
 
 export const PLUGINS = {
 	[CORE_PLUGIN_NAME]: CORE_PLUGIN,

--- a/packages/miniflare/src/plugins/kv/index.ts
+++ b/packages/miniflare/src/plugins/kv/index.ts
@@ -1,11 +1,6 @@
 import fs from "node:fs/promises";
 import SCRIPT_KV_NAMESPACE_OBJECT from "worker:kv/namespace";
 import { z } from "zod";
-import {
-	Service,
-	Worker_Binding,
-	Worker_Binding_DurableObjectNamespaceDesignator,
-} from "../../runtime";
 import { PathSchema } from "../../shared";
 import { SharedBindings } from "../../workers";
 import {
@@ -17,10 +12,8 @@ import {
 	namespaceKeys,
 	objectEntryWorker,
 	PersistenceSchema,
-	Plugin,
 	ProxyNodeBinding,
 	remoteProxyClientWorker,
-	RemoteProxyConnectionString,
 	SERVICE_LOOPBACK,
 } from "../shared";
 import { KV_PLUGIN_NAME } from "./constants";
@@ -28,8 +21,14 @@ import {
 	getSitesBindings,
 	getSitesNodeBindings,
 	getSitesServices,
-	SitesOptions,
 } from "./sites";
+import type {
+	Service,
+	Worker_Binding,
+	Worker_Binding_DurableObjectNamespaceDesignator,
+} from "../../runtime";
+import type { Plugin, RemoteProxyConnectionString } from "../shared";
+import type { SitesOptions } from "./sites";
 
 export const KVOptionsSchema = z.object({
 	kvNamespaces: z

--- a/packages/miniflare/src/plugins/kv/sites.ts
+++ b/packages/miniflare/src/plugins/kv/sites.ts
@@ -2,18 +2,18 @@ import assert from "node:assert";
 import fs from "node:fs/promises";
 import path from "node:path";
 import SCRIPT_KV_SITES from "worker:kv/sites";
-import { Service, Worker_Binding } from "../../runtime";
 import { globsToRegExps } from "../../shared";
 import {
 	encodeSitesKey,
 	serialiseSiteRegExps,
 	SharedBindings,
 	SiteBindings,
-	SiteMatcherRegExps,
 	testSiteRegExps,
 } from "../../workers";
 import { ProxyNodeBinding } from "../shared";
 import { KV_PLUGIN_NAME } from "./constants";
+import type { Service, Worker_Binding } from "../../runtime";
+import type { SiteMatcherRegExps } from "../../workers";
 
 async function* listKeysInDirectoryInner(
 	rootPath: string,

--- a/packages/miniflare/src/plugins/media/index.ts
+++ b/packages/miniflare/src/plugins/media/index.ts
@@ -1,11 +1,10 @@
 import { z } from "zod";
 import {
 	getUserBindingServiceName,
-	Plugin,
 	ProxyNodeBinding,
 	remoteProxyClientWorker,
-	RemoteProxyConnectionString,
 } from "../shared";
+import type { Plugin, RemoteProxyConnectionString } from "../shared";
 
 export const MEDIA_PLUGIN_NAME = "media";
 

--- a/packages/miniflare/src/plugins/mtls/index.ts
+++ b/packages/miniflare/src/plugins/mtls/index.ts
@@ -1,11 +1,10 @@
 import { z } from "zod";
 import {
 	getUserBindingServiceName,
-	Plugin,
 	ProxyNodeBinding,
 	remoteProxyClientWorker,
-	RemoteProxyConnectionString,
 } from "../shared";
+import type { Plugin, RemoteProxyConnectionString } from "../shared";
 
 const MtlsSchema = z.object({
 	certificate_id: z.string(),

--- a/packages/miniflare/src/plugins/pipelines/index.ts
+++ b/packages/miniflare/src/plugins/pipelines/index.ts
@@ -1,13 +1,12 @@
 import SCRIPT_PIPELINE_OBJECT from "worker:pipelines/pipeline";
 import { z } from "zod";
-import { Service } from "../../runtime";
 import {
 	namespaceKeys,
-	Plugin,
 	ProxyNodeBinding,
 	remoteProxyClientWorker,
-	RemoteProxyConnectionString,
 } from "../shared";
+import type { Service } from "../../runtime";
+import type { Plugin, RemoteProxyConnectionString } from "../shared";
 
 export const PipelineOptionsSchema = z.object({
 	pipelines: z

--- a/packages/miniflare/src/plugins/queues/index.ts
+++ b/packages/miniflare/src/plugins/queues/index.ts
@@ -1,11 +1,6 @@
 import SCRIPT_QUEUE_BROKER_OBJECT from "worker:queues/broker";
 import { z } from "zod";
-import {
-	kVoid,
-	Service,
-	Worker_Binding,
-	Worker_Binding_DurableObjectNamespaceDesignator,
-} from "../../runtime";
+import { kVoid } from "../../runtime";
 import {
 	QueueBindings,
 	QueueConsumerOptionsSchema,
@@ -16,11 +11,15 @@ import { getUserServiceName } from "../core";
 import {
 	getMiniflareObjectBindings,
 	objectEntryWorker,
-	Plugin,
 	ProxyNodeBinding,
-	RemoteProxyConnectionString,
 	SERVICE_LOOPBACK,
 } from "../shared";
+import type {
+	Service,
+	Worker_Binding,
+	Worker_Binding_DurableObjectNamespaceDesignator,
+} from "../../runtime";
+import type { Plugin, RemoteProxyConnectionString } from "../shared";
 
 export const QueuesOptionsSchema = z.object({
 	queueProducers: z

--- a/packages/miniflare/src/plugins/r2/index.ts
+++ b/packages/miniflare/src/plugins/r2/index.ts
@@ -1,11 +1,6 @@
 import fs from "node:fs/promises";
 import SCRIPT_R2_BUCKET_OBJECT from "worker:r2/bucket";
 import { z } from "zod";
-import {
-	Service,
-	Worker_Binding,
-	Worker_Binding_DurableObjectNamespaceDesignator,
-} from "../../runtime";
 import { SharedBindings } from "../../workers";
 import {
 	getMiniflareObjectBindings,
@@ -16,12 +11,16 @@ import {
 	namespaceKeys,
 	objectEntryWorker,
 	PersistenceSchema,
-	Plugin,
 	ProxyNodeBinding,
 	remoteProxyClientWorker,
-	RemoteProxyConnectionString,
 	SERVICE_LOOPBACK,
 } from "../shared";
+import type {
+	Service,
+	Worker_Binding,
+	Worker_Binding_DurableObjectNamespaceDesignator,
+} from "../../runtime";
+import type { Plugin, RemoteProxyConnectionString } from "../shared";
 
 export const R2OptionsSchema = z.object({
 	r2Buckets: z

--- a/packages/miniflare/src/plugins/ratelimit/index.ts
+++ b/packages/miniflare/src/plugins/ratelimit/index.ts
@@ -1,7 +1,8 @@
 import SCRIPT_RATELIMIT_OBJECT from "worker:ratelimit/ratelimit";
 import { z } from "zod";
-import { Worker_Binding } from "../../runtime";
-import { Plugin, ProxyNodeBinding } from "../shared";
+import { ProxyNodeBinding } from "../shared";
+import type { Worker_Binding } from "../../runtime";
+import type { Plugin } from "../shared";
 
 export enum PeriodType {
 	TENSECONDS = 10,

--- a/packages/miniflare/src/plugins/secret-store/index.ts
+++ b/packages/miniflare/src/plugins/secret-store/index.ts
@@ -2,7 +2,6 @@ import fs from "node:fs/promises";
 import SCRIPT_KV_NAMESPACE_OBJECT from "worker:kv/namespace";
 import SCRIPT_SECRETS_STORE_SECRET from "worker:secrets-store/secret";
 import { z } from "zod";
-import { Service, Worker_Binding } from "../../runtime";
 import { SharedBindings } from "../../workers";
 import { KV_NAMESPACE_OBJECT_CLASS_NAME } from "../kv";
 import {
@@ -11,10 +10,11 @@ import {
 	getUserBindingServiceName,
 	objectEntryWorker,
 	PersistenceSchema,
-	Plugin,
 	ProxyNodeBinding,
 	SERVICE_LOOPBACK,
 } from "../shared";
+import type { Service, Worker_Binding } from "../../runtime";
+import type { Plugin } from "../shared";
 
 const SecretsStoreSecretsSchema = z.record(
 	z.object({

--- a/packages/miniflare/src/plugins/shared/constants.ts
+++ b/packages/miniflare/src/plugins/shared/constants.ts
@@ -1,12 +1,12 @@
 import SCRIPT_OBJECT_ENTRY from "worker:shared/object-entry";
 import SCRIPT_REMOTE_PROXY_CLIENT from "worker:shared/remote-proxy-client";
-import {
+import { CoreBindings, SharedBindings } from "../../workers";
+import type { RemoteProxyConnectionString } from ".";
+import type {
 	Worker,
 	Worker_Binding,
 	Worker_Binding_DurableObjectNamespaceDesignator,
 } from "../../runtime";
-import { CoreBindings, SharedBindings } from "../../workers";
-import { RemoteProxyConnectionString } from ".";
 
 export const SOCKET_ENTRY = "entry";
 export const SOCKET_ENTRY_LOCAL = "entry:local";

--- a/packages/miniflare/src/plugins/shared/index.ts
+++ b/packages/miniflare/src/plugins/shared/index.ts
@@ -4,27 +4,23 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { z } from "zod";
-import {
+import { MiniflareCoreError, PathSchema } from "../../shared";
+import { sanitisePath } from "../../workers";
+import type {
 	Extension,
 	Service,
 	Worker_Binding,
 	Worker_Module,
 } from "../../runtime";
-import {
-	Log,
-	MiniflareCoreError,
-	OptionalZodTypeOf,
-	PathSchema,
-} from "../../shared";
-import {
+import type { Log, OptionalZodTypeOf } from "../../shared";
+import type {
 	Awaitable,
 	QueueConsumerSchema,
 	QueueProducerSchema,
-	sanitisePath,
 } from "../../workers";
-import { UnsafeUniqueKey } from "./constants";
 import type { DOContainerOptions } from "../do";
 import type { HyperdriveProxyController } from "../hyperdrive/hyperdrive-proxy";
+import type { UnsafeUniqueKey } from "./constants";
 
 export const DEFAULT_PERSIST_ROOT = ".mf";
 

--- a/packages/miniflare/src/plugins/shared/routing.ts
+++ b/packages/miniflare/src/plugins/shared/routing.ts
@@ -1,6 +1,6 @@
 import { domainToUnicode, URL } from "node:url";
 import { MiniflareError } from "../../shared";
-import { WorkerRoute } from "../../workers";
+import type { WorkerRoute } from "../../workers";
 
 export type RouterErrorCode = "ERR_QUERY_STRING" | "ERR_INFIX_WILDCARD";
 

--- a/packages/miniflare/src/plugins/stream/index.ts
+++ b/packages/miniflare/src/plugins/stream/index.ts
@@ -8,12 +8,11 @@ import {
 	getPersistPath,
 	getUserBindingServiceName,
 	PersistenceSchema,
-	Plugin,
 	ProxyNodeBinding,
 	remoteProxyClientWorker,
-	RemoteProxyConnectionString,
 } from "../shared";
 import type { Service } from "../../runtime";
+import type { Plugin, RemoteProxyConnectionString } from "../shared";
 
 const StreamSchema = z.object({
 	binding: z.string(),

--- a/packages/miniflare/src/plugins/vectorize/index.ts
+++ b/packages/miniflare/src/plugins/vectorize/index.ts
@@ -1,11 +1,10 @@
 import { z } from "zod";
 import {
 	getUserBindingServiceName,
-	Plugin,
 	ProxyNodeBinding,
 	remoteProxyClientWorker,
-	RemoteProxyConnectionString,
 } from "../shared";
+import type { Plugin, RemoteProxyConnectionString } from "../shared";
 
 const VectorizeSchema = z.object({
 	index_name: z.string(),

--- a/packages/miniflare/src/plugins/version-metadata/index.ts
+++ b/packages/miniflare/src/plugins/version-metadata/index.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
-import { Worker_Binding } from "../../runtime";
-import { Plugin } from "../shared";
+import type { Worker_Binding } from "../../runtime";
+import type { Plugin } from "../shared";
 
 export const VERSION_METADATA_PLUGIN_NAME = "version-metadata";
 

--- a/packages/miniflare/src/plugins/vpc-networks/index.ts
+++ b/packages/miniflare/src/plugins/vpc-networks/index.ts
@@ -1,11 +1,10 @@
 import { z } from "zod";
 import {
 	getUserBindingServiceName,
-	Plugin,
 	ProxyNodeBinding,
 	remoteProxyClientWorker,
-	RemoteProxyConnectionString,
 } from "../shared";
+import type { Plugin, RemoteProxyConnectionString } from "../shared";
 
 const VpcNetworksSchema = z.union([
 	z.object({

--- a/packages/miniflare/src/plugins/vpc-services/index.ts
+++ b/packages/miniflare/src/plugins/vpc-services/index.ts
@@ -1,11 +1,10 @@
 import { z } from "zod";
 import {
 	getUserBindingServiceName,
-	Plugin,
 	ProxyNodeBinding,
 	remoteProxyClientWorker,
-	RemoteProxyConnectionString,
 } from "../shared";
+import type { Plugin, RemoteProxyConnectionString } from "../shared";
 
 const VpcServicesSchema = z.object({
 	service_id: z.string(),

--- a/packages/miniflare/src/plugins/worker-loader/index.ts
+++ b/packages/miniflare/src/plugins/worker-loader/index.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { Worker_Binding } from "../../runtime";
-import { Plugin } from "../shared";
+import type { Worker_Binding } from "../../runtime";
+import type { Plugin } from "../shared";
 
 export const WorkerLoaderConfigSchema = z.object({});
 export const WorkerLoaderOptionsSchema = z.object({

--- a/packages/miniflare/src/plugins/workflows/index.ts
+++ b/packages/miniflare/src/plugins/workflows/index.ts
@@ -2,16 +2,15 @@ import fs from "node:fs/promises";
 import SCRIPT_WORKFLOWS_BINDING from "worker:workflows/binding";
 import SCRIPT_WORKFLOWS_WRAPPED_BINDING from "worker:workflows/wrapped-binding";
 import { z } from "zod";
-import { Service } from "../../runtime";
 import { getUserServiceName } from "../core";
 import {
 	getPersistPath,
 	getUserBindingServiceName,
 	PersistenceSchema,
-	Plugin,
 	ProxyNodeBinding,
-	RemoteProxyConnectionString,
 } from "../shared";
+import type { Service } from "../../runtime";
+import type { Plugin, RemoteProxyConnectionString } from "../shared";
 
 export const WorkflowsOptionsSchema = z.object({
 	workflows: z

--- a/packages/miniflare/src/runtime/config/index.ts
+++ b/packages/miniflare/src/runtime/config/index.ts
@@ -1,7 +1,9 @@
 import { writeFileSync } from "node:fs";
-import { Data, List, Message, Struct } from "capnp-es";
+import { Message } from "capnp-es";
 import { Config as CapnpConfig } from "./generated/workerd";
-import { Config, kVoid } from "./workerd";
+import { kVoid } from "./workerd";
+import type { Config } from "./workerd";
+import type { Data, List, Struct } from "capnp-es";
 
 function capitalize<S extends string>(str: S): Capitalize<S> {
 	return (

--- a/packages/miniflare/src/runtime/index.ts
+++ b/packages/miniflare/src/runtime/index.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import childProcess, { spawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
-import { Abortable, once } from "node:events";
+import { once } from "node:events";
 import path from "node:path";
 import rl from "node:readline";
 import { Readable, Transform } from "node:stream";
@@ -12,11 +12,10 @@ import workerdPath, {
 import { z } from "zod";
 import { SERVICE_LOOPBACK, SOCKET_ENTRY } from "../plugins";
 import { MiniflareCoreError } from "../shared";
-import { Awaitable } from "../workers";
-import {
-	handleStructuredLogsFromStream,
-	StructuredLogsHandler,
-} from "./structured-logs";
+import { handleStructuredLogsFromStream } from "./structured-logs";
+import type { Awaitable } from "../workers";
+import type { StructuredLogsHandler } from "./structured-logs";
+import type { Abortable } from "node:events";
 
 const ControlMessageSchema = z.discriminatedUnion("event", [
 	z.object({

--- a/packages/miniflare/src/runtime/structured-logs.ts
+++ b/packages/miniflare/src/runtime/structured-logs.ts
@@ -1,4 +1,4 @@
-import { WorkerdStructuredLog } from "../plugins/core";
+import type { WorkerdStructuredLog } from "../plugins/core";
 import type { Stream } from "node:stream";
 
 export type StructuredLogsHandler = (

--- a/packages/miniflare/src/shared/dev-registry.ts
+++ b/packages/miniflare/src/shared/dev-registry.ts
@@ -10,12 +10,13 @@ import {
 } from "node:fs";
 import path from "node:path";
 import { Worker } from "node:worker_threads";
-import { FSWatcher, watch } from "chokidar";
-import { SocketPorts } from "../runtime";
+import { watch } from "chokidar";
 import { getProxyFallbackServiceSocketName } from "./external-service";
-import { Log } from "./log";
 import { getGlobalWranglerConfigPath } from "./wrangler";
+import type { SocketPorts } from "../runtime";
 import type { WorkerDefinition, WorkerRegistry } from "./dev-registry-types";
+import type { Log } from "./log";
+import type { FSWatcher } from "chokidar";
 
 export class DevRegistry {
 	private heartbeats = new Map<string, NodeJS.Timeout>();

--- a/packages/miniflare/src/shared/dev-registry.worker.ts
+++ b/packages/miniflare/src/shared/dev-registry.worker.ts
@@ -1,7 +1,6 @@
 import http from "node:http";
 import https from "node:https";
 import net from "node:net";
-import { Duplex } from "node:stream";
 import { parentPort } from "node:worker_threads";
 import { HOST_CAPNP_CONNECT } from "../plugins/shared/constants";
 import {
@@ -11,6 +10,7 @@ import {
 } from "../shared/external-service";
 import { Log } from "./log";
 import type { WorkerDefinition } from "../shared/dev-registry-types";
+import type { Duplex } from "node:stream";
 import type { MessagePort } from "node:worker_threads";
 
 interface ProxyAddress {

--- a/packages/miniflare/src/shared/event.ts
+++ b/packages/miniflare/src/shared/event.ts
@@ -1,4 +1,4 @@
-import { ValueOf } from "../workers";
+import type { ValueOf } from "../workers";
 
 export type TypedEventListener<E extends Event> =
 	| ((e: E) => void)

--- a/packages/miniflare/src/shared/external-service.ts
+++ b/packages/miniflare/src/shared/external-service.ts
@@ -1,20 +1,16 @@
 import assert from "node:assert";
-import http from "node:http";
-import { z } from "zod";
-import {
-	getUserServiceName,
-	kCurrentWorker,
-	ServiceDesignatorSchema,
-} from "../plugins/core";
-import { RemoteProxyConnectionString } from "../plugins/shared";
-import {
+import { getUserServiceName, kCurrentWorker } from "../plugins/core";
+import { HttpOptions_Style, kVoid } from "../runtime";
+import { CoreHeaders } from "../workers";
+import type { ServiceDesignatorSchema } from "../plugins/core";
+import type { RemoteProxyConnectionString } from "../plugins/shared";
+import type {
 	HttpOptions,
-	HttpOptions_Style,
-	kVoid,
 	Service,
 	Worker_DurableObjectNamespace,
 } from "../runtime";
-import { CoreHeaders } from "../workers";
+import type http from "node:http";
+import type { z } from "zod";
 
 export function normaliseServiceDesignator(
 	service: z.infer<typeof ServiceDesignatorSchema>

--- a/packages/miniflare/src/shared/log.ts
+++ b/packages/miniflare/src/shared/log.ts
@@ -1,7 +1,8 @@
 import path from "node:path";
 import { stripVTControlCharacters } from "node:util";
-import { Colorize, dim, green, grey, red, reset, yellow } from "kleur/colors";
+import { dim, green, grey, red, reset, yellow } from "kleur/colors";
 import { LogLevel } from "../workers";
+import type { Colorize } from "kleur/colors";
 
 const cwd = process.cwd();
 const cwdNodeModules = path.join(cwd, "node_modules");

--- a/packages/miniflare/src/shared/matcher.ts
+++ b/packages/miniflare/src/shared/matcher.ts
@@ -1,5 +1,5 @@
 import globToRegexp from "glob-to-regexp";
-import { MatcherRegExps } from "../workers";
+import type { MatcherRegExps } from "../workers";
 
 export function globsToRegExps(
 	globs: string[] = [],

--- a/packages/miniflare/src/shared/streams.ts
+++ b/packages/miniflare/src/shared/streams.ts
@@ -1,4 +1,5 @@
-import { ReadableStream, TransformStream } from "node:stream/web";
+import { TransformStream } from "node:stream/web";
+import type { ReadableStream } from "node:stream/web";
 
 export function prefixStream(
 	prefix: Uint8Array,

--- a/packages/miniflare/src/shared/types.ts
+++ b/packages/miniflare/src/shared/types.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import path from "node:path";
-import { ParseParams, z } from "zod";
+import { z } from "zod";
+import type { ParseParams } from "zod";
 
 export function zAwaitable<T extends z.ZodTypeAny>(
 	type: T

--- a/packages/miniflare/src/workers/browser-rendering/binding.worker.ts
+++ b/packages/miniflare/src/workers/browser-rendering/binding.worker.ts
@@ -4,16 +4,18 @@ import {
 	GET,
 	HttpError,
 	MiniflareDurableObject,
-	MiniflareDurableObjectCf,
-	MiniflareDurableObjectEnv,
 	POST,
 	PUT,
-	RouteHandler,
 	Router,
 	SharedBindings,
-	TimerHandle,
 } from "miniflare:shared";
 import type { Fetcher } from "@cloudflare/workers-types/experimental";
+import type {
+	MiniflareDurableObjectCf,
+	MiniflareDurableObjectEnv,
+	RouteHandler,
+	TimerHandle,
+} from "miniflare:shared";
 
 interface BrowserSessionEnv extends MiniflareDurableObjectEnv {
 	[SharedBindings.MAYBE_SERVICE_LOOPBACK]: Fetcher;

--- a/packages/miniflare/src/workers/cache/cache-entry.worker.ts
+++ b/packages/miniflare/src/workers/cache/cache-entry.worker.ts
@@ -1,5 +1,7 @@
-import { MiniflareDurableObjectCf, SharedBindings } from "miniflare:shared";
-import { CacheBindings, CacheHeaders, CacheObjectCf } from "./constants";
+import { SharedBindings } from "miniflare:shared";
+import { CacheBindings, CacheHeaders } from "./constants";
+import type { CacheObjectCf } from "./constants";
+import type { MiniflareDurableObjectCf } from "miniflare:shared";
 
 interface Env {
 	[SharedBindings.DURABLE_OBJECT_NAMESPACE_OBJECT]: DurableObjectNamespace;

--- a/packages/miniflare/src/workers/cache/cache.worker.ts
+++ b/packages/miniflare/src/workers/cache/cache.worker.ts
@@ -5,26 +5,28 @@ import {
 	DeferredPromise,
 	DELETE,
 	GET,
-	InclusiveRange,
 	KeyValueStorage,
 	LogLevel,
 	MiniflareDurableObject,
-	MiniflareDurableObjectCf,
-	MultipartReadableStream,
 	parseRanges,
 	PURGE,
 	PUT,
-	RouteHandler,
-	Timers,
 } from "miniflare:shared";
 import { isSitesRequest } from "../kv";
-import { CacheObjectCf } from "./constants";
 import {
 	CacheMiss,
 	PurgeFailure,
 	RangeNotSatisfiable,
 	StorageFailure,
 } from "./errors.worker";
+import type { CacheObjectCf } from "./constants";
+import type {
+	InclusiveRange,
+	MiniflareDurableObjectCf,
+	MultipartReadableStream,
+	RouteHandler,
+	Timers,
+} from "miniflare:shared";
 
 interface CacheMetadata {
 	headers: string[][];

--- a/packages/miniflare/src/workers/core/do-wrapper.worker.ts
+++ b/packages/miniflare/src/workers/core/do-wrapper.worker.ts
@@ -1,9 +1,9 @@
-import { DurableObject } from "cloudflare:workers";
 import { INTROSPECT_SQLITE_METHOD } from "../../plugins/core/constants";
 import type {
 	DoRawQueryResult,
 	DoSqlWithParams,
 } from "../local-explorer/generated/types.gen";
+import type { DurableObject } from "cloudflare:workers";
 
 interface DurableObjectConstructor<T = Cloudflare.Env> {
 	new (

--- a/packages/miniflare/src/workers/core/email.ts
+++ b/packages/miniflare/src/workers/core/email.ts
@@ -1,11 +1,12 @@
 import assert from "node:assert";
-import { ForwardableEmailMessage } from "@cloudflare/workers-types/experimental";
 import { $, blue, red, reset, yellow } from "kleur/colors";
 import { LogLevel, SharedHeaders } from "miniflare:shared";
-import PostalMime, { Email } from "postal-mime";
-import { MiniflareEmailMessage } from "../email/email.worker";
+import PostalMime from "postal-mime";
 import { isEmailReplyable, validateReply } from "../email/validate";
 import { CoreBindings } from "./constants";
+import type { MiniflareEmailMessage } from "../email/email.worker";
+import type { ForwardableEmailMessage } from "@cloudflare/workers-types/experimental";
+import type { Email } from "postal-mime";
 
 // Force-enable colours, because kleur can't detect this setting correctly from within a Worker
 // The user setting should be respected (and ansi stripped out if needed) in https://github.com/cloudflare/workers-sdk/blob/2529848e9ff3ddb01ac8c73f96747f32b47aca3e/packages/miniflare/src/index.ts#L993

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -1,20 +1,13 @@
-import {
-	blue,
-	bold,
-	Colorize,
-	green,
-	grey,
-	red,
-	reset,
-	yellow,
-} from "kleur/colors";
+import { blue, bold, green, grey, red, reset, yellow } from "kleur/colors";
 import { HttpError, LogLevel, SharedHeaders } from "miniflare:shared";
 import { isCompressedByCloudflareFL } from "../../shared/mime-types";
 import { CoreBindings, CoreHeaders, CorePaths } from "./constants";
 import { handleEmail } from "./email";
 import { STATUS_CODES } from "./http";
-import { matchRoutes, WorkerRoute } from "./routing";
+import { matchRoutes } from "./routing";
 import { handleScheduled } from "./scheduled";
+import type { WorkerRoute } from "./routing";
+import type { Colorize } from "kleur/colors";
 
 type Env = {
 	[CoreBindings.SERVICE_LOOPBACK]: Fetcher;

--- a/packages/miniflare/src/workers/core/proxy.worker.ts
+++ b/packages/miniflare/src/workers/core/proxy.worker.ts
@@ -16,12 +16,11 @@ import {
 	createHTTPReducers,
 	createHTTPRevivers,
 	parseWithReadableStreams,
-	PlatformImpl,
-	ReducersRevivers,
 	stringifyWithStreams,
 	structuredSerializableReducers,
 	structuredSerializableRevivers,
 } from "./devalue";
+import type { PlatformImpl, ReducersRevivers } from "./devalue";
 
 const ENCODER = new TextEncoder();
 const DECODER = new TextDecoder();

--- a/packages/miniflare/src/workers/d1/database.worker.ts
+++ b/packages/miniflare/src/workers/d1/database.worker.ts
@@ -3,15 +3,17 @@ import {
 	get,
 	HttpError,
 	MiniflareDurableObject,
-	MiniflareDurableObjectEnv,
 	POST,
-	RouteHandler,
-	TypedSqlStorage,
-	TypedValue,
 	viewToBuffer,
 } from "miniflare:shared";
 import { z } from "miniflare:zod";
 import { dumpSql } from "./dumpSql";
+import type {
+	MiniflareDurableObjectEnv,
+	RouteHandler,
+	TypedSqlStorage,
+	TypedValue,
+} from "miniflare:shared";
 
 const D1ValueSchema = z.union([
 	z.number(),

--- a/packages/miniflare/src/workers/d1/dumpSql.ts
+++ b/packages/miniflare/src/workers/d1/dumpSql.ts
@@ -3,7 +3,7 @@
 //
 // NOTE: this function duplicates the logic inside SQLite's shell.c.in as close
 // as possible, with any deviations noted.
-import { SqlStorage } from "@cloudflare/workers-types/experimental";
+import type { SqlStorage } from "@cloudflare/workers-types/experimental";
 
 export function* dumpSql(
 	db: SqlStorage,

--- a/packages/miniflare/src/workers/dispatch-namespace/dispatch-namespace-proxy.worker.ts
+++ b/packages/miniflare/src/workers/dispatch-namespace/dispatch-namespace-proxy.worker.ts
@@ -1,9 +1,9 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
 import {
 	makeRemoteProxyStub,
-	RemoteBindingEnv,
 	throwRemoteRequired,
 } from "../shared/remote-bindings-utils";
+import type { RemoteBindingEnv } from "../shared/remote-bindings-utils";
 
 /** Proxy client for dispatch namespace bindings. */
 export default class DispatchNamespaceProxy extends WorkerEntrypoint<RemoteBindingEnv> {

--- a/packages/miniflare/src/workers/email/send_email.worker.ts
+++ b/packages/miniflare/src/workers/email/send_email.worker.ts
@@ -1,11 +1,12 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
 import { blue } from "kleur/colors";
 import { LogLevel, SharedHeaders } from "miniflare:shared";
-import PostalMime, { Email } from "postal-mime";
+import PostalMime from "postal-mime";
 import { CoreBindings } from "../core/constants";
 import { RAW_EMAIL } from "./constants";
 import { type MiniflareEmailMessage as EmailMessage } from "./email.worker";
 import type { EmailAddress, MessageBuilder } from "./types";
+import type { Email } from "postal-mime";
 
 /**
  * Extracts email address from string or EmailAddress object

--- a/packages/miniflare/src/workers/email/validate.ts
+++ b/packages/miniflare/src/workers/email/validate.ts
@@ -1,7 +1,8 @@
 import { red } from "kleur/colors";
-import PostalMime, { Email } from "postal-mime";
+import PostalMime from "postal-mime";
 import { RAW_EMAIL } from "./constants";
 import { type MiniflareEmailMessage as EmailMessage } from "./email.worker";
+import type { Email } from "postal-mime";
 
 // Email Routing has some limits on what emails can be responded to, documented at https://developers.cloudflare.com/email-routing/email-workers/reply-email-workers/
 export async function isEmailReplyable(

--- a/packages/miniflare/src/workers/kv/constants.ts
+++ b/packages/miniflare/src/workers/kv/constants.ts
@@ -1,4 +1,5 @@
-import { MatcherRegExps, testRegExps } from "miniflare:shared";
+import { testRegExps } from "miniflare:shared";
+import type { MatcherRegExps } from "miniflare:shared";
 
 export const KVLimits = {
 	MIN_CACHE_TTL_SECONDS: 30,

--- a/packages/miniflare/src/workers/kv/namespace.worker.ts
+++ b/packages/miniflare/src/workers/kv/namespace.worker.ts
@@ -4,13 +4,11 @@ import {
 	DELETE,
 	GET,
 	HttpError,
-	KeyValueEntry,
 	KeyValueStorage,
 	maybeApply,
 	MiniflareDurableObject,
 	POST,
 	PUT,
-	RouteHandler,
 } from "miniflare:shared";
 import { KVHeaders, KVLimits, KVParams, MAX_BULK_GET_KEYS } from "./constants";
 import {
@@ -21,6 +19,7 @@ import {
 	validateListOptions,
 	validatePutOptions,
 } from "./validator.worker";
+import type { KeyValueEntry, RouteHandler } from "miniflare:shared";
 
 interface KVParams {
 	key: string;

--- a/packages/miniflare/src/workers/kv/sites.worker.ts
+++ b/packages/miniflare/src/workers/kv/sites.worker.ts
@@ -5,12 +5,14 @@ import {
 	encodeSitesKey,
 	KVLimits,
 	KVParams,
-	SerialisableSiteMatcherRegExps,
 	SiteBindings,
-	SiteMatcherRegExps,
 	testSiteRegExps,
 } from "./constants";
 import { decodeListOptions, validateListOptions } from "./validator.worker";
+import type {
+	SerialisableSiteMatcherRegExps,
+	SiteMatcherRegExps,
+} from "./constants";
 
 interface Env {
 	[SharedBindings.MAYBE_SERVICE_BLOBS]: Fetcher;

--- a/packages/miniflare/src/workers/local-explorer/explorer.worker.ts
+++ b/packages/miniflare/src/workers/local-explorer/explorer.worker.ts
@@ -3,7 +3,7 @@
 
 import { Hono } from "hono/tiny";
 import mime from "mime";
-import { CoreBindings, CorePaths } from "../core";
+import { CorePaths } from "../core";
 import { errorResponse, validateQuery, validateRequestBody } from "./common";
 import { wrapResponse } from "./common";
 import {
@@ -48,6 +48,7 @@ import {
 } from "./resources/workflows";
 import type { BindingIdMap } from "../../plugins/core/types";
 import type { WorkerRegistry } from "../../shared/dev-registry-types";
+import type { CoreBindings } from "../core";
 import type { LocalExplorerWorker } from "./generated";
 
 export type Env = {

--- a/packages/miniflare/src/workers/local-explorer/resources/d1.ts
+++ b/packages/miniflare/src/workers/local-explorer/resources/d1.ts
@@ -1,14 +1,9 @@
-import { z } from "zod";
 import {
 	aggregateListResults,
 	fetchFromPeer,
 	getPeerUrlsIfAggregating,
 } from "../aggregation";
 import { errorResponse, wrapResponse } from "../common";
-import {
-	zD1ListDatabasesData,
-	zD1RawDatabaseQueryData,
-} from "../generated/zod.gen";
 import type { AppContext } from "../common";
 import type { Env } from "../explorer.worker";
 import type {
@@ -16,6 +11,11 @@ import type {
 	D1RawResultResponse,
 	D1SingleQuery,
 } from "../generated";
+import type {
+	zD1ListDatabasesData,
+	zD1RawDatabaseQueryData,
+} from "../generated/zod.gen";
+import type { z } from "zod";
 
 // ============================================================================
 // Error Codes (matching Cloudflare API)

--- a/packages/miniflare/src/workers/local-explorer/resources/do.ts
+++ b/packages/miniflare/src/workers/local-explorer/resources/do.ts
@@ -5,14 +5,14 @@ import {
 	getPeerUrlsIfAggregating,
 } from "../aggregation";
 import { errorResponse, wrapResponse } from "../common";
-import {
-	zDurableObjectsNamespaceListObjectsData,
-	zDurableObjectsNamespaceQuerySqliteData,
-} from "../generated/zod.gen";
 import type { IntrospectSqliteMethod } from "../../../plugins/core/constants";
 import type { AppContext } from "../common";
 import type { Env } from "../explorer.worker";
 import type { WorkersNamespace } from "../generated";
+import type {
+	zDurableObjectsNamespaceListObjectsData,
+	zDurableObjectsNamespaceQuerySqliteData,
+} from "../generated/zod.gen";
 import type { z } from "zod";
 
 // ============================================================================

--- a/packages/miniflare/src/workers/local-explorer/resources/kv.ts
+++ b/packages/miniflare/src/workers/local-explorer/resources/kv.ts
@@ -1,18 +1,18 @@
-import z from "zod";
 import {
 	aggregateListResults,
 	fetchFromPeer,
 	getPeerUrlsIfAggregating,
 } from "../aggregation";
 import { errorResponse, wrapResponse } from "../common";
-import {
+import type { AppContext } from "../common";
+import type { Env } from "../explorer.worker";
+import type { WorkersKvNamespace } from "../generated";
+import type {
 	zWorkersKvNamespaceGetMultipleKeyValuePairsData,
 	zWorkersKvNamespaceListANamespaceSKeysData,
 	zWorkersKvNamespaceListNamespacesData,
 } from "../generated/zod.gen";
-import type { AppContext } from "../common";
-import type { Env } from "../explorer.worker";
-import type { WorkersKvNamespace } from "../generated";
+import type z from "zod";
 
 // ============================================================================
 // Error Codes (matching Cloudflare API)

--- a/packages/miniflare/src/workers/local-explorer/resources/r2.ts
+++ b/packages/miniflare/src/workers/local-explorer/resources/r2.ts
@@ -1,22 +1,22 @@
-import z from "zod";
 import {
 	aggregateListResults,
 	fetchFromPeer,
 	getPeerUrlsIfAggregating,
 } from "../aggregation";
 import { errorResponse, wrapResponse } from "../common";
-import {
-	zR2BucketDeleteObjectsData,
-	zR2BucketGetObjectData,
-	zR2BucketListObjectsData,
-	zR2BucketPutObjectData,
-} from "../generated/zod.gen";
 import type { AppContext } from "../common";
 import type { Env } from "../explorer.worker";
 import type {
 	R2Bucket as R2BucketType,
 	R2ListBucketsResponse,
 } from "../generated";
+import type {
+	zR2BucketDeleteObjectsData,
+	zR2BucketGetObjectData,
+	zR2BucketListObjectsData,
+	zR2BucketPutObjectData,
+} from "../generated/zod.gen";
+import type z from "zod";
 
 // ============================================================================
 // Error Codes (matching Cloudflare API)

--- a/packages/miniflare/src/workers/local-explorer/resources/workflows.ts
+++ b/packages/miniflare/src/workers/local-explorer/resources/workflows.ts
@@ -1,14 +1,14 @@
-import { z } from "zod";
 import {
 	aggregateListResults,
 	fetchFromPeer,
 	getPeerUrlsIfAggregating,
 } from "../aggregation";
 import { errorResponse, wrapResponse } from "../common";
-import { zWorkflowsListInstancesData } from "../generated/zod.gen";
 import type { AppContext } from "../common";
 import type { Env } from "../explorer.worker";
 import type { WorkflowsWorkflow } from "../generated";
+import type { zWorkflowsListInstancesData } from "../generated/zod.gen";
+import type { z } from "zod";
 
 // ============================================================================
 // Error Codes

--- a/packages/miniflare/src/workers/node.d.ts
+++ b/packages/miniflare/src/workers/node.d.ts
@@ -141,7 +141,7 @@ declare module "node:buffer" {
 }
 
 declare module "node:crypto" {
-	import { Buffer } from "node:buffer";
+	import type { Buffer } from "node:buffer";
 
 	class Hash {
 		update(data: string | ArrayBufferView): Hash;

--- a/packages/miniflare/src/workers/queues/broker.worker.ts
+++ b/packages/miniflare/src/workers/queues/broker.worker.ts
@@ -1,33 +1,38 @@
 import assert from "node:assert";
 import { Buffer } from "node:buffer";
-import { bold, Colorize, green, grey, red, reset, yellow } from "kleur/colors";
+import { bold, green, grey, red, reset, yellow } from "kleur/colors";
 import {
 	HttpError,
 	LogLevel,
 	MiniflareDurableObject,
-	MiniflareDurableObjectCf,
-	MiniflareDurableObjectEnv,
 	POST,
-	RouteHandler,
 	SharedBindings,
-	TimerHandle,
 	viewToBuffer,
 } from "miniflare:shared";
 import { QueueBindings } from "./constants";
 import {
-	QueueConsumer,
 	QueueConsumersSchema,
-	QueueContentType,
 	QueueContentTypeSchema,
-	QueueIncomingMessage,
-	QueueMessageDelay,
 	QueueMessageDelaySchema,
-	QueueOutgoingMessage,
-	QueueProducer,
 	QueueProducersSchema,
 	QueuesBatchRequestSchema,
+} from "./schemas";
+import type {
+	QueueConsumer,
+	QueueContentType,
+	QueueIncomingMessage,
+	QueueMessageDelay,
+	QueueOutgoingMessage,
+	QueueProducer,
 	QueuesOutgoingBatchRequest,
 } from "./schemas";
+import type { Colorize } from "kleur/colors";
+import type {
+	MiniflareDurableObjectCf,
+	MiniflareDurableObjectEnv,
+	RouteHandler,
+	TimerHandle,
+} from "miniflare:shared";
 
 const MAX_MESSAGE_SIZE_BYTES = 128 * 1000;
 const MAX_MESSAGE_BATCH_COUNT = 100;

--- a/packages/miniflare/src/workers/r2/bucket.worker.ts
+++ b/packages/miniflare/src/workers/r2/bucket.worker.ts
@@ -5,18 +5,13 @@ import {
 	all,
 	base64Decode,
 	base64Encode,
-	BlobId,
 	DeferredPromise,
 	GET,
 	get,
-	InclusiveRange,
 	maybeApply,
 	MiniflareDurableObject,
-	MiniflareDurableObjectEnv,
 	PUT,
 	readPrefix,
-	RouteHandler,
-	TypedSql,
 	WaitGroup,
 } from "miniflare:shared";
 import { R2Headers, R2Limits } from "./constants";
@@ -30,33 +25,35 @@ import {
 	NoSuchUpload,
 	PreconditionFailed,
 } from "./errors.worker";
+import { InternalR2Object, InternalR2ObjectBody } from "./r2Object.worker";
 import {
-	EncodedMetadata,
-	InternalR2Object,
-	InternalR2ObjectBody,
-	InternalR2Objects,
-} from "./r2Object.worker";
-import {
+	MultipartUploadState,
+	R2BindingRequestSchema,
+	SQL_SCHEMA,
+} from "./schemas.worker";
+import { R2_HASH_ALGORITHMS, Validator } from "./validator.worker";
+import type { EncodedMetadata, InternalR2Objects } from "./r2Object.worker";
+import type {
 	InternalR2CreateMultipartUploadOptions,
 	InternalR2GetOptions,
 	InternalR2ListOptions,
 	InternalR2PutOptions,
 	MultipartPartRow,
 	MultipartUploadRow,
-	MultipartUploadState,
 	ObjectRow,
-	R2BindingRequestSchema,
 	R2Conditional,
 	R2CreateMultipartUploadResponse,
 	R2PublishedPart,
 	R2UploadPartResponse,
-	SQL_SCHEMA,
 } from "./schemas.worker";
-import {
-	DigestAlgorithm,
-	R2_HASH_ALGORITHMS,
-	Validator,
-} from "./validator.worker";
+import type { DigestAlgorithm } from "./validator.worker";
+import type {
+	BlobId,
+	InclusiveRange,
+	MiniflareDurableObjectEnv,
+	RouteHandler,
+	TypedSql,
+} from "miniflare:shared";
 
 // This file implements Miniflare's R2 simulator, supporting both single and
 // multipart uploads.

--- a/packages/miniflare/src/workers/r2/errors.worker.ts
+++ b/packages/miniflare/src/workers/r2/errors.worker.ts
@@ -1,7 +1,7 @@
-import { Buffer } from "node:buffer";
 import { HttpError } from "miniflare:shared";
 import { R2Headers } from "./constants";
-import { InternalR2Object } from "./r2Object.worker";
+import type { InternalR2Object } from "./r2Object.worker";
+import type { Buffer } from "node:buffer";
 
 const R2ErrorCode = {
 	INTERNAL_ERROR: 10001,

--- a/packages/miniflare/src/workers/r2/r2Object.worker.ts
+++ b/packages/miniflare/src/workers/r2/r2Object.worker.ts
@@ -1,5 +1,5 @@
 import { HEX_REGEXP } from "miniflare:zod";
-import {
+import type {
 	ObjectRow,
 	R2HeadResponse,
 	R2HttpFields,

--- a/packages/miniflare/src/workers/r2/schemas.worker.ts
+++ b/packages/miniflare/src/workers/r2/schemas.worker.ts
@@ -1,5 +1,5 @@
-import { ValueOf } from "miniflare:shared";
 import { Base64DataSchema, HexDataSchema, z } from "miniflare:zod";
+import type { ValueOf } from "miniflare:shared";
 
 export type ObjectRow = {
 	key: string;

--- a/packages/miniflare/src/workers/r2/validator.worker.ts
+++ b/packages/miniflare/src/workers/r2/validator.worker.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 import { Buffer } from "node:buffer";
-import { InclusiveRange, parseRanges } from "miniflare:shared";
+import { parseRanges } from "miniflare:shared";
 import { R2Limits } from "./constants";
 import {
 	BadDigest,
@@ -11,8 +11,13 @@ import {
 	MetadataTooLarge,
 	PreconditionFailed,
 } from "./errors.worker";
-import { InternalR2Object } from "./r2Object.worker";
-import { InternalR2GetOptions, R2Conditional, R2Etag } from "./schemas.worker";
+import type { InternalR2Object } from "./r2Object.worker";
+import type {
+	InternalR2GetOptions,
+	R2Conditional,
+	R2Etag,
+} from "./schemas.worker";
+import type { InclusiveRange } from "miniflare:shared";
 
 function identity(ms: number) {
 	return ms;

--- a/packages/miniflare/src/workers/shared/blob.worker.ts
+++ b/packages/miniflare/src/workers/shared/blob.worker.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import { Buffer } from "node:buffer";
 import { sanitisePath } from "./data";
-import { InclusiveRange } from "./range";
+import type { InclusiveRange } from "./range";
 
 const ENCODER = new TextEncoder();
 

--- a/packages/miniflare/src/workers/shared/keyvalue.worker.ts
+++ b/packages/miniflare/src/workers/shared/keyvalue.worker.ts
@@ -1,16 +1,17 @@
 import assert from "node:assert";
-import {
+import { base64Decode, base64Encode } from "./data";
+import { all, drain, get } from "./sql.worker";
+import type {
 	BlobId,
 	BlobStore,
 	MultipartOptions,
 	MultipartReadableStream,
 } from "./blob.worker";
-import { base64Decode, base64Encode } from "./data";
-import { MiniflareDurableObject } from "./object.worker";
-import { InclusiveRange } from "./range";
-import { all, drain, get, TypedSql } from "./sql.worker";
-import { Timers } from "./timers.worker";
-import { Awaitable } from "./types";
+import type { MiniflareDurableObject } from "./object.worker";
+import type { InclusiveRange } from "./range";
+import type { TypedSql } from "./sql.worker";
+import type { Timers } from "./timers.worker";
+import type { Awaitable } from "./types";
 
 export interface KeyEntry<Metadata = unknown> {
 	key: string;

--- a/packages/miniflare/src/workers/shared/object.worker.ts
+++ b/packages/miniflare/src/workers/shared/object.worker.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert";
 import { BlobStore } from "./blob.worker";
-import { LogLevel, SharedBindings, SharedHeaders } from "./constants";
+import { SharedBindings, SharedHeaders } from "./constants";
 import { Router } from "./router.worker";
-import { all, createTypedSql, isTypedValue, TypedSql } from "./sql.worker";
+import { all, createTypedSql, isTypedValue } from "./sql.worker";
 import { Timers } from "./timers.worker";
 import { reduceError } from "./types";
+import type { LogLevel } from "./constants";
+import type { TypedSql } from "./sql.worker";
 
 export interface MiniflareDurableObjectEnv {
 	// NOTE: "in-memory" storage is never in-memory. We always back simulator

--- a/packages/miniflare/src/workers/shared/remote-proxy-client.worker.ts
+++ b/packages/miniflare/src/workers/shared/remote-proxy-client.worker.ts
@@ -2,9 +2,9 @@ import { WorkerEntrypoint } from "cloudflare:workers";
 import {
 	makeFetch,
 	makeRemoteProxyStub,
-	RemoteBindingEnv,
 	throwRemoteRequired,
 } from "./remote-bindings-utils";
+import type { RemoteBindingEnv } from "./remote-bindings-utils";
 
 /** Generic remote proxy client for bindings. */
 export default class Client extends WorkerEntrypoint<RemoteBindingEnv> {

--- a/packages/miniflare/src/workers/shared/router.worker.ts
+++ b/packages/miniflare/src/workers/shared/router.worker.ts
@@ -1,4 +1,4 @@
-import { Awaitable } from "./types";
+import type { Awaitable } from "./types";
 
 export class HttpError extends Error {
 	constructor(

--- a/packages/miniflare/src/workers/shared/sync.ts
+++ b/packages/miniflare/src/workers/shared/sync.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import { Awaitable } from "./types";
+import type { Awaitable } from "./types";
 
 export type DeferredPromiseResolve<T> = (value: T | PromiseLike<T>) => void;
 export type DeferredPromiseReject = (reason?: any) => void;

--- a/packages/miniflare/src/workers/shared/timers.worker.ts
+++ b/packages/miniflare/src/workers/shared/timers.worker.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import { Awaitable } from "./types";
+import type { Awaitable } from "./types";
 
 const kFakeTimerHandle = Symbol("kFakeTimerHandle");
 export type TimerHandle = number | { [kFakeTimerHandle]: number };

--- a/packages/miniflare/src/workers/workflows/wrapped-binding.worker.ts
+++ b/packages/miniflare/src/workers/workflows/wrapped-binding.worker.ts
@@ -1,4 +1,4 @@
-import { WorkflowBinding } from "@cloudflare/workflows-shared/src/binding";
+import type { WorkflowBinding } from "@cloudflare/workflows-shared/src/binding";
 
 class WorkflowImpl implements Workflow {
 	constructor(private binding: WorkflowBinding) {}

--- a/packages/miniflare/test/dev-registry.spec.ts
+++ b/packages/miniflare/test/dev-registry.spec.ts
@@ -1,6 +1,7 @@
-import { Miniflare, MiniflareOptions, WorkerRegistry } from "miniflare";
+import { Miniflare } from "miniflare";
 import { describe, onTestFinished, test, vi } from "vitest";
 import { useDispose, useTmp } from "./test-shared";
+import type { MiniflareOptions, WorkerRegistry } from "miniflare";
 
 describe.sequential("DevRegistry", () => {
 	test("fetch to service worker", async ({ expect }) => {

--- a/packages/miniflare/test/fixtures/shared/router.ts
+++ b/packages/miniflare/test/fixtures/shared/router.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
-import { GET, POST, RouteHandler, Router } from "miniflare:shared";
+import { GET, POST, Router } from "miniflare:shared";
 import { createTestHandler } from "../worker-test";
+import type { RouteHandler } from "miniflare:shared";
 
 class TestRouter extends Router {
 	@GET("/params/:foo/:bar")

--- a/packages/miniflare/test/fixtures/unsafe-plugin/index.ts
+++ b/packages/miniflare/test/fixtures/unsafe-plugin/index.ts
@@ -1,14 +1,12 @@
 import {
 	getMiniflareObjectBindings,
 	kVoid,
-	Plugin,
 	ProxyNodeBinding,
-	Service,
 	SERVICE_LOOPBACK,
 	SharedBindings,
-	Worker_Binding,
 } from "miniflare";
 import { z } from "miniflare:zod";
+import type { Plugin, Service, Worker_Binding } from "miniflare";
 
 const MODULE_SCRIPTS = {
 	DO_CLASS: "UnsafeBindingObject",

--- a/packages/miniflare/test/http/fetch.spec.ts
+++ b/packages/miniflare/test/http/fetch.spec.ts
@@ -1,17 +1,12 @@
 import { Blob } from "node:buffer";
 import http from "node:http";
-import { AddressInfo } from "node:net";
 import { URLSearchParams } from "node:url";
-import {
-	CloseEvent,
-	DeferredPromise,
-	fetch,
-	FormData,
-	MessageEvent,
-} from "miniflare";
+import { DeferredPromise, fetch, FormData } from "miniflare";
 import { assert, onTestFinished, test } from "vitest";
 import { WebSocketServer } from "ws";
 import { useServer } from "../test-shared";
+import type { CloseEvent, MessageEvent } from "miniflare";
+import type { AddressInfo } from "node:net";
 
 const noop = () => {};
 

--- a/packages/miniflare/test/http/websocket.spec.ts
+++ b/packages/miniflare/test/http/websocket.spec.ts
@@ -1,19 +1,19 @@
 import http from "node:http";
-import { AddressInfo } from "node:net";
 import { setImmediate } from "node:timers/promises";
 import { expectTypeOf } from "expect-type";
 import {
-	CloseEvent,
 	coupleWebSocket,
 	DeferredPromise,
-	MessageEvent,
 	viewToBuffer,
 	WebSocket,
 	WebSocketPair,
 } from "miniflare";
 import { assert, test } from "vitest";
-import NodeWebSocket, { Event as WebSocketEvent, WebSocketServer } from "ws";
+import NodeWebSocket, { WebSocketServer } from "ws";
 import { useServer, utf8Decode, utf8Encode } from "../test-shared";
+import type { CloseEvent, MessageEvent } from "miniflare";
+import type { AddressInfo } from "node:net";
+import type { Event as WebSocketEvent } from "ws";
 
 const noop = () => {};
 

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -6,21 +6,11 @@ import { once } from "node:events";
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import http from "node:http";
-import { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
-import { Writable } from "node:stream";
 import { json, text } from "node:stream/consumers";
 import url from "node:url";
 import util from "node:util";
-import {
-	D1Database,
-	DurableObjectNamespace,
-	Fetcher,
-	KVNamespace,
-	Queue,
-	R2Bucket,
-} from "@cloudflare/workers-types/experimental";
 import {
 	_forceColour,
 	_transformsForContentEncodingAndContentType,
@@ -28,24 +18,15 @@ import {
 	DeferredPromise,
 	fetch,
 	kCurrentWorker,
-	MessageEvent,
 	Miniflare,
 	MiniflareCoreError,
-	MiniflareOptions,
 	parseWithRootPath,
 	PLUGINS,
-	ReplaceWorkersTypes,
 	Response,
 	viewToBuffer,
-	Worker_Module,
-	WorkerOptions,
 } from "miniflare";
 import { onTestFinished, test } from "vitest";
-import {
-	CloseEvent as StandardCloseEvent,
-	MessageEvent as StandardMessageEvent,
-	WebSocketServer,
-} from "ws";
+import { WebSocketServer } from "ws";
 import {
 	FIXTURES_PATH,
 	TestLog,
@@ -55,6 +36,27 @@ import {
 	useTmp,
 	utf8Encode,
 } from "./test-shared";
+import type {
+	D1Database,
+	DurableObjectNamespace,
+	Fetcher,
+	KVNamespace,
+	Queue,
+	R2Bucket,
+} from "@cloudflare/workers-types/experimental";
+import type {
+	MessageEvent,
+	MiniflareOptions,
+	ReplaceWorkersTypes,
+	Worker_Module,
+	WorkerOptions,
+} from "miniflare";
+import type { AddressInfo } from "node:net";
+import type { Writable } from "node:stream";
+import type {
+	CloseEvent as StandardCloseEvent,
+	MessageEvent as StandardMessageEvent,
+} from "ws";
 
 // (base64 encoded module containing a single `add(i32, i32): i32` export)
 const ADD_WASM_MODULE = Buffer.from(

--- a/packages/miniflare/test/logs.spec.ts
+++ b/packages/miniflare/test/logs.spec.ts
@@ -1,6 +1,7 @@
-import { Miniflare, MiniflareCoreError, WorkerdStructuredLog } from "miniflare";
+import { Miniflare, MiniflareCoreError } from "miniflare";
 import { assert, test } from "vitest";
 import { useDispose } from "./test-shared";
+import type { WorkerdStructuredLog } from "miniflare";
 
 test("logs are treated as standard stdout/stderr chunks by default", async ({
 	expect,

--- a/packages/miniflare/test/plugins/browser/index.spec.ts
+++ b/packages/miniflare/test/plugins/browser/index.spec.ts
@@ -1,6 +1,7 @@
-import { Miniflare, MiniflareOptions } from "miniflare";
+import { Miniflare } from "miniflare";
 import { afterEach, beforeEach, describe, test, vi } from "vitest";
 import { useDispose } from "../../test-shared";
+import type { MiniflareOptions } from "miniflare";
 
 async function sendMessage(ws: WebSocket, message: unknown) {
 	// adapted from https://github.com/cloudflare/puppeteer/blob/b4984452165437e26dd1c8e516581cec2a02b4cd/packages/puppeteer-core/src/cloudflare/chunking.ts#L6-L30

--- a/packages/miniflare/test/plugins/cache/index.spec.ts
+++ b/packages/miniflare/test/plugins/cache/index.spec.ts
@@ -3,24 +3,26 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import {
 	CACHE_PLUGIN_NAME,
-	HeadersInit,
 	LogLevel,
 	Miniflare,
-	MiniflareOptions,
-	ReplaceWorkersTypes,
 	Request,
-	RequestInit,
 	Response,
 } from "miniflare";
 import { beforeEach, type ExpectStatic, onTestFinished, test } from "vitest";
 import {
 	MiniflareDurableObjectControlStub,
 	miniflareTest,
-	MiniflareTestContext,
 	useDispose,
 	useTmp,
 } from "../../test-shared";
+import type { MiniflareTestContext } from "../../test-shared";
 import type { CacheStorage } from "@cloudflare/workers-types/experimental";
+import type {
+	HeadersInit,
+	MiniflareOptions,
+	ReplaceWorkersTypes,
+	RequestInit,
+} from "miniflare";
 
 interface Context extends MiniflareTestContext {
 	caches: ReplaceWorkersTypes<CacheStorage>;

--- a/packages/miniflare/test/plugins/core/errors/index.spec.ts
+++ b/packages/miniflare/test/plugins/core/errors/index.spec.ts
@@ -2,12 +2,12 @@ import assert from "node:assert";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import Protocol from "devtools-protocol";
 import esbuild from "esbuild";
 import { DeferredPromise, fetch, Log, LogLevel, Miniflare } from "miniflare";
 import { test } from "vitest";
 import NodeWebSocket from "ws";
 import { useDispose, useTmp } from "../../../test-shared";
+import type Protocol from "devtools-protocol";
 import type { RawSourceMap } from "source-map";
 
 const FIXTURES_PATH = path.resolve(__dirname, "../../../fixtures/source-maps");

--- a/packages/miniflare/test/plugins/core/index.spec.ts
+++ b/packages/miniflare/test/plugins/core/index.spec.ts
@@ -2,7 +2,6 @@ import childProcess from "node:child_process";
 import { once } from "node:events";
 import fs from "node:fs/promises";
 import https from "node:https";
-import { AddressInfo } from "node:net";
 import path from "node:path";
 import { text } from "node:stream/consumers";
 import tls from "node:tls";
@@ -10,6 +9,7 @@ import stoppable from "stoppable";
 import { onTestFinished, test } from "vitest";
 import which from "which";
 import { useTmp } from "../../test-shared";
+import type { AddressInfo } from "node:net";
 
 const opensslInstalled = which.sync("openssl", { nothrow: true });
 const opensslTest = opensslInstalled ? test : test.skip;

--- a/packages/miniflare/test/plugins/core/inspector-proxy/index.spec.ts
+++ b/packages/miniflare/test/plugins/core/inspector-proxy/index.spec.ts
@@ -1,15 +1,11 @@
 import events from "node:events";
 import { setTimeout } from "node:timers/promises";
 import getPort from "get-port";
-import {
-	fetch,
-	Miniflare,
-	MiniflareCoreError,
-	MiniflareOptions,
-} from "miniflare";
+import { fetch, Miniflare, MiniflareCoreError } from "miniflare";
 import { beforeAll, test, vi } from "vitest";
 import WebSocket from "ws";
 import { useDispose } from "../../../test-shared";
+import type { MiniflareOptions } from "miniflare";
 
 const nullScript =
 	'addEventListener("fetch", (event) => event.respondWith(new Response(null, { status: 404 })));';

--- a/packages/miniflare/test/plugins/core/proxy/client.spec.ts
+++ b/packages/miniflare/test/plugins/core/proxy/client.spec.ts
@@ -8,15 +8,14 @@ import {
 	CorePaths,
 	DeferredPromise,
 	fetch,
-	MessageEvent,
 	Miniflare,
-	ReplaceWorkersTypes,
 	Response,
 	WebSocketPair,
 } from "miniflare";
 import { describe, onTestFinished, test } from "vitest";
 import { useDispose } from "../../../test-shared";
 import type { Fetcher } from "@cloudflare/workers-types/experimental";
+import type { MessageEvent, ReplaceWorkersTypes } from "miniflare";
 
 // This file tests API proxy edge cases. Cache, D1, Durable Object and R2 tests
 // make extensive use of the API proxy, testing their specific special cases.

--- a/packages/miniflare/test/plugins/d1/suite.ts
+++ b/packages/miniflare/test/plugins/d1/suite.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert";
 import fs from "node:fs/promises";
 import { type D1Database } from "@cloudflare/workers-types/experimental";
-import { Miniflare, MiniflareOptions } from "miniflare";
+import { Miniflare } from "miniflare";
 import { beforeEach, type ExpectStatic, onTestFinished, test } from "vitest";
 import { useDispose, useTmp, utf8Encode } from "../../test-shared";
 import { binding, ctx, getDatabase, opts } from "./test";
+import type { MiniflareOptions } from "miniflare";
 
 export const SCHEMA = (
 	tableColours: string,

--- a/packages/miniflare/test/plugins/d1/test.ts
+++ b/packages/miniflare/test/plugins/d1/test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
-import { miniflareTest, MiniflareTestContext } from "../../test-shared";
+import { miniflareTest } from "../../test-shared";
+import type { MiniflareTestContext } from "../../test-shared";
 import type { D1Database } from "@cloudflare/workers-types/experimental";
 import type { Miniflare, MiniflareOptions } from "miniflare";
 

--- a/packages/miniflare/test/plugins/do/index.spec.ts
+++ b/packages/miniflare/test/plugins/do/index.spec.ts
@@ -6,13 +6,11 @@ import { removeDir } from "@cloudflare/workers-utils";
 import {
 	DeferredPromise,
 	kUnsafeEphemeralUniqueKey,
-	MessageEvent,
 	Miniflare,
-	MiniflareOptions,
-	RequestInit,
 } from "miniflare";
 import { describe, onTestFinished, test } from "vitest";
 import { disposeWithRetry, useDispose, useTmp } from "../../test-shared";
+import type { MessageEvent, MiniflareOptions, RequestInit } from "miniflare";
 
 const COUNTER_SCRIPT = (responsePrefix = "") => `export class Counter {
   instanceId = crypto.randomUUID();

--- a/packages/miniflare/test/plugins/hyperdrive/index.spec.ts
+++ b/packages/miniflare/test/plugins/hyperdrive/index.spec.ts
@@ -1,7 +1,8 @@
-import { Miniflare, MiniflareOptions } from "miniflare";
+import { Miniflare } from "miniflare";
 import { test } from "vitest";
 import { useDispose } from "../../test-shared";
 import type { Hyperdrive } from "@cloudflare/workers-types/experimental";
+import type { MiniflareOptions } from "miniflare";
 
 test("fields match expected", async ({ expect }) => {
 	const connectionString = `postgresql://user:password@localhost:5432/database`;

--- a/packages/miniflare/test/plugins/kv/index.spec.ts
+++ b/packages/miniflare/test/plugins/kv/index.spec.ts
@@ -3,30 +3,24 @@ import { Blob } from "node:buffer";
 import fs from "node:fs/promises";
 import path from "node:path";
 import consumers from "node:stream/consumers";
-import {
-	KV_PLUGIN_NAME,
-	MAX_BULK_GET_KEYS,
-	Miniflare,
-	MiniflareOptions,
-	ReplaceWorkersTypes,
-} from "miniflare";
+import { KV_PLUGIN_NAME, MAX_BULK_GET_KEYS, Miniflare } from "miniflare";
 import { beforeEach, type ExpectStatic, test } from "vitest";
 import {
 	createJunkStream,
 	FIXTURES_PATH,
 	MiniflareDurableObjectControlStub,
 	miniflareTest,
-	MiniflareTestContext,
 	namespace,
-	Namespaced,
 	useDispose,
 	useTmp,
 } from "../../test-shared";
+import type { MiniflareTestContext, Namespaced } from "../../test-shared";
 import type {
 	KVNamespace,
 	KVNamespaceListOptions,
 	KVNamespaceListResult,
 } from "@cloudflare/workers-types/experimental";
+import type { MiniflareOptions, ReplaceWorkersTypes } from "miniflare";
 
 function secondsToMillis(seconds: number): number {
 	return seconds * 1000;

--- a/packages/miniflare/test/plugins/local-explorer/helpers.ts
+++ b/packages/miniflare/test/plugins/local-explorer/helpers.ts
@@ -1,5 +1,5 @@
-import { z } from "zod";
 import type { ExpectStatic } from "vitest";
+import type { z } from "zod";
 
 /**
  * Validates a response body against a Zod schema and returns typed data.

--- a/packages/miniflare/test/plugins/queues/index.spec.ts
+++ b/packages/miniflare/test/plugins/queues/index.spec.ts
@@ -2,7 +2,6 @@ import {
 	DeferredPromise,
 	LogLevel,
 	Miniflare,
-	MiniflareCoreError,
 	QUEUES_PLUGIN_NAME,
 	QueuesError,
 	Response,
@@ -10,11 +9,12 @@ import {
 import { test } from "vitest";
 import { z } from "zod";
 import {
-	LogEntry,
 	MiniflareDurableObjectControlStub,
 	TestLog,
 	useDispose,
 } from "../../test-shared";
+import type { LogEntry } from "../../test-shared";
+import type { MiniflareCoreError } from "miniflare";
 
 const StringArraySchema = z.string().array();
 const MessageArraySchema = z

--- a/packages/miniflare/test/plugins/r2/index.spec.ts
+++ b/packages/miniflare/test/plugins/r2/index.spec.ts
@@ -5,21 +5,13 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { text } from "node:stream/consumers";
-import {
-	Headers,
-	Miniflare,
-	MiniflareOptions,
-	R2_PLUGIN_NAME,
-	ReplaceWorkersTypes,
-} from "miniflare";
+import { Headers, Miniflare, R2_PLUGIN_NAME } from "miniflare";
 import { beforeEach, type ExpectStatic, onTestFinished, test } from "vitest";
 import {
 	FIXTURES_PATH,
 	MiniflareDurableObjectControlStub,
 	miniflareTest,
-	MiniflareTestContext,
 	namespace,
-	Namespaced,
 	useDispose,
 	useTmp,
 } from "../../test-shared";
@@ -27,6 +19,7 @@ import type {
 	MultipartPartRow,
 	ObjectRow,
 } from "../../../src/workers/r2/schemas.worker";
+import type { MiniflareTestContext, Namespaced } from "../../test-shared";
 import type {
 	R2Bucket,
 	R2Conditional,
@@ -35,6 +28,7 @@ import type {
 	R2ObjectBody,
 	R2Objects,
 } from "@cloudflare/workers-types/experimental";
+import type { MiniflareOptions, ReplaceWorkersTypes } from "miniflare";
 
 const WITHIN_EPSILON = 10_000;
 

--- a/packages/miniflare/test/plugins/stream/index.spec.ts
+++ b/packages/miniflare/test/plugins/stream/index.spec.ts
@@ -1,4 +1,3 @@
-import http from "node:http";
 import { pathToFileURL } from "node:url";
 import {
 	Miniflare,
@@ -20,6 +19,7 @@ import type {
 	StreamWatermark as Watermark,
 } from "@cloudflare/workers-types";
 import type { MiniflareOptions } from "miniflare";
+import type http from "node:http";
 
 // Mock image / video bytes
 const TEST_VIDEO_BYTES = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]);

--- a/packages/miniflare/test/plugins/unsafe/index.spec.ts
+++ b/packages/miniflare/test/plugins/unsafe/index.spec.ts
@@ -1,16 +1,12 @@
 import path from "node:path";
-import {
-	Miniflare,
-	MiniflareCoreError,
-	MiniflareOptions,
-	WorkerOptions,
-} from "miniflare";
+import { Miniflare, MiniflareCoreError } from "miniflare";
 import { test } from "vitest";
 import {
 	EXPORTED_FIXTURES,
 	FIXTURES_PATH,
 	useDispose,
 } from "../../test-shared";
+import type { MiniflareOptions, WorkerOptions } from "miniflare";
 
 /**
  * Use the plugin located in `test/fixtures/unsafe-plugin`

--- a/packages/miniflare/test/plugins/workflows/index.spec.ts
+++ b/packages/miniflare/test/plugins/workflows/index.spec.ts
@@ -1,8 +1,9 @@
 import * as fs from "node:fs/promises";
 import { scheduler } from "node:timers/promises";
-import { Miniflare, MiniflareOptions } from "miniflare";
+import { Miniflare } from "miniflare";
 import { describe, test } from "vitest";
 import { useDispose, useTmp } from "../../test-shared";
+import type { MiniflareOptions } from "miniflare";
 
 const WORKFLOW_SCRIPT = () => `
 import { WorkflowEntrypoint } from "cloudflare:workers";

--- a/packages/miniflare/test/shared/blob.spec.ts
+++ b/packages/miniflare/test/shared/blob.spec.ts
@@ -3,10 +3,11 @@ import { Blob } from "node:buffer";
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { ReadableStream } from "node:stream/web";
-import { InclusiveRange, Miniflare, Response } from "miniflare";
+import { Miniflare } from "miniflare";
 import { afterAll, beforeAll, test } from "vitest";
 import { useTmp } from "../test-shared";
+import type { InclusiveRange, Response } from "miniflare";
+import type { ReadableStream } from "node:stream/web";
 
 class BlobStoreStub {
 	constructor(private readonly mf: Miniflare) {}

--- a/packages/miniflare/test/test-shared/http.ts
+++ b/packages/miniflare/test/test-shared/http.ts
@@ -1,9 +1,10 @@
 import http from "node:http";
-import { AddressInfo } from "node:net";
 import { URL } from "node:url";
 import stoppable from "stoppable";
 import { onTestFinished } from "vitest";
-import NodeWebSocket, { WebSocketServer } from "ws";
+import { WebSocketServer } from "ws";
+import type { AddressInfo } from "node:net";
+import type NodeWebSocket from "ws";
 
 export async function useServer(
 	listener: http.RequestListener,

--- a/packages/miniflare/test/test-shared/miniflare.ts
+++ b/packages/miniflare/test/test-shared/miniflare.ts
@@ -1,4 +1,4 @@
-import { Awaitable, Miniflare, MiniflareOptions } from "miniflare";
+import { Miniflare } from "miniflare";
 import { afterAll, beforeAll, onTestFinished } from "vitest";
 import { TestLog } from "./log";
 import type {
@@ -7,6 +7,7 @@ import type {
 	Request as WorkerRequest,
 	Response as WorkerResponse,
 } from "@cloudflare/workers-types/experimental";
+import type { Awaitable, MiniflareOptions } from "miniflare";
 
 const isWindows = process.platform === "win32";
 

--- a/packages/miniflare/test/test-shared/object.ts
+++ b/packages/miniflare/test/test-shared/object.ts
@@ -1,6 +1,6 @@
-import { ReadableStream } from "node:stream/web";
-import { DurableObjectStub } from "@cloudflare/workers-types/experimental";
-import { ReplaceWorkersTypes } from "miniflare";
+import type { DurableObjectStub } from "@cloudflare/workers-types/experimental";
+import type { ReplaceWorkersTypes } from "miniflare";
+import type { ReadableStream } from "node:stream/web";
 
 export class MiniflareDurableObjectControlStub {
 	constructor(private readonly stub: ReplaceWorkersTypes<DurableObjectStub>) {}

--- a/packages/miniflare/test/test-shared/storage.ts
+++ b/packages/miniflare/test/test-shared/storage.ts
@@ -2,14 +2,14 @@ import assert from "node:assert";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import {
-	ReadableByteStreamController,
-	ReadableStream,
-	ReadableStreamBYOBRequest,
-} from "node:stream/web";
+import { ReadableStream } from "node:stream/web";
 import { TextDecoder, TextEncoder } from "node:util";
 import { sanitisePath } from "miniflare";
 import { onTestFinished } from "vitest";
+import type {
+	ReadableByteStreamController,
+	ReadableStreamBYOBRequest,
+} from "node:stream/web";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();

--- a/packages/miniflare/types/streams.d.ts
+++ b/packages/miniflare/types/streams.d.ts
@@ -21,8 +21,8 @@ declare module "stream/web" {
 }
 
 declare module "stream/consumers" {
-	import { Blob } from "node:buffer";
-	import { Readable } from "node:stream";
+	import type { Blob } from "node:buffer";
+	import type { Readable } from "node:stream";
 
 	// `@types/node`'s types for `stream/consumers` omit `AsyncIterable<any>`,
 	// meaning passing `ReadableStream`s from `stream/web` fails


### PR DESCRIPTION
We have a set of lint overrides for miniflare that we should get rid of:
https://github.com/cloudflare/workers-sdk/blob/fb67a18aa2b4a34c292737591e6d5a3401f8d742/.oxlintrc.jsonc#L123

I think it makes sense to try to gradually get rid of those instead of trying to remove them all in one go.

In this PR I am getting rid of the `consistent-type-imports` one, re-aligning miniflare with the rest of the codebase.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: simple code refactoring
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: simple code refactoring

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
