### PR TITLE
ci: use Kimi model for the changeset review job

### DIFF
--- a/.github/opencode.json
+++ b/.github/opencode.json
@@ -5,7 +5,8 @@
 	"provider": {
 		"cloudflare-ai-gateway": {
 			"models": {
-				"anthropic/claude-sonnet-4-5": {}
+				"anthropic/claude-sonnet-4-5": {},
+				"workers-ai/@cf/moonshotai/kimi-k2.5": {}
 			}
 		}
 	},

--- a/.github/workflows/changeset-review.yml
+++ b/.github/workflows/changeset-review.yml
@@ -41,7 +41,7 @@ jobs:
             .changeset/*.md
           files_ignore: |
             .changeset/README.md
-          # Recover deleted files so Claude can read them (needed for Version Packages PRs)
+          # Recover deleted files so the AI can read them (needed for Version Packages PRs)
           recover_deleted_files: ${{ github.event.pull_request.title == 'Version Packages' }}
 
       - name: Review Changesets with OpenCode
@@ -55,7 +55,7 @@ jobs:
           DELETED_FILES: ${{ steps.changed-changesets.outputs.deleted_files }}
           ADDED_FILES: ${{ steps.changed-changesets.outputs.added_files }}
         run: |
-          opencode run --print-logs \
+          opencode --model "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.5" run --print-logs \
             "Review the changeset files in this PR.
 
             For \"Version Packages\" PRs, review: ${DELETED_FILES}


### PR DESCRIPTION
Switch the changeset review workflow to use the Kimi K2.5 model via the AI Gateway.

- Add `workers-ai/@cf/moonshotai/kimi-k2.5` model to `.github/opencode.json`
- Pass the model explicitly via `opencode --model` CLI flag in the workflow
- Update comment wording ("Claude" → "the AI")

The AI Gateway provider name for Workers AI is `workers-ai`, per the [AI Gateway docs](https://developers.cloudflare.com/ai-gateway/providers/workersai/).

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: CI-only workflow change
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Internal CI change