### PR TITLE
[wrangler] Add list commands for queue consumers

### DIFF
--- a/.changeset/queues-consumer-list-commands.md
+++ b/.changeset/queues-consumer-list-commands.md
@@ -1,0 +1,11 @@
+---
+"wrangler": minor
+---
+
+Add `wrangler queues consumer list` subcommands for listing queue consumers
+
+Three new commands are available for listing consumers on a queue:
+
+- `wrangler queues consumer list <queue-name>` — lists all consumers (both worker and HTTP pull), grouped by type
+- `wrangler queues consumer worker list <queue-name>` — lists only worker consumers
+- `wrangler queues consumer http list <queue-name>` — lists only HTTP pull consumers

--- a/packages/wrangler/src/__tests__/queues/queues.test.ts
+++ b/packages/wrangler/src/__tests__/queues/queues.test.ts
@@ -1862,7 +1862,10 @@ describe("wrangler", () => {
 					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]"
+					  -v, --version   Show version number  [boolean]
+
+					OPTIONS
+					      --json  Output in JSON format  [boolean] [default: false]"
 				`);
 			});
 
@@ -1984,6 +1987,67 @@ describe("wrangler", () => {
 					`[Error: Queue "testQueue" does not exist. To create it, run: wrangler queues create testQueue]`
 				);
 			});
+
+			it('should output consumers as JSON with "--json" flag', async () => {
+				mockGetQueueByNameRequest(expectedQueueName, {
+					queue_id: expectedQueueId,
+					queue_name: expectedQueueName,
+					created_on: "",
+					modified_on: "",
+					producers: [],
+					producers_total_count: 0,
+					consumers: [workerConsumer, httpConsumer],
+					consumers_total_count: 2,
+				});
+
+				await runWrangler("queues consumer list testQueue --json");
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(JSON.parse(std.out)).toMatchInlineSnapshot(`
+					[
+					  {
+					    "consumer_id": "1001",
+					    "dead_letter_queue": "my-dlq",
+					    "script": "my-worker",
+					    "settings": {
+					      "batch_size": 10,
+					      "max_concurrency": 2,
+					      "max_retries": 3,
+					      "max_wait_time_ms": 5000,
+					      "retry_delay": 30,
+					    },
+					    "type": "worker",
+					  },
+					  {
+					    "consumer_id": "1002",
+					    "dead_letter_queue": "my-dlq",
+					    "settings": {
+					      "batch_size": 5,
+					      "max_retries": 2,
+					      "retry_delay": 15,
+					      "visibility_timeout_ms": 10000,
+					    },
+					    "type": "http_pull",
+					  },
+					]
+				`);
+			});
+
+			it('should output empty array as JSON with "--json" flag when no consumers', async () => {
+				mockGetQueueByNameRequest(expectedQueueName, {
+					queue_id: expectedQueueId,
+					queue_name: expectedQueueName,
+					created_on: "",
+					modified_on: "",
+					producers: [],
+					producers_total_count: 0,
+					consumers: [],
+					consumers_total_count: 0,
+				});
+
+				await runWrangler("queues consumer list testQueue --json");
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(JSON.parse(std.out)).toMatchInlineSnapshot(`[]`);
+			});
 		});
 
 		describe("consumer worker list", () => {
@@ -2018,7 +2082,10 @@ describe("wrangler", () => {
 					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]"
+					  -v, --version   Show version number  [boolean]
+
+					OPTIONS
+					      --json  Output in JSON format  [boolean] [default: false]"
 				`);
 			});
 
@@ -2085,6 +2152,62 @@ describe("wrangler", () => {
 					`[Error: Queue "testQueue" does not exist. To create it, run: wrangler queues create testQueue]`
 				);
 			});
+
+			it('should output worker consumers as JSON with "--json" flag', async () => {
+				mockGetQueueByNameRequest(expectedQueueName, {
+					queue_id: expectedQueueId,
+					queue_name: expectedQueueName,
+					created_on: "",
+					modified_on: "",
+					producers: [],
+					producers_total_count: 0,
+					consumers: [workerConsumer],
+					consumers_total_count: 1,
+				});
+
+				await runWrangler("queues consumer worker list testQueue --json");
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(JSON.parse(std.out)).toMatchInlineSnapshot(`
+					[
+					  {
+					    "consumer_id": "1001",
+					    "dead_letter_queue": "my-dlq",
+					    "script": "my-worker",
+					    "settings": {
+					      "batch_size": 10,
+					      "max_concurrency": 2,
+					      "max_retries": 3,
+					      "max_wait_time_ms": 5000,
+					      "retry_delay": 30,
+					    },
+					    "type": "worker",
+					  },
+					]
+				`);
+			});
+
+			it('should output empty array as JSON with "--json" flag when no worker consumers', async () => {
+				mockGetQueueByNameRequest(expectedQueueName, {
+					queue_id: expectedQueueId,
+					queue_name: expectedQueueName,
+					created_on: "",
+					modified_on: "",
+					producers: [],
+					producers_total_count: 0,
+					consumers: [
+						{
+							consumer_id: "1002",
+							type: "http_pull",
+							settings: {},
+						},
+					],
+					consumers_total_count: 1,
+				});
+
+				await runWrangler("queues consumer worker list testQueue --json");
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(JSON.parse(std.out)).toMatchInlineSnapshot(`[]`);
+			});
 		});
 
 		describe("consumer http list", () => {
@@ -2117,7 +2240,10 @@ describe("wrangler", () => {
 					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]"
+					  -v, --version   Show version number  [boolean]
+
+					OPTIONS
+					      --json  Output in JSON format  [boolean] [default: false]"
 				`);
 			});
 
@@ -2184,6 +2310,61 @@ describe("wrangler", () => {
 				).rejects.toThrowErrorMatchingInlineSnapshot(
 					`[Error: Queue "testQueue" does not exist. To create it, run: wrangler queues create testQueue]`
 				);
+			});
+
+			it('should output http consumers as JSON with "--json" flag', async () => {
+				mockGetQueueByNameRequest(expectedQueueName, {
+					queue_id: expectedQueueId,
+					queue_name: expectedQueueName,
+					created_on: "",
+					modified_on: "",
+					producers: [],
+					producers_total_count: 0,
+					consumers: [httpConsumer],
+					consumers_total_count: 1,
+				});
+
+				await runWrangler("queues consumer http list testQueue --json");
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(JSON.parse(std.out)).toMatchInlineSnapshot(`
+					[
+					  {
+					    "consumer_id": "1002",
+					    "dead_letter_queue": "my-dlq",
+					    "settings": {
+					      "batch_size": 5,
+					      "max_retries": 2,
+					      "retry_delay": 15,
+					      "visibility_timeout_ms": 10000,
+					    },
+					    "type": "http_pull",
+					  },
+					]
+				`);
+			});
+
+			it('should output empty array as JSON with "--json" flag when no http consumers', async () => {
+				mockGetQueueByNameRequest(expectedQueueName, {
+					queue_id: expectedQueueId,
+					queue_name: expectedQueueName,
+					created_on: "",
+					modified_on: "",
+					producers: [],
+					producers_total_count: 0,
+					consumers: [
+						{
+							consumer_id: "1001",
+							type: "worker",
+							script: "my-worker",
+							settings: {},
+						},
+					],
+					consumers_total_count: 1,
+				});
+
+				await runWrangler("queues consumer http list testQueue --json");
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(JSON.parse(std.out)).toMatchInlineSnapshot(`[]`);
 			});
 		});
 

--- a/packages/wrangler/src/__tests__/queues/queues.test.ts
+++ b/packages/wrangler/src/__tests__/queues/queues.test.ts
@@ -1845,7 +1845,7 @@ describe("wrangler", () => {
 				},
 			};
 
-			it("should show the correct help text", async () => {
+			it("should show the correct help text", async ({ expect }) => {
 				await runWrangler("queues consumer list --help");
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.out).toMatchInlineSnapshot(`
@@ -1869,7 +1869,7 @@ describe("wrangler", () => {
 				`);
 			});
 
-			it("should list both worker and http consumers", async () => {
+			it("should list both worker and http consumers", async ({ expect }) => {
 				mockGetQueueByNameRequest(expectedQueueName, {
 					queue_id: expectedQueueId,
 					queue_name: expectedQueueName,
@@ -1902,7 +1902,9 @@ describe("wrangler", () => {
 				`);
 			});
 
-			it("should list only worker consumers when queue has no http consumers", async () => {
+			it("should list only worker consumers when queue has no http consumers", async ({
+				expect,
+			}) => {
 				mockGetQueueByNameRequest(expectedQueueName, {
 					queue_id: expectedQueueId,
 					queue_name: expectedQueueName,
@@ -1929,7 +1931,9 @@ describe("wrangler", () => {
 				`);
 			});
 
-			it("should list only http consumers when queue has no worker consumers", async () => {
+			it("should list only http consumers when queue has no worker consumers", async ({
+				expect,
+			}) => {
 				mockGetQueueByNameRequest(expectedQueueName, {
 					queue_id: expectedQueueId,
 					queue_name: expectedQueueName,
@@ -1956,7 +1960,9 @@ describe("wrangler", () => {
 			`);
 			});
 
-			it("should show empty message when queue has no consumers", async () => {
+			it("should show empty message when queue has no consumers", async ({
+				expect,
+			}) => {
 				mockGetQueueByNameRequest(expectedQueueName, {
 					queue_id: expectedQueueId,
 					queue_name: expectedQueueName,
@@ -1978,7 +1984,7 @@ describe("wrangler", () => {
 				`);
 			});
 
-			it("should show error when queue does not exist", async () => {
+			it("should show error when queue does not exist", async ({ expect }) => {
 				mockGetQueueByNameRequest(expectedQueueName, null);
 
 				await expect(
@@ -1988,7 +1994,9 @@ describe("wrangler", () => {
 				);
 			});
 
-			it('should output consumers as JSON with "--json" flag', async () => {
+			it('should output consumers as JSON with "--json" flag', async ({
+				expect,
+			}) => {
 				mockGetQueueByNameRequest(expectedQueueName, {
 					queue_id: expectedQueueId,
 					queue_name: expectedQueueName,
@@ -2032,7 +2040,9 @@ describe("wrangler", () => {
 				`);
 			});
 
-			it('should output empty array as JSON with "--json" flag when no consumers', async () => {
+			it('should output empty array as JSON with "--json" flag when no consumers', async ({
+				expect,
+			}) => {
 				mockGetQueueByNameRequest(expectedQueueName, {
 					queue_id: expectedQueueId,
 					queue_name: expectedQueueName,
@@ -2065,7 +2075,7 @@ describe("wrangler", () => {
 				},
 			};
 
-			it("should show the correct help text", async () => {
+			it("should show the correct help text", async ({ expect }) => {
 				await runWrangler("queues consumer worker list --help");
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.out).toMatchInlineSnapshot(`
@@ -2089,7 +2099,7 @@ describe("wrangler", () => {
 				`);
 			});
 
-			it("should list worker consumers", async () => {
+			it("should list worker consumers", async ({ expect }) => {
 				mockGetQueueByNameRequest(expectedQueueName, {
 					queue_id: expectedQueueId,
 					queue_name: expectedQueueName,
@@ -2115,7 +2125,9 @@ describe("wrangler", () => {
 				`);
 			});
 
-			it("should show empty message when queue has no worker consumers", async () => {
+			it("should show empty message when queue has no worker consumers", async ({
+				expect,
+			}) => {
 				mockGetQueueByNameRequest(expectedQueueName, {
 					queue_id: expectedQueueId,
 					queue_name: expectedQueueName,
@@ -2143,7 +2155,7 @@ describe("wrangler", () => {
 				`);
 			});
 
-			it("should show error when queue does not exist", async () => {
+			it("should show error when queue does not exist", async ({ expect }) => {
 				mockGetQueueByNameRequest(expectedQueueName, null);
 
 				await expect(
@@ -2153,7 +2165,9 @@ describe("wrangler", () => {
 				);
 			});
 
-			it('should output worker consumers as JSON with "--json" flag', async () => {
+			it('should output worker consumers as JSON with "--json" flag', async ({
+				expect,
+			}) => {
 				mockGetQueueByNameRequest(expectedQueueName, {
 					queue_id: expectedQueueId,
 					queue_name: expectedQueueName,
@@ -2186,7 +2200,9 @@ describe("wrangler", () => {
 				`);
 			});
 
-			it('should output empty array as JSON with "--json" flag when no worker consumers', async () => {
+			it('should output empty array as JSON with "--json" flag when no worker consumers', async ({
+				expect,
+			}) => {
 				mockGetQueueByNameRequest(expectedQueueName, {
 					queue_id: expectedQueueId,
 					queue_name: expectedQueueName,
@@ -2223,7 +2239,7 @@ describe("wrangler", () => {
 				},
 			};
 
-			it("should show the correct help text", async () => {
+			it("should show the correct help text", async ({ expect }) => {
 				await runWrangler("queues consumer http list --help");
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.out).toMatchInlineSnapshot(`
@@ -2247,7 +2263,7 @@ describe("wrangler", () => {
 				`);
 			});
 
-			it("should list http consumers", async () => {
+			it("should list http consumers", async ({ expect }) => {
 				mockGetQueueByNameRequest(expectedQueueName, {
 					queue_id: expectedQueueId,
 					queue_name: expectedQueueName,
@@ -2273,7 +2289,9 @@ describe("wrangler", () => {
 			`);
 			});
 
-			it("should show empty message when queue has no http consumers", async () => {
+			it("should show empty message when queue has no http consumers", async ({
+				expect,
+			}) => {
 				mockGetQueueByNameRequest(expectedQueueName, {
 					queue_id: expectedQueueId,
 					queue_name: expectedQueueName,
@@ -2302,7 +2320,7 @@ describe("wrangler", () => {
 				`);
 			});
 
-			it("should show error when queue does not exist", async () => {
+			it("should show error when queue does not exist", async ({ expect }) => {
 				mockGetQueueByNameRequest(expectedQueueName, null);
 
 				await expect(
@@ -2312,7 +2330,9 @@ describe("wrangler", () => {
 				);
 			});
 
-			it('should output http consumers as JSON with "--json" flag', async () => {
+			it('should output http consumers as JSON with "--json" flag', async ({
+				expect,
+			}) => {
 				mockGetQueueByNameRequest(expectedQueueName, {
 					queue_id: expectedQueueId,
 					queue_name: expectedQueueName,
@@ -2343,7 +2363,9 @@ describe("wrangler", () => {
 				`);
 			});
 
-			it('should output empty array as JSON with "--json" flag when no http consumers', async () => {
+			it('should output empty array as JSON with "--json" flag when no http consumers', async ({
+				expect,
+			}) => {
 				mockGetQueueByNameRequest(expectedQueueName, {
 					queue_id: expectedQueueId,
 					queue_name: expectedQueueName,

--- a/packages/wrangler/src/__tests__/queues/queues.test.ts
+++ b/packages/wrangler/src/__tests__/queues/queues.test.ts
@@ -719,6 +719,7 @@ describe("wrangler", () => {
 					COMMANDS
 					  wrangler queues consumer add <queue-name> <script-name>     Add a Queue Worker Consumer
 					  wrangler queues consumer remove <queue-name> <script-name>  Remove a Queue Worker Consumer
+					  wrangler queues consumer list <queue-name>                  List consumers for a queue
 					  wrangler queues consumer http                               Configure Queue HTTP Pull Consumers
 					  wrangler queues consumer worker                             Configure Queue Worker Consumers
 
@@ -1565,6 +1566,7 @@ describe("wrangler", () => {
 					COMMANDS
 					  wrangler queues consumer http add <queue-name>     Add a Queue HTTP Pull Consumer
 					  wrangler queues consumer http remove <queue-name>  Remove a Queue HTTP Pull Consumer
+					  wrangler queues consumer http list <queue-name>    List HTTP pull consumers for a queue
 
 					GLOBAL FLAGS
 					  -c, --config    Path to Wrangler configuration file  [string]
@@ -1813,6 +1815,375 @@ describe("wrangler", () => {
 						Removed consumer from queue testQueue."
 					`);
 				});
+			});
+		});
+
+		describe("consumer list", () => {
+			const workerConsumer = {
+				consumer_id: "1001",
+				type: "worker",
+				script: "my-worker",
+				dead_letter_queue: "my-dlq",
+				settings: {
+					batch_size: 10,
+					max_retries: 3,
+					max_wait_time_ms: 5000,
+					max_concurrency: 2,
+					retry_delay: 30,
+				},
+			};
+
+			const httpConsumer = {
+				consumer_id: "1002",
+				type: "http_pull",
+				dead_letter_queue: "my-dlq",
+				settings: {
+					batch_size: 5,
+					max_retries: 2,
+					visibility_timeout_ms: 10000,
+					retry_delay: 15,
+				},
+			};
+
+			it("should show the correct help text", async () => {
+				await runWrangler("queues consumer list --help");
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"wrangler queues consumer list <queue-name>
+
+					List consumers for a queue
+
+					POSITIONALS
+					  queue-name  Name of the queue  [string] [required]
+
+					GLOBAL FLAGS
+					  -c, --config    Path to Wrangler configuration file  [string]
+					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help      Show help  [boolean]
+					  -v, --version   Show version number  [boolean]"
+				`);
+			});
+
+			it("should list both worker and http consumers", async () => {
+				mockGetQueueByNameRequest(expectedQueueName, {
+					queue_id: expectedQueueId,
+					queue_name: expectedQueueName,
+					created_on: "",
+					modified_on: "",
+					producers: [],
+					producers_total_count: 0,
+					consumers: [workerConsumer, httpConsumer],
+					consumers_total_count: 2,
+				});
+
+				await runWrangler("queues consumer list testQueue");
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"
+					 ⛅️ wrangler x.x.x
+					──────────────────
+					Worker consumers:
+					┌─┬─┬─┬─┬─┬─┬─┬─┐
+					│ consumer_id │ script │ dead_letter_queue │ batch_size │ max_retries │ max_wait_time_ms │ max_concurrency │ retry_delay │
+					├─┼─┼─┼─┼─┼─┼─┼─┤
+					│ 1001 │ my-worker │ my-dlq │ 10 │ 3 │ 5000 │ 2 │ 30 │
+					└─┴─┴─┴─┴─┴─┴─┴─┘
+					HTTP pull consumers:
+					┌─┬─┬─┬─┬─┬─┐
+					│ consumer_id │ dead_letter_queue │ batch_size │ max_retries │ visibility_timeout_ms │ retry_delay │
+					├─┼─┼─┼─┼─┼─┤
+					│ 1002 │ my-dlq │ 5 │ 2 │ 10000 │ 15 │
+					└─┴─┴─┴─┴─┴─┘"
+				`);
+			});
+
+			it("should list only worker consumers when queue has no http consumers", async () => {
+				mockGetQueueByNameRequest(expectedQueueName, {
+					queue_id: expectedQueueId,
+					queue_name: expectedQueueName,
+					created_on: "",
+					modified_on: "",
+					producers: [],
+					producers_total_count: 0,
+					consumers: [workerConsumer],
+					consumers_total_count: 1,
+				});
+
+				await runWrangler("queues consumer list testQueue");
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"
+					 ⛅️ wrangler x.x.x
+					──────────────────
+					Worker consumers:
+					┌─┬─┬─┬─┬─┬─┬─┬─┐
+					│ consumer_id │ script │ dead_letter_queue │ batch_size │ max_retries │ max_wait_time_ms │ max_concurrency │ retry_delay │
+					├─┼─┼─┼─┼─┼─┼─┼─┤
+					│ 1001 │ my-worker │ my-dlq │ 10 │ 3 │ 5000 │ 2 │ 30 │
+					└─┴─┴─┴─┴─┴─┴─┴─┘"
+				`);
+			});
+
+			it("should list only http consumers when queue has no worker consumers", async () => {
+				mockGetQueueByNameRequest(expectedQueueName, {
+					queue_id: expectedQueueId,
+					queue_name: expectedQueueName,
+					created_on: "",
+					modified_on: "",
+					producers: [],
+					producers_total_count: 0,
+					consumers: [httpConsumer],
+					consumers_total_count: 1,
+				});
+
+				await runWrangler("queues consumer list testQueue");
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"
+					 ⛅️ wrangler x.x.x
+					──────────────────
+					HTTP pull consumers:
+					┌─┬─┬─┬─┬─┬─┐
+					│ consumer_id │ dead_letter_queue │ batch_size │ max_retries │ visibility_timeout_ms │ retry_delay │
+					├─┼─┼─┼─┼─┼─┤
+					│ 1002 │ my-dlq │ 5 │ 2 │ 10000 │ 15 │
+					└─┴─┴─┴─┴─┴─┘"
+			`);
+			});
+
+			it("should show empty message when queue has no consumers", async () => {
+				mockGetQueueByNameRequest(expectedQueueName, {
+					queue_id: expectedQueueId,
+					queue_name: expectedQueueName,
+					created_on: "",
+					modified_on: "",
+					producers: [],
+					producers_total_count: 0,
+					consumers: [],
+					consumers_total_count: 0,
+				});
+
+				await runWrangler("queues consumer list testQueue");
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"
+					 ⛅️ wrangler x.x.x
+					──────────────────
+					No consumers found for queue "testQueue"."
+				`);
+			});
+
+			it("should show error when queue does not exist", async () => {
+				mockGetQueueByNameRequest(expectedQueueName, null);
+
+				await expect(
+					runWrangler("queues consumer list testQueue")
+				).rejects.toThrowErrorMatchingInlineSnapshot(
+					`[Error: Queue "testQueue" does not exist. To create it, run: wrangler queues create testQueue]`
+				);
+			});
+		});
+
+		describe("consumer worker list", () => {
+			const workerConsumer = {
+				consumer_id: "1001",
+				type: "worker",
+				script: "my-worker",
+				dead_letter_queue: "my-dlq",
+				settings: {
+					batch_size: 10,
+					max_retries: 3,
+					max_wait_time_ms: 5000,
+					max_concurrency: 2,
+					retry_delay: 30,
+				},
+			};
+
+			it("should show the correct help text", async () => {
+				await runWrangler("queues consumer worker list --help");
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"wrangler queues consumer worker list <queue-name>
+
+					List worker consumers for a queue
+
+					POSITIONALS
+					  queue-name  Name of the queue  [string] [required]
+
+					GLOBAL FLAGS
+					  -c, --config    Path to Wrangler configuration file  [string]
+					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help      Show help  [boolean]
+					  -v, --version   Show version number  [boolean]"
+				`);
+			});
+
+			it("should list worker consumers", async () => {
+				mockGetQueueByNameRequest(expectedQueueName, {
+					queue_id: expectedQueueId,
+					queue_name: expectedQueueName,
+					created_on: "",
+					modified_on: "",
+					producers: [],
+					producers_total_count: 0,
+					consumers: [workerConsumer],
+					consumers_total_count: 1,
+				});
+
+				await runWrangler("queues consumer worker list testQueue");
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"
+					 ⛅️ wrangler x.x.x
+					──────────────────
+					┌─┬─┬─┬─┬─┬─┬─┬─┐
+					│ consumer_id │ script │ dead_letter_queue │ batch_size │ max_retries │ max_wait_time_ms │ max_concurrency │ retry_delay │
+					├─┼─┼─┼─┼─┼─┼─┼─┤
+					│ 1001 │ my-worker │ my-dlq │ 10 │ 3 │ 5000 │ 2 │ 30 │
+					└─┴─┴─┴─┴─┴─┴─┴─┘"
+				`);
+			});
+
+			it("should show empty message when queue has no worker consumers", async () => {
+				mockGetQueueByNameRequest(expectedQueueName, {
+					queue_id: expectedQueueId,
+					queue_name: expectedQueueName,
+					created_on: "",
+					modified_on: "",
+					producers: [],
+					producers_total_count: 0,
+					consumers: [
+						{
+							consumer_id: "1002",
+							type: "http_pull",
+							settings: {},
+						},
+					],
+					consumers_total_count: 1,
+				});
+
+				await runWrangler("queues consumer worker list testQueue");
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"
+					 ⛅️ wrangler x.x.x
+					──────────────────
+					No worker consumers found for queue "testQueue"."
+				`);
+			});
+
+			it("should show error when queue does not exist", async () => {
+				mockGetQueueByNameRequest(expectedQueueName, null);
+
+				await expect(
+					runWrangler("queues consumer worker list testQueue")
+				).rejects.toThrowErrorMatchingInlineSnapshot(
+					`[Error: Queue "testQueue" does not exist. To create it, run: wrangler queues create testQueue]`
+				);
+			});
+		});
+
+		describe("consumer http list", () => {
+			const httpConsumer = {
+				consumer_id: "1002",
+				type: "http_pull",
+				dead_letter_queue: "my-dlq",
+				settings: {
+					batch_size: 5,
+					max_retries: 2,
+					visibility_timeout_ms: 10000,
+					retry_delay: 15,
+				},
+			};
+
+			it("should show the correct help text", async () => {
+				await runWrangler("queues consumer http list --help");
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"wrangler queues consumer http list <queue-name>
+
+					List HTTP pull consumers for a queue
+
+					POSITIONALS
+					  queue-name  Name of the queue  [string] [required]
+
+					GLOBAL FLAGS
+					  -c, --config    Path to Wrangler configuration file  [string]
+					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help      Show help  [boolean]
+					  -v, --version   Show version number  [boolean]"
+				`);
+			});
+
+			it("should list http consumers", async () => {
+				mockGetQueueByNameRequest(expectedQueueName, {
+					queue_id: expectedQueueId,
+					queue_name: expectedQueueName,
+					created_on: "",
+					modified_on: "",
+					producers: [],
+					producers_total_count: 0,
+					consumers: [httpConsumer],
+					consumers_total_count: 1,
+				});
+
+				await runWrangler("queues consumer http list testQueue");
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"
+					 ⛅️ wrangler x.x.x
+					──────────────────
+					┌─┬─┬─┬─┬─┬─┐
+					│ consumer_id │ dead_letter_queue │ batch_size │ max_retries │ visibility_timeout_ms │ retry_delay │
+					├─┼─┼─┼─┼─┼─┤
+					│ 1002 │ my-dlq │ 5 │ 2 │ 10000 │ 15 │
+					└─┴─┴─┴─┴─┴─┘"
+			`);
+			});
+
+			it("should show empty message when queue has no http consumers", async () => {
+				mockGetQueueByNameRequest(expectedQueueName, {
+					queue_id: expectedQueueId,
+					queue_name: expectedQueueName,
+					created_on: "",
+					modified_on: "",
+					producers: [],
+					producers_total_count: 0,
+					consumers: [
+						{
+							consumer_id: "1001",
+							type: "worker",
+							script: "my-worker",
+							settings: {},
+						},
+					],
+					consumers_total_count: 1,
+				});
+
+				await runWrangler("queues consumer http list testQueue");
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"
+					 ⛅️ wrangler x.x.x
+					──────────────────
+					No HTTP pull consumers found for queue "testQueue"."
+				`);
+			});
+
+			it("should show error when queue does not exist", async () => {
+				mockGetQueueByNameRequest(expectedQueueName, null);
+
+				await expect(
+					runWrangler("queues consumer http list testQueue")
+				).rejects.toThrowErrorMatchingInlineSnapshot(
+					`[Error: Queue "testQueue" does not exist. To create it, run: wrangler queues create testQueue]`
+				);
 			});
 		});
 

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -257,9 +257,12 @@ import { queuesNamespace } from "./queues/cli/commands";
 import { queuesConsumerNamespace } from "./queues/cli/commands/consumer";
 import { queuesConsumerHttpNamespace } from "./queues/cli/commands/consumer/http-pull";
 import { queuesConsumerHttpAddCommand } from "./queues/cli/commands/consumer/http-pull/add";
+import { queuesConsumerHttpListCommand } from "./queues/cli/commands/consumer/http-pull/list";
 import { queuesConsumerHttpRemoveCommand } from "./queues/cli/commands/consumer/http-pull/remove";
+import { queuesConsumerListCommand } from "./queues/cli/commands/consumer/list";
 import { queuesConsumerWorkerNamespace } from "./queues/cli/commands/consumer/worker";
 import { queuesConsumerAddCommand } from "./queues/cli/commands/consumer/worker/add";
+import { queuesConsumerWorkerListCommand } from "./queues/cli/commands/consumer/worker/list";
 import { queuesConsumerRemoveCommand } from "./queues/cli/commands/consumer/worker/remove";
 import { queuesCreateCommand } from "./queues/cli/commands/create";
 import { queuesDeleteCommand } from "./queues/cli/commands/delete";
@@ -1010,6 +1013,10 @@ export function createCLIParser(argv: string[]) {
 			definition: queuesConsumerRemoveCommand,
 		},
 		{
+			command: "wrangler queues consumer list",
+			definition: queuesConsumerListCommand,
+		},
+		{
 			command: "wrangler queues consumer http",
 			definition: queuesConsumerHttpNamespace,
 		},
@@ -1022,6 +1029,10 @@ export function createCLIParser(argv: string[]) {
 			definition: queuesConsumerHttpRemoveCommand,
 		},
 		{
+			command: "wrangler queues consumer http list",
+			definition: queuesConsumerHttpListCommand,
+		},
+		{
 			command: "wrangler queues consumer worker",
 			definition: queuesConsumerWorkerNamespace,
 		},
@@ -1032,6 +1043,10 @@ export function createCLIParser(argv: string[]) {
 		{
 			command: "wrangler queues consumer worker remove",
 			definition: queuesConsumerRemoveCommand,
+		},
+		{
+			command: "wrangler queues consumer worker list",
+			definition: queuesConsumerWorkerListCommand,
 		},
 	]);
 	registry.registerNamespace("queues");

--- a/packages/wrangler/src/queues/cli/commands/consumer/http-pull/list.ts
+++ b/packages/wrangler/src/queues/cli/commands/consumer/http-pull/list.ts
@@ -1,0 +1,43 @@
+import { createCommand } from "../../../../../core/create-command";
+import { logger } from "../../../../../logger";
+import { listConsumers } from "../../../../client";
+import type { Consumer } from "../../../../client";
+
+export function mapHttpConsumerForDisplay(consumer: Consumer) {
+	return {
+		consumer_id: consumer.consumer_id,
+		dead_letter_queue: consumer.dead_letter_queue ?? "-",
+		batch_size: consumer.settings.batch_size?.toString() ?? "-",
+		max_retries: consumer.settings.max_retries?.toString() ?? "-",
+		visibility_timeout_ms:
+			consumer.settings.visibility_timeout_ms?.toString() ?? "-",
+		retry_delay: consumer.settings.retry_delay?.toString() ?? "-",
+	};
+}
+
+export const queuesConsumerHttpListCommand = createCommand({
+	metadata: {
+		description: "List HTTP pull consumers for a queue",
+		owner: "Product: Queues",
+		status: "stable",
+	},
+	args: {
+		"queue-name": {
+			type: "string",
+			demandOption: true,
+			description: "Name of the queue",
+		},
+	},
+	positionalArgs: ["queue-name"],
+	async handler(args, { config }) {
+		const consumers = await listConsumers(config, args.queueName);
+		const httpConsumers = consumers.filter((c) => c.type === "http_pull");
+
+		if (httpConsumers.length === 0) {
+			logger.log(`No HTTP pull consumers found for queue "${args.queueName}".`);
+			return;
+		}
+
+		logger.table(httpConsumers.map(mapHttpConsumerForDisplay));
+	},
+});

--- a/packages/wrangler/src/queues/cli/commands/consumer/http-pull/list.ts
+++ b/packages/wrangler/src/queues/cli/commands/consumer/http-pull/list.ts
@@ -21,17 +21,30 @@ export const queuesConsumerHttpListCommand = createCommand({
 		owner: "Product: Queues",
 		status: "stable",
 	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
 	args: {
 		"queue-name": {
 			type: "string",
 			demandOption: true,
 			description: "Name of the queue",
 		},
+		json: {
+			describe: "Output in JSON format",
+			type: "boolean",
+			default: false,
+		},
 	},
 	positionalArgs: ["queue-name"],
 	async handler(args, { config }) {
 		const consumers = await listConsumers(config, args.queueName);
 		const httpConsumers = consumers.filter((c) => c.type === "http_pull");
+
+		if (args.json) {
+			logger.log(JSON.stringify(httpConsumers, null, 2));
+			return;
+		}
 
 		if (httpConsumers.length === 0) {
 			logger.log(`No HTTP pull consumers found for queue "${args.queueName}".`);

--- a/packages/wrangler/src/queues/cli/commands/consumer/list.ts
+++ b/packages/wrangler/src/queues/cli/commands/consumer/list.ts
@@ -10,16 +10,29 @@ export const queuesConsumerListCommand = createCommand({
 		owner: "Product: Queues",
 		status: "stable",
 	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
 	args: {
 		"queue-name": {
 			type: "string",
 			demandOption: true,
 			description: "Name of the queue",
 		},
+		json: {
+			describe: "Output in JSON format",
+			type: "boolean",
+			default: false,
+		},
 	},
 	positionalArgs: ["queue-name"],
 	async handler(args, { config }) {
 		const consumers = await listConsumers(config, args.queueName);
+
+		if (args.json) {
+			logger.log(JSON.stringify(consumers, null, 2));
+			return;
+		}
 
 		if (consumers.length === 0) {
 			logger.log(`No consumers found for queue "${args.queueName}".`);

--- a/packages/wrangler/src/queues/cli/commands/consumer/list.ts
+++ b/packages/wrangler/src/queues/cli/commands/consumer/list.ts
@@ -1,0 +1,42 @@
+import { createCommand } from "../../../../core/create-command";
+import { logger } from "../../../../logger";
+import { listConsumers } from "../../../client";
+import { mapHttpConsumerForDisplay } from "./http-pull/list";
+import { mapWorkerConsumerForDisplay } from "./worker/list";
+
+export const queuesConsumerListCommand = createCommand({
+	metadata: {
+		description: "List consumers for a queue",
+		owner: "Product: Queues",
+		status: "stable",
+	},
+	args: {
+		"queue-name": {
+			type: "string",
+			demandOption: true,
+			description: "Name of the queue",
+		},
+	},
+	positionalArgs: ["queue-name"],
+	async handler(args, { config }) {
+		const consumers = await listConsumers(config, args.queueName);
+
+		if (consumers.length === 0) {
+			logger.log(`No consumers found for queue "${args.queueName}".`);
+			return;
+		}
+
+		const workerConsumers = consumers.filter((c) => c.type === "worker");
+		const httpConsumers = consumers.filter((c) => c.type === "http_pull");
+
+		if (workerConsumers.length > 0) {
+			logger.log(`Worker consumers:`);
+			logger.table(workerConsumers.map(mapWorkerConsumerForDisplay));
+		}
+
+		if (httpConsumers.length > 0) {
+			logger.log(`HTTP pull consumers:`);
+			logger.table(httpConsumers.map(mapHttpConsumerForDisplay));
+		}
+	},
+});

--- a/packages/wrangler/src/queues/cli/commands/consumer/worker/list.ts
+++ b/packages/wrangler/src/queues/cli/commands/consumer/worker/list.ts
@@ -22,17 +22,30 @@ export const queuesConsumerWorkerListCommand = createCommand({
 		owner: "Product: Queues",
 		status: "stable",
 	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
 	args: {
 		"queue-name": {
 			type: "string",
 			demandOption: true,
 			description: "Name of the queue",
 		},
+		json: {
+			describe: "Output in JSON format",
+			type: "boolean",
+			default: false,
+		},
 	},
 	positionalArgs: ["queue-name"],
 	async handler(args, { config }) {
 		const consumers = await listConsumers(config, args.queueName);
 		const workerConsumers = consumers.filter((c) => c.type === "worker");
+
+		if (args.json) {
+			logger.log(JSON.stringify(workerConsumers, null, 2));
+			return;
+		}
 
 		if (workerConsumers.length === 0) {
 			logger.log(`No worker consumers found for queue "${args.queueName}".`);

--- a/packages/wrangler/src/queues/cli/commands/consumer/worker/list.ts
+++ b/packages/wrangler/src/queues/cli/commands/consumer/worker/list.ts
@@ -1,0 +1,44 @@
+import { createCommand } from "../../../../../core/create-command";
+import { logger } from "../../../../../logger";
+import { listConsumers } from "../../../../client";
+import type { Consumer } from "../../../../client";
+
+export function mapWorkerConsumerForDisplay(consumer: Consumer) {
+	return {
+		consumer_id: consumer.consumer_id,
+		script: consumer.script ?? consumer.service ?? "-",
+		dead_letter_queue: consumer.dead_letter_queue ?? "-",
+		batch_size: consumer.settings.batch_size?.toString() ?? "-",
+		max_retries: consumer.settings.max_retries?.toString() ?? "-",
+		max_wait_time_ms: consumer.settings.max_wait_time_ms?.toString() ?? "-",
+		max_concurrency: consumer.settings.max_concurrency?.toString() ?? "-",
+		retry_delay: consumer.settings.retry_delay?.toString() ?? "-",
+	};
+}
+
+export const queuesConsumerWorkerListCommand = createCommand({
+	metadata: {
+		description: "List worker consumers for a queue",
+		owner: "Product: Queues",
+		status: "stable",
+	},
+	args: {
+		"queue-name": {
+			type: "string",
+			demandOption: true,
+			description: "Name of the queue",
+		},
+	},
+	positionalArgs: ["queue-name"],
+	async handler(args, { config }) {
+		const consumers = await listConsumers(config, args.queueName);
+		const workerConsumers = consumers.filter((c) => c.type === "worker");
+
+		if (workerConsumers.length === 0) {
+			logger.log(`No worker consumers found for queue "${args.queueName}".`);
+			return;
+		}
+
+		logger.table(workerConsumers.map(mapWorkerConsumerForDisplay));
+	},
+});

--- a/packages/wrangler/src/queues/client.ts
+++ b/packages/wrangler/src/queues/client.ts
@@ -414,6 +414,14 @@ async function getDefaultService(
 	return service.default_environment.environment;
 }
 
+export async function listConsumers(
+	config: Config,
+	queueName: string
+): Promise<Consumer[]> {
+	const queue = await getQueue(config, queueName);
+	return queue.consumers;
+}
+
 export async function deleteWorkerConsumer(
 	config: Config,
 	queueName: string,


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/MQ-1243, https://jira.cfdata.org/browse/MQ-1244 , https://jira.cfdata.org/browse/MQ-1245

_Describe your change..._

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: automatically dociumented: https://wiki.cfdata.org/spaces/Prod/pages/1291605894/Add+Automatic+Wrangler+command+docs

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
