### PR TITLE
Remove some more `no-restricted-imports` lint disabling comments from wrangler

### DIFF
--- a/packages/wrangler/src/__tests__/autoconfig/run.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/run.test.ts
@@ -7,8 +7,7 @@ import {
 	getTodaysCompatDate,
 } from "@cloudflare/workers-utils";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import * as details from "../../autoconfig/details";
 import { Astro } from "../../autoconfig/frameworks/astro";
 import { Static } from "../../autoconfig/frameworks/static";
@@ -30,6 +29,7 @@ import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { writeWorkerSource } from "../helpers/write-worker-source";
 import type { Framework } from "../../autoconfig/frameworks";
+import type { ExpectStatic } from "vitest";
 import type { MockInstance } from "vitest";
 
 vi.mock("../../package-manager", () => ({
@@ -57,7 +57,7 @@ vi.mock("../deploy/deploy", async (importOriginal) => ({
 	},
 }));
 
-async function runDeploy(withArgs: string = "") {
+async function runDeploy(expect: ExpectStatic, withArgs: string = "") {
 	// Expect "Bailing early in tests" to be thrown
 	await expect(runWrangler(`deploy ${withArgs}`)).rejects.toThrowError();
 }
@@ -88,24 +88,28 @@ describe("autoconfig (deploy)", () => {
 		clearOutputFilePath();
 	});
 
-	it("should not check for autoconfig when `deploy` is run with `--x-autoconfig=false`", async () => {
+	it("should not check for autoconfig when `deploy` is run with `--x-autoconfig=false`", async ({
+		expect,
+	}) => {
 		writeWorkerSource();
 		writeWranglerConfig({ main: "index.js" });
 		const getDetailsSpy = vi.spyOn(details, "getDetailsForAutoConfig");
-		await runDeploy(`--x-autoconfig=false`);
+		await runDeploy(expect, `--x-autoconfig=false`);
 
 		expect(getDetailsSpy).not.toHaveBeenCalled();
 	});
 
-	it("should check for autoconfig with flag", async () => {
+	it("should check for autoconfig with flag", async ({ expect }) => {
 		const getDetailsSpy = vi.spyOn(details, "getDetailsForAutoConfig");
 
-		await runDeploy("--x-autoconfig");
+		await runDeploy(expect, "--x-autoconfig");
 
 		expect(getDetailsSpy).toHaveBeenCalled();
 	});
 
-	it("should run autoconfig if project is not configured", async () => {
+	it("should run autoconfig if project is not configured", async ({
+		expect,
+	}) => {
 		const getDetailsSpy = vi
 			.spyOn(details, "getDetailsForAutoConfig")
 			.mockImplementationOnce(() =>
@@ -120,13 +124,15 @@ describe("autoconfig (deploy)", () => {
 			);
 		const runSpy = vi.spyOn(run, "runAutoConfig");
 
-		await runDeploy("--x-autoconfig");
+		await runDeploy(expect, "--x-autoconfig");
 
 		expect(getDetailsSpy).toHaveBeenCalled();
 		expect(runSpy).toHaveBeenCalled();
 	});
 
-	it("should not run autoconfig if project is already configured", async () => {
+	it("should not run autoconfig if project is already configured", async ({
+		expect,
+	}) => {
 		const getDetailsSpy = vi
 			.spyOn(details, "getDetailsForAutoConfig")
 			.mockImplementationOnce(() =>
@@ -139,13 +145,15 @@ describe("autoconfig (deploy)", () => {
 			);
 		const runSpy = vi.spyOn(run, "runAutoConfig");
 
-		await runDeploy("--x-autoconfig");
+		await runDeploy(expect, "--x-autoconfig");
 
 		expect(getDetailsSpy).toHaveBeenCalled();
 		expect(runSpy).not.toHaveBeenCalled();
 	});
 
-	it("should warn and prompt when Pages project is detected", async () => {
+	it("should warn and prompt when Pages project is detected", async ({
+		expect,
+	}) => {
 		vi.spyOn(details, "getDetailsForAutoConfig").mockImplementationOnce(() =>
 			Promise.resolve({
 				configured: false,
@@ -189,7 +197,7 @@ describe("autoconfig (deploy)", () => {
 				.mockImplementation(async () => {});
 		});
 
-		it("happy path", async () => {
+		it("happy path", async ({ expect }) => {
 			await writeFile(
 				"package.json",
 				JSON.stringify({
@@ -325,7 +333,9 @@ describe("autoconfig (deploy)", () => {
 			expect(existsSync(".assetsignore")).toBeFalsy();
 		});
 
-		it("new gitignore should not have leading empty lines", async () => {
+		it("new gitignore should not have leading empty lines", async ({
+			expect,
+		}) => {
 			// Create a .git directory so gitignore will be created
 			await mkdir(".git");
 
@@ -358,7 +368,9 @@ describe("autoconfig (deploy)", () => {
 			`);
 		});
 
-		it("pre-existing gitignore with trailing newline gets one empty separator line", async () => {
+		it("pre-existing gitignore with trailing newline gets one empty separator line", async ({
+			expect,
+		}) => {
 			// Create gitignore with content ending in newline
 			await writeFile(".gitignore", "node_modules\n");
 			mockConfirm({
@@ -393,7 +405,9 @@ describe("autoconfig (deploy)", () => {
 			`);
 		});
 
-		it("allows users to edit the auto-detected settings", async () => {
+		it("allows users to edit the auto-detected settings", async ({
+			expect,
+		}) => {
 			mockConfirm({
 				text: "Do you want to modify these settings?",
 				result: true,
@@ -480,7 +494,9 @@ describe("autoconfig (deploy)", () => {
 			`);
 		});
 
-		it(".assetsignore should contain Wrangler files if outputDir === projectPath", async () => {
+		it(".assetsignore should contain Wrangler files if outputDir === projectPath", async ({
+			expect,
+		}) => {
 			mockConfirm({
 				text: "Do you want to modify these settings?",
 				result: false,
@@ -510,7 +526,9 @@ describe("autoconfig (deploy)", () => {
 			`);
 		});
 
-		it("pre-existing assetsignore with trailing newline gets one empty separator line", async () => {
+		it("pre-existing assetsignore with trailing newline gets one empty separator line", async ({
+			expect,
+		}) => {
 			await writeFile(".assetsignore", "*.bak\n");
 			mockConfirm({
 				text: "Do you want to modify these settings?",
@@ -543,7 +561,9 @@ describe("autoconfig (deploy)", () => {
 			`);
 		});
 
-		it("errors if no output directory is specified in the autoconfig details", async () => {
+		it("errors if no output directory is specified in the autoconfig details", async ({
+			expect,
+		}) => {
 			mockConfirm({
 				text: "Do you want to modify these settings?",
 				result: false,
@@ -563,7 +583,9 @@ describe("autoconfig (deploy)", () => {
 			);
 		});
 
-		it("errors with Pages-specific message when framework is cf-pages", async () => {
+		it("errors with Pages-specific message when framework is cf-pages", async ({
+			expect,
+		}) => {
 			mockConfirm({
 				text: "Do you want to modify these settings?",
 				result: false,
@@ -588,7 +610,9 @@ describe("autoconfig (deploy)", () => {
 			);
 		});
 
-		it("errors with generic message when unsupported framework is not cf-pages", async () => {
+		it("errors with generic message when unsupported framework is not cf-pages", async ({
+			expect,
+		}) => {
 			mockConfirm({
 				text: "Do you want to modify these settings?",
 				result: false,
@@ -614,7 +638,9 @@ describe("autoconfig (deploy)", () => {
 		});
 
 		describe("nodejs_compat compatibility flag", () => {
-			it("should add nodejs_compat when framework specifies no compatibility flags", async () => {
+			it("should add nodejs_compat when framework specifies no compatibility flags", async ({
+				expect,
+			}) => {
 				mockConfirm({
 					text: "Do you want to modify these settings?",
 					result: false,
@@ -650,7 +676,9 @@ describe("autoconfig (deploy)", () => {
 				expect(wranglerConfig.compatibility_flags).toEqual(["nodejs_compat"]);
 			});
 
-			it("should preserve other compatibility flags while adding nodejs_compat", async () => {
+			it("should preserve other compatibility flags while adding nodejs_compat", async ({
+				expect,
+			}) => {
 				mockConfirm({
 					text: "Do you want to modify these settings?",
 					result: false,
@@ -689,7 +717,9 @@ describe("autoconfig (deploy)", () => {
 				]);
 			});
 
-			it("should not duplicate nodejs_compat if already present", async () => {
+			it("should not duplicate nodejs_compat if already present", async ({
+				expect,
+			}) => {
 				mockConfirm({
 					text: "Do you want to modify these settings?",
 					result: false,
@@ -725,7 +755,7 @@ describe("autoconfig (deploy)", () => {
 				expect(wranglerConfig.compatibility_flags).toEqual(["nodejs_compat"]);
 			});
 
-			it("should replace nodejs_als with nodejs_compat", async () => {
+			it("should replace nodejs_als with nodejs_compat", async ({ expect }) => {
 				mockConfirm({
 					text: "Do you want to modify these settings?",
 					result: false,
@@ -764,7 +794,9 @@ describe("autoconfig (deploy)", () => {
 			});
 		});
 
-		it("validateFrameworkVersion is called before configure for a supported framework", async () => {
+		it("validateFrameworkVersion is called before configure for a supported framework", async ({
+			expect,
+		}) => {
 			mockConfirm({
 				text: "Do you want to modify these settings?",
 				result: false,

--- a/packages/wrangler/src/__tests__/cloudchamber/apply.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/apply.test.ts
@@ -6,8 +6,7 @@ import {
 } from "@cloudflare/containers-shared";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, test } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockCLIOutput } from "../helpers/mock-cli-output";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -21,6 +20,7 @@ import type {
 	CreateApplicationRequest,
 	ModifyApplicationRequestBody,
 } from "@cloudflare/containers-shared";
+import type { ExpectStatic } from "vitest";
 
 function mockGetApplications(applications: Application[]) {
 	msw.use(
@@ -35,6 +35,7 @@ function mockGetApplications(applications: Application[]) {
 }
 
 function mockCreateApplication(
+	expect: ExpectStatic,
 	response?: Partial<Application>,
 	expected?: Partial<CreateApplicationRequest>
 ) {
@@ -55,6 +56,7 @@ function mockCreateApplication(
 }
 
 function mockModifyApplication(
+	expect: ExpectStatic,
 	expected?: Application
 ): Promise<ModifyApplicationRequestBody> {
 	let response: (value: ModifyApplicationRequestBody) => void;
@@ -95,10 +97,12 @@ describe("cloudchamber apply", () => {
 		msw.resetHandlers();
 	});
 
-	test("should show deprecation warning when running cloudchamber apply", async () => {
+	test("should show deprecation warning when running cloudchamber apply", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		mockGetApplications([]);
-		mockCreateApplication({ id: "test-abc" });
+		mockCreateApplication(expect, { id: "test-abc" });
 
 		await writeWranglerConfig({
 			name: "test-container",
@@ -119,7 +123,7 @@ describe("cloudchamber apply", () => {
 		expect(console.warn).toContain("next major version");
 	});
 
-	test("can apply a simple application", async () => {
+	test("can apply a simple application", async ({ expect }) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			name: "my-container",
@@ -136,7 +140,7 @@ describe("cloudchamber apply", () => {
 			],
 		});
 		mockGetApplications([]);
-		mockCreateApplication({ id: "abc" });
+		mockCreateApplication(expect, { id: "abc" });
 		await runWrangler("cloudchamber apply");
 		expect(std.stderr).toMatchInlineSnapshot(`""`);
 		expect(std.stdout).toMatchInlineSnapshot(`
@@ -167,7 +171,7 @@ describe("cloudchamber apply", () => {
 		`);
 	});
 
-	test("can apply a simple existing application", async () => {
+	test("can apply a simple existing application", async ({ expect }) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			name: "my-container",
@@ -207,7 +211,7 @@ describe("cloudchamber apply", () => {
 				},
 			},
 		]);
-		const applicationReqBodyPromise = mockModifyApplication();
+		const applicationReqBodyPromise = mockModifyApplication(expect);
 		await runWrangler("cloudchamber apply");
 		expect(std.stdout).toMatchInlineSnapshot(`
 			"╭ Deploy a container application deploy changes to your application
@@ -242,7 +246,9 @@ describe("cloudchamber apply", () => {
 		expect(app.instances).toEqual(4);
 	});
 
-	test("can apply a simple existing application and create other (max_instances)", async () => {
+	test("can apply a simple existing application and create other (max_instances)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			name: "my-container",
@@ -286,8 +292,8 @@ describe("cloudchamber apply", () => {
 				},
 			},
 		]);
-		const res = mockModifyApplication();
-		mockCreateApplication({ id: "abc" });
+		const res = mockModifyApplication(expect);
+		mockCreateApplication(expect, { id: "abc" });
 		await runWrangler("cloudchamber apply");
 		const body = await res;
 		expect(body).not.toHaveProperty("instances");
@@ -331,7 +337,9 @@ describe("cloudchamber apply", () => {
 		expect(std.stderr).toMatchInlineSnapshot(`""`);
 	});
 
-	test("can skip a simple existing application and create other", async () => {
+	test("can skip a simple existing application and create other", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			name: "my-container",
@@ -375,7 +383,7 @@ describe("cloudchamber apply", () => {
 				},
 			},
 		]);
-		mockCreateApplication({ id: "abc" });
+		mockCreateApplication(expect, { id: "abc" });
 		await runWrangler("cloudchamber apply");
 
 		expect(std.stdout).toMatchInlineSnapshot(`
@@ -417,7 +425,9 @@ describe("cloudchamber apply", () => {
 		expect(std.stderr).toMatchInlineSnapshot(`""`);
 	});
 
-	test("can apply a simple existing application and create other", async () => {
+	test("can apply a simple existing application and create other", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			name: "my-container",
@@ -460,8 +470,8 @@ describe("cloudchamber apply", () => {
 				},
 			},
 		]);
-		const res = mockModifyApplication();
-		mockCreateApplication({ id: "abc" });
+		const res = mockModifyApplication(expect);
+		mockCreateApplication(expect, { id: "abc" });
 		await runWrangler("cloudchamber apply");
 		await res;
 		expect(std.stdout).toMatchInlineSnapshot(`
@@ -503,7 +513,9 @@ describe("cloudchamber apply", () => {
 		expect(std.stderr).toMatchInlineSnapshot(`""`);
 	});
 
-	test("can apply a simple existing application (labels)", async () => {
+	test("can apply a simple existing application (labels)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			name: "my-container",
@@ -595,7 +607,7 @@ describe("cloudchamber apply", () => {
 				},
 			},
 		]);
-		const res = mockModifyApplication();
+		const res = mockModifyApplication(expect);
 		await runWrangler("cloudchamber apply");
 		await res;
 		expect(std.stdout).toMatchInlineSnapshot(`
@@ -643,7 +655,9 @@ describe("cloudchamber apply", () => {
 		expect(std.stderr).toMatchInlineSnapshot(`""`);
 	});
 
-	test("can apply an application, and there is no changes (retrocompatibility with regional scheduling policy)", async () => {
+	test("can apply an application, and there is no changes (retrocompatibility with regional scheduling policy)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			name: "my-container",
@@ -752,7 +766,9 @@ describe("cloudchamber apply", () => {
 		expect(std.stderr).toMatchInlineSnapshot(`""`);
 	});
 
-	test("can apply an application, and there is no changes (two applications)", async () => {
+	test("can apply an application, and there is no changes (two applications)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		const app = {
 			name: "my-container-app",
@@ -866,7 +882,9 @@ describe("cloudchamber apply", () => {
 		expect(std.stderr).toMatchInlineSnapshot(`""`);
 	});
 
-	test("can apply an application, and there is no changes", async () => {
+	test("can apply an application, and there is no changes", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			name: "my-container",
@@ -975,7 +993,9 @@ describe("cloudchamber apply", () => {
 		expect(std.stderr).toMatchInlineSnapshot(`""`);
 	});
 
-	test("can enable observability logs (top-level field)", async () => {
+	test("can enable observability logs (top-level field)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			name: "my-container",
@@ -1013,7 +1033,7 @@ describe("cloudchamber apply", () => {
 				},
 			},
 		]);
-		const applicationReqBodyPromise = mockModifyApplication();
+		const applicationReqBodyPromise = mockModifyApplication(expect);
 		await runWrangler("cloudchamber apply");
 		expect(std.stdout).toMatchInlineSnapshot(`
 			"╭ Deploy a container application deploy changes to your application
@@ -1042,7 +1062,7 @@ describe("cloudchamber apply", () => {
 		expect(app.instances).toEqual(1);
 	});
 
-	test("can enable observability logs (logs field)", async () => {
+	test("can enable observability logs (logs field)", async ({ expect }) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			name: "my-container",
@@ -1080,7 +1100,7 @@ describe("cloudchamber apply", () => {
 				},
 			},
 		]);
-		const applicationReqBodyPromise = mockModifyApplication();
+		const applicationReqBodyPromise = mockModifyApplication(expect);
 		await runWrangler("cloudchamber apply");
 		expect(std.stdout).toMatchInlineSnapshot(`
 			"╭ Deploy a container application deploy changes to your application
@@ -1109,7 +1129,9 @@ describe("cloudchamber apply", () => {
 		expect(app.instances).toEqual(1);
 	});
 
-	test("can disable observability logs (top-level field)", async () => {
+	test("can disable observability logs (top-level field)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			name: "my-container",
@@ -1152,7 +1174,7 @@ describe("cloudchamber apply", () => {
 				},
 			},
 		]);
-		const applicationReqBodyPromise = mockModifyApplication();
+		const applicationReqBodyPromise = mockModifyApplication(expect);
 		await runWrangler("cloudchamber apply");
 		expect(std.stdout).toMatchInlineSnapshot(`
 			"╭ Deploy a container application deploy changes to your application
@@ -1181,7 +1203,7 @@ describe("cloudchamber apply", () => {
 		expect(app.instances).toEqual(1);
 	});
 
-	test("can disable observability logs (logs field)", async () => {
+	test("can disable observability logs (logs field)", async ({ expect }) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			name: "my-container",
@@ -1224,7 +1246,7 @@ describe("cloudchamber apply", () => {
 				},
 			},
 		]);
-		const applicationReqBodyPromise = mockModifyApplication();
+		const applicationReqBodyPromise = mockModifyApplication(expect);
 		await runWrangler("cloudchamber apply");
 		expect(std.stdout).toMatchInlineSnapshot(`
 			"╭ Deploy a container application deploy changes to your application
@@ -1253,7 +1275,7 @@ describe("cloudchamber apply", () => {
 		expect(app.instances).toEqual(1);
 	});
 
-	test("can disable observability logs (absent field)", async () => {
+	test("can disable observability logs (absent field)", async ({ expect }) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			name: "my-container",
@@ -1295,7 +1317,7 @@ describe("cloudchamber apply", () => {
 				},
 			},
 		]);
-		const applicationReqBodyPromise = mockModifyApplication();
+		const applicationReqBodyPromise = mockModifyApplication(expect);
 		await runWrangler("cloudchamber apply");
 		expect(std.stdout).toMatchInlineSnapshot(`
 			"╭ Deploy a container application deploy changes to your application
@@ -1324,7 +1346,7 @@ describe("cloudchamber apply", () => {
 		expect(app.instances).toEqual(1);
 	});
 
-	test("keeps observability logs enabled", async () => {
+	test("keeps observability logs enabled", async ({ expect }) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			name: "my-container",
@@ -1382,7 +1404,9 @@ describe("cloudchamber apply", () => {
 		expect(std.stderr).toMatchInlineSnapshot(`""`);
 	});
 
-	test("keeps observability logs disabled (undefined in the app)", async () => {
+	test("keeps observability logs disabled (undefined in the app)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			name: "my-container",
@@ -1434,7 +1458,9 @@ describe("cloudchamber apply", () => {
 		expect(std.stderr).toMatchInlineSnapshot(`""`);
 	});
 
-	test("keeps observability logs disabled (false in the app)", async () => {
+	test("keeps observability logs disabled (false in the app)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			name: "my-container",
@@ -1491,7 +1517,7 @@ describe("cloudchamber apply", () => {
 		expect(std.stderr).toMatchInlineSnapshot(`""`);
 	});
 
-	test("can apply a simple application (instance type)", async () => {
+	test("can apply a simple application (instance type)", async ({ expect }) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			name: "my-container",
@@ -1509,7 +1535,7 @@ describe("cloudchamber apply", () => {
 			],
 		});
 		mockGetApplications([]);
-		mockCreateApplication({ id: "abc" });
+		mockCreateApplication(expect, { id: "abc" });
 		await runWrangler("cloudchamber apply");
 		expect(std.stdout).toMatchInlineSnapshot(`
 			"╭ Deploy a container application deploy changes to your application
@@ -1540,7 +1566,9 @@ describe("cloudchamber apply", () => {
 		expect(std.stderr).toMatchInlineSnapshot(`""`);
 	});
 
-	test("can apply a simple application (custom instance type)", async () => {
+	test("can apply a simple application (custom instance type)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			name: "my-container",
@@ -1562,7 +1590,7 @@ describe("cloudchamber apply", () => {
 			],
 		});
 		mockGetApplications([]);
-		mockCreateApplication({ id: "abc" });
+		mockCreateApplication(expect, { id: "abc" });
 		await runWrangler("cloudchamber apply");
 		expect(std.stdout).toMatchInlineSnapshot(`
 			"╭ Deploy a container application deploy changes to your application
@@ -1597,7 +1625,9 @@ describe("cloudchamber apply", () => {
 		expect(std.stderr).toMatchInlineSnapshot(`""`);
 	});
 
-	test("can apply a simple existing application (instance type)", async () => {
+	test("can apply a simple existing application (instance type)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			name: "my-container",
@@ -1638,7 +1668,7 @@ describe("cloudchamber apply", () => {
 				},
 			},
 		]);
-		const applicationReqBodyPromise = mockModifyApplication();
+		const applicationReqBodyPromise = mockModifyApplication(expect);
 		await runWrangler("cloudchamber apply");
 		expect(std.stdout).toMatchInlineSnapshot(`
 			"╭ Deploy a container application deploy changes to your application
@@ -1672,7 +1702,9 @@ describe("cloudchamber apply", () => {
 		expect(app.configuration?.instance_type).toEqual("standard");
 	});
 
-	test("can apply a simple existing application (custom instance type)", async () => {
+	test("can apply a simple existing application (custom instance type)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			name: "my-container",
@@ -1717,7 +1749,7 @@ describe("cloudchamber apply", () => {
 				},
 			},
 		]);
-		const applicationReqBodyPromise = mockModifyApplication();
+		const applicationReqBodyPromise = mockModifyApplication(expect);
 		await runWrangler("cloudchamber apply");
 		expect(std.stdout).toMatchInlineSnapshot(`
 			"╭ Deploy a container application deploy changes to your application
@@ -1758,7 +1790,9 @@ describe("cloudchamber apply", () => {
 		expect(app.configuration?.instance_type).toBeUndefined();
 	});
 
-	test("falls back on dev instance type when instance type is absent", async () => {
+	test("falls back on dev instance type when instance type is absent", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			name: "my-container",
@@ -1798,7 +1832,7 @@ describe("cloudchamber apply", () => {
 				},
 			},
 		]);
-		const applicationReqBodyPromise = mockModifyApplication();
+		const applicationReqBodyPromise = mockModifyApplication(expect);
 		await runWrangler("cloudchamber apply");
 		expect(std.stdout).toMatchInlineSnapshot(`
 			"╭ Deploy a container application deploy changes to your application
@@ -1832,7 +1866,9 @@ describe("cloudchamber apply", () => {
 		expect(app.configuration?.instance_type).toEqual("lite");
 	});
 
-	test("expands image names from managed registry when creating an application", async () => {
+	test("expands image names from managed registry when creating an application", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		const registry = getCloudflareContainerRegistry();
 		writeWranglerConfig({
@@ -1852,6 +1888,7 @@ describe("cloudchamber apply", () => {
 
 		mockGetApplications([]);
 		mockCreateApplication(
+			expect,
 			{ id: "abc" },
 			{
 				configuration: {
@@ -1890,7 +1927,9 @@ describe("cloudchamber apply", () => {
 		`);
 	});
 
-	test("expands image names from managed registry when modifying an application", async () => {
+	test("expands image names from managed registry when modifying an application", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		const registry = getCloudflareContainerRegistry();
 		writeWranglerConfig({
@@ -1934,7 +1973,7 @@ describe("cloudchamber apply", () => {
 			},
 		]);
 
-		const applicationReqBodyPromise = mockModifyApplication();
+		const applicationReqBodyPromise = mockModifyApplication(expect);
 		await runWrangler("cloudchamber apply");
 		expect(std.stdout).toMatchInlineSnapshot(`
 			"╭ Deploy a container application deploy changes to your application
@@ -1963,7 +2002,7 @@ describe("cloudchamber apply", () => {
 		expect(app.configuration?.instance_type).toEqual("standard");
 	});
 
-	test("updates affinities", async () => {
+	test("updates affinities", async ({ expect }) => {
 		setIsTTY(false);
 		const registry = getCloudflareContainerRegistry();
 		writeWranglerConfig({
@@ -2013,7 +2052,7 @@ describe("cloudchamber apply", () => {
 			},
 		]);
 
-		const applicationReqBodyPromise = mockModifyApplication();
+		const applicationReqBodyPromise = mockModifyApplication(expect);
 		await runWrangler("cloudchamber apply");
 		expect(std.stdout).toMatchInlineSnapshot(`
 			"╭ Deploy a container application deploy changes to your application

--- a/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
@@ -1,8 +1,7 @@
 import * as fs from "node:fs";
 import { http, HttpResponse } from "msw";
 import * as TOML from "smol-toml";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { MOCK_DEPLOYMENTS_COMPLEX } from "../helpers/mock-cloudchamber";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -12,8 +11,9 @@ import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { mockAccount, setWranglerConfig } from "./utils";
 import type { SSHPublicKeyItem } from "@cloudflare/containers-shared";
+import type { ExpectStatic } from "vitest";
 
-function mockDeploymentPost() {
+function mockDeploymentPost(expect: ExpectStatic) {
 	msw.use(
 		http.post(
 			"*/deployments/v2",
@@ -72,7 +72,7 @@ describe("cloudchamber create", () => {
 		msw.resetHandlers();
 	});
 
-	it("should help", async () => {
+	it("should help", async ({ expect }) => {
 		await runWrangler("cloudchamber create --help");
 		expect(std.err).toMatchInlineSnapshot(`""`);
 		expect(std.out).toMatchInlineSnapshot(`
@@ -102,7 +102,9 @@ describe("cloudchamber create", () => {
 		`);
 	});
 
-	it("should fail with a nice message when parameters are missing", async () => {
+	it("should fail with a nice message when parameters are missing", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		await expect(
@@ -112,7 +114,9 @@ describe("cloudchamber create", () => {
 		);
 	});
 
-	it("should fail with a nice message when image is invalid", async () => {
+	it("should fail with a nice message when image is invalid", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		await expect(
@@ -128,7 +132,9 @@ describe("cloudchamber create", () => {
 		);
 	});
 
-	it("should fail with a nice message when parameters are mistyped", async () => {
+	it("should fail with a nice message when parameters are mistyped", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		fs.writeFileSync(
 			"./wrangler.toml",
@@ -147,7 +153,9 @@ describe("cloudchamber create", () => {
 		);
 	});
 
-	it("should fail with a nice message when instance type is invalid", async () => {
+	it("should fail with a nice message when instance type is invalid", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		fs.writeFileSync(
 			"./wrangler.toml",
@@ -170,7 +178,9 @@ describe("cloudchamber create", () => {
 		);
 	});
 
-	it("should fail with a nice message when instance type is set with vcpu", async () => {
+	it("should fail with a nice message when instance type is set with vcpu", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		fs.writeFileSync(
 			"./wrangler.toml",
@@ -194,11 +204,13 @@ describe("cloudchamber create", () => {
 		);
 	});
 
-	it("should create deployment (detects no interactivity)", async () => {
+	it("should create deployment (detects no interactivity)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		mockGetKey();
-		mockDeploymentPost();
+		mockDeploymentPost(expect);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 		await runWrangler(
 			"cloudchamber create --image hello:world --location sfo06 --var HELLO:WORLD --var YOU:CONQUERED --vcpu 3 --memory 400GB --ipv4 true"
@@ -230,7 +242,9 @@ describe("cloudchamber create", () => {
 		`);
 	});
 
-	it("should create deployment with instance type (detects no interactivity)", async () => {
+	it("should create deployment with instance type (detects no interactivity)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		mockGetKey();
@@ -253,7 +267,7 @@ describe("cloudchamber create", () => {
 		expect(std.out).toMatchInlineSnapshot(`"{}"`);
 	});
 
-	it("properly reads wrangler config", async () => {
+	it("properly reads wrangler config", async ({ expect }) => {
 		// This is very similar to the previous tests except config
 		// is set in wrangler and not overridden by the CLI
 		setIsTTY(false);
@@ -267,7 +281,7 @@ describe("cloudchamber create", () => {
 		// if values are not read by wrangler, this mock won't work
 		// since the wrangler command wont get the right parameters
 		mockGetKey();
-		mockDeploymentPost();
+		mockDeploymentPost(expect);
 		await runWrangler(
 			"cloudchamber create --var HELLO:WORLD --var YOU:CONQUERED"
 		);
@@ -297,7 +311,7 @@ describe("cloudchamber create", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	it("properly reads wrangler config for instance type", async () => {
+	it("properly reads wrangler config for instance type", async ({ expect }) => {
 		// This is very similar to the previous tests except config
 		// is set in wrangler and not overridden by the CLI
 		setIsTTY(false);
@@ -329,7 +343,9 @@ describe("cloudchamber create", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	it("should create deployment indicating ssh keys (detects no interactivity)", async () => {
+	it("should create deployment indicating ssh keys (detects no interactivity)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		setWranglerConfig({
 			vcpu: 40,
@@ -393,7 +409,9 @@ describe("cloudchamber create", () => {
 		`);
 	});
 
-	it("can't create deployment due to lack of fields (json)", async () => {
+	it("can't create deployment due to lack of fields (json)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		expect(std.err).toMatchInlineSnapshot(`""`);

--- a/packages/wrangler/src/__tests__/cloudchamber/modify.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/modify.test.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { MOCK_DEPLOYMENTS_COMPLEX } from "../helpers/mock-cloudchamber";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -9,8 +8,9 @@ import { msw } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { mockAccount, setWranglerConfig } from "./utils";
+import type { ExpectStatic } from "vitest";
 
-function mockDeployment() {
+function mockDeployment(expect: ExpectStatic) {
 	msw.use(
 		http.patch(
 			"*/deployments/1234/v2",
@@ -37,7 +37,7 @@ describe("cloudchamber modify", () => {
 		msw.resetHandlers();
 	});
 
-	it("should help", async () => {
+	it("should help", async ({ expect }) => {
 		await runWrangler("cloudchamber modify --help");
 		expect(std.err).toMatchInlineSnapshot(`""`);
 		expect(std.out).toMatchInlineSnapshot(`
@@ -68,10 +68,12 @@ describe("cloudchamber modify", () => {
 		`);
 	});
 
-	it("should modify deployment (detects no interactivity)", async () => {
+	it("should modify deployment (detects no interactivity)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		setWranglerConfig({});
-		mockDeployment();
+		mockDeployment(expect);
 		await runWrangler(
 			"cloudchamber modify 1234 --image hello:modify --location sfo06 --var HELLO:WORLD --var YOU:CONQUERED --label appname:helloworld --label region:wnam --vcpu 3 --memory 40MB"
 		);
@@ -103,7 +105,9 @@ describe("cloudchamber modify", () => {
 		`);
 	});
 
-	it("should modify deployment with wrangler args (detects no interactivity)", async () => {
+	it("should modify deployment with wrangler args (detects no interactivity)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		setWranglerConfig({
 			image: "hello:modify",
@@ -111,7 +115,7 @@ describe("cloudchamber modify", () => {
 			memory: "40MB",
 			location: "sfo06",
 		});
-		mockDeployment();
+		mockDeployment(expect);
 		await runWrangler(
 			"cloudchamber modify 1234 --var HELLO:WORLD --var YOU:CONQUERED --label appname:helloworld --label region:wnam"
 		);
@@ -141,7 +145,9 @@ describe("cloudchamber modify", () => {
 		`);
 	});
 
-	it("can't modify deployment due to lack of deploymentId (json)", async () => {
+	it("can't modify deployment due to lack of deploymentId (json)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		expect(std.err).toMatchInlineSnapshot(`""`);

--- a/packages/wrangler/src/__tests__/containers/delete.test.ts
+++ b/packages/wrangler/src/__tests__/containers/delete.test.ts
@@ -1,12 +1,12 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, it } from "vitest";
 import { mockAccount, setWranglerConfig } from "../cloudchamber/utils";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockCLIOutput } from "../helpers/mock-cli-output";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { msw } from "../helpers/msw";
 import { runWrangler } from "../helpers/run-wrangler";
+import type { ExpectStatic } from "vitest";
 
 const testContainerID = "6925adea-c4ad-4aa6-bffd-d26783e9afbb";
 
@@ -23,7 +23,7 @@ describe("containers delete", () => {
 		msw.resetHandlers();
 	});
 
-	it("should help", async () => {
+	it("should help", async ({ expect }) => {
 		await runWrangler("containers delete --help");
 		expect(std.err).toMatchInlineSnapshot(`""`);
 		expect(std.out).toMatchInlineSnapshot(`
@@ -44,7 +44,7 @@ describe("containers delete", () => {
 		`);
 	});
 
-	it("should reject invalid container ID format", async () => {
+	it("should reject invalid container ID format", async ({ expect }) => {
 		setWranglerConfig({});
 		await expect(
 			runWrangler("containers delete invalid-id")
@@ -53,7 +53,7 @@ describe("containers delete", () => {
 		);
 	});
 
-	async function testStatusCode(code: number) {
+	async function testStatusCode(expect: ExpectStatic, code: number) {
 		setWranglerConfig({});
 		msw.use(
 			http.delete(
@@ -83,10 +83,12 @@ describe("containers delete", () => {
 		`);
 	}
 
-	it("should delete container with 400", () => testStatusCode(400));
-	it("should delete container with 404", () => testStatusCode(404));
+	it("should delete container with 400", ({ expect }) =>
+		testStatusCode(expect, 400));
+	it("should delete container with 404", ({ expect }) =>
+		testStatusCode(expect, 404));
 
-	it("should delete container with 500", async () => {
+	it("should delete container with 500", async ({ expect }) => {
 		setWranglerConfig({});
 		msw.use(
 			http.delete(
@@ -117,7 +119,7 @@ describe("containers delete", () => {
 		`);
 	});
 
-	it("should delete container", async () => {
+	it("should delete container", async ({ expect }) => {
 		setWranglerConfig({});
 		msw.use(
 			http.delete(

--- a/packages/wrangler/src/__tests__/containers/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/containers/deploy.test.ts
@@ -10,8 +10,7 @@ import {
 import { ApplicationAffinityHardwareGeneration } from "@cloudflare/containers-shared/src/client/models/ApplicationAffinityHardwareGeneration";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, assert, beforeEach, describe, it, vi } from "vitest";
 import { clearCachedAccount } from "../../cloudchamber/locations";
 import * as user from "../../user";
 import { mockAccountV4 as mockContainersAccount } from "../cloudchamber/utils";
@@ -36,6 +35,7 @@ import type {
 	ImageRegistryCredentialsConfiguration,
 } from "@cloudflare/containers-shared";
 import type { ChildProcess } from "node:child_process";
+import type { ExpectStatic } from "vitest";
 
 vi.mock("node:child_process");
 
@@ -56,7 +56,9 @@ describe("wrangler deploy with containers", () => {
 	afterEach(() => {
 		vi.unstubAllEnvs();
 	});
-	it("should fail early if no docker is detected when deploying a container from a dockerfile", async () => {
+	it("should fail early if no docker is detected when deploying a container from a dockerfile", async ({
+		expect,
+	}) => {
 		vi.stubEnv("WRANGLER_DOCKER_BIN", "/usr/bin/bad-docker-path");
 		writeWranglerConfig({
 			...DEFAULT_DURABLE_OBJECTS,
@@ -74,7 +76,9 @@ describe("wrangler deploy with containers", () => {
 		`
 		);
 	});
-	it("should fail early if the account id doesn't match the account id in the image uri", async () => {
+	it("should fail early if the account id doesn't match the account id in the image uri", async ({
+		expect,
+	}) => {
 		writeWranglerConfig({
 			...DEFAULT_DURABLE_OBJECTS,
 			containers: [
@@ -93,18 +97,20 @@ describe("wrangler deploy with containers", () => {
 			Current account: "some-account-id"]
 		`);
 	});
-	it("should be able to deploy a new container from a dockerfile", async () => {
+	it("should be able to deploy a new container from a dockerfile", async ({
+		expect,
+	}) => {
 		mockGetVersion("Galaxy-Class");
-		setupDockerMocks("my-container", "Galaxy");
+		setupDockerMocks(expect, "my-container", "Galaxy");
 		writeWranglerConfig({
 			...DEFAULT_DURABLE_OBJECTS,
 			containers: [DEFAULT_CONTAINER_FROM_DOCKERFILE],
 		});
 		mockGetApplications([]);
 		fs.writeFileSync("./Dockerfile", "FROM scratch");
-		mockGenerateImageRegistryCredentials();
+		mockGenerateImageRegistryCredentials(expect);
 
-		mockCreateApplication({
+		mockCreateApplication(expect, {
 			name: "my-container",
 			max_instances: 10,
 			configuration: {
@@ -174,7 +180,9 @@ describe("wrangler deploy with containers", () => {
 			"
 		`);
 	});
-	it("should be able to deploy a new container from an image uri", async () => {
+	it("should be able to deploy a new container from an image uri", async ({
+		expect,
+	}) => {
 		// note no docker commands have been mocked here!
 		mockGetVersion("Galaxy-Class");
 		writeWranglerConfig({
@@ -189,7 +197,7 @@ describe("wrangler deploy with containers", () => {
 
 		mockGetApplications([]);
 
-		mockCreateApplication({
+		mockCreateApplication(expect, {
 			name: "my-container",
 			max_instances: 10,
 			scheduling_policy: SchedulingPolicy.DEFAULT,
@@ -251,7 +259,9 @@ describe("wrangler deploy with containers", () => {
 		`);
 	});
 
-	it("should be able to deploy a new container with custom instance limits", async () => {
+	it("should be able to deploy a new container with custom instance limits", async ({
+		expect,
+	}) => {
 		// this test checks the deprecated path for setting custom instance limits
 		// note no docker commands have been mocked here!
 		mockGetVersion("Galaxy-Class");
@@ -271,7 +281,7 @@ describe("wrangler deploy with containers", () => {
 
 		mockGetApplications([]);
 
-		mockCreateApplication({
+		mockCreateApplication(expect, {
 			name: "my-container",
 			max_instances: 10,
 			scheduling_policy: SchedulingPolicy.DEFAULT,
@@ -352,7 +362,9 @@ describe("wrangler deploy with containers", () => {
 		`);
 	});
 
-	it("should be able to deploy a new container with custom instance limits (instance_type)", async () => {
+	it("should be able to deploy a new container with custom instance limits (instance_type)", async ({
+		expect,
+	}) => {
 		// tests the preferred method for setting custom instance limits
 		// note no docker commands have been mocked here!
 		mockGetVersion("Galaxy-Class");
@@ -372,7 +384,7 @@ describe("wrangler deploy with containers", () => {
 
 		mockGetApplications([]);
 
-		mockCreateApplication({
+		mockCreateApplication(expect, {
 			name: "my-container",
 			max_instances: 10,
 			scheduling_policy: SchedulingPolicy.DEFAULT,
@@ -447,10 +459,12 @@ describe("wrangler deploy with containers", () => {
 		`);
 	});
 
-	it("should resolve the docker build context path based on the dockerfile location, if image_build_context is not provided", async () => {
+	it("should resolve the docker build context path based on the dockerfile location, if image_build_context is not provided", async ({
+		expect,
+	}) => {
 		vi.stubEnv("WRANGLER_DOCKER_BIN", "/usr/bin/docker");
 		mockGetVersion("Galaxy-Class");
-		setupDockerMocks("my-container", "Galaxy");
+		setupDockerMocks(expect, "my-container", "Galaxy");
 		mockContainersAccount();
 
 		writeWranglerConfig(
@@ -477,9 +491,9 @@ describe("wrangler deploy with containers", () => {
 		);
 		mockGetApplications([]);
 
-		mockGenerateImageRegistryCredentials();
+		mockGenerateImageRegistryCredentials(expect);
 
-		mockCreateApplication({
+		mockCreateApplication(expect, {
 			name: "my-container",
 			max_instances: 10,
 			configuration: {
@@ -522,9 +536,11 @@ describe("wrangler deploy with containers", () => {
 		expect(std.warn).toMatchInlineSnapshot(`""`);
 	});
 
-	it("should resolve dockerfile path relative to wrangler config path", async () => {
+	it("should resolve dockerfile path relative to wrangler config path", async ({
+		expect,
+	}) => {
 		mockGetVersion("Galaxy-Class");
-		setupDockerMocks("my-container", "Galaxy", "FROM alpine");
+		setupDockerMocks(expect, "my-container", "Galaxy", "FROM alpine");
 
 		fs.mkdirSync("nested/src", { recursive: true });
 		fs.writeFileSync("Dockerfile", "FROM alpine");
@@ -550,9 +566,9 @@ describe("wrangler deploy with containers", () => {
 		);
 
 		mockGetApplications([]);
-		mockGenerateImageRegistryCredentials();
+		mockGenerateImageRegistryCredentials(expect);
 
-		mockCreateApplication({
+		mockCreateApplication(expect, {
 			name: "my-container",
 			max_instances: 10,
 			configuration: {
@@ -589,9 +605,11 @@ describe("wrangler deploy with containers", () => {
 		expect(std.warn).toMatchInlineSnapshot(`""`);
 	});
 
-	it("should be able to redeploy an existing application ", async () => {
+	it("should be able to redeploy an existing application ", async ({
+		expect,
+	}) => {
 		mockGetVersion("Galaxy-Class");
-		setupDockerMocks("my-container", "Galaxy");
+		setupDockerMocks(expect, "my-container", "Galaxy");
 		writeWranglerConfig({
 			...DEFAULT_DURABLE_OBJECTS,
 			containers: [
@@ -631,15 +649,15 @@ describe("wrangler deploy with containers", () => {
 			},
 		]);
 		fs.writeFileSync("./Dockerfile", "FROM scratch");
-		mockGenerateImageRegistryCredentials();
-		mockModifyApplication({
+		mockGenerateImageRegistryCredentials(expect);
+		mockModifyApplication(expect, {
 			configuration: {
 				image: "registry.cloudflare.com/some-account-id/my-container:Galaxy",
 			},
 			max_instances: 10,
 			rollout_active_grace_period: 600,
 		});
-		mockCreateApplicationRollout({
+		mockCreateApplicationRollout(expect, {
 			description: "Progressive update",
 			strategy: "rolling",
 			kind: "full_auto",
@@ -676,7 +694,9 @@ describe("wrangler deploy with containers", () => {
 			"
 		`);
 	});
-	it("should be able to redeploy an existing application and create another", async () => {
+	it("should be able to redeploy an existing application and create another", async ({
+		expect,
+	}) => {
 		mockGetVersion("Galaxy-Class", [
 			{
 				type: "durable_object_namespace",
@@ -690,7 +710,7 @@ describe("wrangler deploy with containers", () => {
 			},
 		]);
 
-		setupDockerMocks("my-container", "Galaxy");
+		setupDockerMocks(expect, "my-container", "Galaxy");
 		mockUploadWorkerRequest({
 			expectedBindings: [
 				{
@@ -775,19 +795,19 @@ describe("wrangler deploy with containers", () => {
 			},
 		]);
 		fs.writeFileSync("./Dockerfile", "FROM scratch");
-		mockGenerateImageRegistryCredentials();
-		mockModifyApplication({
+		mockGenerateImageRegistryCredentials(expect);
+		mockModifyApplication(expect, {
 			configuration: {
 				image: "registry.cloudflare.com/some-account-id/my-container:Galaxy",
 			},
 			max_instances: 10,
 		});
-		mockCreateApplication({
+		mockCreateApplication(expect, {
 			name: "my-container-app-2",
 			max_instances: 3,
 			scheduling_policy: SchedulingPolicy.DEFAULT,
 		});
-		mockCreateApplicationRollout({
+		mockCreateApplicationRollout(expect, {
 			description: "Progressive update",
 			strategy: "rolling",
 			kind: "full_auto",
@@ -852,9 +872,11 @@ describe("wrangler deploy with containers", () => {
 		`);
 	});
 
-	it("skips an existing application if there are no changes", async () => {
+	it("skips an existing application if there are no changes", async ({
+		expect,
+	}) => {
 		mockGetVersion("Galaxy-Class");
-		setupDockerMocks("my-container", "Galaxy");
+		setupDockerMocks(expect, "my-container", "Galaxy");
 		writeWranglerConfig({
 			...DEFAULT_DURABLE_OBJECTS,
 			containers: [DEFAULT_CONTAINER_FROM_DOCKERFILE],
@@ -889,7 +911,7 @@ describe("wrangler deploy with containers", () => {
 			},
 		]);
 		fs.writeFileSync("./Dockerfile", "FROM scratch");
-		mockGenerateImageRegistryCredentials();
+		mockGenerateImageRegistryCredentials(expect);
 
 		await runWrangler("deploy index.js");
 
@@ -908,7 +930,7 @@ describe("wrangler deploy with containers", () => {
 		`);
 	});
 
-	it("should error when no scope for containers", async () => {
+	it("should error when no scope for containers", async ({ expect }) => {
 		// Reset the spy from setupCommonMocks before setting empty scopes
 		vi.mocked(user.getScopes).mockReset();
 		mockContainersAccount([]);
@@ -925,7 +947,9 @@ describe("wrangler deploy with containers", () => {
 	});
 
 	describe("rollout_percentage_steps", () => {
-		it("should create rollout with *step_percentage* when rollout_step_percentage is a number", async () => {
+		it("should create rollout with *step_percentage* when rollout_step_percentage is a number", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				...DEFAULT_DURABLE_OBJECTS,
 				containers: [
@@ -940,9 +964,9 @@ describe("wrangler deploy with containers", () => {
 
 			mockGetApplications([]);
 
-			mockCreateApplication();
+			mockCreateApplication(expect);
 
-			mockCreateApplicationRollout({
+			mockCreateApplicationRollout(expect, {
 				description: "Progressive update",
 				strategy: "rolling",
 				kind: "full_auto",
@@ -958,7 +982,9 @@ describe("wrangler deploy with containers", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should create rollout with *steps* when rollout_step_percentage is an array of numbers", async () => {
+		it("should create rollout with *steps* when rollout_step_percentage is an array of numbers", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				...DEFAULT_DURABLE_OBJECTS,
 				containers: [
@@ -1000,9 +1026,9 @@ describe("wrangler deploy with containers", () => {
 				},
 			]);
 
-			mockModifyApplication();
+			mockModifyApplication(expect);
 
-			mockCreateApplicationRollout({
+			mockCreateApplicationRollout(expect, {
 				description: "Progressive update",
 				strategy: "rolling",
 				kind: "full_auto",
@@ -1026,7 +1052,9 @@ describe("wrangler deploy with containers", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should override rollout to 100 if deploying with --containers-rollout=immediate ", async () => {
+		it("should override rollout to 100 if deploying with --containers-rollout=immediate ", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				...DEFAULT_DURABLE_OBJECTS,
 				containers: [
@@ -1041,10 +1069,10 @@ describe("wrangler deploy with containers", () => {
 
 			mockGetApplications([]);
 
-			mockCreateApplication();
+			mockCreateApplication(expect);
 
 			// expect to see 100
-			mockCreateApplicationRollout({
+			mockCreateApplicationRollout(expect, {
 				description: "Progressive update",
 				strategy: "rolling",
 				kind: "full_auto",
@@ -1060,7 +1088,9 @@ describe("wrangler deploy with containers", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		it("deploying with --containers-rollout=rolling should pass through the config value of rollout_step_percentage", async () => {
+		it("deploying with --containers-rollout=rolling should pass through the config value of rollout_step_percentage", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				...DEFAULT_DURABLE_OBJECTS,
 				containers: [
@@ -1075,10 +1105,10 @@ describe("wrangler deploy with containers", () => {
 
 			mockGetApplications([]);
 
-			mockCreateApplication();
+			mockCreateApplication(expect);
 
 			// expect to see 100
-			mockCreateApplicationRollout({
+			mockCreateApplicationRollout(expect, {
 				description: "Progressive update",
 				strategy: "rolling",
 				kind: "full_auto",
@@ -1123,7 +1153,9 @@ describe("wrangler deploy with containers", () => {
 				namespace_id: "1",
 			},
 		};
-		it("should be able to enable observability logs (top level)", async () => {
+		it("should be able to enable observability logs (top level)", async ({
+			expect,
+		}) => {
 			mockGetVersion("Galaxy-Class");
 			writeWranglerConfig({
 				...DEFAULT_DURABLE_OBJECTS,
@@ -1133,13 +1165,13 @@ describe("wrangler deploy with containers", () => {
 
 			mockGetApplications([sharedGetApplicationResult]);
 
-			mockModifyApplication({
+			mockModifyApplication(expect, {
 				configuration: {
 					image: "registry.cloudflare.com/some-account-id/hello:world",
 					observability: { logs: { enabled: true } },
 				},
 			});
-			mockCreateApplicationRollout();
+			mockCreateApplicationRollout(expect);
 
 			await runWrangler("deploy index.js");
 
@@ -1166,7 +1198,9 @@ describe("wrangler deploy with containers", () => {
 			`);
 		});
 
-		it("should be able to enable observability logs (logs field)", async () => {
+		it("should be able to enable observability logs (logs field)", async ({
+			expect,
+		}) => {
 			mockGetVersion("Galaxy-Class");
 			writeWranglerConfig({
 				...DEFAULT_DURABLE_OBJECTS,
@@ -1176,14 +1210,14 @@ describe("wrangler deploy with containers", () => {
 
 			mockGetApplications([sharedGetApplicationResult]);
 
-			mockModifyApplication({
+			mockModifyApplication(expect, {
 				configuration: {
 					image: "registry.cloudflare.com/some-account-id/hello:world",
 					observability: { logs: { enabled: true } },
 				},
 			});
 
-			mockCreateApplicationRollout();
+			mockCreateApplicationRollout(expect);
 
 			await runWrangler("deploy index.js");
 			expect(cliStd.stdout).toMatchInlineSnapshot(`
@@ -1209,7 +1243,9 @@ describe("wrangler deploy with containers", () => {
 			`);
 		});
 
-		it("should be able to disable observability logs (top level)", async () => {
+		it("should be able to disable observability logs (top level)", async ({
+			expect,
+		}) => {
 			mockGetVersion("Galaxy-Class");
 			writeWranglerConfig({
 				...DEFAULT_DURABLE_OBJECTS,
@@ -1231,14 +1267,14 @@ describe("wrangler deploy with containers", () => {
 				},
 			]);
 
-			mockModifyApplication({
+			mockModifyApplication(expect, {
 				configuration: {
 					image: "registry.cloudflare.com/some-account-id/hello:world",
 					observability: { logs: { enabled: false } },
 				},
 			});
 
-			mockCreateApplicationRollout();
+			mockCreateApplicationRollout(expect);
 
 			await runWrangler("deploy index.js");
 
@@ -1265,7 +1301,9 @@ describe("wrangler deploy with containers", () => {
 			`);
 		});
 
-		it("should be able to disable observability logs (logs field)", async () => {
+		it("should be able to disable observability logs (logs field)", async ({
+			expect,
+		}) => {
 			mockGetVersion("Galaxy-Class");
 			writeWranglerConfig({
 				...DEFAULT_DURABLE_OBJECTS,
@@ -1287,14 +1325,14 @@ describe("wrangler deploy with containers", () => {
 				},
 			]);
 
-			mockModifyApplication({
+			mockModifyApplication(expect, {
 				configuration: {
 					image: "registry.cloudflare.com/some-account-id/hello:world",
 					observability: { logs: { enabled: false } },
 				},
 			});
 
-			mockCreateApplicationRollout();
+			mockCreateApplicationRollout(expect);
 
 			await runWrangler("deploy index.js");
 
@@ -1320,7 +1358,9 @@ describe("wrangler deploy with containers", () => {
 				"
 			`);
 		});
-		it("should be able to disable observability logs (absent field)", async () => {
+		it("should be able to disable observability logs (absent field)", async ({
+			expect,
+		}) => {
 			mockGetVersion("Galaxy-Class");
 			writeWranglerConfig({
 				...DEFAULT_DURABLE_OBJECTS,
@@ -1341,14 +1381,14 @@ describe("wrangler deploy with containers", () => {
 				},
 			]);
 
-			mockModifyApplication({
+			mockModifyApplication(expect, {
 				configuration: {
 					image: "registry.cloudflare.com/some-account-id/hello:world",
 					observability: { logs: { enabled: false } },
 				},
 			});
 
-			mockCreateApplicationRollout();
+			mockCreateApplicationRollout(expect);
 			await runWrangler("deploy index.js");
 			expect(cliStd.stdout).toMatchInlineSnapshot(`
 				"╭ Deploy a container application deploy changes to your application
@@ -1372,7 +1412,7 @@ describe("wrangler deploy with containers", () => {
 				"
 			`);
 		});
-		it("should keep observability logs enabled", async () => {
+		it("should keep observability logs enabled", async ({ expect }) => {
 			mockGetVersion("Galaxy-Class");
 			writeWranglerConfig({
 				...DEFAULT_DURABLE_OBJECTS,
@@ -1394,14 +1434,14 @@ describe("wrangler deploy with containers", () => {
 				},
 			]);
 
-			mockModifyApplication({
+			mockModifyApplication(expect, {
 				configuration: {
 					image: "registry.cloudflare.com/some-account-id/hello:world",
 					observability: { logs: { enabled: true } },
 				},
 			});
 
-			mockCreateApplicationRollout();
+			mockCreateApplicationRollout(expect);
 
 			await runWrangler("deploy index.js");
 			expect(cliStd.stdout).toMatchInlineSnapshot(`
@@ -1417,7 +1457,9 @@ describe("wrangler deploy with containers", () => {
 			`);
 		});
 
-		it("should keep obserability logs disabled if api returns false and undefined in config", async () => {
+		it("should keep obserability logs disabled if api returns false and undefined in config", async ({
+			expect,
+		}) => {
 			mockGetVersion("Galaxy-Class");
 			writeWranglerConfig({
 				...DEFAULT_DURABLE_OBJECTS,
@@ -1454,7 +1496,7 @@ describe("wrangler deploy with containers", () => {
 		});
 	});
 
-	it("should expand image names from managed registry", async () => {
+	it("should expand image names from managed registry", async ({ expect }) => {
 		mockGetVersion("Galaxy-Class");
 		const registry = getCloudflareContainerRegistry();
 		writeWranglerConfig({
@@ -1475,7 +1517,7 @@ describe("wrangler deploy with containers", () => {
 
 		mockGetApplications([]);
 
-		mockCreateApplication({
+		mockCreateApplication(expect, {
 			name: "my-container",
 			max_instances: 10,
 			configuration: {
@@ -1520,7 +1562,7 @@ describe("wrangler deploy with containers", () => {
 	});
 
 	describe("affinities", () => {
-		it("may be specified on creation", async () => {
+		it("may be specified on creation", async ({ expect }) => {
 			mockGetVersion("Galaxy-Class");
 			writeWranglerConfig({
 				...DEFAULT_DURABLE_OBJECTS,
@@ -1536,7 +1578,7 @@ describe("wrangler deploy with containers", () => {
 
 			mockGetApplications([]);
 
-			mockCreateApplication();
+			mockCreateApplication(expect);
 
 			await runWrangler("deploy index.js");
 
@@ -1576,7 +1618,7 @@ describe("wrangler deploy with containers", () => {
 			`);
 		});
 
-		it("may be specified on modification", async () => {
+		it("may be specified on modification", async ({ expect }) => {
 			mockGetVersion("Galaxy-Class");
 			writeWranglerConfig({
 				...DEFAULT_DURABLE_OBJECTS,
@@ -1620,13 +1662,13 @@ describe("wrangler deploy with containers", () => {
 				},
 			]);
 
-			mockModifyApplication({
+			mockModifyApplication(expect, {
 				affinities: {
 					hardware_generation:
 						ApplicationAffinityHardwareGeneration.HIGHEST_OVERALL_PERFORMANCE,
 				},
 			});
-			mockCreateApplicationRollout({
+			mockCreateApplicationRollout(expect, {
 				description: "Progressive update",
 				strategy: "rolling",
 				kind: "full_auto",
@@ -1656,27 +1698,40 @@ describe("wrangler deploy with containers", () => {
 		});
 	});
 
-	it("should not repush image if it already exists remotely", async () => {
+	it("should not repush image if it already exists remotely", async ({
+		expect,
+	}) => {
 		mockGetVersion("Galaxy-Class");
 		const containerName = "my-container";
 		const tag = "Galaxy";
 		vi.mocked(spawn).mockReset();
 		vi.mocked(spawn)
-			.mockImplementationOnce(mockDockerInfo())
+			.mockImplementationOnce(mockDockerInfo(expect))
 			.mockImplementationOnce(
-				mockDockerBuild(containerName, tag, "FROM scratch", process.cwd())
+				mockDockerBuild(
+					expect,
+					containerName,
+					tag,
+					"FROM scratch",
+					process.cwd()
+				)
 			)
 			.mockImplementationOnce(
 				mockDockerImageInspectDigestsWithRepoDigest(
+					expect,
 					containerName,
 					tag,
 					"sha256:three"
 				)
 			)
-			.mockImplementationOnce(mockDockerImageInspectSize(containerName, tag))
-			.mockImplementationOnce(mockDockerLogin("mockpassword"))
+			.mockImplementationOnce(
+				mockDockerImageInspectSize(expect, containerName, tag)
+			)
+			.mockImplementationOnce(mockDockerLogin(expect, "mockpassword"))
 			// Mock docker image rm call since we skip the push
-			.mockImplementationOnce(mockDockerImageDelete(containerName, tag));
+			.mockImplementationOnce(
+				mockDockerImageDelete(expect, containerName, tag)
+			);
 		// // Add fallback mocks in case we fall through to push (for debugging)
 		// .mockImplementationOnce(
 		// 	mockDockerTag(containerName, `some-account-id/${containerName}`, tag)
@@ -1740,7 +1795,7 @@ describe("wrangler deploy with containers", () => {
 			},
 		]);
 		fs.writeFileSync("./Dockerfile", "FROM scratch");
-		mockGenerateImageRegistryCredentials();
+		mockGenerateImageRegistryCredentials(expect);
 
 		await runWrangler("deploy index.js");
 
@@ -1760,7 +1815,9 @@ describe("wrangler deploy with containers", () => {
 		expect(std.warn).toMatchInlineSnapshot(`""`);
 	});
 
-	it("should enable ssh when provided for new container", async () => {
+	it("should enable ssh when provided for new container", async ({
+		expect,
+	}) => {
 		mockGetVersion("Galaxy-Class");
 		writeWranglerConfig({
 			...DEFAULT_DURABLE_OBJECTS,
@@ -1784,7 +1841,7 @@ describe("wrangler deploy with containers", () => {
 
 		mockGetApplications([]);
 
-		mockCreateApplication({
+		mockCreateApplication(expect, {
 			name: "my-container",
 			max_instances: 10,
 			scheduling_policy: SchedulingPolicy.DEFAULT,
@@ -1850,7 +1907,9 @@ describe("wrangler deploy with containers", () => {
 		`);
 	});
 
-	it("should enable ssh when provided for an existing container", async () => {
+	it("should enable ssh when provided for an existing container", async ({
+		expect,
+	}) => {
 		mockGetVersion("Galaxy-Class");
 		writeWranglerConfig({
 			...DEFAULT_DURABLE_OBJECTS,
@@ -1890,7 +1949,7 @@ describe("wrangler deploy with containers", () => {
 			},
 		]);
 
-		mockModifyApplication({
+		mockModifyApplication(expect, {
 			configuration: {
 				image: "registry.cloudflare.com/some-account-id/hello:world",
 				wrangler_ssh: {
@@ -1906,7 +1965,7 @@ describe("wrangler deploy with containers", () => {
 			},
 		});
 
-		mockCreateApplicationRollout({
+		mockCreateApplicationRollout(expect, {
 			description: "Progressive update",
 			strategy: "rolling",
 			kind: "full_auto",
@@ -1954,7 +2013,7 @@ describe("wrangler deploy with containers", () => {
 	describe("ctx.exports", async () => {
 		// note how mockGetVersion is NOT mocked in any of these, unlike the other tests.
 		// instead we mock the list durable objects endpoint, which the ctx.exports path uses instead
-		it("should be able to deploy a new container", async () => {
+		it("should be able to deploy a new container", async ({ expect }) => {
 			writeWranglerConfig({
 				// no DO!
 				migrations: [
@@ -1982,7 +2041,7 @@ describe("wrangler deploy with containers", () => {
 				useOldUploadApi: true,
 				expectedContainers: [{ class_name: "ExampleDurableObject" }],
 			});
-			mockCreateApplication({
+			mockCreateApplication(expect, {
 				name: "my-container",
 				max_instances: 10,
 				scheduling_policy: SchedulingPolicy.DEFAULT,
@@ -2043,7 +2102,9 @@ describe("wrangler deploy with containers", () => {
 			`);
 		});
 
-		it("should error if a container name has been used before but attached to a different DO", async () => {
+		it("should error if a container name has been used before but attached to a different DO", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				migrations: [
 					{ tag: "v1", new_sqlite_classes: ["ExampleDurableObject"] },
@@ -2106,7 +2167,9 @@ describe("wrangler deploy with containers", () => {
 			);
 		});
 
-		it("should be able to redeploy an existing application", async () => {
+		it("should be able to redeploy an existing application", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				migrations: [
 					{ tag: "v1", new_sqlite_classes: ["ExampleDurableObject"] },
@@ -2161,15 +2224,15 @@ describe("wrangler deploy with containers", () => {
 				},
 			]);
 			fs.writeFileSync("./Dockerfile", "FROM scratch");
-			mockGenerateImageRegistryCredentials();
-			mockModifyApplication({
+			mockGenerateImageRegistryCredentials(expect);
+			mockModifyApplication(expect, {
 				configuration: {
 					image: "registry.cloudflare.com/some-account-id/hello:world",
 				},
 				max_instances: 10,
 				rollout_active_grace_period: 600,
 			});
-			mockCreateApplicationRollout({
+			mockCreateApplicationRollout(expect, {
 				description: "Progressive update",
 				strategy: "rolling",
 				kind: "full_auto",
@@ -2214,7 +2277,7 @@ describe("wrangler deploy with containers dry run", () => {
 	const cliStd = mockCLIOutput();
 	beforeEach(() => {
 		clearCachedAccount();
-		expect(process.env.CLOUDFLARE_API_TOKEN).toBeUndefined();
+		assert(process.env.CLOUDFLARE_API_TOKEN === undefined);
 		vi.mocked(spawn).mockReset();
 	});
 
@@ -2222,12 +2285,18 @@ describe("wrangler deploy with containers dry run", () => {
 		vi.unstubAllEnvs();
 	});
 
-	it("builds the image without pushing", async () => {
+	it("builds the image without pushing", async ({ expect }) => {
 		// Reduced mock chain for dry run (no delete, push)
 		vi.mocked(spawn)
-			.mockImplementationOnce(mockDockerInfo())
+			.mockImplementationOnce(mockDockerInfo(expect))
 			.mockImplementationOnce(
-				mockDockerBuild("my-container", "worker", "FROM scratch", process.cwd())
+				mockDockerBuild(
+					expect,
+					"my-container",
+					"worker",
+					"FROM scratch",
+					process.cwd()
+				)
 			);
 		vi.stubEnv("WRANGLER_DOCKER_BIN", "/usr/bin/docker");
 		fs.writeFileSync("./Dockerfile", "FROM scratch");
@@ -2259,7 +2328,7 @@ describe("wrangler deploy with containers dry run", () => {
 		expect(cliStd.stdout).toMatchInlineSnapshot(`""`);
 	});
 
-	it("builds the image without pushing", async () => {
+	it("builds the image without pushing", async ({ expect }) => {
 		// No docker mocks at all
 
 		fs.writeFileSync(
@@ -2304,7 +2373,9 @@ describe("containers.unsafe configuration", () => {
 		);
 	});
 
-	it("should merge containers.unsafe config into create request", async () => {
+	it("should merge containers.unsafe config into create request", async ({
+		expect,
+	}) => {
 		mockGetVersion("Galaxy-Class");
 		writeWranglerConfig({
 			...DEFAULT_DURABLE_OBJECTS,
@@ -2322,7 +2393,7 @@ describe("containers.unsafe configuration", () => {
 
 		mockGetApplications([]);
 
-		mockCreateApplication({
+		mockCreateApplication(expect, {
 			name: "my-container",
 			max_instances: 10,
 			custom_field: "custom_value",
@@ -2339,7 +2410,9 @@ describe("containers.unsafe configuration", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	it("should merge containers.unsafe config into modify request", async () => {
+	it("should merge containers.unsafe config into modify request", async ({
+		expect,
+	}) => {
 		mockGetVersion("Galaxy-Class");
 		writeWranglerConfig({
 			...DEFAULT_DURABLE_OBJECTS,
@@ -2385,7 +2458,7 @@ describe("containers.unsafe configuration", () => {
 			},
 		]);
 
-		mockModifyApplication({
+		mockModifyApplication(expect, {
 			max_instances: 20,
 			// @ts-expect-error - testing unsafe.containers with custom fields
 			unsafe_field: "unsafe_value",
@@ -2394,7 +2467,7 @@ describe("containers.unsafe configuration", () => {
 			},
 		});
 
-		mockCreateApplicationRollout({
+		mockCreateApplicationRollout(expect, {
 			description: "Progressive update",
 			strategy: "rolling",
 			kind: "full_auto",
@@ -2413,37 +2486,46 @@ describe("containers.unsafe configuration", () => {
 
 // Docker mock factory
 function createDockerMockChain(
+	expect: ExpectStatic,
 	containerName: string,
 	tag: string,
 	dockerfilePath?: string,
 	buildContext?: string
 ) {
 	const mocks = [
-		mockDockerInfo(),
+		mockDockerInfo(expect),
 		mockDockerBuild(
+			expect,
 			containerName,
 			tag,
 			dockerfilePath || "FROM scratch",
 			buildContext || process.cwd()
 		),
-		mockDockerImageInspectDigests(containerName, tag),
-		mockDockerImageInspectSize(containerName, tag),
-		mockDockerLogin("mockpassword"),
+		mockDockerImageInspectDigests(expect, containerName, tag),
+		mockDockerImageInspectSize(expect, containerName, tag),
+		mockDockerLogin(expect, "mockpassword"),
 		// Skip manifest inspect mock - it's not being called due to empty repoDigests
-		mockDockerTag(containerName, "some-account-id/" + containerName, tag),
-		mockDockerPush("some-account-id/" + containerName, tag),
+		mockDockerTag(
+			expect,
+			containerName,
+			"some-account-id/" + containerName,
+			tag
+		),
+		mockDockerPush(expect, "some-account-id/" + containerName, tag),
 	];
 
 	return mocks;
 }
 
 function setupDockerMocks(
+	expect: ExpectStatic,
 	containerName: string,
 	tag: string,
 	dockerfilePath?: string,
 	buildContext?: string
 ) {
 	const mocks = createDockerMockChain(
+		expect,
 		containerName,
 		tag,
 		dockerfilePath,
@@ -2559,7 +2641,10 @@ function defaultChildProcess() {
 	} as unknown as ChildProcess;
 }
 
-function mockCreateApplication(expected?: Partial<Application>) {
+function mockCreateApplication(
+	expect: ExpectStatic,
+	expected?: Partial<Application>
+) {
 	msw.use(
 		http.post("*/applications", async ({ request }) => {
 			const json = await request.json();
@@ -2572,7 +2657,10 @@ function mockCreateApplication(expected?: Partial<Application>) {
 	);
 }
 
-function mockModifyApplication(expected?: Partial<Application>) {
+function mockModifyApplication(
+	expect: ExpectStatic,
+	expected?: Partial<Application>
+) {
 	msw.use(
 		http.patch("*/applications/:id", async ({ request }) => {
 			const json = await request.json();
@@ -2592,7 +2680,10 @@ function mockModifyApplication(expected?: Partial<Application>) {
 	);
 }
 
-function mockCreateApplicationRollout(expected?: Record<string, unknown>) {
+function mockCreateApplicationRollout(
+	expect: ExpectStatic,
+	expected?: Record<string, unknown>
+) {
 	msw.use(
 		http.post("*/applications/:id/rollouts", async ({ request }) => {
 			const json = await request.json();
@@ -2611,7 +2702,7 @@ function mockCreateApplicationRollout(expected?: Record<string, unknown>) {
 	);
 }
 
-function mockGenerateImageRegistryCredentials() {
+function mockGenerateImageRegistryCredentials(expect: ExpectStatic) {
 	msw.use(
 		http.post(
 			`*/registries/${getCloudflareContainerRegistry()}/credentials`,
@@ -2660,7 +2751,7 @@ function mockListDurableObjects(
 	);
 }
 
-function mockDockerInfo() {
+function mockDockerInfo(expect: ExpectStatic) {
 	return (cmd: string, args: readonly string[]) => {
 		expect(cmd).toBe("/usr/bin/docker");
 		expect(args).toEqual(["info"]);
@@ -2669,6 +2760,7 @@ function mockDockerInfo() {
 }
 
 function mockDockerBuild(
+	expect: ExpectStatic,
 	containerName: string,
 	tag: string,
 	expectedDockerfile: string,
@@ -2715,7 +2807,11 @@ function mockDockerBuild(
 	};
 }
 
-function mockDockerImageInspectDigests(containerName: string, tag: string) {
+function mockDockerImageInspectDigests(
+	expect: ExpectStatic,
+	containerName: string,
+	tag: string
+) {
 	return (cmd: string, args: readonly string[]) => {
 		expect(cmd).toBe("/usr/bin/docker");
 		expect(args).toEqual([
@@ -2752,6 +2848,7 @@ function mockDockerImageInspectDigests(containerName: string, tag: string) {
 }
 
 function mockDockerImageInspectDigestsWithRepoDigest(
+	expect: ExpectStatic,
 	containerName: string,
 	tag: string,
 	imageId: string
@@ -2792,7 +2889,11 @@ function mockDockerImageInspectDigestsWithRepoDigest(
 	};
 }
 
-function mockDockerImageInspectSize(containerName: string, tag: string) {
+function mockDockerImageInspectSize(
+	expect: ExpectStatic,
+	containerName: string,
+	tag: string
+) {
 	return (cmd: string, args: readonly string[]) => {
 		expect(cmd).toBe("/usr/bin/docker");
 		expect(args).toEqual([
@@ -2825,7 +2926,11 @@ function mockDockerImageInspectSize(containerName: string, tag: string) {
 	};
 }
 
-function mockDockerImageDelete(containerName: string, tag: string) {
+function mockDockerImageDelete(
+	expect: ExpectStatic,
+	containerName: string,
+	tag: string
+) {
 	return (cmd: string, args: readonly string[]) => {
 		expect(cmd).toBe("/usr/bin/docker");
 		expect(args).toEqual(["image", "rm", `${containerName}:${tag}`]);
@@ -2833,7 +2938,7 @@ function mockDockerImageDelete(containerName: string, tag: string) {
 	};
 }
 
-function mockDockerLogin(expectedPassword: string) {
+function mockDockerLogin(expect: ExpectStatic, expectedPassword: string) {
 	return (cmd: string, _args: readonly string[]) => {
 		expect(cmd).toBe("/usr/bin/docker");
 		let password = "";
@@ -2857,7 +2962,11 @@ function mockDockerLogin(expectedPassword: string) {
 	};
 }
 
-function mockDockerPush(containerName: string, tag: string) {
+function mockDockerPush(
+	expect: ExpectStatic,
+	containerName: string,
+	tag: string
+) {
 	return (cmd: string, args: readonly string[]) => {
 		expect(cmd).toBe("/usr/bin/docker");
 		expect(args).toEqual([
@@ -2868,7 +2977,12 @@ function mockDockerPush(containerName: string, tag: string) {
 	};
 }
 
-function mockDockerTag(from: string, to: string, tag: string) {
+function mockDockerTag(
+	expect: ExpectStatic,
+	from: string,
+	to: string,
+	tag: string
+) {
 	return (cmd: string, args: readonly string[]) => {
 		expect(cmd).toBe("/usr/bin/docker");
 		expect(args).toEqual([

--- a/packages/wrangler/src/__tests__/containers/registries.test.ts
+++ b/packages/wrangler/src/__tests__/containers/registries.test.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { mockAccount } from "../cloudchamber/utils";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockCLIOutput } from "../helpers/mock-cli-output";
@@ -17,11 +16,12 @@ import {
 import { useMockStdin } from "../helpers/mock-stdin";
 import { createFetchResult, msw } from "../helpers/msw";
 import { runWrangler } from "../helpers/run-wrangler";
+import type { ExpectStatic } from "vitest";
 
 describe("containers registries --help", () => {
 	const std = mockConsoleMethods();
 
-	it("should help", async () => {
+	it("should help", async ({ expect }) => {
 		await runWrangler("containers registries --help");
 		expect(std.out).toMatchInlineSnapshot(`
 			"wrangler containers registries
@@ -57,7 +57,7 @@ describe("containers registries configure", () => {
 	afterEach(() => {
 		clearDialogs();
 	});
-	it("should reject unsupported registry domains", async () => {
+	it("should reject unsupported registry domains", async ({ expect }) => {
 		await expect(
 			runWrangler(
 				`containers registries configure unsupported.domain --public-credential=test-id`
@@ -69,7 +69,9 @@ describe("containers registries configure", () => {
 		`);
 	});
 
-	it("should validate command line arguments for Secrets Store", async () => {
+	it("should validate command line arguments for Secrets Store", async ({
+		expect,
+	}) => {
 		const domain = "123456789012.dkr.ecr.us-west-2.amazonaws.com";
 		await expect(
 			runWrangler(
@@ -106,7 +108,9 @@ describe("containers registries configure", () => {
 		);
 	});
 
-	it("should enforce mutual exclusivity for public credential arguments", async () => {
+	it("should enforce mutual exclusivity for public credential arguments", async ({
+		expect,
+	}) => {
 		await expect(
 			runWrangler(`containers registries configure docker.io`)
 		).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -130,7 +134,7 @@ describe("containers registries configure", () => {
 		);
 	});
 
-	it("should no-op on cloudflare registry (default)", async () => {
+	it("should no-op on cloudflare registry (default)", async ({ expect }) => {
 		await runWrangler(
 			`containers registries configure registry.cloudflare.com`
 		);
@@ -150,7 +154,9 @@ describe("containers registries configure", () => {
 			vi.stubEnv("CLOUDFLARE_COMPLIANCE_REGION", "fedramp_high");
 		});
 
-		it("should configure AWS ECR registry with interactive prompts", async () => {
+		it("should configure AWS ECR registry with interactive prompts", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 			const awsEcrDomain = "123456789012.dkr.ecr.us-west-2.amazonaws.com";
 			mockPrompt({
@@ -159,7 +165,7 @@ describe("containers registries configure", () => {
 				result: "test-secret-access-key",
 			});
 
-			mockPutRegistry({
+			mockPutRegistry(expect, {
 				domain: "123456789012.dkr.ecr.us-west-2.amazonaws.com",
 				is_public: false,
 				auth: {
@@ -193,11 +199,11 @@ describe("containers registries configure", () => {
 			const awsEcrDomain = "123456789012.dkr.ecr.us-west-2.amazonaws.com";
 			const mockStdIn = useMockStdin({ isTTY: false });
 
-			it("should accept the secret from piped input", async () => {
+			it("should accept the secret from piped input", async ({ expect }) => {
 				const secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
 
 				mockStdIn.send(secret);
-				mockPutRegistry({
+				mockPutRegistry(expect, {
 					domain: awsEcrDomain,
 					is_public: false,
 					auth: {
@@ -215,7 +221,9 @@ describe("containers registries configure", () => {
 	});
 
 	describe("AWS ECR registry configuration", () => {
-		it("should configure AWS ECR registry with interactive prompts", async () => {
+		it("should configure AWS ECR registry with interactive prompts", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 			const awsEcrDomain = "123456789012.dkr.ecr.us-west-2.amazonaws.com";
 			const storeId = "test-store-id-123";
@@ -241,7 +249,7 @@ describe("containers registries configure", () => {
 			]);
 			mockListSecrets(storeId, []);
 			mockCreateSecret(storeId);
-			mockPutRegistry({
+			mockPutRegistry(expect, {
 				domain: "123456789012.dkr.ecr.us-west-2.amazonaws.com",
 				is_public: false,
 				auth: {
@@ -261,7 +269,9 @@ describe("containers registries configure", () => {
 			expect(cliStd.stdout).toContain("Using existing Secret Store Default");
 		});
 
-		it("will create a secret store if no existing stores are returned from the api", async () => {
+		it("will create a secret store if no existing stores are returned from the api", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 			const awsEcrDomain = "123456789012.dkr.ecr.us-west-2.amazonaws.com";
 			const newStoreId = "new-store-id-456";
@@ -285,7 +295,7 @@ describe("containers registries configure", () => {
 			mockCreateSecretStore(newStoreId);
 			mockListSecrets(newStoreId, []);
 			mockCreateSecret(newStoreId);
-			mockPutRegistry({
+			mockPutRegistry(expect, {
 				domain: awsEcrDomain,
 				is_public: false,
 				auth: {
@@ -308,7 +318,9 @@ describe("containers registries configure", () => {
 			);
 		});
 
-		it("will use an existing secret store if a store id is provided", async () => {
+		it("will use an existing secret store if a store id is provided", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 			const awsEcrDomain = "123456789012.dkr.ecr.us-west-2.amazonaws.com";
 			const providedStoreId = "provided-store-id-789";
@@ -326,7 +338,7 @@ describe("containers registries configure", () => {
 
 			mockListSecrets(providedStoreId, []);
 			mockCreateSecret(providedStoreId);
-			mockPutRegistry({
+			mockPutRegistry(expect, {
 				domain: awsEcrDomain,
 				is_public: false,
 				auth: {
@@ -372,7 +384,7 @@ describe("containers registries configure", () => {
 			const awsEcrDomain = "123456789012.dkr.ecr.us-west-2.amazonaws.com";
 			const mockStdIn = useMockStdin({ isTTY: false });
 
-			it("should accept the secret from piped input", async () => {
+			it("should accept the secret from piped input", async ({ expect }) => {
 				const secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
 				const storeId = "test-store-id-999";
 
@@ -388,7 +400,7 @@ describe("containers registries configure", () => {
 				]);
 				mockListSecrets(storeId, []);
 				mockCreateSecret(storeId);
-				mockPutRegistry({
+				mockPutRegistry(expect, {
 					domain: awsEcrDomain,
 					is_public: false,
 					auth: {
@@ -405,7 +417,9 @@ describe("containers registries configure", () => {
 				);
 			});
 
-			it("should reuse existing secret with --skip-confirmation", async () => {
+			it("should reuse existing secret with --skip-confirmation", async ({
+				expect,
+			}) => {
 				const storeId = "test-store-id-reuse";
 				const secretName = "existing_secret";
 
@@ -431,7 +445,7 @@ describe("containers registries configure", () => {
 						status: "active",
 					},
 				]);
-				mockPutRegistry({
+				mockPutRegistry(expect, {
 					domain: awsEcrDomain,
 					is_public: false,
 					auth: {
@@ -455,7 +469,9 @@ describe("containers registries configure", () => {
 	});
 
 	describe("DockerHub registry configuration", () => {
-		it("should configure DockerHub registry with interactive prompts", async () => {
+		it("should configure DockerHub registry with interactive prompts", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 			const dockerHubDomain = "docker.io";
 			const storeId = "test-store-id-123";
@@ -481,7 +497,7 @@ describe("containers registries configure", () => {
 			]);
 			mockListSecrets(storeId, []);
 			mockCreateSecret(storeId);
-			mockPutRegistry({
+			mockPutRegistry(expect, {
 				domain: "docker.io",
 				is_public: false,
 				auth: {
@@ -508,7 +524,7 @@ describe("containers registries configure", () => {
 			const dockerHubDomain = "docker.io";
 			const mockStdIn = useMockStdin({ isTTY: false });
 
-			it("should accept the secret from piped input", async () => {
+			it("should accept the secret from piped input", async ({ expect }) => {
 				const secret = "example-pat-token";
 				const storeId = "test-store-id-999";
 
@@ -524,7 +540,7 @@ describe("containers registries configure", () => {
 				]);
 				mockListSecrets(storeId, []);
 				mockCreateSecret(storeId);
-				mockPutRegistry({
+				mockPutRegistry(expect, {
 					domain: dockerHubDomain,
 					is_public: false,
 					auth: {
@@ -555,7 +571,7 @@ describe("containers registries list", () => {
 		mockAccount();
 	});
 
-	it("should list empty registries", async () => {
+	it("should list empty registries", async ({ expect }) => {
 		mockListRegistries([]);
 		await runWrangler("containers registries list");
 		expect(cliStd.stdout).toMatchInlineSnapshot(`
@@ -567,7 +583,7 @@ describe("containers registries list", () => {
 		`);
 	});
 
-	it("should list configured registries", async () => {
+	it("should list configured registries", async ({ expect }) => {
 		const mockRegistries = [
 			{ domain: "123456789012.dkr.ecr.us-west-2.amazonaws.com" },
 			{ domain: "987654321098.dkr.ecr.eu-west-1.amazonaws.com" },
@@ -592,7 +608,9 @@ describe("containers registries list", () => {
 		`);
 	});
 
-	it("should output valid JSON when --json flag is used", async () => {
+	it("should output valid JSON when --json flag is used", async ({
+		expect,
+	}) => {
 		const mockRegistries = [
 			{ domain: "123456789012.dkr.ecr.us-west-2.amazonaws.com" },
 		];
@@ -622,7 +640,7 @@ describe("containers registries delete", () => {
 		clearDialogs();
 	});
 
-	it("should delete a registry with confirmation", async () => {
+	it("should delete a registry with confirmation", async ({ expect }) => {
 		setIsTTY(true);
 		const domain = "123456789012.dkr.ecr.us-west-2.amazonaws.com";
 		mockConfirm({
@@ -641,7 +659,7 @@ describe("containers registries delete", () => {
 		`);
 	});
 
-	it("should cancel deletion when user says no", async () => {
+	it("should cancel deletion when user says no", async ({ expect }) => {
 		setIsTTY(true);
 		const domain = "123456789012.dkr.ecr.us-west-2.amazonaws.com";
 		mockConfirm({
@@ -652,7 +670,9 @@ describe("containers registries delete", () => {
 		expect(cliStd.stdout).toContain("The operation has been cancelled");
 	});
 
-	it("should delete a registry in non-interactive mode without skip confirmation flag", async () => {
+	it("should delete a registry in non-interactive mode without skip confirmation flag", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		const domain = "123456789012.dkr.ecr.us-west-2.amazonaws.com";
 		mockDeleteRegistry(domain);
@@ -674,7 +694,9 @@ describe("containers registries delete", () => {
 		`);
 	});
 
-	it("should delete a registry in interactive mode with --skip-confirmation flag", async () => {
+	it("should delete a registry in interactive mode with --skip-confirmation flag", async ({
+		expect,
+	}) => {
 		setIsTTY(true);
 		const domain = "123456789012.dkr.ecr.us-west-2.amazonaws.com";
 		mockDeleteRegistry(domain);
@@ -698,7 +720,9 @@ describe("containers registries delete", () => {
 		const secretId = "secret-id-456";
 		const secretsStoreRef = `${storeId}:${secretName}`;
 
-		it("should delete registry and associated secret when user confirms", async () => {
+		it("should delete registry and associated secret when user confirms", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 			mockConfirm({
 				text: `Are you sure you want to delete the registry credentials for ${domain}? This action cannot be undone.`,
@@ -729,7 +753,9 @@ describe("containers registries delete", () => {
 			expect(cliStd.stdout).toContain(`Deleted secret ${secretsStoreRef}`);
 		});
 
-		it("should delete registry but not secret when user declines secret deletion", async () => {
+		it("should delete registry but not secret when user declines secret deletion", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 			mockConfirm({
 				text: `Are you sure you want to delete the registry credentials for ${domain}? This action cannot be undone.`,
@@ -747,7 +773,9 @@ describe("containers registries delete", () => {
 			expect(cliStd.stdout).toContain("The secret was not deleted.");
 		});
 
-		it("should delete registry and secret with --skip-confirmation flag", async () => {
+		it("should delete registry and secret with --skip-confirmation flag", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 			mockDeleteRegistry(domain, secretsStoreRef);
 			mockListSecrets(storeId, [
@@ -772,7 +800,9 @@ describe("containers registries delete", () => {
 			expect(cliStd.stdout).toContain(`Deleted secret ${secretsStoreRef}`);
 		});
 
-		it("should handle case when secret is already deleted", async () => {
+		it("should handle case when secret is already deleted", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 			mockConfirm({
 				text: `Are you sure you want to delete the registry credentials for ${domain}? This action cannot be undone.`,
@@ -809,7 +839,7 @@ describe("containers registries credentials", () => {
 		msw.resetHandlers();
 	});
 
-	it("should reject non-Cloudflare registry domains", async () => {
+	it("should reject non-Cloudflare registry domains", async ({ expect }) => {
 		setIsTTY(false);
 		await expect(
 			runWrangler("containers registries credentials example.com --push")
@@ -818,18 +848,24 @@ describe("containers registries credentials", () => {
 		);
 	});
 
-	it("should default to Cloudflare registry when DOMAIN is omitted", async () => {
+	it("should default to Cloudflare registry when DOMAIN is omitted", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
-		mockGenerateCredentials("registry.cloudflare.com", "test-password", 15, [
-			"push",
-		]);
+		mockGenerateCredentials(
+			expect,
+			"registry.cloudflare.com",
+			"test-password",
+			15,
+			["push"]
+		);
 
 		await runWrangler("containers registries credentials --push");
 
 		expect(std.out).toMatchInlineSnapshot(`"test-password"`);
 	});
 
-	it("should require --push or --pull", async () => {
+	it("should require --push or --pull", async ({ expect }) => {
 		setIsTTY(false);
 		await expect(
 			runWrangler("containers registries credentials registry.cloudflare.com")
@@ -838,11 +874,15 @@ describe("containers registries credentials", () => {
 		);
 	});
 
-	it("should generate credentials with --push", async () => {
+	it("should generate credentials with --push", async ({ expect }) => {
 		setIsTTY(false);
-		mockGenerateCredentials("registry.cloudflare.com", "test-password", 15, [
-			"push",
-		]);
+		mockGenerateCredentials(
+			expect,
+			"registry.cloudflare.com",
+			"test-password",
+			15,
+			["push"]
+		);
 
 		await runWrangler(
 			"containers registries credentials registry.cloudflare.com --push"
@@ -851,11 +891,15 @@ describe("containers registries credentials", () => {
 		expect(std.out).toMatchInlineSnapshot(`"test-password"`);
 	});
 
-	it("should generate credentials with --pull", async () => {
+	it("should generate credentials with --pull", async ({ expect }) => {
 		setIsTTY(false);
-		mockGenerateCredentials("registry.cloudflare.com", "test-password", 15, [
-			"pull",
-		]);
+		mockGenerateCredentials(
+			expect,
+			"registry.cloudflare.com",
+			"test-password",
+			15,
+			["pull"]
+		);
 
 		await runWrangler(
 			"containers registries credentials registry.cloudflare.com --pull"
@@ -864,12 +908,17 @@ describe("containers registries credentials", () => {
 		expect(std.out).toMatchInlineSnapshot(`"test-password"`);
 	});
 
-	it("should generate credentials with both --push and --pull", async () => {
+	it("should generate credentials with both --push and --pull", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
-		mockGenerateCredentials("registry.cloudflare.com", "jwt-token", 15, [
-			"push",
-			"pull",
-		]);
+		mockGenerateCredentials(
+			expect,
+			"registry.cloudflare.com",
+			"jwt-token",
+			15,
+			["push", "pull"]
+		);
 
 		await runWrangler(
 			"containers registries credentials registry.cloudflare.com --push --pull"
@@ -878,9 +927,10 @@ describe("containers registries credentials", () => {
 		expect(std.out).toMatchInlineSnapshot(`"jwt-token"`);
 	});
 
-	it("should support custom expiration-minutes", async () => {
+	it("should support custom expiration-minutes", async ({ expect }) => {
 		setIsTTY(false);
 		mockGenerateCredentials(
+			expect,
 			"registry.cloudflare.com",
 			"custom-expiry-token",
 			30,
@@ -894,11 +944,15 @@ describe("containers registries credentials", () => {
 		expect(std.out).toMatchInlineSnapshot(`"custom-expiry-token"`);
 	});
 
-	it("should generate credentials with --library-push", async () => {
+	it("should generate credentials with --library-push", async ({ expect }) => {
 		setIsTTY(false);
-		mockGenerateCredentials("registry.cloudflare.com", "test-password", 15, [
-			"library_push",
-		]);
+		mockGenerateCredentials(
+			expect,
+			"registry.cloudflare.com",
+			"test-password",
+			15,
+			["library_push"]
+		);
 
 		await runWrangler(
 			"containers registries credentials registry.cloudflare.com --library-push"
@@ -907,11 +961,17 @@ describe("containers registries credentials", () => {
 		expect(std.out).toMatchInlineSnapshot(`"test-password"`);
 	});
 
-	it("should output valid JSON when --json flag is used", async () => {
+	it("should output valid JSON when --json flag is used", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
-		mockGenerateCredentials("registry.cloudflare.com", "test-password", 15, [
-			"push",
-		]);
+		mockGenerateCredentials(
+			expect,
+			"registry.cloudflare.com",
+			"test-password",
+			15,
+			["push"]
+		);
 
 		await runWrangler(
 			"containers registries credentials registry.cloudflare.com --push --json"
@@ -928,7 +988,7 @@ describe("containers registries credentials", () => {
 	});
 });
 
-const mockPutRegistry = (expected?: object) => {
+const mockPutRegistry = (expect: ExpectStatic, expected?: object) => {
 	msw.use(
 		http.post(
 			"*/accounts/:accountId/containers/registries",
@@ -974,6 +1034,7 @@ const mockDeleteRegistry = (domain: string, secretsStoreRef?: string) => {
 };
 
 const mockGenerateCredentials = (
+	expect: ExpectStatic,
 	domain: string,
 	password: string,
 	expectedExpirationMinutes: number,

--- a/packages/wrangler/src/__tests__/d1/delete.test.ts
+++ b/packages/wrangler/src/__tests__/d1/delete.test.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { mockConfirm } from "../helpers/mock-dialogs";
@@ -9,6 +8,7 @@ import { mockGetMemberships } from "../helpers/mock-oauth-flow";
 import { createFetchResult, msw } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
+import type { ExpectStatic } from "vitest";
 
 describe("delete", () => {
 	mockAccountId();
@@ -59,7 +59,7 @@ describe("delete", () => {
 			result: true,
 		});
 
-		mockDatabaseDelete("db-uuid-123");
+		mockDatabaseDelete(expect, "db-uuid-123");
 
 		await runWrangler("d1 delete test-db");
 
@@ -82,7 +82,7 @@ describe("delete", () => {
 	}) => {
 		setIsTTY(false);
 
-		mockDatabaseDelete("db-uuid-123");
+		mockDatabaseDelete(expect, "db-uuid-123");
 
 		await runWrangler("d1 delete test-db --skip-confirmation");
 
@@ -113,7 +113,7 @@ function mockDatabaseList(name: string, uuid: string) {
 	);
 }
 
-function mockDatabaseDelete(expectedUuid: string) {
+function mockDatabaseDelete(expect: ExpectStatic, expectedUuid: string) {
 	msw.use(
 		http.delete(
 			"*/accounts/:accountId/d1/database/:databaseId",

--- a/packages/wrangler/src/__tests__/delete.test.ts
+++ b/packages/wrangler/src/__tests__/delete.test.ts
@@ -1,7 +1,6 @@
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { mockConfirm } from "./helpers/mock-dialogs";
@@ -11,6 +10,7 @@ import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type { ServiceReferenceResponse, Tail } from "../delete";
 import type { KVNamespaceInfo } from "../kv/helpers";
+import type { ExpectStatic } from "vitest";
 
 describe("delete", () => {
 	mockAccountId();
@@ -22,15 +22,15 @@ describe("delete", () => {
 	});
 	const std = mockConsoleMethods();
 
-	it("should delete an entire service by name", async () => {
+	it("should delete an entire service by name", async ({ expect }) => {
 		mockConfirm({
 			text: `Are you sure you want to delete my-script? This action cannot be undone.`,
 			result: true,
 		});
-		mockListKVNamespacesRequest();
-		mockListReferencesRequest("my-script");
-		mockListTailsByConsumerRequest("my-script");
-		mockDeleteWorkerRequest({ name: "my-script" });
+		mockListKVNamespacesRequest(expect);
+		mockListReferencesRequest(expect, "my-script");
+		mockListTailsByConsumerRequest(expect, "my-script");
+		mockDeleteWorkerRequest(expect, { name: "my-script" });
 		await runWrangler("delete --name my-script");
 
 		expect(std).toMatchInlineSnapshot(`
@@ -47,15 +47,17 @@ describe("delete", () => {
 		`);
 	});
 
-	it("should delete a service using positional name argument", async () => {
+	it("should delete a service using positional name argument", async ({
+		expect,
+	}) => {
 		mockConfirm({
 			text: `Are you sure you want to delete my-positional-worker? This action cannot be undone.`,
 			result: true,
 		});
-		mockListKVNamespacesRequest();
-		mockListReferencesRequest("my-positional-worker");
-		mockListTailsByConsumerRequest("my-positional-worker");
-		mockDeleteWorkerRequest({ name: "my-positional-worker" });
+		mockListKVNamespacesRequest(expect);
+		mockListReferencesRequest(expect, "my-positional-worker");
+		mockListTailsByConsumerRequest(expect, "my-positional-worker");
+		mockDeleteWorkerRequest(expect, { name: "my-positional-worker" });
 		await runWrangler("delete my-positional-worker");
 
 		expect(std).toMatchInlineSnapshot(`
@@ -72,16 +74,18 @@ describe("delete", () => {
 		`);
 	});
 
-	it("should use positional name argument over the name from the Wrangler config file", async () => {
+	it("should use positional name argument over the name from the Wrangler config file", async ({
+		expect,
+	}) => {
 		writeWranglerConfig({ name: "config-provided-name" });
 		mockConfirm({
 			text: `Are you sure you want to delete cli-provided-name? This action cannot be undone.`,
 			result: true,
 		});
-		mockListKVNamespacesRequest();
-		mockListReferencesRequest("cli-provided-name");
-		mockListTailsByConsumerRequest("cli-provided-name");
-		mockDeleteWorkerRequest({ name: "cli-provided-name" });
+		mockListKVNamespacesRequest(expect);
+		mockListReferencesRequest(expect, "cli-provided-name");
+		mockListTailsByConsumerRequest(expect, "cli-provided-name");
+		mockDeleteWorkerRequest(expect, { name: "cli-provided-name" });
 		await runWrangler("delete cli-provided-name");
 
 		expect(std).toMatchInlineSnapshot(`
@@ -98,16 +102,16 @@ describe("delete", () => {
 		`);
 	});
 
-	it("should delete a script by configuration", async () => {
+	it("should delete a script by configuration", async ({ expect }) => {
 		mockConfirm({
 			text: `Are you sure you want to delete test-name? This action cannot be undone.`,
 			result: true,
 		});
 		writeWranglerConfig();
-		mockListKVNamespacesRequest();
-		mockListReferencesRequest("test-name");
-		mockListTailsByConsumerRequest("test-name");
-		mockDeleteWorkerRequest();
+		mockListKVNamespacesRequest(expect);
+		mockListReferencesRequest(expect, "test-name");
+		mockListTailsByConsumerRequest(expect, "test-name");
+		mockDeleteWorkerRequest(expect);
 		await runWrangler("delete");
 
 		expect(std).toMatchInlineSnapshot(`
@@ -124,7 +128,9 @@ describe("delete", () => {
 		`);
 	});
 
-	it("shouldn't delete a service when doing a --dry-run", async () => {
+	it("shouldn't delete a service when doing a --dry-run", async ({
+		expect,
+	}) => {
 		await runWrangler("delete --name xyz --dry-run");
 
 		expect(std).toMatchInlineSnapshot(`
@@ -141,7 +147,7 @@ describe("delete", () => {
 		`);
 	});
 
-	it('shouldn\'t delete when the user says "no"', async () => {
+	it('shouldn\'t delete when the user says "no"', async ({ expect }) => {
 		mockConfirm({
 			text: `Are you sure you want to delete xyz? This action cannot be undone.`,
 			result: false,
@@ -162,7 +168,9 @@ describe("delete", () => {
 		`);
 	});
 
-	it("should delete a site namespace associated with a worker", async () => {
+	it("should delete a site namespace associated with a worker", async ({
+		expect,
+	}) => {
 		const kvNamespaces = [
 			{
 				title: "__my-script-workers_sites_assets",
@@ -179,7 +187,7 @@ describe("delete", () => {
 			text: `Are you sure you want to delete my-script? This action cannot be undone.`,
 			result: true,
 		});
-		mockListKVNamespacesRequest(...kvNamespaces);
+		mockListKVNamespacesRequest(expect, ...kvNamespaces);
 		// it should only try to delete the site namespace associated with this worker
 		msw.use(
 			http.delete(
@@ -195,9 +203,9 @@ describe("delete", () => {
 			)
 		);
 
-		mockListReferencesRequest("my-script");
-		mockListTailsByConsumerRequest("my-script");
-		mockDeleteWorkerRequest({ name: "my-script" });
+		mockListReferencesRequest(expect, "my-script");
+		mockListTailsByConsumerRequest(expect, "my-script");
+		mockDeleteWorkerRequest(expect, { name: "my-script" });
 		await runWrangler("delete --name my-script");
 		expect(std).toMatchInlineSnapshot(`
 			{
@@ -214,7 +222,9 @@ describe("delete", () => {
 		`);
 	});
 
-	it("should delete a site namespace associated with a worker, including it's preview namespace", async () => {
+	it("should delete a site namespace associated with a worker, including it's preview namespace", async ({
+		expect,
+	}) => {
 		// This is the same test as the previous one, but it includes a preview namespace
 		const kvNamespaces = [
 			{
@@ -238,9 +248,9 @@ describe("delete", () => {
 			text: `Are you sure you want to delete my-script? This action cannot be undone.`,
 			result: true,
 		});
-		mockListKVNamespacesRequest(...kvNamespaces);
-		mockListReferencesRequest("my-script");
-		mockListTailsByConsumerRequest("my-script");
+		mockListKVNamespacesRequest(expect, ...kvNamespaces);
+		mockListReferencesRequest(expect, "my-script");
+		mockListTailsByConsumerRequest(expect, "my-script");
 		// it should only try to delete the site namespace associated with this worker
 
 		msw.use(
@@ -281,7 +291,7 @@ describe("delete", () => {
 			)
 		);
 
-		mockDeleteWorkerRequest({ name: "my-script" });
+		mockDeleteWorkerRequest(expect, { name: "my-script" });
 		await runWrangler("delete --name my-script");
 		expect(std).toMatchInlineSnapshot(`
 			{
@@ -299,7 +309,9 @@ describe("delete", () => {
 		`);
 	});
 
-	it("should error helpfully if pages_build_output_dir is set", async () => {
+	it("should error helpfully if pages_build_output_dir is set", async ({
+		expect,
+	}) => {
 		writeWranglerConfig({ pages_build_output_dir: "dist", name: "test" });
 		await expect(
 			runWrangler("delete")
@@ -311,7 +323,9 @@ describe("delete", () => {
 		);
 	});
 	describe("force deletes", () => {
-		it("should prompt for extra confirmation when service is depended on and use force", async () => {
+		it("should prompt for extra confirmation when service is depended on and use force", async ({
+			expect,
+		}) => {
 			mockConfirm({
 				text: `Are you sure you want to delete test-name? This action cannot be undone.`,
 				result: true,
@@ -330,8 +344,8 @@ Are you sure you want to continue?`,
 				result: true,
 			});
 			writeWranglerConfig();
-			mockListKVNamespacesRequest();
-			mockListReferencesRequest("test-name", {
+			mockListKVNamespacesRequest(expect);
+			mockListReferencesRequest(expect, "test-name", {
 				services: {
 					incoming: [
 						{
@@ -373,7 +387,7 @@ Are you sure you want to continue?`,
 					},
 				],
 			});
-			mockListTailsByConsumerRequest("test-name", [
+			mockListTailsByConsumerRequest(expect, "test-name", [
 				{
 					consumer: { script: "test-name" },
 					producer: { script: "i-make-logs" },
@@ -382,7 +396,7 @@ Are you sure you want to continue?`,
 					modified_on: "",
 				},
 			]);
-			mockDeleteWorkerRequest({ force: true });
+			mockDeleteWorkerRequest(expect, { force: true });
 			await runWrangler("delete");
 
 			expect(std).toMatchInlineSnapshot(`
@@ -399,7 +413,9 @@ Are you sure you want to continue?`,
 			`);
 		});
 
-		it("should not delete when extra confirmation to use force is denied", async () => {
+		it("should not delete when extra confirmation to use force is denied", async ({
+			expect,
+		}) => {
 			mockConfirm({
 				text: `Are you sure you want to delete test-name? This action cannot be undone.`,
 				result: true,
@@ -414,8 +430,8 @@ Are you sure you want to continue?`,
 				result: false,
 			});
 			writeWranglerConfig();
-			mockListKVNamespacesRequest();
-			mockListReferencesRequest("test-name", {
+			mockListKVNamespacesRequest(expect);
+			mockListReferencesRequest(expect, "test-name", {
 				services: {
 					incoming: [
 						{
@@ -427,7 +443,7 @@ Are you sure you want to continue?`,
 					outgoing: [],
 				},
 			});
-			mockListTailsByConsumerRequest("test-name");
+			mockListTailsByConsumerRequest(expect, "test-name");
 			await runWrangler("delete");
 
 			expect(std).toMatchInlineSnapshot(`
@@ -443,10 +459,12 @@ Are you sure you want to continue?`,
 			`);
 		});
 
-		it("should not require confirmation when --force is used", async () => {
+		it("should not require confirmation when --force is used", async ({
+			expect,
+		}) => {
 			writeWranglerConfig();
-			mockListKVNamespacesRequest();
-			mockDeleteWorkerRequest({ force: true });
+			mockListKVNamespacesRequest(expect);
+			mockDeleteWorkerRequest(expect, { force: true });
 			await runWrangler("delete --force");
 
 			expect(std).toMatchInlineSnapshot(`
@@ -463,7 +481,9 @@ Are you sure you want to continue?`,
 			`);
 		});
 
-		it("should prompt for extra confirmation when worker is used by a Pages function", async () => {
+		it("should prompt for extra confirmation when worker is used by a Pages function", async ({
+			expect,
+		}) => {
 			mockConfirm({
 				text: `Are you sure you want to delete test-name? This action cannot be undone.`,
 				result: true,
@@ -478,16 +498,16 @@ Are you sure you want to continue?`,
 				result: true,
 			});
 			writeWranglerConfig();
-			mockListKVNamespacesRequest();
-			mockListReferencesRequest("test-name", {
+			mockListKVNamespacesRequest(expect);
+			mockListReferencesRequest(expect, "test-name", {
 				services: {
 					incoming: [],
 					outgoing: [],
 					pages_function: true,
 				},
 			});
-			mockListTailsByConsumerRequest("test-name");
-			mockDeleteWorkerRequest({ force: true });
+			mockListTailsByConsumerRequest(expect, "test-name");
+			mockDeleteWorkerRequest(expect, { force: true });
 			await runWrangler("delete");
 
 			expect(std).toMatchInlineSnapshot(`
@@ -504,7 +524,9 @@ Are you sure you want to continue?`,
 			`);
 		});
 
-		it("should include Pages function in confirmation when combined with other dependencies", async () => {
+		it("should include Pages function in confirmation when combined with other dependencies", async ({
+			expect,
+		}) => {
 			mockConfirm({
 				text: `Are you sure you want to delete test-name? This action cannot be undone.`,
 				result: true,
@@ -521,8 +543,8 @@ Are you sure you want to continue?`,
 				result: true,
 			});
 			writeWranglerConfig();
-			mockListKVNamespacesRequest();
-			mockListReferencesRequest("test-name", {
+			mockListKVNamespacesRequest(expect);
+			mockListReferencesRequest(expect, "test-name", {
 				services: {
 					incoming: [
 						{
@@ -544,8 +566,8 @@ Are you sure you want to continue?`,
 					},
 				],
 			});
-			mockListTailsByConsumerRequest("test-name");
-			mockDeleteWorkerRequest({ force: true });
+			mockListTailsByConsumerRequest(expect, "test-name");
+			mockDeleteWorkerRequest(expect, { force: true });
 			await runWrangler("delete");
 
 			expect(std).toMatchInlineSnapshot(`
@@ -566,6 +588,7 @@ Are you sure you want to continue?`,
 
 /** Create a mock handler for the request to upload a worker script. */
 function mockDeleteWorkerRequest(
+	expect: ExpectStatic,
 	options: {
 		name?: string;
 		env?: string;
@@ -607,7 +630,10 @@ function mockDeleteWorkerRequest(
 }
 
 /** Create a mock handler for the request to get a list of all KV namespaces. */
-function mockListKVNamespacesRequest(...namespaces: KVNamespaceInfo[]) {
+function mockListKVNamespacesRequest(
+	expect: ExpectStatic,
+	...namespaces: KVNamespaceInfo[]
+) {
 	msw.use(
 		http.get(
 			"*/accounts/:accountId/storage/kv/namespaces",
@@ -629,6 +655,7 @@ function mockListKVNamespacesRequest(...namespaces: KVNamespaceInfo[]) {
 }
 
 function mockListReferencesRequest(
+	expect: ExpectStatic,
 	forScript: string,
 	references: ServiceReferenceResponse = {}
 ) {
@@ -653,7 +680,11 @@ function mockListReferencesRequest(
 	);
 }
 
-function mockListTailsByConsumerRequest(forScript: string, tails: Tail[] = []) {
+function mockListTailsByConsumerRequest(
+	expect: ExpectStatic,
+	forScript: string,
+	tails: Tail[] = []
+) {
 	msw.use(
 		http.get(
 			"*/accounts/:accountId/workers/tails/by-consumer/:scriptName",

--- a/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
@@ -8,8 +8,7 @@ import {
 import * as esbuild from "esbuild";
 import { http, HttpResponse } from "msw";
 import dedent from "ts-dedent";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, assert, beforeEach, describe, it, vi } from "vitest";
 import { getInstalledPackageVersion } from "../../autoconfig/frameworks/utils/packages";
 import { clearOutputFilePath } from "../../output";
 import { fetchSecrets } from "../../utils/fetch-secrets";
@@ -871,7 +870,7 @@ addEventListener('fetch', event => {});`
 					{ filePath: "index.html", content: "<html>test</html>" },
 				];
 				writeAssets(assets);
-				expect(findWranglerConfig().configPath).toBe(undefined);
+				assert(findWranglerConfig().configPath === undefined);
 				mockSubDomainRequest();
 				mockUploadWorkerRequest({
 					expectedAssets: {

--- a/packages/wrangler/src/__tests__/deploy/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/workflows.test.ts
@@ -1,8 +1,7 @@
 import * as fs from "node:fs";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { getInstalledPackageVersion } from "../../autoconfig/frameworks/utils/packages";
 import { WORKFLOW_NOT_FOUND_CODE } from "../../deploy/check-workflow-conflicts";
 import { clearOutputFilePath } from "../../output";
@@ -23,6 +22,7 @@ import {
 	mockLastDeploymentRequest,
 	mockPatchScriptSettings,
 } from "./helpers";
+import type { ExpectStatic } from "vitest";
 
 vi.mock("command-exists");
 vi.mock("../../check/commands", async (importOriginal) => {
@@ -87,7 +87,10 @@ describe("deploy", () => {
 	});
 
 	describe("workflows", () => {
-		function mockDeployWorkflow(expectedWorkflowName?: string) {
+		function mockDeployWorkflow(
+			expect: ExpectStatic,
+			expectedWorkflowName?: string
+		) {
 			const handler = http.put(
 				"*/accounts/:accountId/workflows/:workflowName",
 				({ params }) => {
@@ -138,7 +141,7 @@ describe("deploy", () => {
             `
 			);
 
-			mockDeployWorkflow("my-workflow");
+			mockDeployWorkflow(expect, "my-workflow");
 			mockSubDomainRequest();
 			mockUploadWorkerRequest({
 				expectedBindings: [
@@ -553,7 +556,7 @@ describe("deploy", () => {
 
 				mockSubDomainRequest();
 				mockUploadWorkerRequest();
-				mockDeployWorkflow("my-workflow");
+				mockDeployWorkflow(expect, "my-workflow");
 
 				mockConfirm({
 					text: "Do you want to continue?",
@@ -654,7 +657,7 @@ describe("deploy", () => {
 
 				mockSubDomainRequest();
 				mockUploadWorkerRequest();
-				mockDeployWorkflow("my-workflow");
+				mockDeployWorkflow(expect, "my-workflow");
 
 				await runWrangler("deploy");
 
@@ -692,7 +695,7 @@ describe("deploy", () => {
 
 				mockSubDomainRequest();
 				mockUploadWorkerRequest();
-				mockDeployWorkflow("my-workflow");
+				mockDeployWorkflow(expect, "my-workflow");
 
 				await runWrangler("deploy");
 
@@ -751,7 +754,7 @@ describe("deploy", () => {
 
 				mockSubDomainRequest();
 				mockUploadWorkerRequest();
-				mockDeployWorkflow();
+				mockDeployWorkflow(expect);
 
 				mockConfirm({
 					text: "Do you want to continue?",
@@ -795,7 +798,7 @@ describe("deploy", () => {
 				// Note: we don't mock the workflows API endpoint - if it's called, the test will fail
 				mockSubDomainRequest();
 				mockUploadWorkerRequest();
-				mockDeployWorkflow("my-workflow");
+				mockDeployWorkflow(expect, "my-workflow");
 
 				await runWrangler("deploy");
 

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -9,17 +9,7 @@ import ci from "ci-info";
 import getPort from "get-port";
 import { http, HttpResponse } from "msw";
 import dedent from "ts-dedent";
-/* eslint-disable no-restricted-imports */
-import {
-	afterEach,
-	assert,
-	beforeEach,
-	describe,
-	expect,
-	it,
-	vi,
-} from "vitest";
-/* eslint-enable no-restricted-imports */
+import { afterEach, assert, beforeEach, describe, it, vi } from "vitest";
 import { ConfigController } from "../api/startDevWorker/ConfigController";
 import { unwrapHook } from "../api/startDevWorker/utils";
 import { getWorkerAccountAndContext } from "../dev/remote";
@@ -45,6 +35,7 @@ import type {
 	Trigger,
 } from "../api";
 import type { RawConfig } from "@cloudflare/workers-utils";
+import type { ExpectStatic } from "vitest";
 import type { Mock, MockInstance } from "vitest";
 
 vi.mock("../api/startDevWorker/ConfigController", (importOriginal) =>
@@ -63,6 +54,7 @@ vi.mock("../utils/memoizeGetPort", () => {
 });
 
 async function expectedHostAndZone(
+	expect: ExpectStatic,
 	config: StartDevWorkerOptions & { input: StartDevWorkerInput },
 	host: string,
 	zone: string
@@ -172,7 +164,7 @@ describe.sequential("wrangler dev", () => {
 	}
 
 	describe("config file support", () => {
-		it("should support wrangler.toml", async () => {
+		it("should support wrangler.toml", async ({ expect }) => {
 			writeWranglerConfig({
 				name: "test-worker-toml",
 				main: "index.js",
@@ -184,7 +176,7 @@ describe.sequential("wrangler dev", () => {
 			expect(options.name).toMatchInlineSnapshot(`"test-worker-toml"`);
 		});
 
-		it("should support wrangler.json", async () => {
+		it("should support wrangler.json", async ({ expect }) => {
 			writeWranglerConfig(
 				{
 					name: "test-worker-json",
@@ -199,7 +191,7 @@ describe.sequential("wrangler dev", () => {
 			expect(options.name).toMatchInlineSnapshot(`"test-worker-json"`);
 		});
 
-		it("should support wrangler.jsonc", async () => {
+		it("should support wrangler.jsonc", async ({ expect }) => {
 			writeWranglerConfig(
 				{
 					name: "test-worker-jsonc",
@@ -221,7 +213,9 @@ describe.sequential("wrangler dev", () => {
 			vi.mocked(ci).isCI = true;
 		});
 
-		it("should kick you to the login flow when running wrangler dev in remote mode without authorization", async () => {
+		it("should kick you to the login flow when running wrangler dev in remote mode without authorization", async ({
+			expect,
+		}) => {
 			fs.writeFileSync("index.js", `export default {};`);
 			await expect(
 				runWrangler("dev --remote index.js")
@@ -231,7 +225,7 @@ describe.sequential("wrangler dev", () => {
 		});
 	});
 	describe("authorization with env var", () => {
-		it("should use config.account_id over env var", async () => {
+		it("should use config.account_id over env var", async ({ expect }) => {
 			writeWranglerConfig({
 				name: "test-worker-toml",
 				main: "index.js",
@@ -247,7 +241,9 @@ describe.sequential("wrangler dev", () => {
 			});
 		});
 
-		it("should use env var when config.account_id is not set", async () => {
+		it("should use env var when config.account_id is not set", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				name: "test-worker-toml",
 				main: "index.js",
@@ -264,13 +260,17 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe("compatibility-date", () => {
-		it("should not warn if there is no wrangler.toml and no compatibility-date specified", async () => {
+		it("should not warn if there is no wrangler.toml and no compatibility-date specified", async ({
+			expect,
+		}) => {
 			fs.writeFileSync("index.js", `export default {};`);
 			await runWranglerUntilConfig("dev index.js");
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should warn if there is a wrangler.toml but no compatibility-date", async () => {
+		it("should warn if there is a wrangler.toml but no compatibility-date", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				compatibility_date: undefined,
@@ -293,7 +293,9 @@ describe.sequential("wrangler dev", () => {
 				`);
 		});
 
-		it("should not warn if there is a wrangler.toml but compatibility-date is specified at the command line", async () => {
+		it("should not warn if there is a wrangler.toml but compatibility-date is specified at the command line", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				compatibility_date: undefined,
@@ -305,7 +307,9 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe("entry-points", () => {
-		it("should error if there is no entry-point specified", async () => {
+		it("should error if there is no entry-point specified", async ({
+			expect,
+		}) => {
 			vi.mocked(sniffUserAgent).mockReturnValue("npm");
 			writeWranglerConfig();
 
@@ -375,7 +379,9 @@ describe.sequential("wrangler dev", () => {
 			`);
 		});
 
-		it("should use `main` from the top-level environment", async () => {
+		it("should use `main` from the top-level environment", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 			});
@@ -384,7 +390,7 @@ describe.sequential("wrangler dev", () => {
 			expect(config.entrypoint).toMatch(/index\.js$/);
 		});
 
-		it("should use `main` from a named environment", async () => {
+		it("should use `main` from a named environment", async ({ expect }) => {
 			writeWranglerConfig({
 				env: {
 					ENV1: {
@@ -397,7 +403,9 @@ describe.sequential("wrangler dev", () => {
 			expect(config.entrypoint).toMatch(/index\.js$/);
 		});
 
-		it("should use `main` from a named environment, rather than the top-level", async () => {
+		it("should use `main` from a named environment, rather than the top-level", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "other.js",
 				env: {
@@ -413,11 +421,11 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe("routes", () => {
-		it("should pass routes to emitConfigUpdate", async () => {
+		it("should pass routes to emitConfigUpdate", async ({ expect }) => {
 			fs.writeFileSync("index.js", `export default {};`);
 
 			// config.routes
-			mockGetZones("5.some-host.com", [{ id: "some-zone-id-5" }]);
+			mockGetZones(expect, "5.some-host.com", [{ id: "some-zone-id-5" }]);
 			writeWranglerConfig({
 				main: "index.js",
 				routes: ["http://5.some-host.com/some/path/*"],
@@ -425,6 +433,7 @@ describe.sequential("wrangler dev", () => {
 			const config = await runWranglerUntilConfig("dev --remote");
 
 			const devConfig = await expectedHostAndZone(
+				expect,
 				config,
 				"5.some-host.com",
 				"some-zone-id-5"
@@ -439,7 +448,9 @@ describe.sequential("wrangler dev", () => {
 			});
 		});
 
-		it("should error if custom domains with paths are passed in but allow paths on normal routes", async () => {
+		it("should error if custom domains with paths are passed in but allow paths on normal routes", async ({
+			expect,
+		}) => {
 			fs.writeFileSync("index.js", `export default {};`);
 			writeWranglerConfig({
 				main: "index.js",
@@ -467,7 +478,7 @@ describe.sequential("wrangler dev", () => {
 			`);
 		});
 
-		it("should warn on mounted paths in dev", async () => {
+		it("should warn on mounted paths in dev", async ({ expect }) => {
 			writeWranglerConfig({
 				routes: [
 					"simple.co.uk/path/*",
@@ -498,20 +509,25 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe("host", () => {
-		it("should resolve a host to its zone", async () => {
+		it("should resolve a host to its zone", async ({ expect }) => {
 			writeWranglerConfig({
 				main: "index.js",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			mockGetZones("some-host.com", [{ id: "some-zone-id" }]);
+			mockGetZones(expect, "some-host.com", [{ id: "some-zone-id" }]);
 			const config = await runWranglerUntilConfig(
 				"dev --remote --host some-host.com"
 			);
 
-			await expectedHostAndZone(config, "some-host.com", "some-zone-id");
+			await expectedHostAndZone(
+				expect,
+				config,
+				"some-host.com",
+				"some-zone-id"
+			);
 		});
 
-		it("should read wrangler.toml's dev.host", async () => {
+		it("should read wrangler.toml's dev.host", async ({ expect }) => {
 			writeWranglerConfig({
 				main: "index.js",
 				dev: {
@@ -519,24 +535,29 @@ describe.sequential("wrangler dev", () => {
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			mockGetZones("some-host.com", [{ id: "some-zone-id" }]);
+			mockGetZones(expect, "some-host.com", [{ id: "some-zone-id" }]);
 			const config = await runWranglerUntilConfig("dev");
 			expect(config.dev.origin?.hostname).toEqual("some-host.com");
 		});
 
-		it("should read --route", async () => {
+		it("should read --route", async ({ expect }) => {
 			writeWranglerConfig({
 				main: "index.js",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			mockGetZones("some-host.com", [{ id: "some-zone-id" }]);
+			mockGetZones(expect, "some-host.com", [{ id: "some-zone-id" }]);
 			const config = await runWranglerUntilConfig(
 				"dev --route http://some-host.com/some/path/*"
 			);
-			await expectedHostAndZone(config, "some-host.com", "some-zone-id");
+			await expectedHostAndZone(
+				expect,
+				config,
+				"some-host.com",
+				"some-zone-id"
+			);
 		});
 
-		it("should read wrangler.toml's routes", async () => {
+		it("should read wrangler.toml's routes", async ({ expect }) => {
 			writeWranglerConfig({
 				main: "index.js",
 				routes: [
@@ -545,12 +566,19 @@ describe.sequential("wrangler dev", () => {
 				],
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			mockGetZones("some-host.com", [{ id: "some-zone-id" }]);
+			mockGetZones(expect, "some-host.com", [{ id: "some-zone-id" }]);
 			const config = await runWranglerUntilConfig("dev");
-			await expectedHostAndZone(config, "some-host.com", "some-zone-id");
+			await expectedHostAndZone(
+				expect,
+				config,
+				"some-host.com",
+				"some-zone-id"
+			);
 		});
 
-		it("should read wrangler.toml's environment specific routes", async () => {
+		it("should read wrangler.toml's environment specific routes", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				routes: [
@@ -567,34 +595,55 @@ describe.sequential("wrangler dev", () => {
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			mockGetZones("some-host.com", [{ id: "some-zone-id" }]);
+			mockGetZones(expect, "some-host.com", [{ id: "some-zone-id" }]);
 			const config = await runWranglerUntilConfig("dev --env staging");
-			await expectedHostAndZone(config, "some-host.com", "some-zone-id");
+			await expectedHostAndZone(
+				expect,
+				config,
+				"some-host.com",
+				"some-zone-id"
+			);
 		});
 
-		it("should strip leading `*` from given host when deducing a zone id", async () => {
+		it("should strip leading `*` from given host when deducing a zone id", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				route: "*some-host.com/some/path/*",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			mockGetZones("some-host.com", [{ id: "some-zone-id" }]);
+			mockGetZones(expect, "some-host.com", [{ id: "some-zone-id" }]);
 			const config = await runWranglerUntilConfig("dev");
-			await expectedHostAndZone(config, "some-host.com", "some-zone-id");
+			await expectedHostAndZone(
+				expect,
+				config,
+				"some-host.com",
+				"some-zone-id"
+			);
 		});
 
-		it("should strip leading `*.` from given host when deducing a zone id", async () => {
+		it("should strip leading `*.` from given host when deducing a zone id", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				route: "*.some-host.com/some/path/*",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			mockGetZones("some-host.com", [{ id: "some-zone-id" }]);
+			mockGetZones(expect, "some-host.com", [{ id: "some-zone-id" }]);
 			const config = await runWranglerUntilConfig("dev");
-			await expectedHostAndZone(config, "some-host.com", "some-zone-id");
+			await expectedHostAndZone(
+				expect,
+				config,
+				"some-host.com",
+				"some-zone-id"
+			);
 		});
 
-		it("should, when provided, use a configured zone_id", async () => {
+		it("should, when provided, use a configured zone_id", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				routes: [
@@ -604,10 +653,17 @@ describe.sequential("wrangler dev", () => {
 			fs.writeFileSync("index.js", `export default {};`);
 			const config = await runWranglerUntilConfig("dev --remote");
 
-			await expectedHostAndZone(config, "some-domain.com", "some-zone-id");
+			await expectedHostAndZone(
+				expect,
+				config,
+				"some-domain.com",
+				"some-zone-id"
+			);
 		});
 
-		it("should, when provided, use a zone_name to get a zone_id", async () => {
+		it("should, when provided, use a zone_name to get a zone_id", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				routes: [
@@ -618,13 +674,15 @@ describe.sequential("wrangler dev", () => {
 				],
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			mockGetZones("some-zone.com", [{ id: "a-zone-id" }]);
+			mockGetZones(expect, "some-zone.com", [{ id: "a-zone-id" }]);
 			const config = await runWranglerUntilConfig("dev --remote");
 
-			await expectedHostAndZone(config, "some-zone.com", "a-zone-id");
+			await expectedHostAndZone(expect, config, "some-zone.com", "a-zone-id");
 		});
 
-		it("should find the host from the given pattern, not zone_name", async () => {
+		it("should find the host from the given pattern, not zone_name", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				routes: [
@@ -640,7 +698,9 @@ describe.sequential("wrangler dev", () => {
 			expect(config.dev.origin?.hostname).toBe("subdomain.exists.com");
 		});
 
-		it("should fail for non-existing zones, when falling back from */*", async () => {
+		it("should fail for non-existing zones, when falling back from */*", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				routes: [
@@ -658,7 +718,9 @@ describe.sequential("wrangler dev", () => {
 			`);
 		});
 
-		it("should fallback to zone_name when given the pattern */*", async () => {
+		it("should fallback to zone_name when given the pattern */*", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				routes: [
@@ -677,7 +739,9 @@ describe.sequential("wrangler dev", () => {
 				},
 			]);
 		});
-		it("fails when given the pattern */* and no zone_name", async () => {
+		it("fails when given the pattern */* and no zone_name", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				routes: [
@@ -702,7 +766,9 @@ describe.sequential("wrangler dev", () => {
 			`);
 		});
 
-		it("given a long host, it should use the longest subdomain that resolves to a zone", async () => {
+		it("given a long host, it should use the longest subdomain that resolves to a zone", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 			});
@@ -737,6 +803,7 @@ describe.sequential("wrangler dev", () => {
 			);
 
 			await expectedHostAndZone(
+				expect,
 				config,
 				"111.222.333.some-host.com",
 				"some-zone-id"
@@ -744,34 +811,44 @@ describe.sequential("wrangler dev", () => {
 		});
 
 		describe("should, in order, use args.host/config.dev.host/args.routes/(config.route|config.routes)", () => {
-			it("config.routes", async () => {
+			it("config.routes", async ({ expect }) => {
 				fs.writeFileSync("index.js", `export default {};`);
 
-				mockGetZones("5.some-host.com", [{ id: "some-zone-id-5" }]);
+				mockGetZones(expect, "5.some-host.com", [{ id: "some-zone-id-5" }]);
 				writeWranglerConfig({
 					main: "index.js",
 					routes: ["http://5.some-host.com/some/path/*"],
 				});
 				const config = await runWranglerUntilConfig("dev --remote");
 
-				await expectedHostAndZone(config, "5.some-host.com", "some-zone-id-5");
+				await expectedHostAndZone(
+					expect,
+					config,
+					"5.some-host.com",
+					"some-zone-id-5"
+				);
 			});
-			it("config.route", async () => {
+			it("config.route", async ({ expect }) => {
 				fs.writeFileSync("index.js", `export default {};`);
 
-				mockGetZones("4.some-host.com", [{ id: "some-zone-id-4" }]);
+				mockGetZones(expect, "4.some-host.com", [{ id: "some-zone-id-4" }]);
 				writeWranglerConfig({
 					main: "index.js",
 					route: "https://4.some-host.com/some/path/*",
 				});
 				const config2 = await runWranglerUntilConfig("dev --remote");
 
-				await expectedHostAndZone(config2, "4.some-host.com", "some-zone-id-4");
+				await expectedHostAndZone(
+					expect,
+					config2,
+					"4.some-host.com",
+					"some-zone-id-4"
+				);
 			});
-			it("--routes", async () => {
+			it("--routes", async ({ expect }) => {
 				fs.writeFileSync("index.js", `export default {};`);
 
-				mockGetZones("3.some-host.com", [{ id: "some-zone-id-3" }]);
+				mockGetZones(expect, "3.some-host.com", [{ id: "some-zone-id-3" }]);
 				writeWranglerConfig({
 					main: "index.js",
 					route: "https://4.some-host.com/some/path/*",
@@ -780,12 +857,17 @@ describe.sequential("wrangler dev", () => {
 					"dev --remote --routes http://3.some-host.com/some/path/*"
 				);
 
-				await expectedHostAndZone(config3, "3.some-host.com", "some-zone-id-3");
+				await expectedHostAndZone(
+					expect,
+					config3,
+					"3.some-host.com",
+					"some-zone-id-3"
+				);
 			});
-			it("config.dev.host", async () => {
+			it("config.dev.host", async ({ expect }) => {
 				fs.writeFileSync("index.js", `export default {};`);
 
-				mockGetZones("2.some-host.com", [{ id: "some-zone-id-2" }]);
+				mockGetZones(expect, "2.some-host.com", [{ id: "some-zone-id-2" }]);
 				writeWranglerConfig({
 					main: "index.js",
 					dev: {
@@ -798,10 +880,10 @@ describe.sequential("wrangler dev", () => {
 				);
 				expect(config4.dev.origin?.hostname).toBe("2.some-host.com");
 			});
-			it("host", async () => {
+			it("host", async ({ expect }) => {
 				fs.writeFileSync("index.js", `export default {};`);
 
-				mockGetZones("1.some-host.com", [{ id: "some-zone-id-1" }]);
+				mockGetZones(expect, "1.some-host.com", [{ id: "some-zone-id-1" }]);
 				writeWranglerConfig({
 					main: "index.js",
 					dev: {
@@ -812,15 +894,20 @@ describe.sequential("wrangler dev", () => {
 				const config5 = await runWranglerUntilConfig(
 					"dev --remote --routes http://3.some-host.com/some/path/* --host 1.some-host.com"
 				);
-				await expectedHostAndZone(config5, "1.some-host.com", "some-zone-id-1");
+				await expectedHostAndZone(
+					expect,
+					config5,
+					"1.some-host.com",
+					"some-zone-id-1"
+				);
 			});
 		});
-		it("should error if a host can't resolve to a zone", async () => {
+		it("should error if a host can't resolve to a zone", async ({ expect }) => {
 			writeWranglerConfig({
 				main: "index.js",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			mockGetZones("some-host.com", []);
+			mockGetZones(expect, "some-host.com", []);
 			await expect(runWrangler("dev --remote --host some-host.com")).rejects
 				.toThrowErrorMatchingInlineSnapshot(`
 				[Error: Could not find zone for \`some-host.com\`. Make sure the domain is set up to be proxied by Cloudflare.
@@ -828,7 +915,9 @@ describe.sequential("wrangler dev", () => {
 			`);
 		});
 
-		it("should not try to resolve a zone when starting in local mode", async () => {
+		it("should not try to resolve a zone when starting in local mode", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 			});
@@ -840,7 +929,7 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe("local upstream", () => {
-		it("should use dev.host from toml by default", async () => {
+		it("should use dev.host from toml by default", async ({ expect }) => {
 			writeWranglerConfig({
 				main: "index.js",
 				dev: {
@@ -852,7 +941,7 @@ describe.sequential("wrangler dev", () => {
 			expect(config.dev.origin?.hostname).toEqual("2.some-host.com");
 		});
 
-		it("should use route from toml by default", async () => {
+		it("should use route from toml by default", async ({ expect }) => {
 			writeWranglerConfig({
 				main: "index.js",
 				route: "https://4.some-host.com/some/path/*",
@@ -862,7 +951,7 @@ describe.sequential("wrangler dev", () => {
 			expect(config.dev.origin?.hostname).toEqual("4.some-host.com");
 		});
 
-		it("should respect the option when provided", async () => {
+		it("should respect the option when provided", async ({ expect }) => {
 			writeWranglerConfig({
 				main: "index.js",
 				route: `2.some-host.com`,
@@ -877,7 +966,9 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe("custom builds", () => {
-		it("should run a custom build before starting `dev`", async () => {
+		it("should run a custom build before starting `dev`", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				build: {
 					command: `node -e "4+4; require('fs').writeFileSync('index.js', 'export default { fetch(){ return new Response(123) } }')"`,
@@ -910,7 +1001,7 @@ describe.sequential("wrangler dev", () => {
 
 		it.skipIf(process.platform === "win32")(
 			"should run a custom build of multiple steps combined by && before starting `dev`",
-			async () => {
+			async ({ expect }) => {
 				writeWranglerConfig({
 					build: {
 						command: `echo "export default { fetch(){ return new Response(123) } }" > index.js`,
@@ -936,7 +1027,9 @@ describe.sequential("wrangler dev", () => {
 			}
 		);
 
-		it("should throw an error if the entry doesn't exist after the build finishes", async () => {
+		it("should throw an error if the entry doesn't exist after the build finishes", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				build: {
@@ -1027,7 +1120,9 @@ describe.sequential("wrangler dev", () => {
 					.join("\n");
 			}
 
-			it("should pass environment variables from `.env` to custom builds", async () => {
+			it("should pass environment variables from `.env` to custom builds", async ({
+				expect,
+			}) => {
 				await runWranglerUntilConfig("dev");
 				expect(extractCustomBuildLogs(std.out)).toMatchInlineSnapshot(`
 					"
@@ -1039,7 +1134,9 @@ describe.sequential("wrangler dev", () => {
 				`);
 			});
 
-			it("should prefer to load environment variables from `.env.<environment>` if `--env <environment>` is set", async () => {
+			it("should prefer to load environment variables from `.env.<environment>` if `--env <environment>` is set", async ({
+				expect,
+			}) => {
 				await runWranglerUntilConfig("dev --env custom");
 				expect(extractCustomBuildLogs(std.out)).toMatchInlineSnapshot(`
 					"
@@ -1051,7 +1148,9 @@ describe.sequential("wrangler dev", () => {
 				`);
 			});
 
-			it("should use default `.env` if `.env.<environment>` does not exist", async () => {
+			it("should use default `.env` if `.env.<environment>` does not exist", async ({
+				expect,
+			}) => {
 				await runWranglerUntilConfig("dev --env=noEnv");
 				expect(extractCustomBuildLogs(std.out)).toMatchInlineSnapshot(`
 					"
@@ -1063,7 +1162,9 @@ describe.sequential("wrangler dev", () => {
 				`);
 			});
 
-			it("should not override environment variables already on process.env", async () => {
+			it("should not override environment variables already on process.env", async ({
+				expect,
+			}) => {
 				vi.stubEnv("__DOT_ENV_TEST_CUSTOM_BUILD_VAR_1", "process-env");
 				await runWranglerUntilConfig("dev");
 				expect(extractCustomBuildLogs(std.out)).toMatchInlineSnapshot(`
@@ -1076,7 +1177,9 @@ describe.sequential("wrangler dev", () => {
 				`);
 			});
 
-			it("should prefer to load environment variables from a custom path `.env` if `--env-file` is set", async () => {
+			it("should prefer to load environment variables from a custom path `.env` if `--env-file` is set", async ({
+				expect,
+			}) => {
 				fs.mkdirSync("other", { recursive: true });
 				fs.writeFileSync(
 					"other/.env",
@@ -1105,7 +1208,9 @@ describe.sequential("wrangler dev", () => {
 				`);
 			});
 
-			it("should prefer to load environment variables from a custom path `.env` if multiple `--env-file` is set", async () => {
+			it("should prefer to load environment variables from a custom path `.env` if multiple `--env-file` is set", async ({
+				expect,
+			}) => {
 				fs.mkdirSync("other", { recursive: true });
 				fs.writeFileSync(
 					"other/.env",
@@ -1136,7 +1241,9 @@ describe.sequential("wrangler dev", () => {
 				`);
 			});
 
-			it("should show reasonable debug output if `.env` does not exist", async () => {
+			it("should show reasonable debug output if `.env` does not exist", async ({
+				expect,
+			}) => {
 				fs.rmSync(".env");
 				writeWranglerConfig({
 					main: "index.js",
@@ -1150,7 +1257,9 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe("upstream-protocol", () => {
-		it("should default upstream-protocol to `https` if remote mode", async () => {
+		it("should default upstream-protocol to `https` if remote mode", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 			});
@@ -1159,7 +1268,9 @@ describe.sequential("wrangler dev", () => {
 			expect(config.dev.origin?.secure).toEqual(true);
 		});
 
-		it("should warn if `--upstream-protocol=http` is used in remote mode", async () => {
+		it("should warn if `--upstream-protocol=http` is used in remote mode", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 			});
@@ -1178,7 +1289,9 @@ describe.sequential("wrangler dev", () => {
 			`);
 		});
 
-		it("should default upstream-protocol to local-protocol if local mode", async () => {
+		it("should default upstream-protocol to local-protocol if local mode", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 			});
@@ -1187,7 +1300,9 @@ describe.sequential("wrangler dev", () => {
 			expect(config.dev.origin?.secure).toEqual(true);
 		});
 
-		it("should default upstream-protocol to http if no local-protocol in local mode", async () => {
+		it("should default upstream-protocol to http if no local-protocol in local mode", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 			});
@@ -1198,7 +1313,7 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe("local-protocol", () => {
-		it("should default local-protocol to `http`", async () => {
+		it("should default local-protocol to `http`", async ({ expect }) => {
 			writeWranglerConfig({
 				main: "index.js",
 			});
@@ -1207,7 +1322,9 @@ describe.sequential("wrangler dev", () => {
 			expect(config.dev.server?.secure).toEqual(false);
 		});
 
-		it("should use `local_protocol` from `wrangler.toml`, if available", async () => {
+		it("should use `local_protocol` from `wrangler.toml`, if available", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				dev: {
@@ -1219,7 +1336,9 @@ describe.sequential("wrangler dev", () => {
 			expect(config.dev.server?.secure).toEqual(true);
 		});
 
-		it("should use --local-protocol command line arg, if provided", async () => {
+		it("should use --local-protocol command line arg, if provided", async ({
+			expect,
+		}) => {
 			// Here we show that the command line overrides the wrangler.toml by
 			// setting the config to https, and then setting it back to http on the command line.
 			writeWranglerConfig({
@@ -1235,7 +1354,7 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe("ip", () => {
-		it("should default ip to localhost", async () => {
+		it("should default ip to localhost", async ({ expect }) => {
 			writeWranglerConfig({
 				main: "index.js",
 			});
@@ -1246,7 +1365,9 @@ describe.sequential("wrangler dev", () => {
 			);
 		});
 
-		it("should use to `ip` from `wrangler.toml`, if available", async () => {
+		it("should use to `ip` from `wrangler.toml`, if available", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				dev: {
@@ -1258,7 +1379,7 @@ describe.sequential("wrangler dev", () => {
 			expect(config.dev.server?.hostname).toEqual("::1");
 		});
 
-		it("should use --ip command line arg, if provided", async () => {
+		it("should use --ip command line arg, if provided", async ({ expect }) => {
 			writeWranglerConfig({
 				main: "index.js",
 				dev: {
@@ -1272,7 +1393,7 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe("inspector port", () => {
-		it("should use 9229 as the default port", async () => {
+		it("should use 9229 as the default port", async ({ expect }) => {
 			(getPort as Mock).mockImplementation((options) => options.port);
 			writeWranglerConfig({
 				main: "index.js",
@@ -1283,7 +1404,7 @@ describe.sequential("wrangler dev", () => {
 			expect(config.dev.inspector?.port).toEqual(9229);
 		});
 
-		it("should read --inspector-port", async () => {
+		it("should read --inspector-port", async ({ expect }) => {
 			(getPort as Mock).mockImplementation((options) => options.port);
 			writeWranglerConfig({
 				main: "index.js",
@@ -1294,7 +1415,9 @@ describe.sequential("wrangler dev", () => {
 			expect(config.dev.inspector?.port).toEqual(9999);
 		});
 
-		it("should read dev.inspector_port from wrangler.toml", async () => {
+		it("should read dev.inspector_port from wrangler.toml", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				dev: {
@@ -1307,7 +1430,9 @@ describe.sequential("wrangler dev", () => {
 			expect(config.dev.inspector?.port).toEqual(9999);
 		});
 
-		it("should error if a bad dev.inspector_port config is provided", async () => {
+		it("should error if a bad dev.inspector_port config is provided", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				dev: {
@@ -1325,7 +1450,7 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe("inspector ip", () => {
-		it("should default inspector ip to 127.0.0.1", async () => {
+		it("should default inspector ip to 127.0.0.1", async ({ expect }) => {
 			writeWranglerConfig({
 				main: "index.js",
 			});
@@ -1335,7 +1460,7 @@ describe.sequential("wrangler dev", () => {
 			expect(config.dev.inspector?.hostname).toEqual("127.0.0.1");
 		});
 
-		it("should read --inspector-ip", async () => {
+		it("should read --inspector-ip", async ({ expect }) => {
 			writeWranglerConfig({
 				main: "index.js",
 			});
@@ -1345,7 +1470,9 @@ describe.sequential("wrangler dev", () => {
 			expect(config.dev.inspector?.hostname).toEqual("0.0.0.0");
 		});
 
-		it("should read dev.inspector_ip from wrangler config", async () => {
+		it("should read dev.inspector_ip from wrangler config", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				dev: {
@@ -1358,7 +1485,9 @@ describe.sequential("wrangler dev", () => {
 			expect(config.dev.inspector?.hostname).toEqual("0.0.0.0");
 		});
 
-		it("should use --inspector-ip over dev.inspector_ip from wrangler config", async () => {
+		it("should use --inspector-ip over dev.inspector_ip from wrangler config", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				dev: {
@@ -1373,7 +1502,9 @@ describe.sequential("wrangler dev", () => {
 			expect(config.dev.inspector?.hostname).toEqual("192.168.1.1");
 		});
 
-		it("should error if a bad dev.inspector_ip config is provided", async () => {
+		it("should error if a bad dev.inspector_ip config is provided", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				dev: {
@@ -1391,7 +1522,9 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe("port", () => {
-		it("should default port to 8787 if it is not in use", async () => {
+		it("should default port to 8787 if it is not in use", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 			});
@@ -1400,7 +1533,9 @@ describe.sequential("wrangler dev", () => {
 			expect(config.dev.server?.port).toEqual(8787);
 		});
 
-		it("should use `port` from `wrangler.toml`, if available", async () => {
+		it("should use `port` from `wrangler.toml`, if available", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				dev: {
@@ -1415,7 +1550,9 @@ describe.sequential("wrangler dev", () => {
 			expect(config.dev.server?.port).toEqual(8888);
 		});
 
-		it("should error if a bad dev.port config is provided", async () => {
+		it("should error if a bad dev.port config is provided", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				dev: {
@@ -1431,7 +1568,9 @@ describe.sequential("wrangler dev", () => {
 			`);
 		});
 
-		it("should use --port command line arg, if provided", async () => {
+		it("should use --port command line arg, if provided", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				dev: {
@@ -1446,7 +1585,9 @@ describe.sequential("wrangler dev", () => {
 			expect(config.dev.server?.port).toEqual(9999);
 		});
 
-		it("should use a different port to the default if it is in use", async () => {
+		it("should use a different port to the default if it is in use", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 			});
@@ -1489,7 +1630,9 @@ describe.sequential("wrangler dev", () => {
 
 			mockExecFileSync.mockReturnValue(mockedDockerContextLsOutput);
 		});
-		it("should default to socket of current docker context", async () => {
+		it("should default to socket of current docker context", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				...minimalContainerConfig,
@@ -1501,7 +1644,7 @@ describe.sequential("wrangler dev", () => {
 			);
 		});
 
-		it("should be able to be set by config", async () => {
+		it("should be able to be set by config", async ({ expect }) => {
 			writeWranglerConfig({
 				main: "index.js",
 				dev: {
@@ -1515,7 +1658,7 @@ describe.sequential("wrangler dev", () => {
 			const config = await runWranglerUntilConfig("dev");
 			expect(config.dev.containerEngine).toEqual("test.sock");
 		});
-		it("should be able to be set by env var", async () => {
+		it("should be able to be set by env var", async ({ expect }) => {
 			writeWranglerConfig({
 				main: "index.js",
 				dev: {
@@ -1533,7 +1676,9 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe("durable_objects", () => {
-		it("should warn if there are remote Durable Objects, or missing migrations for local Durable Objects", async () => {
+		it("should warn if there are remote Durable Objects, or missing migrations for local Durable Objects", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				durable_objects: {
@@ -1598,7 +1743,9 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe("variable display", () => {
-		it("should render config vars literally, --var as hidden, and .dev.vars as hidden", async () => {
+		it("should render config vars literally, --var as hidden, and .dev.vars as hidden", async ({
+			expect,
+		}) => {
 			fs.writeFileSync("index.js", `export default {};`);
 			fs.writeFileSync(".dev.vars", `SECRET_VAR=from_dotenv`);
 			writeWranglerConfig({
@@ -1625,7 +1772,9 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe(".dev.vars", () => {
-		it("should override `vars` bindings from `wrangler.toml` with values in `.dev.vars`", async () => {
+		it("should override `vars` bindings from `wrangler.toml` with values in `.dev.vars`", async ({
+			expect,
+		}) => {
 			fs.writeFileSync("index.js", `export default {};`);
 
 			const localVarsEnvContent = dedent`
@@ -1696,7 +1845,9 @@ describe.sequential("wrangler dev", () => {
 			`);
 		});
 
-		it("should prefer `.dev.vars.<environment>` if `--env <environment> set`", async () => {
+		it("should prefer `.dev.vars.<environment>` if `--env <environment> set`", async ({
+			expect,
+		}) => {
 			fs.writeFileSync("index.js", `export default {};`);
 			fs.writeFileSync(".dev.vars", "DEFAULT_VAR=default");
 			fs.writeFileSync(".dev.vars.custom", "CUSTOM_VAR=custom");
@@ -1740,7 +1891,7 @@ describe.sequential("wrangler dev", () => {
 
 		// --- Resolution: sources in priority order ---
 
-		it("should load declared secrets from .dev.vars", async () => {
+		it("should load declared secrets from .dev.vars", async ({ expect }) => {
 			fs.writeFileSync("index.js", `export default {};`);
 			fs.writeFileSync(".dev.vars", `API_KEY=from-dev-dot-vars`);
 			writeWranglerConfig({
@@ -1755,7 +1906,9 @@ describe.sequential("wrangler dev", () => {
 			});
 		});
 
-		it("should load declared secrets from .env when no .dev.vars exists", async () => {
+		it("should load declared secrets from .env when no .dev.vars exists", async ({
+			expect,
+		}) => {
 			fs.writeFileSync("index.js", `export default {};`);
 			fs.writeFileSync(".env", `API_KEY=from-dot-env`);
 			writeWranglerConfig({
@@ -1770,7 +1923,9 @@ describe.sequential("wrangler dev", () => {
 			});
 		});
 
-		it("should load declared secrets from process.env when not in .dev.vars or .env", async () => {
+		it("should load declared secrets from process.env when not in .dev.vars or .env", async ({
+			expect,
+		}) => {
 			fs.writeFileSync("index.js", `export default {};`);
 			// eslint-disable-next-line turbo/no-undeclared-env-vars
 			process.env.API_KEY = "from-process-env";
@@ -1786,7 +1941,9 @@ describe.sequential("wrangler dev", () => {
 			});
 		});
 
-		it("should prefer .dev.vars over .env for declared secrets", async () => {
+		it("should prefer .dev.vars over .env for declared secrets", async ({
+			expect,
+		}) => {
 			fs.writeFileSync("index.js", `export default {};`);
 			fs.writeFileSync(".dev.vars", `API_KEY=from-dev-dot-vars`);
 			fs.writeFileSync(".env", `API_KEY=from-dot-env`);
@@ -1804,7 +1961,7 @@ describe.sequential("wrangler dev", () => {
 
 		// --- Validation ---
 
-		it("should warn when a required secret is missing", async () => {
+		it("should warn when a required secret is missing", async ({ expect }) => {
 			fs.writeFileSync("index.js", `export default {};`);
 			writeWranglerConfig({
 				main: "index.js",
@@ -1818,7 +1975,9 @@ describe.sequential("wrangler dev", () => {
 
 		// --- Filtering ---
 
-		it("should only include declared secrets from .dev.vars", async () => {
+		it("should only include declared secrets from .dev.vars", async ({
+			expect,
+		}) => {
 			fs.writeFileSync("index.js", `export default {};`);
 			fs.writeFileSync(
 				".dev.vars",
@@ -1840,7 +1999,7 @@ describe.sequential("wrangler dev", () => {
 			expect(bindings["EXTRA"]).toBeUndefined();
 		});
 
-		it("should not treat --var values as secrets", async () => {
+		it("should not treat --var values as secrets", async ({ expect }) => {
 			fs.writeFileSync("index.js", `export default {};`);
 			writeWranglerConfig({
 				main: "index.js",
@@ -1860,7 +2019,9 @@ describe.sequential("wrangler dev", () => {
 
 		// --- Edge cases and backward compat ---
 
-		it("should exclude .dev.vars keys when `secrets` is defined", async () => {
+		it("should exclude .dev.vars keys when `secrets` is defined", async ({
+			expect,
+		}) => {
 			fs.writeFileSync("index.js", `export default {};`);
 			fs.writeFileSync(".dev.vars", `SOME_KEY=from-dev-dot-vars`);
 			writeWranglerConfig({
@@ -1874,7 +2035,9 @@ describe.sequential("wrangler dev", () => {
 			expect(std.warn).not.toContain("Missing required secrets");
 		});
 
-		it("should still read .dev.vars when secrets is not defined (backward compat)", async () => {
+		it("should still read .dev.vars when secrets is not defined (backward compat)", async ({
+			expect,
+		}) => {
 			fs.writeFileSync("index.js", `export default {};`);
 			fs.writeFileSync(".dev.vars", `LEGACY_SECRET=from-dev-dot-vars`);
 			writeWranglerConfig({
@@ -1948,7 +2111,7 @@ describe.sequential("wrangler dev", () => {
 				.join("\n");
 		}
 
-		it("should get local dev `vars` from `.env`", async () => {
+		it("should get local dev `vars` from `.env`", async ({ expect }) => {
 			await runWranglerUntilConfig("dev");
 			const out = std.out;
 			expect(extractUsingVars(out)).toMatchInlineSnapshot(`
@@ -1963,7 +2126,9 @@ describe.sequential("wrangler dev", () => {
 			`);
 		});
 
-		it("should not load local dev `vars` from `.env` if there is a `.dev.vars` file", async () => {
+		it("should not load local dev `vars` from `.env` if there is a `.dev.vars` file", async ({
+			expect,
+		}) => {
 			fs.writeFileSync(
 				".dev.vars",
 				dedent`
@@ -1982,7 +2147,9 @@ describe.sequential("wrangler dev", () => {
 			`);
 		});
 
-		it("should not load local dev `vars` from `.env` if CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV is set to false", async () => {
+		it("should not load local dev `vars` from `.env` if CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV is set to false", async ({
+			expect,
+		}) => {
 			await runWranglerUntilConfig("dev", {
 				CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV: "false",
 			});
@@ -1991,7 +2158,9 @@ describe.sequential("wrangler dev", () => {
 			expect(extractBindings(out)).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should get local dev `vars` from appropriate `.env.<environment>` files when --env=<environment> is set", async () => {
+		it("should get local dev `vars` from appropriate `.env.<environment>` files when --env=<environment> is set", async ({
+			expect,
+		}) => {
 			await runWranglerUntilConfig("dev --env custom");
 			const out = std.out;
 			expect(extractUsingVars(out)).toMatchInlineSnapshot(`
@@ -2008,7 +2177,9 @@ describe.sequential("wrangler dev", () => {
 			`);
 		});
 
-		it("should get local dev vars from appropriate `.env` files when --env=<environment> is set but no .env.<environment> file exists", async () => {
+		it("should get local dev vars from appropriate `.env` files when --env=<environment> is set but no .env.<environment> file exists", async ({
+			expect,
+		}) => {
 			await runWranglerUntilConfig("dev --env noEnv");
 			const out = std.out;
 			expect(extractUsingVars(out)).toMatchInlineSnapshot(`
@@ -2023,7 +2194,9 @@ describe.sequential("wrangler dev", () => {
 			`);
 		});
 
-		it("should get local dev `vars` from `process.env` when `CLOUDFLARE_INCLUDE_PROCESS_ENV` is true", async () => {
+		it("should get local dev `vars` from `process.env` when `CLOUDFLARE_INCLUDE_PROCESS_ENV` is true", async ({
+			expect,
+		}) => {
 			await runWranglerUntilConfig("dev --env custom", {
 				CLOUDFLARE_INCLUDE_PROCESS_ENV: "true",
 			});
@@ -2042,7 +2215,9 @@ describe.sequential("wrangler dev", () => {
 			);
 		});
 
-		it("should get local dev `vars` from appropriate `.env.<environment>` files when --env-file is set", async () => {
+		it("should get local dev `vars` from appropriate `.env.<environment>` files when --env-file is set", async ({
+			expect,
+		}) => {
 			fs.mkdirSync("other", { recursive: true });
 			fs.writeFileSync(
 				"other/.env",
@@ -2071,7 +2246,9 @@ describe.sequential("wrangler dev", () => {
 			`);
 		});
 
-		it("should get local dev `vars` from appropriate `.env.<environment>` files when multiple --env-file options are set", async () => {
+		it("should get local dev `vars` from appropriate `.env.<environment>` files when multiple --env-file options are set", async ({
+			expect,
+		}) => {
 			fs.mkdirSync("other", { recursive: true });
 			fs.writeFileSync(
 				"other/.env",
@@ -2107,7 +2284,7 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe("serve static assets", () => {
-		it("should error if --site is used with no value", async () => {
+		it("should error if --site is used with no value", async ({ expect }) => {
 			await expect(
 				runWrangler("dev --site")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -2116,7 +2293,7 @@ describe.sequential("wrangler dev", () => {
 		});
 
 		describe("should indicate whether Sites is being used", () => {
-			it("no use", async () => {
+			it("no use", async ({ expect }) => {
 				writeWranglerConfig({
 					main: "index.js",
 				});
@@ -2125,7 +2302,7 @@ describe.sequential("wrangler dev", () => {
 				const config = await runWranglerUntilConfig("dev");
 				expect(config.legacy.site).toBeFalsy();
 			});
-			it("--site arg", async () => {
+			it("--site arg", async ({ expect }) => {
 				writeWranglerConfig({
 					main: "index.js",
 				});
@@ -2147,7 +2324,9 @@ describe.sequential("wrangler dev", () => {
 			await runWranglerUntilConfig("dev");
 		});
 
-		it("should error if config.site and config.assets are used together", async () => {
+		it("should error if config.site and config.assets are used together", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "./index.js",
 				assets: { directory: "assets" },
@@ -2169,7 +2348,9 @@ describe.sequential("wrangler dev", () => {
 			);
 		});
 
-		it("should error if config.site and --assets are used together", async () => {
+		it("should error if config.site and --assets are used together", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "./index.js",
 				site: {
@@ -2190,7 +2371,9 @@ describe.sequential("wrangler dev", () => {
 			);
 		});
 
-		it("should error if an ASSET binding is provided without a user Worker", async () => {
+		it("should error if an ASSET binding is provided without a user Worker", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				assets: { directory: "assets", binding: "ASSETS" },
 			});
@@ -2205,7 +2388,9 @@ describe.sequential("wrangler dev", () => {
 			);
 		});
 
-		it("should warn if run_worker_first=true but no binding is provided", async () => {
+		it("should warn if run_worker_first=true but no binding is provided", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				assets: {
@@ -2231,7 +2416,9 @@ describe.sequential("wrangler dev", () => {
 			`);
 		});
 
-		it("should error if run_worker_first is true and no user Worker is provided", async () => {
+		it("should error if run_worker_first is true and no user Worker is provided", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				assets: { directory: "assets", run_worker_first: true },
 			});
@@ -2246,7 +2433,9 @@ describe.sequential("wrangler dev", () => {
 			);
 		});
 
-		it("should error if directory specified by '--assets' command line argument does not exist", async () => {
+		it("should error if directory specified by '--assets' command line argument does not exist", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "./index.js",
 			});
@@ -2258,7 +2447,9 @@ describe.sequential("wrangler dev", () => {
 			);
 		});
 
-		it("should error if directory specified by '[assets]' configuration key does not exist", async () => {
+		it("should error if directory specified by '[assets]' configuration key does not exist", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "./index.js",
 				assets: {
@@ -2273,7 +2464,9 @@ describe.sequential("wrangler dev", () => {
 			);
 		});
 
-		it("should error with a clear error message if the path specified by '--assets' command line argument is a file, not a directory", async () => {
+		it("should error with a clear error message if the path specified by '--assets' command line argument is a file, not a directory", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "./index.js",
 			});
@@ -2286,7 +2479,9 @@ describe.sequential("wrangler dev", () => {
 			`);
 		});
 
-		it("should error with a clear error message if the path specified by '[assets]' configuration key is a file, not a directory", async () => {
+		it("should error with a clear error message if the path specified by '[assets]' configuration key is a file, not a directory", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "./index.js",
 				assets: {
@@ -2304,7 +2499,7 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe("service bindings", () => {
-		it("should warn when using service bindings", async () => {
+		it("should warn when using service bindings", async ({ expect }) => {
 			writeWranglerConfig({
 				services: [
 					{ binding: "WorkerA", service: "A" },
@@ -2327,7 +2522,7 @@ describe.sequential("wrangler dev", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should show self-bindings as connected", async () => {
+		it("should show self-bindings as connected", async ({ expect }) => {
 			writeWranglerConfig({
 				name: "my-worker",
 				services: [
@@ -2357,7 +2552,7 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe("print bindings", () => {
-		it("should print bindings", async () => {
+		it("should print bindings", async ({ expect }) => {
 			writeWranglerConfig({
 				services: [
 					{ binding: "WorkerA", service: "A" },
@@ -2380,7 +2575,9 @@ describe.sequential("wrangler dev", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should mask vars that were overriden in .dev.vars", async () => {
+		it("should mask vars that were overriden in .dev.vars", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				vars: {
 					variable: 123,
@@ -2413,7 +2610,7 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe("`browser rendering binding", () => {
-		it("should not show error when running locally", async () => {
+		it("should not show error when running locally", async ({ expect }) => {
 			writeWranglerConfig({
 				browser: {
 					binding: "MYBROWSER",
@@ -2429,7 +2626,9 @@ describe.sequential("wrangler dev", () => {
 		});
 	});
 
-	it("should error helpfully if pages_build_output_dir is set", async () => {
+	it("should error helpfully if pages_build_output_dir is set", async ({
+		expect,
+	}) => {
 		writeWranglerConfig({ pages_build_output_dir: "dist", name: "test" });
 		await expect(runWrangler("dev")).rejects.toThrowErrorMatchingInlineSnapshot(
 			`
@@ -2472,7 +2671,9 @@ describe.sequential("wrangler dev", () => {
 				},
 			],
 		};
-		it("should warn when run in remote mode with (enabled) containers", async () => {
+		it("should warn when run in remote mode with (enabled) containers", async ({
+			expect,
+		}) => {
 			writeWranglerConfig(containerConfig);
 			fs.writeFileSync("Dockerfile", `FROM ubuntu`);
 
@@ -2494,7 +2695,9 @@ describe.sequential("wrangler dev", () => {
 			`);
 		});
 
-		it("should not warn when run in remote mode with disabled containers", async () => {
+		it("should not warn when run in remote mode with disabled containers", async ({
+			expect,
+		}) => {
 			fs.writeFileSync("Dockerfile", `FROM ubuntu`);
 
 			writeWranglerConfig({
@@ -2520,7 +2723,7 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe("generate types", () => {
-		it("should default `generate_types` to `false`", async () => {
+		it("should default `generate_types` to `false`", async ({ expect }) => {
 			writeWranglerConfig({
 				main: "index.js",
 			});
@@ -2529,7 +2732,9 @@ describe.sequential("wrangler dev", () => {
 			expect(config.dev.generateTypes).toBe(false);
 		});
 
-		it("should set `generate_types` to `true` when `--types` flag is passed", async () => {
+		it("should set `generate_types` to `true` when `--types` flag is passed", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 			});
@@ -2538,7 +2743,9 @@ describe.sequential("wrangler dev", () => {
 			expect(config.input.dev?.generateTypes).toBe(true);
 		});
 
-		it("should set `generate_types` to `true` when `--types=true` is passed", async () => {
+		it("should set `generate_types` to `true` when `--types=true` is passed", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 			});
@@ -2547,7 +2754,9 @@ describe.sequential("wrangler dev", () => {
 			expect(config.input.dev?.generateTypes).toBe(true);
 		});
 
-		it("should set `generate_types` to `false` when `--types=false` is passed", async () => {
+		it("should set `generate_types` to `false` when `--types=false` is passed", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 			});
@@ -2556,7 +2765,9 @@ describe.sequential("wrangler dev", () => {
 			expect(config.input.dev?.generateTypes).toBe(false);
 		});
 
-		it("should read `dev.generate_types` from wrangler config file", async () => {
+		it("should read `dev.generate_types` from wrangler config file", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				dev: {
@@ -2568,7 +2779,9 @@ describe.sequential("wrangler dev", () => {
 			expect(config.dev.generateTypes).toBe(true);
 		});
 
-		it("should allow `--types` flag to override `dev.generate_types` from config", async () => {
+		it("should allow `--types` flag to override `dev.generate_types` from config", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				dev: {
@@ -2580,7 +2793,9 @@ describe.sequential("wrangler dev", () => {
 			expect(config.input.dev?.generateTypes).toBe(true);
 		});
 
-		it("should allow `--types=false` to override `dev.generate_types` from config", async () => {
+		it("should allow `--types=false` to override `dev.generate_types` from config", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				dev: {
@@ -2625,7 +2840,9 @@ describe.sequential("wrangler dev", () => {
 				);
 			}
 
-			it("should warn about out of date types when `--types` is not set", async () => {
+			it("should warn about out of date types when `--types` is not set", async ({
+				expect,
+			}) => {
 				writeWranglerConfig({
 					main: "index.ts",
 					vars: { NEW_VAR: "new value" },
@@ -2648,7 +2865,9 @@ describe.sequential("wrangler dev", () => {
 				expect(typesContent).toContain("OLD_VAR");
 			});
 
-			it("should warn about out of date types when `dev.generate_types` is `false` in config", async () => {
+			it("should warn about out of date types when `dev.generate_types` is `false` in config", async ({
+				expect,
+			}) => {
 				writeWranglerConfig({
 					dev: {
 						generate_types: false,
@@ -2673,7 +2892,9 @@ describe.sequential("wrangler dev", () => {
 				expect(typesContent).toContain("old-hash-value");
 			});
 
-			it("should regenerate types when `--types` flag is set and types are out of date", async () => {
+			it("should regenerate types when `--types` flag is set and types are out of date", async ({
+				expect,
+			}) => {
 				writeWranglerConfig({
 					main: "index.ts",
 					vars: { NEW_VAR: "new value" },
@@ -2697,7 +2918,9 @@ describe.sequential("wrangler dev", () => {
 				expect(typesContent).toContain("<mocked runtime types>");
 			});
 
-			it("should regenerate types when `dev.generate_types` is `true` in config and types are out of date", async () => {
+			it("should regenerate types when `dev.generate_types` is `true` in config and types are out of date", async ({
+				expect,
+			}) => {
 				writeWranglerConfig({
 					dev: {
 						generate_types: true,
@@ -2723,7 +2946,9 @@ describe.sequential("wrangler dev", () => {
 				expect(typesContent).toContain("NEW_VAR");
 			});
 
-			it("should not warn about types if the types file does not exist", async () => {
+			it("should not warn about types if the types file does not exist", async ({
+				expect,
+			}) => {
 				writeWranglerConfig({
 					main: "index.ts",
 					vars: { NEW_VAR: "new value" },
@@ -2739,7 +2964,9 @@ describe.sequential("wrangler dev", () => {
 				expect(std.out).not.toContain("types looked out of date");
 			});
 
-			it("should not regenerate types when types file is up to date", async () => {
+			it("should not regenerate types when types file is up to date", async ({
+				expect,
+			}) => {
 				writeWranglerConfig({
 					main: "index.ts",
 					vars: { EXISTING_VAR: "existing value" },
@@ -2762,7 +2989,7 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe("multi-worker mode", () => {
-		it("should pass --env to auxiliary workers", async () => {
+		it("should pass --env to auxiliary workers", async ({ expect }) => {
 			writeWranglerConfig(
 				{
 					name: "primary",
@@ -2820,7 +3047,11 @@ describe.sequential("wrangler dev", () => {
 	});
 });
 
-function mockGetZones(domain: string, zones: { id: string }[] = []) {
+function mockGetZones(
+	expect: ExpectStatic,
+	domain: string,
+	zones: { id: string }[] = []
+) {
 	msw.use(
 		http.get("*/zones", ({ request }) => {
 			const url = new URL(request.url);

--- a/packages/wrangler/src/__tests__/kv/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/kv/bulk.test.ts
@@ -1,7 +1,6 @@
 import { writeFileSync } from "node:fs";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, it } from "vitest";
 import { BATCH_MAX_ERRORS_WARNINGS } from "../../kv/helpers";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -11,6 +10,7 @@ import { createFetchResult, msw } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import type { KeyValue } from "../../kv/helpers";
+import type { ExpectStatic } from "vitest";
 
 describe("kv", () => {
 	mockAccountId();
@@ -30,6 +30,7 @@ describe("kv", () => {
 	describe("bulk", () => {
 		describe("put", () => {
 			function mockPutRequest(
+				expect: ExpectStatic,
 				expectedNamespaceId: string,
 				expectedKeyValues: KeyValue[]
 			) {
@@ -56,7 +57,7 @@ describe("kv", () => {
 				return requests;
 			}
 
-			it("should put the key-values parsed from a file", async () => {
+			it("should put the key-values parsed from a file", async ({ expect }) => {
 				const keyValues: KeyValue[] = [
 					{ key: "someKey1", value: "someValue1" },
 					{ key: "ns:someKey2", value: "123", base64: true },
@@ -64,7 +65,7 @@ describe("kv", () => {
 					{ key: "someKey4", value: "someValue4", expiration_ttl: 500 },
 				];
 				writeFileSync("./keys.json", JSON.stringify(keyValues));
-				const requests = mockPutRequest("some-namespace-id", keyValues);
+				const requests = mockPutRequest(expect, "some-namespace-id", keyValues);
 				await runWrangler(
 					`kv bulk put --remote --namespace-id some-namespace-id keys.json`
 				);
@@ -81,13 +82,15 @@ describe("kv", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should put the key-values in batches of 1000 parsed from a file", async () => {
+			it("should put the key-values in batches of 1000 parsed from a file", async ({
+				expect,
+			}) => {
 				const keyValues: KeyValue[] = new Array(12000).fill({
 					key: "someKey1",
 					value: "someValue1",
 				});
 				writeFileSync("./keys.json", JSON.stringify(keyValues));
-				const requests = mockPutRequest("some-namespace-id", keyValues);
+				const requests = mockPutRequest(expect, "some-namespace-id", keyValues);
 				await runWrangler(
 					`kv bulk put --remote --namespace-id some-namespace-id keys.json`
 				);
@@ -117,7 +120,7 @@ describe("kv", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should error if the file is not a JSON array", async () => {
+			it("should error if the file is not a JSON array", async ({ expect }) => {
 				const keyValues = { key: "someKey1", value: "someValue1" };
 				writeFileSync("./keys.json", JSON.stringify(keyValues));
 				await expect(
@@ -139,7 +142,9 @@ describe("kv", () => {
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should error if the array contains items that are not key-value objects", async () => {
+			it("should error if the array contains items that are not key-value objects", async ({
+				expect,
+			}) => {
 				const keyValues = [
 					123,
 					"a string",
@@ -213,7 +218,7 @@ describe("kv", () => {
 				`);
 			});
 
-			it("should cap the number of errors", async () => {
+			it("should cap the number of errors", async ({ expect }) => {
 				const keyValues = [...Array(BATCH_MAX_ERRORS_WARNINGS + 5).keys()];
 
 				writeFileSync("./keys.json", JSON.stringify(keyValues));
@@ -252,7 +257,7 @@ describe("kv", () => {
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should cap the number of warnings", async () => {
+			it("should cap the number of warnings", async ({ expect }) => {
 				const keyValues: KeyValue[] = new Array(
 					BATCH_MAX_ERRORS_WARNINGS + 5
 				).fill({
@@ -261,7 +266,7 @@ describe("kv", () => {
 					invalid: true,
 				});
 				writeFileSync("./keys.json", JSON.stringify(keyValues));
-				const requests = mockPutRequest("some-namespace-id", keyValues);
+				const requests = mockPutRequest(expect, "some-namespace-id", keyValues);
 				await runWrangler(
 					`kv bulk put --remote --namespace-id some-namespace-id keys.json`
 				);
@@ -291,6 +296,7 @@ describe("kv", () => {
 
 		describe("delete", () => {
 			function mockDeleteRequest(
+				expect: ExpectStatic,
 				expectedNamespaceId: string,
 				expectedKeys: string[]
 			) {
@@ -320,14 +326,16 @@ describe("kv", () => {
 				return requests;
 			}
 
-			it("should delete the keys parsed from a file (string)", async () => {
+			it("should delete the keys parsed from a file (string)", async ({
+				expect,
+			}) => {
 				const keys = ["someKey1", "ns:someKey2"];
 				writeFileSync("./keys.json", JSON.stringify(keys));
 				mockConfirm({
 					text: `Are you sure you want to delete all the keys read from "keys.json" from kv-namespace id: "some-namespace-id"?`,
 					result: true,
 				});
-				const requests = mockDeleteRequest("some-namespace-id", keys);
+				const requests = mockDeleteRequest(expect, "some-namespace-id", keys);
 				await runWrangler(
 					`kv bulk delete --remote --namespace-id some-namespace-id keys.json`
 				);
@@ -344,7 +352,9 @@ describe("kv", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should delete the keys parsed from a file ({ name })", async () => {
+			it("should delete the keys parsed from a file ({ name })", async ({
+				expect,
+			}) => {
 				const keys = [{ name: "someKey1" }, { name: "ns:someKey2" }];
 				writeFileSync("./keys.json", JSON.stringify(keys));
 				mockConfirm({
@@ -352,6 +362,7 @@ describe("kv", () => {
 					result: true,
 				});
 				const requests = mockDeleteRequest(
+					expect,
 					"some-namespace-id",
 					keys.map((k) => k.name)
 				);
@@ -371,14 +382,16 @@ describe("kv", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should delete the keys in batches of 5000 parsed from a file", async () => {
+			it("should delete the keys in batches of 5000 parsed from a file", async ({
+				expect,
+			}) => {
 				const keys = new Array(12000).fill("some-key");
 				writeFileSync("./keys.json", JSON.stringify(keys));
 				mockConfirm({
 					text: `Are you sure you want to delete all the keys read from "keys.json" from kv-namespace id: "some-namespace-id"?`,
 					result: true,
 				});
-				const requests = mockDeleteRequest("some-namespace-id", keys);
+				const requests = mockDeleteRequest(expect, "some-namespace-id", keys);
 				await runWrangler(
 					`kv bulk delete --remote --namespace-id some-namespace-id keys.json`
 				);
@@ -408,7 +421,9 @@ describe("kv", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should not delete the keys if the user confirms no", async () => {
+			it("should not delete the keys if the user confirms no", async ({
+				expect,
+			}) => {
 				const keys = ["someKey1", "ns:someKey2"];
 				writeFileSync("./keys.json", JSON.stringify(keys));
 				mockConfirm({
@@ -432,10 +447,12 @@ describe("kv", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should delete the keys without asking if --force is provided", async () => {
+			it("should delete the keys without asking if --force is provided", async ({
+				expect,
+			}) => {
 				const keys = ["someKey1", "ns:someKey2"];
 				writeFileSync("./keys.json", JSON.stringify(keys));
-				const requests = mockDeleteRequest("some-namespace-id", keys);
+				const requests = mockDeleteRequest(expect, "some-namespace-id", keys);
 				await runWrangler(
 					`kv bulk delete --remote --namespace-id some-namespace-id keys.json --force`
 				);
@@ -452,10 +469,12 @@ describe("kv", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should delete the keys without asking if -f is provided", async () => {
+			it("should delete the keys without asking if -f is provided", async ({
+				expect,
+			}) => {
 				const keys = ["someKey1", "ns:someKey2"];
 				writeFileSync("./keys.json", JSON.stringify(keys));
-				const requests = mockDeleteRequest("some-namespace-id", keys);
+				const requests = mockDeleteRequest(expect, "some-namespace-id", keys);
 				await runWrangler(
 					`kv bulk delete --remote --namespace-id some-namespace-id keys.json -f`
 				);
@@ -472,7 +491,7 @@ describe("kv", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should error if the file is not a JSON array", async () => {
+			it("should error if the file is not a JSON array", async ({ expect }) => {
 				const keys = 12354;
 				writeFileSync("./keys.json", JSON.stringify(keys));
 				mockConfirm({
@@ -499,7 +518,9 @@ describe("kv", () => {
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should error if the file contains non-string items", async () => {
+			it("should error if the file contains non-string items", async ({
+				expect,
+			}) => {
 				const keys = ["good", 12354, { key: "someKey" }, null];
 				writeFileSync("./keys.json", JSON.stringify(keys));
 				mockConfirm({
@@ -531,6 +552,7 @@ describe("kv", () => {
 
 		describe("get", () => {
 			function mockGetRequest(
+				expect: ExpectStatic,
 				expectedNamespaceId: string,
 				expectedKeys: string[]
 			) {
@@ -571,10 +593,12 @@ describe("kv", () => {
 				return requests;
 			}
 
-			it("should get the keys parsed from a file (string)", async () => {
+			it("should get the keys parsed from a file (string)", async ({
+				expect,
+			}) => {
 				const keys = ["someKey1", "key2"];
 				writeFileSync("./keys.json", JSON.stringify(keys));
-				const requests = mockGetRequest("some-namespace-id", keys);
+				const requests = mockGetRequest(expect, "some-namespace-id", keys);
 				await runWrangler(
 					`kv bulk get --remote --namespace-id some-namespace-id keys.json`
 				);
@@ -595,10 +619,13 @@ describe("kv", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should get the keys parsed from a file ({ name })", async () => {
+			it("should get the keys parsed from a file ({ name })", async ({
+				expect,
+			}) => {
 				const keys = [{ name: "someKey1" }, { name: "ns:someKey2" }];
 				writeFileSync("./keys.json", JSON.stringify(keys));
 				const requests = mockGetRequest(
+					expect,
 					"some-namespace-id",
 					keys.map((k) => k.name)
 				);
@@ -622,7 +649,7 @@ describe("kv", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should error if the file is not a JSON array", async () => {
+			it("should error if the file is not a JSON array", async ({ expect }) => {
 				const keys = 12354;
 				writeFileSync("./keys.json", JSON.stringify(keys));
 				await expect(
@@ -642,7 +669,9 @@ describe("kv", () => {
 				`);
 			});
 
-			it("should error if the file contains non-string items", async () => {
+			it("should error if the file contains non-string items", async ({
+				expect,
+			}) => {
 				const keys = ["good", 12354, { key: "someKey" }, null];
 				writeFileSync("./keys.json", JSON.stringify(keys));
 				await expect(

--- a/packages/wrangler/src/__tests__/kv/key.test.ts
+++ b/packages/wrangler/src/__tests__/kv/key.test.ts
@@ -1,8 +1,7 @@
 import { writeFileSync } from "node:fs";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs } from "../helpers/mock-dialogs";
@@ -13,6 +12,7 @@ import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { wranglerKVConfig } from "./constant";
 import type { KeyValue, NamespaceKeyInfo } from "../../kv/helpers";
+import type { ExpectStatic } from "vitest";
 
 describe("kv", () => {
 	mockAccountId();
@@ -33,6 +33,7 @@ describe("kv", () => {
 	describe("key", () => {
 		describe("put", () => {
 			function mockKeyPutRequest(
+				expect: ExpectStatic,
 				expectedNamespaceId: string,
 				expectedKV: KeyValue
 			) {
@@ -82,8 +83,10 @@ describe("kv", () => {
 				return requests;
 			}
 
-			it("should put a key in a given namespace specified by namespace-id", async () => {
-				const requests = mockKeyPutRequest("some-namespace-id", {
+			it("should put a key in a given namespace specified by namespace-id", async ({
+				expect,
+			}) => {
+				const requests = mockKeyPutRequest(expect, "some-namespace-id", {
 					key: "my-key",
 					value: "my-value",
 				});
@@ -106,8 +109,10 @@ describe("kv", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should encode the key in the api request to put a value", async () => {
-				const requests = mockKeyPutRequest("DS9", {
+			it("should encode the key in the api request to put a value", async ({
+				expect,
+			}) => {
+				const requests = mockKeyPutRequest(expect, "DS9", {
 					key: "%2Fmy-key",
 					value: "my-value",
 				});
@@ -130,9 +135,11 @@ describe("kv", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should put a key in a given namespace specified by binding", async () => {
+			it("should put a key in a given namespace specified by binding", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
-				const requests = mockKeyPutRequest("bound-id", {
+				const requests = mockKeyPutRequest(expect, "bound-id", {
 					key: "my-key",
 					value: "my-value",
 				});
@@ -154,9 +161,11 @@ describe("kv", () => {
 				expect(requests.count).toEqual(1);
 			});
 
-			it("should put a key in a given preview namespace specified by binding", async () => {
+			it("should put a key in a given preview namespace specified by binding", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
-				const requests = mockKeyPutRequest("preview-bound-id", {
+				const requests = mockKeyPutRequest(expect, "preview-bound-id", {
 					key: "my-key",
 					value: "my-value",
 				});
@@ -179,8 +188,10 @@ describe("kv", () => {
 				expect(requests.count).toEqual(1);
 			});
 
-			it("should add expiration and ttl properties when putting a key", async () => {
-				const requests = mockKeyPutRequest("some-namespace-id", {
+			it("should add expiration and ttl properties when putting a key", async ({
+				expect,
+			}) => {
+				const requests = mockKeyPutRequest(expect, "some-namespace-id", {
 					key: "my-key",
 					value: "my-value",
 					expiration: 10,
@@ -203,9 +214,11 @@ describe("kv", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should put a key to the specified environment in a given namespace", async () => {
+			it("should put a key to the specified environment in a given namespace", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
-				const requests = mockKeyPutRequest("env-bound-id", {
+				const requests = mockKeyPutRequest(expect, "env-bound-id", {
 					key: "my-key",
 					value: "my-value",
 				});
@@ -226,10 +239,12 @@ describe("kv", () => {
 				expect(requests.count).toEqual(1);
 			});
 
-			it("should put a key with a value loaded from a given path", async () => {
+			it("should put a key with a value loaded from a given path", async ({
+				expect,
+			}) => {
 				const buf = Buffer.from("file-contents", "utf-8");
 				writeFileSync("foo.txt", buf);
-				const requests = mockKeyPutRequest("some-namespace-id", {
+				const requests = mockKeyPutRequest(expect, "some-namespace-id", {
 					key: "my-key",
 					value: buf,
 				});
@@ -250,13 +265,15 @@ describe("kv", () => {
 				expect(requests.count).toEqual(1);
 			});
 
-			it("should put a key with a binary value loaded from a given path", async () => {
+			it("should put a key with a binary value loaded from a given path", async ({
+				expect,
+			}) => {
 				const buf = Buffer.from(
 					"iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAiSURBVHgB7coxEQAACMPAgH/PgAM6dGwu49fA/deIBXrgAj2cAhIFT4QxAAAAAElFTkSuQmCC",
 					"base64"
 				);
 				writeFileSync("test.png", buf);
-				const requests = mockKeyPutRequest("another-namespace-id", {
+				const requests = mockKeyPutRequest(expect, "another-namespace-id", {
 					key: "my-key",
 					value: buf,
 				});
@@ -277,8 +294,8 @@ describe("kv", () => {
 				expect(requests.count).toEqual(1);
 			});
 
-			it("should put a key with metadata", async () => {
-				const requests = mockKeyPutRequest("some-namespace-id", {
+			it("should put a key with metadata", async ({ expect }) => {
+				const requests = mockKeyPutRequest(expect, "some-namespace-id", {
 					key: "dKey",
 					value: "dVal",
 					metadata: {
@@ -302,13 +319,15 @@ describe("kv", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should put a key with a binary value and metadata", async () => {
+			it("should put a key with a binary value and metadata", async ({
+				expect,
+			}) => {
 				const buf = Buffer.from(
 					"iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAiSURBVHgB7coxEQAACMPAgH/PgAM6dGwu49fA/deIBXrgAj2cAhIFT4QxAAAAAElFTkSuQmCC",
 					"base64"
 				);
 				writeFileSync("test.png", buf);
-				const requests = mockKeyPutRequest("some-namespace-id", {
+				const requests = mockKeyPutRequest(expect, "some-namespace-id", {
 					key: "another-my-key",
 					value: buf,
 					metadata: {
@@ -332,7 +351,7 @@ describe("kv", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should error if no key is provided", async () => {
+			it("should error if no key is provided", async ({ expect }) => {
 				await expect(
 					runWrangler("kv key put")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -376,7 +395,9 @@ describe("kv", () => {
 		        `);
 			});
 
-			it("should error if no binding nor namespace is provided", async () => {
+			it("should error if no binding nor namespace is provided", async ({
+				expect,
+			}) => {
 				await expect(
 					runWrangler("kv key put --remote foo bar")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -423,7 +444,9 @@ describe("kv", () => {
 		        `);
 			});
 
-			it("should error if both binding and namespace is provided", async () => {
+			it("should error if both binding and namespace is provided", async ({
+				expect,
+			}) => {
 				await expect(
 					runWrangler(
 						"kv key put --remote foo bar --binding x --namespace-id y"
@@ -472,7 +495,9 @@ describe("kv", () => {
 		        `);
 			});
 
-			it("should error if no value nor path is provided", async () => {
+			it("should error if no value nor path is provided", async ({
+				expect,
+			}) => {
 				await expect(
 					runWrangler("kv key put --remote key --namespace-id 12345")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -519,7 +544,9 @@ describe("kv", () => {
 		        `);
 			});
 
-			it("should error if both --local and --remote are provided", async () => {
+			it("should error if both --local and --remote are provided", async ({
+				expect,
+			}) => {
 				await expect(
 					runWrangler("kv key put --remote --local key value")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -563,7 +590,9 @@ describe("kv", () => {
 				`);
 			});
 
-			it("should error if both value and path is provided", async () => {
+			it("should error if both value and path is provided", async ({
+				expect,
+			}) => {
 				await expect(
 					runWrangler(
 						"kv key put --remote key value --path xyz --namespace-id 12345"
@@ -612,7 +641,9 @@ describe("kv", () => {
 		        `);
 			});
 
-			it("should error if a given binding name is not in the configured kv namespaces", async () => {
+			it("should error if a given binding name is not in the configured kv namespaces", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
 				await expect(
 					runWrangler("kv key put --remote key value --binding otherBinding")
@@ -635,9 +666,11 @@ describe("kv", () => {
 				`);
 			});
 
-			it("should error if a given binding has both preview and non-preview and --preview is not specified", async () => {
+			it("should error if a given binding has both preview and non-preview and --preview is not specified", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
-				const requests = mockKeyPutRequest("preview-bound-id", {
+				const requests = mockKeyPutRequest(expect, "preview-bound-id", {
 					key: "my-key",
 					value: "my-value",
 				});
@@ -666,13 +699,15 @@ describe("kv", () => {
 		});
 
 		describe("list", () => {
-			it("should list the keys of a namespace specified by namespace-id", async () => {
+			it("should list the keys of a namespace specified by namespace-id", async ({
+				expect,
+			}) => {
 				const keys = [
 					{ name: "key-1" },
 					{ name: "key-2", expiration: 123456789 },
 					{ name: "key-3", expiration_ttl: 666 },
 				];
-				mockKeyListRequest("some-namespace-id", keys);
+				mockKeyListRequest(expect, "some-namespace-id", keys);
 				await runWrangler(
 					"kv key list --remote --namespace-id some-namespace-id"
 				);
@@ -694,10 +729,12 @@ describe("kv", () => {
 				`);
 			});
 
-			it("should list the keys of a namespace specified by binding", async () => {
+			it("should list the keys of a namespace specified by binding", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
 				const keys = [{ name: "key-1" }, { name: "key-2" }, { name: "key-3" }];
-				mockKeyListRequest("bound-id", keys);
+				mockKeyListRequest(expect, "bound-id", keys);
 
 				await runWrangler("kv key list --remote --binding someBinding");
 				expect(std.err).toMatchInlineSnapshot(`""`);
@@ -716,10 +753,12 @@ describe("kv", () => {
 				`);
 			});
 
-			it("should list the keys of a preview namespace specified by binding", async () => {
+			it("should list the keys of a preview namespace specified by binding", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
 				const keys = [{ name: "key-1" }, { name: "key-2" }, { name: "key-3" }];
-				mockKeyListRequest("preview-bound-id", keys);
+				mockKeyListRequest(expect, "preview-bound-id", keys);
 				await runWrangler(
 					"kv key list --remote --binding someBinding --preview"
 				);
@@ -739,10 +778,12 @@ describe("kv", () => {
 				`);
 			});
 
-			it("should list the keys of a namespace specified by binding, in a given environment", async () => {
+			it("should list the keys of a namespace specified by binding, in a given environment", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
 				const keys = [{ name: "key-1" }, { name: "key-2" }, { name: "key-3" }];
-				mockKeyListRequest("env-bound-id", keys);
+				mockKeyListRequest(expect, "env-bound-id", keys);
 				await runWrangler(
 					"kv key list --remote --binding someBinding --env some-environment"
 				);
@@ -762,10 +803,12 @@ describe("kv", () => {
 				`);
 			});
 
-			it("should list the keys of a preview namespace specified by binding, in a given environment", async () => {
+			it("should list the keys of a preview namespace specified by binding, in a given environment", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
 				const keys = [{ name: "key-1" }, { name: "key-2" }, { name: "key-3" }];
-				mockKeyListRequest("preview-env-bound-id", keys);
+				mockKeyListRequest(expect, "preview-env-bound-id", keys);
 				await runWrangler(
 					"kv key list --remote --binding someBinding --preview --env some-environment"
 				);
@@ -794,7 +837,9 @@ describe("kv", () => {
 				"",
 			]) {
 				describe(`cursor - ${blankCursorValue}`, () => {
-					it("should make multiple requests for paginated results", async () => {
+					it("should make multiple requests for paginated results", async ({
+						expect,
+					}) => {
 						// Create a lot of mock keys, so that the fetch requests will be paginated
 						const keys: NamespaceKeyInfo[] = [];
 						for (let i = 0; i < 550; i++) {
@@ -802,6 +847,7 @@ describe("kv", () => {
 						}
 						// Ask for the keys in pages of size 100.
 						const requests = mockKeyListRequest(
+							expect,
 							"some-namespace-id",
 							keys,
 							100,
@@ -817,7 +863,9 @@ describe("kv", () => {
 				});
 			}
 
-			it("should error if a given binding name is not in the configured kv namespaces", async () => {
+			it("should error if a given binding name is not in the configured kv namespaces", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
 				await expect(
 					runWrangler("kv key list --remote --binding otherBinding")
@@ -834,8 +882,11 @@ describe("kv", () => {
 		});
 
 		describe("get", () => {
-			it("should get a key in a given namespace specified by namespace-id", async () => {
+			it("should get a key in a given namespace specified by namespace-id", async ({
+				expect,
+			}) => {
 				setMockFetchKVGetValue(
+					expect,
 					"some-account-id",
 					"some-namespace-id",
 					"my-key",
@@ -850,8 +901,11 @@ describe("kv", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should get a key and decode the value from the response as a utf8 string if the `--text` flag is passed", async () => {
+			it("should get a key and decode the value from the response as a utf8 string if the `--text` flag is passed", async ({
+				expect,
+			}) => {
 				setMockFetchKVGetValue(
+					expect,
 					"some-account-id",
 					"some-namespace-id",
 					"my-key",
@@ -872,12 +926,15 @@ describe("kv", () => {
 				`);
 			});
 
-			it("should get a binary and decode as utf8 text, resulting in improper decoding", async () => {
+			it("should get a binary and decode as utf8 text, resulting in improper decoding", async ({
+				expect,
+			}) => {
 				const buf = Buffer.from(
 					"iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAiSURBVHgB7coxEQAACMPAgH/PgAM6dGwu49fA/deIBXrgAj2cAhIFT4QxAAAAAElFTkSuQmCC",
 					"base64"
 				);
 				setMockFetchKVGetValue(
+					expect,
 					"some-account-id",
 					"some-namespace-id",
 					"my-key",
@@ -892,12 +949,15 @@ describe("kv", () => {
 				);
 			});
 
-			it("should get a binary file by key in a given namespace specified by namespace-id", async () => {
+			it("should get a binary file by key in a given namespace specified by namespace-id", async ({
+				expect,
+			}) => {
 				const buf = Buffer.from(
 					"iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAiSURBVHgB7coxEQAACMPAgH/PgAM6dGwu49fA/deIBXrgAj2cAhIFT4QxAAAAAElFTkSuQmCC",
 					"base64"
 				);
 				setMockFetchKVGetValue(
+					expect,
 					"some-account-id",
 					"some-namespace-id",
 					"my-key",
@@ -910,9 +970,12 @@ describe("kv", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should get a key in a given namespace specified by binding", async () => {
+			it("should get a key in a given namespace specified by binding", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
 				setMockFetchKVGetValue(
+					expect,
 					"some-account-id",
 					"bound-id",
 					"my-key",
@@ -925,9 +988,12 @@ describe("kv", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should get a key in a given preview namespace specified by binding", async () => {
+			it("should get a key in a given preview namespace specified by binding", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
 				setMockFetchKVGetValue(
+					expect,
 					"some-account-id",
 					"preview-bound-id",
 					"my-key",
@@ -940,9 +1006,12 @@ describe("kv", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should get a key for the specified environment in a given namespace", async () => {
+			it("should get a key for the specified environment in a given namespace", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
 				setMockFetchKVGetValue(
+					expect,
 					"some-account-id",
 					"env-bound-id",
 					"my-key",
@@ -955,8 +1024,11 @@ describe("kv", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should encode the key in the api request to get a value", async () => {
+			it("should encode the key in the api request to get a value", async ({
+				expect,
+			}) => {
 				setMockFetchKVGetValue(
+					expect,
 					"some-account-id",
 					"some-namespace-id",
 					"%2Fmy%2Ckey", // expect the key /my,key to be encoded
@@ -970,7 +1042,7 @@ describe("kv", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should error if no key is provided", async () => {
+			it("should error if no key is provided", async ({ expect }) => {
 				await expect(
 					runWrangler("kv key get")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -1009,7 +1081,9 @@ describe("kv", () => {
 		        `);
 			});
 
-			it("should error if no binding nor namespace is provided", async () => {
+			it("should error if no binding nor namespace is provided", async ({
+				expect,
+			}) => {
 				await expect(
 					runWrangler("kv key get --remote foo")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -1048,7 +1122,9 @@ describe("kv", () => {
 		        `);
 			});
 
-			it("should error if both binding and namespace is provided", async () => {
+			it("should error if both binding and namespace is provided", async ({
+				expect,
+			}) => {
 				await expect(
 					runWrangler("kv key get --remote foo --binding x --namespace-id y")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -1088,7 +1164,9 @@ describe("kv", () => {
 		        `);
 			});
 
-			it("should error if a given binding name is not in the configured kv namespaces", async () => {
+			it("should error if a given binding name is not in the configured kv namespaces", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
 				await expect(
 					runWrangler("kv key get --remote key --binding otherBinding")
@@ -1106,7 +1184,9 @@ describe("kv", () => {
 			describe("non-interactive", () => {
 				mockAccountId({ accountId: null });
 
-				it("should error if there are multiple accounts available but not interactive on stdin", async () => {
+				it("should error if there are multiple accounts available but not interactive on stdin", async ({
+					expect,
+				}) => {
 					mockGetMemberships([
 						{ id: "xxx", account: { id: "1", name: "one" } },
 						{ id: "yyy", account: { id: "2", name: "two" } },
@@ -1123,7 +1203,9 @@ describe("kv", () => {
 					`);
 				});
 
-				it("should error if there are multiple accounts available but not interactive on stdout", async () => {
+				it("should error if there are multiple accounts available but not interactive on stdout", async ({
+					expect,
+				}) => {
 					mockGetMemberships([
 						{ id: "xxx", account: { id: "1", name: "one" } },
 						{ id: "yyy", account: { id: "2", name: "two" } },
@@ -1140,7 +1222,9 @@ describe("kv", () => {
 					`);
 				});
 
-				it("should recommend using a configuration if unable to fetch memberships", async () => {
+				it("should recommend using a configuration if unable to fetch memberships", async ({
+					expect,
+				}) => {
 					msw.use(
 						http.get(
 							"*/memberships",
@@ -1166,7 +1250,9 @@ describe("kv", () => {
 					`);
 				});
 
-				it("should error if there are multiple accounts available but not interactive at all", async () => {
+				it("should error if there are multiple accounts available but not interactive at all", async ({
+					expect,
+				}) => {
 					mockGetMemberships([
 						{ id: "xxx", account: { id: "1", name: "one" } },
 						{ id: "yyy", account: { id: "2", name: "two" } },
@@ -1187,6 +1273,7 @@ describe("kv", () => {
 
 		describe("delete", () => {
 			function mockDeleteRequest(
+				expect: ExpectStatic,
 				expectedNamespaceId: string,
 				expectedKey: string
 			) {
@@ -1209,16 +1296,24 @@ describe("kv", () => {
 				return requests;
 			}
 
-			it("should delete a key in a namespace specified by id", async () => {
-				const requests = mockDeleteRequest("some-namespace-id", "someKey");
+			it("should delete a key in a namespace specified by id", async ({
+				expect,
+			}) => {
+				const requests = mockDeleteRequest(
+					expect,
+					"some-namespace-id",
+					"someKey"
+				);
 				await runWrangler(
 					`kv key delete --remote --namespace-id some-namespace-id someKey`
 				);
 				expect(requests.count).toEqual(1);
 			});
 
-			it("should encode the key in the api request to delete a value", async () => {
-				const requests = mockDeleteRequest("voyager", "/NCC-74656");
+			it("should encode the key in the api request to delete a value", async ({
+				expect,
+			}) => {
+				const requests = mockDeleteRequest(expect, "voyager", "/NCC-74656");
 				await runWrangler(
 					`kv key delete --remote --namespace-id voyager /NCC-74656`
 				);
@@ -1237,25 +1332,35 @@ describe("kv", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should delete a key in a namespace specified by binding name", async () => {
+			it("should delete a key in a namespace specified by binding name", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
-				const requests = mockDeleteRequest("bound-id", "someKey");
+				const requests = mockDeleteRequest(expect, "bound-id", "someKey");
 				await runWrangler(
 					`kv key delete --remote --binding someBinding --preview false someKey`
 				);
 				expect(requests.count).toEqual(1);
 			});
 
-			it("should delete a key in a preview namespace specified by binding name", async () => {
+			it("should delete a key in a preview namespace specified by binding name", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
-				const requests = mockDeleteRequest("preview-bound-id", "someKey");
+				const requests = mockDeleteRequest(
+					expect,
+					"preview-bound-id",
+					"someKey"
+				);
 				await runWrangler(
 					`kv key delete --remote --binding someBinding --preview someKey`
 				);
 				expect(requests.count).toEqual(1);
 			});
 
-			it("should error if a given binding name is not in the configured kv namespaces", async () => {
+			it("should error if a given binding name is not in the configured kv namespaces", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
 				await expect(
 					runWrangler(`kv key delete --remote --binding otherBinding someKey`)
@@ -1270,9 +1375,11 @@ describe("kv", () => {
 				`);
 			});
 
-			it("should delete a key in a namespace specified by binding name in a given environment", async () => {
+			it("should delete a key in a namespace specified by binding name in a given environment", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
-				const requests = mockDeleteRequest("env-bound-id", "someKey");
+				const requests = mockDeleteRequest(expect, "env-bound-id", "someKey");
 				await runWrangler(
 					`kv key delete --remote --binding someBinding --env some-environment --preview false someKey`
 				);
@@ -1290,9 +1397,15 @@ describe("kv", () => {
 				expect(requests.count).toEqual(1);
 			});
 
-			it("should delete a key in a preview namespace specified by binding name in a given environment", async () => {
+			it("should delete a key in a preview namespace specified by binding name in a given environment", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
-				const requests = mockDeleteRequest("preview-env-bound-id", "someKey");
+				const requests = mockDeleteRequest(
+					expect,
+					"preview-env-bound-id",
+					"someKey"
+				);
 				await runWrangler(
 					`kv key delete --remote --binding someBinding --env some-environment --preview someKey`
 				);
@@ -1317,6 +1430,7 @@ function mockGetMemberships(
 }
 
 function mockKeyListRequest(
+	expect: ExpectStatic,
 	expectedNamespaceId: string,
 	expectedKeys: NamespaceKeyInfo[],
 	keysPerRequest = 1000,
@@ -1361,6 +1475,7 @@ function mockKeyListRequest(
 }
 
 function setMockFetchKVGetValue(
+	expect: ExpectStatic,
 	accountId: string,
 	namespaceId: string,
 	key: string,

--- a/packages/wrangler/src/__tests__/kv/namespace.test.ts
+++ b/packages/wrangler/src/__tests__/kv/namespace.test.ts
@@ -1,8 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs, mockConfirm, mockPrompt } from "../helpers/mock-dialogs";
@@ -12,6 +11,7 @@ import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { wranglerKVConfig } from "./constant";
 import type { KVNamespaceInfo } from "../../kv/helpers";
+import type { ExpectStatic } from "vitest";
 
 describe("kv", () => {
 	mockAccountId();
@@ -30,7 +30,7 @@ describe("kv", () => {
 
 	describe("namespace", () => {
 		describe("create", () => {
-			function mockCreateRequest(expectedTitle: string) {
+			function mockCreateRequest(expect: ExpectStatic, expectedTitle: string) {
 				msw.use(
 					http.post(
 						"*/accounts/:accountId/storage/kv/namespaces",
@@ -49,7 +49,7 @@ describe("kv", () => {
 				);
 			}
 
-			it("should error if no namespace is given", async () => {
+			it("should error if no namespace is given", async ({ expect }) => {
 				await expect(
 					runWrangler("kv namespace create")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -85,7 +85,9 @@ describe("kv", () => {
 		        `);
 			});
 
-			it("should error if the namespace to create contains spaces", async () => {
+			it("should error if the namespace to create contains spaces", async ({
+				expect,
+			}) => {
 				await expect(
 					runWrangler("kv namespace create abc def ghi")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -121,7 +123,7 @@ describe("kv", () => {
 		        `);
 			});
 
-			it("should error if the namespace already exists", async () => {
+			it("should error if the namespace already exists", async ({ expect }) => {
 				msw.use(
 					http.post(
 						"*/accounts/:accountId/storage/kv/namespaces",
@@ -158,9 +160,9 @@ describe("kv", () => {
 			});
 
 			describe.each(["wrangler.json", "wrangler.toml"])("%s", (configPath) => {
-				it("should create a namespace", async () => {
+				it("should create a namespace", async ({ expect }) => {
 					writeWranglerConfig({ name: "worker" }, configPath);
-					mockCreateRequest("UnitTestNamespace");
+					mockCreateRequest(expect, "UnitTestNamespace");
 
 					await runWrangler(
 						"kv namespace create UnitTestNamespace --binding MY_NS"
@@ -169,9 +171,11 @@ describe("kv", () => {
 					expect(await readFile(configPath, "utf8")).toMatchSnapshot();
 				});
 
-				it("should create a namespace with custom binding name", async () => {
+				it("should create a namespace with custom binding name", async ({
+					expect,
+				}) => {
 					writeWranglerConfig({ name: "worker" }, configPath);
-					mockCreateRequest("UnitTestNamespace");
+					mockCreateRequest(expect, "UnitTestNamespace");
 					if (configPath === "wrangler.json") {
 						mockConfirm({
 							text: "Would you like Wrangler to add it on your behalf?",
@@ -191,18 +195,22 @@ describe("kv", () => {
 					expect(await readFile(configPath, "utf8")).toMatchSnapshot();
 				});
 
-				it("should create a preview namespace if configured to do so", async () => {
+				it("should create a preview namespace if configured to do so", async ({
+					expect,
+				}) => {
 					writeWranglerConfig({ name: "worker" }, configPath);
 
-					mockCreateRequest("UnitTestNamespace_preview");
+					mockCreateRequest(expect, "UnitTestNamespace_preview");
 					await runWrangler("kv namespace create UnitTestNamespace --preview");
 					expect(std.out).toMatchSnapshot();
 				});
 
-				it("should create a namespace using configured worker name", async () => {
+				it("should create a namespace using configured worker name", async ({
+					expect,
+				}) => {
 					writeWranglerConfig({ name: "other-worker" }, configPath);
 
-					mockCreateRequest("UnitTestNamespace");
+					mockCreateRequest(expect, "UnitTestNamespace");
 					if (configPath === "wrangler.json") {
 						mockConfirm({
 							text: "Would you like Wrangler to add it on your behalf?",
@@ -220,7 +228,9 @@ describe("kv", () => {
 					expect(await readFile(configPath, "utf8")).toMatchSnapshot();
 				});
 
-				it("should create a namespace in an environment if configured to do so", async () => {
+				it("should create a namespace in an environment if configured to do so", async ({
+					expect,
+				}) => {
 					writeWranglerConfig(
 						{
 							name: "worker",
@@ -233,7 +243,7 @@ describe("kv", () => {
 						configPath
 					);
 
-					mockCreateRequest("customEnv-UnitTestNamespace");
+					mockCreateRequest(expect, "customEnv-UnitTestNamespace");
 					if (configPath === "wrangler.json") {
 						mockConfirm({
 							text: "Would you like Wrangler to add it on your behalf?",
@@ -258,7 +268,10 @@ describe("kv", () => {
 		});
 
 		describe("list", () => {
-			function mockListRequest(namespaces: KVNamespaceInfo[]) {
+			function mockListRequest(
+				expect: ExpectStatic,
+				namespaces: KVNamespaceInfo[]
+			) {
 				const requests = { count: 0 };
 				msw.use(
 					http.get(
@@ -284,25 +297,27 @@ describe("kv", () => {
 				return requests;
 			}
 
-			it("should list namespaces", async () => {
+			it("should list namespaces", async ({ expect }) => {
 				const kvNamespaces: KVNamespaceInfo[] = [
 					{ title: "title-1", id: "id-1" },
 					{ title: "title-2", id: "id-2" },
 				];
-				mockListRequest(kvNamespaces);
+				mockListRequest(expect, kvNamespaces);
 				await runWrangler("kv namespace list");
 
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(JSON.parse(std.out)).toEqual(kvNamespaces);
 			});
 
-			it("should make multiple requests for paginated results", async () => {
+			it("should make multiple requests for paginated results", async ({
+				expect,
+			}) => {
 				// Create a lot of mock namespaces, so that the fetch requests will be paginated
 				const kvNamespaces: KVNamespaceInfo[] = [];
 				for (let i = 0; i < 550; i++) {
 					kvNamespaces.push({ title: "title-" + i, id: "id-" + i });
 				}
-				const requests = mockListRequest(kvNamespaces);
+				const requests = mockListRequest(expect, kvNamespaces);
 				await runWrangler("kv namespace list");
 
 				expect(JSON.parse(std.out)).toEqual(kvNamespaces);
@@ -311,7 +326,10 @@ describe("kv", () => {
 		});
 
 		describe("delete", () => {
-			function mockDeleteRequest(expectedNamespaceId: string) {
+			function mockDeleteRequest(
+				expect: ExpectStatic,
+				expectedNamespaceId: string
+			) {
 				const requests = { count: 0 };
 				msw.use(
 					http.delete(
@@ -329,8 +347,8 @@ describe("kv", () => {
 				return requests;
 			}
 
-			it("should delete a namespace specified by id", async () => {
-				const requests = mockDeleteRequest("some-namespace-id");
+			it("should delete a namespace specified by id", async ({ expect }) => {
+				const requests = mockDeleteRequest(expect, "some-namespace-id");
 
 				mockConfirm({
 					text: "Ok to proceed?",
@@ -342,8 +360,10 @@ describe("kv", () => {
 
 				expect(requests.count).toEqual(1);
 			});
-			it("should not ask for confirmation in non-interactive contexts", async () => {
-				const requests = mockDeleteRequest("some-namespace-id");
+			it("should not ask for confirmation in non-interactive contexts", async ({
+				expect,
+			}) => {
+				const requests = mockDeleteRequest(expect, "some-namespace-id");
 
 				setIsTTY(false);
 				await runWrangler(
@@ -353,33 +373,39 @@ describe("kv", () => {
 				expect(requests.count).toEqual(1);
 			});
 
-			it("should delete a namespace specified by binding name", async () => {
+			it("should delete a namespace specified by binding name", async ({
+				expect,
+			}) => {
 				mockConfirm({
 					text: "Ok to proceed?",
 					result: true,
 				});
 				writeWranglerConfig(wranglerKVConfig);
-				const requests = mockDeleteRequest("bound-id");
+				const requests = mockDeleteRequest(expect, "bound-id");
 				await runWrangler(
 					`kv namespace delete --binding someBinding --preview false`
 				);
 				expect(requests.count).toEqual(1);
 			});
 
-			it("should delete a preview namespace specified by binding name", async () => {
+			it("should delete a preview namespace specified by binding name", async ({
+				expect,
+			}) => {
 				mockConfirm({
 					text: "Ok to proceed?",
 					result: true,
 				});
 				writeWranglerConfig(wranglerKVConfig);
-				const requests = mockDeleteRequest("preview-bound-id");
+				const requests = mockDeleteRequest(expect, "preview-bound-id");
 				await runWrangler(
 					`kv namespace delete --binding someBinding --preview`
 				);
 				expect(requests.count).toEqual(1);
 			});
 
-			it("should error if a given binding name is not in the configured kv namespaces", async () => {
+			it("should error if a given binding name is not in the configured kv namespaces", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
 				await expect(runWrangler("kv namespace delete --binding otherBinding"))
 					.rejects.toThrowErrorMatchingInlineSnapshot(`
@@ -395,9 +421,11 @@ describe("kv", () => {
 				`);
 			});
 
-			it("should delete a namespace specified by binding name in a given environment", async () => {
+			it("should delete a namespace specified by binding name in a given environment", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
-				const requests = mockDeleteRequest("env-bound-id");
+				const requests = mockDeleteRequest(expect, "env-bound-id");
 				mockConfirm({
 					text: "Ok to proceed?",
 					result: true,
@@ -422,9 +450,11 @@ describe("kv", () => {
 				expect(requests.count).toEqual(1);
 			});
 
-			it("should delete a preview namespace specified by binding name in a given environment", async () => {
+			it("should delete a preview namespace specified by binding name in a given environment", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
-				const requests = mockDeleteRequest("preview-env-bound-id");
+				const requests = mockDeleteRequest(expect, "preview-env-bound-id");
 				mockConfirm({
 					text: "Ok to proceed?",
 					result: true,
@@ -435,7 +465,10 @@ describe("kv", () => {
 				expect(requests.count).toEqual(1);
 			});
 
-			function mockListRequestForDelete(namespaces: KVNamespaceInfo[]) {
+			function mockListRequestForDelete(
+				expect: ExpectStatic,
+				namespaces: KVNamespaceInfo[]
+			) {
 				const requests = { count: 0 };
 				msw.use(
 					http.get(
@@ -458,12 +491,12 @@ describe("kv", () => {
 				return requests;
 			}
 
-			it("should delete a namespace specified by name", async () => {
-				const listRequests = mockListRequestForDelete([
+			it("should delete a namespace specified by name", async ({ expect }) => {
+				const listRequests = mockListRequestForDelete(expect, [
 					{ id: "some-namespace-id", title: "my-namespace" },
 					{ id: "other-namespace-id", title: "other-namespace" },
 				]);
-				const deleteRequests = mockDeleteRequest("some-namespace-id");
+				const deleteRequests = mockDeleteRequest(expect, "some-namespace-id");
 
 				mockConfirm({
 					text: "Ok to proceed?",
@@ -479,8 +512,8 @@ describe("kv", () => {
 				);
 			});
 
-			it("should error if namespace name is not found", async () => {
-				mockListRequestForDelete([
+			it("should error if namespace name is not found", async ({ expect }) => {
+				mockListRequestForDelete(expect, [
 					{ id: "other-namespace-id", title: "other-namespace" },
 				]);
 
@@ -494,7 +527,9 @@ describe("kv", () => {
 				);
 			});
 
-			it("should error if both namespace name and --namespace-id are provided", async () => {
+			it("should error if both namespace name and --namespace-id are provided", async ({
+				expect,
+			}) => {
 				await expect(
 					runWrangler("kv namespace delete my-namespace --namespace-id some-id")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -502,7 +537,9 @@ describe("kv", () => {
 				);
 			});
 
-			it("should error if both namespace name and --binding are provided", async () => {
+			it("should error if both namespace name and --binding are provided", async ({
+				expect,
+			}) => {
 				writeWranglerConfig(wranglerKVConfig);
 				await expect(
 					runWrangler("kv namespace delete my-namespace --binding someBinding")
@@ -511,11 +548,13 @@ describe("kv", () => {
 				);
 			});
 
-			it("should delete namespace by name with --skip-confirmation flag", async () => {
-				const listRequests = mockListRequestForDelete([
+			it("should delete namespace by name with --skip-confirmation flag", async ({
+				expect,
+			}) => {
+				const listRequests = mockListRequestForDelete(expect, [
 					{ id: "some-namespace-id", title: "my-namespace" },
 				]);
-				const deleteRequests = mockDeleteRequest("some-namespace-id");
+				const deleteRequests = mockDeleteRequest(expect, "some-namespace-id");
 
 				await runWrangler("kv namespace delete my-namespace -y");
 
@@ -523,7 +562,9 @@ describe("kv", () => {
 				expect(deleteRequests.count).toEqual(1);
 			});
 
-			it("should error if no namespace identifier is provided", async () => {
+			it("should error if no namespace identifier is provided", async ({
+				expect,
+			}) => {
 				await expect(
 					runWrangler("kv namespace delete")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -534,6 +575,7 @@ describe("kv", () => {
 
 		describe("rename", () => {
 			function mockUpdateRequest(
+				expect: ExpectStatic,
 				expectedNamespaceId: string,
 				expectedTitle: string
 			) {
@@ -561,7 +603,10 @@ describe("kv", () => {
 				return requests;
 			}
 
-			function mockListRequestForRename(namespaces: KVNamespaceInfo[]) {
+			function mockListRequestForRename(
+				expect: ExpectStatic,
+				namespaces: KVNamespaceInfo[]
+			) {
 				const requests = { count: 0 };
 				msw.use(
 					http.get(
@@ -588,7 +633,7 @@ describe("kv", () => {
 				return requests;
 			}
 
-			it("should display help for rename command", async () => {
+			it("should display help for rename command", async ({ expect }) => {
 				await expect(
 					runWrangler("kv namespace rename --help")
 				).resolves.toBeUndefined();
@@ -615,7 +660,9 @@ describe("kv", () => {
 				`);
 			});
 
-			it("should error if neither name nor namespace-id is provided", async () => {
+			it("should error if neither name nor namespace-id is provided", async ({
+				expect,
+			}) => {
 				await expect(
 					runWrangler("kv namespace rename --new-name new-name")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -623,7 +670,7 @@ describe("kv", () => {
 				);
 			});
 
-			it("should error if new-name is not provided", async () => {
+			it("should error if new-name is not provided", async ({ expect }) => {
 				await expect(
 					runWrangler("kv namespace rename")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -631,8 +678,9 @@ describe("kv", () => {
 				);
 			});
 
-			it("should rename namespace by ID", async () => {
+			it("should rename namespace by ID", async ({ expect }) => {
 				const requests = mockUpdateRequest(
+					expect,
 					"some-namespace-id",
 					"new-namespace-name"
 				);
@@ -651,12 +699,13 @@ describe("kv", () => {
 				`);
 			});
 
-			it("should rename namespace by old name", async () => {
-				const listRequests = mockListRequestForRename([
+			it("should rename namespace by old name", async ({ expect }) => {
+				const listRequests = mockListRequestForRename(expect, [
 					{ id: "some-namespace-id", title: "old-namespace-name" },
 					{ id: "other-namespace-id", title: "other-namespace" },
 				]);
 				const updateRequests = mockUpdateRequest(
+					expect,
 					"some-namespace-id",
 					"new-namespace-name"
 				);
@@ -678,8 +727,10 @@ describe("kv", () => {
 				`);
 			});
 
-			it("should error if namespace with old name is not found", async () => {
-				mockListRequestForRename([
+			it("should error if namespace with old name is not found", async ({
+				expect,
+			}) => {
+				mockListRequestForRename(expect, [
 					{ id: "other-namespace-id", title: "other-namespace" },
 				]);
 
@@ -692,7 +743,7 @@ describe("kv", () => {
 				);
 			});
 
-			it("should error if namespace ID does not exist", async () => {
+			it("should error if namespace ID does not exist", async ({ expect }) => {
 				// Mock a 404 response for the namespace ID
 				msw.use(
 					http.put(

--- a/packages/wrangler/src/__tests__/metrics.test.ts
+++ b/packages/wrangler/src/__tests__/metrics.test.ts
@@ -3,8 +3,7 @@ import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { detectAgenticEnvironment } from "am-i-vibing";
 import ci from "ci-info";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { logger } from "../logger";
 import { sendMetricsEvent } from "../metrics";
 import {
@@ -29,6 +28,7 @@ import { useMockIsTTY } from "./helpers/mock-istty";
 import { msw } from "./helpers/msw";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
+import type { ExpectStatic } from "vitest";
 
 vi.mock("am-i-vibing");
 vi.mock("../metrics/helpers");
@@ -96,7 +96,7 @@ describe("metrics", () => {
 				});
 			});
 
-			it("should send a request to the default URL", async () => {
+			it("should send a request to the default URL", async ({ expect }) => {
 				const requests = mockMetricRequest();
 
 				const dispatcher = getMetricsDispatcher({
@@ -113,7 +113,9 @@ describe("metrics", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should include parsed wrangler version components in events", async () => {
+			it("should include parsed wrangler version components in events", async ({
+				expect,
+			}) => {
 				const requests = mockMetricRequest();
 
 				const dispatcher = getMetricsDispatcher({
@@ -128,7 +130,9 @@ describe("metrics", () => {
 				expect(std.debug).toContain('"wranglerPatchVersion":3');
 			});
 
-			it("should write a debug log if the dispatcher is disabled", async () => {
+			it("should write a debug log if the dispatcher is disabled", async ({
+				expect,
+			}) => {
 				const requests = mockMetricRequest();
 				const dispatcher = getMetricsDispatcher({
 					sendMetrics: false,
@@ -144,7 +148,9 @@ describe("metrics", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should write a debug log if the request fails", async () => {
+			it("should write a debug log if the request fails", async ({
+				expect,
+			}) => {
 				msw.use(
 					http.post("*/event", async () => {
 						return HttpResponse.error();
@@ -165,7 +171,9 @@ describe("metrics", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should write a warning log if no source key has been provided", async () => {
+			it("should write a warning log if no source key has been provided", async ({
+				expect,
+			}) => {
 				vi.stubEnv("SPARROW_SOURCE_KEY", undefined);
 
 				const requests = mockMetricRequest();
@@ -183,7 +191,7 @@ describe("metrics", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should include agent ID when detected", async () => {
+			it("should include agent ID when detected", async ({ expect }) => {
 				vi.mocked(detectAgenticEnvironment).mockReturnValue({
 					isAgentic: true,
 					id: "claude-code",
@@ -202,7 +210,7 @@ describe("metrics", () => {
 				expect(std.debug).toContain('"agent":"claude-code"');
 			});
 
-			it("should set agent to null if detection throws", async () => {
+			it("should set agent to null if detection throws", async ({ expect }) => {
 				vi.mocked(detectAgenticEnvironment).mockImplementation(() => {
 					throw new Error("Detection failed");
 				});
@@ -277,7 +285,7 @@ describe("metrics", () => {
 				delete globalThis.ALGOLIA_PUBLIC_KEY;
 			});
 
-			it("should send a started and completed event", async () => {
+			it("should send a started and completed event", async ({ expect }) => {
 				writeWranglerConfig();
 				const requests = mockMetricRequest();
 
@@ -285,7 +293,7 @@ describe("metrics", () => {
 
 				expect(requests.count).toBe(2);
 
-				expectLogToContainPostedData(std.debug, {
+				expectLogToContainPostedData(expect, std.debug, {
 					deviceId: "f82b1f46-eb7b-4154-aa9f-ce95f23b2288",
 					event: "wrangler command started",
 					timestamp: 1733961600000,
@@ -296,7 +304,7 @@ describe("metrics", () => {
 					},
 				});
 
-				expectLogToContainPostedData(std.debug, {
+				expectLogToContainPostedData(expect, std.debug, {
 					deviceId: "f82b1f46-eb7b-4154-aa9f-ce95f23b2288",
 					event: "wrangler command completed",
 					timestamp: 1733961606000,
@@ -320,7 +328,7 @@ describe("metrics", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should send a started and errored event", async () => {
+			it("should send a started and errored event", async ({ expect }) => {
 				writeWranglerConfig();
 				const requests = mockMetricRequest();
 				msw.use(
@@ -340,7 +348,7 @@ describe("metrics", () => {
 				);
 				expect(requests.count).toBe(2);
 
-				expectLogToContainPostedData(std.debug, {
+				expectLogToContainPostedData(expect, std.debug, {
 					deviceId: "f82b1f46-eb7b-4154-aa9f-ce95f23b2288",
 					event: "wrangler command started",
 					timestamp: 1733961600000,
@@ -351,7 +359,7 @@ describe("metrics", () => {
 					},
 				});
 
-				expectLogToContainPostedData(std.debug, {
+				expectLogToContainPostedData(expect, std.debug, {
 					deviceId: "f82b1f46-eb7b-4154-aa9f-ce95f23b2288",
 					event: "wrangler command errored",
 					timestamp: 1733961606000,
@@ -366,7 +374,7 @@ describe("metrics", () => {
 				});
 			});
 
-			it("should mark isCI as true if running in CI", async () => {
+			it("should mark isCI as true if running in CI", async ({ expect }) => {
 				vi.mocked(ci).isCI = true;
 				const requests = mockMetricRequest();
 
@@ -376,7 +384,9 @@ describe("metrics", () => {
 				expect(std.debug).toContain('isCI":true');
 			});
 
-			it("should mark isPagesCI as true if running in Pages CI", async () => {
+			it("should mark isPagesCI as true if running in Pages CI", async ({
+				expect,
+			}) => {
 				vi.mocked(ci).CLOUDFLARE_PAGES = true;
 				const requests = mockMetricRequest();
 
@@ -386,7 +396,9 @@ describe("metrics", () => {
 				expect(std.debug).toContain('isPagesCI":true');
 			});
 
-			it("should mark isWorkersCI as true if running in Workers CI", async () => {
+			it("should mark isWorkersCI as true if running in Workers CI", async ({
+				expect,
+			}) => {
 				vi.mocked(ci).CLOUDFLARE_WORKERS = true;
 				const requests = mockMetricRequest();
 
@@ -396,7 +408,7 @@ describe("metrics", () => {
 				expect(std.debug).toContain('isWorkersCI":true');
 			});
 
-			it("should capture Workers + Assets projects", async () => {
+			it("should capture Workers + Assets projects", async ({ expect }) => {
 				writeWranglerConfig({ assets: { directory: "./public" } });
 
 				// set up empty static assets directory
@@ -407,7 +419,7 @@ describe("metrics", () => {
 				await runWrangler("docs arg");
 				expect(requests.count).toBe(2);
 
-				expectLogToContainPostedData(std.debug, {
+				expectLogToContainPostedData(expect, std.debug, {
 					deviceId: "f82b1f46-eb7b-4154-aa9f-ce95f23b2288",
 					event: "wrangler command started",
 					timestamp: 1733961600000,
@@ -418,7 +430,7 @@ describe("metrics", () => {
 					},
 				});
 
-				expectLogToContainPostedData(std.debug, {
+				expectLogToContainPostedData(expect, std.debug, {
 					deviceId: "f82b1f46-eb7b-4154-aa9f-ce95f23b2288",
 					event: "wrangler command completed",
 					timestamp: 1733961606000,
@@ -442,7 +454,9 @@ describe("metrics", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should not send arguments with wrangler login", async () => {
+			it("should not send arguments with wrangler login", async ({
+				expect,
+			}) => {
 				const requests = mockMetricRequest();
 
 				await expect(
@@ -456,7 +470,7 @@ describe("metrics", () => {
 				expect(std.debug).toContain('"sanitizedCommand":""');
 			});
 
-			it("should include args provided by the user", async () => {
+			it("should include args provided by the user", async ({ expect }) => {
 				const requests = mockMetricRequest();
 
 				await runWrangler("docs arg --search 'some search term'");
@@ -466,7 +480,9 @@ describe("metrics", () => {
 				expect(std.debug).toContain('argsCombination":"search"');
 			});
 
-			it("should mark as non-interactive if running in non-interactive environment", async () => {
+			it("should mark as non-interactive if running in non-interactive environment", async ({
+				expect,
+			}) => {
 				setIsTTY(false);
 				const requests = mockMetricRequest();
 
@@ -476,7 +492,9 @@ describe("metrics", () => {
 				expect(std.debug).toContain('"isInteractive":false,');
 			});
 
-			it("should include an error message if the specific error has been allow-listed with {telemetryMessage:true}", async () => {
+			it("should include an error message if the specific error has been allow-listed with {telemetryMessage:true}", async ({
+				expect,
+			}) => {
 				setIsTTY(false);
 				const requests = mockMetricRequest();
 
@@ -489,7 +507,9 @@ describe("metrics", () => {
 				expect(std.debug).toContain('"errorMessage":"yargs validation error"');
 			});
 
-			it("should include an error message if the specific error has been allow-listed with a custom telemetry message", async () => {
+			it("should include an error message if the specific error has been allow-listed with a custom telemetry message", async ({
+				expect,
+			}) => {
 				setIsTTY(false);
 				const requests = mockMetricRequest();
 
@@ -502,7 +522,9 @@ describe("metrics", () => {
 				expect(std.debug).toContain('"errorMessage":"yargs validation error"');
 			});
 
-			it("should include agent ID in command events when detected", async () => {
+			it("should include agent ID in command events when detected", async ({
+				expect,
+			}) => {
 				vi.mocked(detectAgenticEnvironment).mockReturnValue({
 					isAgentic: true,
 					id: "cursor-agent",
@@ -523,7 +545,9 @@ describe("metrics", () => {
 				beforeEach(() => {
 					vi.mocked(getWranglerVersion).mockReturnValue("1.2.3");
 				});
-				it("should print the banner if current version is different to the stored version", async () => {
+				it("should print the banner if current version is different to the stored version", async ({
+					expect,
+				}) => {
 					writeMetricsConfig({
 						permission: {
 							enabled: true,
@@ -546,7 +570,9 @@ describe("metrics", () => {
 
 					expect(requests.count).toBe(2);
 				});
-				it("should not print the banner if current version is the same as the stored version", async () => {
+				it("should not print the banner if current version is the same as the stored version", async ({
+					expect,
+				}) => {
 					writeMetricsConfig({
 						permission: {
 							enabled: true,
@@ -561,7 +587,9 @@ describe("metrics", () => {
 					);
 					expect(requests.count).toBe(2);
 				});
-				it("should print the banner if nothing is stored under bannerLastShown and then store the current version", async () => {
+				it("should print the banner if nothing is stored under bannerLastShown and then store the current version", async ({
+					expect,
+				}) => {
 					writeMetricsConfig({
 						permission: {
 							enabled: true,
@@ -582,7 +610,9 @@ describe("metrics", () => {
 					const { permission } = readMetricsConfig();
 					expect(permission?.bannerLastShown).toEqual("1.2.3");
 				});
-				it("should not print the banner if telemetry permission is disabled", async () => {
+				it("should not print the banner if telemetry permission is disabled", async ({
+					expect,
+				}) => {
 					writeMetricsConfig({
 						permission: {
 							enabled: false,
@@ -599,7 +629,9 @@ describe("metrics", () => {
 					expect(permission?.bannerLastShown).toBeUndefined();
 				});
 
-				it("should *not* print the banner if command is not dev/deploy/docs", async () => {
+				it("should *not* print the banner if command is not dev/deploy/docs", async ({
+					expect,
+				}) => {
 					writeMetricsConfig({
 						permission: {
 							enabled: true,
@@ -633,7 +665,9 @@ describe("metrics", () => {
 
 	describe("getMetricsConfig()", () => {
 		describe("enabled", () => {
-			it("should return the WRANGLER_SEND_METRICS environment variable for enabled if it is defined", async () => {
+			it("should return the WRANGLER_SEND_METRICS environment variable for enabled if it is defined", async ({
+				expect,
+			}) => {
 				vi.stubEnv("WRANGLER_SEND_METRICS", "false");
 				expect(await getMetricsConfig({})).toMatchObject({
 					enabled: false,
@@ -644,7 +678,9 @@ describe("metrics", () => {
 				});
 			});
 
-			it("should return the sendMetrics argument for enabled if it is defined", async () => {
+			it("should return the sendMetrics argument for enabled if it is defined", async ({
+				expect,
+			}) => {
 				expect(await getMetricsConfig({ sendMetrics: false })).toMatchObject({
 					enabled: false,
 				});
@@ -653,7 +689,9 @@ describe("metrics", () => {
 				});
 			});
 
-			it("should return enabled true if the user on this device previously agreed to send metrics", async () => {
+			it("should return enabled true if the user on this device previously agreed to send metrics", async ({
+				expect,
+			}) => {
 				writeMetricsConfig({
 					permission: {
 						enabled: true,
@@ -669,7 +707,9 @@ describe("metrics", () => {
 				});
 			});
 
-			it("should return enabled false if the user on this device previously refused to send metrics", async () => {
+			it("should return enabled false if the user on this device previously refused to send metrics", async ({
+				expect,
+			}) => {
 				writeMetricsConfig({
 					permission: {
 						enabled: false,
@@ -685,7 +725,9 @@ describe("metrics", () => {
 				});
 			});
 
-			it("should print a message if the permission date is older than the current metrics date", async () => {
+			it("should print a message if the permission date is older than the current metrics date", async ({
+				expect,
+			}) => {
 				vi.useFakeTimers({
 					toFake: ["setTimeout", "clearTimeout", "Date"],
 				});
@@ -714,7 +756,9 @@ describe("metrics", () => {
 		});
 
 		describe("deviceId", () => {
-			it("should return a deviceId found in the config file", async () => {
+			it("should return a deviceId found in the config file", async ({
+				expect,
+			}) => {
 				writeMetricsConfig({ deviceId: "XXXX-YYYY-ZZZZ" });
 				const { deviceId } = await getMetricsConfig({
 					sendMetrics: true,
@@ -723,7 +767,9 @@ describe("metrics", () => {
 				expect(readMetricsConfig().deviceId).toEqual(deviceId);
 			});
 
-			it("should create and store a new deviceId if none is found in the config file", async () => {
+			it("should create and store a new deviceId if none is found in the config file", async ({
+				expect,
+			}) => {
 				writeMetricsConfig({});
 				const { deviceId } = await getMetricsConfig({
 					sendMetrics: true,
@@ -747,7 +793,9 @@ describe("metrics", () => {
 			vi.useRealTimers();
 		});
 		describe(`${cmd} status`, () => {
-			it("prints the current telemetry status based on the cached metrics config", async () => {
+			it("prints the current telemetry status based on the cached metrics config", async ({
+				expect,
+			}) => {
 				writeMetricsConfig({
 					permission: {
 						enabled: true,
@@ -768,7 +816,9 @@ describe("metrics", () => {
 				expect(std.out).toContain("Status: Disabled");
 			});
 
-			it("shows wrangler.toml as the source with send_metrics is present", async () => {
+			it("shows wrangler.toml as the source with send_metrics is present", async ({
+				expect,
+			}) => {
 				writeMetricsConfig({
 					permission: {
 						enabled: true,
@@ -780,7 +830,9 @@ describe("metrics", () => {
 				expect(std.out).toContain("Status: Disabled (set by wrangler.toml)");
 			});
 
-			it("shows environment variable as the source if used", async () => {
+			it("shows environment variable as the source if used", async ({
+				expect,
+			}) => {
 				writeMetricsConfig({
 					permission: {
 						enabled: true,
@@ -794,13 +846,17 @@ describe("metrics", () => {
 				);
 			});
 
-			it("defaults to enabled if metrics config is not set", async () => {
+			it("defaults to enabled if metrics config is not set", async ({
+				expect,
+			}) => {
 				writeMetricsConfig({});
 				await runWrangler(`${cmd} status`);
 				expect(std.out).toContain("Status: Enabled");
 			});
 
-			it("prioritises environment variable over send_metrics", async () => {
+			it("prioritises environment variable over send_metrics", async ({
+				expect,
+			}) => {
 				writeMetricsConfig({
 					permission: {
 						enabled: true,
@@ -816,7 +872,9 @@ describe("metrics", () => {
 			});
 		});
 
-		it(`disables telemetry when "wrangler ${cmd} disable" is run`, async () => {
+		it(`disables telemetry when "wrangler ${cmd} disable" is run`, async ({
+			expect,
+		}) => {
 			writeMetricsConfig({
 				permission: {
 					enabled: true,
@@ -835,7 +893,9 @@ Wrangler is no longer collecting telemetry about your usage.`);
 			});
 		});
 
-		it(`doesn't send telemetry when running "wrangler ${cmd} disable"`, async () => {
+		it(`doesn't send telemetry when running "wrangler ${cmd} disable"`, async ({
+			expect,
+		}) => {
 			const requests = mockMetricRequest();
 			writeMetricsConfig({
 				permission: {
@@ -848,7 +908,9 @@ Wrangler is no longer collecting telemetry about your usage.`);
 			expect(std.debug).not.toContain("Metrics dispatcher: Posting data");
 		});
 
-		it(`does send telemetry when running "wrangler ${cmd} enable"`, async () => {
+		it(`does send telemetry when running "wrangler ${cmd} enable"`, async ({
+			expect,
+		}) => {
 			const requests = mockMetricRequest();
 			writeMetricsConfig({
 				permission: {
@@ -861,7 +923,9 @@ Wrangler is no longer collecting telemetry about your usage.`);
 			expect(std.debug).toContain("Metrics dispatcher: Posting data");
 		});
 
-		it(`enables telemetry when "wrangler ${cmd} enable" is run`, async () => {
+		it(`enables telemetry when "wrangler ${cmd} enable" is run`, async ({
+			expect,
+		}) => {
 			writeMetricsConfig({
 				permission: {
 					enabled: false,
@@ -880,7 +944,7 @@ Wrangler is now collecting telemetry about your usage. Thank you for helping mak
 			});
 		});
 
-		it("doesn't overwrite c3 telemetry config", async () => {
+		it("doesn't overwrite c3 telemetry config", async ({ expect }) => {
 			writeMetricsConfig({
 				c3permission: {
 					enabled: false,
@@ -925,6 +989,7 @@ function mockMetricRequest() {
  * @param expectedProperties The expected properties
  */
 function expectLogToContainPostedData(
+	expect: ExpectStatic,
 	output: string,
 	expectedProperties: Record<string, unknown>
 ) {

--- a/packages/wrangler/src/__tests__/pages/deployment-list.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deployment-list.test.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, it } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { mockAccountId, mockApiToken } from "./../helpers/mock-account-id";
@@ -8,6 +7,7 @@ import { msw } from "./../helpers/msw";
 import { runInTempDir } from "./../helpers/run-in-tmp";
 import { runWrangler } from "./../helpers/run-wrangler";
 import type { Deployment } from "./../../pages/types";
+import type { ExpectStatic } from "vitest";
 
 describe("pages deployment list", () => {
 	runInTempDir();
@@ -44,7 +44,7 @@ describe("pages deployment list", () => {
 			},
 		];
 
-		const requests = mockDeploymentListRequest(deployments);
+		const requests = mockDeploymentListRequest(expect, deployments);
 		await runWrangler("pages deployment list --project-name=images");
 
 		expect(requests.count).toBe(1);
@@ -83,7 +83,7 @@ describe("pages deployment list", () => {
 			},
 		];
 
-		const requests = mockDeploymentListRequest(deployments);
+		const requests = mockDeploymentListRequest(expect, deployments);
 		await runWrangler("pages deployment list --project-name=images --json");
 
 		expect(requests.count).toBe(1);
@@ -128,7 +128,7 @@ describe("pages deployment list", () => {
 			},
 		];
 
-		const requests = mockDeploymentListRequest(deployments);
+		const requests = mockDeploymentListRequest(expect, deployments);
 		await runWrangler("pages deployment list --project-name=images");
 		expect(requests.count).toBe(1);
 		expect(
@@ -159,7 +159,7 @@ describe("pages deployment list", () => {
 			},
 		];
 
-		const requests = mockDeploymentListRequest(deployments);
+		const requests = mockDeploymentListRequest(expect, deployments);
 		await runWrangler(
 			"pages deployment list --project-name=images --environment=production"
 		);
@@ -192,7 +192,7 @@ describe("pages deployment list", () => {
 			},
 		];
 
-		const requests = mockDeploymentListRequest(deployments);
+		const requests = mockDeploymentListRequest(expect, deployments);
 		await runWrangler(
 			"pages deployment list --project-name=images --environment=preview"
 		);
@@ -219,7 +219,10 @@ type RequestLogger = {
 	queryParams: [string, string][][];
 };
 
-function mockDeploymentListRequest(deployments: unknown[]): RequestLogger {
+function mockDeploymentListRequest(
+	expect: ExpectStatic,
+	deployments: unknown[]
+): RequestLogger {
 	const requests: RequestLogger = { count: 0, queryParams: [] };
 	msw.use(
 		http.get(

--- a/packages/wrangler/src/__tests__/pages/pages-download-config.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-download-config.test.ts
@@ -3,8 +3,7 @@ import { readFile } from "node:fs/promises";
 import { getTodaysCompatDate } from "@cloudflare/workers-utils";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs, mockConfirm } from "../helpers/mock-dialogs";
@@ -12,6 +11,7 @@ import { useMockIsTTY } from "../helpers/mock-istty";
 import { msw } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
+import type { ExpectStatic } from "vitest";
 
 async function readNormalizedWranglerToml() {
 	return (await readFile("wrangler.toml", "utf8"))
@@ -225,7 +225,10 @@ function makePagesProject(
 	};
 }
 
-function mockSupportingDashRequests(expectedAccountId: string) {
+function mockSupportingDashRequests(
+	expect: ExpectStatic,
+	expectedAccountId: string
+) {
 	msw.use(
 		http.get(
 			`*/accounts/:accountId/pages/projects/NOT_REAL`,
@@ -333,8 +336,8 @@ describe("pages download config", () => {
 	const MOCK_PROJECT_NAME = "MOCK_PROJECT_NAME";
 	mockAccountId({ accountId: MOCK_ACCOUNT_ID });
 
-	beforeEach(() => {
-		mockSupportingDashRequests(MOCK_ACCOUNT_ID);
+	beforeEach(({ expect }) => {
+		mockSupportingDashRequests(expect, MOCK_ACCOUNT_ID);
 		setIsTTY(true);
 	});
 	afterAll(() => {

--- a/packages/wrangler/src/__tests__/pages/project-list.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-list.test.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, it, vi } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { mockAccountId, mockApiToken } from "./../helpers/mock-account-id";
@@ -8,6 +7,7 @@ import { msw } from "./../helpers/msw";
 import { runInTempDir } from "./../helpers/run-in-tmp";
 import { runWrangler } from "./../helpers/run-wrangler";
 import type { Project } from "./../../pages/types";
+import type { ExpectStatic } from "vitest";
 
 describe("pages project list", () => {
 	runInTempDir();
@@ -50,7 +50,7 @@ describe("pages project list", () => {
 			},
 		];
 
-		const requests = mockProjectListRequest(projects);
+		const requests = mockProjectListRequest(expect, projects);
 		await runWrangler("pages project list");
 
 		expect(requests.count).toBe(1);
@@ -75,7 +75,7 @@ describe("pages project list", () => {
 				production_branch: "main",
 			});
 		}
-		const requests = mockProjectListRequest(projects);
+		const requests = mockProjectListRequest(expect, projects);
 		await runWrangler("pages project list");
 		expect(requests.count).toEqual(2);
 	});
@@ -90,7 +90,7 @@ describe("pages project list", () => {
 			};
 		});
 		vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "new-account-id");
-		const requests = mockProjectListRequest([], "new-account-id");
+		const requests = mockProjectListRequest(expect, [], "new-account-id");
 		await runWrangler("pages project list");
 		expect(requests.count).toBe(1);
 	});
@@ -124,7 +124,7 @@ describe("pages project list", () => {
 			},
 		];
 
-		const requests = mockProjectListRequest(projects);
+		const requests = mockProjectListRequest(expect, projects);
 		await runWrangler("pages project list --json");
 
 		expect(requests.count).toBe(1);
@@ -155,6 +155,7 @@ describe("pages project list", () => {
 /* -------------------------------------------------- */
 
 function mockProjectListRequest(
+	expect: ExpectStatic,
 	projects: unknown[],
 	accountId = "some-account-id"
 ) {

--- a/packages/wrangler/src/__tests__/pages/secret.test.ts
+++ b/packages/wrangler/src/__tests__/pages/secret.test.ts
@@ -1,8 +1,7 @@
 import { writeFileSync } from "node:fs";
 import readline from "node:readline";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs, mockConfirm, mockPrompt } from "../helpers/mock-dialogs";
@@ -14,6 +13,7 @@ import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import type { PagesProject } from "../../pages/download-config";
 import type { Interface } from "node:readline";
+import type { ExpectStatic } from "vitest";
 
 export function mockGetMemberships(
 	accounts: { id: string; account: { id: string; name: string } }[]
@@ -41,6 +41,7 @@ describe("wrangler pages secret", () => {
 
 	describe("put", () => {
 		function mockProjectRequests(
+			expect: ExpectStatic,
 			input: { name: string; text: string },
 			env: "production" | "preview" = "production"
 		) {
@@ -93,7 +94,7 @@ describe("wrangler pages secret", () => {
 				  `,
 				});
 
-				mockProjectRequests({ name: `secret-name`, text: `hunter2` });
+				mockProjectRequests(expect, { name: `secret-name`, text: `hunter2` });
 				await runWrangler(
 					"pages secret put secret-name --project some-project-name"
 				);
@@ -113,7 +114,7 @@ describe("wrangler pages secret", () => {
 					result: "the-secret",
 				});
 
-				mockProjectRequests({ name: "the-key", text: "the-secret" });
+				mockProjectRequests(expect, { name: "the-key", text: "the-secret" });
 				await runWrangler(
 					"pages secret put the-key --project some-project-name"
 				);
@@ -135,7 +136,11 @@ describe("wrangler pages secret", () => {
 					result: "the-secret",
 				});
 
-				mockProjectRequests({ name: "the-key", text: "the-secret" }, "preview");
+				mockProjectRequests(
+					expect,
+					{ name: "the-key", text: "the-secret" },
+					"preview"
+				);
 				await runWrangler(
 					"pages secret put the-key --project some-project-name --env preview"
 				);
@@ -152,6 +157,7 @@ describe("wrangler pages secret", () => {
 
 			it("should error with invalid env", async ({ expect }) => {
 				mockProjectRequests(
+					expect,
 					{ name: "the-key", text: "the-secret" },
 					// @ts-expect-error This is intentionally invalid
 					"some-env"
@@ -183,7 +189,7 @@ describe("wrangler pages secret", () => {
 			it("should trim stdin secret value, from piped input", async ({
 				expect,
 			}) => {
-				mockProjectRequests({ name: "the-key", text: "the-secret" });
+				mockProjectRequests(expect, { name: "the-key", text: "the-secret" });
 				// Pipe the secret in as three chunks to test that we reconstitute it correctly.
 				mockStdIn.send(
 					`the`,
@@ -207,7 +213,7 @@ describe("wrangler pages secret", () => {
 			});
 
 			it("should create a secret, from piped input", async ({ expect }) => {
-				mockProjectRequests({ name: "the-key", text: "the-secret" });
+				mockProjectRequests(expect, { name: "the-key", text: "the-secret" });
 				// Pipe the secret in as three chunks to test that we reconstitute it correctly.
 				mockStdIn.send("the", "-", "secret");
 				await runWrangler(
@@ -226,7 +232,7 @@ describe("wrangler pages secret", () => {
 			});
 
 			it("should error if the piped input fails", async ({ expect }) => {
-				mockProjectRequests({ name: "the-key", text: "the-secret" });
+				mockProjectRequests(expect, { name: "the-key", text: "the-secret" });
 				mockStdIn.throwError(new Error("Error in stdin stream"));
 				await expect(
 					runWrangler("pages secret put the-key --project some-project-name")
@@ -306,6 +312,7 @@ describe("wrangler pages secret", () => {
 			setIsTTY(true);
 		});
 		function mockDeleteRequest(
+			expect: ExpectStatic,
 			name: string,
 			env: "production" | "preview" = "production"
 		) {
@@ -347,7 +354,7 @@ describe("wrangler pages secret", () => {
 		}
 
 		it("should delete a secret", async ({ expect }) => {
-			mockDeleteRequest("the-key");
+			mockDeleteRequest(expect, "the-key");
 			mockConfirm({
 				text: "Are you sure you want to permanently delete the secret the-key on the Pages project some-project-name (production)?",
 				result: true,
@@ -366,7 +373,7 @@ describe("wrangler pages secret", () => {
 		});
 
 		it("should delete a secret: preview", async ({ expect }) => {
-			mockDeleteRequest("the-key", "preview");
+			mockDeleteRequest(expect, "the-key", "preview");
 			mockConfirm({
 				text: "Are you sure you want to permanently delete the secret the-key on the Pages project some-project-name (preview)?",
 				result: true,
@@ -492,6 +499,7 @@ describe("wrangler pages secret", () => {
 
 	describe("secret bulk", () => {
 		function mockProjectRequests(
+			expect: ExpectStatic,
 			vars: { name: string; text: string }[],
 			env: "production" | "preview" = "production"
 		) {
@@ -536,7 +544,7 @@ describe("wrangler pages secret", () => {
 		it("should fail secret bulk w/ no pipe or JSON input", async ({
 			expect,
 		}) => {
-			mockProjectRequests([]);
+			mockProjectRequests(expect, []);
 			vi.spyOn(readline, "createInterface").mockImplementation(
 				() => null as unknown as Interface
 			);
@@ -557,7 +565,7 @@ describe("wrangler pages secret", () => {
 					}) as unknown as Interface
 			);
 
-			mockProjectRequests([
+			mockProjectRequests(expect, [
 				{
 					name: "secret1",
 					text: "secret-value",
@@ -589,7 +597,7 @@ describe("wrangler pages secret", () => {
 				})
 			);
 
-			mockProjectRequests([
+			mockProjectRequests(expect, [
 				{
 					name: "secret-name-1",
 					text: "secret_text",
@@ -620,7 +628,7 @@ describe("wrangler pages secret", () => {
 				`SECRET_1=secret-1\nSECRET_2=secret-2\nSECRET_3=secret-3`
 			);
 
-			mockProjectRequests([
+			mockProjectRequests(expect, [
 				{
 					name: "SECRET_1",
 					text: "secret-1",
@@ -657,6 +665,7 @@ describe("wrangler pages secret", () => {
 			);
 
 			mockProjectRequests(
+				expect,
 				[
 					{
 						name: "secret-name-1",

--- a/packages/wrangler/src/__tests__/pipelines-setup.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines-setup.test.ts
@@ -1,7 +1,6 @@
 import { writeFileSync } from "node:fs";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, it, vi } from "vitest";
 import {
 	__testSkipCredentialValidation,
 	__testSkipDelays,
@@ -19,6 +18,7 @@ import { createFetchResult, msw } from "./helpers/msw";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type { Sink, Stream } from "../pipelines/types";
+import type { ExpectStatic } from "vitest";
 
 describe("wrangler pipelines setup", () => {
 	const std = mockConsoleMethods();
@@ -57,6 +57,7 @@ describe("wrangler pipelines setup", () => {
 	}
 
 	function mockCreateStreamRequest(
+		expect: ExpectStatic,
 		expectedName: string,
 		options: { fail?: boolean } = {}
 	) {
@@ -106,6 +107,7 @@ describe("wrangler pipelines setup", () => {
 	}
 
 	function mockCreateSinkRequest(
+		expect: ExpectStatic,
 		expectedName: string,
 		options: { fail?: boolean } = {}
 	) {
@@ -172,7 +174,11 @@ describe("wrangler pipelines setup", () => {
 		return requests;
 	}
 
-	function mockValidateSql(sql: string, options: { fail?: boolean } = {}) {
+	function mockValidateSql(
+		expect: ExpectStatic,
+		sql: string,
+		options: { fail?: boolean } = {}
+	) {
 		const requests = { count: 0 };
 		msw.use(
 			http.post(
@@ -213,6 +219,7 @@ describe("wrangler pipelines setup", () => {
 	}
 
 	function mockCreatePipeline(
+		expect: ExpectStatic,
 		expectedName: string,
 		options: { fail?: boolean } = {}
 	) {
@@ -423,7 +430,7 @@ describe("wrangler pipelines setup", () => {
 		);
 	}
 
-	function mockCreateR2Bucket(bucketName: string) {
+	function mockCreateR2Bucket(expect: ExpectStatic, bucketName: string) {
 		msw.use(
 			http.post(
 				`*/accounts/${accountId}/r2/buckets`,
@@ -443,7 +450,9 @@ describe("wrangler pipelines setup", () => {
 	});
 
 	describe("pipeline name validation", () => {
-		it("validates pipeline name provided via --name flag - rejects hyphens", async () => {
+		it("validates pipeline name provided via --name flag - rejects hyphens", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 
 			await expect(
@@ -453,7 +462,9 @@ describe("wrangler pipelines setup", () => {
 			);
 		});
 
-		it("accepts valid pipeline name with underscores and proceeds to stream config", async () => {
+		it("accepts valid pipeline name with underscores and proceeds to stream config", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 
 			mockBasicStreamConfig();
@@ -469,7 +480,9 @@ describe("wrangler pipelines setup", () => {
 			expect(std.out).toContain("STREAM");
 		});
 
-		it("falls back to interactive prompt when --name is empty string", async () => {
+		it("falls back to interactive prompt when --name is empty string", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 
 			mockPrompt({
@@ -490,7 +503,9 @@ describe("wrangler pipelines setup", () => {
 	});
 
 	describe("interactive validation retry", () => {
-		it("shows retry prompt when invalid pipeline name entered interactively", async () => {
+		it("shows retry prompt when invalid pipeline name entered interactively", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 
 			mockPrompt({
@@ -509,7 +524,9 @@ describe("wrangler pipelines setup", () => {
 			);
 		});
 
-		it("allows retry and accepts valid name on second attempt", async () => {
+		it("allows retry and accepts valid name on second attempt", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 
 			mockPrompt({
@@ -537,7 +554,7 @@ describe("wrangler pipelines setup", () => {
 			expect(std.out).toContain("SINK");
 		});
 
-		it("allows multiple retries before succeeding", async () => {
+		it("allows multiple retries before succeeding", async ({ expect }) => {
 			setIsTTY(true);
 
 			mockPrompt({
@@ -576,7 +593,7 @@ describe("wrangler pipelines setup", () => {
 	});
 
 	describe("bucket name validation", () => {
-		it("rejects bucket names with underscores", async () => {
+		it("rejects bucket names with underscores", async ({ expect }) => {
 			setIsTTY(true);
 
 			mockSinkDialogs("r2", "simple");
@@ -598,7 +615,7 @@ describe("wrangler pipelines setup", () => {
 			expect(std.err).toContain('The bucket name "invalid_bucket_name"');
 		});
 
-		it("rejects bucket names that are too short", async () => {
+		it("rejects bucket names that are too short", async ({ expect }) => {
 			setIsTTY(true);
 
 			mockBasicStreamConfig();
@@ -620,7 +637,9 @@ describe("wrangler pipelines setup", () => {
 			expect(std.err).toContain('The bucket name "ab"');
 		});
 
-		it("allows retry with valid bucket name after invalid input", async () => {
+		it("allows retry with valid bucket name after invalid input", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 
 			mockSinkDialogs("r2", "advanced");
@@ -712,7 +731,9 @@ describe("wrangler pipelines setup", () => {
 	});
 
 	describe("stream configuration", () => {
-		it("proceeds through schema selection options with HTTP auth enabled", async () => {
+		it("proceeds through schema selection options with HTTP auth enabled", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 
 			mockConfirm({
@@ -753,7 +774,7 @@ describe("wrangler pipelines setup", () => {
 	});
 
 	describe("schema loading from file", () => {
-		it("loads schema from JSON file", async () => {
+		it("loads schema from JSON file", async ({ expect }) => {
 			setIsTTY(true);
 
 			const schema = {
@@ -795,7 +816,7 @@ describe("wrangler pipelines setup", () => {
 			expect(std.out).toContain("SINK");
 		});
 
-		it("retries when schema file not found", async () => {
+		it("retries when schema file not found", async ({ expect }) => {
 			setIsTTY(true);
 
 			const schema = {
@@ -845,7 +866,9 @@ describe("wrangler pipelines setup", () => {
 	});
 
 	describe("sink creation retry and cleanup", () => {
-		it("cleans up stream when user cancels after sink failure", async () => {
+		it("cleans up stream when user cancels after sink failure", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 
 			mockSinkDialogs("r2", "advanced");
@@ -862,8 +885,8 @@ describe("wrangler pipelines setup", () => {
 				result: true,
 			});
 
-			mockCreateStreamRequest("test_pipeline_stream");
-			mockCreateSinkRequest("test_pipeline_sink", { fail: true });
+			mockCreateStreamRequest(expect, "test_pipeline_stream");
+			mockCreateSinkRequest(expect, "test_pipeline_sink", { fail: true });
 
 			mockConfirm({
 				text: "  Retry? (stream was created successfully)",
@@ -922,7 +945,9 @@ describe("wrangler pipelines setup", () => {
 	});
 
 	describe("pipeline creation failure", () => {
-		it("exits gracefully when user declines retry after pipeline failure", async () => {
+		it("exits gracefully when user declines retry after pipeline failure", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 
 			mockSinkDialogs("r2", "advanced");
@@ -939,8 +964,8 @@ describe("wrangler pipelines setup", () => {
 				result: true,
 			});
 
-			mockCreateStreamRequest("test_pipeline_stream");
-			mockCreateSinkRequest("test_pipeline_sink");
+			mockCreateStreamRequest(expect, "test_pipeline_stream");
+			mockCreateSinkRequest(expect, "test_pipeline_sink");
 
 			mockSelect({
 				text: "Query:",
@@ -949,10 +974,10 @@ describe("wrangler pipelines setup", () => {
 
 			const sql =
 				"INSERT INTO test_pipeline_sink SELECT * FROM test_pipeline_stream;";
-			mockValidateSql(sql);
+			mockValidateSql(expect, sql);
 
 			// Pipeline creation fails
-			mockCreatePipeline("test_pipeline", { fail: true });
+			mockCreatePipeline(expect, "test_pipeline", { fail: true });
 
 			// Decline retry - should exit gracefully without throwing
 			mockConfirm({
@@ -1017,7 +1042,7 @@ describe("wrangler pipelines setup", () => {
 	});
 
 	describe("rolling policy validation", () => {
-		it("validates file size minimum", async () => {
+		it("validates file size minimum", async ({ expect }) => {
 			setIsTTY(true);
 
 			mockSinkDialogs("r2", "advanced");
@@ -1058,7 +1083,7 @@ describe("wrangler pipelines setup", () => {
 			expect(std.err).toContain("File size must be a number >= 5");
 		});
 
-		it("validates interval minimum", async () => {
+		it("validates interval minimum", async ({ expect }) => {
 			setIsTTY(true);
 
 			mockSinkDialogs("r2", "advanced");
@@ -1105,7 +1130,7 @@ describe("wrangler pipelines setup", () => {
 	});
 
 	describe("Data Catalog sink configuration", () => {
-		it("enables catalog when not already enabled", async () => {
+		it("enables catalog when not already enabled", async ({ expect }) => {
 			setIsTTY(true);
 
 			mockSinkDialogs("r2_data_catalog", "simple");
@@ -1136,7 +1161,9 @@ describe("wrangler pipelines setup", () => {
 			expect(std.out).toContain("done");
 		});
 
-		it("shows already enabled message when catalog is active", async () => {
+		it("shows already enabled message when catalog is active", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 
 			mockSinkDialogs("r2_data_catalog", "simple");
@@ -1166,7 +1193,7 @@ describe("wrangler pipelines setup", () => {
 			expect(std.out).toContain("Data Catalog already enabled");
 		});
 
-		it("creates bucket when it does not exist", async () => {
+		it("creates bucket when it does not exist", async ({ expect }) => {
 			setIsTTY(true);
 
 			mockSinkDialogs("r2_data_catalog", "simple");
@@ -1176,7 +1203,7 @@ describe("wrangler pipelines setup", () => {
 				result: "new-bucket",
 			});
 			mockGetR2Bucket("new-bucket", false);
-			mockCreateR2Bucket("new-bucket");
+			mockCreateR2Bucket(expect, "new-bucket");
 			mockGetR2Catalog("new-bucket", { exists: false });
 			mockEnableR2Catalog("new-bucket");
 
@@ -1198,7 +1225,7 @@ describe("wrangler pipelines setup", () => {
 			expect(std.out).toContain("done");
 		});
 
-		it("retries when catalog token validation fails", async () => {
+		it("retries when catalog token validation fails", async ({ expect }) => {
 			setIsTTY(true);
 
 			mockSinkDialogs("r2_data_catalog", "simple");
@@ -1243,7 +1270,7 @@ describe("wrangler pipelines setup", () => {
 	});
 
 	describe("Advanced mode Data Catalog sink", () => {
-		it("prompts for namespace and table name", async () => {
+		it("prompts for namespace and table name", async ({ expect }) => {
 			setIsTTY(true);
 
 			mockSinkDialogs("r2_data_catalog", "advanced");
@@ -1279,7 +1306,9 @@ describe("wrangler pipelines setup", () => {
 	});
 
 	describe("Data Catalog full flow", () => {
-		it("completes full setup from bucket to pipeline creation", async () => {
+		it("completes full setup from bucket to pipeline creation", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 			vi.useFakeTimers({ now: new Date("2025-01-01T00:00:00Z") });
 
@@ -1308,8 +1337,8 @@ describe("wrangler pipelines setup", () => {
 				result: true,
 			});
 
-			mockCreateStreamRequest("test_pipeline_stream");
-			mockCreateSinkRequest("test_pipeline_sink");
+			mockCreateStreamRequest(expect, "test_pipeline_stream");
+			mockCreateSinkRequest(expect, "test_pipeline_sink");
 
 			mockSelect({
 				text: "Query:",
@@ -1318,8 +1347,8 @@ describe("wrangler pipelines setup", () => {
 
 			const sql =
 				"INSERT INTO test_pipeline_sink SELECT * FROM test_pipeline_stream;";
-			mockValidateSql(sql);
-			mockCreatePipeline("test_pipeline");
+			mockValidateSql(expect, sql);
+			mockCreatePipeline(expect, "test_pipeline");
 
 			await runWrangler('pipelines setup --name "test_pipeline"');
 
@@ -1397,7 +1426,9 @@ describe("wrangler pipelines setup", () => {
 	});
 
 	describe("SQL validation", () => {
-		it("shows error and exits when validation fails and user declines retry", async () => {
+		it("shows error and exits when validation fails and user declines retry", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 
 			mockSinkDialogs("r2", "advanced");
@@ -1414,8 +1445,8 @@ describe("wrangler pipelines setup", () => {
 				result: true,
 			});
 
-			mockCreateStreamRequest("test_pipeline_stream");
-			mockCreateSinkRequest("test_pipeline_sink");
+			mockCreateStreamRequest(expect, "test_pipeline_stream");
+			mockCreateSinkRequest(expect, "test_pipeline_sink");
 
 			mockSelect({
 				text: "Query:",
@@ -1424,7 +1455,7 @@ describe("wrangler pipelines setup", () => {
 
 			const sql =
 				"INSERT INTO test_pipeline_sink SELECT * FROM test_pipeline_stream;";
-			mockValidateSql(sql, { fail: true });
+			mockValidateSql(expect, sql, { fail: true });
 
 			mockConfirm({
 				text: "  SQL validation failed [code: 1000]\n\n  Retry with different SQL?",

--- a/packages/wrangler/src/__tests__/pipelines.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines.test.ts
@@ -1,7 +1,6 @@
 import { writeFileSync } from "node:fs";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { mockConfirm } from "./helpers/mock-dialogs";
@@ -10,6 +9,7 @@ import { msw } from "./helpers/msw";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type { Pipeline, SchemaField, Sink, Stream } from "../pipelines/types";
+import type { ExpectStatic } from "vitest";
 
 describe("wrangler pipelines", () => {
 	const std = mockConsoleMethods();
@@ -19,7 +19,11 @@ describe("wrangler pipelines", () => {
 
 	const accountId = "some-account-id";
 
-	function mockValidateSqlRequest(sql: string, isValid = true) {
+	function mockValidateSqlRequest(
+		expect: ExpectStatic,
+		sql: string,
+		isValid = true
+	) {
 		const requests = { count: 0 };
 		msw.use(
 			http.post(
@@ -54,10 +58,13 @@ describe("wrangler pipelines", () => {
 		return requests;
 	}
 
-	function mockCreatePipelineRequest(expectedRequest: {
-		name: string;
-		sql: string;
-	}) {
+	function mockCreatePipelineRequest(
+		expect: ExpectStatic,
+		expectedRequest: {
+			name: string;
+			sql: string;
+		}
+	) {
 		const requests = { count: 0 };
 		msw.use(
 			http.post(
@@ -196,7 +203,9 @@ describe("wrangler pipelines", () => {
 	}
 
 	describe("pipelines create", () => {
-		it("should error when neither --sql nor --sql-file is provided", async () => {
+		it("should error when neither --sql nor --sql-file is provided", async ({
+			expect,
+		}) => {
 			await expect(
 				runWrangler("pipelines create my_pipeline")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -204,10 +213,10 @@ describe("wrangler pipelines", () => {
 			);
 		});
 
-		it("should create pipeline with inline SQL", async () => {
+		it("should create pipeline with inline SQL", async ({ expect }) => {
 			const sql = "INSERT INTO test_sink SELECT * FROM test_stream;";
-			const validateRequest = mockValidateSqlRequest(sql);
-			const createRequest = mockCreatePipelineRequest({
+			const validateRequest = mockValidateSqlRequest(expect, sql);
+			const createRequest = mockCreatePipelineRequest(expect, {
 				name: "my_pipeline",
 				sql,
 			});
@@ -273,13 +282,13 @@ describe("wrangler pipelines", () => {
 			expect(std.out).toContain("Or via HTTP:");
 		});
 
-		it("should create pipeline from SQL file", async () => {
+		it("should create pipeline from SQL file", async ({ expect }) => {
 			const sql = "INSERT INTO test_sink SELECT * FROM test_stream;";
 			const sqlFile = "pipeline.sql";
 			writeFileSync(sqlFile, sql);
 
-			const validateRequest = mockValidateSqlRequest(sql);
-			const createRequest = mockCreatePipelineRequest({
+			const validateRequest = mockValidateSqlRequest(expect, sql);
+			const createRequest = mockCreatePipelineRequest(expect, {
 				name: "my_pipeline",
 				sql,
 			});
@@ -340,9 +349,9 @@ describe("wrangler pipelines", () => {
 			);
 		});
 
-		it("should error when SQL validation fails", async () => {
+		it("should error when SQL validation fails", async ({ expect }) => {
 			const sql = "INVALID SQL QUERY";
-			const validateRequest = mockValidateSqlRequest(sql, false);
+			const validateRequest = mockValidateSqlRequest(expect, sql, false);
 
 			await expect(
 				runWrangler(`pipelines create my_pipeline --sql "${sql}"`)
@@ -353,9 +362,11 @@ describe("wrangler pipelines", () => {
 			expect(validateRequest.count).toBe(1);
 		});
 
-		it("should show wrangler version message on authentication error", async () => {
+		it("should show wrangler version message on authentication error", async ({
+			expect,
+		}) => {
 			const sql = "INSERT INTO test_sink SELECT * FROM test_stream;";
-			const validateRequest = mockValidateSqlRequest(sql);
+			const validateRequest = mockValidateSqlRequest(expect, sql);
 
 			// Mock create returns auth error (code 10000)
 			msw.use(
@@ -393,7 +404,7 @@ describe("wrangler pipelines", () => {
 	});
 
 	describe("pipelines list", () => {
-		it("should list pipelines", async () => {
+		it("should list pipelines", async ({ expect }) => {
 			const mockPipelines: Pipeline[] = [
 				{
 					id: "pipeline_1",
@@ -433,7 +444,7 @@ describe("wrangler pipelines", () => {
 			`);
 		});
 
-		it("should handle empty pipelines list", async () => {
+		it("should handle empty pipelines list", async ({ expect }) => {
 			const listRequest = mockListPipelinesRequest([]);
 
 			await runWrangler("pipelines list");
@@ -448,7 +459,9 @@ describe("wrangler pipelines", () => {
 			`);
 		});
 
-		it("should merge new and legacy pipelines with Type column for legacy", async () => {
+		it("should merge new and legacy pipelines with Type column for legacy", async ({
+			expect,
+		}) => {
 			const mockNewPipelines: Pipeline[] = [
 				{
 					id: "pipeline_1",
@@ -529,7 +542,7 @@ describe("wrangler pipelines", () => {
 			`);
 		});
 
-		it('supports valid json output with "--json" flag', async () => {
+		it('supports valid json output with "--json" flag', async ({ expect }) => {
 			const mockPipelines: Pipeline[] = [
 				{
 					id: "pipeline_1",
@@ -578,7 +591,7 @@ describe("wrangler pipelines", () => {
 	});
 
 	describe("pipelines get", () => {
-		it("should error when no pipeline ID provided", async () => {
+		it("should error when no pipeline ID provided", async ({ expect }) => {
 			await expect(
 				runWrangler("pipelines get")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -586,7 +599,7 @@ describe("wrangler pipelines", () => {
 			);
 		});
 
-		it("should get pipeline details", async () => {
+		it("should get pipeline details", async ({ expect }) => {
 			const mockPipeline: Pipeline = {
 				id: "pipeline_123",
 				name: "my_pipeline",
@@ -649,7 +662,9 @@ describe("wrangler pipelines", () => {
 			`);
 		});
 
-		it("should fall back to legacy API when pipeline not found in new API", async () => {
+		it("should fall back to legacy API when pipeline not found in new API", async ({
+			expect,
+		}) => {
 			msw.use(
 				http.get(
 					`*/accounts/${accountId}/pipelines/v1/pipelines/my-legacy-pipeline`,
@@ -739,7 +754,7 @@ describe("wrangler pipelines", () => {
 			`);
 		});
 
-		it('supports valid json output with "--json" flag', async () => {
+		it('supports valid json output with "--json" flag', async ({ expect }) => {
 			const mockPipeline: Pipeline = {
 				id: "pipeline_123",
 				name: "my_pipeline",
@@ -804,7 +819,7 @@ describe("wrangler pipelines", () => {
 
 	describe("pipelines delete", () => {
 		const { setIsTTY } = useMockIsTTY();
-		it("should error when no pipeline ID provided", async () => {
+		it("should error when no pipeline ID provided", async ({ expect }) => {
 			await expect(
 				runWrangler("pipelines delete")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -812,7 +827,7 @@ describe("wrangler pipelines", () => {
 			);
 		});
 
-		it("should prompt for confirmation before delete", async () => {
+		it("should prompt for confirmation before delete", async ({ expect }) => {
 			const mockPipeline: Pipeline = {
 				id: "pipeline_123",
 				name: "my_pipeline",
@@ -844,7 +859,9 @@ describe("wrangler pipelines", () => {
 			`);
 		});
 
-		it("should fall back to legacy API when deleting pipeline not in new API", async () => {
+		it("should fall back to legacy API when deleting pipeline not in new API", async ({
+			expect,
+		}) => {
 			msw.use(
 				http.get(
 					`*/accounts/${accountId}/pipelines/v1/pipelines/my-legacy-pipeline`,
@@ -916,7 +933,7 @@ describe("wrangler pipelines", () => {
 	});
 
 	describe("pipelines update", () => {
-		it("should error when trying to update V1 pipeline", async () => {
+		it("should error when trying to update V1 pipeline", async ({ expect }) => {
 			const mockPipeline: Pipeline = {
 				id: "pipeline_123",
 				name: "my_pipeline",
@@ -948,7 +965,7 @@ describe("wrangler pipelines", () => {
 			);
 		});
 
-		it("should update legacy pipeline with warning", async () => {
+		it("should update legacy pipeline with warning", async ({ expect }) => {
 			msw.use(
 				http.get(
 					`*/accounts/${accountId}/pipelines/v1/pipelines/my-legacy-pipeline`,
@@ -1052,10 +1069,13 @@ describe("wrangler pipelines", () => {
 
 	describe("pipelines streams create", () => {
 		const { setIsTTY } = useMockIsTTY();
-		function mockCreateStreamRequest(expectedRequest: {
-			name: string;
-			hasSchema?: boolean;
-		}) {
+		function mockCreateStreamRequest(
+			expect: ExpectStatic,
+			expectedRequest: {
+				name: string;
+				hasSchema?: boolean;
+			}
+		) {
 			const requests = { count: 0 };
 			msw.use(
 				http.post(
@@ -1113,7 +1133,7 @@ describe("wrangler pipelines", () => {
 			return requests;
 		}
 
-		it("should error when no stream name provided", async () => {
+		it("should error when no stream name provided", async ({ expect }) => {
 			await expect(
 				runWrangler("pipelines streams create")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -1121,7 +1141,9 @@ describe("wrangler pipelines", () => {
 			);
 		});
 
-		it("should error when name contains invalid characters", async () => {
+		it("should error when name contains invalid characters", async ({
+			expect,
+		}) => {
 			await expect(
 				runWrangler("pipelines streams create my-stream")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -1129,14 +1151,14 @@ describe("wrangler pipelines", () => {
 			);
 		});
 
-		it("should create stream with default settings", async () => {
+		it("should create stream with default settings", async ({ expect }) => {
 			setIsTTY(true);
 			mockConfirm({
 				text: "No schema file provided. Do you want to create stream without a schema (unstructured JSON)?",
 				result: true,
 			});
 
-			const createRequest = mockCreateStreamRequest({
+			const createRequest = mockCreateStreamRequest(expect, {
 				name: "my_stream",
 			});
 
@@ -1165,7 +1187,7 @@ describe("wrangler pipelines", () => {
 			`);
 		});
 
-		it("should create stream with schema from file", async () => {
+		it("should create stream with schema from file", async ({ expect }) => {
 			const schemaFile = "schema.json";
 			const schema = {
 				fields: [
@@ -1180,7 +1202,7 @@ describe("wrangler pipelines", () => {
 			};
 			writeFileSync(schemaFile, JSON.stringify(schema));
 
-			const createRequest = mockCreateStreamRequest({
+			const createRequest = mockCreateStreamRequest(expect, {
 				name: "my_stream",
 				hasSchema: true,
 			});
@@ -1221,7 +1243,11 @@ describe("wrangler pipelines", () => {
 	});
 
 	describe("pipelines streams list", () => {
-		function mockListStreamsRequest(streams: Stream[], pipelineId?: string) {
+		function mockListStreamsRequest(
+			expect: ExpectStatic,
+			streams: Stream[],
+			pipelineId?: string
+		) {
 			const requests = { count: 0 };
 			msw.use(
 				http.get(
@@ -1251,7 +1277,7 @@ describe("wrangler pipelines", () => {
 			return requests;
 		}
 
-		it("should list streams", async () => {
+		it("should list streams", async ({ expect }) => {
 			const mockStreams: Stream[] = [
 				{
 					id: "stream_1",
@@ -1267,7 +1293,7 @@ describe("wrangler pipelines", () => {
 				},
 			];
 
-			const listRequest = mockListStreamsRequest(mockStreams);
+			const listRequest = mockListStreamsRequest(expect, mockStreams);
 
 			await runWrangler("pipelines streams list");
 
@@ -1285,7 +1311,7 @@ describe("wrangler pipelines", () => {
 			`);
 		});
 
-		it("should filter by pipeline ID", async () => {
+		it("should filter by pipeline ID", async ({ expect }) => {
 			const mockStreams: Stream[] = [
 				{
 					id: "stream_1",
@@ -1301,7 +1327,11 @@ describe("wrangler pipelines", () => {
 				},
 			];
 
-			const listRequest = mockListStreamsRequest(mockStreams, "pipeline_123");
+			const listRequest = mockListStreamsRequest(
+				expect,
+				mockStreams,
+				"pipeline_123"
+			);
 
 			await runWrangler("pipelines streams list --pipeline-id pipeline_123");
 
@@ -1319,7 +1349,7 @@ describe("wrangler pipelines", () => {
 			`);
 		});
 
-		it('supports valid json output with "--json" flag', async () => {
+		it('supports valid json output with "--json" flag', async ({ expect }) => {
 			const mockStreams: Stream[] = [
 				{
 					id: "stream_1",
@@ -1335,7 +1365,7 @@ describe("wrangler pipelines", () => {
 				},
 			];
 
-			mockListStreamsRequest(mockStreams);
+			mockListStreamsRequest(expect, mockStreams);
 
 			await runWrangler("pipelines streams list --json");
 
@@ -1368,7 +1398,7 @@ describe("wrangler pipelines", () => {
 	});
 
 	describe("pipelines streams get", () => {
-		it("should get stream details", async () => {
+		it("should get stream details", async ({ expect }) => {
 			const mockStream: Stream = {
 				id: "stream_123",
 				name: "my_stream",
@@ -1410,7 +1440,7 @@ describe("wrangler pipelines", () => {
 			`);
 		});
 
-		it('supports valid json output with "--json" flag', async () => {
+		it('supports valid json output with "--json" flag', async ({ expect }) => {
 			const mockStream: Stream = {
 				id: "stream_123",
 				name: "my_stream",
@@ -1476,7 +1506,7 @@ describe("wrangler pipelines", () => {
 			return requests;
 		}
 
-		it("should prompt for confirmation", async () => {
+		it("should prompt for confirmation", async ({ expect }) => {
 			const mockStream: Stream = {
 				id: "stream_123",
 				name: "my_stream",
@@ -1514,11 +1544,14 @@ describe("wrangler pipelines", () => {
 	});
 
 	describe("pipelines sinks create", () => {
-		function mockCreateSinkRequest(expectedRequest: {
-			name: string;
-			type: string;
-			isDataCatalog?: boolean;
-		}) {
+		function mockCreateSinkRequest(
+			expect: ExpectStatic,
+			expectedRequest: {
+				name: string;
+				type: string;
+				isDataCatalog?: boolean;
+			}
+		) {
 			const requests = { count: 0 };
 			msw.use(
 				http.post(
@@ -1570,7 +1603,9 @@ describe("wrangler pipelines", () => {
 			return requests;
 		}
 
-		it("should error when name contains invalid characters", async () => {
+		it("should error when name contains invalid characters", async ({
+			expect,
+		}) => {
 			await expect(
 				runWrangler(
 					"pipelines sinks create my-sink --bucket my-bucket --type r2"
@@ -1580,7 +1615,7 @@ describe("wrangler pipelines", () => {
 			);
 		});
 
-		it("should error when type is missing", async () => {
+		it("should error when type is missing", async ({ expect }) => {
 			await expect(
 				runWrangler("pipelines sinks create my_sink --bucket my-bucket")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -1588,7 +1623,7 @@ describe("wrangler pipelines", () => {
 			);
 		});
 
-		it("should error with invalid bucket name", async () => {
+		it("should error with invalid bucket name", async ({ expect }) => {
 			await expect(
 				runWrangler(
 					"pipelines sinks create my_sink --type r2 --bucket invalid_bucket_name"
@@ -1598,8 +1633,10 @@ describe("wrangler pipelines", () => {
 			);
 		});
 
-		it("should create R2 sink with explicit credentials", async () => {
-			const createRequest = mockCreateSinkRequest({
+		it("should create R2 sink with explicit credentials", async ({
+			expect,
+		}) => {
+			const createRequest = mockCreateSinkRequest(expect, {
 				name: "my_sink",
 				type: "r2",
 			});
@@ -1635,8 +1672,8 @@ describe("wrangler pipelines", () => {
 			`);
 		});
 
-		it("should create R2 Data Catalog sink", async () => {
-			const createRequest = mockCreateSinkRequest({
+		it("should create R2 Data Catalog sink", async ({ expect }) => {
+			const createRequest = mockCreateSinkRequest(expect, {
 				name: "my_sink",
 				type: "r2_data_catalog",
 				isDataCatalog: true,
@@ -1672,7 +1709,9 @@ describe("wrangler pipelines", () => {
 			`);
 		});
 
-		it("should error when r2-data-catalog missing required fields", async () => {
+		it("should error when r2-data-catalog missing required fields", async ({
+			expect,
+		}) => {
 			await expect(
 				runWrangler(
 					"pipelines sinks create my_sink --type r2-data-catalog --bucket catalog-bucket"
@@ -1684,7 +1723,11 @@ describe("wrangler pipelines", () => {
 	});
 
 	describe("pipelines sinks list", () => {
-		function mockListSinksRequest(sinks: Sink[], pipelineId?: string) {
+		function mockListSinksRequest(
+			expect: ExpectStatic,
+			sinks: Sink[],
+			pipelineId?: string
+		) {
 			const requests = { count: 0 };
 			msw.use(
 				http.get(
@@ -1714,7 +1757,7 @@ describe("wrangler pipelines", () => {
 			return requests;
 		}
 
-		it("should list sinks", async () => {
+		it("should list sinks", async ({ expect }) => {
 			const mockSinks: Sink[] = [
 				{
 					id: "sink_1",
@@ -1728,7 +1771,7 @@ describe("wrangler pipelines", () => {
 				},
 			];
 
-			const listRequest = mockListSinksRequest(mockSinks);
+			const listRequest = mockListSinksRequest(expect, mockSinks);
 
 			await runWrangler("pipelines sinks list");
 
@@ -1746,7 +1789,7 @@ describe("wrangler pipelines", () => {
 			`);
 		});
 
-		it("should filter by pipeline ID", async () => {
+		it("should filter by pipeline ID", async ({ expect }) => {
 			const mockSinks: Sink[] = [
 				{
 					id: "sink_1",
@@ -1760,7 +1803,11 @@ describe("wrangler pipelines", () => {
 				},
 			];
 
-			const listRequest = mockListSinksRequest(mockSinks, "pipeline_123");
+			const listRequest = mockListSinksRequest(
+				expect,
+				mockSinks,
+				"pipeline_123"
+			);
 
 			await runWrangler("pipelines sinks list --pipeline-id pipeline_123");
 
@@ -1778,7 +1825,7 @@ describe("wrangler pipelines", () => {
 			`);
 		});
 
-		it('supports json output with "--json" flag', async () => {
+		it('supports json output with "--json" flag', async ({ expect }) => {
 			const mockSinks: Sink[] = [
 				{
 					id: "sink_1",
@@ -1792,7 +1839,7 @@ describe("wrangler pipelines", () => {
 				},
 			];
 
-			mockListSinksRequest(mockSinks);
+			mockListSinksRequest(expect, mockSinks);
 			await runWrangler("pipelines sinks list --json");
 
 			expect(std.err).toMatchInlineSnapshot(`""`);
@@ -1834,7 +1881,7 @@ describe("wrangler pipelines", () => {
 	}
 
 	describe("pipelines sinks get", () => {
-		it("should get sink details", async () => {
+		it("should get sink details", async ({ expect }) => {
 			const mockSink: Sink = {
 				id: "sink_123",
 				name: "my_sink",
@@ -1879,7 +1926,7 @@ describe("wrangler pipelines", () => {
 			`);
 		});
 
-		it('supports valid json output with "--json" flag', async () => {
+		it('supports valid json output with "--json" flag', async ({ expect }) => {
 			const mockSink: Sink = {
 				id: "sink_123",
 				name: "my_sink",
@@ -1936,7 +1983,7 @@ describe("wrangler pipelines", () => {
 			return requests;
 		}
 
-		it("should prompt for confirmation", async () => {
+		it("should prompt for confirmation", async ({ expect }) => {
 			const mockSink: Sink = {
 				id: "sink_123",
 				name: "my_sink",

--- a/packages/wrangler/src/__tests__/provision.test.ts
+++ b/packages/wrangler/src/__tests__/provision.test.ts
@@ -5,8 +5,7 @@ import {
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs, mockPrompt, mockSelect } from "./helpers/mock-dialogs";
@@ -28,6 +27,7 @@ import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import { writeWorkerSource } from "./helpers/write-worker-source";
 import type { DatabaseInfo } from "../d1/types";
+import type { ExpectStatic } from "vitest";
 
 vi.mock("../utils/fetch-secrets", () => ({
 	fetchSecrets: async () => [],
@@ -59,7 +59,9 @@ describe("resource provisioning", () => {
 		clearDialogs();
 	});
 
-	it("should inherit KV, R2 and D1 bindings if they could be found from the settings", async () => {
+	it("should inherit KV, R2 and D1 bindings if they could be found from the settings", async ({
+		expect,
+	}) => {
 		mockGetSettings({
 			result: {
 				bindings: [
@@ -121,7 +123,9 @@ describe("resource provisioning", () => {
 	});
 
 	describe("provisions KV, R2 and D1 bindings if not found in worker settings", () => {
-		it("can provision KV, R2 and D1 bindings with existing resources", async () => {
+		it("can provision KV, R2 and D1 bindings with existing resources", async ({
+			expect,
+		}) => {
 			mockGetSettings();
 			mockListKVNamespacesRequest({
 				title: "test-kv",
@@ -227,7 +231,9 @@ describe("resource provisioning", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("can provision KV, R2 and D1 bindings with existing resources, and lets you search when there are too many to list", async () => {
+		it("can provision KV, R2 and D1 bindings with existing resources, and lets you search when there are too many to list", async ({
+			expect,
+		}) => {
 			mockGetSettings();
 			msw.use(
 				http.get(
@@ -348,7 +354,9 @@ describe("resource provisioning", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("can provision KV, R2 and D1 bindings with new resources", async () => {
+		it("can provision KV, R2 and D1 bindings with new resources", async ({
+			expect,
+		}) => {
 			mockGetSettings();
 			mockListKVNamespacesRequest({
 				title: "test-kv",
@@ -399,7 +407,7 @@ describe("resource provisioning", () => {
 				text: "Enter a name for your new D1 Database",
 				result: "new-d1",
 			});
-			mockCreateD1Database({
+			mockCreateD1Database(expect, {
 				assertName: "new-d1",
 				resultId: "new-d1-id",
 			});
@@ -412,7 +420,7 @@ describe("resource provisioning", () => {
 				text: "Enter a name for your new R2 Bucket",
 				result: "new-r2",
 			});
-			mockCreateR2Bucket({
+			mockCreateR2Bucket(expect, {
 				assertBucketName: "new-r2",
 			});
 
@@ -439,45 +447,45 @@ describe("resource provisioning", () => {
 			await runWrangler("deploy --x-auto-create=false");
 
 			expect(std.out).toMatchInlineSnapshot(`
-				"
-				 ⛅️ wrangler x.x.x
-				──────────────────
-				Total Upload: xx KiB / gzip: xx KiB
+			"
+			 ⛅️ wrangler x.x.x
+			──────────────────
+			Total Upload: xx KiB / gzip: xx KiB
 
-				Experimental: The following bindings need to be provisioned:
-				Binding        Resource
-				env.KV         KV Namespace
-				env.D1         D1 Database
-				env.R2         R2 Bucket
+			Experimental: The following bindings need to be provisioned:
+			Binding        Resource
+			env.KV         KV Namespace
+			env.D1         D1 Database
+			env.R2         R2 Bucket
 
 
-				Provisioning KV (KV Namespace)...
-				🌀 Creating new KV Namespace "new-kv"...
-				✨ KV provisioned 🎉
+			Provisioning KV (KV Namespace)...
+			🌀 Creating new KV Namespace "new-kv"...
+			✨ KV provisioned 🎉
 
-				Provisioning D1 (D1 Database)...
-				🌀 Creating new D1 Database "new-d1"...
-				✨ D1 provisioned 🎉
+			Provisioning D1 (D1 Database)...
+			🌀 Creating new D1 Database "new-d1"...
+			✨ D1 provisioned 🎉
 
-				Provisioning R2 (R2 Bucket)...
-				🌀 Creating new R2 Bucket "new-r2"...
-				✨ R2 provisioned 🎉
+			Provisioning R2 (R2 Bucket)...
+			🌀 Creating new R2 Bucket "new-r2"...
+			✨ R2 provisioned 🎉
 
-				Your Worker was deployed with provisioned resources. We've written the IDs of these resources to your config file, which you can choose to save or discard. Either way future deploys will continue to work.
-				🎉 All resources provisioned, continuing with deployment...
+			Your Worker was deployed with provisioned resources. We've written the IDs of these resources to your config file, which you can choose to save or discard. Either way future deploys will continue to work.
+			🎉 All resources provisioned, continuing with deployment...
 
-				Worker Startup Time: 100 ms
-				Your Worker has access to the following bindings:
-				Binding                 Resource
-				env.KV (new-kv-id)      KV Namespace
-				env.D1 (new-d1-id)      D1 Database
-				env.R2 (new-r2)         R2 Bucket
+			Worker Startup Time: 100 ms
+			Your Worker has access to the following bindings:
+			Binding                 Resource
+			env.KV (new-kv-id)      KV Namespace
+			env.D1 (new-d1-id)      D1 Database
+			env.R2 (new-r2)         R2 Bucket
 
-				Uploaded test-name (TIMINGS)
-				Deployed test-name triggers (TIMINGS)
-				  https://test-name.test-sub-domain.workers.dev
-				Current Version ID: Galaxy-Class"
-			`);
+			Uploaded test-name (TIMINGS)
+			Deployed test-name triggers (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev
+			Current Version ID: Galaxy-Class"
+		`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 
@@ -502,7 +510,9 @@ describe("resource provisioning", () => {
 			`);
 		});
 
-		it("can provision KV, R2 and D1 bindings with new resources w/ redirected config", async () => {
+		it("can provision KV, R2 and D1 bindings with new resources w/ redirected config", async ({
+			expect,
+		}) => {
 			writeRedirectedWranglerConfig({
 				main: "../index.js",
 				compatibility_flags: ["nodejs_compat"],
@@ -560,7 +570,7 @@ describe("resource provisioning", () => {
 				text: "Enter a name for your new D1 Database",
 				result: "new-d1",
 			});
-			mockCreateD1Database({
+			mockCreateD1Database(expect, {
 				assertName: "new-d1",
 				resultId: "new-d1-id",
 			});
@@ -573,7 +583,7 @@ describe("resource provisioning", () => {
 				text: "Enter a name for your new R2 Bucket",
 				result: "new-r2",
 			});
-			mockCreateR2Bucket({
+			mockCreateR2Bucket(expect, {
 				assertBucketName: "new-r2",
 			});
 
@@ -665,7 +675,9 @@ describe("resource provisioning", () => {
 			rmSync(".wrangler/deploy/config.json");
 		});
 
-		it("can inject additional bindings in redirected config that aren't written back to disk", async () => {
+		it("can inject additional bindings in redirected config that aren't written back to disk", async ({
+			expect,
+		}) => {
 			writeRedirectedWranglerConfig({
 				main: "../index.js",
 				compatibility_flags: ["nodejs_compat"],
@@ -711,12 +723,12 @@ describe("resource provisioning", () => {
 				resultId: "test-name-kv-id",
 			});
 
-			mockCreateD1Database({
+			mockCreateD1Database(expect, {
 				assertName: "test-name-d1",
 				resultId: "test-name-d1-id",
 			});
 
-			mockCreateR2Bucket({
+			mockCreateR2Bucket(expect, {
 				assertBucketName: "test-name-r2",
 			});
 
@@ -819,7 +831,9 @@ describe("resource provisioning", () => {
 			rmSync(".wrangler/deploy/config.json");
 		});
 
-		it("can prefill d1 database name from config file if provided", async () => {
+		it("can prefill d1 database name from config file if provided", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				d1_databases: [{ binding: "D1", database_name: "prefilled-d1-name" }],
@@ -837,10 +851,10 @@ describe("resource provisioning", () => {
 					);
 				})
 			);
-			mockGetD1Database("prefilled-d1-name", {}, true);
+			mockGetD1Database(expect, "prefilled-d1-name", {}, true);
 
 			// no name prompt
-			mockCreateD1Database({
+			mockCreateD1Database(expect, {
 				assertName: "prefilled-d1-name",
 				resultId: "new-d1-id",
 			});
@@ -890,7 +904,9 @@ describe("resource provisioning", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("can inherit d1 binding when the database name is provided", async () => {
+		it("can inherit d1 binding when the database name is provided", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				d1_databases: [{ binding: "D1", database_name: "prefilled-d1-name" }],
@@ -906,7 +922,7 @@ describe("resource provisioning", () => {
 					],
 				},
 			});
-			mockGetD1Database("d1-id", { name: "prefilled-d1-name" });
+			mockGetD1Database(expect, "d1-id", { name: "prefilled-d1-name" });
 			mockUploadWorkerRequest({
 				expectedBindings: [
 					{
@@ -934,7 +950,9 @@ describe("resource provisioning", () => {
 			`);
 		});
 
-		it("will not inherit d1 binding when the database name is provided but has changed", async () => {
+		it("will not inherit d1 binding when the database name is provided but has changed", async ({
+			expect,
+		}) => {
 			// first deploy used old-d1-name/old-d1-id
 			// now we provide a different database_name that doesn't match
 			writeWranglerConfig({
@@ -964,12 +982,12 @@ describe("resource provisioning", () => {
 					);
 				})
 			);
-			mockGetD1Database("new-d1-name", {}, true);
+			mockGetD1Database(expect, "new-d1-name", {}, true);
 
-			mockGetD1Database("old-d1-id", { name: "old-d1-name" });
+			mockGetD1Database(expect, "old-d1-id", { name: "old-d1-name" });
 
 			// no name prompt
-			mockCreateD1Database({
+			mockCreateD1Database(expect, {
 				assertName: "new-d1-name",
 				resultId: "new-d1-id",
 			});
@@ -1019,7 +1037,9 @@ describe("resource provisioning", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("can prefill r2 bucket name from config file if provided", async () => {
+		it("can prefill r2 bucket name from config file if provided", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				r2_buckets: [
@@ -1045,9 +1065,9 @@ describe("resource provisioning", () => {
 					);
 				})
 			);
-			mockGetR2Bucket("prefilled-r2-name", true);
+			mockGetR2Bucket(expect, "prefilled-r2-name", true);
 			// no name prompt
-			mockCreateR2Bucket({
+			mockCreateR2Bucket(expect, {
 				assertBucketName: "prefilled-r2-name",
 				assertJurisdiction: "eu",
 			});
@@ -1098,7 +1118,9 @@ describe("resource provisioning", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("won't prompt to provision if an r2 bucket name belongs to an existing bucket", async () => {
+		it("won't prompt to provision if an r2 bucket name belongs to an existing bucket", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				r2_buckets: [
@@ -1123,7 +1145,7 @@ describe("resource provisioning", () => {
 					);
 				})
 			);
-			mockGetR2Bucket("existing-bucket-name", false);
+			mockGetR2Bucket(expect, "existing-bucket-name", false);
 			mockUploadWorkerRequest({
 				expectedBindings: [
 					{
@@ -1156,7 +1178,9 @@ describe("resource provisioning", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("won't prompt to provision if a D1 database name belongs to an existing database", async () => {
+		it("won't prompt to provision if a D1 database name belongs to an existing database", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				main: "index.js",
 				d1_databases: [
@@ -1168,7 +1192,7 @@ describe("resource provisioning", () => {
 			});
 			mockGetSettings();
 
-			mockGetD1Database("existing-db-name", {
+			mockGetD1Database(expect, "existing-db-name", {
 				name: "existing-db-name",
 				uuid: "existing-d1-id",
 			});
@@ -1205,7 +1229,7 @@ describe("resource provisioning", () => {
 		});
 
 		// because buckets with the same name can exist in different jurisdictions
-		it("will provision if the jurisdiction changes", async () => {
+		it("will provision if the jurisdiction changes", async ({ expect }) => {
 			writeWranglerConfig({
 				main: "index.js",
 				r2_buckets: [
@@ -1243,7 +1267,7 @@ describe("resource provisioning", () => {
 				})
 			);
 			// since the jurisdiction doesn't match, it should return not found
-			mockGetR2Bucket("existing-bucket-name", true);
+			mockGetR2Bucket(expect, "existing-bucket-name", true);
 			mockUploadWorkerRequest({
 				expectedBindings: [
 					{
@@ -1254,7 +1278,7 @@ describe("resource provisioning", () => {
 					},
 				],
 			});
-			mockCreateR2Bucket({
+			mockCreateR2Bucket(expect, {
 				assertJurisdiction: "eu",
 				assertBucketName: "existing-bucket-name",
 			});
@@ -1295,7 +1319,7 @@ describe("resource provisioning", () => {
 		});
 	});
 
-	it("should error if used with a service environment", async () => {
+	it("should error if used with a service environment", async ({ expect }) => {
 		writeWorkerSource();
 		writeWranglerConfig({
 			main: "index.js",
@@ -1309,6 +1333,7 @@ describe("resource provisioning", () => {
 });
 
 function mockCreateD1Database(
+	expect: ExpectStatic,
 	options: {
 		resultId?: string;
 		assertName?: string;
@@ -1333,6 +1358,7 @@ function mockCreateD1Database(
 }
 
 function mockCreateR2Bucket(
+	expect: ExpectStatic,
 	options: {
 		assertBucketName?: string;
 		assertJurisdiction?: string;
@@ -1358,7 +1384,11 @@ function mockCreateR2Bucket(
 	);
 }
 
-function mockGetR2Bucket(bucketName: string, missing: boolean = false) {
+function mockGetR2Bucket(
+	expect: ExpectStatic,
+	bucketName: string,
+	missing: boolean = false
+) {
 	msw.use(
 		http.get(
 			"*/accounts/:accountId/r2/buckets/:bucketName",
@@ -1380,6 +1410,7 @@ function mockGetR2Bucket(bucketName: string, missing: boolean = false) {
 }
 
 function mockGetD1Database(
+	expect: ExpectStatic,
 	databaseIdOrName: string,
 	databaseInfo: Partial<DatabaseInfo>,
 	missing: boolean = false

--- a/packages/wrangler/src/__tests__/queues/queues.test.ts
+++ b/packages/wrangler/src/__tests__/queues/queues.test.ts
@@ -1,7 +1,6 @@
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { mockPrompt } from "../helpers/mock-dialogs";
@@ -11,6 +10,7 @@ import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { mockGetQueueByNameRequest } from "./mock-utils";
 import type { PostTypedConsumerBody, QueueResponse } from "../../queues/client";
+import type { ExpectStatic } from "vitest";
 
 describe("wrangler", () => {
 	mockAccountId();
@@ -23,7 +23,7 @@ describe("wrangler", () => {
 		const expectedConsumerId = "consumerId";
 		const expectedQueueName = "testQueue";
 
-		it("should show the correct help text", async () => {
+		it("should show the correct help text", async ({ expect }) => {
 			await runWrangler("queues --help");
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.out).toMatchInlineSnapshot(`
@@ -54,7 +54,11 @@ describe("wrangler", () => {
 		});
 
 		describe("list", () => {
-			function mockListRequest(queues: QueueResponse[], page: number) {
+			function mockListRequest(
+				expect: ExpectStatic,
+				queues: QueueResponse[],
+				page: number
+			) {
 				const requests = { count: 0 };
 				msw.use(
 					http.get(
@@ -79,7 +83,7 @@ describe("wrangler", () => {
 				return requests;
 			}
 
-			it("should show the correct help text", async () => {
+			it("should show the correct help text", async ({ expect }) => {
 				await runWrangler("queues list --help");
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.out).toMatchInlineSnapshot(`
@@ -100,7 +104,7 @@ describe("wrangler", () => {
 				`);
 			});
 
-			it("should list queues on page 1 with no --page", async () => {
+			it("should list queues on page 1 with no --page", async ({ expect }) => {
 				const expectedQueues: QueueResponse[] = [
 					{
 						queue_id: "5e1b9969eb974d8c99c48d19df104c7a",
@@ -130,7 +134,7 @@ describe("wrangler", () => {
 					},
 				];
 				const expectedPage = 1;
-				mockListRequest(expectedQueues, expectedPage);
+				mockListRequest(expect, expectedQueues, expectedPage);
 				await runWrangler("queues list");
 
 				expect(std.err).toMatchInlineSnapshot(`""`);
@@ -148,7 +152,7 @@ describe("wrangler", () => {
 				`);
 			});
 
-			it("should list queues using --page=2", async () => {
+			it("should list queues using --page=2", async ({ expect }) => {
 				const expectedQueues: QueueResponse[] = [
 					{
 						queue_id: "7f7c2df28cee49ad-bbb46c9e5426e850",
@@ -165,7 +169,7 @@ describe("wrangler", () => {
 					},
 				];
 				const expectedPage = 2;
-				mockListRequest(expectedQueues, expectedPage);
+				mockListRequest(expect, expectedQueues, expectedPage);
 				await runWrangler("queues list --page=2");
 
 				expect(std.err).toMatchInlineSnapshot(`""`);
@@ -184,6 +188,7 @@ describe("wrangler", () => {
 
 		describe("create", () => {
 			function mockCreateRequest(
+				expect: ExpectStatic,
 				queueName: string,
 				queueSettings?: {
 					delivery_delay?: number;
@@ -224,7 +229,7 @@ describe("wrangler", () => {
 				return requests;
 			}
 
-			it("should show the correct help text", async () => {
+			it("should show the correct help text", async ({ expect }) => {
 				await runWrangler("queues create --help");
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.out).toMatchInlineSnapshot(`
@@ -249,16 +254,18 @@ describe("wrangler", () => {
 				`);
 			});
 			describe.each(["wrangler.json", "wrangler.toml"])("%s", (configPath) => {
-				it("should create a queue", async () => {
+				it("should create a queue", async ({ expect }) => {
 					writeWranglerConfig({}, configPath);
-					const requests = mockCreateRequest("testQueue");
+					const requests = mockCreateRequest(expect, "testQueue");
 					await runWrangler("queues create testQueue");
 					expect(std.out).toMatchSnapshot();
 					expect(requests.count).toEqual(1);
 				});
 
-				it("should send queue settings with delivery delay", async () => {
-					const requests = mockCreateRequest("testQueue", {
+				it("should send queue settings with delivery delay", async ({
+					expect,
+				}) => {
+					const requests = mockCreateRequest(expect, "testQueue", {
 						delivery_delay: 10,
 					});
 					writeWranglerConfig({}, configPath);
@@ -268,8 +275,12 @@ describe("wrangler", () => {
 				});
 			});
 
-			it("should show an error when two delivery delays are set", async () => {
-				const requests = mockCreateRequest("testQueue", { delivery_delay: 0 });
+			it("should show an error when two delivery delays are set", async ({
+				expect,
+			}) => {
+				const requests = mockCreateRequest(expect, "testQueue", {
+					delivery_delay: 0,
+				});
 
 				await expect(
 					runWrangler(
@@ -282,8 +293,12 @@ describe("wrangler", () => {
 				expect(requests.count).toEqual(0);
 			});
 
-			it("should show an error when invalid delivery delay is set", async () => {
-				const requests = mockCreateRequest("testQueue", { delivery_delay: 10 });
+			it("should show an error when invalid delivery delay is set", async ({
+				expect,
+			}) => {
+				const requests = mockCreateRequest(expect, "testQueue", {
+					delivery_delay: 10,
+				});
 				await expect(
 					runWrangler("queues create testQueue --delivery-delay-secs=99999")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -293,8 +308,10 @@ describe("wrangler", () => {
 				expect(requests.count).toEqual(0);
 			});
 
-			it("should send queue settings with message retention period", async () => {
-				const requests = mockCreateRequest("testQueue", {
+			it("should send queue settings with message retention period", async ({
+				expect,
+			}) => {
+				const requests = mockCreateRequest(expect, "testQueue", {
 					message_retention_period: 100,
 				});
 				await runWrangler(
@@ -334,8 +351,10 @@ describe("wrangler", () => {
 				expect(requests.count).toEqual(1);
 			});
 
-			it("should show an error when two message retention periods are set", async () => {
-				const requests = mockCreateRequest("testQueue", {
+			it("should show an error when two message retention periods are set", async ({
+				expect,
+			}) => {
+				const requests = mockCreateRequest(expect, "testQueue", {
 					message_retention_period: 60,
 				});
 
@@ -350,8 +369,10 @@ describe("wrangler", () => {
 				expect(requests.count).toEqual(0);
 			});
 
-			it("should show an error when invalid message retention period is set", async () => {
-				const requests = mockCreateRequest("testQueue", {
+			it("should show an error when invalid message retention period is set", async ({
+				expect,
+			}) => {
+				const requests = mockCreateRequest(expect, "testQueue", {
 					message_retention_period: 100,
 				});
 				await expect(
@@ -368,6 +389,7 @@ describe("wrangler", () => {
 
 		describe("update", () => {
 			function mockUpdateRequest(
+				expect: ExpectStatic,
 				queueName: string,
 				queueSettings:
 					| { delivery_delay?: number; message_retention_period?: number }
@@ -448,7 +470,7 @@ describe("wrangler", () => {
 				return requests;
 			}
 
-			it("should show the correct help text", async () => {
+			it("should show the correct help text", async ({ expect }) => {
 				await runWrangler("queues update --help");
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.out).toMatchInlineSnapshot(`
@@ -473,14 +495,16 @@ describe("wrangler", () => {
 				`);
 			});
 
-			it("should update a queue with new message retention period and preserve old delivery delay", async () => {
+			it("should update a queue with new message retention period and preserve old delivery delay", async ({
+				expect,
+			}) => {
 				const getrequests = mockGetQueueRequest("testQueue", {
 					delivery_delay: 10,
 					message_retention_period: 100,
 				});
 
 				//update queue with new message retention period
-				const requests = mockUpdateRequest("testQueue", {
+				const requests = mockUpdateRequest(expect, "testQueue", {
 					delivery_delay: 10,
 					message_retention_period: 400,
 				});
@@ -500,8 +524,10 @@ describe("wrangler", () => {
 				`);
 			});
 
-			it("should show an error when two message retention periods are set", async () => {
-				const requests = mockUpdateRequest("testQueue", {
+			it("should show an error when two message retention periods are set", async ({
+				expect,
+			}) => {
+				const requests = mockUpdateRequest(expect, "testQueue", {
 					message_retention_period: 60,
 				});
 
@@ -521,8 +547,10 @@ describe("wrangler", () => {
 				expect(requests.count).toEqual(0);
 			});
 
-			it("should show an error when two delivery delays are set", async () => {
-				const requests = mockUpdateRequest("testQueue", {
+			it("should show an error when two delivery delays are set", async ({
+				expect,
+			}) => {
+				const requests = mockUpdateRequest(expect, "testQueue", {
 					delivery_delay: 10,
 				});
 
@@ -542,8 +570,10 @@ describe("wrangler", () => {
 				expect(requests.count).toEqual(0);
 			});
 
-			it("should show an error when invalid delivery delay is set", async () => {
-				const requests = mockUpdateRequest("testQueue", {
+			it("should show an error when invalid delivery delay is set", async ({
+				expect,
+			}) => {
+				const requests = mockUpdateRequest(expect, "testQueue", {
 					delivery_delay: 10,
 				});
 
@@ -561,8 +591,10 @@ describe("wrangler", () => {
 				expect(requests.count).toEqual(0);
 			});
 
-			it("should show an error when invalid message retention period is set", async () => {
-				const requests = mockUpdateRequest("testQueue", {
+			it("should show an error when invalid message retention period is set", async ({
+				expect,
+			}) => {
+				const requests = mockUpdateRequest(expect, "testQueue", {
 					message_retention_period: 100,
 				});
 
@@ -584,7 +616,7 @@ describe("wrangler", () => {
 		});
 
 		describe("delete", () => {
-			function mockDeleteRequest(queueId: string) {
+			function mockDeleteRequest(expect: ExpectStatic, queueId: string) {
 				const requests = { count: 0 };
 				msw.use(
 					http.delete(
@@ -606,7 +638,7 @@ describe("wrangler", () => {
 				return requests;
 			}
 
-			it("should show the correct help text", async () => {
+			it("should show the correct help text", async ({ expect }) => {
 				await runWrangler("queues delete --help");
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.out).toMatchInlineSnapshot(`
@@ -627,7 +659,7 @@ describe("wrangler", () => {
 				`);
 			});
 
-			it("should delete a queue", async () => {
+			it("should delete a queue", async ({ expect }) => {
 				const queueNameResolveRequest = mockGetQueueByNameRequest(
 					expectedQueueName,
 					{
@@ -642,7 +674,7 @@ describe("wrangler", () => {
 					}
 				);
 
-				const deleteRequest = mockDeleteRequest(expectedQueueId);
+				const deleteRequest = mockDeleteRequest(expect, expectedQueueId);
 				await runWrangler("queues delete testQueue");
 				expect(std.out).toMatchInlineSnapshot(`
 					"
@@ -655,13 +687,13 @@ describe("wrangler", () => {
 				expect(deleteRequest.count).toEqual(1);
 			});
 
-			it("should show error when a queue doesn't exist", async () => {
+			it("should show error when a queue doesn't exist", async ({ expect }) => {
 				const queueNameResolveRequest = mockGetQueueByNameRequest(
 					expectedQueueName,
 					null
 				);
 
-				const deleteRequest = mockDeleteRequest(expectedQueueId);
+				const deleteRequest = mockDeleteRequest(expect, expectedQueueId);
 				await runWrangler();
 				await expect(
 					runWrangler("queues delete testQueue")
@@ -675,7 +707,7 @@ describe("wrangler", () => {
 		});
 
 		describe("consumers", () => {
-			it("should show the correct help text", async () => {
+			it("should show the correct help text", async ({ expect }) => {
 				await runWrangler("queues consumer --help");
 
 				expect(std.err).toMatchInlineSnapshot(`""`);
@@ -702,6 +734,7 @@ describe("wrangler", () => {
 
 			describe("add", () => {
 				function mockPostRequest(
+					expect: ExpectStatic,
 					queueName: string,
 					expectedBody: PostTypedConsumerBody
 				) {
@@ -727,7 +760,7 @@ describe("wrangler", () => {
 					return requests;
 				}
 
-				it("should show the correct help text", async () => {
+				it("should show the correct help text", async ({ expect }) => {
 					await runWrangler("queues consumer add --help");
 					expect(std.err).toMatchInlineSnapshot(`""`);
 					expect(std.out).toMatchInlineSnapshot(`
@@ -757,7 +790,7 @@ describe("wrangler", () => {
 					`);
 				});
 
-				it("should add a consumer using defaults", async () => {
+				it("should add a consumer using defaults", async ({ expect }) => {
 					const queueNameResolveRequest = mockGetQueueByNameRequest(
 						expectedQueueName,
 						{
@@ -785,22 +818,26 @@ describe("wrangler", () => {
 						},
 						dead_letter_queue: undefined,
 					};
-					const postRequest = mockPostRequest(expectedQueueId, expectedBody);
+					const postRequest = mockPostRequest(
+						expect,
+						expectedQueueId,
+						expectedBody
+					);
 					await runWrangler("queues consumer add testQueue testScript");
 
 					expect(queueNameResolveRequest.count).toEqual(1);
 					expect(postRequest.count).toEqual(1);
 
 					expect(std.out).toMatchInlineSnapshot(`
-						"
-						 ⛅️ wrangler x.x.x
-						──────────────────
-						Adding consumer to queue testQueue.
-						Added consumer to queue testQueue."
-					`);
+					"
+					 ⛅️ wrangler x.x.x
+					──────────────────
+					Adding consumer to queue testQueue.
+					Added consumer to queue testQueue."
+				`);
 				});
 
-				it("should add a consumer using custom values", async () => {
+				it("should add a consumer using custom values", async ({ expect }) => {
 					const queueNameResolveRequest = mockGetQueueByNameRequest(
 						expectedQueueName,
 						{
@@ -828,7 +865,11 @@ describe("wrangler", () => {
 						},
 						dead_letter_queue: "myDLQ",
 					};
-					const postRequest = mockPostRequest(expectedQueueId, expectedBody);
+					const postRequest = mockPostRequest(
+						expect,
+						expectedQueueId,
+						expectedBody
+					);
 
 					await runWrangler(
 						"queues consumer add testQueue testScript --env myEnv --batch-size 20 --batch-timeout 10 --message-retries 3 --max-concurrency 3 --dead-letter-queue myDLQ --retry-delay-secs=10"
@@ -846,7 +887,9 @@ describe("wrangler", () => {
 					`);
 				});
 
-				it("should add a consumer with batchTimeout of 0", async () => {
+				it("should add a consumer with batchTimeout of 0", async ({
+					expect,
+				}) => {
 					const queueNameResolveRequest = mockGetQueueByNameRequest(
 						expectedQueueName,
 						{
@@ -874,7 +917,11 @@ describe("wrangler", () => {
 						},
 						dead_letter_queue: "myDLQ",
 					};
-					const postRequest = mockPostRequest(expectedQueueId, expectedBody);
+					const postRequest = mockPostRequest(
+						expect,
+						expectedQueueId,
+						expectedBody
+					);
 
 					await runWrangler(
 						"queues consumer add testQueue testScript --env myEnv --batch-size 20 --batch-timeout 0 --message-retries 3 --max-concurrency 3 --dead-letter-queue myDLQ --retry-delay-secs=10"
@@ -892,7 +939,9 @@ describe("wrangler", () => {
 					`);
 				});
 
-				it("should show an error when two retry delays are set", async () => {
+				it("should show an error when two retry delays are set", async ({
+					expect,
+				}) => {
 					const expectedBody: PostTypedConsumerBody = {
 						script_name: "testScript",
 						type: "worker",
@@ -906,7 +955,7 @@ describe("wrangler", () => {
 						},
 						dead_letter_queue: "myDLQ",
 					};
-					const requests = mockPostRequest("testQueue", expectedBody);
+					const requests = mockPostRequest(expect, "testQueue", expectedBody);
 
 					await expect(
 						runWrangler(
@@ -919,7 +968,9 @@ describe("wrangler", () => {
 					expect(requests.count).toEqual(0);
 				});
 
-				it("should show an error when queue does not exist", async () => {
+				it("should show an error when queue does not exist", async ({
+					expect,
+				}) => {
 					const queueNameResolveRequest = mockGetQueueByNameRequest(
 						expectedQueueName,
 						null
@@ -937,7 +988,11 @@ describe("wrangler", () => {
 						},
 						dead_letter_queue: "myDLQ",
 					};
-					const postRequest = mockPostRequest(expectedQueueId, expectedBody);
+					const postRequest = mockPostRequest(
+						expect,
+						expectedQueueId,
+						expectedBody
+					);
 
 					await expect(
 						runWrangler(
@@ -951,7 +1006,9 @@ describe("wrangler", () => {
 					expect(postRequest.count).toEqual(0);
 				});
 
-				it.skip("should show link to dash when not enabled", async () => {
+				it.skip("should show link to dash when not enabled", async ({
+					expect,
+				}) => {
 					const queueName = "testQueueId";
 					msw.use(
 						http.post(
@@ -998,7 +1055,11 @@ describe("wrangler", () => {
 			});
 
 			describe("delete", () => {
-				function mockDeleteRequest(queueId: string, consumerId: string) {
+				function mockDeleteRequest(
+					expect: ExpectStatic,
+					queueId: string,
+					consumerId: string
+				) {
 					const requests = { count: 0 };
 					const resource = `accounts/:accountId/queues/:expectedQueueId/consumers/:expectedConsumerId`;
 
@@ -1027,7 +1088,11 @@ describe("wrangler", () => {
 					return requests;
 				}
 
-				function mockServiceRequest(serviceName: string, defaultEnv: string) {
+				function mockServiceRequest(
+					expect: ExpectStatic,
+					serviceName: string,
+					defaultEnv: string
+				) {
 					const requests = { count: 0 };
 					const resource = `accounts/:accountId/workers/services/:serviceName`;
 
@@ -1059,7 +1124,7 @@ describe("wrangler", () => {
 					return requests;
 				}
 
-				it("should show the correct help text", async () => {
+				it("should show the correct help text", async ({ expect }) => {
 					await runWrangler("queues consumer remove --help");
 					expect(std.err).toMatchInlineSnapshot(`""`);
 					expect(std.out).toMatchInlineSnapshot(`
@@ -1081,12 +1146,15 @@ describe("wrangler", () => {
 					`);
 				});
 
-				it("should show an error when queue does not exist", async () => {
+				it("should show an error when queue does not exist", async ({
+					expect,
+				}) => {
 					const queueNameResolveRequest = mockGetQueueByNameRequest(
 						expectedQueueName,
 						null
 					);
 					const postRequest = mockDeleteRequest(
+						expect,
 						expectedQueueId,
 						expectedConsumerId
 					);
@@ -1104,7 +1172,7 @@ describe("wrangler", () => {
 				});
 
 				describe("when script consumers are in use", () => {
-					it("should delete the correct consumer", async () => {
+					it("should delete the correct consumer", async ({ expect }) => {
 						const queueNameResolveRequest = mockGetQueueByNameRequest(
 							expectedQueueName,
 							{
@@ -1127,6 +1195,7 @@ describe("wrangler", () => {
 						);
 
 						const deleteRequest = mockDeleteRequest(
+							expect,
 							expectedQueueId,
 							expectedConsumerId
 						);
@@ -1135,15 +1204,17 @@ describe("wrangler", () => {
 						expect(queueNameResolveRequest.count).toEqual(1);
 						expect(deleteRequest.count).toEqual(1);
 						expect(std.out).toMatchInlineSnapshot(`
-							"
-							 ⛅️ wrangler x.x.x
-							──────────────────
-							Removing consumer from queue testQueue.
-							Removed consumer from queue testQueue."
-						`);
+						"
+						 ⛅️ wrangler x.x.x
+						──────────────────
+						Removing consumer from queue testQueue.
+						Removed consumer from queue testQueue."
+					`);
 					});
 
-					it("should show error when deleting a non-existing consumer", async () => {
+					it("should show error when deleting a non-existing consumer", async ({
+						expect,
+					}) => {
 						const queueNameResolveRequest = mockGetQueueByNameRequest(
 							expectedQueueName,
 							{
@@ -1166,6 +1237,7 @@ describe("wrangler", () => {
 						);
 
 						const deleteRequest = mockDeleteRequest(
+							expect,
 							expectedQueueId,
 							expectedConsumerId
 						);
@@ -1181,7 +1253,7 @@ describe("wrangler", () => {
 				});
 
 				describe("when service consumers are in use", () => {
-					it("should delete a consumer with env set", async () => {
+					it("should delete a consumer with env set", async ({ expect }) => {
 						const queueNameResolveRequest = mockGetQueueByNameRequest(
 							expectedQueueName,
 							{
@@ -1205,6 +1277,7 @@ describe("wrangler", () => {
 						);
 
 						const deleteRequest = mockDeleteRequest(
+							expect,
 							expectedQueueId,
 							expectedConsumerId
 						);
@@ -1215,15 +1288,17 @@ describe("wrangler", () => {
 						expect(queueNameResolveRequest.count).toEqual(1);
 						expect(deleteRequest.count).toEqual(1);
 						expect(std.out).toMatchInlineSnapshot(`
-							"
-							 ⛅️ wrangler x.x.x
-							──────────────────
-							Removing consumer from queue testQueue.
-							Removed consumer from queue testQueue."
-						`);
+						"
+						 ⛅️ wrangler x.x.x
+						──────────────────
+						Removing consumer from queue testQueue.
+						Removed consumer from queue testQueue."
+					`);
 					});
 
-					it("should show error when deleting a non-matching environment", async () => {
+					it("should show error when deleting a non-matching environment", async ({
+						expect,
+					}) => {
 						const queueNameResolveRequest = mockGetQueueByNameRequest(
 							expectedQueueName,
 							{
@@ -1247,6 +1322,7 @@ describe("wrangler", () => {
 						);
 
 						const deleteRequest = mockDeleteRequest(
+							expect,
 							expectedQueueId,
 							expectedConsumerId
 						);
@@ -1262,7 +1338,7 @@ describe("wrangler", () => {
 						expect(deleteRequest.count).toEqual(0);
 					});
 
-					it("should delete a consumer without env set", async () => {
+					it("should delete a consumer without env set", async ({ expect }) => {
 						const queueNameResolveRequest = mockGetQueueByNameRequest(
 							expectedQueueName,
 							{
@@ -1285,8 +1361,13 @@ describe("wrangler", () => {
 							}
 						);
 
-						const serviceRequest = mockServiceRequest("testScript", "myEnv");
+						const serviceRequest = mockServiceRequest(
+							expect,
+							"testScript",
+							"myEnv"
+						);
 						const deleteRequest = mockDeleteRequest(
+							expect,
 							expectedQueueId,
 							expectedConsumerId
 						);
@@ -1306,7 +1387,9 @@ describe("wrangler", () => {
 					});
 
 					describe("when multiple consumers are set", () => {
-						it("should delete default environment consumer without env set", async () => {
+						it("should delete default environment consumer without env set", async ({
+							expect,
+						}) => {
 							const expectedDefaultEnvironment = "staging";
 							const expectedConsumerIdToDelete = "consumer-id-staging";
 							const queueNameResolveRequest = mockGetQueueByNameRequest(
@@ -1339,10 +1422,12 @@ describe("wrangler", () => {
 							);
 
 							const serviceRequest = mockServiceRequest(
+								expect,
 								"testScript",
 								expectedDefaultEnvironment
 							);
 							const deleteRequest = mockDeleteRequest(
+								expect,
 								expectedQueueId,
 								expectedConsumerIdToDelete
 							);
@@ -1360,7 +1445,9 @@ describe("wrangler", () => {
 							`);
 						});
 
-						it("should delete matching consumer with env set", async () => {
+						it("should delete matching consumer with env set", async ({
+							expect,
+						}) => {
 							const expectedConsumerIdToDelete = "consumer-id-staging";
 							const queueNameResolveRequest = mockGetQueueByNameRequest(
 								expectedQueueName,
@@ -1392,6 +1479,7 @@ describe("wrangler", () => {
 							);
 
 							const deleteRequest = mockDeleteRequest(
+								expect,
 								expectedQueueId,
 								expectedConsumerIdToDelete
 							);
@@ -1410,7 +1498,9 @@ describe("wrangler", () => {
 							`);
 						});
 
-						it("should show error when deleting on a non-matching environment", async () => {
+						it("should show error when deleting on a non-matching environment", async ({
+							expect,
+						}) => {
 							const expectedConsumerIdToDelete = "consumer-id-staging";
 							const queueNameResolveRequest = mockGetQueueByNameRequest(
 								expectedQueueName,
@@ -1442,6 +1532,7 @@ describe("wrangler", () => {
 							);
 
 							const deleteRequest = mockDeleteRequest(
+								expect,
 								expectedQueueId,
 								expectedConsumerId
 							);
@@ -1462,7 +1553,7 @@ describe("wrangler", () => {
 		});
 
 		describe("http_pull consumers", () => {
-			it("should show the correct help text", async () => {
+			it("should show the correct help text", async ({ expect }) => {
 				await runWrangler("queues consumer http --help");
 
 				expect(std.err).toMatchInlineSnapshot(`""`);
@@ -1487,6 +1578,7 @@ describe("wrangler", () => {
 
 			describe("add", () => {
 				function mockPostRequest(
+					expect: ExpectStatic,
 					queueId: string,
 					expectedBody: PostTypedConsumerBody
 				) {
@@ -1512,7 +1604,7 @@ describe("wrangler", () => {
 					return requests;
 				}
 
-				it("should show the correct help text", async () => {
+				it("should show the correct help text", async ({ expect }) => {
 					await runWrangler("queues consumer http add --help");
 					expect(std.err).toMatchInlineSnapshot(`""`);
 					expect(std.out).toMatchInlineSnapshot(`
@@ -1540,7 +1632,7 @@ describe("wrangler", () => {
 					`);
 				});
 
-				it("should add a consumer using defaults", async () => {
+				it("should add a consumer using defaults", async ({ expect }) => {
 					const queueNameResolveRequest = mockGetQueueByNameRequest(
 						expectedQueueName,
 						{
@@ -1565,21 +1657,25 @@ describe("wrangler", () => {
 						},
 						dead_letter_queue: undefined,
 					};
-					const postRequest = mockPostRequest(expectedQueueId, expectedBody);
+					const postRequest = mockPostRequest(
+						expect,
+						expectedQueueId,
+						expectedBody
+					);
 
 					await runWrangler("queues consumer http add testQueue");
 					expect(queueNameResolveRequest.count).toEqual(1);
 					expect(postRequest.count).toEqual(1);
 					expect(std.out).toMatchInlineSnapshot(`
-						"
-						 ⛅️ wrangler x.x.x
-						──────────────────
-						Adding consumer to queue testQueue.
-						Added consumer to queue testQueue."
-					`);
+					"
+					 ⛅️ wrangler x.x.x
+					──────────────────
+					Adding consumer to queue testQueue.
+					Added consumer to queue testQueue."
+				`);
 				});
 
-				it("should add a consumer using custom values", async () => {
+				it("should add a consumer using custom values", async ({ expect }) => {
 					const queueNameResolveRequest = mockGetQueueByNameRequest(
 						expectedQueueName,
 						{
@@ -1604,7 +1700,11 @@ describe("wrangler", () => {
 						},
 						dead_letter_queue: "myDLQ",
 					};
-					const postRequest = mockPostRequest(expectedQueueId, expectedBody);
+					const postRequest = mockPostRequest(
+						expect,
+						expectedQueueId,
+						expectedBody
+					);
 
 					await runWrangler(
 						"queues consumer http add testQueue --batch-size 20 --message-retries 3 --visibility-timeout-secs 6 --retry-delay-secs 3 --dead-letter-queue myDLQ"
@@ -1622,7 +1722,11 @@ describe("wrangler", () => {
 			});
 
 			describe("delete", () => {
-				function mockDeleteRequest(queueId: string, consumerId: string) {
+				function mockDeleteRequest(
+					expect: ExpectStatic,
+					queueId: string,
+					consumerId: string
+				) {
 					const requests = { count: 0 };
 					const resource = `accounts/:accountId/queues/:expectedQueueId/consumers/:expectedConsumerId`;
 					msw.use(
@@ -1650,7 +1754,7 @@ describe("wrangler", () => {
 					return requests;
 				}
 
-				it("should show the correct help text", async () => {
+				it("should show the correct help text", async ({ expect }) => {
 					await runWrangler("queues consumer http remove --help");
 					expect(std.err).toMatchInlineSnapshot(`""`);
 					expect(std.out).toMatchInlineSnapshot(`
@@ -1671,7 +1775,7 @@ describe("wrangler", () => {
 					`);
 				});
 
-				it("should delete a pull consumer", async () => {
+				it("should delete a pull consumer", async ({ expect }) => {
 					const queueNameResolveRequest = mockGetQueueByNameRequest(
 						expectedQueueName,
 						{
@@ -1693,6 +1797,7 @@ describe("wrangler", () => {
 					);
 
 					const postRequest = mockDeleteRequest(
+						expect,
 						expectedQueueId,
 						expectedConsumerId
 					);
@@ -1742,7 +1847,9 @@ describe("wrangler", () => {
 				modified_on: "2024-07-19T14:43:56.70498Z",
 			};
 
-			it("should return the documentation for the info command when using the --help param", async () => {
+			it("should return the documentation for the info command when using the --help param", async ({
+				expect,
+			}) => {
 				await runWrangler("queues info --help");
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.out).toMatchInlineSnapshot(`
@@ -1762,7 +1869,9 @@ describe("wrangler", () => {
 					  -v, --version   Show version number  [boolean]"
 				`);
 			});
-			it("should return queue info with worker producers when the queue has workers configured as producers", async () => {
+			it("should return queue info with worker producers when the queue has workers configured as producers", async ({
+				expect,
+			}) => {
 				mockGetQueueByNameRequest(expectedQueueName, mockQueue);
 				await runWrangler("queues info testQueue");
 				expect(std.out).toMatchInlineSnapshot(`
@@ -1779,7 +1888,9 @@ describe("wrangler", () => {
 					Consumers: worker:test-consumer"
 				`);
 			});
-			it('should return "http consumer" and a curl command when the consumer type is http_pull', async () => {
+			it('should return "http consumer" and a curl command when the consumer type is http_pull', async ({
+				expect,
+			}) => {
 				const mockHTTPPullQueue = {
 					...mockQueue,
 					consumers: [{ ...mockQueue.consumers[0], type: "http_pull" }],
@@ -1805,7 +1916,9 @@ describe("wrangler", () => {
 						--data '{ "visibility_timeout": 10000, "batch_size": 2 }'"
 				`);
 			});
-			it("should return the list of r2 bucket producers when the queue is used in an r2 event notification", async () => {
+			it("should return the list of r2 bucket producers when the queue is used in an r2 event notification", async ({
+				expect,
+			}) => {
 				const mockEventNotificationQueue = {
 					...mockQueue,
 					producers: [
@@ -1843,7 +1956,7 @@ describe("wrangler", () => {
 	});
 
 	describe("pause-delivery", () => {
-		function mockUpdateRequest(queueName: string) {
+		function mockUpdateRequest(expect: ExpectStatic, queueName: string) {
 			const requests = { count: 0 };
 
 			msw.use(
@@ -1915,7 +2028,7 @@ describe("wrangler", () => {
 			return requests;
 		}
 
-		it("should show the correct help text", async () => {
+		it("should show the correct help text", async ({ expect }) => {
 			await runWrangler("queues pause-delivery --help");
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.out).toMatchInlineSnapshot(`
@@ -1936,11 +2049,13 @@ describe("wrangler", () => {
 			`);
 		});
 
-		it("should update the queue's delivery_paused setting", async () => {
+		it("should update the queue's delivery_paused setting", async ({
+			expect,
+		}) => {
 			const getrequests = mockGetQueueRequest("testQueue", {
 				delivery_paused: false,
 			});
-			const requests = mockUpdateRequest("testQueue");
+			const requests = mockUpdateRequest(expect, "testQueue");
 			await runWrangler("queues pause-delivery testQueue");
 
 			expect(requests.count).toEqual(1);
@@ -1957,7 +2072,7 @@ describe("wrangler", () => {
 	});
 
 	describe("resume-delivery", () => {
-		function mockUpdateRequest(queueName: string) {
+		function mockUpdateRequest(expect: ExpectStatic, queueName: string) {
 			const requests = { count: 0 };
 
 			msw.use(
@@ -2029,7 +2144,7 @@ describe("wrangler", () => {
 			return requests;
 		}
 
-		it("should show the correct help text", async () => {
+		it("should show the correct help text", async ({ expect }) => {
 			await runWrangler("queues resume-delivery --help");
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.out).toMatchInlineSnapshot(`
@@ -2050,11 +2165,13 @@ describe("wrangler", () => {
 			`);
 		});
 
-		it("should update the queue's delivery_paused setting to false", async () => {
+		it("should update the queue's delivery_paused setting to false", async ({
+			expect,
+		}) => {
 			const getrequests = mockGetQueueRequest("testQueue", {
 				delivery_paused: false,
 			});
-			const requests = mockUpdateRequest("testQueue");
+			const requests = mockUpdateRequest(expect, "testQueue");
 			await runWrangler("queues resume-delivery testQueue");
 
 			expect(requests.count).toEqual(1);
@@ -2076,7 +2193,7 @@ describe("wrangler", () => {
 			setIsTTY(false);
 		});
 
-		function mockPurgeRequest() {
+		function mockPurgeRequest(expect: ExpectStatic) {
 			const requests = { count: 0 };
 
 			msw.use(
@@ -2135,7 +2252,7 @@ describe("wrangler", () => {
 			return requests;
 		}
 
-		it("should show the correct help text", async () => {
+		it("should show the correct help text", async ({ expect }) => {
 			await runWrangler("queues purge --help");
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.out).toMatchInlineSnapshot(`
@@ -2159,9 +2276,11 @@ describe("wrangler", () => {
 			`);
 		});
 
-		it("rejects a missing --force flag in non-interactive mode", async () => {
+		it("rejects a missing --force flag in non-interactive mode", async ({
+			expect,
+		}) => {
 			const getrequests = mockGetQueueRequest("testQueue");
-			const requests = mockPurgeRequest();
+			const requests = mockPurgeRequest(expect);
 
 			await expect(
 				runWrangler("queues purge testQueue")
@@ -2180,9 +2299,11 @@ describe("wrangler", () => {
 			`);
 		});
 
-		it("allows purge with the --force flag in non-interactive mode", async () => {
+		it("allows purge with the --force flag in non-interactive mode", async ({
+			expect,
+		}) => {
 			const getrequests = mockGetQueueRequest("testQueue");
-			const requests = mockPurgeRequest();
+			const requests = mockPurgeRequest(expect);
 
 			await runWrangler("queues purge testQueue --force");
 
@@ -2197,9 +2318,11 @@ describe("wrangler", () => {
 			`);
 		});
 
-		it("allows purge with the --force flag in non-interactive mode", async () => {
+		it("allows purge with the --force flag in non-interactive mode", async ({
+			expect,
+		}) => {
 			const getrequests = mockGetQueueRequest("testQueue");
-			const requests = mockPurgeRequest();
+			const requests = mockPurgeRequest(expect);
 
 			await runWrangler("queues purge testQueue --force");
 
@@ -2214,10 +2337,12 @@ describe("wrangler", () => {
 			`);
 		});
 
-		it("allows purge with the --force flag in interactive mode", async () => {
+		it("allows purge with the --force flag in interactive mode", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 			const getrequests = mockGetQueueRequest("testQueue");
-			const requests = mockPurgeRequest();
+			const requests = mockPurgeRequest(expect);
 			await runWrangler("queues purge testQueue --force");
 
 			expect(requests.count).toEqual(1);
@@ -2231,10 +2356,12 @@ describe("wrangler", () => {
 			`);
 		});
 
-		it("rejects invalid confirmation in interactive mode", async () => {
+		it("rejects invalid confirmation in interactive mode", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 			const getrequests = mockGetQueueRequest("testQueue");
-			const requests = mockPurgeRequest();
+			const requests = mockPurgeRequest(expect);
 			mockPrompt({
 				text: "This operation will permanently delete all the messages in Queue testQueue. Type testQueue to proceed.",
 				result: "wrong-name",
@@ -2256,10 +2383,12 @@ describe("wrangler", () => {
 			`);
 		});
 
-		it("allows purge with correct confirmation in interactive mode", async () => {
+		it("allows purge with correct confirmation in interactive mode", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 			const getrequests = mockGetQueueRequest("testQueue");
-			const requests = mockPurgeRequest();
+			const requests = mockPurgeRequest(expect);
 			mockPrompt({
 				text: "This operation will permanently delete all the messages in Queue testQueue. Type testQueue to proceed.",
 				result: "testQueue",

--- a/packages/wrangler/src/__tests__/rollback.test.ts
+++ b/packages/wrangler/src/__tests__/rollback.test.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { describe, expect, test } from "vitest";
+import { describe, test } from "vitest";
 import { CANNOT_ROLLBACK_WITH_MODIFIED_SECERT_CODE } from "../versions/rollback";
 import { collectCLIOutput } from "./helpers/collect-cli-output";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
@@ -10,6 +9,7 @@ import { useMockIsTTY } from "./helpers/mock-istty";
 import { createFetchResult, msw } from "./helpers/msw";
 import { runWrangler } from "./helpers/run-wrangler";
 import type { ApiDeployment } from "../versions/types";
+import type { ExpectStatic } from "vitest";
 
 describe("rollback", () => {
 	mockConsoleMethods();
@@ -18,7 +18,7 @@ describe("rollback", () => {
 	mockAccountId();
 	mockApiToken();
 
-	function mockGetDeployments(multiVersion = false) {
+	function mockGetDeployments(expect: ExpectStatic, multiVersion = false) {
 		const versions = multiVersion
 			? [
 					{ version_id: "version-id-1", percentage: 50 },
@@ -51,7 +51,7 @@ describe("rollback", () => {
 		);
 	}
 
-	function mockGetVersion(versionId: string) {
+	function mockGetVersion(expect: ExpectStatic, versionId: string) {
 		msw.use(
 			http.get(
 				`*/accounts/:accountId/workers/scripts/:scriptName/versions/${versionId}`,
@@ -100,7 +100,7 @@ describe("rollback", () => {
 		);
 	}
 
-	function mockPostDeployment(forced = false) {
+	function mockPostDeployment(expect: ExpectStatic, forced = false) {
 		msw.use(
 			http.post(
 				`*/accounts/:accountId/workers/scripts/:scriptName/deployments${forced ? "?force=true" : ""}`,
@@ -115,11 +115,11 @@ describe("rollback", () => {
 		);
 	}
 
-	test("can rollback to an earlier version", async () => {
-		mockGetDeployments();
-		mockGetVersion("version-id-1");
-		mockGetVersion("rollback-version");
-		mockPostDeployment();
+	test("can rollback to an earlier version", async ({ expect }) => {
+		mockGetDeployments(expect);
+		mockGetVersion(expect, "version-id-1");
+		mockGetVersion(expect, "rollback-version");
+		mockPostDeployment(expect);
 
 		mockPrompt({
 			text: "Please provide an optional message for this rollback (120 characters max)",
@@ -139,10 +139,12 @@ describe("rollback", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("rolling back with changed secrets prompts confirmation", async () => {
-		mockGetDeployments();
-		mockGetVersion("version-id-1");
-		mockGetVersion("rollback-version");
+	test("rolling back with changed secrets prompts confirmation", async ({
+		expect,
+	}) => {
+		mockGetDeployments(expect);
+		mockGetVersion(expect, "version-id-1");
+		mockGetVersion(expect, "rollback-version");
 
 		// Deployment will fail due to changed secret
 		msw.use(
@@ -168,7 +170,7 @@ describe("rollback", () => {
 		);
 
 		// Now deploy again with force and succeed
-		mockPostDeployment(true);
+		mockPostDeployment(expect, true);
 
 		mockPrompt({
 			text: "Please provide an optional message for this rollback (120 characters max)",
@@ -196,11 +198,13 @@ describe("rollback", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("rolling back with changed secrets (non-interactive)", async () => {
+	test("rolling back with changed secrets (non-interactive)", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
-		mockGetDeployments();
-		mockGetVersion("version-id-1");
-		mockGetVersion("rollback-version");
+		mockGetDeployments(expect);
+		mockGetVersion(expect, "version-id-1");
+		mockGetVersion(expect, "rollback-version");
 
 		// Deployment will fail due to changed secret
 		msw.use(
@@ -226,7 +230,7 @@ describe("rollback", () => {
 		);
 
 		// Now deploy again with force and succeed
-		mockPostDeployment(true);
+		mockPostDeployment(expect, true);
 
 		await runWrangler(
 			"rollback --name script-name --version-id rollback-version"

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -4,8 +4,7 @@ import readline from "node:readline";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import * as TOML from "smol-toml";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { VERSION_NOT_DEPLOYED_ERR_CODE } from "../secret";
 import {
 	WORKER_NOT_FOUND_ERR_CODE,
@@ -21,6 +20,7 @@ import { msw } from "./helpers/msw";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type { Interface } from "node:readline";
+import type { ExpectStatic } from "vitest";
 
 function createFetchResult(
 	result: unknown,
@@ -99,6 +99,7 @@ describe("wrangler secret", () => {
 
 	describe("put", () => {
 		function mockPutRequest(
+			expect: ExpectStatic,
 			input: { name: string; text: string },
 			env?: string,
 			useServiceEnvironments = true,
@@ -136,7 +137,9 @@ describe("wrangler secret", () => {
 			);
 		}
 
-		it("should error helpfully if pages_build_output_dir is set", async () => {
+		it("should error helpfully if pages_build_output_dir is set", async ({
+			expect,
+		}) => {
 			fs.writeFileSync(
 				"wrangler.toml",
 				TOML.stringify({
@@ -160,7 +163,7 @@ describe("wrangler secret", () => {
 				setIsTTY(true);
 			});
 
-			it("should trim stdin secret value", async () => {
+			it("should trim stdin secret value", async ({ expect }) => {
 				mockPrompt({
 					text: "Enter a secret value:",
 					options: { isSecret: true },
@@ -168,7 +171,7 @@ describe("wrangler secret", () => {
           `,
 				});
 
-				mockPutRequest({ name: `secret-name`, text: `hunter2` });
+				mockPutRequest(expect, { name: `secret-name`, text: `hunter2` });
 				await runWrangler("secret put secret-name --name script-name");
 				expect(std.out).toMatchInlineSnapshot(`
 					"
@@ -179,14 +182,14 @@ describe("wrangler secret", () => {
 				`);
 			});
 
-			it("should create a secret: service envs", async () => {
+			it("should create a secret: service envs", async ({ expect }) => {
 				mockPrompt({
 					text: "Enter a secret value:",
 					options: { isSecret: true },
 					result: "the-secret",
 				});
 
-				mockPutRequest({ name: "the-key", text: "the-secret" });
+				mockPutRequest(expect, { name: "the-key", text: "the-secret" });
 				await runWrangler("secret put the-key --name script-name");
 
 				expect(std.out).toMatchInlineSnapshot(`
@@ -199,7 +202,7 @@ describe("wrangler secret", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should create a secret", async () => {
+			it("should create a secret", async ({ expect }) => {
 				mockPrompt({
 					text: "Enter a secret value:",
 					options: { isSecret: true },
@@ -207,6 +210,7 @@ describe("wrangler secret", () => {
 				});
 
 				mockPutRequest(
+					expect,
 					{ name: "the-key", text: "the-secret" },
 					"some-env",
 					false
@@ -225,7 +229,7 @@ describe("wrangler secret", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should create a secret: service envs", async () => {
+			it("should create a secret: service envs", async ({ expect }) => {
 				mockPrompt({
 					text: "Enter a secret value:",
 					options: { isSecret: true },
@@ -233,6 +237,7 @@ describe("wrangler secret", () => {
 				});
 
 				mockPutRequest(
+					expect,
 					{ name: "the-key", text: "the-secret" },
 					"some-env",
 					true
@@ -251,7 +256,7 @@ describe("wrangler secret", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should error without a script name", async () => {
+			it("should error without a script name", async ({ expect }) => {
 				let error: Error | undefined;
 				try {
 					await runWrangler("secret put the-key");
@@ -274,7 +279,9 @@ describe("wrangler secret", () => {
 				);
 			});
 
-			it("should ask to create a new Worker if no Worker is found under the provided name and abort if declined", async () => {
+			it("should ask to create a new Worker if no Worker is found under the provided name and abort if declined", async ({
+				expect,
+			}) => {
 				mockPrompt({
 					text: "Enter a secret value:",
 					options: { isSecret: true },
@@ -304,8 +311,10 @@ describe("wrangler secret", () => {
 			});
 			const mockStdIn = useMockStdin({ isTTY: false });
 
-			it("should trim stdin secret value, from piped input", async () => {
-				mockPutRequest({ name: "the-key", text: "the-secret" });
+			it("should trim stdin secret value, from piped input", async ({
+				expect,
+			}) => {
+				mockPutRequest(expect, { name: "the-key", text: "the-secret" });
 				// Pipe the secret in as three chunks to test that we reconstitute it correctly.
 				mockStdIn.send(
 					`the`,
@@ -326,8 +335,8 @@ describe("wrangler secret", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should create a secret, from piped input", async () => {
-				mockPutRequest({ name: "the-key", text: "the-secret" });
+			it("should create a secret, from piped input", async ({ expect }) => {
+				mockPutRequest(expect, { name: "the-key", text: "the-secret" });
 				// Pipe the secret in as three chunks to test that we reconstitute it correctly.
 				mockStdIn.send("the", "-", "secret");
 				await runWrangler("secret put the-key --name script-name");
@@ -343,8 +352,8 @@ describe("wrangler secret", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should error if the piped input fails", async () => {
-				mockPutRequest({ name: "the-key", text: "the-secret" });
+			it("should error if the piped input fails", async ({ expect }) => {
+				mockPutRequest(expect, { name: "the-key", text: "the-secret" });
 				mockStdIn.throwError(new Error("Error in stdin stream"));
 				await expect(
 					runWrangler("secret put the-key --name script-name")
@@ -362,7 +371,9 @@ describe("wrangler secret", () => {
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should create a new worker if no worker is found under the provided name", async () => {
+			it("should create a new worker if no worker is found under the provided name", async ({
+				expect,
+			}) => {
 				mockStdIn.send("hunter2");
 				mockNoWorkerFound();
 				msw.use(
@@ -377,6 +388,7 @@ describe("wrangler secret", () => {
 					)
 				);
 				mockPutRequest(
+					expect,
 					{ name: "the-key", text: "hunter2" },
 					undefined,
 					undefined,
@@ -397,7 +409,9 @@ describe("wrangler secret", () => {
 			describe("with accountId", () => {
 				mockAccountId({ accountId: null });
 
-				it("should error if request for memberships fails", async () => {
+				it("should error if request for memberships fails", async ({
+					expect,
+				}) => {
 					mockGetMembershipsFail();
 					await expect(
 						runWrangler("secret put the-key --name script-name")
@@ -406,7 +420,7 @@ describe("wrangler secret", () => {
 					);
 				});
 
-				it("should error if a user has no account", async () => {
+				it("should error if a user has no account", async ({ expect }) => {
 					mockGetMemberships([]);
 					await expect(runWrangler("secret put the-key --name script-name"))
 						.rejects.toThrowErrorMatchingInlineSnapshot(`
@@ -415,7 +429,7 @@ describe("wrangler secret", () => {
 					`);
 				});
 
-				it("should use the account from wrangler.toml", async () => {
+				it("should use the account from wrangler.toml", async ({ expect }) => {
 					fs.writeFileSync(
 						"wrangler.toml",
 						TOML.stringify({
@@ -424,7 +438,7 @@ describe("wrangler secret", () => {
 						"utf-8"
 					);
 					mockStdIn.send("the-secret");
-					mockPutRequest({ name: "the-key", text: "the-secret" });
+					mockPutRequest(expect, { name: "the-key", text: "the-secret" });
 					await runWrangler("secret put the-key --name script-name");
 					expect(std.out).toMatchInlineSnapshot(`
 						"
@@ -437,7 +451,9 @@ describe("wrangler secret", () => {
 					expect(std.err).toMatchInlineSnapshot(`""`);
 				});
 
-				it("should error if a user has multiple accounts, and has not specified an account in wrangler.toml", async () => {
+				it("should error if a user has multiple accounts, and has not specified an account in wrangler.toml", async ({
+					expect,
+				}) => {
 					mockGetMemberships([
 						{
 							id: "1",
@@ -466,14 +482,16 @@ describe("wrangler secret", () => {
 			});
 
 			describe("multi-env warning", () => {
-				it("should warn if the wrangler config contains environments but none was specified in the command", async () => {
+				it("should warn if the wrangler config contains environments but none was specified in the command", async ({
+					expect,
+				}) => {
 					writeWranglerConfig({
 						env: {
 							test: {},
 						},
 					});
 					mockStdIn.send("the-secret");
-					mockPutRequest({ name: "the-key", text: "the-secret" });
+					mockPutRequest(expect, { name: "the-key", text: "the-secret" });
 					await runWrangler("secret put the-key --name script-name");
 					expect(std.warn).toMatchInlineSnapshot(`
 						"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mMultiple environments are defined in the Wrangler configuration file, but no target environment was specified for the secret put command.[0m
@@ -487,7 +505,9 @@ describe("wrangler secret", () => {
 					`);
 				});
 
-				it("should not warn if the wrangler config contains environments and one was specified in the command", async () => {
+				it("should not warn if the wrangler config contains environments and one was specified in the command", async ({
+					expect,
+				}) => {
 					writeWranglerConfig({
 						env: {
 							test: {},
@@ -495,6 +515,7 @@ describe("wrangler secret", () => {
 					});
 					mockStdIn.send("the-secret");
 					mockPutRequest(
+						expect,
 						{ name: "the-key", text: "the-secret" },
 						"test",
 						false
@@ -503,17 +524,21 @@ describe("wrangler secret", () => {
 					expect(std.warn).toMatchInlineSnapshot(`""`);
 				});
 
-				it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async () => {
+				it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async ({
+					expect,
+				}) => {
 					writeWranglerConfig();
 					mockStdIn.send("the-secret");
-					mockPutRequest({ name: "the-key", text: "the-secret" });
+					mockPutRequest(expect, { name: "the-key", text: "the-secret" });
 					await runWrangler("secret put the-key --name script-name");
 					expect(std.warn).toMatchInlineSnapshot(`""`);
 				});
 			});
 		});
 
-		it("should error if the latest version is not deployed", async () => {
+		it("should error if the latest version is not deployed", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 
 			const scriptName = "test-script";
@@ -563,6 +588,7 @@ describe("wrangler secret", () => {
 			setIsTTY(true);
 		});
 		function mockDeleteRequest(
+			expect: ExpectStatic,
 			input: {
 				scriptName: string;
 				secretName: string;
@@ -595,7 +621,9 @@ describe("wrangler secret", () => {
 			);
 		}
 
-		it("should error helpfully if pages_build_output_dir is set", async () => {
+		it("should error helpfully if pages_build_output_dir is set", async ({
+			expect,
+		}) => {
 			fs.writeFileSync(
 				"wrangler.toml",
 				TOML.stringify({
@@ -614,8 +642,11 @@ describe("wrangler secret", () => {
 			);
 		});
 
-		it("should delete a secret", async () => {
-			mockDeleteRequest({ scriptName: "script-name", secretName: "the-key" });
+		it("should delete a secret", async ({ expect }) => {
+			mockDeleteRequest(expect, {
+				scriptName: "script-name",
+				secretName: "the-key",
+			});
 			mockConfirm({
 				text: "Are you sure you want to permanently delete the secret the-key on the Worker script-name?",
 				result: true,
@@ -631,8 +662,13 @@ describe("wrangler secret", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should delete a secret which name includes special characters", async () => {
-			mockDeleteRequest({ scriptName: "script-name", secretName: "the/key" });
+		it("should delete a secret which name includes special characters", async ({
+			expect,
+		}) => {
+			mockDeleteRequest(expect, {
+				scriptName: "script-name",
+				secretName: "the/key",
+			});
 			mockConfirm({
 				text: "Are you sure you want to permanently delete the secret the/key on the Worker script-name?",
 				result: true,
@@ -648,8 +684,9 @@ describe("wrangler secret", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should delete a secret", async () => {
+		it("should delete a secret", async ({ expect }) => {
 			mockDeleteRequest(
+				expect,
 				{ scriptName: "script-name", secretName: "the-key" },
 				"some-env",
 				false
@@ -671,8 +708,9 @@ describe("wrangler secret", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should delete a secret: service envs", async () => {
+		it("should delete a secret: service envs", async ({ expect }) => {
 			mockDeleteRequest(
+				expect,
 				{ scriptName: "script-name", secretName: "the-key" },
 				"some-env"
 			);
@@ -693,7 +731,7 @@ describe("wrangler secret", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should error without a script name", async () => {
+		it("should error without a script name", async ({ expect }) => {
 			let error: Error | undefined;
 
 			try {
@@ -718,13 +756,18 @@ describe("wrangler secret", () => {
 		});
 
 		describe("multi-env warning", () => {
-			it("should warn if the wrangler config contains environments but none was specified in the command", async () => {
+			it("should warn if the wrangler config contains environments but none was specified in the command", async ({
+				expect,
+			}) => {
 				writeWranglerConfig({
 					env: {
 						test: {},
 					},
 				});
-				mockDeleteRequest({ scriptName: "script-name", secretName: "the-key" });
+				mockDeleteRequest(expect, {
+					scriptName: "script-name",
+					secretName: "the-key",
+				});
 				mockConfirm({
 					text: "Are you sure you want to permanently delete the secret the-key on the Worker script-name?",
 					result: true,
@@ -742,13 +785,16 @@ describe("wrangler secret", () => {
 				`);
 			});
 
-			it("should not warn if the wrangler config contains environments and one was specified in the command", async () => {
+			it("should not warn if the wrangler config contains environments and one was specified in the command", async ({
+				expect,
+			}) => {
 				writeWranglerConfig({
 					env: {
 						test: {},
 					},
 				});
 				mockDeleteRequest(
+					expect,
 					{ scriptName: "script-name", secretName: "the-key" },
 					"test",
 					false
@@ -761,9 +807,14 @@ describe("wrangler secret", () => {
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async () => {
+			it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async ({
+				expect,
+			}) => {
 				writeWranglerConfig();
-				mockDeleteRequest({ scriptName: "script-name", secretName: "the-key" });
+				mockDeleteRequest(expect, {
+					scriptName: "script-name",
+					secretName: "the-key",
+				});
 				mockConfirm({
 					text: "Are you sure you want to permanently delete the secret the-key on the Worker script-name?",
 					result: true,
@@ -779,6 +830,7 @@ describe("wrangler secret", () => {
 			setIsTTY(true);
 		});
 		function mockListRequest(
+			expect: ExpectStatic,
 			input: { scriptName: string },
 			env?: string,
 			useServiceEnvironments = true
@@ -815,7 +867,9 @@ describe("wrangler secret", () => {
 			);
 		}
 
-		it("should error helpfully if pages_build_output_dir is set", async () => {
+		it("should error helpfully if pages_build_output_dir is set", async ({
+			expect,
+		}) => {
 			fs.writeFileSync(
 				"wrangler.toml",
 				TOML.stringify({
@@ -834,8 +888,8 @@ describe("wrangler secret", () => {
 			);
 		});
 
-		it("should list secrets", async () => {
-			mockListRequest({ scriptName: "script-name" });
+		it("should list secrets", async ({ expect }) => {
+			mockListRequest(expect, { scriptName: "script-name" });
 			await runWrangler("secret list --name script-name");
 			expect(std.out).toMatchInlineSnapshot(`
 				"[
@@ -848,8 +902,8 @@ describe("wrangler secret", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should list secrets: wrangler environment", async () => {
-			mockListRequest({ scriptName: "script-name" }, "some-env", false);
+		it("should list secrets: wrangler environment", async ({ expect }) => {
+			mockListRequest(expect, { scriptName: "script-name" }, "some-env", false);
 			await runWrangler(
 				"secret list --name script-name --env some-env --legacy-env"
 			);
@@ -864,8 +918,8 @@ describe("wrangler secret", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should list secrets: service envs", async () => {
-			mockListRequest({ scriptName: "script-name" }, "some-env");
+		it("should list secrets: service envs", async ({ expect }) => {
+			mockListRequest(expect, { scriptName: "script-name" }, "some-env");
 			await runWrangler(
 				"secret list --name script-name --env some-env --legacy-env false"
 			);
@@ -880,7 +934,7 @@ describe("wrangler secret", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should error without a script name", async () => {
+		it("should error without a script name", async ({ expect }) => {
 			let error: Error | undefined;
 			try {
 				await runWrangler("secret list");
@@ -898,7 +952,9 @@ describe("wrangler secret", () => {
 			);
 		});
 
-		it("should error if worker is not found (error code 10007)", async () => {
+		it("should error if worker is not found (error code 10007)", async ({
+			expect,
+		}) => {
 			msw.use(
 				http.get(
 					`*/accounts/:accountId/workers/scripts/:scriptName/secrets`,
@@ -928,8 +984,8 @@ describe("wrangler secret", () => {
 		});
 
 		describe("banner tests", () => {
-			it("banner if pretty", async () => {
-				mockListRequest({ scriptName: "script-name" });
+			it("banner if pretty", async ({ expect }) => {
+				mockListRequest(expect, { scriptName: "script-name" });
 				await runWrangler("secret list --name script-name  --format=pretty");
 				expect(std.out).toMatchInlineSnapshot(`
 					"
@@ -939,8 +995,8 @@ describe("wrangler secret", () => {
 					"
 				`);
 			});
-			it("no banner if json", async () => {
-				mockListRequest({ scriptName: "script-name" });
+			it("no banner if json", async ({ expect }) => {
+				mockListRequest(expect, { scriptName: "script-name" });
 				await runWrangler("secret list --name script-name  --format=json");
 				expect(std.out).toMatchInlineSnapshot(`
 					"[
@@ -955,7 +1011,10 @@ describe("wrangler secret", () => {
 	});
 
 	describe("bulk", () => {
-		const mockBulkRequest = (returnNetworkError = false) => {
+		const mockBulkRequest = (
+			expect: ExpectStatic,
+			returnNetworkError = false
+		) => {
 			msw.use(
 				http.get(
 					`*/accounts/:accountId/workers/scripts/:scriptName/settings`,
@@ -977,7 +1036,9 @@ describe("wrangler secret", () => {
 				)
 			);
 		};
-		it("should error helpfully if pages_build_output_dir is set", async () => {
+		it("should error helpfully if pages_build_output_dir is set", async ({
+			expect,
+		}) => {
 			fs.writeFileSync(
 				"wrangler.toml",
 				TOML.stringify({
@@ -996,7 +1057,9 @@ describe("wrangler secret", () => {
 			);
 		});
 
-		it("should fail secret bulk w/ no pipe or JSON input", async () => {
+		it("should fail secret bulk w/ no pipe or JSON input", async ({
+			expect,
+		}) => {
 			vi.spyOn(readline, "createInterface").mockImplementation(
 				() => null as unknown as Interface
 			);
@@ -1017,7 +1080,7 @@ describe("wrangler secret", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should use secret bulk w/ pipe input", async () => {
+		it("should use secret bulk w/ pipe input", async ({ expect }) => {
 			vi.spyOn(readline, "createInterface").mockImplementation(
 				() =>
 					// `readline.Interface` is an async iterator: `[Symbol.asyncIterator](): AsyncIterableIterator<string>`
@@ -1026,7 +1089,7 @@ describe("wrangler secret", () => {
 						password: "hunter2",
 					}) as unknown as Interface
 			);
-			mockBulkRequest();
+			mockBulkRequest(expect);
 
 			await runWrangler(`secret bulk --name script-name`);
 			expect(std.out).toMatchInlineSnapshot(`
@@ -1044,7 +1107,7 @@ describe("wrangler secret", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should create secrets from JSON file", async () => {
+		it("should create secrets from JSON file", async ({ expect }) => {
 			writeFileSync(
 				"secret.json",
 				JSON.stringify({
@@ -1053,7 +1116,7 @@ describe("wrangler secret", () => {
 				})
 			);
 
-			mockBulkRequest();
+			mockBulkRequest(expect);
 
 			await runWrangler("secret bulk ./secret.json --name script-name");
 
@@ -1072,13 +1135,13 @@ describe("wrangler secret", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should create secrets from a env file", async () => {
+		it("should create secrets from a env file", async ({ expect }) => {
 			writeFileSync(
 				".env",
 				`SECRET_NAME_1=secret_text\nSECRET_NAME_2=secret_text`
 			);
 
-			mockBulkRequest();
+			mockBulkRequest(expect);
 
 			await runWrangler("secret bulk ./.env --name script-name");
 
@@ -1097,7 +1160,7 @@ describe("wrangler secret", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should fail if file is not valid JSON", async () => {
+		it("should fail if file is not valid JSON", async ({ expect }) => {
 			writeFileSync("secret.json", "bad file content");
 
 			await expect(
@@ -1107,7 +1170,9 @@ describe("wrangler secret", () => {
 			);
 		});
 
-		it("should fail if JSON file contains a record with non-string values", async () => {
+		it("should fail if JSON file contains a record with non-string values", async ({
+			expect,
+		}) => {
 			writeFileSync(
 				"secret.json",
 				JSON.stringify({
@@ -1122,7 +1187,9 @@ describe("wrangler secret", () => {
 			);
 		});
 
-		it("should count success and network failure on secret bulk", async () => {
+		it("should count success and network failure on secret bulk", async ({
+			expect,
+		}) => {
 			writeFileSync(
 				"secret.json",
 				JSON.stringify({
@@ -1135,7 +1202,7 @@ describe("wrangler secret", () => {
 					"secret-name-7": "secret_text",
 				})
 			);
-			mockBulkRequest(true);
+			mockBulkRequest(expect, true);
 
 			await expect(async () => {
 				await runWrangler("secret bulk ./secret.json --name script-name");
@@ -1161,7 +1228,7 @@ describe("wrangler secret", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should handle network failure on secret bulk", async () => {
+		it("should handle network failure on secret bulk", async ({ expect }) => {
 			writeFileSync(
 				"secret.json",
 				JSON.stringify({
@@ -1169,7 +1236,7 @@ describe("wrangler secret", () => {
 					"secret-name-2": "secret_text",
 				})
 			);
-			mockBulkRequest(true);
+			mockBulkRequest(expect, true);
 
 			await expect(async () => {
 				await runWrangler("secret bulk ./secret.json --name script-name");
@@ -1195,7 +1262,7 @@ describe("wrangler secret", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("throws a meaningful error", async () => {
+		it("throws a meaningful error", async ({ expect }) => {
 			writeFileSync(
 				"secret.json",
 				JSON.stringify({
@@ -1259,7 +1326,9 @@ describe("wrangler secret", () => {
 			`);
 		});
 
-		it("should merge existing bindings and secrets when patching", async () => {
+		it("should merge existing bindings and secrets when patching", async ({
+			expect,
+		}) => {
 			writeFileSync(
 				"secret.json",
 				JSON.stringify({
@@ -1351,7 +1420,9 @@ describe("wrangler secret", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should, in interactive mode, ask to create a new Worker if no Worker is found under the provided name", async () => {
+		it("should, in interactive mode, ask to create a new Worker if no Worker is found under the provided name", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
 			writeFileSync(
 				"secret.json",
@@ -1376,7 +1447,9 @@ describe("wrangler secret", () => {
 			`);
 		});
 
-		it("should, in non-interactive mode, create a new worker if no worker is found under the provided name", async () => {
+		it("should, in non-interactive mode, create a new worker if no worker is found under the provided name", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 			writeFileSync(
 				"secret.json",
@@ -1395,7 +1468,7 @@ describe("wrangler secret", () => {
 					}
 				)
 			);
-			mockBulkRequest();
+			mockBulkRequest(expect);
 
 			await runWrangler("secret bulk ./secret.json --name script-name");
 			expect(std.out).toMatchInlineSnapshot(`
@@ -1412,7 +1485,9 @@ describe("wrangler secret", () => {
 		});
 
 		describe("multi-env warning", () => {
-			it("should warn if the wrangler config contains environments but none was specified in the command", async () => {
+			it("should warn if the wrangler config contains environments but none was specified in the command", async ({
+				expect,
+			}) => {
 				writeWranglerConfig({
 					name: "test-name",
 					main: "./index.js",
@@ -1422,7 +1497,7 @@ describe("wrangler secret", () => {
 				});
 				writeFileSync("secret.json", JSON.stringify({}));
 
-				mockBulkRequest();
+				mockBulkRequest(expect);
 
 				await runWrangler("secret bulk ./secret.json --name script-name");
 				expect(std.warn).toMatchInlineSnapshot(`
@@ -1437,7 +1512,9 @@ describe("wrangler secret", () => {
 				`);
 			});
 
-			it("should not warn if the wrangler config contains environments and one was specified in the command", async () => {
+			it("should not warn if the wrangler config contains environments and one was specified in the command", async ({
+				expect,
+			}) => {
 				writeWranglerConfig({
 					name: "test-name",
 					main: "./index.js",
@@ -1447,7 +1524,7 @@ describe("wrangler secret", () => {
 				});
 				writeFileSync("secret.json", JSON.stringify({}));
 
-				mockBulkRequest();
+				mockBulkRequest(expect);
 
 				await runWrangler(
 					"secret bulk ./secret.json --name script-name -e test"
@@ -1455,14 +1532,16 @@ describe("wrangler secret", () => {
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async () => {
+			it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async ({
+				expect,
+			}) => {
 				writeWranglerConfig({
 					name: "test-name",
 					main: "./index.js",
 				});
 				writeFileSync("secret.json", JSON.stringify({}));
 
-				mockBulkRequest();
+				mockBulkRequest(expect);
 
 				await runWrangler("secret bulk ./secret.json --name script-name");
 				expect(std.warn).toMatchInlineSnapshot(`""`);

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -2,8 +2,7 @@ import { setTimeout } from "node:timers/promises";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { Headers, Request } from "undici";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import MockWebSocketServer from "vitest-websocket-mock";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
@@ -26,6 +25,7 @@ import type {
 	TailInfo,
 } from "../tail/createTail";
 import type { RequestInit } from "undici";
+import type { ExpectStatic } from "vitest";
 import type WebSocket from "ws";
 
 vi.mock("ws", async (importOriginal) => {
@@ -75,7 +75,7 @@ describe("tail", () => {
 	 * deletion, and connection.
 	 */
 	describe("API interaction", () => {
-		it("should throw an error if name isn't provided", async () => {
+		it("should throw an error if name isn't provided", async ({ expect }) => {
 			await expect(
 				runWrangler("tail")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -83,8 +83,8 @@ describe("tail", () => {
 			);
 		});
 
-		it("creates and then delete tails", async () => {
-			api = mockWebsocketAPIs();
+		it("creates and then delete tails", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			expect(api.requests.creation.length).toStrictEqual(0);
 
 			await runWrangler("tail test-worker");
@@ -97,8 +97,10 @@ describe("tail", () => {
 			expect(api.requests.deletion.count).toStrictEqual(1);
 		});
 
-		it("should connect to the worker assigned to a given route", async () => {
-			api = mockWebsocketAPIs();
+		it("should connect to the worker assigned to a given route", async ({
+			expect,
+		}) => {
+			api = mockWebsocketAPIs(expect);
 			expect(api.requests.creation.length).toStrictEqual(0);
 
 			msw.use(
@@ -153,7 +155,9 @@ describe("tail", () => {
 			expect(api.requests.deletion.count).toStrictEqual(1);
 		});
 
-		it("should error if a given route is not assigned to the user's zone", async () => {
+		it("should error if a given route is not assigned to the user's zone", async ({
+			expect,
+		}) => {
 			msw.use(
 				http.get(
 					`*/zones`,
@@ -194,7 +198,9 @@ describe("tail", () => {
 
 			await expect(runWrangler("tail example.com/*")).rejects.toThrow();
 		});
-		it("should error if a given route is not within the user's zone", async () => {
+		it("should error if a given route is not within the user's zone", async ({
+			expect,
+		}) => {
 			msw.use(
 				http.get(
 					`*/zones`,
@@ -219,8 +225,8 @@ describe("tail", () => {
 			await expect(runWrangler("tail example.com/*")).rejects.toThrow();
 		});
 
-		it("creates and then delete tails: legacy envs", async () => {
-			api = mockWebsocketAPIs("some-env", false);
+		it("creates and then delete tails: legacy envs", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect, "some-env", false);
 			expect(api.requests.creation.length).toStrictEqual(0);
 
 			await runWrangler("tail test-worker --env some-env --legacy-env true");
@@ -233,8 +239,8 @@ describe("tail", () => {
 			expect(api.requests.deletion.count).toStrictEqual(1);
 		});
 
-		it("creates and then delete tails: service envs", async () => {
-			api = mockWebsocketAPIs("some-env");
+		it("creates and then delete tails: service envs", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect, "some-env");
 			expect(api.requests.creation.length).toStrictEqual(0);
 
 			await runWrangler("tail test-worker --env some-env --legacy-env false");
@@ -247,8 +253,10 @@ describe("tail", () => {
 			expect(api.requests.deletion.count).toStrictEqual(1);
 		});
 
-		it("activates debug mode when the cli arg is passed in", async () => {
-			api = mockWebsocketAPIs();
+		it("activates debug mode when the cli arg is passed in", async ({
+			expect,
+		}) => {
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker --debug");
 			await expect(api.nextMessageJson()).resolves.toHaveProperty(
 				"debug",
@@ -259,8 +267,8 @@ describe("tail", () => {
 	});
 
 	describe("filtering", () => {
-		it("sends sampling rate filters", async () => {
-			api = mockWebsocketAPIs();
+		it("sends sampling rate filters", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			const tooHigh = runWrangler("tail test-worker --sampling-rate 10");
 			await expect(tooHigh).rejects.toThrow();
 
@@ -275,8 +283,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("sends single status filters", async () => {
-			api = mockWebsocketAPIs();
+		it("sends single status filters", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker --status error");
 			expect(api.requests.creation[0]).toEqual({
 				filters: [
@@ -288,8 +296,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("sends multiple status filters", async () => {
-			api = mockWebsocketAPIs();
+		it("sends multiple status filters", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker --status error --status canceled");
 			expect(api.requests.creation[0]).toEqual({
 				filters: [
@@ -307,8 +315,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("sends single HTTP method filters", async () => {
-			api = mockWebsocketAPIs();
+		it("sends single HTTP method filters", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker --method POST");
 			expect(api.requests.creation[0]).toEqual({
 				filters: [{ method: ["POST"] }],
@@ -316,8 +324,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("sends multiple HTTP method filters", async () => {
-			api = mockWebsocketAPIs();
+		it("sends multiple HTTP method filters", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker --method POST --method GET");
 			expect(api.requests.creation[0]).toEqual({
 				filters: [{ method: ["POST", "GET"] }],
@@ -325,8 +333,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("sends header filters without a query", async () => {
-			api = mockWebsocketAPIs();
+		it("sends header filters without a query", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker --header X-CUSTOM-HEADER");
 			expect(api.requests.creation[0]).toEqual({
 				filters: [{ header: { key: "X-CUSTOM-HEADER" } }],
@@ -334,8 +342,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("sends header filters with a query", async () => {
-			api = mockWebsocketAPIs();
+		it("sends header filters with a query", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker --header X-CUSTOM-HEADER:some-value");
 			expect(api.requests.creation[0]).toEqual({
 				filters: [{ header: { key: "X-CUSTOM-HEADER", query: "some-value" } }],
@@ -343,8 +351,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("sends single IP filters", async () => {
-			api = mockWebsocketAPIs();
+		it("sends single IP filters", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			const fakeIp = "192.0.2.1";
 
 			await runWrangler(`tail test-worker --ip ${fakeIp}`);
@@ -354,8 +362,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("sends multiple IP filters", async () => {
-			api = mockWebsocketAPIs();
+		it("sends multiple IP filters", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			const fakeIp = "192.0.2.1";
 
 			await runWrangler(`tail test-worker --ip ${fakeIp} --ip self`);
@@ -365,8 +373,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("sends search filters", async () => {
-			api = mockWebsocketAPIs();
+		it("sends search filters", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			const search = "filterMe";
 
 			await runWrangler(`tail test-worker --search ${search}`);
@@ -376,8 +384,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("sends version id filters", async () => {
-			api = mockWebsocketAPIs();
+		it("sends version id filters", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			const versionId = "87501bef-3ef2-4464-a3d6-35e548695742";
 
 			await runWrangler(`tail test-worker --version-id ${versionId}`);
@@ -387,8 +395,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("sends everything but the kitchen sink", async () => {
-			api = mockWebsocketAPIs();
+		it("sends everything but the kitchen sink", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			const sampling_rate = 0.69;
 			const status = ["ok", "error"];
 			const method = ["GET", "POST", "PUT"];
@@ -436,8 +444,8 @@ describe("tail", () => {
 	describe("printing", () => {
 		const { setIsTTY } = useMockIsTTY();
 
-		it("logs request messages in JSON format", async () => {
-			api = mockWebsocketAPIs();
+		it("logs request messages in JSON format", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker --format json");
 
 			const event = generateMockRequestEvent();
@@ -451,8 +459,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs scheduled messages in JSON format", async () => {
-			api = mockWebsocketAPIs();
+		it("logs scheduled messages in JSON format", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker --format json");
 
 			const event = generateMockScheduledEvent();
@@ -466,8 +474,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs alarm messages in json format", async () => {
-			api = mockWebsocketAPIs();
+		it("logs alarm messages in json format", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker --format json");
 
 			const event = generateMockAlarmEvent();
@@ -481,8 +489,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs email messages in json format", async () => {
-			api = mockWebsocketAPIs();
+		it("logs email messages in json format", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker --format json");
 
 			const event = generateMockEmailEvent();
@@ -496,8 +504,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs tail messages in json format", async () => {
-			api = mockWebsocketAPIs();
+		it("logs tail messages in json format", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker --format json");
 
 			const event = generateMockTailEvent(["some-worker", "some-worker"]);
@@ -511,8 +519,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs queue messages in json format", async () => {
-			api = mockWebsocketAPIs();
+		it("logs queue messages in json format", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker --format json");
 
 			const event = generateMockQueueEvent();
@@ -526,8 +534,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs request messages in pretty format", async () => {
-			api = mockWebsocketAPIs();
+		it("logs request messages in pretty format", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker --format pretty");
 
 			const event = generateMockRequestEvent();
@@ -553,8 +561,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs rpc messages in pretty format", async () => {
-			api = mockWebsocketAPIs();
+		it("logs rpc messages in pretty format", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker --format pretty");
 
 			const event = generateMockRpcEvent();
@@ -583,8 +591,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs scheduled messages in pretty format", async () => {
-			api = mockWebsocketAPIs();
+		it("logs scheduled messages in pretty format", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker --format pretty");
 
 			const event = generateMockScheduledEvent();
@@ -610,8 +618,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs alarm messages in pretty format", async () => {
-			api = mockWebsocketAPIs();
+		it("logs alarm messages in pretty format", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker --format pretty");
 
 			const event = generateMockAlarmEvent();
@@ -637,8 +645,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs email messages in pretty format", async () => {
-			api = mockWebsocketAPIs();
+		it("logs email messages in pretty format", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker --format pretty");
 
 			const event = generateMockEmailEvent();
@@ -664,8 +672,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs tail messages in pretty format", async () => {
-			api = mockWebsocketAPIs();
+		it("logs tail messages in pretty format", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker --format pretty");
 
 			const event = generateMockTailEvent(["some-worker", "other-worker", ""]);
@@ -694,8 +702,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs tail overload message", async () => {
-			api = mockWebsocketAPIs();
+		it("logs tail overload message", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker --format pretty");
 
 			let event = generateTailInfo(true);
@@ -724,8 +732,8 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs queue messages in pretty format", async () => {
-			api = mockWebsocketAPIs();
+		it("logs queue messages in pretty format", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker --format pretty");
 
 			const event = generateMockQueueEvent();
@@ -751,8 +759,10 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("should not crash when the tail message has a void event", async () => {
-			api = mockWebsocketAPIs();
+		it("should not crash when the tail message has a void event", async ({
+			expect,
+		}) => {
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker --format pretty");
 
 			const message = generateMockEventMessage({ event: null });
@@ -777,9 +787,11 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("defaults to logging in pretty format when the output is a TTY", async () => {
+		it("defaults to logging in pretty format when the output is a TTY", async ({
+			expect,
+		}) => {
 			setIsTTY(true);
-			api = mockWebsocketAPIs();
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker");
 
 			const event = generateMockRequestEvent();
@@ -805,10 +817,12 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("defaults to logging in json format when the output is not a TTY", async () => {
+		it("defaults to logging in json format when the output is not a TTY", async ({
+			expect,
+		}) => {
 			setIsTTY(false);
 
-			api = mockWebsocketAPIs();
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker");
 
 			const event = generateMockRequestEvent();
@@ -822,9 +836,9 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("logs console messages and exceptions", async () => {
+		it("logs console messages and exceptions", async ({ expect }) => {
 			setIsTTY(true);
-			api = mockWebsocketAPIs();
+			api = mockWebsocketAPIs(expect);
 			await runWrangler("tail test-worker");
 
 			const event = generateMockRequestEvent();
@@ -866,29 +880,31 @@ describe("tail", () => {
 				  (error) 1234"
 			`);
 			expect(std.err).toMatchInlineSnapshot(`
-			        "[31mX [41;31m[[41;97mERROR[41;31m][0m [1m  Error: some error[0m
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m  Error: some error[0m
 
 
-			        [31mX [41;31m[[41;97mERROR[41;31m][0m [1m  Error: { complex: 'error' }[0m
+				[31mX [41;31m[[41;97mERROR[41;31m][0m [1m  Error: { complex: 'error' }[0m
 
-			        "
-		      `);
+				"
+			`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 			await api.closeHelper();
 		});
 	});
 
 	describe("disconnects", () => {
-		it("errors when the websocket is already closed", async () => {
-			api = mockWebsocketAPIs();
+		it("errors when the websocket is already closed", async ({ expect }) => {
+			api = mockWebsocketAPIs(expect);
 			await api.closeHelper();
 
 			await expect(runWrangler("tail test-worker")).rejects.toThrow();
 			await api.closeHelper();
 		});
 
-		it("errors when the websocket stops reacting to pings (pretty format)", async () => {
-			api = mockWebsocketAPIs();
+		it("errors when the websocket stops reacting to pings (pretty format)", async ({
+			expect,
+		}) => {
+			api = mockWebsocketAPIs(expect);
 			vi.useFakeTimers({
 				toFake: ["setInterval"],
 			});
@@ -906,8 +922,10 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("errors when the websocket stops reacting to pings (json format)", async () => {
-			api = mockWebsocketAPIs();
+		it("errors when the websocket stops reacting to pings (json format)", async ({
+			expect,
+		}) => {
+			api = mockWebsocketAPIs(expect);
 			vi.useFakeTimers({
 				toFake: ["setInterval"],
 			});
@@ -926,7 +944,9 @@ describe("tail", () => {
 		});
 	});
 
-	it("should error helpfully if pages_build_output_dir is set in wrangler.toml", async () => {
+	it("should error helpfully if pages_build_output_dir is set in wrangler.toml", async ({
+		expect,
+	}) => {
 		writeWranglerConfig({
 			pages_build_output_dir: "public",
 			name: "test-name",
@@ -1034,6 +1054,7 @@ type RequestCounter = {
  * @returns a `RequestCounter` for counting how many times the API is hit
  */
 function mockCreateTailRequest(
+	expect: ExpectStatic,
 	websocketURL: string,
 	env?: string,
 	useServiceEnvironments = true,
@@ -1111,6 +1132,7 @@ const mockEmailEventSize = 45416;
  * @returns a `RequestCounter` for counting how many times the API is hit
  */
 function mockDeleteTailRequest(
+	expect: ExpectStatic,
 	env?: string,
 	useServiceEnvironments = true,
 	expectedScriptName = !useServiceEnvironments && env
@@ -1153,6 +1175,7 @@ let mockWebSockets: MockWebSocketServer[] = [];
  * @returns a mocked-out version of the API
  */
 function mockWebsocketAPIs(
+	expect: ExpectStatic,
 	env?: string,
 	useServiceEnvironments = true,
 	expectedScriptName?: string
@@ -1185,12 +1208,14 @@ function mockWebsocketAPIs(
 		},
 	};
 	api.requests.creation = mockCreateTailRequest(
+		expect,
 		websocketURL,
 		env,
 		useServiceEnvironments,
 		expectedScriptName
 	);
 	api.requests.deletion = mockDeleteTailRequest(
+		expect,
 		env,
 		useServiceEnvironments,
 		expectedScriptName

--- a/packages/wrangler/src/__tests__/utils/log-file.test.ts
+++ b/packages/wrangler/src/__tests__/utils/log-file.test.ts
@@ -1,9 +1,9 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-// eslint-disable-next-line no-restricted-imports
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, it, vi } from "vitest";
 import { appendToDebugLogFile, debugLogFilepath } from "../../utils/log-file";
 import { runInTempDir } from "../helpers/run-in-tmp";
+import type { ExpectStatic } from "vitest";
 
 describe("appendToDebugLogFile", () => {
 	runInTempDir();
@@ -12,7 +12,7 @@ describe("appendToDebugLogFile", () => {
 		vi.stubEnv("WRANGLER_LOG_PATH", "logs");
 	});
 
-	function getLogFileContent(): string {
+	function getLogFileContent(expect: ExpectStatic): string {
 		if (existsSync(debugLogFilepath)) {
 			return readFileSync(debugLogFilepath, "utf8");
 		}
@@ -30,41 +30,45 @@ describe("appendToDebugLogFile", () => {
 		);
 	}
 
-	it("should strip ANSI escape codes from error messages", async () => {
+	it("should strip ANSI escape codes from error messages", async ({
+		expect,
+	}) => {
 		const messageWithAnsi = "\u001b[31mError: Something went wrong\u001b[0m";
 		const expectedCleanMessage = "Error: Something went wrong";
 
 		await appendToDebugLogFile("error", messageWithAnsi);
 
-		const logContent = getLogFileContent();
+		const logContent = getLogFileContent(expect);
 		expect(logContent).toContain(expectedCleanMessage);
 		expect(logContent).not.toContain("\u001b[31m");
 		expect(logContent).not.toContain("\u001b[0m");
 	});
 
-	it("should strip complex ANSI escape sequences", async () => {
+	it("should strip complex ANSI escape sequences", async ({ expect }) => {
 		const messageWithComplexAnsi =
 			"\u001b[1;32mSuccess:\u001b[0m \u001b[33mWarning text\u001b[0m";
 		const expectedCleanMessage = "Success: Warning text";
 
 		await appendToDebugLogFile("log", messageWithComplexAnsi);
 
-		const logContent = getLogFileContent();
+		const logContent = getLogFileContent(expect);
 		expect(logContent).toContain(expectedCleanMessage);
 		expect(logContent).not.toContain("\u001b[1;32m");
 		expect(logContent).not.toContain("\u001b[33m");
 	});
 
-	it("should preserve plain messages without ANSI codes", async () => {
+	it("should preserve plain messages without ANSI codes", async ({
+		expect,
+	}) => {
 		const plainMessage = "This is a plain log message";
 
 		await appendToDebugLogFile("info", plainMessage);
 
-		const logContent = getLogFileContent();
+		const logContent = getLogFileContent(expect);
 		expect(logContent).toContain(plainMessage);
 	});
 
-	it("should handle multiline messages with ANSI codes", async () => {
+	it("should handle multiline messages with ANSI codes", async ({ expect }) => {
 		const multilineMessageWithAnsi =
 			"\u001b[31mLine 1 with color\u001b[0m\nLine 2 plain\n\u001b[32mLine 3 with different color\u001b[0m";
 		const expectedCleanMessage =
@@ -72,18 +76,20 @@ describe("appendToDebugLogFile", () => {
 
 		await appendToDebugLogFile("warn", multilineMessageWithAnsi);
 
-		const logContent = getLogFileContent();
+		const logContent = getLogFileContent(expect);
 		expect(logContent).toContain(expectedCleanMessage);
 		expect(logContent).not.toContain("\u001b[31m");
 		expect(logContent).not.toContain("\u001b[32m");
 	});
 
-	it("should maintain timestamp and log level formatting", async () => {
+	it("should maintain timestamp and log level formatting", async ({
+		expect,
+	}) => {
 		const message = "\u001b[31mTest message\u001b[0m";
 
 		await appendToDebugLogFile("error", message);
 
-		const logContent = getLogFileContent();
+		const logContent = getLogFileContent(expect);
 		expect(logContent).toMatch(
 			/--- \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z error/
 		);
@@ -91,21 +97,21 @@ describe("appendToDebugLogFile", () => {
 		expect(logContent).toContain("---");
 	});
 
-	it("should handle empty messages", async () => {
+	it("should handle empty messages", async ({ expect }) => {
 		await appendToDebugLogFile("debug", "");
 
-		const logContent = getLogFileContent();
+		const logContent = getLogFileContent(expect);
 		expect(logContent).toMatch(
 			/--- \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z debug/
 		);
 	});
 
-	it("should handle messages with only ANSI codes", async () => {
+	it("should handle messages with only ANSI codes", async ({ expect }) => {
 		const onlyAnsiMessage = "\u001b[31m\u001b[0m";
 
 		await appendToDebugLogFile("log", onlyAnsiMessage);
 
-		const logContent = getLogFileContent();
+		const logContent = getLogFileContent(expect);
 		expect(logContent).not.toContain("\u001b[31m");
 		expect(logContent).not.toContain("\u001b[0m");
 		expect(logContent).toMatch(

--- a/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
@@ -53,8 +53,8 @@ describe("versions secret bulk", () => {
 			{ encoding: "utf8" }
 		);
 
-		mockSetupApiCalls();
-		mockPostVersion((metadata) => {
+		mockSetupApiCalls(expect);
+		mockPostVersion(expect, (metadata) => {
 			expect(metadata.bindings).toStrictEqual([
 				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "SECRET_1", text: "secret-1" },
@@ -90,8 +90,8 @@ describe("versions secret bulk", () => {
 			".env",
 			"SECRET_1=secret-1\nSECRET_2=secret-2\nSECRET_3=secret-3"
 		);
-		mockSetupApiCalls();
-		mockPostVersion();
+		mockSetupApiCalls(expect);
+		mockPostVersion(expect);
 		await runWrangler(`versions secret bulk .env --name script-name`);
 		expect(std.out).toMatchInlineSnapshot(
 			`
@@ -112,8 +112,8 @@ describe("versions secret bulk", () => {
 	test("no wrangler configuration warnings shown", async ({ expect }) => {
 		await writeFile("secrets.json", JSON.stringify({ SECRET_1: "secret-1" }));
 		await writeFile("wrangler.json", JSON.stringify({ invalid_field: true }));
-		mockSetupApiCalls();
-		mockPostVersion();
+		mockSetupApiCalls(expect);
+		mockPostVersion(expect);
 		await runWrangler(`versions secret bulk secrets.json --name script-name`);
 		expect(std.warn).toMatchInlineSnapshot(`""`);
 		expect(std.err).toMatchInlineSnapshot(`""`);
@@ -130,8 +130,8 @@ describe("versions secret bulk", () => {
 				}) as unknown as Interface
 		);
 
-		mockSetupApiCalls();
-		mockPostVersion((metadata) => {
+		mockSetupApiCalls(expect);
+		mockPostVersion(expect, (metadata) => {
 			expect(metadata.bindings).toStrictEqual([
 				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "SECRET_1", text: "secret-1" },
@@ -179,8 +179,8 @@ describe("versions secret bulk", () => {
 				"hello world" as unknown as Interface
 		);
 
-		mockSetupApiCalls();
-		mockPostVersion((metadata) => {
+		mockSetupApiCalls(expect);
+		mockPostVersion(expect, (metadata) => {
 			expect(metadata.bindings).toStrictEqual([
 				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "SECRET_1", text: "secret-1" },
@@ -226,8 +226,8 @@ describe("versions secret bulk", () => {
 			{ encoding: "utf8" }
 		);
 
-		mockSetupApiCalls();
-		mockPostVersion((metadata) => {
+		mockSetupApiCalls(expect);
+		mockPostVersion(expect, (metadata) => {
 			expect(metadata.bindings).toStrictEqual([
 				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "SECRET_1", text: "secret-1" },
@@ -276,8 +276,8 @@ describe("versions secret bulk", () => {
 			{ encoding: "utf8" }
 		);
 
-		mockSetupApiCalls();
-		mockPostVersion((metadata) => {
+		mockSetupApiCalls(expect);
+		mockPostVersion(expect, (metadata) => {
 			expect(metadata.bindings).toStrictEqual([
 				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "SECRET_1", text: "secret-1" },
@@ -322,8 +322,8 @@ describe("versions secret bulk", () => {
 			);
 
 			writeWranglerConfig({ env: { test: {} } });
-			mockSetupApiCalls();
-			mockPostVersion();
+			mockSetupApiCalls(expect);
+			mockPostVersion(expect);
 
 			await runWrangler(`versions secret bulk --name script-name`);
 			expect(std.warn).toMatchInlineSnapshot(`
@@ -350,8 +350,8 @@ describe("versions secret bulk", () => {
 			);
 
 			writeWranglerConfig({ env: { test: {} } });
-			mockSetupApiCalls();
-			mockPostVersion();
+			mockSetupApiCalls(expect);
+			mockPostVersion(expect);
 
 			await runWrangler(`versions secret bulk --name script-name --env test`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
@@ -369,8 +369,8 @@ describe("versions secret bulk", () => {
 			);
 
 			writeWranglerConfig();
-			mockSetupApiCalls();
-			mockPostVersion();
+			mockSetupApiCalls(expect);
+			mockPostVersion(expect);
 
 			await runWrangler(`versions secret bulk --name script-name`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);

--- a/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
@@ -27,9 +27,9 @@ describe("versions secret delete", () => {
 			result: true,
 		});
 
-		mockSetupApiCalls();
-		mockGetVersion();
-		mockPostVersion((metadata) => {
+		mockSetupApiCalls(expect);
+		mockGetVersion(expect);
+		mockPostVersion(expect, (metadata) => {
 			// We should have all secrets except the one being deleted
 			expect(metadata.bindings).toStrictEqual([
 				{ type: "inherit", name: "do-binding" },
@@ -55,9 +55,9 @@ describe("versions secret delete", () => {
 	test("can delete a secret (non-interactive)", async ({ expect }) => {
 		setIsTTY(false);
 
-		mockSetupApiCalls();
-		mockGetVersion();
-		mockPostVersion((metadata) => {
+		mockSetupApiCalls(expect);
+		mockGetVersion(expect);
+		mockPostVersion(expect, (metadata) => {
 			expect(metadata.bindings).toStrictEqual([
 				{ type: "inherit", name: "do-binding" },
 				{ type: "inherit", name: "ANOTHER_SECRET" },
@@ -88,9 +88,9 @@ describe("versions secret delete", () => {
 		writeWranglerConfig({ name: "script-name" });
 		setIsTTY(false);
 
-		mockSetupApiCalls();
-		mockGetVersion();
-		mockPostVersion((metadata) => {
+		mockSetupApiCalls(expect);
+		mockGetVersion(expect);
+		mockPostVersion(expect, (metadata) => {
 			expect(metadata.bindings).toStrictEqual([
 				{ type: "inherit", name: "do-binding" },
 				{ type: "inherit", name: "ANOTHER_SECRET" },
@@ -119,9 +119,9 @@ describe("versions secret delete", () => {
 		await writeFile("wrangler.json", JSON.stringify({ invalid_field: true }));
 		setIsTTY(false);
 
-		mockSetupApiCalls();
-		mockGetVersion();
-		mockPostVersion();
+		mockSetupApiCalls(expect);
+		mockGetVersion(expect);
+		mockPostVersion(expect);
 
 		await runWrangler("versions secret delete SECRET --name script-name");
 
@@ -138,9 +138,9 @@ describe("versions secret delete", () => {
 			writeWranglerConfig({
 				env: { test: {} },
 			});
-			mockSetupApiCalls();
-			mockGetVersion();
-			mockPostVersion();
+			mockSetupApiCalls(expect);
+			mockGetVersion(expect);
+			mockPostVersion(expect);
 
 			await runWrangler("versions secret delete SECRET --name script-name");
 
@@ -164,9 +164,9 @@ describe("versions secret delete", () => {
 			writeWranglerConfig({
 				env: { test: {} },
 			});
-			mockSetupApiCalls();
-			mockGetVersion();
-			mockPostVersion();
+			mockSetupApiCalls(expect);
+			mockGetVersion(expect);
+			mockPostVersion(expect);
 
 			await runWrangler(
 				"versions secret delete SECRET --name script-name -e test"
@@ -181,9 +181,9 @@ describe("versions secret delete", () => {
 			setIsTTY(false);
 
 			writeWranglerConfig();
-			mockSetupApiCalls();
-			mockGetVersion();
-			mockPostVersion();
+			mockSetupApiCalls(expect);
+			mockGetVersion(expect);
+			mockPostVersion(expect);
 
 			await runWrangler("versions secret delete SECRET --name script-name");
 

--- a/packages/wrangler/src/__tests__/versions/secrets/list.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/list.test.ts
@@ -1,14 +1,14 @@
 import { writeFile } from "node:fs/promises";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { describe, expect, test } from "vitest";
+import { describe, test } from "vitest";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { createFetchResult, msw } from "../../helpers/msw";
 import { runInTempDir } from "../../helpers/run-in-tmp";
 import { runWrangler } from "../../helpers/run-wrangler";
 import type { ApiDeployment, ApiVersion } from "../../../versions/types";
+import type { ExpectStatic } from "vitest";
 
 describe("versions secret list", () => {
 	runInTempDir();
@@ -16,7 +16,7 @@ describe("versions secret list", () => {
 	mockAccountId();
 	mockApiToken();
 
-	function mockGetDeployments(multiVersion = false) {
+	function mockGetDeployments(expect: ExpectStatic, multiVersion = false) {
 		const versions = multiVersion
 			? [
 					{ version_id: "version-id-1", percentage: 50 },
@@ -49,7 +49,7 @@ describe("versions secret list", () => {
 		);
 	}
 
-	function mockGetVersion(versionId: string) {
+	function mockGetVersion(expect: ExpectStatic, versionId: string) {
 		msw.use(
 			http.get(
 				`*/accounts/:accountId/workers/scripts/:scriptName/versions/${versionId}`,
@@ -98,9 +98,9 @@ describe("versions secret list", () => {
 		);
 	}
 
-	test("Can list secrets in single version deployment", async () => {
-		mockGetDeployments();
-		mockGetVersion("version-id-1");
+	test("Can list secrets in single version deployment", async ({ expect }) => {
+		mockGetDeployments(expect);
+		mockGetVersion(expect, "version-id-1");
 
 		await runWrangler("versions secret list --name script-name");
 
@@ -117,10 +117,10 @@ describe("versions secret list", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("Can list secrets in multi-version deployment", async () => {
-		mockGetDeployments(true);
-		mockGetVersion("version-id-1");
-		mockGetVersion("version-id-2");
+	test("Can list secrets in multi-version deployment", async ({ expect }) => {
+		mockGetDeployments(expect, true);
+		mockGetVersion(expect, "version-id-1");
+		mockGetVersion(expect, "version-id-2");
 
 		await runWrangler("versions secret list --name script-name");
 
@@ -142,11 +142,13 @@ describe("versions secret list", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("Can list secrets in single version deployment reading from wrangler.toml", async () => {
+	test("Can list secrets in single version deployment reading from wrangler.toml", async ({
+		expect,
+	}) => {
 		writeWranglerConfig({ name: "script-name" });
 
-		mockGetDeployments();
-		mockGetVersion("version-id-1");
+		mockGetDeployments(expect);
+		mockGetVersion(expect, "version-id-1");
 
 		await runWrangler("versions secret list");
 
@@ -163,7 +165,7 @@ describe("versions secret list", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("Can list secrets for latest version", async () => {
+	test("Can list secrets for latest version", async ({ expect }) => {
 		writeWranglerConfig({ name: "script-name" });
 
 		msw.use(
@@ -252,8 +254,8 @@ describe("versions secret list", () => {
 			)
 		);
 
-		mockGetDeployments();
-		mockGetVersion("version-id-1");
+		mockGetDeployments(expect);
+		mockGetVersion(expect, "version-id-1");
 
 		await runWrangler("versions secret list --latest-version");
 
@@ -270,10 +272,10 @@ describe("versions secret list", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	test("no wrangler configuration warnings shown", async () => {
+	test("no wrangler configuration warnings shown", async ({ expect }) => {
 		await writeFile("wrangler.json", JSON.stringify({ invalid_field: true }));
-		mockGetDeployments();
-		mockGetVersion("version-id-1");
+		mockGetDeployments(expect);
+		mockGetVersion(expect, "version-id-1");
 
 		await runWrangler("versions secret list --name script-name");
 

--- a/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
@@ -32,8 +32,8 @@ describe("versions secret put", () => {
 			result: "the-secret",
 		});
 
-		mockSetupApiCalls();
-		mockPostVersion((metadata) => {
+		mockSetupApiCalls(expect);
+		mockPostVersion(expect, (metadata) => {
 			expect(metadata.bindings).toStrictEqual([
 				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "NEW_SECRET", text: "the-secret" },
@@ -71,8 +71,8 @@ describe("versions secret put", () => {
 			result: "the-secret",
 		});
 
-		mockSetupApiCalls();
-		mockPostVersion((metadata) => {
+		mockSetupApiCalls(expect);
+		mockPostVersion(expect, (metadata) => {
 			expect(metadata["build_options"]).toStrictEqual({ stable_id: "foo/bar" });
 		});
 		await runWrangler("versions secret put NEW_SECRET --name script-name");
@@ -103,8 +103,8 @@ describe("versions secret put", () => {
 			result: "the-secret",
 		});
 
-		mockSetupApiCalls();
-		mockPostVersion((metadata) => {
+		mockSetupApiCalls(expect);
+		mockPostVersion(expect, (metadata) => {
 			expect(metadata.bindings).toStrictEqual([
 				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "NEW_SECRET", text: "the-secret" },
@@ -138,8 +138,8 @@ describe("versions secret put", () => {
 			result: "the-secret",
 		});
 
-		mockSetupApiCalls();
-		mockPostVersion();
+		mockSetupApiCalls(expect);
+		mockPostVersion(expect);
 		await runWrangler("versions secret put NEW_SECRET --name script-name");
 		expect(std.warn).toMatchInlineSnapshot(`""`);
 		expect(std.err).toMatchInlineSnapshot(`""`);
@@ -148,8 +148,8 @@ describe("versions secret put", () => {
 	describe("(non-interactive)", () => {
 		const mockStdIn = useMockStdin({ isTTY: false });
 		test("can add a new secret (non-interactive)", async ({ expect }) => {
-			mockSetupApiCalls();
-			mockPostVersion((metadata) => {
+			mockSetupApiCalls(expect);
+			mockPostVersion(expect, (metadata) => {
 				expect(metadata.bindings).toStrictEqual([
 					{ type: "inherit", name: "do-binding" },
 					{ type: "secret_text", name: "NEW_SECRET", text: "the-secret" },
@@ -194,8 +194,8 @@ describe("versions secret put", () => {
 			result: "the-secret",
 		});
 
-		mockSetupApiCalls();
-		mockPostVersion((metadata) => {
+		mockSetupApiCalls(expect);
+		mockPostVersion(expect, (metadata) => {
 			expect(metadata.bindings).toStrictEqual([
 				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "NEW_SECRET", text: "the-secret" },
@@ -228,8 +228,8 @@ describe("versions secret put", () => {
 			result: "the-secret",
 		});
 
-		mockSetupApiCalls();
-		mockPostVersion((metadata) => {
+		mockSetupApiCalls(expect);
+		mockPostVersion(expect, (metadata) => {
 			expect(metadata.bindings).toStrictEqual([
 				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "NEW_SECRET", text: "the-secret" },
@@ -269,8 +269,8 @@ describe("versions secret put", () => {
 			result: "the-secret",
 		});
 
-		mockSetupApiCalls();
-		mockPostVersion((metadata) => {
+		mockSetupApiCalls(expect);
+		mockPostVersion(expect, (metadata) => {
 			expect(metadata.bindings).toStrictEqual([
 				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "NEW_SECRET", text: "the-secret" },
@@ -307,7 +307,7 @@ describe("versions secret put", () => {
 	test("all non-secret bindings are inherited", async ({ expect }) => {
 		setIsTTY(true);
 
-		mockSetupApiCalls();
+		mockSetupApiCalls(expect);
 
 		mockPrompt({
 			text: "Enter a secret value:",
@@ -315,7 +315,7 @@ describe("versions secret put", () => {
 			result: "the-secret",
 		});
 
-		mockPostVersion((metadata) => {
+		mockPostVersion(expect, (metadata) => {
 			expect(metadata.bindings).toStrictEqual([
 				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "SECRET", text: "the-secret" },
@@ -348,8 +348,8 @@ describe("versions secret put", () => {
 			result: "the-secret",
 		});
 
-		mockSetupApiCalls();
-		mockPostVersion((metadata) => {
+		mockSetupApiCalls(expect);
+		mockPostVersion(expect, (metadata) => {
 			expect(metadata.bindings).toStrictEqual([
 				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "SECRET", text: "the-secret" },
@@ -383,7 +383,7 @@ describe("versions secret put", () => {
 	test("can add secret on wasm worker", async ({ expect }) => {
 		setIsTTY(true);
 
-		mockSetupApiCalls();
+		mockSetupApiCalls(expect);
 		// Mock content call to have wasm
 		msw.use(
 			http.get(
@@ -425,7 +425,7 @@ describe("versions secret put", () => {
 			result: "the-secret",
 		});
 
-		mockPostVersion((metadata, formData) => {
+		mockPostVersion(expect, (metadata, formData) => {
 			expect(formData.get("module.wasm")).not.toBeNull();
 			expect((formData.get("module.wasm") as File).size).equal(10);
 
@@ -469,8 +469,8 @@ describe("versions secret put", () => {
 				name: "script-name",
 				env: { test: {} },
 			});
-			mockSetupApiCalls();
-			mockPostVersion();
+			mockSetupApiCalls(expect);
+			mockPostVersion(expect);
 
 			mockStdIn.send(
 				`the`,
@@ -499,8 +499,8 @@ describe("versions secret put", () => {
 				name: "script-name",
 				env: { test: {} },
 			});
-			mockSetupApiCalls();
-			mockPostVersion();
+			mockSetupApiCalls(expect);
+			mockPostVersion(expect);
 
 			mockStdIn.send(
 				`the`,
@@ -519,8 +519,8 @@ describe("versions secret put", () => {
 			writeWranglerConfig({
 				name: "script-name",
 			});
-			mockSetupApiCalls();
-			mockPostVersion();
+			mockSetupApiCalls(expect);
+			mockPostVersion(expect);
 
 			mockStdIn.send(
 				`the`,

--- a/packages/wrangler/src/__tests__/versions/secrets/utils.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/utils.ts
@@ -1,12 +1,11 @@
 import { http, HttpResponse } from "msw";
 import { FormData } from "undici";
-// eslint-disable-next-line no-restricted-imports
-import { expect } from "vitest";
 import { createFetchResult, msw } from "../../helpers/msw";
 import type { VersionDetails, WorkerVersion } from "../../../versions/secrets";
 import type { WorkerMetadata } from "@cloudflare/workers-utils";
+import type { ExpectStatic } from "vitest";
 
-function mockGetVersions() {
+function mockGetVersions(expect: ExpectStatic) {
 	msw.use(
 		http.get(
 			`*/accounts/:accountId/workers/scripts/:scriptName/versions`,
@@ -34,7 +33,10 @@ function mockGetVersions() {
 	);
 }
 
-export function mockGetVersion(versionInfo?: VersionDetails) {
+export function mockGetVersion(
+	expect: ExpectStatic,
+	versionInfo?: VersionDetails
+) {
 	msw.use(
 		http.get(
 			`*/accounts/:accountId/workers/scripts/:scriptName/versions/ce15c78b-cc43-4f60-b5a9-15ce4f298c2a`,
@@ -86,7 +88,7 @@ export function mockGetVersion(versionInfo?: VersionDetails) {
 	);
 }
 
-function mockGetVersionContent() {
+function mockGetVersionContent(expect: ExpectStatic) {
 	msw.use(
 		http.get(
 			`*/accounts/:accountId/workers/scripts/:scriptName/content/v2`,
@@ -116,7 +118,7 @@ function mockGetVersionContent() {
 	);
 }
 
-function mockGetWorkerSettings() {
+function mockGetWorkerSettings(expect: ExpectStatic) {
 	msw.use(
 		http.get(
 			`*/accounts/:accountId/workers/scripts/:scriptName/script-settings`,
@@ -137,6 +139,7 @@ function mockGetWorkerSettings() {
 }
 
 export function mockPostVersion(
+	expect: ExpectStatic,
 	validate?: (metadata: WorkerMetadata, formData: FormData) => void
 ) {
 	msw.use(
@@ -168,9 +171,9 @@ export function mockPostVersion(
 	);
 }
 
-export function mockSetupApiCalls() {
-	mockGetVersions();
-	mockGetVersion();
-	mockGetVersionContent();
-	mockGetWorkerSettings();
+export function mockSetupApiCalls(expect: ExpectStatic) {
+	mockGetVersions(expect);
+	mockGetVersion(expect);
+	mockGetVersionContent(expect);
+	mockGetWorkerSettings(expect);
 }

--- a/packages/wrangler/src/__tests__/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/workflows.test.ts
@@ -8,8 +8,7 @@ import {
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, it } from "vitest";
 import { endEventLoop } from "./helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
@@ -19,6 +18,7 @@ import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import { writeWorkerSource } from "./helpers/write-worker-source";
 import type { Instance, Workflow } from "../workflows/types";
+import type { ExpectStatic } from "vitest";
 
 describe("wrangler workflows", () => {
 	const std = mockConsoleMethods();
@@ -46,7 +46,10 @@ describe("wrangler workflows", () => {
 		);
 	};
 
-	const mockChangeStatusRequest = async (expectedInstance: string) => {
+	const mockChangeStatusRequest = async (
+		expect: ExpectStatic,
+		expectedInstance: string
+	) => {
 		msw.use(
 			http.patch(
 				`*/accounts/:accountId/workflows/some-workflow/instances/:instanceId/status`,
@@ -65,6 +68,7 @@ describe("wrangler workflows", () => {
 	};
 
 	const mockSendEventRequest = async (
+		expect: ExpectStatic,
 		expectedInstance: string,
 		event: string
 	) => {
@@ -86,7 +90,10 @@ describe("wrangler workflows", () => {
 		);
 	};
 
-	const mockDeleteWorkflowRequest = async (workflowName: string) => {
+	const mockDeleteWorkflowRequest = async (
+		expect: ExpectStatic,
+		workflowName: string
+	) => {
 		msw.use(
 			http.delete(
 				`*/accounts/:accountId/workflows/:workflowName`,
@@ -105,6 +112,7 @@ describe("wrangler workflows", () => {
 	};
 
 	const mockInstancesTerminateAll = async (
+		expect: ExpectStatic,
 		expectedWorkflow: string,
 		responseStatus: "ok" | "already_running",
 		queryStatus: string | null = null
@@ -131,7 +139,7 @@ describe("wrangler workflows", () => {
 	};
 
 	describe("help", () => {
-		it("should show help when no argument is passed", async () => {
+		it("should show help when no argument is passed", async ({ expect }) => {
 			writeWranglerConfig();
 
 			await runWrangler(`workflows`);
@@ -163,7 +171,9 @@ describe("wrangler workflows", () => {
 	});
 
 	describe("instances help", () => {
-		it("should show instance help when no argument is passed", async () => {
+		it("should show instance help when no argument is passed", async ({
+			expect,
+		}) => {
 			writeWranglerConfig();
 
 			await runWrangler(`workflows instances`);
@@ -231,7 +241,7 @@ describe("wrangler workflows", () => {
 			);
 		};
 
-		it("should get the list of workflows", async () => {
+		it("should get the list of workflows", async ({ expect }) => {
 			writeWranglerConfig();
 			await mockGetWorkflows(mockWorkflows);
 
@@ -324,7 +334,7 @@ describe("wrangler workflows", () => {
 			},
 		];
 
-		it("should get the list of instances given a name", async () => {
+		it("should get the list of instances given a name", async ({ expect }) => {
 			writeWranglerConfig();
 			await mockGetInstances(mockInstances);
 
@@ -442,7 +452,7 @@ describe("wrangler workflows", () => {
 			);
 		};
 
-		it("should describe the bar instance given a name", async () => {
+		it("should describe the bar instance given a name", async ({ expect }) => {
 			writeWranglerConfig();
 			await mockDescribeInstances();
 
@@ -472,7 +482,9 @@ describe("wrangler workflows", () => {
 			`);
 		});
 
-		it("should describe the latest instance if none is given", async () => {
+		it("should describe the latest instance if none is given", async ({
+			expect,
+		}) => {
 			writeWranglerConfig();
 			await mockDescribeInstances();
 
@@ -515,10 +527,12 @@ describe("wrangler workflows", () => {
 			},
 		];
 
-		it("should send an event without payload to the bar instance given a name", async () => {
+		it("should send an event without payload to the bar instance given a name", async ({
+			expect,
+		}) => {
 			writeWranglerConfig();
 			await mockGetInstances(mockInstances);
-			await mockSendEventRequest("bar", "my-event");
+			await mockSendEventRequest(expect, "bar", "my-event");
 
 			await runWrangler(
 				"workflows instances send-event some-workflow bar --type my-event"
@@ -528,10 +542,12 @@ describe("wrangler workflows", () => {
 			);
 		});
 
-		it("should send an event with payload to the bar instance given a name", async () => {
+		it("should send an event with payload to the bar instance given a name", async ({
+			expect,
+		}) => {
 			writeWranglerConfig();
 			await mockGetInstances(mockInstances);
-			await mockSendEventRequest("bar", "my-event");
+			await mockSendEventRequest(expect, "bar", "my-event");
 
 			await runWrangler(
 				`workflows instances send-event some-workflow bar --type my-event --payload '{"key": "value"}'`
@@ -562,10 +578,12 @@ describe("wrangler workflows", () => {
 			},
 		];
 
-		it("should get and pause the bar instance given a name", async () => {
+		it("should get and pause the bar instance given a name", async ({
+			expect,
+		}) => {
 			writeWranglerConfig();
 			await mockGetInstances(mockInstances);
-			await mockChangeStatusRequest("bar");
+			await mockChangeStatusRequest(expect, "bar");
 
 			await runWrangler(`workflows instances pause some-workflow bar`);
 			expect(std.info).toMatchInlineSnapshot(
@@ -594,10 +612,12 @@ describe("wrangler workflows", () => {
 			},
 		];
 
-		it("should get and resume the bar instance given a name", async () => {
+		it("should get and resume the bar instance given a name", async ({
+			expect,
+		}) => {
 			writeWranglerConfig();
 			await mockGetInstances(mockInstances);
-			await mockChangeStatusRequest("bar");
+			await mockChangeStatusRequest(expect, "bar");
 
 			await runWrangler(`workflows instances resume some-workflow bar`);
 			expect(std.info).toMatchInlineSnapshot(
@@ -626,10 +646,12 @@ describe("wrangler workflows", () => {
 			},
 		];
 
-		it("should get and terminate the bar instance given a name", async () => {
+		it("should get and terminate the bar instance given a name", async ({
+			expect,
+		}) => {
 			writeWranglerConfig();
 			await mockGetInstances(mockInstances);
-			await mockChangeStatusRequest("bar");
+			await mockChangeStatusRequest(expect, "bar");
 
 			await runWrangler(`workflows instances terminate some-workflow bar`);
 			expect(std.info).toMatchInlineSnapshot(
@@ -658,10 +680,12 @@ describe("wrangler workflows", () => {
 			},
 		];
 
-		it("should get and restart the bar instance given a name", async () => {
+		it("should get and restart the bar instance given a name", async ({
+			expect,
+		}) => {
 			writeWranglerConfig();
 			await mockGetInstances(mockInstances);
-			await mockChangeStatusRequest("bar");
+			await mockChangeStatusRequest(expect, "bar");
 
 			await runWrangler(`workflows instances restart some-workflow bar`);
 			expect(std.info).toMatchInlineSnapshot(
@@ -671,9 +695,9 @@ describe("wrangler workflows", () => {
 	});
 
 	describe("instances terminate-all", () => {
-		it("should be able to terminate - job created", async () => {
+		it("should be able to terminate - job created", async ({ expect }) => {
 			writeWranglerConfig();
-			await mockInstancesTerminateAll("some-workflow", "ok");
+			await mockInstancesTerminateAll(expect, "some-workflow", "ok");
 
 			await runWrangler(`workflows instances terminate-all some-workflow`);
 			expect(std.info).toMatchInlineSnapshot(
@@ -681,9 +705,9 @@ describe("wrangler workflows", () => {
 			);
 		});
 
-		it("should be able to terminate - job exists", async () => {
+		it("should be able to terminate - job exists", async ({ expect }) => {
 			writeWranglerConfig();
-			await mockInstancesTerminateAll("some-workflow", "ok");
+			await mockInstancesTerminateAll(expect, "some-workflow", "ok");
 
 			await runWrangler(`workflows instances terminate-all some-workflow`);
 			expect(std.info).toMatchInlineSnapshot(
@@ -691,9 +715,11 @@ describe("wrangler workflows", () => {
 			);
 		});
 
-		it("should be able to terminate - specific status, job created", async () => {
+		it("should be able to terminate - specific status, job created", async ({
+			expect,
+		}) => {
 			writeWranglerConfig();
-			await mockInstancesTerminateAll("some-workflow", "ok", "queued");
+			await mockInstancesTerminateAll(expect, "some-workflow", "ok", "queued");
 
 			await runWrangler(
 				`workflows instances terminate-all some-workflow --status queued`
@@ -703,9 +729,12 @@ describe("wrangler workflows", () => {
 			);
 		});
 
-		it("should be able to terminate - specific status, job exists", async () => {
+		it("should be able to terminate - specific status, job exists", async ({
+			expect,
+		}) => {
 			writeWranglerConfig();
 			await mockInstancesTerminateAll(
+				expect,
 				"some-workflow",
 				"already_running",
 				"queued"
@@ -719,7 +748,7 @@ describe("wrangler workflows", () => {
 			);
 		});
 
-		it("invalid status", async () => {
+		it("invalid status", async ({ expect }) => {
 			writeWranglerConfig();
 			await expect(
 				runWrangler(
@@ -761,7 +790,7 @@ describe("wrangler workflows", () => {
 			);
 		};
 
-		it("should trigger a workflow given a name", async () => {
+		it("should trigger a workflow given a name", async ({ expect }) => {
 			writeWranglerConfig();
 			await mockTriggerWorkflow();
 
@@ -774,10 +803,10 @@ describe("wrangler workflows", () => {
 	});
 
 	describe("delete", () => {
-		it("should delete a workflow - green path", async () => {
+		it("should delete a workflow - green path", async ({ expect }) => {
 			writeWranglerConfig();
 
-			await mockDeleteWorkflowRequest("some-workflow");
+			await mockDeleteWorkflowRequest(expect, "some-workflow");
 
 			await runWrangler(`workflows delete some-workflow`);
 			expect(std.out).toMatchInlineSnapshot(
@@ -793,7 +822,9 @@ describe("wrangler workflows", () => {
 	});
 
 	describe("workflow binding validation", () => {
-		it("should validate workflow binding with valid name", async () => {
+		it("should validate workflow binding with valid name", async ({
+			expect,
+		}) => {
 			writeWorkerSource({ format: "ts" });
 			writeWranglerConfig({
 				main: "index.ts",
@@ -811,7 +842,9 @@ describe("wrangler workflows", () => {
 			expect(std.err).toBe("");
 		});
 
-		it("should reject workflow binding with name exceeding 64 characters", async () => {
+		it("should reject workflow binding with name exceeding 64 characters", async ({
+			expect,
+		}) => {
 			const longName = "a".repeat(65); // 65 characters
 			writeWranglerConfig({
 				workflows: [
@@ -835,9 +868,9 @@ describe("wrangler workflows", () => {
 			`);
 		});
 
-		it.each(["", "   ", "\n\nhello", "#1231231!!!!", "-badName"])(
+		it.for(["", "   ", "\n\nhello", "#1231231!!!!", "-badName"])(
 			"should reject workflow binding with name with invalid characters",
-			async function (invalidName) {
+			async function (invalidName, { expect }) {
 				writeWranglerConfig({
 					workflows: [
 						{
@@ -853,7 +886,9 @@ describe("wrangler workflows", () => {
 			}
 		);
 
-		it("should accept workflow binding with name exactly 64 characters", async () => {
+		it("should accept workflow binding with name exactly 64 characters", async ({
+			expect,
+		}) => {
 			const maxLengthName = "a".repeat(64); // exactly 64 characters
 			writeWorkerSource({ format: "ts" });
 			writeWranglerConfig({
@@ -872,7 +907,9 @@ describe("wrangler workflows", () => {
 			expect(std.err).toBe("");
 		});
 
-		it("should validate required fields for workflow binding", async () => {
+		it("should validate required fields for workflow binding", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				workflows: [
 					{
@@ -886,7 +923,9 @@ describe("wrangler workflows", () => {
 			expect(std.err).toContain('should have a string "class_name" field');
 		});
 
-		it("should validate optional fields for workflow binding", async () => {
+		it("should validate optional fields for workflow binding", async ({
+			expect,
+		}) => {
 			writeWorkerSource({ format: "ts" });
 			writeWranglerConfig({
 				main: "index.ts",
@@ -905,7 +944,9 @@ describe("wrangler workflows", () => {
 			expect(std.err).toBe("");
 		});
 
-		it("should reject workflow binding with invalid field types", async () => {
+		it("should reject workflow binding with invalid field types", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				workflows: [
 					{
@@ -920,7 +961,9 @@ describe("wrangler workflows", () => {
 			expect(std.err).toContain('should have a string "binding" field');
 		});
 
-		it("should reject workflow binding that is not an object", async () => {
+		it("should reject workflow binding that is not an object", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				workflows: ["invalid-workflow-config"] as any, // eslint-disable-line @typescript-eslint/no-explicit-any
 			});
@@ -929,7 +972,9 @@ describe("wrangler workflows", () => {
 			expect(std.err).toContain('"workflows" bindings should be objects');
 		});
 
-		it("should accept workflow binding with valid limits", async () => {
+		it("should accept workflow binding with valid limits", async ({
+			expect,
+		}) => {
 			fs.writeFileSync(
 				"index.js",
 				"import { WorkflowEntrypoint } from 'cloudflare:workers';\nexport default {};\nexport class MyWorkflow extends WorkflowEntrypoint {};"
@@ -950,7 +995,9 @@ describe("wrangler workflows", () => {
 			expect(std.err).toBe("");
 		});
 
-		it("should accept workflow binding with empty limits object", async () => {
+		it("should accept workflow binding with empty limits object", async ({
+			expect,
+		}) => {
 			fs.writeFileSync(
 				"index.js",
 				"import { WorkflowEntrypoint } from 'cloudflare:workers';\nexport default {};\nexport class MyWorkflow extends WorkflowEntrypoint {};"
@@ -971,7 +1018,9 @@ describe("wrangler workflows", () => {
 			expect(std.err).toBe("");
 		});
 
-		it("should accept workflow binding with limits.steps at boundary value 1", async () => {
+		it("should accept workflow binding with limits.steps at boundary value 1", async ({
+			expect,
+		}) => {
 			fs.writeFileSync(
 				"index.js",
 				"import { WorkflowEntrypoint } from 'cloudflare:workers';\nexport default {};\nexport class MyWorkflow extends WorkflowEntrypoint {};"
@@ -992,7 +1041,9 @@ describe("wrangler workflows", () => {
 			expect(std.err).toBe("");
 		});
 
-		it("should reject workflow binding with limits.steps of 0", async () => {
+		it("should reject workflow binding with limits.steps of 0", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				workflows: [
 					{
@@ -1010,7 +1061,9 @@ describe("wrangler workflows", () => {
 			);
 		});
 
-		it("should reject workflow binding with non-integer limits.steps", async () => {
+		it("should reject workflow binding with non-integer limits.steps", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				workflows: [
 					{
@@ -1028,7 +1081,9 @@ describe("wrangler workflows", () => {
 			);
 		});
 
-		it("should reject workflow binding with negative limits.steps", async () => {
+		it("should reject workflow binding with negative limits.steps", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				workflows: [
 					{
@@ -1046,7 +1101,9 @@ describe("wrangler workflows", () => {
 			);
 		});
 
-		it("should reject workflow binding with non-object limits", async () => {
+		it("should reject workflow binding with non-object limits", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				workflows: [
 					{
@@ -1064,7 +1121,9 @@ describe("wrangler workflows", () => {
 			);
 		});
 
-		it("should reject workflow binding with array limits", async () => {
+		it("should reject workflow binding with array limits", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				workflows: [
 					{
@@ -1082,7 +1141,9 @@ describe("wrangler workflows", () => {
 			);
 		});
 
-		it("should warn on unexpected fields in workflow binding limits", async () => {
+		it("should warn on unexpected fields in workflow binding limits", async ({
+			expect,
+		}) => {
 			writeWorkerSource({ format: "ts" });
 			writeWranglerConfig({
 				main: "index.ts",
@@ -1107,7 +1168,9 @@ describe("wrangler workflows", () => {
 			);
 		});
 
-		it("should warn when step limit exceeds production maximum", async () => {
+		it("should warn when step limit exceeds production maximum", async ({
+			expect,
+		}) => {
 			fs.writeFileSync(
 				"index.js",
 				"import { WorkflowEntrypoint } from 'cloudflare:workers';\nexport default {};\nexport class MyWorkflow extends WorkflowEntrypoint {};"
@@ -1133,7 +1196,9 @@ describe("wrangler workflows", () => {
 			);
 		});
 
-		it("should not warn when step limit is within production maximum", async () => {
+		it("should not warn when step limit is within production maximum", async ({
+			expect,
+		}) => {
 			fs.writeFileSync(
 				"index.js",
 				"import { WorkflowEntrypoint } from 'cloudflare:workers';\nexport default {};\nexport class MyWorkflow extends WorkflowEntrypoint {};"
@@ -1157,7 +1222,7 @@ describe("wrangler workflows", () => {
 			expect(std.warn).not.toContain("step limit");
 		});
 
-		it("should reject workflows binding with same name", async () => {
+		it("should reject workflows binding with same name", async ({ expect }) => {
 			writeWorkerSource({ format: "ts" });
 			writeWranglerConfig({
 				main: "index.ts",
@@ -1216,7 +1281,7 @@ describe("wrangler workflows", () => {
 		const LOCAL_BASE = `http://localhost:${LOCAL_PORT}/cdn-cgi/explorer/api`;
 
 		describe("workflows list --local", () => {
-			it("should list workflows from local dev session", async () => {
+			it("should list workflows from local dev session", async ({ expect }) => {
 				writeWranglerConfig();
 
 				msw.use(
@@ -1243,7 +1308,7 @@ describe("wrangler workflows", () => {
 				);
 			});
 
-			it("should warn when no local workflows exist", async () => {
+			it("should warn when no local workflows exist", async ({ expect }) => {
 				writeWranglerConfig();
 
 				msw.use(
@@ -1266,7 +1331,9 @@ describe("wrangler workflows", () => {
 		});
 
 		describe("workflows describe --local", () => {
-			it("should describe a workflow from local dev session", async () => {
+			it("should describe a workflow from local dev session", async ({
+				expect,
+			}) => {
 				writeWranglerConfig();
 
 				msw.use(
@@ -1303,7 +1370,9 @@ describe("wrangler workflows", () => {
 		});
 
 		describe("workflows trigger --local", () => {
-			it("should trigger a workflow in local dev session", async () => {
+			it("should trigger a workflow in local dev session", async ({
+				expect,
+			}) => {
 				writeWranglerConfig();
 
 				msw.use(
@@ -1331,7 +1400,9 @@ describe("wrangler workflows", () => {
 				);
 			});
 
-			it("should trigger without params in local dev session", async () => {
+			it("should trigger without params in local dev session", async ({
+				expect,
+			}) => {
 				writeWranglerConfig();
 
 				msw.use(
@@ -1353,7 +1424,9 @@ describe("wrangler workflows", () => {
 		});
 
 		describe("workflows delete --local", () => {
-			it("should delete a workflow in local dev session", async () => {
+			it("should delete a workflow in local dev session", async ({
+				expect,
+			}) => {
 				writeWranglerConfig();
 
 				msw.use(
@@ -1376,7 +1449,7 @@ describe("wrangler workflows", () => {
 		});
 
 		describe("workflows instances list --local", () => {
-			it("should list instances from local dev session", async () => {
+			it("should list instances from local dev session", async ({ expect }) => {
 				writeWranglerConfig();
 
 				msw.use(
@@ -1417,7 +1490,7 @@ describe("wrangler workflows", () => {
 				);
 			});
 
-			it("should warn when no local instances exist", async () => {
+			it("should warn when no local instances exist", async ({ expect }) => {
 				writeWranglerConfig();
 
 				msw.use(
@@ -1445,7 +1518,9 @@ describe("wrangler workflows", () => {
 		});
 
 		describe("workflows instances describe --local", () => {
-			it("should describe an instance from local dev session", async () => {
+			it("should describe an instance from local dev session", async ({
+				expect,
+			}) => {
 				writeWranglerConfig();
 
 				msw.use(
@@ -1512,7 +1587,9 @@ describe("wrangler workflows", () => {
 		});
 
 		describe("workflows instances pause --local", () => {
-			it("should pause an instance in local dev session", async () => {
+			it("should pause an instance in local dev session", async ({
+				expect,
+			}) => {
 				writeWranglerConfig();
 
 				msw.use(
@@ -1543,7 +1620,9 @@ describe("wrangler workflows", () => {
 		});
 
 		describe("workflows instances resume --local", () => {
-			it("should resume an instance in local dev session", async () => {
+			it("should resume an instance in local dev session", async ({
+				expect,
+			}) => {
 				writeWranglerConfig();
 
 				msw.use(
@@ -1574,7 +1653,9 @@ describe("wrangler workflows", () => {
 		});
 
 		describe("workflows instances terminate --local", () => {
-			it("should terminate an instance in local dev session", async () => {
+			it("should terminate an instance in local dev session", async ({
+				expect,
+			}) => {
 				writeWranglerConfig();
 
 				msw.use(
@@ -1605,7 +1686,9 @@ describe("wrangler workflows", () => {
 		});
 
 		describe("workflows instances restart --local", () => {
-			it("should restart an instance in local dev session", async () => {
+			it("should restart an instance in local dev session", async ({
+				expect,
+			}) => {
 				writeWranglerConfig();
 
 				msw.use(
@@ -1636,7 +1719,9 @@ describe("wrangler workflows", () => {
 		});
 
 		describe("workflows instances send-event --local", () => {
-			it("should send an event to an instance in local dev session", async () => {
+			it("should send an event to an instance in local dev session", async ({
+				expect,
+			}) => {
 				writeWranglerConfig();
 
 				msw.use(
@@ -1666,7 +1751,9 @@ describe("wrangler workflows", () => {
 				);
 			});
 
-			it("should send an event without payload in local dev session", async () => {
+			it("should send an event without payload in local dev session", async ({
+				expect,
+			}) => {
 				writeWranglerConfig();
 
 				msw.use(
@@ -1696,7 +1783,9 @@ describe("wrangler workflows", () => {
 		});
 
 		describe("latest instance resolution --local", () => {
-			it("should resolve 'latest' to the most recent instance", async () => {
+			it("should resolve 'latest' to the most recent instance", async ({
+				expect,
+			}) => {
 				writeWranglerConfig();
 
 				msw.use(


### PR DESCRIPTION
Removal of a bunch of comments like:
```
// eslint-disable-next-line no-restricted-imports
```
from the wrangler

Continuation from https://github.com/cloudflare/workers-sdk/pull/13140, https://github.com/cloudflare/workers-sdk/pull/13149 https://github.com/cloudflare/workers-sdk/pull/13164, https://github.com/cloudflare/workers-sdk/pull/13247 and https://github.com/cloudflare/workers-sdk/pull/13245


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal refactoring

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
