### PR TITLE
[create-cloudflare] Prevent secrets from leaking to C3 e2e spawned processes

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -36,12 +36,11 @@ runs:
       if: inputs.turbo-api
       shell: bash
       run: |
-        touch .env
-        echo TURBO_API=${{ inputs.turbo-api }} >> .env
-        echo TURBO_TEAM=${{ inputs.turbo-team }} >> .env
-        echo TURBO_TOKEN=${{ inputs.turbo-token }} >> .env
-        echo TURBO_REMOTE_CACHE_SIGNATURE_KEY=${{ inputs.turbo-signature }} >> .env
-        echo TURBO_ENV_MODE=loose >> .env
+        echo "TURBO_API=${{ inputs.turbo-api }}" >> $GITHUB_ENV
+        echo "TURBO_TEAM=${{ inputs.turbo-team }}" >> $GITHUB_ENV
+        echo "TURBO_TOKEN=${{ inputs.turbo-token }}" >> $GITHUB_ENV
+        echo "TURBO_REMOTE_CACHE_SIGNATURE_KEY=${{ inputs.turbo-signature }}" >> $GITHUB_ENV
+        echo "TURBO_ENV_MODE=loose" >> $GITHUB_ENV
 
     - name: Install NPM Dependencies
       shell: bash

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -46,10 +46,6 @@ jobs:
             everything_but_markdown:
               - '!**/*.md'
 
-      - name: Check if remote tests should run
-        id: check-remote
-        uses: ./.github/actions/check-remote-tests
-
       - name: Install Dependencies
         if: steps.changes.outputs.everything_but_markdown == 'true'
         uses: ./.github/actions/install-dependencies
@@ -82,8 +78,6 @@ jobs:
         run: pnpm run test:e2e:c3
         env:
           NODE_VERSION: ${{ env.NODE_VERSION }}
-          CLOUDFLARE_API_TOKEN: ${{ steps.check-remote.outputs.run-remote == 'true' && secrets.TEST_CLOUDFLARE_API_TOKEN || '' }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ steps.check-remote.outputs.run-remote == 'true' && secrets.TEST_CLOUDFLARE_ACCOUNT_ID || '' }}
           E2E_EXPERIMENTAL: ${{ matrix.experimental }}
           E2E_TEST_PM: ${{ matrix.pm.name }}
           E2E_TEST_PM_VERSION: ${{ matrix.pm.version }}

--- a/packages/create-cloudflare/e2e/helpers/spawn.ts
+++ b/packages/create-cloudflare/e2e/helpers/spawn.ts
@@ -113,6 +113,16 @@ export const waitForExit = async (
 
 export const testEnv = {
 	...process.env,
+	// Strip secrets that should never be accessible to spawned processes.
+	// These tests scaffold third-party framework projects and run their code
+	// (npm install, postinstall scripts, dev servers, etc.) which we do not control.
+	CLOUDFLARE_API_TOKEN: undefined,
+	CLOUDFLARE_ACCOUNT_ID: undefined,
+	GITHUB_TOKEN: undefined,
+	TURBO_API: undefined,
+	TURBO_TEAM: undefined,
+	TURBO_TOKEN: undefined,
+	TURBO_REMOTE_CACHE_SIGNATURE_KEY: undefined,
 	// The following env vars are set to ensure that package managers
 	// do not use the same global cache and accidentally hit race conditions.
 	YARN_CACHE_FOLDER: "./.yarn/cache",

--- a/packages/create-cloudflare/scripts/common.ts
+++ b/packages/create-cloudflare/scripts/common.ts
@@ -42,6 +42,9 @@ const apiFetch = async (
 };
 
 export const deleteProject = async (project: string) => {
+	if (!process.env.CLOUDFLARE_API_TOKEN || !process.env.CLOUDFLARE_ACCOUNT_ID) {
+		return;
+	}
 	try {
 		await apiFetch(`/pages/projects/${project}`, {
 			method: "DELETE",
@@ -52,6 +55,9 @@ export const deleteProject = async (project: string) => {
 };
 
 export const deleteWorker = async (id: string) => {
+	if (!process.env.CLOUDFLARE_API_TOKEN || !process.env.CLOUDFLARE_ACCOUNT_ID) {
+		return;
+	}
 	try {
 		await apiFetch(`/workers/scripts/${id}`, {
 			method: "DELETE",


### PR DESCRIPTION
Fixes no specific issue -- proactive security hardening.

C3 e2e tests scaffold third-party framework projects and run their code (npm install, postinstall scripts, dev servers, etc.) which we do not control. Previously, all secrets (Cloudflare API tokens, Turbo cache credentials, GitHub token) were inherited by these spawned processes via `process.env`, meaning a malicious postinstall script or framework CLI could exfiltrate them.

## Changes

**`.github/actions/install-dependencies/action.yml`**
- Write Turbo remote cache secrets to `$GITHUB_ENV` instead of a `.env` file on disk
- Eliminates secrets persisted to the filesystem (previously any process could read the `.env` file)
- All workflows using this action benefit from this improvement

**`.github/workflows/c3-e2e.yml`**
- Remove `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` from the e2e step env (deploy tests are already skipped when these are absent)
- Remove the `check-remote-tests` step (no longer needed since we never provide Cloudflare secrets)
- Keep `GITHUB_TOKEN` on the step for the test harness (selectively passed to Solid/Redwood via `extraEnv`)

**`packages/create-cloudflare/e2e/helpers/spawn.ts`**
- Strip all sensitive env vars (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `GITHUB_TOKEN`, `TURBO_API`, `TURBO_TEAM`, `TURBO_TOKEN`, `TURBO_REMOTE_CACHE_SIGNATURE_KEY`) from `testEnv`
- Defense-in-depth: spawned child processes never receive secrets even if they are accidentally present in the parent environment

**`packages/create-cloudflare/scripts/common.ts`**
- Add early-return guards to `deleteProject` and `deleteWorker` when credentials are missing, avoiding unnecessary failed API calls during cleanup

## Security model after this change

| Secret | CI workflow step | testEnv (child processes) | On disk |
|---|---|---|---|
| `CLOUDFLARE_API_TOKEN` | Not set | Stripped | N/A |
| `CLOUDFLARE_ACCOUNT_ID` | Not set | Stripped | N/A |
| `GITHUB_TOKEN` | Set (for harness) | Stripped (passed selectively to Solid/Redwood) | N/A |
| `TURBO_*` | Set via `$GITHUB_ENV` | Stripped | No longer written to `.env` |

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: CI/workflow and test infrastructure changes only; existing e2e tests validate the behavior
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal CI security hardening
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
