### PR TITLE
[wrangler] Fix type-gen check for multi-worker setups

### DIFF
--- a/.changeset/fix-type-gen-check-multi-worker.md
+++ b/.changeset/fix-type-gen-check-multi-worker.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler types --check` for multi-worker setups
+
+Previously, `wrangler types --check` ignored secondary worker configs passed via multiple `-c` flags. The check would always report types as out of date because it compared against a hash generated without the secondary worker entries. The secondary config processing now runs before the staleness check, so the comparison includes cross-worker type information.

--- a/packages/wrangler/src/type-generation/helpers.ts
+++ b/packages/wrangler/src/type-generation/helpers.ts
@@ -151,7 +151,8 @@ const unsafeParseBooleanString = (value: unknown): boolean => {
  */
 export const checkTypesUpToDate = async (
 	primaryConfig: Config,
-	typesPath: string = DEFAULT_WORKERS_TYPES_FILE_PATH
+	typesPath: string = DEFAULT_WORKERS_TYPES_FILE_PATH,
+	secondaryEntries: Map<string, Entry> = new Map()
 ): Promise<boolean> => {
 	let typesFileLines = new Array<string>();
 	try {
@@ -215,7 +216,7 @@ export const checkTypesUpToDate = async (
 				args.envInterface,
 				typesPath,
 				entrypoint,
-				new Map(),
+				secondaryEntries,
 				false // don't log anything
 			);
 			const newHash = envHeader?.match(/hash: (?<hash>.*)\)/)?.groups?.hash;

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -166,19 +166,6 @@ export const typesCommand = createCommand({
 			);
 		}
 
-		if (args.check) {
-			const outOfDate = await checkTypesUpToDate(config, outputPath);
-			if (outOfDate) {
-				throw new FatalError(
-					`Types at ${outputPath} are out of date. Run \`wrangler types\` to regenerate.`,
-					1
-				);
-			}
-
-			logger.log(`✨ Types at ${outputPath} are up to date.\n`);
-			return;
-		}
-
 		const secondaryEntries: Map<string, Entry> = new Map();
 
 		if (secondaryConfigs.length > 0) {
@@ -220,6 +207,23 @@ export const typesCommand = createCommand({
 					);
 				}
 			}
+		}
+
+		if (args.check) {
+			const outOfDate = await checkTypesUpToDate(
+				config,
+				outputPath,
+				secondaryEntries
+			);
+			if (outOfDate) {
+				throw new FatalError(
+					`Types at ${outputPath} are out of date. Run \`wrangler types\` to regenerate.`,
+					1
+				);
+			}
+
+			logger.log(`✨ Types at ${outputPath} are up to date.\n`);
+			return;
 		}
 
 		const configContainsEntrypoint =


### PR DESCRIPTION
Fixes #13196.

The `wrangler types --check` command was broken for multi-worker setups. When multiple config files were passed via `-c` flags, the `--check` code path returned early before building secondary worker entries. This meant `generateEnvTypes` always received an empty `secondaryEntries` map, producing a hash that never matched the originally generated types (which did include cross-worker information).

The fix moves secondary entry resolution before the `--check` early return and passes the entries through to `checkTypesUpToDate`, which now forwards them to `generateEnvTypes` for accurate hash comparison.

#### Changes

- `index.ts`: Moved the `secondaryEntries` building block before the `args.check` branch so that secondary worker configs are resolved regardless of whether `--check` is used
- `helpers.ts`: Added an optional `secondaryEntries` parameter to `checkTypesUpToDate` (defaults to an empty map for backward compatibility) and passes it to `generateEnvTypes` instead of a hardcoded empty map

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: existing type-generation tests (120 tests) all pass; the change is a straightforward reordering of existing logic with no new branches
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this is a bug fix with no API surface changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
