### PR TITLE
[wrangler] fix: resolve named service entrypoints for env-scoped workers

### DIFF
--- a/.changeset/sour-rules-matter.md
+++ b/.changeset/sour-rules-matter.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler types` resolution for env-qualified service entrypoints
+
+`wrangler types` now resolves named `services` entrypoints back to the secondary Worker's source module when the secondary config uses an environment-specific `name` override. This restores strongly typed `Service<typeof import(...).Entrypoint>` output for multi-config type generation instead of falling back to an unresolved `Service` comment.

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -1234,6 +1234,99 @@ describe("generate types", () => {
 		`);
 	});
 
+	it("should resolve named service entrypoints when env overrides the worker name", async ({
+		expect,
+	}) => {
+		fs.mkdirSync("primary");
+		fs.mkdirSync("secondary");
+
+		fs.writeFileSync(
+			"./secondary/index.ts",
+			`import { WorkerEntrypoint } from 'cloudflare:workers';
+			export default { async fetch() {} };
+			export class SomeEntrypoint extends WorkerEntrypoint {}
+			`
+		);
+		fs.writeFileSync(
+			"./secondary/wrangler.jsonc",
+			JSON.stringify({
+				compatibility_date: "2022-01-12",
+				name: "secondary-worker",
+				main: "./index.ts",
+				env: {
+					staging: {
+						name: "secondary-worker-staging",
+					},
+				},
+			}),
+			"utf-8"
+		);
+
+		fs.writeFileSync(
+			"./primary/index.ts",
+			"export default { async fetch() {} };"
+		);
+		fs.writeFileSync(
+			"./primary/wrangler.jsonc",
+			JSON.stringify({
+				compatibility_date: "2022-01-12",
+				name: "primary-worker",
+				main: "./index.ts",
+				services: [
+					{
+						binding: "SERVICE_A",
+						service: "secondary-worker",
+						entrypoint: "SomeEntrypoint",
+					},
+				],
+				env: {
+					staging: {
+						name: "primary-worker-staging",
+						services: [
+							{
+								binding: "SERVICE_A",
+								service: "secondary-worker-staging",
+								entrypoint: "SomeEntrypoint",
+							},
+						],
+					},
+				},
+			}),
+			"utf-8"
+		);
+
+		await runWrangler(
+			"types --include-runtime=false -c primary/wrangler.jsonc -c secondary/wrangler.jsonc --path primary/worker-configuration.d.ts"
+		);
+
+		expect(std.out).toMatchInlineSnapshot(`
+			"
+			 ⛅️ wrangler x.x.x
+			──────────────────
+			- Found Worker 'secondary-worker' at 'secondary/index.ts' (secondary/wrangler.jsonc)
+			Generating project types...
+
+			declare namespace Cloudflare {
+				interface GlobalProps {
+					mainModule: typeof import("./index");
+				}
+				interface StagingEnv {
+					SERVICE_A: Service<typeof import("../secondary/index").SomeEntrypoint>;
+				}
+				interface Env {
+					SERVICE_A: Service<typeof import("../secondary/index").SomeEntrypoint>;
+				}
+			}
+			interface Env extends Cloudflare.Env {}
+
+			────────────────────────────────────────────────────────────
+			✨ Types written to primary/worker-configuration.d.ts
+
+			📣 Remember to rerun 'wrangler types' after you change your wrangler.jsonc file.
+			"
+		`);
+	});
+
 	it("should create a DTS file at the location that the command is executed from", async ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -209,9 +209,10 @@ export const typesCommand = createCommand({
 							config: secondaryConfig.configPath,
 							env: envName,
 						});
-						const envKey = envConfig.name;
+						const envEntry = await getEntry({}, envConfig, "types");
+						const envKey = envEntry.name;
 						if (envKey && envKey !== key && !secondaryEntries.has(envKey)) {
-							secondaryEntries.set(envKey, serviceEntry);
+							secondaryEntries.set(envKey, envEntry);
 						}
 					}
 				} else {


### PR DESCRIPTION
This follows up the env-qualified secondary worker resolution fix from #13061 for the named `services[].entrypoint` case.

When `wrangler types` runs across multiple `-c` configs, a secondary worker can expose environment-specific names like `secondary-worker-staging`. Bindings targeting those env-qualified names were already resolvable for the default worker entrypoint, but named `WorkerEntrypoint` bindings could still fall back to an unresolved type comment instead of emitting `Service<typeof import(...).SomeEntrypoint>`.

This change registers each secondary worker's env-qualified name against that env's resolved `Entry` metadata, so named service entrypoints keep the correct source module and export information during type generation.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is a bug fix for generated typings with no public docs changes

![39D7B59B-BFB0-4C29-BBF5-DBF24CC8472E_1_105_c](https://github.com/user-attachments/assets/dd34235c-2ebc-4bc6-8b65-fe04c236d839)


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
