### PR TITLE
SQC-810 Fix tls configuration for hyperdrive local dev

### DIFF
--- a/.changeset/petite-wolves-matter.md
+++ b/.changeset/petite-wolves-matter.md
@@ -1,0 +1,5 @@
+---
+"miniflare": minor
+---
+
+Fix hyperdrive local dev binding tls configuration bug

--- a/packages/miniflare/src/plugins/hyperdrive/hyperdrive-proxy.ts
+++ b/packages/miniflare/src/plugins/hyperdrive/hyperdrive-proxy.ts
@@ -152,6 +152,7 @@ async function handlePostgresTlsConnection(
 			socket: dbSocket,
 			host: targetHost,
 			servername: targetHost,
+			rejectUnauthorized: false,
 		};
 		try {
 			const tlsSocket = await tlsConnect(tlsOptions);
@@ -242,7 +243,7 @@ async function handleMySQLTlsConnection(
 			host: targetHost,
 			servername: targetHost,
 			minVersion: "TLSv1.2",
-			rejectUnauthorized: true,
+			rejectUnauthorized: false,
 		};
 
 		try {


### PR DESCRIPTION
Fixes failed tls connections due to strict self signed cert validation

Fixes 
https://x.com/Checkm3out/status/2040080426518093944

_Describe your change..._
Disable verifying self signed certs when using `npx wrangler dev`
Matches psql experience where this validation is disabled by default

- Tests
  - [X] Tests included/updated - existing tests should still suffice as this is just a small configuration change
  - [X] Automated tests not possible - manual testing has been completed as follows:
1. Created digital ocean database cluster similar to customer environment
2. ran `pnpm run build --filter wrangler` to build wrangler locally
3. set up worker with hyperdrive binding and set digital ocean connection string on localConnectionString
4. run node ~/workers-sdk/packages/wrangler/wrangler-dist/cli.js dev
5. connected to digital ocean database as expected
without the change it fails with 500 error

  - [X] Additional testing not necessary because: this involves real database connections
- Public documentation
  - [] Cloudflare docs PR(s): 
  - [X] Documentation not necessary because: This is expected behavior already documented on https://developers.cloudflare.com/hyperdrive/configuration/local-development/
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
