### PR TITLE
[create-cloudflare] Fix Vue scaffolding failing with `--no-ts` parse error

### DIFF
--- a/.changeset/fix-create-vue-no-ts-arg.md
+++ b/.changeset/fix-create-vue-no-ts-arg.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+Fix Vue project scaffolding failing with `ERR_PARSE_ARGS_UNKNOWN_OPTION` for `--no-ts`
+
+`create-vue` switched to Node's `parseArgs` with strict mode, which does not support `--no-*` negation syntax. The `--no-ts` flag is no longer passed; instead, the `--ts` flag is only included when TypeScript is selected.

--- a/.changeset/fix-create-vue-no-ts-arg.md
+++ b/.changeset/fix-create-vue-no-ts-arg.md
@@ -2,6 +2,4 @@
 "create-cloudflare": patch
 ---
 
-Fix Vue project scaffolding failing with `ERR_PARSE_ARGS_UNKNOWN_OPTION` for `--no-ts`
-
-`create-vue` switched to Node's `parseArgs` with strict mode, which does not support `--no-*` negation syntax. The `--no-ts` flag is no longer passed; instead, the `--ts` flag is only included when TypeScript is selected.
+Fix Vue project scaffolding failing when `javascript` is selected

--- a/packages/create-cloudflare/templates/vue/workers/c3.ts
+++ b/packages/create-cloudflare/templates/vue/workers/c3.ts
@@ -25,7 +25,7 @@ const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, [
 		ctx.project.name,
 		"--router",
-		lang === "ts" ? "--ts" : "--no-ts",
+		...(lang === "ts" ? ["--ts"] : []),
 	]);
 	logRaw("");
 };


### PR DESCRIPTION
Fixes #13256.

`create-vue` (v3.22+) switched from `minimist` to Node's built-in `parseArgs` with `strict: true`, which does not support `--no-*` negation syntax for options not explicitly defined. This caused C3's Vue Workers template to fail with `ERR_PARSE_ARGS_UNKNOWN_OPTION: Unknown option '--no-ts'`.

The fix removes the `--no-ts` flag entirely when JavaScript is selected. Since `--router` is still passed (a recognized feature flag), `create-vue` enters non-interactive mode and defaults TypeScript to `false` when `--ts` is absent.

#### Key review point

Verify that omitting `--ts` while passing `--router` correctly results in a JS project (no TypeScript prompt). In `create-vue`'s source, `isFeatureFlagsUsed` becomes `true` when any feature flag (including `--router`) is set, which skips all interactive prompts and defaults `needsTypeScript` to `false`.

---

- Tests
  - [ ] Tests included/updated
  - [x] Additional testing not necessary because: the change is a one-line fix in a template that invokes an external CLI tool (`create-vue`); unit testing this requires E2E framework scaffolding
- Public documentation
  - [x] Documentation not necessary because: this is a bug fix with no user-facing API change

Link to Devin session: https://app.devin.ai/sessions/51a54170c1744e93b9e45ffd60fc2c0b
Requested by: @emily-shen
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
