### PR TITLE
fix(miniflare): prevent fetch failed on POST 401 responses

### DIFF
--- a/.changeset/fix-miniflare-post-401.md
+++ b/.changeset/fix-miniflare-post-401.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+fix(miniflare): prevent fetch failed on POST 401 responses
+
+Set `credentials: "omit"` in miniflare's fetch wrapper to bypass undici's HTTP 401 authentication retry logic. Workerd uses streamed request bodies where `body.source` is null, causing undici to throw "expected non-null body source" on POST 401 responses.

--- a/packages/miniflare/src/http/fetch.ts
+++ b/packages/miniflare/src/http/fetch.ts
@@ -83,6 +83,15 @@ export async function fetch(
 
 	const response = await undici.fetch(request, {
 		dispatcher: requestInit?.dispatcher,
+		// Prevent undici's HTTP 401 authentication retry logic from triggering.
+		// When a POST request with a streamed body (body.source === null) receives
+		// a 401, undici tries to re-extract the request body for re-sending with
+		// credentials, but fails with "expected non-null body source" because
+		// workerd uses streamed bodies. Setting credentials to "omit" bypasses
+		// the 401 handling entirely (Fetch spec §4.4 step 14). This is safe
+		// because miniflare dispatches to workerd directly — there is no HTTP
+		// authentication to retry.
+		credentials: "omit",
 	});
 	return new Response(response.body, response);
 }

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -2707,6 +2707,14 @@ export class Miniflare {
 
 		const forwardInit = forward as RequestInit;
 		forwardInit.dispatcher = dispatcher;
+		// Omit credentials to prevent undici's HTTP 401 authentication retry
+		// logic from triggering. When a POST request with a streamed body
+		// receives a 401, undici tries to re-extract the body source for
+		// credential re-authentication. Since workerd uses streamed bodies
+		// (body.source === null), this causes a "fetch failed" network error
+		// with "expected non-null body source". Setting credentials to "omit"
+		// bypasses the 401 handling entirely (see Fetch spec step 14).
+		forwardInit.credentials = "omit";
 		const response = await fetch(url, forwardInit);
 
 		// If the Worker threw an uncaught exception, propagate it to the caller


### PR DESCRIPTION
## Summary

POST requests returning HTTP 401 from Workers crash miniflare undici proxy with `TypeError: fetch failed` in dev mode. GET 401, POST 400, POST 403, and POST 500 all work fine.

## Root cause

Undici Fetch spec implementation (step 14) has special handling for 401 responses: it tries to re-extract the request body source for credential re-authentication. But workerd uses **streamed request bodies** where `body.source` is `null`. This causes undici to throw:

```
Error: expected non-null body source
```

...which surfaces as `TypeError: fetch failed` at `processResponse`.

## Fix

Set `credentials: "omit"` in miniflare `fetch()` wrapper when calling `undici.fetch()`. This bypasses the 401 authentication retry logic entirely. Miniflare dispatches to the workerd runtime directly — there is no HTTP authentication scheme to negotiate, so this code path should never trigger.

## Testing

Verified locally by patching the compiled miniflare dist:

| Request | Before | After |
|---------|--------|-------|
| POST 200 | OK | OK |
| POST 400 | OK | OK |
| POST 401 | fetch failed | OK (returns JSON) |
| POST 403 | OK | OK |
| POST 500 | OK | OK |
| GET 401 | OK | OK |

## Impact

This affects any auth library (better-auth, lucia, etc.) running on Cloudflare Workers in dev mode where login with wrong credentials returns 401.

Fixes #13327
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
