### PR TITLE
[wrangler] Fix AI Search bindings not working in local dev without explicit remote: true

### DIFF
--- a/.changeset/fix-ai-search-remote-bindings.md
+++ b/.changeset/fix-ai-search-remote-bindings.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: Treat AI Search bindings as always-remote in local dev
+
+AI Search namespace (`ai_search_namespaces`) and instance (`ai_search`) bindings are always-remote (they have no local simulation), but `pickRemoteBindings()` did not include them in its always-remote type list. This caused the remote proxy session to exclude these bindings when `remote: true` was not explicitly set in the config, resulting in broken AI Search bindings during `wrangler dev`.
+
+Additionally, `removeRemoteConfigFieldFromBindings()` in the deploy config-diff logic was not stripping the `remote` field from AI Search bindings, which could cause false config diffs during deployment.

--- a/packages/wrangler/src/__tests__/deploy/get-remote-config-diff.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/get-remote-config-diff.test.ts
@@ -393,6 +393,18 @@ describe("getRemoteConfigsDiff", () => {
 						tunnel_id: "my-tunnel",
 					},
 				],
+				ai_search_namespaces: [
+					{
+						binding: "MY_AI_SEARCH_NS",
+						namespace: "my-namespace",
+					},
+				],
+				ai_search: [
+					{
+						binding: "MY_AI_SEARCH",
+						instance_name: "my-instance",
+					},
+				],
 			},
 			{
 				name: "my-worker-id",
@@ -505,6 +517,20 @@ describe("getRemoteConfigsDiff", () => {
 					{
 						binding: "MY_NETWORK",
 						tunnel_id: "my-tunnel",
+						remote: true,
+					},
+				],
+				ai_search_namespaces: [
+					{
+						binding: "MY_AI_SEARCH_NS",
+						namespace: "my-namespace",
+						remote: true,
+					},
+				],
+				ai_search: [
+					{
+						binding: "MY_AI_SEARCH",
+						instance_name: "my-instance",
 						remote: true,
 					},
 				],

--- a/packages/wrangler/src/api/remoteBindings/index.ts
+++ b/packages/wrangler/src/api/remoteBindings/index.ts
@@ -35,6 +35,14 @@ export function pickRemoteBindings(
 				return true;
 			}
 
+			if (
+				binding.type === "ai_search_namespace" ||
+				binding.type === "ai_search"
+			) {
+				// AI Search bindings are always remote
+				return true;
+			}
+
 			return "remote" in binding && binding["remote"];
 		})
 	);

--- a/packages/wrangler/src/deploy/config-diffs.ts
+++ b/packages/wrangler/src/deploy/config-diffs.ts
@@ -222,6 +222,19 @@ function removeRemoteConfigFieldFromBindings(normalizedConfig: Config): void {
 		);
 	}
 
+	if (normalizedConfig.ai_search_namespaces?.length) {
+		normalizedConfig.ai_search_namespaces =
+			normalizedConfig.ai_search_namespaces.map(
+				({ remote: _, ...binding }) => binding
+			);
+	}
+
+	if (normalizedConfig.ai_search?.length) {
+		normalizedConfig.ai_search = normalizedConfig.ai_search.map(
+			({ remote: _, ...binding }) => binding
+		);
+	}
+
 	const singleBindingFields = [
 		"browser",
 		"ai",


### PR DESCRIPTION
Fixes AI Search namespace and instance bindings failing during `wrangler dev` when `remote: true` is not explicitly set in the configuration.

## Summary

AI Search bindings (`ai_search_namespaces` and `ai_search`) are always-remote — they have no local simulation, similar to `ai`, `media`, `vpc_service`, and `vpc_network` bindings. However, two places in the codebase were missing AI Search from their handling:

1. **`pickRemoteBindings()`** (`packages/wrangler/src/api/remoteBindings/index.ts`) — This function determines which bindings are included in the remote proxy session during `wrangler dev`. It had a hardcoded list of "always remote" types (`ai`, `media`, `vpc_service`, `vpc_network`) but was missing `ai_search_namespace` and `ai_search`. Without `remote: true` in the config, AI Search bindings were excluded from the remote proxy session, causing the miniflare AI Search plugin to receive an undefined `remoteProxyConnectionString` and fail at runtime.

2. **`removeRemoteConfigFieldFromBindings()`** (`packages/wrangler/src/deploy/config-diffs.ts`) — This function strips the local-only `remote` field from bindings before comparing local vs remote config during deployment. It was missing AI Search bindings, causing false config diffs when deploying workers with `remote: true` set on AI Search bindings.

## Changes

- Add `ai_search_namespace` and `ai_search` to the always-remote type list in `pickRemoteBindings()`
- Add `ai_search_namespaces` and `ai_search` to `removeRemoteConfigFieldFromBindings()`
- Update the existing config-diff test to cover AI Search bindings

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Bug fix only, no new user-facing API
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
