### PR TITLE
[wrangler] Mark Workers VPC as GA

### DIFF
--- a/.changeset/vpc-ga-status.md
+++ b/.changeset/vpc-ga-status.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Mark Workers VPC as GA by changing its status from "open beta" to "stable"
+
+The `wrangler vpc` command namespace is now marked as stable, reflecting that Workers VPC has moved from open beta to general availability. The `[open beta]` badge will no longer appear in CLI help output.

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -66,7 +66,7 @@ describe("wrangler", () => {
 				  wrangler triggers               🎯 Updates the triggers of your current deployment [experimental]
 				  wrangler types [path]           📝 Generate types from your Worker configuration
 				  wrangler versions               🫧 List, view, upload and deploy Versions of your Worker to Cloudflare
-				  wrangler vpc                    🌐 Manage VPC [open beta]
+				  wrangler vpc                    🌐 Manage VPC
 				  wrangler workflows              🔁 Manage Workflows
 
 				STORAGE & DATABASES
@@ -141,7 +141,7 @@ describe("wrangler", () => {
 				  wrangler triggers               🎯 Updates the triggers of your current deployment [experimental]
 				  wrangler types [path]           📝 Generate types from your Worker configuration
 				  wrangler versions               🫧 List, view, upload and deploy Versions of your Worker to Cloudflare
-				  wrangler vpc                    🌐 Manage VPC [open beta]
+				  wrangler vpc                    🌐 Manage VPC
 				  wrangler workflows              🔁 Manage Workflows
 
 				STORAGE & DATABASES

--- a/packages/wrangler/src/__tests__/vpc.test.ts
+++ b/packages/wrangler/src/__tests__/vpc.test.ts
@@ -34,7 +34,7 @@ describe("vpc help", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"wrangler vpc
 
-			🌐 Manage VPC [open beta]
+			🌐 Manage VPC
 
 			COMMANDS
 			  wrangler vpc service  🔗 Manage VPC services

--- a/packages/wrangler/src/vpc/index.ts
+++ b/packages/wrangler/src/vpc/index.ts
@@ -3,7 +3,7 @@ import { createNamespace } from "../core/create-command";
 export const vpcNamespace = createNamespace({
 	metadata: {
 		description: "🌐 Manage VPC",
-		status: "open beta",
+		status: "stable",
 		owner: "Product: WVPC",
 		category: "Compute & AI",
 	},


### PR DESCRIPTION
Fixes WVPC-231.

Mark Workers VPC as generally available by changing the `wrangler vpc` namespace status from `"open beta"` to `"stable"`. The `[open beta]` badge will no longer appear in CLI help output.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [ ] Documentation not necessary because:
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
