### PR TITLE
IMAGES-2191: improve variant URLs returned by miniflare hosted images mock

### DIFF
--- a/.changeset/images-local-delivery-variant-urls.md
+++ b/.changeset/images-local-delivery-variant-urls.md
@@ -1,0 +1,9 @@
+---
+"miniflare": patch
+---
+
+Improve variant URLs returned by the hosted images mock for local development
+
+The miniflare hosted images mock previously returned bare variant names (e.g. `"public"`) in the `variants` field of `ImageMetadata`. In production, this field contains full delivery URLs. The bare names were not usable as image sources, causing applications that render images from variant URLs to fail during local development.
+
+Variant URLs now point to a new local delivery endpoint at `/cdn-cgi/imagedelivery/<image_id>/<variant>` which serves image bytes directly from the local KV store with content-type detection via Sharp.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -75,6 +75,7 @@ import {
 import { InspectorProxyController } from "./plugins/core/inspector-proxy";
 import { HyperdriveProxyController } from "./plugins/hyperdrive/hyperdrive-proxy";
 import { imagesLocalFetcher } from "./plugins/images/fetcher";
+import { getUserBindingServiceName } from "./plugins/shared";
 import {
 	HttpOptions_Style,
 	kInspectorSocket,
@@ -2252,6 +2253,21 @@ export class Miniflare {
 			}
 		}
 
+		// Find the images service name if any worker has a local images binding configured.
+		let imagesServiceName: string | undefined;
+		for (const workerOpts of allWorkerOpts) {
+			if (
+				workerOpts.images.images &&
+				!workerOpts.images.images.remoteProxyConnectionString
+			) {
+				imagesServiceName = getUserBindingServiceName(
+					IMAGES_PLUGIN_NAME,
+					workerOpts.images.images.binding
+				);
+				break;
+			}
+		}
+
 		const globalServices = getGlobalServices({
 			sharedOptions: sharedOpts.core,
 			allWorkerRoutes,
@@ -2275,6 +2291,7 @@ export class Miniflare {
 			durableObjectClassNames,
 			workflowOptions: workflowOptions.size > 0 ? workflowOptions : undefined,
 			allWorkerOpts,
+			imagesServiceName,
 		});
 		for (const service of globalServices) {
 			// Global services should all have unique names

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -76,6 +76,7 @@ import { InspectorProxyController } from "./plugins/core/inspector-proxy";
 import { isModuleFallbackRequest } from "./plugins/core/module-fallback";
 import { HyperdriveProxyController } from "./plugins/hyperdrive/hyperdrive-proxy";
 import { imagesLocalFetcher } from "./plugins/images/fetcher";
+import { getUserBindingServiceName } from "./plugins/shared";
 import {
 	HttpOptions_Style,
 	kInspectorSocket,
@@ -2273,6 +2274,21 @@ export class Miniflare {
 			}
 		}
 
+		// Find the images service name if any worker has a local images binding configured.
+		let imagesServiceName: string | undefined;
+		for (const workerOpts of allWorkerOpts) {
+			if (
+				workerOpts.images.images &&
+				!workerOpts.images.images.remoteProxyConnectionString
+			) {
+				imagesServiceName = getUserBindingServiceName(
+					IMAGES_PLUGIN_NAME,
+					workerOpts.images.images.binding
+				);
+				break;
+			}
+		}
+
 		const globalServices = getGlobalServices({
 			sharedOptions: sharedOpts.core,
 			allWorkerRoutes,
@@ -2297,6 +2313,7 @@ export class Miniflare {
 			durableObjectClassNames,
 			workflowOptions: workflowOptions.size > 0 ? workflowOptions : undefined,
 			allWorkerOpts,
+			imagesServiceName,
 		});
 		for (const service of globalServices) {
 			// Global services should all have unique names

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -76,7 +76,6 @@ import { InspectorProxyController } from "./plugins/core/inspector-proxy";
 import { isModuleFallbackRequest } from "./plugins/core/module-fallback";
 import { HyperdriveProxyController } from "./plugins/hyperdrive/hyperdrive-proxy";
 import { imagesLocalFetcher } from "./plugins/images/fetcher";
-import { getUserBindingServiceName } from "./plugins/shared";
 import {
 	HttpOptions_Style,
 	kInspectorSocket,
@@ -2274,21 +2273,6 @@ export class Miniflare {
 			}
 		}
 
-		// Find the images service name if any worker has a local images binding configured.
-		let imagesServiceName: string | undefined;
-		for (const workerOpts of allWorkerOpts) {
-			if (
-				workerOpts.images.images &&
-				!workerOpts.images.images.remoteProxyConnectionString
-			) {
-				imagesServiceName = getUserBindingServiceName(
-					IMAGES_PLUGIN_NAME,
-					workerOpts.images.images.binding
-				);
-				break;
-			}
-		}
-
 		const globalServices = getGlobalServices({
 			sharedOptions: sharedOpts.core,
 			allWorkerRoutes,
@@ -2313,7 +2297,6 @@ export class Miniflare {
 			durableObjectClassNames,
 			workflowOptions: workflowOptions.size > 0 ? workflowOptions : undefined,
 			allWorkerOpts,
-			imagesServiceName,
 		});
 		for (const service of globalServices) {
 			// Global services should all have unique names

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -999,6 +999,8 @@ export interface GlobalServicesOptions {
 	workflowOptions?: Map<string, WorkflowOption>;
 	/** All worker options for building per-worker resource bindings */
 	allWorkerOpts?: PluginWorkerOptions[];
+	/** Service name for the images delivery endpoint, if images binding is configured */
+	imagesServiceName?: string;
 }
 export function getGlobalServices({
 	sharedOptions,
@@ -1010,6 +1012,7 @@ export function getGlobalServices({
 	durableObjectClassNames,
 	workflowOptions,
 	allWorkerOpts,
+	imagesServiceName,
 }: GlobalServicesOptions): Service[] {
 	// Collect list of workers we could route to, then parse and sort all routes
 	const workerNames = [...allWorkerRoutes.keys()];
@@ -1077,6 +1080,12 @@ export function getGlobalServices({
 				name: getUserBindingServiceName(STREAM_PLUGIN_NAME, "service"),
 				entrypoint: "StreamBinding",
 			},
+		});
+	}
+	if (imagesServiceName) {
+		serviceEntryBindings.push({
+			name: CoreBindings.SERVICE_IMAGES_DELIVERY,
+			service: { name: imagesServiceName },
 		});
 	}
 	if (sharedOptions.upstream !== undefined) {

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -26,6 +26,7 @@ import { CoreBindings, CoreHeaders, viewToBuffer } from "../../workers";
 import { RPC_PROXY_SERVICE_NAME } from "../assets/constants";
 import { getCacheServiceName } from "../cache";
 import { DURABLE_OBJECTS_STORAGE_SERVICE_NAME } from "../do";
+import { IMAGES_PLUGIN_NAME } from "../images";
 import {
 	getUserBindingServiceName,
 	kUnsafeEphemeralUniqueKey,
@@ -1013,8 +1014,6 @@ export interface GlobalServicesOptions {
 	workflowOptions?: Map<string, WorkflowOption>;
 	/** All worker options for building per-worker resource bindings */
 	allWorkerOpts?: PluginWorkerOptions[];
-	/** Service name for the images delivery endpoint, if images binding is configured */
-	imagesServiceName?: string;
 }
 export function getGlobalServices({
 	sharedOptions,
@@ -1027,7 +1026,6 @@ export function getGlobalServices({
 	durableObjectClassNames,
 	workflowOptions,
 	allWorkerOpts,
-	imagesServiceName,
 }: GlobalServicesOptions): Service[] {
 	// Collect list of workers we could route to, then parse and sort all routes
 	const workerNames = [...allWorkerRoutes.keys()];
@@ -1097,10 +1095,20 @@ export function getGlobalServices({
 			},
 		});
 	}
-	if (imagesServiceName) {
+	const imagesBinding = allWorkerOpts
+		?.map((worker) => worker.images?.images)
+		.find(
+			(images) => images !== undefined && !images.remoteProxyConnectionString
+		);
+	if (imagesBinding) {
 		serviceEntryBindings.push({
 			name: CoreBindings.SERVICE_IMAGES_DELIVERY,
-			service: { name: imagesServiceName },
+			service: {
+				name: getUserBindingServiceName(
+					IMAGES_PLUGIN_NAME,
+					imagesBinding.binding
+				),
+			},
 		});
 	}
 	if (sharedOptions.upstream !== undefined) {

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -1013,6 +1013,8 @@ export interface GlobalServicesOptions {
 	workflowOptions?: Map<string, WorkflowOption>;
 	/** All worker options for building per-worker resource bindings */
 	allWorkerOpts?: PluginWorkerOptions[];
+	/** Service name for the images delivery endpoint, if images binding is configured */
+	imagesServiceName?: string;
 }
 export function getGlobalServices({
 	sharedOptions,
@@ -1025,6 +1027,7 @@ export function getGlobalServices({
 	durableObjectClassNames,
 	workflowOptions,
 	allWorkerOpts,
+	imagesServiceName,
 }: GlobalServicesOptions): Service[] {
 	// Collect list of workers we could route to, then parse and sort all routes
 	const workerNames = [...allWorkerRoutes.keys()];
@@ -1092,6 +1095,12 @@ export function getGlobalServices({
 				name: getUserBindingServiceName(STREAM_PLUGIN_NAME, "service"),
 				entrypoint: "StreamBinding",
 			},
+		});
+	}
+	if (imagesServiceName) {
+		serviceEntryBindings.push({
+			name: CoreBindings.SERVICE_IMAGES_DELIVERY,
+			service: { name: imagesServiceName },
 		});
 	}
 	if (sharedOptions.upstream !== undefined) {

--- a/packages/miniflare/src/workers/core/constants.ts
+++ b/packages/miniflare/src/workers/core/constants.ts
@@ -19,6 +19,8 @@ export const CorePaths = {
 	LEGACY_SCHEDULED: "/cdn-cgi/mf/scheduled",
 	/** Stream video serving endpoint */
 	STREAM_VIDEO: "/cdn-cgi/mf/stream",
+	/** Local image delivery endpoint for serving hosted images */
+	IMAGE_DELIVERY: "/cdn-cgi/imagedelivery",
 } as const;
 
 export const CoreHeaders = {
@@ -78,6 +80,7 @@ export const CoreBindings = {
 	JSON_TELEMETRY_CONFIG: "MINIFLARE_TELEMETRY_CONFIG",
 	DEV_REGISTRY_DEBUG_PORT: "DEV_REGISTRY_DEBUG_PORT",
 	SERVICE_STREAM: "MINIFLARE_STREAM",
+	SERVICE_IMAGES_DELIVERY: "MINIFLARE_IMAGES_DELIVERY",
 } as const;
 
 export const ProxyOps = {

--- a/packages/miniflare/src/workers/core/constants.ts
+++ b/packages/miniflare/src/workers/core/constants.ts
@@ -20,7 +20,7 @@ export const CorePaths = {
 	/** Stream video serving endpoint */
 	STREAM_VIDEO: "/cdn-cgi/mf/stream",
 	/** Local image delivery endpoint for serving hosted images */
-	IMAGE_DELIVERY: "/cdn-cgi/imagedelivery",
+	IMAGE_DELIVERY: "/cdn-cgi/mf/imagedelivery",
 } as const;
 
 export const CoreHeaders = {

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -14,6 +14,7 @@ type Env = {
 	[CoreBindings.SERVICE_USER_FALLBACK]: Fetcher;
 	[CoreBindings.SERVICE_LOCAL_EXPLORER]: Fetcher;
 	[CoreBindings.SERVICE_STREAM]?: Fetcher;
+	[CoreBindings.SERVICE_IMAGES_DELIVERY]?: Fetcher;
 	[CoreBindings.TEXT_CUSTOM_SERVICE]: string;
 	[CoreBindings.TEXT_UPSTREAM_URL]?: string;
 	[CoreBindings.JSON_CF_BLOB]: IncomingRequestCfProperties;
@@ -538,6 +539,13 @@ export default <ExportedHandler<Env>>{
 				) {
 					return await env[CoreBindings.SERVICE_LOCAL_EXPLORER].fetch(request);
 				}
+			}
+			const imagesDelivery = env[CoreBindings.SERVICE_IMAGES_DELIVERY];
+			if (
+				imagesDelivery &&
+				url.pathname.startsWith(`${CorePaths.IMAGE_DELIVERY}/`)
+			) {
+				return await imagesDelivery.fetch(request);
 			}
 			if (env[CoreBindings.TRIGGER_HANDLERS]) {
 				if (

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -542,8 +542,9 @@ export default <ExportedHandler<Env>>{
 			}
 			const imagesDelivery = env[CoreBindings.SERVICE_IMAGES_DELIVERY];
 			if (
-				imagesDelivery &&
-				url.pathname.startsWith(`${CorePaths.IMAGE_DELIVERY}/`)
+				(url.pathname === CorePaths.IMAGE_DELIVERY ||
+					url.pathname.startsWith(`${CorePaths.IMAGE_DELIVERY}/`)) &&
+				imagesDelivery
 			) {
 				return await imagesDelivery.fetch(request);
 			}

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -14,6 +14,7 @@ type Env = {
 	[CoreBindings.SERVICE_USER_FALLBACK]: Fetcher;
 	[CoreBindings.SERVICE_LOCAL_EXPLORER]: Fetcher;
 	[CoreBindings.SERVICE_STREAM]?: Fetcher;
+	[CoreBindings.SERVICE_IMAGES_DELIVERY]?: Fetcher;
 	[CoreBindings.TEXT_CUSTOM_SERVICE]: string;
 	[CoreBindings.TEXT_UPSTREAM_URL]?: string;
 	[CoreBindings.JSON_CF_BLOB]: IncomingRequestCfProperties;
@@ -536,6 +537,13 @@ export default <ExportedHandler<Env>>{
 				) {
 					return await env[CoreBindings.SERVICE_LOCAL_EXPLORER].fetch(request);
 				}
+			}
+			const imagesDelivery = env[CoreBindings.SERVICE_IMAGES_DELIVERY];
+			if (
+				imagesDelivery &&
+				url.pathname.startsWith(`${CorePaths.IMAGE_DELIVERY}/`)
+			) {
+				return await imagesDelivery.fetch(request);
 			}
 			if (env[CoreBindings.TRIGGER_HANDLERS]) {
 				if (

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -540,8 +540,9 @@ export default <ExportedHandler<Env>>{
 			}
 			const imagesDelivery = env[CoreBindings.SERVICE_IMAGES_DELIVERY];
 			if (
-				imagesDelivery &&
-				url.pathname.startsWith(`${CorePaths.IMAGE_DELIVERY}/`)
+				(url.pathname === CorePaths.IMAGE_DELIVERY ||
+					url.pathname.startsWith(`${CorePaths.IMAGE_DELIVERY}/`)) &&
+				imagesDelivery
 			) {
 				return await imagesDelivery.fetch(request);
 			}

--- a/packages/miniflare/src/workers/images/images.worker.ts
+++ b/packages/miniflare/src/workers/images/images.worker.ts
@@ -3,7 +3,7 @@
 // Transforms and info operations are handled via HTTP loopback to Node.js Sharp
 
 import { RpcTarget, WorkerEntrypoint } from "cloudflare:workers";
-import { CoreBindings, CoreHeaders } from "../core/constants";
+import { CoreBindings, CoreHeaders, CorePaths } from "../core/constants";
 
 interface Env {
 	IMAGES_STORE: KVNamespace;
@@ -118,7 +118,7 @@ export default class ImagesService extends WorkerEntrypoint<Env> {
 			uploaded: new Date().toISOString(),
 			requireSignedURLs: options?.requireSignedURLs ?? false,
 			meta: options?.metadata ?? {},
-			variants: ["public"],
+			variants: [`${CorePaths.IMAGE_DELIVERY}/${id}/public`],
 			draft: false,
 			creator: options?.creator,
 		};
@@ -180,9 +180,56 @@ export default class ImagesService extends WorkerEntrypoint<Env> {
 		};
 	}
 
-	// Handle HTTP requests for info and transform operations
-	// These are forwarded to Node.js via the loopback service where Sharp runs
+	async #detectContentType(data: ArrayBuffer): Promise<string> {
+		const formData = new FormData();
+		formData.append("image", new Blob([data]));
+
+		const infoRequest = new Request("http://placeholder/info", {
+			method: "POST",
+			body: formData,
+		});
+		infoRequest.headers.set(
+			CoreHeaders.CUSTOM_FETCH_SERVICE,
+			CoreBindings.IMAGES_SERVICE
+		);
+
+		const response =
+			await this.env[CoreBindings.SERVICE_LOOPBACK].fetch(infoRequest);
+		if (response.ok) {
+			const info = (await response.json()) as { format?: string };
+			if (info.format) {
+				return info.format;
+			}
+		}
+		return "application/octet-stream";
+	}
+
+	// Handle HTTP requests for image delivery and transform operations
 	async fetch(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+
+		// Serve image bytes at /cdn-cgi/imagedelivery/<id>/<variant>
+		if (url.pathname.startsWith(`${CorePaths.IMAGE_DELIVERY}/`)) {
+			const parts = url.pathname
+				.slice(CorePaths.IMAGE_DELIVERY.length + 1)
+				.split("/");
+			const imageId = parts[0];
+			if (!imageId) {
+				return new Response("Missing image ID", { status: 400 });
+			}
+
+			const data = await this.env.IMAGES_STORE.get(imageId, "arrayBuffer");
+			if (data === null) {
+				return new Response("Image not found", { status: 404 });
+			}
+
+			const contentType = await this.#detectContentType(data);
+			return new Response(data, {
+				headers: { "Content-Type": contentType },
+			});
+		}
+
+		// Forward transform/info operations to Node.js via loopback where Sharp runs
 		const forwardRequest = new Request(request);
 		forwardRequest.headers.set(
 			CoreHeaders.CUSTOM_FETCH_SERVICE,

--- a/packages/miniflare/src/workers/images/images.worker.ts
+++ b/packages/miniflare/src/workers/images/images.worker.ts
@@ -3,11 +3,37 @@
 // Transforms and info operations are handled via HTTP loopback to Node.js Sharp
 
 import { RpcTarget, WorkerEntrypoint } from "cloudflare:workers";
+import { getPublicUrl } from "miniflare:shared";
 import { CoreBindings, CoreHeaders, CorePaths } from "../core/constants";
 
 interface Env {
 	IMAGES_STORE: KVNamespace;
 	[CoreBindings.SERVICE_LOOPBACK]: Fetcher;
+}
+
+function buildVariantUrl(
+	publicUrl: URL,
+	imageId: string,
+	variant: string
+): string {
+	return new URL(
+		`${CorePaths.IMAGE_DELIVERY}/${imageId}/${variant}`,
+		publicUrl
+	).toString();
+}
+
+// Rewrites stored variant names (e.g. `["public"]`) to absolute URLs.
+async function withResolvedVariants(
+	metadata: ImageMetadata,
+	env: Env
+): Promise<ImageMetadata> {
+	const publicUrl = await getPublicUrl(env[CoreBindings.SERVICE_LOOPBACK]);
+	return {
+		...metadata,
+		variants: metadata.variants.map((variant) =>
+			buildVariantUrl(publicUrl, metadata.id, variant)
+		),
+	};
 }
 
 function base64DecodeArrayBuffer(buffer: ArrayBuffer): ArrayBuffer {
@@ -31,24 +57,27 @@ async function base64DecodeStream(
 
 class ImageHandleImpl extends RpcTarget {
 	readonly #imageId: string;
-	readonly #store: KVNamespace;
+	readonly #env: Env;
 
-	constructor(imageId: string, store: KVNamespace) {
+	constructor(imageId: string, env: Env) {
 		super();
 		this.#imageId = imageId;
-		this.#store = store;
+		this.#env = env;
 	}
 
 	async details(): Promise<ImageMetadata | null> {
-		const result = await this.#store.getWithMetadata<ImageMetadata>(
+		const result = await this.#env.IMAGES_STORE.getWithMetadata<ImageMetadata>(
 			this.#imageId,
 			"arrayBuffer"
 		);
-		return result.metadata ?? null;
+		if (result.metadata === null) {
+			return null;
+		}
+		return withResolvedVariants(result.metadata, this.#env);
 	}
 
 	async bytes(): Promise<ReadableStream<Uint8Array> | null> {
-		const data = await this.#store.get(this.#imageId, "arrayBuffer");
+		const data = await this.#env.IMAGES_STORE.get(this.#imageId, "arrayBuffer");
 		if (data === null) {
 			return null;
 		}
@@ -56,10 +85,11 @@ class ImageHandleImpl extends RpcTarget {
 	}
 
 	async update(options: ImageUpdateOptions): Promise<ImageMetadata> {
-		const existing = await this.#store.getWithMetadata<ImageMetadata>(
-			this.#imageId,
-			"arrayBuffer"
-		);
+		const existing =
+			await this.#env.IMAGES_STORE.getWithMetadata<ImageMetadata>(
+				this.#imageId,
+				"arrayBuffer"
+			);
 		if (existing.value === null || existing.metadata === null) {
 			throw new Error(`Image not found: ${this.#imageId}`);
 		}
@@ -72,25 +102,28 @@ class ImageHandleImpl extends RpcTarget {
 			creator: options.creator ?? existing.metadata.creator,
 		};
 
-		await this.#store.put(this.#imageId, existing.value, {
+		await this.#env.IMAGES_STORE.put(this.#imageId, existing.value, {
 			metadata: updatedMetadata,
 		});
-		return updatedMetadata;
+		return withResolvedVariants(updatedMetadata, this.#env);
 	}
 
 	async delete(): Promise<boolean> {
-		const existing = await this.#store.get(this.#imageId, "arrayBuffer");
+		const existing = await this.#env.IMAGES_STORE.get(
+			this.#imageId,
+			"arrayBuffer"
+		);
 		if (existing === null) {
 			return false;
 		}
-		await this.#store.delete(this.#imageId);
+		await this.#env.IMAGES_STORE.delete(this.#imageId);
 		return true;
 	}
 }
 
 export default class ImagesService extends WorkerEntrypoint<Env> {
 	image(imageId: string): ImageHandleImpl {
-		return new ImageHandleImpl(imageId, this.env.IMAGES_STORE);
+		return new ImageHandleImpl(imageId, this.env);
 	}
 
 	async upload(
@@ -118,13 +151,13 @@ export default class ImagesService extends WorkerEntrypoint<Env> {
 			uploaded: new Date().toISOString(),
 			requireSignedURLs: options?.requireSignedURLs ?? false,
 			meta: options?.metadata ?? {},
-			variants: [`${CorePaths.IMAGE_DELIVERY}/${id}/public`],
+			variants: ["public"],
 			draft: false,
 			creator: options?.creator,
 		};
 
 		await this.env.IMAGES_STORE.put(id, buffer, { metadata });
-		return metadata;
+		return withResolvedVariants(metadata, this.env);
 	}
 
 	async list(options?: ImageListOptions): Promise<ImageList> {
@@ -173,8 +206,19 @@ export default class ImagesService extends WorkerEntrypoint<Env> {
 		const hasMore = startIndex + limit < allImages.length;
 		const lastImage = page[page.length - 1];
 
+		// Resolve variant URLs once per page.
+		const publicUrl = await getPublicUrl(
+			this.env[CoreBindings.SERVICE_LOOPBACK]
+		);
+		const resolvedPage = page.map((metadata) => ({
+			...metadata,
+			variants: metadata.variants.map((variant) =>
+				buildVariantUrl(publicUrl, metadata.id, variant)
+			),
+		}));
+
 		return {
-			images: page,
+			images: resolvedPage,
 			cursor: hasMore && lastImage ? lastImage.id : undefined,
 			listComplete: !hasMore,
 		};

--- a/packages/miniflare/src/workers/images/images.worker.ts
+++ b/packages/miniflare/src/workers/images/images.worker.ts
@@ -206,7 +206,6 @@ export default class ImagesService extends WorkerEntrypoint<Env> {
 		const hasMore = startIndex + limit < allImages.length;
 		const lastImage = page[page.length - 1];
 
-		// Resolve variant URLs once per page.
 		const publicUrl = await getPublicUrl(
 			this.env[CoreBindings.SERVICE_LOOPBACK]
 		);
@@ -252,7 +251,7 @@ export default class ImagesService extends WorkerEntrypoint<Env> {
 	async fetch(request: Request): Promise<Response> {
 		const url = new URL(request.url);
 
-		// Serve image bytes at /cdn-cgi/imagedelivery/<id>/<variant>
+		// Serve image bytes at /cdn-cgi/mf/imagedelivery/<id>/<variant>
 		if (url.pathname.startsWith(`${CorePaths.IMAGE_DELIVERY}/`)) {
 			const parts = url.pathname
 				.slice(CorePaths.IMAGE_DELIVERY.length + 1)

--- a/packages/miniflare/src/workers/shared/index.worker.ts
+++ b/packages/miniflare/src/workers/shared/index.worker.ts
@@ -29,6 +29,8 @@ export type {
 	MiniflareDurableObjectCf,
 } from "./object.worker";
 
+export { getPublicUrl } from "./public-url";
+
 export { parseRanges } from "./range";
 export type { InclusiveRange } from "./range";
 

--- a/packages/miniflare/src/workers/shared/public-url.ts
+++ b/packages/miniflare/src/workers/shared/public-url.ts
@@ -1,0 +1,12 @@
+// Fetches the configured `publicUrl` of the Miniflare instance via the
+// loopback service, falling back to the runtime entry URL. Resolving at
+// request time means workers see the latest value even after workerd
+// restarts or the host server's port changes (e.g. Vite port-bump).
+export async function getPublicUrl(loopback: Fetcher): Promise<URL> {
+	const resp = await loopback.fetch("http://localhost/core/public-url");
+	const url = (await resp.json()) as string | null;
+	if (!url) {
+		throw new Error("Miniflare public URL is not available.");
+	}
+	return new URL(url);
+}

--- a/packages/miniflare/src/workers/shared/public-url.ts
+++ b/packages/miniflare/src/workers/shared/public-url.ts
@@ -1,12 +1,15 @@
-// Fetches the configured `publicUrl` of the Miniflare instance via the
-// loopback service, falling back to the runtime entry URL. Resolving at
-// request time means workers see the latest value even after workerd
-// restarts or the host server's port changes (e.g. Vite port-bump).
+// Fetches the public URL from the Miniflare loopback. This returns
+// the publicUrl if one was set (e.g. Vite dev server URL), otherwise
+// falls back to the runtime entry URL. Using the loopback means the
+// binding always sees the latest value — even if the URL was
+// updated after workerd started (e.g. when Vite bumps the port).
 export async function getPublicUrl(loopback: Fetcher): Promise<URL> {
 	const resp = await loopback.fetch("http://localhost/core/public-url");
 	const url = (await resp.json()) as string | null;
 	if (!url) {
-		throw new Error("Miniflare public URL is not available.");
+		throw new Error(
+			"Runtime entry URL is not available. This may be because the worker is not yet ready to accept requests."
+		);
 	}
 	return new URL(url);
 }

--- a/packages/miniflare/src/workers/stream/binding.worker.ts
+++ b/packages/miniflare/src/workers/stream/binding.worker.ts
@@ -1,4 +1,5 @@
 import { RpcTarget, WorkerEntrypoint } from "cloudflare:workers";
+import { getPublicUrl } from "miniflare:shared";
 import { BadRequestError, InvalidURLError } from "./errors";
 import {
 	rowToStreamCaption,
@@ -16,24 +17,6 @@ interface Env {
 function getStub(env: Env): DurableObjectStub<StreamObject> {
 	const id = env.store.idFromName("stream-data");
 	return env.store.get(id);
-}
-
-async function getEntryUrl(env: Env): Promise<URL> {
-	// Fetches the public URL from the Miniflare loopback. This returns
-	// the publicUrl if one was set (e.g. Vite dev server URL), otherwise
-	// falls back to the runtime entry URL. Using the loopback means the
-	// stream binding always sees the latest value — even if the URL was
-	// updated after workerd started (e.g. when Vite bumps the port).
-	const resp = await env.MINIFLARE_LOOPBACK.fetch(
-		"http://localhost/core/public-url"
-	);
-	const url = (await resp.json()) as string | null;
-	if (!url) {
-		throw new Error(
-			"Runtime entry URL is not available. This may be because the worker is not yet ready to accept requests."
-		);
-	}
-	return new URL(url);
 }
 
 function rowsToDownloadResponse(
@@ -89,7 +72,7 @@ export class StreamBinding extends WorkerEntrypoint<Env> {
 		}
 		const stub = getStub(this.env);
 		const row = await stub.createVideo(body, params ?? {});
-		const entryUrl = await getEntryUrl(this.env);
+		const entryUrl = await getPublicUrl(this.env.MINIFLARE_LOOPBACK);
 		return rowToStreamVideo(row, entryUrl);
 	}
 
@@ -201,14 +184,14 @@ class StreamVideoHandleImpl extends RpcTarget implements StreamVideoHandle {
 	async details(): Promise<StreamVideo> {
 		const stub = getStub(this.#env);
 		const row = await stub.getVideo(this.id);
-		const entryUrl = await getEntryUrl(this.#env);
+		const entryUrl = await getPublicUrl(this.#env.MINIFLARE_LOOPBACK);
 		return rowToStreamVideo(row, entryUrl);
 	}
 
 	async update(params: StreamUpdateVideoParams): Promise<StreamVideo> {
 		const stub = getStub(this.#env);
 		const row = await stub.updateVideo(this.id, params);
-		const entryUrl = await getEntryUrl(this.#env);
+		const entryUrl = await getPublicUrl(this.#env.MINIFLARE_LOOPBACK);
 		return rowToStreamVideo(row, entryUrl);
 	}
 
@@ -242,7 +225,7 @@ class StreamVideosImpl extends RpcTarget implements StreamVideos {
 	async list(params?: StreamVideosListParams): Promise<StreamVideo[]> {
 		const stub = getStub(this.#env);
 		const rows = await stub.listVideos(params);
-		const entryUrl = await getEntryUrl(this.#env);
+		const entryUrl = await getPublicUrl(this.#env.MINIFLARE_LOOPBACK);
 		return rows.map((row) => rowToStreamVideo(row, entryUrl));
 	}
 }

--- a/packages/miniflare/test/plugins/images/index.spec.ts
+++ b/packages/miniflare/test/plugins/images/index.spec.ts
@@ -1,14 +1,54 @@
-import assert from "node:assert";
 import { Miniflare } from "miniflare";
 import { describe, test } from "vitest";
 import { useDispose } from "../../test-shared";
+import type { ImageList, ImageMetadata } from "@cloudflare/workers-types";
+import type { MiniflareOptions } from "miniflare";
 
 // The worker stores and retrieves bytes without validation, so we don't need a real image.
 const TEST_IMAGE_BYTES = new Uint8Array([1, 2, 3, 4, 5]);
 
-function imageBuffer(): ArrayBuffer {
-	return new Uint8Array(TEST_IMAGE_BYTES).buffer as ArrayBuffer;
+const WORKER_SCRIPT = `
+export default {
+	async fetch(request, env) {
+		try {
+			const { op, args } = await request.json();
+			const result = await handleCommand(env.IMAGES, op, args || {});
+			return Response.json({ ok: true, result });
+		} catch (err) {
+			return Response.json(
+				{ ok: false, error: err.message },
+				{ status: 200 }
+			);
+		}
+	}
+};
+
+async function handleCommand(images, op, args) {
+	const hosted = images.hosted;
+	switch (op) {
+		case "upload": {
+			const bytes = new Uint8Array(args.bytes);
+			return hosted.upload(bytes.buffer, args.options);
+		}
+		case "bytes": {
+			const stream = await hosted.image(args.id).bytes();
+			if (stream === null) return null;
+			const buffer = await new Response(stream).arrayBuffer();
+			return Array.from(new Uint8Array(buffer));
+		}
+		case "details":
+			return hosted.image(args.id).details();
+		case "update":
+			return hosted.image(args.id).update(args.options);
+		case "delete":
+			return hosted.image(args.id).delete();
+		case "list":
+			return hosted.list(args.options);
+		default:
+			throw new Error("Unknown op: " + op);
+	}
 }
+`;
 
 function createMiniflare(): Miniflare {
 	return new Miniflare({
@@ -16,33 +56,64 @@ function createMiniflare(): Miniflare {
 		images: { binding: "IMAGES" },
 		imagesPersist: false,
 		modules: true,
-		script: `export default { fetch() { return new Response(null, { status: 404 }); } }`,
+		script: WORKER_SCRIPT,
+	} satisfies MiniflareOptions);
+}
+
+async function sendCmd<T>(
+	mf: Miniflare,
+	op: string,
+	args: Record<string, unknown> = {}
+): Promise<T> {
+	const resp = await mf.dispatchFetch("http://placeholder", {
+		method: "POST",
+		body: JSON.stringify({ op, args }),
+		headers: { "Content-Type": "application/json" },
+	});
+	const data = (await resp.json()) as {
+		ok: boolean;
+		result: T;
+		error?: string;
+	};
+	if (!data.ok) {
+		throw new Error(data.error);
+	}
+	return data.result;
+}
+
+function upload(
+	mf: Miniflare,
+	bytes: Uint8Array,
+	options?: Record<string, unknown>
+): Promise<ImageMetadata> {
+	return sendCmd(mf, "upload", {
+		bytes: Array.from(bytes),
+		options,
 	});
 }
 
 describe("Images local delivery", () => {
-	test("variant URLs use /cdn-cgi/imagedelivery/ path", async ({ expect }) => {
+	test("variant URLs are absolute and use /cdn-cgi/imagedelivery/ path", async ({
+		expect,
+	}) => {
 		const mf = createMiniflare();
 		useDispose(mf);
-		const images = await mf.getImagesBinding("IMAGES");
+		const url = await mf.ready;
 
-		const metadata = await images.hosted.upload(imageBuffer(), {
-			id: "variant-test",
-		});
+		const metadata = await upload(mf, TEST_IMAGE_BYTES, { id: "variant-test" });
 		expect(metadata.variants).toHaveLength(1);
 		expect(metadata.variants[0]).toBe(
-			"/cdn-cgi/imagedelivery/variant-test/public"
+			`${url.origin}/cdn-cgi/imagedelivery/variant-test/public`
 		);
 	});
 
 	test("image delivery endpoint serves image bytes", async ({ expect }) => {
 		const mf = createMiniflare();
 		useDispose(mf);
-		const images = await mf.getImagesBinding("IMAGES");
-
-		await images.hosted.upload(imageBuffer(), { id: "delivery-test" });
-
 		const url = await mf.ready;
+
+		await upload(mf, TEST_IMAGE_BYTES, { id: "delivery-test" });
+
 		const response = await mf.dispatchFetch(
 			`${url.origin}/cdn-cgi/imagedelivery/delivery-test/public`
 		);
@@ -70,11 +141,8 @@ describe("Images hosted CRUD", () => {
 	test("upload and retrieve metadata", async ({ expect }) => {
 		const mf = createMiniflare();
 		useDispose(mf);
-		const images = await mf.getImagesBinding("IMAGES");
 
-		const metadata = await images.hosted.upload(imageBuffer(), {
-			id: "test-123",
-		});
+		const metadata = await upload(mf, TEST_IMAGE_BYTES, { id: "test-123" });
 		expect(metadata.id).toBe("test-123");
 		expect(metadata.filename).toBe("uploaded.jpg");
 		expect(metadata.requireSignedURLs).toBe(false);
@@ -83,37 +151,28 @@ describe("Images hosted CRUD", () => {
 	test("upload and retrieve image data", async ({ expect }) => {
 		const mf = createMiniflare();
 		useDispose(mf);
-		const images = await mf.getImagesBinding("IMAGES");
 
-		await images.hosted.upload(imageBuffer(), { id: "blob-test" });
+		await upload(mf, TEST_IMAGE_BYTES, { id: "blob-test" });
 
-		const stream = await images.hosted.image("blob-test").bytes();
-		assert(stream !== null);
-		const data = new Uint8Array(await new Response(stream).arrayBuffer());
-		expect(data).toEqual(TEST_IMAGE_BYTES);
+		const data = await sendCmd<number[]>(mf, "bytes", { id: "blob-test" });
+		expect(new Uint8Array(data)).toEqual(TEST_IMAGE_BYTES);
 	});
 
 	test("upload with base64 encoding", async ({ expect }) => {
 		const mf = createMiniflare();
 		useDispose(mf);
-		const images = await mf.getImagesBinding("IMAGES");
 
 		const base64String = btoa(String.fromCharCode(...TEST_IMAGE_BYTES));
 		const base64Bytes = new TextEncoder().encode(base64String);
 
-		const metadata = await images.hosted.upload(
-			base64Bytes.buffer as ArrayBuffer,
-			{
-				id: "base64-test",
-				encoding: "base64",
-			}
-		);
+		const metadata = await upload(mf, base64Bytes, {
+			id: "base64-test",
+			encoding: "base64",
+		});
 		expect(metadata.id).toBe("base64-test");
 
-		const stream = await images.hosted.image("base64-test").bytes();
-		assert(stream !== null);
-		const data = new Uint8Array(await new Response(stream).arrayBuffer());
-		expect(data).toEqual(TEST_IMAGE_BYTES);
+		const data = await sendCmd<number[]>(mf, "bytes", { id: "base64-test" });
+		expect(new Uint8Array(data)).toEqual(TEST_IMAGE_BYTES);
 	});
 
 	test("get details for non-existent image returns null", async ({
@@ -121,9 +180,10 @@ describe("Images hosted CRUD", () => {
 	}) => {
 		const mf = createMiniflare();
 		useDispose(mf);
-		const images = await mf.getImagesBinding("IMAGES");
 
-		const metadata = await images.hosted.image("does-not-exist").details();
+		const metadata = await sendCmd<ImageMetadata | null>(mf, "details", {
+			id: "does-not-exist",
+		});
 		expect(metadata).toBe(null);
 	});
 
@@ -132,21 +192,22 @@ describe("Images hosted CRUD", () => {
 	}) => {
 		const mf = createMiniflare();
 		useDispose(mf);
-		const images = await mf.getImagesBinding("IMAGES");
 
-		const stream = await images.hosted.image("does-not-exist").bytes();
-		expect(stream).toBe(null);
+		const data = await sendCmd<number[] | null>(mf, "bytes", {
+			id: "does-not-exist",
+		});
+		expect(data).toBe(null);
 	});
 
 	test("update image metadata", async ({ expect }) => {
 		const mf = createMiniflare();
 		useDispose(mf);
-		const images = await mf.getImagesBinding("IMAGES");
 
-		await images.hosted.upload(imageBuffer(), { id: "update-test" });
+		await upload(mf, TEST_IMAGE_BYTES, { id: "update-test" });
 
-		const metadata = await images.hosted.image("update-test").update({
-			requireSignedURLs: true,
+		const metadata = await sendCmd<ImageMetadata>(mf, "update", {
+			id: "update-test",
+			options: { requireSignedURLs: true },
 		});
 		expect(metadata.requireSignedURLs).toBe(true);
 	});
@@ -154,34 +215,35 @@ describe("Images hosted CRUD", () => {
 	test("delete image", async ({ expect }) => {
 		const mf = createMiniflare();
 		useDispose(mf);
-		const images = await mf.getImagesBinding("IMAGES");
 
-		await images.hosted.upload(imageBuffer(), { id: "delete-test" });
+		await upload(mf, TEST_IMAGE_BYTES, { id: "delete-test" });
 
-		const deleted = await images.hosted.image("delete-test").delete();
+		const deleted = await sendCmd<boolean>(mf, "delete", { id: "delete-test" });
 		expect(deleted).toBe(true);
 
-		const metadata = await images.hosted.image("delete-test").details();
+		const metadata = await sendCmd<ImageMetadata | null>(mf, "details", {
+			id: "delete-test",
+		});
 		expect(metadata).toBe(null);
 	});
 
 	test("delete non-existent image returns false", async ({ expect }) => {
 		const mf = createMiniflare();
 		useDispose(mf);
-		const images = await mf.getImagesBinding("IMAGES");
 
-		const deleted = await images.hosted.image("does-not-exist").delete();
+		const deleted = await sendCmd<boolean>(mf, "delete", {
+			id: "does-not-exist",
+		});
 		expect(deleted).toBe(false);
 	});
 
 	test("list images", async ({ expect }) => {
 		const mf = createMiniflare();
 		useDispose(mf);
-		const images = await mf.getImagesBinding("IMAGES");
 
-		await images.hosted.upload(imageBuffer(), { id: "list-1" });
+		await upload(mf, TEST_IMAGE_BYTES, { id: "list-1" });
 
-		const list = await images.hosted.list();
+		const list = await sendCmd<ImageList>(mf, "list");
 		expect(list.listComplete).toBe(true);
 		expect(list.images).toHaveLength(1);
 		expect(list.images[0].id).toBe("list-1");
@@ -190,18 +252,13 @@ describe("Images hosted CRUD", () => {
 	test("list images filtered by creator", async ({ expect }) => {
 		const mf = createMiniflare();
 		useDispose(mf);
-		const images = await mf.getImagesBinding("IMAGES");
 
-		await images.hosted.upload(imageBuffer(), {
-			id: "img1",
-			creator: "socrates",
-		});
-		await images.hosted.upload(imageBuffer(), {
-			id: "img2",
-			creator: "plato",
-		});
+		await upload(mf, TEST_IMAGE_BYTES, { id: "img1", creator: "socrates" });
+		await upload(mf, TEST_IMAGE_BYTES, { id: "img2", creator: "plato" });
 
-		const list = await images.hosted.list({ creator: "plato" });
+		const list = await sendCmd<ImageList>(mf, "list", {
+			options: { creator: "plato" },
+		});
 		expect(list.images).toHaveLength(1);
 		expect(list.images[0].id).toBe("img2");
 	});
@@ -209,28 +266,27 @@ describe("Images hosted CRUD", () => {
 	test("list images with cursor pagination", async ({ expect }) => {
 		const mf = createMiniflare();
 		useDispose(mf);
-		const images = await mf.getImagesBinding("IMAGES");
 
 		for (const id of ["img1", "img2", "img3", "img4", "img5"]) {
-			await images.hosted.upload(imageBuffer(), { id });
+			await upload(mf, TEST_IMAGE_BYTES, { id });
 		}
 
-		const page1 = await images.hosted.list({ limit: 2 });
+		const page1 = await sendCmd<ImageList>(mf, "list", {
+			options: { limit: 2 },
+		});
 		expect(page1.images).toHaveLength(2);
 		expect(page1.listComplete).toBe(false);
 		expect(page1.cursor).toBeDefined();
 
-		const page2 = await images.hosted.list({
-			limit: 2,
-			cursor: page1.cursor,
+		const page2 = await sendCmd<ImageList>(mf, "list", {
+			options: { limit: 2, cursor: page1.cursor },
 		});
 		expect(page2.images).toHaveLength(2);
 		expect(page2.listComplete).toBe(false);
 		expect(page2.cursor).toBeDefined();
 
-		const page3 = await images.hosted.list({
-			limit: 2,
-			cursor: page2.cursor,
+		const page3 = await sendCmd<ImageList>(mf, "list", {
+			options: { limit: 2, cursor: page2.cursor },
 		});
 		expect(page3.images).toHaveLength(1);
 		expect(page3.listComplete).toBe(true);

--- a/packages/miniflare/test/plugins/images/index.spec.ts
+++ b/packages/miniflare/test/plugins/images/index.spec.ts
@@ -20,8 +20,53 @@ function createMiniflare(): Miniflare {
 	});
 }
 
-// Tests temporarily skipped pending workerd API change (https://github.com/cloudflare/workerd/pull/6288)
-describe.skip("Images hosted CRUD", () => {
+describe("Images local delivery", () => {
+	test("variant URLs use /cdn-cgi/imagedelivery/ path", async ({ expect }) => {
+		const mf = createMiniflare();
+		useDispose(mf);
+		const images = await mf.getImagesBinding("IMAGES");
+
+		const metadata = await images.hosted.upload(imageBuffer(), {
+			id: "variant-test",
+		});
+		expect(metadata.variants).toHaveLength(1);
+		expect(metadata.variants[0]).toBe(
+			"/cdn-cgi/imagedelivery/variant-test/public"
+		);
+	});
+
+	test("image delivery endpoint serves image bytes", async ({ expect }) => {
+		const mf = createMiniflare();
+		useDispose(mf);
+		const images = await mf.getImagesBinding("IMAGES");
+
+		await images.hosted.upload(imageBuffer(), { id: "delivery-test" });
+
+		const url = await mf.ready;
+		const response = await mf.dispatchFetch(
+			`${url.origin}/cdn-cgi/imagedelivery/delivery-test/public`
+		);
+		expect(response.status).toBe(200);
+		const data = new Uint8Array(await response.arrayBuffer());
+		expect(data).toEqual(TEST_IMAGE_BYTES);
+	});
+
+	test("image delivery returns 404 for non-existent image", async ({
+		expect,
+	}) => {
+		const mf = createMiniflare();
+		useDispose(mf);
+
+		const url = await mf.ready;
+		const response = await mf.dispatchFetch(
+			`${url.origin}/cdn-cgi/imagedelivery/does-not-exist/public`
+		);
+		expect(response.status).toBe(404);
+		await response.arrayBuffer();
+	});
+});
+
+describe("Images hosted CRUD", () => {
 	test("upload and retrieve metadata", async ({ expect }) => {
 		const mf = createMiniflare();
 		useDispose(mf);

--- a/packages/miniflare/test/plugins/images/index.spec.ts
+++ b/packages/miniflare/test/plugins/images/index.spec.ts
@@ -93,7 +93,7 @@ function upload(
 }
 
 describe("Images local delivery", () => {
-	test("variant URLs are absolute and use /cdn-cgi/imagedelivery/ path", async ({
+	test("variant URLs are absolute and use /cdn-cgi/mf/imagedelivery/ path", async ({
 		expect,
 	}) => {
 		const mf = createMiniflare();
@@ -103,7 +103,7 @@ describe("Images local delivery", () => {
 		const metadata = await upload(mf, TEST_IMAGE_BYTES, { id: "variant-test" });
 		expect(metadata.variants).toHaveLength(1);
 		expect(metadata.variants[0]).toBe(
-			`${url.origin}/cdn-cgi/imagedelivery/variant-test/public`
+			`${url.origin}/cdn-cgi/mf/imagedelivery/variant-test/public`
 		);
 	});
 
@@ -115,7 +115,7 @@ describe("Images local delivery", () => {
 		await upload(mf, TEST_IMAGE_BYTES, { id: "delivery-test" });
 
 		const response = await mf.dispatchFetch(
-			`${url.origin}/cdn-cgi/imagedelivery/delivery-test/public`
+			`${url.origin}/cdn-cgi/mf/imagedelivery/delivery-test/public`
 		);
 		expect(response.status).toBe(200);
 		const data = new Uint8Array(await response.arrayBuffer());
@@ -130,7 +130,7 @@ describe("Images local delivery", () => {
 
 		const url = await mf.ready;
 		const response = await mf.dispatchFetch(
-			`${url.origin}/cdn-cgi/imagedelivery/does-not-exist/public`
+			`${url.origin}/cdn-cgi/mf/imagedelivery/does-not-exist/public`
 		);
 		expect(response.status).toBe(404);
 		await response.arrayBuffer();


### PR DESCRIPTION
The miniflare hosted images mock currently returns bare variant names (e.g. `"public"`) in the variants field of ImageMetadata. In production, this field contains full delivery URLs such as `https://imagedelivery.net/<account_hash>/<image_id>/public`. These bare names are not usable in an `<img src=...>`, resulting in variant URLs failing to display when running in local mode.

This PR introduces a local image delivery endpoint at `/cdn-cgi/imagedelivery/<image_id>/<variant>` that serves image bytes directly from the existing miniflare KV store. The variants field now returns absolute URLs pointing to this endpoint (`<hostname>/cdn-cgi/imagedelivery/<image>/public`), making them functional in a browser during local development.

### Implementation Details
The approach follows the same pattern used by the Stream binding (#13234), with a reserved `/cdn-cgi/` path intercepted by the entry worker and forwarded to the images service.

- `CorePaths.IMAGE_DELIVERY` and `CoreBindings.SERVICE_IMAGES_DELIVERY` have been added as entry worker constants.
- The entry worker routes `/cdn-cgi/imagedelivery/` requests to the images service
- The images service `fetch()` handler serves raw bytes from KV using sharp.js for content type detection (via `/info` in the binding)
- The images service name is passed from the miniflare config assembler to the global services builder, which conditionally binds it to the entry worker
- Variant URLs are resolved to absolute URLs at read time via the `/core/public-url` loopback route introduced in #13234, so they always reflect the current Miniflare `publicUrl` (tolerating restarts). This boilerplate previously lived in a stream specific nook of the codebase, but has been relocated to a helper in `miniflare:shared`.

### Testing

Three new tests added for the delivery endpoint:
- Variant URLs use the correct `/cdn-cgi/imagedelivery/` format
- Delivery endpoint serves uploaded image bytes
- Delivery endpoint returns 404 for non-existent images

Running my local test worker, the images now load:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/96012828-4ee8-410c-88e3-ced626eda3fb" />


### Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this feature hasn't been released yet

<img width="320" height="212" alt="image" src="https://github.com/user-attachments/assets/e3b4f2aa-67b1-42d5-a770-9d77a73a73f6" />

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
