### PR TITLE
[C3] Gate frameworks E2E tests to merge queue, release branch, or label

### DIFF
--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         experimental: [false]
-        filter: ["cli", "workers", "frameworks"]
+        filter: ["cli", "workers"]
         os: [{ name: ubuntu-latest, description: Linux }]
         pm:
           - { name: pnpm, version: "10.33.0" }
@@ -29,6 +29,10 @@ jobs:
         include:
           - os: { name: windows-latest, description: Windows }
             pm: { name: pnpm, version: "10.33.0" }
+            filter: "cli"
+          - os: { name: windows-latest, description: Windows }
+            pm: { name: pnpm, version: "10.33.0" }
+            filter: "workers"
           - os: { name: ubuntu-latest, description: Linux }
             pm: { name: pnpm, version: "10.33.0" }
             experimental: true
@@ -98,5 +102,91 @@ jobs:
         if: ${{ !cancelled() && steps.changes.outputs.everything_but_markdown == 'true' }}
         with:
           name: ${{ format('turbo-runs-{0}-{1}-{2}-{3}', matrix.pm.name, matrix.os.description, matrix.experimental && 'experimental' || 'normal', matrix.filter) }}
+          path: .turbo/runs
+          include-hidden-files: true
+
+  frameworks-e2e:
+    # Runs the C3 frameworks E2E tests only in the merge queue, on the release branch, or when explicitly requested via label.
+    if: >
+      github.event_name == 'merge_group' ||
+      github.head_ref == 'changeset-release/main' ||
+      contains(github.event.pull_request.labels.*.name, 'run-c3-frameworks-tests')
+    timeout-minutes: 45
+    concurrency:
+      group: ${{ github.workflow }}-frameworks-${{ github.ref }}-${{ matrix.os.name }}-${{ matrix.pm.name }}-${{ matrix.pm.version }}
+      cancel-in-progress: true
+    name: ${{ format('C3 E2E ({0}, {1}) - frameworks', matrix.pm.name, matrix.os.description) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [{ name: ubuntu-latest, description: Linux }]
+        pm:
+          - { name: pnpm, version: "10.33.0" }
+          - { name: npm, version: "0.0.0" }
+    runs-on: ${{ matrix.os.name }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        id: changes
+        with:
+          filters: |
+            everything_but_markdown:
+              - '!**/*.md'
+
+      - name: Install Dependencies
+        if: steps.changes.outputs.everything_but_markdown == 'true'
+        uses: ./.github/actions/install-dependencies
+        with:
+          turbo-api: ${{ secrets.TURBO_API }}
+          turbo-team: ${{ secrets.TURBO_TEAM }}
+          turbo-token: ${{ secrets.TURBO_TOKEN }}
+          turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+
+      - name: Install Python uv
+        if: steps.changes.outputs.everything_but_markdown == 'true'
+        uses: ./.github/actions/install-python-uv
+
+      - name: Bump package versions
+        if: steps.changes.outputs.everything_but_markdown == 'true'
+        run: node .github/changeset-version.js
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Configure Git
+        shell: bash
+        run: |
+          git config --global user.email wrangler@cloudflare.com
+          git config --global user.name 'Wrangler Tester'
+
+      - id: run-e2e
+        if: steps.changes.outputs.everything_but_markdown == 'true'
+        shell: bash
+        run: pnpm run test:e2e:c3
+        env:
+          NODE_VERSION: ${{ env.NODE_VERSION }}
+          E2E_EXPERIMENTAL: false
+          E2E_TEST_PM: ${{ matrix.pm.name }}
+          E2E_TEST_PM_VERSION: ${{ matrix.pm.version }}
+          E2E_TEST_FILTER: frameworks
+          CI_OS: ${{ runner.os }}
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Upload Logs
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() && steps.changes.outputs.everything_but_markdown == 'true' }}
+        with:
+          name: ${{ format('e2e-logs-{0}-{1}-normal-frameworks', matrix.pm.name, matrix.os.description) }}
+          path: packages/create-cloudflare/.e2e-logs/${{ matrix.pm.name }}/frameworks
+          include-hidden-files: true
+
+      - name: Upload Turbo Summary
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() && steps.changes.outputs.everything_but_markdown == 'true' }}
+        with:
+          name: ${{ format('turbo-runs-{0}-{1}-normal-frameworks', matrix.pm.name, matrix.os.description) }}
           path: .turbo/runs
           include-hidden-files: true

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -107,10 +107,6 @@ jobs:
 
   frameworks-e2e:
     # Runs the C3 frameworks E2E tests only in the merge queue, on the release branch, or when explicitly requested via label.
-    if: >
-      github.event_name == 'merge_group' ||
-      github.head_ref == 'changeset-release/main' ||
-      contains(github.event.pull_request.labels.*.name, 'run-c3-frameworks-tests')
     timeout-minutes: 45
     concurrency:
       group: ${{ github.workflow }}-frameworks-${{ github.ref }}-${{ matrix.os.name }}-${{ matrix.pm.name }}-${{ matrix.pm.version }}
@@ -137,8 +133,30 @@ jobs:
             everything_but_markdown:
               - '!**/*.md'
 
+      - name: Check if frameworks tests should run
+        id: check-frameworks
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ "$EVENT_NAME" = "merge_group" ] || \
+             [ "$HEAD_REF" = "changeset-release/main" ]; then
+            echo "run_frameworks=true" >> "$GITHUB_OUTPUT"
+          elif [ "$EVENT_NAME" = "pull_request" ]; then
+            HAS_LABEL=$(gh pr view "$PR_NUMBER" \
+              --repo "$REPO" --json labels \
+              --jq '[.labels[].name] | any(. == "run-c3-frameworks-tests")')
+            echo "run_frameworks=${HAS_LABEL}" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_frameworks=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install Dependencies
-        if: steps.changes.outputs.everything_but_markdown == 'true'
+        if: steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true'
         uses: ./.github/actions/install-dependencies
         with:
           turbo-api: ${{ secrets.TURBO_API }}
@@ -147,23 +165,24 @@ jobs:
           turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
 
       - name: Install Python uv
-        if: steps.changes.outputs.everything_but_markdown == 'true'
+        if: steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true'
         uses: ./.github/actions/install-python-uv
 
       - name: Bump package versions
-        if: steps.changes.outputs.everything_but_markdown == 'true'
+        if: steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true'
         run: node .github/changeset-version.js
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Configure Git
+        if: steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true'
         shell: bash
         run: |
           git config --global user.email wrangler@cloudflare.com
           git config --global user.name 'Wrangler Tester'
 
       - id: run-e2e
-        if: steps.changes.outputs.everything_but_markdown == 'true'
+        if: steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true'
         shell: bash
         run: pnpm run test:e2e:c3
         env:
@@ -177,7 +196,7 @@ jobs:
 
       - name: Upload Logs
         uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() && steps.changes.outputs.everything_but_markdown == 'true' }}
+        if: ${{ !cancelled() && steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true' }}
         with:
           name: ${{ format('e2e-logs-{0}-{1}-normal-frameworks', matrix.pm.name, matrix.os.description) }}
           path: packages/create-cloudflare/.e2e-logs/${{ matrix.pm.name }}/frameworks
@@ -185,7 +204,7 @@ jobs:
 
       - name: Upload Turbo Summary
         uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() && steps.changes.outputs.everything_but_markdown == 'true' }}
+        if: ${{ !cancelled() && steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true' }}
         with:
           name: ${{ format('turbo-runs-{0}-{1}-normal-frameworks', matrix.pm.name, matrix.os.description) }}
           path: .turbo/runs

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -36,6 +36,11 @@ jobs:
           - os: { name: ubuntu-latest, description: Linux }
             pm: { name: pnpm, version: "10.33.0" }
             experimental: true
+            filter: "cli"
+          - os: { name: ubuntu-latest, description: Linux }
+            pm: { name: pnpm, version: "10.33.0" }
+            experimental: true
+            filter: "workers"
     runs-on: ${{ matrix.os.name }}
     steps:
       - name: Checkout Repo

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -111,19 +111,24 @@ jobs:
           include-hidden-files: true
 
   frameworks-e2e:
-    # Runs the C3 frameworks E2E tests only in the merge queue, on the release branch, or when explicitly requested via label.
+    # Runs the C3 frameworks E2E tests only in the merge queue, on the release branch, if create-cloudflare has changed, or when explicitly requested via label.
     timeout-minutes: 45
     concurrency:
-      group: ${{ github.workflow }}-frameworks-${{ github.ref }}-${{ matrix.os.name }}-${{ matrix.pm.name }}-${{ matrix.pm.version }}
+      group: ${{ github.workflow }}-frameworks${{ matrix.experimental && '-experimental' || '' }}-${{ github.ref }}-${{ matrix.os.name }}-${{ matrix.pm.name }}-${{ matrix.pm.version }}
       cancel-in-progress: true
-    name: ${{ format('C3 E2E ({0}, {1}) - frameworks', matrix.pm.name, matrix.os.description) }}
+    name: ${{ format('C3 E2E ({0}, {1}{2}) - frameworks', matrix.pm.name, matrix.os.description, matrix.experimental && ', experimental' || '') }}
     strategy:
       fail-fast: false
       matrix:
+        experimental: [false]
         os: [{ name: ubuntu-latest, description: Linux }]
         pm:
           - { name: pnpm, version: "10.33.0" }
           - { name: npm, version: "0.0.0" }
+        include:
+          - os: { name: ubuntu-latest, description: Linux }
+            pm: { name: pnpm, version: "10.33.0" }
+            experimental: true
     runs-on: ${{ matrix.os.name }}
     steps:
       - name: Checkout Repo
@@ -196,7 +201,7 @@ jobs:
         run: pnpm run test:e2e:c3
         env:
           NODE_VERSION: ${{ env.NODE_VERSION }}
-          E2E_EXPERIMENTAL: false
+          E2E_EXPERIMENTAL: ${{ matrix.experimental }}
           E2E_TEST_PM: ${{ matrix.pm.name }}
           E2E_TEST_PM_VERSION: ${{ matrix.pm.version }}
           E2E_TEST_FILTER: frameworks
@@ -207,14 +212,14 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() && steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true' }}
         with:
-          name: ${{ format('e2e-logs-{0}-{1}-normal-frameworks', matrix.pm.name, matrix.os.description) }}
-          path: packages/create-cloudflare/.e2e-logs/${{ matrix.pm.name }}/frameworks
+          name: ${{ format('e2e-logs-{0}-{1}-{2}-frameworks', matrix.pm.name, matrix.os.description, matrix.experimental && 'experimental' || 'normal') }}
+          path: packages/create-cloudflare/.e2e-logs${{matrix.experimental == 'true' && '-experimental' || ''}}/${{ matrix.pm.name }}/frameworks
           include-hidden-files: true
 
       - name: Upload Turbo Summary
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() && steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true' }}
         with:
-          name: ${{ format('turbo-runs-{0}-{1}-normal-frameworks', matrix.pm.name, matrix.os.description) }}
+          name: ${{ format('turbo-runs-{0}-{1}-{2}-frameworks', matrix.pm.name, matrix.os.description, matrix.experimental && 'experimental' || 'normal') }}
           path: .turbo/runs
           include-hidden-files: true

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -138,7 +138,7 @@ jobs:
             everything_but_markdown:
               - '!**/*.md'
             framework_deps:
-              - 'packages/create-cloudflare/src/frameworks/package.json'
+              - 'packages/create-cloudflare/**'
 
       - name: Check if frameworks tests should run
         id: check-frameworks

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -137,6 +137,8 @@ jobs:
           filters: |
             everything_but_markdown:
               - '!**/*.md'
+            framework_deps:
+              - 'packages/create-cloudflare/src/frameworks/package.json'
 
       - name: Check if frameworks tests should run
         id: check-frameworks
@@ -147,9 +149,11 @@ jobs:
           HEAD_REF: ${{ github.head_ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          FRAMEWORK_DEPS_CHANGED: ${{ steps.changes.outputs.framework_deps }}
         run: |
           if [ "$EVENT_NAME" = "merge_group" ] || \
-             [ "$HEAD_REF" = "changeset-release/main" ]; then
+             [ "$HEAD_REF" = "changeset-release/main" ] || \
+             [ "$FRAMEWORK_DEPS_CHANGED" = "true" ]; then
             echo "run_frameworks=true" >> "$GITHUB_OUTPUT"
           elif [ "$EVENT_NAME" = "pull_request" ]; then
             HAS_LABEL=$(gh pr view "$PR_NUMBER" \

--- a/.github/workflows/rerun-remote-tests.yml
+++ b/.github/workflows/rerun-remote-tests.yml
@@ -69,3 +69,52 @@ jobs:
               && echo "Re-triggered ${workflow} (run ${run_id})" \
               || echo "Failed to re-run ${workflow} (run ${run_id})"
           done
+
+  rerun-c3-frameworks:
+    name: "Rerun C3 Frameworks E2E Tests"
+    if: github.event.label.name == 'run-c3-frameworks-tests'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: "Re-run C3 E2E workflow"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          workflow=c3-e2e.yml
+          run=$(gh api "repos/${REPO}/actions/workflows/${workflow}/runs?head_sha=${HEAD_SHA}&per_page=1" \
+            --jq '.workflow_runs[0] | "\(.id) \(.status)"' || true)
+
+          run_id=$(echo "$run" | awk '{print $1}')
+          status=$(echo "$run" | awk '{print $2}')
+
+          if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+            echo "No run found for ${workflow} at SHA ${HEAD_SHA}"
+            exit 0
+          fi
+
+          if [ "$status" != "completed" ] && [ "$status" != "in_progress" ]; then
+            echo "${workflow} run ${run_id} is ${status} — not yet started, skipping."
+            exit 0
+          fi
+
+          if [ "$status" = "in_progress" ]; then
+            echo "Cancelling in-progress ${workflow} run ${run_id}..."
+            gh api "repos/${REPO}/actions/runs/${run_id}/cancel" --method POST || true
+
+            for i in $(seq 1 30); do
+              current=$(gh api "repos/${REPO}/actions/runs/${run_id}" --jq '.status')
+              if [ "$current" = "completed" ]; then
+                echo "Run ${run_id} is now completed (cancelled)."
+                break
+              fi
+              echo "  Waiting for cancellation to finish (${i}/30, status: ${current})..."
+              sleep 2
+            done
+          fi
+
+          gh api "repos/${REPO}/actions/runs/${run_id}/rerun" --method POST \
+            && echo "Re-triggered ${workflow} (run ${run_id})" \
+            || echo "Failed to re-run ${workflow} (run ${run_id})"


### PR DESCRIPTION
Gate C3 frameworks E2E tests so they only run during CI in the following cases:
- `merge_group` trigger (merge queue)
- `changeset-release/main` branch (release PR)
- PR has the `run-c3-frameworks-tests` label attached
- PR modifies `packages/create-cloudflare/src/frameworks/package.json` (e.g. dependabot framework dependency updates)

This reduces CI time on regular PRs where frameworks E2E tests are not needed. The `cli` and `workers` E2E tests continue to run unconditionally on every PR.

### Changes

**`.github/workflows/c3-e2e.yml`:**
- Removed `"frameworks"` from the `e2e` job's matrix filter list (`["cli", "workers", "frameworks"]` -> `["cli", "workers"]`)
- Split the Windows `include` entry into explicit `cli` and `workers` entries (frameworks tests are already skipped internally on Windows)
- Added a new `frameworks-e2e` job with a conditional gate that only runs when the conditions above are met
- Added a `framework_deps` path filter that detects changes to the frameworks `package.json`, so dependabot PRs automatically trigger the frameworks tests

**`.github/workflows/rerun-remote-tests.yml`:**
- Added a `rerun-c3-frameworks` job that re-triggers the C3 E2E workflow when the `run-c3-frameworks-tests` label is added to a PR

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: CI-only workflow change, can be verified by observing GitHub Actions behavior on this PR
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Internal CI configuration change