### PR TITLE
remove most lint disabling comments for no-restricted-imports in wrangler/src/__tests__/helpers

### DIFF
--- a/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
@@ -546,8 +546,8 @@ addEventListener('fetch', event => {});`
 			writeAssets(assets);
 			mockUploadWorkerRequest();
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, []);
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, []);
 			mockUploadAssetsToKVRequest(kvNamespace.id, assets);
 			await runWrangler("deploy ./index.js");
 
@@ -610,8 +610,8 @@ addEventListener('fetch', event => {});`
 			process.chdir("..");
 			mockUploadWorkerRequest();
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, []);
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, []);
 			mockUploadAssetsToKVRequest(kvNamespace.id, assets);
 			await runWrangler("deploy --config ./my-site/wrangler.toml");
 

--- a/packages/wrangler/src/__tests__/deploy/legacy-assets.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/legacy-assets.test.ts
@@ -115,8 +115,8 @@ describe("deploy", () => {
 			writeAssets(assets);
 			mockUploadWorkerRequest();
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, []);
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, []);
 			mockUploadAssetsToKVRequest(kvNamespace.id, assets);
 			await runWrangler("deploy");
 
@@ -176,8 +176,8 @@ describe("deploy", () => {
 				},
 			});
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, []);
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, []);
 			mockUploadAssetsToKVRequest(kvNamespace.id, assets);
 
 			await runWrangler("deploy");
@@ -245,8 +245,8 @@ describe("deploy", () => {
 				useOldUploadApi: true,
 			});
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, []);
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, []);
 			mockUploadAssetsToKVRequest(kvNamespace.id, assets);
 
 			await runWrangler("deploy");
@@ -350,8 +350,8 @@ describe("deploy", () => {
 				},
 			});
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, []);
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, []);
 			mockUploadAssetsToKVRequest(kvNamespace.id, assets);
 
 			await runWrangler("deploy");
@@ -426,8 +426,8 @@ describe("deploy", () => {
 				useOldUploadApi: true,
 			});
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, []);
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, []);
 			mockUploadAssetsToKVRequest(kvNamespace.id, assets);
 			await runWrangler("deploy --env some-env --legacy-env false");
 
@@ -487,8 +487,8 @@ describe("deploy", () => {
 				],
 			});
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, []);
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, []);
 			mockUploadAssetsToKVRequest(kvNamespace.id, assets);
 			await runWrangler("deploy --env some-env --legacy-env true");
 
@@ -536,9 +536,11 @@ describe("deploy", () => {
 			writeAssets(assets);
 			mockUploadWorkerRequest();
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
+			mockListKVNamespacesRequest(expect, kvNamespace);
 			// Put file-1 in the KV namespace
-			mockKeyListRequest(kvNamespace.id, [{ name: "file-1.2ca234f380.txt" }]);
+			mockKeyListRequest(expect, kvNamespace.id, [
+				{ name: "file-1.2ca234f380.txt" },
+			]);
 			// Check we do not upload file-1
 			mockUploadAssetsToKVRequest(
 				kvNamespace.id,
@@ -582,8 +584,8 @@ describe("deploy", () => {
 			writeAssets(assets);
 			mockUploadWorkerRequest();
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, []);
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, []);
 			// Check we only upload file-1
 			mockUploadAssetsToKVRequest(
 				kvNamespace.id,
@@ -634,8 +636,8 @@ describe("deploy", () => {
 			writeAssets(assets);
 			mockUploadWorkerRequest();
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, []);
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, []);
 			// Check we only upload file-1
 			mockUploadAssetsToKVRequest(
 				kvNamespace.id,
@@ -687,8 +689,8 @@ describe("deploy", () => {
 			writeAssets(assets);
 			mockUploadWorkerRequest();
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, []);
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, []);
 			// Check we only upload file-1
 			mockUploadAssetsToKVRequest(
 				kvNamespace.id,
@@ -740,8 +742,8 @@ describe("deploy", () => {
 			writeAssets(assets);
 			mockUploadWorkerRequest();
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, []);
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, []);
 			// Check we only upload file-1
 			mockUploadAssetsToKVRequest(
 				kvNamespace.id,
@@ -793,8 +795,8 @@ describe("deploy", () => {
 			writeAssets(assets);
 			mockUploadWorkerRequest();
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, []);
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, []);
 			// Check we only upload file-1
 			mockUploadAssetsToKVRequest(
 				kvNamespace.id,
@@ -846,8 +848,8 @@ describe("deploy", () => {
 			writeAssets(assets);
 			mockUploadWorkerRequest();
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, []);
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, []);
 			// Check we only upload file-1
 			mockUploadAssetsToKVRequest(
 				kvNamespace.id,
@@ -902,8 +904,8 @@ describe("deploy", () => {
 			writeAssets(assets);
 			mockUploadWorkerRequest();
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, []);
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, []);
 			// Only expect file-1 to be uploaded
 			mockUploadAssetsToKVRequest(kvNamespace.id, assets.slice(0, 1));
 			await runWrangler("deploy");
@@ -961,8 +963,8 @@ describe("deploy", () => {
 			writeAssets(assets);
 			mockUploadWorkerRequest();
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, []);
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, []);
 			// Only expect file-2 to be uploaded
 			mockUploadAssetsToKVRequest(kvNamespace.id, assets.slice(2));
 			await runWrangler("deploy");
@@ -1016,8 +1018,8 @@ describe("deploy", () => {
 			writeAssets(assets);
 			mockUploadWorkerRequest();
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, []);
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, []);
 
 			await expect(
 				runWrangler("deploy")
@@ -1064,8 +1066,8 @@ describe("deploy", () => {
 			writeAssets(assets);
 			mockUploadWorkerRequest();
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, []);
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, []);
 			const requests = mockUploadAssetsToKVRequest(kvNamespace.id);
 
 			await runWrangler("deploy");
@@ -1161,8 +1163,8 @@ describe("deploy", () => {
 			writeAssets([longFilePathAsset]);
 			mockUploadWorkerRequest();
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, []);
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, []);
 
 			await expect(
 				runWrangler("deploy")
@@ -1208,8 +1210,8 @@ describe("deploy", () => {
 			writeAssets(assets);
 			mockUploadWorkerRequest();
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, [
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, [
 				// Put file-1 in the KV namespace
 				{ name: "file-1.2ca234f380.txt" },
 				// As well as a couple from a previous upload
@@ -1292,8 +1294,8 @@ describe("deploy", () => {
 				},
 			});
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, []);
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, []);
 			mockUploadAssetsToKVRequest(kvNamespace.id, assets);
 
 			process.chdir("./src");
@@ -1343,8 +1345,8 @@ describe("deploy", () => {
 			mockSubDomainRequest();
 			writeWorkerSource();
 			mockUploadWorkerRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, []);
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, []);
 			mockUploadAssetsToKVRequest(kvNamespace.id, assets);
 			process.chdir("./my-assets");
 			await runWrangler("deploy --site .");
@@ -1398,8 +1400,8 @@ describe("deploy", () => {
 			writeAssets(assets);
 			mockUploadWorkerRequest();
 			mockSubDomainRequest();
-			mockListKVNamespacesRequest(kvNamespace);
-			mockKeyListRequest(kvNamespace.id, []);
+			mockListKVNamespacesRequest(expect, kvNamespace);
+			mockKeyListRequest(expect, kvNamespace.id, []);
 
 			let requestCount = 0;
 			const bulkUrl =
@@ -1443,16 +1445,17 @@ describe("deploy", () => {
 		});
 
 		describe("should truncate diff with over 100 assets unless debug log level set", () => {
+			const kvNamespace = {
+				title: "__test-name-workers_sites_assets",
+				id: "__test-name-workers_sites_assets-id",
+			};
+
 			beforeEach(() => {
 				const assets = Array.from({ length: 110 }, (_, index) => ({
 					filePath: `file-${`${index}`.padStart(3, "0")}.txt`,
 					content: "X",
 				}));
 
-				const kvNamespace = {
-					title: "__test-name-workers_sites_assets",
-					id: "__test-name-workers_sites_assets-id",
-				};
 				writeWranglerConfig({
 					main: "./index.js",
 					site: {
@@ -1461,14 +1464,16 @@ describe("deploy", () => {
 				});
 				writeWorkerSource();
 				writeAssets(assets);
-				mockUploadWorkerRequest();
 				mockSubDomainRequest();
-				mockListKVNamespacesRequest(kvNamespace);
-				mockKeyListRequest(kvNamespace.id, []);
 				mockUploadAssetsToKVRequest(kvNamespace.id);
 			});
 
 			it("default log level", async ({ expect }) => {
+				mockUploadWorkerRequest();
+
+				mockListKVNamespacesRequest(expect, kvNamespace);
+				mockKeyListRequest(expect, kvNamespace.id, []);
+
 				await runWrangler("deploy");
 				expect(std).toMatchInlineSnapshot(`
 					{
@@ -1595,6 +1600,11 @@ describe("deploy", () => {
 			});
 
 			it("debug log level", async ({ expect }) => {
+				mockUploadWorkerRequest();
+
+				mockListKVNamespacesRequest(expect, kvNamespace);
+				mockKeyListRequest(expect, kvNamespace.id, []);
+
 				vi.stubEnv("WRANGLER_LOG", "debug");
 				vi.stubEnv("WRANGLER_LOG_SANITIZE", "false");
 

--- a/packages/wrangler/src/__tests__/deploy/routes.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/routes.test.ts
@@ -107,7 +107,7 @@ describe("deploy", () => {
 	});
 
 	describe("routes", () => {
-		it("should deploy the worker to a route", async () => {
+		it("should deploy the worker to a route", async ({ expect }) => {
 			writeWranglerConfig({
 				routes: ["example.com/some-route/*"],
 			});
@@ -116,8 +116,8 @@ describe("deploy", () => {
 			mockUploadWorkerRequest({ expectedType: "esm" });
 			// These run during route conflict resolution.
 			// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-			mockGetZones("example.com", [{ id: "example-com-id" }]);
-			mockGetZoneWorkerRoutes("example-com-id");
+			mockGetZones(expect, "example.com", [{ id: "example-com-id" }]);
+			mockGetZoneWorkerRoutes(expect, "example-com-id");
 			// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 			mockPublishRoutesRequest({ routes: ["example.com/some-route/*"] });
 			await runWrangler("deploy ./index");
@@ -176,7 +176,7 @@ describe("deploy", () => {
 			mockUploadWorkerRequest({ expectedType: "esm" });
 			// These run during route conflict resolution.
 			// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-			mockGetZonesMulti({
+			mockGetZonesMulti(expect, {
 				"some-example.com": {
 					accountId: "some-account-id",
 					zones: [{ id: "some-example-com-id" }],
@@ -202,7 +202,7 @@ describe("deploy", () => {
 					zones: [{ id: "more-examples-id" }],
 				},
 			});
-			mockGetZoneWorkerRoutesMulti({
+			mockGetZoneWorkerRoutesMulti(expect, {
 				"some-example-com-id": [],
 				"a-boring-website-id": [],
 				"another-boring-website-id": [],
@@ -260,8 +260,8 @@ describe("deploy", () => {
 			writeWorkerSource();
 			mockUploadWorkerRequest();
 			mockGetWorkerSubdomain({ enabled: false });
-			mockGetZones("owned-zone.com", [{ id: "owned-zone-id-1" }]);
-			mockGetZoneWorkerRoutes("owned-zone-id-1");
+			mockGetZones(expect, "owned-zone.com", [{ id: "owned-zone-id-1" }]);
+			mockGetZoneWorkerRoutes(expect, "owned-zone-id-1");
 			mockPublishRoutesRequest({
 				routes: [
 					{
@@ -303,8 +303,8 @@ describe("deploy", () => {
 			writeWorkerSource();
 			mockUploadWorkerRequest();
 			mockGetWorkerSubdomain({ enabled: false });
-			mockGetZones("owned-zone.com", [{ id: "owned-zone-id-1" }]);
-			mockGetZoneWorkerRoutes("owned-zone-id-1");
+			mockGetZones(expect, "owned-zone.com", [{ id: "owned-zone-id-1" }]);
+			mockGetZoneWorkerRoutes(expect, "owned-zone-id-1");
 			mockPublishRoutesRequest({
 				routes: [
 					{
@@ -373,7 +373,7 @@ describe("deploy", () => {
 			});
 			// These run during route conflict resolution.
 			// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-			mockGetZonesMulti({
+			mockGetZonesMulti(expect, {
 				"some-example.com": {
 					accountId: "some-account-id",
 					zones: [{ id: "some-example-com-id" }],
@@ -399,7 +399,7 @@ describe("deploy", () => {
 					zones: [{ id: "more-examples-id" }],
 				},
 			});
-			mockGetZoneWorkerRoutesMulti({
+			mockGetZoneWorkerRoutesMulti(expect, {
 				"some-example-com-id": [],
 				"a-boring-website-id": [],
 				"another-boring-website-id": [],
@@ -451,7 +451,9 @@ describe("deploy", () => {
 			`);
 		});
 
-		it("should deploy to legacy environment specific routes", async () => {
+		it("should deploy to legacy environment specific routes", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				routes: ["example.com/some-route/*"],
 				env: {
@@ -473,7 +475,7 @@ describe("deploy", () => {
 			});
 			// These run during route conflict resolution.
 			// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-			mockGetZonesMulti({
+			mockGetZonesMulti(expect, {
 				"example.com": {
 					accountId: "some-account-id",
 					zones: [{ id: "example-com-id" }],
@@ -483,7 +485,7 @@ describe("deploy", () => {
 					zones: [{ id: "dev-example-com-id" }],
 				},
 			});
-			mockGetZoneWorkerRoutesMulti({
+			mockGetZoneWorkerRoutesMulti(expect, {
 				"example-com-id": [],
 				"dev-example-com-id": [],
 			});
@@ -496,7 +498,9 @@ describe("deploy", () => {
 			await runWrangler("deploy ./index --env dev --legacy-env true");
 		});
 
-		it("services: should deploy to service environment specific routes", async () => {
+		it("services: should deploy to service environment specific routes", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				routes: ["example.com/some-route/*"],
 				env: {
@@ -513,7 +517,7 @@ describe("deploy", () => {
 			});
 			// These run during route conflict resolution.
 			// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-			mockGetZonesMulti({
+			mockGetZonesMulti(expect, {
 				"example.com": {
 					accountId: "some-account-id",
 					zones: [{ id: "example-com-id" }],
@@ -523,7 +527,7 @@ describe("deploy", () => {
 					zones: [{ id: "dev-example-com-id" }],
 				},
 			});
-			mockGetZoneWorkerRoutesMulti({
+			mockGetZoneWorkerRoutesMulti(expect, {
 				"example-com-id": [],
 				"dev-example-com-id": [],
 			});
@@ -546,8 +550,8 @@ describe("deploy", () => {
 			mockUploadWorkerRequest({ expectedType: "esm" });
 			// These run during route conflict resolution.
 			// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-			mockGetZones("example.com", [{ id: "example-com-id" }]);
-			mockGetZoneWorkerRoutes("example-com-id", [
+			mockGetZones(expect, "example.com", [{ id: "example-com-id" }]);
+			mockGetZoneWorkerRoutes(expect, "example-com-id", [
 				// Simulate that the worker has already been deployed to another route.
 				{
 					pattern: "foo.example.com/other-route",
@@ -604,8 +608,8 @@ describe("deploy", () => {
 			mockUpdateWorkerSubdomain({ env: "staging", enabled: false });
 			// These run during route conflict resolution.
 			// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-			mockGetZones("example.com", [{ id: "example-com-id" }]);
-			mockGetZoneWorkerRoutes("example-com-id", [
+			mockGetZones(expect, "example.com", [{ id: "example-com-id" }]);
+			mockGetZoneWorkerRoutes(expect, "example-com-id", [
 				// Simulate that the worker has already been deployed to another route.
 				{
 					pattern: "foo.example.com/other-route",
@@ -638,8 +642,8 @@ describe("deploy", () => {
 				mockUploadWorkerRequest({ expectedType: "esm" });
 				// These run during route conflict resolution.
 				// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-				mockGetZones("api.example.com", [{ id: "api-example-com-id" }]);
-				mockGetZoneWorkerRoutes("api-example-com-id", []);
+				mockGetZones(expect, "api.example.com", [{ id: "api-example-com-id" }]);
+				mockGetZoneWorkerRoutes(expect, "api-example-com-id", []);
 				// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 				mockCustomDomainsChangesetRequest({});
 				mockPublishCustomDomainsRequest({
@@ -665,8 +669,8 @@ describe("deploy", () => {
 				mockUploadWorkerRequest({ expectedType: "esm" });
 				// These run during route conflict resolution.
 				// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-				mockGetZones("api.example.com", [{ id: "api-example-com-id" }]);
-				mockGetZoneWorkerRoutes("api-example-com-id", []);
+				mockGetZones(expect, "api.example.com", [{ id: "api-example-com-id" }]);
+				mockGetZoneWorkerRoutes(expect, "api-example-com-id", []);
 				// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 				mockCustomDomainsChangesetRequest({
 					originConflicts: [
@@ -717,8 +721,8 @@ Update them to point to this script instead?`,
 				mockUploadWorkerRequest({ expectedType: "esm" });
 				// These run during route conflict resolution.
 				// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-				mockGetZones("api.example.com", [{ id: "api-example-com-id" }]);
-				mockGetZoneWorkerRoutes("api-example-com-id", []);
+				mockGetZones(expect, "api.example.com", [{ id: "api-example-com-id" }]);
+				mockGetZoneWorkerRoutes(expect, "api-example-com-id", []);
 				// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 				mockCustomDomainsChangesetRequest({
 					dnsRecordConflicts: [
@@ -761,8 +765,8 @@ Update them to point to this script instead?`,
 				mockUploadWorkerRequest({ expectedType: "esm" });
 				// These run during route conflict resolution.
 				// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-				mockGetZones("api.example.com", [{ id: "api-example-com-id" }]);
-				mockGetZoneWorkerRoutes("api-example-com-id", []);
+				mockGetZones(expect, "api.example.com", [{ id: "api-example-com-id" }]);
+				mockGetZoneWorkerRoutes(expect, "api-example-com-id", []);
 				// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 				mockCustomDomainsChangesetRequest({
 					originConflicts: [
@@ -862,8 +866,8 @@ Update them to point to this script instead?`,
 				mockUploadWorkerRequest({ expectedType: "esm" });
 				// These run during route conflict resolution.
 				// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-				mockGetZones("api.example.com", [{ id: "api-example-com-id" }]);
-				mockGetZoneWorkerRoutes("api-example-com-id", []);
+				mockGetZones(expect, "api.example.com", [{ id: "api-example-com-id" }]);
+				mockGetZoneWorkerRoutes(expect, "api-example-com-id", []);
 				// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 				mockCustomDomainsChangesetRequest({
 					originConflicts: [
@@ -958,7 +962,7 @@ Update them to point to this script instead?`,
 				mockUploadWorkerRequest({ expectedType: "esm" });
 				// These run during route conflict resolution.
 				// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-				mockGetZonesMulti({
+				mockGetZonesMulti(expect, {
 					"example.com": {
 						accountId: "some-account-id",
 						zones: [{ id: "example-com-id" }],
@@ -968,7 +972,7 @@ Update them to point to this script instead?`,
 						zones: [{ id: "api-example-com-id" }],
 					},
 				});
-				mockGetZoneWorkerRoutesMulti({
+				mockGetZoneWorkerRoutesMulti(expect, {
 					"example-com-id": [],
 					"api-example-com-id": [],
 				});
@@ -1047,7 +1051,7 @@ Update them to point to this script instead?`,
 				mockUploadWorkerRequest({ expectedType: "esm" });
 				// These run during route conflict resolution.
 				// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-				mockGetZonesMulti({
+				mockGetZonesMulti(expect, {
 					"config.com": {
 						accountId: "some-account-id",
 						zones: [{ id: "config-com-id" }],
@@ -1061,7 +1065,7 @@ Update them to point to this script instead?`,
 						zones: [{ id: "cli-com-id" }],
 					},
 				});
-				mockGetZoneWorkerRoutesMulti({
+				mockGetZoneWorkerRoutesMulti(expect, {
 					"config-com-id": [],
 					"api-example-com-id": [],
 					"cli-com-id": [],
@@ -1163,7 +1167,7 @@ Update them to point to this script instead?`,
 				});
 				// These run during route conflict resolution.
 				// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-				mockGetZonesMulti({
+				mockGetZonesMulti(expect, {
 					"simple.co.uk": {
 						accountId: "some-account-id",
 						zones: [{ id: "simple-co-uk-id" }],
@@ -1173,7 +1177,7 @@ Update them to point to this script instead?`,
 						zones: [{ id: "example-com-id" }],
 					},
 				});
-				mockGetZoneWorkerRoutesMulti({
+				mockGetZoneWorkerRoutesMulti(expect, {
 					"simple-co-uk-id": [],
 					"example-com-id": [],
 				});
@@ -1270,8 +1274,8 @@ Update them to point to this script instead?`,
 				});
 				// These run during route conflict resolution.
 				// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-				mockGetZones("example.com", [{ id: "example-com-id" }]);
-				mockGetZoneWorkerRoutes("example-com-id", []);
+				mockGetZones(expect, "example.com", [{ id: "example-com-id" }]);
+				mockGetZoneWorkerRoutes(expect, "example-com-id", []);
 				// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 				mockPublishRoutesRequest({
 					routes: [
@@ -1344,8 +1348,8 @@ Update them to point to this script instead?`,
 				});
 				// These run during route conflict resolution.
 				// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-				mockGetZones("example.com", [{ id: "example-com-id" }]);
-				mockGetZoneWorkerRoutes("example-com-id", []);
+				mockGetZones(expect, "example.com", [{ id: "example-com-id" }]);
+				mockGetZoneWorkerRoutes(expect, "example-com-id", []);
 				// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 				mockPublishRoutesRequest({
 					routes: [
@@ -1425,7 +1429,7 @@ Update them to point to this script instead?`,
 				});
 				// These run during route conflict resolution.
 				// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-				mockGetZonesMulti({
+				mockGetZonesMulti(expect, {
 					"simple.co.uk": {
 						accountId: "some-account-id",
 						zones: [{ id: "simple-co-uk-id" }],
@@ -1435,7 +1439,7 @@ Update them to point to this script instead?`,
 						zones: [{ id: "example-com-id" }],
 					},
 				});
-				mockGetZoneWorkerRoutesMulti({
+				mockGetZoneWorkerRoutesMulti(expect, {
 					"simple-co-uk-id": [],
 					"example-com-id": [],
 				});

--- a/packages/wrangler/src/__tests__/deploy/workers-dev.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/workers-dev.test.ts
@@ -928,8 +928,8 @@ describe("deploy", () => {
 			mockUploadWorkerRequest();
 			mockGetWorkerSubdomain({ enabled: false });
 			// no set-subdomain call
-			mockGetZones("example.com", [{ id: "example-id" }]);
-			mockGetZoneWorkerRoutes("example-id");
+			mockGetZones(expect, "example.com", [{ id: "example-id" }]);
+			mockGetZoneWorkerRoutes(expect, "example-id");
 			mockPublishRoutesRequest({ routes: ["http://example.com/*"] });
 			await runWrangler("deploy index.js");
 
@@ -969,8 +969,8 @@ describe("deploy", () => {
 				env: "production",
 				useServiceEnvironments: false,
 			});
-			mockGetZones("production.example.com", [{ id: "example-id" }]);
-			mockGetZoneWorkerRoutes("example-id");
+			mockGetZones(expect, "production.example.com", [{ id: "example-id" }]);
+			mockGetZoneWorkerRoutes(expect, "example-id");
 			mockPublishRoutesRequest({
 				routes: ["http://production.example.com/*"],
 				env: "production",
@@ -1014,8 +1014,8 @@ describe("deploy", () => {
 				env: "production",
 				useServiceEnvironments: false,
 			});
-			mockGetZones("production.example.com", [{ id: "example-id" }]);
-			mockGetZoneWorkerRoutes("example-id");
+			mockGetZones(expect, "production.example.com", [{ id: "example-id" }]);
+			mockGetZoneWorkerRoutes(expect, "example-id");
 			mockPublishRoutesRequest({
 				routes: ["http://production.example.com/*"],
 				env: "production",
@@ -1200,8 +1200,8 @@ describe("deploy", () => {
 				env: "production",
 				useServiceEnvironments: false,
 			});
-			mockGetZones("production.example.com", [{ id: "example-id" }]);
-			mockGetZoneWorkerRoutes("example-id");
+			mockGetZones(expect, "production.example.com", [{ id: "example-id" }]);
+			mockGetZoneWorkerRoutes(expect, "example-id");
 			mockPublishRoutesRequest({
 				routes: ["http://production.example.com/*"],
 				env: "production",
@@ -1246,8 +1246,8 @@ describe("deploy", () => {
 				env: "production",
 				useServiceEnvironments: false,
 			});
-			mockGetZones("production.example.com", [{ id: "example-id" }]);
-			mockGetZoneWorkerRoutes("example-id");
+			mockGetZones(expect, "production.example.com", [{ id: "example-id" }]);
+			mockGetZoneWorkerRoutes(expect, "example-id");
 			mockPublishRoutesRequest({
 				routes: ["http://production.example.com/*"],
 				env: "production",

--- a/packages/wrangler/src/__tests__/helpers/assert-request.ts
+++ b/packages/wrangler/src/__tests__/helpers/assert-request.ts
@@ -1,6 +1,6 @@
-// eslint-disable-next-line no-restricted-imports
-import { assert, beforeEach, expect, vi } from "vitest";
+import { assert, beforeEach, vi } from "vitest";
 import type { mockConsoleMethods } from "./mock-console";
+import type { ExpectStatic } from "vitest";
 
 /**
  * Assert that Wrangler has made a request matching a certain pattern. Unlike MSW (which mocks the return value of the request),
@@ -18,6 +18,7 @@ export function makeApiRequestAsserter(
 		vi.stubEnv("WRANGLER_LOG_SANITIZE", "false");
 	});
 	return function assertApiRequest(
+		expect: ExpectStatic,
 		url: RegExp,
 		{ method, body }: { method?: string; body?: RegExp }
 	) {

--- a/packages/wrangler/src/__tests__/helpers/mock-get-pages-upload-token.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-get-pages-upload-token.ts
@@ -1,12 +1,12 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { expect } from "vitest";
 import { msw } from "./msw";
+import type { ExpectStatic } from "vitest";
 
 /**
  * Mocks the `/accounts/:accountId/pages/projects/:projectName/upload-token` GET request
  */
 export function mockGetUploadTokenRequest(
+	expect: ExpectStatic,
 	jwt: string,
 	accountId: string,
 	projectName: string

--- a/packages/wrangler/src/__tests__/helpers/mock-get-zone-from-host.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-get-zone-from-host.ts
@@ -1,10 +1,10 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { expect } from "vitest";
 import { msw } from "./msw";
 import type { RequestHandlerOptions } from "msw";
+import type { ExpectStatic } from "vitest";
 
 export function mockGetZonesMulti(
+	expect: ExpectStatic,
 	domains: {
 		[domain: string]: { accountId: string; zones: { id: string }[] };
 	} = {},
@@ -41,12 +41,14 @@ export function mockGetZonesMulti(
 }
 
 export function mockGetZones(
+	expect: ExpectStatic,
 	domain: string,
 	zones: { id: string }[] = [],
 	accountId = "some-account-id",
 	options: RequestHandlerOptions = {}
 ) {
 	return mockGetZonesMulti(
+		expect,
 		{
 			[domain]: { accountId, zones },
 		},

--- a/packages/wrangler/src/__tests__/helpers/mock-kv.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-kv.ts
@@ -1,10 +1,10 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { expect } from "vitest";
 import { createFetchResult, msw } from "./msw";
 import type { KVNamespaceInfo, NamespaceKeyInfo } from "../../kv/helpers";
+import type { ExpectStatic } from "vitest";
 
 export function mockKeyListRequest(
+	expect: ExpectStatic,
 	expectedNamespaceId: string,
 	expectedKeys: NamespaceKeyInfo[],
 	keysPerRequest = 1000,
@@ -47,7 +47,10 @@ export function mockKeyListRequest(
 	return requests;
 }
 
-export function mockListKVNamespacesRequest(...namespaces: KVNamespaceInfo[]) {
+export function mockListKVNamespacesRequest(
+	expect: ExpectStatic,
+	...namespaces: KVNamespaceInfo[]
+) {
 	msw.use(
 		http.get(
 			"*/accounts/:accountId/storage/kv/namespaces",
@@ -61,6 +64,7 @@ export function mockListKVNamespacesRequest(...namespaces: KVNamespaceInfo[]) {
 }
 
 export function mockCreateKVNamespace(
+	expect: ExpectStatic,
 	options: {
 		resultId?: string;
 		assertTitle?: string;

--- a/packages/wrangler/src/__tests__/helpers/mock-legacy-script.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-legacy-script.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { expect } from "vitest";
+import { assert } from "vitest";
 import { msw } from "./msw";
 
 type LegacyScriptInfo = { id: string; migration_tag?: string };
@@ -11,7 +10,7 @@ export function mockLegacyScriptData(options: { scripts: LegacyScriptInfo[] }) {
 		http.get(
 			"*/accounts/:accountId/workers/scripts",
 			({ params }) => {
-				expect(params.accountId).toEqual("some-account-id");
+				assert(params.accountId === "some-account-id");
 				return HttpResponse.json({
 					success: true,
 					errors: [],

--- a/packages/wrangler/src/__tests__/helpers/mock-worker-settings.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-worker-settings.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { expect } from "vitest";
+import { assert } from "vitest";
 import { msw } from "./msw";
 import type { Settings } from "../../deployment-bundle/bindings";
 
@@ -16,11 +15,11 @@ export function mockGetSettings(
 			"*/accounts/:accountId/workers/scripts/:scriptName/settings",
 			async ({ params }) => {
 				if (options.assertAccountId) {
-					expect(params.accountId).toEqual(options.assertAccountId);
+					assert(params.accountId === options.assertAccountId);
 				}
 
 				if (options.assertScriptName) {
-					expect(params.scriptName).toEqual(options.assertScriptName);
+					assert(params.scriptName === options.assertScriptName);
 				}
 
 				if (!options.result) {

--- a/packages/wrangler/src/__tests__/helpers/mock-workers-subdomain.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-workers-subdomain.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { expect } from "vitest";
+import { assert } from "vitest";
 import { createFetchResult, msw } from "./msw";
 
 /** Create a mock handler for the request to get the account's subdomain. */
@@ -59,12 +58,12 @@ export function mockGetWorkerSubdomain({
 		http.get(
 			url,
 			({ params }) => {
-				expect(params.accountId).toEqual("some-account-id");
+				assert(params.accountId === "some-account-id");
 				if (expectedScriptName !== false) {
-					expect(params.scriptName).toEqual(expectedScriptName);
+					assert(params.scriptName === expectedScriptName);
 				}
 				if (useServiceEnvironments) {
-					expect(params.envName).toEqual(env);
+					assert(params.envName === env);
 				}
 
 				return HttpResponse.json(
@@ -112,16 +111,19 @@ export function mockUpdateWorkerSubdomain({
 		http.post(
 			url,
 			async ({ request, params }) => {
-				expect(params.accountId).toEqual("some-account-id");
+				assert(params.accountId === "some-account-id");
 				if (expectedScriptName !== false) {
-					expect(params.scriptName).toEqual(expectedScriptName);
+					assert(params.scriptName === expectedScriptName);
 				}
 				if (useServiceEnvironments) {
-					expect(params.envName).toEqual(env);
+					assert(params.envName === env);
 				}
 				const body = await request.json();
-				const expectBody = { enabled, previews_enabled };
-				expect(body).toEqual(expectBody);
+				assert(body instanceof Object);
+				assert(body.enabled === enabled);
+				if (previews_enabled !== undefined) {
+					assert(body.previews_enabled === previews_enabled);
+				}
 				return HttpResponse.json(createFetchResult(response));
 			},
 			{ once: true }

--- a/packages/wrangler/src/__tests__/helpers/mock-zone-routes.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-zone-routes.ts
@@ -1,10 +1,10 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { expect } from "vitest";
 import { msw } from "./msw";
 import type { RequestHandlerOptions } from "msw";
+import type { ExpectStatic } from "vitest";
 
 export function mockGetZoneWorkerRoutesMulti(
+	expect: ExpectStatic,
 	zones: {
 		[zoneId: string]: { pattern: string; script: string }[];
 	},
@@ -32,9 +32,10 @@ export function mockGetZoneWorkerRoutesMulti(
 }
 
 export function mockGetZoneWorkerRoutes(
+	expect: ExpectStatic,
 	zoneId: string,
 	routes: { pattern: string; script: string }[] = [],
 	options: RequestHandlerOptions = {}
 ) {
-	return mockGetZoneWorkerRoutesMulti({ [zoneId]: routes }, options);
+	return mockGetZoneWorkerRoutesMulti(expect, { [zoneId]: routes }, options);
 }

--- a/packages/wrangler/src/__tests__/helpers/msw/handlers/deployments.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/handlers/deployments.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
-import { expect } from "vitest";
+import { assert } from "vitest";
 import { createFetchResult } from "../index";
 
 const latestDeployment = (scriptTag: string) => ({
@@ -131,7 +130,7 @@ export const mswSuccessDeploymentDetails = [
 				];
 			}
 
-			expect(url.toString().includes("1701-E"));
+			assert(url.toString().includes("1701-E"));
 			return HttpResponse.json(
 				createFetchResult({
 					id: "1701-E",

--- a/packages/wrangler/src/__tests__/pages/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deploy.test.ts
@@ -131,6 +131,7 @@ describe("pages deploy", () => {
 	it("should upload a directory of files", async ({ expect }) => {
 		writeFileSync("logo.png", "foobar");
 		mockGetUploadTokenRequest(
+			expect,
 			"<<funfetti-auth-jwt>>",
 			"some-account-id",
 			"foo"
@@ -275,6 +276,7 @@ describe("pages deploy", () => {
 		writeFileSync("logo.txt", "foobar");
 
 		mockGetUploadTokenRequest(
+			expect,
 			"<<funfetti-auth-jwt>>",
 			"some-account-id",
 			"foo"
@@ -448,6 +450,7 @@ describe("pages deploy", () => {
 		writeFileSync("logo.txt", "foobar");
 
 		mockGetUploadTokenRequest(
+			expect,
 			"<<funfetti-auth-jwt>>",
 			"some-account-id",
 			"foo"
@@ -630,6 +633,7 @@ describe("pages deploy", () => {
 		);
 
 		mockGetUploadTokenRequest(
+			expect,
 			"<<funfetti-auth-jwt>>",
 			"some-account-id",
 			"foo"
@@ -1060,6 +1064,7 @@ describe("pages deploy", () => {
 		writeFileSync("logo.js", "foobar");
 
 		mockGetUploadTokenRequest(
+			expect,
 			"<<funfetti-auth-jwt>>",
 			"some-account-id",
 			"foo"
@@ -1259,6 +1264,7 @@ describe("pages deploy", () => {
 		writeFileSync("public/logo.js", "foobar");
 
 		mockGetUploadTokenRequest(
+			expect,
 			"<<funfetti-auth-jwt>>",
 			"some-account-id",
 			"foo"
@@ -1455,6 +1461,7 @@ describe("pages deploy", () => {
 		writeFileSync("public/logo.js", "foobar");
 
 		mockGetUploadTokenRequest(
+			expect,
 			"<<funfetti-auth-jwt>>",
 			"some-account-id",
 			"foo"
@@ -1653,6 +1660,7 @@ describe("pages deploy", () => {
 		writeFileSync(".well-known/foobar", "foobar");
 
 		mockGetUploadTokenRequest(
+			expect,
 			"<<funfetti-auth-jwt>>",
 			"some-account-id",
 			"foo"
@@ -1797,6 +1805,7 @@ describe("pages deploy", () => {
 		await execa("git", ["init"]);
 		writeFileSync("logo.png", "foobar");
 		mockGetUploadTokenRequest(
+			expect,
 			"<<funfetti-auth-jwt>>",
 			"some-account-id",
 			"foo"
@@ -2010,6 +2019,7 @@ describe("pages deploy", () => {
 			);
 
 			mockGetUploadTokenRequest(
+				expect,
 				"<<funfetti-auth-jwt>>",
 				"some-account-id",
 				"foo"
@@ -2274,6 +2284,7 @@ describe("pages deploy", () => {
 			);
 
 			mockGetUploadTokenRequest(
+				expect,
 				"<<funfetti-auth-jwt>>",
 				"some-account-id",
 				"foo"
@@ -2548,6 +2559,7 @@ async function onRequest() {
 			);
 
 			mockGetUploadTokenRequest(
+				expect,
 				"<<funfetti-auth-jwt>>",
 				"some-account-id",
 				"foo"
@@ -2812,6 +2824,7 @@ async function onRequest() {
 			);
 
 			mockGetUploadTokenRequest(
+				expect,
 				"<<funfetti-auth-jwt>>",
 				"some-account-id",
 				"foo"
@@ -2932,6 +2945,7 @@ and that at least one include rule is provided.
 			);
 
 			mockGetUploadTokenRequest(
+				expect,
 				"<<funfetti-auth-jwt>>",
 				"some-account-id",
 				"foo"
@@ -3149,6 +3163,7 @@ and that at least one include rule is provided.
 			);
 
 			mockGetUploadTokenRequest(
+				expect,
 				"<<funfetti-auth-jwt>>",
 				"some-account-id",
 				"foo"
@@ -3359,6 +3374,7 @@ and that at least one include rule is provided.
 			);
 
 			mockGetUploadTokenRequest(
+				expect,
 				"<<funfetti-auth-jwt>>",
 				"some-account-id",
 				"foo"
@@ -3630,6 +3646,7 @@ and that at least one include rule is provided.
 			);
 
 			mockGetUploadTokenRequest(
+				expect,
 				"<<funfetti-auth-jwt>>",
 				"some-account-id",
 				"foo"
@@ -3902,6 +3919,7 @@ and that at least one include rule is provided.
 			);
 
 			mockGetUploadTokenRequest(
+				expect,
 				"<<funfetti-auth-jwt>>",
 				"some-account-id",
 				"foo"
@@ -4033,6 +4051,7 @@ and that at least one include rule is provided.
 			);
 
 			mockGetUploadTokenRequest(
+				expect,
 				"<<funfetti-auth-jwt>>",
 				"some-account-id",
 				"foo"
@@ -4260,6 +4279,7 @@ and that at least one include rule is provided.
 			);
 
 			mockGetUploadTokenRequest(
+				expect,
 				"<<funfetti-auth-jwt>>",
 				"some-account-id",
 				"foo"
@@ -4384,6 +4404,7 @@ and that at least one include rule is provided.
 			);
 
 			mockGetUploadTokenRequest(
+				expect,
 				"<<funfetti-auth-jwt>>",
 				"some-account-id",
 				"foo"
@@ -4573,6 +4594,7 @@ and that at least one include rule is provided.
 			);
 
 			mockGetUploadTokenRequest(
+				expect,
 				"<<funfetti-auth-jwt>>",
 				"some-account-id",
 				"foo"
@@ -4788,6 +4810,7 @@ and that at least one include rule is provided.
 				);
 
 				mockGetUploadTokenRequest(
+					expect,
 					"<<funfetti-auth-jwt>>",
 					"some-account-id",
 					"pages-is-awesome"
@@ -5038,6 +5061,7 @@ and that at least one include rule is provided.
 				);
 
 				mockGetUploadTokenRequest(
+					expect,
 					"<<funfetti-auth-jwt>>",
 					"some-account-id",
 					"pages-project"
@@ -5219,6 +5243,7 @@ and that at least one include rule is provided.
 		aliases?: string[]
 	) => {
 		mockGetUploadTokenRequest(
+			expect,
 			"<<funfetti-auth-jwt>>",
 			"some-account-id",
 			"foo"
@@ -5737,6 +5762,7 @@ and that at least one include rule is provided.
 			writeFileSync("public/README.md", "# Test project");
 
 			mockGetUploadTokenRequest(
+				expect,
 				"<<funfetti-auth-jwt>>",
 				"some-account-id",
 				"foo"
@@ -5858,6 +5884,7 @@ and that at least one include rule is provided.
 			writeFileSync("public/README.md", "# Test project");
 
 			mockGetUploadTokenRequest(
+				expect,
 				"<<funfetti-auth-jwt>>",
 				"some-account-id",
 				"foo"
@@ -5955,6 +5982,7 @@ and that at least one include rule is provided.
 			writeFileSync("public/README.md", "# Test project");
 
 			mockGetUploadTokenRequest(
+				expect,
 				"<<funfetti-auth-jwt>>",
 				"some-account-id",
 				"foo"
@@ -6221,7 +6249,7 @@ and that at least one include rule is provided.
 					"base64"
 				) +
 				".signature";
-			mockGetUploadTokenRequest(jwt, "some-account-id", "foo");
+			mockGetUploadTokenRequest(expect, jwt, "some-account-id", "foo");
 
 			await expect(
 				runWrangler("pages deploy . --project-name=foo")
@@ -6240,7 +6268,7 @@ and that at least one include rule is provided.
 					"base64"
 				) +
 				".signature";
-			mockGetUploadTokenRequest(jwt, "some-account-id", "foo");
+			mockGetUploadTokenRequest(expect, jwt, "some-account-id", "foo");
 
 			await runWrangler("pages deploy . --project-name=foo");
 

--- a/packages/wrangler/src/__tests__/pages/project-upload.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-upload.test.ts
@@ -429,6 +429,7 @@ describe("pages project upload", () => {
 		writeFileSync("logo.js", "foobar");
 
 		mockGetUploadTokenRequest(
+			expect,
 			"<<funfetti-auth-jwt>>",
 			"some-account-id",
 			"foo"
@@ -549,6 +550,7 @@ describe("pages project upload", () => {
 		}
 
 		mockGetUploadTokenRequest(
+			expect,
 			"<<funfetti-auth-jwt>>",
 			"some-account-id",
 			"foo"
@@ -608,6 +610,7 @@ describe("pages project upload", () => {
 		writeFileSync(".well-known/foobar", "foobar");
 
 		mockGetUploadTokenRequest(
+			expect,
 			"<<funfetti-auth-jwt>>",
 			"some-account-id",
 			"foo"

--- a/packages/wrangler/src/__tests__/provision.test.ts
+++ b/packages/wrangler/src/__tests__/provision.test.ts
@@ -127,7 +127,7 @@ describe("resource provisioning", () => {
 			expect,
 		}) => {
 			mockGetSettings();
-			mockListKVNamespacesRequest({
+			mockListKVNamespacesRequest(expect, {
 				title: "test-kv",
 				id: "existing-kv-id",
 			});
@@ -358,7 +358,7 @@ describe("resource provisioning", () => {
 			expect,
 		}) => {
 			mockGetSettings();
-			mockListKVNamespacesRequest({
+			mockListKVNamespacesRequest(expect, {
 				title: "test-kv",
 				id: "existing-kv-id",
 			});
@@ -394,7 +394,7 @@ describe("resource provisioning", () => {
 				text: "Enter a name for your new KV Namespace",
 				result: "new-kv",
 			});
-			mockCreateKVNamespace({
+			mockCreateKVNamespace(expect, {
 				assertTitle: "new-kv",
 				resultId: "new-kv-id",
 			});
@@ -521,7 +521,7 @@ describe("resource provisioning", () => {
 				d1_databases: [{ binding: "D1" }],
 			});
 			mockGetSettings();
-			mockListKVNamespacesRequest({
+			mockListKVNamespacesRequest(expect, {
 				title: "test-kv",
 				id: "existing-kv-id",
 			});
@@ -557,7 +557,7 @@ describe("resource provisioning", () => {
 				text: "Enter a name for your new KV Namespace",
 				result: "new-kv",
 			});
-			mockCreateKVNamespace({
+			mockCreateKVNamespace(expect, {
 				assertTitle: "new-kv",
 				resultId: "new-kv-id",
 			});
@@ -686,7 +686,7 @@ describe("resource provisioning", () => {
 				d1_databases: [{ binding: "D1" }],
 			});
 			mockGetSettings();
-			mockListKVNamespacesRequest({
+			mockListKVNamespacesRequest(expect, {
 				title: "test-kv",
 				id: "existing-kv-id",
 			});
@@ -713,12 +713,12 @@ describe("resource provisioning", () => {
 					);
 				})
 			);
-			mockCreateKVNamespace({
+			mockCreateKVNamespace(expect, {
 				assertTitle: "test-name-platform-kv",
 				resultId: "test-name-platform-kv-id",
 			});
 
-			mockCreateKVNamespace({
+			mockCreateKVNamespace(expect, {
 				assertTitle: "test-name-kv",
 				resultId: "test-name-kv-id",
 			});

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -336,7 +336,7 @@ describe("versions upload", () => {
 
 		await runWrangler("versions upload");
 
-		assertApiRequest(/.*?workers\/scripts\/test-name\/versions/, {
+		assertApiRequest(expect, /.*?workers\/scripts\/test-name\/versions/, {
 			method: "POST",
 			// Make sure the main module (index.py) has a text/x-python content type
 			body: /Content-Disposition: form-data; name="index.py"; filename="index.py"\nContent-Type: text\/x-python/,


### PR DESCRIPTION
Removal of most of the comments like:
```
// eslint-disable-next-line no-restricted-imports
```
from `wrangler/src/__tests__/helpers`

Continuation from https://github.com/cloudflare/workers-sdk/pull/13140, https://github.com/cloudflare/workers-sdk/pull/13149 https://github.com/cloudflare/workers-sdk/pull/13164, https://github.com/cloudflare/workers-sdk/pull/13247, https://github.com/cloudflare/workers-sdk/pull/13245 and https://github.com/cloudflare/workers-sdk/pull/13255

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
