### PR TITLE
Support named lookups for VPC Service IDs

### DIFF
--- a/.changeset/vpc-service-name-binding.md
+++ b/.changeset/vpc-service-name-binding.md
@@ -1,0 +1,30 @@
+---
+"wrangler": minor
+"@cloudflare/workers-utils": minor
+---
+
+Allow VPC service bindings to use `service_name` (name) instead of `service_id`
+
+VPC service bindings can now be configured with a human-readable service name instead of copying
+the service UUID. When `service_name` is provided, Wrangler will automatically look up the `service_id`
+via the Cloudflare API at deploy time.
+
+```json
+{
+  "vpc_services": [
+    { "binding": "MY_DB", "service_name": "my-database" }
+  ]
+}
+```
+
+This is equivalent to the existing form:
+
+```json
+{
+  "vpc_services": [
+    { "binding": "MY_DB", "service_id": "0199295b-b3ac-7760-8246-bca40877b3e9" }
+  ]
+}
+```
+
+The `service_name` and `service_id` fields are mutually exclusive — only one may be specified per binding.

--- a/.changeset/vpc-service-name-binding.md
+++ b/.changeset/vpc-service-name-binding.md
@@ -12,7 +12,7 @@ via the Cloudflare API at deploy time.
 ```json
 {
   "vpc_services": [
-    { "binding": "MY_DB", "service_name": "my-database" }
+    { "binding": "API_FOO", "service_name": "foo-api-internal" }
   ]
 }
 ```
@@ -22,7 +22,7 @@ This is equivalent to the existing form:
 ```json
 {
   "vpc_services": [
-    { "binding": "MY_DB", "service_id": "0199295b-b3ac-7760-8246-bca40877b3e9" }
+    { "binding": "API_FOO", "service_id": "0199295b-b3ac-7760-8246-bca40877b3e9" }
   ]
 }
 ```

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -1398,8 +1398,10 @@ export interface EnvironmentNonInheritable {
 	vpc_services: {
 		/** The binding name used to refer to the VPC service in the Worker. */
 		binding: string;
-		/** The service ID of the VPC connectivity service. */
-		service_id: string;
+		/** The service ID of the VPC connectivity service. Mutually exclusive with `service`. */
+		service_id?: string;
+		/** The name of the VPC connectivity service. Wrangler will look up the service_id automatically. Mutually exclusive with `service_id`. */
+		service_name?: string;
 		/** Whether the VPC service is remote or not */
 		remote?: boolean;
 	}[];

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -1398,7 +1398,7 @@ export interface EnvironmentNonInheritable {
 	vpc_services: {
 		/** The binding name used to refer to the VPC service in the Worker. */
 		binding: string;
-		/** The service ID of the VPC connectivity service. Mutually exclusive with `service`. */
+		/** The service ID of the VPC connectivity service. Mutually exclusive with `service_name`. */
 		service_id?: string;
 		/** The name of the VPC connectivity service. Wrangler will look up the service_id automatically. Mutually exclusive with `service_id`. */
 		service_name?: string;

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -4324,7 +4324,7 @@ const validateServiceBinding: ValidatorFn = (diagnostics, field, value) => {
 	}
 	if (!isRequiredProperty(value, "service", "string")) {
 		diagnostics.errors.push(
-			`"${field}" bindings should have a string "service_name" field but got ${JSON.stringify(
+			`"${field}" bindings should have a string "service" field but got ${JSON.stringify(
 				value
 			)}.`
 		);

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -4088,7 +4088,7 @@ const validateVpcServiceBinding: ValidatorFn = (diagnostics, field, value) => {
 		return false;
 	}
 	let isValid = true;
-	// VPC service bindings must have a binding and a service_id.
+	// VPC service bindings must have a binding and either a service_id or a service name.
 	if (!isRequiredProperty(value, "binding", "string")) {
 		diagnostics.errors.push(
 			`"${field}" bindings should have a string "binding" field but got ${JSON.stringify(
@@ -4097,9 +4097,35 @@ const validateVpcServiceBinding: ValidatorFn = (diagnostics, field, value) => {
 		);
 		isValid = false;
 	}
-	if (!isRequiredProperty(value, "service_id", "string")) {
+	const hasServiceId = hasProperty(value, "service_id");
+	const hasServiceName = hasProperty(value, "service_name");
+	if (!hasServiceId && !hasServiceName) {
 		diagnostics.errors.push(
-			`"${field}" bindings must have a "service_id" field but got ${JSON.stringify(
+			`"${field}" bindings must have either a "service_id" or "service_name" field but got ${JSON.stringify(
+				value
+			)}.`
+		);
+		isValid = false;
+	}
+	if (hasServiceId && hasServiceName) {
+		diagnostics.errors.push(
+			`"${field}" bindings must have either "service_id" or "service_name", but not both. Got ${JSON.stringify(
+				value
+			)}.`
+		);
+		isValid = false;
+	}
+	if (hasServiceId && !isOptionalProperty(value, "service_id", "string")) {
+		diagnostics.errors.push(
+			`"${field}" bindings should have a string "service_id" field but got ${JSON.stringify(
+				value
+			)}.`
+		);
+		isValid = false;
+	}
+	if (hasServiceName && !isOptionalProperty(value, "service_name", "string")) {
+		diagnostics.errors.push(
+			`"${field}" bindings should have a string "service_name" field but got ${JSON.stringify(
 				value
 			)}.`
 		);
@@ -4109,6 +4135,7 @@ const validateVpcServiceBinding: ValidatorFn = (diagnostics, field, value) => {
 	validateAdditionalProperties(diagnostics, field, Object.keys(value), [
 		"binding",
 		"service_id",
+		"service_name",
 		"remote",
 	]);
 
@@ -4297,7 +4324,7 @@ const validateServiceBinding: ValidatorFn = (diagnostics, field, value) => {
 	}
 	if (!isRequiredProperty(value, "service", "string")) {
 		diagnostics.errors.push(
-			`"${field}" bindings should have a string "service" field but got ${JSON.stringify(
+			`"${field}" bindings should have a string "service_name" field but got ${JSON.stringify(
 				value
 			)}.`
 		);

--- a/packages/workers-utils/src/worker.ts
+++ b/packages/workers-utils/src/worker.ts
@@ -284,7 +284,8 @@ export interface CfService {
 
 export interface CfVpcService {
 	binding: string;
-	service_id: string;
+	service_id?: string;
+	service_name?: string;
 	remote?: boolean;
 }
 

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -36,6 +36,7 @@ import { getScriptName } from "../../utils/getScriptName";
 import { memoizeGetPort } from "../../utils/memoizeGetPort";
 import { printBindings } from "../../utils/print-bindings";
 import { useServiceEnvironments } from "../../utils/useServiceEnvironments";
+import { resolveVpcServiceBindings } from "../../vpc/client";
 import { getZoneIdForPreview } from "../../zones";
 import { Controller } from "./BaseController";
 import { castErrorCause } from "./events";
@@ -185,6 +186,9 @@ async function resolveBindings(
 		input.bindings,
 		input.defaultBindings
 	);
+
+	// Resolve VPC service name bindings to service_id
+	await resolveVpcServiceBindings(config, bindings);
 
 	// Create a print function that captures the current bindings context
 	const printCurrentBindings = (registry: WorkerRegistry | null) => {

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -70,6 +70,7 @@ import { parseConfigPlacement } from "../utils/placement";
 import { printBindings } from "../utils/print-bindings";
 import { retryOnAPIFailure } from "../utils/retry";
 import { isWorkerNotFoundError } from "../utils/worker-not-found-error";
+import { resolveVpcServiceBindings } from "../vpc/client";
 import {
 	createDeployment,
 	patchNonVersionedScriptSettings,
@@ -1002,6 +1003,9 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 					props.config
 				);
 			}
+
+			// Resolve VPC service name bindings to service_id
+			await resolveVpcServiceBindings(config, bindings);
 
 			workerBundle = createWorkerUploadForm(
 				worker,

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -393,7 +393,7 @@ export function createWorkerUploadForm(
 		});
 	});
 
-		vpc_services.forEach(({ binding, service_id, service_name }) => {
+	vpc_services.forEach(({ binding, service_id, service_name }) => {
 		assert(
 			service_id,
 			`VPC service binding "${binding}" is missing a "service_id". ${service_name ? `The service name "${service_name}" should have been resolved before upload.` : "Please provide a service_id or service_name."}`

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -394,6 +394,13 @@ export function createWorkerUploadForm(
 	});
 
 	vpc_services.forEach(({ binding, service_id, service_name }) => {
+		if (options?.dryRun && !service_id) {
+			metadataBindings.push({
+				name: binding,
+				type: "inherit",
+			});
+			return;
+		}
 		assert(
 			service_id,
 			`VPC service binding "${binding}" is missing a "service_id". ${service_name ? `The service name "${service_name}" should have been resolved before upload.` : "Please provide a service_id or service_name."}`

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -393,7 +393,11 @@ export function createWorkerUploadForm(
 		});
 	});
 
-	vpc_services.forEach(({ binding, service_id }) => {
+		vpc_services.forEach(({ binding, service_id, service_name }) => {
+		assert(
+			service_id,
+			`VPC service binding "${binding}" is missing a "service_id". ${service_name ? `The service name "${service_name}" should have been resolved before upload.` : "Please provide a service_id or service_name."}`
+		);
 		metadataBindings.push({
 			name: binding,
 			type: "vpc_service",

--- a/packages/wrangler/src/utils/print-bindings.ts
+++ b/packages/wrangler/src/utils/print-bindings.ts
@@ -367,11 +367,11 @@ export function printBindings(
 
 	if (vpc_services.length > 0) {
 		output.push(
-			...vpc_services.map(({ binding, service_id, remote }) => {
+			...vpc_services.map(({ binding, service_id, service_name, remote }) => {
 				return {
 					name: binding,
 					type: getBindingTypeFriendlyName("vpc_service"),
-					value: service_id,
+					value: service_name ?? service_id,
 					mode: getMode({
 						isSimulatedLocally:
 							remote && !context.remoteBindingsDisabled ? false : undefined,

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -71,6 +71,7 @@ import { printBindings } from "../utils/print-bindings";
 import { retryOnAPIFailure } from "../utils/retry";
 import { useServiceEnvironments } from "../utils/useServiceEnvironments";
 import { isWorkerNotFoundError } from "../utils/worker-not-found-error";
+import { resolveVpcServiceBindings } from "../vpc/client";
 import { patchNonVersionedScriptSettings } from "./api";
 import type { AssetsOptions } from "../assets";
 import type { Entry } from "../deployment-bundle/entry";
@@ -800,6 +801,10 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 					props.config
 				);
 			}
+
+			// Resolve VPC service name bindings to service_id
+			await resolveVpcServiceBindings(config, bindings);
+
 			workerBundle = createWorkerUploadForm(worker, bindings, {
 				unsafe: config.unsafe,
 			});

--- a/packages/wrangler/src/vpc/client.ts
+++ b/packages/wrangler/src/vpc/client.ts
@@ -1,5 +1,8 @@
+import { UserError } from "@cloudflare/workers-utils";
 import { fetchPagedListResult, fetchResult } from "../cfetch";
+import { logger } from "../logger";
 import { requireAuth } from "../user";
+import type { Binding } from "../api/startDevWorker/types";
 import type { ConnectivityService, ConnectivityServiceRequest } from "./index";
 import type { Config } from "@cloudflare/workers-utils";
 
@@ -81,4 +84,73 @@ export async function updateService(
 			body: JSON.stringify(body),
 		}
 	);
+}
+
+export async function getServiceByName(
+	config: Config,
+	name: string
+): Promise<ConnectivityService> {
+	const services = await listServices(config);
+	const matches = services.filter((s) => s.name === name);
+	if (matches.length === 0) {
+		throw new UserError(
+			`No VPC service found with name "${name}". Use "wrangler vpc service list" to see available services.`
+		);
+	}
+	if (matches.length > 1) {
+		throw new UserError(
+			`Multiple VPC services found with name "${name}". Use "service_id" instead to specify the exact service.`
+		);
+	}
+	return matches[0];
+}
+
+/**
+ * Resolves VPC service bindings that use `service_name` instead of `service_id`.
+ * Looks up each named service via the API and replaces the `service_name` field with `service_id`.
+ */
+export async function resolveVpcServiceBindings(
+	config: Config,
+	bindings: Record<string, Binding>
+): Promise<void> {
+	const toResolve: { bindingName: string; serviceName: string }[] = [];
+	for (const [bindingName, binding] of Object.entries(bindings)) {
+		if (
+			binding.type === "vpc_service" &&
+			!binding.service_id &&
+			binding.service_name
+		) {
+			toResolve.push({ bindingName, serviceName: binding.service_name });
+		}
+	}
+
+	if (toResolve.length === 0) {
+		return;
+	}
+
+	// Fetch all services once and resolve all names from the cached list
+	const allServices = await listServices(config);
+
+	for (const { bindingName, serviceName } of toResolve) {
+		const matches = allServices.filter((s) => s.name === serviceName);
+		if (matches.length === 0) {
+			throw new UserError(
+				`VPC service binding "${bindingName}": no service found with name "${serviceName}". Use "wrangler vpc service list" to see available services.`
+			);
+		}
+		if (matches.length > 1) {
+			throw new UserError(
+				`VPC service binding "${bindingName}": multiple services found with name "${serviceName}". Use "service_id" instead to specify the exact service.`
+			);
+		}
+		const binding = bindings[bindingName] as Extract<
+			Binding,
+			{ type: "vpc_service" }
+		>;
+		logger.log(
+			`Resolved VPC service "${serviceName}" to service_id "${matches[0].service_id}" for binding "${bindingName}".`
+		);
+		binding.service_id = matches[0].service_id;
+		delete binding.service_name;
+	}
 }


### PR DESCRIPTION
Fixes #13211

Today, we have to copy vpc service ids from the Cloudflare Dashboard or use an automation tool like terraform to look up the id and emit it to stdout, and a delete-and-recreate means copying a new ID. This PR proposes a config option to use the friendly name of the vpc service and look up its id at deploy time:

New, can use `service_name`:
```json
  {
    "vpc_services": [
      { "binding": "API_FOO", "service_name": "api-foo" }
    ]
  }
```

Existing, can only use `service_id`:
```json
  {
    "vpc_services": [
      { "binding": "API_FOO", "service_id": "0199295b-b3ac-7760-8246-bca40877b3e9" }
    ]
  }
```

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
