### PR TITLE
fix(miniflare): Skip creating hyperdrive proxy server for local database

### DIFF
--- a/.changeset/quiet-houses-attack.md
+++ b/.changeset/quiet-houses-attack.md
@@ -1,0 +1,7 @@
+---
+"miniflare": minor
+---
+
+Fix Hyperdrive binding issue where some customers are unable to connect to local databases using `wrangler dev`
+
+- Skips creating a local TCP proxy server for Hyperdrive bindings when SSL is not enabled, connecting directly to the database instead. This avoids connection refused errors caused by firewall rules or proxy port binding issues on Windows/macOS.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1022,6 +1022,7 @@ export class Miniflare {
 		}
 
 		this.#log = this.#sharedOpts.core.log ?? new NoOpLog();
+		this.#hyperdriveProxyController.log = this.#log;
 		this.#structuredWorkerdLogs =
 			this.#sharedOpts.core.structuredWorkerdLogs ??
 			// If there is a `handleStructuredLogs` set then `structuredWorkerdLogs` defaults
@@ -2732,6 +2733,7 @@ export class Miniflare {
 		this.#sharedOpts = sharedOpts;
 		this.#workerOpts = workerOpts;
 		this.#log = this.#sharedOpts.core.log ?? this.#log;
+		this.#hyperdriveProxyController.log = this.#log;
 		this.#structuredWorkerdLogs =
 			this.#sharedOpts.core.structuredWorkerdLogs ??
 			this.#structuredWorkerdLogs;

--- a/packages/miniflare/src/plugins/hyperdrive/hyperdrive-proxy.ts
+++ b/packages/miniflare/src/plugins/hyperdrive/hyperdrive-proxy.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import net from "node:net";
 import tls from "node:tls";
+import type { Log } from "../../shared";
 
 export interface HyperdriveProxyConfig {
 	// Name of the Hyperdrive binding
@@ -112,6 +113,7 @@ function buildTlsConnectionOptions(
 export class HyperdriveProxyController {
 	// Map hyperdrive binding name to proxy server
 	#servers = new Map<string, net.Server>();
+	log?: Log;
 
 	/**
 	 * Creates a proxy server for a Hyperdrive binding.
@@ -132,13 +134,22 @@ export class HyperdriveProxyController {
 				sslrootcert
 			);
 		});
+		server.on("error", (err) => {
+			this.log?.error(
+				new Error(
+					`Hyperdrive proxy server error for binding "${name}": ${err.message}`
+				)
+			);
+		});
 		const port = await new Promise<number>((resolve, reject) => {
+			server.once("error", reject);
 			server.listen(0, "127.0.0.1", () => {
+				server.off("error", reject);
 				const address = server.address() as net.AddressInfo;
 				if (address && typeof address !== "string") {
 					resolve(address.port);
 				} else {
-					reject("Invalid port");
+					reject(new Error("Invalid port"));
 				}
 			});
 		});

--- a/packages/miniflare/src/plugins/hyperdrive/index.ts
+++ b/packages/miniflare/src/plugins/hyperdrive/index.ts
@@ -120,19 +120,33 @@ export const HYPERDRIVE_PLUGIN: Plugin<typeof HyperdriveInputOptionsSchema> = {
 		const services = [];
 		for (const [name, url] of Object.entries(options.hyperdrives ?? {})) {
 			const scheme = url.protocol.replace(":", "");
+			const sslmode = parseSslMode(url, scheme);
+			const targetPort = getPort(url);
 
-			const proxyPort = await hyperdriveProxyController.createProxyServer({
-				name,
-				targetHost: url.hostname,
-				targetPort: getPort(url),
-				scheme,
-				sslmode: parseSslMode(url, scheme),
-				sslrootcert: parseSslRootCert(url),
-			});
+			let address: string;
+			if (sslmode === "disable") {
+				// No SSL requested (either explicitly disabled or not specified):
+				// connect directly to the database without a proxy server, avoiding
+				// potential issues with local proxy port binding or firewall rules
+				address = `${url.hostname}:${targetPort}`;
+			} else {
+				// SSL modes (require, prefer) need the proxy to handle
+				// TLS negotiation with the target database
+				const proxyPort = await hyperdriveProxyController.createProxyServer({
+					name,
+					targetHost: url.hostname,
+					targetPort,
+					scheme,
+					sslmode,
+					sslrootcert: parseSslRootCert(url),
+				});
+				address = `127.0.0.1:${proxyPort}`;
+			}
+
 			services.push({
 				name: `${HYPERDRIVE_PLUGIN_NAME}:${name}`,
 				external: {
-					address: `127.0.0.1:${proxyPort}`,
+					address,
 					tcp: {},
 				},
 			});

--- a/packages/miniflare/test/plugins/hyperdrive/index.spec.ts
+++ b/packages/miniflare/test/plugins/hyperdrive/index.spec.ts
@@ -1,5 +1,5 @@
-import { Miniflare } from "miniflare";
-import { test } from "vitest";
+import { HYPERDRIVE_PLUGIN, Miniflare } from "miniflare";
+import { describe, test, vi } from "vitest";
 import { useDispose } from "../../test-shared";
 import type { Hyperdrive } from "@cloudflare/workers-types/experimental";
 import type { MiniflareOptions } from "miniflare";
@@ -141,4 +141,200 @@ test("sets default port based on protocol", async ({ expect }) => {
 	await mf.setOptions(opts);
 	res = await mf.dispatchFetch("http://localhost/");
 	expect(await res.text()).toBe("5432");
+});
+
+describe("proxy server creation", () => {
+	type GetServicesOptions = Parameters<typeof HYPERDRIVE_PLUGIN.getServices>[0];
+	type HyperdriveProxyController =
+		GetServicesOptions["hyperdriveProxyController"];
+
+	function createMockProxyController() {
+		return {
+			createProxyServer: vi.fn().mockResolvedValue(12345),
+			dispose: vi.fn().mockResolvedValue(undefined),
+		} as unknown as HyperdriveProxyController & {
+			createProxyServer: ReturnType<typeof vi.fn>;
+		};
+	}
+
+	function serviceOpts(
+		hyperdrives: Record<string, URL>,
+		controller: HyperdriveProxyController & {
+			createProxyServer: ReturnType<typeof vi.fn>;
+		}
+	) {
+		// Returns hyperdrive services from the hyperdrive_plugin
+		return {
+			options: { hyperdrives },
+			hyperdriveProxyController: controller,
+		} as unknown as Parameters<typeof HYPERDRIVE_PLUGIN.getServices>[0];
+	}
+
+	test("skips proxy when sslmode is not specified (postgres)", async ({
+		expect,
+	}) => {
+		const controller = createMockProxyController();
+		const services = await HYPERDRIVE_PLUGIN.getServices(
+			serviceOpts(
+				{ DB: new URL("postgres://user:pass@db.example.com:5432/mydb") },
+				controller
+			)
+		);
+		expect(controller.createProxyServer).not.toHaveBeenCalled();
+		expect(services).toEqual([
+			{
+				name: "hyperdrive:DB",
+				external: { address: "db.example.com:5432", tcp: {} },
+			},
+		]);
+	});
+
+	test("skips proxy when sslmode is explicitly disabled (postgres)", async ({
+		expect,
+	}) => {
+		const controller = createMockProxyController();
+		const services = await HYPERDRIVE_PLUGIN.getServices(
+			serviceOpts(
+				{
+					DB: new URL(
+						"postgres://user:pass@db.example.com:5432/mydb?sslmode=disable"
+					),
+				},
+				controller
+			)
+		);
+		expect(controller.createProxyServer).not.toHaveBeenCalled();
+		expect(services).toEqual([
+			{
+				name: "hyperdrive:DB",
+				external: { address: "db.example.com:5432", tcp: {} },
+			},
+		]);
+	});
+
+	test("wraps IPv6 hosts when skipping proxy for disabled sslmode", async ({
+		expect,
+	}) => {
+		const controller = createMockProxyController();
+		const services = await HYPERDRIVE_PLUGIN.getServices(
+			serviceOpts(
+				{
+					DB: new URL("postgres://user:pass@[::1]:5432/mydb?sslmode=disable"),
+				},
+				controller
+			)
+		);
+		expect(controller.createProxyServer).not.toHaveBeenCalled();
+		expect(services).toEqual([
+			{
+				name: "hyperdrive:DB",
+				external: { address: "[::1]:5432", tcp: {} },
+			},
+		]);
+	});
+
+	test("skips proxy when ssl-mode is disabled (mysql)", async ({ expect }) => {
+		const controller = createMockProxyController();
+		const services = await HYPERDRIVE_PLUGIN.getServices(
+			serviceOpts(
+				{
+					DB: new URL(
+						"mysql://user:pass@db.example.com:3306/mydb?ssl-mode=disabled"
+					),
+				},
+				controller
+			)
+		);
+		expect(controller.createProxyServer).not.toHaveBeenCalled();
+		expect(services).toEqual([
+			{
+				name: "hyperdrive:DB",
+				external: { address: "db.example.com:3306", tcp: {} },
+			},
+		]);
+	});
+
+	test("creates proxy when sslmode=require (postgres)", async ({ expect }) => {
+		const controller = createMockProxyController();
+		const services = await HYPERDRIVE_PLUGIN.getServices(
+			serviceOpts(
+				{
+					DB: new URL(
+						"postgres://user:pass@db.example.com:5432/mydb?sslmode=require"
+					),
+				},
+				controller
+			)
+		);
+		expect(controller.createProxyServer).toHaveBeenCalledOnce();
+		expect(controller.createProxyServer).toHaveBeenCalledWith({
+			name: "DB",
+			targetHost: "db.example.com",
+			targetPort: "5432",
+			scheme: "postgres",
+			sslmode: "require",
+		});
+		expect(services).toEqual([
+			{
+				name: "hyperdrive:DB",
+				external: { address: "127.0.0.1:12345", tcp: {} },
+			},
+		]);
+	});
+
+	test("creates proxy when sslmode=prefer (postgres)", async ({ expect }) => {
+		const controller = createMockProxyController();
+		const services = await HYPERDRIVE_PLUGIN.getServices(
+			serviceOpts(
+				{
+					DB: new URL(
+						"postgres://user:pass@db.example.com:5432/mydb?sslmode=prefer"
+					),
+				},
+				controller
+			)
+		);
+		expect(controller.createProxyServer).toHaveBeenCalledOnce();
+		expect(controller.createProxyServer).toHaveBeenCalledWith({
+			name: "DB",
+			targetHost: "db.example.com",
+			targetPort: "5432",
+			scheme: "postgres",
+			sslmode: "prefer",
+		});
+		expect(services).toEqual([
+			{
+				name: "hyperdrive:DB",
+				external: { address: "127.0.0.1:12345", tcp: {} },
+			},
+		]);
+	});
+
+	test("creates proxy when ssl-mode=required (mysql)", async ({ expect }) => {
+		const controller = createMockProxyController();
+		const services = await HYPERDRIVE_PLUGIN.getServices(
+			serviceOpts(
+				{
+					DB: new URL(
+						"mysql://user:pass@db.example.com:3306/mydb?ssl-mode=required"
+					),
+				},
+				controller
+			)
+		);
+		expect(controller.createProxyServer).toHaveBeenCalledOnce();
+		expect(controller.createProxyServer).toHaveBeenCalledWith({
+			name: "DB",
+			targetHost: "db.example.com",
+			targetPort: "3306",
+			scheme: "mysql",
+			sslmode: "require",
+		});
+		expect(services).toEqual([
+			{
+				name: "hyperdrive:DB",
+				external: { address: "127.0.0.1:12345", tcp: {} },
+			},
+		]);
+	});
 });

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -750,6 +750,19 @@ describe.each([{ cmd: "wrangler dev" }])(
 	}
 );
 
+// When `wrangler dev` is force-killed via tree-kill at test teardown,
+// workerd's outbound TCP connection to the mock database server is reset
+// rather than gracefully closed. With the Hyperdrive proxy now skipped for
+// `sslmode=disable` (the default), that RST surfaces directly on the
+// per-connection socket of the test's `nodeNet.Server`. Without an `error`
+// listener Node escalates it to `uncaughtException`, which Vitest catches as
+// an unhandled error and fails the run even though the test itself passed.
+function ignoreEconnreset(err: NodeJS.ErrnoException): void {
+	if (err.code !== "ECONNRESET") {
+		throw err;
+	}
+}
+
 describe.each(HYPERDRIVE_DATABASES)(
 	"hyperdrive dev tests ($scheme)",
 	({ scheme, defaultPort, envVar }) => {
@@ -766,6 +779,11 @@ describe.each(HYPERDRIVE_DATABASES)(
 					})
 					.listen();
 			}
+			// Attach a no-op-on-ECONNRESET listener to every accepted socket.
+			// See `ignoreEconnreset` for context.
+			server.on("connection", (socket) => {
+				socket.on("error", ignoreEconnreset);
+			});
 		});
 
 		it("matches expected configuration parameters", async ({ expect }) => {

--- a/packages/wrangler/e2e/get-platform-proxy.test.ts
+++ b/packages/wrangler/e2e/get-platform-proxy.test.ts
@@ -393,6 +393,16 @@ describe("getPlatformProxy()", () => {
 					if (scheme === "mysql") {
 						socket.write(MYSQL_INITIAL_HANDSHAKE_PACKET);
 					}
+					// When the spawned child process exits after `dispose()`, workerd's
+					// outbound TCP connection (now direct, not via the Hyperdrive proxy
+					// for `sslmode=disable`) can close with RST rather than FIN — most
+					// reliably reproduced on Windows. Swallow the resulting ECONNRESET
+					// so it doesn't leak as an `uncaughtException` in the test process.
+					socket.on("error", (err: NodeJS.ErrnoException) => {
+						if (err.code !== "ECONNRESET") {
+							throw err;
+						}
+					});
 					socket.on("data", (chunk) => {
 						// Handle PostgreSQL SSL request packet
 						if (


### PR DESCRIPTION
Skip creating a local TCP proxy server for Hyperdrive bindings when SSL is not needed (sslmode disabled or not specified), connecting directly to the database instead. This avoids connection refused errors caused by firewall rules or proxy port binding issues on Windows/macOS.

Also fixes two bugs in HyperdriveProxyController:
- Add missing error handler on the proxy net.Server to prevent silent crashes
- Fix missing return in dispose() that caused servers not to be awaited on cleanup

Fixes: https://github.com/cloudflare/workers-sdk/issues/11556

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [X] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:

On Windows 10 Machine
1.  pnpm run build --filter wrangler
2. Run custom build of wrangler in worker with Hyperdrive pointing at local postgres
3. node ..\workers-sdk\packages\wrangler\wrangler-dist\cli.js dev
4. Confirm that connecting to localhost works as expected
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: This is expected behavior, and attempting to fix customers that run into this issue. 

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
