### PR TITLE
[miniflare] Fix D1 dumpSql test timeout flake on Windows

### DIFF
--- a/packages/miniflare/test/plugins/d1/suite.ts
+++ b/packages/miniflare/test/plugins/d1/suite.ts
@@ -596,20 +596,14 @@ test("dumpSql exports and imports complete database structure and content correc
 	expect,
 }) => {
 	// Create a new Miniflare instance with D1 database
+	const tmp1 = await useTmp();
 	const originalMF = new Miniflare({
 		...opts,
+		d1Persist: tmp1,
 		d1Databases: { test: "test" },
 	});
-	const mirrorMF = new Miniflare({
-		...opts,
-		d1Databases: { test: "test" },
-	});
-
 	useDispose(originalMF);
-	useDispose(mirrorMF);
-
 	const originalDb = await originalMF.getD1Database("test");
-	const mirrorDb = await mirrorMF.getD1Database("test");
 
 	// Fill the original database with dummy data
 	await fillDummyData(originalDb);
@@ -619,10 +613,19 @@ test("dumpSql exports and imports complete database structure and content correc
 		.prepare("PRAGMA miniflare_d1_export(?,?,?);")
 		.bind(0, 0)
 		.raw();
-
 	const [dumpStatements] = result as [string[]];
 	const dump = dumpStatements.join("\n");
 
+	// Create a new Miniflare instance and import the dump into a new database
+	const tmp2 = await useTmp();
+	const mirrorMF = new Miniflare({
+		...opts,
+		d1Persist: tmp2,
+		d1Databases: { test: "test" },
+	});
+	useDispose(mirrorMF);
+
+	const mirrorDb = await mirrorMF.getD1Database("test");
 	await mirrorDb.exec(dump);
 
 	// Verify that the schema and data in both databases are equal


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/actions/runs/24253310643/job/70818272196?pr=13330#step:7:419.

The `dumpSql exports and imports complete database structure and content correctly` test was flaking on Windows with a 30s timeout. The root cause was that the test created two Miniflare instances (originalMF and mirrorMF) simultaneously, both using D1 with the same implicit persist directory. On Windows, this causes SQLite file locking contention, leading to the timeout.

The fix:
- Gives each Miniflare instance its own `d1Persist` path via `useTmp()`
- Creates the mirror instance only **after** the dump from the original is complete, rather than up-front alongside the original

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: test-only change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
