### PR TITLE
Ignore .opencode/package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,3 +237,4 @@ dist/**
 AGENTS.local.md
 .opencode/plans/
 .agents/skills
+.opencode/package-lock.json


### PR DESCRIPTION
## Summary

Add `.opencode/package-lock.json` to `.gitignore` so it isn't accidentally committed.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: gitignore-only change
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal tooling config change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
