### PR TITLE
[wrangler] Fix proxy startup notice polluting stdout for --json commands

### DIFF
--- a/.changeset/proxy-json-stdout.md
+++ b/.changeset/proxy-json-stdout.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Keep proxy notices off stdout for JSON Wrangler commands
+
+Wrangler now writes the startup notice for `HTTP_PROXY` and `HTTPS_PROXY` to stderr instead of stdout. This keeps commands like `wrangler auth token --json` machine-readable when a proxy is configured.

--- a/packages/wrangler/src/__tests__/proxy-output.test.ts
+++ b/packages/wrangler/src/__tests__/proxy-output.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, it, vi } from "vitest";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import { runInTempDir } from "./helpers/run-in-tmp";
+
+describe("proxy startup output", () => {
+	runInTempDir();
+	const std = mockConsoleMethods();
+
+	beforeEach(() => {
+		vi.resetModules();
+	});
+
+	it("keeps JSON output parseable when a proxy is configured", async ({
+		expect,
+	}) => {
+		vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:8080");
+		vi.stubEnv("CLOUDFLARE_API_TOKEN", "env-api-token");
+
+		const { main } = await import("../index");
+
+		await main(["auth", "token", "--json"]);
+
+		expect(std.out).not.toContain("Proxy environment variables detected");
+		expect(JSON.parse(std.out)).toEqual({
+			type: "api_token",
+			token: "env-api-token",
+		});
+		expect(std.warn).toContain(
+			"Proxy environment variables detected. We'll use your proxy for fetch requests."
+		);
+	});
+});

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -463,7 +463,7 @@ if (proxy) {
 	setGlobalDispatcher(
 		new EnvHttpProxyAgent({ noProxy: noProxy || "localhost,127.0.0.1,::1" })
 	);
-	logger.log(
+	logger.warn(
 		`Proxy environment variables detected. We'll use your proxy for fetch requests.`
 	);
 }


### PR DESCRIPTION
Fixes #13411.

Fix Wrangler's proxy startup notice polluting stdout for `--json` commands.

Before: setting `HTTP_PROXY` or `HTTPS_PROXY` could prepend a proxy notice to stdout and break JSON parsing. After: the notice is still shown, but on stderr, so commands like `wrangler auth token --json` keep stdout machine-readable.

This changes the proxy notice in Wrangler startup from `logger.log(...)` to `logger.warn(...)`, which preserves the existing message while keeping it out of stdout for machine-readable commands.

A focused regression test now imports the CLI with `HTTPS_PROXY` set and asserts that JSON output remains parseable while the proxy notice is emitted on the warning stream. I also manually smoke-tested the built CLI path to confirm stdout contains only JSON and stderr contains the proxy notice.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is a small Wrangler bug fix with no user-facing workflow change beyond restoring valid JSON stdout.

*A picture of a cute animal (not mandatory, but encouraged)*
