### PR TITLE
fix(miniflare): reject non-local /cdn-cgi requests

### DIFF
--- a/.changeset/green-taxis-draw.md
+++ b/.changeset/green-taxis-draw.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Reject non-local `/cdn-cgi/*` requests in Miniflare
+
+Miniflare now validates `Host` and `Origin` on `/cdn-cgi/*` requests before request rewriting. Requests are still allowed for localhost, configured route hostnames, and the configured upstream hostname, but non-local hostnames can no longer reach internal development endpoints such as platform-proxy, handler routes, live reload, and the local explorer.

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -31,6 +31,7 @@ type Env = {
 };
 
 const encoder = new TextEncoder();
+
 function getUserRequest(
 	request: Request<unknown, IncomingRequestCfProperties>,
 	env: Env,
@@ -146,16 +147,33 @@ function getTargetService(request: Request, url: URL, env: Env) {
 
 const LOCALHOST_HOSTNAMES = ["localhost", "127.0.0.1", "[::1]"];
 
+function isCdnCgiRequest(url: string | null): boolean {
+	if (url === null) return false;
+
+	try {
+		return new URL(url).pathname.startsWith("/cdn-cgi/");
+	} catch {
+		return false;
+	}
+}
+
 /**
- * Validates that a request to the local explorer API is a same-origin request.
+ * Validates that a request to a /cdn-cgi/* endpoint originates from an allowed host.
  * This check must happen BEFORE any header rewriting (getUserRequest) to ensure
  * we're checking the actual browser-sent headers, not Miniflare rewritten ones.
  */
-function validateLocalExplorerRequest(
+function validateCdnCgiRequest(
 	request: Request,
 	routes: WorkerRoute[],
 	upstreamUrl: string | undefined
 ): void {
+	if (
+		!isCdnCgiRequest(request.url) &&
+		!isCdnCgiRequest(request.headers.get(CoreHeaders.ORIGINAL_URL))
+	) {
+		return;
+	}
+
 	// Build allowed hostnames set from localhost + user configured routes
 	const allowedHostnames = new Set<string>();
 	for (const route of routes) {
@@ -461,8 +479,27 @@ export default <ExportedHandler<Env>>{
 				};
 		request = new Request(request, { cf });
 
+		// Block /cdn-cgi/* requests from non-local origins.
+		// These endpoints (platform-proxy, scheduled handlers, live-reload, explorer)
+		// are for local development only and must not be reachable through a tunnel.
+		// This must happen BEFORE getUserRequest() to check the actual browser-sent
+		// headers, not Miniflare-rewritten ones.
+		const requestUrl = new URL(request.url);
+		try {
+			validateCdnCgiRequest(
+				request,
+				env[CoreBindings.JSON_ROUTES],
+				env[CoreBindings.TEXT_UPSTREAM_URL]
+			);
+		} catch (e) {
+			if (e instanceof HttpError) {
+				return e.toResponse();
+			}
+			throw e;
+		}
+
 		// The magic proxy client (used by getPlatformProxy)
-		if (new URL(request.url).pathname === CorePaths.PLATFORM_PROXY) {
+		if (requestUrl.pathname === CorePaths.PLATFORM_PROXY) {
 			if (request.headers.get(CoreHeaders.OP) !== null) {
 				return handleProxy(request, env);
 			}
@@ -479,22 +516,6 @@ export default <ExportedHandler<Env>>{
 		const clientAcceptEncoding = request.headers.get("Accept-Encoding");
 
 		try {
-			// Security check for local explorer API - must happen BEFORE getUserRequest()
-			// to check the original headers before any rewriting (e.g., for custom routes/upstream).
-			if (env[CoreBindings.SERVICE_LOCAL_EXPLORER]) {
-				const preRewriteUrl = new URL(request.url);
-				if (
-					preRewriteUrl.pathname === CorePaths.EXPLORER ||
-					preRewriteUrl.pathname.startsWith(`${CorePaths.EXPLORER}/`)
-				) {
-					validateLocalExplorerRequest(
-						request,
-						env[CoreBindings.JSON_ROUTES],
-						env[CoreBindings.TEXT_UPSTREAM_URL]
-					);
-				}
-			}
-
 			request = getUserRequest(request, env, clientIp);
 		} catch (e) {
 			if (e instanceof HttpError) {

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -479,11 +479,11 @@ export default <ExportedHandler<Env>>{
 				};
 		request = new Request(request, { cf });
 
-		// Block /cdn-cgi/* requests from non-local origins.
-		// These endpoints (platform-proxy, scheduled handlers, live-reload, explorer)
-		// are for local development only and must not be reachable through a tunnel.
-		// This must happen BEFORE getUserRequest() to check the actual browser-sent
-		// headers, not Miniflare-rewritten ones.
+		// Restrict /cdn-cgi/* requests to allowed hostnames.
+		// These endpoints should be served only when the browser-sent Host and
+		// Origin headers match localhost, a configured route, or the configured upstream.
+		// This must happen before getUserRequest() so we validate the
+		// original browser-sent headers, not Miniflare-rewritten ones.
 		const requestUrl = new URL(request.url);
 		try {
 			validateCdnCgiRequest(

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -1918,6 +1918,58 @@ test("Miniflare: other /cdn-cgi/ routes", async ({ expect }) => {
 	expect(res.status).toBe(200);
 });
 
+test("Miniflare: blocks non-local Host headers from reaching /cdn-cgi/ routes", async ({
+	expect,
+}) => {
+	const mf = new Miniflare({
+		modules: true,
+		script: `
+			export default {
+				fetch() {
+					return new Response("Hello world");
+				}
+			}
+		`,
+		unsafeTriggerHandlers: true,
+	});
+	useDispose(mf);
+
+	const url = await mf.ready;
+	const directUrlStatus = await new Promise<number>((resolve, reject) => {
+		const req = http.get(
+			`${url.origin}/cdn-cgi/foo`,
+			{ setHost: false, headers: { Host: "example.trycloudflare.com" } },
+			(res) => {
+				res.resume();
+				resolve(res.statusCode ?? 0);
+			}
+		);
+		req.on("error", reject);
+	});
+
+	expect(directUrlStatus).toBe(403);
+
+	const originalUrlStatus = await new Promise<number>((resolve, reject) => {
+		const req = http.get(
+			`${url.origin}/foo`,
+			{
+				setHost: false,
+				headers: {
+					Host: "example.trycloudflare.com",
+					"MF-Original-URL": "http://localhost/cdn-cgi/handler/scheduled",
+				},
+			},
+			(res) => {
+				res.resume();
+				resolve(res.statusCode ?? 0);
+			}
+		);
+		req.on("error", reject);
+	});
+
+	expect(originalUrlStatus).toBe(403);
+});
+
 test("Miniflare: listens on ipv6", async ({ expect }) => {
 	const log = new TestLog();
 


### PR DESCRIPTION
Fixes [DEVX-2556](https://jira.cfdata.org/browse/DEVX-2556).

This extends the origin validation added for the local explorer to cover all cdn-cgi requests.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no feature change.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
