### PR TITLE
fix(vite-plugin-cloudflare): deny worker files in dev server

### DIFF
--- a/.changeset/lucky-comics-share.md
+++ b/.changeset/lucky-comics-share.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Harden file serving for Vite dev
+
+The Vite plugin now includes Wrangler config files and `.wrangler` state files in `server.fs.deny` so they cannot be fetched directly from the Vite dev server.

--- a/.changeset/lucky-comics-share.md
+++ b/.changeset/lucky-comics-share.md
@@ -4,4 +4,4 @@
 
 Harden file serving for Vite dev
 
-The Vite plugin now includes Wrangler config files and `.wrangler` state files in `server.fs.deny` so they cannot be fetched directly from the Vite dev server.
+The Vite plugin now includes Wrangler config files, Vite config files, and `.wrangler` state files in `server.fs.deny` so they cannot be fetched directly from the Vite dev server.

--- a/packages/vite-plugin-cloudflare/playground/sensitive-files/__tests__/sensitive-files.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/sensitive-files/__tests__/sensitive-files.spec.ts
@@ -32,6 +32,26 @@ describe.skipIf(isBuild)("denies access to sensitive files in dev", () => {
 		expect(response.status()).toBe(403);
 	});
 
+	test("denies access to .env in subdirectory", async ({ expect }) => {
+		const response = await getResponse("/worker-b/.env");
+		expect(response.status()).toBe(403);
+	});
+
+	test("denies access to .env.* in subdirectory", async ({ expect }) => {
+		const response = await getResponse("/worker-b/.env.staging");
+		expect(response.status()).toBe(403);
+	});
+
+	test("denies access to root wrangler config", async ({ expect }) => {
+		const response = await getResponse("/wrangler.jsonc");
+		expect(response.status()).toBe(403);
+	});
+
+	test("denies access to auxiliary wrangler config", async ({ expect }) => {
+		const response = await getResponse("/worker-b/wrangler.jsonc");
+		expect(response.status()).toBe(403);
+	});
+
 	test("denies access to custom-sensitive-file", async ({ expect }) => {
 		const response = await getResponse("/custom-sensitive-file");
 		expect(response.status()).toBe(403);
@@ -56,6 +76,26 @@ describe.runIf(isBuild)("doesn't serve sensitive files in preview", () => {
 
 	test("doesn't serve .dev.vars.*", async ({ expect }) => {
 		const response = await getTextResponse("/.dev.vars.staging");
+		expect(response).toBe("Worker A response");
+	});
+
+	test("doesn't serve .env in subdirectory", async ({ expect }) => {
+		const response = await getTextResponse("/worker-b/.env");
+		expect(response).toBe("Worker A response");
+	});
+
+	test("doesn't serve .env.* in subdirectory", async ({ expect }) => {
+		const response = await getTextResponse("/worker-b/.env.staging");
+		expect(response).toBe("Worker A response");
+	});
+
+	test("doesn't serve root wrangler config", async ({ expect }) => {
+		const response = await getTextResponse("/wrangler.jsonc");
+		expect(response).toBe("Worker A response");
+	});
+
+	test("doesn't serve auxiliary wrangler config", async ({ expect }) => {
+		const response = await getTextResponse("/worker-b/wrangler.jsonc");
 		expect(response).toBe("Worker A response");
 	});
 

--- a/packages/vite-plugin-cloudflare/playground/sensitive-files/__tests__/sensitive-files.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/sensitive-files/__tests__/sensitive-files.spec.ts
@@ -52,6 +52,11 @@ describe.skipIf(isBuild)("denies access to sensitive files in dev", () => {
 		expect(response.status()).toBe(403);
 	});
 
+	test("denies access to vite config", async ({ expect }) => {
+		const response = await getResponse("/vite.config.ts");
+		expect(response.status()).toBe(403);
+	});
+
 	test("denies access to custom-sensitive-file", async ({ expect }) => {
 		const response = await getResponse("/custom-sensitive-file");
 		expect(response.status()).toBe(403);
@@ -96,6 +101,11 @@ describe.runIf(isBuild)("doesn't serve sensitive files in preview", () => {
 
 	test("doesn't serve auxiliary wrangler config", async ({ expect }) => {
 		const response = await getTextResponse("/worker-b/wrangler.jsonc");
+		expect(response).toBe("Worker A response");
+	});
+
+	test("doesn't serve vite config", async ({ expect }) => {
+		const response = await getTextResponse("/vite.config.ts");
 		expect(response).toBe("Worker A response");
 	});
 

--- a/packages/vite-plugin-cloudflare/playground/sensitive-files/worker-b/.env
+++ b/packages/vite-plugin-cloudflare/playground/sensitive-files/worker-b/.env
@@ -1,0 +1,1 @@
+WORKER_B_ENV=1

--- a/packages/vite-plugin-cloudflare/playground/sensitive-files/worker-b/.env.staging
+++ b/packages/vite-plugin-cloudflare/playground/sensitive-files/worker-b/.env.staging
@@ -1,0 +1,1 @@
+WORKER_B_ENV=staging

--- a/packages/vite-plugin-cloudflare/src/plugins/config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/config.ts
@@ -54,7 +54,7 @@ export const configPlugin = createPlugin("config", (ctx) => {
 							...defaultDeniedFiles,
 							...Array.from(
 								ctx.resolvedPluginConfig.configPaths,
-								normalizePath
+								(configPath) => normalizePath(configPath)
 							),
 						],
 					},

--- a/packages/vite-plugin-cloudflare/src/plugins/config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/config.ts
@@ -40,6 +40,7 @@ export const configPlugin = createPlugin("config", (ctx) => {
 				".env.*",
 				"*.{crt,pem}",
 				"**/.git/**",
+				"vite.config.*",
 				".dev.vars",
 				".dev.vars.*",
 				"**/.wrangler/**",

--- a/packages/vite-plugin-cloudflare/src/plugins/config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/config.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
 import * as path from "node:path";
+import { normalizePath } from "vite";
 import { hasAssetsConfigChanged } from "../asset-config";
 import { createBuildApp, removeAssetsField } from "../build";
 import {
@@ -39,13 +40,22 @@ export const configPlugin = createPlugin("config", (ctx) => {
 				".env.*",
 				"*.{crt,pem}",
 				"**/.git/**",
+				".dev.vars",
+				".dev.vars.*",
+				"**/.wrangler/**",
 			];
 
 			return {
 				appType: "custom",
 				server: {
 					fs: {
-						deny: [...defaultDeniedFiles, ".dev.vars", ".dev.vars.*"],
+						deny: [
+							...defaultDeniedFiles,
+							...Array.from(
+								ctx.resolvedPluginConfig.configPaths,
+								normalizePath
+							),
+						],
 					},
 				},
 				environments: getEnvironmentsConfig(ctx, userConfig, env.mode),


### PR DESCRIPTION
Fixes [DEVX-2557](https://jira.cfdata.org/browse/DEVX-2557).

This extends Vite's file-serving deny list to cover Worker-related files derived from the resolved plugin config.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no feature change.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
