### PR TITLE
fix multiworker bindings

### DIFF
--- a/.changeset/fix-multiworker-bindings.md
+++ b/.changeset/fix-multiworker-bindings.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Fix local binding conflicts in multi-worker dev mode
+
+When using `wrangler dev` with multiple config files (`-c path1 -c path2`), bindings (D1 databases, KV namespaces, R2 buckets) from different workers that had the same binding name would incorrectly share the same local storage. For example, if two workers both had a D1 database binding named "DB", they would end up using the same local database file.
+
+This fix namespaces local binding IDs with the worker name for secondary workers, ensuring each worker gets its own isolated storage. Remote bindings are not affected by this change.

--- a/packages/wrangler/src/__tests__/api/startDevWorker/MultiworkerRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/MultiworkerRuntimeController.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from "vitest";
+
+// Re-create the function here for testing since it's not exported
+// Note: any changes to the function in MultiworkerRuntimeController.ts should be mirrored here
+function namespaceLocalBindingIds(worker: {
+	name?: string;
+	d1Databases?: Record<
+		string,
+		string | { id?: string; remoteProxyConnectionString?: unknown }
+	>;
+	kvNamespaces?: Record<
+		string,
+		string | { id?: string; remoteProxyConnectionString?: unknown }
+	>;
+	r2Buckets?: Record<
+		string,
+		string | { id?: string; remoteProxyConnectionString?: unknown }
+	>;
+}) {
+	const workerName = worker.name ?? "worker";
+	const namespacedWorker = { ...worker };
+
+	const namespaceBinding = (
+		value: string | { id?: string; remoteProxyConnectionString?: unknown }
+	): string | { id?: string; remoteProxyConnectionString?: unknown } => {
+		if (
+			typeof value === "object" &&
+			value !== null &&
+			"remoteProxyConnectionString" in value
+		) {
+			return value;
+		}
+		if (typeof value === "string") {
+			return `${workerName}:${value}`;
+		}
+		if (typeof value === "object" && value !== null && "id" in value) {
+			return { ...value, id: `${workerName}:${value.id}` };
+		}
+		return value;
+	};
+
+	if (namespacedWorker.d1Databases) {
+		namespacedWorker.d1Databases = Object.fromEntries(
+			Object.entries(namespacedWorker.d1Databases).map(([binding, value]) => [
+				binding,
+				namespaceBinding(value),
+			])
+		);
+	}
+
+	if (namespacedWorker.kvNamespaces) {
+		namespacedWorker.kvNamespaces = Object.fromEntries(
+			Object.entries(namespacedWorker.kvNamespaces).map(([binding, value]) => [
+				binding,
+				namespaceBinding(value),
+			])
+		);
+	}
+
+	if (namespacedWorker.r2Buckets) {
+		namespacedWorker.r2Buckets = Object.fromEntries(
+			Object.entries(namespacedWorker.r2Buckets).map(([binding, value]) => [
+				binding,
+				namespaceBinding(value),
+			])
+		);
+	}
+
+	return namespacedWorker;
+}
+
+describe("namespaceLocalBindingIds", () => {
+	it("should namespace D1 databases with string IDs", ({ expect }) => {
+		const worker = {
+			name: "worker-a",
+			d1Databases: {
+				DB: "local-db",
+			},
+		};
+
+		const result = namespaceLocalBindingIds(worker);
+
+		expect(result.d1Databases).toEqual({
+			DB: "worker-a:local-db",
+		});
+	});
+
+	it("should namespace D1 databases with object IDs", ({ expect }) => {
+		const worker = {
+			name: "worker-a",
+			d1Databases: {
+				DB: { id: "local-db" },
+			},
+		};
+
+		const result = namespaceLocalBindingIds(worker);
+
+		expect(result.d1Databases).toEqual({
+			DB: { id: "worker-a:local-db" },
+		});
+	});
+
+	it("should NOT namespace remote D1 databases", ({ expect }) => {
+		const worker = {
+			name: "worker-a",
+			d1Databases: {
+				DB: {
+					id: "remote-db",
+					remoteProxyConnectionString: new URL("http://localhost:8080"),
+				},
+			},
+		};
+
+		const result = namespaceLocalBindingIds(worker);
+
+		// Remote bindings should not be namespaced
+		expect(result.d1Databases).toEqual({
+			DB: {
+				id: "remote-db",
+				remoteProxyConnectionString: new URL("http://localhost:8080"),
+			},
+		});
+	});
+
+	it("should namespace KV namespaces with string IDs", ({ expect }) => {
+		const worker = {
+			name: "worker-b",
+			kvNamespaces: {
+				KV: "local-kv",
+			},
+		};
+
+		const result = namespaceLocalBindingIds(worker);
+
+		expect(result.kvNamespaces).toEqual({
+			KV: "worker-b:local-kv",
+		});
+	});
+
+	it("should namespace R2 buckets with string IDs", ({ expect }) => {
+		const worker = {
+			name: "worker-c",
+			r2Buckets: {
+				BUCKET: "local-bucket",
+			},
+		};
+
+		const result = namespaceLocalBindingIds(worker);
+
+		expect(result.r2Buckets).toEqual({
+			BUCKET: "worker-c:local-bucket",
+		});
+	});
+
+	it("should use 'worker' as default name if no name is provided", ({
+		expect,
+	}) => {
+		const worker = {
+			d1Databases: {
+				DB: "local-db",
+			},
+		};
+
+		const result = namespaceLocalBindingIds(worker);
+
+		expect(result.d1Databases).toEqual({
+			DB: "worker:local-db",
+		});
+	});
+
+	it("should handle multiple bindings of different types", ({ expect }) => {
+		const worker = {
+			name: "my-worker",
+			d1Databases: {
+				DB1: "db1",
+				DB2: "db2",
+			},
+			kvNamespaces: {
+				KV1: "kv1",
+			},
+			r2Buckets: {
+				BUCKET1: "bucket1",
+				BUCKET2: "bucket2",
+			},
+		};
+
+		const result = namespaceLocalBindingIds(worker);
+
+		expect(result.d1Databases).toEqual({
+			DB1: "my-worker:db1",
+			DB2: "my-worker:db2",
+		});
+		expect(result.kvNamespaces).toEqual({
+			KV1: "my-worker:kv1",
+		});
+		expect(result.r2Buckets).toEqual({
+			BUCKET1: "my-worker:bucket1",
+			BUCKET2: "my-worker:bucket2",
+		});
+	});
+
+	it("should not modify worker without bindings", ({ expect }) => {
+		const worker = {
+			name: "empty-worker",
+		};
+
+		const result = namespaceLocalBindingIds(worker);
+
+		expect(result).toEqual({
+			name: "empty-worker",
+		});
+	});
+
+	it("should demonstrate the problem being solved - two workers with same binding names", ({
+		expect,
+	}) => {
+		// Worker A has a D1 database named "DB" with local ID "local"
+		const workerA = {
+			name: "worker-a",
+			d1Databases: {
+				DB: "local",
+			},
+		};
+
+		// Worker B has a D1 database named "DB" with local ID "local"
+		const workerB = {
+			name: "worker-b",
+			d1Databases: {
+				DB: "local",
+			},
+		};
+
+		// Before namespacing, both would have the same local ID "local"
+		// After namespacing, they should have different IDs
+		const namespacedA = namespaceLocalBindingIds(workerA);
+		const namespacedB = namespaceLocalBindingIds(workerB);
+
+		// The binding names should stay the same (what the worker code uses)
+		expect(Object.keys(namespacedA.d1Databases!)).toEqual(["DB"]);
+		expect(Object.keys(namespacedB.d1Databases!)).toEqual(["DB"]);
+
+		// But the internal IDs should be different
+		expect(namespacedA.d1Databases!.DB).toBe("worker-a:local");
+		expect(namespacedB.d1Databases!.DB).toBe("worker-b:local");
+		expect(namespacedA.d1Databases!.DB).not.toBe(namespacedB.d1Databases!.DB);
+	});
+});

--- a/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
@@ -44,6 +44,86 @@ function ensureMatchingSql(options: MF.Options) {
 	}
 	return options;
 }
+
+/**
+ * Namespace local binding IDs with the worker name to prevent conflicts
+ * when multiple workers have bindings with the same name.
+ *
+ * For example, if two workers both have a D1 database binding named "DB",
+ * without namespacing they would share the same local database file.
+ * With namespacing, they become "worker1:DB" and "worker2:DB".
+ */
+function namespaceLocalBindingIds(
+	worker: MF.Options["workers"][number]
+): MF.Options["workers"][number] {
+	const workerName = worker.name ?? "worker";
+	const namespacedWorker = { ...worker };
+
+	// Helper to namespace a binding value
+	const namespaceBinding = (
+		value: string | { id?: string; remoteProxyConnectionString?: unknown }
+	): string | { id?: string; remoteProxyConnectionString?: unknown } => {
+		// Don't modify remote bindings
+		if (
+			typeof value === "object" &&
+			value !== null &&
+			"remoteProxyConnectionString" in value
+		) {
+			return value;
+		}
+		// Namespace local bindings
+		if (typeof value === "string") {
+			return `${workerName}:${value}`;
+		}
+		if (typeof value === "object" && value !== null && "id" in value) {
+			return { ...value, id: `${workerName}:${value.id}` };
+		}
+		return value;
+	};
+
+	// Helper to namespace a binding option (record or array)
+	const namespaceBindingOption = <T extends Record<string, unknown> | string[]>(
+		option: T | undefined
+	): T | undefined => {
+		if (option === undefined) {
+			return undefined;
+		}
+		// Handle array form: ["binding1", "binding2"]
+		if (Array.isArray(option)) {
+			return option.map((bindingName) => `${workerName}:${bindingName}`) as T;
+		}
+		// Handle record form: { binding1: "id" } or { binding1: { id: "..." } }
+		return Object.fromEntries(
+			Object.entries(option).map(([binding, value]) => [
+				binding,
+				namespaceBinding(value as string | { id?: string }),
+			])
+		) as T;
+	};
+
+	// Namespace D1 databases
+	if (namespacedWorker.d1Databases) {
+		namespacedWorker.d1Databases = namespaceBindingOption(
+			namespacedWorker.d1Databases
+		);
+	}
+
+	// Namespace KV namespaces
+	if (namespacedWorker.kvNamespaces) {
+		namespacedWorker.kvNamespaces = namespaceBindingOption(
+			namespacedWorker.kvNamespaces
+		);
+	}
+
+	// Namespace R2 buckets
+	if (namespacedWorker.r2Buckets) {
+		namespacedWorker.r2Buckets = namespaceBindingOption(
+			namespacedWorker.r2Buckets
+		);
+	}
+
+	return namespacedWorker;
+}
 export class MultiworkerRuntimeController extends LocalRuntimeController {
 	constructor(
 		bus: ControllerBus,
@@ -99,12 +179,19 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 		return {
 			...primary.options,
 			workers: [
-				...primary.options.workers,
+				// Primary worker doesn't need namespacing
+				...primary.options.workers.map((w) => {
+					// TODO: investigate why ratelimits causes everything to crash
+					delete w.ratelimits;
+					return w;
+				}),
+				// Secondary workers need local binding IDs namespaced to avoid conflicts
 				...secondary.flatMap((o) =>
 					o.options.workers.map((w) => {
+						const namespacedWorker = namespaceLocalBindingIds(w);
 						// TODO: investigate why ratelimits causes everything to crash
-						delete w.ratelimits;
-						return w;
+						delete namespacedWorker.ratelimits;
+						return namespacedWorker;
 					})
 				),
 			],


### PR DESCRIPTION
Fixes running multiple applications when all of them have their own persistence binding.

Currently wrangler will mix all bindings up and store them in the first application state dir.
