### PR TITLE
[create-cloudflare] Unquarantine experimental svelte:workers e2e test

### DIFF
--- a/packages/create-cloudflare/e2e/helpers/framework-helpers.ts
+++ b/packages/create-cloudflare/e2e/helpers/framework-helpers.ts
@@ -260,6 +260,12 @@ export async function verifyPreviewScript(
 		"Expected a preview script is we are verifying the preview in " +
 			projectPath
 	);
+	if (verifyPreview.generateTypes) {
+		await runCommand([packageManager.name, "exec", "wrangler", "types"], {
+			cwd: projectPath,
+		});
+	}
+
 	if (verifyPreview.build) {
 		await runCommand([packageManager.name, "run", "build"], {
 			cwd: projectPath,

--- a/packages/create-cloudflare/e2e/helpers/run-c3.ts
+++ b/packages/create-cloudflare/e2e/helpers/run-c3.ts
@@ -42,6 +42,7 @@ export type RunnerConfig = {
 		route: string;
 		expectedText: string;
 		build?: boolean;
+		generateTypes?: boolean;
 	};
 	/**
 	 * Specifies whether to run the test script for the project and verify the exit code.

--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -677,7 +677,6 @@ function getExperimentalFrameworkTestConfig(
 		},
 		{
 			name: "svelte:workers",
-			quarantine: true,
 			argv: ["--platform", "workers"],
 			flags: [
 				"--no-install",
@@ -698,6 +697,7 @@ function getExperimentalFrameworkTestConfig(
 				previewArgs: ["--inspector-port=0"],
 				route: "/test",
 				expectedText: "C3_TEST",
+				generateTypes: true,
 			},
 			nodeCompat: false,
 			verifyTypes: false,


### PR DESCRIPTION
Fixes the quarantined experimental `svelte:workers` e2e test.

The test was quarantined because the preview step fails — after C3 scaffolds the project via `wrangler setup` (autoconfig), the e2e test modifies the wrangler config to add test vars (`TEST: "C3_TEST"`). When the preview script then builds the SvelteKit app, TypeScript fails because `worker-configuration.d.ts` is stale/missing the updated bindings.

This PR adds a `generateTypes` option to the `verifyPreview` test config. When set, `verifyPreviewScript` runs `<pm> exec wrangler types` before spawning the preview server, ensuring the types file reflects the current wrangler config.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: e2e test-only change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
