### PR TITLE
[create-cloudflare] Upgrade OpenAPI template to chanfana 3 and Zod v4

### DIFF
--- a/.changeset/upgrade-openapi-template-chanfana-3.md
+++ b/.changeset/upgrade-openapi-template-chanfana-3.md
@@ -1,0 +1,15 @@
+---
+"create-cloudflare": minor
+---
+
+Upgrade OpenAPI template to chanfana 3 and Zod v4
+
+The OpenAPI worker template has been upgraded to use chanfana v3.3 (from v2.6) and Zod v4 (from v3). All removed chanfana parameter helpers (`Str`, `Bool`, `Num`, `DateTime`) have been replaced with native Zod v4 equivalents. Other dependency updates include hono v4.12, wrangler v4, and @cloudflare/workers-types.
+
+Additional template improvements:
+
+- Fix response schemas to match actual handler return values
+- Use `NotFoundException` for 404 responses instead of raw `Response.json()`
+- Use HTTP 201 status for the create endpoint
+- Enable full `strict` mode in tsconfig (previously silently overridden)
+- Remove unused `@types/service-worker-mock` dependency

--- a/packages/create-cloudflare/templates/openapi/ts/package.json
+++ b/packages/create-cloudflare/templates/openapi/ts/package.json
@@ -9,14 +9,13 @@
 		"cf-typegen": "wrangler types"
 	},
 	"dependencies": {
-		"chanfana": "^2.6.3",
-		"hono": "^4.6.20",
-		"zod": "^3.24.1"
+		"chanfana": "^3.3.0",
+		"hono": "^4.12.12",
+		"zod": "^4.3.6"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20250129.0",
-		"@types/node": "22.13.0",
-		"@types/service-worker-mock": "^2.0.4",
-		"wrangler": "^3.107.2"
+		"@cloudflare/workers-types": "^4.20260413.1",
+		"@types/node": "^25.6.0",
+		"wrangler": "^4.81.1"
 	}
 }

--- a/packages/create-cloudflare/templates/openapi/ts/src/endpoints/taskCreate.ts
+++ b/packages/create-cloudflare/templates/openapi/ts/src/endpoints/taskCreate.ts
@@ -1,4 +1,4 @@
-import { Bool, OpenAPIRoute } from "chanfana";
+import { OpenAPIRoute } from "chanfana";
 import { z } from "zod";
 import { type AppContext, Task } from "../types";
 
@@ -16,17 +16,13 @@ export class TaskCreate extends OpenAPIRoute {
 			},
 		},
 		responses: {
-			"200": {
+			"201": {
 				description: "Returns the created task",
 				content: {
 					"application/json": {
 						schema: z.object({
-							series: z.object({
-								success: Bool(),
-								result: z.object({
-									task: Task,
-								}),
-							}),
+							success: z.boolean(),
+							task: Task,
 						}),
 					},
 				},
@@ -44,15 +40,18 @@ export class TaskCreate extends OpenAPIRoute {
 		// Implement your own object insertion here
 
 		// return the new task
-		return {
-			success: true,
-			task: {
-				name: taskToCreate.name,
-				slug: taskToCreate.slug,
-				description: taskToCreate.description,
-				completed: taskToCreate.completed,
-				due_date: taskToCreate.due_date,
+		return c.json(
+			{
+				success: true,
+				task: {
+					name: taskToCreate.name,
+					slug: taskToCreate.slug,
+					description: taskToCreate.description,
+					completed: taskToCreate.completed,
+					due_date: taskToCreate.due_date,
+				},
 			},
-		};
+			201,
+		);
 	}
 }

--- a/packages/create-cloudflare/templates/openapi/ts/src/endpoints/taskDelete.ts
+++ b/packages/create-cloudflare/templates/openapi/ts/src/endpoints/taskDelete.ts
@@ -1,4 +1,4 @@
-import { Bool, OpenAPIRoute, Str } from "chanfana";
+import { OpenAPIRoute } from "chanfana";
 import { z } from "zod";
 import { type AppContext, Task } from "../types";
 
@@ -8,7 +8,7 @@ export class TaskDelete extends OpenAPIRoute {
 		summary: "Delete a Task",
 		request: {
 			params: z.object({
-				taskSlug: Str({ description: "Task slug" }),
+				taskSlug: z.string().describe("Task slug"),
 			}),
 		},
 		responses: {
@@ -17,11 +17,9 @@ export class TaskDelete extends OpenAPIRoute {
 				content: {
 					"application/json": {
 						schema: z.object({
-							series: z.object({
-								success: Bool(),
-								result: z.object({
-									task: Task,
-								}),
+							success: z.boolean(),
+							result: z.object({
+								task: Task,
 							}),
 						}),
 					},

--- a/packages/create-cloudflare/templates/openapi/ts/src/endpoints/taskFetch.ts
+++ b/packages/create-cloudflare/templates/openapi/ts/src/endpoints/taskFetch.ts
@@ -1,4 +1,4 @@
-import { Bool, OpenAPIRoute, Str } from "chanfana";
+import { NotFoundException, OpenAPIRoute } from "chanfana";
 import { z } from "zod";
 import { type AppContext, Task } from "../types";
 
@@ -8,7 +8,7 @@ export class TaskFetch extends OpenAPIRoute {
 		summary: "Get a single Task by slug",
 		request: {
 			params: z.object({
-				taskSlug: Str({ description: "Task slug" }),
+				taskSlug: z.string().describe("Task slug"),
 			}),
 		},
 		responses: {
@@ -17,25 +17,8 @@ export class TaskFetch extends OpenAPIRoute {
 				content: {
 					"application/json": {
 						schema: z.object({
-							series: z.object({
-								success: Bool(),
-								result: z.object({
-									task: Task,
-								}),
-							}),
-						}),
-					},
-				},
-			},
-			"404": {
-				description: "Task not found",
-				content: {
-					"application/json": {
-						schema: z.object({
-							series: z.object({
-								success: Bool(),
-								error: Str(),
-							}),
+							success: z.boolean(),
+							task: Task,
 						}),
 					},
 				},
@@ -54,17 +37,8 @@ export class TaskFetch extends OpenAPIRoute {
 
 		const exists = true;
 
-		// @ts-ignore: check if the object exists
-		if (exists === false) {
-			return Response.json(
-				{
-					success: false,
-					error: "Object not found",
-				},
-				{
-					status: 404,
-				},
-			);
+		if (!exists) {
+			throw new NotFoundException();
 		}
 
 		return {

--- a/packages/create-cloudflare/templates/openapi/ts/src/endpoints/taskList.ts
+++ b/packages/create-cloudflare/templates/openapi/ts/src/endpoints/taskList.ts
@@ -1,4 +1,4 @@
-import { Bool, Num, OpenAPIRoute } from "chanfana";
+import { OpenAPIRoute } from "chanfana";
 import { z } from "zod";
 import { type AppContext, Task } from "../types";
 
@@ -8,14 +8,11 @@ export class TaskList extends OpenAPIRoute {
 		summary: "List Tasks",
 		request: {
 			query: z.object({
-				page: Num({
-					description: "Page number",
-					default: 0,
-				}),
-				isCompleted: Bool({
-					description: "Filter by completed flag",
-					required: false,
-				}),
+				page: z.number().default(0).describe("Page number"),
+				isCompleted: z
+					.boolean()
+					.optional()
+					.describe("Filter by completed flag"),
 			}),
 		},
 		responses: {
@@ -24,12 +21,8 @@ export class TaskList extends OpenAPIRoute {
 				content: {
 					"application/json": {
 						schema: z.object({
-							series: z.object({
-								success: Bool(),
-								result: z.object({
-									tasks: Task.array(),
-								}),
-							}),
+							success: z.boolean(),
+							tasks: Task.array(),
 						}),
 					},
 				},
@@ -52,7 +45,7 @@ export class TaskList extends OpenAPIRoute {
 				{
 					name: "Clean my room",
 					slug: "clean-room",
-					description: null,
+					description: undefined,
 					completed: false,
 					due_date: "2025-01-05",
 				},

--- a/packages/create-cloudflare/templates/openapi/ts/src/types.ts
+++ b/packages/create-cloudflare/templates/openapi/ts/src/types.ts
@@ -1,13 +1,12 @@
-import { DateTime, Str } from "chanfana";
 import type { Context } from "hono";
 import { z } from "zod";
 
 export type AppContext = Context<{ Bindings: Env }>;
 
 export const Task = z.object({
-	name: Str({ example: "lorem" }),
-	slug: Str(),
-	description: Str({ required: false }),
+	name: z.string().openapi({ example: "lorem" }),
+	slug: z.string(),
+	description: z.string().optional(),
 	completed: z.boolean().default(false),
-	due_date: DateTime(),
+	due_date: z.iso.date(),
 });

--- a/packages/create-cloudflare/templates/openapi/ts/tsconfig.json
+++ b/packages/create-cloudflare/templates/openapi/ts/tsconfig.json
@@ -9,9 +9,6 @@
 		"resolveJsonModule": true,
 		"moduleDetection": "force",
 		/* Strictness */
-		"noImplicitAny": false,
-		"noImplicitThis": true,
-		"strictNullChecks": false,
 		"strict": true,
 		"noUncheckedIndexedAccess": true,
 		/* If NOT transpiling with TypeScript: */
@@ -20,8 +17,7 @@
 		"noEmit": true,
 		"lib": ["es2024"],
 		"types": [
-			"@types/node",
-			"@types/service-worker-mock",
+			"@types/node"
 		]
 	},
 	"exclude": ["node_modules", "dist", "tests"],


### PR DESCRIPTION
Upgrade the OpenAPI worker template from chanfana v2 (Zod v3) to chanfana v3.3 (Zod v4).

**Changes:**
- Bump `chanfana` from ^2.6.3 to ^3.3.0 and `zod` from ^3.24.1 to ^4.0.0
- Replace all removed chanfana parameter helpers (`Str`, `Bool`, `Num`, `DateTime`) with native Zod v4 equivalents (`z.string()`, `z.boolean()`, `z.number()`, `z.iso.date()`)
- Use chanfana's `NotFoundException` in `taskFetch.ts` instead of manual `Response.json()` for 404 responses
- Fix `due_date` field to use `z.iso.date()` (matching the actual date-only example data) instead of `DateTime()` which mapped to datetime format

Migration reference: https://chanfana.pages.dev/migration-to-chanfana-3

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: This is a template-only change — template type-checks cleanly with the updated dependencies. No runtime tests exist for templates.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: No user-facing doc changes needed; chanfana's own migration guide covers the API changes.