### PR TITLE
[wrangler] Add e2e test to validate default OAuth scopes

### DIFF
--- a/packages/wrangler/e2e/auth-scopes.test.ts
+++ b/packages/wrangler/e2e/auth-scopes.test.ts
@@ -1,3 +1,4 @@
+import { fetch } from "undici";
 import { describe, it } from "vitest";
 import {
 	getAuthUrlFromEnv,

--- a/packages/wrangler/e2e/auth-scopes.test.ts
+++ b/packages/wrangler/e2e/auth-scopes.test.ts
@@ -1,0 +1,29 @@
+import { describe, it } from "vitest";
+import {
+	getAuthUrlFromEnv,
+	getClientIdFromEnv,
+} from "../src/user/auth-variables";
+import { generateAuthUrl } from "../src/user/generate-auth-url";
+import { DefaultScopeKeys } from "../src/user/user";
+
+describe("auth scopes", () => {
+	it("default OAuth scopes are accepted by the Cloudflare backend", async ({
+		expect,
+	}) => {
+		const url = generateAuthUrl({
+			authUrl: getAuthUrlFromEnv(),
+			clientId: getClientIdFromEnv(),
+			scopes: DefaultScopeKeys,
+			stateQueryParam: "test-state",
+			codeChallenge: "test-code-challenge",
+		});
+
+		const response = await fetch(url, { redirect: "manual" });
+
+		expect(response.status).toBe(302);
+
+		const location = response.headers.get("location");
+		expect(location).toEqual(expect.any(String));
+		expect(location).not.toContain("error=invalid_scope");
+	});
+});


### PR DESCRIPTION
Add an e2e test that validates all default OAuth scopes in `DefaultScopes` are accepted by the Cloudflare backend.

The test constructs the OAuth authorization URL with all current default scopes and makes a request to `https://dash.cloudflare.com/oauth2/auth`. If any scope is invalid or unsupported, the backend responds with `error=invalid_scope` in the redirect location header, which the test asserts against.

This ensures we catch scope mismatches early — for example, if a scope is added to wrangler but not yet registered on the backend, or if a backend scope is renamed/removed.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this is a test-only change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
