### PR TITLE
[wrangler] Add schedule property to Workflow bindings for cron-based triggering

### DIFF
--- a/.changeset/workflows-schedule.md
+++ b/.changeset/workflows-schedule.md
@@ -1,0 +1,38 @@
+---
+"wrangler": minor
+---
+
+Add `schedule` property to Workflow bindings for cron-based triggering
+
+Workflow bindings in `wrangler.json` now accept an optional `schedule` field that configures one or more cron expressions to automatically trigger new workflow instances on a schedule.
+
+```jsonc
+// wrangler.json
+{
+	"workflows": [
+		{
+			"binding": "MY_WORKFLOW",
+			"name": "my-workflow",
+			"class_name": "MyWorkflow",
+			"schedule": "0 9 * * 1",
+		},
+	],
+}
+```
+
+Multiple schedules can be provided as an array:
+
+```jsonc
+{
+	"workflows": [
+		{
+			"binding": "MY_WORKFLOW",
+			"name": "my-workflow",
+			"class_name": "MyWorkflow",
+			"schedule": ["0 9 * * 1", "0 17 * * 5"],
+		},
+	],
+}
+```
+
+The schedule is sent to the Workflows control plane on `wrangler deploy`. Configuring `schedule` on a workflow binding that references an external `script_name` is an error — the schedule must be configured on the worker that defines the workflow.

--- a/.changeset/workflows-schedule.md
+++ b/.changeset/workflows-schedule.md
@@ -4,6 +4,8 @@
 
 Add `schedule` property to Workflow bindings for cron-based triggering
 
+> **Note:** This is a configuration-only change. Scheduled triggering of Workflow instances is not yet available — adding `schedule` to a Workflow binding will not result in scheduled invocations at this time. This change lays the groundwork for an upcoming feature.
+
 Workflow bindings in `wrangler.json` now accept an optional `schedule` field that configures one or more cron expressions to automatically trigger new workflow instances on a schedule.
 
 ```jsonc

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -692,6 +692,8 @@ export type WorkflowBinding = {
 		/** Maximum number of steps a Workflow instance can execute */
 		steps?: number;
 	};
+	/** Optional cron schedule(s) for automatically triggering workflow instances */
+	schedule?: string | string[];
 };
 
 /**

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -728,6 +728,8 @@ export type WorkflowBinding = {
 		/** Maximum number of steps a Workflow instance can execute */
 		steps?: number;
 	};
+	/** Optional cron schedule(s) for automatically triggering workflow instances */
+	schedule?: string | string[];
 };
 
 /**

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -2659,12 +2659,31 @@ const validateWorkflowBinding: ValidatorFn = (diagnostics, field, value) => {
 
 	if (hasProperty(value, "schedule") && value.schedule !== undefined) {
 		if (typeof value.schedule === "string") {
-			// valid single cron expression - no further validation needed
-		} else if (
-			Array.isArray(value.schedule) &&
-			value.schedule.every((s: unknown) => typeof s === "string")
-		) {
-			// valid array of cron expressions - no further validation needed
+			if (value.schedule.length === 0) {
+				diagnostics.errors.push(
+					`"${field}" bindings "schedule" field must not be an empty string.`
+				);
+				isValid = false;
+			}
+		} else if (Array.isArray(value.schedule)) {
+			if (value.schedule.length === 0) {
+				diagnostics.errors.push(
+					`"${field}" bindings "schedule" field must not be an empty array.`
+				);
+				isValid = false;
+			} else if (!value.schedule.every((s: unknown) => typeof s === "string")) {
+				diagnostics.errors.push(
+					`"${field}" bindings should, optionally, have a string or array of strings "schedule" field but got ${JSON.stringify(
+						value
+					)}.`
+				);
+				isValid = false;
+			} else if (value.schedule.some((s: unknown) => s === "")) {
+				diagnostics.errors.push(
+					`"${field}" bindings "schedule" field must not contain empty strings.`
+				);
+				isValid = false;
+			}
 		} else {
 			diagnostics.errors.push(
 				`"${field}" bindings should, optionally, have a string or array of strings "schedule" field but got ${JSON.stringify(

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -2657,6 +2657,24 @@ const validateWorkflowBinding: ValidatorFn = (diagnostics, field, value) => {
 		isValid = false;
 	}
 
+	if (hasProperty(value, "schedule") && value.schedule !== undefined) {
+		if (typeof value.schedule === "string") {
+			// valid single cron expression - no further validation needed
+		} else if (
+			Array.isArray(value.schedule) &&
+			value.schedule.every((s: unknown) => typeof s === "string")
+		) {
+			// valid array of cron expressions - no further validation needed
+		} else {
+			diagnostics.errors.push(
+				`"${field}" bindings should, optionally, have a string or array of strings "schedule" field but got ${JSON.stringify(
+					value
+				)}.`
+			);
+			isValid = false;
+		}
+	}
+
 	if (hasProperty(value, "limits") && value.limits !== undefined) {
 		if (
 			typeof value.limits !== "object" ||
@@ -2705,6 +2723,7 @@ const validateWorkflowBinding: ValidatorFn = (diagnostics, field, value) => {
 		"script_name",
 		"remote",
 		"limits",
+		"schedule",
 	]);
 
 	return isValid;

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -2699,6 +2699,24 @@ const validateWorkflowBinding: ValidatorFn = (diagnostics, field, value) => {
 		isValid = false;
 	}
 
+	if (hasProperty(value, "schedule") && value.schedule !== undefined) {
+		if (typeof value.schedule === "string") {
+			// valid single cron expression - no further validation needed
+		} else if (
+			Array.isArray(value.schedule) &&
+			value.schedule.every((s: unknown) => typeof s === "string")
+		) {
+			// valid array of cron expressions - no further validation needed
+		} else {
+			diagnostics.errors.push(
+				`"${field}" bindings should, optionally, have a string or array of strings "schedule" field but got ${JSON.stringify(
+					value
+				)}.`
+			);
+			isValid = false;
+		}
+	}
+
 	if (hasProperty(value, "limits") && value.limits !== undefined) {
 		if (
 			typeof value.limits !== "object" ||
@@ -2747,6 +2765,7 @@ const validateWorkflowBinding: ValidatorFn = (diagnostics, field, value) => {
 		"script_name",
 		"remote",
 		"limits",
+		"schedule",
 	]);
 
 	return isValid;

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -2701,12 +2701,31 @@ const validateWorkflowBinding: ValidatorFn = (diagnostics, field, value) => {
 
 	if (hasProperty(value, "schedule") && value.schedule !== undefined) {
 		if (typeof value.schedule === "string") {
-			// valid single cron expression - no further validation needed
-		} else if (
-			Array.isArray(value.schedule) &&
-			value.schedule.every((s: unknown) => typeof s === "string")
-		) {
-			// valid array of cron expressions - no further validation needed
+			if (value.schedule.length === 0) {
+				diagnostics.errors.push(
+					`"${field}" bindings "schedule" field must not be an empty string.`
+				);
+				isValid = false;
+			}
+		} else if (Array.isArray(value.schedule)) {
+			if (value.schedule.length === 0) {
+				diagnostics.errors.push(
+					`"${field}" bindings "schedule" field must not be an empty array.`
+				);
+				isValid = false;
+			} else if (!value.schedule.every((s: unknown) => typeof s === "string")) {
+				diagnostics.errors.push(
+					`"${field}" bindings should, optionally, have a string or array of strings "schedule" field but got ${JSON.stringify(
+						value
+					)}.`
+				);
+				isValid = false;
+			} else if (value.schedule.some((s: unknown) => s === "")) {
+				diagnostics.errors.push(
+					`"${field}" bindings "schedule" field must not contain empty strings.`
+				);
+				isValid = false;
+			}
 		} else {
 			diagnostics.errors.push(
 				`"${field}" bindings should, optionally, have a string or array of strings "schedule" field but got ${JSON.stringify(

--- a/packages/workers-utils/src/worker.ts
+++ b/packages/workers-utils/src/worker.ts
@@ -192,6 +192,7 @@ export interface CfWorkflow {
 	limits?: {
 		steps?: number;
 	};
+	schedule?: string | string[];
 }
 
 export interface CfQueue {

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -4956,6 +4956,52 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBe(false);
 			});
 
+			it("should accept valid workflow bindings with schedule as a string", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						workflows: [
+							{
+								binding: "MY_WORKFLOW",
+								name: "my-workflow",
+								class_name: "MyWorkflow",
+								schedule: "*/5 * * * *",
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(diagnostics.hasWarnings()).toBe(false);
+			});
+
+			it("should accept valid workflow bindings with schedule as an array of strings", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						workflows: [
+							{
+								binding: "MY_WORKFLOW",
+								name: "my-workflow",
+								class_name: "MyWorkflow",
+								schedule: ["*/5 * * * *", "0 9 * * 1"],
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(diagnostics.hasWarnings()).toBe(false);
+			});
+
 			it("should error if workflow bindings are not valid", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
@@ -5033,6 +5079,56 @@ describe("normalizeAndValidateConfig()", () => {
 					"Processing wrangler configuration:
 					  - "workflows[0]" bindings should, optionally, have a string "script_name" field but got {"binding":"MY_WORKFLOW","name":"my-workflow","class_name":"MyWorkflow","script_name":123,"remote":"yes"}.
 					  - "workflows[0]" bindings should, optionally, have a boolean "remote" field but got {"binding":"MY_WORKFLOW","name":"my-workflow","class_name":"MyWorkflow","script_name":123,"remote":"yes"}."
+				`);
+			});
+
+			it("should error if schedule has wrong type", ({ expect }) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						workflows: [
+							{
+								binding: "MY_WORKFLOW",
+								name: "my-workflow",
+								class_name: "MyWorkflow",
+								schedule: 123,
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "workflows[0]" bindings should, optionally, have a string or array of strings "schedule" field but got {"binding":"MY_WORKFLOW","name":"my-workflow","class_name":"MyWorkflow","schedule":123}."
+				`);
+			});
+
+			it("should error if schedule is an array containing non-strings", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						workflows: [
+							{
+								binding: "MY_WORKFLOW",
+								name: "my-workflow",
+								class_name: "MyWorkflow",
+								schedule: ["*/5 * * * *", 123],
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "workflows[0]" bindings should, optionally, have a string or array of strings "schedule" field but got {"binding":"MY_WORKFLOW","name":"my-workflow","class_name":"MyWorkflow","schedule":["*/5 * * * *",123]}."
 				`);
 			});
 

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -5106,6 +5106,54 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
+			it("should error if schedule is an empty string", ({ expect }) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						workflows: [
+							{
+								binding: "MY_WORKFLOW",
+								name: "my-workflow",
+								class_name: "MyWorkflow",
+								schedule: "",
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "workflows[0]" bindings "schedule" field must not be an empty string."
+				`);
+			});
+
+			it("should error if schedule is an empty array", ({ expect }) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						workflows: [
+							{
+								binding: "MY_WORKFLOW",
+								name: "my-workflow",
+								class_name: "MyWorkflow",
+								schedule: [],
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "workflows[0]" bindings "schedule" field must not be an empty array."
+				`);
+			});
+
 			it("should error if schedule is an array containing non-strings", ({
 				expect,
 			}) => {
@@ -5129,6 +5177,32 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
 					  - "workflows[0]" bindings should, optionally, have a string or array of strings "schedule" field but got {"binding":"MY_WORKFLOW","name":"my-workflow","class_name":"MyWorkflow","schedule":["*/5 * * * *",123]}."
+				`);
+			});
+
+			it("should error if schedule is an array containing empty strings", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						workflows: [
+							{
+								binding: "MY_WORKFLOW",
+								name: "my-workflow",
+								class_name: "MyWorkflow",
+								schedule: ["*/5 * * * *", ""],
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "workflows[0]" bindings "schedule" field must not contain empty strings."
 				`);
 			});
 

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -5204,6 +5204,52 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBe(false);
 			});
 
+			it("should accept valid workflow bindings with schedule as a string", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						workflows: [
+							{
+								binding: "MY_WORKFLOW",
+								name: "my-workflow",
+								class_name: "MyWorkflow",
+								schedule: "*/5 * * * *",
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(diagnostics.hasWarnings()).toBe(false);
+			});
+
+			it("should accept valid workflow bindings with schedule as an array of strings", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						workflows: [
+							{
+								binding: "MY_WORKFLOW",
+								name: "my-workflow",
+								class_name: "MyWorkflow",
+								schedule: ["*/5 * * * *", "0 9 * * 1"],
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(diagnostics.hasWarnings()).toBe(false);
+			});
+
 			it("should error if workflow bindings are not valid", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
@@ -5281,6 +5327,56 @@ describe("normalizeAndValidateConfig()", () => {
 					"Processing wrangler configuration:
 					  - "workflows[0]" bindings should, optionally, have a string "script_name" field but got {"binding":"MY_WORKFLOW","name":"my-workflow","class_name":"MyWorkflow","script_name":123,"remote":"yes"}.
 					  - "workflows[0]" bindings should, optionally, have a boolean "remote" field but got {"binding":"MY_WORKFLOW","name":"my-workflow","class_name":"MyWorkflow","script_name":123,"remote":"yes"}."
+				`);
+			});
+
+			it("should error if schedule has wrong type", ({ expect }) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						workflows: [
+							{
+								binding: "MY_WORKFLOW",
+								name: "my-workflow",
+								class_name: "MyWorkflow",
+								schedule: 123,
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "workflows[0]" bindings should, optionally, have a string or array of strings "schedule" field but got {"binding":"MY_WORKFLOW","name":"my-workflow","class_name":"MyWorkflow","schedule":123}."
+				`);
+			});
+
+			it("should error if schedule is an array containing non-strings", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						workflows: [
+							{
+								binding: "MY_WORKFLOW",
+								name: "my-workflow",
+								class_name: "MyWorkflow",
+								schedule: ["*/5 * * * *", 123],
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "workflows[0]" bindings should, optionally, have a string or array of strings "schedule" field but got {"binding":"MY_WORKFLOW","name":"my-workflow","class_name":"MyWorkflow","schedule":["*/5 * * * *",123]}."
 				`);
 			});
 

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -5354,6 +5354,54 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
+			it("should error if schedule is an empty string", ({ expect }) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						workflows: [
+							{
+								binding: "MY_WORKFLOW",
+								name: "my-workflow",
+								class_name: "MyWorkflow",
+								schedule: "",
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "workflows[0]" bindings "schedule" field must not be an empty string."
+				`);
+			});
+
+			it("should error if schedule is an empty array", ({ expect }) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						workflows: [
+							{
+								binding: "MY_WORKFLOW",
+								name: "my-workflow",
+								class_name: "MyWorkflow",
+								schedule: [],
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "workflows[0]" bindings "schedule" field must not be an empty array."
+				`);
+			});
+
 			it("should error if schedule is an array containing non-strings", ({
 				expect,
 			}) => {
@@ -5377,6 +5425,32 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
 					  - "workflows[0]" bindings should, optionally, have a string or array of strings "schedule" field but got {"binding":"MY_WORKFLOW","name":"my-workflow","class_name":"MyWorkflow","schedule":["*/5 * * * *",123]}."
+				`);
+			});
+
+			it("should error if schedule is an array containing empty strings", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						workflows: [
+							{
+								binding: "MY_WORKFLOW",
+								name: "my-workflow",
+								class_name: "MyWorkflow",
+								schedule: ["*/5 * * * *", ""],
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "workflows[0]" bindings "schedule" field must not contain empty strings."
 				`);
 			});
 

--- a/packages/wrangler/src/__tests__/deploy/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/workflows.test.ts
@@ -230,6 +230,177 @@ describe("deploy", () => {
 			expect(std.out).toContain("workflow: my-workflow");
 		});
 
+		it("should deploy a workflow with schedule", async ({ expect }) => {
+			writeWranglerConfig({
+				main: "index.js",
+				workflows: [
+					{
+						binding: "WORKFLOW",
+						name: "my-workflow",
+						class_name: "MyWorkflow",
+						schedule: "0 * * * *",
+					},
+				],
+			});
+			await fs.promises.writeFile(
+				"index.js",
+				`
+                import { WorkflowEntrypoint } from 'cloudflare:workers';
+                export default {};
+                export class MyWorkflow extends WorkflowEntrypoint {};
+            `
+			);
+
+			const handler = http.put(
+				"*/accounts/:accountId/workflows/:workflowName",
+				async ({ params, request }) => {
+					expect(params.workflowName).toBe("my-workflow");
+					const body = (await request.json()) as Record<string, unknown>;
+					expect(body).toEqual({
+						script_name: "test-name",
+						class_name: "MyWorkflow",
+						schedule: "0 * * * *",
+					});
+					return HttpResponse.json(
+						createFetchResult({ id: "mock-new-workflow-id" })
+					);
+				}
+			);
+			msw.use(handler);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedBindings: [
+					{
+						type: "workflow",
+						name: "WORKFLOW",
+						workflow_name: "my-workflow",
+						class_name: "MyWorkflow",
+					},
+				],
+			});
+
+			await runWrangler("deploy");
+
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+			expect(std.out).toContain("workflow: my-workflow");
+		});
+
+		it("should deploy a workflow with schedule as an array of cron expressions", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				main: "index.js",
+				workflows: [
+					{
+						binding: "WORKFLOW",
+						name: "my-workflow",
+						class_name: "MyWorkflow",
+						schedule: ["0 * * * *", "0 9 * * 1"],
+					},
+				],
+			});
+			await fs.promises.writeFile(
+				"index.js",
+				`
+                import { WorkflowEntrypoint } from 'cloudflare:workers';
+                export default {};
+                export class MyWorkflow extends WorkflowEntrypoint {};
+            `
+			);
+
+			const handler = http.put(
+				"*/accounts/:accountId/workflows/:workflowName",
+				async ({ params, request }) => {
+					expect(params.workflowName).toBe("my-workflow");
+					const body = (await request.json()) as Record<string, unknown>;
+					expect(body).toEqual({
+						script_name: "test-name",
+						class_name: "MyWorkflow",
+						schedule: ["0 * * * *", "0 9 * * 1"],
+					});
+					return HttpResponse.json(
+						createFetchResult({ id: "mock-new-workflow-id" })
+					);
+				}
+			);
+			msw.use(handler);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedBindings: [
+					{
+						type: "workflow",
+						name: "WORKFLOW",
+						workflow_name: "my-workflow",
+						class_name: "MyWorkflow",
+					},
+				],
+			});
+
+			await runWrangler("deploy");
+
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+			expect(std.out).toContain("workflow: my-workflow");
+		});
+
+		it("should deploy a workflow with both limits and schedule", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				main: "index.js",
+				workflows: [
+					{
+						binding: "WORKFLOW",
+						name: "my-workflow",
+						class_name: "MyWorkflow",
+						limits: { steps: 5000 },
+						schedule: "*/15 * * * *",
+					},
+				],
+			});
+			await fs.promises.writeFile(
+				"index.js",
+				`
+                import { WorkflowEntrypoint } from 'cloudflare:workers';
+                export default {};
+                export class MyWorkflow extends WorkflowEntrypoint {};
+            `
+			);
+
+			const handler = http.put(
+				"*/accounts/:accountId/workflows/:workflowName",
+				async ({ params, request }) => {
+					expect(params.workflowName).toBe("my-workflow");
+					const body = (await request.json()) as Record<string, unknown>;
+					expect(body).toEqual({
+						script_name: "test-name",
+						class_name: "MyWorkflow",
+						limits: { steps: 5000 },
+						schedule: "*/15 * * * *",
+					});
+					return HttpResponse.json(
+						createFetchResult({ id: "mock-new-workflow-id" })
+					);
+				}
+			);
+			msw.use(handler);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedBindings: [
+					{
+						type: "workflow",
+						name: "WORKFLOW",
+						workflow_name: "my-workflow",
+						class_name: "MyWorkflow",
+					},
+				],
+			});
+
+			await runWrangler("deploy");
+
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+			expect(std.out).toContain("workflow: my-workflow");
+		});
+
 		it("should not call Workflow's API if the workflow binds to another script", async ({
 			expect,
 		}) => {
@@ -335,6 +506,48 @@ describe("deploy", () => {
 
 			await expect(runWrangler("deploy")).rejects.toThrow(
 				'Workflow "my-workflow" has "limits" configured but references external script "another-script"'
+			);
+		});
+
+		it("should error when deploying a workflow with schedule that references an external script", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				main: "index.js",
+				name: "this-script",
+				workflows: [
+					{
+						binding: "WORKFLOW",
+						name: "my-workflow",
+						class_name: "MyWorkflow",
+						script_name: "another-script",
+						schedule: "0 * * * *",
+					},
+				],
+			});
+
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedScriptName: "this-script",
+				expectedBindings: [
+					{
+						type: "workflow",
+						name: "WORKFLOW",
+						workflow_name: "my-workflow",
+						class_name: "MyWorkflow",
+						script_name: "another-script",
+					},
+				],
+			});
+			await fs.promises.writeFile(
+				"index.js",
+				`
+                export default {};
+            `
+			);
+
+			await expect(runWrangler("deploy")).rejects.toThrow(
+				'Workflow "my-workflow" has "schedule" configured but references external script "another-script"'
 			);
 		});
 

--- a/packages/wrangler/src/__tests__/deploy/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/workflows.test.ts
@@ -289,6 +289,177 @@ describe("deploy", () => {
 			expect(std.out).toContain("workflow: my-workflow");
 		});
 
+		it("should deploy a workflow with schedule", async ({ expect }) => {
+			writeWranglerConfig({
+				main: "index.js",
+				workflows: [
+					{
+						binding: "WORKFLOW",
+						name: "my-workflow",
+						class_name: "MyWorkflow",
+						schedule: "0 * * * *",
+					},
+				],
+			});
+			await fs.promises.writeFile(
+				"index.js",
+				`
+                import { WorkflowEntrypoint } from 'cloudflare:workers';
+                export default {};
+                export class MyWorkflow extends WorkflowEntrypoint {};
+            `
+			);
+
+			const handler = http.put(
+				"*/accounts/:accountId/workflows/:workflowName",
+				async ({ params, request }) => {
+					expect(params.workflowName).toBe("my-workflow");
+					const body = (await request.json()) as Record<string, unknown>;
+					expect(body).toEqual({
+						script_name: "test-name",
+						class_name: "MyWorkflow",
+						schedule: "0 * * * *",
+					});
+					return HttpResponse.json(
+						createFetchResult({ id: "mock-new-workflow-id" })
+					);
+				}
+			);
+			msw.use(handler);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedBindings: [
+					{
+						type: "workflow",
+						name: "WORKFLOW",
+						workflow_name: "my-workflow",
+						class_name: "MyWorkflow",
+					},
+				],
+			});
+
+			await runWrangler("deploy");
+
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+			expect(std.out).toContain("workflow: my-workflow");
+		});
+
+		it("should deploy a workflow with schedule as an array of cron expressions", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				main: "index.js",
+				workflows: [
+					{
+						binding: "WORKFLOW",
+						name: "my-workflow",
+						class_name: "MyWorkflow",
+						schedule: ["0 * * * *", "0 9 * * 1"],
+					},
+				],
+			});
+			await fs.promises.writeFile(
+				"index.js",
+				`
+                import { WorkflowEntrypoint } from 'cloudflare:workers';
+                export default {};
+                export class MyWorkflow extends WorkflowEntrypoint {};
+            `
+			);
+
+			const handler = http.put(
+				"*/accounts/:accountId/workflows/:workflowName",
+				async ({ params, request }) => {
+					expect(params.workflowName).toBe("my-workflow");
+					const body = (await request.json()) as Record<string, unknown>;
+					expect(body).toEqual({
+						script_name: "test-name",
+						class_name: "MyWorkflow",
+						schedule: ["0 * * * *", "0 9 * * 1"],
+					});
+					return HttpResponse.json(
+						createFetchResult({ id: "mock-new-workflow-id" })
+					);
+				}
+			);
+			msw.use(handler);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedBindings: [
+					{
+						type: "workflow",
+						name: "WORKFLOW",
+						workflow_name: "my-workflow",
+						class_name: "MyWorkflow",
+					},
+				],
+			});
+
+			await runWrangler("deploy");
+
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+			expect(std.out).toContain("workflow: my-workflow");
+		});
+
+		it("should deploy a workflow with both limits and schedule", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				main: "index.js",
+				workflows: [
+					{
+						binding: "WORKFLOW",
+						name: "my-workflow",
+						class_name: "MyWorkflow",
+						limits: { steps: 5000 },
+						schedule: "*/15 * * * *",
+					},
+				],
+			});
+			await fs.promises.writeFile(
+				"index.js",
+				`
+                import { WorkflowEntrypoint } from 'cloudflare:workers';
+                export default {};
+                export class MyWorkflow extends WorkflowEntrypoint {};
+            `
+			);
+
+			const handler = http.put(
+				"*/accounts/:accountId/workflows/:workflowName",
+				async ({ params, request }) => {
+					expect(params.workflowName).toBe("my-workflow");
+					const body = (await request.json()) as Record<string, unknown>;
+					expect(body).toEqual({
+						script_name: "test-name",
+						class_name: "MyWorkflow",
+						limits: { steps: 5000 },
+						schedule: "*/15 * * * *",
+					});
+					return HttpResponse.json(
+						createFetchResult({ id: "mock-new-workflow-id" })
+					);
+				}
+			);
+			msw.use(handler);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedBindings: [
+					{
+						type: "workflow",
+						name: "WORKFLOW",
+						workflow_name: "my-workflow",
+						class_name: "MyWorkflow",
+					},
+				],
+			});
+
+			await runWrangler("deploy");
+
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+			expect(std.out).toContain("workflow: my-workflow");
+		});
+
 		it("should not call Workflow's API if the workflow binds to another script", async ({
 			expect,
 		}) => {
@@ -394,6 +565,48 @@ describe("deploy", () => {
 
 			await expect(runWrangler("deploy")).rejects.toThrow(
 				'Workflow "my-workflow" has "limits" configured but references external script "another-script"'
+			);
+		});
+
+		it("should error when deploying a workflow with schedule that references an external script", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				main: "index.js",
+				name: "this-script",
+				workflows: [
+					{
+						binding: "WORKFLOW",
+						name: "my-workflow",
+						class_name: "MyWorkflow",
+						script_name: "another-script",
+						schedule: "0 * * * *",
+					},
+				],
+			});
+
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedScriptName: "this-script",
+				expectedBindings: [
+					{
+						type: "workflow",
+						name: "WORKFLOW",
+						workflow_name: "my-workflow",
+						class_name: "MyWorkflow",
+						script_name: "another-script",
+					},
+				],
+			});
+			await fs.promises.writeFile(
+				"index.js",
+				`
+                export default {};
+            `
+			);
+
+			await expect(runWrangler("deploy")).rejects.toThrow(
+				'Workflow "my-workflow" has "schedule" configured but references external script "another-script"'
 			);
 		});
 

--- a/packages/wrangler/src/__tests__/deploy/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/workflows.test.ts
@@ -748,6 +748,144 @@ describe("deploy", () => {
 
 				expect(std.out).toContain("Uploaded my-app-staging");
 			});
+
+			it("should error when script_name matches top-level name but not env-suffixed name and schedule is set", async ({
+				expect,
+			}) => {
+				writeWranglerConfig({
+					main: "index.js",
+					name: "my-app",
+					env: {
+						staging: {
+							workflows: [
+								{
+									binding: "WORKFLOW",
+									name: "my-workflow",
+									class_name: "MyWorkflow",
+									script_name: "my-app",
+									schedule: "0 * * * *",
+								},
+							],
+						},
+					},
+				});
+				await fs.promises.writeFile("index.js", `export default {};`);
+
+				mockSubDomainRequest();
+				mockUploadWorkerRequest({
+					expectedScriptName: "my-app-staging",
+				});
+
+				await expect(runWrangler("deploy --env staging")).rejects.toThrow(
+					'Workflow "my-workflow" has "schedule" configured but references external script "my-app"'
+				);
+			});
+
+			it("should allow schedule when script_name matches the env-suffixed name", async ({
+				expect,
+			}) => {
+				writeWranglerConfig({
+					main: "index.js",
+					name: "my-app",
+					env: {
+						staging: {
+							workflows: [
+								{
+									binding: "WORKFLOW",
+									name: "my-workflow",
+									class_name: "MyWorkflow",
+									script_name: "my-app-staging",
+									schedule: "0 * * * *",
+								},
+							],
+						},
+					},
+				});
+				await fs.promises.writeFile(
+					"index.js",
+					`
+					import { WorkflowEntrypoint } from 'cloudflare:workers';
+					export default {};
+					export class MyWorkflow extends WorkflowEntrypoint {};
+				`
+				);
+
+				const handler = http.put(
+					"*/accounts/:accountId/workflows/:workflowName",
+					async ({ params, request }) => {
+						expect(params.workflowName).toBe("my-workflow");
+						const body = (await request.json()) as Record<string, unknown>;
+						expect(body).toEqual({
+							script_name: "my-app-staging",
+							class_name: "MyWorkflow",
+							schedule: "0 * * * *",
+						});
+						return HttpResponse.json(
+							createFetchResult({ id: "mock-new-workflow-id" })
+						);
+					}
+				);
+				msw.use(handler);
+				mockSubDomainRequest();
+				mockUploadWorkerRequest({
+					expectedScriptName: "my-app-staging",
+				});
+
+				await runWrangler("deploy --env staging");
+
+				expect(std.warn).toMatchInlineSnapshot(`""`);
+				expect(std.out).toContain("workflow: my-workflow");
+			});
+
+			it("should deploy external script_name under env without schedule", async ({
+				expect,
+			}) => {
+				writeWranglerConfig({
+					main: "index.js",
+					name: "my-app",
+					env: {
+						staging: {
+							workflows: [
+								{
+									binding: "WORKFLOW",
+									name: "my-workflow",
+									class_name: "MyWorkflow",
+									script_name: "another-script",
+								},
+							],
+						},
+					},
+				});
+				await fs.promises.writeFile("index.js", `export default {};`);
+
+				const handler = http.put(
+					"*/accounts/:accountId/workflows/:workflowName",
+					() => {
+						expect(
+							false,
+							"Workflows API should not be called for external bindings."
+						);
+					}
+				);
+				msw.use(handler);
+				mockSubDomainRequest();
+				mockUploadWorkerRequest({
+					expectedScriptName: "my-app-staging",
+					expectedBindings: [
+						{
+							type: "workflow",
+							name: "WORKFLOW",
+							workflow_name: "my-workflow",
+							class_name: "MyWorkflow",
+							script_name: "another-script",
+						},
+					],
+				});
+
+				await runWrangler("deploy --env staging");
+
+				expect(std.out).toContain("Uploaded my-app-staging");
+			});
 		});
 
 		describe("workflow conflict detection", () => {

--- a/packages/wrangler/src/dev/miniflare/index.ts
+++ b/packages/wrangler/src/dev/miniflare/index.ts
@@ -770,13 +770,20 @@ export function buildMiniflareBindingOptions(
 			workflows.map((workflow) => {
 				if (
 					workflow.script_name !== undefined &&
-					workflow.script_name !== config.name &&
-					workflow.limits
+					workflow.script_name !== config.name
 				) {
-					throw new UserError(
-						`Workflow "${workflow.name}" has "limits" configured but references external script "${workflow.script_name}". ` +
-							`Configure limits on the worker that defines the workflow.`
-					);
+					if (workflow.limits) {
+						throw new UserError(
+							`Workflow "${workflow.name}" has "limits" configured but references external script "${workflow.script_name}". ` +
+								`Configure limits on the worker that defines the workflow.`
+						);
+					}
+					if (workflow.schedule) {
+						throw new UserError(
+							`Workflow "${workflow.name}" has "schedule" configured but references external script "${workflow.script_name}". ` +
+								`Configure schedule on the worker that defines the workflow.`
+						);
+					}
 				}
 				return workflowEntry(workflow, remoteProxyConnectionString);
 			})

--- a/packages/wrangler/src/dev/miniflare/index.ts
+++ b/packages/wrangler/src/dev/miniflare/index.ts
@@ -789,14 +789,22 @@ export function buildMiniflareBindingOptions(
 			workflows.map((workflow) => {
 				if (
 					workflow.script_name !== undefined &&
-					workflow.script_name !== config.name &&
-					workflow.limits
+					workflow.script_name !== config.name
 				) {
-					throw new UserError(
-						`Workflow "${workflow.name}" has "limits" configured but references external script "${workflow.script_name}". ` +
+					if (workflow.limits) {
+						throw new UserError(
+							`Workflow "${workflow.name}" has "limits" configured but references external script "${workflow.script_name}". ` +
 							`Configure limits on the worker that defines the workflow.`,
-						{ telemetryMessage: "workflow limits on external script" }
-					);
+							{ telemetryMessage: "workflow limits on external script" }
+						);
+					}
+					if (workflow.schedule) {
+						throw new UserError(
+							`Workflow "${workflow.name}" has "schedule" configured but references external script "${workflow.script_name}". ` +
+							`Configure schedule on the worker that defines the workflow.`,
+							{ telemetryMessage: "workflow schedule on external script" }
+						);
+					}
 				}
 				return workflowEntry(
 					workflow,

--- a/packages/wrangler/src/dev/miniflare/index.ts
+++ b/packages/wrangler/src/dev/miniflare/index.ts
@@ -794,14 +794,14 @@ export function buildMiniflareBindingOptions(
 					if (workflow.limits) {
 						throw new UserError(
 							`Workflow "${workflow.name}" has "limits" configured but references external script "${workflow.script_name}". ` +
-							`Configure limits on the worker that defines the workflow.`,
+								`Configure limits on the worker that defines the workflow.`,
 							{ telemetryMessage: "workflow limits on external script" }
 						);
 					}
 					if (workflow.schedule) {
 						throw new UserError(
 							`Workflow "${workflow.name}" has "schedule" configured but references external script "${workflow.script_name}". ` +
-							`Configure schedule on the worker that defines the workflow.`,
+								`Configure schedule on the worker that defines the workflow.`,
 							{ telemetryMessage: "workflow schedule on external script" }
 						);
 					}

--- a/packages/wrangler/src/triggers/deploy.ts
+++ b/packages/wrangler/src/triggers/deploy.ts
@@ -265,6 +265,12 @@ export default async function triggersDeploy(
 							`Configure limits on the worker that defines the workflow.`
 					);
 				}
+				if (workflow.schedule) {
+					throw new UserError(
+						`Workflow "${workflow.name}" has "schedule" configured but references external script "${workflow.script_name}". ` +
+							`Configure schedule on the worker that defines the workflow.`
+					);
+				}
 				continue;
 			}
 
@@ -278,6 +284,7 @@ export default async function triggersDeploy(
 							script_name: scriptName,
 							class_name: workflow.class_name,
 							...(workflow.limits && { limits: workflow.limits }),
+							...(workflow.schedule && { schedule: workflow.schedule }),
 						}),
 						headers: {
 							"Content-Type": "application/json",

--- a/packages/wrangler/src/triggers/deploy.ts
+++ b/packages/wrangler/src/triggers/deploy.ts
@@ -283,7 +283,11 @@ export default async function triggersDeploy(
 				if (workflow.schedule) {
 					throw new UserError(
 						`Workflow "${workflow.name}" has "schedule" configured but references external script "${workflow.script_name}". ` +
-							`Configure schedule on the worker that defines the workflow.`
+							`Configure schedule on the worker that defines the workflow.`,
+						{
+							telemetryMessage:
+								"triggers deploy workflow schedule external script",
+						}
 					);
 				}
 				continue;

--- a/packages/wrangler/src/triggers/deploy.ts
+++ b/packages/wrangler/src/triggers/deploy.ts
@@ -280,6 +280,12 @@ export default async function triggersDeploy(
 						}
 					);
 				}
+				if (workflow.schedule) {
+					throw new UserError(
+						`Workflow "${workflow.name}" has "schedule" configured but references external script "${workflow.script_name}". ` +
+							`Configure schedule on the worker that defines the workflow.`
+					);
+				}
 				continue;
 			}
 
@@ -293,6 +299,7 @@ export default async function triggersDeploy(
 							script_name: scriptName,
 							class_name: workflow.class_name,
 							...(workflow.limits && { limits: workflow.limits }),
+							...(workflow.schedule && { schedule: workflow.schedule }),
 						}),
 						headers: {
 							"Content-Type": "application/json",


### PR DESCRIPTION
Fixes WOR-1221.

Add an optional `schedule` field to Workflow bindings that accepts a cron expression string or array of cron expressions. On `wrangler deploy`, the schedule is sent to the Workflows control plane API, enabling automatic triggering of workflow instances on a cron schedule.

**NOTE**: This is a configuration-only change. Scheduled triggering of Workflow instances is not yet available - adding `schedule` to a Workflow binding will not result in scheduled invocations at this time. This change lays the groundwork for an upcoming feature.

#### Changes

- Added `schedule?: string | string[]` to `WorkflowBinding` type and `CfWorkflow` interface
- Added validation in `validateWorkflowBinding` — accepts a non-empty string or non-empty array of non-empty strings; errors on wrong type, empty string, empty array, or mixed array
- Added `schedule` to the API payload in `triggers/deploy.ts`, with an error if `schedule` is configured on a workflow that references an external `script_name` (consistent with how `limits` is handled)

#### Usage

```jsonc
// wrangler.json
{
  "workflows": [
    {
      "binding": "MY_WORKFLOW",
      "name": "my-workflow",
      "class_name": "MyWorkflow",
      "schedule": "0 9 * * 1"
    }
  ]
}
```

Multiple schedules:

```jsonc
{
  "workflows": [
    {
      "binding": "MY_WORKFLOW",
      "name": "my-workflow",
      "class_name": "MyWorkflow",
      "schedule": ["0 9 * * 1", "0 17 * * 5"]
    }
  ]
}
```

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/29836
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*