### PR TITLE
Make all properties in `previews` optional

### DIFF
--- a/.changeset/stupid-papayas-kneel.md
+++ b/.changeset/stupid-papayas-kneel.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/workers-utils": patch
+---
+
+Make all properties in `previews` optional
+
+All properties in `previews` were previously incorrectly typed as required.

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -1608,4 +1608,6 @@ export type ContainerEngine =
 export interface PreviewsConfig
 	extends
 		Partial<EnvironmentNonInheritable>,
-		Partial<Pick<EnvironmentInheritable, "logpush" | "observability" | "limits">> {}
+		Partial<
+			Pick<EnvironmentInheritable, "logpush" | "observability" | "limits">
+		> {}

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -1607,5 +1607,5 @@ export type ContainerEngine =
  */
 export interface PreviewsConfig
 	extends
-		EnvironmentNonInheritable,
-		Pick<EnvironmentInheritable, "logpush" | "observability" | "limits"> {}
+		Partial<EnvironmentNonInheritable>,
+		Partial<Pick<EnvironmentInheritable, "logpush" | "observability" | "limits">> {}

--- a/packages/wrangler/src/__tests__/preview.test.ts
+++ b/packages/wrangler/src/__tests__/preview.test.ts
@@ -27,10 +27,10 @@ vi.mock("node:child_process", async () => {
 	};
 });
 
-function configWithPreviews(previews: Partial<PreviewsConfig>): Config {
+function configWithPreviews(previews: PreviewsConfig): Config {
 	return {
 		...defaultWranglerConfig,
-		previews: previews as PreviewsConfig,
+		previews,
 	};
 }
 


### PR DESCRIPTION
Make all properties in `previews` optional

All properties in `previews` were previously incorrectly typed as required.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: types change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: types fix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
