### PR TITLE
fix(wrangler): `wrangler preview` no longer warns about missing inheritable bindings

### DIFF
--- a/.changeset/four-banks-peel.md
+++ b/.changeset/four-banks-peel.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+`wrangler preview` no longer warns on inheritable binding types being missing from `previews` config.

--- a/packages/wrangler/src/__tests__/preview.test.ts
+++ b/packages/wrangler/src/__tests__/preview.test.ts
@@ -505,6 +505,92 @@ describe("wrangler preview", () => {
 			expect(std.warn).not.toContain("IMPORTANT_BINDING");
 		});
 
+		test("should not warn about inheritable top-level bindings missing from previews", async ({
+			expect,
+		}) => {
+			mkdirSync("public", { recursive: true });
+			writeFileSync("public/index.html", "<h1>Hello</h1>");
+			writeFileSync(
+				"wrangler.json",
+				JSON.stringify({
+					name: "test-worker",
+					main: "src/index.ts",
+					compatibility_date: "2025-01-01",
+					assets: {
+						binding: "ASSETS",
+						directory: "public",
+					},
+				})
+			);
+
+			msw.use(
+				http.get(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId`,
+					() =>
+						HttpResponse.json(
+							{
+								success: false,
+								result: null,
+								errors: [{ code: 10025, message: "Preview not found" }],
+							},
+							{ status: 404 }
+						)
+				),
+				http.post(
+					`*/accounts/:accountId/workers/workers/:workerId/previews`,
+					() =>
+						HttpResponse.json({
+							success: true,
+							result: {
+								id: "preview-id-assets",
+								name: "test-preview",
+								slug: "test-preview",
+								urls: ["https://test-preview.test-worker.cloudflare.app"],
+								worker_name: "test-worker",
+								created_on: new Date().toISOString(),
+							},
+						})
+				),
+				http.post(
+					`*/accounts/:accountId/workers/scripts/:workerId/assets-upload-session`,
+					() =>
+						HttpResponse.json({
+							success: true,
+							result: { buckets: [], jwt: "assets-jwt-from-session" },
+						})
+				),
+				http.post(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId/deployments`,
+					() =>
+						HttpResponse.json({
+							success: true,
+							result: {
+								id: "deployment-id-assets",
+								preview_id: "preview-id-assets",
+								preview_name: "test-preview",
+								urls: ["https://assets123.test-worker.cloudflare.app"],
+								compatibility_date: "2025-01-01",
+								env: {},
+								created_on: new Date().toISOString(),
+							},
+						})
+				),
+				http.get(`*/accounts/:accountId/workers/workers/:workerId`, () =>
+					HttpResponse.json({
+						success: true,
+						result: {
+							preview_defaults: {},
+						},
+					})
+				)
+			);
+
+			await runWrangler("preview --name test-preview");
+
+			expect(std.warn).not.toContain("Your configuration has diverged.");
+			expect(std.warn).not.toContain("ASSETS");
+		});
+
 		test("should output preview and deployment JSON with --json", async ({
 			expect,
 		}) => {

--- a/packages/wrangler/src/preview/preview.ts
+++ b/packages/wrangler/src/preview/preview.ts
@@ -721,6 +721,12 @@ function formatDeploymentResource(
 	return drawConnectedChildBox(lines, { footerLines, indent: "  " });
 }
 
+function isInheritableBinding(
+	binding: Exclude<StartDevWorkerInput["bindings"], undefined>[string]
+) {
+	return binding.type === "assets";
+}
+
 function logMissingPreviewsBindingsWarning(
 	topLevelBindings: StartDevWorkerInput["bindings"],
 	remotePreviewDefaultBindings: Record<string, Binding> | undefined,
@@ -732,7 +738,8 @@ function logMissingPreviewsBindingsWarning(
 	]);
 	const missingBindings = Object.fromEntries(
 		Object.entries(topLevelBindings ?? {}).filter(
-			([name]) => !availableBindingNames.has(name)
+			([name, binding]) =>
+				!availableBindingNames.has(name) && !isInheritableBinding(binding)
 		)
 	);
 


### PR DESCRIPTION
This PR removes inheritable bindings from the missing bindings warning in `wrangler preview`.

Currently, this warning incorrectly advises the user to add these bindings to their `previews` config, but this is not allowed.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
