### PR TITLE
fix(miniflare): skip named entrypoint for stream binding in remote mode

### DIFF
--- a/.changeset/fix-stream-remote-entrypoint.md
+++ b/.changeset/fix-stream-remote-entrypoint.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Fix `wrangler dev` crash when using a Stream binding with `remote: true`
+
+In remote mode, the Stream binding is backed by a generic proxy worker that only has a default export. The plugin was requesting a named entrypoint `"StreamBinding"` which doesn't exist on it, causing workerd to reject the binding at startup. The named entrypoint is now omitted in remote mode so workerd routes to the default export, which correctly proxies all RPC calls to the remote Stream service.

--- a/packages/miniflare/src/plugins/stream/index.ts
+++ b/packages/miniflare/src/plugins/stream/index.ts
@@ -56,7 +56,9 @@ export const STREAM_PLUGIN: Plugin<
 						options.stream.binding,
 						options.stream.remoteProxyConnectionString
 					),
-					entrypoint: "StreamBinding",
+					entrypoint: options.stream.remoteProxyConnectionString
+					? undefined
+					: "StreamBinding",
 				},
 			},
 		];

--- a/packages/miniflare/src/plugins/stream/index.ts
+++ b/packages/miniflare/src/plugins/stream/index.ts
@@ -57,8 +57,8 @@ export const STREAM_PLUGIN: Plugin<
 						options.stream.remoteProxyConnectionString
 					),
 					entrypoint: options.stream.remoteProxyConnectionString
-					? undefined
-					: "StreamBinding",
+						? undefined
+						: "StreamBinding",
 				},
 			},
 		];


### PR DESCRIPTION
## Summary

- Fix `wrangler dev` crash when using a Stream binding with `remote: true`

## Details

In remote mode, the stream binding is backed by a generic proxy worker that forwards RPC calls to Cloudflare's edge. That proxy worker only has a `default` export, but the plugin was telling workerd to look for a named export called `"StreamBinding"` — which doesn't exist on it, causing workerd to fail with:

```
Worker "core:user:..."'s binding "STREAM" refers to service "stream:STREAM:remote-..."
with a named entrypoint "StreamBinding", but "stream:STREAM:remote-..." has no such named entrypoint.
```

The fix skips the named entrypoint in remote mode so workerd uses the default export instead, which correctly proxies all method calls to the remote service. This is the same issue that was fixed for the Flagship binding in #13472.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: Same one-line pattern fix as #13472 for Flagship; no new logic introduced.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Bug fix only, no user-facing API change.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
