### PR TITLE
ci: disable cancel-in-progress for Version Packages PRs

### DIFF
--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 45
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os.name }}-${{ matrix.pm.name }}-${{ matrix.pm.version }}${{ matrix.experimental && '-experimental' || '' }}-${{ matrix.filter }}
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
     name: ${{ format('C3 E2E ({0}, {1}{2}) - {3}', matrix.pm.name, matrix.os.description, matrix.experimental && ', experimental' || '', matrix.filter) }}
     strategy:
       fail-fast: false
@@ -115,7 +115,7 @@ jobs:
     timeout-minutes: 45
     concurrency:
       group: ${{ github.workflow }}-frameworks${{ matrix.experimental && '-experimental' || '' }}-${{ github.ref }}-${{ matrix.os.name }}-${{ matrix.pm.name }}-${{ matrix.pm.version }}
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
     name: ${{ format('C3 E2E ({0}, {1}{2}) - frameworks', matrix.pm.name, matrix.os.description, matrix.experimental && ', experimental' || '') }}
     strategy:
       fail-fast: false

--- a/.github/workflows/changeset-review.yml
+++ b/.github/workflows/changeset-review.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   group: codeowners-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/e2e-local-explorer-ui.yml
+++ b/.github/workflows/e2e-local-explorer-ui.yml
@@ -16,7 +16,7 @@ jobs:
     name: Local Explorer UI E2E
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e-vite.yml
+++ b/.github/workflows/e2e-vite.yml
@@ -13,7 +13,7 @@ jobs:
     name: ${{ format('Vite Plugin E2E ({0})', matrix.description) }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e-wrangler.yml
+++ b/.github/workflows/e2e-wrangler.yml
@@ -13,7 +13,7 @@ jobs:
     name: ${{ format('Wrangler E2E ({0}, shard {1}/4)', matrix.description, matrix.shard) }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.shard }}
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-slim
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
     timeout-minutes: 30
     steps:
       - name: Checkout Repo

--- a/.github/workflows/test-and-check-other-node.yml
+++ b/.github/workflows/test-and-check-other-node.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.node_version }}-test-other-node-versions
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
     name: ${{ format('Tests ({0})', matrix.description) }}
     strategy:
       fail-fast: false

--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.head_ref != 'changeset-release/main'
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-add-pr
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
     timeout-minutes: 30
     name: Add PR to project
     runs-on: ubuntu-latest
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 30
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-checks
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
 
     name: "Checks"
     runs-on: ubuntu-latest
@@ -76,7 +76,7 @@ jobs:
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.suite }}-test
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
 
     name: ${{ format('Tests ({0}, {1})', matrix.description, matrix.suite) }}
     strategy:

--- a/.github/workflows/triage-issue.yml
+++ b/.github/workflows/triage-issue.yml
@@ -17,7 +17,7 @@ permissions:
 # Cancel in-progress runs for the same issue
 concurrency:
   group: triage-${{ github.event.issue.number || inputs.issue-number }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
 
 jobs:
   triage:

--- a/.github/workflows/validate-pr-description.yml
+++ b/.github/workflows/validate-pr-description.yml
@@ -24,7 +24,7 @@ jobs:
     if: github.event_name != 'merge_group' && github.head_ref != 'changeset-release/main'
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-add-pr
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
     timeout-minutes: 30
     name: Check
     runs-on: ubuntu-slim

--- a/.github/workflows/vite-plugin-playgrounds.yml
+++ b/.github/workflows/vite-plugin-playgrounds.yml
@@ -9,7 +9,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
 
 env:
   # We run `playwright install` manually instead


### PR DESCRIPTION
Prevent CI runs from being cancelled on the `changeset-release/main` branch so that when multiple PRs are merged in quick succession, each workflow run completes and we can identify which specific PR broke the build.

## Summary

- Changes all 15 `cancel-in-progress: true` blocks across 12 workflow files to use `${{ github.head_ref != 'changeset-release/main' }}`
- This evaluates to `false` (don't cancel) for the Version Packages PR, and `true` (cancel as before) for all other PRs/events
- The 2 workflows that already had `cancel-in-progress: false` (`bonk.yml`, `bonk-pr-review.yml`) are unchanged

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: CI-only change — behaviour will be validated by the next Version Packages PR cycle
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal CI configuration change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
