### PR TITLE
[wrangler] Make e2e mTLS certificate cleanup best-effort

### DIFF
--- a/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
+++ b/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
@@ -262,7 +262,7 @@ export class WranglerE2ETestHelper {
 		const certificateId = match?.groups?.certId;
 		assert(certificateId, `Cannot find ID in ${JSON.stringify(output)}`);
 		this.onTeardown(async () => {
-			await this.run(`wrangler cert delete --name ${name}`);
+			await this.bestEffortRun(`wrangler cert delete --name ${name}`);
 		});
 		return certificateId;
 	}

--- a/packages/wrangler/e2e/remote-binding/miniflare-remote-resources.test.ts
+++ b/packages/wrangler/e2e/remote-binding/miniflare-remote-resources.test.ts
@@ -859,7 +859,14 @@ function useTeardown(options: { timeout?: number } = {}) {
 	}
 	afterAll(async () => {
 		for (const fn of tearDownCallbacks.reverse()) {
-			await fn();
+			try {
+				await fn();
+			} catch (e) {
+				console.warn(
+					"Teardown callback failed:",
+					e instanceof Error ? e.message : e
+				);
+			}
 		}
 		tearDownCallbacks.length = 0;
 	}, options.timeout);

--- a/tools/e2e/common.ts
+++ b/tools/e2e/common.ts
@@ -330,7 +330,7 @@ export const listCertificates = async () => {
 };
 
 export const deleteCertificate = async (id: string) => {
-	await apiFetch(`/mtls_certificates/${id}`, "DELETE");
+	return await apiFetch(`/mtls_certificates/${id}`, "DELETE");
 };
 
 // Note: the container images functions below don't directly use the REST API since

--- a/tools/e2e/e2eCleanup.ts
+++ b/tools/e2e/e2eCleanup.ts
@@ -160,14 +160,14 @@ async function deleteMtlsCertificates() {
 	const mtlsCertificates = await listCertificates();
 	for (const certificate of mtlsCertificates) {
 		console.log("Deleting mTLS certificate: " + certificate.id);
-		await deleteCertificate(certificate.id);
+		if (await deleteCertificate(certificate.id)) {
+			console.log(`Successfully deleted mTLS certificate ${certificate.id}`);
+		} else {
+			console.log(`Failed to delete mTLS certificate ${certificate.id}`);
+		}
 	}
 	if (mtlsCertificates.length === 0) {
 		console.log(`No mTLS certificates to delete.`);
-	} else {
-		console.log(
-			`Successfully deleted ${mtlsCertificates.length} mTLS certificates`
-		);
 	}
 }
 


### PR DESCRIPTION
The `cert()` teardown in e2e tests used `this.run()` which throws on failure, unlike `worker()` which uses `bestEffortRun()`. When the Cloudflare API is slow to process worker deletion, the subsequent cert deletion can fail because the cert is still considered "in use", and the thrown error masks the real test result.

This has been causing e2e test failures like https://github.com/cloudflare/workers-sdk/actions/runs/24452086048/job/71443228851.

The cron cleanup job (running every 2 hours) acts as a safety net for any orphaned certs, so it is safe to make test teardown best-effort here.

**Changes:**
- Switch `cert()` teardown to `bestEffortRun()` (matches `worker()` pattern)
- Add try/catch to `useTeardown()` so one failed callback does not skip the remaining cleanup callbacks
- Improve cron cleanup script to log per-certificate success/failure instead of unconditionally claiming success

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this changes e2e test cleanup behavior only — no user-facing logic affected
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal test infrastructure change only
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
