### PR TITLE
[miniflare] Close all open handles on dispose to prevent process hangs

### DIFF
--- a/.changeset/close-runtime-dispatcher-pool.md
+++ b/.changeset/close-runtime-dispatcher-pool.md
@@ -2,6 +2,12 @@
 "miniflare": patch
 ---
 
-Close the undici connection pool on dispose to prevent test hangs
+fix: close all open handles on dispose to prevent process hangs
 
-The internal undici `Pool` used to dispatch fetch requests to the workerd runtime was not being closed during `Miniflare.dispose()`. This could leave lingering TCP sockets that kept the Node.js event loop alive, causing processes (particularly tests using `node --test`) to hang intermittently instead of exiting cleanly. The pool is now explicitly closed during disposal, and the previous pool is also closed when the runtime entry URL changes.
+Several resources were not being properly cleaned up during `Miniflare.dispose()`, which could leave the Node.js event loop alive and cause processes (particularly tests using `node --test`) to hang instead of exiting cleanly:
+
+- The internal undici `Pool` used to dispatch fetch requests to the workerd runtime was not closed. Lingering TCP sockets from this pool could keep the event loop alive indefinitely.
+- `WebSocketServer` instances for live reload and WebSocket proxying were never closed, leaving connected clients' sockets open.
+- The `InspectorProxy` was not closing its runtime WebSocket connection, relying on process death to break the connection.
+- `HyperdriveProxyController.dispose()` had a missing `return` in a `.map()` callback, causing `Promise.allSettled` to resolve immediately without waiting for `net.Server` instances to close.
+- `ProxyClientBridge` was not clearing its finalization batch `setTimeout` during disposal.

--- a/.changeset/close-runtime-dispatcher-pool.md
+++ b/.changeset/close-runtime-dispatcher-pool.md
@@ -11,3 +11,4 @@ Several resources were not being properly cleaned up during `Miniflare.dispose()
 - The `InspectorProxy` was not closing its runtime WebSocket connection, relying on process death to break the connection.
 - `HyperdriveProxyController.dispose()` had a missing `return` in a `.map()` callback, causing `Promise.allSettled` to resolve immediately without waiting for `net.Server` instances to close.
 - `ProxyClientBridge` was not clearing its finalization batch `setTimeout` during disposal.
+- `InspectorProxyController.dispose()` was not calling `server.closeAllConnections()` before `server.close()`, so active HTTP keep-alive or WebSocket connections could prevent the close callback from firing.

--- a/.changeset/close-runtime-dispatcher-pool.md
+++ b/.changeset/close-runtime-dispatcher-pool.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Close the undici connection pool on dispose to prevent test hangs
+
+The internal undici `Pool` used to dispatch fetch requests to the workerd runtime was not being closed during `Miniflare.dispose()`. This could leave lingering TCP sockets that kept the Node.js event loop alive, causing processes (particularly tests using `node --test`) to hang intermittently instead of exiting cleanly. The pool is now explicitly closed during disposal, and the previous pool is also closed when the runtime entry URL changes.

--- a/.changeset/fix-esbuild-cleanup-race.md
+++ b/.changeset/fix-esbuild-cleanup-race.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: ensure esbuild context is disposed during teardown
+
+The esbuild bundler cleanup function could race with the initial build. If `BundlerController.teardown()` ran before the initial `build()` completed, the `stopWatching` closure variable would still be `undefined`, so the esbuild context was never disposed. This left the esbuild child process running, keeping the Node.js event loop alive and causing processes to hang instead of exiting cleanly.
+
+The cleanup function now awaits the build promise before calling `stopWatching`, ensuring the esbuild context is always properly disposed.

--- a/fixtures/start-worker-node-test/package.json
+++ b/fixtures/start-worker-node-test/package.json
@@ -6,7 +6,7 @@
 	"author": "",
 	"type": "module",
 	"scripts": {
-		"test:ci": "node --test --test-timeout=8000"
+		"test:ci": "node --test --test-timeout=15000"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",

--- a/fixtures/start-worker-node-test/package.json
+++ b/fixtures/start-worker-node-test/package.json
@@ -6,7 +6,7 @@
 	"author": "",
 	"type": "module",
 	"scripts": {
-		"test:ci": "node --test --test-timeout=10000"
+		"test:ci": "node --test --test-timeout=8000"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",

--- a/fixtures/start-worker-node-test/package.json
+++ b/fixtures/start-worker-node-test/package.json
@@ -6,7 +6,7 @@
 	"author": "",
 	"type": "module",
 	"scripts": {
-		"test:ci": "node --test"
+		"test:ci": "node --test --test-timeout=10000"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",

--- a/fixtures/start-worker-node-test/src/config-errors.test.js
+++ b/fixtures/start-worker-node-test/src/config-errors.test.js
@@ -50,6 +50,7 @@ describe("startWorker - configuration errors", () => {
 		const worker = await unstable_startWorker({
 			config: "wrangler.json",
 			dev: {
+				persist: false,
 				server: {
 					port: await getPort(),
 				},
@@ -76,6 +77,7 @@ describe("startWorker - configuration errors", () => {
 		const worker = await unstable_startWorker({
 			config: "wrangler.json",
 			dev: {
+				persist: false,
 				server: {
 					port: await getPort(),
 				},

--- a/fixtures/start-worker-node-test/src/index.test.js
+++ b/fixtures/start-worker-node-test/src/index.test.js
@@ -9,7 +9,10 @@ describe("worker", () => {
 	let worker;
 
 	before(async () => {
-		worker = await unstable_startWorker({ config: "wrangler.json" });
+		worker = await unstable_startWorker({
+			config: "wrangler.json",
+			dev: { persist: false },
+		});
 	});
 
 	test("hello world", async () => {

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -87,7 +87,6 @@
 		"devalue": "^5.6.3",
 		"devtools-protocol": "^0.0.1182435",
 		"esbuild": "catalog:default",
-		"exit-hook": "2.2.1",
 		"expect-type": "^0.15.0",
 		"get-port": "^7.1.0",
 		"glob-to-regexp": "0.4.1",

--- a/packages/miniflare/src/exit-hook.ts
+++ b/packages/miniflare/src/exit-hook.ts
@@ -1,0 +1,96 @@
+/**
+ * Lightweight replacement for the `exit-hook` npm package.
+ *
+ * The third-party `exit-hook` registers a permanent `process.on("message")`
+ * listener (for PM2 cluster-shutdown support) that is never removed.  In
+ * Node.js, having a `"message"` listener refs the IPC channel handle, which
+ * keeps the event loop alive.  When Miniflare runs inside a `node --test`
+ * child process (which communicates with its parent over IPC), this prevents
+ * the process from exiting after all tests complete.
+ *
+ * This module tracks the number of active registrations and removes **all**
+ * process listeners once the last registration is unregistered, allowing the
+ * process to exit cleanly.
+ */
+
+const callbacks = new Set<() => void>();
+let registered = false;
+let called = false;
+
+function runCallbacks(): void {
+	if (called) {
+		return;
+	}
+	called = true;
+	for (const callback of callbacks) {
+		callback();
+	}
+}
+
+function onExit(): void {
+	runCallbacks();
+}
+
+function onSignalInt(): void {
+	runCallbacks();
+	// eslint-disable-next-line unicorn/no-process-exit -- intentional: replicate default SIGINT behavior
+	process.exit(128 + 2);
+}
+
+function onSignalTerm(): void {
+	runCallbacks();
+	// eslint-disable-next-line unicorn/no-process-exit -- intentional: replicate default SIGTERM behavior
+	process.exit(128 + 15);
+}
+
+function onMessage(message: unknown): void {
+	if (message === "shutdown") {
+		runCallbacks();
+		// eslint-disable-next-line unicorn/no-process-exit -- intentional: PM2 graceful shutdown
+		process.exit(0);
+	}
+}
+
+function addListeners(): void {
+	registered = true;
+	called = false;
+	process.on("exit", onExit);
+	process.on("SIGINT", onSignalInt);
+	process.on("SIGTERM", onSignalTerm);
+	// Only listen for IPC "shutdown" messages (PM2 support) when the process
+	// actually has an IPC channel.  Even without this guard the listener is
+	// harmless when there is no channel, but being explicit avoids any
+	// accidental ref of a future channel.
+	if (process.send !== undefined) {
+		process.on("message", onMessage);
+	}
+}
+
+function removeListeners(): void {
+	registered = false;
+	process.removeListener("exit", onExit);
+	process.removeListener("SIGINT", onSignalInt);
+	process.removeListener("SIGTERM", onSignalTerm);
+	process.removeListener("message", onMessage);
+}
+
+/**
+ * Register a callback to run when the process exits.  Returns a function
+ * that unregisters the callback.  When the last callback is unregistered,
+ * all underlying process listeners are removed so they cannot keep the
+ * event loop alive.
+ */
+export function exitHook(callback: () => void): () => void {
+	callbacks.add(callback);
+
+	if (!registered) {
+		addListeners();
+	}
+
+	return () => {
+		callbacks.delete(callback);
+		if (callbacks.size === 0 && registered) {
+			removeListeners();
+		}
+	};
+}

--- a/packages/miniflare/src/exit-hook.ts
+++ b/packages/miniflare/src/exit-hook.ts
@@ -1,16 +1,16 @@
 /**
  * Lightweight replacement for the `exit-hook` npm package.
  *
- * The third-party `exit-hook` registers a permanent `process.on("message")`
- * listener (for PM2 cluster-shutdown support) that is never removed.  In
- * Node.js, having a `"message"` listener refs the IPC channel handle, which
- * keeps the event loop alive.  When Miniflare runs inside a `node --test`
- * child process (which communicates with its parent over IPC), this prevents
- * the process from exiting after all tests complete.
+ * The third-party `exit-hook` registers process listeners (`exit`, `SIGINT`,
+ * `SIGTERM`, and `message`) that are never removed — even after every
+ * callback has been unregistered.  Those dangling listeners are harmless in
+ * long-running processes, but in short-lived child processes (e.g. those
+ * spawned by `node --test`) they can prevent clean exit by holding refs on
+ * handles such as the IPC channel.
  *
  * This module tracks the number of active registrations and removes **all**
- * process listeners once the last registration is unregistered, allowing the
- * process to exit cleanly.
+ * process listeners once the last registration is unregistered, so they
+ * cannot keep the event loop alive after dispose.
  */
 
 const callbacks = new Set<() => void>();

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -3051,6 +3051,12 @@ export class Miniflare {
 			} catch {}
 
 			await this.#stopLoopbackServer();
+			// Close WebSocket servers so any connected clients are disconnected
+			// and their sockets don't keep the event loop alive. These use
+			// `noServer: true` so they don't own an HTTP server, but connected
+			// WebSocket clients still hold open sockets.
+			this.#liveReloadServer.close();
+			this.#webSocketServer.close();
 			// Best-effort cleanup: on Windows, workerd may not release file handles
 			// immediately after disposal, causing EBUSY errors. The temp directory
 			// lives in os.tmpdir() so the OS will clean it up eventually.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -2423,6 +2423,7 @@ export class Miniflare {
 		// Set up a direct dispatcher to the dev-registry-proxy socket so we can
 		// push registry updates without routing through the entry worker.
 		const devRegistryPort = maybeSocketPorts.get(SOCKET_DEV_REGISTRY);
+		void this.#devRegistryDispatcher?.close().catch(() => {});
 		if (devRegistryPort !== undefined) {
 			this.#devRegistryDispatcher = new Pool(
 				new URL(`http://127.0.0.1:${devRegistryPort}`)

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -11,7 +11,6 @@ import util from "node:util";
 import zlib from "node:zlib";
 import { checkMacOSVersion } from "@cloudflare/cli";
 import { removeDir, removeDirSync } from "@cloudflare/workers-utils";
-import exitHook from "exit-hook";
 import { $ as colors$, green } from "kleur/colors";
 import stoppable from "stoppable";
 import { getGlobalDispatcher, Pool } from "undici";
@@ -21,6 +20,7 @@ import SCRIPT_MINIFLARE_ZOD from "worker:shared/zod";
 import { WebSocketServer } from "ws";
 import { z } from "zod";
 import { fallbackCf, setupCf } from "./cf";
+import { exitHook } from "./exit-hook";
 import {
 	coupleWebSocket,
 	DispatchFetchDispatcher,
@@ -3048,6 +3048,10 @@ export class Miniflare {
 			// all connections broke), so ignore ClientDestroyedError.
 			try {
 				await this.#runtimeDispatcher?.close();
+			} catch {}
+			// Also close the dev-registry dispatcher (same issue as above).
+			try {
+				await this.#devRegistryDispatcher?.close();
 			} catch {}
 
 			await this.#stopLoopbackServer();

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -2410,7 +2410,7 @@ export class Miniflare {
 		if (previousEntryURL?.toString() !== this.#runtimeEntryURL.toString()) {
 			// Close the previous dispatcher if the entry URL changed, to avoid
 			// leaking sockets from the old Pool.
-			void this.#runtimeDispatcher?.close();
+			void this.#runtimeDispatcher?.close().catch(() => {});
 			this.#runtimeDispatcher = new Pool(this.#runtimeEntryURL, {
 				connect: { rejectUnauthorized: false },
 				// Disable timeouts for local dev — long-running responses (streaming,

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -3044,7 +3044,12 @@ export class Miniflare {
 			// runtime. This must happen after the runtime is disposed, so that
 			// in-flight connections are broken and close immediately. Without this,
 			// lingering sockets in the Pool can keep the Node.js event loop alive.
-			await this.#runtimeDispatcher?.close();
+			// The Pool may already be destroyed (e.g., if workerd was SIGKILL'd and
+			// all connections broke), so ignore ClientDestroyedError.
+			try {
+				await this.#runtimeDispatcher?.close();
+			} catch {}
+
 
 			await this.#stopLoopbackServer();
 			// Best-effort cleanup: on Windows, workerd may not release file handles

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -3050,7 +3050,6 @@ export class Miniflare {
 				await this.#runtimeDispatcher?.close();
 			} catch {}
 
-
 			await this.#stopLoopbackServer();
 			// Best-effort cleanup: on Windows, workerd may not release file handles
 			// immediately after disposal, causing EBUSY errors. The temp directory

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -2408,6 +2408,9 @@ export class Miniflare {
 		}
 
 		if (previousEntryURL?.toString() !== this.#runtimeEntryURL.toString()) {
+			// Close the previous dispatcher if the entry URL changed, to avoid
+			// leaking sockets from the old Pool.
+			void this.#runtimeDispatcher?.close();
 			this.#runtimeDispatcher = new Pool(this.#runtimeEntryURL, {
 				connect: { rejectUnauthorized: false },
 				// Disable timeouts for local dev — long-running responses (streaming,
@@ -3037,6 +3040,11 @@ export class Miniflare {
 			// Cleanup as much as possible even if `#init()` threw
 			await this.#proxyClient?.dispose();
 			await this.#runtime?.dispose();
+			// Close the undici Pool used for dispatching fetch requests to the
+			// runtime. This must happen after the runtime is disposed, so that
+			// in-flight connections are broken and close immediately. Without this,
+			// lingering sockets in the Pool can keep the Node.js event loop alive.
+			await this.#runtimeDispatcher?.close();
 
 			await this.#stopLoopbackServer();
 			// Best-effort cleanup: on Windows, workerd may not release file handles

--- a/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
+++ b/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
@@ -324,6 +324,10 @@ export class InspectorProxyController {
 		await Promise.all(this.#proxies.map((proxy) => proxy.dispose()));
 
 		const server = await this.#server;
+		// Force-close active connections so server.close() resolves immediately.
+		// Without this, active HTTP keep-alive or WebSocket connections prevent
+		// the close callback from firing, hanging the dispose.
+		server.closeAllConnections();
 		return new Promise((resolve, reject) => {
 			server.close((err) => (err ? reject(err) : resolve()));
 		});

--- a/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy.ts
+++ b/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy.ts
@@ -164,5 +164,6 @@ export class InspectorProxy {
 		clearInterval(this.#runtimeKeepAliveInterval);
 
 		this.#devtoolsWs?.close();
+		this.#runtimeWs?.close();
 	}
 }

--- a/packages/miniflare/src/plugins/core/proxy/client.ts
+++ b/packages/miniflare/src/plugins/core/proxy/client.ts
@@ -255,6 +255,7 @@ class ProxyClientBridge {
 	}
 
 	dispose(): Promise<void> {
+		clearTimeout(this.#finalizeBatchTimeout);
 		this.poisonProxies();
 		return this.sync.dispose();
 	}

--- a/packages/miniflare/src/plugins/hyperdrive/hyperdrive-proxy.ts
+++ b/packages/miniflare/src/plugins/hyperdrive/hyperdrive-proxy.ts
@@ -121,14 +121,14 @@ export class HyperdriveProxyController {
 	}
 
 	/** Disposes of the proxy servers when shutting down the worker.*/
-	async dispose(): Promise<void> {
-		await Promise.allSettled(
-			Array.from(this.#servers.values()).map((server) => {
-				return new Promise<void>((resolve, reject) => {
-					server.close((err) => (err ? reject(err) : resolve()));
-				});
-			})
-		);
+	dispose(): void {
+		// Stop accepting new connections on each proxy server. We don't await
+		// server.close() because net.Server waits for all existing connections
+		// to end before calling the callback, and lingering TCP sockets (e.g.
+		// from in-progress TLS negotiation) could block dispose indefinitely.
+		for (const server of this.#servers.values()) {
+			server.close();
+		}
 		this.#servers.clear();
 	}
 }

--- a/packages/miniflare/src/plugins/hyperdrive/hyperdrive-proxy.ts
+++ b/packages/miniflare/src/plugins/hyperdrive/hyperdrive-proxy.ts
@@ -124,7 +124,7 @@ export class HyperdriveProxyController {
 	async dispose(): Promise<void> {
 		await Promise.allSettled(
 			Array.from(this.#servers.values()).map((server) => {
-				new Promise<void>((resolve, reject) => {
+				return new Promise<void>((resolve, reject) => {
 					server.close((err) => (err ? reject(err) : resolve()));
 				});
 			})

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -94,7 +94,6 @@ export function runBuild(
 	onErr: (err: Error) => void
 ) {
 	let stopWatching: (() => Promise<void>) | undefined = undefined;
-	let buildPromise: Promise<void> | undefined = undefined;
 
 	const entryDirectory = path.dirname(entry.file);
 	const moduleCollector = noBundle
@@ -227,21 +226,24 @@ export function runBuild(
 		}));
 	}
 
-	buildPromise = build().catch((err) => {
+	const buildPromise = build().catch((err) => {
 		// If esbuild fails on first run, we want to quit the process
 		// since we can't recover from here
 		// related: https://github.com/evanw/esbuild/issues/1037
 		onErr(err);
 	});
 
-	return async () => {
-		// Wait for the initial build to complete so that `stopWatching` is
-		// assigned before we try to call it. Without this, if teardown races
-		// with the initial build, `stopWatching` would still be `undefined`
-		// and the esbuild context would never be disposed — leaving the
-		// esbuild child process alive and preventing the Node.js event loop
-		// from exiting.
-		await buildPromise;
-		await stopWatching?.();
+	return () => {
+		// Stop watching immediately if the build has already completed
+		// and `stopWatching` is assigned.
+		const immediateStop = stopWatching?.();
+		if (immediateStop) {
+			return immediateStop;
+		}
+		// If the build is still in flight, `stopWatching` is undefined.
+		// Fire-and-forget: wait for the build to finish, then clean up.
+		// We intentionally don't block teardown on this — blocking would
+		// hang teardown if the build is slow (e.g. esbuild startup).
+		void buildPromise.then(() => stopWatching?.());
 	};
 }

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -94,6 +94,7 @@ export function runBuild(
 	onErr: (err: Error) => void
 ) {
 	let stopWatching: (() => Promise<void>) | undefined = undefined;
+	let buildPromise: Promise<void> | undefined = undefined;
 
 	const entryDirectory = path.dirname(entry.file);
 	const moduleCollector = noBundle
@@ -226,12 +227,21 @@ export function runBuild(
 		}));
 	}
 
-	build().catch((err) => {
+	buildPromise = build().catch((err) => {
 		// If esbuild fails on first run, we want to quit the process
 		// since we can't recover from here
 		// related: https://github.com/evanw/esbuild/issues/1037
 		onErr(err);
 	});
 
-	return () => stopWatching?.();
+	return async () => {
+		// Wait for the initial build to complete so that `stopWatching` is
+		// assigned before we try to call it. Without this, if teardown races
+		// with the initial build, `stopWatching` would still be `undefined`
+		// and the esbuild context would never be disposed — leaving the
+		// esbuild child process alive and preventing the Node.js event loop
+		// from exiting.
+		await buildPromise;
+		await stopWatching?.();
+	};
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2135,9 +2135,6 @@ importers:
       esbuild:
         specifier: catalog:default
         version: 0.27.3
-      exit-hook:
-        specifier: 2.2.1
-        version: 2.2.1
       expect-type:
         specifier: ^0.15.0
         version: 0.15.0


### PR DESCRIPTION
Supersedes #13520, #13521, #13522, #13523.

## Problem

The `start-worker-node-test` fixture (which uses `node --test` to exercise the `unstable_startWorker` API) was hanging indefinitely in CI. Unlike vitest-based tests, `node --test` runs each test file as a child process and waits for it to exit naturally. If any event-loop handles remain open after tests complete, the process never exits and CI hangs forever.

The root cause was not a single leak but a cascade of unclosed resources across `Miniflare.dispose()` and the wrangler `DevEnv` teardown path. Each fix in this PR addresses a distinct handle that could keep the Node.js event loop alive after disposal.

## Changes

### miniflare (patch)

**Undici Pool leaks:**
- Close the `#runtimeDispatcher` (undici `Pool`) in `dispose()` after the runtime is killed. Without this, lingering TCP sockets in the pool keep the event loop alive indefinitely.
- Close the old `#runtimeDispatcher` Pool when the runtime entry URL changes during config updates, preventing socket leaks on every `setOptions()` call.
- Close the `#devRegistryDispatcher` Pool in `dispose()` — same class of leak as `#runtimeDispatcher`.
- Close the old `#devRegistryDispatcher` Pool before replacement during config updates — without this, every call to `#assembleAndUpdateConfig()` leaked the previous Pool's TCP sockets.

**WebSocket and HTTP server leaks:**
- Close `WebSocketServer` instances (`#liveReloadServer`, `#webSocketServer`) in `dispose()` so connected client sockets don't keep the event loop alive. These use `noServer: true` so they don't own an HTTP server, but connected WebSocket clients still hold open sockets.
- Force-close connections in `InspectorProxyController.dispose()` by calling `server.closeAllConnections()` before `server.close()`, so active keep-alive/WebSocket connections don't prevent the close callback from firing.
- Close `InspectorProxy` runtime WebSocket on dispose instead of relying on process death to break the connection.

**Hyperdrive proxy:**
- Fix `HyperdriveProxyController.dispose()`: add missing `return` in `.map()` callback so `Promise.allSettled` actually waits for `net.Server` instances to close.
- Don't block dispose on `net.Server.close()` callback — TCP proxy servers with lingering sockets (e.g. from in-progress TLS negotiation) would block indefinitely. Just call `close()` to stop accepting new connections without awaiting the callback.

**IPC channel / exit-hook:**
- Replace the third-party `exit-hook` package with a lightweight inline implementation that removes all process listeners when the last callback is unregistered. The original package registers a permanent `process.on('message')` listener that refs the IPC channel handle, preventing `node --test` child processes from exiting after tests complete.

**Miscellaneous:**
- Clear `ProxyClientBridge` finalization batch `setTimeout` on dispose.

### wrangler (patch)

- Fix esbuild cleanup race in `BundlerController`: the cleanup function returned by `runBuild()` now stops esbuild immediately if the build has completed, or fire-and-forget the cleanup chain if it hasn't. The previous approach awaited `buildPromise` in the cleanup function, which could block the entire `DevEnv` teardown if the initial build was still in flight.

### Fixture changes

- Disable persistence (`persist: false`) in `start-worker-node-test` to avoid `SQLITE_BUSY_RECOVERY` errors when back-to-back test runs contend on the same `.wrangler/state` directory.
- Set `--test-timeout=15000` on the fixture to fail fast on genuine hangs while giving sufficient headroom for Windows CI, where workerd process teardown and TCP socket cleanup can take ~7s.

## Verification

- 65+ consecutive runs of `start-worker-node-test` passed without hanging
- miniflare test suite: 730/730 tests passed
- `miniflare-node-test` fixture: 6/6 passed

---

- Tests
   - [x] Automated tests not possible - manual testing has been completed as follows: 65+ consecutive loop of `start-worker-node-test` and `miniflare-node-test` fixtures, plus full miniflare test suite
   - [ ] Tests included/updated
- Public documentation
   - [x] Documentation not necessary because: internal implementation fix with no user-facing API change