### PR TITLE
[miniflare] Fix Hyperdrive proxy servers not closing on dispose

### DIFF
--- a/.changeset/fix-hyperdrive-proxy-dispose.md
+++ b/.changeset/fix-hyperdrive-proxy-dispose.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Fix Hyperdrive proxy servers not closing on dispose
+
+The `dispose()` method in `HyperdriveProxyController` was missing a `return` statement, so the Promises from `server.close()` were never passed to `Promise.allSettled()`. This meant the proxy `net.Server` instances were never actually waited on to close, potentially keeping the Node.js event loop alive.

--- a/packages/miniflare/src/plugins/hyperdrive/hyperdrive-proxy.ts
+++ b/packages/miniflare/src/plugins/hyperdrive/hyperdrive-proxy.ts
@@ -124,7 +124,7 @@ export class HyperdriveProxyController {
 	async dispose(): Promise<void> {
 		await Promise.allSettled(
 			Array.from(this.#servers.values()).map((server) => {
-				new Promise<void>((resolve, reject) => {
+				return new Promise<void>((resolve, reject) => {
 					server.close((err) => (err ? reject(err) : resolve()));
 				});
 			})


### PR DESCRIPTION
The `dispose()` method in `HyperdriveProxyController` was missing a `return` statement in its `.map()` callback, so the Promises from `server.close()` were never passed to `Promise.allSettled()`. This meant the proxy `net.Server` instances were never actually waited on to close, potentially keeping the Node.js event loop alive and contributing to `wrangler dev` hanging on Ctrl-C.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: one-word fix (missing `return`); existing Hyperdrive tests confirm no regression
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal implementation fix with no user-facing API change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
