### PR TITLE
[miniflare] Close WebSocket servers during dispose

### DIFF
--- a/.changeset/fix-close-websocket-servers-dispose.md
+++ b/.changeset/fix-close-websocket-servers-dispose.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Close WebSocket servers during dispose to prevent lingering connections
+
+The `#liveReloadServer` and `#webSocketServer` (both created with `noServer: true`) were never explicitly closed during `Miniflare.dispose()`. Connected WebSocket clients (e.g., browser live reload, devtools) would keep sockets alive, preventing the Node.js event loop from draining cleanly.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -3030,6 +3030,17 @@ export class Miniflare {
 			await this.#runtime?.dispose();
 
 			await this.#stopLoopbackServer();
+			// Terminate connected WebSocket clients and close the WebSocket servers.
+			// These are created with `noServer: true` so they aren't closed by
+			// stopping the loopback HTTP server.
+			for (const ws of this.#liveReloadServer.clients) {
+				ws.terminate();
+			}
+			this.#liveReloadServer.close();
+			for (const ws of this.#webSocketServer.clients) {
+				ws.terminate();
+			}
+			this.#webSocketServer.close();
 			// Best-effort cleanup: on Windows, workerd may not release file handles
 			// immediately after disposal, causing EBUSY errors. The temp directory
 			// lives in os.tmpdir() so the OS will clean it up eventually.


### PR DESCRIPTION
The `#liveReloadServer` and `#webSocketServer` (both `ws.WebSocketServer` instances created with `noServer: true`) were never explicitly closed during `Miniflare.dispose()`. Stopping the loopback HTTP server doesn't cascade to `noServer` WebSocket servers, so connected WebSocket clients (e.g., browser live reload, devtools) would keep sockets alive, preventing the Node.js event loop from draining and contributing to `wrangler dev` hanging on Ctrl-C.

This PR terminates all connected WebSocket clients and closes both servers during `dispose()`, placed after `#stopLoopbackServer()`.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: straightforward cleanup addition; existing test suite confirms no regression
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal implementation fix with no user-facing API change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
