### PR TITLE
[miniflare] Close runtime WebSocket in InspectorProxy dispose

### DIFF
--- a/.changeset/fix-inspector-proxy-close-runtime-ws.md
+++ b/.changeset/fix-inspector-proxy-close-runtime-ws.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Close runtime WebSocket in InspectorProxy dispose
+
+`InspectorProxy.dispose()` was closing the devtools WebSocket but not the runtime WebSocket connection to workerd's inspector server. The open WebSocket kept the Node.js event loop alive, contributing to `wrangler dev` hanging on Ctrl-C.

--- a/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy.ts
+++ b/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy.ts
@@ -163,6 +163,7 @@ export class InspectorProxy {
 	async dispose(): Promise<void> {
 		clearInterval(this.#runtimeKeepAliveInterval);
 
+		this.#runtimeWs?.close();
 		this.#devtoolsWs?.close();
 	}
 }

--- a/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy.ts
+++ b/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy.ts
@@ -163,7 +163,9 @@ export class InspectorProxy {
 	async dispose(): Promise<void> {
 		clearInterval(this.#runtimeKeepAliveInterval);
 
-		this.#runtimeWs?.close();
+		// Close devtools first: its close handler sends Debugger.disable to
+		// the runtime WS, so the runtime WS must still be open at that point.
 		this.#devtoolsWs?.close();
+		this.#runtimeWs?.close();
 	}
 }


### PR DESCRIPTION
`InspectorProxy.dispose()` was closing the devtools WebSocket connection but not the runtime WebSocket connection to workerd's inspector server. The open runtime WebSocket (and its 10-second keep-alive interval, which was correctly cleared) kept the socket alive, preventing the Node.js event loop from draining and contributing to `wrangler dev` hanging on Ctrl-C.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: one-line addition; existing inspector proxy tests confirm no regression
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal implementation fix with no user-facing API change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
