### PR TITLE
[miniflare] Force-close connections in InspectorProxyController dispose

### DIFF
--- a/.changeset/fix-inspector-proxy-controller-close-connections.md
+++ b/.changeset/fix-inspector-proxy-controller-close-connections.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Force-close connections in InspectorProxyController dispose
+
+`InspectorProxyController.dispose()` was calling `server.close()` without first calling `server.closeAllConnections()`. Active HTTP keep-alive or WebSocket connections would prevent the close callback from firing, hanging the dispose and contributing to `wrangler dev` not exiting on Ctrl-C. The same file's `#closeServer()` method already used `closeAllConnections()` — this brings `dispose()` in line with that pattern.

--- a/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
+++ b/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
@@ -324,6 +324,10 @@ export class InspectorProxyController {
 		await Promise.all(this.#proxies.map((proxy) => proxy.dispose()));
 
 		const server = await this.#server;
+		// Force-close active connections so server.close() resolves immediately.
+		// Without this, active HTTP keep-alive or WebSocket connections prevent
+		// the close callback from firing, hanging the dispose.
+		server.closeAllConnections();
 		return new Promise((resolve, reject) => {
 			server.close((err) => (err ? reject(err) : resolve()));
 		});


### PR DESCRIPTION
`InspectorProxyController.dispose()` was calling `server.close()` without first calling `server.closeAllConnections()`. Active HTTP keep-alive or WebSocket connections would prevent the `close` callback from firing, hanging the dispose indefinitely and contributing to `wrangler dev` not exiting on Ctrl-C.

The same file's `#closeServer()` method (used during port changes via `setOptions()`) already uses `closeAllConnections()` — this brings `dispose()` in line with that pattern.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: consistent with existing `#closeServer()` pattern in the same file; existing inspector proxy tests confirm no regression
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal implementation fix with no user-facing API change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
