### PR TITLE
fix(local-explorer-ui): correct 'occured' -> 'occurred' in ResourceError fallback

### DIFF
--- a/.changeset/local-explorer-ui-fix-occured-typo.md
+++ b/.changeset/local-explorer-ui-fix-occured-typo.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/local-explorer-ui": patch
+---
+
+Fix `occured` -> `occurred` typo in the `ResourceError` fallback message rendered by the local explorer UI when a worker resource fails to load.

--- a/packages/local-explorer-ui/src/components/ResourceError.tsx
+++ b/packages/local-explorer-ui/src/components/ResourceError.tsx
@@ -4,7 +4,7 @@ import { Link, type ErrorComponentProps } from "@tanstack/react-router";
 import type { WorkersApiResponseCommonFailure } from "../api";
 
 const DEFAULT_ERROR_DESCRIPTION =
-	"An unknown error occured. Please report this issue to Cloudflare.";
+	"An unknown error occurred. Please report this issue to Cloudflare.";
 
 export function ResourceError({
 	error,


### PR DESCRIPTION
`DEFAULT_ERROR_DESCRIPTION` in `packages/local-explorer-ui/src/components/ResourceError.tsx:6` is the text the local explorer renders when a worker resource fails to load and the upstream error message is empty:

```tsx
const DEFAULT_ERROR_DESCRIPTION =
    "An unknown error occured. Please report this issue to Cloudflare.";
```

Fix the spelling. Includes a `@cloudflare/local-explorer-ui` changeset (`.changeset/local-explorer-ui-fix-occured-typo.md`) so the package picks up a patch bump on the next release. Source verified against current `main`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
