### PR TITLE
[miniflare] Rename Flags type to Flagship

### DIFF
--- a/.changeset/rename-flags-to-flagship.md
+++ b/.changeset/rename-flags-to-flagship.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Rename `Flags` type to `Flagship` to match the upstream rename in `@cloudflare/workers-types`
+
+The `Flags` type was renamed to `Flagship` in `@cloudflare/workers-types`. This updates the import and the return type of `getFlagshipBinding` accordingly.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -2976,7 +2976,10 @@ export class Miniflare {
 	}> {
 		return this.#getProxy(HELLO_WORLD_PLUGIN_NAME, bindingName, workerName);
 	}
-	getFlagshipBinding(bindingName: string, workerName?: string): Promise<Flagship> {
+	getFlagshipBinding(
+		bindingName: string,
+		workerName?: string
+	): Promise<Flagship> {
 		return this.#getProxy(FLAGSHIP_PLUGIN_NAME, bindingName, workerName);
 	}
 	getStreamBinding(

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -149,7 +149,7 @@ import type {
 	D1Database,
 	DurableObjectNamespace,
 	Fetcher,
-	Flags,
+	Flagship,
 	ImagesBinding,
 	KVNamespace,
 	KVNamespaceListKey,
@@ -2976,7 +2976,7 @@ export class Miniflare {
 	}> {
 		return this.#getProxy(HELLO_WORLD_PLUGIN_NAME, bindingName, workerName);
 	}
-	getFlagshipBinding(bindingName: string, workerName?: string): Promise<Flags> {
+	getFlagshipBinding(bindingName: string, workerName?: string): Promise<Flagship> {
 		return this.#getProxy(FLAGSHIP_PLUGIN_NAME, bindingName, workerName);
 	}
 	getStreamBinding(


### PR DESCRIPTION
Rename the `Flags` type import to `Flagship` to match the upstream rename in `@cloudflare/workers-types` (https://github.com/cloudflare/workerd/pull/6584).

- Import: `Flags` -> `Flagship` from `@cloudflare/workers-types/experimental`
- Return type of `getFlagshipBinding`: `Promise<Flags>` -> `Promise<Flagship>`

Fixes #13557 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: Type-only rename, no runtime behavior change.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Internal type rename, no user-facing API change.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
