### PR TITLE
Various local explorer UI fixes

### DIFF
--- a/.changeset/local-explorer-ui-refinements.md
+++ b/.changeset/local-explorer-ui-refinements.md
@@ -1,0 +1,11 @@
+---
+"@cloudflare/local-explorer-ui": patch
+---
+
+Local Explorer UI refinements
+
+- Add scrolling to the D1 table selector, instead of cutting off the table list
+- Simplify the dark/light mode toggle to a two-state cycle (removed "system" option)
+- Show table headers in R2 empty states
+- Persist the `delimiter` search param when navigating to R2 object details
+- Hide breadcrumb path segments when viewing R2 objects in ungrouped mode

--- a/.changeset/local-explorer-ui-refinements.md
+++ b/.changeset/local-explorer-ui-refinements.md
@@ -5,7 +5,6 @@
 Local Explorer UI refinements
 
 - Add scrolling to the D1 table selector, instead of cutting off the table list
-- Simplify the dark/light mode toggle to a two-state cycle (removed "system" option)
 - Show table headers in R2 empty states
 - Persist the `delimiter` search param when navigating to R2 object details
 - Hide breadcrumb path segments when viewing R2 objects in ungrouped mode

--- a/packages/local-explorer-ui/src/__e2e__/d1/d1-database.spec.ts
+++ b/packages/local-explorer-ui/src/__e2e__/d1/d1-database.spec.ts
@@ -38,7 +38,7 @@ describe("D1 Database Studio", () => {
 			await selectTableButton.click();
 
 			// Should show the users table from seed data
-			const usersOption = page.getByRole("option", { name: "users" });
+			const usersOption = page.getByRole("menuitem", { name: "users" });
 			const isUsersVisible = await usersOption.isVisible();
 			expect(isUsersVisible).toBe(true);
 		});
@@ -192,7 +192,9 @@ describe("D1 Database Studio", () => {
 
 			await openTableSelector();
 
-			const productsOption = page.getByRole("option", { name: "products" });
+			const productsOption = page.getByRole("menuitem", {
+				name: "products",
+			});
 			const isProductsVisible = await productsOption.isVisible();
 			expect(isProductsVisible).toBe(true);
 		});

--- a/packages/local-explorer-ui/src/__e2e__/do/durable-object.spec.ts
+++ b/packages/local-explorer-ui/src/__e2e__/do/durable-object.spec.ts
@@ -103,7 +103,9 @@ describe("Durable Objects", () => {
 
 			await openTableSelector();
 
-			const productsOption = page.getByRole("option", { name: "products" });
+			const productsOption = page.getByRole("menuitem", {
+				name: "products",
+			});
 			const isProductsVisible = await productsOption.isVisible();
 			expect(isProductsVisible).toBe(true);
 		});

--- a/packages/local-explorer-ui/src/__e2e__/r2/r2-bucket.spec.ts
+++ b/packages/local-explorer-ui/src/__e2e__/r2/r2-bucket.spec.ts
@@ -212,6 +212,45 @@ describe("R2 Bucket", () => {
 			await waitForText("images/");
 			await waitForText("documents/");
 		});
+
+		test("delimiter param persists when navigating to an object and back", async ({
+			expect,
+		}) => {
+			await navigateToR2Bucket("my-bucket");
+			await waitForTableRows(1);
+
+			// Switch to ungrouped mode (sets delimiter=false in URL)
+			await page.getByRole("button", { name: /Grouped|Ungrouped/ }).click();
+			await page
+				.getByRole("menuitem", { name: "Ungrouped", exact: true })
+				.click();
+			await waitForTableRows(1);
+			await waitForText("images/logo.svg");
+
+			// Navigate to an object
+			const objectLink = page
+				.getByRole("link", { name: "images/logo.svg" })
+				.first();
+			await objectLink.click();
+			await waitForText("Object Details");
+
+			// URL should still contain delimiter=false
+			expect(page.url()).toContain("delimiter=false");
+
+			// Navigate back via the bucket breadcrumb
+			const bucketBreadcrumb = page
+				.locator('nav[aria-label="breadcrumb"]')
+				.getByRole("link", { name: "my-bucket" })
+				.first();
+			await bucketBreadcrumb.click();
+			await waitForTableRows(1);
+
+			// Should still be in ungrouped mode — full keys visible, no directories
+			await waitForText("images/logo.svg");
+
+			// The toolbar button should still show "Ungrouped"
+			await waitForText("Ungrouped");
+		});
 	});
 
 	describe("object detail page", () => {

--- a/packages/local-explorer-ui/src/__e2e__/utils.ts
+++ b/packages/local-explorer-ui/src/__e2e__/utils.ts
@@ -398,7 +398,7 @@ export async function openTableSelector(): Promise<void> {
 		.first();
 	await tableSelector.click();
 
-	await page.waitForSelector('[role="listbox"]', {
+	await page.waitForSelector('[role="menu"]', {
 		state: "visible",
 		timeout: 5_000,
 	});

--- a/packages/local-explorer-ui/src/components/R2ObjectTable.tsx
+++ b/packages/local-explorer-ui/src/components/R2ObjectTable.tsx
@@ -1,4 +1,4 @@
-import { Button, Checkbox, DropdownMenu, Table } from "@cloudflare/kumo";
+import { Button, Checkbox, DropdownMenu, Table, Text } from "@cloudflare/kumo";
 import {
 	DotsThreeIcon,
 	DownloadIcon,
@@ -275,21 +275,6 @@ export function R2ObjectTable({
 		onSelectionChange(newSelection);
 	}
 
-	if (items.length === 0) {
-		return (
-			<div className="flex flex-col items-center justify-center space-y-2 p-12 text-center text-kumo-subtle">
-				<h2 className="text-2xl font-medium">
-					{currentPrefix
-						? "No objects in this directory"
-						: "No objects in this bucket"}
-				</h2>
-				<p className="text-sm font-light">
-					Upload an object using the button above.
-				</p>
-			</div>
-		);
-	}
-
 	return (
 		<div className="overflow-hidden rounded-lg border border-kumo-fill">
 			<Table>
@@ -322,6 +307,22 @@ export function R2ObjectTable({
 				</Table.Header>
 
 				<Table.Body>
+					{items.length === 0 ? (
+						<Table.Row>
+							<Table.Cell colSpan={6} className="py-20! text-center">
+								<div className="flex flex-col items-center justify-center gap-1">
+									<Text size="sm" bold>
+										{currentPrefix
+											? "No objects in this directory"
+											: "No objects in this bucket"}
+									</Text>
+									<Text variant="secondary" size="xs">
+										Upload an object using the button above.
+									</Text>
+								</div>
+							</Table.Cell>
+						</Table.Row>
+					) : null}
 					{items.map((item) => {
 						if (item.type === "directory") {
 							const displayName = getDisplayName(item.prefix, currentPrefix);
@@ -399,6 +400,7 @@ export function R2ObjectTable({
 									<Link
 										to="/r2/$bucketName/object/$"
 										params={{ bucketName, _splat: key }}
+										search={(prev) => prev}
 										className="flex items-center gap-2 text-kumo-default no-underline hover:text-kumo-link"
 									>
 										<FileIcon size={16} className="text-kumo-subtle" />

--- a/packages/local-explorer-ui/src/components/TableSelect.tsx
+++ b/packages/local-explorer-ui/src/components/TableSelect.tsx
@@ -1,4 +1,4 @@
-import { Select } from "@cloudflare/kumo/primitives/select";
+import { DropdownMenu } from "@cloudflare/kumo";
 import {
 	CaretUpDownIcon,
 	CheckIcon,
@@ -6,7 +6,7 @@ import {
 	TableIcon,
 } from "@phosphor-icons/react";
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import type { StudioRef } from "./studio";
 import type { RefObject } from "react";
 
@@ -22,14 +22,9 @@ export function TableSelect({
 	selectedTable,
 }: TableSelectProps): JSX.Element {
 	const navigate = useNavigate();
-	const [open, setOpen] = useState(false);
 
 	const handleTableChange = useCallback(
-		(tableName: string | null) => {
-			if (tableName === null) {
-				return;
-			}
-
+		(tableName: string) => {
 			void navigate({
 				search: (prev) => ({ ...prev, table: tableName }),
 				to: ".",
@@ -39,77 +34,46 @@ export function TableSelect({
 	);
 
 	const handleCreateTable = useCallback((): void => {
-		setOpen(false);
 		studioRef.current?.openCreateTableTab();
 	}, [studioRef]);
 
 	return (
-		<Select.Root
-			key="table-select"
-			onOpenChange={setOpen}
-			onValueChange={handleTableChange}
-			open={open}
-			value={selectedTable}
-		>
-			<Select.Trigger className="-mx-1.5 inline-flex cursor-pointer items-center gap-1 rounded-md border-none bg-transparent p-2 text-sm text-kumo-default transition-colors hover:bg-kumo-fill data-popup-open:bg-kumo-fill">
-				{selectedTable ? <Select.Value /> : "Select table"}
-				<Select.Icon>
-					<CaretUpDownIcon className="h-3.5 w-3.5 text-kumo-subtle" />
-				</Select.Icon>
-			</Select.Trigger>
+		<DropdownMenu>
+			<DropdownMenu.Trigger
+				render={
+					<button
+						className="-mx-1.5 inline-flex cursor-pointer items-center gap-1 rounded-md border-none bg-transparent p-2 text-sm text-kumo-default transition-colors hover:bg-kumo-fill data-[popup-open]:bg-kumo-fill"
+						type="button"
+					/>
+				}
+			>
+				{selectedTable ?? "Select table"}
+				<CaretUpDownIcon className="h-3.5 w-3.5 text-kumo-subtle" />
+			</DropdownMenu.Trigger>
 
-			<Select.Portal>
-				<Select.Positioner
-					align="start"
-					alignItemWithTrigger={false}
-					className="z-100"
-					side="bottom"
-					sideOffset={4}
-				>
-					<Select.Popup className="max-h-72 min-w-36 overflow-hidden rounded-lg border border-kumo-fill bg-kumo-base shadow-[0_4px_12px_rgba(0,0,0,0.15)] transition-[opacity,transform] duration-150 data-ending-style:-translate-y-1 data-ending-style:opacity-0 data-starting-style:-translate-y-1 data-starting-style:opacity-0">
-						<div className="p-1">
-							<button
-								className="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm text-kumo-default transition-colors outline-none select-none hover:bg-kumo-elevated"
-								onClick={handleCreateTable}
-								type="button"
-							>
-								<span className="flex w-4 items-center">
-									<PlusIcon className="h-3.5 w-3.5" />
-								</span>
-								Create table
-							</button>
-						</div>
+			<DropdownMenu.Content className="max-h-72 overflow-y-auto" style={{ zIndex: 50 }}>
+				<DropdownMenu.Item icon={PlusIcon} onClick={handleCreateTable}>
+					Create table
+				</DropdownMenu.Item>
 
-						<div className="mx-1 border-t border-kumo-fill" />
+				<DropdownMenu.Separator />
 
-						<Select.List className="p-1">
-							{tables.length > 0 ? (
-								tables.map((table) => {
-									const Icon =
-										selectedTable === table.value ? CheckIcon : TableIcon;
-
-									return (
-										<Select.Item
-											className="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm text-kumo-default transition-colors outline-none select-none data-highlighted:bg-kumo-elevated"
-											key={table.value}
-											value={table.value}
-										>
-											<span className="flex w-4 items-center">
-												<Icon className="h-3.5 w-3.5" />
-											</span>
-											<Select.ItemText>{table.label}</Select.ItemText>
-										</Select.Item>
-									);
-								})
-							) : (
-								<span className="flex w-full items-center justify-center gap-2 px-2 py-1.5 text-sm text-kumo-subtle">
-									No tables
-								</span>
-							)}
-						</Select.List>
-					</Select.Popup>
-				</Select.Positioner>
-			</Select.Portal>
-		</Select.Root>
+				{tables.length > 0 ? (
+					tables.map((table) => (
+						<DropdownMenu.Item
+							icon={selectedTable === table.value ? CheckIcon : TableIcon}
+							key={table.value}
+							onClick={() => handleTableChange(table.value)}
+						>
+							{table.label}
+						</DropdownMenu.Item>
+					))
+				) : (
+					<span className="flex w-full items-center justify-center gap-2 px-2 py-1.5 text-sm text-kumo-subtle">
+						No tables
+					</span>
+				)}
+			</DropdownMenu.Content>
+		</DropdownMenu>
 	);
 }

--- a/packages/local-explorer-ui/src/components/TableSelect.tsx
+++ b/packages/local-explorer-ui/src/components/TableSelect.tsx
@@ -51,7 +51,10 @@ export function TableSelect({
 				<CaretUpDownIcon className="h-3.5 w-3.5 text-kumo-subtle" />
 			</DropdownMenu.Trigger>
 
-			<DropdownMenu.Content className="max-h-72 overflow-y-auto" style={{ zIndex: 50 }}>
+			<DropdownMenu.Content
+				className="max-h-72 overflow-y-auto"
+				style={{ zIndex: 50 }}
+			>
 				<DropdownMenu.Item icon={PlusIcon} onClick={handleCreateTable}>
 					Create table
 				</DropdownMenu.Item>

--- a/packages/local-explorer-ui/src/routes/r2/$bucketName/index.tsx
+++ b/packages/local-explorer-ui/src/routes/r2/$bucketName/index.tsx
@@ -317,9 +317,10 @@ function BucketView(): JSX.Element {
 	}
 
 	// Build breadcrumb items
-	const pathSegments = search.prefix
-		? search.prefix.split("/").filter(Boolean)
-		: [];
+	const pathSegments =
+		directoryView && search.prefix
+			? search.prefix.split("/").filter(Boolean)
+			: [];
 	const breadcrumbItems = [
 		<Link
 			className="text-kumo-default no-underline hover:text-kumo-link"
@@ -341,7 +342,7 @@ function BucketView(): JSX.Element {
 					search={{ prefix: segmentPrefix }}
 					to="/r2/$bucketName"
 				>
-					{segment}
+					{segment}/
 				</Link>
 			);
 		}),

--- a/packages/local-explorer-ui/src/routes/r2/$bucketName/object.$.tsx
+++ b/packages/local-explorer-ui/src/routes/r2/$bucketName/object.$.tsx
@@ -5,6 +5,7 @@ import {
 	Link,
 	notFound,
 	useNavigate,
+	useRouterState,
 } from "@tanstack/react-router";
 import { useState } from "react";
 import { r2BucketDeleteObjects, r2BucketGetObject } from "../../../api";
@@ -181,14 +182,22 @@ function ObjectDetailView(): JSX.Element {
 	}
 
 	// Build breadcrumb items - bucket, parent folders, and object name
-	const pathSegments = search.objectKey.split("/").filter(Boolean);
-	const fileName = pathSegments.pop() || search.objectKey;
+	const routerState = useRouterState();
+	const urlParams = new URLSearchParams(routerState.location.searchStr);
+	const directoryView = urlParams.get("delimiter") !== "false";
+
+	const pathSegments = directoryView
+		? search.objectKey.split("/").filter(Boolean)
+		: [];
+	const fileName = directoryView
+		? pathSegments.pop() || search.objectKey
+		: search.objectKey;
 	const breadcrumbItems = [
 		<Link
 			className="text-kumo-default no-underline hover:text-kumo-link"
 			key="bucket"
 			params={{ bucketName: params.bucketName }}
-			search={{}}
+			search={(prev) => ({ ...prev, prefix: undefined })}
 			to="/r2/$bucketName"
 		>
 			{params.bucketName}
@@ -200,10 +209,10 @@ function ObjectDetailView(): JSX.Element {
 					className="text-kumo-default no-underline hover:text-kumo-link"
 					key={segmentPrefix}
 					params={{ bucketName: params.bucketName }}
-					search={{ prefix: segmentPrefix }}
+					search={(prev) => ({ ...prev, prefix: segmentPrefix })}
 					to="/r2/$bucketName"
 				>
-					{segment}
+					{segment}/
 				</Link>
 			);
 		}),

--- a/packages/local-explorer-ui/src/routes/r2/$bucketName/object.$.tsx
+++ b/packages/local-explorer-ui/src/routes/r2/$bucketName/object.$.tsx
@@ -5,7 +5,6 @@ import {
 	Link,
 	notFound,
 	useNavigate,
-	useRouterState,
 } from "@tanstack/react-router";
 import { useState } from "react";
 import { r2BucketDeleteObjects, r2BucketGetObject } from "../../../api";
@@ -17,9 +16,16 @@ import { ResourceError } from "../../../components/ResourceError";
 import { formatDate, formatSize } from "../../../utils/format";
 import type { R2HeadObjectResult } from "../../../api";
 
+export interface ObjectDetailSearch {
+	delimiter?: boolean;
+}
+
 export const Route = createFileRoute("/r2/$bucketName/object/$")({
 	component: ObjectDetailView,
 	errorComponent: ResourceError,
+	validateSearch: (search: Record<string, unknown>): ObjectDetailSearch => ({
+		delimiter: search.delimiter === false ? false : true,
+	}),
 	loader: async ({ params }) => {
 		const objectKey = params._splat;
 		if (!objectKey) {
@@ -133,7 +139,8 @@ function CustomMetadataCard({
 
 function ObjectDetailView(): JSX.Element {
 	const params = Route.useParams();
-	const search = Route.useLoaderData();
+	const loaderData = Route.useLoaderData();
+	const search = Route.useSearch();
 	const navigate = useNavigate();
 
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState<boolean>(false);
@@ -141,10 +148,10 @@ function ObjectDetailView(): JSX.Element {
 	const [error, setError] = useState<string | null>(null);
 
 	function handleDownload(): void {
-		const downloadUrl = `/cdn-cgi/explorer/api/r2/buckets/${encodeURIComponent(params.bucketName)}/objects/${encodeURIComponent(search.objectKey)}`;
+		const downloadUrl = `/cdn-cgi/explorer/api/r2/buckets/${encodeURIComponent(params.bucketName)}/objects/${encodeURIComponent(loaderData.objectKey)}`;
 		const link = document.createElement("a");
 		link.href = downloadUrl;
-		link.download = search.objectKey.split("/").pop() || "download";
+		link.download = loaderData.objectKey.split("/").pop() || "download";
 		document.body.appendChild(link);
 		link.click();
 		document.body.removeChild(link);
@@ -157,11 +164,14 @@ function ObjectDetailView(): JSX.Element {
 				path: {
 					bucket_name: params.bucketName,
 				},
-				body: [search.objectKey],
+				body: [loaderData.objectKey],
 			});
 			// Navigate back to bucket root or parent prefix
-			const parentPrefix = search.objectKey.includes("/")
-				? search.objectKey.substring(0, search.objectKey.lastIndexOf("/") + 1)
+			const parentPrefix = loaderData.objectKey.includes("/")
+				? loaderData.objectKey.substring(
+						0,
+						loaderData.objectKey.lastIndexOf("/") + 1
+					)
 				: undefined;
 			void navigate({
 				params: {
@@ -182,17 +192,16 @@ function ObjectDetailView(): JSX.Element {
 	}
 
 	// Build breadcrumb items - bucket, parent folders, and object name
-	const routerState = useRouterState();
-	const urlParams = new URLSearchParams(routerState.location.searchStr);
-	const directoryView = urlParams.get("delimiter") !== "false";
+	const directoryView = search.delimiter !== false;
 
 	const pathSegments = directoryView
-		? search.objectKey.split("/").filter(Boolean)
+		? loaderData.objectKey.split("/").filter(Boolean)
 		: [];
 	const fileName = directoryView
-		? pathSegments.pop() || search.objectKey
-		: search.objectKey;
+		? pathSegments.pop() || loaderData.objectKey
+		: loaderData.objectKey;
 	const breadcrumbItems = [
+		// bucket name
 		<Link
 			className="text-kumo-default no-underline hover:text-kumo-link"
 			key="bucket"
@@ -202,6 +211,7 @@ function ObjectDetailView(): JSX.Element {
 		>
 			{params.bucketName}
 		</Link>,
+		// optional path segments (only if set to folder mode)
 		...pathSegments.map((segment, index) => {
 			const segmentPrefix = pathSegments.slice(0, index + 1).join("/") + "/";
 			return (
@@ -216,6 +226,7 @@ function ObjectDetailView(): JSX.Element {
 				</Link>
 			);
 		}),
+		// file name (may be full object key if not in folder mode)
 		<span key="file">{fileName}</span>,
 	];
 
@@ -234,11 +245,11 @@ function ObjectDetailView(): JSX.Element {
 					<div className="flex min-w-0 items-center gap-2">
 						<h1
 							className="truncate text-base text-kumo-default"
-							title={search.objectKey}
+							title={loaderData.objectKey}
 						>
-							{search.objectKey}
+							{loaderData.objectKey}
 						</h1>
-						<CopyButton text={search.objectKey} />
+						<CopyButton text={loaderData.objectKey} />
 					</div>
 
 					<div className="flex shrink-0 items-center gap-2">
@@ -260,8 +271,8 @@ function ObjectDetailView(): JSX.Element {
 				</div>
 
 				<div className="space-y-6">
-					<ObjectDetailsCard object={search.object} />
-					<CustomMetadataCard metadata={search.object.custom_metadata} />
+					<ObjectDetailsCard object={loaderData.object} />
+					<CustomMetadataCard metadata={loaderData.object.custom_metadata} />
 				</div>
 
 				{/* Delete Confirmation Dialog */}
@@ -277,7 +288,7 @@ function ObjectDetailView(): JSX.Element {
 
 						{/* @ts-expect-error - Type mismatch due to pnpm monorepo @types/react version conflict */}
 						<Dialog.Description className="mb-2 text-kumo-subtle">
-							Are you sure you want to delete &ldquo;{search.objectKey}
+							Are you sure you want to delete &ldquo;{loaderData.objectKey}
 							&rdquo;? This cannot be undone.
 						</Dialog.Description>
 


### PR DESCRIPTION
Fixes #13559 
- Add scrolling to the D1 table selector, instead of cutting off the table list. This is also now a kumo dropdown component instead of a base-ui select.

- Show table headers in R2 empty states. In the future this could be an upload drop zone. 
<img width="1464" height="396" alt="Screenshot 2026-04-16 at 12 36 40" src="https://github.com/user-attachments/assets/e7072911-af8e-425e-8ff1-3cd2604c37dd" />

- Persist the `delimiter` search param when navigating to R2 object details
- Hide breadcrumb path segments when viewing R2 objects in ungrouped mode. So when we're not in grouped mode, the breadcrumb shows 'foo/index.js' instead of 'foo > index.js'. 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ui updates

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
