### PR TITLE
[workflows] adding restart-from-step support to the sdk

### DIFF
--- a/.changeset/restart-from-step.md
+++ b/.changeset/restart-from-step.md
@@ -1,0 +1,10 @@
+---
+"@cloudflare/workflows-shared": minor
+"miniflare": minor
+---
+
+Add restart from step support for local Workflows development
+
+Workflow instances can now be restarted from a specific step in local development. When restarting from a step, all earlier steps preserve their cached results and replay instantly, while the target step and everything after it re-execute.
+
+The `WorkflowInstance.restart()` method now accepts an optional `{ from: { name, count?, type? } }` parameter to specify which step to restart from.

--- a/fixtures/vitest-pool-workers-examples/workflows/test/integration.test.ts
+++ b/fixtures/vitest-pool-workers-examples/workflows/test/integration.test.ts
@@ -140,6 +140,8 @@ describe("workflow instance lifecycle methods", () => {
 		// DISPOSE: ensured by `await using`
 	});
 
+	// TODO(vaish): add restart-from-step test here once @cloudflare/workers-types ships restart options
+
 	it("should pause a workflow instance", async ({ expect }) => {
 		// CONFIG:
 		await using introspector = await introspectWorkflow(env.MODERATOR);

--- a/packages/miniflare/src/workers/local-explorer/resources/workflows.ts
+++ b/packages/miniflare/src/workers/local-explorer/resources/workflows.ts
@@ -8,6 +8,7 @@ import type { AppContext } from "../common";
 import type { Env } from "../explorer.worker";
 import type { WorkflowsWorkflow } from "../generated";
 import type { zWorkflowsListInstancesData } from "../generated/zod.gen";
+import type { RestartFromStep } from "@cloudflare/workflows-shared/src/binding";
 import type { z } from "zod";
 
 // ============================================================================
@@ -30,7 +31,7 @@ interface DirectoryEntry {
 interface WorkflowHandle {
 	pause(): Promise<void>;
 	resume(): Promise<void>;
-	restart(): Promise<void>;
+	restart(options?: { from?: RestartFromStep }): Promise<void>;
 	terminate(): Promise<void>;
 	sendEvent(args: { payload: unknown; type: string }): Promise<void>;
 	status(): Promise<{ status: string; output?: unknown; error?: unknown }>;
@@ -873,7 +874,10 @@ export async function changeWorkflowInstanceStatus(
 	}
 
 	try {
-		const body = (await c.req.json()) as { action: string };
+		const body = (await c.req.json()) as {
+			action: string;
+			from?: RestartFromStep;
+		};
 		const { action } = body;
 
 		if (!["pause", "resume", "restart", "terminate"].includes(action)) {
@@ -893,9 +897,19 @@ export async function changeWorkflowInstanceStatus(
 			case "resume":
 				await handle.resume();
 				break;
-			case "restart":
-				await handle.restart();
+			case "restart": {
+				if (body.from && !body.from.name) {
+					return errorResponse(
+						400,
+						10001,
+						"'from.name' is required when restarting from a specific step."
+					);
+				}
+				const opts = body.from ? { from: body.from } : undefined;
+				// TODO(vaish): remove cast once @cloudflare/workers-types ships restart options
+				await (handle as unknown as WorkflowHandle).restart(opts);
 				break;
+			}
 			case "terminate":
 				await handle.terminate();
 				break;

--- a/packages/miniflare/src/workers/workflows/wrapped-binding.worker.ts
+++ b/packages/miniflare/src/workers/workflows/wrapped-binding.worker.ts
@@ -1,4 +1,7 @@
-import type { WorkflowBinding } from "@cloudflare/workflows-shared/src/binding";
+import type {
+	WorkflowBinding,
+	WorkflowInstanceRestartOptions,
+} from "@cloudflare/workflows-shared/src/binding";
 
 class WorkflowImpl implements Workflow {
 	constructor(private binding: WorkflowBinding) {}
@@ -86,9 +89,13 @@ class InstanceImpl implements WorkflowInstance {
 		await instance.terminate();
 	}
 
-	public async restart(): Promise<void> {
+	public async restart(
+		options?: WorkflowInstanceRestartOptions
+	): Promise<void> {
 		using instance = await this.getInstance();
-		await instance.restart();
+		// TODO(vaish): remove @ts-expect-error once @cloudflare/workers-types ships restart options
+		// @ts-expect-error WorkflowInstance type does not include options yet
+		await instance.restart(options);
 	}
 
 	public async status(): Promise<InstanceStatus> {

--- a/packages/workflows-shared/src/binding.ts
+++ b/packages/workflows-shared/src/binding.ts
@@ -21,6 +21,17 @@ type Env = {
 	BINDING_NAME: string;
 };
 
+// TODO(vaish): import from @cloudflare/workers-types once restart options are published
+export interface RestartFromStep {
+	name: string;
+	count?: number;
+	type?: "do" | "sleep" | "waitForEvent";
+}
+
+export interface WorkflowInstanceRestartOptions {
+	from?: RestartFromStep;
+}
+
 // this.env.WORKFLOW is WorkflowBinding
 export class WorkflowBinding extends WorkerEntrypoint<Env> {
 	constructor(ctx: ExecutionContext, env: Env) {
@@ -208,9 +219,11 @@ export class WorkflowHandle extends RpcTarget implements WorkflowInstance {
 		}
 	}
 
-	public async restart(): Promise<void> {
+	public async restart(
+		options?: WorkflowInstanceRestartOptions
+	): Promise<void> {
 		try {
-			await this.stub.changeInstanceStatus("restart");
+			await this.stub.changeInstanceStatus("restart", options?.from);
 		} catch (e) {
 			// restart causes instance abortion
 			if (!isUserTriggeredRestart(e)) {

--- a/packages/workflows-shared/src/engine.ts
+++ b/packages/workflows-shared/src/engine.ts
@@ -15,6 +15,7 @@ import {
 	isAbortError,
 	PreservedNonRetryableError,
 	shouldPreserveNonRetryableError,
+	stepNotFoundError,
 	WorkflowFatalError,
 } from "./lib/errors";
 import {
@@ -23,19 +24,22 @@ import {
 	startGracePeriod,
 } from "./lib/gracePeriodSemaphore";
 import {
+	readAndClearRestartFromStep,
+	resolveGroupKeysToWipe,
+	storeRestartFromStep,
+	wipeRestartState,
+} from "./lib/restart";
+import {
 	createReplayReadableStream,
 	getInvalidStoredStreamOutputError,
 	getStoredStreamOutputPreview,
 	StreamOutputState,
 } from "./lib/streams";
 import { TimePriorityQueue } from "./lib/timePriorityQueue";
-import {
-	isModifierKey,
-	MODIFIER_KEYS,
-	WorkflowInstanceModifier,
-} from "./modifier";
+import { MODIFIER_KEYS, WorkflowInstanceModifier } from "./modifier";
 import type { Event } from "./context";
 import type { InstanceMetadata, RawInstanceLog } from "./instance";
+import type { RestartFromStep } from "./binding";
 import type { StreamOutputMeta } from "./lib/streams";
 import type { WorkflowEntrypoint, WorkflowEvent } from "cloudflare:workers";
 
@@ -753,7 +757,8 @@ export class Engine extends DurableObject<Env> {
 	}
 
 	async changeInstanceStatus(
-		newStatus: "resume" | "pause" | "terminate" | "restart"
+		newStatus: "resume" | "pause" | "terminate" | "restart",
+		from?: RestartFromStep
 	) {
 		const metadata =
 			await this.ctx.storage.get<InstanceMetadata>(INSTANCE_METADATA);
@@ -802,6 +807,12 @@ export class Engine extends DurableObject<Env> {
 				break;
 			}
 			case "restart":
+				if (from) {
+					if (!resolveGroupKeysToWipe(this.ctx.storage.sql, from)) {
+						throw stepNotFoundError(from.name);
+					}
+					await storeRestartFromStep(this.ctx.storage, from);
+				}
 				await this.userTriggeredRestart();
 				break;
 		}
@@ -889,60 +900,26 @@ export class Engine extends DurableObject<Env> {
 		await this.abort(ABORT_REASONS.USER_RESTART);
 	}
 
-	private getMockedEventMapKeys(allKeys: Map<string, unknown>): Set<string> {
-		const mockEventTypes = new Set<string>();
-		for (const key of allKeys.keys()) {
-			if (key.startsWith(MODIFIER_KEYS.MOCK_EVENT)) {
-				mockEventTypes.add(key.slice(MODIFIER_KEYS.MOCK_EVENT.length));
-			}
-		}
-
-		if (mockEventTypes.size === 0) {
-			return new Set();
-		}
-
-		const preserved = new Set<string>();
-		for (const key of allKeys.keys()) {
-			if (key.startsWith(`${EVENT_MAP_PREFIX}\n`)) {
-				// EVENT_MAP keys are formatted as "EVENT_MAP\n{type}\n{idx}"
-				const eventType = key.split("\n")[1];
-				if (eventType !== undefined && mockEventTypes.has(eventType)) {
-					preserved.add(key);
-				}
-			}
-		}
-
-		return preserved;
-	}
-
 	async attemptRestart() {
-		this.ctx.storage.sql.exec("DELETE FROM states");
-		this.ctx.storage.sql.exec("DELETE FROM priority_queue");
-		// Only delete non-mock streaming chunks. Mock stream outputs are stored
-		// at attempt=0 (see modifier.ts mockStepResult) and their sentinels
-		// survive restart via isModifierKey(), so the underlying SQL rows must
-		// be preserved too.
-		this.ctx.storage.sql.exec(
-			"DELETE FROM streaming_step_chunks WHERE attempt != 0"
-		);
+		const restartFromStep = await readAndClearRestartFromStep(this.ctx.storage);
 
-		const allKeys = await this.ctx.storage.list();
-		const preservedEventMapKeys = this.getMockedEventMapKeys(allKeys);
-
-		// Remove all KV keys except:
-		// - INSTANCE_METADATA (needed to re-run the workflow)
-		// - Modifier/mock keys (so mocks survive restart)
-		// - EVENT_MAP entries for mocked event types
-		for (const key of allKeys.keys()) {
-			if (
-				key === INSTANCE_METADATA ||
-				isModifierKey(key) ||
-				preservedEventMapKeys.has(key)
-			) {
-				continue;
+		let groupKeysToWipe: Set<string> | null = null;
+		if (restartFromStep) {
+			groupKeysToWipe = resolveGroupKeysToWipe(
+				this.ctx.storage.sql,
+				restartFromStep
+			);
+			if (!groupKeysToWipe) {
+				throw stepNotFoundError(restartFromStep.name);
 			}
-			await this.ctx.storage.delete(key);
 		}
+
+		await wipeRestartState(
+			this.ctx.storage,
+			ENGINE_STATUS_KEY,
+			PAUSE_DATETIME,
+			groupKeysToWipe
+		);
 
 		const metadata =
 			await this.ctx.storage.get<InstanceMetadata>(INSTANCE_METADATA);
@@ -956,14 +933,16 @@ export class Engine extends DurableObject<Env> {
 
 		const { accountId, workflow, version, instance, event } = metadata;
 
-		this.writeLog(InstanceEvent.WORKFLOW_QUEUED, null, null, {
-			params: event.payload,
-			versionId: version.id,
-			trigger: {
-				source: InstanceTrigger.API,
-			},
-		});
-		this.writeLog(InstanceEvent.WORKFLOW_START, null, null, {});
+		if (!groupKeysToWipe) {
+			this.writeLog(InstanceEvent.WORKFLOW_QUEUED, null, null, {
+				params: event.payload,
+				versionId: version.id,
+				trigger: {
+					source: InstanceTrigger.API,
+				},
+			});
+			this.writeLog(InstanceEvent.WORKFLOW_START, null, null, {});
+		}
 
 		void this.init(accountId, workflow, version, instance, event);
 	}

--- a/packages/workflows-shared/src/engine.ts
+++ b/packages/workflows-shared/src/engine.ts
@@ -37,9 +37,9 @@ import {
 } from "./lib/streams";
 import { TimePriorityQueue } from "./lib/timePriorityQueue";
 import { MODIFIER_KEYS, WorkflowInstanceModifier } from "./modifier";
+import type { RestartFromStep } from "./binding";
 import type { Event } from "./context";
 import type { InstanceMetadata, RawInstanceLog } from "./instance";
-import type { RestartFromStep } from "./binding";
 import type { StreamOutputMeta } from "./lib/streams";
 import type { WorkflowEntrypoint, WorkflowEvent } from "cloudflare:workers";
 

--- a/packages/workflows-shared/src/lib/errors.ts
+++ b/packages/workflows-shared/src/lib/errors.ts
@@ -114,3 +114,10 @@ function getCompatFlag(name: string): boolean {
 export function shouldPreserveNonRetryableError(): boolean {
 	return getCompatFlag("workflows_preserve_non_retryable_error_message");
 }
+
+export function stepNotFoundError(name: string): WorkflowError {
+	return createWorkflowError(
+		`Step "${name}" not found in execution history`,
+		"instance.cannot_restart"
+	);
+}

--- a/packages/workflows-shared/src/lib/restart.ts
+++ b/packages/workflows-shared/src/lib/restart.ts
@@ -1,0 +1,171 @@
+import { InstanceEvent } from "../instance";
+import { MODIFIER_KEYS } from "../modifier";
+import type { RestartFromStep } from "../binding";
+import type { RawInstanceLog } from "../instance";
+
+const EVENT_MAP_PREFIX = "EVENT_MAP";
+const RESTART_FROM_STEP_KEY = "RESTART_FROM_STEP";
+
+const KV_STEP_SUFFIXES = [
+	"-value",
+	"-error",
+	"-config",
+	"-metadata",
+	"-log-written",
+	"-pending",
+	"-value-stream-meta",
+] as const;
+
+export function resolveGroupKeysToWipe(
+	sql: DurableObjectStorage["sql"],
+	param: RestartFromStep
+): Set<string> | null {
+	const stepTypeToEvent: Record<string, InstanceEvent> = {
+		do: InstanceEvent.STEP_START,
+		sleep: InstanceEvent.SLEEP_START,
+		waitForEvent: InstanceEvent.WAIT_START,
+	};
+	const targetEvent = param.type ? stepTypeToEvent[param.type] : null;
+	const targetCount = param.count ?? 1;
+
+	const cursor = sql.exec<RawInstanceLog>(
+		"SELECT event, target, groupKey FROM states WHERE event IN (?, ?, ?) ORDER BY id",
+		InstanceEvent.STEP_START,
+		InstanceEvent.SLEEP_START,
+		InstanceEvent.WAIT_START
+	);
+
+	let nameOccurrence = 0;
+	let found = false;
+	const groupKeys = new Set<string>();
+
+	for (const row of cursor) {
+		if (row.groupKey === null) {
+			continue;
+		}
+		const groupKey = String(row.groupKey);
+
+		if (found) {
+			groupKeys.add(groupKey);
+			continue;
+		}
+
+		if (row.target === null) {
+			continue;
+		}
+		const rawStepName = String(row.target).replace(/-\d+$/, "");
+		if (rawStepName !== param.name) {
+			continue;
+		}
+		if (targetEvent && row.event !== targetEvent) {
+			continue;
+		}
+
+		nameOccurrence++;
+		if (nameOccurrence === targetCount) {
+			found = true;
+			groupKeys.add(groupKey);
+		}
+	}
+
+	return found ? groupKeys : null;
+}
+
+function getMockedEventMapKeys(allKeys: Map<string, unknown>): Set<string> {
+	const mockEventTypes = new Set<string>();
+	for (const key of allKeys.keys()) {
+		if (key.startsWith(MODIFIER_KEYS.MOCK_EVENT)) {
+			mockEventTypes.add(key.slice(MODIFIER_KEYS.MOCK_EVENT.length));
+		}
+	}
+
+	if (mockEventTypes.size === 0) {
+		return new Set();
+	}
+
+	const preserved = new Set<string>();
+	for (const key of allKeys.keys()) {
+		if (key.startsWith(`${EVENT_MAP_PREFIX}\n`)) {
+			const eventType = key.split("\n")[1];
+			if (eventType !== undefined && mockEventTypes.has(eventType)) {
+				preserved.add(key);
+			}
+		}
+	}
+
+	return preserved;
+}
+
+async function deleteGroupKeyBatch(
+	storage: DurableObjectStorage,
+	batch: string[]
+): Promise<void> {
+	const kvKeys: string[] = [];
+	for (const groupKey of batch) {
+		for (const suffix of KV_STEP_SUFFIXES) {
+			kvKeys.push(`${groupKey}${suffix}`);
+		}
+		storage.sql.exec("DELETE FROM states WHERE groupKey = ?", groupKey);
+		storage.sql.exec(
+			"DELETE FROM streaming_step_chunks WHERE attempt != 0 AND cache_key = ?",
+			groupKey
+		);
+	}
+	await storage.delete(kvKeys);
+}
+
+export async function wipeRestartState(
+	storage: DurableObjectStorage,
+	engineStatusKey: string,
+	pauseDatetimeKey: string,
+	groupKeysToWipe: Set<string> | null
+): Promise<void> {
+	if (groupKeysToWipe) {
+		await deleteGroupKeyBatch(storage, Array.from(groupKeysToWipe));
+		storage.sql.exec(
+			"DELETE FROM states WHERE groupKey IS NULL AND event NOT IN (?, ?)",
+			InstanceEvent.WORKFLOW_START,
+			InstanceEvent.WORKFLOW_QUEUED
+		);
+	} else {
+		const cursor = storage.sql.exec<{ groupKey: string }>(
+			"SELECT DISTINCT groupKey FROM states WHERE groupKey IS NOT NULL"
+		);
+		const allGroupKeys = [...cursor].map((r) => r.groupKey);
+		if (allGroupKeys.length > 0) {
+			await deleteGroupKeyBatch(storage, allGroupKeys);
+		}
+		storage.sql.exec("DELETE FROM states");
+	}
+
+	const keysToDelete: string[] = [engineStatusKey, pauseDatetimeKey];
+
+	const allKeys = await storage.list();
+	const preservedEventMapKeys = getMockedEventMapKeys(allKeys);
+	for (const key of allKeys.keys()) {
+		if (
+			key.startsWith(`${EVENT_MAP_PREFIX}\n`) &&
+			!preservedEventMapKeys.has(key)
+		) {
+			keysToDelete.push(key);
+		}
+	}
+	await storage.delete(keysToDelete);
+
+	storage.sql.exec("DELETE FROM priority_queue");
+}
+
+export async function readAndClearRestartFromStep(
+	storage: DurableObjectStorage
+): Promise<RestartFromStep | undefined> {
+	const value = await storage.get<RestartFromStep>(RESTART_FROM_STEP_KEY);
+	await storage.delete(RESTART_FROM_STEP_KEY);
+	return value;
+}
+
+export async function storeRestartFromStep(
+	storage: DurableObjectStorage,
+	from: RestartFromStep
+): Promise<void> {
+	await storage.put(RESTART_FROM_STEP_KEY, from);
+}

--- a/packages/workflows-shared/tests/engine.test.ts
+++ b/packages/workflows-shared/tests/engine.test.ts
@@ -634,6 +634,89 @@ describe("Engine", () => {
 			}
 		);
 
+		it("should restart from a specific step and preserve earlier results", async ({
+			expect,
+		}) => {
+			const instanceId = "RESTART-FROM-STEP";
+			const engineId = env.ENGINE.idFromName(instanceId);
+
+			const engineStub = await runWorkflowAndAwait(
+				instanceId,
+				async (_event: unknown, step: WorkflowStep) => {
+					const a = await step.do("step-a", async () => "result-a");
+					const b = await step.do("step-b", async () => "result-b");
+					return { a, b };
+				}
+			);
+
+			const statusBefore = await runInDurableObject(engineStub, (engine) =>
+				engine.getStatus()
+			);
+			expect(statusBefore).toBe(InstanceStatus.Complete);
+
+			try {
+				await runInDurableObject(engineStub, async (engine) => {
+					await engine.changeInstanceStatus("restart", {
+						name: "step-b",
+					});
+				});
+			} catch (e) {
+				if (!isAbortError(e)) {
+					throw e;
+				}
+			}
+
+			const restartedStub = env.ENGINE.get(engineId);
+
+			await runInDurableObject(restartedStub, async (engine) => {
+				await engine.attemptRestart();
+			});
+
+			await vi.waitUntil(
+				async () => {
+					const status = await runInDurableObject(restartedStub, (engine) =>
+						engine.getStatus()
+					);
+					return status === InstanceStatus.Complete;
+				},
+				{ timeout: 5000 }
+			);
+
+			const logs = (await restartedStub.readLogs()) as EngineLogs;
+
+			// step-a should still have its cached result from the first run
+			const stepSuccessLogs = logs.logs.filter(
+				(log) => log.event === InstanceEvent.STEP_SUCCESS
+			);
+			expect(stepSuccessLogs.length).toBeGreaterThanOrEqual(2);
+
+			expect(
+				logs.logs.some((log) => log.event === InstanceEvent.WORKFLOW_SUCCESS)
+			).toBe(true);
+		});
+
+		it("should throw when restarting from a non-existing step", async ({
+			expect,
+		}) => {
+			const instanceId = "RESTART-FROM-BAD-STEP";
+
+			const engineStub = await runWorkflowAndAwait(
+				instanceId,
+				async (_event: unknown, step: WorkflowStep) => {
+					await step.do("step-a", async () => "result-a");
+					return "done";
+				}
+			);
+
+			await expect(
+				runInDurableObject(engineStub, async (engine) => {
+					await engine.changeInstanceStatus("restart", {
+						name: "nonexistent-step",
+					});
+				})
+			).rejects.toThrow("not found in execution history");
+		});
+
 		it("should pause after in-flight step.do finishes", async ({ expect }) => {
 			const instanceId = "PAUSE-AFTER-DO";
 			const engineId = env.ENGINE.idFromName(instanceId);


### PR DESCRIPTION
## Workflows: Add restart from step support for local dev

Extends `WorkflowHandle.restart()` to accept an optional from parameter for selective restart

_Describe your change..._

Adds support for:
`await instance.restart({ from: { name: 'aggregate' } });`
`await instance.restart({ from: { name: 'process', count: 3 } });`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated:
    - Added "should restart a workflow instance from a specific step" integration test in `fixtures/vitest-pool-workers-examples/workflows/test/integration.test.ts`
  - [ ]  Automated tests not possible - manual testing has been completed as follows:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/30411
  - [ ] Documentation not necessary because:
*A picture of a cute animal (not mandatory, but encouraged)*
(her name's coconut)
<img width="737" height="1600" alt="image" src="https://github.com/user-attachments/assets/5a891003-38ce-4c8e-9297-917152088286" />

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
