### PR TITLE
Detect Cloudflare WAF block pages and show a helpful error message in stead of "Received a malformed response from the API"

### DIFF
--- a/.changeset/detect-waf-block-response.md
+++ b/.changeset/detect-waf-block-response.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Detect Cloudflare WAF block pages and show a helpful error message instead of "Received a malformed response from the API"
+
+When the Cloudflare WAF blocks an API request, the response is an HTML page rather than JSON. Previously, this caused a confusing "Received a malformed response from the API" error with a truncated HTML snippet. Wrangler now detects WAF block pages and displays a clear error message explaining that the request was blocked by the firewall, along with the Cloudflare Ray ID (when available) for use in support tickets.

--- a/.changeset/detect-waf-block-response.md
+++ b/.changeset/detect-waf-block-response.md
@@ -2,6 +2,8 @@
 "wrangler": patch
 ---
 
-Detect Cloudflare WAF block pages and show a helpful error message instead of "Received a malformed response from the API"
+Detect Cloudflare WAF block pages and include Ray ID in API error messages
 
 When the Cloudflare WAF blocks an API request, the response is an HTML page rather than JSON. Previously, this caused a confusing "Received a malformed response from the API" error with a truncated HTML snippet. Wrangler now detects WAF block pages and displays a clear error message explaining that the request was blocked by the firewall, along with the Cloudflare Ray ID (when available) for use in support tickets.
+
+For other non-JSON responses that aren't WAF blocks, the "malformed response" error also now includes the Ray ID to help reference failing requests in support tickets.

--- a/.changeset/malformed-response-ray-id.md
+++ b/.changeset/malformed-response-ray-id.md
@@ -1,7 +1,0 @@
----
-"wrangler": patch
----
-
-Include Cloudflare Ray ID in the "malformed response" API error
-
-When the Cloudflare API returns non-JSON content that isn't detected as a WAF block page, the resulting "Received a malformed response from the API" error now includes the Cloudflare Ray ID (from the `cf-ray` header) when available. This makes it easier to reference the failing request in support tickets.

--- a/.changeset/malformed-response-ray-id.md
+++ b/.changeset/malformed-response-ray-id.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Include Cloudflare Ray ID in the "malformed response" API error
+
+When the Cloudflare API returns non-JSON content that isn't detected as a WAF block page, the resulting "Received a malformed response from the API" error now includes the Cloudflare Ray ID (from the `cf-ray` header) when available. This makes it easier to reference the failing request in support tickets.

--- a/packages/wrangler/src/__tests__/cfetch-internal.test.ts
+++ b/packages/wrangler/src/__tests__/cfetch-internal.test.ts
@@ -1,0 +1,180 @@
+import { COMPLIANCE_REGION_CONFIG_UNKNOWN } from "@cloudflare/workers-utils";
+import { http, HttpResponse } from "msw";
+import { describe, it } from "vitest";
+import { fetchGraphqlResult } from "../cfetch";
+import { extractWAFBlockRayId, isWAFBlockResponse } from "../cfetch/internal";
+import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
+import { msw } from "./helpers/msw";
+
+const WAF_BLOCK_HTML = `<!DOCTYPE html>
+<html>
+<head><title>Attention Required! | Cloudflare</title></head>
+<body>
+  <h1 data-translate="block_headline">Sorry, you have been blocked</h1>
+  <h2 class="cf-subheadline"><span data-translate="unable_to_access">You are unable to access</span> api.cloudflare.com</h2>
+  <p>Cloudflare Ray ID: 9e8116df4823e2c5</p>
+</body>
+</html>`;
+
+const WAF_BLOCK_HTML_NO_RAY_ID = `<!DOCTYPE html>
+<html>
+<head><title>Attention Required! | Cloudflare</title></head>
+<body>
+  <h1 data-translate="block_headline">Sorry, you have been blocked</h1>
+  <h2 class="cf-subheadline"><span data-translate="unable_to_access">You are unable to access</span> api.cloudflare.com</h2>
+</body>
+</html>`;
+
+describe("isWAFBlockResponse", () => {
+	it("should detect a WAF block page", ({ expect }) => {
+		expect(isWAFBlockResponse(WAF_BLOCK_HTML)).toBe(true);
+	});
+
+	it("should detect a WAF block page without a Ray ID", ({ expect }) => {
+		expect(isWAFBlockResponse(WAF_BLOCK_HTML_NO_RAY_ID)).toBe(true);
+	});
+
+	it("should return false for valid JSON", ({ expect }) => {
+		expect(
+			isWAFBlockResponse(
+				JSON.stringify({ success: true, result: {}, errors: [], messages: [] })
+			)
+		).toBe(false);
+	});
+
+	it("should return false for other HTML error pages", ({ expect }) => {
+		expect(
+			isWAFBlockResponse("<html><body>Internal Server Error</body></html>")
+		).toBe(false);
+	});
+});
+
+describe("extractWAFBlockRayId", () => {
+	it("should extract the Ray ID from a WAF block page", ({ expect }) => {
+		expect(extractWAFBlockRayId(WAF_BLOCK_HTML)).toBe("9e8116df4823e2c5");
+	});
+
+	it("should return undefined when no Ray ID is present", ({ expect }) => {
+		expect(extractWAFBlockRayId(WAF_BLOCK_HTML_NO_RAY_ID)).toBeUndefined();
+	});
+
+	it("should return undefined for non-HTML content", ({ expect }) => {
+		expect(extractWAFBlockRayId("some random text")).toBeUndefined();
+	});
+});
+
+describe("fetchInternal WAF block detection", () => {
+	mockAccountId({ accountId: null });
+	mockApiToken();
+
+	it("should throw a helpful error when the API returns a WAF block page", async ({
+		expect,
+	}) => {
+		msw.use(
+			http.post("*/graphql", async () => {
+				return new HttpResponse(WAF_BLOCK_HTML, {
+					status: 403,
+					statusText: "Forbidden",
+					headers: { "Content-Type": "text/html" },
+				});
+			})
+		);
+		await expect(
+			fetchGraphqlResult(COMPLIANCE_REGION_CONFIG_UNKNOWN, {
+				body: JSON.stringify({ query: "{ viewer { __typename } }" }),
+			})
+		).rejects.toThrow(
+			"The Cloudflare API responded with a WAF block page instead of the expected JSON response"
+		);
+	});
+
+	it("should include the Ray ID in the error when present", async ({
+		expect,
+	}) => {
+		msw.use(
+			http.post("*/graphql", async () => {
+				return new HttpResponse(WAF_BLOCK_HTML, {
+					status: 403,
+					statusText: "Forbidden",
+					headers: { "Content-Type": "text/html" },
+				});
+			})
+		);
+		try {
+			await fetchGraphqlResult(COMPLIANCE_REGION_CONFIG_UNKNOWN, {
+				body: JSON.stringify({ query: "{ viewer { __typename } }" }),
+			});
+			expect.unreachable("should have thrown");
+		} catch (e) {
+			const error = e as { notes: { text: string }[] };
+			const rayIdNote = error.notes.find((n: { text: string }) =>
+				n.text.includes("Cloudflare Ray ID:")
+			);
+			expect(rayIdNote).toBeDefined();
+			expect(rayIdNote?.text).toBe("Cloudflare Ray ID: 9e8116df4823e2c5");
+			const supportNote = error.notes.find((n: { text: string }) =>
+				n.text.includes("open a Cloudflare Support ticket")
+			);
+			expect(supportNote?.text).toBe(
+				"If the issue persists, please open a Cloudflare Support ticket and include the Ray ID above."
+			);
+		}
+	});
+
+	it("should still throw a WAF error without the Ray ID note when Ray ID is absent", async ({
+		expect,
+	}) => {
+		msw.use(
+			http.post("*/graphql", async () => {
+				return new HttpResponse(WAF_BLOCK_HTML_NO_RAY_ID, {
+					status: 403,
+					statusText: "Forbidden",
+					headers: { "Content-Type": "text/html" },
+				});
+			})
+		);
+		try {
+			await fetchGraphqlResult(COMPLIANCE_REGION_CONFIG_UNKNOWN, {
+				body: JSON.stringify({ query: "{ viewer { __typename } }" }),
+			});
+			expect.unreachable("should have thrown");
+		} catch (e) {
+			const error = e as { text: string; notes: { text: string }[] };
+			expect(error.text).toBe(
+				"The Cloudflare API responded with a WAF block page instead of the expected JSON response"
+			);
+			const rayIdNote = error.notes.find((n: { text: string }) =>
+				n.text.includes("Cloudflare Ray ID:")
+			);
+			expect(rayIdNote).toBeUndefined();
+			const supportNote = error.notes.find((n: { text: string }) =>
+				n.text.includes("open a Cloudflare Support ticket")
+			);
+			expect(supportNote?.text).toBe(
+				"If the issue persists, please open a Cloudflare Support ticket. You can find the Cloudflare Ray ID on the block page in your browser."
+			);
+		}
+	});
+
+	it("should still throw 'malformed response' for non-WAF HTML responses", async ({
+		expect,
+	}) => {
+		msw.use(
+			http.post("*/graphql", async () => {
+				return new HttpResponse(
+					"<html><body>Internal Server Error</body></html>",
+					{
+						status: 500,
+						statusText: "Internal Server Error",
+						headers: { "Content-Type": "text/html" },
+					}
+				);
+			})
+		);
+		await expect(
+			fetchGraphqlResult(COMPLIANCE_REGION_CONFIG_UNKNOWN, {
+				body: JSON.stringify({ query: "{ viewer { __typename } }" }),
+			})
+		).rejects.toThrow("Received a malformed response from the API");
+	});
+});

--- a/packages/wrangler/src/__tests__/cfetch-internal.test.ts
+++ b/packages/wrangler/src/__tests__/cfetch-internal.test.ts
@@ -162,4 +162,72 @@ describe("fetchInternal WAF block detection", () => {
 			})
 		).rejects.toThrow("Received a malformed response from the API");
 	});
+
+	it("should include the Ray ID in 'malformed response' error when cf-ray header is present", async ({
+		expect,
+	}) => {
+		msw.use(
+			http.post("*/graphql", async () => {
+				return new HttpResponse(
+					"<html><body>Internal Server Error</body></html>",
+					{
+						status: 500,
+						statusText: "Internal Server Error",
+						headers: {
+							"Content-Type": "text/html",
+							"cf-ray": "abc123def456",
+						},
+					}
+				);
+			})
+		);
+		try {
+			await fetchGraphqlResult(COMPLIANCE_REGION_CONFIG_UNKNOWN, {
+				body: JSON.stringify({ query: "{ viewer { __typename } }" }),
+			});
+			expect.unreachable("should have thrown");
+		} catch (e) {
+			const error = e as { text: string; notes: { text: string }[] };
+			expect(error.text).toBe(
+				"Received a malformed response from the API"
+			);
+			const rayIdNote = error.notes.find((n: { text: string }) =>
+				n.text.includes("Cloudflare Ray ID:")
+			);
+			expect(rayIdNote).toBeDefined();
+			expect(rayIdNote?.text).toBe("Cloudflare Ray ID: abc123def456");
+		}
+	});
+
+	it("should omit the Ray ID in 'malformed response' error when cf-ray header is absent", async ({
+		expect,
+	}) => {
+		msw.use(
+			http.post("*/graphql", async () => {
+				return new HttpResponse(
+					"<html><body>Internal Server Error</body></html>",
+					{
+						status: 500,
+						statusText: "Internal Server Error",
+						headers: { "Content-Type": "text/html" },
+					}
+				);
+			})
+		);
+		try {
+			await fetchGraphqlResult(COMPLIANCE_REGION_CONFIG_UNKNOWN, {
+				body: JSON.stringify({ query: "{ viewer { __typename } }" }),
+			});
+			expect.unreachable("should have thrown");
+		} catch (e) {
+			const error = e as { text: string; notes: { text: string }[] };
+			expect(error.text).toBe(
+				"Received a malformed response from the API"
+			);
+			const rayIdNote = error.notes.find((n: { text: string }) =>
+				n.text.includes("Cloudflare Ray ID:")
+			);
+			expect(rayIdNote).toBeUndefined();
+		}
+	});
 });

--- a/packages/wrangler/src/__tests__/cfetch-internal.test.ts
+++ b/packages/wrangler/src/__tests__/cfetch-internal.test.ts
@@ -6,60 +6,34 @@ import { extractWAFBlockRayId, isWAFBlockResponse } from "../cfetch/internal";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { msw } from "./helpers/msw";
 
-const WAF_BLOCK_HTML = `<!DOCTYPE html>
-<html>
-<head><title>Attention Required! | Cloudflare</title></head>
-<body>
-  <h1 data-translate="block_headline">Sorry, you have been blocked</h1>
-  <h2 class="cf-subheadline"><span data-translate="unable_to_access">You are unable to access</span> api.cloudflare.com</h2>
-  <p>Cloudflare Ray ID: 9e8116df4823e2c5</p>
-</body>
-</html>`;
-
-const WAF_BLOCK_HTML_NO_RAY_ID = `<!DOCTYPE html>
-<html>
-<head><title>Attention Required! | Cloudflare</title></head>
-<body>
-  <h1 data-translate="block_headline">Sorry, you have been blocked</h1>
-  <h2 class="cf-subheadline"><span data-translate="unable_to_access">You are unable to access</span> api.cloudflare.com</h2>
-</body>
-</html>`;
-
 describe("isWAFBlockResponse", () => {
-	it("should detect a WAF block page", ({ expect }) => {
-		expect(isWAFBlockResponse(WAF_BLOCK_HTML)).toBe(true);
+	it("should detect a WAF-mitigated response", ({ expect }) => {
+		const headers = new Headers({ "cf-mitigated": "challenge" });
+		expect(isWAFBlockResponse(headers)).toBe(true);
 	});
 
-	it("should detect a WAF block page without a Ray ID", ({ expect }) => {
-		expect(isWAFBlockResponse(WAF_BLOCK_HTML_NO_RAY_ID)).toBe(true);
+	it("should return false when cf-mitigated header is absent", ({ expect }) => {
+		const headers = new Headers();
+		expect(isWAFBlockResponse(headers)).toBe(false);
 	});
 
-	it("should return false for valid JSON", ({ expect }) => {
-		expect(
-			isWAFBlockResponse(
-				JSON.stringify({ success: true, result: {}, errors: [], messages: [] })
-			)
-		).toBe(false);
-	});
-
-	it("should return false for other HTML error pages", ({ expect }) => {
-		expect(
-			isWAFBlockResponse("<html><body>Internal Server Error</body></html>")
-		).toBe(false);
+	it("should return false when cf-mitigated has a different value", ({
+		expect,
+	}) => {
+		const headers = new Headers({ "cf-mitigated": "other" });
+		expect(isWAFBlockResponse(headers)).toBe(false);
 	});
 });
 
 describe("extractWAFBlockRayId", () => {
-	it("should extract the Ray ID from a WAF block page", ({ expect }) => {
-		expect(extractWAFBlockRayId(WAF_BLOCK_HTML)).toBe("9e8116df4823e2c5");
+	it("should extract the Ray ID from the cf-ray header", ({ expect }) => {
+		const headers = new Headers({ "cf-ray": "9e8116df4823e2c5" });
+		expect(extractWAFBlockRayId(headers)).toBe("9e8116df4823e2c5");
 	});
 
-	it("should return undefined when no Ray ID is present", ({ expect }) => {
-		expect(extractWAFBlockRayId(WAF_BLOCK_HTML_NO_RAY_ID)).toBeUndefined();
-	});
-
-	it("should return undefined for non-HTML content", ({ expect }) => {
-		expect(extractWAFBlockRayId("some random text")).toBeUndefined();
+	it("should return undefined when cf-ray header is absent", ({ expect }) => {
+		const headers = new Headers();
+		expect(extractWAFBlockRayId(headers)).toBeUndefined();
 	});
 });
 
@@ -67,15 +41,19 @@ describe("fetchInternal WAF block detection", () => {
 	mockAccountId({ accountId: null });
 	mockApiToken();
 
-	it("should throw a helpful error when the API returns a WAF block page", async ({
+	it("should throw a helpful error when the API returns a WAF block response", async ({
 		expect,
 	}) => {
 		msw.use(
 			http.post("*/graphql", async () => {
-				return new HttpResponse(WAF_BLOCK_HTML, {
+				return new HttpResponse("blocked", {
 					status: 403,
 					statusText: "Forbidden",
-					headers: { "Content-Type": "text/html" },
+					headers: {
+						"Content-Type": "text/html",
+						"cf-mitigated": "challenge",
+						"cf-ray": "9e8116df4823e2c5",
+					},
 				});
 			})
 		);
@@ -88,15 +66,19 @@ describe("fetchInternal WAF block detection", () => {
 		);
 	});
 
-	it("should include the Ray ID in the error when present", async ({
+	it("should include the Ray ID in the error when cf-ray header is present", async ({
 		expect,
 	}) => {
 		msw.use(
 			http.post("*/graphql", async () => {
-				return new HttpResponse(WAF_BLOCK_HTML, {
+				return new HttpResponse("blocked", {
 					status: 403,
 					statusText: "Forbidden",
-					headers: { "Content-Type": "text/html" },
+					headers: {
+						"Content-Type": "text/html",
+						"cf-mitigated": "challenge",
+						"cf-ray": "9e8116df4823e2c5",
+					},
 				});
 			})
 		);
@@ -121,15 +103,18 @@ describe("fetchInternal WAF block detection", () => {
 		}
 	});
 
-	it("should still throw a WAF error without the Ray ID note when Ray ID is absent", async ({
+	it("should still throw a WAF error without the Ray ID note when cf-ray header is absent", async ({
 		expect,
 	}) => {
 		msw.use(
 			http.post("*/graphql", async () => {
-				return new HttpResponse(WAF_BLOCK_HTML_NO_RAY_ID, {
+				return new HttpResponse("blocked", {
 					status: 403,
 					statusText: "Forbidden",
-					headers: { "Content-Type": "text/html" },
+					headers: {
+						"Content-Type": "text/html",
+						"cf-mitigated": "challenge",
+					},
 				});
 			})
 		);

--- a/packages/wrangler/src/__tests__/cfetch-internal.test.ts
+++ b/packages/wrangler/src/__tests__/cfetch-internal.test.ts
@@ -188,9 +188,7 @@ describe("fetchInternal WAF block detection", () => {
 			expect.unreachable("should have thrown");
 		} catch (e) {
 			const error = e as { text: string; notes: { text: string }[] };
-			expect(error.text).toBe(
-				"Received a malformed response from the API"
-			);
+			expect(error.text).toBe("Received a malformed response from the API");
 			const rayIdNote = error.notes.find((n: { text: string }) =>
 				n.text.includes("Cloudflare Ray ID:")
 			);
@@ -221,9 +219,7 @@ describe("fetchInternal WAF block detection", () => {
 			expect.unreachable("should have thrown");
 		} catch (e) {
 			const error = e as { text: string; notes: { text: string }[] };
-			expect(error.text).toBe(
-				"Received a malformed response from the API"
-			);
+			expect(error.text).toBe("Received a malformed response from the API");
 			const rayIdNote = error.notes.find((n: { text: string }) =>
 				n.text.includes("Cloudflare Ray ID:")
 			);

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -193,11 +193,11 @@ export async function fetchInternal<ResponseType>(
 		};
 	}
 
-	// Detect Cloudflare WAF block pages that return HTML instead of JSON.
+	// Detect Cloudflare WAF block pages via the cf-mitigated response header.
 	// Without this check, the JSON parser throws a confusing "malformed response" error.
-	if (isWAFBlockResponse(jsonText)) {
+	if (isWAFBlockResponse(response.headers)) {
 		throwWAFBlockError(
-			jsonText,
+			response.headers,
 			method,
 			resource,
 			response.status,
@@ -233,35 +233,33 @@ export function truncate(text: string, maxLength: number): string {
 }
 
 /**
- * Checks whether the response body looks like a Cloudflare WAF block page.
- * These are HTML pages returned when the WAF rejects a request, and will
- * never parse as JSON.
+ * Checks whether the response was blocked by Cloudflare's WAF by inspecting
+ * the `cf-mitigated` response header. When the WAF blocks or challenges a
+ * request the response will include `cf-mitigated: challenge`.
  *
- * @param body - The raw response body text to check.
- * @returns `true` if the body appears to be a Cloudflare WAF block page.
+ * @see https://developers.cloudflare.com/cloudflare-challenges/challenge-types/challenge-pages/detect-response/
+ *
+ * @param headers - The response headers to inspect.
+ * @returns `true` if the response was mitigated by the WAF.
  */
-export function isWAFBlockResponse(body: string): boolean {
-	return (
-		body.includes("<html") && body.includes("Sorry, you have been blocked")
-	);
+export function isWAFBlockResponse(headers: Headers): boolean {
+	return headers.get("cf-mitigated") === "challenge";
 }
 
 /**
- * Extracts the Cloudflare Ray ID from a WAF block page, if present.
- * The Ray ID is a hex string typically shown at the bottom of the page.
+ * Extracts the Cloudflare Ray ID from the `cf-ray` response header.
  *
- * @param html - The HTML body of a WAF block page.
- * @returns The Ray ID hex string, or `undefined` if not found.
+ * @param headers - The response headers to inspect.
+ * @returns The Ray ID string, or `undefined` if the header is absent.
  */
-export function extractWAFBlockRayId(html: string): string | undefined {
-	const match = html.match(/Cloudflare Ray ID:\s*([0-9a-f]+)/i);
-	return match?.[1];
+export function extractWAFBlockRayId(headers: Headers): string | undefined {
+	return headers.get("cf-ray") ?? undefined;
 }
 
 /**
  * Throws a descriptive {@link APIError} for a WAF block response.
  *
- * @param body - The raw HTML body of the WAF block page.
+ * @param headers - The response headers (used to extract the Ray ID).
  * @param method - The HTTP method of the blocked request.
  * @param resource - The URL or path that was requested.
  * @param status - The HTTP status code returned.
@@ -269,13 +267,13 @@ export function extractWAFBlockRayId(html: string): string | undefined {
  * @throws {APIError} Always — this function never returns.
  */
 function throwWAFBlockError(
-	body: string,
+	headers: Headers,
 	method: string,
 	resource: string,
 	status: number,
 	statusText: string
 ): never {
-	const rayId = extractWAFBlockRayId(body);
+	const rayId = extractWAFBlockRayId(headers);
 	throw new APIError({
 		text: "The Cloudflare API responded with a WAF block page instead of the expected JSON response",
 		notes: [

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -193,6 +193,18 @@ export async function fetchInternal<ResponseType>(
 		};
 	}
 
+	// Detect Cloudflare WAF block pages that return HTML instead of JSON.
+	// Without this check, the JSON parser throws a confusing "malformed response" error.
+	if (isWAFBlockResponse(jsonText)) {
+		throwWAFBlockError(
+			jsonText,
+			method,
+			resource,
+			response.status,
+			response.statusText
+		);
+	}
+
 	try {
 		const json = parseJSON(jsonText) as ResponseType;
 		return { response: json, status: response.status };
@@ -218,6 +230,70 @@ export function truncate(text: string, maxLength: number): string {
 		return text;
 	}
 	return `${text.substring(0, maxLength)}... (length = ${length})`;
+}
+
+/**
+ * Checks whether the response body looks like a Cloudflare WAF block page.
+ * These are HTML pages returned when the WAF rejects a request, and will
+ * never parse as JSON.
+ *
+ * @param body - The raw response body text to check.
+ * @returns `true` if the body appears to be a Cloudflare WAF block page.
+ */
+export function isWAFBlockResponse(body: string): boolean {
+	return (
+		body.includes("<html") && body.includes("Sorry, you have been blocked")
+	);
+}
+
+/**
+ * Extracts the Cloudflare Ray ID from a WAF block page, if present.
+ * The Ray ID is a hex string typically shown at the bottom of the page.
+ *
+ * @param html - The HTML body of a WAF block page.
+ * @returns The Ray ID hex string, or `undefined` if not found.
+ */
+export function extractWAFBlockRayId(html: string): string | undefined {
+	const match = html.match(/Cloudflare Ray ID:\s*([0-9a-f]+)/i);
+	return match?.[1];
+}
+
+/**
+ * Throws a descriptive {@link APIError} for a WAF block response.
+ *
+ * @param body - The raw HTML body of the WAF block page.
+ * @param method - The HTTP method of the blocked request.
+ * @param resource - The URL or path that was requested.
+ * @param status - The HTTP status code returned.
+ * @param statusText - The HTTP status text returned.
+ * @throws {APIError} Always — this function never returns.
+ */
+function throwWAFBlockError(
+	body: string,
+	method: string,
+	resource: string,
+	status: number,
+	statusText: string
+): never {
+	const rayId = extractWAFBlockRayId(body);
+	throw new APIError({
+		text: "The Cloudflare API responded with a WAF block page instead of the expected JSON response",
+		notes: [
+			{
+				text: "Cloudflare's firewall (WAF) blocked this API request. This is usually a false positive.",
+			},
+			...(rayId ? [{ text: `Cloudflare Ray ID: ${rayId}` }] : []),
+			{
+				text: rayId
+					? "If the issue persists, please open a Cloudflare Support ticket and include the Ray ID above."
+					: "If the issue persists, please open a Cloudflare Support ticket. You can find the Cloudflare Ray ID on the block page in your browser.",
+			},
+			{
+				text: `${method} ${resource} -> ${status} ${statusText}`,
+			},
+		],
+		status,
+	});
 }
 
 function cloneHeaders(headers: HeadersInit | undefined): Headers {

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -209,6 +209,8 @@ export async function fetchInternal<ResponseType>(
 		const json = parseJSON(jsonText) as ResponseType;
 		return { response: json, status: response.status };
 	} catch {
+		const rayId = extractWAFBlockRayId(response.headers);
+
 		throw new APIError({
 			text: "Received a malformed response from the API",
 			notes: [
@@ -218,6 +220,7 @@ export async function fetchInternal<ResponseType>(
 				{
 					text: `${method} ${resource} -> ${response.status} ${response.statusText}`,
 				},
+				...(rayId ? [{ text: `Cloudflare Ray ID: ${rayId}` }] : []),
 			],
 			status: response.status,
 		});


### PR DESCRIPTION
Fixes #13312 

When the Cloudflare WAF blocks an API request, the response is an HTML page rather than JSON. Previously, this caused a confusing "Received a malformed response from the API" error with a truncated HTML snippet. Wrangler now detects WAF block pages and displays a clear error message explaining that the request was blocked by the firewall, along with the Cloudflare Ray ID (when available) for use in support tickets.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: UX improvement

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
