### PR TITLE
Add D1 export prompt message for unavailability

### DIFF
--- a/.changeset/tricky-experts-fry.md
+++ b/.changeset/tricky-experts-fry.md
@@ -1,5 +1,5 @@
 ---
-"@fake-scope/fake-pkg": patch
+"wrangler": patch
 ---
 
 Add D1 export prompt message for unavailability, use `--skip-confirmation` to not show the prompt.

--- a/.changeset/tricky-experts-fry.md
+++ b/.changeset/tricky-experts-fry.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+Add D1 export prompt message for unavailability, use `--skip-confirmation` to not show the prompt.

--- a/packages/wrangler/src/__tests__/d1/export.test.ts
+++ b/packages/wrangler/src/__tests__/d1/export.test.ts
@@ -5,6 +5,7 @@ import { http, HttpResponse } from "msw";
 import { describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
+import { mockConfirm } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { mockGetMemberships } from "../helpers/mock-oauth-flow";
 import { msw } from "../helpers/msw";
@@ -134,6 +135,83 @@ describe("export", () => {
 		);
 
 		await runWrangler("d1 export db --remote --output test-remote.sql");
+		expect(fs.readFileSync("test-remote.sql", "utf8")).toBe(mockSqlContent);
+	});
+
+	it("should prompt for confirmation when exporting remotely in interactive mode", async ({
+		expect,
+	}) => {
+		setIsTTY(true);
+		writeWranglerConfig({
+			d1_databases: [
+				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+			],
+		});
+		mockGetMemberships([
+			{ id: "IG-88", account: { id: "1701", name: "enterprise" } },
+		]);
+		const mockSqlContent = "PRAGMA defer_foreign_keys=TRUE;";
+
+		mockConfirm({
+			text: `⚠️ This process may take some time, during which your D1 database will be unavailable to serve queries.\n  Ok to proceed?`,
+			result: true,
+		});
+
+		mockResponses();
+
+		msw.use(
+			http.get("https://example.com/xxxx-yyyy.sql", async () => {
+				return HttpResponse.text(mockSqlContent, { status: 200 });
+			})
+		);
+
+		await runWrangler("d1 export db --remote --output test-remote.sql");
+		expect(fs.readFileSync("test-remote.sql", "utf8")).toBe(mockSqlContent);
+	});
+
+	it("should not export when confirmation is rejected", async ({ expect }) => {
+		setIsTTY(true);
+		writeWranglerConfig({
+			d1_databases: [
+				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+			],
+		});
+
+		mockConfirm({
+			text: `⚠️ This process may take some time, during which your D1 database will be unavailable to serve queries.\n  Ok to proceed?`,
+			result: false,
+		});
+
+		await runWrangler("d1 export db --remote --output test-remote.sql");
+		expect(std.out).toContain("Not exporting.");
+		expect(fs.existsSync("test-remote.sql")).toBe(false);
+	});
+
+	it("should skip confirmation when --skip-confirmation flag is used", async ({
+		expect,
+	}) => {
+		setIsTTY(true);
+		writeWranglerConfig({
+			d1_databases: [
+				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+			],
+		});
+		mockGetMemberships([
+			{ id: "IG-88", account: { id: "1701", name: "enterprise" } },
+		]);
+		const mockSqlContent = "PRAGMA defer_foreign_keys=TRUE;";
+
+		mockResponses();
+
+		msw.use(
+			http.get("https://example.com/xxxx-yyyy.sql", async () => {
+				return HttpResponse.text(mockSqlContent, { status: 200 });
+			})
+		);
+
+		await runWrangler(
+			"d1 export db --remote --skip-confirmation --output test-remote.sql"
+		);
 		expect(fs.readFileSync("test-remote.sql", "utf8")).toBe(mockSqlContent);
 	});
 

--- a/packages/wrangler/src/d1/export.ts
+++ b/packages/wrangler/src/d1/export.ts
@@ -9,6 +9,7 @@ import { fetch } from "undici";
 import { fetchResult } from "../cfetch";
 import { createCommand } from "../core/create-command";
 import { getLocalPersistencePath } from "../dev/get-local-persistence-path";
+import { confirm } from "../dialogs";
 import { logger } from "../logger";
 import { readableRelative } from "../paths";
 import { requireAuth } from "../user";
@@ -41,6 +42,12 @@ export const d1ExportCommand = createCommand({
 			type: "boolean",
 			description: "Export from a remote D1 database",
 			conflicts: "local",
+		},
+		"skip-confirmation": {
+			type: "boolean",
+			description: "Skip confirmation",
+			alias: "y",
+			default: false,
 		},
 		output: {
 			type: "string",
@@ -78,7 +85,8 @@ export const d1ExportCommand = createCommand({
 	},
 	positionalArgs: ["name"],
 	async handler(args, { config }) {
-		const { remote, name, output, schema, data, table } = args;
+		const { remote, name, output, schema, data, table, skipConfirmation } =
+			args;
 
 		if (!schema && !data) {
 			throw new UserError(`You cannot specify both --no-schema and --no-data`);
@@ -95,6 +103,16 @@ export const d1ExportCommand = createCommand({
 		const tables = table ?? [];
 
 		if (remote) {
+			if (!skipConfirmation) {
+				const response = await confirm(
+					`⚠️ This process may take some time, during which your D1 database will be unavailable to serve queries.\n  Ok to proceed?`
+				);
+				if (!response) {
+					logger.log(`Not exporting.`);
+					return;
+				}
+			}
+
 			return await exportRemotely(config, name, output, tables, !schema, !data);
 		} else {
 			return await exportLocal(config, name, output, tables, !schema, !data);


### PR DESCRIPTION
Fixes #[CFSQL-1608].

Add a confirmation prompt that the database will be unavailable to queries during the export.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no feature change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
