### PR TITLE
[wrangler] Expand telemetry arg allow list to restore dropped boolean flags

### DIFF
--- a/.changeset/expand-telemetry-arg-allow-list.md
+++ b/.changeset/expand-telemetry-arg-allow-list.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Restore telemetry tracking for common CLI flags that were unintentionally dropped during sanitisation
+
+When argument sanitisation was introduced, only explicitly allow-listed args had their values included in telemetry. The allow list was very conservative, which meant common boolean flags like `--remote`, `--json`, `--dry-run`, `--force`, and many others were no longer being captured in `sanitizedArgs` despite previously being tracked. Boolean flags are inherently safe (values are only `true`/`false`), so these have now been added back to the global allow list. A small number of fixed-choice args (`--local-protocol`, `--upstream-protocol`, `--containers-rollout`) have also been added with their known value sets.

--- a/packages/wrangler/src/__tests__/metrics/sanitization.test.ts
+++ b/packages/wrangler/src/__tests__/metrics/sanitization.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "vitest";
 import {
 	ALLOW,
+	COMMAND_ARG_ALLOW_LIST,
 	getAllowedArgs,
 	REDACT,
 	sanitizeArgKeys,
@@ -132,5 +133,39 @@ describe("getAllowedArgs", () => {
 		expect(r2Result.sharedArg).toBe(ALLOW);
 		expect(r2Result.r2Only).toBe(ALLOW);
 		expect(r2Result.global).toBe(ALLOW);
+	});
+});
+
+describe("COMMAND_ARG_ALLOW_LIST", () => {
+	it("should pass boolean flag values through the full sanitisation pipeline for any command", ({
+		expect,
+	}) => {
+		// Simulate a user running: wrangler <command> --remote --dry-run --json
+		const args = {
+			remote: true,
+			"dry-run": true,
+			dryRun: true,
+			json: true,
+			$0: "wrangler",
+			_: [],
+		};
+		const argv = [
+			"node",
+			"wrangler",
+			"some-command",
+			"--remote",
+			"--dry-run",
+			"--json",
+		];
+
+		const argsWithSanitizedKeys = sanitizeArgKeys(args, argv);
+		const allowedArgs = getAllowedArgs(COMMAND_ARG_ALLOW_LIST, "some-command");
+		const sanitizedArgs = sanitizeArgValues(argsWithSanitizedKeys, allowedArgs);
+
+		expect(sanitizedArgs).toEqual({
+			remote: true,
+			dryRun: true,
+			json: true,
+		});
 	});
 });

--- a/packages/wrangler/src/metrics/sanitization.ts
+++ b/packages/wrangler/src/metrics/sanitization.ts
@@ -48,15 +48,56 @@ export type AllowList = Record<string, AllowedArgs>;
  * - ALLOW: all values for that arg are allowed
  */
 export const COMMAND_ARG_ALLOW_LIST: AllowList = {
-	// * applies to all commands
+	// * applies to all commands.
+	// Boolean flags are inherently safe (values are only true/false).
 	"*": {
 		format: ALLOW,
 		logLevel: ALLOW,
+		json: ALLOW,
+		force: ALLOW,
+		remote: ALLOW,
+		local: ALLOW,
+		dryRun: ALLOW,
+		preview: ALLOW,
+		yes: ALLOW,
+		skipConfirmation: ALLOW,
+		noBundle: ALLOW,
+		bundle: ALLOW,
+		minify: ALLOW,
+		latest: ALLOW,
+		uploadSourceMaps: ALLOW,
+		legacyEnv: ALLOW,
+		liveReload: ALLOW,
+		keepVars: ALLOW,
+		logpush: ALLOW,
+		strict: ALLOW,
+		testScheduled: ALLOW,
+		showInteractiveDevSession: ALLOW,
+		skipCaching: ALLOW,
+		commitDirty: ALLOW,
+		includeRuntime: ALLOW,
+		includeEnv: ALLOW,
+		strictVars: ALLOW,
+		check: ALLOW,
+		useRemote: ALLOW,
+		updateConfig: ALLOW,
+		nodeCompat: ALLOW,
+		enableContainers: ALLOW,
+		xAutoconfig: ALLOW,
+		ignoreDefaults: ALLOW,
 	},
 	tail: { status: ALLOW },
 	types: {
 		xIncludeRuntime: [".wrangler/types/runtime.d.ts"],
 		path: ["worker-configuration.d.ts"],
+	},
+	// Fixed-choice args scoped to their commands.
+	dev: {
+		localProtocol: ["http", "https"],
+		upstreamProtocol: ["http", "https"],
+	},
+	deploy: {
+		containersRollout: ["immediate", "gradual"],
 	},
 };
 

--- a/packages/wrangler/src/metrics/sanitization.ts
+++ b/packages/wrangler/src/metrics/sanitization.ts
@@ -95,13 +95,6 @@ export const COMMAND_ARG_ALLOW_LIST: AllowList = {
 	dev: {
 		localProtocol: ["http", "https"],
 		upstreamProtocol: ["http", "https"],
-	dev: {
-		localProtocol: ["http", "https"],
-		upstreamProtocol: ["http", "https"],
-	},
-	"pages dev": {
-		localProtocol: ["http", "https"],
-		upstreamProtocol: ["http", "https"],
 	},
 	deploy: {
 		containersRollout: ["immediate", "gradual"],

--- a/packages/wrangler/src/metrics/sanitization.ts
+++ b/packages/wrangler/src/metrics/sanitization.ts
@@ -95,6 +95,13 @@ export const COMMAND_ARG_ALLOW_LIST: AllowList = {
 	dev: {
 		localProtocol: ["http", "https"],
 		upstreamProtocol: ["http", "https"],
+	dev: {
+		localProtocol: ["http", "https"],
+		upstreamProtocol: ["http", "https"],
+	},
+	"pages dev": {
+		localProtocol: ["http", "https"],
+		upstreamProtocol: ["http", "https"],
 	},
 	deploy: {
 		containersRollout: ["immediate", "gradual"],


### PR DESCRIPTION
Fixes the issue where common CLI flags like `--remote`, `--json`, `--dry-run`, `--force`, and many others were being silently dropped from `sanitizedArgs` in telemetry events.

When argument sanitisation was introduced, the `COMMAND_ARG_ALLOW_LIST` was very conservative — only `--format` and `--log-level` were permitted globally. Any arg not in the list had its value completely dropped from `sanitizedArgs` by `sanitizeArgValues`. These flags were previously tracked and were unintentionally removed as part of the sanitisation process.

This PR expands the allow list with:

- **32 boolean flags** added to the global `*` entry (inherently safe — values are only `true`/`false`): `json`, `force`, `remote`, `local`, `dryRun`, `preview`, `yes`, `skipConfirmation`, `noBundle`, `bundle`, `minify`, `latest`, `uploadSourceMaps`, `legacyEnv`, `liveReload`, `keepVars`, `logpush`, `strict`, `testScheduled`, `showInteractiveDevSession`, `skipCaching`, `commitDirty`, `includeRuntime`, `includeEnv`, `strictVars`, `check`, `useRemote`, `updateConfig`, `nodeCompat`, `enableContainers`, `xAutoconfig`, `ignoreDefaults`
- **3 fixed-choice args** scoped to their commands: `localProtocol` and `upstreamProtocol` for `dev` (`["http", "https"]`), `containersRollout` for `deploy` (`["immediate", "gradual"]`)

An integration test has been added that exercises the full sanitisation pipeline (sanitizeArgKeys → getAllowedArgs → sanitizeArgValues) against the real `COMMAND_ARG_ALLOW_LIST` to verify flags like `--remote` now pass through correctly.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: telemetry.md already describes the intended behaviour; this change makes the implementation match.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
