### PR TITLE
[miniflare] Fix resource leaks during config updates

### DIFF
--- a/.changeset/miniflare-dispose-cleanup-followup.md
+++ b/.changeset/miniflare-dispose-cleanup-followup.md
@@ -1,0 +1,10 @@
+---
+"miniflare": patch
+---
+
+Fix resource leaks during config updates
+
+Two follow-up fixes to the dispose cleanup in #13515:
+
+- Only close and recreate the dev-registry dispatcher when its port actually changes, matching the existing `runtimeDispatcher` behavior. Previously, every config update unconditionally tore down and rebuilt the connection pool, which could cause brief request failures if a registry push was in-flight.
+- Dispose old `InspectorProxy` instances before replacing them during `updateConnection()`. Previously, stale proxies were silently discarded, leaking their runtime WebSocket connections and 10-second keepalive interval timers.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1107,6 +1107,7 @@ export class Miniflare {
 	 * Called when the dev registry detects changes to external services.
 	 */
 	#devRegistryDispatcher?: Dispatcher;
+	#devRegistryPort?: number;
 
 	async #pushRegistryUpdate(retries = 3): Promise<void> {
 		if (this.#disposeController.signal.aborted) return;
@@ -2422,14 +2423,19 @@ export class Miniflare {
 
 		// Set up a direct dispatcher to the dev-registry-proxy socket so we can
 		// push registry updates without routing through the entry worker.
+		// Only close/recreate when the port actually changes, to avoid tearing
+		// down the connection pool while a #pushRegistryUpdate is in-flight.
 		const devRegistryPort = maybeSocketPorts.get(SOCKET_DEV_REGISTRY);
-		void this.#devRegistryDispatcher?.close().catch(() => {});
-		if (devRegistryPort !== undefined) {
-			this.#devRegistryDispatcher = new Pool(
-				new URL(`http://127.0.0.1:${devRegistryPort}`)
-			);
-		} else {
-			this.#devRegistryDispatcher = undefined;
+		if (devRegistryPort !== this.#devRegistryPort) {
+			void this.#devRegistryDispatcher?.close().catch(() => {});
+			this.#devRegistryPort = devRegistryPort;
+			if (devRegistryPort !== undefined) {
+				this.#devRegistryDispatcher = new Pool(
+					new URL(`http://127.0.0.1:${devRegistryPort}`)
+				);
+			} else {
+				this.#devRegistryDispatcher = undefined;
+			}
 		}
 		if (this.#proxyClient === undefined) {
 			this.#proxyClient = new ProxyClient(

--- a/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
+++ b/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
@@ -289,6 +289,10 @@ export class InspectorProxyController {
 			id: string;
 		}[];
 
+		// Dispose old proxies before replacing them, so their runtime WebSocket
+		// connections and keepalive intervals are properly cleaned up.
+		await Promise.all(this.#proxies.map((proxy) => proxy.dispose()));
+
 		this.#proxies = workerdInspectorJson
 			.map(({ id }) => {
 				if (!id.startsWith("core:user:")) {


### PR DESCRIPTION
Fixes #13584, #13585.

Follow-up to #13515 addressing two resource-cleanup issues identified during review:

**devRegistryDispatcher unconditionally closed on every config update (#13584):**
The `#devRegistryDispatcher` was torn down and rebuilt on every `#assembleAndUpdateConfig()` call, regardless of whether the port changed. This is inconsistent with `#runtimeDispatcher` (which only recreates when the entry URL changes) and could cause brief request failures if `#pushRegistryUpdate()` is in-flight when the pool is closed. Fixed by tracking the port and only closing/recreating when it actually changes.

**Old InspectorProxy instances not disposed during updateConnection (#13585):**
`InspectorProxyController.updateConnection()` replaced `this.#proxies` with new `InspectorProxy` instances without first disposing the old ones. This leaked runtime WebSocket connections and their 10-second keepalive interval timers. Fixed by disposing old proxies before replacement.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: existing miniflare test suite (734 tests) passes; both fixes are straightforward resource-cleanup changes with no behavioral impact beyond preventing leaks
- Public documentation
  - [x] Documentation not necessary because: internal implementation fix with no user-facing API change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
