### PR TITLE
[workflows-shared] Fix test flakiness on Windows CI

### DIFF
--- a/packages/workflows-shared/tests/binding.test.ts
+++ b/packages/workflows-shared/tests/binding.test.ts
@@ -24,7 +24,7 @@ function createBinding(): WorkflowBinding {
 async function waitUntilLogEvent(
 	engineStub: DurableObjectStub<Engine>,
 	event: InstanceEvent,
-	timeout = 1000
+	timeout = 5000
 ): Promise<void> {
 	await vi.waitUntil(
 		async () => {
@@ -77,7 +77,7 @@ describe("WorkflowBinding", () => {
 					const s = await instance.status();
 					return s.status === "complete";
 				},
-				{ timeout: 1000 }
+				{ timeout: 5000 }
 			);
 		});
 
@@ -120,7 +120,7 @@ describe("WorkflowBinding", () => {
 					const s = await instance.status();
 					return s.status === "complete";
 				},
-				{ timeout: 1000 }
+				{ timeout: 5000 }
 			);
 		});
 	});
@@ -150,7 +150,7 @@ describe("WorkflowBinding", () => {
 						const s = await instance.status();
 						return s.status === "complete";
 					},
-					{ timeout: 1000 }
+					{ timeout: 5000 }
 				);
 			}
 		});
@@ -209,7 +209,7 @@ describe("WorkflowBinding", () => {
 				const status = await instance.status();
 				return status.status === "complete";
 			},
-			{ timeout: 1000 }
+			{ timeout: 5000 }
 		);
 
 		expect(disposeSpy).not.toHaveBeenCalled();
@@ -386,7 +386,7 @@ describe("WorkflowHandle", () => {
 					const status = await instance.status();
 					return status.status === "complete";
 				},
-				{ timeout: 1000 }
+				{ timeout: 5000 }
 			);
 
 			const status = await instance.status();
@@ -431,7 +431,7 @@ describe("WorkflowHandle", () => {
 					);
 					return waitStarts.length === 2;
 				},
-				{ timeout: 1000 }
+				{ timeout: 5000 }
 			);
 
 			await instance.sendEvent({
@@ -444,7 +444,7 @@ describe("WorkflowHandle", () => {
 					const status = await instance.status();
 					return status.status === "complete";
 				},
-				{ timeout: 1000 }
+				{ timeout: 5000 }
 			);
 
 			const status = await instance.status();
@@ -531,7 +531,7 @@ describe("WorkflowHandle", () => {
 					const s = await instance.status();
 					return s.status === "complete";
 				},
-				{ timeout: 1000 }
+				{ timeout: 5000 }
 			);
 
 			// Verify second run completed
@@ -570,7 +570,7 @@ describe("WorkflowHandle", () => {
 					const s = await instance.status();
 					return s.status === "paused";
 				},
-				{ timeout: 2000 }
+				{ timeout: 5000 }
 			);
 
 			const finalStatus = await instance.status();
@@ -608,7 +608,7 @@ describe("WorkflowHandle", () => {
 					const s = await instance.status();
 					return s.status === "paused";
 				},
-				{ timeout: 2000 }
+				{ timeout: 5000 }
 			);
 
 			await instance.resume();
@@ -618,7 +618,7 @@ describe("WorkflowHandle", () => {
 					const s = await instance.status();
 					return s.status === "complete";
 				},
-				{ timeout: 3000 }
+				{ timeout: 5000 }
 			);
 
 			const finalStatus = await instance.status();
@@ -665,7 +665,7 @@ describe("WorkflowHandle", () => {
 					const s = await instance.status();
 					return s.status === "complete";
 				},
-				{ timeout: 3000 }
+				{ timeout: 5000 }
 			);
 
 			const finalStatus = await instance.status();

--- a/packages/workflows-shared/tests/context.test.ts
+++ b/packages/workflows-shared/tests/context.test.ts
@@ -224,6 +224,7 @@ describe("Context", () => {
 			}
 		);
 
+		// Needs extra headroom: 3 sequential step.do calls + cold DO startup on Windows
 		await vi.waitUntil(
 			async () => {
 				const logs = (await engineStub.readLogs()) as EngineLogs;
@@ -231,7 +232,7 @@ describe("Context", () => {
 					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
 				);
 			},
-			{ timeout: 5000 }
+			{ timeout: 10000 }
 		);
 
 		expect(receivedContexts[0]).toMatchObject({

--- a/packages/workflows-shared/tests/context.test.ts
+++ b/packages/workflows-shared/tests/context.test.ts
@@ -50,7 +50,7 @@ describe("Context", () => {
 					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
 				);
 			},
-			{ timeout: 1000 }
+			{ timeout: 5000 }
 		);
 
 		expect(receivedAttempt).toBe(1);
@@ -86,7 +86,7 @@ describe("Context", () => {
 					(val) => val.event === InstanceEvent.WORKFLOW_FAILURE
 				);
 			},
-			{ timeout: 1000 }
+			{ timeout: 5000 }
 		);
 
 		// Should have received attempts 1, 2, and 3
@@ -192,7 +192,7 @@ describe("Context", () => {
 					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
 				);
 			},
-			{ timeout: 1000 }
+			{ timeout: 5000 }
 		);
 
 		expect(receivedCtx).toMatchObject({
@@ -231,7 +231,7 @@ describe("Context", () => {
 					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
 				);
 			},
-			{ timeout: 1000 }
+			{ timeout: 5000 }
 		);
 
 		expect(receivedContexts[0]).toMatchObject({
@@ -269,7 +269,7 @@ describe("Context", () => {
 					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
 				);
 			},
-			{ timeout: 1000 }
+			{ timeout: 5000 }
 		);
 
 		expect(receivedCtx).toMatchObject({
@@ -317,7 +317,7 @@ describe("Context", () => {
 					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
 				);
 			},
-			{ timeout: 1000 }
+			{ timeout: 5000 }
 		);
 
 		// User overrides should be merged with defaults
@@ -369,7 +369,7 @@ describe("Context", () => {
 					(val) => val.event === InstanceEvent.WORKFLOW_FAILURE
 				);
 			},
-			{ timeout: 1000 }
+			{ timeout: 5000 }
 		);
 
 		// With limit: 1, the engine should execute attempt 1 + 1 retry = 2 attempts total.

--- a/packages/workflows-shared/tests/engine.test.ts
+++ b/packages/workflows-shared/tests/engine.test.ts
@@ -49,7 +49,7 @@ describe("Engine", () => {
 					throw e;
 				}
 			},
-			{ timeout: 3000 }
+			{ timeout: 5000 }
 		);
 
 		const logs = (await env.ENGINE.get(engineId).readLogs()) as EngineLogs;
@@ -90,7 +90,7 @@ describe("Engine", () => {
 					(val) => val.event == InstanceEvent.WORKFLOW_SUCCESS
 				);
 			},
-			{ timeout: 1000 }
+			{ timeout: 5000 }
 		);
 
 		const logs = (await engineStub.readLogs()) as EngineLogs;
@@ -116,10 +116,13 @@ describe("Engine", () => {
 			}
 		);
 
-		await vi.waitUntil(async () => {
-			const logs = (await engineStub.readLogs()) as EngineLogs;
-			return logs.logs.filter((val) => val.event == InstanceEvent.WAIT_START);
-		}, 500);
+		await vi.waitUntil(
+			async () => {
+				const logs = (await engineStub.readLogs()) as EngineLogs;
+				return logs.logs.filter((val) => val.event == InstanceEvent.WAIT_START);
+			},
+			{ timeout: 5000 }
+		);
 
 		await engineStub.receiveEvent({
 			type: "event-type-1",
@@ -127,12 +130,15 @@ describe("Engine", () => {
 			payload: {},
 		});
 
-		await vi.waitUntil(async () => {
-			const logs = (await engineStub.readLogs()) as EngineLogs;
-			return logs.logs.filter(
-				(val) => val.event == InstanceEvent.WORKFLOW_SUCCESS
-			);
-		}, 500);
+		await vi.waitUntil(
+			async () => {
+				const logs = (await engineStub.readLogs()) as EngineLogs;
+				return logs.logs.filter(
+					(val) => val.event == InstanceEvent.WORKFLOW_SUCCESS
+				);
+			},
+			{ timeout: 5000 }
+		);
 	});
 
 	// eslint-disable-next-line jest/expect-expect
@@ -147,10 +153,13 @@ describe("Engine", () => {
 			}
 		);
 
-		await vi.waitUntil(async () => {
-			const logs = (await engineStub.readLogs()) as EngineLogs;
-			return logs.logs.filter((val) => val.event == InstanceEvent.WAIT_START);
-		}, 500);
+		await vi.waitUntil(
+			async () => {
+				const logs = (await engineStub.readLogs()) as EngineLogs;
+				return logs.logs.filter((val) => val.event == InstanceEvent.WAIT_START);
+			},
+			{ timeout: 5000 }
+		);
 
 		try {
 			await runInDurableObject(engineStub, async (engine) => {
@@ -171,12 +180,15 @@ describe("Engine", () => {
 			payload: {},
 		});
 
-		await vi.waitUntil(async () => {
-			const logs = (await newStub.readLogs()) as EngineLogs;
-			return logs.logs.filter(
-				(val) => val.event == InstanceEvent.WORKFLOW_SUCCESS
-			);
-		}, 500);
+		await vi.waitUntil(
+			async () => {
+				const logs = (await newStub.readLogs()) as EngineLogs;
+				return logs.logs.filter(
+					(val) => val.event == InstanceEvent.WORKFLOW_SUCCESS
+				);
+			},
+			{ timeout: 5000 }
+		);
 	});
 
 	it("waitForEvent should not deliver events to timed-out events with the same type", async ({
@@ -213,7 +225,7 @@ describe("Engine", () => {
 						.length >= 1
 				);
 			},
-			{ timeout: 500 }
+			{ timeout: 5000 }
 		);
 
 		await engineStub.receiveEvent({
@@ -230,7 +242,7 @@ describe("Engine", () => {
 						.length >= 2
 				);
 			},
-			{ timeout: 500 }
+			{ timeout: 5000 }
 		);
 
 		// 2nd waitForEvent iteration - should timeout (500ms)
@@ -241,7 +253,7 @@ describe("Engine", () => {
 					(val) => val.event === InstanceEvent.WAIT_TIMED_OUT
 				);
 			},
-			{ timeout: 1000 }
+			{ timeout: 5000 }
 		);
 
 		// 3rd waitForEvent iteration - should receive event
@@ -253,7 +265,7 @@ describe("Engine", () => {
 						.length >= 3
 				);
 			},
-			{ timeout: 500 }
+			{ timeout: 5000 }
 		);
 
 		await engineStub.receiveEvent({
@@ -269,7 +281,7 @@ describe("Engine", () => {
 					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
 				);
 			},
-			{ timeout: 1000 }
+			{ timeout: 5000 }
 		);
 
 		const logs = (await engineStub.readLogs()) as EngineLogs;
@@ -515,7 +527,7 @@ describe("Engine", () => {
 						);
 						return status === InstanceStatus.Complete;
 					},
-					{ timeout: 1000 }
+					{ timeout: 5000 }
 				);
 
 				// Verify the workflow ran again by checking logs
@@ -559,7 +571,7 @@ describe("Engine", () => {
 						);
 					});
 				},
-				{ timeout: 1000 }
+				{ timeout: 5000 }
 			);
 
 			// Request pause while long-step is in flight
@@ -588,7 +600,7 @@ describe("Engine", () => {
 						throw e;
 					}
 				},
-				{ timeout: 2000 }
+				{ timeout: 5000 }
 			);
 
 			const freshStub = env.ENGINE.get(engineId);
@@ -640,7 +652,7 @@ describe("Engine", () => {
 						);
 					});
 				},
-				{ timeout: 1000 }
+				{ timeout: 5000 }
 			);
 
 			// Request pause while both slow steps are in flight
@@ -669,7 +681,7 @@ describe("Engine", () => {
 						throw e;
 					}
 				},
-				{ timeout: 2000 }
+				{ timeout: 5000 }
 			);
 
 			const freshStub = env.ENGINE.get(engineId);
@@ -718,7 +730,7 @@ describe("Engine", () => {
 						);
 					});
 				},
-				{ timeout: 1000 }
+				{ timeout: 5000 }
 			);
 
 			await runInDurableObject(engineStub, async (engine) => {
@@ -732,7 +744,7 @@ describe("Engine", () => {
 						async (engine) =>
 							(await engine.getStatus()) === InstanceStatus.WaitingForPause
 					),
-				{ timeout: 1000 }
+				{ timeout: 5000 }
 			);
 
 			// Resume before slow-step finishes
@@ -805,7 +817,7 @@ describe("Engine", () => {
 						throw e;
 					}
 				},
-				{ timeout: 1000 }
+				{ timeout: 5000 }
 			);
 
 			// Request pause while in step.sleep — should pause immediately
@@ -834,7 +846,7 @@ describe("Engine", () => {
 						throw e;
 					}
 				},
-				{ timeout: 2000 }
+				{ timeout: 5000 }
 			);
 
 			expect(
@@ -930,7 +942,7 @@ describe("Engine", () => {
 						throw e;
 					}
 				},
-				{ timeout: 1000 }
+				{ timeout: 5000 }
 			);
 
 			// Request pause while in waitForEvent
@@ -959,7 +971,7 @@ describe("Engine", () => {
 						throw e;
 					}
 				},
-				{ timeout: 2000 }
+				{ timeout: 5000 }
 			);
 
 			expect(

--- a/packages/workflows-shared/tests/engine.test.ts
+++ b/packages/workflows-shared/tests/engine.test.ts
@@ -104,8 +104,7 @@ describe("Engine", () => {
 		).toHaveLength(1);
 	});
 
-	// eslint-disable-next-line jest/expect-expect
-	it("waitForEvent should receive events while active", async () => {
+	it("waitForEvent should receive events while active", async ({ expect }) => {
 		const engineStub = await runWorkflow(
 			"MOCK-INSTANCE-ID-WAIT-FOR-EVENT",
 			async (_, step) => {
@@ -119,7 +118,7 @@ describe("Engine", () => {
 		await vi.waitUntil(
 			async () => {
 				const logs = (await engineStub.readLogs()) as EngineLogs;
-				return logs.logs.filter((val) => val.event == InstanceEvent.WAIT_START);
+				return logs.logs.some((val) => val.event === InstanceEvent.WAIT_START);
 			},
 			{ timeout: 5000 }
 		);
@@ -133,16 +132,25 @@ describe("Engine", () => {
 		await vi.waitUntil(
 			async () => {
 				const logs = (await engineStub.readLogs()) as EngineLogs;
-				return logs.logs.filter(
-					(val) => val.event == InstanceEvent.WORKFLOW_SUCCESS
+				return logs.logs.some(
+					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
 				);
 			},
 			{ timeout: 5000 }
 		);
+
+		const logs = (await engineStub.readLogs()) as EngineLogs;
+		expect(logs.logs.some((v) => v.event === InstanceEvent.WAIT_START)).toBe(
+			true
+		);
+		expect(
+			logs.logs.some((v) => v.event === InstanceEvent.WORKFLOW_SUCCESS)
+		).toBe(true);
 	});
 
-	// eslint-disable-next-line jest/expect-expect
-	it("waitForEvent should receive events even if not active", async () => {
+	it("waitForEvent should receive events even if not active", async ({
+		expect,
+	}) => {
 		const engineStub = await runWorkflow(
 			"MOCK-INSTANCE-ID-WAIT-FOR-EVENT-NOT-ACTIVE",
 			async (_, step) => {
@@ -156,7 +164,7 @@ describe("Engine", () => {
 		await vi.waitUntil(
 			async () => {
 				const logs = (await engineStub.readLogs()) as EngineLogs;
-				return logs.logs.filter((val) => val.event == InstanceEvent.WAIT_START);
+				return logs.logs.some((val) => val.event === InstanceEvent.WAIT_START);
 			},
 			{ timeout: 5000 }
 		);
@@ -183,12 +191,20 @@ describe("Engine", () => {
 		await vi.waitUntil(
 			async () => {
 				const logs = (await newStub.readLogs()) as EngineLogs;
-				return logs.logs.filter(
-					(val) => val.event == InstanceEvent.WORKFLOW_SUCCESS
+				return logs.logs.some(
+					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
 				);
 			},
 			{ timeout: 5000 }
 		);
+
+		const logs = (await newStub.readLogs()) as EngineLogs;
+		expect(logs.logs.some((v) => v.event === InstanceEvent.WAIT_START)).toBe(
+			true
+		);
+		expect(
+			logs.logs.some((v) => v.event === InstanceEvent.WORKFLOW_SUCCESS)
+		).toBe(true);
 	});
 
 	it("waitForEvent should not deliver events to timed-out events with the same type", async ({

--- a/packages/workflows-shared/vitest.config.mts
+++ b/packages/workflows-shared/vitest.config.mts
@@ -1,15 +1,19 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
+import configShared from "../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			miniflare: {
-				compatibilityFlags: ["service_binding_extra_handlers"],
-			},
-			wrangler: {
-				configPath: "./wrangler.jsonc",
-			},
-		}),
-	],
-});
+export default mergeConfig(
+	configShared,
+	defineConfig({
+		plugins: [
+			cloudflareTest({
+				miniflare: {
+					compatibilityFlags: ["service_binding_extra_handlers"],
+				},
+				wrangler: {
+					configPath: "./wrangler.jsonc",
+				},
+			}),
+		],
+	})
+);


### PR DESCRIPTION
Fixes consistent `@cloudflare/workflows-shared` test failures on Windows CI runners (e.g. https://github.com/cloudflare/workers-sdk/actions/runs/24634528457/job/72027500951).

**Root cause:** The `workflows-shared` vitest config was not extending the monorepo-wide `vitest.shared.ts`. This meant tests ran with vitest's default 5s test timeout (vs the shared 50s used everywhere else) and zero retries. Combined with tight `vi.waitUntil` polling timeouts (500–1000ms), the first tests in each file consistently timed out on slow Windows runners due to cold workerd/DO startup costs.

Six tests across 3 files were failing:
- `binding.test.ts`: 2 failures (test timeout 5000ms, waitUntil timeout 1000ms)
- `context.test.ts`: 2 failures (test timeout 5000ms, waitUntil timeout 1000ms)
- `engine.test.ts`: 2 failures (test timeout 5000ms, waitUntil timeout 1000ms)

**Changes:**
- **Merge `vitest.shared.ts`** into `workflows-shared/vitest.config.mts` — picks up `testTimeout: 50_000`, `retry: 2`, `restoreMocks: true`
- **Raise `waitUntilLogEvent` helper default** from 1000ms → 5000ms (affects all 13 call sites in binding.test.ts)
- **Fix 4 bare-number `vi.waitUntil(cb, 500)` calls** in engine.test.ts to proper `{ timeout: 5000 }` format
- **Bump all `vi.waitUntil` polling timeouts** from 500–3000ms → 5000ms across all 3 test files

Deliberately **not changed**: `step.waitForEvent` timeouts, `step.sleep` durations, and `retries.delay` values — those test real workflow timeout semantics.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: test-only changes to internal package
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
