### PR TITLE
[ci] Speed up package tests by enabling parallel execution

### DIFF
--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -140,7 +140,8 @@ jobs:
         if: steps.changes.outputs.everything_but_markdown == 'true' && matrix.suite == 'packages-and-tools'
         # We skip @cloudflare/vitest-pool-workers tests in CI on Windows because they're very flaky. We still run the vitest-pool-workers-examples fixture, which is a comprehensive set of example tests and gives us a lot of confidence.
         # The @cloudflare/vitest-pool-workers tests skipped are things like watch mode, which constantly times out probably due to the github runners in use.
-        run: pnpm run test:ci --log-order=stream --concurrency=1 --filter="./packages/*" ${{ matrix.os == 'windows-latest' && '--filter="!./packages/vitest-pool-workers"' || '' }}
+        # Package tests are well-isolated (separate processes, temp dirs, random ports, MSW mocks) and can safely run in parallel.
+        run: pnpm run test:ci --log-order=stream --filter="./packages/*" ${{ matrix.os == 'windows-latest' && '--filter="!./packages/vitest-pool-workers"' || '' }}
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
           WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-debug-logs/


### PR DESCRIPTION
Fixes no specific issue — CI performance improvement. Companion to #13596 (which does the same for fixture tests).

The `packages-and-tools` CI job runs all package test suites serially (`--concurrency=1`), taking **~9.5 min on Linux** and **~20 min on Windows**. The three heaviest packages dominate:

| Package | Linux | Windows |
|---------|-------|---------|
| wrangler | 282s | 489s |
| miniflare | 108s | 434s |
| vitest-pool-workers | 73s | (skipped) |
| everything else | ~30s | ~50s |

Since these run sequentially today, the total is the sum. With parallel execution, the total is bounded by the slowest package (wrangler).

## Why Parallel Execution Is Safe

All packages are well-isolated:

- **Wrangler**: purely in-process tests — `runWrangler(cmd)` calls `main()` directly with MSW for API mocking, `runInTempDir()` for filesystem isolation, mocked `get-port` (no real ports). Pool: `forks` (each test file is its own process).
- **Miniflare**: `pool: "forks"`, `maxWorkers: 1` (sequential internally), `server.listen(0)` for random ports, `.tmp/` local to package root.
- **vitest-pool-workers**: private Verdaccio npm registry on random port via `getPort()`, workerd on random ports, temp dirs in `os.tmpdir()` with unique prefixes.
- **All other packages**: lightweight unit tests with no shared resources (vite-plugin, create-cloudflare, workers-shared, etc.)

No shared ports, sockets, temp directories, dev registry usage, or environment variables between packages.

## Change

Remove `--concurrency=1` from the packages test Turbo command, letting Turbo parallelize based on the dependency graph and available CPU cores.

## Validation

Ran package tests locally **4 times** with unlimited concurrency. All runs passed with zero retries:

| Run | Tasks | Result | Time |
|-----|-------|--------|------|
| 1 | 34/34 | Pass | 2m14s |
| 2 | 34/34 | Pass | 2m08s |
| 3 | 34/34 | Pass | 2m07s |
| 4 | 34/34 | Pass | 2m04s |

**Expected CI improvement:**
- **Linux**: ~9.5min → ~5min (wrangler at 282s is the critical path)
- **Windows**: ~20min → ~9-10min (wrangler at 489s is the critical path)

## Risks & Fallback

The main risk is resource pressure on CI runners (4 vCPUs, 16GB RAM) when wrangler (forks pool, 233 test files) runs alongside miniflare (workerd processes). If this causes OOM or increased flakiness, we can set `--concurrency=3` as a middle ground.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: CI-only change, no user-facing impact
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
