### PR TITLE
Fix flaky CI tests in miniflare browser and workflow fixtures

### DIFF
--- a/.changeset/fix-workflow-introspector-dispose-ordering.md
+++ b/.changeset/fix-workflow-introspector-dispose-ordering.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+fix: Restore workflow binding before async cleanup in `WorkflowIntrospectorHandle.dispose()`
+
+Previously, `dispose()` awaited all instance abort operations before restoring the original `env` binding. On slower CI environments (especially Windows), this left a window where the next test could see a stale proxy, causing "Trying to mock step multiple times" errors or failed introspection. The binding is now restored synchronously before the async instance cleanup begins.

--- a/fixtures/vitest-pool-workers-examples/workflows/test/unit.test.ts
+++ b/fixtures/vitest-pool-workers-examples/workflows/test/unit.test.ts
@@ -2,19 +2,19 @@ import { introspectWorkflowInstance } from "cloudflare:test";
 import { env } from "cloudflare:workers";
 import { it } from "vitest";
 
-const INSTANCE_ID = "12345678910";
 const STATUS_COMPLETE = "complete";
 const STATUS_ERROR = "errored";
 const STEP_NAME = "AI content scan";
 
 // This example implicitly disposes the Workflow instance
 it("should mock a non-violation score and complete", async ({ expect }) => {
+	const instanceId = crypto.randomUUID();
 	const mockResult = { violationScore: 0 };
 
 	// CONFIG with `await using` to ensure Workflow instances cleanup:
 	await using instance = await introspectWorkflowInstance(
 		env.MODERATOR,
-		INSTANCE_ID
+		instanceId
 	);
 	await instance.modify(async (m) => {
 		await m.disableSleeps();
@@ -22,7 +22,7 @@ it("should mock a non-violation score and complete", async ({ expect }) => {
 	});
 
 	await env.MODERATOR.create({
-		id: INSTANCE_ID,
+		id: instanceId,
 	});
 
 	// ASSERTIONS:
@@ -45,10 +45,11 @@ it("should mock a non-violation score and complete", async ({ expect }) => {
 it("should mock the violation score calculation to fail 2 times and then complete", async ({
 	expect,
 }) => {
+	const instanceId = crypto.randomUUID();
 	const mockResult = { violationScore: 0 };
 
 	// CONFIG:
-	const instance = await introspectWorkflowInstance(env.MODERATOR, INSTANCE_ID);
+	const instance = await introspectWorkflowInstance(env.MODERATOR, instanceId);
 
 	try {
 		await instance.modify(async (m) => {
@@ -62,7 +63,7 @@ it("should mock the violation score calculation to fail 2 times and then complet
 		});
 
 		await env.MODERATOR.create({
-			id: INSTANCE_ID,
+			id: instanceId,
 		});
 
 		// ASSERTIONS:
@@ -88,11 +89,12 @@ it("should mock the violation score calculation to fail 2 times and then complet
 });
 
 it("should mock a violation score and complete", async ({ expect }) => {
+	const instanceId = crypto.randomUUID();
 	const mockResult = { violationScore: 99 };
 
 	await using instance = await introspectWorkflowInstance(
 		env.MODERATOR,
-		INSTANCE_ID
+		instanceId
 	);
 	await instance.modify(async (m) => {
 		await m.disableSleeps();
@@ -100,7 +102,7 @@ it("should mock a violation score and complete", async ({ expect }) => {
 	});
 
 	await env.MODERATOR.create({
-		id: INSTANCE_ID,
+		id: instanceId,
 	});
 
 	expect(await instance.waitForStepResult({ name: STEP_NAME })).toEqual(
@@ -117,11 +119,12 @@ it("should mock a violation score and complete", async ({ expect }) => {
 });
 
 it("should be reviewed, accepted and complete", async ({ expect }) => {
+	const instanceId = crypto.randomUUID();
 	const mockResult = { violationScore: 50 };
 
 	await using instance = await introspectWorkflowInstance(
 		env.MODERATOR,
-		INSTANCE_ID
+		instanceId
 	);
 	await instance.modify(async (m) => {
 		await m.disableSleeps();
@@ -133,7 +136,7 @@ it("should be reviewed, accepted and complete", async ({ expect }) => {
 	});
 
 	await env.MODERATOR.create({
-		id: INSTANCE_ID,
+		id: instanceId,
 	});
 
 	expect(await instance.waitForStepResult({ name: STEP_NAME })).toEqual(
@@ -152,11 +155,12 @@ it("should be reviewed, accepted and complete", async ({ expect }) => {
 it("should disable retry delays when mocking step errors", async ({
 	expect,
 }) => {
+	const instanceId = crypto.randomUUID();
 	const mockResult = { violationScore: 0 };
 
 	await using instance = await introspectWorkflowInstance(
 		env.MODERATOR,
-		INSTANCE_ID
+		instanceId
 	);
 	await instance.modify(async (m) => {
 		await m.disableSleeps();
@@ -170,7 +174,7 @@ it("should disable retry delays when mocking step errors", async ({
 	});
 
 	await env.MODERATOR.create({
-		id: INSTANCE_ID,
+		id: instanceId,
 	});
 
 	expect(await instance.waitForStepResult({ name: STEP_NAME })).toEqual(
@@ -184,11 +188,12 @@ it("should disable retry delays when mocking step errors", async ({
 });
 
 it("should force human review to timeout and error", async ({ expect }) => {
+	const instanceId = crypto.randomUUID();
 	const mockResult = { violationScore: 50 };
 
 	await using instance = await introspectWorkflowInstance(
 		env.MODERATOR,
-		INSTANCE_ID
+		instanceId
 	);
 	await instance.modify(async (m) => {
 		await m.disableSleeps();
@@ -197,7 +202,7 @@ it("should force human review to timeout and error", async ({ expect }) => {
 	});
 
 	await env.MODERATOR.create({
-		id: INSTANCE_ID,
+		id: instanceId,
 	});
 
 	expect(await instance.waitForStepResult({ name: STEP_NAME })).toEqual(

--- a/packages/miniflare/test/plugins/browser/index.spec.ts
+++ b/packages/miniflare/test/plugins/browser/index.spec.ts
@@ -532,7 +532,12 @@ export default {
 			expect(typeof version.Browser).toBe("string");
 			expect(typeof version["Protocol-Version"]).toBe("string");
 			expect(Array.isArray(list)).toBe(true);
-			expect(list).toEqual(listAlias);
+			// The page title for about:blank can change between sequential
+			// requests (from "" to "about:blank"), so strip the volatile
+			// `title` field before comparing the two alias endpoints.
+			const stripTitle = (arr: any[]) =>
+				arr.map(({ title, ...rest }: any) => rest);
+			expect(stripTitle(list)).toEqual(stripTitle(listAlias));
 		}
 	);
 

--- a/packages/vitest-pool-workers/src/worker/workflows.ts
+++ b/packages/vitest-pool-workers/src/worker/workflows.ts
@@ -259,13 +259,16 @@ class WorkflowIntrospectorHandle implements WorkflowIntrospector {
 	}
 
 	async dispose(): Promise<void> {
-		// also disposes all instance introspectors
-		await Promise.all(
-			this.#instanceIntrospectors.map((introspector) => introspector.dispose())
-		);
+		// Restore the original env binding immediately so the next test gets a
+		// clean binding even if instance disposal (unsafeAbort) is still in flight.
+		this.#disposeCallback();
+		const introspectors = this.#instanceIntrospectors;
 		this.#modifierCallbacks = [];
 		this.#instanceIntrospectors = [];
-		this.#disposeCallback();
+		// Dispose all instance introspectors after binding is restored
+		await Promise.all(
+			introspectors.map((introspector) => introspector.dispose())
+		);
 	}
 
 	async [Symbol.asyncDispose](): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes three pre-existing flaky CI test failures:

- **miniflare browser test** (`test/plugins/browser/index.spec.ts`): The `/json/list` vs `/json` alias comparison fails because the page `title` for `about:blank` changes between sequential requests (from `""` to `"about:blank"`). Fix: strip the volatile `title` field before comparing.
- **workflow unit tests** (`fixtures/vitest-pool-workers-examples/workflows/test/unit.test.ts`): All 6 tests shared `INSTANCE_ID = "12345678910"`, causing Durable Object state leakage between tests when `unsafeAbort`/`deleteAll()` hadn't fully completed before the next test started. Fix: use `crypto.randomUUID()` per test.
- **vitest-pool-workers dispose ordering** (`src/worker/workflows.ts`): `WorkflowIntrospectorHandle.dispose()` restored the original `env` binding *after* awaiting all async instance aborts, leaving a window where the next test could see a stale proxy. Fix: restore the binding synchronously first, then await cleanup.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: test-only and internal library fix
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13607" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
