### PR TITLE
Fix miniflare sourcemap warnings caused by references to files outside the package boundary

### DIFF
--- a/.changeset/fix-miniflare-sourcemap-warnings.md
+++ b/.changeset/fix-miniflare-sourcemap-warnings.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Fix sourcemap warnings caused by references to files outside the package boundary
+
+miniflare's bundled sourcemap contained `sources` entries pointing into `node_modules` dependencies (zod, capnp-es, chokidar, etc.), which produced dozens of warnings in pnpm monorepos when tools like Vite or Vitest validated the sourcemaps at runtime. The build now inlines `sourcesContent` and patches any null entries left by upstream dependencies that don't publish their original source files

--- a/packages/miniflare/scripts/build.mjs
+++ b/packages/miniflare/scripts/build.mjs
@@ -184,7 +184,7 @@ const embedWorkersPlugin = {
 					target: "esnext",
 					bundle: true,
 					sourcemap: true,
-					sourcesContent: false,
+					sourcesContent: true,
 					// These virtual modules are provided by workerd at runtime
 					external: ["miniflare:shared", "miniflare:zod", "cloudflare:workers"],
 					metafile: true,
@@ -281,6 +281,60 @@ function copyLocalExplorerUi(outPath, pkgRoot) {
 	}
 }
 
+// --- Sourcemap post-processing ---
+
+/**
+ * Patch sourcemaps so that every entry in `sourcesContent` is non-null.
+ *
+ * esbuild sets `sourcesContent: true` but some upstream dependencies ship
+ * their own sourcemaps that reference `.ts` source files they don't publish.
+ * esbuild follows the sourcemap chain and records those paths in `sources`,
+ * but can't read the files — leaving `null` holes in `sourcesContent`.
+ *
+ * Consumers (Vite, Vitest, etc.) warn when they encounter sourcemaps with
+ * missing sources. To avoid this, we replace null entries with an empty
+ * string so the sourcemap is fully self-contained.
+ *
+ * See https://github.com/cloudflare/workers-sdk/issues/13555
+ *
+ * @param {string} outPath  The miniflare dist output directory (dist/)
+ */
+async function patchSourcemaps(outPath) {
+	const mapFiles = [];
+
+	// Collect all .js.map files under outPath
+	async function walk(dir) {
+		for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
+			const fullPath = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				await walk(fullPath);
+			} else if (entry.name.endsWith(".js.map")) {
+				mapFiles.push(fullPath);
+			}
+		}
+	}
+
+	await walk(outPath);
+
+	for (const mapFile of mapFiles) {
+		const raw = await fs.readFile(mapFile, "utf8");
+		const map = JSON.parse(raw);
+		if (!Array.isArray(map.sourcesContent)) continue;
+
+		let patched = false;
+		for (let i = 0; i < map.sourcesContent.length; i++) {
+			if (map.sourcesContent[i] == null) {
+				map.sourcesContent[i] = "";
+				patched = true;
+			}
+		}
+
+		if (patched) {
+			await fs.writeFile(mapFile, JSON.stringify(map));
+		}
+	}
+}
+
 // --- Main build ---
 
 /**
@@ -289,6 +343,7 @@ function copyLocalExplorerUi(outPath, pkgRoot) {
  *      fixtures) into dist/ as CJS. The embedWorkersPlugin handles all
  *      "worker:..." imports by creating nested sub-builds.
  *   2. Copy local-explorer-ui assets into dist/.
+ *   3. Patch sourcemaps to fill any missing sourcesContent entries.
  */
 async function buildPackage() {
 	const pkg = getPackage(pkgRoot);
@@ -302,7 +357,7 @@ async function buildPackage() {
 		target: "esnext",
 		bundle: true,
 		sourcemap: true,
-		sourcesContent: false,
+		sourcesContent: true,
 		tsconfig: path.join(pkgRoot, "tsconfig.json"),
 		external: [
 			// Don't bundle miniflare itself — we want tests to run against
@@ -330,6 +385,7 @@ async function buildPackage() {
 	}
 
 	copyLocalExplorerUi(outPath, pkgRoot);
+	await patchSourcemaps(outPath);
 }
 
 buildPackage().catch((e) => {

--- a/packages/miniflare/test/sourcemap.spec.ts
+++ b/packages/miniflare/test/sourcemap.spec.ts
@@ -1,0 +1,31 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it } from "vitest";
+
+const DIST_PATH = path.resolve(__dirname, "..", "dist", "src");
+
+describe("sourcemap", () => {
+	const mapPath = path.join(DIST_PATH, "index.js.map");
+	const map = JSON.parse(fs.readFileSync(mapPath, "utf8"));
+
+	it("should include sourcesContent in the main bundle sourcemap", ({
+		expect,
+	}) => {
+		expect(map.sourcesContent).toBeDefined();
+		expect(Array.isArray(map.sourcesContent)).toBe(true);
+		expect(map.sourcesContent).toHaveLength(map.sources.length);
+	});
+
+	it("should have non-null sourcesContent for every source entry", ({
+		expect,
+	}) => {
+		// Every source must have a non-null sourcesContent entry so the
+		// sourcemap is fully self-contained. This prevents warnings from
+		// tools like Vite/Vitest that validate sourcemaps at runtime.
+		// See https://github.com/cloudflare/workers-sdk/issues/13555
+		const nullEntries = map.sources.filter(
+			(_: string, i: number) => map.sourcesContent[i] == null
+		);
+		expect(nullEntries).toEqual([]);
+	});
+});


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/13555

miniflare's bundled sourcemap contained `sources` entries pointing into `node_modules` dependencies (zod, capnp-es, chokidar, etc.), which produced dozens of warnings in pnpm monorepos when tools like Vite or Vitest validated the sourcemaps at runtime. The build now inlines `sourcesContent` and patches any null entries left by upstream dependencies that don't publish their original source files

> [!WARNING]
> This solution significantly increase the Miniflare sourcemap file's size from 1.8MB to 6.0MB (bringing the total dist size from 10.9MB to ~15MB).
> I think this is ok especially since Miniflare is a dev-dependency not used in production systems, but do let me know what you think.

This PR also fixes these types of warnings that we get in tests: https://github.com/cloudflare/workers-sdk/actions/runs/24677650006/job/72165992447?pr=13605#step:8:474

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: self explanatory DX improvement

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
