### PR TITLE
Un-skip hono pages C3 e2e tests

### DIFF
--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -244,10 +244,6 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 		{
 			name: "hono:pages",
 			argv: ["--platform", "pages"],
-			// The hono started template for pages is currently broken so we need to skip the test
-			// this will be fixed upstream
-			// TODO: un-quarantine this once https://github.com/honojs/starter/pull/116 is merged
-			quarantine: true,
 			testCommitMessage: true,
 			unsupportedOSs: ["win32"],
 			verifyDeploy: {


### PR DESCRIPTION
The upstream issue that required us to skip the hono pages C3 e2e tests has been fixed in https://github.com/honojs/vite-plugins/pull/355 so we can re-enable the tests now

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: un-skipping C3 e2e tests
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: un-skipping C3 e2e tests

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
