### PR TITLE
skip vpc remote binding tests temporarily

### DIFF
--- a/packages/wrangler/e2e/remote-binding/miniflare-remote-resources.test.ts
+++ b/packages/wrangler/e2e/remote-binding/miniflare-remote-resources.test.ts
@@ -538,6 +538,9 @@ const testCases: TestCase[] = [
 	{
 		name: "VPC Network",
 		scriptPath: "vpc-network.js",
+		// Currently these tests start failing whenever the VPC worker is doing a deployment
+		// Re-enable when EW-10563 is resolved
+		skip: true,
 		setup: async (helper) => {
 			// Create a real Cloudflare tunnel for testing
 			const tunnelId = await helper.tunnel();


### PR DESCRIPTION
Currently these tests start failing whenever the VPC worker is doing a deployment
Re-enable when EW-10563 is resolved

tracked here: https://github.com/cloudflare/workers-sdk/issues/13620

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: skipping a test
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: skipping a test

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
