### PR TITLE
[wrangler] Fix inherited ai_search_namespaces binding display

### DIFF
--- a/.changeset/ai-search-inherit-display.md
+++ b/.changeset/ai-search-inherit-display.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix inherited `ai_search_namespaces` binding display in `wrangler deploy`
+
+When an `ai_search_namespaces` binding inherits from the existing deployment, the bindings table now correctly shows `(inherited)` instead of a raw `Symbol(inherit_binding)` string.

--- a/packages/wrangler/src/__tests__/print-bindings.test.ts
+++ b/packages/wrangler/src/__tests__/print-bindings.test.ts
@@ -1,4 +1,5 @@
 import { stripVTControlCharacters } from "node:util";
+import { INHERIT_SYMBOL } from "@cloudflare/workers-utils";
 import { describe, it } from "vitest";
 import { printBindings } from "../utils/print-bindings";
 import type { StartDevWorkerInput } from "../api/startDevWorker/types";
@@ -97,6 +98,21 @@ describe("printBindings — AI Search bindings", () => {
 		expect(output).toContain("BLOG_SEARCH");
 		expect(output).toContain("AI Search Instance");
 		expect(output).toContain("cloudflare-blog");
+	});
+
+	it("renders inherited AI Search namespace bindings as `(inherited)`", ({
+		expect,
+	}) => {
+		const output = callPrintBindings({
+			AI_SEARCH: {
+				type: "ai_search_namespace",
+				namespace: INHERIT_SYMBOL,
+			},
+		});
+
+		expect(output).toContain("AI_SEARCH");
+		expect(output).toContain("(inherited)");
+		expect(output).not.toContain("Symbol(inherit_binding)");
 	});
 });
 

--- a/packages/wrangler/src/utils/print-bindings.ts
+++ b/packages/wrangler/src/utils/print-bindings.ts
@@ -332,7 +332,11 @@ export function printBindings(
 			...ai_search_namespaces.map(({ binding, namespace }) => ({
 				name: binding,
 				type: getBindingTypeFriendlyName("ai_search_namespace"),
-				value: namespace ? String(namespace) : undefined,
+				// Preserve `namespace` as-is so `typeof === "symbol"` handling
+				// downstream can render INHERIT_SYMBOL as `"inherited"`. Using
+				// `String(namespace)` would stringify it to
+				// `"Symbol(inherit_binding)"` and defeat that check.
+				value: namespace ?? undefined,
 				mode: getMode({ isSimulatedLocally: false }),
 			}))
 		);


### PR DESCRIPTION
## Summary

Fixes the `wrangler deploy` bindings table so that an
`ai_search_namespaces` binding that inherits from the existing deployment
renders as `(inherited)` instead of the raw string `Symbol(inherit_binding)`.

## Root cause

In `packages/wrangler/src/utils/print-bindings.ts`, the `ai_search_namespaces`
block stringifies the `namespace` value up front:

```ts
value: namespace ? String(namespace) : undefined,
```

When `namespace === INHERIT_SYMBOL`, `String(namespace)` returns the literal
string `"Symbol(inherit_binding)"`. Downstream at lines 866-868, the
formatter specifically checks `typeof value === "symbol"` to render
`"inherited"` — but by then the value is a string, so the check fails and
we print the stringified symbol.

Switching to `namespace ?? undefined` preserves the symbol so the downstream
check fires correctly. This matches the pattern used for `agent_memory`
bindings in the same file.

## Scope

Only `ai_search_namespaces` needs this fix. The adjacent `ai_search` block
uses `instance_name: string`, which is never a symbol, so it is not affected.

## Test plan

- New unit test `renders inherited AI Search namespace bindings as \`(inherited)\`` in `print-bindings.test.ts`.
- All existing `print-bindings` tests still pass.
- `pnpm check` passes (lint, format, type).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix to `wrangler deploy` output rendering — user-facing behaviour improves with no API changes.

*A picture of a cute animal (not mandatory, but encouraged)*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13622" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
