### PR TITLE
ci: pin OpenCode for CI jobs

### DIFF
--- a/.github/workflows/bonk-pr-review.yml
+++ b/.github/workflows/bonk-pr-review.yml
@@ -61,4 +61,5 @@ jobs:
           model: "cloudflare-ai-gateway/anthropic/claude-opus-4-6"
           forks: "false"
           permissions: write
+          opencode_version: "1.4.6" # pin to this version as newer versions are causing ProviderInitError issues
           prompt: ${{ steps.prompt.outputs.value }}

--- a/.github/workflows/bonk-pr-review.yml
+++ b/.github/workflows/bonk-pr-review.yml
@@ -6,9 +6,7 @@ on:
 
 jobs:
   review:
-    if: false
-    # Temporarily skipping this while we investigate model issues
-    # if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -71,4 +71,5 @@ jobs:
           mentions: "/bonk,@ask-bonk"
           permissions: write
           agent: bonk
+          opencode_version: "1.4.6" # pin to this version as newer versions are causing ProviderInitError issues
           prompt: ${{ steps.prompt.outputs.value }}

--- a/.github/workflows/changeset-review.yml
+++ b/.github/workflows/changeset-review.yml
@@ -18,9 +18,7 @@ permissions:
 jobs:
   review-changesets:
     runs-on: ubuntu-latest
-    # Temporarily skipping this while we investigate model issues
-    # if: github.event.pull_request.head.repo.full_name == github.repository
-    if: false
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout changesets
         uses: actions/checkout@v4

--- a/.github/workflows/changeset-review.yml
+++ b/.github/workflows/changeset-review.yml
@@ -31,8 +31,9 @@ jobs:
             .github/opencode.json
 
       - name: Install OpenCode
+        # pin OpenCode to 1.4.6 version as newer versions are causing ProviderInitError issues
         run: |
-          npm install -g opencode-ai
+          npm install -g opencode-ai@1.4.6
           cp .github/opencode.json ./opencode.json
 
       - name: Get changed changeset files


### PR DESCRIPTION
There is a regression in the current version of OpenCode causing a ProviderInitError.
Pinning to 1.4.6 appears to fix this.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows: 
  - [x] Additional testing not necessary because: either the CI job works or it doesn't!
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal CI-only change.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->