### PR TITLE
[wrangler] Prioritize CLOUDFLARE_ACCOUNT_ID over cached account id for Pages commands

### DIFF
--- a/.changeset/pages-deploy-env-account-id.md
+++ b/.changeset/pages-deploy-env-account-id.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: prioritise `CLOUDFLARE_ACCOUNT_ID` over a cached account id for all Pages commands
+
+Previously, some Pages commands (`pages deploy`, `pages deployment list/delete/tail`, `pages download config`, `pages secret`) used a cached account id over the `CLOUDFLARE_ACCOUNT_ID` environment variable. The `pages project` commands already correctly prioritised `CLOUDFLARE_ACCOUNT_ID`.

--- a/packages/wrangler/src/__tests__/pages/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deploy.test.ts
@@ -9,8 +9,12 @@ import dedent from "ts-dedent";
 // eslint-disable-next-line no-restricted-imports
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { version } from "../../../package.json";
+import { saveToConfigCache } from "../../config-cache";
 import { logger } from "../../logger";
-import { ROUTES_SPEC_VERSION } from "../../pages/constants";
+import {
+	PAGES_CONFIG_CACHE_FILENAME,
+	ROUTES_SPEC_VERSION,
+} from "../../pages/constants";
 import { ApiErrorCodes } from "../../pages/errors";
 import { isRoutesJSONSpec } from "../../pages/functions/routes-validation";
 import { endEventLoop } from "../helpers/end-event-loop";
@@ -28,7 +32,11 @@ import {
 	formDataToObject,
 	toString,
 } from "../helpers/serialize-form-data-entry";
-import type { Project, UploadPayloadFile } from "../../pages/types";
+import type {
+	PagesConfigCache,
+	Project,
+	UploadPayloadFile,
+} from "../../pages/types";
 import type { StrictRequest } from "msw";
 import type { FormDataEntryValue } from "undici";
 
@@ -6274,6 +6282,46 @@ and that at least one include rule is provided.
 
 			expect(std.out).toContain("Success! Uploaded 6 files");
 			expect(std.out).toContain("Deployment complete!");
+		});
+	});
+
+	describe("account id resolution", () => {
+		it("should prefer the CLOUDFLARE_ACCOUNT_ID environment variable over a stale cached account id in pages.json", async ({
+			expect,
+		}) => {
+			vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "env-var-account-id");
+
+			// Seed the Pages config cache with a stale account id, simulating
+			// a previous deploy against a different account.
+			saveToConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME, {
+				account_id: "stale-cached-account-id",
+				project_name: "foo",
+			});
+
+			writeFileSync("logo.png", "foobar");
+
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/pages/projects/foo",
+					({ params }) => {
+						expect(params.accountId).toEqual("env-var-account-id");
+						return HttpResponse.json(
+							{
+								success: false,
+								errors: [{ code: 10000, message: "Authentication error" }],
+								messages: [],
+								result: null,
+							},
+							{ status: 401 }
+						);
+					},
+					{ once: true }
+				)
+			);
+
+			await expect(
+				runWrangler("pages deploy . --project-name=foo")
+			).rejects.toThrow();
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/pages/deployment-delete.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deployment-delete.test.ts
@@ -1,5 +1,7 @@
 import { http, HttpResponse } from "msw";
-import { afterEach, beforeEach, describe, it } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
+import { saveToConfigCache } from "../../config-cache";
+import { PAGES_CONFIG_CACHE_FILENAME } from "../../pages/constants";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -8,6 +10,7 @@ import { useMockIsTTY } from "../helpers/mock-istty";
 import { msw } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
+import type { PagesConfigCache } from "../../pages/types";
 import type { ExpectStatic } from "vitest";
 
 /** Create a mock handler for the request to delete a Pages deployment. */
@@ -119,5 +122,39 @@ describe("pages deployment delete", () => {
 		);
 
 		expect(std.out).toContain("Successfully deleted deployment abc123");
+	});
+
+	it("should prefer CLOUDFLARE_ACCOUNT_ID over cached account id", async ({
+		expect,
+	}) => {
+		vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "env-var-account-id");
+
+		saveToConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME, {
+			account_id: "stale-cached-account-id",
+			project_name: "my-project",
+		});
+
+		msw.use(
+			http.delete(
+				"*/accounts/:accountId/pages/projects/:projectName/deployments/:deploymentId",
+				({ params }) => {
+					expect(params.accountId).toEqual("env-var-account-id");
+					return HttpResponse.json(
+						{
+							result: null,
+							success: true,
+							errors: [],
+							messages: [],
+						},
+						{ status: 200 }
+					);
+				},
+				{ once: true }
+			)
+		);
+
+		await runWrangler(
+			"pages deployment delete abc123 --project-name=my-project --force"
+		);
 	});
 });

--- a/packages/wrangler/src/__tests__/pages/deployment-list.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deployment-list.test.ts
@@ -1,11 +1,14 @@
 import { http, HttpResponse } from "msw";
-import { afterEach, describe, it } from "vitest";
+import { afterEach, describe, it, vi } from "vitest";
+import { saveToConfigCache } from "../../config-cache";
+import { PAGES_CONFIG_CACHE_FILENAME } from "../../pages/constants";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { mockAccountId, mockApiToken } from "./../helpers/mock-account-id";
 import { msw } from "./../helpers/msw";
 import { runInTempDir } from "./../helpers/run-in-tmp";
 import { runWrangler } from "./../helpers/run-wrangler";
+import type { PagesConfigCache } from "../../pages/types";
 import type { Deployment } from "./../../pages/types";
 import type { ExpectStatic } from "vitest";
 
@@ -202,6 +205,38 @@ describe("pages deployment list", () => {
 				return key === "env";
 			})
 		).toStrictEqual(["env", "preview"]);
+	});
+
+	it("should prefer CLOUDFLARE_ACCOUNT_ID over cached account id", async ({
+		expect,
+	}) => {
+		vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "env-var-account-id");
+
+		saveToConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME, {
+			account_id: "stale-cached-account-id",
+			project_name: "images",
+		});
+
+		msw.use(
+			http.get(
+				"*/accounts/:accountId/pages/projects/:project/deployments",
+				({ params }) => {
+					expect(params.accountId).toEqual("env-var-account-id");
+					return HttpResponse.json(
+						{
+							success: true,
+							errors: [],
+							messages: [],
+							result: [],
+						},
+						{ status: 200 }
+					);
+				},
+				{ once: true }
+			)
+		);
+
+		await runWrangler("pages deployment list --project-name=images");
 	});
 });
 

--- a/packages/wrangler/src/__tests__/pages/pages-download-config.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-download-config.test.ts
@@ -3,7 +3,9 @@ import { readFile } from "node:fs/promises";
 import { getTodaysCompatDate } from "@cloudflare/workers-utils";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-import { afterAll, beforeEach, describe, it } from "vitest";
+import { afterAll, beforeEach, describe, it, vi } from "vitest";
+import { saveToConfigCache } from "../../config-cache";
+import { PAGES_CONFIG_CACHE_FILENAME } from "../../pages/constants";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs, mockConfirm } from "../helpers/mock-dialogs";
@@ -11,6 +13,7 @@ import { useMockIsTTY } from "../helpers/mock-istty";
 import { msw } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
+import type { PagesConfigCache } from "../../pages/types";
 import type { ExpectStatic } from "vitest";
 
 async function readNormalizedWranglerToml() {
@@ -837,6 +840,48 @@ describe("pages download config", () => {
 			"
 		`);
 	});
+	it("should prefer CLOUDFLARE_ACCOUNT_ID over cached account id", async ({
+		expect,
+	}) => {
+		vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "env-var-account-id");
+
+		saveToConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME, {
+			account_id: "stale-cached-account-id",
+			project_name: MOCK_PROJECT_NAME,
+		});
+
+		msw.use(
+			http.get(
+				`*/accounts/:accountId/pages/projects/:projectName`,
+				({ params }) => {
+					expect(params.accountId).toEqual("env-var-account-id");
+					return HttpResponse.json(makePagesProject(), { status: 200 });
+				},
+				{ once: true }
+			),
+			http.get(
+				`*/accounts/:accountId/workers/durable_objects/namespaces/:doId`,
+				({ params }) => {
+					expect(params.accountId).toEqual("env-var-account-id");
+					return HttpResponse.json(
+						{
+							success: true,
+							errors: [],
+							result: {
+								script: `some-script-${params.doId}`,
+								class: `some-class-${params.doId}`,
+								environment: `some-environment-${params.doId}`,
+							},
+						},
+						{ status: 200 }
+					);
+				}
+			)
+		);
+
+		await runWrangler(`pages download config ${MOCK_PROJECT_NAME}`);
+	});
+
 	it("should fail if not given a project name", async ({ expect }) => {
 		await expect(
 			runWrangler(`pages download config`)

--- a/packages/wrangler/src/__tests__/pages/secret.test.ts
+++ b/packages/wrangler/src/__tests__/pages/secret.test.ts
@@ -2,6 +2,8 @@ import { writeFileSync } from "node:fs";
 import readline from "node:readline";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
+import { saveToConfigCache } from "../../config-cache";
+import { PAGES_CONFIG_CACHE_FILENAME } from "../../pages/constants";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs, mockConfirm, mockPrompt } from "../helpers/mock-dialogs";
@@ -12,6 +14,7 @@ import { createFetchResult, msw } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import type { PagesProject } from "../../pages/download-config";
+import type { PagesConfigCache } from "../../pages/types";
 import type { Interface } from "node:readline";
 import type { ExpectStatic } from "vitest";
 
@@ -824,6 +827,56 @@ describe("wrangler pages secret", () => {
 				  "warn": "",
 				}
 			`);
+		});
+	});
+
+	describe("account id resolution", () => {
+		beforeEach(() => {
+			setIsTTY(true);
+		});
+
+		it("should prefer CLOUDFLARE_ACCOUNT_ID over cached account id", async ({
+			expect,
+		}) => {
+			vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "env-var-account-id");
+
+			saveToConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME, {
+				account_id: "stale-cached-account-id",
+				project_name: "some-project-name",
+			});
+
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/pages/projects/:project",
+					({ params }) => {
+						expect(params.accountId).toEqual("env-var-account-id");
+						return HttpResponse.json(
+							{
+								success: true,
+								errors: [],
+								messages: [],
+								result: {
+									name: "some-project-name",
+									deployment_configs: {
+										production: {
+											wrangler_config_hash: "wch",
+											env_vars: {
+												"the-secret": {
+													type: "secret_text",
+												},
+											},
+										},
+										preview: {},
+									},
+								},
+							},
+							{ status: 200 }
+						);
+					}
+				)
+			);
+
+			await runWrangler("pages secret list --project some-project-name");
 		});
 	});
 });

--- a/packages/wrangler/src/pages/deploy.ts
+++ b/packages/wrangler/src/pages/deploy.ts
@@ -19,6 +19,7 @@ import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { writeOutput } from "../output";
 import { requireAuth } from "../user";
+import { getCloudflareAccountIdFromEnv } from "../user/auth-variables";
 import { diagnoseStartupError } from "../utils/friendly-validator-errors";
 import {
 	MAX_DEPLOYMENT_STATUS_ATTEMPTS,
@@ -186,7 +187,8 @@ export const pagesDeployCommand = createCommand({
 		const configCache = getConfigCache<PagesConfigCache>(
 			PAGES_CONFIG_CACHE_FILENAME
 		);
-		const accountId = await requireAuth(configCache);
+		const accountId =
+			getCloudflareAccountIdFromEnv() ?? (await requireAuth(configCache));
 
 		let projectName =
 			args.projectName ?? config?.name ?? configCache.project_name;

--- a/packages/wrangler/src/pages/deployment-tails.ts
+++ b/packages/wrangler/src/pages/deployment-tails.ts
@@ -18,6 +18,7 @@ import {
 } from "../tail/createTail";
 import { translateCLICommandToFilterMessage } from "../tail/filters";
 import { requireAuth } from "../user";
+import { getCloudflareAccountIdFromEnv } from "../user/auth-variables";
 import { PAGES_CONFIG_CACHE_FILENAME } from "./constants";
 import { promptSelectProject } from "./prompt-select-project";
 import { isUrl } from "./utils";
@@ -144,7 +145,8 @@ export const pagesDeploymentTailCommand = createCommand({
 		const pagesConfig = getConfigCache<PagesConfigCache>(
 			PAGES_CONFIG_CACHE_FILENAME
 		);
-		const accountId = await requireAuth(pagesConfig);
+		const accountId =
+			getCloudflareAccountIdFromEnv() ?? (await requireAuth(pagesConfig));
 		let deploymentId = deployment;
 
 		if (!isInteractive()) {

--- a/packages/wrangler/src/pages/deployments.ts
+++ b/packages/wrangler/src/pages/deployments.ts
@@ -11,6 +11,7 @@ import { isNonInteractiveOrCI } from "../is-interactive";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { requireAuth } from "../user";
+import { getCloudflareAccountIdFromEnv } from "../user/auth-variables";
 import { PAGES_CONFIG_CACHE_FILENAME } from "./constants";
 import { promptSelectProject } from "./prompt-select-project";
 import type { PagesConfigCache } from "./types";
@@ -48,7 +49,8 @@ export const pagesDeploymentListCommand = createCommand({
 		const config = getConfigCache<PagesConfigCache>(
 			PAGES_CONFIG_CACHE_FILENAME
 		);
-		const accountId = await requireAuth(config);
+		const accountId =
+			getCloudflareAccountIdFromEnv() ?? (await requireAuth(config));
 
 		projectName ??= config.project_name;
 
@@ -144,7 +146,8 @@ export const pagesDeploymentDeleteCommand = createCommand({
 		const config = getConfigCache<PagesConfigCache>(
 			PAGES_CONFIG_CACHE_FILENAME
 		);
-		const accountId = await requireAuth(config);
+		const accountId =
+			getCloudflareAccountIdFromEnv() ?? (await requireAuth(config));
 
 		projectName ??= config.project_name;
 

--- a/packages/wrangler/src/pages/download-config.ts
+++ b/packages/wrangler/src/pages/download-config.ts
@@ -14,6 +14,7 @@ import { confirm } from "../dialogs";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { requireAuth } from "../user";
+import { getCloudflareAccountIdFromEnv } from "../user/auth-variables";
 import { PAGES_CONFIG_CACHE_FILENAME } from "./constants";
 import type { PagesConfigCache } from "./types";
 import type { Project } from "@cloudflare/types";
@@ -318,7 +319,8 @@ export const pagesDownloadConfigCommand = createCommand({
 		const projectConfig = getConfigCache<PagesConfigCache>(
 			PAGES_CONFIG_CACHE_FILENAME
 		);
-		const accountId = await requireAuth(projectConfig);
+		const accountId =
+			getCloudflareAccountIdFromEnv() ?? (await requireAuth(projectConfig));
 
 		projectName ??= projectConfig.project_name;
 

--- a/packages/wrangler/src/pages/secret/index.ts
+++ b/packages/wrangler/src/pages/secret/index.ts
@@ -15,6 +15,7 @@ import { logger } from "../../logger";
 import * as metrics from "../../metrics";
 import { parseBulkInputToObject } from "../../secret";
 import { requireAuth } from "../../user";
+import { getCloudflareAccountIdFromEnv } from "../../user/auth-variables";
 import { readFromStdin, trimTrailingWhitespace } from "../../utils/std";
 import { PAGES_CONFIG_CACHE_FILENAME } from "../constants";
 import { EXIT_CODE_INVALID_PAGES_CONFIG } from "../errors";
@@ -79,7 +80,8 @@ async function pagesProject(
 	const configCache = getConfigCache<PagesConfigCache>(
 		PAGES_CONFIG_CACHE_FILENAME
 	);
-	const accountId = await requireAuth(configCache);
+	const accountId =
+		getCloudflareAccountIdFromEnv() ?? (await requireAuth(configCache));
 
 	const projectName =
 		cliProjectName ?? config?.name ?? configCache.project_name;


### PR DESCRIPTION
Fixes #13590.

Most pages commands previously read the account id from their cached `pages.json` before checking the `CLOUDFLARE_ACCOUNT_ID` environment variable. 

This is inconsistent with other commands, including the `pages project list/create/delete` commands which already _do_ prioritise `CLOUDFLARE_ACCOUNT_ID`.


This PR applies the same pattern to the remaining Pages commands:

- `wrangler pages deploy`
- `wrangler pages deployment list` / `deployment delete`
- `wrangler pages deployment tail`
- `wrangler pages download config`
- `wrangler pages secret` (put/bulk/delete/list)


- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

Devin PR requested by @emily-shen (eshen@cloudflare.com)


Link to Devin session: https://app.devin.ai/sessions/c2f96415cbf44d12a22dec27fad422b4