### PR TITLE
workers-sdk causing PRs to workerd main to fail

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3409,7 +3409,7 @@ importers:
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
         specifier: catalog:default
-        version: 4.20260420.1
+        version: 4.20260421.1
       typescript:
         specifier: catalog:default
         version: 5.8.3


### PR DESCRIPTION
This was due to a version mismatch by PR #13615 being merged and later. PR #13234 had the earlier version of 4.20260420.1 but the version needed was 4.20260421.1. No tests because the only way to test is to run workerd cli.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
