### PR TITLE
Fix flaky worker-app fixture due to SQLite contention

### DIFF
--- a/fixtures/shared/src/run-wrangler-long-lived.ts
+++ b/fixtures/shared/src/run-wrangler-long-lived.ts
@@ -64,6 +64,7 @@ async function runLongLivedWrangler(
 	let resolveReadyPromise: (value: { ip: string; port: number }) => void;
 	let rejectReadyPromise: (reason: unknown) => void;
 	let processExited = false;
+	let stopping = false;
 
 	const ready = new Promise<{ ip: string; port: number }>((resolve, reject) => {
 		resolveReadyPromise = resolve;
@@ -108,6 +109,11 @@ async function runLongLivedWrangler(
 			);
 			return;
 		}
+		if (stopping) {
+			// Exit was triggered by `stop()` (normal test teardown). No diagnostic
+			// needed — the tests are already done.
+			return;
+		}
 		// The process exited *after* we sent back a ready signal — any pending
 		// tests will now see ECONNREFUSED. Dump the captured output so CI logs
 		// contain the diagnostic info needed to understand what happened.
@@ -139,6 +145,7 @@ async function runLongLivedWrangler(
 	}, 50_000);
 
 	async function stop() {
+		stopping = true;
 		return new Promise<void>((resolve) => {
 			if (processExited) {
 				// Already dead — nothing to kill. Avoid noisy Windows taskkill errors.

--- a/fixtures/shared/src/run-wrangler-long-lived.ts
+++ b/fixtures/shared/src/run-wrangler-long-lived.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert";
 import { fork } from "node:child_process";
+import { createConnection } from "node:net";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import treeKill from "tree-kill";
 
 export const wranglerEntryPath = path.resolve(
@@ -61,6 +63,7 @@ async function runLongLivedWrangler(
 	let settledReadyPromise = false;
 	let resolveReadyPromise: (value: { ip: string; port: number }) => void;
 	let rejectReadyPromise: (reason: unknown) => void;
+	let processExited = false;
 
 	const ready = new Promise<{ ip: string; port: number }>((resolve, reject) => {
 		resolveReadyPromise = resolve;
@@ -72,7 +75,9 @@ async function runLongLivedWrangler(
 		cwd,
 		env: { ...process.env, ...env, PWD: cwd },
 	}).on("message", (message) => {
-		if (settledReadyPromise) return;
+		if (settledReadyPromise) {
+			return;
+		}
 		settledReadyPromise = true;
 		clearTimeout(timeoutHandle);
 		resolveReadyPromise(JSON.parse(message.toString()));
@@ -91,18 +96,37 @@ async function runLongLivedWrangler(
 		}
 		chunks.push(chunk);
 	});
-	wranglerProcess.once("exit", (exitCode) => {
-		if (exitCode !== 0) {
-			rejectReadyPromise(
-				`Wrangler exited with error code: ${exitCode}\nOutput: ${getOutput()}`
-			);
-		}
-	});
 	const getOutput = () => Buffer.concat(chunks).toString();
 	const clearOutput = () => (chunks.length = 0);
 
+	wranglerProcess.once("exit", (exitCode, signal) => {
+		processExited = true;
+		if (!settledReadyPromise) {
+			settledReadyPromise = true;
+			rejectReadyPromise(
+				`Wrangler exited with error code: ${exitCode}\nOutput: ${getOutput()}`
+			);
+			return;
+		}
+		// The process exited *after* we sent back a ready signal — any pending
+		// tests will now see ECONNREFUSED. Dump the captured output so CI logs
+		// contain the diagnostic info needed to understand what happened.
+		const separator = "=".repeat(80);
+		console.error(
+			[
+				`Wrangler process exited unexpectedly after startup (code=${exitCode}, signal=${signal})`,
+				`Command: ${command.join(" ")}`,
+				separator,
+				getOutput(),
+				separator,
+			].join("\n")
+		);
+	});
+
 	const timeoutHandle = setTimeout(() => {
-		if (settledReadyPromise) return;
+		if (settledReadyPromise) {
+			return;
+		}
 		settledReadyPromise = true;
 		const separator = "=".repeat(80);
 		const message = [
@@ -116,6 +140,11 @@ async function runLongLivedWrangler(
 
 	async function stop() {
 		return new Promise<void>((resolve) => {
+			if (processExited) {
+				// Already dead — nothing to kill. Avoid noisy Windows taskkill errors.
+				resolve();
+				return;
+			}
 			assert(
 				wranglerProcess.pid,
 				`Command "${command.join(" ")}" had no process id`
@@ -137,5 +166,81 @@ async function runLongLivedWrangler(
 	}
 
 	const { ip, port } = await ready;
+
+	// Close the race between Wrangler's IPC "ready" message and the TCP socket
+	// actually accepting connections. Without this, tests can run immediately
+	// after `beforeAll` returns and hit ECONNREFUSED — especially under CI load
+	// when fixtures run in parallel (see ci-flake label for prior art). If the
+	// server never starts listening, surface a clear error with captured output
+	// instead of letting every test in the suite fail with ECONNREFUSED.
+	await waitForServerListening(ip, port, getOutput, () => processExited, stop);
+
 	return { ip, port, stop, getOutput, clearOutput };
+}
+
+/**
+ * Polls `ip:port` until it accepts a TCP connection, giving up after
+ * `totalTimeoutMs`. Throws with a diagnostic message (including the captured
+ * Wrangler output) if the server never starts listening or the process exits.
+ */
+async function waitForServerListening(
+	ip: string,
+	port: number,
+	getOutput: () => string,
+	hasExited: () => boolean,
+	stop: () => Promise<void>,
+	totalTimeoutMs = 10_000
+) {
+	const deadline = Date.now() + totalTimeoutMs;
+	let lastError: unknown;
+	while (Date.now() < deadline) {
+		if (hasExited()) {
+			break;
+		}
+		try {
+			await tryConnect(ip, port);
+			return;
+		} catch (e) {
+			lastError = e;
+			await delay(100);
+		}
+	}
+	await stop();
+	const separator = "=".repeat(80);
+	throw new Error(
+		[
+			`Wrangler reported ready on ${ip}:${port} but the server is not accepting connections (last error: ${lastError instanceof Error ? lastError.message : String(lastError)})`,
+			separator,
+			getOutput(),
+			separator,
+		].join("\n")
+	);
+}
+
+function tryConnect(ip: string, port: number, timeoutMs = 500): Promise<void> {
+	return new Promise<void>((resolve, reject) => {
+		const socket = createConnection({ host: ip, port });
+		const onError = (err: Error) => {
+			cleanup();
+			reject(err);
+		};
+		const onConnect = () => {
+			cleanup();
+			resolve();
+		};
+		const onTimeout = () => {
+			cleanup();
+			reject(new Error("TCP connect timed out"));
+		};
+		const cleanup = () => {
+			socket.removeListener("error", onError);
+			socket.removeListener("connect", onConnect);
+			socket.removeListener("timeout", onTimeout);
+			socket.destroy();
+		};
+		socket.setTimeout(timeoutMs);
+		socket.once("error", onError);
+		socket.once("connect", onConnect);
+		socket.once("timeout", onTimeout);
+	});
 }

--- a/fixtures/worker-app/vitest.config.mts
+++ b/fixtures/worker-app/vitest.config.mts
@@ -4,6 +4,14 @@ import configShared from "../../vitest.shared";
 export default mergeConfig(
 	configShared,
 	defineProject({
-		test: {},
+		test: {
+			// The three test files in this fixture each spawn their own
+			// `wrangler dev` against the same working directory, so they share
+			// the `.wrangler/state` SQLite cache. Running them in parallel hits
+			// `SQLITE_BUSY` intermittently and causes workerd to abort with
+			// "The Workers runtime failed to start", leaving tests to fail with
+			// ECONNREFUSED. Run the files serially to avoid the contention.
+			fileParallelism: false,
+		},
 	})
 );


### PR DESCRIPTION
_Describe your change..._

The three test files in `fixtures/worker-app` each spawn their own `wrangler dev` process against the same working directory. Running them in parallel causes contention on the shared `.wrangler/state` SQLite cache, producing `SQLITE_BUSY` errors that crash workerd with *"The Workers runtime failed to start"*, leaving every test in `tests/index.test.ts` to fail with `ECONNREFUSED`.

Example failure: https://github.com/cloudflare/workers-sdk/actions/runs/24763132304/job/72451136971 (hits ~10% of failed CI runs; seen on both Linux and Windows, across unrelated PRs — not specific to the dependabot `workerd` bump that triggered this investigation).

The flake became more visible after #13596 enabled parallel fixture execution (`--concurrency=2`).

## Changes

1. **`fixtures/worker-app/vitest.config.mts`** — disable file-level parallelism so the three dev servers never run concurrently. Each file is fast (~1–2s), so wall-clock cost is minimal (~4.7s total).
2. **`fixtures/shared/src/run-wrangler-long-lived.ts`** — harden the shared helper so similar flakes are *diagnosable* next time:
   - After the IPC "ready" message, verify the TCP port is actually accepting connections. Closes a second, narrower race (port-not-listening-yet) and surfaces a clear error with captured output if the probe never succeeds.
   - If the wrangler process exits *after* ready, dump the captured stdout/stderr to stderr so CI logs contain the actual crash cause instead of just `ECONNREFUSED`. This is how I diagnosed this bug — locally reproducing the flake and seeing the `SQLITE_BUSY` message from workerd.
   - Skip `stop()`'s `treeKill` when the process is already dead, avoiding the noisy `ERROR: The process "X" not found` on Windows.

## Validation

Ran the fixture 5 times locally (previously flaky ~10%, worse under load):

```
=== Run 1 ===  4 files, 20 tests, 4.57s — pass
=== Run 2 ===  4 files, 20 tests, 4.68s — pass
=== Run 3 ===  4 files, 20 tests, 4.58s — pass
=== Run 4 ===  4 files, 20 tests, 4.66s — pass
=== Run 5 ===  4 files, 20 tests, 4.71s — pass
```

Also spot-checked neighbouring fixtures that use the same helper (`@fixture/nodejs-als`, `@fixture/import-wasm`, `@fixture/redirected-config-worker-with-environments`, `@fixture/dynamic-worker-loading`) — all pass.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: CI/test-only changes, no user-facing impact