### PR TITLE
[cli] Update @clack/core and @clack/prompts to v1.2.0

### DIFF
--- a/.changeset/update-clack-to-v1.md
+++ b/.changeset/update-clack-to-v1.md
@@ -6,4 +6,4 @@
 
 Update `@clack/core` and `@clack/prompts` to v1.2.0
 
-Bumps the bundled `@clack/core` dependency used internally by `@cloudflare/cli` from `0.3.x` to `1.2.0`, and the unused `@clack/prompts` reference in `create-cloudflare` from `0.6.x` to `1.2.0`. Clack v1 is ESM-only and renames `TextPrompt#valueWithCursor` to `userInputWithCursor`; internal call sites have been updated accordingly. Validator return types have been widened to accept `Error` instances alongside strings, matching Clack's new API. No user-facing prompt behaviour changes are expected.
+Bumps the bundled `@clack/core` dependency used internally by `@cloudflare/cli` from `0.3.x` to `1.2.0`, and the `@clack/prompts` dependency in `create-cloudflare` from `0.6.x` to `1.2.0`. Clack v1 includes a number of API changes, but no user-facing prompt behaviour changes are expected.

--- a/.changeset/update-clack-to-v1.md
+++ b/.changeset/update-clack-to-v1.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+"create-cloudflare": patch
+"miniflare": patch
+---
+
+Update `@clack/core` and `@clack/prompts` to v1.2.0
+
+Bumps the bundled `@clack/core` dependency used internally by `@cloudflare/cli` from `0.3.x` to `1.2.0`, and the unused `@clack/prompts` reference in `create-cloudflare` from `0.6.x` to `1.2.0`. Clack v1 is ESM-only and renames `TextPrompt#valueWithCursor` to `userInputWithCursor`; internal call sites have been updated accordingly. Validator return types have been widened to accept `Error` instances alongside strings, matching Clack's new API. No user-facing prompt behaviour changes are expected.

--- a/packages/cli/interactive.ts
+++ b/packages/cli/interactive.ts
@@ -59,7 +59,7 @@ export type BasePromptConfig = {
 	// Pretty-prints the value in the interactive prompt
 	format?: (value: Arg) => string;
 	// Returns a user displayed error if the value is invalid
-	validate?: (value: Arg) => string | void;
+	validate?: (value: Arg) => string | Error | undefined;
 	// Override some/all renderers (can be used for custom renderers before hoisting back into shared code)
 	renderers?: Partial<ReturnType<typeof getRenderers>>;
 	// Whether to throw an error if the prompt is crashed or cancelled
@@ -116,10 +116,11 @@ function acceptDefault<T>(
 ): T {
 	const error = promptConfig.validate?.(initialValue as Arg);
 	if (error) {
+		const errorMessage = error instanceof Error ? error.message : error;
 		if (promptConfig.throwOnError) {
-			throw new Error(error);
+			throw new Error(errorMessage);
 		} else {
-			crash(error);
+			crash(errorMessage);
 		}
 	}
 
@@ -145,7 +146,10 @@ export const inputPrompt = async <T = string>(
 		| SelectRefreshablePrompt;
 
 	// Looks up the needed renderer by the current state ('initial', 'submitted', etc.)
-	const dispatchRender = (props: RenderProps, p: Prompt): string | void => {
+	const dispatchRender = (
+		props: RenderProps,
+		p: Prompt<unknown>
+	): string | undefined => {
 		let state = props.state;
 
 		if (state === "initial" && promptConfig.initialErrorMessage) {
@@ -263,7 +267,7 @@ type Renderer = (
 		cursor?: number;
 		value: Arg;
 	},
-	prompt: Prompt
+	prompt: Prompt<unknown>
 ) => string[];
 
 const renderSubmit = (config: PromptConfig, value: string) => {
@@ -302,10 +306,10 @@ const getTextRenderers = (config: TextPromptConfig) => {
 	const format = config.format ?? ((val: Arg) => String(val));
 	const defaultValue = config.defaultValue?.toString() ?? "";
 	const activeRenderer = (props: RenderProps) => {
-		const { valueWithCursor } = props as TextPrompt;
+		const { userInputWithCursor } = props as TextPrompt;
 		return [
 			`${blCorner} ${bold(question)} ${dim(helpText)}`,
-			`${space(2)}${format(valueWithCursor || dim(defaultValue))}`,
+			`${space(2)}${format(userInputWithCursor || dim(defaultValue))}`,
 			``, // extra line for readability
 		];
 	};
@@ -434,7 +438,7 @@ const getSelectRenderers = (
 		initial: defaultRenderer,
 		active: defaultRenderer,
 		confirm: defaultRenderer,
-		error: (opts: { value: Arg; error: string }, prompt: Prompt) => {
+		error: (opts: { value: Arg; error: string }, prompt: Prompt<unknown>) => {
 			return [
 				`${leftT} ${status.error} ${dim(opts.error)}`,
 				`${grayBar}`,
@@ -466,7 +470,10 @@ const getSelectListRenderers = (config: ListPromptConfig) => {
 	let options = config.options;
 	const helpText = _helpText ?? "";
 	const { rows } = stdout;
-	const defaultRenderer: Renderer = ({ cursor, value }, prompt: Prompt) => {
+	const defaultRenderer: Renderer = (
+		{ cursor, value },
+		prompt: Prompt<unknown>
+	) => {
 		if (prompt instanceof SelectRefreshablePrompt) {
 			options = prompt.options;
 		}
@@ -558,7 +565,7 @@ const getSelectListRenderers = (config: ListPromptConfig) => {
 		initial: defaultRenderer,
 		active: defaultRenderer,
 		confirm: defaultRenderer,
-		error: (opts: { value: Arg; error: string }, prompt: Prompt) => {
+		error: (opts: { value: Arg; error: string }, prompt: Prompt<unknown>) => {
 			return [
 				`${leftT} ${status.error} ${dim(opts.error)}`,
 				`${grayBar}`,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
 		"ci-info": "catalog:default"
 	},
 	"devDependencies": {
-		"@clack/core": "^0.3.2",
+		"@clack/core": "^1.2.0",
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-utils": "workspace:*",
 		"@types/cross-spawn": "^6.0.2",

--- a/packages/cli/select-list.ts
+++ b/packages/cli/select-list.ts
@@ -18,7 +18,7 @@ export type SelectRefreshableOptions = ConstructorParameters<
 	options: OptionWithDetails[];
 };
 
-export default class SelectRefreshablePrompt extends Prompt {
+export default class SelectRefreshablePrompt extends Prompt<string> {
 	options: OptionWithDetails[];
 	cursor = 0;
 

--- a/packages/create-cloudflare/e2e/helpers/run-c3.ts
+++ b/packages/create-cloudflare/e2e/helpers/run-c3.ts
@@ -143,7 +143,7 @@ export const runC3 = async (
 				currentSelectDialog === undefined;
 
 			// Our select prompt options start with ○ / ◁ for unselected options and ● / ◀ for the current selection
-			const selectedOptionRegex = /^(●|◀)\s/;
+			const selectedOptionRegex = /^\u200a+(●|◀)\s/;
 			const currentSelection = lines
 				.find((line) => line.match(selectedOptionRegex))
 				?.replace(selectedOptionRegex, "");

--- a/packages/create-cloudflare/e2e/helpers/run-c3.ts
+++ b/packages/create-cloudflare/e2e/helpers/run-c3.ts
@@ -146,7 +146,8 @@ export const runC3 = async (
 			const selectedOptionRegex = /^\u200a+(●|◀)\s/;
 			const currentSelection = lines
 				.find((line) => line.match(selectedOptionRegex))
-				?.replace(selectedOptionRegex, "");
+				?.replace(selectedOptionRegex, "")
+				.trim();
 
 			if (!currentSelection) {
 				// sometimes `lines` contain only the 'clear screen' ANSI codes and not the prompt options

--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -39,7 +39,7 @@
 	"devDependencies": {
 		"@babel/parser": "^7.21.3",
 		"@babel/types": "^7.21.4",
-		"@clack/prompts": "^0.6.3",
+		"@clack/prompts": "^1.2.0",
 		"@cloudflare/cli": "workspace:*",
 		"@cloudflare/codemod": "workspace:*",
 		"@cloudflare/mock-npm-registry": "workspace:*",

--- a/packages/create-cloudflare/src/helpers/args.ts
+++ b/packages/create-cloudflare/src/helpers/args.ts
@@ -431,7 +431,11 @@ export const processArgument = async <Key extends keyof C3Args>(
 		disableTelemetry: args[key] !== undefined,
 		async promise() {
 			const value = args[key];
-			const error = promptConfig.validate?.(value) ?? null;
+			const validationResult = promptConfig.validate?.(value);
+			const error =
+				validationResult instanceof Error
+					? validationResult.message
+					: (validationResult ?? null);
 			const result = await inputPrompt<Required<C3Args>[Key]>({
 				...promptConfig,
 				// Accept the default value if the arg is already set

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1531,8 +1531,8 @@ importers:
         version: 4.4.0
     devDependencies:
       '@clack/core':
-        specifier: ^0.3.2
-        version: 0.3.2
+        specifier: ^1.2.0
+        version: 1.2.0
       '@cloudflare/workers-tsconfig':
         specifier: workspace:*
         version: link:../workers-tsconfig
@@ -1618,8 +1618,8 @@ importers:
         specifier: ^7.21.4
         version: 7.26.3
       '@clack/prompts':
-        specifier: ^0.6.3
-        version: 0.6.3
+        specifier: ^1.2.0
+        version: 1.2.0
       '@cloudflare/cli':
         specifier: workspace:*
         version: link:../cli
@@ -4883,13 +4883,11 @@ packages:
   '@chevrotain/utils@10.5.0':
     resolution: {integrity: sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==}
 
-  '@clack/core@0.3.2':
-    resolution: {integrity: sha512-FZnsNynwGDIDktx6PEZK1EuCkFpY4ldEX6VYvfl0dqeoLPb9Jpw1xoUXaVcGR8ExmYNm1w2vdGdJkEUYD/2pqg==}
+  '@clack/core@1.2.0':
+    resolution: {integrity: sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==}
 
-  '@clack/prompts@0.6.3':
-    resolution: {integrity: sha512-AM+kFmAHawpUQv2q9+mcB6jLKxXGjgu/r2EQjEwujgpCdzrST6BJqYw00GRn56/L/Izw5U7ImoLmy00X/r80Pw==}
-    bundledDependencies:
-      - is-unicode-supported
+  '@clack/prompts@1.2.0':
+    resolution: {integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==}
 
   '@cloudflare/component-box@4.0.2':
     resolution: {integrity: sha512-CInPo9qsB/XCFe5w3hllRhnuMIr9VpHfT4qHSMvSnXaKgeAcldGCw19EgcrkBST+Ye44cY9eO8sMycLLxG7luw==}
@@ -10714,8 +10712,17 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-string-truncated-width@1.2.1:
+    resolution: {integrity: sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==}
+
+  fast-string-width@1.1.0:
+    resolution: {integrity: sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==}
+
   fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
+
+  fast-wrap-ansi@0.1.6:
+    resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
 
   fast-xml-parser@4.4.1:
     resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
@@ -16199,15 +16206,16 @@ snapshots:
 
   '@chevrotain/utils@10.5.0': {}
 
-  '@clack/core@0.3.2':
+  '@clack/core@1.2.0':
     dependencies:
-      picocolors: 1.1.1
+      fast-wrap-ansi: 0.1.6
       sisteransi: 1.0.5
 
-  '@clack/prompts@0.6.3':
+  '@clack/prompts@1.2.0':
     dependencies:
-      '@clack/core': 0.3.2
-      picocolors: 1.1.1
+      '@clack/core': 1.2.0
+      fast-string-width: 1.1.0
+      fast-wrap-ansi: 0.1.6
       sisteransi: 1.0.5
 
   '@cloudflare/component-box@4.0.2(@cloudflare/style-const@5.7.3(react@18.3.1))(@cloudflare/style-container@7.12.2(@cloudflare/style-const@5.7.3(react@18.3.1))(react@18.3.1))(react@18.3.1)':
@@ -21856,7 +21864,17 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-string-truncated-width@1.2.1: {}
+
+  fast-string-width@1.1.0:
+    dependencies:
+      fast-string-truncated-width: 1.2.1
+
   fast-uri@3.0.6: {}
+
+  fast-wrap-ansi@0.1.6:
+    dependencies:
+      fast-string-width: 1.1.0
 
   fast-xml-parser@4.4.1:
     dependencies:


### PR DESCRIPTION
Addresses [this comment](https://github.com/cloudflare/workers-sdk/pull/12933#issuecomment-4259375119).

Updates the Clack dependencies used by `@cloudflare/cli` from 0.x to 1.2.0. Clack 1.0 ships as ESM-only and includes new features like typeahead search in core components.

#### Changes

- **`@clack/core`** `^0.3.2` → `^1.2.0` in `packages/cli`
- **`@clack/prompts`** `^0.6.3` → `^1.2.0` in `packages/create-cloudflare`
- `TextPrompt#valueWithCursor` renamed to `userInputWithCursor` (Clack breaking change) — updated in `packages/cli/interactive.ts`
- `Prompt` class now requires a generic parameter — `SelectRefreshablePrompt` and `Renderer` type updated
- Validator return type widened from `string | void` to `string | Error | undefined` to match Clack's new API — normalisation added in `acceptDefault()` and `packages/create-cloudflare/src/helpers/args.ts`

#### Testing

- `@cloudflare/cli`: type-check passes, 41 unit tests pass
- `create-cloudflare`: type-check passes, 192 unit tests pass
- `wrangler`: type-check passes, 3703 tests pass
- `miniflare`: type-check passes
- Manual: `c3` scaffold flow completes end-to-end, `wrangler dev` boots successfully with Miniflare

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal dependency bump with no user-facing API changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
