### PR TITLE
[miniflare] Forward service binding and tail consumer props across the dev registry

### DIFF
--- a/.changeset/fix-dev-registry-service-binding-props.md
+++ b/.changeset/fix-dev-registry-service-binding-props.md
@@ -1,0 +1,24 @@
+---
+"miniflare": patch
+"wrangler": patch
+---
+
+Fix service binding and tail consumer `props` being dropped between workers in different local dev instances
+
+When a service binding or tail consumer configured with `props` targeted a worker running in a separate `wrangler dev` instance (via the dev registry), the `props` were silently dropped and the remote entrypoint saw an empty `ctx.props`. Props are now forwarded correctly across the dev registry boundary, matching the behavior users get when all workers run in a single instance.
+
+```jsonc
+// wrangler.json
+{
+	"services": [
+		{
+			"binding": "AUTH",
+			"service": "auth-worker", // may be in a separate `wrangler dev` process
+			"entrypoint": "SessionEntry",
+			"props": { "tenant": "acme" },
+		},
+	],
+}
+```
+
+The target worker's `SessionEntry` entrypoint now correctly receives `{ tenant: "acme" }` on `ctx.props` regardless of which local dev instance it runs in.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -521,7 +521,7 @@ function getExternalServiceEntrypoints(allWorkerOpts: PluginWorkerOptions[]) {
 			for (const [name, service] of Object.entries(
 				workerOpts.core.serviceBindings
 			)) {
-				const { serviceName, entrypoint, remoteProxyConnectionString } =
+				const { serviceName, entrypoint, props, remoteProxyConnectionString } =
 					normaliseServiceDesignator(service);
 
 				if (
@@ -535,7 +535,13 @@ function getExternalServiceEntrypoints(allWorkerOpts: PluginWorkerOptions[]) {
 					workerOpts.core.serviceBindings[name] = {
 						name: SERVICE_DEV_REGISTRY_PROXY,
 						entrypoint: "ExternalServiceProxy",
-						props: { service: serviceName, entrypoint: entrypoint ?? null },
+						// User-supplied `props` are preserved in `userProps` so the proxy
+						// can forward them to the remote entrypoint via the debug port.
+						props: {
+							service: serviceName,
+							entrypoint: entrypoint ?? null,
+							userProps: props,
+						},
 					};
 				}
 			}
@@ -584,6 +590,7 @@ function getExternalServiceEntrypoints(allWorkerOpts: PluginWorkerOptions[]) {
 				const {
 					serviceName = workerOpts.core.name,
 					entrypoint,
+					props,
 					remoteProxyConnectionString,
 				} = normaliseServiceDesignator(workerOpts.core.tails[i]);
 
@@ -598,7 +605,13 @@ function getExternalServiceEntrypoints(allWorkerOpts: PluginWorkerOptions[]) {
 					workerOpts.core.tails[i] = {
 						name: SERVICE_DEV_REGISTRY_PROXY,
 						entrypoint: "ExternalServiceProxy",
-						props: { service: serviceName, entrypoint: entrypoint ?? null },
+						// User-supplied `props` are preserved in `userProps` so the proxy
+						// can forward them to the remote entrypoint via the debug port.
+						props: {
+							service: serviceName,
+							entrypoint: entrypoint ?? null,
+							userProps: props,
+						},
 					};
 				}
 			}

--- a/packages/miniflare/src/shared/external-service.ts
+++ b/packages/miniflare/src/shared/external-service.ts
@@ -8,10 +8,12 @@ export function normaliseServiceDesignator(
 ): {
 	serviceName: string | undefined;
 	entrypoint: string | undefined;
+	props: Record<string, unknown> | undefined;
 	remoteProxyConnectionString: RemoteProxyConnectionString | undefined;
 } {
 	let serviceName: string | undefined;
 	let entrypoint: string | undefined;
+	let props: Record<string, unknown> | undefined;
 	let remoteProxyConnectionString: RemoteProxyConnectionString | undefined;
 
 	if (typeof service === "string") {
@@ -19,12 +21,14 @@ export function normaliseServiceDesignator(
 	} else if (typeof service === "object" && "name" in service) {
 		serviceName = service.name !== kCurrentWorker ? service.name : undefined;
 		entrypoint = service.entrypoint;
+		props = service.props;
 		remoteProxyConnectionString = service.remoteProxyConnectionString;
 	}
 
 	return {
 		serviceName,
 		entrypoint,
+		props,
 		remoteProxyConnectionString,
 	};
 }

--- a/packages/miniflare/src/workers/core/dev-registry-proxy.worker.ts
+++ b/packages/miniflare/src/workers/core/dev-registry-proxy.worker.ts
@@ -32,10 +32,14 @@ interface Env {
 interface Props {
 	service: string;
 	entrypoint: string | null;
+	// User-supplied `props` from the original service binding / tail consumer.
+	// Forwarded to the remote entrypoint via the debug port so they are
+	// available as `ctx.props` on the callee.
+	userProps?: Record<string, unknown>;
 }
 
 function resolve(props: Props, env: Env): Fetcher | null {
-	const { service, entrypoint } = props;
+	const { service, entrypoint, userProps } = props;
 	const target = resolveTarget(service);
 	if (!target || !target.debugPortAddress) {
 		return null;
@@ -45,7 +49,7 @@ function resolve(props: Props, env: Env): Fetcher | null {
 			? target.defaultEntrypointService
 			: target.userWorkerService;
 	const client = env.DEV_REGISTRY_DEBUG_PORT.connect(target.debugPortAddress);
-	return client.getEntrypoint(serviceName, entrypoint ?? undefined);
+	return client.getEntrypoint(serviceName, entrypoint ?? undefined, userProps);
 }
 
 export class ExternalServiceProxy extends WorkerEntrypoint<Env, Props> {

--- a/packages/miniflare/test/dev-registry.spec.ts
+++ b/packages/miniflare/test/dev-registry.spec.ts
@@ -350,6 +350,60 @@ describe.sequential("DevRegistry", () => {
 		);
 	});
 
+	test("service binding props are propagated across instances", async ({
+		expect,
+	}) => {
+		const unsafeDevRegistryPath = await useTmp();
+		const remote = new Miniflare({
+			name: "remote-worker",
+			unsafeDevRegistryPath,
+			compatibilityFlags: ["experimental"],
+			modules: true,
+			script: `
+				import { WorkerEntrypoint } from "cloudflare:workers";
+				export class PropsEntrypoint extends WorkerEntrypoint {
+					getProps() { return this.ctx.props; }
+				}
+			`,
+		});
+		useDispose(remote);
+		await remote.ready;
+
+		const local = new Miniflare({
+			name: "local-worker",
+			unsafeDevRegistryPath,
+			serviceBindings: {
+				SERVICE: {
+					name: "remote-worker",
+					entrypoint: "PropsEntrypoint",
+					props: { foo: 123, bar: { baz: "hello from props" } },
+				},
+			},
+			compatibilityFlags: ["experimental"],
+			modules: true,
+			script: `
+				export default {
+					async fetch(request, env) {
+						return Response.json(await env.SERVICE.getProps());
+					}
+				}
+			`,
+		});
+		useDispose(local);
+
+		await vi.waitFor(
+			async () => {
+				const res = await local.dispatchFetch("http://placeholder");
+				expect(res.status).toBe(200);
+				expect(await res.json()).toEqual({
+					foo: 123,
+					bar: { baz: "hello from props" },
+				});
+			},
+			{ timeout: 10_000, interval: 100 }
+		);
+	});
+
 	test("fetch to module worker with node bindings", async ({ expect }) => {
 		const unsafeDevRegistryPath = await useTmp();
 		const local = new Miniflare({
@@ -1134,6 +1188,86 @@ describe.sequential("DevRegistry", () => {
 
 		expect(result2).toEqual(
 			`Worker "remote-worker" not found. Make sure it is running locally.`
+		);
+	});
+
+	test("tail consumer props are propagated across instances", async ({
+		expect,
+	}) => {
+		const unsafeDevRegistryPath = await useTmp();
+		const remote = new Miniflare({
+			name: "remote-worker",
+			unsafeDevRegistryPath,
+			compatibilityFlags: ["experimental"],
+			modules: true,
+			script: `
+				import { WorkerEntrypoint } from "cloudflare:workers";
+				let resolve;
+				const captured = new Promise((res) => { resolve = res; });
+				export default {
+					async fetch() {
+						try {
+							const result = await Promise.race([
+								captured,
+								new Promise((_, cancel) =>
+									setTimeout(() => cancel(new Error("no tail event received")), 2000)
+								)
+							]);
+							return Response.json(result);
+						} catch (e) {
+							return new Response(e.message, { status: 500 });
+						}
+					}
+				};
+				export class TailCollector extends WorkerEntrypoint {
+					async tail() {
+						resolve({ props: this.ctx.props ?? null });
+					}
+				}
+			`,
+		});
+		useDispose(remote);
+		await remote.ready;
+
+		const local = new Miniflare({
+			name: "local-worker",
+			unsafeDevRegistryPath,
+			tails: [
+				{
+					name: "remote-worker",
+					entrypoint: "TailCollector",
+					props: { tailKey: "from-tail-binding" },
+				},
+			],
+			handleRuntimeStdio: () => {},
+			compatibilityFlags: ["experimental"],
+			modules: true,
+			script: `
+				export default {
+					async fetch() {
+						console.log("DevReg: trigger tail event");
+						return new Response("ok");
+					}
+				}
+			`,
+		});
+		useDispose(local);
+
+		await vi.waitFor(
+			async () => {
+				// Fire a request that produces a log, which triggers a tail event
+				// targeting the remote worker's TailCollector entrypoint.
+				const trigger = await local.dispatchFetch("http://example.com");
+				expect(await trigger.text()).toBe("ok");
+
+				// Read the captured ctx.props back via the remote's default fetch.
+				const res = await remote.dispatchFetch("http://placeholder");
+				expect(res.status).toBe(200);
+				expect(await res.json()).toEqual({
+					props: { tailKey: "from-tail-binding" },
+				});
+			},
+			{ timeout: 10_000, interval: 100 }
 		);
 	});
 


### PR DESCRIPTION
Fixes a bug where service binding and tail consumer `props` were silently dropped when the target worker was running in a separate local dev instance (via the dev registry).

When Miniflare encounters a service binding or tail consumer pointing at a worker that isn't in the current Miniflare config, it rewrites the binding to redirect through a local `dev-registry-proxy` worker. Two issues on that path caused props to be lost:

1. `getExternalServiceEntrypoints` in `packages/miniflare/src/index.ts` overwrote the user-supplied `props` with internal routing metadata (`{ service, entrypoint }`).
2. The proxy worker called `WorkerdDebugPortClient.getEntrypoint(service, entrypoint)` without ever passing the user's props as the optional third argument.

The fix preserves the original props as `userProps` inside the proxy's routing metadata, and passes them to `getEntrypoint(service, entrypoint, userProps)`. Workerd's debug-port RPC already accepts this argument (see [`worker-interface.capnp`](https://github.com/cloudflare/workerd/blob/main/src/workerd/io/worker-interface.capnp) — `getEntrypoint @0 (service :Text, entrypoint :Text, props :Frankenvalue)`) and populates `ctx.props` on the callee, so no workerd-side changes are needed.

The same rewrite/drop pattern applies to tail consumers (`workerOpts.core.tails`), so both are fixed in one pass. Durable Object bindings are not affected because workerd has no `props` field on `DurableObjectNamespaceDesignator`; streaming tails aren't rewritten by the dev registry at all today and are out of scope here.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this restores expected behavior to an existing documented feature.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
