### PR TITLE
fix multiple workers with browser bindings

### DIFF
--- a/.changeset/fix-browser-rendering-multi-worker.md
+++ b/.changeset/fix-browser-rendering-multi-worker.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+fix: allow multiple workers with browser bindings in dev
+
+You can now run multiple workers with multiple browser bindings in miniflare. Previously, this would crash with `kj/table.c++:49: failed: inserted row already exists in table`.

--- a/packages/miniflare/src/plugins/browser-rendering/index.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/index.ts
@@ -54,7 +54,7 @@ export const BROWSER_RENDERING_PLUGIN: Plugin<
 				service: {
 					name: getUserBindingServiceName(
 						BROWSER_RENDERING_PLUGIN_NAME,
-						options.browserRendering.binding,
+						"service",
 						options.browserRendering.remoteProxyConnectionString
 					),
 				},
@@ -78,7 +78,7 @@ export const BROWSER_RENDERING_PLUGIN: Plugin<
 			{
 				name: getUserBindingServiceName(
 					BROWSER_RENDERING_PLUGIN_NAME,
-					options.browserRendering.binding,
+					"service",
 					options.browserRendering.remoteProxyConnectionString
 				),
 				worker: options.browserRendering.remoteProxyConnectionString
@@ -107,6 +107,7 @@ export const BROWSER_RENDERING_PLUGIN: Plugin<
 							durableObjectNamespaces: [
 								{
 									className: "BrowserSession",
+									uniqueKey: "miniflare-BrowserSession",
 								},
 							],
 							durableObjectStorage: { inMemory: kVoid },

--- a/packages/miniflare/test/plugins/browser/index.spec.ts
+++ b/packages/miniflare/test/plugins/browser/index.spec.ts
@@ -96,15 +96,15 @@ describe.sequential("browser rendering", { timeout: 20_000 }, () => {
 		{ retry: 3 },
 		async ({ expect }) => {
 			const workerScript = (bindingName: string) => `
-export default {
-	async fetch(request, env) {
-		if (request.url.endsWith("session")) {
-			const newBrowserSession = await env.${bindingName}.fetch("https://localhost/v1/acquire")
-			return new Response(await newBrowserSession.text())
-		}
-	}
-};
-`;
+			export default {
+				async fetch(request, env) {
+					if (request.url.endsWith("session")) {
+						const newBrowserSession = await env.${bindingName}.fetch("https://localhost/v1/acquire")
+						return new Response(await newBrowserSession.text())
+					}
+				}
+			};
+			`;
 			const mf = new Miniflare({
 				workers: [
 					{

--- a/packages/miniflare/test/plugins/browser/index.spec.ts
+++ b/packages/miniflare/test/plugins/browser/index.spec.ts
@@ -91,6 +91,46 @@ describe.sequential("browser rendering", { timeout: 20_000 }, () => {
 		expect(text.includes("sessionId")).toBe(true);
 	});
 
+	test(
+		"two workers with different browser bindings can coexist",
+		{ retry: 3 },
+		async ({ expect }) => {
+			const workerScript = (bindingName: string) => `
+export default {
+	async fetch(request, env) {
+		if (request.url.endsWith("session")) {
+			const newBrowserSession = await env.${bindingName}.fetch("https://localhost/v1/acquire")
+			return new Response(await newBrowserSession.text())
+		}
+	}
+};
+`;
+			const mf = new Miniflare({
+				workers: [
+					{
+						name: "worker-a",
+						compatibilityDate: "2024-11-20",
+						modules: true,
+						script: workerScript("BROWSER_A"),
+						browserRendering: { binding: "BROWSER_A" },
+					},
+					{
+						name: "worker-b",
+						compatibilityDate: "2024-11-20",
+						modules: true,
+						script: workerScript("BROWSER_B"),
+						browserRendering: { binding: "BROWSER_B" },
+					},
+				],
+			});
+			useDispose(mf);
+
+			const res = await mf.dispatchFetch("https://localhost/session");
+			const text = await res.text();
+			expect(text.includes("sessionId")).toBe(true);
+		}
+	);
+
 	const BROWSER_WORKER_CLOSE_SCRIPT = `
 ${sendMessage.toString()}
 ${waitForClosedConnection.toString()}


### PR DESCRIPTION
Fixes #11635 

previously we would try and create a browser service per binding, which would try and create multiple DOs with the same className. this would crash with `kj/table.c++:49: failed: inserted row already exists in table`.

now the browser service has a stable name (not tied to the binding name), meaning we only try and create one DO.



---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
