### PR TITLE
[local-explorer-ui] Fix Workflows page (colors, icons, etc)

### DIFF
--- a/.changeset/fix-workflows-instance-ui.md
+++ b/.changeset/fix-workflows-instance-ui.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/local-explorer-ui": patch
+---
+
+fix: Preserve expanded workflow steps across polling and improve instance page UX
+
+Expanded steps no longer collapse when new steps arrive via polling. Expansion state is lifted into the parent component and tracked by stable step keys, and polling skips state updates when data hasn't changed.
+
+Also: navigate to instance page after triggering, distinct refresh/restart icons, toolbar layout below stats strip, always-visible stats, unified status colors, and visual-only stripping of internal step name suffixes.

--- a/.changeset/fix-workflows-step-name-suffix.md
+++ b/.changeset/fix-workflows-step-name-suffix.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+fix: Preserve internal counter suffix on workflow step names in local explorer API
+
+Stop stripping the `-N` suffix from step names in the API response so the UI can distinguish duplicate step names. The suffix is now stripped only visually in the UI.

--- a/packages/local-explorer-ui/src/__e2e__/workflows/workflow.spec.ts
+++ b/packages/local-explorer-ui/src/__e2e__/workflows/workflow.spec.ts
@@ -83,7 +83,7 @@ describe("Workflows", () => {
 			await waitForText("Trigger this workflow?");
 		});
 
-		test("triggers a new instance with params", async () => {
+		test("triggers a new instance and navigates to its detail page", async () => {
 			await navigateToWorkflow(WORKFLOW_NAME);
 
 			await clickButton("Trigger");
@@ -95,10 +95,9 @@ describe("Workflows", () => {
 
 			await dialog.getByRole("button", { name: "Trigger Instance" }).click();
 
-			await page.waitForSelector('[role="dialog"]', {
-				state: "hidden",
-				timeout: 10_000,
-			});
+			// Should navigate to the instance detail page
+			await waitForText("Steps Completed", { timeout: 10_000 });
+			await waitForText("Input params", { timeout: 10_000 });
 		});
 
 		test("cancels the trigger dialog", async () => {

--- a/packages/local-explorer-ui/src/__tests__/workflows/step-helpers.test.ts
+++ b/packages/local-explorer-ui/src/__tests__/workflows/step-helpers.test.ts
@@ -1,0 +1,55 @@
+import { describe, test } from "vitest";
+import {
+	getStepDisplayName,
+	getStepKey,
+} from "../../components/workflows/StepRow";
+
+describe("getStepKey", () => {
+	test("produces key from type and name", ({ expect }) => {
+		expect(getStepKey({ type: "step", name: "fetch-1" })).toBe("step-fetch-1");
+	});
+
+	test("different counter suffixes produce different keys", ({ expect }) => {
+		const a = getStepKey({ type: "step", name: "fetch-1" });
+		const b = getStepKey({ type: "step", name: "fetch-2" });
+		expect(a).not.toBe(b);
+	});
+
+	test("same name with different types produce different keys", ({
+		expect,
+	}) => {
+		const a = getStepKey({ type: "step", name: "process-1" });
+		const b = getStepKey({ type: "waitForEvent", name: "process-1" });
+		expect(a).not.toBe(b);
+	});
+
+	test("handles undefined type and name", ({ expect }) => {
+		expect(getStepKey({})).toBe("undefined-undefined");
+	});
+});
+
+describe("getStepDisplayName", () => {
+	test("strips trailing counter suffix", ({ expect }) => {
+		expect(getStepDisplayName("fetch-1")).toBe("fetch");
+	});
+
+	test("strips multi-digit counter suffix", ({ expect }) => {
+		expect(getStepDisplayName("fetch-12")).toBe("fetch");
+	});
+
+	test("preserves name when no suffix", ({ expect }) => {
+		expect(getStepDisplayName("fetch")).toBe("fetch");
+	});
+
+	test("only strips the last numeric suffix", ({ expect }) => {
+		expect(getStepDisplayName("retry-3-1")).toBe("retry-3");
+	});
+
+	test("returns 'Unknown step' for undefined", ({ expect }) => {
+		expect(getStepDisplayName(undefined)).toBe("Unknown step");
+	});
+
+	test("handles name that is just a number suffix", ({ expect }) => {
+		expect(getStepDisplayName("step-0")).toBe("step");
+	});
+});

--- a/packages/local-explorer-ui/src/components/workflows/CreateInstanceDialog.tsx
+++ b/packages/local-explorer-ui/src/components/workflows/CreateInstanceDialog.tsx
@@ -3,7 +3,7 @@ import { useCallback, useState } from "react";
 import { workflowsCreateInstance } from "../../api";
 
 interface CreateWorkflowInstanceDialogProps {
-	onCreated: () => void;
+	onCreated: (instanceId: string) => void;
 	onOpenChange: (open: boolean) => void;
 	open: boolean;
 	workflowName: string;
@@ -68,13 +68,20 @@ export function CreateWorkflowInstanceDialog({
 				body.params = result.value;
 			}
 
-			await workflowsCreateInstance({
+			const response = await workflowsCreateInstance({
 				path: { workflow_name: workflowName },
 				body,
 			});
 
+			const newId = (response.data?.result as { id?: string } | undefined)?.id;
+
+			if (!newId) {
+				setError("Instance was created but no ID was returned");
+				return;
+			}
+
 			resetForm();
-			onCreated();
+			onCreated(newId);
 		} catch (err) {
 			setError(
 				err instanceof Error ? err.message : "Failed to create instance"

--- a/packages/local-explorer-ui/src/components/workflows/StatusBadge.tsx
+++ b/packages/local-explorer-ui/src/components/workflows/StatusBadge.tsx
@@ -4,7 +4,7 @@ import type { WorkflowsInstance } from "../../api";
 type WorkflowStatus = NonNullable<WorkflowsInstance["status"]>;
 
 const statusStyles: Record<WorkflowStatus, string> = {
-	complete: "bg-kumo-success text-white",
+	complete: "bg-emerald-600 text-white",
 	errored: "bg-kumo-danger text-white",
 	terminated: "bg-kumo-danger text-white",
 	waiting: "bg-kumo-brand text-white",

--- a/packages/local-explorer-ui/src/components/workflows/StatusBadge.tsx
+++ b/packages/local-explorer-ui/src/components/workflows/StatusBadge.tsx
@@ -4,9 +4,9 @@ import type { WorkflowsInstance } from "../../api";
 type WorkflowStatus = NonNullable<WorkflowsInstance["status"]>;
 
 const statusStyles: Record<WorkflowStatus, string> = {
-	complete: "bg-emerald-600 text-white",
-	errored: "bg-kumo-danger text-white",
-	terminated: "bg-kumo-danger text-white",
+	complete: "bg-kumo-badge-teal text-white",
+	errored: "bg-kumo-badge-red text-white",
+	terminated: "bg-kumo-badge-red text-white",
 	waiting: "bg-kumo-brand text-white",
 	paused: "bg-kumo-brand text-white",
 	running: "bg-kumo-brand text-white",

--- a/packages/local-explorer-ui/src/components/workflows/StatusIcon.tsx
+++ b/packages/local-explorer-ui/src/components/workflows/StatusIcon.tsx
@@ -22,7 +22,7 @@ export function StatusIcon({ status }: { status: string }): JSX.Element {
 					<WarningCircleIcon
 						size={20}
 						weight="fill"
-						className="text-[var(--color-kumo-danger)]"
+						className="text-kumo-danger"
 					/>
 				</Tooltip>
 			);

--- a/packages/local-explorer-ui/src/components/workflows/StatusIcon.tsx
+++ b/packages/local-explorer-ui/src/components/workflows/StatusIcon.tsx
@@ -22,7 +22,7 @@ export function StatusIcon({ status }: { status: string }): JSX.Element {
 					<WarningCircleIcon
 						size={20}
 						weight="fill"
-						className="text-kumo-danger"
+						className="text-[var(--color-kumo-danger)]"
 					/>
 				</Tooltip>
 			);

--- a/packages/local-explorer-ui/src/components/workflows/StepRow.tsx
+++ b/packages/local-explorer-ui/src/components/workflows/StepRow.tsx
@@ -27,7 +27,7 @@ function StepStatusIcon({
 			);
 		}
 		return (
-			<div className="flex size-5 items-center justify-center rounded bg-kumo-danger">
+			<div className="flex size-5 items-center justify-center rounded bg-kumo-badge-red">
 				<span className="text-xs font-bold text-white">!</span>
 			</div>
 		);
@@ -41,7 +41,7 @@ function StepStatusIcon({
 			);
 		}
 		return (
-			<div className="flex size-5 items-center justify-center rounded bg-emerald-600">
+			<div className="flex size-5 items-center justify-center rounded bg-kumo-badge-teal">
 				<CheckIcon size={12} weight="bold" className="text-white" />
 			</div>
 		);
@@ -56,7 +56,7 @@ function StepStatusIcon({
 const TYPE_BADGE_STYLES: Record<string, string> = {
 	step: "bg-kumo-tint text-kumo-subtle",
 	sleep: "bg-kumo-overlay text-kumo-subtle",
-	waitForEvent: "bg-violet-100 text-violet-600",
+	waitForEvent: "bg-kumo-badge-purple/10 text-kumo-badge-purple",
 };
 
 export function getStepKey(step: StepData): string {

--- a/packages/local-explorer-ui/src/components/workflows/StepRow.tsx
+++ b/packages/local-explorer-ui/src/components/workflows/StepRow.tsx
@@ -1,6 +1,6 @@
 import { Loader } from "@cloudflare/kumo";
 import { CheckIcon, PlusIcon } from "@phosphor-icons/react";
-import { useState } from "react";
+import { memo } from "react";
 import { CopyButton } from "./CopyButton";
 import { formatDuration, formatJson } from "./helpers";
 import { ScrollableCodeBlock } from "./ScrollableCodeBlock";
@@ -41,7 +41,7 @@ function StepStatusIcon({
 			);
 		}
 		return (
-			<div className="flex size-5 items-center justify-center rounded bg-kumo-success">
+			<div className="flex size-5 items-center justify-center rounded bg-emerald-600">
 				<CheckIcon size={12} weight="bold" className="text-white" />
 			</div>
 		);
@@ -56,23 +56,38 @@ function StepStatusIcon({
 const TYPE_BADGE_STYLES: Record<string, string> = {
 	step: "bg-kumo-tint text-kumo-subtle",
 	sleep: "bg-kumo-overlay text-kumo-subtle",
-	waitForEvent: "bg-kumo-brand/10 text-kumo-brand",
+	waitForEvent: "bg-violet-100 text-violet-600",
 };
 
-export function StepRow({ step }: { step: StepData }): JSX.Element {
-	const [expanded, setExpanded] = useState(false);
+export function getStepKey(step: StepData): string {
+	return `${step.type}-${step.name}`;
+}
 
+/** Strip the internal "-N" counter suffix for display purposes */
+export function getStepDisplayName(name: string | undefined): string {
+	return (name ?? "Unknown step").replace(/-\d+$/, "");
+}
+
+export const StepRow = memo(function StepRow({
+	step,
+	isExpanded,
+	onToggleExpanded,
+}: {
+	step: StepData;
+	isExpanded: boolean;
+	onToggleExpanded: () => void;
+}): JSX.Element {
 	const hasDetails =
 		step.type === "step" ||
 		(step.type === "waitForEvent" &&
-			(step.error || step.output !== undefined || step.finished));
+			(step.error || step.output != null || step.finished));
 
 	return (
 		<div className="border-b border-kumo-fill p-1 last:border-b-0">
 			{/* Collapsed row */}
 			<div
 				className={`grid h-10 grid-cols-[20px_1fr_160px_160px_80px_24px] items-center gap-3 rounded-lg px-2 transition-colors ${hasDetails ? "cursor-pointer hover:bg-kumo-fill" : ""}`}
-				onClick={hasDetails ? () => setExpanded(!expanded) : undefined}
+				onClick={hasDetails ? onToggleExpanded : undefined}
 			>
 				<StepStatusIcon
 					success={step.success}
@@ -89,7 +104,7 @@ export function StepRow({ step }: { step: StepData }): JSX.Element {
 						</span>
 					)}
 					<span className="truncate text-sm text-kumo-default">
-						{step.name ?? "Unknown step"}
+						{getStepDisplayName(step.name)}
 					</span>
 				</div>
 
@@ -103,7 +118,7 @@ export function StepRow({ step }: { step: StepData }): JSX.Element {
 					{hasDetails ? (
 						<PlusIcon
 							size={14}
-							className={`text-kumo-subtle transition-transform ${expanded ? "rotate-45" : ""}`}
+							className={`text-kumo-subtle transition-transform ${isExpanded ? "rotate-45" : ""}`}
 						/>
 					) : (
 						<div className="w-6" />
@@ -112,7 +127,7 @@ export function StepRow({ step }: { step: StepData }): JSX.Element {
 			</div>
 
 			{/* Expanded detail panel */}
-			{expanded && hasDetails && (
+			{isExpanded && hasDetails && (
 				<div className="-mx-1 -mb-1">
 					<div className="mt-1 h-2 rounded-t-lg border-t border-kumo-fill" />
 					<div className="px-4 pt-3 pb-4">
@@ -125,7 +140,7 @@ export function StepRow({ step }: { step: StepData }): JSX.Element {
 			)}
 		</div>
 	);
-}
+});
 
 function StepCodeCard({
 	label,

--- a/packages/local-explorer-ui/src/routes/workflows/$workflowName/$instanceId.tsx
+++ b/packages/local-explorer-ui/src/routes/workflows/$workflowName/$instanceId.tsx
@@ -530,7 +530,7 @@ function InstanceDetailView() {
 											key={action}
 											className={`inline-flex h-9 cursor-pointer items-center gap-1.5 rounded-lg border px-3 text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
 												isTerminate
-													? "border-kumo-fill bg-kumo-base text-[var(--color-kumo-danger)] hover:bg-kumo-danger/10"
+													? "border-kumo-fill bg-kumo-base text-kumo-danger hover:bg-kumo-badge-red/10"
 													: "border-kumo-fill bg-kumo-base text-kumo-default hover:bg-kumo-fill"
 											}`}
 											disabled={actionInProgress !== null}
@@ -560,7 +560,7 @@ function InstanceDetailView() {
 										</button>
 									)}
 								<button
-									className="inline-flex size-9 cursor-pointer items-center justify-center rounded-lg border border-kumo-fill bg-kumo-base text-[var(--color-kumo-danger)] transition-colors hover:bg-kumo-danger/10 disabled:cursor-not-allowed disabled:opacity-40"
+									className="inline-flex size-9 cursor-pointer items-center justify-center rounded-lg border border-kumo-fill bg-kumo-base text-kumo-danger transition-colors hover:bg-kumo-badge-red/10 disabled:cursor-not-allowed disabled:opacity-40"
 									disabled={actionInProgress !== null}
 									onClick={() => setDeleteDialogOpen(true)}
 									title="Delete"

--- a/packages/local-explorer-ui/src/routes/workflows/$workflowName/$instanceId.tsx
+++ b/packages/local-explorer-ui/src/routes/workflows/$workflowName/$instanceId.tsx
@@ -1,11 +1,4 @@
-import {
-	Button,
-	Dialog,
-	DropdownMenu,
-	LayerCard,
-	Text,
-	Tooltip,
-} from "@cloudflare/kumo";
+import { Button, Dialog, DropdownMenu, Tooltip } from "@cloudflare/kumo";
 import {
 	ArrowClockwiseIcon,
 	BellIcon,
@@ -45,7 +38,11 @@ import {
 import { ScrollableCodeBlock } from "../../../components/workflows/ScrollableCodeBlock";
 import { WorkflowStatusBadge } from "../../../components/workflows/StatusBadge";
 import { StatusIcon } from "../../../components/workflows/StatusIcon";
-import { StepRow } from "../../../components/workflows/StepRow";
+import {
+	getStepDisplayName,
+	getStepKey,
+	StepRow,
+} from "../../../components/workflows/StepRow";
 import {
 	getAvailableActions,
 	isTerminalStatus,
@@ -214,11 +211,13 @@ const ErrorCard = memo(function ErrorCard({
 	error: { name?: string; message?: string };
 }) {
 	return (
-		<LayerCard>
-			<LayerCard.Secondary className="bg-kumo-tint px-4! py-2.5!">
-				<Text bold>{error.name ?? "Error"}</Text>
-			</LayerCard.Secondary>
-			<LayerCard.Primary className="relative p-0!">
+		<div className="overflow-hidden rounded-xl border border-kumo-fill bg-kumo-tint">
+			<div className="px-4 py-2.5">
+				<span className="text-sm font-medium text-kumo-default">
+					{error.name ?? "Error"}
+				</span>
+			</div>
+			<div className="relative rounded-t-lg border-t border-kumo-fill bg-kumo-base">
 				<pre className="max-h-64 overflow-y-auto px-4 py-3 font-mono text-sm wrap-break-word whitespace-pre-wrap text-kumo-subtle">
 					{error.message ?? "Unknown error"}
 				</pre>
@@ -228,8 +227,8 @@ const ErrorCard = memo(function ErrorCard({
 						label="Copy error"
 					/>
 				</div>
-			</LayerCard.Primary>
-		</LayerCard>
+			</div>
+		</div>
 	);
 });
 
@@ -249,13 +248,30 @@ const StepHistory = memo(function StepHistory({
 	const [search, setSearch] = useState("");
 	const [typeFilter, setTypeFilter] = useState("all");
 
+	// Track expanded steps by stable key — persists across polling refreshes
+	const [expandedStepKeys, setExpandedStepKeys] = useState<Set<string>>(
+		() => new Set()
+	);
+
+	const toggleStepExpanded = useCallback((stepKey: string) => {
+		setExpandedStepKeys((prev) => {
+			const next = new Set(prev);
+			if (next.has(stepKey)) {
+				next.delete(stepKey);
+			} else {
+				next.add(stepKey);
+			}
+			return next;
+		});
+	}, []);
+
 	const filtered = [...stepList].reverse().filter((step) => {
 		if (typeFilter !== "all" && step.type !== typeFilter) {
 			return false;
 		}
 		if (search.trim()) {
 			const q = search.trim().toLowerCase();
-			return (step.name ?? "").toLowerCase().includes(q);
+			return getStepDisplayName(step.name).toLowerCase().includes(q);
 		}
 		return true;
 	});
@@ -332,9 +348,17 @@ const StepHistory = memo(function StepHistory({
 							No steps match your search
 						</div>
 					) : (
-						filtered.map((step, i) => (
-							<StepRow key={`${step.name}-${i}`} step={step} />
-						))
+						filtered.map((step) => {
+							const key = getStepKey(step);
+							return (
+								<StepRow
+									key={key}
+									step={step}
+									isExpanded={expandedStepKeys.has(key)}
+									onToggleExpanded={() => toggleStepExpanded(key)}
+								/>
+							);
+						})
 					)}
 				</div>
 			</div>
@@ -362,9 +386,16 @@ function InstanceDetailView() {
 	const [eventPayload, setEventPayload] = useState("");
 	const [sendingEvent, setSendingEvent] = useState(false);
 
+	// Track last-seen JSON so we skip state updates when polled data is unchanged
+	const lastDetailsJsonRef = useRef(JSON.stringify(loaderData.details));
+
 	// Sync from loader on navigation
 	useEffect(() => {
-		setDetails(loaderData.details);
+		const json = JSON.stringify(loaderData.details);
+		if (json !== lastDetailsJsonRef.current) {
+			lastDetailsJsonRef.current = json;
+			setDetails(loaderData.details);
+		}
 	}, [loaderData]);
 
 	const status = details.status ?? "unknown";
@@ -383,27 +414,38 @@ function InstanceDetailView() {
 			});
 			const result = response.data?.result as InstanceDetails | undefined;
 			if (result) {
-				setDetails(result);
+				const json = JSON.stringify(result);
+				if (json !== lastDetailsJsonRef.current) {
+					lastDetailsJsonRef.current = json;
+					setDetails(result);
+				}
 			}
 		} catch {
 			// Silent fail on poll
 		}
 	}, [instanceId, params.workflowName]);
 
-	// Poll every 1s, but stop on terminal states
+	// Poll every 1s, but stop on terminal states.
+	// Uses a setTimeout loop so the next poll waits for the current fetch to
+	// finish — no overlapping requests if a response is slow.
 	const isTerminal = isTerminalStatus(status);
-	const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 	useEffect(() => {
 		if (isTerminal) {
 			return;
 		}
-		pollRef.current = setInterval(() => {
-			void fetchDetails();
-		}, 1_000);
-		return () => {
-			if (pollRef.current) {
-				clearInterval(pollRef.current);
+		let active = true;
+		async function poll() {
+			while (active) {
+				await new Promise((r) => setTimeout(r, 1_000));
+				if (!active) {
+					break;
+				}
+				await fetchDetails();
 			}
+		}
+		void poll();
+		return () => {
+			active = false;
 		};
 	}, [fetchDetails, isTerminal]);
 
@@ -488,7 +530,7 @@ function InstanceDetailView() {
 											key={action}
 											className={`inline-flex h-9 cursor-pointer items-center gap-1.5 rounded-lg border px-3 text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
 												isTerminate
-													? "border-kumo-fill bg-kumo-base text-kumo-danger hover:bg-kumo-danger/10"
+													? "border-kumo-fill bg-kumo-base text-[var(--color-kumo-danger)] hover:bg-kumo-danger/10"
 													: "border-kumo-fill bg-kumo-base text-kumo-default hover:bg-kumo-fill"
 											}`}
 											disabled={actionInProgress !== null}
@@ -518,7 +560,7 @@ function InstanceDetailView() {
 										</button>
 									)}
 								<button
-									className="inline-flex size-9 cursor-pointer items-center justify-center rounded-lg border border-kumo-fill bg-kumo-base text-kumo-danger transition-colors hover:bg-kumo-danger/10 disabled:cursor-not-allowed disabled:opacity-40"
+									className="inline-flex size-9 cursor-pointer items-center justify-center rounded-lg border border-kumo-fill bg-kumo-base text-[var(--color-kumo-danger)] transition-colors hover:bg-kumo-danger/10 disabled:cursor-not-allowed disabled:opacity-40"
 									disabled={actionInProgress !== null}
 									onClick={() => setDeleteDialogOpen(true)}
 									title="Delete"

--- a/packages/local-explorer-ui/src/routes/workflows/$workflowName/index.tsx
+++ b/packages/local-explorer-ui/src/routes/workflows/$workflowName/index.tsx
@@ -1,7 +1,7 @@
 import { Button, Dialog, DropdownMenu, Pagination } from "@cloudflare/kumo";
 import {
 	ArrowClockwiseIcon,
-	CaretDownIcon,
+	ArrowsClockwiseIcon,
 	CaretUpDownIcon,
 	CheckCircleIcon,
 	CircleNotchIcon,
@@ -93,7 +93,7 @@ const STATUS_SUMMARY_CONFIG = [
 		key: "errored",
 		label: "Errored",
 		icon: WarningCircleIcon,
-		color: "text-kumo-danger",
+		color: "text-[var(--color-kumo-danger)]",
 		weight: "fill" as const,
 	},
 	{
@@ -139,7 +139,7 @@ const StatusSummary = memo(function StatusSummary({
 	statusCounts: Record<string, number>;
 }): JSX.Element {
 	return (
-		<div className="mb-4 flex divide-x divide-kumo-fill overflow-hidden rounded-lg border border-kumo-fill bg-kumo-elevated">
+		<div className="mb-4 flex divide-x divide-kumo-fill overflow-hidden rounded-lg border border-kumo-fill bg-kumo-base">
 			{STATUS_SUMMARY_CONFIG.map(
 				({ key, label, icon: Icon, color, weight }) => (
 					<div className="flex-1 space-y-1 px-4.5 pt-4 pb-3.5" key={key}>
@@ -183,7 +183,7 @@ const ACTION_CONFIG_LIST: Record<
 	terminate: {
 		icon: StopIcon,
 		style:
-			"border-kumo-fill bg-kumo-base text-kumo-danger hover:bg-kumo-danger/10",
+			"border-kumo-fill bg-kumo-base text-[var(--color-kumo-danger)] hover:bg-kumo-danger/10",
 		weight: "fill",
 	},
 };
@@ -307,7 +307,7 @@ const InstanceRow = memo(function InstanceRow({
 
 	return (
 		<>
-			<div className="border-b border-kumo-fill bg-kumo-elevated p-1 last:border-b-0">
+			<div className="border-b border-kumo-fill bg-kumo-base p-1 last:border-b-0">
 				<div
 					className="grid h-10 cursor-pointer grid-cols-[100px_60px_1fr_auto] items-center gap-3 rounded-lg px-2 transition-colors hover:bg-kumo-fill"
 					onClick={handleRowClick}
@@ -356,7 +356,7 @@ const InstanceRow = memo(function InstanceRow({
 								</button>
 							)}
 						<button
-							className="inline-flex size-7 cursor-pointer items-center justify-center rounded-md border border-kumo-fill bg-kumo-base text-kumo-danger transition-colors hover:bg-kumo-danger/10 disabled:cursor-not-allowed disabled:opacity-40"
+							className="inline-flex size-7 cursor-pointer items-center justify-center rounded-md border border-kumo-fill bg-kumo-base text-[var(--color-kumo-danger)] transition-colors hover:bg-kumo-danger/10 disabled:cursor-not-allowed disabled:opacity-40"
 							disabled={actionInProgress !== null}
 							onClick={handleDeleteClick}
 							title="Delete"
@@ -484,6 +484,7 @@ const InstanceRow = memo(function InstanceRow({
 function WorkflowInstancesView() {
 	const params = Route.useParams();
 	const loaderData = Route.useLoaderData();
+	const navigate = useNavigate();
 
 	const [deleteAllConfirmOpen, setDeleteAllConfirmOpen] =
 		useState<boolean>(false);
@@ -567,10 +568,14 @@ function WorkflowInstancesView() {
 
 				setInstances(response.data?.result ?? []);
 				setTotalCount(response.data?.result_info?.total_count ?? 0);
-				setStatusCounts(
-					((response.data?.result_info as Record<string, unknown> | undefined)
-						?.status_counts as Record<string, number>) ?? {}
-				);
+				// Only update status counts from unfiltered responses so the
+				// stats strip stays visible when a filter yields zero results
+				if (!st || st === "all") {
+					setStatusCounts(
+						((response.data?.result_info as Record<string, unknown> | undefined)
+							?.status_counts as Record<string, number>) ?? {}
+					);
+				}
 				setPage(response.data?.result_info?.page ?? p);
 				setInitialLoad(false);
 			} catch (err) {
@@ -617,9 +622,15 @@ function WorkflowInstancesView() {
 		void fetchInstances(1, newPerPage);
 	}
 
-	function handleCreated(): void {
+	function handleCreated(newInstanceId: string): void {
 		setDialogOpen(false);
-		void fetchInstances(1);
+		void navigate({
+			to: "/workflows/$workflowName/$instanceId",
+			params: {
+				workflowName: params.workflowName,
+				instanceId: newInstanceId,
+			},
+		});
 	}
 
 	function handleStatusFilterChange(newStatus: string): void {
@@ -663,89 +674,100 @@ function WorkflowInstancesView() {
 					</span>,
 				]}
 				title="Workflows"
-			>
-				<Button
-					onClick={(e: MouseEvent<HTMLButtonElement>) => {
-						(e.target as HTMLButtonElement).blur();
-						setDialogOpen(true);
-					}}
-					variant="primary"
-				>
-					<PlayIcon size={14} weight="fill" />
-					Trigger
-				</Button>
-
-				<DropdownMenu>
-					<DropdownMenu.Trigger
-						render={
-							<Button className="min-w-36" icon={CaretDownIcon}>
-								<span>
-									{statusFilter === "all"
-										? "All"
-										: (STATUS_SUMMARY_CONFIG.find((s) => s.key === statusFilter)
-												?.label ?? statusFilter)}
-								</span>
-							</Button>
-						}
-					/>
-					<DropdownMenu.Content
-						align="start"
-						className="w-36 bg-kumo-base"
-						side="bottom"
-					>
-						<DropdownMenu.Item
-							className="cursor-pointer gap-2 rounded-md transition-colors hover:bg-kumo-fill"
-							icon={<ListIcon />}
-							onClick={() => handleStatusFilterChange("all")}
-						>
-							All
-						</DropdownMenu.Item>
-						{STATUS_SUMMARY_CONFIG.map(({ key, label, icon: Icon }) => (
-							<DropdownMenu.Item
-								className="cursor-pointer gap-2 rounded-md transition-colors hover:bg-kumo-fill"
-								icon={<Icon />}
-								key={key}
-								onClick={() => handleStatusFilterChange(key)}
-							>
-								{label}
-							</DropdownMenu.Item>
-						))}
-					</DropdownMenu.Content>
-				</DropdownMenu>
-
-				<Button
-					aria-label="Refresh"
-					icon={ArrowClockwiseIcon}
-					loading={refreshing}
-					onClick={() => void handleRefresh()}
-					shape="square"
-					variant="secondary"
-				></Button>
-
-				<DropdownMenu>
-					<DropdownMenu.Trigger
-						render={
-							<Button aria-label="More actions" shape="square">
-								<DotsThreeIcon size={14} weight="bold" />
-							</Button>
-						}
-					/>
-					<DropdownMenu.Content align="end" sideOffset={4}>
-						<DropdownMenu.Item
-							className="flex cursor-pointer items-center gap-2 text-kumo-danger"
-							onClick={() => handleDeleteAllOpenChange(true)}
-						>
-							<TrashIcon />
-							<span>Delete all instances</span>
-						</DropdownMenu.Item>
-					</DropdownMenu.Content>
-				</DropdownMenu>
-			</Breadcrumbs>
+			/>
 
 			<div className="px-8 py-6">
-				{totalCount > 0 && !initialLoad && (
-					<StatusSummary statusCounts={statusCounts} />
-				)}
+				<StatusSummary statusCounts={statusCounts} />
+
+				<hr className="-mx-8 my-4 border-kumo-fill" />
+
+				{/* Toolbar: filter (left), actions (right) */}
+				<div className="mb-4 flex items-center justify-between">
+					<DropdownMenu>
+						<DropdownMenu.Trigger
+							render={
+								<button className="inline-flex h-9 min-w-36 cursor-pointer items-center justify-between rounded-lg border border-kumo-fill bg-kumo-base px-3 text-sm text-kumo-default transition-colors hover:bg-kumo-fill">
+									<span>
+										{statusFilter === "all"
+											? "All"
+											: (STATUS_SUMMARY_CONFIG.find(
+													(s) => s.key === statusFilter
+												)?.label ?? statusFilter)}
+									</span>
+									<CaretUpDownIcon size={14} className="text-kumo-subtle" />
+								</button>
+							}
+						/>
+						<DropdownMenu.Content
+							align="start"
+							className="w-36 bg-kumo-base"
+							side="bottom"
+						>
+							<DropdownMenu.Item
+								className="cursor-pointer gap-2 rounded-md transition-colors hover:bg-kumo-fill"
+								icon={<ListIcon />}
+								onClick={() => handleStatusFilterChange("all")}
+							>
+								All
+							</DropdownMenu.Item>
+							{STATUS_SUMMARY_CONFIG.map(({ key, label, icon: Icon }) => (
+								<DropdownMenu.Item
+									className="cursor-pointer gap-2 rounded-md transition-colors hover:bg-kumo-fill"
+									icon={<Icon />}
+									key={key}
+									onClick={() => handleStatusFilterChange(key)}
+								>
+									{label}
+								</DropdownMenu.Item>
+							))}
+						</DropdownMenu.Content>
+					</DropdownMenu>
+
+					<div className="flex items-center gap-2">
+						<Button
+							onClick={(e: MouseEvent<HTMLButtonElement>) => {
+								(e.target as HTMLButtonElement).blur();
+								setDialogOpen(true);
+							}}
+							variant="primary"
+						>
+							<PlayIcon size={14} weight="fill" />
+							Trigger
+						</Button>
+
+						<Button
+							aria-label="Refresh"
+							disabled={refreshing}
+							onClick={() => void handleRefresh()}
+							shape="square"
+							variant="secondary"
+						>
+							<ArrowsClockwiseIcon
+								size={18}
+								className={refreshing ? "animate-spin" : ""}
+							/>
+						</Button>
+
+						<DropdownMenu>
+							<DropdownMenu.Trigger
+								render={
+									<Button aria-label="More actions" shape="square">
+										<DotsThreeIcon size={14} weight="bold" />
+									</Button>
+								}
+							/>
+							<DropdownMenu.Content align="end" sideOffset={4}>
+								<DropdownMenu.Item
+									className="flex cursor-pointer items-center gap-2 text-[var(--color-kumo-danger)]"
+									onClick={() => handleDeleteAllOpenChange(true)}
+								>
+									<TrashIcon />
+									<span>Delete all instances</span>
+								</DropdownMenu.Item>
+							</DropdownMenu.Content>
+						</DropdownMenu>
+					</div>
+				</div>
 
 				{error && (
 					<div className="mb-4 rounded-md border border-kumo-danger/20 bg-kumo-danger/8 p-4 text-kumo-danger">
@@ -771,7 +793,7 @@ function WorkflowInstancesView() {
 					<div
 						className={`transition-opacity duration-150 ${fetching ? "opacity-60" : "opacity-100"}`}
 					>
-						<div className="overflow-hidden rounded-lg border border-kumo-fill">
+						<div className="overflow-hidden rounded-lg border border-kumo-fill bg-kumo-base">
 							{instances.map((instance) => (
 								<InstanceRow
 									instance={instance}
@@ -786,7 +808,11 @@ function WorkflowInstancesView() {
 							<div className="flex items-center justify-between gap-2 pt-4">
 								<DropdownMenu>
 									<DropdownMenu.Trigger
-										render={<Button icon={CaretUpDownIcon}>{perPage}</Button>}
+										render={
+											<Button>
+												{perPage} <CaretUpDownIcon size={14} />
+											</Button>
+										}
 									/>
 									<DropdownMenu.Content
 										align="start"

--- a/packages/local-explorer-ui/src/routes/workflows/$workflowName/index.tsx
+++ b/packages/local-explorer-ui/src/routes/workflows/$workflowName/index.tsx
@@ -93,7 +93,7 @@ const STATUS_SUMMARY_CONFIG = [
 		key: "errored",
 		label: "Errored",
 		icon: WarningCircleIcon,
-		color: "text-[var(--color-kumo-danger)]",
+		color: "text-kumo-danger",
 		weight: "fill" as const,
 	},
 	{
@@ -183,7 +183,7 @@ const ACTION_CONFIG_LIST: Record<
 	terminate: {
 		icon: StopIcon,
 		style:
-			"border-kumo-fill bg-kumo-base text-[var(--color-kumo-danger)] hover:bg-kumo-danger/10",
+			"border-kumo-fill bg-kumo-base text-kumo-danger hover:bg-kumo-badge-red/10",
 		weight: "fill",
 	},
 };
@@ -356,7 +356,7 @@ const InstanceRow = memo(function InstanceRow({
 								</button>
 							)}
 						<button
-							className="inline-flex size-7 cursor-pointer items-center justify-center rounded-md border border-kumo-fill bg-kumo-base text-[var(--color-kumo-danger)] transition-colors hover:bg-kumo-danger/10 disabled:cursor-not-allowed disabled:opacity-40"
+							className="inline-flex size-7 cursor-pointer items-center justify-center rounded-md border border-kumo-fill bg-kumo-base text-kumo-danger transition-colors hover:bg-kumo-badge-red/10 disabled:cursor-not-allowed disabled:opacity-40"
 							disabled={actionInProgress !== null}
 							onClick={handleDeleteClick}
 							title="Delete"
@@ -758,7 +758,7 @@ function WorkflowInstancesView() {
 							/>
 							<DropdownMenu.Content align="end" sideOffset={4}>
 								<DropdownMenu.Item
-									className="flex cursor-pointer items-center gap-2 text-[var(--color-kumo-danger)]"
+									className="flex cursor-pointer items-center gap-2 text-kumo-danger"
 									onClick={() => handleDeleteAllOpenChange(true)}
 								>
 									<TrashIcon />

--- a/packages/miniflare/src/workers/local-explorer/resources/workflows.ts
+++ b/packages/miniflare/src/workers/local-explorer/resources/workflows.ts
@@ -633,9 +633,7 @@ async function executeGetInstanceDetails(
 		const steps: Array<Record<string, unknown>> = [];
 		for (const [, groupLogs] of stepGroups) {
 			const firstLog = groupLogs[0];
-			// Strip the trailing "-{count}" suffix from target for the step name
-			const rawTarget = firstLog.target ?? "";
-			const name = rawTarget.replace(/-\d+$/, "");
+			const name = firstLog.target ?? "";
 
 			const stepStart = groupLogs.find((l) => l.event === EVT.STEP_START);
 			const stepSuccess = groupLogs.find((l) => l.event === EVT.STEP_SUCCESS);


### PR DESCRIPTION
Fixes WOR-1197.

Expanded workflow steps no longer collapse when new steps arrive via polling. Polling also skips state updates when the response data hasn't changed, avoiding unnecessary re-renders.

The miniflare local explorer API now preserves the internal -N counter suffix on step names, giving the UI naturally unique keys. The suffix is stripped only visually when rendering.

Other instance page improvements:
- Triggering a workflow navigates directly to the new instance's detail page
- Distinct refresh/restart icons
- Filter dropdown and action buttons moved to a toolbar below the stats strip
- Stats strip always visible regardless of filters or instance count
- Unified status colors (reds, greens, wait-for-event violet)
- Error card header matches Input params/Output header sizing

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: fixes only

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
