### PR TITLE
[miniflare] Use polling watcher for dev registry on Windows

### DIFF
--- a/.changeset/dev-registry-windows-polling.md
+++ b/.changeset/dev-registry-windows-polling.md
@@ -1,0 +1,9 @@
+---
+"miniflare": patch
+---
+
+Make the dev registry watcher reliable on Windows
+
+The filesystem-based dev registry used `chokidar` with default settings, which on Windows backs onto `fs.watch` (`ReadDirectoryChangesW`). That API is known to drop or delay create events for files added shortly after the watcher attaches, which is especially common under CI virtualization. When this happened, a process that had attached its watcher before another process registered its worker would never be notified of the new entry until the next 30-second heartbeat — long enough to time out cross-process service-binding calls.
+
+Switch to chokidar's polling mode on Windows so the dev registry observes cross-process worker registrations reliably. The registry directory is small and a 100ms poll interval has negligible cost. Non-Windows platforms continue to use the more efficient native filesystem-event backend.

--- a/fixtures/dev-registry/tests/dev-registry.test.ts
+++ b/fixtures/dev-registry/tests/dev-registry.test.ts
@@ -18,7 +18,7 @@ import {
 } from "../../../packages/vite-plugin-cloudflare/e2e/helpers";
 import { runWranglerDev as baseRunWranglerDev } from "../../shared/src/run-wrangler-long-lived";
 
-const waitForTimeout = 10_000;
+const waitForTimeout = 20_000;
 const cwd = resolve(__dirname, "..");
 const tmpPathBase = path.join(os.tmpdir(), "wrangler-tests");
 const it = test.extend<{

--- a/packages/miniflare/src/shared/dev-registry.ts
+++ b/packages/miniflare/src/shared/dev-registry.ts
@@ -56,7 +56,17 @@ export class DevRegistry {
 		mkdirSync(this.registryPath, { recursive: true });
 
 		if (!this.watcher) {
-			this.watcher = watch(this.registryPath).on("all", () => {
+			this.watcher = watch(this.registryPath, {
+				// On Windows, chokidar's default `fs.watch` backend
+				// (`ReadDirectoryChangesW`) frequently drops or delays create
+				// events for files added shortly after the watcher attaches —
+				// especially under CI virtualization. Fall back to polling on
+				// Windows so cross-process worker registrations are observed
+				// reliably. The registry directory is small, so the cost is
+				// negligible.
+				usePolling: process.platform === "win32",
+				interval: 100,
+			}).on("all", () => {
 				this.refresh();
 			});
 		}


### PR DESCRIPTION
Fixes the flaky `fixtures/dev-registry/tests/dev-registry.test.ts:959` assertion that has been failing intermittently on Windows CI (e.g. [this run](https://github.com/cloudflare/workers-sdk/actions/runs/24875086603/job/72829816592?pr=13657)).

### Root cause

The filesystem-based dev registry uses `chokidar` with default settings to watch `~/.wrangler/registry/`. On Windows, chokidar defaults to `fs.watch` (backed by `ReadDirectoryChangesW`), which is known to drop or delay create events for files added shortly after the watcher attaches — especially under CI virtualization.

The `getPlatformProxy → wrangler/vite dev` test suite is uniquely exposed to this because, unlike the other suites in the file, it attaches its watcher **in-process first**, then spawns a subprocess that writes the peer worker's registry file. Every other suite spawns both processes as subprocesses, so by the time the second process's watcher attaches, the file already exists on disk and chokidar's initial directory scan reliably picks it up.

When the `add` event is dropped, the platform proxy never learns of the new worker until the 30s heartbeat touches `mtime` — far beyond the test's 10s `waitForTimeout`. All subsequent `env.WORKER_ENTRYPOINT_WITH_ASSETS.fetch()` calls return the "not found" 503 and the test times out.

### Fix

- Pass `{ usePolling: process.platform === "win32", interval: 100 }` to the chokidar watcher in `packages/miniflare/src/shared/dev-registry.ts`. Polling sidesteps the dropped-event problem; the registry directory is tiny so the cost is negligible. Non-Windows platforms continue to use the efficient native backend. There's existing precedent for this pattern in `packages/vite-plugin-cloudflare/playground/vitest-setup.ts`.
- Bump the fixture test's `waitForTimeout` from 10s to 20s as defense-in-depth on slow Windows CI runners.

### Verification

- `pnpm --filter @fixture/dev-registry test:ci` → 23/23 passed locally on macOS (polling is disabled there, so this confirms no regression on the native-backend path).
- Windows behaviour will be validated by the CI job on this PR across multiple runs.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal reliability fix, no user-facing API change.

*A picture of a cute animal (not mandatory, but encouraged)*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13659" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
