### PR TITLE
[wrangler] Fix flaky container-rebuild test on Linux CI

### DIFF
--- a/fixtures/interactive-dev-tests/tests/index.test.ts
+++ b/fixtures/interactive-dev-tests/tests/index.test.ts
@@ -444,10 +444,9 @@ if (process.platform === "win32") {
 					"utf-8"
 				);
 
-				// Capture the current stdout length so we can scope the
-				// log match below to output produced AFTER the rebuild
-				// hotkey is pressed.
-				const outputLengthBeforeRebuild = wrangler.stdout.length;
+				// Clear the captured stdout so we can match on log output
+				// produced AFTER the rebuild hotkey is pressed.
+				wrangler.stdout = "";
 				wrangler.pty.write("r");
 
 				// Wait for the rebuild and workerd reload to actually
@@ -459,9 +458,7 @@ if (process.platform === "win32") {
 				// on slow CI.
 				await vi.waitFor(
 					() => {
-						expect(wrangler.stdout.slice(outputLengthBeforeRebuild)).toMatch(
-							/Local server updated and ready/
-						);
+						expect(wrangler.stdout).toMatch(/Local server updated and ready/);
 					},
 					{ timeout: 30_000, interval: 500 }
 				);

--- a/fixtures/interactive-dev-tests/tests/index.test.ts
+++ b/fixtures/interactive-dev-tests/tests/index.test.ts
@@ -394,7 +394,9 @@ if (process.platform === "win32") {
 
 				// wait container to be ready
 				await vi.waitFor(async () => {
-					const status = await fetch(wrangler.url + "/status");
+					const status = await fetch(wrangler.url + "/status", {
+						signal: AbortSignal.timeout(500),
+					});
 					expect(await status.json()).toBe(true);
 				}, WAITFOR_OPTIONS);
 
@@ -442,16 +444,40 @@ if (process.platform === "win32") {
 					"utf-8"
 				);
 
+				// Capture the current stdout length so we can scope the
+				// log match below to output produced AFTER the rebuild
+				// hotkey is pressed.
+				const outputLengthBeforeRebuild = wrangler.stdout.length;
 				wrangler.pty.write("r");
 
+				// Wait for the rebuild and workerd reload to actually
+				// finish before asserting on `/status`. Without this,
+				// the old workerd (which still reports the container as
+				// running even after `docker rm`) can satisfy /status
+				// requests during the rebuild window, and requests can
+				// hang while miniflare is reloading — both cause flakes
+				// on slow CI.
+				await vi.waitFor(
+					() => {
+						expect(wrangler.stdout.slice(outputLengthBeforeRebuild)).toMatch(
+							/Local server updated and ready/
+						);
+					},
+					{ timeout: 30_000, interval: 500 }
+				);
+
 				await vi.waitFor(async () => {
-					const status = await fetch(wrangler.url + "/status");
+					const status = await fetch(wrangler.url + "/status", {
+						signal: AbortSignal.timeout(500),
+					});
 					expect(await status.json()).toBe(false);
 				}, WAITFOR_OPTIONS);
 
 				await fetch(wrangler.url + "/start");
 				await vi.waitFor(async () => {
-					const status = await fetch(wrangler.url + "/status");
+					const status = await fetch(wrangler.url + "/status", {
+						signal: AbortSignal.timeout(500),
+					});
 					expect(await status.json()).toBe(true);
 				}, WAITFOR_OPTIONS);
 				await vi.waitFor(async () => {


### PR DESCRIPTION
_Describe your change..._

Fixes a flaky Linux CI failure in `fixtures/interactive-dev-tests/tests/index.test.ts` for the test `containers > container dev > should rebuild a container when the hotkey is pressed`.

Observed, for example, in: https://github.com/cloudflare/workers-sdk/actions/runs/24875086603/attempts/1 (`Tests (Linux, fixtures)`).

## Root cause

The test presses the `r` rebuild hotkey and then immediately polls `/status` expecting `false`, with a 2 s `vi.waitFor` timeout and no `AbortSignal` on the fetch.

After the hotkey press, the actual lifecycle is:

1. ~250 ms debounce in `packages/wrangler/src/dev/hotkeys.ts`
2. `cleanupContainers()` — synchronous `docker rm -f` on the running container
3. A config patch that drives: bundle rebuild → image prep → `miniflare.setOptions()` → workerd reload

Only after step 3 does the new workerd's DO reliably report `ctx.container.running === false`. The old workerd continues to report `running === true` while it is still alive (its view is internal to workerd, not synced from the Docker daemon), and `/status` requests that land mid-reload can also hang in undici (the CI log showed a request taking 2,134 ms — past the 2 s `waitFor` window).

## Fix

Synchronize explicitly on the rebuild lifecycle instead of racing it:

- Capture `wrangler.stdout.length` before writing `r`, then `vi.waitFor` the new output to contain `Local server updated and ready` (30 s timeout). This log line is produced by `LocalRuntimeController` / `MultiworkerRuntimeController` once `miniflare.setOptions()` completes, and the e2e test helper already matches on this same string (`packages/wrangler/e2e/helpers/wrangler.ts:48`).
- Only then poll `/status`, keeping the existing 2 s `WAITFOR_OPTIONS` window — by this point we know the new workerd is live and should report `false`.
- Add `AbortSignal.timeout(500)` to all three `/status` fetches in this test file, matching the pattern already applied to `/fetch` calls by #10010, so no request can hang through a reload window.

No production code changes — this is a pure test-ordering fix.

## Verification

- Ran `pnpm --filter @fixture/interactive-dev test:ci` locally (macOS + Docker) multiple times: the target test passes consistently.
- No changeset required (test-only change in an internal fixture package).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal test-only change, no user-facing behaviour changes.

*A picture of a cute animal (not mandatory, but encouraged)*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
