### PR TITLE
[wrangler] print stack trace when logging in wrangler CLI tail command

### DIFF
--- a/.changeset/feat-wrangler-tail-stack-trace.md
+++ b/.changeset/feat-wrangler-tail-stack-trace.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+print stack trace when logging in wrangler CLI tail command

--- a/.changeset/feat-wrangler-tail-stack-trace.md
+++ b/.changeset/feat-wrangler-tail-stack-trace.md
@@ -2,4 +2,5 @@
 "wrangler": minor
 ---
 
-print stack trace when logging in wrangler CLI tail command
+`wrangler tail` will now log stack traces. These stack traces already include resolved
+frames if you have chosen to upload sourcemaps.

--- a/.changeset/feat-wrangler-tail-stack-trace.md
+++ b/.changeset/feat-wrangler-tail-stack-trace.md
@@ -2,5 +2,4 @@
 "wrangler": minor
 ---
 
-`wrangler tail` will now log stack traces. These stack traces already include resolved
-frames if you have chosen to upload sourcemaps.
+`wrangler tail` will now log stack traces. These stack traces already include resolved frames if you have chosen to upload sourcemaps.

--- a/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
@@ -790,8 +790,18 @@ describe("pages deployment tail", () => {
 					{ message: [1234], level: "error", timestamp: 1234563 },
 				],
 				exceptions: [
-					{ name: "Error", message: "some error", timestamp: 1234564 },
-					{ name: "Error", message: { complex: "error" }, timestamp: 1234564 },
+					{
+						name: "Error",
+						message: "some error",
+						timestamp: 1234564,
+						stack: "  at Object.foo (file.js:1:2)",
+					},
+					{
+						name: "Error",
+						message: { complex: "error" },
+						timestamp: 1234564,
+						stack: "  at Object.foo (file.js:1:2)",
+					},
 				],
 			});
 			const serializedMessage = serialize(message);
@@ -816,8 +826,12 @@ describe("pages deployment tail", () => {
 			expect(std.err).toMatchInlineSnapshot(`
 					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m  Error: some error[0m
 
+					  at Object.foo (file.js:1:2)
+
 
 					[31mX [41;31m[[41;97mERROR[41;31m][0m [1m  Error: { complex: 'error' }[0m
+
+					  at Object.foo (file.js:1:2)
 
 					"
 			`);

--- a/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
@@ -1,5 +1,5 @@
 import { setTimeout } from "node:timers/promises";
-import { stripVTControlCharacters } from "node:util";
+import { normalizeString } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { Headers, Request } from "undici";
 import { afterEach, describe, it, vi } from "vitest";
@@ -829,16 +829,16 @@ describe("pages deployment tail", () => {
 				  (log) { complex: 'object' }
 				  (error) 1234"
 			`);
-			expect(stripVTControlCharacters(std.err)).toMatchInlineSnapshot(`
-				"X [ERROR] Error: some error
+			expect(normalizeString(std.err)).toMatchInlineSnapshot(`
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mError: some error[0m
 
 				    at Object.foo (file.js:1:2)
 
 
-				X [ERROR] Error: some error without stack trace
+				[31mX [41;31m[[41;97mERROR[41;31m][0m [1mError: some error without stack trace[0m
 
 
-				X [ERROR] Error: { complex: 'error' }
+				[31mX [41;31m[[41;97mERROR[41;31m][0m [1mError: { complex: 'error' }[0m
 
 				    at Object.foo (file.js:1:2)
 

--- a/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
@@ -829,14 +829,21 @@ describe("pages deployment tail", () => {
 				  (log) { complex: 'object' }
 				  (error) 1234"
 			`);
-			expect(stripVTControlCharacters(std.err)).toBe(
-				"" +
-					"X [ERROR] Error: some error\n\n" +
-					"    at Object.foo (file.js:1:2)\n\n\n" +
-					"X [ERROR] Error: some error without stack trace\n\n\n" +
-					"X [ERROR] Error: { complex: 'error' }\n\n" +
-					"    at Object.foo (file.js:1:2)\n\n"
-			);
+			expect(stripVTControlCharacters(std.err)).toMatchInlineSnapshot(`
+				"X [ERROR] Error: some error
+
+				    at Object.foo (file.js:1:2)
+
+
+				X [ERROR] Error: some error without stack trace
+
+
+				X [ERROR] Error: { complex: 'error' }
+
+				    at Object.foo (file.js:1:2)
+
+				"
+			`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 			await api.closeHelper();
 		});

--- a/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
@@ -1,4 +1,5 @@
 import { setTimeout } from "node:timers/promises";
+import { stripVTControlCharacters } from "node:util";
 import { http, HttpResponse } from "msw";
 import { Headers, Request } from "undici";
 import { afterEach, describe, it, vi } from "vitest";
@@ -798,6 +799,11 @@ describe("pages deployment tail", () => {
 					},
 					{
 						name: "Error",
+						message: "some error without stack trace",
+						timestamp: 1234564,
+					},
+					{
+						name: "Error",
 						message: { complex: "error" },
 						timestamp: 1234564,
 						stack: "  at Object.foo (file.js:1:2)",
@@ -823,18 +829,14 @@ describe("pages deployment tail", () => {
 				  (log) { complex: 'object' }
 				  (error) 1234"
 			`);
-			expect(std.err).toMatchInlineSnapshot(`
-					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m  Error: some error[0m
-
-					  at Object.foo (file.js:1:2)
-
-
-					[31mX [41;31m[[41;97mERROR[41;31m][0m [1m  Error: { complex: 'error' }[0m
-
-					  at Object.foo (file.js:1:2)
-
-					"
-			`);
+			expect(stripVTControlCharacters(std.err)).toBe(
+				"" +
+					"X [ERROR] Error: some error\n\n" +
+					"    at Object.foo (file.js:1:2)\n\n\n" +
+					"X [ERROR] Error: some error without stack trace\n\n\n" +
+					"X [ERROR] Error: { complex: 'error' }\n\n" +
+					"    at Object.foo (file.js:1:2)\n\n"
+			);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 			await api.closeHelper();
 		});

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -1,6 +1,8 @@
 import { setTimeout } from "node:timers/promises";
-import { stripVTControlCharacters } from "node:util";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	normalizeString,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { Headers, Request } from "undici";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
@@ -895,16 +897,16 @@ describe("tail", () => {
 				  (log) { complex: 'object' }
 				  (error) 1234"
 			`);
-			expect(stripVTControlCharacters(std.err)).toMatchInlineSnapshot(`
-				"X [ERROR] Error: some error
+			expect(normalizeString(std.err)).toMatchInlineSnapshot(`
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mError: some error[0m
 
 				    at Object.foo (file.js:1:2)
 
 
-				X [ERROR] Error: some error without stack trace
+				[31mX [41;31m[[41;97mERROR[41;31m][0m [1mError: some error without stack trace[0m
 
 
-				X [ERROR] Error: { complex: 'error' }
+				[31mX [41;31m[[41;97mERROR[41;31m][0m [1mError: { complex: 'error' }[0m
 
 				    at Object.foo (file.js:1:2)
 

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -854,8 +854,18 @@ describe("tail", () => {
 					{ message: [1234], level: "error", timestamp: 1234563 },
 				],
 				exceptions: [
-					{ name: "Error", message: "some error", timestamp: 1234564 },
-					{ name: "Error", message: { complex: "error" }, timestamp: 1234564 },
+					{
+						name: "Error",
+						message: "some error",
+						timestamp: 1234564,
+						stack: "  at Object.foo (file.js:1:2)",
+					},
+					{
+						name: "Error",
+						message: { complex: "error" },
+						timestamp: 1234564,
+						stack: "  at Object.foo (file.js:1:2)",
+					},
 				],
 			});
 			const serializedMessage = serialize(message);
@@ -882,8 +892,12 @@ describe("tail", () => {
 			expect(std.err).toMatchInlineSnapshot(`
 				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m  Error: some error[0m
 
+				  at Object.foo (file.js:1:2)
+
 
 				[31mX [41;31m[[41;97mERROR[41;31m][0m [1m  Error: { complex: 'error' }[0m
+
+				  at Object.foo (file.js:1:2)
 
 				"
 			`);

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -862,6 +862,11 @@ describe("tail", () => {
 					},
 					{
 						name: "Error",
+						message: "some error without stack trace",
+						timestamp: 1234564,
+					},
+					{
+						name: "Error",
 						message: { complex: "error" },
 						timestamp: 1234564,
 						stack: "  at Object.foo (file.js:1:2)",
@@ -894,6 +899,7 @@ describe("tail", () => {
 
 				  at Object.foo (file.js:1:2)
 
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m  Error: some error without stack trace[0m
 
 				[31mX [41;31m[[41;97mERROR[41;31m][0m [1m  Error: { complex: 'error' }[0m
 

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -1,4 +1,5 @@
 import { setTimeout } from "node:timers/promises";
+import { stripVTControlCharacters } from "node:util";
 import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { Headers, Request } from "undici";
@@ -894,20 +895,15 @@ describe("tail", () => {
 				  (log) { complex: 'object' }
 				  (error) 1234"
 			`);
-			expect(std.err).toMatchInlineSnapshot(`
-				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m  Error: some error[0m
-
-				  at Object.foo (file.js:1:2)
-
-				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m  Error: some error without stack trace[0m
-
-				[31mX [41;31m[[41;97mERROR[41;31m][0m [1m  Error: { complex: 'error' }[0m
-
-				  at Object.foo (file.js:1:2)
-
-				"
-			`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
+			expect(stripVTControlCharacters(std.err)).toBe(
+				"" +
+					"X [ERROR] Error: some error\n\n" +
+					"    at Object.foo (file.js:1:2)\n\n\n" +
+					"X [ERROR] Error: some error without stack trace\n\n\n" +
+					"X [ERROR] Error: { complex: 'error' }\n\n" +
+					"    at Object.foo (file.js:1:2)\n\n"
+			);
+			expect(std.warn).toBe("");
 			await api.closeHelper();
 		});
 	});

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -895,15 +895,22 @@ describe("tail", () => {
 				  (log) { complex: 'object' }
 				  (error) 1234"
 			`);
-			expect(stripVTControlCharacters(std.err)).toBe(
-				"" +
-					"X [ERROR] Error: some error\n\n" +
-					"    at Object.foo (file.js:1:2)\n\n\n" +
-					"X [ERROR] Error: some error without stack trace\n\n\n" +
-					"X [ERROR] Error: { complex: 'error' }\n\n" +
-					"    at Object.foo (file.js:1:2)\n\n"
-			);
-			expect(std.warn).toBe("");
+			expect(stripVTControlCharacters(std.err)).toMatchInlineSnapshot(`
+				"X [ERROR] Error: some error
+
+				    at Object.foo (file.js:1:2)
+
+
+				X [ERROR] Error: some error without stack trace
+
+
+				X [ERROR] Error: { complex: 'error' }
+
+				    at Object.foo (file.js:1:2)
+
+				"
+			`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
 			await api.closeHelper();
 		});
 	});

--- a/packages/wrangler/src/tail/createTail.ts
+++ b/packages/wrangler/src/tail/createTail.ts
@@ -257,6 +257,11 @@ export type TailEventMessage = {
 		 * When the exception was raised/thrown
 		 */
 		timestamp: number;
+
+		/**
+		 * The stack trace of the exception, sourcemaps are already resolved.
+		 */
+		stack: string;
 	}[];
 
 	/**

--- a/packages/wrangler/src/tail/createTail.ts
+++ b/packages/wrangler/src/tail/createTail.ts
@@ -261,7 +261,7 @@ export type TailEventMessage = {
 		/**
 		 * The stack trace of the exception, sourcemaps are already resolved.
 		 */
-		stack: string;
+		stack?: string;
 	}[];
 
 	/**

--- a/packages/wrangler/src/tail/printing.ts
+++ b/packages/wrangler/src/tail/printing.ts
@@ -129,8 +129,11 @@ export function prettyPrintLogs(data: WebSocket.RawData): void {
 
 	if (eventMessage.exceptions.length > 0) {
 		eventMessage.exceptions.forEach((err) => {
-			const errorLine = `${err.name}: ${typeof err.message === "string" ? err.message : JSON.stringify(err.message)}`;
-			logger.error(`${errorLine}\n${err.stack}`);
+			logger.error(
+				typeof err.message === "string"
+					? err.message
+					: JSON.stringify(err.message) + "\n" + err.stack
+			);
 		});
 	}
 }

--- a/packages/wrangler/src/tail/printing.ts
+++ b/packages/wrangler/src/tail/printing.ts
@@ -129,7 +129,8 @@ export function prettyPrintLogs(data: WebSocket.RawData): void {
 
 	if (eventMessage.exceptions.length > 0) {
 		eventMessage.exceptions.forEach((err) => {
-			logger.error(err.message + "\n" + err.stack);
+			const errorLine = `${err.name}: ${typeof err.message === "string" ? err.message : JSON.stringify(err.message)}`;
+			logger.error(`${errorLine}\n${err.stack}`);
 		});
 	}
 }

--- a/packages/wrangler/src/tail/printing.ts
+++ b/packages/wrangler/src/tail/printing.ts
@@ -128,8 +128,8 @@ export function prettyPrintLogs(data: WebSocket.RawData): void {
 	}
 
 	if (eventMessage.exceptions.length > 0) {
-		eventMessage.exceptions.forEach(({ name, message }) => {
-			logger.error(`  ${name}:`, message);
+		eventMessage.exceptions.forEach((err) => {
+			logger.error(err.message + "\n" + err.stack);
 		});
 	}
 }

--- a/packages/wrangler/src/tail/printing.ts
+++ b/packages/wrangler/src/tail/printing.ts
@@ -1,3 +1,4 @@
+import { inspect } from "node:util";
 import chalk from "chalk";
 import { logger } from "../logger";
 import type {
@@ -129,11 +130,8 @@ export function prettyPrintLogs(data: WebSocket.RawData): void {
 
 	if (eventMessage.exceptions.length > 0) {
 		eventMessage.exceptions.forEach((err) => {
-			logger.error(
-				typeof err.message === "string"
-					? err.message
-					: JSON.stringify(err.message) + "\n" + err.stack
-			);
+			const errorLine = `${err.name}: ${typeof err.message === "string" ? err.message : inspect(err.message)}`;
+			logger.error(`${errorLine}\n${err.stack}`);
 		});
 	}
 }

--- a/packages/wrangler/src/tail/printing.ts
+++ b/packages/wrangler/src/tail/printing.ts
@@ -32,8 +32,9 @@ export function realishPrintLogs(data: WebSocket.RawData): void {
 	}
 
 	if (eventMessage.exceptions.length > 0) {
-		eventMessage.exceptions.forEach(({ message }) => {
-			logger.error(message);
+		eventMessage.exceptions.forEach(({ name, message, stack }) => {
+			const errorLine = `${name}: ${typeof message === "string" ? message : inspect(message)}`;
+			logger.error(`${errorLine}${stack ? `\n${stack}` : ""}`);
 		});
 	}
 }
@@ -131,7 +132,7 @@ export function prettyPrintLogs(data: WebSocket.RawData): void {
 	if (eventMessage.exceptions.length > 0) {
 		eventMessage.exceptions.forEach((err) => {
 			const errorLine = `${err.name}: ${typeof err.message === "string" ? err.message : inspect(err.message)}`;
-			logger.error(`${errorLine}\n${err.stack}`);
+			logger.error(`${errorLine}${err.stack ? `\n${err.stack}` : ""}`);
 		});
 	}
 }


### PR DESCRIPTION
Displays the traceback when catching uncaught worker exceptions in `wrangler tail`

Before:

![](https://cdn.discordapp.com/attachments/799437470004412476/1497181772184817714/image.png?ex=69ec96ae&is=69eb452e&hm=9b9b1a32e98d029b847dfddc9e4d336a7e867d0e564977c6957cfef64603c33b&)

After:

![](https://cdn.discordapp.com/attachments/799437470004412476/1497184614849187931/image.png?ex=69ec9954&is=69eb47d4&hm=8208194e33839e635d01f343db3dd5bb4add10ec5f4bc89b7a00a958ddd1289f&)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: simple change

![](https://http.cat/images/500.jpg)

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
