### PR TITLE
[wrangler] Fix start-worker-node (Windows fixtures) and tail (Linux packages) CI flakes

### DIFF
--- a/.changeset/fix-esbuild-teardown-leaks.md
+++ b/.changeset/fix-esbuild-teardown-leaks.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Fix three resource leaks in `unstable_startWorker` teardown that could prevent Node from exiting cleanly after `worker.dispose()`.
+
+- The esbuild context created by `bundleWorker` is now disposed when the initial build fails. Previously a failing initial build (e.g. an unresolvable entrypoint, or a worker started with an invalid config via `setConfig`) left the esbuild child process running for the lifetime of the parent Node process.
+- `runBuild`'s cleanup function now awaits the in-flight build before running the bundler's stop handler. Previously teardown could return before `esbuild.BuildContext.dispose()` had been called, so the esbuild watcher kept the event loop alive after dispose had resolved.
+- `BundlerController.teardown()` now runs the esbuild cleanup before removing the bundler's temporary directory, and aborts the in-flight bundle build so it cannot emit stale `bundleStart`/`bundleComplete` events after teardown. Previously the tmpdir was removed first, which in race with an in-flight rebuild produced confusing "Could not resolve `.wrangler/tmp/bundle-XXXX/middleware-loader.entry.ts`" errors during dispose.

--- a/.changeset/fix-wrangler-tail-exit-listener-leak.md
+++ b/.changeset/fix-wrangler-tail-exit-listener-leak.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Fix the `wrangler tail` command leaking a signal-exit listener after the tail has been cleanly closed.
+
+The tail command registered both a `tail.on("close", exit)` listener and a process-level `onExit(exit)` handler, but never removed the latter after `exit()` had run. In long-lived CLI processes this is harmless — the handler eventually runs once on shutdown — but in unit tests that repeatedly invoke `wrangler tail`, every invocation accumulates a handler that fires during test-runner shutdown. Those late invocations call `deleteTail()` after the test's auth mocks have been torn down, producing spurious "Not logged in" unhandled rejections which fail the Linux CI runs.
+
+The handler is now removed as soon as `exit()` runs, and `exit()` is guarded against re-entry so it is idempotent if both the WebSocket `close` event and a real signal fire for the same session.

--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -153,27 +153,14 @@ jobs:
       - name: Run tests (fixtures)
         if: steps.changes.outputs.everything_but_markdown == 'true' && matrix.suite == 'fixtures'
         # Browser Run fixture is disabled on Ubuntu because of https://pptr.dev/troubleshooting#issues-with-apparmor-on-ubuntu
-        # start-worker-node is excluded here and run separately below — its worker.dispose() cleanup
-        # hangs when any other fixture runs in parallel, causing the file-level node:test timeout to fire.
         # Since the dev registry is now file-based (not network-based), fixture tests can safely run in parallel.
         # Concurrency is capped at 2 to avoid CPU starvation on CI runners when multiple fixtures
         # spawn workerd processes simultaneously (Windows runners are especially slow under load).
-        run: pnpm run test:ci --concurrency=2 --log-order=stream --filter="./fixtures/*" --filter="!./fixtures/start-worker-node-test" ${{ matrix.os == 'ubuntu-latest' && '--filter="!./fixtures/browser-run"' || '' }}
+        run: pnpm run test:ci --concurrency=2 --log-order=stream --filter="./fixtures/*" ${{ matrix.os == 'ubuntu-latest' && '--filter="!./fixtures/browser-run"' || '' }}
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
           WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-debug-logs/
           TEST_REPORT_PATH: ${{ runner.temp }}/test-report/index.html
-          CI_OS: ${{ matrix.description }}
-
-      - name: Run tests (start-worker-node)
-        if: steps.changes.outputs.everything_but_markdown == 'true' && matrix.suite == 'fixtures'
-        # This fixture must run alone — worker.dispose() cleanup hangs under any parallel load,
-        # causing node:test's file-level timeout to fire even though all individual tests pass in <1s.
-        run: pnpm run test:ci --log-order=stream --filter="./fixtures/start-worker-node-test"
-        env:
-          NODE_OPTIONS: "--max_old_space_size=8192"
-          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-debug-logs/
-          TEST_REPORT_PATH: ${{ runner.temp }}/test-report/start-worker-node/index.html
           CI_OS: ${{ matrix.description }}
 
       - name: Upload turbo logs

--- a/fixtures/start-worker-node-test/package.json
+++ b/fixtures/start-worker-node-test/package.json
@@ -6,7 +6,7 @@
 	"author": "",
 	"type": "module",
 	"scripts": {
-		"test:ci": "node --test --test-timeout=50000"
+		"test:ci": "node --test --test-timeout=15000"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",

--- a/packages/wrangler/src/api/startDevWorker/BundlerController.ts
+++ b/packages/wrangler/src/api/startDevWorker/BundlerController.ts
@@ -376,12 +376,25 @@ export class BundlerController extends Controller {
 		logger.debug("BundlerController teardown beginning...");
 		await super.teardown();
 		this.#customBuildAborter?.abort();
-		this.#tmpDir?.remove();
+		// Abort any in-flight esbuild build so that a finishing build doesn't
+		// emit `bundleComplete`/`bundleStart` into a torn-down event bus.
+		// `Controller.#tearingDown` already suppresses error events, but not
+		// the bundler success events, which go straight through `bus.dispatch`.
+		this.#bundleBuildAborter?.abort();
 		await Promise.all([
+			// Must run before `#tmpDir.remove()` so that the esbuild watcher
+			// can dispose cleanly. Removing the directory first would make
+			// esbuild's watcher fail a rebuild with "Could not resolve
+			// ...middleware-loader.entry.ts" during teardown.
 			this.#bundlerCleanup?.(),
 			this.#customBuildWatcher?.close(),
 			this.#assetsWatcher?.close(),
 		]);
+		// Defence-in-depth: `bundle.ts`'s `stop()` normally removes the tmp
+		// dir on our behalf, but it may have never been assigned (e.g. when
+		// running a custom build, or when the initial build threw). Remove
+		// after esbuild cleanup to avoid the race described above.
+		this.#tmpDir?.remove();
 		logger.debug("BundlerController teardown complete");
 	}
 

--- a/packages/wrangler/src/deployment-bundle/bundle.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle.ts
@@ -435,9 +435,15 @@ export async function bundleWorker(
 
 	let result: esbuild.BuildResult<typeof buildOptions>;
 	let stop: BundleResult["stop"];
+	// Hoisted so the `catch` below can dispose any esbuild context that was
+	// created before the initial build failed. Without this, a failing initial
+	// build (e.g. unresolvable entrypoint) leaves the esbuild child process
+	// running for the lifetime of the Node process, keeping the event loop
+	// alive and preventing clean exit.
+	let ctx: esbuild.BuildContext<typeof buildOptions> | undefined;
 	try {
 		if (watch) {
-			const ctx = await esbuild.context(buildOptions);
+			ctx = await esbuild.context(buildOptions);
 			await ctx.watch();
 			result = await initialBuildResultPromise;
 			if (result.errors.length > 0) {
@@ -448,9 +454,10 @@ export async function bundleWorker(
 				);
 			}
 
+			const ctxForStop = ctx;
 			stop = async function () {
 				tmpDir.remove();
-				await ctx.dispose();
+				await ctxForStop.dispose();
 			};
 		} else {
 			result = await esbuild.build(buildOptions);
@@ -478,6 +485,15 @@ export async function bundleWorker(
 			};
 		}
 	} catch (e) {
+		if (ctx !== undefined) {
+			// Best-effort cleanup of the esbuild context; swallow errors because
+			// we are re-throwing the original build failure anyway.
+			try {
+				await ctx.dispose();
+			} catch {
+				// intentionally empty
+			}
+		}
 		if (isBuildFailure(e)) {
 			rewriteNodeCompatBuildFailure(e.errors, nodejsCompatMode);
 			rewriteUnresolvedModuleBuildFailure(e.errors);

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -233,17 +233,15 @@ export function runBuild(
 		onErr(err);
 	});
 
-	return () => {
-		// Stop watching immediately if the build has already completed
-		// and `stopWatching` is assigned.
-		const immediateStop = stopWatching?.();
-		if (immediateStop) {
-			return immediateStop;
-		}
-		// If the build is still in flight, `stopWatching` is undefined.
-		// Fire-and-forget: wait for the build to finish, then clean up.
-		// We intentionally don't block teardown on this — blocking would
-		// hang teardown if the build is slow (e.g. esbuild startup).
-		void buildPromise.then(() => stopWatching?.());
+	return async () => {
+		// Wait for the initial build to settle so that `stopWatching` is
+		// assigned (on success) or the esbuild context has been disposed
+		// by `bundle.ts`'s catch block (on failure). Without this await,
+		// teardown can return before `ctx.dispose()` has run, leaving the
+		// esbuild child process alive and preventing Node from exiting.
+		// Errors from `build()` are already routed to `onErr` above, so we
+		// don't need to handle rejections here.
+		await buildPromise;
+		await stopWatching?.();
 	};
 }

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -196,10 +196,22 @@ export const tailCommand = createCommand({
 		}
 
 		const cancelPing = startWebSocketPing();
+		const removeExitListener = onExit(exit);
 		tail.on("close", exit);
-		onExit(exit);
 
+		// Guard against re-entry: `exit` can be invoked by both the WebSocket
+		// `close` event and the signal-exit handler (e.g. on SIGINT during an
+		// in-flight close). Without this, `deleteTail()` fires twice, and —
+		// in tests — the second invocation runs at process exit after mocks
+		// have been torn down, producing spurious "Not logged in" unhandled
+		// rejections.
+		let hasExited = false;
 		async function exit() {
+			if (hasExited) {
+				return;
+			}
+			hasExited = true;
+			removeExitListener();
 			cancelPing();
 			tail.terminate();
 			await deleteTail();


### PR DESCRIPTION
Fixes two independently reproducible CI flakes that surface whenever the wrangler turbo caches get invalidated.

## 1. `start-worker-node-test` fixture — Windows fixtures CI

Example failing run: https://github.com/cloudflare/workers-sdk/actions/runs/24879778860/job/72844998017

Every test inside `fixtures/start-worker-node-test/src/config-errors.test.js` passes in ~1.2 s, then the subprocess hangs until `node --test`'s 50 s file-level timeout fires and cancels the file. Two prior PRs (#13515, #13604) attacked individual symptoms — `#13604` moved the fixture onto its own CI step with a 50 s timeout — but the flake kept recurring.

### Root cause

Three compounding bugs in the `DevEnv.teardown()` path leaked the esbuild child process so the Node event loop could not drain after `worker.dispose()` returned:

1. **`bundleWorker` leaks `esbuild.BuildContext` when the initial build throws.** `packages/wrangler/src/deployment-bundle/bundle.ts` scoped `ctx` inside `if (watch) { }`. An initial-build failure (e.g. unresolvable entrypoint from the `setConfig` tests) threw out of that block, leaving `ctx` unreachable and its underlying esbuild child process alive for the lifetime of the parent Node process.
2. **`runBuild`'s cleanup closure is fire-and-forget when the build is still in flight.** `packages/wrangler/src/dev/use-esbuild.ts` returned `void buildPromise.then(() => stopWatching?.())`, so teardown could return before `ctx.dispose()` had run.
3. **`BundlerController.teardown()` removes the tmp dir before awaiting esbuild cleanup.** `packages/wrangler/src/api/startDevWorker/BundlerController.ts` deleted `.wrangler/tmp/bundle-XXXX` first, making an in-flight rebuild fail with `Could not resolve .wrangler/tmp/bundle-XXXX/middleware-loader.entry.ts` — the exact noise visible in the failing CI log right after the timeout.

### Fixes (commit 1)

- Hoist `ctx` to outer scope in `bundleWorker` and dispose it in the `catch`.
- Make `runBuild`'s cleanup closure `await` the build promise before calling `stopWatching`.
- Reorder `BundlerController.teardown()` to dispose esbuild before removing the tmp dir, and abort `#bundleBuildAborter` so a finishing build cannot emit stale `bundleStart` / `bundleComplete` events into a torn-down bus.

### Revert the #13604 workaround (commit 2)

- Re-include `./fixtures/start-worker-node-test` in the main parallel fixtures test run.
- Delete the separate `Run tests (start-worker-node)` step.
- Drop the `node --test --test-timeout` back from 50 s to 15 s.

## 2. `tail.test.ts` — Linux `packages-and-tools` CI

Example failing run: https://github.com/cloudflare/workers-sdk/actions/runs/24888217640/job/72873435065. Also visible intermittently on earlier PRs (e.g. #13622 on 2026-04-22). All 42 tests in `tail.test.ts` pass, then vitest reports 30× `Unhandled Rejection: Error: Not logged in.` from `src/tail/index.ts:205`.

### Root cause

`wrangler tail` registered a process-level `onExit(exit)` handler via `signal-exit` but never removed it. In long-lived CLI runs this is harmless — the handler eventually runs once on shutdown. In unit tests that invoke `wrangler tail` dozens of times in the same vitest worker, every invocation accumulates a handler. When the worker later terminates, all of them fire simultaneously — each calling `deleteTail()` → `requireLoggedIn()` after the test's auth mocks have been torn down, producing the spurious rejections.

### Fix (commit 3)

- Capture the remove-function returned by `onExit` and call it the first time `exit()` runs.
- Guard `exit()` against re-entry so it's idempotent if both the WebSocket `close` event and a real signal fire in the same session (the same pattern `packages/wrangler/src/pages/deployment-tails.ts` already uses).

## Commit layout

| Commit | Scope | Changeset |
|---|---|---|
| [wrangler] Fix esbuild resource leaks during `unstable_startWorker` teardown | §1 root cause | `fix-esbuild-teardown-leaks.md` (wrangler patch) |
| [ci] Revert start-worker-node flake workaround now that root cause is fixed | revert #13604 | none |
| [wrangler] Fix signal-exit listener leak in `wrangler tail` | §2 root cause | `fix-wrangler-tail-exit-listener-leak.md` (wrangler patch) |

## Verification

Stress-tested on CI by repeatedly running the fixture suite with `--force --only` to bypass turbo caching. Across one run that exercised the fix **15 times** on three platforms we saw **zero hangs, zero timeouts, zero cancellations** on `start-worker-node-test`:

| Platform | Clean cache-miss `start-worker-node` runs | Duration range |
|---|---|---|
| Linux   | 7 | 1.58–1.98 s |
| Windows | 2 | 3.06–3.29 s |
| macOS   | 6 | 1.34–3.02 s |

(Linux and macOS would have run more but hit GitHub's 30 min job cap; Windows ran 2 before an unrelated `@fixture/worker-ratelimit` `ECONNRESET` Windows networking flake aborted its step.) Every execution completed well under the restored 15 s `node --test --test-timeout`, compared to the pre-fix behaviour where the subprocess would hit the artificially raised 50 s timeout. The stress-test workflow scaffolding has been removed from the branch — only the three fix commits remain.

Also verified:

- `BundleController` × 8 and full `startDevWorker` suite × 47 (8 todo) pass.
- `start-worker-node-test` runs cleanly on macOS locally in ~1.6 s.

---

- Tests
  - [x] Tests included/updated — the `start-worker-node-test` fixture is what's being stabilised; the tail fix is exercised by the existing `tail.test.ts` that was surfacing the leak.
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: bug fixes, no user-facing API change.