### PR TITLE
[create-cloudflare] Install @rsbuild/core in tanstack-start template

### DIFF
--- a/.changeset/fix-c3-tanstack-start-rsbuild.md
+++ b/.changeset/fix-c3-tanstack-start-rsbuild.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+Install `@rsbuild/core` when scaffolding a TanStack Start project
+
+A recent release of `@tanstack/create-start` relies on `@rsbuild/core` but only declares it as an optional peer dependency, so newly generated TanStack Start projects fail out of the box. C3 now installs `@rsbuild/core` as a dev dependency immediately after the framework generator completes, restoring the template. This also re-enables the TanStack Start entries in the C3 framework E2E test matrix, which had been quarantined while the upstream breakage was investigated.

--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -587,7 +587,6 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 		},
 		{
 			name: "tanstack-start",
-			quarantine: true,
 			testCommitMessage: true,
 			timeout: LONG_TIMEOUT,
 			unsupportedOSs: ["win32"],
@@ -756,7 +755,6 @@ function getExperimentalFrameworkTestConfig(
 		},
 		{
 			name: "tanstack-start",
-			quarantine: true,
 			testCommitMessage: true,
 			timeout: LONG_TIMEOUT,
 			unsupportedOSs: ["win32"],

--- a/packages/create-cloudflare/templates/tanstack-start/c3.ts
+++ b/packages/create-cloudflare/templates/tanstack-start/c3.ts
@@ -1,6 +1,7 @@
 import { logRaw } from "@cloudflare/cli-shared-helpers";
 import { runFrameworkGenerator } from "frameworks/index";
 import { detectPackageManager } from "helpers/packageManagers";
+import { installPackages } from "helpers/packages";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
 
@@ -18,6 +19,12 @@ const generate = async (ctx: C3Context) => {
 	]);
 
 	logRaw(""); // newline
+
+	await installPackages(["@rsbuild/core"], {
+		dev: true,
+		startText: "Installing @rsbuild/core...",
+		doneText: "@rsbuild/core installed.",
+	});
 };
 
 const config: TemplateConfig = {


### PR DESCRIPTION
Fix the C3 TanStack Start template and re-enable its E2E tests.

A recent `@tanstack/create-start` release depends on `@rsbuild/core` but only declares it as an optional peer dependency, so a freshly generated project fails without it (see upstream issue [TanStack/router#7247](https://github.com/TanStack/router/issues/7247)).

This PR:

- Installs `@rsbuild/core` as a dev dependency after `runFrameworkGenerator` completes in `templates/tanstack-start/c3.ts`.
- Removes the `quarantine: true` flag from the `tanstack-start` entries in `e2e/tests/frameworks/test-config.ts` (both the regular and experimental framework test tables) so those tests run in CI again.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal template fix, no user-facing documentation impact
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
