### PR TITLE
DIAGNOSTIC: verify tail flake on main

### DIFF
--- a/packages/wrangler/src/cli.ts
+++ b/packages/wrangler/src/cli.ts
@@ -1,6 +1,8 @@
 /**
  * This file is the main entrypoint for the CLI, which calls `main()` from `index.ts`.
  * It also re-exports the public API of the package.
+ *
+ * NOTE: this comment bump invalidates the turbo cache so wrangler:test:ci runs fresh.
  */
 
 import "cloudflare/shims/web";


### PR DESCRIPTION
Pushed purely to see if wrangler:test:ci fails on main with the same tail.test.ts unhandled rejections when turbo cache is invalidated. Will be closed unmerged.