### PR TITLE
feat(vite-plugin-cloudflare): add quick tunnel support

### DIFF
--- a/.changeset/vite-plugin-dev-tunnel-sharing.md
+++ b/.changeset/vite-plugin-dev-tunnel-sharing.md
@@ -1,0 +1,25 @@
+---
+"@cloudflare/vite-plugin": minor
+---
+
+Add `tunnel: true` to the `cloudflare()` Vite plugin for sharing your local dev server via Cloudflare Quick Tunnels
+
+You can now expose your local dev server publicly by setting `tunnel: true`:
+
+```ts
+cloudflare({
+	tunnel: true,
+});
+```
+
+You can also enable tunnel sharing dynamically using an environment variable:
+
+```ts
+cloudflare({
+	tunnel: process.env.ENABLE_DEV_TUNNEL === "true",
+});
+```
+
+This starts a Cloudflare Quick Tunnel that gives you a random `*.trycloudflare.com` URL to share. The tunnel stops automatically when the dev session ends. Quick tunnels don't require a Cloudflare account or any configuration.
+
+A warning is shown when Server-Sent Events (SSE) responses are detected through the tunnel, since quick tunnels don't support SSE.

--- a/packages/vite-plugin-cloudflare/src/__tests__/shortcuts.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/shortcuts.spec.ts
@@ -6,7 +6,12 @@ import { removeDirSync } from "@cloudflare/workers-utils";
 import { afterAll, beforeAll, beforeEach, describe, test, vi } from "vitest";
 import { PluginContext } from "../context";
 import { resolvePluginConfig } from "../plugin-config";
-import { addBindingsShortcut, addExplorerShortcut } from "../plugins/shortcuts";
+import {
+	addBindingsShortcut,
+	addExplorerShortcut,
+	addTunnelShortcut,
+} from "../plugins/shortcuts";
+import * as tunnelPlugin from "../plugins/tunnel";
 import { satisfiesMinimumViteVersion } from "../utils";
 import type * as vite from "vite";
 
@@ -123,6 +128,7 @@ describe.skipIf(!satisfiesMinimumViteVersion("7.2.7"))("shortcuts", () => {
 		const mockContext = new PluginContext({
 			hasShownWorkerConfigWarnings: false,
 			restartingDevServerCount: 0,
+			tunnelHostnames: new Set(),
 		});
 		mockContext.setResolvedPluginConfig(
 			resolvePluginConfig(
@@ -152,6 +158,7 @@ describe.skipIf(!satisfiesMinimumViteVersion("7.2.7"))("shortcuts", () => {
 		const mockContext = new PluginContext({
 			hasShownWorkerConfigWarnings: false,
 			restartingDevServerCount: 0,
+			tunnelHostnames: new Set(),
 		});
 
 		mockContext.setResolvedPluginConfig(
@@ -200,6 +207,7 @@ describe.skipIf(!satisfiesMinimumViteVersion("7.2.7"))("shortcuts", () => {
 		const mockContext = new PluginContext({
 			hasShownWorkerConfigWarnings: false,
 			restartingDevServerCount: 0,
+			tunnelHostnames: new Set(),
 		});
 
 		mockContext.setResolvedPluginConfig(
@@ -273,5 +281,31 @@ describe.skipIf(!satisfiesMinimumViteVersion("7.2.7"))("shortcuts", () => {
 		expect(mockOpen).toHaveBeenCalledWith(
 			expect.stringMatching(/^http:\/\/localhost:\d+\/cdn-cgi\/explorer$/)
 		);
+	});
+
+	test("registers tunnel shortcut and extends expiry", async ({ expect }) => {
+		const mockBindCLIShortcuts = vi.spyOn(mockServer, "bindCLIShortcuts");
+		const extendExpirySpy = vi
+			.spyOn(tunnelPlugin, "extendTunnelExpiry")
+			.mockImplementation(() => {});
+
+		addTunnelShortcut(mockServer);
+
+		expect(mockBindCLIShortcuts).toHaveBeenCalledWith({
+			customShortcuts: [
+				{
+					key: "t",
+					description: "extend tunnel by 1 hour",
+					action: expect.any(Function),
+				},
+			],
+		});
+
+		const { customShortcuts } = mockBindCLIShortcuts.mock.calls[0]?.[0] ?? {};
+		const tunnelShortcut = customShortcuts?.find((s) => s.key === "t");
+
+		await tunnelShortcut?.action?.(mockServer);
+
+		expect(extendExpirySpy).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/vite-plugin-cloudflare/src/__tests__/tunnel.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/tunnel.spec.ts
@@ -4,17 +4,19 @@ import { createServer } from "vite";
 import { afterEach, describe, it, onTestFinished, vi } from "vitest";
 import { PluginContext } from "../context";
 import {
+	getTunnelOrigin,
 	PUBLIC_EXPOSURE_WARNING,
 	TunnelManager,
 	setupTunnel,
 	tunnelPlugin,
 } from "../plugins/tunnel";
+import type * as vite from "vite";
 
 vi.mock("@cloudflare/workers-utils");
 
 describe("tunnel plugin", () => {
 	afterEach(() => {
-		vi.clearAllMocks();
+		vi.resetAllMocks();
 	});
 
 	it("starts a tunnel after the server starts listening", async ({
@@ -180,8 +182,52 @@ describe("tunnel plugin", () => {
 		});
 	});
 
+	it("rejects tunnel sharing in middleware mode", async ({ expect }) => {
+		const server = { httpServer: null } as unknown as vite.ViteDevServer;
+
+		await expect(getTunnelOrigin(server)).rejects.toThrow(
+			"No HTTP server available for tunnel sharing. Tunnels are not supported in middleware mode."
+		);
+	});
+
+	it("rejects when disposing the previous tunnel fails", async ({ expect }) => {
+		const disposeError = new Error("dispose failed");
+		vi.mocked(startTunnel)
+			.mockReturnValueOnce({
+				ready: vi.fn().mockResolvedValue({
+					publicUrl: new URL("https://foo.trycloudflare.com"),
+				}),
+				extendExpiry: vi.fn(),
+				dispose: vi.fn(() => {
+					throw disposeError;
+				}),
+			})
+			.mockReturnValueOnce({
+				ready: vi.fn().mockResolvedValue({
+					publicUrl: new URL("https://bar.trycloudflare.com"),
+				}),
+				extendExpiry: vi.fn(),
+				dispose: vi.fn().mockResolvedValue(undefined),
+			});
+
+		const server = await createServer();
+		const tunnelManager = new TunnelManager(server.config.logger);
+
+		onTestFinished(() => server.close());
+
+		await tunnelManager.startTunnel("http://localhost:3000");
+
+		await expect(
+			tunnelManager.startTunnel("http://localhost:3001")
+		).rejects.toBe(disposeError);
+
+		expect(startTunnel).toHaveBeenCalledTimes(1);
+		expect(tunnelManager.publicUrl).toBeUndefined();
+	});
+
 	it("rejects server.listen when tunnel startup fails", async ({ expect }) => {
 		const tunnelError = new Error("quick tunnel rate limited");
+		const disposeError = new Error("failed to dispose tunnel");
 		const server = await createServer();
 		const ctx = new PluginContext({
 			hasShownWorkerConfigWarnings: false,
@@ -192,7 +238,9 @@ describe("tunnel plugin", () => {
 		vi.mocked(startTunnel).mockReturnValue({
 			ready: vi.fn().mockRejectedValue(tunnelError),
 			extendExpiry: vi.fn(),
-			dispose: vi.fn().mockResolvedValue(undefined),
+			dispose: vi.fn(() => {
+				throw disposeError;
+			}),
 		});
 		Object.defineProperty(ctx, "resolvedPluginConfig", {
 			value: {
@@ -214,6 +262,7 @@ describe("tunnel plugin", () => {
 			cause: tunnelError,
 		});
 		expect(close).toHaveBeenCalledTimes(1);
+		expect(server.httpServer?.listening).toBe(false);
 	});
 
 	it("prints tunnel details with server.printUrls", async ({ expect }) => {

--- a/packages/vite-plugin-cloudflare/src/__tests__/tunnel.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/tunnel.spec.ts
@@ -1,0 +1,266 @@
+import { stripVTControlCharacters } from "node:util";
+import { startTunnel } from "@cloudflare/workers-utils";
+import { createServer } from "vite";
+import { afterEach, describe, it, onTestFinished, vi } from "vitest";
+import { PluginContext } from "../context";
+import {
+	PUBLIC_EXPOSURE_WARNING,
+	TunnelManager,
+	setupTunnel,
+	tunnelPlugin,
+} from "../plugins/tunnel";
+
+vi.mock("@cloudflare/workers-utils");
+
+describe("tunnel plugin", () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("starts a tunnel after the server starts listening", async ({
+		expect,
+	}) => {
+		vi.mocked(startTunnel).mockReturnValue({
+			ready: vi.fn().mockResolvedValue({
+				publicUrl: new URL("https://example.trycloudflare.com"),
+			}),
+			extendExpiry: vi.fn(),
+			dispose: vi.fn(),
+		});
+
+		const server = await createServer();
+		const ctx = new PluginContext({
+			hasShownWorkerConfigWarnings: false,
+			restartingDevServerCount: 0,
+			tunnelHostnames: new Set(),
+		});
+		const tunnelManager = new TunnelManager(server.config.logger);
+		const restart = vi.spyOn(server, "restart").mockResolvedValue();
+
+		const info = vi
+			.spyOn(server.config.logger, "info")
+			.mockReturnValue(undefined);
+		const error = vi
+			.spyOn(server.config.logger, "error")
+			.mockReturnValue(undefined);
+
+		onTestFinished(() => server.close());
+
+		await server.listen(0);
+		await setupTunnel(server, ctx, tunnelManager);
+
+		expect(ctx.getTunnelHostnames()).toEqual(["example.trycloudflare.com"]);
+		expect(restart).toHaveBeenCalledTimes(1);
+		expect(startTunnel).toHaveBeenCalledWith({
+			origin: new URL(server.resolvedUrls?.local?.[0] ?? ""),
+			extendHint: "Press t + enter to extend by 1 hour.",
+			logger: expect.objectContaining({
+				log: expect.any(Function),
+				warn: expect.any(Function),
+				debug: expect.any(Function),
+			}),
+		});
+		expect(startTunnel).toHaveBeenCalledTimes(1);
+		expect(error).not.toHaveBeenCalled();
+		expect(tunnelManager.publicUrl).toBe("https://example.trycloudflare.com/");
+
+		const infoLog = info.mock.calls
+			.map(([message]) => stripVTControlCharacters(message))
+			.join("\n");
+		expect(infoLog).not.toContain("Tunnel:");
+	});
+
+	it("reuses the same tunnel when the origin is unchanged", async ({
+		expect,
+	}) => {
+		vi.mocked(startTunnel).mockReturnValue({
+			ready: vi.fn().mockResolvedValue({
+				publicUrl: new URL("https://example.trycloudflare.com"),
+			}),
+			extendExpiry: vi.fn(),
+			dispose: vi.fn(),
+		});
+
+		const server = await createServer();
+		const ctx = new PluginContext({
+			hasShownWorkerConfigWarnings: false,
+			restartingDevServerCount: 0,
+			tunnelHostnames: new Set(),
+		});
+		const tunnelManager = new TunnelManager(server.config.logger);
+		const restart = vi.spyOn(server, "restart").mockResolvedValue();
+
+		onTestFinished(() => server.close());
+
+		await server.listen(0);
+		await setupTunnel(server, ctx, tunnelManager);
+
+		expect(startTunnel).toHaveBeenCalledTimes(1);
+		expect(restart).toHaveBeenCalledTimes(1);
+		restart.mockClear();
+
+		await server.restart();
+
+		expect(startTunnel).toHaveBeenCalledTimes(1);
+		expect(restart).toHaveBeenCalledTimes(1);
+		restart.mockClear();
+
+		await setupTunnel(server, ctx, tunnelManager);
+
+		expect(startTunnel).toHaveBeenCalledTimes(1);
+		expect(restart).not.toHaveBeenCalled();
+	});
+
+	it("starts a new tunnel when the origin changes", async ({ expect }) => {
+		vi.mocked(startTunnel)
+			.mockReturnValueOnce({
+				ready: vi.fn().mockResolvedValue({
+					publicUrl: new URL("https://foo.trycloudflare.com"),
+				}),
+				extendExpiry: vi.fn(),
+				dispose: vi.fn(),
+			})
+			.mockReturnValueOnce({
+				ready: vi.fn().mockResolvedValue({
+					publicUrl: new URL("https://bar.trycloudflare.com"),
+				}),
+				extendExpiry: vi.fn(),
+				dispose: vi.fn(),
+			});
+
+		const server1 = await createServer();
+		const ctx = new PluginContext({
+			hasShownWorkerConfigWarnings: false,
+			restartingDevServerCount: 0,
+			tunnelHostnames: new Set(),
+		});
+		const tunnelManager = new TunnelManager(server1.config.logger);
+		const restart1 = vi.spyOn(server1, "restart").mockResolvedValue();
+		onTestFinished(() => server1.close());
+
+		await server1.listen(0);
+		await setupTunnel(server1, ctx, tunnelManager);
+
+		expect(ctx.getTunnelHostnames()).toEqual(["foo.trycloudflare.com"]);
+		expect(restart1).toHaveBeenCalledTimes(1);
+		expect(startTunnel).toHaveBeenCalledTimes(1);
+		expect(startTunnel).toHaveBeenNthCalledWith(1, {
+			origin: new URL(server1.resolvedUrls?.local?.[0] ?? ""),
+			extendHint: "Press t + enter to extend by 1 hour.",
+			logger: expect.objectContaining({
+				log: expect.any(Function),
+				warn: expect.any(Function),
+				debug: expect.any(Function),
+			}),
+		});
+
+		const server2 = await createServer();
+		const restart2 = vi.spyOn(server2, "restart").mockResolvedValue();
+		onTestFinished(() => server2.close());
+
+		await server2.listen(0);
+
+		expect(server2.resolvedUrls?.local?.[0]).not.toBe(
+			server1.resolvedUrls?.local?.[0]
+		);
+
+		await setupTunnel(server2, ctx, tunnelManager);
+
+		expect(ctx.getTunnelHostnames()).toEqual(["bar.trycloudflare.com"]);
+		expect(restart2).toHaveBeenCalledTimes(1);
+		expect(startTunnel).toHaveBeenCalledTimes(2);
+		expect(startTunnel).toHaveBeenNthCalledWith(2, {
+			origin: new URL(server2.resolvedUrls?.local?.[0] ?? ""),
+			extendHint: "Press t + enter to extend by 1 hour.",
+			logger: expect.objectContaining({
+				log: expect.any(Function),
+				warn: expect.any(Function),
+				debug: expect.any(Function),
+			}),
+		});
+	});
+
+	it("rejects server.listen when tunnel startup fails", async ({ expect }) => {
+		const tunnelError = new Error("quick tunnel rate limited");
+		const server = await createServer();
+		const ctx = new PluginContext({
+			hasShownWorkerConfigWarnings: false,
+			restartingDevServerCount: 0,
+			tunnelHostnames: new Set(),
+		});
+
+		vi.mocked(startTunnel).mockReturnValue({
+			ready: vi.fn().mockRejectedValue(tunnelError),
+			extendExpiry: vi.fn(),
+			dispose: vi.fn().mockResolvedValue(undefined),
+		});
+		Object.defineProperty(ctx, "resolvedPluginConfig", {
+			value: {
+				type: "workers",
+				tunnel: true,
+			},
+		});
+
+		const plugin = tunnelPlugin(ctx);
+		const close = vi.spyOn(server, "close");
+
+		onTestFinished(() => server.close());
+
+		// @ts-expect-error The tunnel plugin accepts a server instance directly without relying on `this`
+		await plugin.configureServer(server);
+
+		await expect(() => server.listen(0)).rejects.toMatchObject({
+			message: "Failed to start tunnel: quick tunnel rate limited",
+			cause: tunnelError,
+		});
+		expect(close).toHaveBeenCalledTimes(1);
+	});
+
+	it("prints tunnel details with server.printUrls", async ({ expect }) => {
+		vi.mocked(startTunnel).mockReturnValue({
+			ready: vi.fn().mockResolvedValue({
+				publicUrl: new URL("https://example.trycloudflare.com"),
+			}),
+			extendExpiry: vi.fn(),
+			dispose: vi.fn().mockResolvedValue(undefined),
+		});
+
+		const server = await createServer();
+		const ctx = new PluginContext({
+			hasShownWorkerConfigWarnings: false,
+			restartingDevServerCount: 0,
+			tunnelHostnames: new Set(),
+		});
+		Object.defineProperty(ctx, "resolvedPluginConfig", {
+			value: {
+				type: "workers",
+				tunnel: true,
+			},
+		});
+
+		const plugin = tunnelPlugin(ctx);
+		vi.spyOn(server, "restart").mockResolvedValue();
+
+		onTestFinished(() => server.close());
+
+		// @ts-expect-error The tunnel plugin accepts a server instance directly without relying on `this`
+		await plugin.configureServer(server);
+		await server.listen(0);
+
+		const info = vi
+			.spyOn(server.config.logger, "info")
+			.mockReturnValue(undefined);
+		const warnOnce = vi
+			.spyOn(server.config.logger, "warnOnce")
+			.mockReturnValue(undefined);
+
+		server.printUrls();
+
+		const infoLog = info.mock.calls
+			.map(([message]) => stripVTControlCharacters(message))
+			.join("\n");
+
+		expect(infoLog).toContain("Tunnel:  https://example.trycloudflare.com/");
+		expect(warnOnce).toHaveBeenCalledWith(PUBLIC_EXPOSURE_WARNING);
+	});
+});

--- a/packages/vite-plugin-cloudflare/src/context.ts
+++ b/packages/vite-plugin-cloudflare/src/context.ts
@@ -26,6 +26,8 @@ export interface SharedContext {
 	hasShownWorkerConfigWarnings: boolean;
 	/** Tracks the number of in-flight dev server restarts (0 means no restart in progress) */
 	restartingDevServerCount: number;
+	/** Allowed hostnames for tunnel connections */
+	tunnelHostnames: Set<string>;
 }
 
 /**
@@ -118,6 +120,21 @@ export class PluginContext {
 
 	get isRestartingDevServer(): boolean {
 		return this.#sharedContext.restartingDevServerCount > 0;
+	}
+
+	getTunnelHostnames(): string[] {
+		return Array.from(this.#sharedContext.tunnelHostnames);
+	}
+
+	replaceTunnelHostnames(tunnelHostnames: string[]): void {
+		this.#sharedContext.tunnelHostnames.clear();
+		for (const tunnelHostname of tunnelHostnames) {
+			this.#sharedContext.tunnelHostnames.add(tunnelHostname);
+		}
+	}
+
+	clearTunnelHostnames(): void {
+		this.#sharedContext.tunnelHostnames.clear();
 	}
 
 	setResolvedPluginConfig(resolvedPluginConfig: ResolvedPluginConfig): void {

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -16,6 +16,7 @@ import { previewPlugin } from "./plugins/preview";
 import { rscPlugin } from "./plugins/rsc";
 import { shortcutsPlugin } from "./plugins/shortcuts";
 import { triggerHandlersPlugin } from "./plugins/trigger-handlers";
+import { tunnelPlugin } from "./plugins/tunnel";
 import {
 	virtualClientFallbackPlugin,
 	virtualModulesPlugin,
@@ -51,6 +52,7 @@ export type { WorkerConfig } from "./workers-configs";
 const sharedContext: SharedContext = {
 	hasShownWorkerConfigWarnings: false,
 	restartingDevServerCount: 0,
+	tunnelHostnames: new Set(),
 };
 
 await assertWranglerVersion();
@@ -96,6 +98,7 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 		configPlugin(ctx),
 		rscPlugin(ctx),
 		devPlugin(ctx),
+		tunnelPlugin(ctx),
 		previewPlugin(ctx),
 		shortcutsPlugin(ctx),
 		debugPlugin(ctx),

--- a/packages/vite-plugin-cloudflare/src/plugin-config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugin-config.ts
@@ -74,6 +74,7 @@ export interface PluginConfig extends EntryWorkerConfig {
 	persistState?: PersistState;
 	inspectorPort?: number | false;
 	remoteBindings?: boolean;
+	tunnel?: boolean;
 	experimental?: Experimental;
 }
 
@@ -97,6 +98,7 @@ interface BaseResolvedConfig {
 	inspectorPort: number | false | undefined;
 	experimental: Pick<Experimental, "headersAndRedirectsDevModeSupport">;
 	remoteBindings: boolean;
+	tunnel: boolean;
 }
 
 interface NonPreviewResolvedConfig extends BaseResolvedConfig {
@@ -270,6 +272,7 @@ export function resolvePluginConfig(
 	const shared = {
 		persistState: pluginConfig.persistState ?? true,
 		inspectorPort: pluginConfig.inspectorPort,
+		tunnel: pluginConfig.tunnel ?? false,
 		experimental: {
 			headersAndRedirectsDevModeSupport:
 				pluginConfig.experimental?.headersAndRedirectsDevModeSupport,

--- a/packages/vite-plugin-cloudflare/src/plugins/config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/config.ts
@@ -48,6 +48,7 @@ export const configPlugin = createPlugin("config", (ctx) => {
 			return {
 				appType: "custom",
 				server: {
+					allowedHosts: getAllowedHosts(ctx, userConfig),
 					fs: {
 						deny: [
 							...defaultDeniedFiles,
@@ -225,4 +226,18 @@ function getEnvironmentsConfig(
 			},
 		},
 	};
+}
+
+function getAllowedHosts(
+	ctx: PluginContext,
+	userConfig: UserConfig
+): true | string[] | undefined {
+	const userAllowedHosts = userConfig.server?.allowedHosts;
+	const tunnelHostnames = ctx.getTunnelHostnames();
+
+	if (tunnelHostnames.length === 0 || userAllowedHosts === true) {
+		return userAllowedHosts;
+	}
+
+	return Array.from(new Set([...(userAllowedHosts ?? []), ...tunnelHostnames]));
 }

--- a/packages/vite-plugin-cloudflare/src/plugins/shortcuts.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/shortcuts.ts
@@ -8,6 +8,7 @@ import colors from "picocolors";
 import * as wrangler from "wrangler";
 import { assertIsNotPreview, assertIsPreview } from "../context";
 import { createPlugin, satisfiesMinimumViteVersion } from "../utils";
+import { extendTunnelExpiry } from "./tunnel";
 import type { PluginContext } from "../context";
 import type * as vite from "vite";
 
@@ -25,6 +26,9 @@ export const shortcutsPlugin = createPlugin("shortcuts", (ctx) => {
 			assertIsNotPreview(ctx);
 			addBindingsShortcut(viteDevServer, ctx);
 			addExplorerShortcut(viteDevServer);
+			if (ctx.resolvedPluginConfig.tunnel) {
+				addTunnelShortcut(viteDevServer);
+			}
 		},
 		async configurePreviewServer(vitePreviewServer) {
 			if (!isCustomShortcutsSupported) {
@@ -169,5 +173,25 @@ export function addExplorerShortcut(
 
 	server.bindCLIShortcuts({
 		customShortcuts: [openExplorerShortcut],
+	});
+}
+
+export function addTunnelShortcut(
+	server: vite.ViteDevServer | vite.PreviewServer
+) {
+	if (!process.stdin.isTTY) {
+		return;
+	}
+
+	const extendTunnelExpiryShortcut = {
+		key: "t",
+		description: "extend tunnel by 1 hour",
+		action: () => {
+			extendTunnelExpiry();
+		},
+	} satisfies vite.CLIShortcut<vite.ViteDevServer | vite.PreviewServer>;
+
+	server.bindCLIShortcuts({
+		customShortcuts: [extendTunnelExpiryShortcut],
 	});
 }

--- a/packages/vite-plugin-cloudflare/src/plugins/tunnel.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/tunnel.ts
@@ -46,7 +46,7 @@ export class TunnelManager {
 		const previousTunnel = this.#tunnel;
 
 		if (previousTunnel) {
-			void this.dispose();
+			this.dispose();
 		}
 
 		this.#origin = origin;
@@ -103,7 +103,8 @@ export class TunnelManager {
 		if (
 			this.#hasWarnedAboutSse ||
 			!this.#tunnel ||
-			!isSseContentType(contentType)
+			contentType === null ||
+			!contentType.toLowerCase().startsWith("text/event-stream")
 		) {
 			return;
 		}
@@ -112,7 +113,7 @@ export class TunnelManager {
 		this.#logger.warn(QUICK_TUNNEL_SSE_WARNING);
 	}
 
-	async dispose() {
+	dispose() {
 		const tunnel = this.#tunnel;
 
 		this.#origin = undefined;
@@ -123,7 +124,18 @@ export class TunnelManager {
 		debuglog("Disposing tunnel...");
 
 		if (tunnel) {
-			await tunnel.dispose();
+			tunnel.dispose();
+		}
+	}
+
+	disposeOnExit() {
+		try {
+			this.dispose();
+		} catch (e) {
+			this.#logger.error(
+				"Failed to dispose tunnel on exit:" +
+					(e instanceof Error ? e.message : `${e}`)
+			);
 		}
 	}
 }
@@ -131,9 +143,7 @@ export class TunnelManager {
 let tunnelManager: TunnelManager;
 
 process.on("exit", () => {
-	// We can't await this since the process is exiting. This is just a best-effort
-	// fallback; normal tunnel cleanup happens during Vite server shutdown.
-	void tunnelManager?.dispose();
+	tunnelManager?.disposeOnExit();
 });
 
 export function warnIfQuickTunnelSseResponse(contentType: string | null) {
@@ -145,9 +155,17 @@ export function extendTunnelExpiry() {
 }
 
 export async function getTunnelOrigin(server: vite.ViteDevServer) {
-	if (!server.httpServer?.listening) {
+	const httpServer = server.httpServer;
+
+	if (!httpServer) {
+		throw new Error(
+			"No HTTP server available for tunnel sharing. Tunnels are not supported in middleware mode."
+		);
+	}
+
+	if (!httpServer.listening) {
 		await new Promise<void>((resolve) => {
-			server.httpServer?.once("listening", () => resolve());
+			httpServer.once("listening", () => resolve());
 		});
 	}
 
@@ -207,33 +225,26 @@ export async function setupTunnel(
 	}
 }
 
-export function isSseContentType(contentType: string | null): boolean {
-	return (
-		typeof contentType === "string" &&
-		contentType.toLowerCase().startsWith("text/event-stream")
-	);
-}
-
 export const tunnelPlugin = createPlugin("tunnel", (ctx) => {
-	async function stopTunnel() {
+	function stopTunnel() {
 		ctx.clearTunnelHostnames();
-		await tunnelManager?.dispose();
+		tunnelManager?.dispose();
 	}
 
 	return {
 		/**
 		 * Vite runs `buildEnd` when the dev server restarts or closes.
 		 */
-		async buildEnd() {
+		buildEnd() {
 			if (!ctx.isRestartingDevServer) {
-				await stopTunnel();
+				stopTunnel();
 			}
 		},
-		async configureServer(server) {
+		configureServer(server) {
 			assertIsNotPreview(ctx);
 
 			if (!ctx.resolvedPluginConfig.tunnel) {
-				await stopTunnel();
+				stopTunnel();
 				return;
 			}
 
@@ -243,7 +254,7 @@ export const tunnelPlugin = createPlugin("tunnel", (ctx) => {
 			server.printUrls = () => {
 				serverPrintUrls();
 
-				const publicUrl = tunnelManager?.publicUrl;
+				const publicUrl = tunnelManager.publicUrl;
 				if (!publicUrl) {
 					return;
 				}
@@ -262,7 +273,12 @@ export const tunnelPlugin = createPlugin("tunnel", (ctx) => {
 					await setupTunnel(server, ctx, tunnelManager);
 					return result;
 				} catch (error) {
-					await Promise.allSettled([stopTunnel(), server.close()]);
+					await Promise.allSettled([
+						(async () => {
+							stopTunnel();
+						})(),
+						server.close(),
+					]);
 
 					// The user explicitly requested tunnel sharing, so tunnel startup failure is fatal.
 					throw error;

--- a/packages/vite-plugin-cloudflare/src/plugins/tunnel.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/tunnel.ts
@@ -1,0 +1,273 @@
+import { startTunnel } from "@cloudflare/workers-utils";
+import colors from "picocolors";
+import { assertIsNotPreview } from "../context";
+import { debuglog, createPlugin } from "../utils";
+import type { PluginContext } from "../context";
+import type { Tunnel } from "@cloudflare/workers-utils";
+import type * as vite from "vite";
+
+export const PUBLIC_EXPOSURE_WARNING = [
+	"",
+	`     ${colors.dim("This URL is ")}publicly accessible${colors.dim(". Anyone with it can:")}`,
+	colors.dim("     • Call ungated endpoints"),
+	colors.dim("     • Trigger logic that uses remote bindings"),
+	colors.dim("     • Reach internal services if your Worker proxies requests"),
+	colors.dim("     • Access HMR messages and request module source"),
+	"",
+	colors.dim(
+		"     Consider using a named tunnel with Cloudflare Access to restrict access."
+	),
+	"",
+].join("\n");
+
+export const QUICK_TUNNEL_SSE_WARNING =
+	"Quick tunnels do not support Server-Sent Events (SSE). Use a named Cloudflare Tunnel if you need SSE over a public URL.";
+
+export class TunnelManager {
+	#logger: vite.Logger;
+	#origin?: string;
+	#publicUrl?: string;
+	#tunnel?: Tunnel;
+	#hasWarnedAboutSse = false;
+
+	constructor(logger: vite.Logger) {
+		this.#logger = logger;
+	}
+
+	isStarted(origin: string): boolean {
+		return this.#origin === origin && this.#tunnel !== undefined;
+	}
+
+	async startTunnel(origin: string): Promise<string | null> {
+		if (this.#origin === origin && this.#tunnel) {
+			return await this.#waitForPublicUrl(this.#tunnel);
+		}
+
+		const previousTunnel = this.#tunnel;
+
+		if (previousTunnel) {
+			void this.dispose();
+		}
+
+		this.#origin = origin;
+		this.#publicUrl = undefined;
+
+		const tunnel = startTunnel({
+			origin: new URL(origin),
+			extendHint: "Press t + enter to extend by 1 hour.",
+			logger: {
+				log: (message) => this.#logger.info(message),
+				warn: (message) => this.#logger.warn(message),
+				debug: (message) => debuglog(message),
+			},
+		});
+		this.#tunnel = tunnel;
+
+		return await this.#waitForPublicUrl(tunnel);
+	}
+
+	async #waitForPublicUrl(tunnel: Tunnel): Promise<string | null> {
+		try {
+			const { publicUrl } = await tunnel.ready();
+			if (this.#tunnel !== tunnel) {
+				debuglog(
+					"Tunnel was restarted before it finished starting. Ignoring this tunnel's public URL:",
+					publicUrl
+				);
+				return null;
+			}
+
+			debuglog("Tunnel is ready with public URL:", publicUrl);
+			this.#publicUrl = publicUrl.toString();
+			return publicUrl.toString();
+		} catch (error) {
+			if (this.#tunnel !== tunnel) {
+				return null;
+			}
+
+			this.#publicUrl = undefined;
+			this.#tunnel = undefined;
+			throw error;
+		}
+	}
+
+	get publicUrl(): string | undefined {
+		return this.#publicUrl;
+	}
+
+	extendExpiry() {
+		this.#tunnel?.extendExpiry();
+	}
+
+	warnIfQuickTunnelSseResponse(contentType: string | null) {
+		if (
+			this.#hasWarnedAboutSse ||
+			!this.#tunnel ||
+			!isSseContentType(contentType)
+		) {
+			return;
+		}
+
+		this.#hasWarnedAboutSse = true;
+		this.#logger.warn(QUICK_TUNNEL_SSE_WARNING);
+	}
+
+	async dispose() {
+		const tunnel = this.#tunnel;
+
+		this.#origin = undefined;
+		this.#publicUrl = undefined;
+		this.#tunnel = undefined;
+		this.#hasWarnedAboutSse = false;
+
+		debuglog("Disposing tunnel...");
+
+		if (tunnel) {
+			await tunnel.dispose();
+		}
+	}
+}
+
+let tunnelManager: TunnelManager;
+
+process.on("exit", () => {
+	// We can't await this since the process is exiting. This is just a best-effort
+	// fallback; normal tunnel cleanup happens during Vite server shutdown.
+	void tunnelManager?.dispose();
+});
+
+export function warnIfQuickTunnelSseResponse(contentType: string | null) {
+	tunnelManager?.warnIfQuickTunnelSseResponse(contentType);
+}
+
+export function extendTunnelExpiry() {
+	tunnelManager?.extendExpiry();
+}
+
+export async function getTunnelOrigin(server: vite.ViteDevServer) {
+	if (!server.httpServer?.listening) {
+		await new Promise<void>((resolve) => {
+			server.httpServer?.once("listening", () => resolve());
+		});
+	}
+
+	const url =
+		server.resolvedUrls?.local?.[0] ?? server.resolvedUrls?.network?.[0];
+
+	if (!url) {
+		throw new Error(
+			"Could not determine the local dev server URL for tunnel sharing."
+		);
+	}
+
+	return url;
+}
+
+export async function setupTunnel(
+	server: vite.ViteDevServer,
+	ctx: PluginContext,
+	manager: TunnelManager
+): Promise<void> {
+	const origin = await getTunnelOrigin(server);
+
+	if (manager.isStarted(origin)) {
+		debuglog("Tunnel is already started on", origin);
+		return;
+	}
+
+	try {
+		server.config.logger.info(
+			colors.dim("\n  ➜  Starting tunnel (usually takes a few seconds)...\n")
+		);
+
+		const publicUrl = await manager.startTunnel(origin);
+
+		if (!publicUrl) {
+			// This happens if the tunnel was restarted with a different origin before the first tunnel finished starting.
+			// In this case, we don't want to log anything since the new tunnel will log its own URL once it's ready.
+			return;
+		}
+
+		const allowedHosts = server.config.server.allowedHosts;
+		const tunnelHostnames = [new URL(publicUrl).hostname];
+
+		ctx.replaceTunnelHostnames(tunnelHostnames);
+
+		if (
+			allowedHosts !== true &&
+			tunnelHostnames.some((hostname) => !allowedHosts.includes(hostname))
+		) {
+			await server.restart();
+		}
+	} catch (error) {
+		throw new Error(
+			`Failed to start tunnel: ${error instanceof Error ? error.message : String(error)}`,
+			{ cause: error }
+		);
+	}
+}
+
+export function isSseContentType(contentType: string | null): boolean {
+	return (
+		typeof contentType === "string" &&
+		contentType.toLowerCase().startsWith("text/event-stream")
+	);
+}
+
+export const tunnelPlugin = createPlugin("tunnel", (ctx) => {
+	async function stopTunnel() {
+		ctx.clearTunnelHostnames();
+		await tunnelManager?.dispose();
+	}
+
+	return {
+		/**
+		 * Vite runs `buildEnd` when the dev server restarts or closes.
+		 */
+		async buildEnd() {
+			if (!ctx.isRestartingDevServer) {
+				await stopTunnel();
+			}
+		},
+		async configureServer(server) {
+			assertIsNotPreview(ctx);
+
+			if (!ctx.resolvedPluginConfig.tunnel) {
+				await stopTunnel();
+				return;
+			}
+
+			tunnelManager ??= new TunnelManager(server.config.logger);
+
+			const serverPrintUrls = server.printUrls.bind(server);
+			server.printUrls = () => {
+				serverPrintUrls();
+
+				const publicUrl = tunnelManager?.publicUrl;
+				if (!publicUrl) {
+					return;
+				}
+
+				server.config.logger.info(
+					`${colors.green("  ➜")}  ${colors.bold("Tunnel:")}  ${colors.cyan(publicUrl)}`
+				);
+				server.config.logger.warnOnce(PUBLIC_EXPOSURE_WARNING);
+			};
+
+			const serverListen = server.listen.bind(server);
+			server.listen = async (...args) => {
+				const result = await serverListen(...args);
+
+				try {
+					await setupTunnel(server, ctx, tunnelManager);
+					return result;
+				} catch (error) {
+					await Promise.allSettled([stopTunnel(), server.close()]);
+
+					// The user explicitly requested tunnel sharing, so tunnel startup failure is fatal.
+					throw error;
+				}
+			};
+		},
+	};
+});

--- a/packages/vite-plugin-cloudflare/src/utils.ts
+++ b/packages/vite-plugin-cloudflare/src/utils.ts
@@ -10,6 +10,7 @@ import semverGte from "semver/functions/gte";
 import { version as viteVersion } from "vite";
 import * as vite from "vite";
 import { PROXY_SHARED_SECRET } from "./constants";
+import { warnIfQuickTunnelSseResponse } from "./plugins/tunnel";
 import type { PluginContext } from "./context";
 import type * as http from "node:http";
 
@@ -89,6 +90,8 @@ export function createRequestHandler(
 				// HTTP/2 disallows use of the `transfer-encoding` header
 				response.headers.delete("transfer-encoding");
 			}
+
+			warnIfQuickTunnelSseResponse(response.headers.get("content-type"));
 
 			await sendResponse(res, response as unknown as Response);
 		} catch (error) {

--- a/packages/workers-utils/src/tunnel.ts
+++ b/packages/workers-utils/src/tunnel.ts
@@ -24,7 +24,7 @@ export interface TunnelResult {
 
 export interface Tunnel {
 	ready: () => Promise<TunnelResult>;
-	dispose: () => Promise<void>;
+	dispose: () => void;
 	extendExpiry: (ms?: number) => void;
 }
 
@@ -50,6 +50,7 @@ export function startTunnel(options: TunnelOptions): Tunnel {
 	let reminderInterval: ReturnType<typeof setInterval> | undefined;
 	let expiryTimeout: ReturnType<typeof setTimeout> | undefined;
 	let expiresAt = 0;
+	let cloudflaredProcess: ChildProcess | undefined;
 
 	const logger = options.logger;
 	const timeoutMs = options.timeoutMs ?? TUNNEL_STARTUP_TIMEOUT_MS;
@@ -71,6 +72,8 @@ export function startTunnel(options: TunnelOptions): Tunnel {
 		skipVersionCheck: true,
 		logger,
 	}).then((process) => {
+		cloudflaredProcess = process;
+
 		if (disposed) {
 			terminateCloudflared(process);
 		}
@@ -94,12 +97,12 @@ export function startTunnel(options: TunnelOptions): Tunnel {
 			return result;
 		});
 
-	async function disposeTunnel() {
+	function disposeTunnel() {
 		disposed = true;
 		clearTunnelTimers();
-		const process = await cloudflaredPromise.catch(() => undefined);
-		if (process) {
-			terminateCloudflared(process);
+
+		if (cloudflaredProcess) {
+			terminateCloudflared(cloudflaredProcess);
 		}
 	}
 
@@ -151,7 +154,7 @@ export function startTunnel(options: TunnelOptions): Tunnel {
 				}
 
 				logger?.log("Tunnel expired. Closing tunnel.");
-				void disposeTunnel();
+				disposeTunnel();
 			},
 			Math.max(0, expiresAt - Date.now())
 		);
@@ -213,6 +216,7 @@ function terminateCloudflared(cloudflared: ChildProcess) {
 		return;
 	}
 
+	cloudflared.unref();
 	cloudflared.kill("SIGTERM");
 
 	const forceKillTimer = setTimeout(() => {

--- a/packages/workers-utils/tests/tunnel.test.ts
+++ b/packages/workers-utils/tests/tunnel.test.ts
@@ -1,5 +1,12 @@
 import { EventEmitter } from "node:events";
-import { afterEach, beforeEach, describe, it, vi } from "vitest";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	it,
+	onTestFinished,
+	vi,
+} from "vitest";
 import { spawnCloudflared } from "../src/cloudflared";
 import { UserError } from "../src/errors";
 import { startTunnel } from "../src/tunnel";
@@ -16,6 +23,7 @@ function createMockProcess() {
 		stdout: EventEmitter;
 		killed: boolean;
 		kill: (signal?: string) => boolean;
+		unref: () => void;
 	};
 	proc.stderr = new EventEmitter();
 	proc.stdout = new EventEmitter();
@@ -24,6 +32,7 @@ function createMockProcess() {
 		proc.killed = true;
 		return true;
 	};
+	proc.unref = vi.fn();
 	return proc;
 }
 
@@ -72,6 +81,7 @@ describe("startTunnel", () => {
 			origin: new URL("http://localhost:8787"),
 			timeoutMs: TEST_TIMEOUT_MS,
 		});
+		onTestFinished(() => tunnel.dispose());
 
 		await emitStderrNextTick(
 			proc,
@@ -81,8 +91,6 @@ describe("startTunnel", () => {
 		await expect(tunnel.ready()).resolves.toEqual({
 			publicUrl: new URL("https://foo-bar-baz.trycloudflare.com"),
 		});
-
-		await tunnel.dispose();
 	});
 
 	it("should pass the correct args to spawnCloudflared", async ({ expect }) => {
@@ -190,8 +198,63 @@ describe("startTunnel", () => {
 
 		await emitStderrNextTick(proc, "INF https://my-tunnel.trycloudflare.com\n");
 		await tunnel.ready();
-		await tunnel.dispose();
+		tunnel.dispose();
 
+		expect(killSpy).toHaveBeenCalledWith("SIGTERM");
+	});
+
+	it("should detach the cloudflared process before dispose", async ({
+		expect,
+	}) => {
+		const proc = createMockProcess();
+		const unrefSpy = vi.spyOn(proc, "unref");
+		const killSpy = vi.spyOn(proc, "kill");
+		vi.mocked(spawnCloudflared).mockResolvedValue(proc as never);
+
+		const tunnel = startTunnel({
+			origin: new URL("http://localhost:8787"),
+			timeoutMs: TEST_TIMEOUT_MS,
+		});
+
+		await emitStderrNextTick(proc, "INF https://my-tunnel.trycloudflare.com\n");
+		await tunnel.ready();
+
+		tunnel.dispose();
+
+		expect(unrefSpy).toHaveBeenCalledTimes(1);
+		expect(killSpy).toHaveBeenCalledWith("SIGTERM");
+	});
+
+	it("should terminate cloudflared when disposed before spawn resolves", async ({
+		expect,
+	}) => {
+		const proc = createMockProcess();
+		const unrefSpy = vi.spyOn(proc, "unref");
+		const killSpy = vi.spyOn(proc, "kill");
+		let resolveProcess:
+			| ((value: ReturnType<typeof createMockProcess>) => void)
+			| undefined;
+
+		vi.mocked(spawnCloudflared).mockImplementation(
+			() =>
+				new Promise<ReturnType<typeof createMockProcess>>((resolve) => {
+					resolveProcess = resolve;
+				}) as never
+		);
+
+		const tunnel = startTunnel({
+			origin: new URL("http://localhost:8787"),
+			timeoutMs: TEST_TIMEOUT_MS,
+		});
+
+		tunnel.dispose();
+		expect(unrefSpy).not.toHaveBeenCalled();
+		expect(killSpy).not.toHaveBeenCalled();
+
+		resolveProcess?.(proc);
+		await Promise.resolve();
+
+		expect(unrefSpy).toHaveBeenCalledTimes(1);
 		expect(killSpy).toHaveBeenCalledWith("SIGTERM");
 	});
 

--- a/packages/wrangler/src/dev/start-dev.ts
+++ b/packages/wrangler/src/dev/start-dev.ts
@@ -177,7 +177,7 @@ export async function startDev(args: StartDevOptions) {
 
 			// Clean up tunnel on teardown
 			primaryDevEnv.on("teardown", () => {
-				void tunnel?.dispose();
+				tunnel?.dispose();
 			});
 
 			// User requested tunnel sharing explicitly. If it fails, let it throw
@@ -215,7 +215,9 @@ export async function startDev(args: StartDevOptions) {
 			(async () => {
 				unregisterHotKeys?.();
 			})(),
-			tunnel?.dispose(),
+			(async () => {
+				tunnel?.dispose();
+			})(),
 		]);
 		throw e;
 	}


### PR DESCRIPTION
Fixes n/a.

Add `tunnel: true` to the `cloudflare()` Vite plugin for sharing your local dev server via Cloudflare Quick Tunnels

You can now expose your local dev server publicly by setting `tunnel: true`:

```ts
cloudflare({
    tunnel: true,
});
```

You can also enable tunnel sharing dynamically using an environment variable:

```ts
cloudflare({
   tunnel: process.env.ENABLE_DEV_TUNNEL === "true",
});
```

This starts a Cloudflare Quick Tunnel that gives you a random `*.trycloudflare.com` URL to share. The tunnel stops automatically when the dev session ends. Quick tunnels don't require a Cloudflare account or any configuration.

<img width="815" height="430" alt="Screenshot 2026-04-14 at 18 04 50" src="https://github.com/user-attachments/assets/bc86326f-74fe-4454-8246-484aa7921f2e" />

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/30186
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
