### PR TITLE
fix: correctly save auth from previous remote sessions 

### DIFF
--- a/.changeset/fix-remote-proxy-session-auth-persistence.md
+++ b/.changeset/fix-remote-proxy-session-auth-persistence.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Preserve auth in remote proxy session data to avoid unnecessary session restarts
+
+`maybeStartOrUpdateRemoteProxySession` was not including `auth` in its return value, so on subsequent calls `preExistingRemoteProxySessionData.auth` was always `undefined`. This caused the auth comparison to always detect a change, disposing and recreating the remote proxy session on every reload even when auth had not changed.

--- a/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
+++ b/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
@@ -55,6 +55,7 @@ const remoteProxyConnectionString = new URL(
 ) as RemoteProxyConnectionString;
 let proxyWorkerBindings: Record<string, Binding> | undefined;
 let sessionOptions: StartRemoteProxySessionOptions | undefined;
+let startRemoteProxySessionCallCount = 0;
 vi.mock("../../api/remoteBindings/start-remote-proxy-session", async () => {
 	const actual = await vi.importActual<
 		typeof import("../../api/remoteBindings/start-remote-proxy-session")
@@ -67,6 +68,7 @@ vi.mock("../../api/remoteBindings/start-remote-proxy-session", async () => {
 		) {
 			proxyWorkerBindings = remoteBindings;
 			sessionOptions = options;
+			startRemoteProxySessionCallCount++;
 			return {
 				ready: Promise.resolve(),
 				async dispose() {},
@@ -119,6 +121,7 @@ describe("dev with remote bindings", { sequential: true, retry: 2 }, () => {
 		};
 		sessionOptions = undefined;
 		proxyWorkerBindings = undefined;
+		startRemoteProxySessionCallCount = 0;
 		workerOptions = [];
 	});
 
@@ -608,6 +611,45 @@ describe("dev with remote bindings", { sequential: true, retry: 2 }, () => {
 
 		await stopWrangler();
 		await wranglerStopped;
+	});
+
+	it("should not recreate the remote proxy session on reload when auth has not changed", async () => {
+		const { maybeStartOrUpdateRemoteProxySession } = await import(
+			"../../api/remoteBindings"
+		);
+
+		const remoteBindings: Record<string, Binding> = {
+			REMOTE_WORKER: {
+				type: "service",
+				service: "remote-service-binding-worker",
+				remote: true,
+			},
+		};
+
+		const auth = async () => ({
+			accountId: "some-account-id",
+			apiToken: { apiToken: "some-api-token" } as const,
+		});
+
+		// First call — creates a new session
+		const firstResult = await maybeStartOrUpdateRemoteProxySession(
+			{ name: "worker", bindings: remoteBindings },
+			null,
+			auth
+		);
+		expect(startRemoteProxySessionCallCount).toBe(1);
+		expect(firstResult).not.toBeNull();
+
+		// Second call — passes the previous result back as pre-existing session data
+		// with the same auth reference. The session should be reused, not recreated.
+		const secondResult = await maybeStartOrUpdateRemoteProxySession(
+			{ name: "worker", bindings: remoteBindings },
+			firstResult,
+			auth
+		);
+		expect(startRemoteProxySessionCallCount).toBe(1);
+		expect(secondResult).not.toBeNull();
+		expect(secondResult?.session).toBe(firstResult?.session);
 	});
 
 	it("should allow both local and remote KV bindings to the same namespace in a single dev session", async () => {

--- a/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
+++ b/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
@@ -614,9 +614,8 @@ describe("dev with remote bindings", { sequential: true, retry: 2 }, () => {
 	});
 
 	it("should not recreate the remote proxy session on reload when auth has not changed", async () => {
-		const { maybeStartOrUpdateRemoteProxySession } = await import(
-			"../../api/remoteBindings"
-		);
+		const { maybeStartOrUpdateRemoteProxySession } =
+			await import("../../api/remoteBindings");
 
 		const remoteBindings: Record<string, Binding> = {
 			REMOTE_WORKER: {

--- a/packages/wrangler/src/api/remoteBindings/index.ts
+++ b/packages/wrangler/src/api/remoteBindings/index.ts
@@ -93,6 +93,7 @@ export async function maybeStartOrUpdateRemoteProxySession(
 ): Promise<{
 	session: RemoteProxySession;
 	remoteBindings: Record<string, Binding>;
+	auth?: AsyncHook<CfAccount> | undefined;
 } | null> {
 	let config: Config | undefined;
 	if ("path" in wranglerOrWorkerConfigObject) {
@@ -180,6 +181,7 @@ export async function maybeStartOrUpdateRemoteProxySession(
 	return {
 		session: remoteProxySession,
 		remoteBindings,
+		auth,
 	};
 }
 

--- a/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
+++ b/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import chalk from "chalk";
 import { DeferredPromise } from "miniflare";
 import remoteBindingsWorkerPath from "worker:remoteBindings/ProxyServerWorker";
 import { logger } from "../../logger";
@@ -20,6 +21,7 @@ export async function startRemoteProxySession(
 	bindings: StartDevWorkerInput["bindings"],
 	options?: StartRemoteProxySessionOptions
 ): Promise<RemoteProxySession> {
+	logger.log(chalk.dim("⎔ Establishing remote connection..."));
 	// Transform all bindings to use "raw" mode
 	const rawBindings = Object.fromEntries(
 		Object.entries(bindings ?? {}).map(([key, binding]) => [

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -15,6 +15,7 @@ import { logger } from "../../logger";
 import { RuntimeController } from "./BaseController";
 import { castErrorCause } from "./events";
 import { getBinaryFileContents } from "./utils";
+import type { CfAccount } from "../../dev/create-worker-preview";
 import type { RemoteProxySession } from "../remoteBindings";
 import type {
 	BundleCompleteEvent,
@@ -24,7 +25,6 @@ import type {
 	ReloadCompleteEvent,
 	ReloadStartEvent,
 } from "./events";
-import type { CfAccount } from "../../dev/create-worker-preview";
 import type { AsyncHook, Binding, File, StartDevWorkerOptions } from "./types";
 import type { ContainerDevOptions } from "@cloudflare/containers-shared";
 

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -24,7 +24,8 @@ import type {
 	ReloadCompleteEvent,
 	ReloadStartEvent,
 } from "./events";
-import type { Binding, File, StartDevWorkerOptions } from "./types";
+import type { CfAccount } from "../../dev/create-worker-preview";
+import type { AsyncHook, Binding, File, StartDevWorkerOptions } from "./types";
 import type { ContainerDevOptions } from "@cloudflare/containers-shared";
 
 async function getTextFileContents(file: File<string | Uint8Array>) {
@@ -179,6 +180,7 @@ export class LocalRuntimeController extends RuntimeController {
 	#remoteProxySessionData: {
 		session: RemoteProxySession;
 		remoteBindings: Record<string, Binding>;
+		auth?: AsyncHook<CfAccount> | undefined;
 	} | null = null;
 
 	// Set of container images that have been seen in the current dev session.


### PR DESCRIPTION
`preExistingRemoteProxySessionData.auth` was always undefined because `maybeStartOrUpdateRemoteProxySession` never included auth in its return value. This caused the `authSameAsBefore` check to always return false, triggering a full session dispose + recreate on every reload in LocalRuntimeController.

This only affects the LocalRuntimeController afaict, since both auth values are always undefined in every other place `maybeStartOrUpdateRemoteProxySession` is called. I'm a bit confused by that, but I don't know this code very well and this appears to fix the problem.

I've tested this manually as well - in a fixture with a remote binding, previously any code change would trigger a long reload. 

I've also added a log for when we start the remote connection, since some users are confused by the hang while this is happening.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
