### PR TITLE
fix(workers-shared): guard against undefined user_worker static_routing rules

### DIFF
--- a/.changeset/fix-router-worker-user-worker-rules-iterable.md
+++ b/.changeset/fix-router-worker-user-worker-rules-iterable.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/workers-shared": patch
+"miniflare": patch
+---
+
+Fix `TypeError: rules is not iterable` in the router-worker when `static_routing` is configured without `user_worker` rules
+
+The router-worker's static-routing include-rule evaluation passed `config.static_routing.user_worker` directly to the matcher, which iterates with `for...of`. When `static_routing` was set but `user_worker` was omitted, the matcher threw `TypeError: rules is not iterable` and failed the request. The adjacent `asset_worker` branch already falls back to `[]` in this case; the `user_worker` branch now does the same.

--- a/packages/workers-shared/router-worker/src/worker.ts
+++ b/packages/workers-shared/router-worker/src/worker.ts
@@ -219,7 +219,7 @@ export default {
 				}
 				// evaluate "include" rules
 				const includeRulesMatcher = generateStaticRoutingRuleMatcher(
-					config.static_routing.user_worker
+					config.static_routing.user_worker ?? []
 				);
 				if (
 					includeRulesMatcher({

--- a/packages/workers-shared/router-worker/tests/index.test.ts
+++ b/packages/workers-shared/router-worker/tests/index.test.ts
@@ -201,6 +201,43 @@ describe("unit tests", () => {
 		expect(await response.text()).toEqual("hello from asset worker");
 	});
 
+	// Regression test for WC-5014 / Sentry #31445454: previously threw
+	// `TypeError: rules is not iterable` when static_routing was defined but
+	// user_worker was undefined, because the matcher's for...of loop ran over
+	// an undefined value. The request URL must not match any asset_worker rule
+	// so that execution reaches the user_worker include-rule branch.
+	it("does not throw when static_routing is defined without user_worker rules", async ({
+		expect,
+	}) => {
+		const request = new Request("https://example.com/unmatched-path");
+		const ctx = createExecutionContext();
+
+		const env = {
+			CONFIG: {
+				has_user_worker: true,
+				static_routing: {
+					asset_worker: ["/assets/*"],
+				},
+			},
+			USER_WORKER: {
+				async fetch(_request: Request): Promise<Response> {
+					return new Response("hello from user worker");
+				},
+			},
+			ASSET_WORKER: {
+				async fetch(_request: Request): Promise<Response> {
+					return new Response("hello from asset worker");
+				},
+				async unstable_canFetch(_request: Request): Promise<boolean> {
+					return true;
+				},
+			},
+		} as Env;
+
+		const response = await worker.fetch(request, env, ctx);
+		expect(await response.text()).toEqual("hello from asset worker");
+	});
+
 	it("returns fetch from asset worker when no static_routing rule matches but asset exists", async ({
 		expect,
 	}) => {

--- a/packages/workers-shared/router-worker/tests/index.test.ts
+++ b/packages/workers-shared/router-worker/tests/index.test.ts
@@ -203,9 +203,7 @@ describe("unit tests", () => {
 
 	// Regression test for WC-5014 / Sentry #31445454: previously threw
 	// `TypeError: rules is not iterable` when static_routing was defined but
-	// user_worker was undefined, because the matcher's for...of loop ran over
-	// an undefined value. The request URL must not match any asset_worker rule
-	// so that execution reaches the user_worker include-rule branch.
+	// user_worker was undefined.
 	it("does not throw when static_routing is defined without user_worker rules", async ({
 		expect,
 	}) => {


### PR DESCRIPTION
The router-worker's include-rule evaluation passed config.static_routing.user_worker directly to generateStaticRoutingRuleMatcher, which iterates with for...of. When static_routing was configured but user_worker was undefined, this threw `TypeError: rules is not iterable`, breaking all requests.

The adjacent asset_worker branch on line 207 already applies `?? []`; this brings the user_worker branch into parity.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [X] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: bugfix with no user facing changes

*A picture of a cute animal (not mandatory, but encouraged)*
<img width="3024" height="4032" alt="PXL_20230402_194223879 PORTRAIT" src="https://github.com/user-attachments/assets/b58841fc-0dd2-4875-b6a9-4630280a107c" />

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
