### PR TITLE
[wrangler] Add artifacts CLI commands

### DIFF
--- a/.changeset/green-books-accept.md
+++ b/.changeset/green-books-accept.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Add `wrangler artifacts` commands for managing Artifacts namespaces, repos, and repo tokens.

--- a/.changeset/green-books-accept.md
+++ b/.changeset/green-books-accept.md
@@ -3,3 +3,7 @@
 ---
 
 Add `wrangler artifacts` commands for managing Artifacts namespaces, repos, and repo tokens.
+
+This adds CLI support for the Artifacts control-plane workflows that were previously only available through the API. You can now create, list, inspect, and delete namespaces and repos directly from Wrangler, and issue repo-scoped tokens when you need to authenticate git access.
+
+The new commands support both human-readable output and `--json` output so they fit existing Wrangler automation patterns.

--- a/.changeset/green-books-accept.md
+++ b/.changeset/green-books-accept.md
@@ -2,8 +2,8 @@
 "wrangler": minor
 ---
 
-Add `wrangler artifacts` commands for managing Artifacts namespaces, repos, and repo tokens.
+Add `wrangler artifacts` commands for managing Artifacts repos and repo tokens.
 
-This adds CLI support for the Artifacts control-plane workflows that were previously only available through the API. You can now create, list, inspect, and delete namespaces and repos directly from Wrangler, and issue repo-scoped tokens when you need to authenticate git access.
+This adds CLI support for the Artifacts control-plane workflows that were previously only available through the API. You can now list and inspect namespaces, create, list, inspect, and delete repos, and issue repo-scoped tokens when you need to authenticate git access.
 
 The new commands support both human-readable output and `--json` output so they fit existing Wrangler automation patterns.

--- a/packages/wrangler/src/__tests__/artifacts.test.ts
+++ b/packages/wrangler/src/__tests__/artifacts.test.ts
@@ -1,7 +1,9 @@
 import { http, HttpResponse } from "msw";
-import { afterEach, describe, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
+import { clearDialogs, mockConfirm } from "./helpers/mock-dialogs";
+import { useMockIsTTY } from "./helpers/mock-istty";
 import { createFetchResult, msw } from "./helpers/msw";
 import { runWrangler } from "./helpers/run-wrangler";
 import type * as WorkersUtilsModule from "@cloudflare/workers-utils";
@@ -17,11 +19,17 @@ vi.mock("@cloudflare/workers-utils", async (importOriginal) => {
 
 describe("artifacts", () => {
 	const std = mockConsoleMethods();
+	const { setIsTTY } = useMockIsTTY();
 
 	mockAccountId();
 	mockApiToken();
 
+	beforeEach(() => {
+		setIsTTY(true);
+	});
+
 	afterEach(() => {
+		clearDialogs();
 		msw.resetHandlers();
 	});
 
@@ -139,10 +147,37 @@ describe("artifacts", () => {
 				)
 			);
 
-			await runWrangler("artifacts namespaces delete default --json");
+			await runWrangler("artifacts namespaces delete default --force --json");
 
 			expect(std.err).toBe("");
 			expect(JSON.parse(std.out)).toEqual({ deleted: true, name: "default" });
+		});
+
+		it("should cancel namespace deletion when not confirmed", async ({
+			expect,
+		}) => {
+			let requestCount = 0;
+
+			mockConfirm({
+				text: 'Are you sure you want to delete Artifacts namespace "default"? This action cannot be undone.',
+				options: { defaultValue: true },
+				result: false,
+			});
+
+			msw.use(
+				http.delete(
+					"*/accounts/:accountId/artifacts/namespaces/:namespace",
+					() => {
+						requestCount += 1;
+						return HttpResponse.json(createFetchResult({ id: "ns_default" }));
+					}
+				)
+			);
+
+			await runWrangler("artifacts namespaces delete default");
+
+			expect(std.out).toContain("Deletion cancelled.");
+			expect(requestCount).toBe(0);
 		});
 	});
 
@@ -345,7 +380,7 @@ describe("artifacts", () => {
 			);
 
 			await runWrangler(
-				"artifacts repos delete starter-repo --namespace default --json"
+				"artifacts repos delete starter-repo --namespace default --force --json"
 			);
 
 			expect(JSON.parse(std.out)).toEqual({
@@ -353,6 +388,33 @@ describe("artifacts", () => {
 				name: "starter-repo",
 				namespace: "default",
 			});
+		});
+
+		it("should cancel repo deletion when not confirmed", async ({ expect }) => {
+			let requestCount = 0;
+
+			mockConfirm({
+				text: 'Are you sure you want to delete Artifacts repo "starter-repo" from namespace "default"? This action cannot be undone.',
+				options: { defaultValue: true },
+				result: false,
+			});
+
+			msw.use(
+				http.delete(
+					"*/accounts/:accountId/artifacts/namespaces/:namespace/repos/:repo",
+					() => {
+						requestCount += 1;
+						return HttpResponse.json(createFetchResult({ id: "repo_123" }));
+					}
+				)
+			);
+
+			await runWrangler(
+				"artifacts repos delete starter-repo --namespace default"
+			);
+
+			expect(std.out).toContain("Deletion cancelled.");
+			expect(requestCount).toBe(0);
 		});
 
 		it("should reject invalid token TTL", async ({ expect }) => {

--- a/packages/wrangler/src/__tests__/artifacts.test.ts
+++ b/packages/wrangler/src/__tests__/artifacts.test.ts
@@ -1,7 +1,6 @@
 import { http, HttpResponse } from "msw";
 import { afterEach, describe, it, vi } from "vitest";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
-import { mockCLIOutput } from "./helpers/mock-cli-output";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { createFetchResult, msw } from "./helpers/msw";
 import { runWrangler } from "./helpers/run-wrangler";
@@ -17,7 +16,6 @@ vi.mock("@cloudflare/workers-utils", async (importOriginal) => {
 });
 
 describe("artifacts", () => {
-	const cliStd = mockCLIOutput();
 	const std = mockConsoleMethods();
 
 	mockAccountId();
@@ -244,10 +242,9 @@ describe("artifacts", () => {
 			expect(std.out).toContain(
 				'Created Artifacts repo "starter-repo" in namespace "default".'
 			);
-			expect(std.out).not.toContain("art_v1_token?expires=1760000000");
-			expect(cliStd.stdout).toContain("token:");
-			expect(cliStd.stdout).toContain("art_v1_token?expires=1760000000");
-			expect(cliStd.stdout).toContain("read_only:");
+			expect(std.out).toContain("token:");
+			expect(std.out).toContain("art_v1_token?expires=1760000000");
+			expect(std.out).toContain("read_only:");
 		});
 
 		it("should list repos with JSON output", async ({ expect }) => {
@@ -433,9 +430,8 @@ describe("artifacts", () => {
 			expect(std.out).toContain(
 				'Issued a read token for repo "starter-repo" in namespace "default".'
 			);
-			expect(std.out).not.toContain("art_v1_token?expires=1760000000");
-			expect(cliStd.stdout).toContain("plaintext:");
-			expect(cliStd.stdout).toContain("art_v1_token?expires=1760000000");
+			expect(std.out).toContain("plaintext:");
+			expect(std.out).toContain("art_v1_token?expires=1760000000");
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/artifacts.test.ts
+++ b/packages/wrangler/src/__tests__/artifacts.test.ts
@@ -6,10 +6,12 @@ import { clearDialogs, mockConfirm } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { createFetchResult, msw } from "./helpers/msw";
 import { runWrangler } from "./helpers/run-wrangler";
-import type * as WorkersUtilsModule from "@cloudflare/workers-utils";
 
 vi.mock("@cloudflare/workers-utils", async (importOriginal) => {
-	const actual = await importOriginal<WorkersUtilsModule>();
+	const actual = await importOriginal();
+	if (typeof actual !== "object" || actual === null) {
+		throw new Error("Expected @cloudflare/workers-utils module object");
+	}
 
 	return {
 		...actual,

--- a/packages/wrangler/src/__tests__/artifacts.test.ts
+++ b/packages/wrangler/src/__tests__/artifacts.test.ts
@@ -1,0 +1,441 @@
+import { http, HttpResponse } from "msw";
+import { afterEach, describe, it, vi } from "vitest";
+import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
+import { mockCLIOutput } from "./helpers/mock-cli-output";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import { createFetchResult, msw } from "./helpers/msw";
+import { runWrangler } from "./helpers/run-wrangler";
+import type * as WorkersUtilsModule from "@cloudflare/workers-utils";
+
+vi.mock("@cloudflare/workers-utils", async (importOriginal) => {
+	const actual = await importOriginal<WorkersUtilsModule>();
+
+	return {
+		...actual,
+		getWranglerCacheDirFromEnv: () => "/tmp/wrangler-artifacts-test-cache",
+	};
+});
+
+describe("artifacts", () => {
+	const cliStd = mockCLIOutput();
+	const std = mockConsoleMethods();
+
+	mockAccountId();
+	mockApiToken();
+
+	afterEach(() => {
+		msw.resetHandlers();
+	});
+
+	describe("namespaces", () => {
+		it("should show help for namespace commands", async ({ expect }) => {
+			await runWrangler("artifacts namespaces --help");
+
+			expect(std.err).toBe("");
+			expect(std.out).toContain("wrangler artifacts namespaces");
+			expect(std.out).toContain("create");
+			expect(std.out).toContain("list");
+			expect(std.out).toContain("get");
+			expect(std.out).toContain("delete");
+		});
+
+		it("should create a namespace with JSON output", async ({ expect }) => {
+			let requestBody: unknown;
+
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/artifacts/namespaces",
+					async ({ params, request }) => {
+						requestBody = await request.json();
+						expect(params.accountId).toBe("some-account-id");
+						return HttpResponse.json(
+							createFetchResult({
+								id: "ns_123",
+								name: "sandbox",
+								created_at: "2026-04-23T12:00:00.000Z",
+								updated_at: "2026-04-23T12:00:00.000Z",
+							})
+						);
+					}
+				)
+			);
+
+			await runWrangler("artifacts namespaces create sandbox --json");
+
+			expect(requestBody).toEqual({ name: "sandbox" });
+			expect(std.err).toBe("");
+			expect(JSON.parse(std.out)).toEqual({
+				id: "ns_123",
+				name: "sandbox",
+				created_at: "2026-04-23T12:00:00.000Z",
+				updated_at: "2026-04-23T12:00:00.000Z",
+			});
+		});
+
+		it("should list namespaces in human mode", async ({ expect }) => {
+			msw.use(
+				http.get("*/accounts/:accountId/artifacts/namespaces", ({ params }) => {
+					expect(params.accountId).toBe("some-account-id");
+					return HttpResponse.json(
+						createFetchResult([
+							{
+								name: "default",
+								created_at: "2026-04-20T10:00:00.000Z",
+								updated_at: "2026-04-20T10:00:00.000Z",
+							},
+							{
+								name: "sandbox",
+								created_at: "2026-04-21T10:00:00.000Z",
+								updated_at: "2026-04-22T10:00:00.000Z",
+							},
+						])
+					);
+				})
+			);
+
+			await runWrangler("artifacts namespaces list");
+
+			expect(std.err).toBe("");
+			expect(std.out).toContain("wrangler x.x.x");
+			expect(std.out).toContain("default");
+			expect(std.out).toContain("sandbox");
+			expect(std.out).toContain("created_at");
+		});
+
+		it("should get a namespace in human mode", async ({ expect }) => {
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/artifacts/namespaces/:namespace",
+					({ params }) => {
+						expect(params.accountId).toBe("some-account-id");
+						expect(params.namespace).toBe("default");
+						return HttpResponse.json(
+							createFetchResult({
+								id: "ns_default",
+								name: "default",
+								created_at: "2026-04-20T10:00:00.000Z",
+								updated_at: "2026-04-22T10:00:00.000Z",
+							})
+						);
+					}
+				)
+			);
+
+			await runWrangler("artifacts namespaces get default");
+
+			expect(std.err).toBe("");
+			expect(std.out).toContain("name:");
+			expect(std.out).toContain("default");
+			expect(std.out).toContain("id:");
+		});
+
+		it("should delete a namespace with JSON output", async ({ expect }) => {
+			msw.use(
+				http.delete(
+					"*/accounts/:accountId/artifacts/namespaces/:namespace",
+					({ params }) => {
+						expect(params.accountId).toBe("some-account-id");
+						expect(params.namespace).toBe("default");
+						return HttpResponse.json(createFetchResult({ id: "ns_default" }));
+					}
+				)
+			);
+
+			await runWrangler("artifacts namespaces delete default --json");
+
+			expect(std.err).toBe("");
+			expect(JSON.parse(std.out)).toEqual({ deleted: true, name: "default" });
+		});
+	});
+
+	describe("repos", () => {
+		it("should show help for repo commands", async ({ expect }) => {
+			await runWrangler("artifacts repos --help");
+
+			expect(std.err).toBe("");
+			expect(std.out).toContain("wrangler artifacts repos");
+			expect(std.out).toContain("create");
+			expect(std.out).toContain("list");
+			expect(std.out).toContain("get");
+			expect(std.out).toContain("delete");
+			expect(std.out).toContain("issue-token");
+		});
+
+		it("should require --namespace for repo commands", async ({ expect }) => {
+			await expect(runWrangler("artifacts repos list")).rejects.toThrowError(
+				/Missing required argument: namespace/
+			);
+		});
+
+		it("should create a repo with JSON output", async ({ expect }) => {
+			let requestBody: unknown;
+
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/artifacts/namespaces/:namespace/repos",
+					async ({ params, request }) => {
+						requestBody = await request.json();
+						expect(params.accountId).toBe("some-account-id");
+						expect(params.namespace).toBe("default");
+						return HttpResponse.json(
+							createFetchResult({
+								id: "repo_123",
+								name: "starter-repo",
+								description: "Starter repo",
+								default_branch: "main",
+								remote:
+									"https://some-account-id.artifacts.cloudflare.net/git/default/starter-repo.git",
+								token: "art_v1_token?expires=1760000000",
+							})
+						);
+					}
+				)
+			);
+
+			await runWrangler(
+				"artifacts repos create starter-repo --namespace default --description 'Starter repo' --default-branch main --read-only --json"
+			);
+
+			expect(requestBody).toEqual({
+				name: "starter-repo",
+				description: "Starter repo",
+				default_branch: "main",
+				read_only: true,
+			});
+			expect(JSON.parse(std.out)).toEqual({
+				id: "repo_123",
+				name: "starter-repo",
+				description: "Starter repo",
+				default_branch: "main",
+				remote:
+					"https://some-account-id.artifacts.cloudflare.net/git/default/starter-repo.git",
+				token: "art_v1_token?expires=1760000000",
+			});
+		});
+
+		it("should create a repo in human mode without sending secrets through the logger", async ({
+			expect,
+		}) => {
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/artifacts/namespaces/:namespace/repos",
+					({ params }) => {
+						expect(params.accountId).toBe("some-account-id");
+						expect(params.namespace).toBe("default");
+						return HttpResponse.json(
+							createFetchResult({
+								id: "repo_123",
+								name: "starter-repo",
+								description: "Starter repo",
+								default_branch: "main",
+								remote:
+									"https://some-account-id.artifacts.cloudflare.net/git/default/starter-repo.git",
+								token: "art_v1_token?expires=1760000000",
+							})
+						);
+					}
+				)
+			);
+
+			await runWrangler(
+				"artifacts repos create starter-repo --namespace default --description 'Starter repo' --default-branch main --read-only"
+			);
+
+			expect(std.out).toContain(
+				'Created Artifacts repo "starter-repo" in namespace "default".'
+			);
+			expect(std.out).not.toContain("art_v1_token?expires=1760000000");
+			expect(cliStd.stdout).toContain("token:");
+			expect(cliStd.stdout).toContain("art_v1_token?expires=1760000000");
+			expect(cliStd.stdout).toContain("read_only:");
+		});
+
+		it("should list repos with JSON output", async ({ expect }) => {
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/artifacts/namespaces/:namespace/repos",
+					({ params }) => {
+						expect(params.accountId).toBe("some-account-id");
+						expect(params.namespace).toBe("default");
+						return HttpResponse.json(
+							createFetchResult([
+								{
+									id: "repo_123",
+									name: "starter-repo",
+									description: "Starter repo",
+									default_branch: "main",
+									created_at: "2026-04-20T10:00:00.000Z",
+									updated_at: "2026-04-22T10:00:00.000Z",
+									last_push_at: "2026-04-22T10:00:00.000Z",
+									source: null,
+									read_only: false,
+									remote:
+										"https://some-account-id.artifacts.cloudflare.net/git/default/starter-repo.git",
+									status: "ready",
+								},
+							])
+						);
+					}
+				)
+			);
+
+			await runWrangler("artifacts repos list --namespace default --json");
+
+			expect(JSON.parse(std.out)).toEqual([
+				{
+					id: "repo_123",
+					name: "starter-repo",
+					description: "Starter repo",
+					default_branch: "main",
+					created_at: "2026-04-20T10:00:00.000Z",
+					updated_at: "2026-04-22T10:00:00.000Z",
+					last_push_at: "2026-04-22T10:00:00.000Z",
+					source: null,
+					read_only: false,
+					remote:
+						"https://some-account-id.artifacts.cloudflare.net/git/default/starter-repo.git",
+					status: "ready",
+				},
+			]);
+		});
+
+		it("should get a repo in human mode", async ({ expect }) => {
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/artifacts/namespaces/:namespace/repos/:repo",
+					({ params }) => {
+						expect(params.accountId).toBe("some-account-id");
+						expect(params.namespace).toBe("default");
+						expect(params.repo).toBe("starter-repo");
+						return HttpResponse.json(
+							createFetchResult({
+								id: "repo_123",
+								name: "starter-repo",
+								description: "Starter repo",
+								default_branch: "main",
+								created_at: "2026-04-20T10:00:00.000Z",
+								updated_at: "2026-04-22T10:00:00.000Z",
+								last_push_at: "2026-04-22T10:00:00.000Z",
+								source: null,
+								read_only: false,
+								remote:
+									"https://some-account-id.artifacts.cloudflare.net/git/default/starter-repo.git",
+								status: "ready",
+							})
+						);
+					}
+				)
+			);
+
+			await runWrangler("artifacts repos get starter-repo --namespace default");
+
+			expect(std.out).toContain("starter-repo");
+			expect(std.out).toContain("remote:");
+			expect(std.out).toContain("status:");
+		});
+
+		it("should delete a repo with JSON output", async ({ expect }) => {
+			msw.use(
+				http.delete(
+					"*/accounts/:accountId/artifacts/namespaces/:namespace/repos/:repo",
+					({ params }) => {
+						expect(params.accountId).toBe("some-account-id");
+						expect(params.namespace).toBe("default");
+						expect(params.repo).toBe("starter-repo");
+						return HttpResponse.json(createFetchResult({ id: "repo_123" }));
+					}
+				)
+			);
+
+			await runWrangler(
+				"artifacts repos delete starter-repo --namespace default --json"
+			);
+
+			expect(JSON.parse(std.out)).toEqual({
+				deleted: true,
+				name: "starter-repo",
+				namespace: "default",
+			});
+		});
+
+		it("should reject invalid token TTL", async ({ expect }) => {
+			await expect(
+				runWrangler(
+					"artifacts repos issue-token starter-repo --namespace default --ttl 0"
+				)
+			).rejects.toThrowError(/--ttl must be greater than 0/);
+		});
+
+		it("should issue a repo token with JSON output", async ({ expect }) => {
+			let requestBody: unknown;
+
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/artifacts/namespaces/:namespace/tokens",
+					async ({ params, request }) => {
+						requestBody = await request.json();
+						expect(params.accountId).toBe("some-account-id");
+						expect(params.namespace).toBe("default");
+						return HttpResponse.json(
+							createFetchResult({
+								id: "tok_123",
+								plaintext: "art_v1_token?expires=1760000000",
+								scope: "read",
+								expires_at: "2026-04-24T10:00:00.000Z",
+							})
+						);
+					}
+				)
+			);
+
+			await runWrangler(
+				"artifacts repos issue-token starter-repo --namespace default --scope read --ttl 3600 --json"
+			);
+
+			expect(requestBody).toEqual({
+				repo: "starter-repo",
+				scope: "read",
+				ttl: 3600,
+			});
+			expect(JSON.parse(std.out)).toEqual({
+				id: "tok_123",
+				plaintext: "art_v1_token?expires=1760000000",
+				scope: "read",
+				expires_at: "2026-04-24T10:00:00.000Z",
+			});
+		});
+
+		it("should issue a repo token in human mode without sending plaintext through the logger", async ({
+			expect,
+		}) => {
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/artifacts/namespaces/:namespace/tokens",
+					({ params }) => {
+						expect(params.accountId).toBe("some-account-id");
+						expect(params.namespace).toBe("default");
+						return HttpResponse.json(
+							createFetchResult({
+								id: "tok_123",
+								plaintext: "art_v1_token?expires=1760000000",
+								scope: "read",
+								expires_at: "2026-04-24T10:00:00.000Z",
+							})
+						);
+					}
+				)
+			);
+
+			await runWrangler(
+				"artifacts repos issue-token starter-repo --namespace default --scope read --ttl 3600"
+			);
+
+			expect(std.out).toContain(
+				'Issued a read token for repo "starter-repo" in namespace "default".'
+			);
+			expect(std.out).not.toContain("art_v1_token?expires=1760000000");
+			expect(cliStd.stdout).toContain("plaintext:");
+			expect(cliStd.stdout).toContain("art_v1_token?expires=1760000000");
+		});
+	});
+});

--- a/packages/wrangler/src/__tests__/artifacts.test.ts
+++ b/packages/wrangler/src/__tests__/artifacts.test.ts
@@ -104,10 +104,18 @@ describe("artifacts", () => {
 			await runWrangler("artifacts namespaces list");
 
 			expect(std.err).toBe("");
-			expect(std.out).toContain("wrangler x.x.x");
-			expect(std.out).toContain("default");
-			expect(std.out).toContain("sandbox");
-			expect(std.out).toContain("created_at");
+			expect(std.out).toMatchInlineSnapshot(`
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				┌─┬─┬─┐
+				│ name │ created_at │ updated_at │
+				├─┼─┼─┤
+				│ default │ 2026-04-20T10:00:00.000Z │ 2026-04-20T10:00:00.000Z │
+				├─┼─┼─┤
+				│ sandbox │ 2026-04-21T10:00:00.000Z │ 2026-04-22T10:00:00.000Z │
+				└─┴─┴─┘"
+			`);
 		});
 
 		it("should get a namespace in human mode", async ({ expect }) => {
@@ -132,9 +140,16 @@ describe("artifacts", () => {
 			await runWrangler("artifacts namespaces get default");
 
 			expect(std.err).toBe("");
-			expect(std.out).toContain("name:");
-			expect(std.out).toContain("default");
-			expect(std.out).toContain("id:");
+			expect(std.out).toContain("ns_default");
+			expect(std.out).toMatchInlineSnapshot(`
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				name:        default
+				id:          ns_default
+				created_at:  2026-04-20T10:00:00.000Z
+				updated_at:  2026-04-22T10:00:00.000Z"
+			`);
 		});
 
 		it("should delete a namespace with JSON output", async ({ expect }) => {
@@ -158,7 +173,7 @@ describe("artifacts", () => {
 		it("should cancel namespace deletion when not confirmed", async ({
 			expect,
 		}) => {
-			let requestCount = 0;
+			let requestReceived = false;
 
 			mockConfirm({
 				text: 'Are you sure you want to delete Artifacts namespace "default"? This action cannot be undone.',
@@ -170,7 +185,7 @@ describe("artifacts", () => {
 				http.delete(
 					"*/accounts/:accountId/artifacts/namespaces/:namespace",
 					() => {
-						requestCount += 1;
+						requestReceived = true;
 						return HttpResponse.json(createFetchResult({ id: "ns_default" }));
 					}
 				)
@@ -179,7 +194,7 @@ describe("artifacts", () => {
 			await runWrangler("artifacts namespaces delete default");
 
 			expect(std.out).toContain("Deletion cancelled.");
-			expect(requestCount).toBe(0);
+			expect(requestReceived).toBe(false);
 		});
 	});
 
@@ -276,12 +291,20 @@ describe("artifacts", () => {
 				"artifacts repos create starter-repo --namespace default --description 'Starter repo' --default-branch main --read-only"
 			);
 
-			expect(std.out).toContain(
-				'Created Artifacts repo "starter-repo" in namespace "default".'
-			);
-			expect(std.out).toContain("token:");
-			expect(std.out).toContain("art_v1_token?expires=1760000000");
-			expect(std.out).toContain("read_only:");
+			expect(std.out).toContain("read_only:       true");
+			expect(std.out).toMatchInlineSnapshot(`
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				Created Artifacts repo "starter-repo" in namespace "default".
+				id:              repo_123
+				name:            starter-repo
+				description:     Starter repo
+				default_branch:  main
+				read_only:       true
+				remote:          https://some-account-id.artifacts.cloudflare.net/git/default/starter-repo.git
+				token:           art_v1_token?expires=1760000000"
+			`);
 		});
 
 		it("should list repos with JSON output", async ({ expect }) => {
@@ -363,9 +386,22 @@ describe("artifacts", () => {
 
 			await runWrangler("artifacts repos get starter-repo --namespace default");
 
-			expect(std.out).toContain("starter-repo");
-			expect(std.out).toContain("remote:");
-			expect(std.out).toContain("status:");
+			expect(std.out).toMatchInlineSnapshot(`
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				id:              repo_123
+				name:            starter-repo
+				description:     Starter repo
+				default_branch:  main
+				remote:          https://some-account-id.artifacts.cloudflare.net/git/default/starter-repo.git
+				read_only:       false
+				status:          ready
+				created_at:      2026-04-20T10:00:00.000Z
+				updated_at:      2026-04-22T10:00:00.000Z
+				last_push_at:    2026-04-22T10:00:00.000Z
+				source:          "
+			`);
 		});
 
 		it("should delete a repo with JSON output", async ({ expect }) => {
@@ -393,7 +429,7 @@ describe("artifacts", () => {
 		});
 
 		it("should cancel repo deletion when not confirmed", async ({ expect }) => {
-			let requestCount = 0;
+			let requestReceived = false;
 
 			mockConfirm({
 				text: 'Are you sure you want to delete Artifacts repo "starter-repo" from namespace "default"? This action cannot be undone.',
@@ -405,7 +441,7 @@ describe("artifacts", () => {
 				http.delete(
 					"*/accounts/:accountId/artifacts/namespaces/:namespace/repos/:repo",
 					() => {
-						requestCount += 1;
+						requestReceived = true;
 						return HttpResponse.json(createFetchResult({ id: "repo_123" }));
 					}
 				)
@@ -416,7 +452,7 @@ describe("artifacts", () => {
 			);
 
 			expect(std.out).toContain("Deletion cancelled.");
-			expect(requestCount).toBe(0);
+			expect(requestReceived).toBe(false);
 		});
 
 		it("should reject invalid token TTL", async ({ expect }) => {
@@ -491,11 +527,16 @@ describe("artifacts", () => {
 				"artifacts repos issue-token starter-repo --namespace default --scope read --ttl 3600"
 			);
 
-			expect(std.out).toContain(
-				'Issued a read token for repo "starter-repo" in namespace "default".'
-			);
-			expect(std.out).toContain("plaintext:");
-			expect(std.out).toContain("art_v1_token?expires=1760000000");
+			expect(std.out).toMatchInlineSnapshot(`
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				Issued a read token for repo "starter-repo" in namespace "default".
+				id:          tok_123
+				scope:       read
+				expires_at:  2026-04-24T10:00:00.000Z
+				plaintext:   art_v1_token?expires=1760000000"
+			`);
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/artifacts.test.ts
+++ b/packages/wrangler/src/__tests__/artifacts.test.ts
@@ -41,43 +41,8 @@ describe("artifacts", () => {
 
 			expect(std.err).toBe("");
 			expect(std.out).toContain("wrangler artifacts namespaces");
-			expect(std.out).toContain("create");
 			expect(std.out).toContain("list");
 			expect(std.out).toContain("get");
-			expect(std.out).toContain("delete");
-		});
-
-		it("should create a namespace with JSON output", async ({ expect }) => {
-			let requestBody: unknown;
-
-			msw.use(
-				http.post(
-					"*/accounts/:accountId/artifacts/namespaces",
-					async ({ params, request }) => {
-						requestBody = await request.json();
-						expect(params.accountId).toBe("some-account-id");
-						return HttpResponse.json(
-							createFetchResult({
-								id: "ns_123",
-								name: "sandbox",
-								created_at: "2026-04-23T12:00:00.000Z",
-								updated_at: "2026-04-23T12:00:00.000Z",
-							})
-						);
-					}
-				)
-			);
-
-			await runWrangler("artifacts namespaces create sandbox --json");
-
-			expect(requestBody).toEqual({ name: "sandbox" });
-			expect(std.err).toBe("");
-			expect(JSON.parse(std.out)).toEqual({
-				id: "ns_123",
-				name: "sandbox",
-				created_at: "2026-04-23T12:00:00.000Z",
-				updated_at: "2026-04-23T12:00:00.000Z",
-			});
 		});
 
 		it("should list namespaces in human mode", async ({ expect }) => {
@@ -87,12 +52,14 @@ describe("artifacts", () => {
 					return HttpResponse.json(
 						createFetchResult([
 							{
-								name: "default",
+								namespace: "default",
+								repo_count: 3,
 								created_at: "2026-04-20T10:00:00.000Z",
 								updated_at: "2026-04-20T10:00:00.000Z",
 							},
 							{
-								name: "sandbox",
+								namespace: "sandbox",
+								repo_count: 1,
 								created_at: "2026-04-21T10:00:00.000Z",
 								updated_at: "2026-04-22T10:00:00.000Z",
 							},
@@ -108,13 +75,13 @@ describe("artifacts", () => {
 				"
 				 ⛅️ wrangler x.x.x
 				──────────────────
-				┌─┬─┬─┐
-				│ name │ created_at │ updated_at │
-				├─┼─┼─┤
-				│ default │ 2026-04-20T10:00:00.000Z │ 2026-04-20T10:00:00.000Z │
-				├─┼─┼─┤
-				│ sandbox │ 2026-04-21T10:00:00.000Z │ 2026-04-22T10:00:00.000Z │
-				└─┴─┴─┘"
+				┌─┬─┬─┬─┐
+				│ namespace │ repo_count │ created_at │ updated_at │
+				├─┼─┼─┼─┤
+				│ default │ 3 │ 2026-04-20T10:00:00.000Z │ 2026-04-20T10:00:00.000Z │
+				├─┼─┼─┼─┤
+				│ sandbox │ 1 │ 2026-04-21T10:00:00.000Z │ 2026-04-22T10:00:00.000Z │
+				└─┴─┴─┴─┘"
 			`);
 		});
 
@@ -127,8 +94,8 @@ describe("artifacts", () => {
 						expect(params.namespace).toBe("default");
 						return HttpResponse.json(
 							createFetchResult({
-								id: "ns_default",
-								name: "default",
+								namespace: "default",
+								repo_count: 3,
 								created_at: "2026-04-20T10:00:00.000Z",
 								updated_at: "2026-04-22T10:00:00.000Z",
 							})
@@ -140,61 +107,15 @@ describe("artifacts", () => {
 			await runWrangler("artifacts namespaces get default");
 
 			expect(std.err).toBe("");
-			expect(std.out).toContain("ns_default");
 			expect(std.out).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
 				──────────────────
-				name:        default
-				id:          ns_default
+				namespace:   default
+				repo_count:  3
 				created_at:  2026-04-20T10:00:00.000Z
 				updated_at:  2026-04-22T10:00:00.000Z"
 			`);
-		});
-
-		it("should delete a namespace with JSON output", async ({ expect }) => {
-			msw.use(
-				http.delete(
-					"*/accounts/:accountId/artifacts/namespaces/:namespace",
-					({ params }) => {
-						expect(params.accountId).toBe("some-account-id");
-						expect(params.namespace).toBe("default");
-						return HttpResponse.json(createFetchResult({ id: "ns_default" }));
-					}
-				)
-			);
-
-			await runWrangler("artifacts namespaces delete default --force --json");
-
-			expect(std.err).toBe("");
-			expect(JSON.parse(std.out)).toEqual({ deleted: true, name: "default" });
-		});
-
-		it("should cancel namespace deletion when not confirmed", async ({
-			expect,
-		}) => {
-			let requestReceived = false;
-
-			mockConfirm({
-				text: 'Are you sure you want to delete Artifacts namespace "default"? This action cannot be undone.',
-				options: { defaultValue: true },
-				result: false,
-			});
-
-			msw.use(
-				http.delete(
-					"*/accounts/:accountId/artifacts/namespaces/:namespace",
-					() => {
-						requestReceived = true;
-						return HttpResponse.json(createFetchResult({ id: "ns_default" }));
-					}
-				)
-			);
-
-			await runWrangler("artifacts namespaces delete default");
-
-			expect(std.out).toContain("Deletion cancelled.");
-			expect(requestReceived).toBe(false);
 		});
 	});
 

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -72,7 +72,7 @@ describe("wrangler", () => {
 				  wrangler workflows              🔁 Manage Workflows
 
 				STORAGE & DATABASES
-				  wrangler artifacts              🧱 Manage Artifacts namespaces and repos [open beta]
+				  wrangler artifacts              🧱 Manage Artifacts namespaces and repos [private beta]
 				  wrangler d1                     🗄️ Manage Workers D1 databases
 				  wrangler hyperdrive             🚀 Manage Hyperdrive databases
 				  wrangler kv                     🗂️ Manage Workers KV Namespaces
@@ -150,7 +150,7 @@ describe("wrangler", () => {
 				  wrangler workflows              🔁 Manage Workflows
 
 				STORAGE & DATABASES
-				  wrangler artifacts              🧱 Manage Artifacts namespaces and repos [open beta]
+				  wrangler artifacts              🧱 Manage Artifacts namespaces and repos [private beta]
 				  wrangler d1                     🗄️ Manage Workers D1 databases
 				  wrangler hyperdrive             🚀 Manage Hyperdrive databases
 				  wrangler kv                     🗂️ Manage Workers KV Namespaces

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -72,6 +72,7 @@ describe("wrangler", () => {
 				  wrangler workflows              🔁 Manage Workflows
 
 				STORAGE & DATABASES
+				  wrangler artifacts              🧱 Manage Artifacts namespaces and repos [open beta]
 				  wrangler d1                     🗄️ Manage Workers D1 databases
 				  wrangler hyperdrive             🚀 Manage Hyperdrive databases
 				  wrangler kv                     🗂️ Manage Workers KV Namespaces
@@ -149,6 +150,7 @@ describe("wrangler", () => {
 				  wrangler workflows              🔁 Manage Workflows
 
 				STORAGE & DATABASES
+				  wrangler artifacts              🧱 Manage Artifacts namespaces and repos [open beta]
 				  wrangler d1                     🗄️ Manage Workers D1 databases
 				  wrangler hyperdrive             🚀 Manage Hyperdrive databases
 				  wrangler kv                     🗂️ Manage Workers KV Namespaces

--- a/packages/wrangler/src/artifacts/client.ts
+++ b/packages/wrangler/src/artifacts/client.ts
@@ -1,0 +1,149 @@
+import { fetchListResult, fetchResult } from "../cfetch";
+import { requireAuth } from "../user";
+import type {
+	ArtifactsCreateRepoRequest,
+	ArtifactsCreateRepoResult,
+	ArtifactsIssueTokenRequest,
+	ArtifactsIssueTokenResult,
+	ArtifactsNamespace,
+	ArtifactsRepo,
+} from "./types";
+import type { Config } from "@cloudflare/workers-utils";
+
+function getArtifactsNamespacesPath(accountId: string): string {
+	return `/accounts/${accountId}/artifacts/namespaces`;
+}
+
+function getArtifactsNamespacePath(
+	accountId: string,
+	namespace: string
+): string {
+	return `${getArtifactsNamespacesPath(accountId)}/${encodeURIComponent(namespace)}`;
+}
+
+function getArtifactsReposPath(accountId: string, namespace: string): string {
+	return `${getArtifactsNamespacePath(accountId, namespace)}/repos`;
+}
+
+function getArtifactsRepoPath(
+	accountId: string,
+	namespace: string,
+	name: string
+): string {
+	return `${getArtifactsReposPath(accountId, namespace)}/${encodeURIComponent(name)}`;
+}
+
+export async function createNamespace(
+	config: Config,
+	name: string
+): Promise<ArtifactsNamespace> {
+	const accountId = await requireAuth(config);
+	return await fetchResult(config, getArtifactsNamespacesPath(accountId), {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ name }),
+	});
+}
+
+export async function listNamespaces(
+	config: Config
+): Promise<ArtifactsNamespace[]> {
+	const accountId = await requireAuth(config);
+	return await fetchListResult(config, getArtifactsNamespacesPath(accountId), {
+		method: "GET",
+	});
+}
+
+export async function getNamespace(
+	config: Config,
+	name: string
+): Promise<ArtifactsNamespace> {
+	const accountId = await requireAuth(config);
+	return await fetchResult(config, getArtifactsNamespacePath(accountId, name), {
+		method: "GET",
+	});
+}
+
+export async function deleteNamespace(
+	config: Config,
+	name: string
+): Promise<void> {
+	const accountId = await requireAuth(config);
+	await fetchResult(config, getArtifactsNamespacePath(accountId, name), {
+		method: "DELETE",
+	});
+}
+
+export async function createRepo(
+	config: Config,
+	namespace: string,
+	body: ArtifactsCreateRepoRequest
+): Promise<ArtifactsCreateRepoResult> {
+	const accountId = await requireAuth(config);
+	return await fetchResult(
+		config,
+		getArtifactsReposPath(accountId, namespace),
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		}
+	);
+}
+
+export async function listRepos(
+	config: Config,
+	namespace: string
+): Promise<ArtifactsRepo[]> {
+	const accountId = await requireAuth(config);
+	return await fetchListResult(
+		config,
+		getArtifactsReposPath(accountId, namespace),
+		{
+			method: "GET",
+		}
+	);
+}
+
+export async function getRepo(
+	config: Config,
+	namespace: string,
+	name: string
+): Promise<ArtifactsRepo> {
+	const accountId = await requireAuth(config);
+	return await fetchResult(
+		config,
+		getArtifactsRepoPath(accountId, namespace, name),
+		{
+			method: "GET",
+		}
+	);
+}
+
+export async function deleteRepo(
+	config: Config,
+	namespace: string,
+	name: string
+): Promise<void> {
+	const accountId = await requireAuth(config);
+	await fetchResult(config, getArtifactsRepoPath(accountId, namespace, name), {
+		method: "DELETE",
+	});
+}
+
+export async function issueRepoToken(
+	config: Config,
+	namespace: string,
+	body: ArtifactsIssueTokenRequest
+): Promise<ArtifactsIssueTokenResult> {
+	const accountId = await requireAuth(config);
+	return await fetchResult(
+		config,
+		`${getArtifactsNamespacePath(accountId, namespace)}/tokens`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		}
+	);
+}

--- a/packages/wrangler/src/artifacts/client.ts
+++ b/packages/wrangler/src/artifacts/client.ts
@@ -37,9 +37,13 @@ export async function listNamespaces(
 	config: Config
 ): Promise<ArtifactsNamespace[]> {
 	const accountId = await requireAuth(config);
-	return await fetchPagedListResult(config, getArtifactsNamespacesPath(accountId), {
-		method: "GET",
-	});
+	return await fetchPagedListResult(
+		config,
+		getArtifactsNamespacesPath(accountId),
+		{
+			method: "GET",
+		}
+	);
 }
 
 export async function getNamespace(

--- a/packages/wrangler/src/artifacts/client.ts
+++ b/packages/wrangler/src/artifacts/client.ts
@@ -1,4 +1,4 @@
-import { fetchListResult, fetchResult } from "../cfetch";
+import { fetchPagedListResult, fetchResult } from "../cfetch";
 import { requireAuth } from "../user";
 import type {
 	ArtifactsCreateRepoRequest,
@@ -33,23 +33,11 @@ function getArtifactsRepoPath(
 	return `${getArtifactsReposPath(accountId, namespace)}/${encodeURIComponent(name)}`;
 }
 
-export async function createNamespace(
-	config: Config,
-	name: string
-): Promise<ArtifactsNamespace> {
-	const accountId = await requireAuth(config);
-	return await fetchResult(config, getArtifactsNamespacesPath(accountId), {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ name }),
-	});
-}
-
 export async function listNamespaces(
 	config: Config
 ): Promise<ArtifactsNamespace[]> {
 	const accountId = await requireAuth(config);
-	return await fetchListResult(config, getArtifactsNamespacesPath(accountId), {
+	return await fetchPagedListResult(config, getArtifactsNamespacesPath(accountId), {
 		method: "GET",
 	});
 }
@@ -61,16 +49,6 @@ export async function getNamespace(
 	const accountId = await requireAuth(config);
 	return await fetchResult(config, getArtifactsNamespacePath(accountId, name), {
 		method: "GET",
-	});
-}
-
-export async function deleteNamespace(
-	config: Config,
-	name: string
-): Promise<void> {
-	const accountId = await requireAuth(config);
-	await fetchResult(config, getArtifactsNamespacePath(accountId, name), {
-		method: "DELETE",
 	});
 }
 
@@ -96,7 +74,7 @@ export async function listRepos(
 	namespace: string
 ): Promise<ArtifactsRepo[]> {
 	const accountId = await requireAuth(config);
-	return await fetchListResult(
+	return await fetchPagedListResult(
 		config,
 		getArtifactsReposPath(accountId, namespace),
 		{

--- a/packages/wrangler/src/artifacts/index.ts
+++ b/packages/wrangler/src/artifacts/index.ts
@@ -1,0 +1,26 @@
+import { createNamespace } from "../core/create-command";
+
+export const artifactsNamespace = createNamespace({
+	metadata: {
+		description: "🧱 Manage Artifacts namespaces and repos",
+		status: "open beta",
+		owner: "Product: Artifacts",
+		category: "Storage & databases",
+	},
+});
+
+export {
+	artifactsNamespacesCreateCommand,
+	artifactsNamespacesDeleteCommand,
+	artifactsNamespacesGetCommand,
+	artifactsNamespacesListCommand,
+	artifactsNamespacesNamespace,
+} from "./namespaces";
+export {
+	artifactsReposCreateCommand,
+	artifactsReposDeleteCommand,
+	artifactsReposGetCommand,
+	artifactsReposIssueTokenCommand,
+	artifactsReposListCommand,
+	artifactsReposNamespace,
+} from "./repos";

--- a/packages/wrangler/src/artifacts/index.ts
+++ b/packages/wrangler/src/artifacts/index.ts
@@ -3,7 +3,7 @@ import { createNamespace } from "../core/create-command";
 export const artifactsNamespace = createNamespace({
 	metadata: {
 		description: "🧱 Manage Artifacts namespaces and repos",
-		status: "open beta",
+		status: "private beta",
 		owner: "Product: Artifacts",
 		category: "Storage & databases",
 	},

--- a/packages/wrangler/src/artifacts/index.ts
+++ b/packages/wrangler/src/artifacts/index.ts
@@ -10,8 +10,6 @@ export const artifactsNamespace = createNamespace({
 });
 
 export {
-	artifactsNamespacesCreateCommand,
-	artifactsNamespacesDeleteCommand,
 	artifactsNamespacesGetCommand,
 	artifactsNamespacesListCommand,
 	artifactsNamespacesNamespace,

--- a/packages/wrangler/src/artifacts/namespaces.ts
+++ b/packages/wrangler/src/artifacts/namespaces.ts
@@ -1,0 +1,173 @@
+import { createCommand, createNamespace } from "../core/create-command";
+import { logger } from "../logger";
+import formatLabelledValues from "../utils/render-labelled-values";
+import {
+	createNamespace as createArtifactsNamespace,
+	deleteNamespace,
+	getNamespace,
+	listNamespaces,
+} from "./client";
+import type { ArtifactsNamespace } from "./types";
+
+export const artifactsNamespacesNamespace = createNamespace({
+	metadata: {
+		description: "Manage Artifacts namespaces",
+		status: "open beta",
+		owner: "Product: Artifacts",
+	},
+});
+
+function formatNamespaceDetails(
+	namespace: ArtifactsNamespace
+): Record<string, string> {
+	return Object.fromEntries(
+		[
+			["name", namespace.name],
+			namespace.id ? ["id", namespace.id] : undefined,
+			namespace.created_at ? ["created_at", namespace.created_at] : undefined,
+			namespace.updated_at ? ["updated_at", namespace.updated_at] : undefined,
+		].filter((entry): entry is [string, string] => entry !== undefined)
+	);
+}
+
+export const artifactsNamespacesCreateCommand = createCommand({
+	metadata: {
+		description: "Create an Artifacts namespace",
+		status: "open beta",
+		owner: "Product: Artifacts",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	positionalArgs: ["name"],
+	args: {
+		name: {
+			type: "string",
+			demandOption: true,
+			description: "The Artifacts namespace name",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	async handler({ name, json }, { config }) {
+		const namespace = await createArtifactsNamespace(config, name);
+
+		if (json) {
+			logger.json(namespace);
+			return;
+		}
+
+		logger.log(`Created Artifacts namespace "${namespace.name}".`);
+		logger.log(formatLabelledValues(formatNamespaceDetails(namespace)));
+	},
+});
+
+export const artifactsNamespacesListCommand = createCommand({
+	metadata: {
+		description: "List Artifacts namespaces",
+		status: "open beta",
+		owner: "Product: Artifacts",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	async handler({ json }, { config }) {
+		const namespaces = await listNamespaces(config);
+
+		if (json) {
+			logger.json(namespaces);
+			return;
+		}
+
+		if (namespaces.length === 0) {
+			logger.log("No Artifacts namespaces found.");
+			return;
+		}
+
+		logger.table(
+			namespaces.map((namespace) => ({
+				name: namespace.name,
+				created_at: namespace.created_at ?? "",
+				updated_at: namespace.updated_at ?? "",
+			}))
+		);
+	},
+});
+
+export const artifactsNamespacesGetCommand = createCommand({
+	metadata: {
+		description: "Get an Artifacts namespace",
+		status: "open beta",
+		owner: "Product: Artifacts",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	positionalArgs: ["name"],
+	args: {
+		name: {
+			type: "string",
+			demandOption: true,
+			description: "The Artifacts namespace name",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	async handler({ name, json }, { config }) {
+		const namespace = await getNamespace(config, name);
+
+		if (json) {
+			logger.json(namespace);
+			return;
+		}
+
+		logger.log(formatLabelledValues(formatNamespaceDetails(namespace)));
+	},
+});
+
+export const artifactsNamespacesDeleteCommand = createCommand({
+	metadata: {
+		description: "Delete an Artifacts namespace",
+		status: "open beta",
+		owner: "Product: Artifacts",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	positionalArgs: ["name"],
+	args: {
+		name: {
+			type: "string",
+			demandOption: true,
+			description: "The Artifacts namespace name",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as JSON",
+		},
+	},
+	async handler({ name, json }, { config }) {
+		await deleteNamespace(config, name);
+
+		if (json) {
+			logger.json({ deleted: true, name });
+			return;
+		}
+
+		logger.log(`Deleted Artifacts namespace "${name}".`);
+	},
+});

--- a/packages/wrangler/src/artifacts/namespaces.ts
+++ b/packages/wrangler/src/artifacts/namespaces.ts
@@ -13,7 +13,7 @@ import type { ArtifactsNamespace } from "./types";
 export const artifactsNamespacesNamespace = createNamespace({
 	metadata: {
 		description: "Manage Artifacts namespaces",
-		status: "open beta",
+		status: "private beta",
 		owner: "Product: Artifacts",
 	},
 });
@@ -34,7 +34,7 @@ function formatNamespaceDetails(
 export const artifactsNamespacesCreateCommand = createCommand({
 	metadata: {
 		description: "Create an Artifacts namespace",
-		status: "open beta",
+		status: "private beta",
 		owner: "Product: Artifacts",
 	},
 	behaviour: {
@@ -69,7 +69,7 @@ export const artifactsNamespacesCreateCommand = createCommand({
 export const artifactsNamespacesListCommand = createCommand({
 	metadata: {
 		description: "List Artifacts namespaces",
-		status: "open beta",
+		status: "private beta",
 		owner: "Product: Artifacts",
 	},
 	behaviour: {
@@ -108,7 +108,7 @@ export const artifactsNamespacesListCommand = createCommand({
 export const artifactsNamespacesGetCommand = createCommand({
 	metadata: {
 		description: "Get an Artifacts namespace",
-		status: "open beta",
+		status: "private beta",
 		owner: "Product: Artifacts",
 	},
 	behaviour: {
@@ -142,7 +142,7 @@ export const artifactsNamespacesGetCommand = createCommand({
 export const artifactsNamespacesDeleteCommand = createCommand({
 	metadata: {
 		description: "Delete an Artifacts namespace",
-		status: "open beta",
+		status: "private beta",
 		owner: "Product: Artifacts",
 	},
 	behaviour: {

--- a/packages/wrangler/src/artifacts/namespaces.ts
+++ b/packages/wrangler/src/artifacts/namespaces.ts
@@ -10,6 +10,25 @@ import {
 } from "./client";
 import type { ArtifactsNamespace } from "./types";
 
+const namespaceNameArg = {
+	type: "string",
+	demandOption: true,
+	description: "The Artifacts namespace name",
+} as const;
+
+const jsonArg = {
+	type: "boolean",
+	default: false,
+	description: "Return output as JSON",
+} as const;
+
+const forceArg = {
+	type: "boolean",
+	alias: "y",
+	default: false,
+	description: "Skip confirmation",
+} as const;
+
 export const artifactsNamespacesNamespace = createNamespace({
 	metadata: {
 		description: "Manage Artifacts namespaces",
@@ -21,13 +40,19 @@ export const artifactsNamespacesNamespace = createNamespace({
 function formatNamespaceDetails(
 	namespace: ArtifactsNamespace
 ): Record<string, string> {
+	return formatDefinedValues([
+		["name", namespace.name],
+		["id", namespace.id],
+		["created_at", namespace.created_at],
+		["updated_at", namespace.updated_at],
+	]);
+}
+
+function formatDefinedValues(
+	values: [string, string | undefined][]
+): Record<string, string> {
 	return Object.fromEntries(
-		[
-			["name", namespace.name],
-			namespace.id ? ["id", namespace.id] : undefined,
-			namespace.created_at ? ["created_at", namespace.created_at] : undefined,
-			namespace.updated_at ? ["updated_at", namespace.updated_at] : undefined,
-		].filter((entry): entry is [string, string] => entry !== undefined)
+		values.filter((entry): entry is [string, string] => entry[1] !== undefined)
 	);
 }
 
@@ -42,16 +67,8 @@ export const artifactsNamespacesCreateCommand = createCommand({
 	},
 	positionalArgs: ["name"],
 	args: {
-		name: {
-			type: "string",
-			demandOption: true,
-			description: "The Artifacts namespace name",
-		},
-		json: {
-			type: "boolean",
-			default: false,
-			description: "Return output as JSON",
-		},
+		name: namespaceNameArg,
+		json: jsonArg,
 	},
 	async handler({ name, json }, { config }) {
 		const namespace = await createArtifactsNamespace(config, name);
@@ -76,11 +93,7 @@ export const artifactsNamespacesListCommand = createCommand({
 		printBanner: (args) => !args.json,
 	},
 	args: {
-		json: {
-			type: "boolean",
-			default: false,
-			description: "Return output as JSON",
-		},
+		json: jsonArg,
 	},
 	async handler({ json }, { config }) {
 		const namespaces = await listNamespaces(config);
@@ -116,16 +129,8 @@ export const artifactsNamespacesGetCommand = createCommand({
 	},
 	positionalArgs: ["name"],
 	args: {
-		name: {
-			type: "string",
-			demandOption: true,
-			description: "The Artifacts namespace name",
-		},
-		json: {
-			type: "boolean",
-			default: false,
-			description: "Return output as JSON",
-		},
+		name: namespaceNameArg,
+		json: jsonArg,
 	},
 	async handler({ name, json }, { config }) {
 		const namespace = await getNamespace(config, name);
@@ -150,22 +155,9 @@ export const artifactsNamespacesDeleteCommand = createCommand({
 	},
 	positionalArgs: ["name"],
 	args: {
-		name: {
-			type: "string",
-			demandOption: true,
-			description: "The Artifacts namespace name",
-		},
-		force: {
-			type: "boolean",
-			alias: "y",
-			default: false,
-			description: "Skip confirmation",
-		},
-		json: {
-			type: "boolean",
-			default: false,
-			description: "Return output as JSON",
-		},
+		name: namespaceNameArg,
+		force: forceArg,
+		json: jsonArg,
 	},
 	async handler({ name, force, json }, { config }) {
 		if (!force) {

--- a/packages/wrangler/src/artifacts/namespaces.ts
+++ b/packages/wrangler/src/artifacts/namespaces.ts
@@ -1,4 +1,5 @@
 import { createCommand, createNamespace } from "../core/create-command";
+import { confirm } from "../dialogs";
 import { logger } from "../logger";
 import formatLabelledValues from "../utils/render-labelled-values";
 import {
@@ -154,13 +155,30 @@ export const artifactsNamespacesDeleteCommand = createCommand({
 			demandOption: true,
 			description: "The Artifacts namespace name",
 		},
+		force: {
+			type: "boolean",
+			alias: "y",
+			default: false,
+			description: "Skip confirmation",
+		},
 		json: {
 			type: "boolean",
 			default: false,
 			description: "Return output as JSON",
 		},
 	},
-	async handler({ name, json }, { config }) {
+	async handler({ name, force, json }, { config }) {
+		if (!force) {
+			const confirmedDeletion = await confirm(
+				`Are you sure you want to delete Artifacts namespace "${name}"? This action cannot be undone.`,
+				{ fallbackValue: false }
+			);
+			if (!confirmedDeletion) {
+				logger.log("Deletion cancelled.");
+				return;
+			}
+		}
+
 		await deleteNamespace(config, name);
 
 		if (json) {

--- a/packages/wrangler/src/artifacts/namespaces.ts
+++ b/packages/wrangler/src/artifacts/namespaces.ts
@@ -1,13 +1,7 @@
 import { createCommand, createNamespace } from "../core/create-command";
-import { confirm } from "../dialogs";
 import { logger } from "../logger";
 import formatLabelledValues from "../utils/render-labelled-values";
-import {
-	createNamespace as createArtifactsNamespace,
-	deleteNamespace,
-	getNamespace,
-	listNamespaces,
-} from "./client";
+import { getNamespace, listNamespaces } from "./client";
 import type { ArtifactsNamespace } from "./types";
 
 const namespaceNameArg = {
@@ -22,13 +16,6 @@ const jsonArg = {
 	description: "Return output as JSON",
 } as const;
 
-const forceArg = {
-	type: "boolean",
-	alias: "y",
-	default: false,
-	description: "Skip confirmation",
-} as const;
-
 export const artifactsNamespacesNamespace = createNamespace({
 	metadata: {
 		description: "Manage Artifacts namespaces",
@@ -41,47 +28,24 @@ function formatNamespaceDetails(
 	namespace: ArtifactsNamespace
 ): Record<string, string> {
 	return formatDefinedValues([
-		["name", namespace.name],
-		["id", namespace.id],
+		["namespace", namespace.namespace],
+		["repo_count", namespace.repo_count],
 		["created_at", namespace.created_at],
 		["updated_at", namespace.updated_at],
 	]);
 }
 
 function formatDefinedValues(
-	values: [string, string | undefined][]
+	values: [string, string | number | undefined][]
 ): Record<string, string> {
 	return Object.fromEntries(
-		values.filter((entry): entry is [string, string] => entry[1] !== undefined)
+		values
+			.filter(
+				(entry): entry is [string, string | number] => entry[1] !== undefined
+			)
+			.map(([key, value]) => [key, String(value)])
 	);
 }
-
-export const artifactsNamespacesCreateCommand = createCommand({
-	metadata: {
-		description: "Create an Artifacts namespace",
-		status: "private beta",
-		owner: "Product: Artifacts",
-	},
-	behaviour: {
-		printBanner: (args) => !args.json,
-	},
-	positionalArgs: ["name"],
-	args: {
-		name: namespaceNameArg,
-		json: jsonArg,
-	},
-	async handler({ name, json }, { config }) {
-		const namespace = await createArtifactsNamespace(config, name);
-
-		if (json) {
-			logger.json(namespace);
-			return;
-		}
-
-		logger.log(`Created Artifacts namespace "${namespace.name}".`);
-		logger.log(formatLabelledValues(formatNamespaceDetails(namespace)));
-	},
-});
 
 export const artifactsNamespacesListCommand = createCommand({
 	metadata: {
@@ -110,9 +74,10 @@ export const artifactsNamespacesListCommand = createCommand({
 
 		logger.table(
 			namespaces.map((namespace) => ({
-				name: namespace.name,
-				created_at: namespace.created_at ?? "",
-				updated_at: namespace.updated_at ?? "",
+				namespace: namespace.namespace,
+				repo_count: String(namespace.repo_count),
+				created_at: namespace.created_at,
+				updated_at: namespace.updated_at,
 			}))
 		);
 	},
@@ -141,43 +106,5 @@ export const artifactsNamespacesGetCommand = createCommand({
 		}
 
 		logger.log(formatLabelledValues(formatNamespaceDetails(namespace)));
-	},
-});
-
-export const artifactsNamespacesDeleteCommand = createCommand({
-	metadata: {
-		description: "Delete an Artifacts namespace",
-		status: "private beta",
-		owner: "Product: Artifacts",
-	},
-	behaviour: {
-		printBanner: (args) => !args.json,
-	},
-	positionalArgs: ["name"],
-	args: {
-		name: namespaceNameArg,
-		force: forceArg,
-		json: jsonArg,
-	},
-	async handler({ name, force, json }, { config }) {
-		if (!force) {
-			const confirmedDeletion = await confirm(
-				`Are you sure you want to delete Artifacts namespace "${name}"? This action cannot be undone.`,
-				{ fallbackValue: false }
-			);
-			if (!confirmedDeletion) {
-				logger.log("Deletion cancelled.");
-				return;
-			}
-		}
-
-		await deleteNamespace(config, name);
-
-		if (json) {
-			logger.json({ deleted: true, name });
-			return;
-		}
-
-		logger.log(`Deleted Artifacts namespace "${name}".`);
 	},
 });

--- a/packages/wrangler/src/artifacts/repos.ts
+++ b/packages/wrangler/src/artifacts/repos.ts
@@ -29,6 +29,12 @@ const namespaceArg = {
 	description: "The Artifacts namespace name",
 } as const;
 
+const repoNameArg = {
+	type: "string",
+	demandOption: true,
+	description: "The Artifacts repository name",
+} as const;
+
 const forceArg = {
 	type: "boolean",
 	alias: "y",
@@ -45,42 +51,37 @@ export const artifactsReposNamespace = createNamespace({
 });
 
 function formatRepoDetails(repo: ArtifactsRepo): Record<string, string> {
-	return Object.fromEntries(
-		[
-			["id", repo.id],
-			["name", repo.name],
-			["description", repo.description ?? ""],
-			["default_branch", repo.default_branch],
-			["remote", repo.remote],
-			["read_only", String(repo.read_only)],
-			repo.status ? ["status", repo.status] : undefined,
-			["created_at", repo.created_at],
-			["updated_at", repo.updated_at],
-			["last_push_at", repo.last_push_at ?? ""],
-			["source", repo.source ?? ""],
-		].filter((entry): entry is [string, string] => entry !== undefined)
-	);
+	return formatDefinedValues([
+		["id", repo.id],
+		["name", repo.name],
+		["description", repo.description ?? ""],
+		["default_branch", repo.default_branch],
+		["remote", repo.remote],
+		["read_only", repo.read_only],
+		["status", repo.status],
+		["created_at", repo.created_at],
+		["updated_at", repo.updated_at],
+		["last_push_at", repo.last_push_at ?? ""],
+		["source", repo.source ?? ""],
+	]);
 }
 
 function formatCreateRepoDetails(
 	repo: ArtifactsCreateRepoResult,
 	readOnly: boolean | undefined
 ): Record<string, string> {
+	// The create response may omit read_only, so preserve the submitted flag for human output.
 	const resolvedReadOnly = repo.read_only ?? readOnly;
 
-	return Object.fromEntries(
-		[
-			["id", repo.id],
-			["name", repo.name],
-			["description", repo.description ?? ""],
-			["default_branch", repo.default_branch],
-			typeof resolvedReadOnly === "boolean"
-				? ["read_only", String(resolvedReadOnly)]
-				: undefined,
-			["remote", repo.remote],
-			["token", repo.token],
-		].filter((entry): entry is [string, string] => entry !== undefined)
-	);
+	return formatDefinedValues([
+		["id", repo.id],
+		["name", repo.name],
+		["description", repo.description ?? ""],
+		["default_branch", repo.default_branch],
+		["read_only", resolvedReadOnly],
+		["remote", repo.remote],
+		["token", repo.token],
+	]);
 }
 
 function formatIssuedTokenDetails(
@@ -94,6 +95,18 @@ function formatIssuedTokenDetails(
 	};
 }
 
+function formatDefinedValues(
+	values: [string, string | boolean | undefined][]
+): Record<string, string> {
+	return Object.fromEntries(
+		values
+			.filter(
+				(entry): entry is [string, string | boolean] => entry[1] !== undefined
+			)
+			.map(([key, value]) => [key, String(value)])
+	);
+}
+
 export const artifactsReposCreateCommand = createCommand({
 	metadata: {
 		description: "Create an Artifacts repository",
@@ -105,11 +118,7 @@ export const artifactsReposCreateCommand = createCommand({
 	},
 	positionalArgs: ["name"],
 	args: {
-		name: {
-			type: "string",
-			demandOption: true,
-			description: "The Artifacts repository name",
-		},
+		name: repoNameArg,
 		namespace: namespaceArg,
 		description: {
 			type: "string",
@@ -141,6 +150,7 @@ export const artifactsReposCreateCommand = createCommand({
 		logger.log(
 			`Created Artifacts repo "${repo.name}" in namespace "${args.namespace}".`
 		);
+		// Token-bearing output bypasses logger.log so plaintext tokens are not persisted to debug logs.
 		logger.console(
 			"log",
 			formatLabelledValues(formatCreateRepoDetails(repo, args.readOnly))
@@ -197,11 +207,7 @@ export const artifactsReposGetCommand = createCommand({
 	},
 	positionalArgs: ["name"],
 	args: {
-		name: {
-			type: "string",
-			demandOption: true,
-			description: "The Artifacts repository name",
-		},
+		name: repoNameArg,
 		namespace: namespaceArg,
 		json: jsonArg,
 	},
@@ -228,11 +234,7 @@ export const artifactsReposDeleteCommand = createCommand({
 	},
 	positionalArgs: ["name"],
 	args: {
-		name: {
-			type: "string",
-			demandOption: true,
-			description: "The Artifacts repository name",
-		},
+		name: repoNameArg,
 		namespace: namespaceArg,
 		force: forceArg,
 		json: jsonArg,
@@ -273,11 +275,7 @@ export const artifactsReposIssueTokenCommand = createCommand({
 	},
 	positionalArgs: ["repo"],
 	args: {
-		repo: {
-			type: "string",
-			demandOption: true,
-			description: "The Artifacts repository name",
-		},
+		repo: repoNameArg,
 		namespace: namespaceArg,
 		scope: {
 			type: "string",
@@ -313,6 +311,7 @@ export const artifactsReposIssueTokenCommand = createCommand({
 		logger.log(
 			`Issued a ${issuedToken.scope} token for repo "${repo}" in namespace "${namespace}".`
 		);
+		// Token-bearing output bypasses logger.log so plaintext tokens are not persisted to debug logs.
 		logger.console(
 			"log",
 			formatLabelledValues(formatIssuedTokenDetails(issuedToken))

--- a/packages/wrangler/src/artifacts/repos.ts
+++ b/packages/wrangler/src/artifacts/repos.ts
@@ -289,7 +289,9 @@ export const artifactsReposIssueTokenCommand = createCommand({
 			description: "The token TTL in seconds",
 			coerce: (value: number | undefined) => {
 				if (value !== undefined && value <= 0) {
-					throw new UserError("--ttl must be greater than 0");
+					throw new UserError("--ttl must be greater than 0", {
+						telemetryMessage: "artifacts repo token ttl invalid",
+					});
 				}
 				return value;
 			},

--- a/packages/wrangler/src/artifacts/repos.ts
+++ b/packages/wrangler/src/artifacts/repos.ts
@@ -1,5 +1,6 @@
 import { UserError } from "@cloudflare/workers-utils";
 import { createCommand, createNamespace } from "../core/create-command";
+import { confirm } from "../dialogs";
 import { logger } from "../logger";
 import formatLabelledValues from "../utils/render-labelled-values";
 import {
@@ -26,6 +27,13 @@ const namespaceArg = {
 	type: "string",
 	demandOption: true,
 	description: "The Artifacts namespace name",
+} as const;
+
+const forceArg = {
+	type: "boolean",
+	alias: "y",
+	default: false,
+	description: "Skip confirmation",
 } as const;
 
 export const artifactsReposNamespace = createNamespace({
@@ -226,9 +234,21 @@ export const artifactsReposDeleteCommand = createCommand({
 			description: "The Artifacts repository name",
 		},
 		namespace: namespaceArg,
+		force: forceArg,
 		json: jsonArg,
 	},
-	async handler({ name, namespace, json }, { config }) {
+	async handler({ name, namespace, force, json }, { config }) {
+		if (!force) {
+			const confirmedDeletion = await confirm(
+				`Are you sure you want to delete Artifacts repo "${name}" from namespace "${namespace}"? This action cannot be undone.`,
+				{ fallbackValue: false }
+			);
+			if (!confirmedDeletion) {
+				logger.log("Deletion cancelled.");
+				return;
+			}
+		}
+
 		await deleteRepo(config, namespace, name);
 
 		if (json) {

--- a/packages/wrangler/src/artifacts/repos.ts
+++ b/packages/wrangler/src/artifacts/repos.ts
@@ -1,4 +1,3 @@
-import { logRaw } from "@cloudflare/cli";
 import { UserError } from "@cloudflare/workers-utils";
 import { createCommand, createNamespace } from "../core/create-command";
 import { logger } from "../logger";
@@ -134,7 +133,10 @@ export const artifactsReposCreateCommand = createCommand({
 		logger.log(
 			`Created Artifacts repo "${repo.name}" in namespace "${args.namespace}".`
 		);
-		logRaw(formatLabelledValues(formatCreateRepoDetails(repo, args.readOnly)));
+		logger.console(
+			"log",
+			formatLabelledValues(formatCreateRepoDetails(repo, args.readOnly))
+		);
 	},
 });
 
@@ -289,6 +291,9 @@ export const artifactsReposIssueTokenCommand = createCommand({
 		logger.log(
 			`Issued a ${issuedToken.scope} token for repo "${repo}" in namespace "${namespace}".`
 		);
-		logRaw(formatLabelledValues(formatIssuedTokenDetails(issuedToken)));
+		logger.console(
+			"log",
+			formatLabelledValues(formatIssuedTokenDetails(issuedToken))
+		);
 	},
 });

--- a/packages/wrangler/src/artifacts/repos.ts
+++ b/packages/wrangler/src/artifacts/repos.ts
@@ -39,7 +39,7 @@ const forceArg = {
 export const artifactsReposNamespace = createNamespace({
 	metadata: {
 		description: "Manage Artifacts repositories",
-		status: "open beta",
+		status: "private beta",
 		owner: "Product: Artifacts",
 	},
 });
@@ -97,7 +97,7 @@ function formatIssuedTokenDetails(
 export const artifactsReposCreateCommand = createCommand({
 	metadata: {
 		description: "Create an Artifacts repository",
-		status: "open beta",
+		status: "private beta",
 		owner: "Product: Artifacts",
 	},
 	behaviour: {
@@ -151,7 +151,7 @@ export const artifactsReposCreateCommand = createCommand({
 export const artifactsReposListCommand = createCommand({
 	metadata: {
 		description: "List Artifacts repositories in a namespace",
-		status: "open beta",
+		status: "private beta",
 		owner: "Product: Artifacts",
 	},
 	behaviour: {
@@ -189,7 +189,7 @@ export const artifactsReposListCommand = createCommand({
 export const artifactsReposGetCommand = createCommand({
 	metadata: {
 		description: "Get an Artifacts repository",
-		status: "open beta",
+		status: "private beta",
 		owner: "Product: Artifacts",
 	},
 	behaviour: {
@@ -220,7 +220,7 @@ export const artifactsReposGetCommand = createCommand({
 export const artifactsReposDeleteCommand = createCommand({
 	metadata: {
 		description: "Delete an Artifacts repository",
-		status: "open beta",
+		status: "private beta",
 		owner: "Product: Artifacts",
 	},
 	behaviour: {
@@ -265,7 +265,7 @@ export const artifactsReposDeleteCommand = createCommand({
 export const artifactsReposIssueTokenCommand = createCommand({
 	metadata: {
 		description: "Issue a repo-scoped Artifacts token",
-		status: "open beta",
+		status: "private beta",
 		owner: "Product: Artifacts",
 	},
 	behaviour: {

--- a/packages/wrangler/src/artifacts/repos.ts
+++ b/packages/wrangler/src/artifacts/repos.ts
@@ -1,0 +1,294 @@
+import { logRaw } from "@cloudflare/cli";
+import { UserError } from "@cloudflare/workers-utils";
+import { createCommand, createNamespace } from "../core/create-command";
+import { logger } from "../logger";
+import formatLabelledValues from "../utils/render-labelled-values";
+import {
+	createRepo,
+	deleteRepo,
+	getRepo,
+	issueRepoToken,
+	listRepos,
+} from "./client";
+import type {
+	ArtifactsCreateRepoResult,
+	ArtifactsIssueTokenResult,
+	ArtifactsRepo,
+	ArtifactsTokenScope,
+} from "./types";
+
+const jsonArg = {
+	type: "boolean",
+	default: false,
+	description: "Return output as JSON",
+} as const;
+
+const namespaceArg = {
+	type: "string",
+	demandOption: true,
+	description: "The Artifacts namespace name",
+} as const;
+
+export const artifactsReposNamespace = createNamespace({
+	metadata: {
+		description: "Manage Artifacts repositories",
+		status: "open beta",
+		owner: "Product: Artifacts",
+	},
+});
+
+function formatRepoDetails(repo: ArtifactsRepo): Record<string, string> {
+	return Object.fromEntries(
+		[
+			["id", repo.id],
+			["name", repo.name],
+			["description", repo.description ?? ""],
+			["default_branch", repo.default_branch],
+			["remote", repo.remote],
+			["read_only", String(repo.read_only)],
+			repo.status ? ["status", repo.status] : undefined,
+			["created_at", repo.created_at],
+			["updated_at", repo.updated_at],
+			["last_push_at", repo.last_push_at ?? ""],
+			["source", repo.source ?? ""],
+		].filter((entry): entry is [string, string] => entry !== undefined)
+	);
+}
+
+function formatCreateRepoDetails(
+	repo: ArtifactsCreateRepoResult,
+	readOnly: boolean | undefined
+): Record<string, string> {
+	const resolvedReadOnly = repo.read_only ?? readOnly;
+
+	return Object.fromEntries(
+		[
+			["id", repo.id],
+			["name", repo.name],
+			["description", repo.description ?? ""],
+			["default_branch", repo.default_branch],
+			typeof resolvedReadOnly === "boolean"
+				? ["read_only", String(resolvedReadOnly)]
+				: undefined,
+			["remote", repo.remote],
+			["token", repo.token],
+		].filter((entry): entry is [string, string] => entry !== undefined)
+	);
+}
+
+function formatIssuedTokenDetails(
+	token: ArtifactsIssueTokenResult
+): Record<string, string> {
+	return {
+		id: token.id,
+		scope: token.scope,
+		expires_at: token.expires_at,
+		plaintext: token.plaintext,
+	};
+}
+
+export const artifactsReposCreateCommand = createCommand({
+	metadata: {
+		description: "Create an Artifacts repository",
+		status: "open beta",
+		owner: "Product: Artifacts",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	positionalArgs: ["name"],
+	args: {
+		name: {
+			type: "string",
+			demandOption: true,
+			description: "The Artifacts repository name",
+		},
+		namespace: namespaceArg,
+		description: {
+			type: "string",
+			description: "An optional description for the repository",
+		},
+		"default-branch": {
+			type: "string",
+			description: "The default branch for the repository",
+		},
+		"read-only": {
+			type: "boolean",
+			description: "Create the repository as read-only",
+		},
+		json: jsonArg,
+	},
+	async handler(args, { config }) {
+		const repo = await createRepo(config, args.namespace, {
+			name: args.name,
+			description: args.description,
+			default_branch: args.defaultBranch,
+			read_only: args.readOnly,
+		});
+
+		if (args.json) {
+			logger.json(repo);
+			return;
+		}
+
+		logger.log(
+			`Created Artifacts repo "${repo.name}" in namespace "${args.namespace}".`
+		);
+		logRaw(formatLabelledValues(formatCreateRepoDetails(repo, args.readOnly)));
+	},
+});
+
+export const artifactsReposListCommand = createCommand({
+	metadata: {
+		description: "List Artifacts repositories in a namespace",
+		status: "open beta",
+		owner: "Product: Artifacts",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		namespace: namespaceArg,
+		json: jsonArg,
+	},
+	async handler({ namespace, json }, { config }) {
+		const repos = await listRepos(config, namespace);
+
+		if (json) {
+			logger.json(repos);
+			return;
+		}
+
+		if (repos.length === 0) {
+			logger.log(`No Artifacts repos found in namespace "${namespace}".`);
+			return;
+		}
+
+		logger.table(
+			repos.map((repo) => ({
+				name: repo.name,
+				default_branch: repo.default_branch,
+				read_only: String(repo.read_only),
+				status: repo.status ?? "",
+				updated_at: repo.updated_at,
+			}))
+		);
+	},
+});
+
+export const artifactsReposGetCommand = createCommand({
+	metadata: {
+		description: "Get an Artifacts repository",
+		status: "open beta",
+		owner: "Product: Artifacts",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	positionalArgs: ["name"],
+	args: {
+		name: {
+			type: "string",
+			demandOption: true,
+			description: "The Artifacts repository name",
+		},
+		namespace: namespaceArg,
+		json: jsonArg,
+	},
+	async handler({ name, namespace, json }, { config }) {
+		const repo = await getRepo(config, namespace, name);
+
+		if (json) {
+			logger.json(repo);
+			return;
+		}
+
+		logger.log(formatLabelledValues(formatRepoDetails(repo)));
+	},
+});
+
+export const artifactsReposDeleteCommand = createCommand({
+	metadata: {
+		description: "Delete an Artifacts repository",
+		status: "open beta",
+		owner: "Product: Artifacts",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	positionalArgs: ["name"],
+	args: {
+		name: {
+			type: "string",
+			demandOption: true,
+			description: "The Artifacts repository name",
+		},
+		namespace: namespaceArg,
+		json: jsonArg,
+	},
+	async handler({ name, namespace, json }, { config }) {
+		await deleteRepo(config, namespace, name);
+
+		if (json) {
+			logger.json({ deleted: true, name, namespace });
+			return;
+		}
+
+		logger.log(
+			`Deleted Artifacts repo "${name}" from namespace "${namespace}".`
+		);
+	},
+});
+
+export const artifactsReposIssueTokenCommand = createCommand({
+	metadata: {
+		description: "Issue a repo-scoped Artifacts token",
+		status: "open beta",
+		owner: "Product: Artifacts",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	positionalArgs: ["repo"],
+	args: {
+		repo: {
+			type: "string",
+			demandOption: true,
+			description: "The Artifacts repository name",
+		},
+		namespace: namespaceArg,
+		scope: {
+			type: "string",
+			choices: ["read", "write"] as ArtifactsTokenScope[],
+			description: "The token scope",
+		},
+		ttl: {
+			type: "number",
+			description: "The token TTL in seconds",
+			coerce: (value: number | undefined) => {
+				if (value !== undefined && value <= 0) {
+					throw new UserError("--ttl must be greater than 0");
+				}
+				return value;
+			},
+		},
+		json: jsonArg,
+	},
+	async handler({ repo, namespace, scope, ttl, json }, { config }) {
+		const issuedToken = await issueRepoToken(config, namespace, {
+			repo,
+			scope,
+			ttl,
+		});
+
+		if (json) {
+			logger.json(issuedToken);
+			return;
+		}
+
+		logger.log(
+			`Issued a ${issuedToken.scope} token for repo "${repo}" in namespace "${namespace}".`
+		);
+		logRaw(formatLabelledValues(formatIssuedTokenDetails(issuedToken)));
+	},
+});

--- a/packages/wrangler/src/artifacts/types.ts
+++ b/packages/wrangler/src/artifacts/types.ts
@@ -1,0 +1,54 @@
+export type ArtifactsTokenScope = "read" | "write";
+
+export type ArtifactsRepoStatus = "ready" | "importing" | "forking";
+
+export interface ArtifactsNamespace {
+	id?: string;
+	name: string;
+	created_at?: string;
+	updated_at?: string;
+}
+
+export interface ArtifactsRepo {
+	id: string;
+	name: string;
+	description: string | null;
+	default_branch: string;
+	created_at: string;
+	updated_at: string;
+	last_push_at: string | null;
+	source: string | null;
+	read_only: boolean;
+	remote: string;
+	status?: ArtifactsRepoStatus;
+}
+
+export interface ArtifactsCreateRepoRequest {
+	name: string;
+	description?: string;
+	default_branch?: string;
+	read_only?: boolean;
+}
+
+export interface ArtifactsCreateRepoResult {
+	id: string;
+	name: string;
+	description: string | null;
+	default_branch: string;
+	remote: string;
+	token: string;
+	read_only?: boolean;
+}
+
+export interface ArtifactsIssueTokenRequest {
+	repo: string;
+	scope?: ArtifactsTokenScope;
+	ttl?: number;
+}
+
+export interface ArtifactsIssueTokenResult {
+	id: string;
+	plaintext: string;
+	scope: ArtifactsTokenScope;
+	expires_at: string;
+}

--- a/packages/wrangler/src/artifacts/types.ts
+++ b/packages/wrangler/src/artifacts/types.ts
@@ -3,10 +3,10 @@ export type ArtifactsTokenScope = "read" | "write";
 export type ArtifactsRepoStatus = "ready" | "importing" | "forking";
 
 export interface ArtifactsNamespace {
-	id?: string;
-	name: string;
-	created_at?: string;
-	updated_at?: string;
+	namespace: string;
+	repo_count: number;
+	created_at: string;
+	updated_at: string;
 }
 
 export interface ArtifactsRepo {

--- a/packages/wrangler/src/core/teams.d.ts
+++ b/packages/wrangler/src/core/teams.d.ts
@@ -24,4 +24,5 @@ export type Teams =
 	| "Product: WVPC"
 	| "Product: Tunnels"
 	| "Product: Email Service"
-	| "Product: Browser Run";
+	| "Product: Browser Run"
+	| "Product: Artifacts";

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -28,6 +28,20 @@ import { aiFineTuneCreateCommand } from "./ai/createFinetune";
 import { aiModelsCommand } from "./ai/listCatalog";
 import { aiFineTuneListCommand } from "./ai/listFinetune";
 import {
+	artifactsNamespace,
+	artifactsNamespacesCreateCommand,
+	artifactsNamespacesDeleteCommand,
+	artifactsNamespacesGetCommand,
+	artifactsNamespacesListCommand,
+	artifactsNamespacesNamespace,
+	artifactsReposCreateCommand,
+	artifactsReposDeleteCommand,
+	artifactsReposGetCommand,
+	artifactsReposIssueTokenCommand,
+	artifactsReposListCommand,
+	artifactsReposNamespace,
+} from "./artifacts";
+import {
 	browserCloseCommand,
 	browserCreateCommand,
 	browserListCommand,
@@ -963,6 +977,55 @@ export function createCLIParser(argv: string[]) {
 		{ command: "wrangler kv bulk delete", definition: kvBulkDeleteCommand },
 	]);
 	registry.registerNamespace("kv");
+
+	registry.define([
+		{ command: "wrangler artifacts", definition: artifactsNamespace },
+		{
+			command: "wrangler artifacts namespaces",
+			definition: artifactsNamespacesNamespace,
+		},
+		{
+			command: "wrangler artifacts namespaces create",
+			definition: artifactsNamespacesCreateCommand,
+		},
+		{
+			command: "wrangler artifacts namespaces list",
+			definition: artifactsNamespacesListCommand,
+		},
+		{
+			command: "wrangler artifacts namespaces get",
+			definition: artifactsNamespacesGetCommand,
+		},
+		{
+			command: "wrangler artifacts namespaces delete",
+			definition: artifactsNamespacesDeleteCommand,
+		},
+		{
+			command: "wrangler artifacts repos",
+			definition: artifactsReposNamespace,
+		},
+		{
+			command: "wrangler artifacts repos create",
+			definition: artifactsReposCreateCommand,
+		},
+		{
+			command: "wrangler artifacts repos list",
+			definition: artifactsReposListCommand,
+		},
+		{
+			command: "wrangler artifacts repos get",
+			definition: artifactsReposGetCommand,
+		},
+		{
+			command: "wrangler artifacts repos delete",
+			definition: artifactsReposDeleteCommand,
+		},
+		{
+			command: "wrangler artifacts repos issue-token",
+			definition: artifactsReposIssueTokenCommand,
+		},
+	]);
+	registry.registerNamespace("artifacts");
 
 	registry.define([
 		{ command: "wrangler queues", definition: queuesNamespace },

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -979,7 +979,10 @@ export function createCLIParser(argv: string[]) {
 	registry.registerNamespace("kv");
 
 	registry.define([
-		{ command: "wrangler artifacts", definition: artifactsNamespace },
+		{
+			command: "wrangler artifacts",
+			definition: artifactsNamespace,
+		},
 		{
 			command: "wrangler artifacts namespaces",
 			definition: artifactsNamespacesNamespace,

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -29,8 +29,6 @@ import { aiModelsCommand } from "./ai/listCatalog";
 import { aiFineTuneListCommand } from "./ai/listFinetune";
 import {
 	artifactsNamespace,
-	artifactsNamespacesCreateCommand,
-	artifactsNamespacesDeleteCommand,
 	artifactsNamespacesGetCommand,
 	artifactsNamespacesListCommand,
 	artifactsNamespacesNamespace,
@@ -988,20 +986,12 @@ export function createCLIParser(argv: string[]) {
 			definition: artifactsNamespacesNamespace,
 		},
 		{
-			command: "wrangler artifacts namespaces create",
-			definition: artifactsNamespacesCreateCommand,
-		},
-		{
 			command: "wrangler artifacts namespaces list",
 			definition: artifactsNamespacesListCommand,
 		},
 		{
 			command: "wrangler artifacts namespaces get",
 			definition: artifactsNamespacesGetCommand,
-		},
-		{
-			command: "wrangler artifacts namespaces delete",
-			definition: artifactsNamespacesDeleteCommand,
 		},
 		{
 			command: "wrangler artifacts repos",


### PR DESCRIPTION
Add `wrangler artifacts` commands for viewing Artifacts namespaces and managing repositories from Wrangler.

Wrangler already supports Artifacts bindings in config, but it did not expose the control-plane workflows from the Artifacts API. This adds the namespace and repo command surface under Storage & databases, keeps the repo commands scoped by `--namespace`, and avoids persisting issued credentials through Wrangler's debug logger in human mode.

- add `artifacts namespaces list|get`
- add `artifacts repos create|list|get|delete|issue-token`
- add targeted tests for help text, request payloads, JSON output, and secret-safe human output
- add a changeset for the new Wrangler CLI surface

```sh
wrangler artifacts namespaces list
wrangler artifacts namespaces get sandbox
wrangler artifacts repos create starter-repo --namespace sandbox
wrangler artifacts repos issue-token starter-repo --namespace sandbox --scope read
```

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/30183
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->