### PR TITLE
[miniflare] Fix flaky dev-registry prop forwarding tests

### DIFF
--- a/packages/miniflare/test/dev-registry.spec.ts
+++ b/packages/miniflare/test/dev-registry.spec.ts
@@ -394,8 +394,9 @@ describe.sequential("DevRegistry", () => {
 		await vi.waitFor(
 			async () => {
 				const res = await local.dispatchFetch("http://placeholder");
+				const json = await res.json();
 				expect(res.status).toBe(200);
-				expect(await res.json()).toEqual({
+				expect(json).toEqual({
 					foo: 123,
 					bar: { baz: "hello from props" },
 				});
@@ -1262,8 +1263,9 @@ describe.sequential("DevRegistry", () => {
 
 				// Read the captured ctx.props back via the remote's default fetch.
 				const res = await remote.dispatchFetch("http://placeholder");
+				const json = await res.json();
 				expect(res.status).toBe(200);
-				expect(await res.json()).toEqual({
+				expect(json).toEqual({
 					props: { tailKey: "from-tail-binding" },
 				});
 			},


### PR DESCRIPTION
Fixes flaky `dev-registry.spec.ts` tests added in #13649, seen failing in https://github.com/cloudflare/workerd/actions/runs/24897548221/job/72920052926?pr=6663.

### Root cause

The miniflare test suite runs with `MINIFLARE_ASSERT_BODIES_CONSUMED=true` (set in `packages/miniflare/vitest.config.mts`). Every `Miniflare#dispatchFetch()` call queues a `setImmediate` that throws an uncaught exception if the response body hasn't been consumed by the next tick (see `packages/miniflare/src/index.ts:2817-2834`).

The two new prop-forwarding tests were written like this:

```ts
await vi.waitFor(async () => {
  const res = await local.dispatchFetch("http://placeholder");
  expect(res.status).toBe(200);        // may throw
  expect(await res.json()).toEqual({ ... });
});
```

When the first `vi.waitFor` iteration returns a non-200 response — which is expected during the window before the dev-registry wires up the cross-instance connection, or before a tail event propagates within the remote worker's 2s internal timeout — the `toBe(200)` assertion throws before `res.json()` runs. `vi.waitFor` plans to retry, but the queued `setImmediate` fires first with `response.bodyUsed === false` and throws an uncaught exception that isn't catchable by `vi.waitFor`, failing the test.

Whether the first iteration is the lucky-fast one is timing-dependent, which is why the tests only fail sometimes (and more often on busy CI runners).

### Fix

Consume the body into a local binding before any intermediate assertion, so each `vi.waitFor` iteration consumes the body regardless of status:

```ts
const res = await local.dispatchFetch("http://placeholder");
const json = await res.json();
expect(res.status).toBe(200);
expect(json).toEqual({ ... });
```

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test-only change, no user-facing behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
