### PR TITLE
remove unnecessary lint disabling comments

### DIFF
--- a/packages/cli/__tests__/gitignore.test.ts
+++ b/packages/cli/__tests__/gitignore.test.ts
@@ -350,15 +350,11 @@ describe("maybeAppendWranglerToGitIgnore", () => {
 
 		appendFileSyncMock = vi.mocked(appendFileSync);
 
-		vi.mocked(statSync).mockImplementation(
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
-			(path: string) => ({
-				isDirectory() {
-					return path.endsWith(".git");
-				},
-			})
-		);
+		vi.mocked(statSync).mockImplementation(((path: string) => ({
+			isDirectory() {
+				return path.endsWith(".git");
+			},
+		})) as typeof statSync);
 	});
 
 	test("should not create the gitignore file if neither the .git directory not the .gitingore file exist", ({

--- a/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
+++ b/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
@@ -21,8 +21,7 @@ const workersDomain =
 	"devprod-testing7928.workers.dev";
 
 describe("Create Cloudflare CLI", () => {
-	// eslint-disable-next-line no-empty-pattern
-	beforeAll(({}, ctx) => {
+	beforeAll((_, ctx) => {
 		recreateLogFolder(ctx as RunnerTestSuite);
 	});
 

--- a/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
+++ b/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
@@ -21,7 +21,8 @@ const workersDomain =
 	"devprod-testing7928.workers.dev";
 
 describe("Create Cloudflare CLI", () => {
-	beforeAll((_, ctx) => {
+	// eslint-disable-next-line no-empty-pattern -- Vitest requires the 1st argument to use object destructuring
+	beforeAll(({}, ctx) => {
 		recreateLogFolder(ctx as RunnerTestSuite);
 	});
 

--- a/packages/create-cloudflare/e2e/tests/frameworks/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/frameworks.test.ts
@@ -32,7 +32,8 @@ const frameworkTests = getFrameworksTests();
 describe
 	.skipIf(frameworkTests.length === 0)
 	.concurrent(`E2E: Web frameworks`, () => {
-		beforeAll((_, ctx) => {
+		// eslint-disable-next-line no-empty-pattern -- Vitest 4 requires the 1st argument to use object destructuring
+		beforeAll(({}, ctx) => {
 			if (frameworkToTestFilter) {
 				debuglog("Running framework tests with filter:", frameworkToTestFilter);
 				frameworkTests.forEach((testConfig) => {

--- a/packages/create-cloudflare/e2e/tests/frameworks/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/frameworks.test.ts
@@ -32,8 +32,7 @@ const frameworkTests = getFrameworksTests();
 describe
 	.skipIf(frameworkTests.length === 0)
 	.concurrent(`E2E: Web frameworks`, () => {
-		// eslint-disable-next-line no-empty-pattern
-		beforeAll(({}, ctx) => {
+		beforeAll((_, ctx) => {
 			if (frameworkToTestFilter) {
 				debuglog("Running framework tests with filter:", frameworkToTestFilter);
 				frameworkTests.forEach((testConfig) => {

--- a/packages/create-cloudflare/e2e/tests/frameworks/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/frameworks.test.ts
@@ -32,7 +32,7 @@ const frameworkTests = getFrameworksTests();
 describe
 	.skipIf(frameworkTests.length === 0)
 	.concurrent(`E2E: Web frameworks`, () => {
-		// eslint-disable-next-line no-empty-pattern -- Vitest 4 requires the 1st argument to use object destructuring
+		// eslint-disable-next-line no-empty-pattern -- Vitest requires the 1st argument to use object destructuring
 		beforeAll(({}, ctx) => {
 			if (frameworkToTestFilter) {
 				debuglog("Running framework tests with filter:", frameworkToTestFilter);

--- a/packages/create-cloudflare/e2e/tests/workers/workers.test.ts
+++ b/packages/create-cloudflare/e2e/tests/workers/workers.test.ts
@@ -25,8 +25,7 @@ const workerTests = getWorkerTests();
 describe
 	.skipIf(workerTests.length === 0 || isWindows)
 	.concurrent(`E2E: Workers templates`, () => {
-		// eslint-disable-next-line no-empty-pattern
-		beforeAll(({}, ctx) => {
+		beforeAll((_, ctx) => {
 			recreateLogFolder(ctx as RunnerTestSuite);
 
 			if (workerTemplateToTest) {

--- a/packages/create-cloudflare/e2e/tests/workers/workers.test.ts
+++ b/packages/create-cloudflare/e2e/tests/workers/workers.test.ts
@@ -25,7 +25,8 @@ const workerTests = getWorkerTests();
 describe
 	.skipIf(workerTests.length === 0 || isWindows)
 	.concurrent(`E2E: Workers templates`, () => {
-		beforeAll((_, ctx) => {
+		// eslint-disable-next-line no-empty-pattern -- Vitest requires the 1st argument to use object destructuring
+		beforeAll(({}, ctx) => {
 			recreateLogFolder(ctx as RunnerTestSuite);
 
 			if (workerTemplateToTest) {

--- a/packages/pages-shared/asset-server/patchUrl.ts
+++ b/packages/pages-shared/asset-server/patchUrl.ts
@@ -1,6 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
-globalThis.URL = (function (globalURL) {
+(globalThis as unknown as Record<string, unknown>).URL = (function (globalURL) {
 	PatchedURL.prototype = globalURL.prototype;
 	PatchedURL.createObjectURL = globalURL.createObjectURL;
 	PatchedURL.revokeObjectURL = globalURL.revokeObjectURL;
@@ -12,8 +10,9 @@ globalThis.URL = (function (globalURL) {
 
 		return new Proxy(url, {
 			get(target, prop) {
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				return globalThis.decodeURIComponent((target as any)[prop]);
+				return globalThis.decodeURIComponent(
+					(target as unknown as Record<string | symbol, string>)[prop]
+				);
 			},
 		});
 	}

--- a/packages/pages-shared/asset-server/responses.ts
+++ b/packages/pages-shared/asset-server/responses.ts
@@ -138,8 +138,7 @@ export class NotAcceptableResponse extends Response {
 export class InternalServerErrorResponse extends Response {
 	constructor(err: Error, init?: ConstructorParameters<typeof Response>[1]) {
 		let body: string | undefined = undefined;
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		if ((globalThis as any).DEBUG) {
+		if ((globalThis as Record<string, unknown>).DEBUG) {
 			body = `${err.message}\n\n${err.stack}`;
 		}
 

--- a/packages/pages-shared/environment-polyfills/html-rewriter.ts
+++ b/packages/pages-shared/environment-polyfills/html-rewriter.ts
@@ -46,10 +46,7 @@ export class HTMLRewriter {
 				// will also synchronously compile a WebAssembly module, so delay doing
 				// this until we really need it.
 				// TODO: async compile the WebAssembly module
-				const {
-					HTMLRewriter: BaseHTMLRewriter,
-					// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-				}: typeof import("html-rewriter-wasm") =
+				const { HTMLRewriter: BaseHTMLRewriter } =
 					await import("html-rewriter-wasm");
 				rewriter = new BaseHTMLRewriter((output) => {
 					// enqueue will throw on empty chunks

--- a/packages/unenv-preset/src/runtime/node/console.ts
+++ b/packages/unenv-preset/src/runtime/node/console.ts
@@ -26,10 +26,9 @@ export {
 // This code relies on the that rollup/esbuild/webpack don't evaluate string concatenation
 // so they don't recognize the below as `globalThis.console` which they would try to rewrite
 // into unenv/node/console, thus creating a circular dependency, and breaking this polyfill.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const workerdConsole = (globalThis as any)[
-	"con" + "sole"
-] as typeof nodeConsole;
+const workerdConsole = (
+	globalThis as unknown as Record<string, typeof nodeConsole>
+)["con" + "sole"];
 
 // TODO: Ideally this list is not hardcoded but instead is generated when the preset is being generated in the `env()` call
 //       This generation should use information from https://github.com/cloudflare/workerd/issues/2097

--- a/packages/unenv-preset/src/runtime/node/process.ts
+++ b/packages/unenv-preset/src/runtime/node/process.ts
@@ -12,8 +12,9 @@ import { Process as UnenvProcess } from "unenv/node/internal/process/process";
 // This code relies on the that rollup/esbuild/webpack don't evaluate string concatenation
 // so they don't recognize the below as `globalThis.process` which they would try to rewrite
 // into unenv/node/process, thus creating a circular dependency, and breaking this polyfill.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const globalProcess: NodeJS.Process = (globalThis as any)["pro" + "cess"];
+const globalProcess = (globalThis as unknown as Record<string, NodeJS.Process>)[
+	"pro" + "cess"
+];
 
 export const getBuiltinModule: NodeJS.Process["getBuiltinModule"] =
 	globalProcess.getBuiltinModule;

--- a/packages/workers-playground/src/QuickEditor/WorkersLogo.tsx
+++ b/packages/workers-playground/src/QuickEditor/WorkersLogo.tsx
@@ -2,7 +2,6 @@
 // but I'm not aware why this was done in the first place, so leaving
 // the plain html attributes as is
 
-/* eslint-disable react/no-unknown-property */
 import { Div } from "@cloudflare/elements";
 import { createComponent } from "@cloudflare/style-container";
 

--- a/packages/wrangler/src/api/integrations/platform/caches.ts
+++ b/packages/wrangler/src/api/integrations/platform/caches.ts
@@ -1,5 +1,3 @@
-/* eslint-disable unused-imports/no-unused-vars */
-
 /**
  * Note about this file:
  *
@@ -42,7 +40,7 @@ export class CacheStorage {
 		});
 	}
 
-	async open(cacheName: string): Promise<Cache> {
+	async open(_cacheName: string): Promise<Cache> {
 		return new Cache();
 	}
 
@@ -65,20 +63,20 @@ type CacheResponse = any;
  */
 class Cache {
 	async delete(
-		request: CacheRequest,
-		options?: CacheQueryOptions
+		_request: CacheRequest,
+		_options?: CacheQueryOptions
 	): Promise<boolean> {
 		return false;
 	}
 
 	async match(
-		request: CacheRequest,
-		options?: CacheQueryOptions
+		_request: CacheRequest,
+		_options?: CacheQueryOptions
 	): Promise<CacheResponse | undefined> {
 		return undefined;
 	}
 
-	async put(request: CacheRequest, response: CacheResponse): Promise<void> {}
+	async put(_request: CacheRequest, _response: CacheResponse): Promise<void> {}
 }
 
 type CacheQueryOptions = {

--- a/packages/wrangler/src/cloudchamber/cli/deployments.ts
+++ b/packages/wrangler/src/cloudchamber/cli/deployments.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import { exit } from "node:process";
 import {
 	cancel,
@@ -160,8 +161,9 @@ export async function listDeploymentsAndChoose(
 		})),
 		label: "deployment",
 	});
-	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	return deployments.find((d) => d.id === deployment)!;
+	const chosenDeployment = deployments.find((d) => d.id === deployment);
+	assert(chosenDeployment);
+	return chosenDeployment;
 }
 
 export async function pickDeployment(deploymentIdPrefix?: string) {

--- a/packages/wrangler/src/cloudchamber/cli/locations.ts
+++ b/packages/wrangler/src/cloudchamber/cli/locations.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import { processArgument } from "@cloudflare/cli-shared-helpers/args";
 import { inputPrompt } from "@cloudflare/cli-shared-helpers/interactive";
 import { getLocations } from "../locations";
@@ -101,8 +102,9 @@ export async function getLocation(
 
 	const pops = locationToPops[location];
 	if (pops.length === 1) {
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		return pops.pop()!.location;
+		const pop = pops.pop();
+		assert(pop);
+		return pop.location;
 	}
 
 	const chosenPop = await inputPrompt({

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
@@ -242,8 +242,9 @@ function handleNodeJSGlobals(
 				module
 			);
 		}
-		// eslint-disable-next-line  @typescript-eslint/no-non-null-assertion
-		injectsByModule.get(module)!.push({ injectedName, exportName, importName });
+		const moduleInjects = injectsByModule.get(module);
+		assert(moduleInjects);
+		moduleInjects.push({ injectedName, exportName, importName });
 	}
 
 	build.initialOptions.inject = [

--- a/packages/wrangler/src/deployment-bundle/guess-worker-format.ts
+++ b/packages/wrangler/src/deployment-bundle/guess-worker-format.ts
@@ -35,8 +35,7 @@ export async function guessWorkerFormat(
 	});
 
 	// result.metafile is defined because of the `metafile: true` option above.
-	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	const metafile = result.metafile!;
+	const metafile = result.metafile;
 
 	const { exports } = getEntryPointFromMetafile(entryFile, metafile);
 	let guessedWorkerFormat: CfScriptFormat;

--- a/packages/wrangler/src/deployment-bundle/module-collection.ts
+++ b/packages/wrangler/src/deployment-bundle/module-collection.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import crypto from "node:crypto";
 import { readdirSync } from "node:fs";
 import { readFile } from "node:fs/promises";
@@ -210,9 +211,9 @@ export function createModuleCollector(props: {
 							// take the file and massage it to a
 							// transportable/manageable format
 							const cleanedPath = stripQueryString(args.path);
+							assert(props.wrangler1xLegacyModuleReferences);
 							const filePath = path.join(
-								// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-								props.wrangler1xLegacyModuleReferences!.rootDirectory,
+								props.wrangler1xLegacyModuleReferences.rootDirectory,
 								cleanedPath
 							);
 							const fileContent = (await readFile(

--- a/packages/wrangler/src/deployment-bundle/rules.ts
+++ b/packages/wrangler/src/deployment-bundle/rules.ts
@@ -73,8 +73,7 @@ export function parseRules(userRules: Rule[] = []): ParsedRules {
 		}
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	rulesToRemove.forEach((rule) => rules!.splice(rules!.indexOf(rule), 1));
+	rulesToRemove.forEach((rule) => rules.splice(rules.indexOf(rule), 1));
 
 	return { rules, removedRules: rulesToRemove };
 }

--- a/packages/wrangler/src/kv/index.ts
+++ b/packages/wrangler/src/kv/index.ts
@@ -470,10 +470,8 @@ export const kvKeyPutCommand = createCommand({
 			localMode
 		);
 		// One of `args.path` and `args.value` must be defined
-		const value = args.path
-			? readFileSyncToBuffer(args.path)
-			: // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				args.value!;
+		const value = args.path ? readFileSyncToBuffer(args.path) : args.value;
+		assert(value);
 
 		const metadataLog = metadata
 			? ` with metadata "${JSON.stringify(metadata)}"`

--- a/packages/wrangler/src/pages/deployment-tails.ts
+++ b/packages/wrangler/src/pages/deployment-tails.ts
@@ -27,11 +27,8 @@ import type { Deployment } from "@cloudflare/types";
 
 const statusChoices = ["ok", "error", "canceled"] as const;
 type StatusChoice = (typeof statusChoices)[number];
-const isStatusChoiceList = (
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	data?: any[]
-): data is StatusChoice[] =>
-	data?.every((d) => statusChoices.includes(d)) ?? false;
+const isStatusChoiceList = (data?: unknown[]): data is StatusChoice[] =>
+	data?.every((d) => statusChoices.includes(d as StatusChoice)) ?? false;
 
 export const pagesDeploymentTailCommand = createCommand({
 	metadata: {


### PR DESCRIPTION
This PR removes some eslint/oxlint disabling directives/comments that are either not necessary at all or easily avoidable

(Just some minor cleanup, I think these disabling directives should be avoided if possible)

Note: the `no-empty-pattern` ones can't actually be removed although it looks like they could be, so I added explanations to them

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: just some refactoring
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: just some refactoring

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
