### PR TITLE
wrangler types --check` fails with `Invalid value: true

### DIFF
--- a/.changeset/fix-types-check-boolean-flag.md
+++ b/.changeset/fix-types-check-boolean-flag.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+`wrangler types --check` no longer throws when the types file was generated with an explicit boolean flag. Previously, yargs would parse such flags as actual booleans rather than strings, causing an internal parse error.

--- a/packages/wrangler/e2e/types.test.ts
+++ b/packages/wrangler/e2e/types.test.ts
@@ -314,6 +314,20 @@ describe("types", () => {
 			expect(output.status).toBe(1);
 		});
 
+		it("should not error on `--check` when types generated with a boolean flag like `--strict-vars=false`", async ({
+			expect,
+		}) => {
+			// Regression test: yargs parses boolean flags (e.g. --strict-vars=false) as
+			// actual booleans, not strings. Previously, `unsafeParseBooleanString` would
+			// throw when given a boolean value, causing `--check` to fail.
+			await helper.run(`wrangler types --strict-vars=false`);
+
+			const output = await helper.run(`wrangler types --check`);
+			expect(output.stderr).toBeFalsy();
+			expect(output.stdout).toContain("up to date");
+			expect(output.status).toBe(0);
+		});
+
 		describe("--env-interface", () => {
 			it("should not error when --check uses same --env-interface as generation", async ({
 				expect,

--- a/packages/wrangler/e2e/types.test.ts
+++ b/packages/wrangler/e2e/types.test.ts
@@ -314,13 +314,13 @@ describe("types", () => {
 			expect(output.status).toBe(1);
 		});
 
-		it("should not error on `--check` when types generated with a boolean flag like `--strict-vars=false`", async ({
+		it("should not error on `--check` when types generated with a boolean flag like `--strict-vars`", async ({
 			expect,
 		}) => {
-			// Regression test: yargs parses boolean flags (e.g. --strict-vars=false) as
+			// Regression test: yargs parses boolean flags (e.g. --strict-vars) as
 			// actual booleans, not strings. Previously, `unsafeParseBooleanString` would
 			// throw when given a boolean value, causing `--check` to fail.
-			await helper.run(`wrangler types --strict-vars=false`);
+			await helper.run(`wrangler types --strict-vars`);
 
 			const output = await helper.run(`wrangler types --check`);
 			expect(output.stderr).toBeFalsy();

--- a/packages/wrangler/src/type-generation/helpers.ts
+++ b/packages/wrangler/src/type-generation/helpers.ts
@@ -117,6 +117,10 @@ export const getRuntimeHeader = (
  * @throws {ParseError} If the provided value cannot be parsed as a boolean.
  */
 const unsafeParseBooleanString = (value: unknown): boolean => {
+	if (typeof value === "boolean") {
+		return value;
+	}
+
 	if (typeof value !== "string") {
 		throw new ParseError({
 			text: `Invalid value: ${value}`,


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/13694

**Root cause**

`wrangler` 4.85.0 introduced a `--check` flag that reads back the command stored in the worker-configuration.d.ts header comment (e.g. `wrangler types --include-runtime --include-env --strict-vars`) and re-parses it with yargs to reconstruct the original arguments.

The problem: yargs parses `--include-runtime`, `--include-env`, and `--strict-vars` as native boolean `true`, but `unsafeParseBooleanString` — the internal helper used to interpret those values — only handles `string` inputs. Passing a boolean throws `ParseError: Invalid value: true`.

**Fix**

Add an early boolean passthrough in `unsafeParseBooleanString`:

```js
if (typeof value === "boolean") {
  return value;
}
```

This is a minimal, non-breaking fix that handles the case where yargs already coerced the flag value to a boolean, which is the correct yargs behavior for boolean flags.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: a boolean should be a boolean
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
