### PR TITLE
[vite-plugin] fix flaky abort signal E2E test

### DIFF
--- a/packages/vite-plugin-cloudflare/e2e/basic.test.ts
+++ b/packages/vite-plugin-cloudflare/e2e/basic.test.ts
@@ -35,16 +35,34 @@ describe("basic e2e tests", () => {
 					const proc = await runLongLived(pm, command, projectPath);
 					const url = await waitForReady(proc);
 
-					// Check that no request has been aborted yet
-					const response = await fetch(url + "/aborted");
-					await expect(response.text()).resolves.toEqual("Request not aborted");
+					// Check that no request has been aborted yet (use waitFor since the
+					// server may still be warming up after waitForReady resolves)
+					await vi.waitFor(
+						async () => {
+							const r = await fetch(url + "/aborted");
+							await expect(r.text()).resolves.toEqual("Request not aborted");
+						},
+						{ timeout: 10000 }
+					);
 
-					// Send a request that we will abort after 1 second
-					await Promise.allSettled([
-						fetch(url + "/wait", {
-							signal: AbortSignal.timeout(1000),
-						}),
-					]);
+					// Send a request to the /wait endpoint and wait for it to start streaming,
+					// which proves the Worker is processing and has registered the abort listener.
+					// Then abort the request — this eliminates the race condition where
+					// AbortSignal.timeout could fire before the Worker even received the request.
+					const controller = new AbortController();
+					const waitResponse = await fetch(url + "/wait", {
+						signal: controller.signal,
+					});
+
+					// Read at least one chunk to confirm the stream is active
+					const reader = waitResponse.body?.getReader();
+					if (!reader) {
+						expect.unreachable("Expected response body to be readable");
+					}
+					await reader.read();
+
+					// Now abort — the Worker has definitely registered its abort listener
+					controller.abort();
 
 					await vi.waitFor(
 						async () => {


### PR DESCRIPTION
The "can listen to abort signals on the request" test in the Vite Plugin E2E suite has been flaking consistently on Linux CI — it was the sole failure in nearly every recent Vite Plugin E2E run.

**Root cause:** `AbortSignal.timeout(1000)` starts a timer at signal creation time, not when the Worker receives the request. Under CI load, the request can take long enough to reach the Worker that either:
- The abort fires before the Worker even registers its abort listener
- The connection-close propagation through Vite middleware → miniflare → workerd is too slow for the abort event to fire within the poll window

**Fix:** Replace the timing-based `AbortSignal.timeout(1000)` + `Promise.allSettled` pattern with an explicit `AbortController`. The test now:
1. Sends a request to `/wait` with the controller's signal
2. Reads at least one chunk from the streaming response (proving the Worker is processing and has registered its abort listener)
3. Only then calls `controller.abort()`

This eliminates the race entirely — the abort is guaranteed to happen after the Worker is ready to handle it.

Also wraps the initial `/aborted` check in `vi.waitFor` for resilience against slow server warm-up.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Test-only change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
