### PR TITLE
Add require-description-when-disabling linting rule

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -48,6 +48,7 @@
 		"turbo/no-undeclared-env-vars": "error",
 		"workers-sdk/no-unsafe-command-execution": "error",
 		"workers-sdk/no-direct-recursive-rm": "error",
+		"workers-sdk/require-description-when-disabling": "error",
 
 		"no-unused-vars": [
 			"error",
@@ -195,6 +196,27 @@
 			"files": ["packages/vite-plugin-cloudflare/**"],
 			"rules": {
 				"workers-sdk/no-wrangler-named-imports": "error",
+			},
+		},
+		// Gradually rolling out require-description-when-disabling.
+		// TODO: Remove the following overrides.
+		{
+			"files": [
+				"packages/create-cloudflare/**",
+				"packages/local-explorer-ui/**",
+				"packages/miniflare/**",
+				"packages/playground-preview-worker/**",
+				"packages/quick-edit-extension/**",
+				"packages/vite-plugin-cloudflare/**",
+				"packages/vitest-pool-workers/**",
+				"packages/workers-editor-shared/**",
+				"packages/workers-shared/**",
+				"packages/workers-utils/**",
+				"packages/workflows-shared/**",
+				"packages/wrangler/**",
+			],
+			"rules": {
+				"workers-sdk/require-description-when-disabling": "off",
 			},
 		},
 	],

--- a/packages/cli/check-macos-version.ts
+++ b/packages/cli/check-macos-version.ts
@@ -35,7 +35,8 @@ export function checkMacOSVersion(options: { shouldThrow: boolean }): void {
 					`If you cannot upgrade your version of macOS, you could try running in a DevContainer setup with a supported version of Linux (glibc 2.35+ required).`
 			);
 		} else {
-			// eslint-disable-next-line no-console
+			/* eslint-disable-next-line no-console -- this package has no logger to use
+			   (TODO: disable the `no-console` rule on packages that do not use a logger) */
 			console.warn(
 				`⚠️  Warning: Unsupported macOS version detected (${macOSVersion}). ` +
 					`The Cloudflare Workers runtime may not work correctly on macOS versions below ${MINIMUM_MACOS_VERSION}. ` +

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -246,7 +246,7 @@ export const stripAnsi = (str: string) => {
 // Regular Expression that matches a hyperlink
 // e.g. `\u001B]8;;http://example.com/\u001B\\This is a link\u001B]8;;\u001B\`
 export const linkRegex =
-	// eslint-disable-next-line no-control-regex
+	// eslint-disable-next-line no-control-regex -- regex intentionally matches ANSI escape sequences for hyperlink parsing
 	/\u001B\]8;;(?<url>.+)\u001B\\(?<label>.+)\u001B\]8;;\u001B\\/g;
 
 // Create a hyperlink in terminal

--- a/packages/lint-config-shared/oxlint-plugin.mjs
+++ b/packages/lint-config-shared/oxlint-plugin.mjs
@@ -1,11 +1,13 @@
 import noDirectRecursiveRm from "./rules/no-direct-recursive-rm.mjs";
 import noUnsafeCommandExecution from "./rules/no-unsafe-command-execution.mjs";
 import noWranglerNamedImports from "./rules/no-wrangler-named-imports.mjs";
+import requireDescriptionWhenDisabling from "./rules/require-description-when-disabling.mjs";
 
 export default {
 	rules: {
 		"no-direct-recursive-rm": noDirectRecursiveRm,
 		"no-unsafe-command-execution": noUnsafeCommandExecution,
 		"no-wrangler-named-imports": noWranglerNamedImports,
+		"require-description-when-disabling": requireDescriptionWhenDisabling,
 	},
 };

--- a/packages/lint-config-shared/rules/require-description-when-disabling.mjs
+++ b/packages/lint-config-shared/rules/require-description-when-disabling.mjs
@@ -1,0 +1,83 @@
+/**
+ * Directive prefixes recognised by both ESLint and oxlint.
+ *
+ * Each prefix may optionally be followed by rule names and must contain a
+ * description separated by ` -- ` to pass this rule.
+ *
+ * Covers:
+ *   eslint-disable / eslint-disable-next-line
+ *   oxlint-disable / oxlint-disable-next-line
+ *
+ * Note: eslint-enable / oxlint-enable are intentionally excluded — they
+ * re-enable rules rather than suppress them, so a justification is not needed.
+ */
+const DIRECTIVE_PATTERN =
+	/^\s*(?:eslint-disable(?:-next-line)?|oxlint-disable(?:-next-line)?)\b/;
+
+/**
+ * A description is everything after the first ` -- ` separator. It must
+ * contain at least one non-whitespace character to count.
+ */
+function hasDescription(text) {
+	const separatorIndex = text.indexOf("--");
+	if (separatorIndex === -1) {
+		return false;
+	}
+	const description = text.slice(separatorIndex + 2);
+	return description.trim().length > 0;
+}
+
+/**
+ * Extract a human-friendly directive name from the comment text so the
+ * error message is useful.  e.g. "eslint-disable-next-line"
+ */
+function getDirectiveName(text) {
+	const match = text.match(/\b((?:eslint|oxlint)-disable(?:-next-line)?)\b/);
+	return match ? match[1] : "disable directive";
+}
+
+export default {
+	meta: {
+		type: "suggestion",
+		docs: {
+			description:
+				"Require a description after `--` in eslint/oxlint disable directive comments",
+			category: "Best Practices",
+			recommended: true,
+		},
+		messages: {
+			missingDescription:
+				"Unexpected `{{ directive }}` comment without description. Include a description after ` -- ` to explain why the rule is disabled.",
+		},
+		schema: [],
+	},
+
+	create(context) {
+		return {
+			Program() {
+				const sourceCode = context.sourceCode || context.getSourceCode();
+				const comments = sourceCode.getAllComments
+					? sourceCode.getAllComments()
+					: [];
+
+				for (const comment of comments) {
+					const text = comment.value;
+
+					if (!DIRECTIVE_PATTERN.test(text)) {
+						continue;
+					}
+
+					if (!hasDescription(text)) {
+						context.report({
+							loc: comment.loc,
+							messageId: "missingDescription",
+							data: {
+								directive: getDirectiveName(text),
+							},
+						});
+					}
+				}
+			},
+		};
+	},
+};

--- a/packages/mock-npm-registry/src/index.ts
+++ b/packages/mock-npm-registry/src/index.ts
@@ -136,7 +136,7 @@ async function getPackagesToPublish(names: string[]) {
 				`{ package(name: "${name}") { path, allDependencies { items { name, path } } } }`
 			);
 			const results = JSON.parse(
-				// eslint-disable-next-line workers-sdk/no-unsafe-command-execution
+				// eslint-disable-next-line workers-sdk/no-unsafe-command-execution -- The following command uses turboQueryPath which is a path we computed so it is safe to run
 				execSync("pnpm exec turbo query " + turboQueryPath, {
 					encoding: "utf8",
 					stdio: "pipe",

--- a/packages/workers-playground/src/main.tsx
+++ b/packages/workers-playground/src/main.tsx
@@ -24,7 +24,7 @@ function syncDarkModeWithSystem() {
 }
 syncDarkModeWithSystem();
 setDarkMode(DarkModeSettings.SYSTEM);
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the root element of an html pages is always defined
 ReactDOM.createRoot(document.getElementById("root")!).render(
 	<React.StrictMode>
 		<StyleProvider renderer={felaRenderer}>

--- a/tools/deployments/alert-on-error.ts
+++ b/tools/deployments/alert-on-error.ts
@@ -1,4 +1,4 @@
-/* eslint-disable turbo/no-undeclared-env-vars */
+/* eslint-disable turbo/no-undeclared-env-vars -- this script reads CI environment variables */
 if (require.main === module) {
 	const status = [];
 

--- a/tools/deployments/validate-package-dependencies.ts
+++ b/tools/deployments/validate-package-dependencies.ts
@@ -109,7 +109,7 @@ export function loadExternalDependencies(packageDir: string): string[] | null {
 	}
 
 	// Use require with esbuild-register (which is already loaded)
-	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	// eslint-disable-next-line @typescript-eslint/no-require-imports -- dynamic require needed for esbuild-register compatibility
 	const depsModule = require(depsFilePath) as {
 		EXTERNAL_DEPENDENCIES?: string[];
 	};

--- a/tools/deployments/validate-pr-description.ts
+++ b/tools/deployments/validate-pr-description.ts
@@ -1,4 +1,4 @@
-/* eslint-disable turbo/no-undeclared-env-vars */
+/* eslint-disable turbo/no-undeclared-env-vars -- this script reads CI environment variables */
 if (require.main === module) {
 	const errors = validateDescription(
 		process.env.TITLE as string,

--- a/tools/e2e/__tests__/common.test.ts
+++ b/tools/e2e/__tests__/common.test.ts
@@ -113,7 +113,7 @@ describe("listTmpE2EProjects()", () => {
 });
 
 describe("deleteProject()", () => {
-	// eslint-disable-next-line jest/expect-expect
+	// eslint-disable-next-line jest/expect-expect -- assertions are implicit via undici mock agent interceptors
 	it("makes a REST request to delete the given project", async () => {
 		const MOCK_PROJECT = "mock-pages-project";
 		agent
@@ -195,7 +195,7 @@ describe("listTmpKVNamespaces()", () => {
 });
 
 describe("deleteKVNamespace()", () => {
-	// eslint-disable-next-line jest/expect-expect
+	// eslint-disable-next-line jest/expect-expect -- assertions are implicit via undici mock agent interceptors
 	it("makes a REST request to delete the given project", async () => {
 		const MOCK_KV = "tmp_e2e_kv";
 		agent
@@ -289,7 +289,7 @@ describe("listTmpDatabases()", () => {
 });
 
 describe("deleteDatabase()", () => {
-	// eslint-disable-next-line jest/expect-expect
+	// eslint-disable-next-line jest/expect-expect -- assertions are implicit via undici mock agent interceptors
 	it("makes a REST request to delete the given project", async () => {
 		const MOCK_DB = "tmp-e2e-db";
 		agent
@@ -347,7 +347,7 @@ describe("listTmpE2EWorkers()", () => {
 });
 
 describe("deleteWorker()", () => {
-	// eslint-disable-next-line jest/expect-expect
+	// eslint-disable-next-line jest/expect-expect -- assertions are implicit via undici mock agent interceptors
 	it("makes a REST request to delete the given project", async () => {
 		const MOCK_WORKER = "mock-worker";
 		agent
@@ -406,7 +406,7 @@ describe("listTmpR2Buckets()", () => {
 });
 
 describe("deleteR2Bucket()", () => {
-	// eslint-disable-next-line jest/expect-expect
+	// eslint-disable-next-line jest/expect-expect -- assertions are implicit via undici mock agent interceptors
 	it("makes a REST request to delete the given R2 bucket", async () => {
 		const MOCK_BUCKET = "tmp-e2e-abc123-next--workers-opennext-cache";
 		agent


### PR DESCRIPTION
I think that ideally every eslint disabling comment should have a description explaining why it is being used, in this PR I am introducing a rule for that (note: I am not using [`eslint-comments/require-description`](https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/require-description.html) because that doesn't support oxlint comments).

Instead of attempting to fix all such comments all at once this PR is instead just introducing the rule and skipping it for a bunch of packages which will be handled in followup PRs.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: linting change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal linting change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
