### PR TITLE
Prompt for Worker name interactively when not provided during `wrangler deploy`

### DIFF
--- a/.changeset/interactive-worker-name-prompt.md
+++ b/.changeset/interactive-worker-name-prompt.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Prompt for Worker name interactively when not provided during `wrangler deploy`
+
+When deploying without a `name` in your Wrangler config or `--name` CLI argument, `wrangler deploy` now interactively prompts you to choose a Worker name instead of failing. The default suggestion is derived from the entry-point filename (e.g. `my-api.ts` → `my-api`), falling back to the current directory name when the entry-point has a generic name like `index.js` or `worker.ts`. Input is validated against Cloudflare's Worker naming rules (lowercase alphanumeric and dashes, max 63 characters). In non-interactive or CI environments, the existing error message is still shown.

--- a/packages/wrangler/src/__tests__/deploy/core.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/core.test.ts
@@ -17,7 +17,7 @@ import { fetchSecrets } from "../../utils/fetch-secrets";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockAuthDomain } from "../helpers/mock-auth-domain";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import { clearDialogs, mockConfirm } from "../helpers/mock-dialogs";
+import { clearDialogs, mockConfirm, mockPrompt } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import {
 	mockExchangeRefreshTokenForAccessToken,
@@ -1424,5 +1424,66 @@ describe("deploy", () => {
 			  "wranglerInstall": true,
 			}
 		`);
+	});
+
+	describe("interactive worker name prompt", () => {
+		it("should prompt for name when not provided and default to script basename for non-generic scripts", async ({
+			expect,
+		}) => {
+			setIsTTY(true);
+			// Write a worker source with a non-generic filename
+			fs.writeFileSync(
+				"my-api.js",
+				`export default { async fetch() { return new Response("hello"); } };`
+			);
+			fs.writeFileSync("another.js", `export const foo = 100;`);
+			writeWranglerConfig(
+				{ name: undefined as unknown as string },
+				"./wrangler.toml"
+			);
+			mockPrompt({
+				text: "What would you like your Worker to be named? (Note: You can also set the name via the `--name` CLI argument or `name` in your Wrangler config file)",
+				options: { defaultValue: "my-api" },
+				result: "my-api",
+			});
+
+			await runWrangler("deploy my-api.js --dry-run");
+			expect(std.out).toContain("--dry-run: exiting now.");
+		});
+
+		it("should fall back to cwd basename when script has a generic name like index.js", async ({
+			expect,
+		}) => {
+			setIsTTY(true);
+			writeWorkerSource();
+			writeWranglerConfig(
+				{ name: undefined as unknown as string },
+				"./wrangler.toml"
+			);
+			// The cwd basename is set by runInTempDir() — it creates a random temp dir.
+			// We can't predict it, so we just check the prompt is shown without asserting the defaultValue.
+			mockPrompt({
+				text: "What would you like your Worker to be named? (Note: You can also set the name via the `--name` CLI argument or `name` in your Wrangler config file)",
+				result: "my-test-worker",
+			});
+
+			await runWrangler("deploy ./index.js --dry-run");
+			expect(std.out).toContain("--dry-run: exiting now.");
+		});
+
+		it("should error in non-interactive mode when no name is provided", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			writeWorkerSource();
+			writeWranglerConfig(
+				{ name: undefined as unknown as string },
+				"./wrangler.toml"
+			);
+
+			await expect(runWrangler("deploy ./index.js")).rejects.toThrowError(
+				'You need to provide a name when publishing a worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
+			);
+		});
 	});
 });

--- a/packages/wrangler/src/__tests__/utils-worker-name-validation.test.ts
+++ b/packages/wrangler/src/__tests__/utils-worker-name-validation.test.ts
@@ -1,0 +1,153 @@
+import { describe, it } from "vitest";
+import {
+	checkWorkerNameValidity,
+	toValidWorkerName,
+} from "../utils/worker-name-validation";
+
+describe("checkWorkerNameValidity()", () => {
+	it("should accept a simple valid name", ({ expect }) => {
+		expect(checkWorkerNameValidity("my-worker")).toEqual({ valid: true });
+	});
+
+	it("should accept a name with only lowercase letters", ({ expect }) => {
+		expect(checkWorkerNameValidity("worker")).toEqual({ valid: true });
+	});
+
+	it("should accept a name with numbers", ({ expect }) => {
+		expect(checkWorkerNameValidity("worker123")).toEqual({ valid: true });
+	});
+
+	it("should accept a name with dashes in the middle", ({ expect }) => {
+		expect(checkWorkerNameValidity("my-cool-worker")).toEqual({
+			valid: true,
+		});
+	});
+
+	it("should accept a single character name", ({ expect }) => {
+		expect(checkWorkerNameValidity("a")).toEqual({ valid: true });
+	});
+
+	it("should accept a name that is exactly 63 characters", ({ expect }) => {
+		const name = "a".repeat(63);
+		expect(checkWorkerNameValidity(name)).toEqual({ valid: true });
+	});
+
+	it("should reject an empty string", ({ expect }) => {
+		const result = checkWorkerNameValidity("");
+		expect(result.valid).toBe(false);
+		if (!result.valid) {
+			expect(result.cause).toBe("Worker names cannot be empty.");
+		}
+	});
+
+	it("should reject a name starting with a dash", ({ expect }) => {
+		const result = checkWorkerNameValidity("-my-worker");
+		expect(result.valid).toBe(false);
+		if (!result.valid) {
+			expect(result.cause).toBe(
+				"Worker names cannot start or end with a dash."
+			);
+		}
+	});
+
+	it("should reject a name ending with a dash", ({ expect }) => {
+		const result = checkWorkerNameValidity("my-worker-");
+		expect(result.valid).toBe(false);
+		if (!result.valid) {
+			expect(result.cause).toBe(
+				"Worker names cannot start or end with a dash."
+			);
+		}
+	});
+
+	it("should reject a name with uppercase characters", ({ expect }) => {
+		const result = checkWorkerNameValidity("MyWorker");
+		expect(result.valid).toBe(false);
+		if (!result.valid) {
+			expect(result.cause).toBe(
+				"Project names must only contain lowercase characters, numbers, and dashes."
+			);
+		}
+	});
+
+	it("should reject a name with underscores", ({ expect }) => {
+		const result = checkWorkerNameValidity("my_worker");
+		expect(result.valid).toBe(false);
+		if (!result.valid) {
+			expect(result.cause).toBe(
+				"Project names must only contain lowercase characters, numbers, and dashes."
+			);
+		}
+	});
+
+	it("should reject a name with special characters", ({ expect }) => {
+		const result = checkWorkerNameValidity("my@worker!");
+		expect(result.valid).toBe(false);
+		if (!result.valid) {
+			expect(result.cause).toBe(
+				"Project names must only contain lowercase characters, numbers, and dashes."
+			);
+		}
+	});
+
+	it("should reject a name longer than 63 characters", ({ expect }) => {
+		const name = "a".repeat(64);
+		const result = checkWorkerNameValidity(name);
+		expect(result.valid).toBe(false);
+		if (!result.valid) {
+			expect(result.cause).toBe(
+				"Project names must be less than 63 characters."
+			);
+		}
+	});
+});
+
+describe("toValidWorkerName()", () => {
+	it("should return an already-valid name unchanged", ({ expect }) => {
+		expect(toValidWorkerName("my-worker")).toBe("my-worker");
+	});
+
+	it("should replace underscores with dashes", ({ expect }) => {
+		expect(toValidWorkerName("my_cool_worker")).toBe("my-cool-worker");
+	});
+
+	it("should replace special characters with dashes", ({ expect }) => {
+		// @ and ! are replaced with dashes, then trailing dash is stripped
+		expect(toValidWorkerName("my@worker!")).toBe("my-worker");
+	});
+
+	it("should strip leading dashes after normalization", ({ expect }) => {
+		expect(toValidWorkerName("--my-worker")).toBe("my-worker");
+	});
+
+	it("should strip trailing dashes after normalization", ({ expect }) => {
+		expect(toValidWorkerName("my-worker--")).toBe("my-worker");
+	});
+
+	it("should lowercase uppercase letters", ({ expect }) => {
+		expect(toValidWorkerName("MyWorker")).toBe("myworker");
+	});
+
+	it("should truncate names longer than 63 characters", ({ expect }) => {
+		const longName = "a".repeat(100);
+		const result = toValidWorkerName(longName);
+		expect(result.length).toBeLessThanOrEqual(63);
+		expect(result).toBe("a".repeat(63));
+	});
+
+	it("should return 'my-worker' when input normalizes to empty string", ({
+		expect,
+	}) => {
+		expect(toValidWorkerName("@@@")).toBe("my-worker");
+	});
+
+	it("should handle a mix of underscores and special characters", ({
+		expect,
+	}) => {
+		expect(toValidWorkerName("my_cool@worker")).toBe("my-cool-worker");
+	});
+
+	it("should return the input unchanged if already valid", ({ expect }) => {
+		expect(toValidWorkerName("hello-world-123")).toBe("hello-world-123");
+	});
+});

--- a/packages/wrangler/src/autoconfig/details/index.ts
+++ b/packages/wrangler/src/autoconfig/details/index.ts
@@ -14,6 +14,10 @@ import { confirm, prompt, select } from "../../dialogs";
 import { logger } from "../../logger";
 import { sendMetricsEvent } from "../../metrics";
 import { NpmPackageManager } from "../../package-manager";
+import {
+	checkWorkerNameValidity,
+	toValidWorkerName,
+} from "../../utils/worker-name-validation";
 import { getFrameworkClassInstance } from "../frameworks";
 import {
 	allFrameworksInfos,
@@ -283,94 +287,6 @@ function getProjectBuildCommand(
 
 	// The command is something like `astro build` so we need to prefix it with `npx` and equivalents
 	return `${npx} ${detectedFramework.buildCommand}`;
-}
-
-const invalidWorkerNameCharsRegex = /[^a-z0-9- ]/g;
-const invalidWorkerNameStartEndRegex = /^(-+)|(-+)$/g;
-const workerNameLengthLimit = 63;
-
-/**
- * Checks whether the provided worker name is valid, this means that:
- *  - the name is not empty
- *  - the name doesn't start nor ends with a dash
- *  - the name doesn't contain special characters besides dashes
- *  - the name is not longer than 63 characters
- *
- * See: https://developers.cloudflare.com/workers/configuration/routing/workers-dev/#limitations
- *
- * @param input The name to check
- * @returns Object indicating whether the name is valid, and if not a cause indicating why it isn't
- */
-function checkWorkerNameValidity(
-	input: string
-): { valid: false; cause: string } | { valid: true } {
-	if (!input) {
-		return {
-			valid: false,
-			cause: "Worker names cannot be empty.",
-		};
-	}
-
-	if (input.match(invalidWorkerNameStartEndRegex)) {
-		return {
-			valid: false,
-			cause: "Worker names cannot start or end with a dash.",
-		};
-	}
-
-	if (input.match(invalidWorkerNameCharsRegex)) {
-		return {
-			valid: false,
-			cause:
-				"Project names must only contain lowercase characters, numbers, and dashes.",
-		};
-	}
-
-	if (input.length > workerNameLengthLimit) {
-		return {
-			valid: false,
-			cause: "Project names must be less than 63 characters.",
-		};
-	}
-
-	return { valid: true };
-}
-
-/**
- * Given an input string it converts it to a valid worker name
- *
- * A worker name is valid if:
- *  - the name is not empty
- *  - the name doesn't start nor ends with a dash
- *  - the name doesn't contain special characters besides dashes
- *  - the name is not longer than 63 characters
- *
- * See: https://developers.cloudflare.com/workers/configuration/routing/workers-dev/#limitations
- *
- * @param input The input to convert
- * @returns The input itself if it was already valid, the input converted to a valid worker name otherwise
- */
-export function toValidWorkerName(input: string): string {
-	if (checkWorkerNameValidity(input).valid) {
-		return input;
-	}
-
-	input = input
-		// Replace all underscores with dashes
-		.replaceAll("_", "-")
-		// Replace all the special characters (besides dashes) with dashes
-		.replace(invalidWorkerNameCharsRegex, "-")
-		// Remove invalid start/end dashes
-		.replace(invalidWorkerNameStartEndRegex, "")
-		// If the name is longer than the limit let's truncate it to that
-		.slice(0, workerNameLengthLimit);
-
-	if (!input.length) {
-		// If we've emptied the whole name let's replace it with a fallback value
-		return "my-worker";
-	}
-
-	return input;
 }
 
 export function displayAutoConfigDetails(

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -30,6 +30,10 @@ import { collectKeyValues } from "../utils/collectKeyValues";
 import { getRules } from "../utils/getRules";
 import { getScriptName } from "../utils/getScriptName";
 import { useServiceEnvironments } from "../utils/useServiceEnvironments";
+import {
+	checkWorkerNameValidity,
+	toValidWorkerName,
+} from "../utils/worker-name-validation";
 import deploy from "./deploy";
 import { maybeDelegateToOpenNextDeployCommand } from "./open-next";
 
@@ -450,10 +454,14 @@ export const deployCommand = createCommand({
 		}
 
 		if (!name) {
-			throw new UserError(
-				'You need to provide a name when publishing a worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`',
-				{ telemetryMessage: true }
-			);
+			if (isNonInteractiveOrCI()) {
+				throw new UserError(
+					'You need to provide a name when publishing a worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`',
+					{ telemetryMessage: true }
+				);
+			} else {
+				name = await promptForWorkerName(entry.file);
+			}
 		}
 
 		if (!args.dryRun) {
@@ -541,6 +549,42 @@ export const deployCommand = createCommand({
 });
 
 export type DeployArgs = (typeof deployCommand)["args"];
+
+/**
+ * Interactively prompts the user for a Worker name, validating input against
+ * Cloudflare's Worker naming rules (lowercase alphanumeric and dashes, max 63 chars).
+ *
+ * The default value is derived from the entry-point filename (e.g. `my-api.ts` → `my-api`),
+ * unless the filename is generic (`index` or `worker`), in which case the current working
+ * directory's basename is used instead. The raw default is normalized via {@link toValidWorkerName}.
+ *
+ * @param entryPoint Absolute path to the Worker's entry-point file.
+ * @returns The worker name chosen by the user.
+ */
+async function promptForWorkerName(entryPoint: string) {
+	const scriptBasename = path.basename(entryPoint).replace(/\.[^.]+$/, "");
+	const genericNames = ["worker", "index"];
+	const rawDefault = !genericNames.includes(scriptBasename.toLowerCase())
+		? scriptBasename
+		: path.basename(process.cwd());
+	const defaultName = toValidWorkerName(rawDefault);
+
+	const name = await prompt(
+		"What would you like your Worker to be named? (Note: You can also set the name via the `--name` CLI argument or `name` in your Wrangler config file)",
+		{
+			defaultValue: defaultName,
+			validate: (value) => {
+				const validity = checkWorkerNameValidity(value.trim());
+				if (validity.valid) {
+					return true;
+				}
+				return validity.cause;
+			},
+		}
+	);
+
+	return name.trim();
+}
 
 /**
  * Handles the case where:

--- a/packages/wrangler/src/utils/worker-name-validation.ts
+++ b/packages/wrangler/src/utils/worker-name-validation.ts
@@ -1,0 +1,89 @@
+const invalidWorkerNameCharsRegex = /[^a-z0-9- ]/g;
+const invalidWorkerNameStartEndRegex = /^(-+)|(-+)$/g;
+const workerNameLengthLimit = 63;
+
+/**
+ * Checks whether the provided worker name is valid, this means that:
+ *  - the name is not empty
+ *  - the name doesn't start nor ends with a dash
+ *  - the name doesn't contain special characters besides dashes
+ *  - the name is not longer than 63 characters
+ *
+ * See: https://developers.cloudflare.com/workers/configuration/routing/workers-dev/#limitations
+ *
+ * @param input The name to check
+ * @returns Object indicating whether the name is valid, and if not a cause indicating why it isn't
+ */
+export function checkWorkerNameValidity(
+	input: string
+): { valid: false; cause: string } | { valid: true } {
+	if (!input) {
+		return {
+			valid: false,
+			cause: "Worker names cannot be empty.",
+		};
+	}
+
+	if (input.match(invalidWorkerNameStartEndRegex)) {
+		return {
+			valid: false,
+			cause: "Worker names cannot start or end with a dash.",
+		};
+	}
+
+	if (input.match(invalidWorkerNameCharsRegex)) {
+		return {
+			valid: false,
+			cause:
+				"Project names must only contain lowercase characters, numbers, and dashes.",
+		};
+	}
+
+	if (input.length > workerNameLengthLimit) {
+		return {
+			valid: false,
+			cause: "Project names must be less than 63 characters.",
+		};
+	}
+
+	return { valid: true };
+}
+
+/**
+ * Given an input string it converts it to a valid worker name
+ *
+ * A worker name is valid if:
+ *  - the name is not empty
+ *  - the name doesn't start nor ends with a dash
+ *  - the name doesn't contain special characters besides dashes
+ *  - the name is not longer than 63 characters
+ *
+ * See: https://developers.cloudflare.com/workers/configuration/routing/workers-dev/#limitations
+ *
+ * @param input The input to convert
+ * @returns The input itself if it was already valid, the input converted to a valid worker name otherwise
+ */
+export function toValidWorkerName(input: string): string {
+	if (checkWorkerNameValidity(input).valid) {
+		return input;
+	}
+
+	input = input
+		// Lowercase uppercase letters before replacing invalid chars
+		.toLowerCase()
+		// Replace all underscores with dashes
+		.replaceAll("_", "-")
+		// Replace all the special characters (besides dashes) with dashes
+		.replace(invalidWorkerNameCharsRegex, "-")
+		// Remove invalid start/end dashes
+		.replace(invalidWorkerNameStartEndRegex, "")
+		// If the name is longer than the limit let's truncate it to that
+		.slice(0, workerNameLengthLimit);
+
+	if (!input.length) {
+		// If we've emptied the whole name let's replace it with a fallback value
+		return "my-worker";
+	}
+
+	return input;
+}


### PR DESCRIPTION
When deploying without a `name` in your Wrangler config or `--name` CLI argument, `wrangler deploy` now interactively prompts you to choose a Worker name instead of failing. The default suggestion is derived from the entry-point filename (e.g. `my-api.ts` → `my-api`), falling back to the current directory name when the entry-point has a generic name like `index.js` or `worker.ts`. Input is validated against Cloudflare's Worker naming rules (lowercase alphanumeric and dashes, max 63 characters). In non-interactive or CI environments, the existing error message is still shown.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: self-explanatory improvement

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
