### PR TITLE
Prompt for missing name and compatibility date interactively during `wrangler deploy`

### DIFF
--- a/.changeset/interactive-compatibility-date-prompt.md
+++ b/.changeset/interactive-compatibility-date-prompt.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Prompt for compatibility date interactively when not provided during `wrangler deploy`
+
+When deploying without a `compatibility_date` in your Wrangler config or `--compatibility-date` CLI argument, `wrangler deploy` now interactively prompts you to use today's date instead of failing with an error. In non-interactive or CI environments, the existing error message is still shown.

--- a/.changeset/interactive-compatibility-date-prompt.md
+++ b/.changeset/interactive-compatibility-date-prompt.md
@@ -2,6 +2,8 @@
 "wrangler": minor
 ---
 
-Prompt for compatibility date interactively when not provided during `wrangler deploy`
+Prompt for missing deployment config interactively during `wrangler deploy`
 
-When deploying without a `compatibility_date` in your Wrangler config or `--compatibility-date` CLI argument, `wrangler deploy` now interactively prompts you to use today's date instead of failing with an error. In non-interactive or CI environments, the existing error message is still shown.
+When deploying without a `compatibility_date` in your Wrangler configuration file or `--compatibility-date` CLI argument, `wrangler deploy` now interactively prompts you to use today's date instead of failing with an error. In non-interactive or CI environments, the existing error message is still shown.
+
+Additionally, interactive prompting for project name, compatibility date, and config file creation is now available for all `wrangler deploy` invocations when no config file exists — not just asset-only deployments. If you run `wrangler deploy ./index.js` without a `wrangler.json` file, Wrangler will prompt for any missing configuration and offer to save it to a `wrangler.jsonc` file for future use.

--- a/.changeset/interactive-compatibility-date-prompt.md
+++ b/.changeset/interactive-compatibility-date-prompt.md
@@ -2,8 +2,8 @@
 "wrangler": minor
 ---
 
-Prompt for missing deployment config interactively during `wrangler deploy`
+Prompt for missing name and compatibility date interactively during `wrangler deploy`
 
-When deploying without a `compatibility_date` in your Wrangler configuration file or `--compatibility-date` CLI argument, `wrangler deploy` now interactively prompts you to use today's date instead of failing with an error. In non-interactive or CI environments, the existing error message is still shown.
+When deploying without a project name or `compatibility_date` in your configuration or CLI arguments, `wrangler deploy` now interactively prompts for the missing values instead of immediately failing with an error. For compatibility date, the prompt offers to use today's date; if you decline, the existing error is shown. The compatibility date prompt is skipped when `--latest` is passed. In non-interactive or CI environments, behavior is unchanged.
 
-Additionally, interactive prompting for project name, compatibility date, and config file creation is now available for all `wrangler deploy` invocations when no config file exists — not just asset-only deployments. If you run `wrangler deploy ./index.js` without a `wrangler.json` file, Wrangler will prompt for any missing configuration and offer to save it to a `wrangler.jsonc` file for future use.
+Additionally, when no config file exists, `wrangler deploy` now offers to save the prompted name and compatibility date to a `wrangler.jsonc` file for future use. This interactive flow is available for all `wrangler deploy` invocations — not just asset-only deployments.

--- a/packages/wrangler/src/__tests__/deploy/core.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/core.test.ts
@@ -17,7 +17,7 @@ import { fetchSecrets } from "../../utils/fetch-secrets";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockAuthDomain } from "../helpers/mock-auth-domain";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import { clearDialogs, mockConfirm } from "../helpers/mock-dialogs";
+import { clearDialogs, mockConfirm, mockPrompt } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import {
 	mockExchangeRefreshTokenForAccessToken,
@@ -1424,5 +1424,62 @@ describe("deploy", () => {
 			  "wranglerInstall": true,
 			}
 		`);
+	});
+
+	describe("interactive compatibility date prompt", () => {
+		it("should prompt and use today's date when user confirms", async ({
+			expect,
+		}) => {
+			vi.setSystemTime(new Date(2024, 5, 15));
+			setIsTTY(true);
+			writeWorkerSource();
+			writeWranglerConfig(
+				{ compatibility_date: undefined as unknown as string },
+				"./wrangler.toml"
+			);
+			mockConfirm({
+				text: "No compatibility date is set. Would you like to use today's date (2024-06-15)?",
+				result: true,
+			});
+
+			await runWrangler("deploy ./index.js --name test-name --dry-run");
+			expect(std.out).toContain("--dry-run: exiting now.");
+			expect(std.out).toContain(
+				"To avoid this prompt, add `compatibility_date` to your wrangler.toml file or pass `--compatibility-date 2024-06-15` via CLI."
+			);
+		});
+
+		it("should error when user declines the prompt", async ({ expect }) => {
+			vi.setSystemTime(new Date(2024, 5, 15));
+			setIsTTY(true);
+			writeWorkerSource();
+			writeWranglerConfig(
+				{ compatibility_date: undefined as unknown as string },
+				"./wrangler.toml"
+			);
+			mockConfirm({
+				text: "No compatibility date is set. Would you like to use today's date (2024-06-15)?",
+				result: false,
+			});
+
+			await expect(
+				runWrangler("deploy ./index.js --name test-name --dry-run")
+			).rejects.toThrow("A compatibility_date is required when publishing");
+		});
+
+		it("should error in non-interactive mode when no compatibility_date is provided", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			writeWorkerSource();
+			writeWranglerConfig(
+				{ compatibility_date: undefined as unknown as string },
+				"./wrangler.toml"
+			);
+
+			await expect(
+				runWrangler("deploy ./index.js --name test-name")
+			).rejects.toThrow("A compatibility_date is required when publishing");
+		});
 	});
 });

--- a/packages/wrangler/src/__tests__/deploy/core.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/core.test.ts
@@ -17,7 +17,7 @@ import { fetchSecrets } from "../../utils/fetch-secrets";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockAuthDomain } from "../helpers/mock-auth-domain";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import { clearDialogs, mockConfirm, mockPrompt } from "../helpers/mock-dialogs";
+import { clearDialogs, mockConfirm } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import {
 	mockExchangeRefreshTokenForAccessToken,

--- a/packages/wrangler/src/__tests__/deploy/core.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/core.test.ts
@@ -17,7 +17,7 @@ import { fetchSecrets } from "../../utils/fetch-secrets";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockAuthDomain } from "../helpers/mock-auth-domain";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import { clearDialogs, mockConfirm } from "../helpers/mock-dialogs";
+import { clearDialogs, mockConfirm, mockPrompt } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import {
 	mockExchangeRefreshTokenForAccessToken,
@@ -1480,6 +1480,158 @@ describe("deploy", () => {
 			await expect(
 				runWrangler("deploy ./index.js --name test-name")
 			).rejects.toThrow("A compatibility_date is required when publishing");
+		});
+
+		it("should not show config-write prompt when config file already exists", async ({
+			expect,
+		}) => {
+			vi.setSystemTime(new Date(2024, 5, 15));
+			setIsTTY(true);
+			writeWorkerSource();
+			writeWranglerConfig(
+				{ compatibility_date: undefined as unknown as string },
+				"./wrangler.toml"
+			);
+			mockConfirm({
+				text: "No compatibility date is set. Would you like to use today's date (2024-06-15)?",
+				result: true,
+			});
+
+			await runWrangler("deploy ./index.js --name test-name --dry-run");
+			expect(std.out).toContain("--dry-run: exiting now.");
+			// Should NOT be asked to write a config file since one already exists
+			expect(std.out).not.toContain(
+				"Do you want Wrangler to write a wrangler.json config file"
+			);
+			expect(std.out).not.toContain("Proceeding with deployment...");
+		});
+
+		it("should skip the compat date prompt when --latest is passed", async ({
+			expect,
+		}) => {
+			setIsTTY(true);
+			writeWorkerSource();
+			writeWranglerConfig(
+				{ compatibility_date: undefined as unknown as string },
+				"./wrangler.toml"
+			);
+
+			await runWrangler(
+				"deploy ./index.js --name test-name --latest --dry-run"
+			);
+			expect(std.out).toContain("--dry-run: exiting now.");
+			// No compat date prompt should have been shown
+			expect(std.out).not.toContain("No compatibility date is set");
+		});
+
+		it("should prompt for name, compat date, and offer to write config when no config file exists", async ({
+			expect,
+		}) => {
+			vi.setSystemTime(new Date(2024, 5, 15));
+			setIsTTY(true);
+			writeWorkerSource();
+			// No writeWranglerConfig call — no config file exists
+			mockPrompt({
+				text: "What do you want to name your project?",
+				result: "test-worker",
+			});
+			mockConfirm({
+				text: "No compatibility date is set. Would you like to use today's date (2024-06-15)?",
+				result: true,
+			});
+			mockConfirm({
+				text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
+				result: true,
+			});
+
+			await runWrangler("deploy ./index.js --dry-run");
+			expect(std.out).toContain("--dry-run: exiting now.");
+			// Config file should be written without an assets key
+			const writtenConfig = JSON.parse(
+				fs.readFileSync("wrangler.jsonc", "utf-8")
+			);
+			expect(writtenConfig).toEqual({
+				name: "test-worker",
+				compatibility_date: "2024-06-15",
+			});
+			expect(writtenConfig).not.toHaveProperty("assets");
+			expect(std.out).toContain(
+				"Next time you run `wrangler deploy` Wrangler will automatically use the configuration saved to wrangler.jsonc."
+			);
+			expect(std.out).toContain("Proceeding with deployment...");
+		});
+
+		it("should show suggested CLI flags when user declines config file write", async ({
+			expect,
+		}) => {
+			vi.setSystemTime(new Date(2024, 5, 15));
+			setIsTTY(true);
+			writeWorkerSource();
+			// No writeWranglerConfig call — no config file exists
+			mockPrompt({
+				text: "What do you want to name your project?",
+				result: "test-worker",
+			});
+			mockConfirm({
+				text: "No compatibility date is set. Would you like to use today's date (2024-06-15)?",
+				result: true,
+			});
+			mockConfirm({
+				text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
+				result: false,
+			});
+
+			await runWrangler("deploy ./index.js --dry-run");
+			expect(std.out).toContain("--dry-run: exiting now.");
+			expect(fs.existsSync("wrangler.jsonc")).toBe(false);
+			expect(std.out).toContain(
+				"wrangler deploy --name test-worker --compatibility-date 2024-06-15"
+			);
+			// Should not include --assets since no assets were used
+			expect(std.out).not.toContain("--assets");
+			expect(std.out).toContain("Proceeding with deployment...");
+		});
+
+		it("should prompt for name when config file exists but has no name", async ({
+			expect,
+		}) => {
+			vi.setSystemTime(new Date(2024, 5, 15));
+			setIsTTY(true);
+			writeWorkerSource();
+			writeWranglerConfig({ name: undefined as unknown as string });
+			mockPrompt({
+				text: "What do you want to name your project?",
+				result: "prompted-name",
+			});
+
+			await runWrangler("deploy ./index.js --dry-run");
+			expect(std.out).toContain("--dry-run: exiting now.");
+			// Should NOT be asked to write a config file since one already exists
+			expect(std.out).not.toContain(
+				"Do you want Wrangler to write a wrangler.json config file"
+			);
+			expect(std.out).not.toContain("Proceeding with deployment...");
+		});
+
+		it("should not prompt for name when config file provides one", async ({
+			expect,
+		}) => {
+			vi.setSystemTime(new Date(2024, 5, 15));
+			setIsTTY(true);
+			writeWorkerSource();
+			writeWranglerConfig({
+				name: "config-provided-name",
+				compatibility_date: undefined as unknown as string,
+			});
+			mockConfirm({
+				text: "No compatibility date is set. Would you like to use today's date (2024-06-15)?",
+				result: true,
+			});
+
+			await runWrangler("deploy ./index.js --dry-run");
+			expect(std.out).toContain("--dry-run: exiting now.");
+			// Should NOT have been asked for a name
+			expect(std.out).not.toContain("What do you want to name your project?");
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/deploy/core.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/core.test.ts
@@ -1537,7 +1537,7 @@ describe("deploy", () => {
 				result: true,
 			});
 			mockConfirm({
-				text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
+				text: "Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
 				result: true,
 			});
 
@@ -1575,7 +1575,7 @@ describe("deploy", () => {
 				result: true,
 			});
 			mockConfirm({
-				text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
+				text: "Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
 				result: false,
 			});
 
@@ -1603,7 +1603,7 @@ describe("deploy", () => {
 			});
 			// No compat date prompt — --latest skips it
 			mockConfirm({
-				text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
+				text: "Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
 				result: true,
 			});
 
@@ -1635,7 +1635,7 @@ describe("deploy", () => {
 			});
 			// No compat date prompt — --latest skips it
 			mockConfirm({
-				text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
+				text: "Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
 				result: false,
 			});
 

--- a/packages/wrangler/src/__tests__/deploy/core.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/core.test.ts
@@ -1444,9 +1444,6 @@ describe("deploy", () => {
 
 			await runWrangler("deploy ./index.js --name test-name --dry-run");
 			expect(std.out).toContain("--dry-run: exiting now.");
-			expect(std.out).toContain(
-				"To avoid this prompt, add `compatibility_date` to your wrangler.toml file or pass `--compatibility-date 2024-06-15` via CLI."
-			);
 		});
 
 		it("should error when user declines the prompt", async ({ expect }) => {

--- a/packages/wrangler/src/__tests__/deploy/core.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/core.test.ts
@@ -1543,13 +1543,14 @@ describe("deploy", () => {
 
 			await runWrangler("deploy ./index.js --dry-run");
 			expect(std.out).toContain("--dry-run: exiting now.");
-			// Config file should be written without an assets key
+			// Config file should be written with main but without an assets key
 			const writtenConfig = JSON.parse(
 				fs.readFileSync("wrangler.jsonc", "utf-8")
 			);
 			expect(writtenConfig).toEqual({
 				name: "test-worker",
 				compatibility_date: "2024-06-15",
+				main: "./index.js",
 			});
 			expect(writtenConfig).not.toHaveProperty("assets");
 			expect(std.out).toContain(
@@ -1582,10 +1583,70 @@ describe("deploy", () => {
 			expect(std.out).toContain("--dry-run: exiting now.");
 			expect(fs.existsSync("wrangler.jsonc")).toBe(false);
 			expect(std.out).toContain(
-				"wrangler deploy --name test-worker --compatibility-date 2024-06-15"
+				"wrangler deploy ./index.js --name test-worker --compatibility-date 2024-06-15"
 			);
 			// Should not include --assets since no assets were used
 			expect(std.out).not.toContain("--assets");
+			expect(std.out).toContain("Proceeding with deployment...");
+		});
+
+		it("should write config with today's compat date when --latest is used and no config file exists", async ({
+			expect,
+		}) => {
+			vi.setSystemTime(new Date(2024, 5, 15));
+			setIsTTY(true);
+			writeWorkerSource();
+			// No writeWranglerConfig call — no config file exists
+			mockPrompt({
+				text: "What do you want to name your project?",
+				result: "test-worker",
+			});
+			// No compat date prompt — --latest skips it
+			mockConfirm({
+				text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
+				result: true,
+			});
+
+			await runWrangler("deploy ./index.js --latest --dry-run");
+			expect(std.out).toContain("--dry-run: exiting now.");
+			// Config file should include today's date even though --latest was used
+			const writtenConfig = JSON.parse(
+				fs.readFileSync("wrangler.jsonc", "utf-8")
+			);
+			expect(writtenConfig).toEqual({
+				name: "test-worker",
+				compatibility_date: "2024-06-15",
+				main: "./index.js",
+			});
+			expect(std.out).not.toContain("No compatibility date is set");
+			expect(std.out).toContain("Proceeding with deployment...");
+		});
+
+		it("should include compat date in suggested CLI command when --latest is used and config write declined", async ({
+			expect,
+		}) => {
+			vi.setSystemTime(new Date(2024, 5, 15));
+			setIsTTY(true);
+			writeWorkerSource();
+			// No writeWranglerConfig call — no config file exists
+			mockPrompt({
+				text: "What do you want to name your project?",
+				result: "test-worker",
+			});
+			// No compat date prompt — --latest skips it
+			mockConfirm({
+				text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
+				result: false,
+			});
+
+			await runWrangler("deploy ./index.js --latest --dry-run");
+			expect(std.out).toContain("--dry-run: exiting now.");
+			expect(fs.existsSync("wrangler.jsonc")).toBe(false);
+			// Suggested command should include the resolved compat date
+			expect(std.out).toContain(
+				"wrangler deploy ./index.js --name test-worker --compatibility-date 2024-06-15"
+			);
+			expect(std.out).not.toContain("No compatibility date is set");
 			expect(std.out).toContain("Proceeding with deployment...");
 		});
 

--- a/packages/wrangler/src/__tests__/deploy/core.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/core.test.ts
@@ -1554,7 +1554,7 @@ describe("deploy", () => {
 			});
 			expect(writtenConfig).not.toHaveProperty("assets");
 			expect(std.out).toContain(
-				"Next time you run `wrangler deploy` Wrangler will automatically use the configuration saved to wrangler.jsonc."
+				"Simply run `wrangler deploy` next time. Wrangler will automatically use the configuration saved to wrangler.jsonc."
 			);
 			expect(std.out).toContain("Proceeding with deployment...");
 		});

--- a/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
@@ -945,7 +945,7 @@ addEventListener('fetch', event => {});`
 					  }
 					}
 					 to <cwd>/wrangler.jsonc.
-					Please run \`wrangler deploy\` instead of \`wrangler deploy ./assets\` next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.
+					Simply run \`wrangler deploy\` next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.
 
 					Proceeding with deployment...
 
@@ -1029,7 +1029,7 @@ addEventListener('fetch', event => {});`
 					  }
 					}
 					 to <cwd>/wrangler.jsonc.
-					Please run \`wrangler deploy\` instead of \`wrangler deploy ./assets\` next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.
+					Simply run \`wrangler deploy\` next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.
 
 					Proceeding with deployment...
 
@@ -1101,7 +1101,7 @@ addEventListener('fetch', event => {});`
 					  }
 					}
 					 to <cwd>/wrangler.jsonc.
-					Please run \`wrangler deploy\` instead of \`wrangler deploy ./assets\` next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.
+					Simply run \`wrangler deploy\` next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.
 
 					Proceeding with deployment...
 
@@ -1180,7 +1180,7 @@ addEventListener('fetch', event => {});`
 					  }
 					}
 					 to <cwd>/wrangler.jsonc.
-					Please run \`wrangler deploy\` instead of \`wrangler deploy ./assets\` next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.
+					Simply run \`wrangler deploy\` next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.
 
 					Proceeding with deployment...
 
@@ -1266,7 +1266,7 @@ addEventListener('fetch', event => {});`
 					  }
 					}
 					 to <cwd>/wrangler.jsonc.
-					Please run \`wrangler deploy\` instead of \`wrangler deploy ./assets\` next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.
+					Simply run \`wrangler deploy\` next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.
 
 					Proceeding with deployment...
 

--- a/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
@@ -935,6 +935,7 @@ addEventListener('fetch', event => {});`
 
 					
 
+					
 					Wrote
 					{
 					  "name": "test-name",
@@ -1018,6 +1019,7 @@ addEventListener('fetch', event => {});`
 
 					
 
+					
 					Wrote
 					{
 					  "name": "test-name",
@@ -1089,6 +1091,7 @@ addEventListener('fetch', event => {});`
 					 ⛅️ wrangler x.x.x
 					──────────────────
 
+					
 					Wrote
 					{
 					  "name": "test-name",
@@ -1167,6 +1170,7 @@ addEventListener('fetch', event => {});`
 					 ⛅️ wrangler x.x.x
 					──────────────────
 
+					
 					Wrote
 					{
 					  "name": "test-name",
@@ -1252,6 +1256,7 @@ addEventListener('fetch', event => {});`
 
 					
 
+					
 					Wrote
 					{
 					  "name": "test-name",
@@ -1378,6 +1383,7 @@ addEventListener('fetch', event => {});`
 					 ⛅️ wrangler x.x.x
 					──────────────────
 
+					
 					You should run wrangler deploy --name test-name --compatibility-date 2024-01-01 --assets ./assets next time to deploy this Worker without going through this flow again.
 
 					Proceeding with deployment...

--- a/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
@@ -897,6 +897,10 @@ addEventListener('fetch', event => {});`
 					result: "test-name",
 				});
 				mockConfirm({
+					text: "No compatibility date is set. Would you like to use today's date (2024-01-01)?",
+					result: true,
+				});
+				mockConfirm({
 					text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
 					result: true,
 				});
@@ -929,10 +933,10 @@ addEventListener('fetch', event => {});`
 					 ⛅️ wrangler x.x.x
 					──────────────────
 
+					
 
-
-					No compatibility date found Defaulting to today: 2024-01-01
-
+					To avoid this prompt, add \`compatibility_date\` to your Wrangler configuration file or pass \`--compatibility-date 2024-01-01\` via CLI.
+					See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.
 					Wrote
 					{
 					  "name": "test-name",
@@ -978,6 +982,10 @@ addEventListener('fetch', event => {});`
 					result: "test-name",
 				});
 				mockConfirm({
+					text: "No compatibility date is set. Would you like to use today's date (2024-01-01)?",
+					result: true,
+				});
+				mockConfirm({
 					text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
 					result: true,
 				});
@@ -1010,10 +1018,10 @@ addEventListener('fetch', event => {});`
 					 ⛅️ wrangler x.x.x
 					──────────────────
 
+					
 
-
-					No compatibility date found Defaulting to today: 2024-01-01
-
+					To avoid this prompt, add \`compatibility_date\` to your Wrangler configuration file or pass \`--compatibility-date 2024-01-01\` via CLI.
+					See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.
 					Wrote
 					{
 					  "name": "test-name",
@@ -1049,6 +1057,10 @@ addEventListener('fetch', event => {});`
 					result: "test-name",
 				});
 				mockConfirm({
+					text: "No compatibility date is set. Would you like to use today's date (2024-01-01)?",
+					result: true,
+				});
+				mockConfirm({
 					text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
 					result: true,
 				});
@@ -1081,9 +1093,8 @@ addEventListener('fetch', event => {});`
 					 ⛅️ wrangler x.x.x
 					──────────────────
 
-
-					No compatibility date found Defaulting to today: 2024-01-01
-
+					To avoid this prompt, add \`compatibility_date\` to your Wrangler configuration file or pass \`--compatibility-date 2024-01-01\` via CLI.
+					See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.
 					Wrote
 					{
 					  "name": "test-name",
@@ -1126,6 +1137,10 @@ addEventListener('fetch', event => {});`
 					result: "test-name",
 				});
 				mockConfirm({
+					text: "No compatibility date is set. Would you like to use today's date (2024-01-01)?",
+					result: true,
+				});
+				mockConfirm({
 					text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
 					result: true,
 				});
@@ -1158,9 +1173,8 @@ addEventListener('fetch', event => {});`
 					 ⛅️ wrangler x.x.x
 					──────────────────
 
-
-					No compatibility date found Defaulting to today: 2024-01-01
-
+					To avoid this prompt, add \`compatibility_date\` to your Wrangler configuration file or pass \`--compatibility-date 2024-01-01\` via CLI.
+					See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.
 					Wrote
 					{
 					  "name": "test-name",
@@ -1208,6 +1222,10 @@ addEventListener('fetch', event => {});`
 					result: "test-name",
 				});
 				mockConfirm({
+					text: "No compatibility date is set. Would you like to use today's date (2024-01-01)?",
+					result: true,
+				});
+				mockConfirm({
 					text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
 					result: true,
 				});
@@ -1240,10 +1258,10 @@ addEventListener('fetch', event => {});`
 					 ⛅️ wrangler x.x.x
 					──────────────────
 
+					
 
-
-					No compatibility date found Defaulting to today: 2024-01-01
-
+					To avoid this prompt, add \`compatibility_date\` to your Wrangler configuration file or pass \`--compatibility-date 2024-01-01\` via CLI.
+					See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.
 					Wrote
 					{
 					  "name": "test-name",
@@ -1280,6 +1298,10 @@ addEventListener('fetch', event => {});`
 					// not [blah] because it is an invalid worker name
 					options: { defaultValue: "my-project" },
 					result: "test-name",
+				});
+				mockConfirm({
+					text: "No compatibility date is set. Would you like to use today's date (2024-01-01)?",
+					result: true,
 				});
 				mockConfirm({
 					text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
@@ -1339,6 +1361,10 @@ addEventListener('fetch', event => {});`
 					result: "test-name",
 				});
 				mockConfirm({
+					text: "No compatibility date is set. Would you like to use today's date (2024-01-01)?",
+					result: true,
+				});
+				mockConfirm({
 					text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
 					result: false,
 				});
@@ -1362,9 +1388,8 @@ addEventListener('fetch', event => {});`
 					 ⛅️ wrangler x.x.x
 					──────────────────
 
-
-					No compatibility date found Defaulting to today: 2024-01-01
-
+					To avoid this prompt, add \`compatibility_date\` to your Wrangler configuration file or pass \`--compatibility-date 2024-01-01\` via CLI.
+					See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.
 					You should run wrangler deploy --name test-name --compatibility-date 2024-01-01 --assets ./assets next time to deploy this Worker without going through this flow again.
 
 					Proceeding with deployment...

--- a/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
@@ -935,8 +935,6 @@ addEventListener('fetch', event => {});`
 
 					
 
-					To avoid this prompt, add \`compatibility_date\` to your Wrangler configuration file or pass \`--compatibility-date 2024-01-01\` via CLI.
-					See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.
 					Wrote
 					{
 					  "name": "test-name",
@@ -1020,8 +1018,6 @@ addEventListener('fetch', event => {});`
 
 					
 
-					To avoid this prompt, add \`compatibility_date\` to your Wrangler configuration file or pass \`--compatibility-date 2024-01-01\` via CLI.
-					See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.
 					Wrote
 					{
 					  "name": "test-name",
@@ -1093,8 +1089,6 @@ addEventListener('fetch', event => {});`
 					 ⛅️ wrangler x.x.x
 					──────────────────
 
-					To avoid this prompt, add \`compatibility_date\` to your Wrangler configuration file or pass \`--compatibility-date 2024-01-01\` via CLI.
-					See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.
 					Wrote
 					{
 					  "name": "test-name",
@@ -1173,8 +1167,6 @@ addEventListener('fetch', event => {});`
 					 ⛅️ wrangler x.x.x
 					──────────────────
 
-					To avoid this prompt, add \`compatibility_date\` to your Wrangler configuration file or pass \`--compatibility-date 2024-01-01\` via CLI.
-					See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.
 					Wrote
 					{
 					  "name": "test-name",
@@ -1260,8 +1252,6 @@ addEventListener('fetch', event => {});`
 
 					
 
-					To avoid this prompt, add \`compatibility_date\` to your Wrangler configuration file or pass \`--compatibility-date 2024-01-01\` via CLI.
-					See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.
 					Wrote
 					{
 					  "name": "test-name",
@@ -1388,8 +1378,6 @@ addEventListener('fetch', event => {});`
 					 ⛅️ wrangler x.x.x
 					──────────────────
 
-					To avoid this prompt, add \`compatibility_date\` to your Wrangler configuration file or pass \`--compatibility-date 2024-01-01\` via CLI.
-					See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.
 					You should run wrangler deploy --name test-name --compatibility-date 2024-01-01 --assets ./assets next time to deploy this Worker without going through this flow again.
 
 					Proceeding with deployment...

--- a/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
@@ -901,7 +901,7 @@ addEventListener('fetch', event => {});`
 					result: true,
 				});
 				mockConfirm({
-					text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
+					text: "Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
 					result: true,
 				});
 
@@ -933,9 +933,9 @@ addEventListener('fetch', event => {});`
 					 ⛅️ wrangler x.x.x
 					──────────────────
 
-					
 
-					
+
+
 					Wrote
 					{
 					  "name": "test-name",
@@ -985,7 +985,7 @@ addEventListener('fetch', event => {});`
 					result: true,
 				});
 				mockConfirm({
-					text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
+					text: "Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
 					result: true,
 				});
 
@@ -1017,9 +1017,9 @@ addEventListener('fetch', event => {});`
 					 ⛅️ wrangler x.x.x
 					──────────────────
 
-					
 
-					
+
+
 					Wrote
 					{
 					  "name": "test-name",
@@ -1059,7 +1059,7 @@ addEventListener('fetch', event => {});`
 					result: true,
 				});
 				mockConfirm({
-					text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
+					text: "Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
 					result: true,
 				});
 
@@ -1091,7 +1091,7 @@ addEventListener('fetch', event => {});`
 					 ⛅️ wrangler x.x.x
 					──────────────────
 
-					
+
 					Wrote
 					{
 					  "name": "test-name",
@@ -1138,7 +1138,7 @@ addEventListener('fetch', event => {});`
 					result: true,
 				});
 				mockConfirm({
-					text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
+					text: "Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
 					result: true,
 				});
 
@@ -1170,7 +1170,7 @@ addEventListener('fetch', event => {});`
 					 ⛅️ wrangler x.x.x
 					──────────────────
 
-					
+
 					Wrote
 					{
 					  "name": "test-name",
@@ -1222,7 +1222,7 @@ addEventListener('fetch', event => {});`
 					result: true,
 				});
 				mockConfirm({
-					text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
+					text: "Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
 					result: true,
 				});
 
@@ -1254,9 +1254,9 @@ addEventListener('fetch', event => {});`
 					 ⛅️ wrangler x.x.x
 					──────────────────
 
-					
 
-					
+
+
 					Wrote
 					{
 					  "name": "test-name",
@@ -1299,7 +1299,7 @@ addEventListener('fetch', event => {});`
 					result: true,
 				});
 				mockConfirm({
-					text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
+					text: "Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
 					result: true,
 				});
 
@@ -1360,7 +1360,7 @@ addEventListener('fetch', event => {});`
 					result: true,
 				});
 				mockConfirm({
-					text: "Do you want Wrangler to write a wrangler.json config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
+					text: "Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
 					result: false,
 				});
 
@@ -1383,7 +1383,7 @@ addEventListener('fetch', event => {});`
 					 ⛅️ wrangler x.x.x
 					──────────────────
 
-					
+
 					You should run wrangler deploy --name test-name --compatibility-date 2024-01-01 --assets ./assets next time to deploy this Worker without going through this flow again.
 
 					Proceeding with deployment...

--- a/packages/wrangler/src/__tests__/deploy/workers-dev.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/workers-dev.test.ts
@@ -770,6 +770,7 @@ describe("deploy", () => {
 		it("should error if a compatibility_date is not available in wrangler.toml or cli args", async ({
 			expect,
 		}) => {
+			setIsTTY(false);
 			writeWorkerSource();
 			let err: undefined | Error;
 			try {
@@ -791,6 +792,7 @@ describe("deploy", () => {
 		it("should error if a compatibility_date is missing and suggest the correct date", async ({
 			expect,
 		}) => {
+			setIsTTY(false);
 			vi.setSystemTime(new Date(2020, 11, 1));
 
 			writeWorkerSource();

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -565,22 +565,40 @@ export default async function deploy(props: Props): Promise<{
 		}
 	}
 
-	const compatibilityDate =
-		props.compatibilityDate ?? config.compatibility_date;
+	let compatibilityDate = props.compatibilityDate ?? config.compatibility_date;
 	const compatibilityFlags =
 		props.compatibilityFlags ?? config.compatibility_flags;
 
 	if (!compatibilityDate) {
 		const compatibilityDateStr = getTodaysCompatDate();
 
-		throw new UserError(
-			`A compatibility_date is required when publishing. Add the following to your ${configFileName(config.configPath)} file:
+		if (isNonInteractiveOrCI()) {
+			throw new UserError(
+				`A compatibility_date is required when publishing. Add the following to your ${configFileName(config.configPath)} file:
     \`\`\`
     ${formatConfigSnippet({ compatibility_date: compatibilityDateStr }, config.configPath, false)}
     \`\`\`
     Or you could pass it in your terminal as \`--compatibility-date ${compatibilityDateStr}\`
 See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`,
-			{ telemetryMessage: "missing compatibility date when deploying" }
+				{ telemetryMessage: "missing compatibility date when deploying" }
+			);
+		}
+
+		if (
+			!(await confirm(
+				`No compatibility date is set. Would you like to use today's date (${compatibilityDateStr})?`
+			))
+		) {
+			throw new UserError(
+				`A compatibility_date is required when publishing. Add it to your ${configFileName(config.configPath)} file or pass \`--compatibility-date\` via CLI.\nSee https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`,
+				{ telemetryMessage: "missing compatibility date when deploying" }
+			);
+		}
+
+		compatibilityDate = compatibilityDateStr;
+
+		logger.log(
+			`To avoid this prompt, add \`compatibility_date\` to your ${configFileName(config.configPath)} file or pass \`--compatibility-date ${compatibilityDateStr}\` via CLI.\nSee https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`
 		);
 	}
 

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -565,40 +565,22 @@ export default async function deploy(props: Props): Promise<{
 		}
 	}
 
-	let compatibilityDate = props.compatibilityDate ?? config.compatibility_date;
+	const compatibilityDate =
+		props.compatibilityDate ?? config.compatibility_date;
 	const compatibilityFlags =
 		props.compatibilityFlags ?? config.compatibility_flags;
 
 	if (!compatibilityDate) {
 		const compatibilityDateStr = getTodaysCompatDate();
 
-		if (isNonInteractiveOrCI()) {
-			throw new UserError(
-				`A compatibility_date is required when publishing. Add the following to your ${configFileName(config.configPath)} file:
+		throw new UserError(
+			`A compatibility_date is required when publishing. Add the following to your ${configFileName(config.configPath)} file:
     \`\`\`
     ${formatConfigSnippet({ compatibility_date: compatibilityDateStr }, config.configPath, false)}
     \`\`\`
     Or you could pass it in your terminal as \`--compatibility-date ${compatibilityDateStr}\`
 See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`,
-				{ telemetryMessage: "missing compatibility date when deploying" }
-			);
-		}
-
-		if (
-			!(await confirm(
-				`No compatibility date is set. Would you like to use today's date (${compatibilityDateStr})?`
-			))
-		) {
-			throw new UserError(
-				`A compatibility_date is required when publishing. Add it to your ${configFileName(config.configPath)} file or pass \`--compatibility-date\` via CLI.\nSee https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`,
-				{ telemetryMessage: "missing compatibility date when deploying" }
-			);
-		}
-
-		compatibilityDate = compatibilityDateStr;
-
-		logger.log(
-			`To avoid this prompt, add \`compatibility_date\` to your ${configFileName(config.configPath)} file or pass \`--compatibility-date ${compatibilityDateStr}\` via CLI.\nSee https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`
+			{ telemetryMessage: "missing compatibility date when deploying" }
 		);
 	}
 

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -632,6 +632,7 @@ export async function promptForMissingDeployConfig(
 		) {
 			args.compatibilityDate = compatibilityDateStr;
 			promptedForMissing = true;
+			logger.log("");
 		} else {
 			throw new UserError(
 				`A compatibility_date is required when publishing. Add it to your ${configFileName(config.configPath)} file or pass \`--compatibility-date\` via CLI.\nSee https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`,

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -643,10 +643,18 @@ export async function promptForMissingDeployConfig(
 
 	// When no config file exists and we prompted for missing config, offer to write one
 	if (!hasConfigFile && promptedForMissing) {
+		// When --latest was used, the compat date prompt was skipped but we still
+		// need a concrete date in the config file for future deploys without --latest
+		const effectiveCompatDate =
+			args.compatibilityDate ?? (args.latest ? getTodaysCompatDate() : undefined);
+
 		const configContent: Record<string, unknown> = {
 			name: args.name,
-			compatibility_date: args.compatibilityDate,
+			compatibility_date: effectiveCompatDate,
 		};
+		if (args.script) {
+			configContent.main = args.script;
+		}
 		if (args.assets) {
 			configContent.assets = { directory: args.assets };
 		}
@@ -674,10 +682,11 @@ export async function promptForMissingDeployConfig(
 				);
 			}
 		} else {
+			const scriptPart = args.script ? `${args.script} ` : "";
 			const flagParts = [
 				args.name ? `--name ${args.name}` : "",
-				args.compatibilityDate
-					? `--compatibility-date ${args.compatibilityDate}`
+				effectiveCompatDate
+					? `--compatibility-date ${effectiveCompatDate}`
 					: "",
 				args.assets ? `--assets ${args.assets}` : "",
 			]
@@ -685,7 +694,7 @@ export async function promptForMissingDeployConfig(
 				.join(" ");
 			logger.log(
 				`You should run ${chalk.bold(
-					`wrangler deploy ${flagParts}`
+					`wrangler deploy ${scriptPart}${flagParts}`
 				)} next time to deploy this Worker without going through this flow again.`
 			);
 		}

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -423,6 +423,33 @@ export const deployCommand = createCommand({
 			);
 		}
 
+		// Interactively prompt for compatibility_date when not provided via CLI or config
+		if (
+			!args.latest &&
+			!args.compatibilityDate &&
+			!config.compatibility_date &&
+			// In non-interactive/CI mode, let the deploy command continue and throw its detailed error message
+			!isNonInteractiveOrCI()
+		) {
+			const compatibilityDateStr = getTodaysCompatDate();
+
+			if (
+				await confirm(
+					`No compatibility date is set. Would you like to use today's date (${compatibilityDateStr})?`
+				)
+			) {
+				args.compatibilityDate = compatibilityDateStr;
+				logger.log(
+					`To avoid this prompt, add \`compatibility_date\` to your ${configFileName(config.configPath)} file or pass \`--compatibility-date ${compatibilityDateStr}\` via CLI.\nSee https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`
+				);
+			} else {
+				throw new UserError(
+					`A compatibility_date is required when publishing. Add it to your ${configFileName(config.configPath)} file or pass \`--compatibility-date\` via CLI.\nSee https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`,
+					{ telemetryMessage: "missing compatibility date when deploying" }
+				);
+			}
+		}
+
 		const cliVars = collectKeyValues(args.var);
 		const cliDefines = collectKeyValues(args.define);
 		const cliAlias = collectKeyValues(args.alias);

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -396,7 +396,7 @@ export const deployCommand = createCommand({
 					const stats = statSync(args.script);
 					if (stats.isDirectory()) {
 						scriptIsDirectory = true;
-						args = await handleMaybeAssetsDeployment(args.script, args);
+						args = await promptForMissingAssetFlag(args.script, args);
 					}
 				} catch (error) {
 					// If this is our UserError, re-throw it
@@ -556,7 +556,7 @@ export type DeployArgs = (typeof deployCommand)["args"];
  * @param args - The current deploy command arguments (mutated in place)
  * @returns The updated deploy args with `assets` set and `script` cleared if the user confirmed
  */
-export async function handleMaybeAssetsDeployment(
+export async function promptForMissingAssetFlag(
 	assetDirectory: string,
 	args: DeployArgs
 ): Promise<DeployArgs> {

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -606,7 +606,12 @@ export async function promptForMissingDeployConfig(
 
 	// Prompt for name when missing from both CLI args and config
 	if (!args.name && !config.name) {
-		const defaultName = process.cwd().split(path.sep).pop()?.replace("_", "-");
+		const defaultName = process
+			.cwd()
+			.split(path.sep)
+			.pop()
+			?.replace("_", "-")
+			.trim();
 		const isValidName = defaultName && /^[a-zA-Z0-9-]+$/.test(defaultName);
 		const projectName = await prompt("What do you want to name your project?", {
 			defaultValue: isValidName ? defaultName : "my-project",

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -661,7 +661,7 @@ export async function promptForMissingDeployConfig(
 		}
 
 		const writeConfigFile = await confirm(
-			`Do you want Wrangler to write a wrangler.json config file to store this configuration?\n${chalk.dim(
+			`Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\n${chalk.dim(
 				"This will allow you to simply run `wrangler deploy` on future deployments."
 			)}`
 		);

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -602,7 +602,6 @@ export async function promptForMissingDeployConfig(
 	}
 
 	let promptedForMissing = false;
-	const hasConfigFile = !!config.configPath;
 
 	// Prompt for name when missing from both CLI args and config
 	if (!args.name && !config.name) {
@@ -640,6 +639,8 @@ export async function promptForMissingDeployConfig(
 			);
 		}
 	}
+
+	const hasConfigFile = !!config.configPath;
 
 	// When no config file exists and we prompted for missing config, offer to write one
 	if (!hasConfigFile && promptedForMissing) {

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -388,12 +388,14 @@ export const deployCommand = createCommand({
 			return;
 		}
 
+		let scriptIsDirectory = false;
 		if (!config.configPath) {
 			// Attempt to interactively handle `wrangler deploy <directory>`
 			if (args.script) {
 				try {
 					const stats = statSync(args.script);
 					if (stats.isDirectory()) {
+						scriptIsDirectory = true;
 						args = await handleMaybeAssetsDeployment(args.script, args);
 					}
 				} catch (error) {
@@ -404,10 +406,13 @@ export const deployCommand = createCommand({
 					// If stat fails, let the original flow handle the error
 				}
 			}
-			// attempt to interactively handle `wrangler deploy --assets <directory>` missing compat date or name
-			else if (args.assets && (!args.compatibilityDate || !args.name)) {
-				args = await handleMaybeAssetsDeployment(args.assets, args);
-			}
+		}
+
+		// Interactively prompt for missing deployment config (compat date, and name + config file when no config exists).
+		// Skip when the user was offered an assets deployment and declined (script is still a directory) —
+		// getEntry will produce the appropriate error about the directory entry point.
+		if (!(scriptIsDirectory && !args.assets)) {
+			args = await promptForMissingDeployConfig(args, config);
 		}
 
 		const entry = await getEntry(args, config, "deploy");
@@ -421,33 +426,6 @@ export const deployCommand = createCommand({
 					config.configPath
 				)} file.`
 			);
-		}
-
-		// Interactively prompt for compatibility_date when not provided via CLI or config
-		if (
-			!args.latest &&
-			!args.compatibilityDate &&
-			!config.compatibility_date &&
-			// In non-interactive/CI mode, let the deploy command continue and throw its detailed error message
-			!isNonInteractiveOrCI()
-		) {
-			const compatibilityDateStr = getTodaysCompatDate();
-
-			if (
-				await confirm(
-					`No compatibility date is set. Would you like to use today's date (${compatibilityDateStr})?`
-				)
-			) {
-				args.compatibilityDate = compatibilityDateStr;
-				logger.log(
-					`To avoid this prompt, add \`compatibility_date\` to your ${configFileName(config.configPath)} file or pass \`--compatibility-date ${compatibilityDateStr}\` via CLI.\nSee https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`
-				);
-			} else {
-				throw new UserError(
-					`A compatibility_date is required when publishing. Add it to your ${configFileName(config.configPath)} file or pass \`--compatibility-date\` via CLI.\nSee https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`,
-					{ telemetryMessage: "missing compatibility date when deploying" }
-				);
-			}
 		}
 
 		const cliVars = collectKeyValues(args.var);
@@ -570,12 +548,13 @@ export const deployCommand = createCommand({
 export type DeployArgs = (typeof deployCommand)["args"];
 
 /**
- * Handles the case where:
- * - a user provides a directory as a positional argument probably intending to deploy static assets. e.g. wrangler deploy ./public
- * - a user provides `--assets` but does not provide a name or compatibility date.
- * We then interactively take the user through deployment (missing name and/or compatibility date)
- * and ask to output this as a wrangler.jsonc for future deployments.
- * If this successfully completes, continue deploying with the updated values.
+ * Handles the case where a user provides a directory as a positional argument,
+ * probably intending to deploy static assets. e.g. `wrangler deploy ./public`.
+ * If the user confirms, sets `args.assets` and clears `args.script`.
+ *
+ * @param assetDirectory - The directory path the user provided as the positional argument
+ * @param args - The current deploy command arguments (mutated in place)
+ * @returns The updated deploy args with `assets` set and `script` cleared if the user confirmed
  */
 export async function handleMaybeAssetsDeployment(
 	assetDirectory: string,
@@ -602,8 +581,31 @@ export async function handleMaybeAssetsDeployment(
 		}
 	}
 
-	// Check if name is provided, if not ask for it
-	if (!args.name) {
+	return args;
+}
+
+/**
+ * Interactively prompts for missing deployment configuration (name, compatibility date,
+ * and optionally config file writing when no config file exists).
+ * No-op in non-interactive/CI environments or when all required config is already present.
+ *
+ * @param args - The current deploy command arguments (mutated in place)
+ * @param config - The resolved wrangler config, used to check for existing configPath, name, and compatibility_date
+ * @returns The updated deploy args with any prompted values filled in
+ */
+export async function promptForMissingDeployConfig(
+	args: DeployArgs,
+	config: { configPath?: string; compatibility_date?: string; name?: string }
+): Promise<DeployArgs> {
+	if (isNonInteractiveOrCI()) {
+		return args;
+	}
+
+	let promptedForMissing = false;
+	const hasConfigFile = !!config.configPath;
+
+	// Prompt for name when missing from both CLI args and config
+	if (!args.name && !config.name) {
 		const defaultName = process.cwd().split(path.sep).pop()?.replace("_", "-");
 		const isValidName = defaultName && /^[a-zA-Z0-9-]+$/.test(defaultName);
 		const projectName = await prompt("What do you want to name your project?", {
@@ -611,51 +613,81 @@ export async function handleMaybeAssetsDeployment(
 		});
 		args.name = projectName;
 		logger.log("");
+		promptedForMissing = true;
 	}
 
-	// Set compatibility date if not provided
-	if (!args.compatibilityDate) {
-		const compatibilityDate = getTodaysCompatDate();
-		args.compatibilityDate = compatibilityDate;
-		logger.log(
-			`${chalk.bold("No compatibility date found")} Defaulting to today:`,
-			compatibilityDate
-		);
-		logger.log("");
+	// Prompt for compatibility date when missing
+	if (!args.latest && !args.compatibilityDate && !config.compatibility_date) {
+		const compatibilityDateStr = getTodaysCompatDate();
+
+		if (
+			await confirm(
+				`No compatibility date is set. Would you like to use today's date (${compatibilityDateStr})?`
+			)
+		) {
+			args.compatibilityDate = compatibilityDateStr;
+			promptedForMissing = true;
+			logger.log(
+				`To avoid this prompt, add \`compatibility_date\` to your ${configFileName(config.configPath)} file or pass \`--compatibility-date ${compatibilityDateStr}\` via CLI.\nSee https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`
+			);
+		} else {
+			throw new UserError(
+				`A compatibility_date is required when publishing. Add it to your ${configFileName(config.configPath)} file or pass \`--compatibility-date\` via CLI.\nSee https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`,
+				{ telemetryMessage: "missing compatibility date when deploying" }
+			);
+		}
 	}
 
-	// Ask if user wants to write config file
-	const writeConfig = await confirm(
-		`Do you want Wrangler to write a wrangler.json config file to store this configuration?\n${chalk.dim(
-			"This will allow you to simply run `wrangler deploy` on future deployments."
-		)}`
-	);
+	// When no config file exists and we prompted for missing config, offer to write one
+	if (!hasConfigFile && promptedForMissing) {
+		const configContent: Record<string, unknown> = {
+			name: args.name,
+			compatibility_date: args.compatibilityDate,
+		};
+		if (args.assets) {
+			configContent.assets = { directory: args.assets };
+		}
 
-	if (writeConfig) {
-		const configPath = path.join(process.cwd(), "wrangler.jsonc");
-		const jsonString = JSON.stringify(
-			{
-				name: args.name,
-				compatibility_date: args.compatibilityDate,
-				assets: { directory: args.assets },
-			},
-			null,
-			2
+		const writeConfigFile = await confirm(
+			`Do you want Wrangler to write a wrangler.json config file to store this configuration?\n${chalk.dim(
+				"This will allow you to simply run `wrangler deploy` on future deployments."
+			)}`
 		);
-		writeFileSync(configPath, jsonString);
-		logger.log(`Wrote \n${jsonString}\n to ${chalk.bold(configPath)}.`);
-		logger.log(
-			`Please run ${chalk.bold("`wrangler deploy`")} instead of ${chalk.bold(
-				`\`wrangler deploy ${args.assets}\``
-			)} next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.`
-		);
-	} else {
-		logger.log(
-			`You should run ${chalk.bold(
-				`wrangler deploy --name ${args.name} --compatibility-date ${args.compatibilityDate} --assets ${args.assets}`
-			)} next time to deploy this Worker without going through this flow again.`
-		);
+
+		if (writeConfigFile) {
+			const configPath = path.join(process.cwd(), "wrangler.jsonc");
+			const jsonString = JSON.stringify(configContent, null, 2);
+			writeFileSync(configPath, jsonString);
+			logger.log(`Wrote \n${jsonString}\n to ${chalk.bold(configPath)}.`);
+			if (args.assets) {
+				logger.log(
+					`Please run ${chalk.bold("`wrangler deploy`")} instead of ${chalk.bold(
+						`\`wrangler deploy ${args.assets}\``
+					)} next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.`
+				);
+			} else {
+				logger.log(
+					`Next time you run ${chalk.bold("`wrangler deploy`")} Wrangler will automatically use the configuration saved to wrangler.jsonc.`
+				);
+			}
+		} else {
+			const flagParts = [
+				args.name ? `--name ${args.name}` : "",
+				args.compatibilityDate
+					? `--compatibility-date ${args.compatibilityDate}`
+					: "",
+				args.assets ? `--assets ${args.assets}` : "",
+			]
+				.filter(Boolean)
+				.join(" ");
+			logger.log(
+				`You should run ${chalk.bold(
+					`wrangler deploy ${flagParts}`
+				)} next time to deploy this Worker without going through this flow again.`
+			);
+		}
+		logger.log("\nProceeding with deployment...\n");
 	}
-	logger.log("\nProceeding with deployment...\n");
+
 	return args;
 }

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -610,7 +610,7 @@ export async function promptForMissingDeployConfig(
 			.cwd()
 			.split(path.sep)
 			.pop()
-			?.replace("_", "-")
+			?.replaceAll("_", "-")
 			.trim();
 		const isValidName = defaultName && /^[a-zA-Z0-9-]+$/.test(defaultName);
 		const projectName = await prompt("What do you want to name your project?", {

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -627,9 +627,6 @@ export async function promptForMissingDeployConfig(
 		) {
 			args.compatibilityDate = compatibilityDateStr;
 			promptedForMissing = true;
-			logger.log(
-				`To avoid this prompt, add \`compatibility_date\` to your ${configFileName(config.configPath)} file or pass \`--compatibility-date ${compatibilityDateStr}\` via CLI.\nSee https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`
-			);
 		} else {
 			throw new UserError(
 				`A compatibility_date is required when publishing. Add it to your ${configFileName(config.configPath)} file or pass \`--compatibility-date\` via CLI.\nSee https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`,

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -671,17 +671,9 @@ export async function promptForMissingDeployConfig(
 			const jsonString = JSON.stringify(configContent, null, 2);
 			writeFileSync(configPath, jsonString);
 			logger.log(`Wrote \n${jsonString}\n to ${chalk.bold(configPath)}.`);
-			if (args.assets) {
-				logger.log(
-					`Please run ${chalk.bold("`wrangler deploy`")} instead of ${chalk.bold(
-						`\`wrangler deploy ${args.assets}\``
-					)} next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.`
-				);
-			} else {
-				logger.log(
-					`Next time you run ${chalk.bold("`wrangler deploy`")} Wrangler will automatically use the configuration saved to wrangler.jsonc.`
-				);
-			}
+			logger.log(
+				`Simply run ${chalk.bold("`wrangler deploy`")} next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.`
+			);
 		} else {
 			const scriptPart = args.script ? `${args.script} ` : "";
 			const flagParts = [

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -646,7 +646,8 @@ export async function promptForMissingDeployConfig(
 		// When --latest was used, the compat date prompt was skipped but we still
 		// need a concrete date in the config file for future deploys without --latest
 		const effectiveCompatDate =
-			args.compatibilityDate ?? (args.latest ? getTodaysCompatDate() : undefined);
+			args.compatibilityDate ??
+			(args.latest ? getTodaysCompatDate() : undefined);
 
 		const configContent: Record<string, unknown> = {
 			name: args.name,


### PR DESCRIPTION
When deploying without a project name or `compatibility_date` in your configuration or CLI arguments, `wrangler deploy` now interactively prompts for the missing values instead of immediately failing with an error. For compatibility date, the prompt offers to use today's date; if you decline, the existing error is shown. The compatibility date prompt is skipped when `--latest` is passed. In non-interactive or CI environments, behavior is unchanged.

Additionally, when no config file exists, `wrangler deploy` now offers to save the prompted name and compatibility date to a `wrangler.jsonc` file for future use. This interactive flow is available for all `wrangler deploy` invocations — not just asset-only deployments.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: self-explanatory UX improvement

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
