### PR TITLE
Enable require-description-when-disabling lint rule on workers-utils, workflows-shared and playground-preview-worker

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -211,7 +211,6 @@
 				"packages/vitest-pool-workers/**",
 				"packages/workers-editor-shared/**",
 				"packages/workers-shared/**",
-				"packages/workflows-shared/**",
 				"packages/wrangler/**",
 			],
 			"rules": {

--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -211,7 +211,6 @@
 				"packages/vitest-pool-workers/**",
 				"packages/workers-editor-shared/**",
 				"packages/workers-shared/**",
-				"packages/workers-utils/**",
 				"packages/workflows-shared/**",
 				"packages/wrangler/**",
 			],

--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -205,7 +205,6 @@
 				"packages/create-cloudflare/**",
 				"packages/local-explorer-ui/**",
 				"packages/miniflare/**",
-				"packages/playground-preview-worker/**",
 				"packages/quick-edit-extension/**",
 				"packages/vite-plugin-cloudflare/**",
 				"packages/vitest-pool-workers/**",

--- a/packages/workers-utils/src/environment-variables/factory.ts
+++ b/packages/workers-utils/src/environment-variables/factory.ts
@@ -247,8 +247,7 @@ export function getEnvironmentVariableFactory<
 		if (deprecatedName && deprecatedName in process.env) {
 			if (!hasWarned) {
 				hasWarned = true;
-				// Ideally we'd use `logger.warn` here, but that creates a circular dependency that Vitest is unable to resolve
-				// eslint-disable-next-line no-console
+				// eslint-disable-next-line no-console -- ideally we'd use `logger.warn` here, but that creates a circular dependency that Vitest is unable to resolve
 				console.warn(
 					`Using "${deprecatedName}" environment variable. This is deprecated. Please use "${variableName}", instead.`
 				);

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import TOML from "smol-toml";
-import { describe, it, test, vi } from "vitest";
+import { assert, describe, it, test, vi } from "vitest";
 import { normalizeAndValidateConfig } from "../../../src/config/validation";
 import { normalizeString } from "../../../src/test-helpers";
 import type {
@@ -1066,8 +1066,8 @@ describe("normalizeAndValidateConfig()", () => {
 				{ env: undefined }
 			);
 
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			expect({ ...config, tsconfig: normalizePath(config.tsconfig!) }).toEqual(
+			assert(config.tsconfig);
+			expect({ ...config, tsconfig: normalizePath(config.tsconfig) }).toEqual(
 				expect.objectContaining({
 					...expectedConfig,
 					main: resolvedMain,
@@ -7272,8 +7272,8 @@ describe("normalizeAndValidateConfig()", () => {
 						{ env: "ENV1" }
 					);
 
-					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					expect(config).toEqual(expect.objectContaining(rawConfig.env!.ENV1));
+					assert(rawConfig.env);
+					expect(config).toEqual(expect.objectContaining(rawConfig.env.ENV1));
 					expect(diagnostics.hasWarnings()).toBe(false);
 					expect(diagnostics.hasErrors()).toBe(false);
 				});
@@ -7300,8 +7300,8 @@ describe("normalizeAndValidateConfig()", () => {
 						{ env: "ENV1" }
 					);
 
-					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					expect(config).toEqual(expect.objectContaining(rawConfig.env!.ENV1));
+					assert(rawConfig.env);
+					expect(config).toEqual(expect.objectContaining(rawConfig.env.ENV1));
 					expect(diagnostics.hasWarnings()).toBe(false);
 					expect(diagnostics.hasErrors()).toBe(true);
 
@@ -7338,8 +7338,8 @@ describe("normalizeAndValidateConfig()", () => {
 						{ env: "ENV1" }
 					);
 
-					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					expect(config).toEqual(expect.objectContaining(rawConfig.env!.ENV1));
+					assert(rawConfig.env);
+					expect(config).toEqual(expect.objectContaining(rawConfig.env.ENV1));
 					expect(diagnostics.hasWarnings()).toBe(true);
 					expect(diagnostics.hasErrors()).toBe(false);
 
@@ -7390,8 +7390,8 @@ describe("normalizeAndValidateConfig()", () => {
 						{ env: "ENV1" }
 					);
 
-					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					expect(config).toEqual(expect.objectContaining(rawConfig.env!.ENV1));
+					assert(rawConfig.env);
+					expect(config).toEqual(expect.objectContaining(rawConfig.env.ENV1));
 					expect(diagnostics.hasWarnings()).toBe(false);
 					expect(diagnostics.hasErrors()).toBe(true);
 

--- a/packages/workflows-shared/src/lib/validators.ts
+++ b/packages/workflows-shared/src/lib/validators.ts
@@ -13,7 +13,7 @@ const ALLOWED_WORKFLOW_INSTANCE_ID_REGEX = new RegExp(
 );
 const ALLOWED_WORKFLOW_NAME_REGEX = ALLOWED_WORKFLOW_INSTANCE_ID_REGEX;
 
-// eslint-disable-next-line no-control-regex
+// eslint-disable-next-line no-control-regex -- intentional use of control character range to detect invalid characters in workflow names
 const CONTROL_CHAR_REGEX = new RegExp("[\x00-\x1F]");
 
 export function isValidWorkflowName(name: string): boolean {


### PR DESCRIPTION
This PR enables the `require-description-when-disabling` lint rule on the workers-utils, workflows-shared and playground-preview-worker pacakges.

This is a followup PR for https://github.com/cloudflare/workers-sdk/pull/13698

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: internal linting change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal linting change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
