### PR TITLE
fix(miniflare):  Fix local scheduled handler returning `exception` when `assets` is enabled

### DIFF
--- a/.changeset/brave-teeth-flow.md
+++ b/.changeset/brave-teeth-flow.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+Fix local scheduled handler returning `exception` when `assets` is enabled

--- a/packages/miniflare/src/workers/assets/rpc-proxy.worker.ts
+++ b/packages/miniflare/src/workers/assets/rpc-proxy.worker.ts
@@ -26,6 +26,13 @@ export default class RPCProxyWorker extends WorkerEntrypoint<Env> {
 		return this.env.ROUTER_WORKER.fetch(request);
 	}
 
+	async scheduled(controller: ScheduledController) {
+		await this.env.USER_WORKER.scheduled({
+			scheduledTime: new Date(controller.scheduledTime),
+			cron: controller.cron,
+		});
+	}
+
 	tail(events: TraceItem[]) {
 		// Temporary workaround: the tail events is not serializable over capnproto yet
 		// But they are effectively JSON, so we are serializing them to JSON and parsing it back to make it transferable.

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -1650,6 +1650,49 @@ test("Miniflare: manually triggered scheduled events", async ({ expect }) => {
 	expect(await res.text()).toBe("true");
 });
 
+test("Miniflare: manually triggered scheduled events with assets", async ({
+	expect,
+}) => {
+	const log = new TestLog();
+	const tmp = await useTmp();
+	await fs.writeFile(path.join(tmp, "foo.html"), "asset", "utf8");
+
+	const mf = new Miniflare({
+		log,
+		modules: true,
+		script: `
+				let scheduledRun = false;
+				export default {
+					fetch() {
+						return new Response(scheduledRun);
+					},
+					scheduled() {
+						scheduledRun = true;
+					}
+				}`,
+		assets: {
+			directory: tmp,
+			routerConfig: {
+				has_user_worker: true,
+			},
+		},
+		unsafeTriggerHandlers: true,
+	});
+	useDispose(mf);
+
+	let res = await mf.dispatchFetch("http://localhost");
+	expect(await res.text()).toBe("false");
+
+	res = await mf.dispatchFetch("http://localhost/foo");
+	expect(await res.text()).toBe("asset");
+
+	res = await mf.dispatchFetch("http://localhost/cdn-cgi/handler/scheduled");
+	expect(await res.text()).toBe("ok");
+
+	res = await mf.dispatchFetch("http://localhost");
+	expect(await res.text()).toBe("true");
+});
+
 test("Miniflare: manually triggered email handler - valid email", async ({
 	expect,
 }) => {


### PR DESCRIPTION
Fixes #9882

add scheduled handler for asset's rpc-proxy worker

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
