### PR TITLE
fix(miniflare): skip SNI for Hyperdrive IP targets

### DIFF
--- a/packages/miniflare/src/plugins/hyperdrive/hyperdrive-proxy.ts
+++ b/packages/miniflare/src/plugins/hyperdrive/hyperdrive-proxy.ts
@@ -86,7 +86,8 @@ function buildTlsConnectionOptions(
 	const options: tls.ConnectionOptions = {
 		socket: dbSocket,
 		host: targetHost,
-		servername: targetHost,
+		// SNI only accepts hostnames. Passing an IP here breaks on Node 25+
+		servername: net.isIP(targetHost) === 0 ? targetHost : undefined,
 		rejectUnauthorized: tlsConfig.rejectUnauthorized,
 		...extra,
 	};


### PR DESCRIPTION
Fixes #13599 .

The hyperdrive test [fails in Node 25](https://github.com/cloudflare/workers-sdk/actions/runs/25048201119/job/73371483886?pr=13665#step:6:197) as it has a stricter validation on `servername` and fails if it is an IP address.

No changeset as the corresponding change is not yet released.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: covered by existing test
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13708" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
