### PR TITLE
[fixtures] Extend vitest.shared.ts in vitest-pool-workers-examples projects

### DIFF
--- a/fixtures/vitest-pool-workers-examples/ai-vectorize/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/ai-vectorize/vitest.config.ts
@@ -1,15 +1,18 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			remoteBindings: false,
-			wrangler: { configPath: "./wrangler.jsonc" },
-		}),
-	],
-
-	test: {
-		globalSetup: ["./global-setup.ts"],
-	},
-});
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				remoteBindings: false,
+				wrangler: { configPath: "./wrangler.jsonc" },
+			}),
+		],
+		test: {
+			globalSetup: ["./global-setup.ts"],
+		},
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/basics-integration-auxiliary/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/basics-integration-auxiliary/vitest.config.ts
@@ -1,43 +1,46 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			miniflare: {
-				// Configuration for the test runner Worker
-				compatibilityDate: "2024-01-01",
-				compatibilityFlags: [
-					// This illustrates a Worker that in production only wants v1 of Node.js compatibility.
-					// The Vitest pool integration will need to remove this flag since the `MockAgent` requires v2.
-					"no_nodejs_compat_v2",
-					"nodejs_compat",
-					// Required to use `WORKER.scheduled()`. This is an experimental
-					// compatibility flag, and cannot be enabled in production.
-					"service_binding_extra_handlers",
-				],
-				serviceBindings: {
-					WORKER: "worker-under-test",
-				},
-
-				workers: [
-					// Configuration for the "auxiliary" Worker under test.
-					// Unfortunately, auxiliary Workers cannot load their configuration
-					// from `wrangler.toml` files, and must be configured with Miniflare
-					// `WorkerOptions`.
-					{
-						name: "worker-under-test",
-						modules: true,
-						scriptPath: "./dist/index.js", // Built by `global-setup.ts`
-						compatibilityDate: "2024-01-01",
-						compatibilityFlags: ["nodejs_compat"],
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				miniflare: {
+					// Configuration for the test runner Worker
+					compatibilityDate: "2024-01-01",
+					compatibilityFlags: [
+						// This illustrates a Worker that in production only wants v1 of Node.js compatibility.
+						// The Vitest pool integration will need to remove this flag since the `MockAgent` requires v2.
+						"no_nodejs_compat_v2",
+						"nodejs_compat",
+						// Required to use `WORKER.scheduled()`. This is an experimental
+						// compatibility flag, and cannot be enabled in production.
+						"service_binding_extra_handlers",
+					],
+					serviceBindings: {
+						WORKER: "worker-under-test",
 					},
-				],
-			},
-		}),
-	],
 
-	test: {
-		globalSetup: ["./global-setup.ts"],
-	},
-});
+					workers: [
+						// Configuration for the "auxiliary" Worker under test.
+						// Unfortunately, auxiliary Workers cannot load their configuration
+						// from `wrangler.toml` files, and must be configured with Miniflare
+						// `WorkerOptions`.
+						{
+							name: "worker-under-test",
+							modules: true,
+							scriptPath: "./dist/index.js", // Built by `global-setup.ts`
+							compatibilityDate: "2024-01-01",
+							compatibilityFlags: ["nodejs_compat"],
+						},
+					],
+				},
+			}),
+		],
+		test: {
+			globalSetup: ["./global-setup.ts"],
+		},
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/basics-unit-integration-self/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/basics-unit-integration-self/vitest.config.ts
@@ -1,19 +1,21 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			miniflare: {
-				// Required to use `exports.default.scheduled()`. This is an experimental
-				// compatibility flag, and cannot be enabled in production.
-				compatibilityFlags: ["service_binding_extra_handlers"],
-			},
-			wrangler: {
-				configPath: "./wrangler.jsonc",
-			},
-		}),
-	],
-
-	test: {},
-});
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				miniflare: {
+					// Required to use `exports.default.scheduled()`. This is an experimental
+					// compatibility flag, and cannot be enabled in production.
+					compatibilityFlags: ["service_binding_extra_handlers"],
+				},
+				wrangler: {
+					configPath: "./wrangler.jsonc",
+				},
+			}),
+		],
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/container-app/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/container-app/vitest.config.ts
@@ -1,12 +1,14 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			wrangler: { configPath: "./wrangler.jsonc" },
-		}),
-	],
-
-	test: {},
-});
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				wrangler: { configPath: "./wrangler.jsonc" },
+			}),
+		],
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/context-exports/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/context-exports/vitest.config.ts
@@ -1,5 +1,6 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
 // Configuration for the "auxiliary" Worker under test.
 // Unfortunately, auxiliary Workers cannot load their configuration
@@ -16,26 +17,28 @@ export const auxiliaryWorker = {
 	},
 };
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			wrangler: { configPath: "./src/wrangler.jsonc" },
-			miniflare: {
-				workers: [auxiliaryWorker],
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				wrangler: { configPath: "./src/wrangler.jsonc" },
+				miniflare: {
+					workers: [auxiliaryWorker],
+				},
+				additionalExports: {
+					// This entrypoint is wildcard re-exported from a virtual module so we cannot automatically infer it.
+					ConfiguredVirtualEntryPoint: "WorkerEntrypoint",
+				},
+			}),
+		],
+		test: {
+			globalSetup: ["./global-setup.ts"],
+			alias: {
+				// This alias is used to simulate a virtual module that Vitest and TypeScript can understand,
+				// but esbuild (used by the vitest-pool-workers to guess exports) cannot.
+				"@virtual-module": "./virtual.ts",
 			},
-			additionalExports: {
-				// This entrypoint is wildcard re-exported from a virtual module so we cannot automatically infer it.
-				ConfiguredVirtualEntryPoint: "WorkerEntrypoint",
-			},
-		}),
-	],
-
-	test: {
-		globalSetup: ["./global-setup.ts"],
-		alias: {
-			// This alias is used to simulate a virtual module that Vitest and TypeScript can understand,
-			// but esbuild (used by the vitest-pool-workers to guess exports) cannot.
-			"@virtual-module": "./virtual.ts",
 		},
-	},
-});
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/d1/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/d1/vitest.config.ts
@@ -3,29 +3,33 @@ import {
 	cloudflareTest,
 	readD1Migrations,
 } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineConfig, defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
 export default defineConfig(async () => {
 	// Read all migrations in the `migrations` directory
 	const migrationsPath = path.join(__dirname, "migrations");
 	const migrations = await readD1Migrations(migrationsPath);
 
-	return {
-		plugins: [
-			cloudflareTest({
-				wrangler: {
-					configPath: "./wrangler.jsonc",
-					environment: "production",
-				},
-				miniflare: {
-					// Add a test-only binding for migrations, so we can apply them in a
-					// setup file
-					bindings: { TEST_MIGRATIONS: migrations },
-				},
-			}),
-		],
-		test: {
-			setupFiles: ["./test/apply-migrations.ts"],
-		},
-	};
+	return mergeConfig(
+		configShared,
+		defineProject({
+			plugins: [
+				cloudflareTest({
+					wrangler: {
+						configPath: "./wrangler.jsonc",
+						environment: "production",
+					},
+					miniflare: {
+						// Add a test-only binding for migrations, so we can apply them in a
+						// setup file
+						bindings: { TEST_MIGRATIONS: migrations },
+					},
+				}),
+			],
+			test: {
+				setupFiles: ["./test/apply-migrations.ts"],
+			},
+		})
+	);
 });

--- a/fixtures/vitest-pool-workers-examples/durable-objects/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/durable-objects/vitest.config.ts
@@ -1,16 +1,19 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			wrangler: {
-				configPath: "./wrangler.jsonc",
-			},
-		}),
-	],
-
-	test: {
-		name: "@scoped/durable-objects",
-	},
-});
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				wrangler: {
+					configPath: "./wrangler.jsonc",
+				},
+			}),
+		],
+		test: {
+			name: "@scoped/durable-objects",
+		},
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/dynamic-import/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/dynamic-import/vitest.config.ts
@@ -1,14 +1,16 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			wrangler: {
-				configPath: "./wrangler.jsonc",
-			},
-		}),
-	],
-
-	test: {},
-});
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				wrangler: {
+					configPath: "./wrangler.jsonc",
+				},
+			}),
+		],
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/hyperdrive/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/hyperdrive/vitest.config.ts
@@ -1,26 +1,29 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest(({ inject }) => {
-			// Provided in `global-setup.ts`
-			const echoServerPort = inject("echoServerPort");
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest(({ inject }) => {
+				// Provided in `global-setup.ts`
+				const echoServerPort = inject("echoServerPort");
 
-			return {
-				miniflare: {
-					hyperdrives: {
-						ECHO_SERVER_HYPERDRIVE: `postgres://user:pass@127.0.0.1:${echoServerPort}/db`,
+				return {
+					miniflare: {
+						hyperdrives: {
+							ECHO_SERVER_HYPERDRIVE: `postgres://user:pass@127.0.0.1:${echoServerPort}/db`,
+						},
 					},
-				},
-				wrangler: {
-					configPath: "./wrangler.jsonc",
-				},
-			};
-		}),
-	],
-
-	test: {
-		globalSetup: ["./global-setup.ts"],
-	},
-});
+					wrangler: {
+						configPath: "./wrangler.jsonc",
+					},
+				};
+			}),
+		],
+		test: {
+			globalSetup: ["./global-setup.ts"],
+		},
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/images/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/images/vitest.config.ts
@@ -1,14 +1,16 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			wrangler: {
-				configPath: "./wrangler.jsonc",
-			},
-		}),
-	],
-
-	test: {},
-});
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				wrangler: {
+					configPath: "./wrangler.jsonc",
+				},
+			}),
+		],
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/kv-r2-caches/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/kv-r2-caches/vitest.config.ts
@@ -1,14 +1,16 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			wrangler: {
-				configPath: "./wrangler.jsonc",
-			},
-		}),
-	],
-
-	test: {},
-});
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				wrangler: {
+					configPath: "./wrangler.jsonc",
+				},
+			}),
+		],
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/misc/vitest.assets.config.ts
+++ b/fixtures/vitest-pool-workers-examples/misc/vitest.assets.config.ts
@@ -1,23 +1,27 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			miniflare: {
-				assets: {
-					directory: "./public",
-					binding: "ASSETS",
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				miniflare: {
+					assets: {
+						directory: "./public",
+						binding: "ASSETS",
+					},
 				},
-			},
-			wrangler: {
-				configPath: "./wrangler.assets.jsonc",
-			},
-		}),
-	],
+				wrangler: {
+					configPath: "./wrangler.assets.jsonc",
+				},
+			}),
+		],
 
-	test: {
-		name: "misc-assets",
-		include: ["test/assets.test.ts"],
-	},
-});
+		test: {
+			name: "misc-assets",
+			include: ["test/assets.test.ts"],
+		},
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/misc/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/misc/vitest.config.ts
@@ -1,42 +1,46 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
 import { Response } from "miniflare";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			miniflare: {
-				kvNamespaces: ["KV_NAMESPACE"],
-				outboundService(request) {
-					return new Response(`fallthrough:${request.method} ${request.url}`);
-				},
-				serviceBindings: {
-					ASSETS(request) {
-						return new Response(`assets:${request.method} ${request.url}`);
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				miniflare: {
+					kvNamespaces: ["KV_NAMESPACE"],
+					outboundService(request) {
+						return new Response(`fallthrough:${request.method} ${request.url}`);
 					},
-				},
-				workers: [
-					{
-						name: "other",
-						modules: true,
-						scriptPath: "./src/other-worker.mjs",
+					serviceBindings: {
+						ASSETS(request) {
+							return new Response(`assets:${request.method} ${request.url}`);
+						},
 					},
-				],
-			},
-			wrangler: {
-				configPath: "./wrangler.jsonc",
-			},
-		}),
-	],
+					workers: [
+						{
+							name: "other",
+							modules: true,
+							scriptPath: "./src/other-worker.mjs",
+						},
+					],
+				},
+				wrangler: {
+					configPath: "./wrangler.jsonc",
+				},
+			}),
+		],
 
-	define: {
-		CONFIG_DEFINED_THING: '"thing"',
-		"CONFIG_NESTED.DEFINED.THING": "[1,2,3]",
-	},
+		define: {
+			CONFIG_DEFINED_THING: '"thing"',
+			"CONFIG_NESTED.DEFINED.THING": "[1,2,3]",
+		},
 
-	test: {
-		exclude: ["test/assets.test.ts", "test/nodejs.test.ts"],
-		globalSetup: ["./global-setup.ts"],
-		setupFiles: ["test/setup.ts"],
-	},
-});
+		test: {
+			exclude: ["test/assets.test.ts", "test/nodejs.test.ts"],
+			globalSetup: ["./global-setup.ts"],
+			setupFiles: ["test/setup.ts"],
+		},
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/misc/vitest.nodejs.config.ts
+++ b/fixtures/vitest-pool-workers-examples/misc/vitest.nodejs.config.ts
@@ -1,17 +1,21 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			wrangler: {
-				configPath: "./wrangler.nodejs.jsonc",
-			},
-		}),
-	],
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				wrangler: {
+					configPath: "./wrangler.nodejs.jsonc",
+				},
+			}),
+		],
 
-	test: {
-		name: "misc-nodejs",
-		include: ["test/nodejs.test.ts"],
-	},
-});
+		test: {
+			name: "misc-nodejs",
+			include: ["test/nodejs.test.ts"],
+		},
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/module-resolution/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/module-resolution/vitest.config.ts
@@ -1,10 +1,14 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			wrangler: { configPath: "./wrangler.jsonc" },
-		}),
-	],
-});
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				wrangler: { configPath: "./wrangler.jsonc" },
+			}),
+		],
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/multiple-workers/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/multiple-workers/vitest.config.ts
@@ -2,7 +2,8 @@ import crypto from "node:crypto";
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
 import { importPKCS8, SignJWT } from "jose";
 import { Request, Response } from "miniflare";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
 // Generate RSA keypair for signing/verifying JWTs
 const authKeypair = crypto.generateKeyPairSync("rsa", {
@@ -57,64 +58,66 @@ async function handleAuthServiceOutbound(request: Request): Promise<Response> {
 	return new Response("Not Found", { status: 404 });
 }
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			// Configuration for the test runner and "API service" Worker
-			wrangler: {
-				configPath: "./api-service/wrangler.jsonc",
-			},
-			miniflare: {
-				bindings: {
-					TEST_AUTH_PUBLIC_KEY: authKeypair.publicKey,
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				// Configuration for the test runner and "API service" Worker
+				wrangler: {
+					configPath: "./api-service/wrangler.jsonc",
 				},
+				miniflare: {
+					bindings: {
+						TEST_AUTH_PUBLIC_KEY: authKeypair.publicKey,
+					},
 
-				workers: [
-					// Configuration for "auxiliary" Worker dependencies.
-					// Unfortunately, auxiliary Workers cannot load their configuration
-					// from `wrangler.toml` files, and must be configured with Miniflare
-					// `WorkerOptions`.
-					{
-						name: "auth-service",
-						modules: true,
-						scriptPath: "./auth-service/dist/index.js", // Built by `global-setup.ts`
-						compatibilityDate: "2024-01-01",
-						compatibilityFlags: ["nodejs_compat"],
-						bindings: { AUTH_PUBLIC_KEY: authKeypair.publicKey },
-						// Mock outbound `fetch()`es from the `auth-service`
-						outboundService: handleAuthServiceOutbound,
-					},
-					{
-						name: "database-service",
-						modules: true,
-						scriptPath: "./database-service/dist/index.js", // Built by `global-setup.ts`
-						compatibilityDate: "2024-01-01",
-						compatibilityFlags: ["nodejs_compat"],
-						kvNamespaces: ["KV_NAMESPACE"],
-					},
-					{
-						name: "tail-consumer",
-						modules: [
-							{
-								path: "index.js",
-								type: "ESModule",
-								contents: /* javascript */ `
+					workers: [
+						// Configuration for "auxiliary" Worker dependencies.
+						// Unfortunately, auxiliary Workers cannot load their configuration
+						// from `wrangler.toml` files, and must be configured with Miniflare
+						// `WorkerOptions`.
+						{
+							name: "auth-service",
+							modules: true,
+							scriptPath: "./auth-service/dist/index.js", // Built by `global-setup.ts`
+							compatibilityDate: "2024-01-01",
+							compatibilityFlags: ["nodejs_compat"],
+							bindings: { AUTH_PUBLIC_KEY: authKeypair.publicKey },
+							// Mock outbound `fetch()`es from the `auth-service`
+							outboundService: handleAuthServiceOutbound,
+						},
+						{
+							name: "database-service",
+							modules: true,
+							scriptPath: "./database-service/dist/index.js", // Built by `global-setup.ts`
+							compatibilityDate: "2024-01-01",
+							compatibilityFlags: ["nodejs_compat"],
+							kvNamespaces: ["KV_NAMESPACE"],
+						},
+						{
+							name: "tail-consumer",
+							modules: [
+								{
+									path: "index.js",
+									type: "ESModule",
+									contents: /* javascript */ `
                                 export default {
                                     tail(event) {
                                     console.log("tail event received")
                                     }
                                 }
                                 `,
-							},
-						],
-						compatibilityDate: "2024-01-01",
-					},
-				],
-			},
-		}),
-	],
-
-	test: {
-		globalSetup: ["./global-setup.ts"],
-	},
-});
+								},
+							],
+							compatibilityDate: "2024-01-01",
+						},
+					],
+				},
+			}),
+		],
+		test: {
+			globalSetup: ["./global-setup.ts"],
+		},
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/pages-functions-unit-integration-self/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/pages-functions-unit-integration-self/vitest.config.ts
@@ -3,27 +3,30 @@ import {
 	buildPagesASSETSBinding,
 	cloudflareTest,
 } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
 const assetsPath = path.join(__dirname, "public");
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			main: "./dist-functions/index.js", // Built by `global-setup.ts`
-			miniflare: {
-				compatibilityFlags: ["nodejs_compat"],
-				compatibilityDate: "2024-01-01",
-				kvNamespaces: ["KV_NAMESPACE"],
-				serviceBindings: {
-					ASSETS: await buildPagesASSETSBinding(assetsPath),
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				main: "./dist-functions/index.js", // Built by `global-setup.ts`
+				miniflare: {
+					compatibilityFlags: ["nodejs_compat"],
+					compatibilityDate: "2024-01-01",
+					kvNamespaces: ["KV_NAMESPACE"],
+					serviceBindings: {
+						ASSETS: await buildPagesASSETSBinding(assetsPath),
+					},
 				},
-			},
-		}),
-	],
-
-	test: {
-		// Only required for integration tests
-		globalSetup: ["./global-setup.ts"],
-	},
-});
+			}),
+		],
+		test: {
+			// Only required for integration tests
+			globalSetup: ["./global-setup.ts"],
+		},
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/pages-with-config/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/pages-with-config/vitest.config.ts
@@ -1,12 +1,14 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			wrangler: { configPath: "./wrangler.jsonc" },
-		}),
-	],
-
-	test: {},
-});
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				wrangler: { configPath: "./wrangler.jsonc" },
+			}),
+		],
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/pipelines/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/pipelines/vitest.config.ts
@@ -1,14 +1,16 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			wrangler: {
-				configPath: "./wrangler.jsonc",
-			},
-		}),
-	],
-
-	test: {},
-});
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				wrangler: {
+					configPath: "./wrangler.jsonc",
+				},
+			}),
+		],
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/queues/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/queues/vitest.config.ts
@@ -1,22 +1,25 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			miniflare: {
-				// Required to use `exports.default.queue()`. This is an experimental
-				// compatibility flag, and cannot be enabled in production.
-				compatibilityFlags: ["service_binding_extra_handlers"],
-				// Use a shorter `max_batch_timeout` in tests
-				queueConsumers: {
-					queue: { maxBatchTimeout: 0.05 /* 50ms */ },
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				miniflare: {
+					// Required to use `exports.default.queue()`. This is an experimental
+					// compatibility flag, and cannot be enabled in production.
+					compatibilityFlags: ["service_binding_extra_handlers"],
+					// Use a shorter `max_batch_timeout` in tests
+					queueConsumers: {
+						queue: { maxBatchTimeout: 0.05 /* 50ms */ },
+					},
 				},
-			},
-			wrangler: {
-				configPath: "./wrangler.jsonc",
-			},
-		}),
-	],
-	test: {},
-});
+				wrangler: {
+					configPath: "./wrangler.jsonc",
+				},
+			}),
+		],
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/request-mocking/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/request-mocking/vitest.config.ts
@@ -1,16 +1,19 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			wrangler: {
-				configPath: "./wrangler.jsonc",
-			},
-		}),
-	],
-
-	test: {
-		setupFiles: ["test/setup.ts"],
-	},
-});
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				wrangler: {
+					configPath: "./wrangler.jsonc",
+				},
+			}),
+		],
+		test: {
+			setupFiles: ["test/setup.ts"],
+		},
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/reset/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/reset/vitest.config.ts
@@ -1,16 +1,19 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			wrangler: {
-				configPath: "./wrangler.jsonc",
-			},
-		}),
-	],
-
-	test: {
-		name: "@scoped/reset",
-	},
-});
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				wrangler: {
+					configPath: "./wrangler.jsonc",
+				},
+			}),
+		],
+		test: {
+			name: "@scoped/reset",
+		},
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/rpc/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/rpc/vitest.config.ts
@@ -1,17 +1,24 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			miniflare: {
-				// Required to use `exports.default.scheduled()`. This is an experimental
-				// compatibility flag, and cannot be enabled in production.
-				compatibilityFlags: ["service_binding_extra_handlers", "nodejs_compat"],
-			},
-			wrangler: {
-				configPath: "./wrangler.jsonc",
-			},
-		}),
-	],
-});
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				miniflare: {
+					// Required to use `exports.default.scheduled()`. This is an experimental
+					// compatibility flag, and cannot be enabled in production.
+					compatibilityFlags: [
+						"service_binding_extra_handlers",
+						"nodejs_compat",
+					],
+				},
+				wrangler: {
+					configPath: "./wrangler.jsonc",
+				},
+			}),
+		],
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/vitest.config.ts
@@ -1,9 +1,12 @@
 // Root vitest config for the vitest-pool-workers-examples fixture.
+// Per the Vitest 4 docs, only `globalSetup`, `reporters`, `coverage`, and
+// other "global" options are inherited from this root config; project test
+// options (testTimeout, retry, etc.) are NOT inherited. Each project under
+// `*/vitest.*config.*ts` extends `vitest.shared.ts` directly via mergeConfig.
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
 	test: {
-		teardownTimeout: 1_000,
 		projects: [
 			"*/vitest.*config.*ts",
 			// workerd's Windows SQLite VFS uses kj::Path::toString() (Unix-style

--- a/fixtures/vitest-pool-workers-examples/web-assembly/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/web-assembly/vitest.config.ts
@@ -1,18 +1,20 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			// Specifying a `wrangler.configPath` will enable Wrangler's default
-			// module rules including support for `.wasm` files. Refer to
-			// https://developers.cloudflare.com/workers/wrangler/bundling/#files-which-will-not-be-bundled
-			// for more information.
-			wrangler: {
-				configPath: "./wrangler.jsonc",
-			},
-		}),
-	],
-
-	test: {},
-});
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				// Specifying a `wrangler.configPath` will enable Wrangler's default
+				// module rules including support for `.wasm` files. Refer to
+				// https://developers.cloudflare.com/workers/wrangler/bundling/#files-which-will-not-be-bundled
+				// for more information.
+				wrangler: {
+					configPath: "./wrangler.jsonc",
+				},
+			}),
+		],
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/workers-assets-no-dir/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/workers-assets-no-dir/vitest.config.ts
@@ -1,10 +1,14 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			wrangler: { configPath: "./wrangler.jsonc" },
-		}),
-	],
-});
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				wrangler: { configPath: "./wrangler.jsonc" },
+			}),
+		],
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/workers-assets/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/workers-assets/vitest.config.ts
@@ -1,10 +1,14 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineConfig } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineConfig({
-	plugins: [
-		cloudflareTest({
-			wrangler: { configPath: "./wrangler.jsonc" },
-		}),
-	],
-});
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				wrangler: { configPath: "./wrangler.jsonc" },
+			}),
+		],
+	})
+);

--- a/fixtures/vitest-pool-workers-examples/workflows/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/workflows/vitest.config.ts
@@ -1,12 +1,16 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
-import { defineProject } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../../vitest.shared";
 
-export default defineProject({
-	plugins: [
-		cloudflareTest({
-			wrangler: {
-				configPath: "./wrangler.jsonc",
-			},
-		}),
-	],
-});
+export default mergeConfig(
+	configShared,
+	defineProject({
+		plugins: [
+			cloudflareTest({
+				wrangler: {
+					configPath: "./wrangler.jsonc",
+				},
+			}),
+		],
+	})
+);


### PR DESCRIPTION
_Removes the longstanding Windows-CI flake on the `vitest-pool-workers-examples` fixture by inheriting the repo-wide test timeouts and retry policy._

## Background

CI on `changeset-release/main` regularly fails on the Windows fixtures matrix (e.g. [run 25044703278](https://github.com/cloudflare/workers-sdk/actions/runs/25044703278/job/73356636188)). Different tests fail every time, but they all time out at exactly 5000 ms — the Vitest default. Tests that flake include:

- `workflows/test/integration.test.ts > workflow batch should be able to reach the end and be successful` (3-workflow batch, ~5–6 s on Windows)
- `workflows/test/unit.test.ts > should mock the violation score calculation to fail 2 times and then complete` (waits through default workflow retry backoff, ~6 s)
- `reset/test/reset.test.ts > clears Durable Object storage between tests` and `> sees reset Durable Object storage after reset` (~5–6.5 s)
- `basics-unit-integration-self/test/scheduled-integration-self.test.ts > dispatches scheduled event` (~5 s)

The same tests pass in 1.5–3.5 s on macOS/Linux and most Windows runs, confirming this is a CI-pressure-induced timing flake, not a logic bug. Pressure is highest on `changeset-release/main` because version bumps invalidate Turbo cache and force fresh rebuilds across the matrix.

## Root cause

Per the [Vitest 4 docs](https://vitest.dev/guide/projects):

> **None of the configuration options are inherited from the root-level config file.** You can create a shared config file and merge it with the project config yourself.

`fixtures/vitest-pool-workers-examples/` is a multi-project Vitest workspace (`projects: ["*/vitest.*config.*ts", ...]`). Each of the ~25 project configs under it was using `defineConfig`/`defineProject` directly, so they all ran with Vitest's defaults:

| Setting | Was | Now (from `vitest.shared.ts`) |
|---|---|---|
| `testTimeout` | 5 000 ms | 50 000 ms |
| `hookTimeout` | 10 000 ms | 50 000 ms |
| `teardownTimeout` | 10 000 ms | 50 000 ms |
| `retry` | 0 | 1 |
| `restoreMocks` | false | true |

Every other fixture in the repo (`fixtures/worker-app`, `fixtures/workflow`, `fixtures/d1-worker-app`, …) already extends `vitest.shared.ts` via `mergeConfig(configShared, defineProject(...))`. The 25 project configs inside `vitest-pool-workers-examples` were the only outliers.

The `packages/vitest-pool-workers/AGENTS.md` "Does NOT extend `vitest.shared.ts`" rule applies to the **package itself** (which sets its own 60 s hookTimeout and `retry: 2`), not to consumer fixtures.

Also dropped `test.teardownTimeout: 1_000` from the root `vitest.config.ts` — per Vitest 4 it had no effect on projects (the root only influences global options like reporters and coverage), so it was dead config.

## Changes

1. Refactor every project config under `fixtures/vitest-pool-workers-examples/*/vitest.config.ts` (25 files) to use `mergeConfig(configShared, defineProject({...}))`. Standardised on `defineProject` (some files were using `defineConfig` despite being project members).
2. Drop the dead `test.teardownTimeout: 1_000` from the root `fixtures/vitest-pool-workers-examples/vitest.config.ts` and add a brief comment explaining why projects extend the shared config directly.
3. The `d1` project keeps its async factory (`defineConfig(async () => {...})`) since it reads D1 migrations from disk; the `mergeConfig` happens inside the factory.

## Test Plan

Ran `pnpm --filter @fixture/vitest-pool-workers test:ci` three times locally on macOS — 54/54 files, 145/145 tests pass each time in ~12–15 s. Also ran `pnpm check:lint`, `pnpm check:type --filter @fixture/vitest-pool-workers`, `pnpm check:format` — all clean.

`restoreMocks: true` (now inherited) is safe: the only `vi.spyOn`/`vi.fn` use sites either explicitly call `vi.restoreAllMocks()` in `afterEach` already, or are local to a single test. `vi.mock()` (module mocks, used in `misc/test/module-mocking.test.ts`) is not affected by `restoreMocks` per Vitest semantics.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this PR exclusively touches Vitest project configs in a fixture; the existing fixture test suite is the validation. Verified locally and the fix targets a Windows-CI-only timing issue that we'll observe over the next few `changeset-release/main` runs.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal test infrastructure change with no user-facing impact.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
