### PR TITLE
Enable require-description-when-disabling lint rule on create-cloudflare

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -202,7 +202,6 @@
 		// TODO: Remove the following overrides.
 		{
 			"files": [
-				"packages/create-cloudflare/**",
 				"packages/local-explorer-ui/**",
 				"packages/miniflare/**",
 				"packages/quick-edit-extension/**",

--- a/packages/create-cloudflare/e2e/helpers/framework-helpers.ts
+++ b/packages/create-cloudflare/e2e/helpers/framework-helpers.ts
@@ -76,7 +76,7 @@ export async function runC3ForFrameworkTest(
 
 	const match = output.replaceAll("\n", "").match(deployedUrlRe);
 	if (!match || !match[1]) {
-		// eslint-disable-next-line no-console
+		// eslint-disable-next-line no-console -- we dump raw C3 output for tests debugging
 		console.error(output);
 		expect(false, "Couldn't find deployment url in C3 output").toBe(true);
 		return "";
@@ -87,8 +87,7 @@ export async function runC3ForFrameworkTest(
 
 export function updateWranglerConfig(
 	projectPath: string,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	handleUpdate: <T extends Record<string, any>>(config: T) => T
+	handleUpdate: <T extends Record<string, unknown>>(config: T) => T
 ) {
 	const wranglerTomlPath = join(projectPath, "wrangler.toml");
 	const wranglerJsoncPath = join(projectPath, "wrangler.jsonc");
@@ -131,7 +130,7 @@ export async function addTestVarsToWranglerToml(projectPath: string) {
 		return {
 			...config,
 			vars: {
-				...config.vars,
+				...(config.vars as Record<string, unknown>),
 				TEST: "C3_TEST",
 			},
 		};
@@ -223,7 +222,7 @@ export async function verifyDevScript(
 			restoreConfig = updateWranglerConfig(projectPath, (config) => ({
 				...config,
 				vars: {
-					...config.vars,
+					...(config.vars as Record<string, unknown>),
 					...updatedVars,
 				},
 			}));

--- a/packages/create-cloudflare/e2e/helpers/index.ts
+++ b/packages/create-cloudflare/e2e/helpers/index.ts
@@ -91,17 +91,15 @@ export const test = originalTest.extend<{
 		const { logPath, logStream } = createTestLogStream(task);
 
 		onTestFailed(() => {
-			// eslint-disable-next-line no-console
+			// eslint-disable no-console -- raw console outputs for testing logs
 			console.error("##[group]Logs from failed test:", logPath);
 			try {
-				// eslint-disable-next-line no-console
 				console.error(readFileSync(logPath, "utf8"));
 			} catch {
-				// eslint-disable-next-line no-console
 				console.error("Unable to read log file");
 			}
-			// eslint-disable-next-line no-console
 			console.error("##[endgroup]");
+			// eslint-enable no-console
 		});
 
 		await use(logStream);

--- a/packages/create-cloudflare/e2e/helpers/log-stream.ts
+++ b/packages/create-cloudflare/e2e/helpers/log-stream.ts
@@ -20,14 +20,15 @@ export function createTestLogStream(task: RunnerTask) {
 
 export function recreateLogFolder(suite: RunnerTestSuite) {
 	// Clean the old folder if exists (useful for dev)
-	//
-	// Note: this is intentionally inlined rather than importing `removeDirSync`
-	// from `@cloudflare/workers-utils`. That package's barrel export pulls in CJS
-	// dependencies (e.g. `xdg-app-paths`) that break when Vite bundles the vitest
-	// config (which imports this file) into ESM — the shimmed `require()` calls
-	// throw "Dynamic require of 'path' is not supported".
-	// Keep aligned with `removeDirSync()` in `packages/workers-utils/src/fs-helpers.ts`.
-	// eslint-disable-next-line workers-sdk/no-direct-recursive-rm
+
+	/* eslint-disable-next-line workers-sdk/no-direct-recursive-rm --
+	   Note: this is intentionally inlined rather than importing `removeDirSync`
+	   from `@cloudflare/workers-utils`. That package's barrel export pulls in CJS
+	   dependencies (e.g. `xdg-app-paths`) that break when Vite bundles the vitest
+	   config (which imports this file) into ESM — the shimmed `require()` calls
+	   throw "Dynamic require of 'path' is not supported".
+	   Keep aligned with `removeDirSync()` in `packages/workers-utils/src/fs-helpers.ts`.
+	*/
 	rmSync(getLogPath(suite), {
 		recursive: true,
 		force: true,

--- a/packages/create-cloudflare/e2e/helpers/to-exist.ts
+++ b/packages/create-cloudflare/e2e/helpers/to-exist.ts
@@ -6,9 +6,9 @@ declare module "vitest" {
 	interface CustomMatchers<R = unknown> {
 		toExist(): R;
 	}
-	// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+	// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- required by vitest's module augmentation pattern
 	interface Assertion<T> extends CustomMatchers<T> {}
-	// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+	// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- required by vitest's module augmentation pattern
 	interface AsymmetricMatchersContaining extends CustomMatchers {}
 }
 

--- a/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
+++ b/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
@@ -509,7 +509,7 @@ describe("Create Cloudflare CLI", () => {
 						throw new Error("Remote worker not found");
 					}
 				} catch {
-					// eslint-disable-next-line no-console
+					// eslint-disable-next-line no-console -- e2e setup logging for worker redeployment
 					console.log(
 						"Redeploying the existing-script-test-do-not-delete worker"
 					);

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -52,7 +52,7 @@ export const main = async (argv: string[]) => {
 		}
 
 		if (result.errorMessage) {
-			// eslint-disable-next-line no-console
+			// eslint-disable-next-line no-console -- display raw error message before exit
 			console.error(`\n${result.errorMessage}`);
 		}
 

--- a/packages/create-cloudflare/src/helpers/packageManagers.ts
+++ b/packages/create-cloudflare/src/helpers/packageManagers.ts
@@ -105,14 +105,15 @@ export const rectifyPmMismatch = async (ctx: C3Context) => {
 
 	const nodeModulesPath = nodePath.join(ctx.project.path, "node_modules");
 	if (existsSync(nodeModulesPath)) {
-		// Note: this is intentionally inlined rather than importing `removeDirSync`
-		// from `@cloudflare/workers-utils`. That package's barrel export pulls in CJS
-		// dependencies (e.g. `xdg-app-paths`) that break when Vite bundles code into
-		// ESM — the shimmed `require()` calls throw "Dynamic require of 'path' is not
-		// supported". While the production build (esbuild → CJS) would handle this
-		// fine, the e2e tests import this file through Vitest which uses Vite's bundler.
-		// Keep aligned with `removeDirSync()` in `packages/workers-utils/src/fs-helpers.ts`.
-		// eslint-disable-next-line workers-sdk/no-direct-recursive-rm
+		/* eslint-disable-next-line workers-sdk/no-direct-recursive-rm --
+		   Note: this is intentionally inlined rather than importing `removeDirSync`
+		   from `@cloudflare/workers-utils`. That package's barrel export pulls in CJS
+		   dependencies (e.g. `xdg-app-paths`) that break when Vite bundles code into
+		   ESM — the shimmed `require()` calls throw "Dynamic require of 'path' is not
+		   supported". While the production build (esbuild → CJS) would handle this
+		   fine, the e2e tests import this file through Vitest which uses Vite's bundler.
+		   Keep aligned with `removeDirSync()` in `packages/workers-utils/src/fs-helpers.ts`.
+		*/
 		rmSync(nodeModulesPath, {
 			recursive: true,
 			force: true,

--- a/packages/create-cloudflare/src/helpers/sparrow.ts
+++ b/packages/create-cloudflare/src/helpers/sparrow.ts
@@ -18,7 +18,7 @@ export function hasSparrowSourceKey() {
 
 export async function sendEvent(payload: EventPayload, enableLog?: boolean) {
 	if (enableLog) {
-		// eslint-disable-next-line no-console
+		// eslint-disable-next-line no-console -- intentional raw debug logging for telemetry diagnostics
 		console.log("[telemetry]", JSON.stringify(payload, null, 2));
 	}
 
@@ -34,7 +34,7 @@ export async function sendEvent(payload: EventPayload, enableLog?: boolean) {
 	} catch (error) {
 		// Ignore any network errors
 		if (enableLog) {
-			// eslint-disable-next-line no-console
+			// eslint-disable-next-line no-console -- intentional raw debug logging for telemetry diagnostics
 			console.log("[telemetry]", error);
 		}
 	}


### PR DESCRIPTION
This PR enables the `require-description-when-disabling` lint rule on the c3 package.

This is a followup PR for https://github.com/cloudflare/workers-sdk/pull/13698 and https://github.com/cloudflare/workers-sdk/pull/13703

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: internal linting change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal linting change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
