### PR TITLE
fix: skip auto-config and OpenNext delegation when `--config` is explicitly provided

### DIFF
--- a/.changeset/fix-config-flag-autoconfig-opennext.md
+++ b/.changeset/fix-config-flag-autoconfig-opennext.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: skip auto-config and OpenNext delegation when `--config` is explicitly provided
+
+When `--config` is passed to `wrangler deploy`, the user is explicitly targeting a specific Worker configuration. Previously, wrangler would ignore `--config` and delegate to `opennextjs-cloudflare deploy` if it detected an OpenNext project in the working directory, silently deploying the wrong Worker. Now, both auto-config detection and OpenNext delegation are skipped when `--config` is provided, matching the existing behavior for `--script` and `--assets`.

--- a/packages/wrangler/src/__tests__/deploy/core.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/core.test.ts
@@ -651,6 +651,39 @@ describe("deploy", () => {
 			"Using fallback value in non-interactive context: yes"
 		);
 	});
+
+	it("should not run autoconfig when --config is explicitly provided", async ({
+		expect,
+	}) => {
+		const getDetailsForAutoConfigSpy = vi.spyOn(
+			await import("../../autoconfig/details"),
+			"getDetailsForAutoConfig"
+		);
+
+		writeWorkerSource();
+		writeWranglerConfig({ main: "../index.js" }, "./config/wrangler.jsonc");
+		mockSubDomainRequest();
+		mockUploadWorkerRequest();
+
+		await runWrangler("deploy --config config/wrangler.jsonc");
+
+		expect(getDetailsForAutoConfigSpy).not.toHaveBeenCalled();
+
+		expect(std.out).toMatchInlineSnapshot(`
+			"
+			 ⛅️ wrangler x.x.x
+			──────────────────
+			Total Upload: xx KiB / gzip: xx KiB
+			Worker Startup Time: 100 ms
+			Uploaded test-name (TIMINGS)
+			Deployed test-name triggers (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev
+			Current Version ID: Galaxy-Class"
+		`);
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		expect(std.warn).toMatchInlineSnapshot(`""`);
+	});
+
 	describe("output additional script information", () => {
 		it("for first party workers, it should print worker information at log level", async ({
 			expect,

--- a/packages/wrangler/src/__tests__/deploy/open-next.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/open-next.test.ts
@@ -3,6 +3,7 @@ import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import dedent from "ts-dedent";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
+import { getDetailsForAutoConfig } from "../../autoconfig/details";
 import { getInstalledPackageVersion } from "../../autoconfig/frameworks/utils/packages";
 import { clearOutputFilePath } from "../../output";
 import { fetchSecrets } from "../../utils/fetch-secrets";
@@ -57,6 +58,7 @@ vi.mock("../../package-manager", async (importOriginal) => ({
 	},
 }));
 
+vi.mock("../../autoconfig/details");
 vi.mock("../../autoconfig/run");
 vi.mock("../../autoconfig/frameworks/utils/packages");
 vi.mock("@cloudflare/cli-shared-helpers/command");
@@ -88,6 +90,12 @@ describe("deploy", () => {
 		);
 		vi.mocked(fetchSecrets).mockResolvedValue([]);
 		vi.mocked(getInstalledPackageVersion).mockReturnValue(undefined);
+		vi.mocked(getDetailsForAutoConfig).mockResolvedValue({
+			configured: true,
+			workerName: "test-name",
+			projectPath: process.cwd(),
+			packageManager: { type: "npm" as const, npx: "npx" },
+		} as Awaited<ReturnType<typeof getDetailsForAutoConfig>>);
 	});
 
 	afterEach(() => {
@@ -369,6 +377,38 @@ describe("deploy", () => {
 			fs.rmSync("./open-next.config.ts");
 
 			await runWrangler("deploy --x-autoconfig");
+
+			expect(runCommandSpy).not.toHaveBeenCalledOnce();
+
+			expect(std.out).toMatchInlineSnapshot(`
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				Total Upload: xx KiB / gzip: xx KiB
+				Worker Startup Time: 100 ms
+				Your Worker has access to the following bindings:
+				Binding            Resource
+				env.ASSETS         Assets
+
+				Uploaded test-name (TIMINGS)
+				Deployed test-name triggers (TIMINGS)
+				  https://test-name.test-sub-domain.workers.dev
+				Current Version ID: Galaxy-Class"
+			`);
+			expect(std.err).toMatchInlineSnapshot(`""`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
+
+		it("should not delegate to open-next deploy when --config is explicitly provided", async ({
+			expect,
+		}) => {
+			const runCommandSpy = (
+				await import("@cloudflare/cli-shared-helpers/command")
+			).runCommand;
+
+			await mockOpenNextLikeProject();
+
+			await runWrangler("deploy --config wrangler.jsonc");
 
 			expect(runCommandSpy).not.toHaveBeenCalledOnce();
 

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -286,11 +286,12 @@ export const deployCommand = createCommand({
 	async handler(args, { config }) {
 		const shouldRunAutoConfig =
 			args.experimentalAutoconfig &&
-			// If there is a positional parameter or an assets directory specified via --assets then
-			// we don't want to run autoconfig since we assume that the user knows what they are doing
-			// and that they are specifying what needs to be deployed
+			// If there is a positional parameter, an assets directory specified via --assets, or an
+			// explicit --config path then we don't want to run autoconfig since we assume that the
+			// user knows what they are doing and that they are specifying what needs to be deployed
 			!args.script &&
-			!args.assets;
+			!args.assets &&
+			!args.config;
 
 		if (
 			config.pages_build_output_dir &&
@@ -380,6 +381,8 @@ export const deployCommand = createCommand({
 			// https://github.com/cloudflare/workers-sdk/pull/11694 and https://github.com/cloudflare/workers-sdk/pull/11710)
 			// but as a precaution we're gating the feature under the autoconfig flag for the time being
 			args.experimentalAutoconfig &&
+			// If the user explicitly provided a --config path, they are targeting a specific Worker config and we should not delegate to open-next
+			!args.config &&
 			!args.dryRun &&
 			(await maybeDelegateToOpenNextDeployCommand(process.cwd()));
 


### PR DESCRIPTION
Fixes #13693 

When `--config` is passed to `wrangler deploy`, the user is explicitly targeting a specific Worker configuration. Previously, wrangler would ignore `--config` and delegate to `opennextjs-cloudflare deploy` if it detected an OpenNext project in the working directory, silently deploying the wrong Worker. Now, both auto-config detection and OpenNext delegation are skipped when `--config` is provided, matching the existing behavior for `--script` and `--assets`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: self-explanatory UX improvement/fix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
