### PR TITLE
Support stream (but keep pipeline backwards compatible) binding for Pipelines

### DIFF
--- a/.changeset/pipeline-stream-rename.md
+++ b/.changeset/pipeline-stream-rename.md
@@ -1,0 +1,37 @@
+---
+"wrangler": minor
+"@cloudflare/workers-utils": minor
+"miniflare": minor
+---
+
+Rename `pipeline` field to `stream` in pipeline bindings configuration
+
+The `pipeline` field inside `pipelines` bindings has been renamed to `stream` to align with the updated API wire format. The old `pipeline` field is still accepted but deprecated and will emit a warning.
+
+Before:
+
+```jsonc
+// wrangler.json
+{
+	"pipelines": [
+		{
+			"binding": "MY_PIPELINE",
+			"pipeline": "my-stream-name",
+		},
+	],
+}
+```
+
+After:
+
+```jsonc
+// wrangler.json
+{
+	"pipelines": [
+		{
+			"binding": "MY_PIPELINE",
+			"stream": "my-stream-name",
+		},
+	],
+}
+```

--- a/fixtures/vitest-pool-workers-examples/pipelines/wrangler.jsonc
+++ b/fixtures/vitest-pool-workers-examples/pipelines/wrangler.jsonc
@@ -5,7 +5,7 @@
 	"pipelines": [
 		{
 			"binding": "PIPELINE",
-			"pipeline": "my-pipeline",
+			"stream": "my-pipeline",
 		},
 	],
 }

--- a/packages/miniflare/src/plugins/pipelines/index.ts
+++ b/packages/miniflare/src/plugins/pipelines/index.ts
@@ -15,7 +15,14 @@ export const PipelineOptionsSchema = z.object({
 				z.union([
 					z.string(),
 					z.object({
-						pipeline: z.string(),
+						stream: z.string().optional(),
+						remoteProxyConnectionString: z
+							.custom<RemoteProxyConnectionString>()
+							.optional(),
+					}),
+					z.object({
+						/** @deprecated Use `stream` instead. */
+						pipeline: z.string().optional(),
 						remoteProxyConnectionString: z
 							.custom<RemoteProxyConnectionString>()
 							.optional(),
@@ -79,7 +86,9 @@ function bindingEntries(
 				string,
 				| string
 				| {
-						pipeline: string;
+						stream?: string;
+						/** @deprecated Use `stream` instead. */
+						pipeline?: string;
 						remoteProxyConnectionString?: RemoteProxyConnectionString;
 				  }
 		  >
@@ -97,7 +106,8 @@ function bindingEntries(
 				(
 					| string
 					| {
-							pipeline: string;
+							stream?: string;
+							pipeline?: string;
 							remoteProxyConnectionString?: RemoteProxyConnectionString;
 					  }
 				),
@@ -107,7 +117,7 @@ function bindingEntries(
 			typeof opts === "string"
 				? { id: opts }
 				: {
-						id: opts.pipeline,
+						id: opts.stream ?? opts.pipeline ?? "",
 						remoteProxyConnectionString: opts.remoteProxyConnectionString,
 					},
 		]);

--- a/packages/miniflare/src/plugins/pipelines/index.ts
+++ b/packages/miniflare/src/plugins/pipelines/index.ts
@@ -14,12 +14,23 @@ export const PipelineOptionsSchema = z.object({
 			z.record(
 				z.union([
 					z.string(),
-					z.object({
-						pipeline: z.string(),
-						remoteProxyConnectionString: z
-							.custom<RemoteProxyConnectionString>()
-							.optional(),
-					}),
+					z
+						.object({
+							stream: z.string().optional(),
+							/** @deprecated Use `stream` instead. */
+							pipeline: z.string().optional(),
+							remoteProxyConnectionString: z
+								.custom<RemoteProxyConnectionString>()
+								.optional(),
+						})
+						.refine(
+							({ stream, pipeline }) => {
+								return stream !== undefined || pipeline !== undefined;
+							},
+							{
+								message: "Stream or pipeline (deprecated) must be defined",
+							}
+						),
 				])
 			),
 			z.string().array(),
@@ -79,7 +90,9 @@ function bindingEntries(
 				string,
 				| string
 				| {
-						pipeline: string;
+						stream?: string;
+						/** @deprecated Use `stream` instead. */
+						pipeline?: string;
 						remoteProxyConnectionString?: RemoteProxyConnectionString;
 				  }
 		  >
@@ -97,7 +110,8 @@ function bindingEntries(
 				(
 					| string
 					| {
-							pipeline: string;
+							stream?: string;
+							pipeline?: string;
 							remoteProxyConnectionString?: RemoteProxyConnectionString;
 					  }
 				),
@@ -107,7 +121,7 @@ function bindingEntries(
 			typeof opts === "string"
 				? { id: opts }
 				: {
-						id: opts.pipeline,
+						id: opts.stream ?? opts.pipeline ?? "",
 						remoteProxyConnectionString: opts.remoteProxyConnectionString,
 					},
 		]);

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -1344,8 +1344,13 @@ export interface EnvironmentNonInheritable {
 	pipelines: {
 		/** The binding name used to refer to the bound service. */
 		binding: string;
-		/** Name of the Pipeline to bind */
-		pipeline: string;
+		/** Name of the Stream to bind */
+		stream?: string;
+		/**
+		 * Name of the Stream to bind
+		 * @deprecated Use `stream` instead.
+		 */
+		pipeline?: string;
 		/** Whether the pipeline should be remote or not in local development */
 		remote?: boolean;
 	}[];

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -1343,8 +1343,13 @@ export interface EnvironmentNonInheritable {
 	pipelines: {
 		/** The binding name used to refer to the bound service. */
 		binding: string;
-		/** Name of the Pipeline to bind */
-		pipeline: string;
+		/** Name of the Stream to bind */
+		stream?: string;
+		/**
+		 * Name of the Stream to bind
+		 * @deprecated Use `stream` instead.
+		 */
+		pipeline?: string;
 		/** Whether the pipeline should be remote or not in local development */
 		remote?: boolean;
 	}[];

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -4784,7 +4784,7 @@ const validatePipelineBinding: ValidatorFn = (diagnostics, field, value) => {
 		return false;
 	}
 	let isValid = true;
-	// Pipeline bindings must have a binding and a pipeline.
+	// Pipeline bindings must have a binding and a stream (or deprecated pipeline).
 	if (!isRequiredProperty(value, "binding", "string")) {
 		diagnostics.errors.push(
 			`"${field}" bindings must have a string "binding" field but got ${JSON.stringify(
@@ -4793,9 +4793,23 @@ const validatePipelineBinding: ValidatorFn = (diagnostics, field, value) => {
 		);
 		isValid = false;
 	}
-	if (!isRequiredProperty(value, "pipeline", "string")) {
+
+	const hasStream = isOptionalProperty(value, "stream", "string");
+	const hasPipeline = isOptionalProperty(value, "pipeline", "string");
+	const v = value as Record<string, unknown>;
+
+	if (hasStream && v.stream) {
+		// "stream" is the primary field — use it as-is
+	} else if (hasPipeline && v.pipeline) {
+		// Deprecated "pipeline" field — normalize to "stream"
+		diagnostics.warnings.push(
+			`The "pipeline" field in "${field}" bindings is deprecated. Use "stream" instead.`
+		);
+		v.stream = v.pipeline;
+		delete v.pipeline;
+	} else {
 		diagnostics.errors.push(
-			`"${field}" bindings must have a string "pipeline" field but got ${JSON.stringify(
+			`"${field}" bindings must have a string "stream" field but got ${JSON.stringify(
 				value
 			)}.`
 		);
@@ -4808,6 +4822,7 @@ const validatePipelineBinding: ValidatorFn = (diagnostics, field, value) => {
 
 	validateAdditionalProperties(diagnostics, field, Object.keys(value), [
 		"binding",
+		"stream",
 		"pipeline",
 		"remote",
 	]);

--- a/packages/workers-utils/src/map-worker-metadata-bindings.ts
+++ b/packages/workers-utils/src/map-worker-metadata-bindings.ts
@@ -322,7 +322,8 @@ export function mapWorkerMetadataBindings(
 							...(configObj.pipelines ?? []),
 							{
 								binding: binding.name,
-								pipeline: binding.pipeline,
+								// NOTE: stream is the primary field, but we also support pipeline for backward compatibility
+								stream: binding.stream ?? binding.pipeline,
 							},
 						];
 						break;

--- a/packages/workers-utils/src/map-worker-metadata-bindings.ts
+++ b/packages/workers-utils/src/map-worker-metadata-bindings.ts
@@ -322,7 +322,8 @@ export function mapWorkerMetadataBindings(
 							...(configObj.pipelines ?? []),
 							{
 								binding: binding.name,
-								pipeline: binding.pipeline,
+								// NOTE: stream is the primary field, but we also support pipeline for backward compatibility
+								stream: binding.stream || binding.pipeline,
 							},
 						];
 						break;

--- a/packages/workers-utils/src/types.ts
+++ b/packages/workers-utils/src/types.ts
@@ -149,7 +149,7 @@ export type WorkerMetadataBinding =
 			};
 	  }
 	| { type: "mtls_certificate"; name: string; certificate_id: string }
-	| { type: "pipelines"; name: string; pipeline: string }
+	| { type: "pipelines"; name: string; stream?: string; pipeline?: string }
 	| {
 			type: "secrets_store_secret";
 			name: string;

--- a/packages/workers-utils/src/worker.ts
+++ b/packages/workers-utils/src/worker.ts
@@ -344,7 +344,8 @@ export interface CfAssetsBinding {
 
 export interface CfPipeline {
 	binding: string;
-	pipeline: string;
+	stream?: string;
+	pipeline?: string;
 	remote?: boolean;
 }
 

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -4466,7 +4466,28 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should accept valid bindings", ({ expect }) => {
+			it("should accept valid bindings with stream field", ({ expect }) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						pipelines: [
+							{
+								binding: "VALID",
+								stream: "343cd4f1d58c42fbb5bd082592fd7143",
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(diagnostics.hasWarnings()).toBe(false);
+			});
+
+			it("should accept deprecated pipeline field with warning", ({
+				expect,
+			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						pipelines: [
@@ -4482,6 +4503,11 @@ describe("normalizeAndValidateConfig()", () => {
 				);
 
 				expect(diagnostics.hasErrors()).toBe(false);
+				expect(diagnostics.hasWarnings()).toBe(true);
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - The "pipeline" field in "pipelines[0]" bindings is deprecated. Use "stream" instead."
+				`);
 			});
 
 			it("should error if pipelines.bindings are not valid", ({ expect }) => {
@@ -4491,7 +4517,7 @@ describe("normalizeAndValidateConfig()", () => {
 							{},
 							{
 								binding: "VALID",
-								pipeline: "343cd4f1d58c42fbb5bd082592fd7143",
+								stream: "343cd4f1d58c42fbb5bd082592fd7143",
 							},
 							{ binding: 2000, project: 2111 },
 						],
@@ -4508,9 +4534,9 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
 					  - "pipelines[0]" bindings must have a string "binding" field but got {}.
-					  - "pipelines[0]" bindings must have a string "pipeline" field but got {}.
+					  - "pipelines[0]" bindings must have a string "stream" field but got {}.
 					  - "pipelines[2]" bindings must have a string "binding" field but got {"binding":2000,"project":2111}.
-					  - "pipelines[2]" bindings must have a string "pipeline" field but got {"binding":2000,"project":2111}."
+					  - "pipelines[2]" bindings must have a string "stream" field but got {"binding":2000,"project":2111}."
 				`);
 			});
 		});

--- a/packages/wrangler/e2e/remote-binding/miniflare-remote-resources.test.ts
+++ b/packages/wrangler/e2e/remote-binding/miniflare-remote-resources.test.ts
@@ -490,14 +490,14 @@ const testCases: TestCase[] = [
 				bindings: {
 					PIPELINE: {
 						type: "pipeline",
-						pipeline: "preserve-e2e-pipelines",
+						stream: "preserve-e2e-pipelines",
 					},
 				},
 			},
 			miniflareConfig: (connection) => ({
 				pipelines: {
 					PIPELINE: {
-						pipeline: "preserve-e2e-pipelines",
+						stream: "preserve-e2e-pipelines",
 						remoteProxyConnectionString: connection,
 					},
 				},

--- a/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
@@ -1485,7 +1485,7 @@ describe("LocalRuntimeController", () => {
 				bindings: {
 					PIPELINE: {
 						type: "pipeline",
-						pipeline: "preserve-e2e-pipelines",
+						stream: "preserve-e2e-pipelines",
 					},
 				},
 			});

--- a/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
@@ -1440,7 +1440,7 @@ describe("LocalRuntimeController", () => {
 				bindings: {
 					PIPELINE: {
 						type: "pipeline",
-						pipeline: "preserve-e2e-pipelines",
+						stream: "preserve-e2e-pipelines",
 					},
 				},
 			});

--- a/packages/wrangler/src/__tests__/create-worker-upload-form/bindings.test.ts
+++ b/packages/wrangler/src/__tests__/create-worker-upload-form/bindings.test.ts
@@ -376,13 +376,13 @@ describe("createWorkerUploadForm — bindings", () => {
 	describe("pipeline bindings", () => {
 		it("should transform type from pipeline to pipelines", ({ expect }) => {
 			const bindings: StartDevWorkerInput["bindings"] = {
-				MY_PIPELINE: { type: "pipeline", pipeline: "my-pipeline" },
+				MY_PIPELINE: { type: "pipeline", stream: "my-pipeline" },
 			};
 			const form = createWorkerUploadForm(createEsmWorker(), bindings);
 			expect(getBindings(form)).toContainEqual({
 				name: "MY_PIPELINE",
 				type: "pipelines",
-				pipeline: "my-pipeline",
+				stream: "my-pipeline",
 			});
 		});
 	});

--- a/packages/wrangler/src/__tests__/deploy/durable-objects.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/durable-objects.test.ts
@@ -1384,7 +1384,7 @@ describe("deploy", () => {
 				pipelines: [
 					{
 						binding: "MY_PIPELINE",
-						pipeline: "my-pipeline",
+						stream: "my-pipeline",
 					},
 				],
 			});
@@ -1395,7 +1395,7 @@ describe("deploy", () => {
 					{
 						type: "pipelines",
 						name: "MY_PIPELINE",
-						pipeline: "my-pipeline",
+						stream: "my-pipeline",
 					},
 				],
 			});

--- a/packages/wrangler/src/__tests__/deploy/get-remote-config-diff.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/get-remote-config-diff.test.ts
@@ -356,7 +356,7 @@ describe("getRemoteConfigsDiff", () => {
 				pipelines: [
 					{
 						binding: "MY_PIPELINE",
-						pipeline: "my-pipeline",
+						stream: "my-pipeline",
 					},
 				],
 				vectorize: [
@@ -482,7 +482,7 @@ describe("getRemoteConfigsDiff", () => {
 				pipelines: [
 					{
 						binding: "MY_PIPELINE",
-						pipeline: "my-pipeline",
+						stream: "my-pipeline",
 						remote: true,
 					},
 				],

--- a/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
+++ b/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
@@ -435,14 +435,14 @@ describe("dev with remote bindings", { sequential: true, retry: 2 }, () => {
 				pipelines: [
 					{
 						binding: "PIPELINE",
-						pipeline: "preserve-e2e-pipelines",
+						stream: "preserve-e2e-pipelines",
 						remote: true,
 					},
 				],
 			},
 			expectedProxyWorkerBindings: {
 				PIPELINE: {
-					pipeline: "preserve-e2e-pipelines",
+					stream: "preserve-e2e-pipelines",
 					remote: true,
 					type: "pipeline",
 				},
@@ -451,7 +451,7 @@ describe("dev with remote bindings", { sequential: true, retry: 2 }, () => {
 				expect.objectContaining({
 					pipelines: {
 						PIPELINE: {
-							pipeline: "preserve-e2e-pipelines",
+							stream: "preserve-e2e-pipelines",
 							remoteProxyConnectionString,
 						},
 					},

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -328,7 +328,7 @@ describe("init", () => {
 				{
 					type: "pipelines",
 					name: "PIPELINE_BINDING",
-					pipeline: "some-name",
+					stream: "some-name",
 				},
 				{
 					type: "mtls_certificate",
@@ -561,7 +561,7 @@ describe("init", () => {
 			pipelines: [
 				{
 					binding: "PIPELINE_BINDING",
-					pipeline: "some-name",
+					stream: "some-name",
 				},
 			],
 			queues: {
@@ -1094,7 +1094,7 @@ describe("init", () => {
 					  "pipelines": [
 					    {
 					      "binding": "PIPELINE_BINDING",
-					      "pipeline": "some-name"
+					      "stream": "some-name"
 					    }
 					  ],
 					  "mtls_certificates": [

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -521,7 +521,7 @@ const bindingsConfigMock: Omit<
 		},
 		{ type: "CompiledWasm", globs: ["**/*.wasm"], fallthrough: true },
 	],
-	pipelines: [{ binding: "PIPELINE", pipeline: "my-pipeline" }],
+	pipelines: [{ binding: "PIPELINE", stream: "my-pipeline" }],
 	assets: {
 		binding: "ASSETS_BINDING",
 		directory: "/assets",
@@ -3932,7 +3932,7 @@ describe("pipeline schema type generation", () => {
 				name: "test-worker",
 				main: "./index.ts",
 				compatibility_date: "2024-01-01",
-				pipelines: [{ binding: "ANALYTICS", pipeline: "analytics-stream-id" }],
+				pipelines: [{ binding: "ANALYTICS", stream: "analytics-stream-id" }],
 			})
 		);
 		fs.writeFileSync("./index.ts", "export default { fetch() {} }");
@@ -3989,7 +3989,7 @@ describe("pipeline schema type generation", () => {
 				name: "test-worker",
 				main: "./index.ts",
 				compatibility_date: "2024-01-01",
-				pipelines: [{ binding: "LOGS", pipeline: "unstructured-stream-id" }],
+				pipelines: [{ binding: "LOGS", stream: "unstructured-stream-id" }],
 			})
 		);
 		fs.writeFileSync("./index.ts", "export default { fetch() {} }");
@@ -4043,7 +4043,7 @@ describe("pipeline schema type generation", () => {
 				name: "test-worker",
 				main: "./index.ts",
 				compatibility_date: "2024-01-01",
-				pipelines: [{ binding: "MISSING", pipeline: "non-existent-stream" }],
+				pipelines: [{ binding: "MISSING", stream: "non-existent-stream" }],
 			})
 		);
 		fs.writeFileSync("./index.ts", "export default { fetch() {} }");
@@ -4137,8 +4137,8 @@ describe("pipeline schema type generation", () => {
 				main: "./index.ts",
 				compatibility_date: "2024-01-01",
 				pipelines: [
-					{ binding: "EVENTS", pipeline: "events-stream" },
-					{ binding: "METRICS", pipeline: "metrics-stream" },
+					{ binding: "EVENTS", stream: "events-stream" },
+					{ binding: "METRICS", stream: "metrics-stream" },
 				],
 			})
 		);
@@ -4208,7 +4208,7 @@ describe("pipeline schema type generation", () => {
 				name: "test-worker",
 				main: "./index.ts",
 				compatibility_date: "2024-01-01",
-				pipelines: [{ binding: "NESTED", pipeline: "nested-stream" }],
+				pipelines: [{ binding: "NESTED", stream: "nested-stream" }],
 			})
 		);
 		fs.writeFileSync("./index.ts", "export default { fetch() {} }");
@@ -4274,7 +4274,7 @@ describe("pipeline schema type generation", () => {
 				name: "test-worker",
 				main: "./index.js",
 				compatibility_date: "2024-01-01",
-				pipelines: [{ binding: "EVENTS", pipeline: "events-stream" }],
+				pipelines: [{ binding: "EVENTS", stream: "events-stream" }],
 			})
 		);
 

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -515,7 +515,7 @@ const bindingsConfigMock: Omit<
 		},
 		{ type: "CompiledWasm", globs: ["**/*.wasm"], fallthrough: true },
 	],
-	pipelines: [{ binding: "PIPELINE", pipeline: "my-pipeline" }],
+	pipelines: [{ binding: "PIPELINE", stream: "my-pipeline" }],
 	assets: {
 		binding: "ASSETS_BINDING",
 		directory: "/assets",
@@ -3639,7 +3639,7 @@ describe("pipeline schema type generation", () => {
 				name: "test-worker",
 				main: "./index.ts",
 				compatibility_date: "2024-01-01",
-				pipelines: [{ binding: "ANALYTICS", pipeline: "analytics-stream-id" }],
+				pipelines: [{ binding: "ANALYTICS", stream: "analytics-stream-id" }],
 			})
 		);
 		fs.writeFileSync("./index.ts", "export default { fetch() {} }");
@@ -3696,7 +3696,7 @@ describe("pipeline schema type generation", () => {
 				name: "test-worker",
 				main: "./index.ts",
 				compatibility_date: "2024-01-01",
-				pipelines: [{ binding: "LOGS", pipeline: "unstructured-stream-id" }],
+				pipelines: [{ binding: "LOGS", stream: "unstructured-stream-id" }],
 			})
 		);
 		fs.writeFileSync("./index.ts", "export default { fetch() {} }");
@@ -3750,7 +3750,7 @@ describe("pipeline schema type generation", () => {
 				name: "test-worker",
 				main: "./index.ts",
 				compatibility_date: "2024-01-01",
-				pipelines: [{ binding: "MISSING", pipeline: "non-existent-stream" }],
+				pipelines: [{ binding: "MISSING", stream: "non-existent-stream" }],
 			})
 		);
 		fs.writeFileSync("./index.ts", "export default { fetch() {} }");
@@ -3844,8 +3844,8 @@ describe("pipeline schema type generation", () => {
 				main: "./index.ts",
 				compatibility_date: "2024-01-01",
 				pipelines: [
-					{ binding: "EVENTS", pipeline: "events-stream" },
-					{ binding: "METRICS", pipeline: "metrics-stream" },
+					{ binding: "EVENTS", stream: "events-stream" },
+					{ binding: "METRICS", stream: "metrics-stream" },
 				],
 			})
 		);
@@ -3915,7 +3915,7 @@ describe("pipeline schema type generation", () => {
 				name: "test-worker",
 				main: "./index.ts",
 				compatibility_date: "2024-01-01",
-				pipelines: [{ binding: "NESTED", pipeline: "nested-stream" }],
+				pipelines: [{ binding: "NESTED", stream: "nested-stream" }],
 			})
 		);
 		fs.writeFileSync("./index.ts", "export default { fetch() {} }");
@@ -3981,7 +3981,7 @@ describe("pipeline schema type generation", () => {
 				name: "test-worker",
 				main: "./index.js",
 				compatibility_date: "2024-01-01",
-				pipelines: [{ binding: "EVENTS", pipeline: "events-stream" }],
+				pipelines: [{ binding: "EVENTS", stream: "events-stream" }],
 			})
 		);
 

--- a/packages/wrangler/src/api/startDevWorker/utils.ts
+++ b/packages/wrangler/src/api/startDevWorker/utils.ts
@@ -709,7 +709,11 @@ export function convertWorkerMetadataBindingsToFlatBindings(
 					WorkerMetadataBinding,
 					{ type: "pipelines" }
 				>;
-				output[name] = { type: "pipeline", pipeline: b.pipeline };
+				output[name] = {
+					type: "pipeline",
+					stream: b.stream,
+					pipeline: b.pipeline,
+				};
 				break;
 			}
 			case "browser":

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -487,11 +487,11 @@ export function createWorkerUploadForm(
 		});
 	});
 
-	pipelines.forEach(({ binding, pipeline }) => {
+	pipelines.forEach(({ binding, stream: pipelineStream, pipeline }) => {
 		metadataBindings.push({
 			name: binding,
 			type: "pipelines",
-			pipeline: pipeline,
+			stream: pipelineStream || pipeline,
 		});
 	});
 

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -481,11 +481,11 @@ export function createWorkerUploadForm(
 		});
 	});
 
-	pipelines.forEach(({ binding, pipeline }) => {
+	pipelines.forEach(({ binding, stream: pipelineStream, pipeline }) => {
 		metadataBindings.push({
 			name: binding,
 			type: "pipelines",
-			pipeline: pipeline,
+			stream: pipelineStream || pipeline,
 		});
 	});
 

--- a/packages/wrangler/src/dev/miniflare/index.ts
+++ b/packages/wrangler/src/dev/miniflare/index.ts
@@ -288,17 +288,18 @@ function pipelineEntry(
 ): [
 	string,
 	{
-		pipeline: string;
+		stream: string;
 		remoteProxyConnectionString?: RemoteProxyConnectionString;
 	},
 ] {
-	if (!remoteProxyConnectionString || !pipeline.remote) {
-		return [pipeline.binding, { pipeline: pipeline.pipeline }];
+	const stream = pipeline.stream || pipeline.pipeline;
+	if (!stream) {
+		throw new Error("pipeline binding is missing stream ID");
 	}
-	return [
-		pipeline.binding,
-		{ pipeline: pipeline.pipeline, remoteProxyConnectionString },
-	];
+	if (!remoteProxyConnectionString || !pipeline.remote) {
+		return [pipeline.binding, { stream }];
+	}
+	return [pipeline.binding, { stream, remoteProxyConnectionString }];
 }
 function hyperdriveEntry(hyperdrive: CfHyperdrive): [string, string] {
 	return [hyperdrive.binding, hyperdrive.localConnectionString ?? ""];

--- a/packages/wrangler/src/preview/api.ts
+++ b/packages/wrangler/src/preview/api.ts
@@ -34,6 +34,7 @@ export interface Binding {
 	};
 	certificate_id?: string;
 	pipeline?: string;
+	stream?: string;
 	store_id?: string;
 	secret_name?: string;
 	simple?: {

--- a/packages/wrangler/src/preview/api.ts
+++ b/packages/wrangler/src/preview/api.ts
@@ -35,6 +35,7 @@ export interface Binding {
 	};
 	certificate_id?: string;
 	pipeline?: string;
+	stream?: string;
 	store_id?: string;
 	secret_name?: string;
 	simple?: {

--- a/packages/wrangler/src/preview/shared.ts
+++ b/packages/wrangler/src/preview/shared.ts
@@ -111,7 +111,7 @@ export function getBindingValue(binding: Binding): string {
 		case "mtls_certificate":
 			return String(binding.certificate_id ?? "");
 		case "pipelines":
-			return String(binding.pipeline ?? "");
+			return String(binding.stream ?? binding.pipeline ?? "");
 		case "secrets_store_secret":
 			return binding.secret_name
 				? `${binding.store_id}/${binding.secret_name}`
@@ -245,7 +245,10 @@ export function extractConfigBindings(config: Config): EnvBindings {
 	}
 
 	for (const pipeline of previews?.pipelines ?? []) {
-		env[pipeline.binding] = { type: "pipelines", pipeline: pipeline.pipeline };
+		env[pipeline.binding] = {
+			type: "pipelines",
+			stream: pipeline.stream || pipeline.pipeline,
+		};
 	}
 
 	for (const secret of previews?.secrets_store_secrets ?? []) {

--- a/packages/wrangler/src/preview/shared.ts
+++ b/packages/wrangler/src/preview/shared.ts
@@ -110,7 +110,7 @@ export function getBindingValue(binding: Binding): string {
 		case "mtls_certificate":
 			return String(binding.certificate_id ?? "");
 		case "pipelines":
-			return String(binding.pipeline ?? "");
+			return String(binding.stream ?? binding.pipeline ?? "");
 		case "secrets_store_secret":
 			return binding.secret_name
 				? `${binding.store_id}/${binding.secret_name}`
@@ -242,7 +242,10 @@ export function extractConfigBindings(config: Config): EnvBindings {
 	}
 
 	for (const pipeline of previews?.pipelines ?? []) {
-		env[pipeline.binding] = { type: "pipelines", pipeline: pipeline.pipeline };
+		env[pipeline.binding] = {
+			type: "pipelines",
+			stream: pipeline.stream || pipeline.pipeline,
+		};
 	}
 
 	for (const secret of previews?.secrets_store_secrets ?? []) {

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -2733,19 +2733,21 @@ function collectAllUnsafeBindings(
  *
  * @param args - All the CLI arguments passed to the `types` command
  *
- * @returns An array of collected pipeline bindings with their names and pipeline IDs.
+ * @returns An array of collected pipeline bindings with their names and stream IDs.
  */
 function collectAllPipelines(
 	args: Partial<(typeof typesCommand)["args"]>
 ): Array<{
 	binding: string;
-	pipeline: string;
+	stream?: string;
+	pipeline?: string;
 }> {
 	const pipelinesMap = new Map<
 		string,
 		{
 			binding: string;
-			pipeline: string;
+			stream?: string;
+			pipeline?: string;
 		}
 	>();
 
@@ -2769,13 +2771,13 @@ function collectAllPipelines(
 				});
 			}
 
-			if (!pipeline.pipeline) {
+			if (!pipeline.stream && !pipeline.pipeline) {
 				throwMissingBindingError({
 					binding: pipeline,
 					bindingType: "pipelines",
 					configPath: args.config,
 					envName,
-					fieldName: "pipeline",
+					fieldName: "stream",
 					index,
 				});
 			}
@@ -2786,6 +2788,7 @@ function collectAllPipelines(
 
 			pipelinesMap.set(pipeline.binding, {
 				binding: pipeline.binding,
+				stream: pipeline.stream,
 				pipeline: pipeline.pipeline,
 			});
 		}
@@ -3880,14 +3883,14 @@ function collectPipelinesPerEnvironment(
 	string,
 	Array<{
 		binding: string;
-		pipeline: string;
+		stream: string;
 	}>
 > {
 	const result = new Map<
 		string,
 		Array<{
 			binding: string;
-			pipeline: string;
+			stream: string;
 		}>
 	>();
 
@@ -3896,11 +3899,11 @@ function collectPipelinesPerEnvironment(
 		envName: string
 	): Array<{
 		binding: string;
-		pipeline: string;
+		stream: string;
 	}> {
 		const pipelines = new Array<{
 			binding: string;
-			pipeline: string;
+			stream: string;
 		}>();
 
 		if (!env?.pipelines) {
@@ -3919,20 +3922,22 @@ function collectPipelinesPerEnvironment(
 				});
 			}
 
-			if (!pipeline.pipeline) {
+			const stream = pipeline.stream || pipeline.pipeline;
+			if (!stream) {
 				throwMissingBindingError({
 					binding: pipeline,
 					bindingType: "pipelines",
 					configPath: args.config,
 					envName,
-					fieldName: "pipeline",
+					fieldName: "stream",
 					index,
 				});
 			}
 
 			pipelines.push({
 				binding: pipeline.binding,
-				pipeline: pipeline.pipeline,
+				// eslint-disable-next-line no-non-null-assertion -- we asserted above that stream is not null|undefined
+				stream: stream!,
 			});
 		}
 

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -2365,19 +2365,21 @@ function collectAllUnsafeBindings(
  *
  * @param args - All the CLI arguments passed to the `types` command
  *
- * @returns An array of collected pipeline bindings with their names and pipeline IDs.
+ * @returns An array of collected pipeline bindings with their names and stream IDs.
  */
 function collectAllPipelines(
 	args: Partial<(typeof typesCommand)["args"]>
 ): Array<{
 	binding: string;
-	pipeline: string;
+	stream?: string;
+	pipeline?: string;
 }> {
 	const pipelinesMap = new Map<
 		string,
 		{
 			binding: string;
-			pipeline: string;
+			stream?: string;
+			pipeline?: string;
 		}
 	>();
 
@@ -2401,13 +2403,13 @@ function collectAllPipelines(
 				});
 			}
 
-			if (!pipeline.pipeline) {
+			if (!pipeline.stream && !pipeline.pipeline) {
 				throwMissingBindingError({
 					binding: pipeline,
 					bindingType: "pipelines",
 					configPath: args.config,
 					envName,
-					fieldName: "pipeline",
+					fieldName: "stream",
 					index,
 				});
 			}
@@ -2418,6 +2420,7 @@ function collectAllPipelines(
 
 			pipelinesMap.set(pipeline.binding, {
 				binding: pipeline.binding,
+				stream: pipeline.stream,
 				pipeline: pipeline.pipeline,
 			});
 		}
@@ -3512,14 +3515,14 @@ function collectPipelinesPerEnvironment(
 	string,
 	Array<{
 		binding: string;
-		pipeline: string;
+		stream: string;
 	}>
 > {
 	const result = new Map<
 		string,
 		Array<{
 			binding: string;
-			pipeline: string;
+			stream: string;
 		}>
 	>();
 
@@ -3528,11 +3531,11 @@ function collectPipelinesPerEnvironment(
 		envName: string
 	): Array<{
 		binding: string;
-		pipeline: string;
+		stream: string;
 	}> {
 		const pipelines = new Array<{
 			binding: string;
-			pipeline: string;
+			stream: string;
 		}>();
 
 		if (!env?.pipelines) {
@@ -3551,20 +3554,22 @@ function collectPipelinesPerEnvironment(
 				});
 			}
 
-			if (!pipeline.pipeline) {
+			const stream = pipeline.stream || pipeline.pipeline;
+			if (!stream) {
 				throwMissingBindingError({
 					binding: pipeline,
 					bindingType: "pipelines",
 					configPath: args.config,
 					envName,
-					fieldName: "pipeline",
+					fieldName: "stream",
 					index,
 				});
 			}
 
 			pipelines.push({
 				binding: pipeline.binding,
-				pipeline: pipeline.pipeline,
+				// eslint-disable-next-line no-non-null-assertion -- we asserted above that stream is not null|undefined
+				stream: stream!,
 			});
 		}
 

--- a/packages/wrangler/src/type-generation/pipeline-schema.ts
+++ b/packages/wrangler/src/type-generation/pipeline-schema.ts
@@ -213,7 +213,7 @@ export interface PipelineTypeResult {
  */
 export async function fetchPipelineTypes(
 	config: Config,
-	pipelines: Array<{ binding: string; pipeline: string }>
+	pipelines: Array<{ binding: string; stream?: string; pipeline?: string }>
 ): Promise<PipelineTypeResult[]> {
 	if (pipelines.length === 0) {
 		return [];
@@ -233,7 +233,15 @@ export async function fetchPipelineTypes(
 
 	// Fetch all streams in parallel for better performance
 	const streams = await Promise.all(
-		pipelines.map((p) => fetchStream(config, p.pipeline))
+		pipelines.map((p) => {
+			const streamID = p.stream || p.pipeline;
+			if (!streamID) {
+				throw new Error(
+					`Pipeline binding ${p.binding} is missing the stream ID`
+				);
+			}
+			return fetchStream(config, streamID);
+		})
 	);
 
 	const results = pipelines.map((pipeline, i) => {

--- a/packages/wrangler/src/utils/print-bindings.ts
+++ b/packages/wrangler/src/utils/print-bindings.ts
@@ -637,14 +637,16 @@ export function printBindings(
 
 	if (pipelines.length > 0) {
 		output.push(
-			...pipelines.map(({ binding, pipeline, remote }) => ({
-				name: binding,
-				type: getBindingTypeFriendlyName("pipeline"),
-				value: pipeline,
-				mode: getMode({
-					isSimulatedLocally: context.remoteBindingsDisabled || !remote,
-				}),
-			}))
+			...pipelines.map(
+				({ binding, stream: pipelineStream, pipeline, remote }) => ({
+					name: binding,
+					type: getBindingTypeFriendlyName("pipeline"),
+					value: pipelineStream || pipeline,
+					mode: getMode({
+						isSimulatedLocally: context.remoteBindingsDisabled || !remote,
+					}),
+				})
+			)
 		);
 	}
 


### PR DESCRIPTION
…

PIPE-374

Fixes the mismatch between original Pipeline bindings and v1 Pipeline entities.  Specifically that we are binding to a Stream now, which then feeds the Pipeline that delivers traffic to a Sink.  We preserve the original bindings to avoid breaking existing pipelines, but issue a warning of the deprecated usage.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: PIPE-633

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
