### PR TITLE
feat(wrangler): add custom metadata to instance creation on ai search

### DIFF
--- a/.changeset/ai-search-create-custom-metadata.md
+++ b/.changeset/ai-search-create-custom-metadata.md
@@ -1,0 +1,31 @@
+---
+"wrangler": minor
+---
+
+Add optional `custom_metadata` step to `wrangler ai-search create`
+
+The `wrangler ai-search create` interactive wizard now lets you declare custom metadata fields that the new AI Search instance should index. Each field is a `field_name` paired with a `data_type` (`text`, `number`, `boolean`, or `datetime`).
+
+You can provide fields up-front via the new repeatable `--custom-metadata` flag using `field_name:data_type` syntax:
+
+```sh
+wrangler ai-search create my-instance \
+  --type r2 --source my-bucket \
+  --custom-metadata title:text \
+  --custom-metadata views:number
+```
+
+For larger schemas, use `--custom-metadata-schema` to point at a JSON file containing an array of `{ field_name, data_type }` objects:
+
+```sh
+wrangler ai-search create my-instance \
+  --type r2 --source my-bucket \
+  --custom-metadata-schema schema.json
+```
+
+```json
+[
+	{ "field_name": "title", "data_type": "text" },
+	{ "field_name": "views", "data_type": "number" }
+]
+```

--- a/packages/wrangler/src/__tests__/ai-search.test.ts
+++ b/packages/wrangler/src/__tests__/ai-search.test.ts
@@ -1,3 +1,4 @@
+import { writeFileSync } from "node:fs";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { endEventLoop } from "./helpers/end-event-loop";
@@ -292,6 +293,10 @@ describe("ai-search commands", () => {
 			let capturedBody: Record<string, unknown> | undefined;
 			let capturedNamespace: string | undefined;
 			mockListTokens([MOCK_TOKEN]);
+			mockConfirm({
+				text: "Configure custom metadata fields? (optional)",
+				result: false,
+			});
 			msw.use(
 				http.post(
 					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances",
@@ -328,6 +333,10 @@ describe("ai-search commands", () => {
 		}) => {
 			let capturedNamespace: string | undefined;
 			mockListTokens([MOCK_TOKEN]);
+			mockConfirm({
+				text: "Configure custom metadata fields? (optional)",
+				result: false,
+			});
 			msw.use(
 				http.post(
 					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances",
@@ -349,6 +358,10 @@ describe("ai-search commands", () => {
 
 		it("should create instance and print details", async ({ expect }) => {
 			mockListTokens([MOCK_TOKEN]);
+			mockConfirm({
+				text: "Configure custom metadata fields? (optional)",
+				result: false,
+			});
 			mockCreateInstance(MOCK_INSTANCE);
 			await runWrangler(
 				"ai-search create my-instance --namespace default --type r2 --source my-bucket"
@@ -404,6 +417,10 @@ describe("ai-search commands", () => {
 				text: "Select a namespace:",
 				result: "blog",
 			});
+			mockConfirm({
+				text: "Configure custom metadata fields? (optional)",
+				result: false,
+			});
 			msw.use(
 				http.post(
 					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances",
@@ -432,6 +449,10 @@ describe("ai-search commands", () => {
 			mockSelect({
 				text: "Select a namespace:",
 				result: "default",
+			});
+			mockConfirm({
+				text: "Configure custom metadata fields? (optional)",
+				result: false,
 			});
 			msw.use(
 				http.post(
@@ -487,6 +508,10 @@ describe("ai-search commands", () => {
 				text: "Enter a name for the new namespace:",
 				result: "my-new-ns",
 			});
+			mockConfirm({
+				text: "Configure custom metadata fields? (optional)",
+				result: false,
+			});
 			msw.use(
 				http.post(
 					"*/accounts/:accountId/ai-search/namespaces",
@@ -537,6 +562,10 @@ describe("ai-search commands", () => {
 		}) => {
 			let capturedBody: Record<string, unknown> | undefined;
 			mockListTokens([MOCK_TOKEN]);
+			mockConfirm({
+				text: "Configure custom metadata fields? (optional)",
+				result: false,
+			});
 			msw.use(
 				http.post(
 					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances",
@@ -593,10 +622,16 @@ describe("ai-search commands", () => {
 			// second call (with token) first, then first call (empty) on top.
 			mockListTokens([MOCK_TOKEN]);
 			mockListTokens([]);
-			mockConfirm({
-				text: "Have you created a token?",
-				result: true,
-			});
+			mockConfirm(
+				{
+					text: "Have you created a token?",
+					result: true,
+				},
+				{
+					text: "Configure custom metadata fields? (optional)",
+					result: false,
+				}
+			);
 			mockCreateInstance(MOCK_INSTANCE);
 			await runWrangler(
 				"ai-search create my-instance --namespace default --type r2 --source my-bucket"
@@ -631,6 +666,10 @@ describe("ai-search commands", () => {
 			mockSelect({
 				text: "Select an R2 bucket:",
 				result: "my-bucket",
+			});
+			mockConfirm({
+				text: "Configure custom metadata fields? (optional)",
+				result: false,
 			});
 			mockCreateInstance(MOCK_INSTANCE);
 			await runWrangler("ai-search create my-instance --namespace default");
@@ -668,6 +707,10 @@ describe("ai-search commands", () => {
 					{ once: true }
 				)
 			);
+			mockConfirm({
+				text: "Configure custom metadata fields? (optional)",
+				result: false,
+			});
 			mockCreateInstance({
 				...MOCK_INSTANCE,
 				source: "new-bucket",
@@ -705,6 +748,10 @@ describe("ai-search commands", () => {
 				text: "Select a zone:",
 				result: "example.com",
 			});
+			mockConfirm({
+				text: "Configure custom metadata fields? (optional)",
+				result: false,
+			});
 			mockCreateInstance({
 				...MOCK_INSTANCE,
 				type: "web-crawler",
@@ -734,6 +781,10 @@ describe("ai-search commands", () => {
 			mockPrompt({
 				text: "Enter the website URL to index:",
 				result: "https://my-site.com",
+			});
+			mockConfirm({
+				text: "Configure custom metadata fields? (optional)",
+				result: false,
 			});
 			mockCreateInstance({
 				...MOCK_INSTANCE,
@@ -786,6 +837,374 @@ describe("ai-search commands", () => {
 					"ai-search create my-instance --namespace default --type web-crawler"
 				)
 			).rejects.toThrowError(/Missing required flag.*--source/);
+		});
+
+		// ── custom_metadata ─────────────────────────────────────────────────────
+
+		it("should send custom_metadata when --custom-metadata is provided", async ({
+			expect,
+		}) => {
+			let capturedBody: Record<string, unknown> | undefined;
+			mockListTokens([MOCK_TOKEN]);
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(createFetchResult(MOCK_INSTANCE, true));
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(
+				"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata title:text"
+			);
+			expect(capturedBody).toMatchObject({
+				custom_metadata: [{ field_name: "title", data_type: "text" }],
+			});
+		});
+
+		it("should accept multiple --custom-metadata flags", async ({ expect }) => {
+			let capturedBody: Record<string, unknown> | undefined;
+			mockListTokens([MOCK_TOKEN]);
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(createFetchResult(MOCK_INSTANCE, true));
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(
+				"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata title:text --custom-metadata views:number --custom-metadata published:boolean"
+			);
+			expect(capturedBody).toMatchObject({
+				custom_metadata: [
+					{ field_name: "title", data_type: "text" },
+					{ field_name: "views", data_type: "number" },
+					{ field_name: "published", data_type: "boolean" },
+				],
+			});
+		});
+
+		it("should reject --custom-metadata with an invalid data_type", async ({
+			expect,
+		}) => {
+			mockListTokens([MOCK_TOKEN]);
+			await expect(
+				runWrangler(
+					"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata title:bogus"
+				)
+			).rejects.toThrowError(
+				/data_type must be one of text, number, boolean, datetime/
+			);
+		});
+
+		it("should reject --custom-metadata that is missing a separator", async ({
+			expect,
+		}) => {
+			mockListTokens([MOCK_TOKEN]);
+			await expect(
+				runWrangler(
+					"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata title"
+				)
+			).rejects.toThrowError(/Expected format: field_name:data_type/);
+		});
+
+		it("should reject --custom-metadata with a reserved field name", async ({
+			expect,
+		}) => {
+			mockListTokens([MOCK_TOKEN]);
+			await expect(
+				runWrangler(
+					"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata timestamp:number"
+				)
+			).rejects.toThrowError(/reserved field name/);
+		});
+
+		it("should interactively configure custom_metadata when the flag is omitted", async ({
+			expect,
+		}) => {
+			let capturedBody: Record<string, unknown> | undefined;
+			mockListTokens([MOCK_TOKEN]);
+			mockConfirm({
+				text: "Configure custom metadata fields? (optional)",
+				result: true,
+			});
+			mockPrompt({
+				text: "Field name:",
+				result: "category",
+			});
+			mockSelect({
+				text: "Data type:",
+				result: "text",
+			});
+			mockConfirm({
+				text: "Add another field?",
+				result: false,
+			});
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(createFetchResult(MOCK_INSTANCE, true));
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(
+				"ai-search create my-instance --namespace default --type r2 --source my-bucket"
+			);
+			expect(capturedBody).toMatchObject({
+				custom_metadata: [{ field_name: "category", data_type: "text" }],
+			});
+		});
+
+		it("should not send custom_metadata when the user declines the optional step", async ({
+			expect,
+		}) => {
+			let capturedBody: Record<string, unknown> | undefined;
+			mockListTokens([MOCK_TOKEN]);
+			mockConfirm({
+				text: "Configure custom metadata fields? (optional)",
+				result: false,
+			});
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(createFetchResult(MOCK_INSTANCE, true));
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(
+				"ai-search create my-instance --namespace default --type r2 --source my-bucket"
+			);
+			expect(capturedBody).not.toHaveProperty("custom_metadata");
+		});
+
+		it("should skip the custom_metadata prompt in non-interactive mode", async ({
+			expect,
+		}) => {
+			let capturedBody: Record<string, unknown> | undefined;
+			setIsTTY(false);
+			mockListTokens([MOCK_TOKEN]);
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(createFetchResult(MOCK_INSTANCE, true));
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(
+				"ai-search create my-instance --namespace default --type r2 --source my-bucket"
+			);
+			expect(capturedBody).not.toHaveProperty("custom_metadata");
+		});
+
+		it("should skip the custom_metadata prompt when --json is passed", async ({
+			expect,
+		}) => {
+			let capturedBody: Record<string, unknown> | undefined;
+			mockListTokens([MOCK_TOKEN]);
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(createFetchResult(MOCK_INSTANCE, true));
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(
+				"ai-search create my-instance --namespace default --type r2 --source my-bucket --json"
+			);
+			expect(capturedBody).not.toHaveProperty("custom_metadata");
+		});
+
+		it("should print the custom_metadata fields in the success summary", async ({
+			expect,
+		}) => {
+			mockListTokens([MOCK_TOKEN]);
+			mockCreateInstance({
+				...MOCK_INSTANCE,
+				custom_metadata: [
+					{ field_name: "title", data_type: "text" },
+					{ field_name: "views", data_type: "number" },
+				],
+			});
+			await runWrangler(
+				"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata title:text --custom-metadata views:number"
+			);
+			expect(std.out).toContain("Metadata:   title:text, views:number");
+		});
+
+		it("should reject --custom-metadata-schema with the legacy object form", async ({
+			expect,
+		}) => {
+			mockListTokens([MOCK_TOKEN]);
+			writeFileSync(
+				"schema.json",
+				JSON.stringify({
+					custom_metadata: [{ field_name: "title", data_type: "text" }],
+				})
+			);
+			await expect(
+				runWrangler(
+					"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata-schema schema.json"
+				)
+			).rejects.toThrowError(
+				/Expected an array of \{ field_name, data_type \} objects/
+			);
+		});
+
+		it("should load custom_metadata from --custom-metadata-schema (bare array form)", async ({
+			expect,
+		}) => {
+			let capturedBody: Record<string, unknown> | undefined;
+			mockListTokens([MOCK_TOKEN]);
+			writeFileSync(
+				"schema.json",
+				JSON.stringify([
+					{ field_name: "category", data_type: "text" },
+					{ field_name: "published", data_type: "boolean" },
+				])
+			);
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(createFetchResult(MOCK_INSTANCE, true));
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(
+				"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata-schema schema.json"
+			);
+			expect(capturedBody).toMatchObject({
+				custom_metadata: [
+					{ field_name: "category", data_type: "text" },
+					{ field_name: "published", data_type: "boolean" },
+				],
+			});
+		});
+
+		it("should reject --custom-metadata-schema with malformed JSON", async ({
+			expect,
+		}) => {
+			mockListTokens([MOCK_TOKEN]);
+			writeFileSync("schema.json", "{ not valid json");
+			await expect(
+				runWrangler(
+					"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata-schema schema.json"
+				)
+			).rejects.toThrowError();
+		});
+
+		it("should reject --custom-metadata-schema with an unsupported shape", async ({
+			expect,
+		}) => {
+			mockListTokens([MOCK_TOKEN]);
+			writeFileSync(
+				"schema.json",
+				JSON.stringify({ fields: [{ field_name: "title", data_type: "text" }] })
+			);
+			await expect(
+				runWrangler(
+					"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata-schema schema.json"
+				)
+			).rejects.toThrowError(
+				/Expected an array of \{ field_name, data_type \} objects/
+			);
+		});
+
+		it("should reject --custom-metadata-schema with an invalid data_type", async ({
+			expect,
+		}) => {
+			mockListTokens([MOCK_TOKEN]);
+			writeFileSync(
+				"schema.json",
+				JSON.stringify([{ field_name: "title", data_type: "bogus" }])
+			);
+			await expect(
+				runWrangler(
+					"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata-schema schema.json"
+				)
+			).rejects.toThrowError(
+				/"data_type" must be one of text, number, boolean, datetime/
+			);
+		});
+
+		it("should reject --custom-metadata-schema with a reserved field name", async ({
+			expect,
+		}) => {
+			mockListTokens([MOCK_TOKEN]);
+			writeFileSync(
+				"schema.json",
+				JSON.stringify([{ field_name: "timestamp", data_type: "number" }])
+			);
+			await expect(
+				runWrangler(
+					"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata-schema schema.json"
+				)
+			).rejects.toThrowError(/reserved field name/);
+		});
+
+		it("should reject combining --custom-metadata and --custom-metadata-schema", async ({
+			expect,
+		}) => {
+			mockListTokens([MOCK_TOKEN]);
+			writeFileSync(
+				"schema.json",
+				JSON.stringify([{ field_name: "title", data_type: "text" }])
+			);
+			await expect(
+				runWrangler(
+					"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata title:text --custom-metadata-schema schema.json"
+				)
+			).rejects.toThrowError(
+				/custom-metadata and custom-metadata-schema are mutually exclusive/
+			);
+		});
+
+		it("should skip the interactive prompt when --custom-metadata-schema is provided", async ({
+			expect,
+		}) => {
+			let capturedBody: Record<string, unknown> | undefined;
+			mockListTokens([MOCK_TOKEN]);
+			// No mockConfirm for "Configure custom metadata fields? (optional)" — if
+			// the prompt fires the test will fail with an unexpected-call error.
+			writeFileSync(
+				"schema.json",
+				JSON.stringify([{ field_name: "title", data_type: "text" }])
+			);
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/ai-search/namespaces/:namespace/instances",
+					async ({ request }) => {
+						capturedBody = (await request.json()) as Record<string, unknown>;
+						return HttpResponse.json(createFetchResult(MOCK_INSTANCE, true));
+					},
+					{ once: true }
+				)
+			);
+			await runWrangler(
+				"ai-search create my-instance --namespace default --type r2 --source my-bucket --custom-metadata-schema schema.json"
+			);
+			expect(capturedBody).toMatchObject({
+				custom_metadata: [{ field_name: "title", data_type: "text" }],
+			});
 		});
 	});
 

--- a/packages/wrangler/src/ai-search/create.ts
+++ b/packages/wrangler/src/ai-search/create.ts
@@ -1,4 +1,5 @@
-import { UserError } from "@cloudflare/workers-utils";
+import path from "node:path";
+import { parseJSON, readFileSync, UserError } from "@cloudflare/workers-utils";
 import { fetchPagedListResult } from "../cfetch";
 import { createCommand } from "../core/create-command";
 import { confirm, prompt, select } from "../dialogs";
@@ -13,9 +14,191 @@ import {
 	listNamespaces,
 	listTokens,
 } from "./client";
+import type {
+	AiSearchCustomMetadata,
+	AiSearchCustomMetadataDataType,
+} from "./types";
 
 const CREATE_NEW_BUCKET = "__create_new__";
 const CREATE_NEW_NAMESPACE = "__create_new__";
+
+const CUSTOM_METADATA_DATA_TYPES = [
+	"text",
+	"number",
+	"boolean",
+	"datetime",
+] as const satisfies readonly AiSearchCustomMetadataDataType[];
+
+// Reserved field names rejected by the AI Search backend; validated client-side
+// for fast feedback. Keep in sync with apps/config-api validation rules.
+const CUSTOM_METADATA_RESERVED_FIELD_NAMES = new Set([
+	"timestamp",
+	"folder",
+	"filename",
+]);
+
+const CUSTOM_METADATA_MAX_ENTRIES = 20;
+
+function isCustomMetadataDataType(
+	value: string
+): value is AiSearchCustomMetadataDataType {
+	return (CUSTOM_METADATA_DATA_TYPES as readonly string[]).includes(value);
+}
+
+function validateCustomMetadataFieldName(
+	fieldName: string,
+	existing: AiSearchCustomMetadata[]
+): true | string {
+	if (fieldName.length === 0) {
+		return "Field name is required.";
+	}
+	if (CUSTOM_METADATA_RESERVED_FIELD_NAMES.has(fieldName.toLowerCase())) {
+		return `"${fieldName}" is a reserved field name. Reserved: ${[...CUSTOM_METADATA_RESERVED_FIELD_NAMES].join(", ")}.`;
+	}
+	const lower = fieldName.toLowerCase();
+	if (existing.some((m) => m.field_name.toLowerCase() === lower)) {
+		return `Field name "${fieldName}" is already defined.`;
+	}
+	return true;
+}
+
+function parseCustomMetadataFlag(
+	values: ReadonlyArray<string | number>
+): AiSearchCustomMetadata[] {
+	const result: AiSearchCustomMetadata[] = [];
+	const errors: string[] = [];
+	for (const value of values) {
+		const raw = String(value);
+		const idx = raw.indexOf(":");
+		if (idx === -1) {
+			errors.push(
+				`Invalid --custom-metadata value "${raw}". ` +
+					`Expected format: field_name:data_type ` +
+					`(data_type one of ${CUSTOM_METADATA_DATA_TYPES.join(", ")}).`
+			);
+			continue;
+		}
+		const fieldName = raw.slice(0, idx).trim();
+		const dataType = raw.slice(idx + 1).trim();
+		const fieldValidation = validateCustomMetadataFieldName(fieldName, result);
+		if (fieldValidation !== true) {
+			errors.push(
+				`Invalid --custom-metadata value "${raw}": ${fieldValidation}`
+			);
+			continue;
+		}
+		if (!isCustomMetadataDataType(dataType)) {
+			errors.push(
+				`Invalid --custom-metadata value "${raw}": data_type must be one of ${CUSTOM_METADATA_DATA_TYPES.join(", ")}.`
+			);
+			continue;
+		}
+		result.push({ field_name: fieldName, data_type: dataType });
+	}
+	if (result.length > CUSTOM_METADATA_MAX_ENTRIES) {
+		errors.push(
+			`At most ${CUSTOM_METADATA_MAX_ENTRIES} custom metadata fields are allowed (got ${result.length}).`
+		);
+	}
+	if (errors.length > 0) {
+		throw new UserError(
+			errors.length === 1
+				? errors[0]
+				: `Found ${errors.length} errors in --custom-metadata values:\n` +
+						errors.map((e) => `  - ${e}`).join("\n"),
+			{
+				telemetryMessage: false,
+			}
+		);
+	}
+	return result;
+}
+
+/**
+ * Reads a JSON file describing custom metadata fields and returns the parsed
+ * list. Only accepts a bare array of `{ field_name, data_type }` objects, e.g.
+ * `[{ "field_name": "title", "data_type": "text" }]`.
+ */
+function parseCustomMetadataSchemaFile(
+	filePath: string
+): AiSearchCustomMetadata[] {
+	const resolvedPath = path.resolve(filePath);
+	const parsed = parseJSON(readFileSync(resolvedPath), resolvedPath) as unknown;
+
+	if (!Array.isArray(parsed)) {
+		throw new UserError(
+			`Invalid custom metadata schema in "${resolvedPath}". ` +
+				`Expected an array of { field_name, data_type } objects.`,
+			{
+				telemetryMessage: false,
+			}
+		);
+	}
+
+	const result: AiSearchCustomMetadata[] = [];
+	const errors: string[] = [];
+	parsed.forEach((entry, index) => {
+		if (entry === null || typeof entry !== "object") {
+			errors.push(
+				`Invalid custom metadata entry at index ${index} in "${resolvedPath}": ` +
+					`expected an object with "field_name" and "data_type".`
+			);
+			return;
+		}
+		const { field_name: fieldNameRaw, data_type: dataTypeRaw } = entry as {
+			field_name?: unknown;
+			data_type?: unknown;
+		};
+		if (typeof fieldNameRaw !== "string") {
+			errors.push(
+				`Invalid custom metadata entry at index ${index} in "${resolvedPath}": ` +
+					`"field_name" must be a string.`
+			);
+			return;
+		}
+		if (typeof dataTypeRaw !== "string") {
+			errors.push(
+				`Invalid custom metadata entry at index ${index} in "${resolvedPath}": ` +
+					`"data_type" must be a string.`
+			);
+			return;
+		}
+		const fieldName = fieldNameRaw.trim();
+		const fieldValidation = validateCustomMetadataFieldName(fieldName, result);
+		if (fieldValidation !== true) {
+			errors.push(
+				`Invalid custom metadata entry at index ${index} in "${resolvedPath}": ${fieldValidation}`
+			);
+			return;
+		}
+		if (!isCustomMetadataDataType(dataTypeRaw)) {
+			errors.push(
+				`Invalid custom metadata entry at index ${index} in "${resolvedPath}": ` +
+					`"data_type" must be one of ${CUSTOM_METADATA_DATA_TYPES.join(", ")}.`
+			);
+			return;
+		}
+		result.push({ field_name: fieldName, data_type: dataTypeRaw });
+	});
+
+	if (result.length > CUSTOM_METADATA_MAX_ENTRIES) {
+		errors.push(
+			`At most ${CUSTOM_METADATA_MAX_ENTRIES} custom metadata fields are allowed (got ${result.length}) in "${resolvedPath}".`
+		);
+	}
+	if (errors.length > 0) {
+		throw new UserError(
+			errors.length === 1
+				? errors[0]
+				: `Found ${errors.length} errors in custom metadata schema "${resolvedPath}":\n` +
+						errors.map((e) => `  - ${e}`).join("\n"),
+			{
+				telemetryMessage: false,
+			}
+		);
+	}
+	return result;
+}
 
 export const aiSearchCreateCommand = createCommand({
 	metadata: {
@@ -100,6 +283,24 @@ export const aiSearchCreateCommand = createCommand({
 			type: "array",
 			string: true,
 			description: "Glob patterns for items to exclude.",
+		},
+		"custom-metadata": {
+			type: "array",
+			string: true,
+			description:
+				"Custom metadata fields, formatted as 'field_name:data_type'. " +
+				`data_type must be one of: ${CUSTOM_METADATA_DATA_TYPES.join(", ")}. ` +
+				"Repeat the flag for multiple fields (e.g. --custom-metadata title:text --custom-metadata views:number).",
+			conflicts: ["custom-metadata-schema"],
+		},
+		"custom-metadata-schema": {
+			type: "string",
+			requiresArg: true,
+			description:
+				"Path to a JSON file describing custom metadata fields. " +
+				'The file must contain an array of { "field_name", "data_type" } objects. ' +
+				"Mutually exclusive with --custom-metadata.",
+			conflicts: ["custom-metadata"],
 		},
 		json: {
 			type: "boolean",
@@ -340,6 +541,64 @@ export const aiSearchCreateCommand = createCommand({
 			}
 		}
 
+		// 3. Custom metadata (optional). Honors --custom-metadata or
+		// --custom-metadata-schema; otherwise prompts interactively when
+		// running attached to a TTY.
+		if (
+			args.customMetadata &&
+			args.customMetadata.length > 0 &&
+			args.customMetadataSchema
+		) {
+			throw new UserError(
+				"--custom-metadata and --custom-metadata-schema are mutually exclusive. " +
+					"Pick one.",
+				{
+					telemetryMessage: false,
+				}
+			);
+		}
+		let customMetadata: AiSearchCustomMetadata[] = [];
+		if (args.customMetadata && args.customMetadata.length > 0) {
+			customMetadata = parseCustomMetadataFlag(args.customMetadata);
+		} else if (args.customMetadataSchema) {
+			customMetadata = parseCustomMetadataSchemaFile(args.customMetadataSchema);
+		} else if (!isNonInteractiveOrCI() && !args.json) {
+			const configure = await confirm(
+				"Configure custom metadata fields? (optional)",
+				{ defaultValue: false }
+			);
+			if (configure) {
+				let addAnother = true;
+				while (addAnother) {
+					const fieldName = await prompt("Field name:", {
+						validate: (value: string) =>
+							validateCustomMetadataFieldName(value.trim(), customMetadata),
+					});
+					const dataType = await select("Data type:", {
+						choices: CUSTOM_METADATA_DATA_TYPES.map((t) => ({
+							title: t,
+							value: t,
+						})),
+						defaultOption: 0,
+					});
+					customMetadata.push({
+						field_name: fieldName.trim(),
+						data_type: dataType,
+					});
+					if (customMetadata.length >= CUSTOM_METADATA_MAX_ENTRIES) {
+						logger.log(
+							`Reached the maximum of ${CUSTOM_METADATA_MAX_ENTRIES} custom metadata fields.`
+						);
+						addAnother = false;
+					} else {
+						addAnother = await confirm("Add another field?", {
+							defaultValue: false,
+						});
+					}
+				}
+			}
+		}
+
 		const body: Record<string, unknown> = {
 			id: instanceName,
 			source: instanceSource,
@@ -376,6 +635,9 @@ export const aiSearchCreateCommand = createCommand({
 		if (args.scoreThreshold !== undefined) {
 			body.score_threshold = args.scoreThreshold;
 		}
+		if (customMetadata.length > 0) {
+			body.custom_metadata = customMetadata;
+		}
 
 		const sourceParams: Record<string, unknown> = {};
 		if (args.prefix) {
@@ -411,15 +673,21 @@ export const aiSearchCreateCommand = createCommand({
 		if (args.json) {
 			logger.log(JSON.stringify(instance, null, 2));
 		} else {
-			logger.log(
+			let summary =
 				`Successfully created AI Search instance "${instance.id}"\n` +
-					`  Name:       ${instance.id}\n` +
-					`  Namespace:  ${instance.namespace ?? instanceNamespace}\n` +
-					`  Type:       ${instance.type}\n` +
-					`  Source:     ${instance.source}\n` +
-					`  Model:      ${instance.ai_search_model ?? "default"}\n` +
-					`  Embedding:  ${instance.embedding_model ?? "default"}`
-			);
+				`  Name:       ${instance.id}\n` +
+				`  Namespace:  ${instance.namespace ?? instanceNamespace}\n` +
+				`  Type:       ${instance.type}\n` +
+				`  Source:     ${instance.source}\n` +
+				`  Model:      ${instance.ai_search_model ?? "default"}\n` +
+				`  Embedding:  ${instance.embedding_model ?? "default"}`;
+			if (instance.custom_metadata && instance.custom_metadata.length > 0) {
+				const fields = instance.custom_metadata
+					.map((m) => `${m.field_name}:${m.data_type}`)
+					.join(", ");
+				summary += `\n  Metadata:   ${fields}`;
+			}
+			logger.log(summary);
 		}
 	},
 });

--- a/packages/wrangler/src/ai-search/types.ts
+++ b/packages/wrangler/src/ai-search/types.ts
@@ -44,8 +44,14 @@ export interface AiSearchInstance {
 	token_id?: string;
 }
 
+export type AiSearchCustomMetadataDataType =
+	| "text"
+	| "number"
+	| "boolean"
+	| "datetime";
+
 export interface AiSearchCustomMetadata {
-	data_type: string;
+	data_type: AiSearchCustomMetadataDataType;
 	field_name: string;
 }
 


### PR DESCRIPTION
Fixes #RAG-1145.

Adds ability to specify custom metadata on instance creation on AI Search

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: it will automatically generated by docs component


<img width="900" height="720" alt="900_Cast-About-Photography_272A8079___Merkat" src="https://github.com/user-attachments/assets/2096e685-9d83-4f2f-a027-67d1bfd42f52" />


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
