### PR TITLE
fix(miniflare): expose send_email in platform proxy

### DIFF
--- a/.changeset/email-platform-proxy.md
+++ b/.changeset/email-platform-proxy.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Expose `send_email` bindings from `getPlatformProxy()`
+
+Projects developing in Node can now access `send_email` bindings from the platform proxy. This supports the plain-object MessageBuilder API locally, so calls like `env.EMAIL.send({ from, to, subject, text })` no longer fail because the binding is missing.

--- a/packages/miniflare/src/plugins/email/index.ts
+++ b/packages/miniflare/src/plugins/email/index.ts
@@ -5,8 +5,8 @@ import SEND_EMAIL_BINDING from "worker:email/send_email";
 import { z } from "zod";
 import {
 	getUserBindingServiceName,
-	ProxyNodeBinding,
 	remoteProxyClientWorker,
+	ProxyNodeBinding,
 } from "../shared";
 import type { Service, Worker_Binding } from "../../runtime";
 import type { Plugin, RemoteProxyConnectionString } from "../shared";
@@ -86,7 +86,9 @@ export const EMAIL_PLUGIN: Plugin<typeof EmailOptionsSchema> = {
 			return [];
 		}
 
-		const emailDirectory = path.join(args.tmpPath, EMAIL_PLUGIN_NAME).replaceAll("\\", "/");
+		const emailDirectory = path
+			.join(args.tmpPath, EMAIL_PLUGIN_NAME)
+			.replaceAll("\\", "/");
 		await mkdir(emailDirectory, { recursive: true });
 
 		const services: Service[] = [

--- a/packages/miniflare/src/plugins/email/index.ts
+++ b/packages/miniflare/src/plugins/email/index.ts
@@ -1,10 +1,12 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
 import EMAIL_MESSAGE from "worker:email/email";
 import SEND_EMAIL_BINDING from "worker:email/send_email";
 import { z } from "zod";
 import {
 	getUserBindingServiceName,
+	ProxyNodeBinding,
 	remoteProxyClientWorker,
-	WORKER_BINDING_SERVICE_LOOPBACK,
 } from "../shared";
 import type { Service, Worker_Binding } from "../../runtime";
 import type { Plugin, RemoteProxyConnectionString } from "../shared";
@@ -41,6 +43,8 @@ export const EmailOptionsSchema = z.object({
 
 export const EMAIL_PLUGIN_NAME = "email";
 const SERVICE_SEND_EMAIL_WORKER_PREFIX = `SEND-EMAIL-WORKER`;
+const EMAIL_DISK_SERVICE_NAME = `${EMAIL_PLUGIN_NAME}:disk`;
+const EMAIL_DISK_BINDING_NAME = "MINIFLARE_EMAIL_DISK";
 
 function buildJsonBindings(bindings: Record<string, any>): Worker_Binding[] {
 	return Object.entries(bindings).map(([name, value]) => ({
@@ -68,11 +72,32 @@ export const EMAIL_PLUGIN: Plugin<typeof EmailOptionsSchema> = {
 			},
 		}));
 	},
-	getNodeBindings(_options) {
-		return {};
+	getNodeBindings(options) {
+		if (!options.email?.send_email) {
+			return {};
+		}
+
+		return Object.fromEntries(
+			options.email.send_email.map(({ name }) => [name, new ProxyNodeBinding()])
+		);
 	},
 	async getServices(args) {
-		const services: Service[] = [];
+		if (!args.options.email?.send_email) {
+			return [];
+		}
+
+		const emailDirectory = path.join(args.tmpPath, EMAIL_PLUGIN_NAME);
+		await mkdir(emailDirectory, { recursive: true });
+
+		const services: Service[] = [
+			{
+				name: EMAIL_DISK_SERVICE_NAME,
+				disk: {
+					path: emailDirectory,
+					writable: true,
+				},
+			},
+		];
 
 		for (const { name, remoteProxyConnectionString, ...config } of args.options
 			.email?.send_email ?? []) {
@@ -90,7 +115,14 @@ export const EMAIL_PLUGIN: Plugin<typeof EmailOptionsSchema> = {
 							],
 							bindings: [
 								...buildJsonBindings(config),
-								WORKER_BINDING_SERVICE_LOOPBACK,
+								{
+									name: EMAIL_DISK_BINDING_NAME,
+									service: { name: EMAIL_DISK_SERVICE_NAME },
+								},
+								{
+									name: "email_directory",
+									json: JSON.stringify(emailDirectory),
+								},
 							],
 						},
 			});

--- a/packages/miniflare/src/plugins/email/index.ts
+++ b/packages/miniflare/src/plugins/email/index.ts
@@ -86,7 +86,7 @@ export const EMAIL_PLUGIN: Plugin<typeof EmailOptionsSchema> = {
 			return [];
 		}
 
-		const emailDirectory = path.join(args.tmpPath, EMAIL_PLUGIN_NAME);
+		const emailDirectory = path.join(args.tmpPath, EMAIL_PLUGIN_NAME).replaceAll("\\", "/");
 		await mkdir(emailDirectory, { recursive: true });
 
 		const services: Service[] = [

--- a/packages/miniflare/src/plugins/email/index.ts
+++ b/packages/miniflare/src/plugins/email/index.ts
@@ -86,9 +86,7 @@ export const EMAIL_PLUGIN: Plugin<typeof EmailOptionsSchema> = {
 			return [];
 		}
 
-		const emailDirectory = path
-			.join(args.tmpPath, EMAIL_PLUGIN_NAME)
-			.replaceAll("\\", "/");
+		const emailDirectory = path.join(args.tmpPath, EMAIL_PLUGIN_NAME);
 		await mkdir(emailDirectory, { recursive: true });
 
 		const services: Service[] = [

--- a/packages/miniflare/src/workers/email/send_email.worker.ts
+++ b/packages/miniflare/src/workers/email/send_email.worker.ts
@@ -64,6 +64,11 @@ function formatMessageBuilder(builder: MessageBuilder): string {
 	return lines.join("\n");
 }
 
+function joinPath(base: string, ...segments: string[]): string {
+	const separator = base.includes("\\") ? "\\" : "/";
+	return [base.replace(/[\\/]+$/, ""), ...segments].join(separator);
+}
+
 interface SendEmailEnv {
 	MINIFLARE_EMAIL_DISK: Fetcher;
 	email_directory: string;
@@ -107,7 +112,8 @@ export class SendEmailBinding extends WorkerEntrypoint<SendEmailEnv> {
 			method: "PUT",
 			body,
 		});
-		return `${this.env.email_directory}/${prefix}/${fileName}`;
+
+		return joinPath(this.env.email_directory, prefix, fileName);
 	}
 
 	private checkDestinationAllowed(to: string) {

--- a/packages/miniflare/src/workers/email/send_email.worker.ts
+++ b/packages/miniflare/src/workers/email/send_email.worker.ts
@@ -64,6 +64,11 @@ function formatMessageBuilder(builder: MessageBuilder): string {
 	return lines.join("\n");
 }
 
+/**
+ * Appends path segments to a base path using the separator already implied by
+ * the base path string. This trims trailing `/` and `\` from the base before
+ * joining, but does not otherwise normalize the full path.
+ */
 function joinPath(base: string, ...segments: string[]): string {
 	const separator = base.includes("\\") ? "\\" : "/";
 	return [base.replace(/[\\/]+$/, ""), ...segments].join(separator);

--- a/packages/miniflare/src/workers/email/send_email.worker.ts
+++ b/packages/miniflare/src/workers/email/send_email.worker.ts
@@ -1,8 +1,6 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
 import { blue } from "kleur/colors";
-import { LogLevel, SharedHeaders } from "miniflare:shared";
 import PostalMime from "postal-mime";
-import { CoreBindings } from "../core/constants";
 import { RAW_EMAIL } from "./constants";
 import { type MiniflareEmailMessage as EmailMessage } from "./email.worker";
 import type { EmailAddress, MessageBuilder } from "./types";
@@ -67,7 +65,8 @@ function formatMessageBuilder(builder: MessageBuilder): string {
 }
 
 interface SendEmailEnv {
-	[CoreBindings.SERVICE_LOOPBACK]: Fetcher;
+	MINIFLARE_EMAIL_DISK: Fetcher;
+	email_directory: string;
 	destination_address: string | undefined;
 	allowed_destination_addresses: string[] | undefined;
 	allowed_sender_addresses: string[] | undefined;
@@ -75,22 +74,13 @@ interface SendEmailEnv {
 
 export class SendEmailBinding extends WorkerEntrypoint<SendEmailEnv> {
 	/**
-	 * Logs a message via the loopback service
+	 * Logs a message via the runtime console.
 	 */
-	private log(message: string, level: LogLevel = LogLevel.INFO): void {
-		this.ctx.waitUntil(
-			this.env[CoreBindings.SERVICE_LOOPBACK].fetch(
-				"http://localhost/core/log",
-				{
-					method: "POST",
-					headers: { [SharedHeaders.LOG_LEVEL]: level.toString() },
-					body: message,
-				}
-			)
-		);
+	private log(message: string): void {
+		console.log(message);
 	}
 	/**
-	 * Stores content to a temporary file via the loopback service
+	 * Stores content to a temporary file via the disk service.
 	 */
 	private async storeTempFile(
 		content: string | ArrayBuffer | ArrayBufferView,
@@ -111,14 +101,13 @@ export class SendEmailBinding extends WorkerEntrypoint<SendEmailEnv> {
 			);
 		}
 
-		const resp = await this.env[CoreBindings.SERVICE_LOOPBACK].fetch(
-			`http://localhost/core/store-temp-file?extension=${extension}&prefix=${prefix}`,
-			{
-				method: "POST",
-				body,
-			}
-		);
-		return await resp.text();
+		const fileName = `${crypto.randomUUID()}.${extension}`;
+		const url = new URL(`${prefix}/${fileName}`, "http://placeholder/");
+		await this.env.MINIFLARE_EMAIL_DISK.fetch(url, {
+			method: "PUT",
+			body,
+		});
+		return `${this.env.email_directory}/${prefix}/${fileName}`;
 	}
 
 	private checkDestinationAllowed(to: string) {

--- a/packages/miniflare/test/plugins/email/index.spec.ts
+++ b/packages/miniflare/test/plugins/email/index.spec.ts
@@ -43,6 +43,9 @@ test("Unbound send_email binding works", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: SEND_EMAIL_WORKER,
 		email: {
@@ -132,6 +135,9 @@ test("Single allowed destination send_email binding works", async ({
 
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: SEND_EMAIL_WORKER,
 		email: {
@@ -426,6 +432,9 @@ test("reply validation: x-auto-response-suppress", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: REPLY_EMAIL_WORKER(),
 		unsafeTriggerHandlers: true,
@@ -463,6 +472,9 @@ test("reply validation: Auto-Submitted", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: REPLY_EMAIL_WORKER(),
 		unsafeTriggerHandlers: true,
@@ -500,6 +512,9 @@ test("reply validation: only In-Reply-To", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: REPLY_EMAIL_WORKER(),
 		unsafeTriggerHandlers: true,
@@ -537,6 +552,9 @@ test("reply validation: only References", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: REPLY_EMAIL_WORKER(),
 		unsafeTriggerHandlers: true,
@@ -574,6 +592,9 @@ test("reply validation: >100 References", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: REPLY_EMAIL_WORKER(),
 		unsafeTriggerHandlers: true,
@@ -616,6 +637,9 @@ test("reply: mismatched From: header", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: REPLY_EMAIL_WORKER(),
 		unsafeTriggerHandlers: true,
@@ -653,6 +677,9 @@ test("reply: unparseable", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: REPLY_EMAIL_WORKER('""'),
 		unsafeTriggerHandlers: true,
@@ -690,6 +717,9 @@ test("reply: no message id", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: REPLY_EMAIL_WORKER(
 			JSON.stringify(dedent`
@@ -735,6 +765,9 @@ test("reply: disallowed header", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: REPLY_EMAIL_WORKER(
 			JSON.stringify(dedent`
@@ -782,6 +815,9 @@ test("reply: missing In-Reply-To", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: REPLY_EMAIL_WORKER(
 			JSON.stringify(dedent`
@@ -830,6 +866,9 @@ test("reply: wrong In-Reply-To", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: REPLY_EMAIL_WORKER(
 			JSON.stringify(dedent`
@@ -881,6 +920,9 @@ test("reply: invalid references", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: REPLY_EMAIL_WORKER(
 			JSON.stringify(dedent`
@@ -928,6 +970,9 @@ test("reply: references generated correctly", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: REPLY_EMAIL_WORKER(
 			JSON.stringify(dedent`
@@ -998,6 +1043,9 @@ test("MessageBuilder with text only", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: MESSAGE_BUILDER_WORKER,
 		email: {
@@ -1041,6 +1089,11 @@ test("MessageBuilder with text only", async ({ expect }) => {
 			expect(message).toContain("To: recipient@example.com");
 			expect(message).toContain("Subject: Test Email");
 			expect(message).toContain("Text: ");
+			const textFile = message.match(/^Text: (.+)$/m)?.[1];
+			expect(textFile).toBeDefined();
+			expect(await readFile(String(textFile), "utf-8")).toBe(
+				"Hello, this is a test email!"
+			);
 		},
 		{ timeout: 5_000, interval: 100 }
 	);
@@ -1103,6 +1156,9 @@ test("MessageBuilder with attachments", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: MESSAGE_BUILDER_WORKER,
 		email: {
@@ -1148,6 +1204,13 @@ test("MessageBuilder with attachments", async ({ expect }) => {
 
 			// Verify attachment file path is logged
 			expect(message).toContain("Attachment (attachment): test.txt ->");
+			const attachmentFile = message.match(
+				/^Attachment \(attachment\): test\.txt -> (.+)$/m
+			)?.[1];
+			expect(attachmentFile).toBeDefined();
+			expect(await readFile(String(attachmentFile), "utf-8")).toBe(
+				"base64content"
+			);
 		},
 		{ timeout: 5_000, interval: 100 }
 	);
@@ -1157,6 +1220,9 @@ test("MessageBuilder log output format snapshot", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: MESSAGE_BUILDER_WORKER,
 		email: {
@@ -1277,6 +1343,9 @@ test("MessageBuilder with EmailAddress objects", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: MESSAGE_BUILDER_WORKER,
 		email: {
@@ -1325,6 +1394,9 @@ test("MessageBuilder with multiple recipients", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: MESSAGE_BUILDER_WORKER,
 		email: {
@@ -1605,6 +1677,40 @@ test("send() on a MessageBuilder returns a synthesized messageId", async ({
 
 	expect(res.status).toBe(200);
 	expect(await res.json()).toEqual({
+		messageId: synthesizedMessageId(expect, "sender.domain"),
+	});
+});
+
+test("send_email binding is available from getBindings", async ({ expect }) => {
+	const mf = new Miniflare({
+		modules: true,
+		script: "",
+		email: {
+			send_email: [{ name: "SEND_EMAIL" }],
+		},
+		compatibilityDate: "2025-03-17",
+	});
+
+	useDispose(mf);
+
+	const env = await mf.getBindings<{
+		SEND_EMAIL: {
+			send(message: {
+				from: string;
+				to: string;
+				subject: string;
+				text: string;
+			}): Promise<{ messageId: string }>;
+		};
+	}>();
+	const result = await env.SEND_EMAIL.send({
+		from: "sender@sender.domain",
+		to: "recipient@example.com",
+		subject: "s",
+		text: "t",
+	});
+
+	expect(result).toEqual({
 		messageId: synthesizedMessageId(expect, "sender.domain"),
 	});
 });

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import * as nodeNet from "node:net";
 import { setTimeout } from "node:timers/promises";
+import { stripVTControlCharacters } from "node:util";
 import dedent from "ts-dedent";
 import { fetch } from "undici";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
@@ -2418,7 +2419,8 @@ This is a random email body.
 		);
 
 		const maybeReplyPath = await vi.waitUntil(
-			() => pathRegexp.exec(worker.currentOutput)?.[1],
+			() =>
+				pathRegexp.exec(stripVTControlCharacters(worker.currentOutput))?.[1],
 			{ interval: 100, timeout: 5000 }
 		);
 
@@ -2586,7 +2588,10 @@ This is a random email body.
 		);
 
 		const maybeReplyPath = await vi.waitUntil(
-			() => pathRegexp.exec(worker.currentOutput)?.[1],
+			() =>
+				pathRegexp.exec(
+					worker.currentOutput.replace(/\x1b\[[0-9;]*m/g, "")
+				)?.[1],
 			{ interval: 100, timeout: 5000 }
 		);
 

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -2589,9 +2589,7 @@ This is a random email body.
 
 		const maybeReplyPath = await vi.waitUntil(
 			() =>
-				pathRegexp.exec(
-					worker.currentOutput.replace(/\x1b\[[0-9;]*m/g, "")
-				)?.[1],
+				pathRegexp.exec(stripVTControlCharacters(worker.currentOutput))?.[1],
 			{ interval: 100, timeout: 5000 }
 		);
 

--- a/packages/wrangler/e2e/get-platform-proxy.test.ts
+++ b/packages/wrangler/e2e/get-platform-proxy.test.ts
@@ -656,12 +656,11 @@ describe("getPlatformProxy()", () => {
 			root = makeRoot();
 
 			await seed(root, {
-				"wrangler.toml": dedent`
-						name = "email-app"
-						compatibility_date = "2025-03-17"
-
-						send_email = [{ name = "EMAIL" }]
-				`,
+				"wrangler.jsonc": JSON.stringify({
+					name: "email-app",
+					compatibility_date: "2025-03-17",
+					send_email: [{ name: "EMAIL" }],
+				}),
 				"index.mjs": dedent /* javascript */ `
 						import { getPlatformProxy } from "${WRANGLER_IMPORT}";
 

--- a/packages/wrangler/e2e/get-platform-proxy.test.ts
+++ b/packages/wrangler/e2e/get-platform-proxy.test.ts
@@ -648,4 +648,51 @@ describe("getPlatformProxy()", () => {
 			);
 		}
 	);
+
+	describe("send_email", () => {
+		let root: string;
+
+		beforeEach(async () => {
+			root = makeRoot();
+
+			await seed(root, {
+				"wrangler.toml": dedent`
+						name = "email-app"
+						compatibility_date = "2025-03-17"
+
+						send_email = [{ name = "EMAIL" }]
+				`,
+				"index.mjs": dedent /* javascript */ `
+						import { getPlatformProxy } from "${WRANGLER_IMPORT}";
+
+						const { env, dispose } = await getPlatformProxy();
+						const result = await env.EMAIL.send({
+							from: "sender@sender.domain",
+							to: "recipient@example.com",
+							subject: "s",
+							text: "t",
+						});
+
+						console.log(result.messageId);
+						await dispose();
+				`,
+				"package.json": dedent`
+						{
+							"name": "email-app",
+							"version": "0.0.0",
+							"private": true
+						}
+				`,
+			});
+		});
+
+		it("can send a MessageBuilder email", async ({ expect }) => {
+			const stdout = execSync(`node index.mjs`, {
+				cwd: root,
+				encoding: "utf-8",
+			});
+
+			expect(stdout).toMatch(/^<[A-Za-z0-9]{36}@sender\.domain>/);
+		});
+	});
 });


### PR DESCRIPTION
Fixes #13715

This was not originally supported because email bindings relied on the `EmailMessage` class from `cloudflare:email` module, which is not available in the Node environment. Now that `send_email` supports the plain-object `MessageBuilder` interface, I think we should be able to enable this through the `getPlatformProxy()`.

The local email binding previously used Miniflare's loopback server to write preview files. That deadlocks when called through the Node proxy, so this switches those file writes to a workerd disk service instead.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
