### PR TITLE
Hard fail on Node.js < 22

### DIFF
--- a/.changeset/drop-node-20.md
+++ b/.changeset/drop-node-20.md
@@ -1,0 +1,10 @@
+---
+"wrangler": minor
+"miniflare": minor
+"@cloudflare/kv-asset-handler": minor
+"create-cloudflare": minor
+---
+
+Hard fail on Node.js < 22
+
+Wrangler no longer supports Node.js 20.x, as it reached end-of-life on 2026-04-30. The minimum supported Node.js version is now 22.0.0. See https://github.com/nodejs/release?tab=readme-ov-file#end-of-life-releases.

--- a/.github/workflows/test-and-check-other-node.yml
+++ b/.github/workflows/test-and-check-other-node.yml
@@ -24,7 +24,6 @@ jobs:
         # These versions are skipped on normal PRs but run on Version Packages PRs
         # (changeset-release/main) or when the 'test all node versions' label is added.
         include:
-          - { node_version: 20, description: "Node 20" }
           - { node_version: 24, description: "Node 24", expected_to_fail: true }
           - { node_version: 25, description: "Node 25", expected_to_fail: true }
 

--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -56,20 +56,12 @@ jobs:
           NODE_OPTIONS: "--max_old_space_size=8192"
 
       # Check for old Node.js version warnings and errors
-      - name: Use Node.js v16
+      - name: Use Node.js v20
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
-      - name: Check for error message on Node.js < v18
-        run: node packages/wrangler/src/__tests__/test-old-node-version.js error
-
-      - name: Use Node.js v18
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-
-      - name: Check for error message on Node.js < v20
+      - name: Check for error message on Node.js < v22
         run: node packages/wrangler/src/__tests__/test-old-node-version.js error
 
   test:

--- a/fixtures/additional-modules/package.json
+++ b/fixtures/additional-modules/package.json
@@ -18,8 +18,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/browser-run/package.json
+++ b/fixtures/browser-run/package.json
@@ -17,8 +17,5 @@
 		"typescript": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/container-app/package.json
+++ b/fixtures/container-app/package.json
@@ -16,9 +16,5 @@
 		"ts-dedent": "^2.2.0",
 		"typescript": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json",
-		"node": "20.19.2"
 	}
 }

--- a/fixtures/d1-read-replication-app/package.json
+++ b/fixtures/d1-read-replication-app/package.json
@@ -15,8 +15,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/d1-worker-app/package.json
+++ b/fixtures/d1-worker-app/package.json
@@ -18,8 +18,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/durable-objects-app/package.json
+++ b/fixtures/durable-objects-app/package.json
@@ -16,8 +16,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/dynamic-worker-loading/package.json
+++ b/fixtures/dynamic-worker-loading/package.json
@@ -12,8 +12,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/email-worker/package.json
+++ b/fixtures/email-worker/package.json
@@ -10,8 +10,5 @@
 		"@types/mimetext": "^2.0.4",
 		"mimetext": "^3.0.27",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/entrypoints-rpc-tests/package.json
+++ b/fixtures/entrypoints-rpc-tests/package.json
@@ -12,8 +12,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/get-platform-proxy-remote-bindings/package.json
+++ b/fixtures/get-platform-proxy-remote-bindings/package.json
@@ -13,8 +13,5 @@
 		"typescript": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/get-platform-proxy/package.json
+++ b/fixtures/get-platform-proxy/package.json
@@ -16,8 +16,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/import-wasm-example/package.json
+++ b/fixtures/import-wasm-example/package.json
@@ -19,8 +19,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/import-wasm-static/package.json
+++ b/fixtures/import-wasm-static/package.json
@@ -4,8 +4,5 @@
 	"sideEffects": false,
 	"exports": {
 		"./multiply.wasm": "./wasm/multiply.wasm"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/interactive-dev-tests/package.json
+++ b/fixtures/interactive-dev-tests/package.json
@@ -12,8 +12,5 @@
 	},
 	"optionalDependencies": {
 		"@cdktf/node-pty-prebuilt-multiarch": "0.10.2"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/isomorphic-random-example/package.json
+++ b/fixtures/isomorphic-random-example/package.json
@@ -7,8 +7,5 @@
 		"node": "./src/node.js",
 		"workerd": "./src/workerd.mjs",
 		"default": "./src/default.js"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/legacy-site-app/package.json
+++ b/fixtures/legacy-site-app/package.json
@@ -5,8 +5,5 @@
 	"keywords": [],
 	"license": "ISC",
 	"author": "",
-	"main": "index.js",
-	"volta": {
-		"extends": "../../package.json"
-	}
+	"main": "index.js"
 }

--- a/fixtures/miniflare-node-test/package.json
+++ b/fixtures/miniflare-node-test/package.json
@@ -15,8 +15,5 @@
 		"is-even": "^1.0.0",
 		"miniflare": "workspace:*",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/multi-worker/package.json
+++ b/fixtures/multi-worker/package.json
@@ -14,8 +14,5 @@
 		"@cloudflare/workers-types": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/no-bundle-import/package.json
+++ b/fixtures/no-bundle-import/package.json
@@ -11,8 +11,5 @@
 		"get-port": "^7.0.0",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/node-app-pages/package.json
+++ b/fixtures/node-app-pages/package.json
@@ -20,11 +20,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"engines": {
-		"node": ">=18.0.0"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/node-env/package.json
+++ b/fixtures/node-env/package.json
@@ -21,8 +21,5 @@
 		"typescript": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/pages-dev-proxy-with-script/package.json
+++ b/fixtures/pages-dev-proxy-with-script/package.json
@@ -15,11 +15,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"engines": {
-		"node": ">=18.0.0"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/pages-functions-app/package.json
+++ b/fixtures/pages-functions-app/package.json
@@ -21,11 +21,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"engines": {
-		"node": ">=18.0.0"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/pages-functions-unenv-alias/package.json
+++ b/fixtures/pages-functions-unenv-alias/package.json
@@ -16,11 +16,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"engines": {
-		"node": ">=18"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/pages-functions-wasm-app/package.json
+++ b/fixtures/pages-functions-wasm-app/package.json
@@ -16,11 +16,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"engines": {
-		"node": ">=18.0.0"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/pages-functions-with-config-file-app/package.json
+++ b/fixtures/pages-functions-with-config-file-app/package.json
@@ -16,11 +16,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"engines": {
-		"node": ">=18.0.0"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/pages-functions-with-routes-app/package.json
+++ b/fixtures/pages-functions-with-routes-app/package.json
@@ -16,11 +16,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"engines": {
-		"node": ">=18.0.0"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/pages-nodejs-v2-compat/package.json
+++ b/fixtures/pages-nodejs-v2-compat/package.json
@@ -18,11 +18,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"engines": {
-		"node": ">=18.0.0"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/pages-plugin-example/package.json
+++ b/fixtures/pages-plugin-example/package.json
@@ -17,8 +17,5 @@
 		"@cloudflare/workers-types": "catalog:default",
 		"is-odd": "^3.0.1",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/pages-plugin-mounted-on-root-app/package.json
+++ b/fixtures/pages-plugin-mounted-on-root-app/package.json
@@ -21,11 +21,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"engines": {
-		"node": ">=18.0.0"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/pages-proxy-app/package.json
+++ b/fixtures/pages-proxy-app/package.json
@@ -19,11 +19,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"engines": {
-		"node": ">=14"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/pages-redirected-config/package.json
+++ b/fixtures/pages-redirected-config/package.json
@@ -16,8 +16,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/pages-simple-assets/package.json
+++ b/fixtures/pages-simple-assets/package.json
@@ -17,11 +17,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"engines": {
-		"node": ">=18.0.0"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/pages-workerjs-and-functions-app/package.json
+++ b/fixtures/pages-workerjs-and-functions-app/package.json
@@ -16,11 +16,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"engines": {
-		"node": ">=18.0.0"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/pages-workerjs-app/package.json
+++ b/fixtures/pages-workerjs-app/package.json
@@ -15,11 +15,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"engines": {
-		"node": ">=18.0.0"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/pages-workerjs-directory/package.json
+++ b/fixtures/pages-workerjs-directory/package.json
@@ -14,11 +14,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"engines": {
-		"node": ">=18.0.0"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/pages-workerjs-wasm-app/package.json
+++ b/fixtures/pages-workerjs-wasm-app/package.json
@@ -16,11 +16,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"engines": {
-		"node": ">=18.0.0"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/pages-workerjs-with-config-file-app/package.json
+++ b/fixtures/pages-workerjs-with-config-file-app/package.json
@@ -15,11 +15,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"engines": {
-		"node": ">=18.0.0"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/pages-workerjs-with-routes-app/package.json
+++ b/fixtures/pages-workerjs-with-routes-app/package.json
@@ -15,11 +15,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"engines": {
-		"node": ">=18.0.0"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/ratelimit-app/package.json
+++ b/fixtures/ratelimit-app/package.json
@@ -17,8 +17,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/redirected-config-worker-with-environments/package.json
+++ b/fixtures/redirected-config-worker-with-environments/package.json
@@ -16,8 +16,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/redirected-config-worker/package.json
+++ b/fixtures/redirected-config-worker/package.json
@@ -16,8 +16,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/routing-app/package.json
+++ b/fixtures/routing-app/package.json
@@ -7,8 +7,5 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "catalog:default"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/rules-app/package.json
+++ b/fixtures/rules-app/package.json
@@ -10,8 +10,5 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "catalog:default"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/secrets-store/package.json
+++ b/fixtures/secrets-store/package.json
@@ -8,8 +8,5 @@
 	"devDependencies": {
 		"@cloudflare/workers-types": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/shared/package.json
+++ b/fixtures/shared/package.json
@@ -5,8 +5,5 @@
 	"devDependencies": {
 		"@cloudflare/workers-utils": "workspace:*",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/sites-app/package.json
+++ b/fixtures/sites-app/package.json
@@ -8,8 +8,5 @@
 	"main": "index.js",
 	"devDependencies": {
 		"@cloudflare/kv-asset-handler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/start-worker-node-test/package.json
+++ b/fixtures/start-worker-node-test/package.json
@@ -16,8 +16,5 @@
 		"is-even": "^1.0.0",
 		"miniflare": "workspace:*",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/unbound-durable-object/package.json
+++ b/fixtures/unbound-durable-object/package.json
@@ -11,8 +11,5 @@
 		"@cloudflare/workers-types": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/vitest-pool-workers-examples/package.json
+++ b/fixtures/vitest-pool-workers-examples/package.json
@@ -32,8 +32,5 @@
 		"vite": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/wasm-app/package.json
+++ b/fixtures/wasm-app/package.json
@@ -1,7 +1,4 @@
 {
 	"name": "@fixture/wasm-basic",
-	"private": true,
-	"volta": {
-		"extends": "../../package.json"
-	}
+	"private": true
 }

--- a/fixtures/wildcard-modules/package.json
+++ b/fixtures/wildcard-modules/package.json
@@ -16,8 +16,5 @@
 		"@fixture/shared": "workspace:*",
 		"undici": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/worker-app/package.json
+++ b/fixtures/worker-app/package.json
@@ -21,8 +21,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/worker-logs/package.json
+++ b/fixtures/worker-logs/package.json
@@ -15,8 +15,5 @@
 		"typescript": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/worker-ts/package.json
+++ b/fixtures/worker-ts/package.json
@@ -8,8 +8,5 @@
 	"devDependencies": {
 		"@cloudflare/workers-types": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/worker-with-resources/package.json
+++ b/fixtures/worker-with-resources/package.json
@@ -16,8 +16,5 @@
 		"typescript": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/workers-shared-asset-config/package.json
+++ b/fixtures/workers-shared-asset-config/package.json
@@ -20,8 +20,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/workers-with-assets-and-service-bindings/package.json
+++ b/fixtures/workers-with-assets-and-service-bindings/package.json
@@ -14,8 +14,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/workers-with-assets-only/package.json
+++ b/fixtures/workers-with-assets-only/package.json
@@ -14,8 +14,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/workers-with-assets-run-worker-first/package.json
+++ b/fixtures/workers-with-assets-run-worker-first/package.json
@@ -15,8 +15,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/workers-with-assets-spa/package.json
+++ b/fixtures/workers-with-assets-spa/package.json
@@ -20,8 +20,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/workers-with-assets-static-routing/package.json
+++ b/fixtures/workers-with-assets-static-routing/package.json
@@ -19,9 +19,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json",
-		"node": "20.19.2"
 	}
 }

--- a/fixtures/workers-with-assets/package.json
+++ b/fixtures/workers-with-assets/package.json
@@ -15,8 +15,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/workflow-multiple/package.json
+++ b/fixtures/workflow-multiple/package.json
@@ -12,8 +12,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/fixtures/workflow/package.json
+++ b/fixtures/workflow/package.json
@@ -13,8 +13,5 @@
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -54,11 +54,11 @@
 		"vitest": "catalog:default"
 	},
 	"engines": {
-		"node": ">=20.0.0",
+		"node": ">=22.0.0",
 		"pnpm": "^10.33.0"
 	},
 	"volta": {
-		"node": "20.19.3",
+		"node": "22.22.1",
 		"pnpm": "10.33.0"
 	},
 	"packageManager": "pnpm@10.33.0"

--- a/packages/containers-shared/package.json
+++ b/packages/containers-shared/package.json
@@ -30,7 +30,7 @@
 		"vitest": "catalog:default"
 	},
 	"engines": {
-		"node": ">20.0.0"
+		"node": ">=22.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -90,7 +90,7 @@
 		"yargs": "^17.7.2"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=22.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/packages/kv-asset-handler/package.json
+++ b/packages/kv-asset-handler/package.json
@@ -48,7 +48,7 @@
 		"vitest": "catalog:default"
 	},
 	"engines": {
-		"node": ">=18.0.0"
+		"node": ">=22.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -107,7 +107,7 @@
 		"zod": "^3.25.76"
 	},
 	"engines": {
-		"node": ">=18.0.0"
+		"node": ">=22.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/packages/quick-edit/package.json
+++ b/packages/quick-edit/package.json
@@ -29,7 +29,7 @@
 		"wrangler": "workspace:*"
 	},
 	"engines": {
-		"node": ">=18.15"
+		"node": ">=22.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/packages/workers-shared/package.json
+++ b/packages/workers-shared/package.json
@@ -55,7 +55,7 @@
 		"zod": "^3.25.76"
 	},
 	"engines": {
-		"node": ">=18.0.0"
+		"node": ">=22.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/packages/workflows-shared/package.json
+++ b/packages/workflows-shared/package.json
@@ -48,7 +48,7 @@
 		"vitest": "catalog:default"
 	},
 	"engines": {
-		"node": ">=18.0.0"
+		"node": ">=22.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/packages/wrangler/bin/wrangler.js
+++ b/packages/wrangler/bin/wrangler.js
@@ -2,15 +2,14 @@
 const { spawn } = require("child_process");
 const path = require("path");
 
-const ERR_NODE_VERSION = "20.0.0";
-const MIN_NODE_VERSION = "20.0.0";
+const MIN_NODE_VERSION = "22.0.0";
 let wranglerProcess;
 
 /**
  * Executes ../wrangler-dist/cli.js
  */
 function runWrangler() {
-	if (semiver(process.versions.node, ERR_NODE_VERSION) < 0) {
+	if (semiver(process.versions.node, MIN_NODE_VERSION) < 0) {
 		// Note Volta and nvm are also recommended in the official docs:
 		// https://developers.cloudflare.com/workers/get-started/guide#2-install-the-workers-cli
 		console.error(

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -180,7 +180,7 @@
 		"fsevents": "~2.3.2"
 	},
 	"engines": {
-		"node": ">=20.3.0"
+		"node": ">=22.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/packages/wrangler/src/__tests__/test-old-node-version.js
+++ b/packages/wrangler/src/__tests__/test-old-node-version.js
@@ -42,7 +42,7 @@ wranglerProcess.once("exit", (code) => {
 	} catch (err) {
 		console.error("Error:", err);
 		throw new Error(
-			"This test has to be run with a version of Node.js under 20 to pass"
+			"This test has to be run with a version of Node.js under 22 to pass"
 		);
 	}
 });

--- a/packages/wrangler/src/__tests__/test-old-node-version.js
+++ b/packages/wrangler/src/__tests__/test-old-node-version.js
@@ -1,4 +1,4 @@
-// this test has to be run with a version of Node.js older than 20.0.0 to pass
+// this test has to be run with a version of Node.js older than 22.0.0 to pass
 
 const { spawn } = require("child_process");
 const path = require("path");

--- a/packages/wrangler/src/wrangler-banner.ts
+++ b/packages/wrangler/src/wrangler-banner.ts
@@ -7,7 +7,7 @@ import { version as wranglerVersion } from "../package.json";
 import { logger } from "./logger";
 import { updateCheck } from "./update-check";
 
-const MIN_NODE_VERSION = "20.0.0";
+const MIN_NODE_VERSION = "22.0.0";
 
 // Grace period for a cached update-check result to settle. One event loop
 // tick is enough for a /tmp readFile (<1 ms on SSD). On cache miss the


### PR DESCRIPTION
Bump the minimum supported Node.js version from 20 to 22, following Node's [EOL policy](https://github.com/nodejs/release?tab=readme-ov-file#end-of-life-releases) (Node 20 reaches EOL on 2026-04-30). Mirrors the structure of #9112 + #9393 (the previous Node 18 → 20 transition), combined into a single hard-fail PR.

### Changes

**Wrangler enforcement**
- `packages/wrangler/bin/wrangler.js` — `MIN_NODE_VERSION` → `22.0.0`. The separate `ERR_NODE_VERSION` constant used during the previous soft-warning phase is removed since this is a hard fail.
- `packages/wrangler/src/wrangler-banner.ts` — `MIN_NODE_VERSION` → `22.0.0`.
- `packages/wrangler/src/__tests__/test-old-node-version.js` — comment updated.

**CI workflows**
- `.github/workflows/test-and-check.yml` — added a third old-node check that runs Wrangler on Node v20 and asserts it errors out with a `< v22` message.
- `.github/workflows/test-and-check-other-node.yml` — dropped Node 20 from the "other versions" matrix.

**`engines.node` bumps to `>=22.0.0`**
- Root `package.json` (also bumps `volta.node` to `22.22.1`)
- `wrangler`, `miniflare`, `@cloudflare/kv-asset-handler`, `create-cloudflare`, `@cloudflare/workers-shared`, `@cloudflare/workflows-shared`, `@cloudflare/containers-shared`, `@cloudflare/quick-edit`

**Fixture cleanup**
- Removed redundant `engines.node` from 17 fixtures (root constraint already enforces this for any monorepo install).
- Removed redundant `volta` blocks (mostly `extends: "../../package.json"` no-ops, plus two pinned overrides that now match root) from 65 fixtures.

**Changeset**
- `.changeset/drop-node-20.md` — single combined `minor` bump for `wrangler`, `miniflare`, `@cloudflare/kv-asset-handler`, and `create-cloudflare`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Node.js version support is already documented and follows Node's published EOL policy.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
