### PR TITLE
[miniflare] Fix Browser Run Windows race condition

### DIFF
--- a/.changeset/fix-miniflare-browser-rendering-windows-race.md
+++ b/.changeset/fix-miniflare-browser-rendering-windows-race.md
@@ -1,0 +1,9 @@
+---
+"miniflare": patch
+---
+
+Fix race condition that broke Browser Run on Windows when Chrome had not yet started accepting connections
+
+When Miniflare launched Chrome for Browser Run bindings, it returned the WebSocket endpoint as soon as Chrome printed its `DevTools listening on ws://...` banner. On Windows the underlying listening socket is occasionally not yet accepting connections at that point, causing the first request from workerd to Chrome to fail with `ConnectEx (#1225) The remote computer refused the network connection.` and the user worker to receive an error response from `/v1/acquire`.
+
+Miniflare now probes Chrome's `/json/version` HTTP endpoint with retry/backoff after the banner is logged, only declaring the browser ready once the socket actually accepts connections. As an additional safety net, the browser binding worker also retries transient `ConnectEx`/`WSARecv` failures when establishing connections to Chrome.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -106,5 +106,7 @@
 	},
 	"[json]": {
 		"editor.defaultFormatter": "oxc.oxc-vscode"
-	}
+	},
+	"oxc.path.oxfmt": "node_modules/.bin/oxfmt",
+	"oxc.path.oxlint": "node_modules/.bin/oxlint"
 }

--- a/packages/miniflare/src/plugins/browser-rendering/index.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/index.ts
@@ -227,6 +227,64 @@ export async function launchBrowser({
 	const wsEndpoint = await browserProcess.waitForLineOutput(
 		CDP_WEBSOCKET_ENDPOINT_REGEX
 	);
+	// On Windows in particular, Chrome may print the DevTools URL slightly
+	// before its listening socket is fully ready to accept connections.
+	// Probe the HTTP /json/version endpoint (served on the same port as the
+	// WS endpoint) with retry/backoff before declaring the browser ready, so
+	// that subsequent fetches from workerd don't race the OS and surface as
+	// `ConnectEx (#1225) connection refused` errors.
+	await waitForBrowserReady(wsEndpoint, log);
 	const startTime = Date.now();
 	return { sessionId, browserProcess, startTime, wsEndpoint };
+}
+
+/**
+ * Probe Chrome's HTTP DevTools endpoint until it accepts connections.
+ *
+ * `waitForLineOutput` resolves as soon as Chrome logs the
+ * `DevTools listening on ws://...` banner, but on Windows the underlying
+ * listening socket is occasionally not yet accepting connections at that
+ * point. Without this probe, the first request from workerd to Chrome can
+ * fail with `ConnectEx (#1225) The remote computer refused the network
+ * connection.` even though Chrome is otherwise healthy.
+ */
+async function waitForBrowserReady(
+	wsEndpoint: string,
+	log: Log
+): Promise<void> {
+	const timeoutMs = 5000;
+	const initialDelayMs = 25;
+	const maxDelayMs = 250;
+	const perRequestTimeoutMs = 500;
+	const probeUrl = `${new URL(wsEndpoint.replace("ws://", "http://")).origin}/json/version`;
+	const deadline = Date.now() + timeoutMs;
+	let attempt = 0;
+	let lastError: unknown;
+	while (Date.now() < deadline) {
+		try {
+			const response = await fetch(probeUrl, {
+				signal: AbortSignal.timeout(perRequestTimeoutMs),
+			});
+			// Drain the body so the connection can be reused/closed cleanly.
+			await response.arrayBuffer();
+			if (response.ok) {
+				if (attempt > 0) {
+					log.debug(`Chrome ready after ${attempt + 1} attempt(s)`);
+				}
+				return;
+			}
+			lastError = new Error(
+				`Chrome readiness probe got status ${response.status}`
+			);
+		} catch (e) {
+			lastError = e;
+		}
+		const delay = Math.min(maxDelayMs, initialDelayMs * 2 ** attempt);
+		await new Promise((resolve) => setTimeout(resolve, delay));
+		attempt++;
+	}
+	throw new Error(
+		`Chrome readiness probe at ${probeUrl} timed out after ${timeoutMs}ms`,
+		{ cause: lastError }
+	);
 }

--- a/packages/miniflare/src/workers/browser-rendering/binding.worker.ts
+++ b/packages/miniflare/src/workers/browser-rendering/binding.worker.ts
@@ -43,6 +43,68 @@ function chromeBaseUrl(wsEndpoint: string): string {
 	return `http://${u.host}`;
 }
 
+// Substrings of workerd / underlying kj socket error messages that indicate
+// a transient connection failure and are safe to retry. Matched
+// case-insensitively against `Error.message`.
+const RETRYABLE_FETCH_ERROR_SUBSTRINGS = [
+	// kj/async-io-win32.c++ ConnectEx (#1225) — the remote socket refused us.
+	// Surfaces on Windows when Chrome announced the DevTools URL but isn't
+	// quite accepting connections yet.
+	"connection refused",
+	"remote computer refused",
+	// kj/async-io-win32.c++ WSARecv (#64) — the connection went away mid-read.
+	"network name is no longer available",
+	// Generic workerd disconnect classifications.
+	"network connection lost",
+	"disconnected",
+];
+
+function isRetryableFetchError(error: unknown): boolean {
+	const message = (error as { message?: string } | undefined)?.message;
+	if (typeof message !== "string") {
+		return false;
+	}
+	const lower = message.toLowerCase();
+	return RETRYABLE_FETCH_ERROR_SUBSTRINGS.some((needle) =>
+		lower.includes(needle)
+	);
+}
+
+/**
+ * Wrapper around `fetch` that retries on transient connection failures.
+ *
+ * On Windows, the first fetches from this worker to a freshly-launched
+ * Chrome process can occasionally fail with `ConnectEx (#1225)` or
+ * `WSARecv (#64)` even after the readiness probe in `launchBrowser` has
+ * succeeded. We retry a small number of times with exponential backoff so
+ * those transient failures don't surface as `/v1/acquire` errors to the
+ * user worker.
+ */
+async function fetchWithConnectRetry(
+	url: string | URL,
+	init?: RequestInit,
+	{
+		maxAttempts = 5,
+		baseDelayMs = 25,
+		maxDelayMs = 250,
+	}: { maxAttempts?: number; baseDelayMs?: number; maxDelayMs?: number } = {}
+): Promise<Response> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt < maxAttempts; attempt++) {
+		try {
+			return await fetch(url, init);
+		} catch (e) {
+			lastError = e;
+			if (!isRetryableFetchError(e) || attempt === maxAttempts - 1) {
+				break;
+			}
+			const delay = Math.min(maxDelayMs, baseDelayMs * 2 ** attempt);
+			await new Promise((resolve) => setTimeout(resolve, delay));
+		}
+	}
+	throw lastError;
+}
+
 // Reserved codes 1005 (No Status Received) and 1006 (Abnormal Closure) are
 // valid in CloseEvent but throw InvalidAccessError when passed to .close().
 function forwardClose(target?: WebSocket, e?: CloseEvent) {
@@ -72,7 +134,9 @@ export class BrowserSession extends MiniflareDurableObject<BrowserSessionEnv> {
 		// This serves as the health indicator for the session and is reused
 		// by the legacy chunked-framing client (/v1/connectDevtools).
 		const wsUrl = this.sessionInfo.wsEndpoint.replace("ws://", "http://");
-		const resp = await fetch(wsUrl, { headers: { Upgrade: "websocket" } });
+		const resp = await fetchWithConnectRetry(wsUrl, {
+			headers: { Upgrade: "websocket" },
+		});
 		assert(resp.webSocket !== null, "Expected a WebSocket response");
 		this.chromeWs = resp.webSocket;
 		this.chromeWs.accept();
@@ -275,9 +339,10 @@ export class BrowserSession extends MiniflareDurableObject<BrowserSessionEnv> {
 
 		server.accept();
 
-		const response = await fetch(targetWsUrl.replace("ws://", "http://"), {
-			headers: { Upgrade: "websocket" },
-		});
+		const response = await fetchWithConnectRetry(
+			targetWsUrl.replace("ws://", "http://"),
+			{ headers: { Upgrade: "websocket" } }
+		);
 
 		assert(response.webSocket !== null, "Expected a WebSocket response");
 		const chrome = response.webSocket;
@@ -309,7 +374,7 @@ export class BrowserSession extends MiniflareDurableObject<BrowserSessionEnv> {
 		if (!this.sessionInfo) {
 			return Response.json({ error: "Browser not found" }, { status: 404 });
 		}
-		const resp = await fetch(
+		const resp = await fetchWithConnectRetry(
 			`${chromeBaseUrl(this.sessionInfo.wsEndpoint)}${chromePath}`,
 			{ method }
 		);


### PR DESCRIPTION
Fixes the flaky `Tests (Windows, packages-and-tools)` CI failures observed in [run 25108579707/job 73576107174](https://github.com/cloudflare/workers-sdk/actions/runs/25108579707/job/73576107174), where 11 of 21 tests in `packages/miniflare/test/plugins/browser/index.spec.ts` failed even with `{ retry: 3 }`.

When Miniflare launches Chrome for Browser Run bindings, it returns the WebSocket endpoint as soon as Chrome prints its `DevTools listening on ws://...` banner. On Windows the underlying listening socket is occasionally not yet accepting connections at that point, so the first request from workerd to Chrome fails with `kj/async-io-win32.c++:281: failed: ConnectEx(): #1225 The remote computer refused the network connection.`. The error propagates up through `/v1/acquire` as the response body `Error: The remote computer refused…`, which the user worker then fails to JSON-parse — the surface the test sees is `SyntaxError: Unexpected token 'E', "Error: The"... is not valid JSON`.

This PR addresses the issue at two layers:

1. **Chrome readiness probe in `launchBrowser`** (`packages/miniflare/src/plugins/browser-rendering/index.ts`). After `waitForLineOutput` resolves with the WS endpoint, probe Chrome's `/json/version` HTTP endpoint with retry/backoff (25ms → 250ms, ~5s total) until it accepts a connection. This addresses the root cause of `ConnectEx (#1225)`.
2. **Defense-in-depth retry inside the binding worker** (`packages/miniflare/src/workers/browser-rendering/binding.worker.ts`). A new `fetchWithConnectRetry` helper retries on substring-matched transient workerd/kj errors (`connection refused`, `remote computer refused`, `network name is no longer available`, `network connection lost`, `disconnected`) and is applied to `setSessionInfoRoute`, `#proxyRawWebSocket`, and `#proxyJsonRequest`. This catches `WSARecv (#64)` and similar mid-fetch socket failures that the readiness probe alone cannot prevent.

The fix is internal — there are no API or behaviour changes for users beyond the elimination of the spurious connection errors. On macOS the probe succeeds on the first attempt, adding ~no measurable overhead (browser test suite still completes in ~9–10s locally over 4 consecutive runs).

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: covered by current tests

- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal flake fix; user-visible impact is just that browser rendering bindings no longer fail with spurious connection errors during startup on Windows.

**Additional testing:**

Ran `pnpm -F miniflare test test/plugins/browser/index.spec.ts` four consecutive times locally on macOS — all 21 tests pass each time. The failure mode being fixed is Windows-specific and not reproducible on macOS/Linux without artificial fault injection.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
