### PR TITLE
[wrangler] Allow `text_blobs` in ES module workers

### DIFF
--- a/.changeset/text-blobs-esm.md
+++ b/.changeset/text-blobs-esm.md
@@ -1,0 +1,9 @@
+---
+"wrangler": minor
+---
+
+Allow `text_blobs` in ES module workers
+
+`text_blobs` previously errored on ES module workers, with the recommendation to `import` the file directly. That does not cover the case of binding a different file per environment to the same bundle at deploy time, for example, binding an environment-specific config blob without building a separate artifact per environment.
+
+`data_blobs` and `wasm_modules` keep their existing ESM restrictions.

--- a/packages/wrangler/src/__tests__/deploy/bindings.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/bindings.test.ts
@@ -966,7 +966,7 @@ describe("deploy", () => {
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should error when defining text blobs for modules format workers", async ({
+			it("should be able to define text blobs for modules format workers", async ({
 				expect,
 			}) => {
 				writeWranglerConfig({
@@ -977,23 +977,35 @@ describe("deploy", () => {
 				writeWorkerSource({ type: "esm" });
 				fs.mkdirSync("./path/to", { recursive: true });
 				fs.writeFileSync("./path/to/text.file", "SOME TEXT CONTENT");
-
-				await expect(
-					runWrangler("deploy index.js")
-				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: You cannot configure [text_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure \`[rules]\` in your wrangler.toml file]`
-				);
+				mockUploadWorkerRequest({
+					expectedType: "esm",
+					expectedModules: { TESTTEXTBLOBNAME: "SOME TEXT CONTENT" },
+					expectedBindings: [
+						{
+							name: "TESTTEXTBLOBNAME",
+							part: "TESTTEXTBLOBNAME",
+							type: "text_blob",
+						},
+					],
+				});
+				mockSubDomainRequest();
+				await runWrangler("deploy index.js");
 				expect(std.out).toMatchInlineSnapshot(`
 					"
 					 ⛅️ wrangler x.x.x
 					──────────────────
-					"
-				`);
-				expect(std.err).toMatchInlineSnapshot(`
-					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mYou cannot configure [text_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure \`[rules]\` in your wrangler.toml file[0m
+					Total Upload: xx KiB / gzip: xx KiB
+					Worker Startup Time: 100 ms
+					Your Worker has access to the following bindings:
+					Binding                                       Resource
+					env.TESTTEXTBLOBNAME (path/to/text.file)      Text Blob
 
-					"
+					Uploaded test-name (TIMINGS)
+					Deployed test-name triggers (TIMINGS)
+					  https://test-name.test-sub-domain.workers.dev
+					Current Version ID: Galaxy-Class"
 				`);
+				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -681,13 +681,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		);
 	}
 
-	if (config.text_blobs && format === "modules") {
-		throw new UserError(
-			`You cannot configure [text_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure \`[rules]\` in your ${configFileName(config.configPath)} file`,
-			{ telemetryMessage: "[text_blobs] with an ES module worker" }
-		);
-	}
-
 	if (config.data_blobs && format === "modules") {
 		throw new UserError(
 			`You cannot configure [data_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure \`[rules]\` in your ${configFileName(config.configPath)} file`,

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -551,12 +551,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		);
 	}
 
-	if (config.text_blobs && format === "modules") {
-		throw new UserError(
-			`You cannot configure [text_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure \`[rules]\` in your ${configFileName(config.configPath)} file`
-		);
-	}
-
 	if (config.data_blobs && format === "modules") {
 		throw new UserError(
 			`You cannot configure [data_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure \`[rules]\` in your ${configFileName(config.configPath)} file`


### PR DESCRIPTION
Lifts the deploy-time guard that errors when `text_blobs` is
configured on an ES module worker.

The guard was added in #518 with the rationale that ESM workers
should `import` files directly. That assumes file content is known
at build time. It does not cover the case of attaching a different
file per environment to the same bundle at deploy time, for
example, binding an environment-specific config blob without
producing a separate build artifact per environment, which is
the motivating use case here.

The upload form, validation, miniflare adapter, and runtime
binding plumbing already handle `text_blobs` in ESM workers. Only
the explicit guard in `deploy.ts` and `versions/upload.ts` needed
to be lifted. `data_blobs` and `wasm_modules` keep their existing
ESM restrictions.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: the wrangler config docs describe `text_blobs` as a generic binding without restricting to service-worker format. Lifting the wrangler-side guard makes behaviour match the documented configuration.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
