### PR TITLE
Enable require-description-when-disabling lint rule on the vite plugin

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -206,7 +206,6 @@
 				"packages/local-explorer-ui/**",
 				"packages/miniflare/**",
 				"packages/quick-edit-extension/**",
-				"packages/vite-plugin-cloudflare/**",
 				"packages/vitest-pool-workers/**",
 				"packages/workers-editor-shared/**",
 				"packages/workers-shared/**",

--- a/packages/vite-plugin-cloudflare/e2e/fixtures/basic/src/main.tsx
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/basic/src/main.tsx
@@ -3,9 +3,11 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
 
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-createRoot(document.getElementById("root")!).render(
-	<StrictMode>
-		<App />
-	</StrictMode>
-);
+const rootElement = document.getElementById("root");
+if (rootElement) {
+	createRoot(rootElement).render(
+		<StrictMode>
+			<App />
+		</StrictMode>
+	);
+}

--- a/packages/vite-plugin-cloudflare/playground/containers/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/containers/src/index.ts
@@ -10,7 +10,7 @@ export class Container extends DurableObject<Env> {
 
 	constructor(ctx: DurableObjectState, env: Env) {
 		super(ctx, env);
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we know that the container is defined on ctx
 		this.container = ctx.container!;
 	}
 

--- a/packages/vite-plugin-cloudflare/playground/external-workers/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/external-workers/src/index.ts
@@ -81,7 +81,7 @@ export default {
 			const stream = await (
 				await fetch("https://thispersondoesnotexist.com/")
 			).body;
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we are sure that at this point there will be a stream
 			const transform = await env.IMAGES.input(stream!)
 				.transform({ blur: 250 })
 				.output({ format: "image/avif" });

--- a/packages/vite-plugin-cloudflare/playground/module-resolution/src/third-party/discord-api-types.ts
+++ b/packages/vite-plugin-cloudflare/playground/module-resolution/src/third-party/discord-api-types.ts
@@ -1,11 +1,14 @@
-import { RPCErrorCodes, Utils } from "discord-api-types/v10";
+import {
+	RPCErrorCodes,
+	Utils,
+	type APIButtonComponent,
+} from "discord-api-types/v10";
 
 // resolving discord-api-types/v10 (package which uses `require()`s without extensions
 // can be problematic, see: https://github.com/dario-piotrowicz/vitest-pool-workers-ext-repro)
 export default {
 	"(discord-api-types/v10) Utils.isLinkButton({})": Utils.isLinkButton(
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		{} as any
+		{} as APIButtonComponent
 	),
 	"(discord-api-types/v10) RPCErrorCodes.InvalidUser":
 		RPCErrorCodes.InvalidUser,

--- a/packages/vite-plugin-cloudflare/playground/node-compat/__tests__/worker-postgres/serve.ts
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/__tests__/worker-postgres/serve.ts
@@ -12,7 +12,7 @@ export async function preServe() {
 	mockPg = await createMockPostgresServer({
 		rows: [{ id: "21", name: "mock-row" }],
 	});
-	// eslint-disable-next-line turbo/no-undeclared-env-vars
+	// eslint-disable-next-line turbo/no-undeclared-env-vars -- internal to the test process: set here, read by vite.config.worker-postgres.ts in the same run
 	process.env.MOCK_PG_PORT = String(mockPg.port);
 }
 

--- a/packages/vite-plugin-cloudflare/playground/node-compat/vite.config.worker-postgres.ts
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/vite.config.worker-postgres.ts
@@ -10,7 +10,7 @@ export default defineConfig({
 			configPath: "./worker-postgres/wrangler.jsonc",
 			// Inject the mock Postgres server port set by serve.ts preServe()
 			config: () => {
-				// eslint-disable-next-line turbo/no-undeclared-env-vars
+				// eslint-disable-next-line turbo/no-undeclared-env-vars -- internal to the test process: set by serve.ts preServe(), not an external input
 				const mockPgPort = process.env.MOCK_PG_PORT;
 				if (mockPgPort) {
 					return {

--- a/packages/vite-plugin-cloudflare/playground/node-compat/worker-process-populated-env/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/worker-process-populated-env/index.ts
@@ -8,9 +8,9 @@ export default {
 
 function testProcessBehaviour() {
 	try {
-		// eslint-disable-next-line turbo/no-undeclared-env-vars
+		// eslint-disable-next-line turbo/no-undeclared-env-vars -- Worker runtime code: populated via Worker bindings, not a Node.js process env var
 		assert(process.env.FOO === "foo value", "process.env.FOO not populated");
-		// eslint-disable-next-line turbo/no-undeclared-env-vars
+		// eslint-disable-next-line turbo/no-undeclared-env-vars -- Worker runtime code: populated via Worker bindings, not a Node.js process env var
 		assert(process.env.BAR === "bar secret", "process.env.BAR not populated");
 
 		const processEnvKeys = Object.keys(process.env).sort();

--- a/packages/vite-plugin-cloudflare/playground/node-env/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/node-env/src/index.ts
@@ -9,7 +9,7 @@ export default {
 				React.createElement(
 					"p",
 					null,
-					// eslint-disable-next-line turbo/no-undeclared-env-vars
+					// eslint-disable-next-line turbo/no-undeclared-env-vars -- Worker runtime code: build-time replaced by Vite, not a Node.js process env var
 					`The value of process.env.NODE_ENV is "${process.env.NODE_ENV}"`
 				),
 			])

--- a/packages/vite-plugin-cloudflare/playground/partyserver/src/main.tsx
+++ b/packages/vite-plugin-cloudflare/playground/partyserver/src/main.tsx
@@ -2,9 +2,11 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-createRoot(document.getElementById("root")!).render(
-	<StrictMode>
-		<App />
-	</StrictMode>
-);
+const rootElement = document.getElementById("root");
+if (rootElement) {
+	createRoot(rootElement).render(
+		<StrictMode>
+			<App />
+		</StrictMode>
+	);
+}

--- a/packages/vite-plugin-cloudflare/playground/react-spa/src/main.tsx
+++ b/packages/vite-plugin-cloudflare/playground/react-spa/src/main.tsx
@@ -3,9 +3,11 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
 
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-createRoot(document.getElementById("root")!).render(
-	<StrictMode>
-		<App />
-	</StrictMode>
-);
+const rootElement = document.getElementById("root");
+if (rootElement) {
+	createRoot(rootElement).render(
+		<StrictMode>
+			<App />
+		</StrictMode>
+	);
+}

--- a/packages/vite-plugin-cloudflare/playground/spa-with-api/src/main.tsx
+++ b/packages/vite-plugin-cloudflare/playground/spa-with-api/src/main.tsx
@@ -3,9 +3,11 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
 
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-createRoot(document.getElementById("root")!).render(
-	<StrictMode>
-		<App />
-	</StrictMode>
-);
+const rootElement = document.getElementById("root");
+if (rootElement) {
+	createRoot(rootElement).render(
+		<StrictMode>
+			<App />
+		</StrictMode>
+	);
+}

--- a/packages/vite-plugin-cloudflare/playground/static/src/main.ts
+++ b/packages/vite-plugin-cloudflare/playground/static/src/main.ts
@@ -3,24 +3,28 @@ import viteLogo from "/vite.svg";
 import { setupCounter } from "./counter";
 import typescriptLogo from "./typescript.svg";
 
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
-  <div>
-    <a href="https://vite.dev" target="_blank">
-      <img src="${viteLogo}" class="logo" alt="Vite logo" />
-    </a>
-    <a href="https://www.typescriptlang.org/" target="_blank">
-      <img src="${typescriptLogo}" class="logo vanilla" alt="TypeScript logo" />
-    </a>
-    <h1>Vite + TypeScript</h1>
-    <div class="card">
-      <button id="counter" type="button"></button>
-    </div>
-    <p class="read-the-docs">
-      Click on the Vite and TypeScript logos to learn more
-    </p>
-  </div>
-`;
+const appElement = document.querySelector<HTMLDivElement>("#app");
+if (appElement) {
+	appElement.innerHTML = `
+		<div>
+			<a href="https://vite.dev" target="_blank">
+				<img src="${viteLogo}" class="logo" alt="Vite logo" />
+			</a>
+			<a href="https://www.typescriptlang.org/" target="_blank">
+				<img src="${typescriptLogo}" class="logo vanilla" alt="TypeScript logo" />
+			</a>
+			<h1>Vite + TypeScript</h1>
+			<div class="card">
+				<button id="counter" type="button"></button>
+			</div>
+			<p class="read-the-docs">
+				Click on the Vite and TypeScript logos to learn more
+			</p>
+		</div>
+	`;
+}
 
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-setupCounter(document.querySelector<HTMLButtonElement>("#counter")!);
+const counterElement = document.querySelector<HTMLButtonElement>("#counter");
+if (counterElement) {
+	setupCounter(counterElement);
+}

--- a/packages/vite-plugin-cloudflare/playground/stream-binding/__tests__/serve.ts
+++ b/packages/vite-plugin-cloudflare/playground/stream-binding/__tests__/serve.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import http from "node:http";
 import path from "node:path";
 import { cloudflare } from "@cloudflare/vite-plugin";
@@ -41,8 +42,9 @@ export async function serve() {
 		plugins: [cloudflare({ inspectorPort: false, persistState: false })],
 	});
 	viteServer = await server.listen();
-	// oxlint-disable-next-line typescript/no-non-null-assertion
-	viteTestUrl = viteServer.resolvedUrls!.local[0]!.replace(/\/$/, "");
+	assert(viteServer.resolvedUrls);
+	assert(viteServer.resolvedUrls.local[0]);
+	viteTestUrl = viteServer.resolvedUrls.local[0].replace(/\/$/, "");
 	return viteServer;
 }
 

--- a/packages/vite-plugin-cloudflare/playground/turbo.json
+++ b/packages/vite-plugin-cloudflare/playground/turbo.json
@@ -3,16 +3,33 @@
 	"extends": ["//"],
 	"tasks": {
 		"test:ci": {
-			"env": ["NODE_DEBUG"]
+			"env": ["NODE_DEBUG"],
+			"passThroughEnv": [
+				"CLOUDFLARE_VITE_BUILD",
+				"VITE_DEBUG_SERVE",
+				"VITE_INLINE",
+				"VITE_TEST_BUILD"
+			]
 		},
 		"test:ci:serve": {
 			"dependsOn": ["build"],
-			"env": ["NODE_DEBUG", "VITE_VERSION"],
+			"env": ["NODE_DEBUG", "NODE_ENV", "VITE_VERSION"],
+			"passThroughEnv": [
+				"CLOUDFLARE_VITE_BUILD",
+				"VITE_DEBUG_SERVE",
+				"VITE_INLINE",
+				"VITE_TEST_BUILD"
+			],
 			"outputLogs": "new-only"
 		},
 		"test:ci:build": {
 			"dependsOn": ["build"],
-			"env": ["NODE_DEBUG", "VITE_VERSION"],
+			"env": ["NODE_DEBUG", "NODE_ENV", "VITE_TEST_BUILD", "VITE_VERSION"],
+			"passThroughEnv": [
+				"CLOUDFLARE_VITE_BUILD",
+				"VITE_DEBUG_SERVE",
+				"VITE_INLINE"
+			],
 			"outputLogs": "new-only"
 		}
 	}

--- a/packages/vite-plugin-cloudflare/playground/vitest-global-setup.ts
+++ b/packages/vite-plugin-cloudflare/playground/vitest-global-setup.ts
@@ -8,13 +8,11 @@ import type { TestProject } from "vitest/node";
 let browserServer: BrowserServer | undefined;
 
 export async function setup({ provide }: TestProject): Promise<void> {
-	// eslint-disable-next-line turbo/no-undeclared-env-vars
 	process.env.NODE_ENV = process.env.VITE_TEST_BUILD
 		? "production"
 		: "development";
 
 	browserServer = await chromium.launchServer({
-		// eslint-disable-next-line turbo/no-undeclared-env-vars
 		headless: !process.env.VITE_DEBUG_SERVE,
 		args: process.env.CI
 			? ["--no-sandbox", "--disable-setuid-sandbox"]

--- a/packages/vite-plugin-cloudflare/playground/vitest-setup.ts
+++ b/packages/vite-plugin-cloudflare/playground/vitest-setup.ts
@@ -8,7 +8,7 @@ import {
 	mergeConfig,
 	preview,
 } from "vite";
-import { beforeAll, inject } from "vitest";
+import { assert, beforeAll, inject } from "vitest";
 import type { Browser, Page } from "playwright-chromium";
 import type {
 	ConfigEnv,
@@ -26,7 +26,6 @@ import type { RunnerTestFile } from "vitest";
 
 export const workspaceRoot = path.resolve(__dirname, "../");
 
-// eslint-disable-next-line turbo/no-undeclared-env-vars
 export const isBuild = !!process.env.VITE_TEST_BUILD;
 export const isWindows = process.platform === "win32";
 
@@ -69,13 +68,11 @@ export const serverLogs: {
 export const browserLogs: string[] = [];
 export const browserErrors: Error[] = [];
 
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-export let resolvedConfig: ResolvedConfig = undefined!;
+export let resolvedConfig: ResolvedConfig =
+	undefined as unknown as ResolvedConfig;
 
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-export let page: Page = undefined!;
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-export let browser: Browser = undefined!;
+export let page: Page = undefined as unknown as Page;
+export let browser: Browser = undefined as unknown as Browser;
 export let viteTestUrl: string = "";
 export const watcher: Rollup.RollupWatcher | undefined = undefined;
 
@@ -89,17 +86,19 @@ export function resetServerLogs() {
 	serverLogs.errors.splice(0, serverLogs.errors.length);
 }
 
-// eslint-disable-next-line no-empty-pattern
+// eslint-disable-next-line no-empty-pattern -- Vitest requires the 1st argument to use object destructuring
 beforeAll(async ({}, s) => {
 	let server: ViteDevServer | PreviewServer | undefined;
 	let postServe: (() => Promise<void>) | undefined;
 
 	const suite = s as RunnerTestFile;
 
-	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	testPath = suite.filepath!;
-	// eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain, @typescript-eslint/no-non-null-assertion
-	testName = slash(testPath).match(/playground\/([\w-♫]+)\//)?.[1]!;
+	assert(suite.filepath);
+	testPath = suite.filepath;
+	const regexMatchArray = slash(testPath).match(/playground\/([\w-♫]+)\//);
+	assert(regexMatchArray);
+	assert(regexMatchArray[1]);
+	testName = regexMatchArray[1];
 	testDir = path.dirname(testPath);
 	if (testName) {
 		testDir = path.resolve(workspaceRoot, "playground", testName);
@@ -133,7 +132,6 @@ beforeAll(async ({}, s) => {
 			console.timeLog(logLabel, `BROWSER LOG [${msg.type()}]: ${msg.text()}`);
 			// ignore favicon requests in headed browser
 			if (
-				// eslint-disable-next-line turbo/no-undeclared-env-vars
 				process.env.VITE_DEBUG_SERVE &&
 				msg.text().includes("Failed to load resource:") &&
 				msg.location().url.includes("favicon.ico")
@@ -285,23 +283,21 @@ export async function startDefaultServe(): Promise<
 	setupConsoleWarnCollector(serverLogs.warns);
 
 	// Vitest 4 sets NODE_ENV=test — override so Vite uses the correct mode
-	// eslint-disable-next-line turbo/no-undeclared-env-vars
 	process.env.NODE_ENV = isBuild ? "production" : "development";
 
 	if (!isBuild) {
-		// eslint-disable-next-line turbo/no-undeclared-env-vars
 		process.env.VITE_INLINE = "inline-serve";
 		const config = await loadConfig({ command: "serve", mode: "development" });
 		viteServer = await (await createServer(config)).listen();
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		viteTestUrl = viteServer.resolvedUrls!.local[0]!;
+		assert(viteServer.resolvedUrls);
+		assert(viteServer.resolvedUrls.local[0]);
+		viteTestUrl = viteServer.resolvedUrls.local[0];
 		if (viteServer.config.base === "/") {
 			viteTestUrl = viteTestUrl.replace(/\/$/, "");
 		}
 		await page.goto(viteTestUrl);
 		return viteServer;
 	} else {
-		// eslint-disable-next-line turbo/no-undeclared-env-vars
 		process.env.VITE_INLINE = "inline-build";
 		// determine build watch
 		const resolvedPlugin: () => PluginOption = () => ({
@@ -324,7 +320,6 @@ export async function startDefaultServe(): Promise<
 
 		// This environment variable is used to indicate to the preview server that it is being run during a build
 		// We need to delete it here as, during testing, preview also runs in the same process after the build completes
-		// eslint-disable-next-line turbo/no-undeclared-env-vars
 		delete process.env.CLOUDFLARE_VITE_BUILD;
 
 		const previewConfig = await loadConfig({
@@ -332,18 +327,17 @@ export async function startDefaultServe(): Promise<
 			mode: "development",
 			isPreview: true,
 		});
-		// eslint-disable-next-line turbo/no-undeclared-env-vars
 		const _nodeEnv = process.env.NODE_ENV;
 		// Make sure we are running from within the playground.
 		// Otherwise workerd will error with messages about not being allowed to escape the starting directory with `..`.
 		process.chdir(previewConfig.root);
 		const previewServer = await preview(previewConfig);
 		// prevent preview change NODE_ENV
-		// eslint-disable-next-line turbo/no-undeclared-env-vars
 		process.env.NODE_ENV = _nodeEnv;
 		viteServer = previewServer;
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		viteTestUrl = previewServer!.resolvedUrls!.local[0]!;
+		assert(previewServer.resolvedUrls);
+		assert(previewServer.resolvedUrls.local[0]);
+		viteTestUrl = previewServer.resolvedUrls.local[0];
 		if (previewServer.config.base === "/") {
 			viteTestUrl = viteTestUrl.replace(/\/$/, "");
 		}

--- a/packages/vite-plugin-cloudflare/playground/worker-♫/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/worker-♫/src/index.ts
@@ -7,7 +7,7 @@ export default {
 		if (
 			url.pathname ===
 			// doing base path normalization, in real world you would built in framework features from libs like Hono
-			// eslint-disable-next-line turbo/no-undeclared-env-vars
+			// eslint-disable-next-line turbo/no-undeclared-env-vars -- Worker runtime code: build-time replaced by Vite, not a Node.js process env var
 			`${import.meta.env.BASE_URL}/x-forwarded-host`.replace(/\/+/g, "/")
 		) {
 			return new Response(request.headers.get("X-Forwarded-Host"));

--- a/packages/vite-plugin-cloudflare/src/__tests__/validate-worker-environment-options.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/validate-worker-environment-options.spec.ts
@@ -1,16 +1,19 @@
 import { describe, test } from "vitest";
 import { validateWorkerEnvironmentOptions } from "../vite-config";
+import type {
+	AssetsOnlyResolvedConfig,
+	WorkersResolvedConfig,
+} from "../plugin-config";
+import type { ResolvedConfig } from "vite";
 
 describe("validateWorkerEnvironmentOptions", () => {
 	test("doesn't throw if there are no config violations", ({ expect }) => {
 		const resolvedPluginConfig = {
 			environmentNameToWorkerMap: new Map([["worker", { config: {} }]]),
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		} as any;
+		} as unknown as AssetsOnlyResolvedConfig | WorkersResolvedConfig;
 		const resolvedViteConfig = {
 			environments: { worker: { resolve: { external: [] } } },
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		} as any;
+		} as unknown as ResolvedConfig;
 
 		expect(() =>
 			validateWorkerEnvironmentOptions(resolvedPluginConfig, resolvedViteConfig)
@@ -22,12 +25,10 @@ describe("validateWorkerEnvironmentOptions", () => {
 	}) => {
 		const resolvedPluginConfig = {
 			environmentNameToWorkerMap: new Map([["worker", { config: {} }]]),
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		} as any;
+		} as unknown as AssetsOnlyResolvedConfig | WorkersResolvedConfig;
 		const resolvedViteConfig = {
 			environments: { worker: { resolve: { external: true } } },
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		} as any;
+		} as unknown as ResolvedConfig;
 
 		expect(() =>
 			validateWorkerEnvironmentOptions(resolvedPluginConfig, resolvedViteConfig)
@@ -50,8 +51,7 @@ describe("validateWorkerEnvironmentOptions", () => {
 				["workerB", { config: {} }],
 				["workerC", { config: {} }],
 			]),
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		} as any;
+		} as unknown as AssetsOnlyResolvedConfig | WorkersResolvedConfig;
 		const resolvedViteConfig = {
 			environments: {
 				workerA: {
@@ -66,8 +66,7 @@ describe("validateWorkerEnvironmentOptions", () => {
 				},
 				workerC: { resolve: { external: [] } },
 			},
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		} as any;
+		} as unknown as ResolvedConfig;
 
 		expect(() =>
 			validateWorkerEnvironmentOptions(resolvedPluginConfig, resolvedViteConfig)

--- a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
+++ b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
@@ -349,7 +349,6 @@ function getProcessEnvReplacements(
 	hasNodeJsCompat: boolean,
 	mode: vite.ConfigEnv["mode"]
 ): Record<string, string> {
-	// eslint-disable-next-line turbo/no-undeclared-env-vars
 	const nodeEnv = process.env.NODE_ENV || mode;
 	const nodeEnvReplacements = {
 		"process.env.NODE_ENV": JSON.stringify(nodeEnv),

--- a/packages/vite-plugin-cloudflare/src/workers-configs.ts
+++ b/packages/vite-plugin-cloudflare/src/workers-configs.ts
@@ -284,8 +284,9 @@ function isReplacedByVite(
 function isNotRelevant(
 	configName: string
 ): configName is NonApplicableConfigNotRelevant {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	return nonApplicableWorkerConfigs.notRelevant.includes(configName as any);
+	return nonApplicableWorkerConfigs.notRelevant.includes(
+		configName as NonApplicableConfigNotRelevant
+	);
 }
 
 function missingFieldErrorMessage(

--- a/packages/vite-plugin-cloudflare/src/workers/runner-worker/__tests__/env.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/workers/runner-worker/__tests__/env.spec.ts
@@ -1,10 +1,10 @@
 import { describe, test } from "vitest";
 import { stripInternalEnv } from "../env";
+import type { __VITE_RUNNER_OBJECT__ } from "../module-runner";
 
 const internalEnv = {
 	__VITE_RUNNER_OBJECT__: {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		get: () => ({}) as any,
+		get: () => ({}) as __VITE_RUNNER_OBJECT__,
 	},
 	__VITE_INVOKE_MODULE__: {
 		fetch: async () => new Response(),

--- a/packages/vite-plugin-cloudflare/src/workers/runner-worker/env.ts
+++ b/packages/vite-plugin-cloudflare/src/workers/runner-worker/env.ts
@@ -12,7 +12,6 @@ export interface WrapperEnv {
 	};
 	/** Binding for evaluating code */
 	__VITE_UNSAFE_EVAL__: {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- unsafe eval is generic so we need to use a generif
 		eval: (code: string, filename: string) => (...args: unknown[]) => unknown;
 	};
 	/** User-defined env */

--- a/packages/vite-plugin-cloudflare/src/workers/runner-worker/env.ts
+++ b/packages/vite-plugin-cloudflare/src/workers/runner-worker/env.ts
@@ -12,8 +12,8 @@ export interface WrapperEnv {
 	};
 	/** Binding for evaluating code */
 	__VITE_UNSAFE_EVAL__: {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-		eval: (code: string, filename: string) => Function;
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- unsafe eval is generic so we need to use a generif
+		eval: (code: string, filename: string) => (...args: unknown[]) => unknown;
 	};
 	/** User-defined env */
 	[key: string]: unknown;

--- a/packages/vite-plugin-cloudflare/src/workers/runner-worker/errors.ts
+++ b/packages/vite-plugin-cloudflare/src/workers/runner-worker/errors.ts
@@ -6,13 +6,14 @@
  * Converts an error to an object that can be be serialized and revived by Miniflare.
  * Copied from `packages/wrangler/templates/middleware/middleware-miniflare3-json-error.ts`
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function reduceError(e: any): any {
+function reduceError(e: unknown): unknown {
+	const errorObj = (e ?? {}) as Record<string, unknown>;
 	return {
-		name: e?.name,
-		message: e?.message ?? String(e),
-		stack: e?.stack,
-		cause: e?.cause === undefined ? undefined : reduceError(e.cause),
+		name: errorObj.name,
+		message: errorObj.message ?? String(e),
+		stack: errorObj.stack,
+		cause:
+			errorObj.cause === undefined ? undefined : reduceError(errorObj.cause),
 	};
 }
 

--- a/packages/vite-plugin-cloudflare/src/workers/runner-worker/index.ts
+++ b/packages/vite-plugin-cloudflare/src/workers/runner-worker/index.ts
@@ -441,7 +441,7 @@ export function createDurableObjectWrapper(
 				);
 			}
 
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic method assignment in a loop can't satisfy the intersection of all method signatures
 			return (maybeFn as (...args: unknown[]) => any).apply(instance, args);
 		};
 	}
@@ -483,8 +483,7 @@ export function createWorkflowEntrypointWrapper(
 				);
 			}
 
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			return (maybeFn as (...args: unknown[]) => any).apply(instance, args);
+			return (maybeFn as (...args: unknown[]) => unknown).apply(instance, args);
 		};
 	}
 

--- a/packages/vite-plugin-cloudflare/src/workers/runner-worker/keys.ts
+++ b/packages/vite-plugin-cloudflare/src/workers/runner-worker/keys.ts
@@ -49,7 +49,7 @@ function _checkExhaustiveKeys() {
 	const _workflowEntrypointExhaustive: (typeof WORKFLOW_ENTRYPOINT_KEYS)[number] =
 		undefined as unknown as UnbrandedKeys<WorkflowEntrypoint>;
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- these unused expressions are here to exercise the typechecker
 	_workerEntrypointExhaustive ||
 		_durableObjectExhaustive ||
 		_workflowEntrypointExhaustive;

--- a/packages/vite-plugin-cloudflare/src/workers/runner-worker/module-runner.ts
+++ b/packages/vite-plugin-cloudflare/src/workers/runner-worker/module-runner.ts
@@ -213,8 +213,7 @@ async function createModuleRunner(
 					);
 					const result = await response.json();
 
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					return result as { result: any } | { error: any };
+					return result as { result: unknown } | { error: unknown };
 				},
 			},
 			hmr: true,

--- a/packages/vite-plugin-cloudflare/turbo.json
+++ b/packages/vite-plugin-cloudflare/turbo.json
@@ -3,6 +3,7 @@
 	"extends": ["//"],
 	"tasks": {
 		"build": {
+			"env": ["NODE_ENV"],
 			"outputs": ["dist/**"]
 		},
 		"test:e2e": {


### PR DESCRIPTION
This PR enables the `require-description-when-disabling` lint rule on the vite plugin package.

This is a followup PR for https://github.com/cloudflare/workers-sdk/pull/13698, https://github.com/cloudflare/workers-sdk/pull/13703 and https://github.com/cloudflare/workers-sdk/pull/13710

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: internal linting change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal linting change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
