### PR TITLE
feat(wrangler): send detected framework as annotation during deploy

### DIFF
--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -141,6 +141,8 @@ type Props = {
 	tag: string | undefined;
 	message: string | undefined;
 	secretsFile: string | undefined;
+	/** Detected framework name from autoconfig (e.g. "astro", "next", "static") */
+	framework: string | undefined;
 };
 
 export type RouteObject = ZoneIdRoute | ZoneNameRoute | CustomDomainRoute;
@@ -912,10 +914,11 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			streaming_tail_consumers: config.streaming_tail_consumers,
 			limits: config.limits,
 			annotations:
-				props.tag || props.message
+				props.tag || props.message || props.framework
 					? {
 							"workers/message": props.message,
 							"workers/tag": props.tag,
+							"workers/framework": props.framework,
 						}
 					: undefined,
 			assets:

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -305,6 +305,8 @@ export const deployCommand = createCommand({
 			);
 		}
 
+		let detectedFramework: string | undefined;
+
 		if (shouldRunAutoConfig) {
 			sendAutoConfigProcessStartedMetricsEvent({
 				command: "wrangler deploy",
@@ -315,6 +317,8 @@ export const deployCommand = createCommand({
 				const details = await getDetailsForAutoConfig({
 					wranglerConfig: config,
 				});
+
+				detectedFramework = details.framework?.id;
 
 				if (details.framework?.id === "cloudflare-pages") {
 					// If the project is a Pages project then warn the user but allow them to proceed if they wish so
@@ -516,6 +520,7 @@ export const deployCommand = createCommand({
 			tag: args.tag,
 			message: args.message,
 			secretsFile: args.secretsFile,
+			framework: detectedFramework,
 		});
 
 		writeOutput({


### PR DESCRIPTION
## Summary

When autoconfig detects a framework during `wrangler deploy`, include it as a `workers/framework` annotation in the deploy metadata sent to EWC.

## Why

The [Pages Convergence dashboard](https://grafana.cfdata.org/d/efkkw60x3nu9se/pages-convergence) needs to cross-reference **framework** with **deploy type** (static vs dynamic) for Workers. Currently:

- Wrangler's autoconfig **already detects the framework** (Next.js, Astro, Nuxt, SvelteKit, etc.) — this is GA since Feb 2026
- But it only sends the framework to Sparrow telemetry (`autoconfig_detection_completed`), NOT to EWC
- EWC's `workerdeploy` Ready Analytics event has no framework field

## What

- Thread `detectedFramework` (from `getDetailsForAutoConfig()`) through to `deploy()`
- Include it as `"workers/framework"` in the `annotations` record (same pattern as `workers/message` and `workers/tag`)
- 2 files changed, 9 insertions, 1 deletion

## Companion changes

- **EWC** ([Draft MR !9152](https://gitlab.cfdata.org/cloudflare/ew/edgeworker-config-service/-/merge_requests/9152)): Read `workers/framework` from annotations and emit as `blob9` in the `workerdeploy` RA event
- **Jira**: [BANDA-1799](https://jira.cfdata.org/browse/BANDA-1799)

## Impact

| Deploy path | Framework sent? |
|---|---|
| `wrangler deploy` (auto-config detects framework) | Yes — via `workers/framework` annotation |
| `wrangler deploy` (existing wrangler.toml, no autoconfig) | No — `detectedFramework` is undefined, annotation omitted |
| Workers CI build → wrangler deploy | Yes — CI uses wrangler internally, autoconfig runs |
| Dashboard / API deploy | No — no wrangler involved |

## Supported frameworks (from autoconfig)

Next.js, Astro, Nuxt, TanStack Start, SolidStart, React Router, SvelteKit, Docusaurus, Qwik, Analog, Hono, Vite, Vike, Waku, Hydrogen, + "static" for static-only sites