### PR TITLE
[vite-plugin] honor caller-supplied MF-Route-Override header

### DIFF
--- a/packages/vite-plugin-cloudflare/src/__tests__/websockets.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/websockets.spec.ts
@@ -1,7 +1,15 @@
 import http from "node:http";
 import net from "node:net";
-import { DeferredPromise, Miniflare, Response } from "miniflare";
-import { afterEach, assert, beforeEach, describe, test, vi } from "vitest";
+import { CoreHeaders, DeferredPromise, Miniflare, Response } from "miniflare";
+import {
+	afterEach,
+	assert,
+	beforeEach,
+	describe,
+	type ExpectStatic,
+	test,
+	vi,
+} from "vitest";
 import { handleWebSocket } from "../websockets";
 import type { AddressInfo } from "node:net";
 
@@ -109,5 +117,78 @@ describe("handleWebSocket", () => {
 		);
 		expect(init.headers.get("sec-websocket-protocol")).toBe("vite-hmr");
 		expect(init.headers.get("sec-websocket-version")).toBe("13");
+	});
+});
+
+describe("handleWebSocket with entryWorkerName", () => {
+	let httpServer: http.Server;
+	let miniflare: Miniflare;
+	let port: number;
+
+	beforeEach(async () => {
+		httpServer = http.createServer((_req, res) => res.end("OK"));
+		miniflare = new Miniflare({
+			modules: true,
+			script: `export default {
+				fetch() {
+					const [client, server] = Object.values(new WebSocketPair());
+					server.accept();
+					return new Response(null, { status: 101, webSocket: client });
+				}
+			}`,
+		});
+		handleWebSocket(httpServer, miniflare, "entry-worker");
+		await new Promise<void>((r) => httpServer.listen(0, "127.0.0.1", r));
+		port = (httpServer.address() as AddressInfo).port;
+	});
+
+	afterEach(async () => {
+		await miniflare?.dispose();
+		await new Promise<void>((resolve, reject) =>
+			httpServer?.close((e) => (e ? reject(e) : resolve()))
+		);
+	});
+
+	async function performUpgrade(expect: ExpectStatic, extraHeaders: string) {
+		const deferred = new DeferredPromise<Response>();
+		const spy = vi.spyOn(miniflare, "dispatchFetch").mockReturnValue(deferred);
+
+		const socket = net.connect(port, "127.0.0.1");
+		await new Promise<void>((r) => socket.on("connect", r));
+		socket.write(
+			"GET / HTTP/1.1\r\n" +
+				"Host: localhost\r\n" +
+				"Upgrade: websocket\r\n" +
+				"Connection: Upgrade\r\n" +
+				"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+				"Sec-WebSocket-Version: 13\r\n" +
+				extraHeaders +
+				"\r\n"
+		);
+
+		await vi.waitFor(() => expect(spy).toHaveBeenCalled());
+		deferred.resolve(new Response(null));
+
+		assert(spy.mock.lastCall);
+		const [, init] = spy.mock.lastCall;
+		assert(init);
+		assert(init.headers instanceof Headers);
+		socket.destroy();
+		return init.headers;
+	}
+
+	test("sets MF-Route-Override to the entry worker name when absent", async ({
+		expect,
+	}) => {
+		const headers = await performUpgrade(expect, "");
+		expect(headers.get(CoreHeaders.ROUTE_OVERRIDE)).toBe("entry-worker");
+	});
+
+	test("preserves a caller-supplied MF-Route-Override", async ({ expect }) => {
+		const headers = await performUpgrade(
+			expect,
+			`${CoreHeaders.ROUTE_OVERRIDE}: other-worker\r\n`
+		);
+		expect(headers.get(CoreHeaders.ROUTE_OVERRIDE)).toBe("other-worker");
 	});
 });

--- a/packages/vite-plugin-cloudflare/src/plugins/dev.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/dev.ts
@@ -181,6 +181,35 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 					);
 				}
 
+				// Pre-middleware that honours an inbound MF-Route-Override header by
+				// dispatching directly to Miniflare, bypassing Vite's HTML/transform
+				// middlewares. This lets external Vite plugins (e.g. host-based
+				// routers) target an auxiliary worker for paths Vite would otherwise
+				// serve itself, such as `/`. Repositioned below in Vite 6 so it runs
+				// after the host-check middleware. In Vite 7+ pre-middleware is
+				// already in the correct position.
+				const routeOverrideHandler = createRequestHandler((request) =>
+					ctx.miniflare.dispatchFetch(request, { redirect: "manual" })
+				);
+				viteDevServer.middlewares.use(
+					async function cloudflareRouteOverrideMiddleware(req, res, next) {
+						let hasRouteOverride = false;
+						for (let i = 0; i < req.rawHeaders.length; i += 2) {
+							if (
+								req.rawHeaders[i]?.toLowerCase() ===
+								CoreHeaders.ROUTE_OVERRIDE.toLowerCase()
+							) {
+								hasRouteOverride = true;
+								break;
+							}
+						}
+						if (!hasRouteOverride) {
+							return next();
+						}
+						return routeOverrideHandler(req, res, next);
+					}
+				);
+
 				const staticRouting: StaticRouting | undefined =
 					entryWorkerConfig.assets?.run_worker_first === true
 						? { user_worker: ["/*"] }
@@ -194,7 +223,9 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 						staticRouting.user_worker
 					);
 					const userWorkerHandler = createRequestHandler(async (request) => {
-						request.headers.set(CoreHeaders.ROUTE_OVERRIDE, entryWorkerName);
+						if (!request.headers.has(CoreHeaders.ROUTE_OVERRIDE)) {
+							request.headers.set(CoreHeaders.ROUTE_OVERRIDE, entryWorkerName);
+						}
 
 						return ctx.miniflare.dispatchFetch(request, {
 							redirect: "manual",
@@ -305,21 +336,28 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 				// correct position so no action is needed.
 				if (!satisfiesMinimumViteVersion("7.0.0")) {
 					const middlewareStack = viteDevServer.middlewares.stack;
-					const preMiddlewareIndex = middlewareStack.findIndex(
-						(middleware) =>
-							"name" in middleware.handle &&
-							middleware.handle.name === "cloudflarePreMiddleware"
-					);
 
-					if (preMiddlewareIndex !== -1) {
+					// Move our pre-middlewares (added earlier in `configureServer`)
+					// from before the host-check middleware to after it, by
+					// re-inserting them just before viteCachedTransformMiddleware.
+					for (const name of [
+						"cloudflarePreMiddleware",
+						"cloudflareRouteOverrideMiddleware",
+					]) {
+						const preMiddlewareIndex = middlewareStack.findIndex(
+							(middleware) =>
+								"name" in middleware.handle && middleware.handle.name === name
+						);
+
+						if (preMiddlewareIndex === -1) {
+							continue;
+						}
+
 						const [preMiddleware] = middlewareStack.splice(
 							preMiddlewareIndex,
 							1
 						);
-						assert(
-							preMiddleware,
-							"Failed to remove cloudflarePreMiddleware from stack"
-						);
+						assert(preMiddleware, `Failed to remove ${name} from stack`);
 
 						const cachedTransformMiddlewareIndex = middlewareStack.findIndex(
 							(middleware) =>
@@ -341,25 +379,18 @@ export const devPlugin = createPlugin("dev", (ctx) => {
 				// post middleware
 				viteDevServer.middlewares.use(
 					createRequestHandler(async (request, req) => {
-						if (req[kRequestType] === "asset") {
+						if (!request.headers.has(CoreHeaders.ROUTE_OVERRIDE)) {
 							request.headers.set(
 								CoreHeaders.ROUTE_OVERRIDE,
-								ASSET_WORKER_NAME
+								req[kRequestType] === "asset"
+									? ASSET_WORKER_NAME
+									: ROUTER_WORKER_NAME
 							);
-
-							return ctx.miniflare.dispatchFetch(request, {
-								redirect: "manual",
-							});
-						} else {
-							request.headers.set(
-								CoreHeaders.ROUTE_OVERRIDE,
-								ROUTER_WORKER_NAME
-							);
-
-							return ctx.miniflare.dispatchFetch(request, {
-								redirect: "manual",
-							});
 						}
+
+						return ctx.miniflare.dispatchFetch(request, {
+							redirect: "manual",
+						});
 					})
 				);
 			};

--- a/packages/vite-plugin-cloudflare/src/plugins/trigger-handlers.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/trigger-handlers.ts
@@ -16,7 +16,9 @@ export const triggerHandlersPlugin = createPlugin("trigger-handlers", (ctx) => {
 
 			const entryWorkerName = entryWorkerConfig.name;
 			const requestHandler = createRequestHandler((request) => {
-				request.headers.set(CoreHeaders.ROUTE_OVERRIDE, entryWorkerName);
+				if (!request.headers.has(CoreHeaders.ROUTE_OVERRIDE)) {
+					request.headers.set(CoreHeaders.ROUTE_OVERRIDE, entryWorkerName);
+				}
 				return ctx.miniflare.dispatchFetch(request, {
 					redirect: "manual",
 				});

--- a/packages/vite-plugin-cloudflare/src/websockets.ts
+++ b/packages/vite-plugin-cloudflare/src/websockets.ts
@@ -40,7 +40,7 @@ export function handleWebSocket(
 
 			const headers = createHeaders(request);
 
-			if (entryWorkerName) {
+			if (entryWorkerName && !headers.has(CoreHeaders.ROUTE_OVERRIDE)) {
 				headers.set(CoreHeaders.ROUTE_OVERRIDE, entryWorkerName);
 			}
 


### PR DESCRIPTION
Previously the plugin unconditionally overwrote `MF-Route-Override` when forwarding requests to Miniflare. This diverges from the implementation in `vite preview` which preserves any existing `MF-Route-Override` headers. 

This change opens up niche but interesting possibilities for external callers to route requests to auxiliary workers.

Note, internal init paths in cloudflare-environment.ts continue to set the header unconditionally — they are not user-reachable.

Adds two websocket tests covering the new behavior.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because:


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
