### PR TITLE
[wrangler] fix: show clear error for DO migrations on service-worker format Workers

### DIFF
--- a/.changeset/fix-do-service-worker-migrations-error.md
+++ b/.changeset/fix-do-service-worker-migrations-error.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: show a clear error when deploying a service-worker format Worker with Durable Object migrations instead of an opaque API error

--- a/.changeset/fix-do-service-worker-migrations-error.md
+++ b/.changeset/fix-do-service-worker-migrations-error.md
@@ -2,4 +2,4 @@
 "wrangler": patch
 ---
 
-fix: show a clear error when deploying a service-worker format Worker with Durable Object migrations instead of an opaque API error
+Show a clear error when deploying a service-worker format Worker with Durable Object migrations or bindings instead of an opaque API error

--- a/packages/wrangler/src/__tests__/deploy/bindings.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/bindings.test.ts
@@ -1765,6 +1765,31 @@ describe("deploy", () => {
 					https://developers.cloudflare.com/workers/learning/migrating-to-module-workers/]
 				`);
 			});
+
+			it("should error when deploying service-worker worker with migrations", async ({
+				expect,
+			}) => {
+				writeWranglerConfig({
+					durable_objects: {
+						bindings: [],
+					},
+					migrations: [
+						{
+							tag: "v1",
+							new_classes: ["ExampleDurableObject"],
+						},
+					],
+				});
+				writeWorkerSource({ type: "sw" });
+				mockSubDomainRequest();
+
+				await expect(runWrangler("deploy index.js")).rejects
+					.toThrowErrorMatchingInlineSnapshot(`
+					[Error: Durable Object migrations require ES Module format Workers, but yours is being built as service-worker format. Migrations cannot be applied to service-worker format Workers.
+					Migrate your worker to ES Module syntax to use Durable Object migrations:
+					https://developers.cloudflare.com/workers/learning/migrating-to-module-workers/]
+				`);
+			});
 		});
 
 		describe("[services]", () => {

--- a/packages/wrangler/src/__tests__/deploy/bindings.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/bindings.test.ts
@@ -1777,7 +1777,7 @@ describe("deploy", () => {
 				await expect(runWrangler("deploy index.js")).rejects
 					.toThrowErrorMatchingInlineSnapshot(`
 					[Error: Durable Object migrations require ES Module format Workers, but yours is being built as service-worker format. Migrations cannot be applied to service-worker format Workers.
-					Migrate your worker to ES Module syntax to use Durable Object migrations:
+					To use Durable Object migrations, deploy in ES Module format by adding a default export handler (e.g. "export default { fetch() {} }"), or remove "migrations" from your config if you don't need them. See:
 					https://developers.cloudflare.com/workers/learning/migrating-to-module-workers/]
 				`);
 			});

--- a/packages/wrangler/src/__tests__/deploy/bindings.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/bindings.test.ts
@@ -96,12 +96,6 @@ describe("deploy", () => {
 	describe("bindings", () => {
 		it("should allow bindings with different names", async ({ expect }) => {
 			writeWranglerConfig({
-				migrations: [
-					{
-						tag: "v1",
-						new_classes: ["SomeDurableObject", "AnotherDurableObject"],
-					},
-				],
 				durable_objects: {
 					bindings: [
 						{
@@ -1770,9 +1764,6 @@ describe("deploy", () => {
 				expect,
 			}) => {
 				writeWranglerConfig({
-					durable_objects: {
-						bindings: [],
-					},
 					migrations: [
 						{
 							tag: "v1",

--- a/packages/wrangler/src/deployment-bundle/entry.ts
+++ b/packages/wrangler/src/deployment-bundle/entry.ts
@@ -133,7 +133,7 @@ export async function getEntry(
 			const errorMessage =
 				"Durable Object migrations require ES Module format Workers, but yours is being built as service-worker format. Migrations cannot be applied to service-worker format Workers.";
 			const migrateText =
-				"Migrate your worker to ES Module syntax to use Durable Object migrations:";
+				'To use Durable Object migrations, deploy in ES Module format by adding a default export handler (e.g. "export default { fetch() {} }"), or remove "migrations" from your config if you don\'t need them. See:';
 			const migrateUrl =
 				"https://developers.cloudflare.com/workers/learning/migrating-to-module-workers/";
 			throw new UserError(`${errorMessage}\n${migrateText}\n${migrateUrl}`, {

--- a/packages/wrangler/src/deployment-bundle/entry.ts
+++ b/packages/wrangler/src/deployment-bundle/entry.ts
@@ -118,7 +118,8 @@ export async function getEntry(
 			const errorMessage =
 				"You seem to be trying to use Durable Objects in a Worker written as a service-worker.";
 			const addScriptName = `You can use Durable Objects defined in other Workers by specifying a \`script_name\` in your ${configFileName(config.configPath)} file, where \`script_name\` is the name of the Worker that implements that Durable Object. For example:`;
-			const addScriptNameExamples = generateAddScriptNameExamples(localBindings);
+			const addScriptNameExamples =
+				generateAddScriptNameExamples(localBindings);
 			const migrateText =
 				"Alternatively, migrate your worker to ES Module syntax to implement a Durable Object in this Worker:";
 			const migrateUrl =
@@ -135,10 +136,10 @@ export async function getEntry(
 				"Migrate your worker to ES Module syntax to use Durable Object migrations:";
 			const migrateUrl =
 				"https://developers.cloudflare.com/workers/learning/migrating-to-module-workers/";
-			throw new UserError(
-				`${errorMessage}\n${migrateText}\n${migrateUrl}`,
-				{ telemetryMessage: "durable object migrations unsupported service worker" }
-			);
+			throw new UserError(`${errorMessage}\n${migrateText}\n${migrateUrl}`, {
+				telemetryMessage:
+					"durable object migrations unsupported service worker",
+			});
 		}
 	}
 

--- a/packages/wrangler/src/deployment-bundle/entry.ts
+++ b/packages/wrangler/src/deployment-bundle/entry.ts
@@ -113,32 +113,33 @@ export async function getEntry(
 
 	const { localBindings } = partitionDurableObjectBindings(config);
 
-	if (format === "service-worker" && localBindings.length > 0) {
-		const errorMessage =
-			"You seem to be trying to use Durable Objects in a Worker written as a service-worker.";
-		const addScriptName = `You can use Durable Objects defined in other Workers by specifying a \`script_name\` in your ${configFileName(config.configPath)} file, where \`script_name\` is the name of the Worker that implements that Durable Object. For example:`;
-		const addScriptNameExamples = generateAddScriptNameExamples(localBindings);
-		const migrateText =
-			"Alternatively, migrate your worker to ES Module syntax to implement a Durable Object in this Worker:";
-		const migrateUrl =
-			"https://developers.cloudflare.com/workers/learning/migrating-to-module-workers/";
-		throw new UserError(
-			`${errorMessage}\n${addScriptName}\n${addScriptNameExamples}\n${migrateText}\n${migrateUrl}`,
-			{ telemetryMessage: "tried to use DO with service worker" }
-		);
-	}
-
-	if (format === "service-worker" && config.migrations?.length) {
-		const errorMessage =
-			"Durable Object migrations require ES Module format Workers, but yours is being built as service-worker format. Migrations cannot be applied to service-worker format Workers.";
-		const migrateText =
-			"Migrate your worker to ES Module syntax to use Durable Object migrations:";
-		const migrateUrl =
-			"https://developers.cloudflare.com/workers/learning/migrating-to-module-workers/";
-		throw new UserError(
-			`${errorMessage}\n${migrateText}\n${migrateUrl}`,
-			{ telemetryMessage: "durable object migrations unsupported service worker" }
-		);
+	if (format === "service-worker") {
+		if (localBindings.length > 0) {
+			const errorMessage =
+				"You seem to be trying to use Durable Objects in a Worker written as a service-worker.";
+			const addScriptName = `You can use Durable Objects defined in other Workers by specifying a \`script_name\` in your ${configFileName(config.configPath)} file, where \`script_name\` is the name of the Worker that implements that Durable Object. For example:`;
+			const addScriptNameExamples = generateAddScriptNameExamples(localBindings);
+			const migrateText =
+				"Alternatively, migrate your worker to ES Module syntax to implement a Durable Object in this Worker:";
+			const migrateUrl =
+				"https://developers.cloudflare.com/workers/learning/migrating-to-module-workers/";
+			throw new UserError(
+				`${errorMessage}\n${addScriptName}\n${addScriptNameExamples}\n${migrateText}\n${migrateUrl}`,
+				{ telemetryMessage: "tried to use DO with service worker" }
+			);
+		}
+		if (config.migrations?.length) {
+			const errorMessage =
+				"Durable Object migrations require ES Module format Workers, but yours is being built as service-worker format. Migrations cannot be applied to service-worker format Workers.";
+			const migrateText =
+				"Migrate your worker to ES Module syntax to use Durable Object migrations:";
+			const migrateUrl =
+				"https://developers.cloudflare.com/workers/learning/migrating-to-module-workers/";
+			throw new UserError(
+				`${errorMessage}\n${migrateText}\n${migrateUrl}`,
+				{ telemetryMessage: "durable object migrations unsupported service worker" }
+			);
+		}
 	}
 
 	return {

--- a/packages/wrangler/src/deployment-bundle/entry.ts
+++ b/packages/wrangler/src/deployment-bundle/entry.ts
@@ -128,6 +128,19 @@ export async function getEntry(
 		);
 	}
 
+	if (format === "service-worker" && config.migrations?.length) {
+		const errorMessage =
+			"Durable Object migrations require ES Module format Workers, but yours is being built as service-worker format. Migrations cannot be applied to service-worker format Workers.";
+		const migrateText =
+			"Migrate your worker to ES Module syntax to use Durable Object migrations:";
+		const migrateUrl =
+			"https://developers.cloudflare.com/workers/learning/migrating-to-module-workers/";
+		throw new UserError(
+			`${errorMessage}\n${migrateText}\n${migrateUrl}`,
+			{ telemetryMessage: "durable object migrations unsupported service worker" }
+		);
+	}
+
 	return {
 		file: paths.absolutePath,
 		projectRoot,


### PR DESCRIPTION
Fixes #4943.

When deploying a service-worker format Worker with Durable Object migrations, Wrangler previously let the deployment proceed and the Cloudflare API returned an opaque error: `Cannot apply new-class migration to class X that is not exported by script [code: 10070]`.

This PR detects the mismatch early in `getEntry()` and shows a clear error explaining that DO migrations require ES Module format.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is a developer-facing error message improvement; no public API or behaviour change requiring docs.