### PR TITLE
fix: store config in ~/.config/wrangler/ instead of ~/.config/.wrangler/ on Linux

### DIFF
--- a/.changeset/fix-config-path-wrangler-no-dot.md
+++ b/.changeset/fix-config-path-wrangler-no-dot.md
@@ -5,4 +5,4 @@
 "wrangler": patch
 ---
 
-fix: store config in ~/.config/wrangler/ instead of the incorrectly-hidden ~/.config/.wrangler/. Existing data is automatically migrated.
+Fix global Wrangler config directory name to use `wrangler` instead of `.wrangler` (removes the unintended hidden-directory effect on XDG-compliant systems). Existing config data is automatically migrated. Note: users who had the Browser Rendering Chromium binary cached under the old path may need to re-download it.

--- a/.changeset/fix-config-path-wrangler-no-dot.md
+++ b/.changeset/fix-config-path-wrangler-no-dot.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+"miniflare": patch
+"create-cloudflare": patch
+---
+
+fix: store config in ~/.config/wrangler/ instead of the incorrectly-hidden ~/.config/.wrangler/ on Linux. Existing data is automatically migrated.

--- a/.changeset/fix-config-path-wrangler-no-dot.md
+++ b/.changeset/fix-config-path-wrangler-no-dot.md
@@ -1,7 +1,8 @@
 ---
-"wrangler": patch
-"miniflare": patch
+"@cloudflare/workers-utils": patch
 "create-cloudflare": patch
+"miniflare": patch
+"wrangler": patch
 ---
 
-fix: store config in ~/.config/wrangler/ instead of the incorrectly-hidden ~/.config/.wrangler/ on Linux. Existing data is automatically migrated.
+fix: store config in ~/.config/wrangler/ instead of the incorrectly-hidden ~/.config/.wrangler/. Existing data is automatically migrated.

--- a/packages/create-cloudflare/src/helpers/global-wrangler-config-path.ts
+++ b/packages/create-cloudflare/src/helpers/global-wrangler-config-path.ts
@@ -26,7 +26,12 @@ export function getGlobalWranglerConfigPath() {
 		try {
 			fs.renameSync(brokenConfigDir, configDir);
 		} catch {
-			// If rename fails, use the broken path to avoid data loss
+			// Another process may have completed the migration first.
+			// If the new path exists now, prefer it; otherwise fall back
+			// to the broken path to avoid data loss.
+			if (isDirectory(configDir)) {
+				return configDir;
+			}
 			return brokenConfigDir;
 		}
 	}

--- a/packages/create-cloudflare/src/helpers/global-wrangler-config-path.ts
+++ b/packages/create-cloudflare/src/helpers/global-wrangler-config-path.ts
@@ -12,13 +12,24 @@ function isDirectory(configPath: string) {
 
 export function getGlobalWranglerConfigPath() {
 	//TODO: We should implement a custom path --global-config and/or the WRANGLER_HOME type environment variable
-	const configDir = xdgAppPaths(".wrangler").config(); // New XDG compliant config path
+	const brokenConfigDir = xdgAppPaths(".wrangler").config(); // ~/.config/.wrangler/ (incorrect — from versions with this bug)
+	const configDir = xdgAppPaths("wrangler").config(); // Correct XDG-compliant config path
 	const legacyConfigDir = nodePath.join(os.homedir(), ".wrangler"); // Legacy config in user's home directory
 
 	// Check for the .wrangler directory in root if it is not there then use the XDG compliant path.
 	if (isDirectory(legacyConfigDir)) {
 		return legacyConfigDir;
-	} else {
-		return configDir;
 	}
+
+	// Migrate from the previously-buggy hidden-in-.config path
+	if (isDirectory(brokenConfigDir) && !isDirectory(configDir)) {
+		try {
+			fs.renameSync(brokenConfigDir, configDir);
+		} catch {
+			// If rename fails, use the broken path to avoid data loss
+			return brokenConfigDir;
+		}
+	}
+
+	return configDir;
 }

--- a/packages/miniflare/src/shared/wrangler.ts
+++ b/packages/miniflare/src/shared/wrangler.ts
@@ -42,6 +42,8 @@ export function getGlobalWranglerCachePath() {
 	const brokenCacheDir = xdgAppPaths(".wrangler").cache(); // ~/.cache/.wrangler/ (incorrect — from versions with this bug)
 	const cacheDir = xdgAppPaths("wrangler").cache(); // Correct XDG-compliant cache path
 
+	// Note: the cache dir contains the Browser Rendering Chromium binary. Users who previously
+	// cached it under the old (broken) path may need to re-download the binary after migration.
 	if (isDirectory(brokenCacheDir) && !isDirectory(cacheDir)) {
 		try {
 			fs.renameSync(brokenCacheDir, cacheDir);

--- a/packages/miniflare/src/shared/wrangler.ts
+++ b/packages/miniflare/src/shared/wrangler.ts
@@ -25,7 +25,12 @@ export function getGlobalWranglerConfigPath() {
 		try {
 			fs.renameSync(brokenConfigDir, configDir);
 		} catch {
-			// If rename fails, use the broken path to avoid data loss
+			// Another process may have completed the migration first.
+			// If the new path exists now, prefer it; otherwise fall back
+			// to the broken path to avoid data loss.
+			if (isDirectory(configDir)) {
+				return configDir;
+			}
 			return brokenConfigDir;
 		}
 	}
@@ -34,5 +39,19 @@ export function getGlobalWranglerConfigPath() {
 }
 
 export function getGlobalWranglerCachePath() {
-	return xdgAppPaths("wrangler").cache();
+	const brokenCacheDir = xdgAppPaths(".wrangler").cache(); // ~/.cache/.wrangler/ (incorrect — from versions with this bug)
+	const cacheDir = xdgAppPaths("wrangler").cache(); // Correct XDG-compliant cache path
+
+	if (isDirectory(brokenCacheDir) && !isDirectory(cacheDir)) {
+		try {
+			fs.renameSync(brokenCacheDir, cacheDir);
+		} catch {
+			if (isDirectory(cacheDir)) {
+				return cacheDir;
+			}
+			return brokenCacheDir;
+		}
+	}
+
+	return cacheDir;
 }

--- a/packages/miniflare/src/shared/wrangler.ts
+++ b/packages/miniflare/src/shared/wrangler.ts
@@ -11,17 +11,28 @@ function isDirectory(configPath: string) {
 
 export function getGlobalWranglerConfigPath() {
 	//TODO: We should implement a custom path --global-config and/or the WRANGLER_HOME type environment variable
-	const configDir = xdgAppPaths(".wrangler").config(); // New XDG compliant config path
+	const brokenConfigDir = xdgAppPaths(".wrangler").config(); // ~/.config/.wrangler/ (incorrect — from versions with this bug)
+	const configDir = xdgAppPaths("wrangler").config(); // Correct XDG-compliant config path
 	const legacyConfigDir = path.join(os.homedir(), ".wrangler"); // Legacy config in user's home directory
 
 	// Check for the .wrangler directory in root if it is not there then use the XDG compliant path.
 	if (isDirectory(legacyConfigDir)) {
 		return legacyConfigDir;
-	} else {
-		return configDir;
 	}
+
+	// Migrate from the previously-buggy hidden-in-.config path
+	if (isDirectory(brokenConfigDir) && !isDirectory(configDir)) {
+		try {
+			fs.renameSync(brokenConfigDir, configDir);
+		} catch {
+			// If rename fails, use the broken path to avoid data loss
+			return brokenConfigDir;
+		}
+	}
+
+	return configDir;
 }
 
 export function getGlobalWranglerCachePath() {
-	return xdgAppPaths(".wrangler").cache();
+	return xdgAppPaths("wrangler").cache();
 }

--- a/packages/workers-utils/src/global-wrangler-config-path.ts
+++ b/packages/workers-utils/src/global-wrangler-config-path.ts
@@ -1,3 +1,4 @@
+import { renameSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import xdgAppPaths from "xdg-app-paths";
@@ -5,13 +6,24 @@ import { isDirectory } from "./fs-helpers";
 
 export function getGlobalWranglerConfigPath() {
 	//TODO: We should implement a custom path --global-config and/or the WRANGLER_HOME type environment variable
-	const configDir = xdgAppPaths(".wrangler").config(); // New XDG compliant config path
+	const brokenConfigDir = xdgAppPaths(".wrangler").config(); // ~/.config/.wrangler/ (incorrect — from versions with this bug)
+	const configDir = xdgAppPaths("wrangler").config(); // Correct XDG-compliant config path
 	const legacyConfigDir = path.join(os.homedir(), ".wrangler"); // Legacy config in user's home directory
 
 	// Check for the .wrangler directory in root if it is not there then use the XDG compliant path.
 	if (isDirectory(legacyConfigDir)) {
 		return legacyConfigDir;
-	} else {
-		return configDir;
 	}
+
+	// Migrate from the previously-buggy hidden-in-.config path
+	if (isDirectory(brokenConfigDir) && !isDirectory(configDir)) {
+		try {
+			renameSync(brokenConfigDir, configDir);
+		} catch {
+			// If rename fails, use the broken path to avoid data loss
+			return brokenConfigDir;
+		}
+	}
+
+	return configDir;
 }

--- a/packages/workers-utils/src/global-wrangler-config-path.ts
+++ b/packages/workers-utils/src/global-wrangler-config-path.ts
@@ -20,7 +20,12 @@ export function getGlobalWranglerConfigPath() {
 		try {
 			renameSync(brokenConfigDir, configDir);
 		} catch {
-			// If rename fails, use the broken path to avoid data loss
+			// Another process may have completed the migration first.
+			// If the new path exists now, prefer it; otherwise fall back
+			// to the broken path to avoid data loss.
+			if (isDirectory(configDir)) {
+				return configDir;
+			}
 			return brokenConfigDir;
 		}
 	}


### PR DESCRIPTION
Fixes #11032.

Wrangler stored its config in `~/.config/.wrangler/` — a hidden directory inside the already-hidden `.config`. The XDG Base Directory specification says config should go in `$XDG_CONFIG_HOME/<app>/` (default: `~/.config/wrangler/`).

**Changes:**
- Changed `xdgAppPaths(".wrangler")` → `xdgAppPaths("wrangler")` in all 3 packages (workers-utils, miniflare, create-cloudflare)
- Added automatic migration: if the old `~/.config/.wrangler/` exists but `~/.config/wrangler/` doesn't, the directory is renamed
- Legacy `~/.wrangler` (home directory) still takes precedence if it exists