### PR TITLE
[fixtures] Fix entrypoints-rpc test flakiness for first-fetch sites

### DIFF
--- a/fixtures/entrypoints-rpc-tests/tests/entrypoints.spec.ts
+++ b/fixtures/entrypoints-rpc-tests/tests/entrypoints.spec.ts
@@ -126,11 +126,13 @@ describe("entrypoints", () => {
 		`,
 		});
 
-		const response = await fetch(url);
-		// Check protocol, host, and cf preserved
-		expect(await response.text()).toBe(
-			'POST https://placeholder:9999/loopback {"thing":true}'
-		);
+		await waitFor(async () => {
+			const response = await fetch(url);
+			// Check protocol, host, and cf preserved
+			expect(await response.text()).toBe(
+				'POST https://placeholder:9999/loopback {"thing":true}'
+			);
+		});
 	});
 
 	test("should support default ExportedHandler entrypoints", async ({
@@ -266,11 +268,13 @@ describe("entrypoints", () => {
 		};
 		const { url } = await dev(files, ["--test-scheduled"]);
 
-		let response = await fetch(url);
-		expect(await response.text()).toBe("GET /");
+		await waitFor(async () => {
+			const response = await fetch(url);
+			expect(await response.text()).toBe("GET /");
+		});
 
 		// Check other events can be dispatched
-		response = await fetch(new URL("/__scheduled?cron=* * * * 30", url));
+		let response = await fetch(new URL("/__scheduled?cron=* * * * 30", url));
 		expect(response.status).toBe(200);
 		expect(await response.text()).toBe("Ran scheduled event");
 		response = await fetch(new URL("/controller", url));
@@ -319,11 +323,13 @@ describe("entrypoints", () => {
 		`,
 		});
 
-		const response = await fetch(url);
-		// Check protocol, host, and cf preserved
-		expect(await response.text()).toBe(
-			'POST https://placeholder:9999/ {"thing":true}'
-		);
+		await waitFor(async () => {
+			const response = await fetch(url);
+			// Check protocol, host, and cf preserved
+			expect(await response.text()).toBe(
+				'POST https://placeholder:9999/ {"thing":true}'
+			);
+		});
 	});
 
 	test("should support named ExportedHandler entrypoints", async ({
@@ -642,8 +648,10 @@ describe("entrypoints", () => {
 		`,
 		});
 
-		const response = await fetch(url);
-		expect(await response.text()).toBe("pong");
+		await waitFor(async () => {
+			const response = await fetch(url);
+			expect(await response.text()).toBe("pong");
+		});
 	});
 
 	test("should support binding to Durable Object in same worker with explicit script_name", async ({
@@ -677,8 +685,10 @@ describe("entrypoints", () => {
 		`,
 		});
 
-		const response = await fetch(url);
-		expect(await response.text()).toBe("pong");
+		await waitFor(async () => {
+			const response = await fetch(url);
+			expect(await response.text()).toBe("pong");
+		});
 	});
 
 	test("should throw if binding to named entrypoint exported by version of wrangler without entrypoints support", async ({
@@ -706,11 +716,13 @@ describe("entrypoints", () => {
 			}
 		`,
 		});
-		let response = await fetch(url);
-		expect(response.status).toBe(503);
-		expect(await response.text()).toBe(
-			'Worker "bound" not found. Make sure it is running locally.'
-		);
+		await waitFor(async () => {
+			const response = await fetch(url);
+			expect(response.status).toBe(503);
+			expect(await response.text()).toBe(
+				'Worker "bound" not found. Make sure it is running locally.'
+			);
+		});
 
 		await writeFile(
 			path.join(isolatedDevRegistryPath, "bound"),
@@ -759,10 +771,12 @@ describe("entrypoints", () => {
 			}
 		`,
 		});
-		let response = await fetch(url);
-		expect(await response.text()).toBe(
-			'Worker "bound" not found. Make sure it is running locally.'
-		);
+		await waitFor(async () => {
+			const response = await fetch(url);
+			expect(await response.text()).toBe(
+				'Worker "bound" not found. Make sure it is running locally.'
+			);
+		});
 
 		// Start up the bound worker without the expected entrypoint
 		await dev({
@@ -813,10 +827,12 @@ describe("entrypoints", () => {
 			}
 		`,
 		});
-		let response = await fetch(url);
-		expect(await response.text()).toBe(
-			'Worker "bound" not found. Make sure it is running locally.'
-		);
+		await waitFor(async () => {
+			const response = await fetch(url);
+			expect(await response.text()).toBe(
+				'Worker "bound" not found. Make sure it is running locally.'
+			);
+		});
 
 		// Start up the bound worker using HTTPS
 		const files: Record<string, string> = {
@@ -864,10 +880,12 @@ describe("entrypoints", () => {
 			}
 		`,
 		});
-		let response = await fetch(url);
-		expect(await response.text()).toBe(
-			'Worker "bound" not found. Make sure it is running locally.'
-		);
+		await waitFor(async () => {
+			const response = await fetch(url);
+			expect(await response.text()).toBe(
+				'Worker "bound" not found. Make sure it is running locally.'
+			);
+		});
 
 		const boundWorker = new Miniflare({
 			name: "bound",
@@ -919,13 +937,15 @@ describe("entrypoints", () => {
 		`,
 		});
 
-		const response = await fetch(url);
-		const errors = await response.json();
-		expect(errors).toMatchInlineSnapshot(`
-			[
-			  "Error: Worker "bound" not found. Make sure it is running locally.",
-			  "Error: Worker "bound" not found. Make sure it is running locally.",
-			]
-		`);
+		await waitFor(async () => {
+			const response = await fetch(url);
+			const errors = await response.json();
+			expect(errors).toMatchInlineSnapshot(`
+				[
+				  "Error: Worker "bound" not found. Make sure it is running locally.",
+				  "Error: Worker "bound" not found. Make sure it is running locally.",
+				]
+			`);
+		});
 	});
 });


### PR DESCRIPTION
Three tests in [\`fixtures/entrypoints-rpc-tests/tests/entrypoints.spec.ts\`](https://github.com/cloudflare/workers-sdk/blob/main/fixtures/entrypoints-rpc-tests/tests/entrypoints.spec.ts) flaked on the Windows fixtures CI lane in [this run](https://github.com/cloudflare/workers-sdk/actions/runs/25210651915/job/73920415251?pr=12690) (an unrelated PR) with \`UND_ERR_HEADERS_TIMEOUT\`:

- \`should support binding to Durable Object in same worker\`
- \`should support binding to Durable Object in same worker with explicit script_name\`
- \`should throw if binding to named entrypoint exported by version of wrangler without entrypoints support\`

The file installs an aggressive 2 s global undici dispatcher (\`connectTimeout\` / \`bodyTimeout\` / \`headersTimeout\`). On a slow Windows runner the **first** request to a freshly started \`wrangler dev\` session can exceed 2 s — the TCP socket is already accepting connections (we wait for that in [\`run-wrangler-long-lived.ts\`](https://github.com/cloudflare/workers-sdk/blob/main/fixtures/shared/src/run-wrangler-long-lived.ts)), but workerd hasn't finished warming up enough to respond to the first hit, especially when DO bindings or stubbed service bindings are involved.

Most other tests in this file already wrap their first \`fetch(url)\` in \`waitFor(...)\` so a slow first hit retries within a 5 s budget. The three failing tests didn't. This PR extends the same \`waitFor\` pattern to **every** remaining bare first-fetch in the file (10 sites total) so:

- the failing trio is fixed, and
- sister tests using the same pattern can't regress into the same flake on a future slow runner.

Subsequent fetches inside the same test (after the first response has come back) are intentionally left bare — by then the dev server is warm and the aggressive timeout is exactly what we want.

Same root cause and approach as #13142 (which previously bumped the global timeout from 500 ms → 2 s and added retry budget to the HTTPS \`waitFor\`s). This PR completes the cleanup for the rest of the file.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this PR only modifies a fixture's tests to make existing assertions less timing-sensitive; no production code is touched.
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: fixture-only test change.