### PR TITLE
[wrangler] Generate `Fetcher` for `unsafe.bindings` service entries

### DIFF
--- a/.changeset/fix-wrangler-types-unsafe-service-binding.md
+++ b/.changeset/fix-wrangler-types-unsafe-service-binding.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler types` to generate `Fetcher` for `unsafe.bindings` entries with `type: "service"`
+
+Previously, all entries in `unsafe.bindings` (other than `ratelimit`) generated a fallback `any` type. `wrangler types` now generates `Fetcher` for unsafe bindings declared with `type: "service"`, matching the type used for regular service bindings.

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -500,6 +500,11 @@ const bindingsConfigMock: Omit<
 		bindings: [
 			{ name: "testing_unsafe", type: "plain_text" },
 			{ name: "UNSAFE_RATELIMIT", type: "ratelimit" },
+			{
+				name: "UNSAFE_SERVICE_BINDING",
+				type: "service",
+				service: "some-unsafe-service",
+			},
 		],
 		metadata: { some_key: "some_value" },
 	},
@@ -809,6 +814,7 @@ describe("generate types - CLI", () => {
 					MY_WORKFLOW: Workflow<Parameters<import("./index").MyWorkflow['run']>[0]['payload']>;
 					testing_unsafe: any;
 					UNSAFE_RATELIMIT: RateLimit;
+					UNSAFE_SERVICE_BINDING: Fetcher;
 					SOME_DATA_BLOB1: ArrayBuffer;
 					SOME_DATA_BLOB2: ArrayBuffer;
 					SOME_TEXT_BLOB1: string;
@@ -927,6 +933,7 @@ describe("generate types - CLI", () => {
 					MY_WORKFLOW: Workflow<Parameters<import("./index").MyWorkflow['run']>[0]['payload']>;
 					testing_unsafe: any;
 					UNSAFE_RATELIMIT: RateLimit;
+					UNSAFE_SERVICE_BINDING: Fetcher;
 					SOME_DATA_BLOB1: ArrayBuffer;
 					SOME_DATA_BLOB2: ArrayBuffer;
 					SOME_TEXT_BLOB1: string;
@@ -1107,6 +1114,7 @@ describe("generate types - CLI", () => {
 					MY_WORKFLOW: Workflow<Parameters<import("./index").MyWorkflow['run']>[0]['payload']>;
 					testing_unsafe: any;
 					UNSAFE_RATELIMIT: RateLimit;
+					UNSAFE_SERVICE_BINDING: Fetcher;
 					SOME_DATA_BLOB1: ArrayBuffer;
 					SOME_DATA_BLOB2: ArrayBuffer;
 					SOME_TEXT_BLOB1: string;
@@ -1474,6 +1482,7 @@ describe("generate types - CLI", () => {
 			declare global {
 				const testing_unsafe: any;
 				const UNSAFE_RATELIMIT: RateLimit;
+				const UNSAFE_SERVICE_BINDING: Fetcher;
 			}
 
 			────────────────────────────────────────────────────────────

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -1059,6 +1059,14 @@ async function generateSimpleEnvTypes(
 			continue;
 		}
 
+		if (unsafe.type === "service") {
+			envTypeStructure.push({
+				key: constructTypeKey(unsafe.name),
+				type: "Fetcher",
+			});
+			continue;
+		}
+
 		envTypeStructure.push({
 			key: constructTypeKey(unsafe.name),
 			type: "any",
@@ -1384,7 +1392,12 @@ async function generatePerEnvironmentTypes(
 
 		const unsafeBindings = unsafePerEnv.get(envName) ?? [];
 		for (const unsafe of unsafeBindings) {
-			const type = unsafe.type === "ratelimit" ? "RateLimit" : "any";
+			const type =
+				unsafe.type === "ratelimit"
+					? "RateLimit"
+					: unsafe.type === "service"
+						? "Fetcher"
+						: "any";
 			envBindings.push({ key: constructTypeKey(unsafe.name), value: type });
 			trackBinding(unsafe.name, type, envName);
 		}


### PR DESCRIPTION
Previously, all entries in `unsafe.bindings` (other than `ratelimit`) generated a fallback `any` type from `wrangler types`. They now generate `Fetcher`, matching the type used for regular service bindings.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is a behaviour fix for an existing config field