### PR TITLE
[workers-shared] Add cohort-based deployment support to router worker

### DIFF
--- a/.changeset/router-worker-cohort-deployments.md
+++ b/.changeset/router-worker-cohort-deployments.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+During deployment, routes requests to new versions of router-worker based on customer account plan.

--- a/packages/workers-shared/asset-worker/src/worker.ts
+++ b/packages/workers-shared/asset-worker/src/worker.ts
@@ -1,4 +1,5 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
+import { lookupCohort } from "../../utils/cohort";
 import { PerformanceTimer } from "../../utils/performance";
 import { setupSentry } from "../../utils/sentry";
 import { mockJaegerBinding } from "../../utils/tracing";
@@ -16,7 +17,7 @@ import type {
 	SpanContext,
 	UnsafePerformanceTimer,
 } from "../../utils/types";
-import type { AccountCohortQuerierBinding } from "../worker-configuration";
+import type { AccountCohortQuerierBinding } from "../../utils/cohort";
 import type { Environment, ReadyAnalytics } from "./types";
 
 // ============================================================
@@ -212,48 +213,6 @@ async function unstableGetByPathnameImpl(
 	});
 }
 
-export const COHORT_LOOKUP_TIMEOUT_MS = 5;
-
-/**
- * Resolves the deployment cohort for a customer account via the
- * AccountCohortQuerier RPC binding. Returns null when the binding is
- * unavailable, the RPC fails, times out, or the cohort is undetermined
- * (cold cache). Intentionally fails open — a null cohort means the
- * request runs under default routing.
- */
-export async function lookupCohort(
-	env: Env,
-	accountId: number | undefined
-): Promise<string | null> {
-	const querier = env.ACCOUNT_COHORT_QUERIER;
-	if (!querier || !accountId) {
-		return null;
-	}
-	const ac = new AbortController();
-	try {
-		const rpc = querier.lookupAccountCohort(accountId.toString());
-		// Prevent unhandled rejection if timeout wins but RPC later rejects.
-		void rpc.catch(() => {});
-		const timeout = new Promise<never>((_, reject) => {
-			const id = setTimeout(() => {
-				reject(new Error("cohort lookup timed out"));
-			}, COHORT_LOOKUP_TIMEOUT_MS);
-			ac.signal.addEventListener("abort", () => clearTimeout(id));
-		});
-		const res = await Promise.race([rpc, timeout]);
-		if (!res.ok) {
-			console.error("cohort lookup failed", res.errors);
-			return null;
-		}
-		return res.result ?? null;
-	} catch (e: unknown) {
-		console.error("cohort lookup failed", e);
-		return null;
-	} finally {
-		ac.abort();
-	}
-}
-
 async function runFetchRequest(
 	request: Request,
 	env: Env,
@@ -373,7 +332,7 @@ export default class AssetWorkerOuter<TEnv extends Env = Env>
 	private async getCohort(): Promise<string | null> {
 		if (this.resolvedCohort === undefined) {
 			this.resolvedCohort = await lookupCohort(
-				this.env,
+				this.env.ACCOUNT_COHORT_QUERIER,
 				this.env.CONFIG?.account_id
 			);
 		}

--- a/packages/workers-shared/asset-worker/src/worker.ts
+++ b/packages/workers-shared/asset-worker/src/worker.ts
@@ -10,6 +10,7 @@ import { ExperimentAnalytics } from "./experiment-analytics";
 import { canFetch, handleRequest } from "./handler";
 import { handleError, submitMetrics } from "./utils/final-operations";
 import { getAssetWithMetadataFromKV } from "./utils/kv";
+import type { AccountCohortQuerierBinding } from "../../utils/cohort";
 import type {
 	AssetConfig,
 	ColoMetadata,
@@ -17,7 +18,6 @@ import type {
 	SpanContext,
 	UnsafePerformanceTimer,
 } from "../../utils/types";
-import type { AccountCohortQuerierBinding } from "../../utils/cohort";
 import type { Environment, ReadyAnalytics } from "./types";
 
 // ============================================================

--- a/packages/workers-shared/asset-worker/src/worker.ts
+++ b/packages/workers-shared/asset-worker/src/worker.ts
@@ -24,7 +24,7 @@ import type { Environment, ReadyAnalytics } from "./types";
 // SECTION 1: SHARED TYPES & INTERFACE CONTRACT
 // ============================================================
 
-export type Env = {
+export interface Env {
 	/*
 	 * ASSETS_MANIFEST is a pipeline binding to an ArrayBuffer containing the
 	 * binary-encoded site manifest
@@ -52,7 +52,7 @@ export type Env = {
 	UNSAFE_PERFORMANCE: UnsafePerformanceTimer;
 	VERSION_METADATA: WorkerVersionMetadata;
 	ACCOUNT_COHORT_QUERIER?: AccountCohortQuerierBinding;
-};
+}
 
 export type AssetWorkerEntrypointProps = {
 	traceContext?: SpanContext | null;

--- a/packages/workers-shared/asset-worker/tests/cohort.test.ts
+++ b/packages/workers-shared/asset-worker/tests/cohort.test.ts
@@ -1,15 +1,9 @@
 import { describe, it, vi } from "vitest";
-import { COHORT_LOOKUP_TIMEOUT_MS, lookupCohort } from "../src/worker";
-import type { Env } from "../src/worker";
-import type { AccountCohortQuerierBinding } from "../worker-configuration";
-
-function makeEnv(
-	querier?: Partial<AccountCohortQuerierBinding>
-): Pick<Env, "ACCOUNT_COHORT_QUERIER"> {
-	return {
-		ACCOUNT_COHORT_QUERIER: querier as AccountCohortQuerierBinding | undefined,
-	};
-}
+import {
+	COHORT_LOOKUP_TIMEOUT_MS,
+	lookupCohort,
+} from "../../utils/cohort";
+import type { AccountCohortQuerierBinding } from "../../utils/cohort";
 
 describe("[Asset Worker] lookupCohort", () => {
 	it("calls querier with account ID as string", async ({ expect }) => {
@@ -20,7 +14,7 @@ describe("[Asset Worker] lookupCohort", () => {
 		});
 
 		const result = await lookupCohort(
-			makeEnv({ lookupAccountCohort: lookupMock }) as Env,
+			{ lookupAccountCohort: lookupMock } as AccountCohortQuerierBinding,
 			42
 		);
 
@@ -30,7 +24,7 @@ describe("[Asset Worker] lookupCohort", () => {
 
 	it("returns null when result is ok:false", async ({ expect }) => {
 		const result = await lookupCohort(
-			makeEnv({
+			{
 				lookupAccountCohort: () =>
 					Promise.resolve({
 						ok: false as const,
@@ -38,7 +32,7 @@ describe("[Asset Worker] lookupCohort", () => {
 							{ name: "Error", message: "invalid account", code: "ERR" },
 						],
 					}),
-			}) as Env,
+			},
 			42
 		);
 
@@ -47,14 +41,14 @@ describe("[Asset Worker] lookupCohort", () => {
 
 	it("returns null when result is null", async ({ expect }) => {
 		const result = await lookupCohort(
-			makeEnv({
+			{
 				lookupAccountCohort: () =>
 					Promise.resolve({
 						ok: true as const,
 						result: null,
 						meta: { workersVersion: "test" },
 					}),
-			}) as Env,
+			},
 			42
 		);
 
@@ -63,7 +57,7 @@ describe("[Asset Worker] lookupCohort", () => {
 
 	it("times out after COHORT_LOOKUP_TIMEOUT_MS", async ({ expect }) => {
 		const result = await lookupCohort(
-			makeEnv({
+			{
 				lookupAccountCohort: () =>
 					new Promise((resolve) => {
 						setTimeout(
@@ -76,7 +70,7 @@ describe("[Asset Worker] lookupCohort", () => {
 							COHORT_LOOKUP_TIMEOUT_MS * 2
 						);
 					}),
-			}) as Env,
+			},
 			42
 		);
 

--- a/packages/workers-shared/asset-worker/tests/cohort.test.ts
+++ b/packages/workers-shared/asset-worker/tests/cohort.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, vi } from "vitest";
-import {
-	COHORT_LOOKUP_TIMEOUT_MS,
-	lookupCohort,
-} from "../../utils/cohort";
+import { COHORT_LOOKUP_TIMEOUT_MS, lookupCohort } from "../../utils/cohort";
 import type { AccountCohortQuerierBinding } from "../../utils/cohort";
 
 describe("[Asset Worker] lookupCohort", () => {

--- a/packages/workers-shared/asset-worker/worker-configuration.d.ts
+++ b/packages/workers-shared/asset-worker/worker-configuration.d.ts
@@ -17,17 +17,5 @@ interface ExecutionContext<Props = unknown> {
 	};
 }
 
-/**
- * Minimal RPC binding type for the AccountCohortQuerier entrypoint
- * in the account-services worker. Replace with the published type from
- * `@cloudflare/workers-toolbox-types` once available with bundled deps.
- */
-export interface AccountCohortQuerierBinding {
-	lookupAccountCohort(accountID: string): Promise<
-		| { ok: true; result: string | null; meta: { workersVersion: string } }
-		| {
-				ok: false;
-				errors: Array<{ name: string; message: string; code: string }>;
-		  }
-	>;
-}
+// AccountCohortQuerierBinding is exported from ../../utils/cohort.ts
+export type { AccountCohortQuerierBinding } from "../utils/cohort";

--- a/packages/workers-shared/router-worker/src/analytics.ts
+++ b/packages/workers-shared/router-worker/src/analytics.ts
@@ -46,6 +46,8 @@ type Data = {
 	timeToDispatch?: number;
 	// double10 - Entrypoint type (0 = Outer, 1 = Inner)
 	entrypoint?: EntrypointType;
+	// double11 - Time from outer entrypoint start until handoff to RouterInnerEntrypoint
+	timeToHandoff?: number;
 
 	// -- Blobs --
 	// blob1 - Hostname of the request
@@ -113,6 +115,7 @@ export class Analytics {
 				this.data.userWorkerFreeTierLimiting ? 1 : 0, // double8
 				this.data.timeToDispatch ?? -1, // double9
 				this.data.entrypoint ?? -1, // double10
+				this.data.timeToHandoff ?? -1, // double11
 			],
 			blobs: [
 				this.data.hostname?.substring(0, 256), // blob1 - trim to 256 bytes

--- a/packages/workers-shared/router-worker/src/analytics.ts
+++ b/packages/workers-shared/router-worker/src/analytics.ts
@@ -14,6 +14,11 @@ export enum DISPATCH_TYPE {
 	WORKER = "worker",
 }
 
+export enum EntrypointType {
+	Outer = 0,
+	Inner = 1,
+}
+
 // When adding new columns please update the schema
 type Data = {
 	// -- Indexes --
@@ -39,6 +44,8 @@ type Data = {
 	userWorkerFreeTierLimiting?: boolean;
 	// double9 - The time it takes for the request to be handed off the Asset Worker or user Worker in milliseconds
 	timeToDispatch?: number;
+	// double10 - Entrypoint type (0 = Outer, 1 = Inner)
+	entrypoint?: EntrypointType;
 
 	// -- Blobs --
 	// blob1 - Hostname of the request
@@ -57,6 +64,8 @@ type Data = {
 	xssDetectionImageHref?: string;
 	// blob8 - cdn-cgi backslash bypass attempt URL
 	cdnCgiBackslashBypassUrl?: string;
+	// blob9 - Deployment cohort
+	cohort?: string;
 };
 
 export class Analytics {
@@ -103,6 +112,7 @@ export class Analytics {
 				this.data.abuseMitigationBlocked ? 1 : 0, // double7
 				this.data.userWorkerFreeTierLimiting ? 1 : 0, // double8
 				this.data.timeToDispatch ?? -1, // double9
+				this.data.entrypoint ?? -1, // double10
 			],
 			blobs: [
 				this.data.hostname?.substring(0, 256), // blob1 - trim to 256 bytes
@@ -113,6 +123,7 @@ export class Analytics {
 				this.data.abuseMitigationURLHost, // blob6
 				this.data.xssDetectionImageHref, // blob7
 				this.data.cdnCgiBackslashBypassUrl?.substring(0, 256), // blob8 - trim to 256 bytes
+				this.data.cohort, // blob9
 			],
 		});
 	}

--- a/packages/workers-shared/router-worker/src/worker.ts
+++ b/packages/workers-shared/router-worker/src/worker.ts
@@ -63,9 +63,11 @@ type LoopbackExecutionContext = ExecutionContext & {
 };
 
 export class RouterPlatformError extends Error {
-	constructor(public readonly cause: unknown) {
+	public override readonly cause: unknown;
+	constructor(cause: unknown) {
 		super(cause instanceof Error ? cause.message : "unknown platform error");
 		this.name = "RouterPlatformError";
+		this.cause = cause;
 	}
 }
 

--- a/packages/workers-shared/router-worker/src/worker.ts
+++ b/packages/workers-shared/router-worker/src/worker.ts
@@ -46,15 +46,20 @@ export interface Env {
 	ACCOUNT_COHORT_QUERIER?: AccountCohortQuerierBinding;
 }
 
+type RouterInnerEntrypointProps = {
+	timeToHandoff?: number;
+};
+
 type LoopbackExecutionContext = ExecutionContext & {
 	exports: {
 		RouterInnerEntrypoint(options: {
-			props: Record<string, never>;
+			props: RouterInnerEntrypointProps;
 			version?: { cohort?: string };
 		}): {
 			fetch(request: Request): Promise<Response>;
 		};
 	};
+	props?: RouterInnerEntrypointProps;
 };
 
 export class RouterPlatformError extends Error {
@@ -111,9 +116,10 @@ export default {
 			// worker-configuration.d.ts, so `ctx.exports.RouterInnerEntrypoint` does not
 			// resolve structurally. Keep this narrow cast so loopback typechecks in both
 			// compilation contexts without changing runtime behavior.
+			const timeToHandoff = performance.now() - startTimeMs;
 			const loopbackCtx = ctx as LoopbackExecutionContext;
 			const inner = loopbackCtx.exports.RouterInnerEntrypoint({
-				props: {},
+				props: { timeToHandoff },
 				...(cohort ? { version: { cohort } } : {}),
 			});
 
@@ -143,6 +149,7 @@ export default {
 
 export class RouterInnerEntrypoint extends WorkerEntrypoint<Env> {
 	override async fetch(request: Request): Promise<Response> {
+		const loopbackCtx = this.ctx as LoopbackExecutionContext;
 		let sentry: ReturnType<typeof setupSentry> | undefined;
 		let userWorkerInvocation = false;
 		const analytics = new Analytics(this.env.ANALYTICS);
@@ -191,6 +198,7 @@ export class RouterInnerEntrypoint extends WorkerEntrypoint<Env> {
 					userWorkerAhead: config.invoke_user_worker_ahead_of_assets,
 					entrypoint: EntrypointType.Inner,
 					cohort: this.ctx.version?.cohort ?? "unknown",
+					timeToHandoff: loopbackCtx.props?.timeToHandoff ?? -1,
 				});
 			}
 

--- a/packages/workers-shared/router-worker/src/worker.ts
+++ b/packages/workers-shared/router-worker/src/worker.ts
@@ -1,16 +1,23 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
 import { generateStaticRoutingRuleMatcher } from "../../asset-worker/src/utils/rules-engine";
+import { lookupCohort } from "../../utils/cohort";
 import { PerformanceTimer } from "../../utils/performance";
 import { TemporaryRedirectResponse } from "../../utils/responses";
 import { setupSentry } from "../../utils/sentry";
 import { mockJaegerBinding } from "../../utils/tracing";
-import { Analytics, DISPATCH_TYPE, STATIC_ROUTING_DECISION } from "./analytics";
+import {
+	Analytics,
+	DISPATCH_TYPE,
+	EntrypointType,
+	STATIC_ROUTING_DECISION,
+} from "./analytics";
 import {
 	applyEyeballConfigDefaults,
 	applyRouterConfigDefaults,
 } from "./configuration";
 import { renderLimitedResponse } from "./limited-response";
 import type AssetWorker from "../../asset-worker";
+import type { AccountCohortQuerierBinding } from "../../utils/cohort";
 import type {
 	EyeballRouterConfig,
 	JaegerTracing,
@@ -35,45 +42,50 @@ export interface Env {
 
 	SENTRY_ACCESS_CLIENT_ID: string;
 	SENTRY_ACCESS_CLIENT_SECRET: string;
+
+	ACCOUNT_COHORT_QUERIER?: AccountCohortQuerierBinding;
 }
 
 type LoopbackExecutionContext = ExecutionContext & {
 	exports: {
-		RouterInnerEntrypoint(options: { props: Record<string, never> }): {
+		RouterInnerEntrypoint(options: {
+			props: Record<string, never>;
+			version?: { cohort?: string };
+		}): {
 			fetch(request: Request): Promise<Response>;
 		};
 	};
 };
 
+export class RouterPlatformError extends Error {
+	constructor(public readonly cause: unknown) {
+		super(cause instanceof Error ? cause.message : "unknown platform error");
+		this.name = "RouterPlatformError";
+	}
+}
+
 export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext) {
-		// Router worker is typechecked both in this package and as a transitive
-		// dependency during miniflare builds. In the miniflare type context,
-		// Cloudflare.Exports may not include this worker's mainModule mapping from
-		// worker-configuration.d.ts, so `ctx.exports.RouterInnerEntrypoint` does not
-		// resolve structurally. Keep this narrow cast so loopback typechecks in both
-		// compilation contexts without changing runtime behavior.
-		const loopbackCtx = ctx as LoopbackExecutionContext;
-
 		const analytics = new Analytics(env.ANALYTICS);
-		let inner;
+		const performance = new PerformanceTimer(env.UNSAFE_PERFORMANCE);
+		const startTimeMs = performance.now();
+		let sentry: ReturnType<typeof setupSentry> | undefined;
+		let innerCalled = false;
+
 		try {
-			if (env.COLO_METADATA && env.VERSION_METADATA && env.CONFIG) {
-				const url = new URL(request.url);
-				analytics.setData({
-					accountId: env.CONFIG.account_id,
-					scriptId: env.CONFIG.script_id,
-					coloId: env.COLO_METADATA.coloId,
-					metalId: env.COLO_METADATA.metalId,
-					coloTier: env.COLO_METADATA.coloTier,
-					coloRegion: env.COLO_METADATA.coloRegion,
-					hostname: url.hostname,
-					version: env.VERSION_METADATA.tag,
-				});
-			}
-			inner = loopbackCtx.exports.RouterInnerEntrypoint({ props: {} });
-		} catch (err) {
-			const sentry = setupSentry(
+			analytics.setData({
+				entrypoint: EntrypointType.Outer,
+				accountId: env.CONFIG?.account_id,
+				scriptId: env.CONFIG?.script_id,
+				coloId: env.COLO_METADATA?.coloId,
+				metalId: env.COLO_METADATA?.metalId,
+				coloTier: env.COLO_METADATA?.coloTier,
+				coloRegion: env.COLO_METADATA?.coloRegion,
+				version: env.VERSION_METADATA?.tag,
+				hostname: new URL(request.url).hostname,
+			});
+
+			sentry = setupSentry(
 				request,
 				ctx,
 				env.SENTRY_DSN,
@@ -84,17 +96,48 @@ export default {
 				env.CONFIG?.account_id,
 				env.CONFIG?.script_id
 			);
-			sentry?.captureException(err);
 
-			if (err instanceof Error) {
+			// Cohort lookup
+			const cohort = await lookupCohort(
+				env.ACCOUNT_COHORT_QUERIER,
+				env.CONFIG?.account_id
+			);
+			analytics.setData({ cohort: cohort ?? "unknown" });
+
+			// Create inner entrypoint with cohort
+			// Router worker is typechecked both in this package and as a transitive
+			// dependency during miniflare builds. In the miniflare type context,
+			// Cloudflare.Exports may not include this worker's mainModule mapping from
+			// worker-configuration.d.ts, so `ctx.exports.RouterInnerEntrypoint` does not
+			// resolve structurally. Keep this narrow cast so loopback typechecks in both
+			// compilation contexts without changing runtime behavior.
+			const loopbackCtx = ctx as LoopbackExecutionContext;
+			const inner = loopbackCtx.exports.RouterInnerEntrypoint({
+				props: {},
+				...(cohort ? { version: { cohort } } : {}),
+			});
+
+			innerCalled = true;
+			const response = await inner.fetch(request);
+			return response;
+		} catch (err) {
+			if (err instanceof RouterPlatformError) {
+				// Inner platform error
 				analytics.setData({ error: err.message });
+				sentry?.captureException(err.cause);
+			} else if (!innerCalled) {
+				// Outer-originated error (before inner.fetch)
+				analytics.setData({
+					error: err instanceof Error ? err.message : "unknown",
+				});
+				sentry?.captureException(err);
 			}
-			analytics.write();
-
+			// User worker errors (innerCalled=true, not PlatformError): no error blob
 			throw err;
+		} finally {
+			analytics.setData({ requestTime: performance.now() - startTimeMs });
+			analytics.write();
 		}
-
-		return inner.fetch(request);
 	},
 };
 
@@ -146,6 +189,8 @@ export class RouterInnerEntrypoint extends WorkerEntrypoint<Env> {
 					hostname: url.hostname,
 					version: this.env.VERSION_METADATA.tag,
 					userWorkerAhead: config.invoke_user_worker_ahead_of_assets,
+					entrypoint: EntrypointType.Inner,
+					cohort: this.ctx.version?.cohort ?? "unknown",
 				});
 			}
 
@@ -336,18 +381,13 @@ export class RouterInnerEntrypoint extends WorkerEntrypoint<Env> {
 			return await routeToAssets({ asset: assetsExist ? "found" : "none" });
 		} catch (err) {
 			if (userWorkerInvocation) {
-				// Don't send user Worker errors to sentry; we have no way to distinguish between
-				// CF errors and errors from the user's code.
 				throw err;
-			} else if (err instanceof Error) {
-				analytics.setData({ error: err.message });
 			}
-
-			// Log to Sentry if we can
-			if (sentry) {
-				sentry.captureException(err);
-			}
-			throw err;
+			analytics.setData({
+				error: err instanceof Error ? err.message : "unknown",
+			});
+			sentry?.captureException(err);
+			throw new RouterPlatformError(err);
 		} finally {
 			analytics.setData({ requestTime: performance.now() - startTimeMs });
 			analytics.write();

--- a/packages/workers-shared/router-worker/tests/index.test.ts
+++ b/packages/workers-shared/router-worker/tests/index.test.ts
@@ -4,10 +4,7 @@ import {
 	env as runtimeEnv,
 } from "cloudflare:test";
 import { describe, it, vi } from "vitest";
-import {
-	COHORT_LOOKUP_TIMEOUT_MS,
-	lookupCohort,
-} from "../../utils/cohort";
+import { COHORT_LOOKUP_TIMEOUT_MS, lookupCohort } from "../../utils/cohort";
 import { EntrypointType } from "../src/analytics";
 import routerWorker, {
 	RouterInnerEntrypoint,
@@ -1309,9 +1306,7 @@ describe("gateway (outer entrypoint)", () => {
 	});
 
 	it("sets error blob for platform errors from inner", async ({ expect }) => {
-		const platformError = new RouterPlatformError(
-			new Error("platform boom")
-		);
+		const platformError = new RouterPlatformError(new Error("platform boom"));
 		const ctx = createGatewayCtx(async () => {
 			throw platformError;
 		});

--- a/packages/workers-shared/router-worker/tests/index.test.ts
+++ b/packages/workers-shared/router-worker/tests/index.test.ts
@@ -1122,13 +1122,15 @@ function createGatewayEnv(overrides?: Record<string, unknown>): {
 // ============================================================
 
 describe("gateway (outer entrypoint)", () => {
-	it("passes cohort through ctx.version to inner", async ({ expect }) => {
+	it("passes cohort and timeToHandoff to inner and writes outer analytics", async ({
+		expect,
+	}) => {
 		const capturedOptions: InnerEntrypointOptions[] = [];
 		const ctx = createGatewayCtx(
 			async () => new Response("ok"),
 			capturedOptions
 		);
-		const { env } = createGatewayEnv({
+		const { env, analyticsEvents } = createGatewayEnv({
 			ACCOUNT_COHORT_QUERIER: {
 				lookupAccountCohort: () =>
 					Promise.resolve({
@@ -1141,9 +1143,15 @@ describe("gateway (outer entrypoint)", () => {
 
 		await routerWorker.fetch(new Request("https://example.com"), env, ctx);
 
+		// Verify inner entrypoint received cohort and timeToHandoff
 		expect(capturedOptions).toHaveLength(1);
 		expect(capturedOptions[0].version).toEqual({ cohort: "ent" });
 		expect(capturedOptions[0].props.timeToHandoff).toBeGreaterThanOrEqual(0);
+
+		// Verify outer analytics
+		expect(analyticsEvents).toHaveLength(1);
+		expect(analyticsEvents[0].doubles?.[9]).toBe(EntrypointType.Outer);
+		expect(analyticsEvents[0].blobs?.[8]).toBe("ent");
 	});
 
 	it("does not pass version when cohort is null", async ({ expect }) => {
@@ -1159,28 +1167,6 @@ describe("gateway (outer entrypoint)", () => {
 
 		expect(capturedOptions).toHaveLength(1);
 		expect(capturedOptions[0].version).toBeUndefined();
-	});
-
-	it("writes entrypoint = Outer and cohort in analytics", async ({
-		expect,
-	}) => {
-		const ctx = createGatewayCtx(async () => new Response("ok"));
-		const { env, analyticsEvents } = createGatewayEnv({
-			ACCOUNT_COHORT_QUERIER: {
-				lookupAccountCohort: () =>
-					Promise.resolve({
-						ok: true as const,
-						result: "ent",
-						meta: { workersVersion: "test" },
-					}),
-			},
-		});
-
-		await routerWorker.fetch(new Request("https://example.com"), env, ctx);
-
-		expect(analyticsEvents).toHaveLength(1);
-		expect(analyticsEvents[0].doubles?.[9]).toBe(EntrypointType.Outer);
-		expect(analyticsEvents[0].blobs?.[8]).toBe("ent");
 	});
 
 	it("does not set error blob for user worker errors", async ({ expect }) => {

--- a/packages/workers-shared/router-worker/tests/index.test.ts
+++ b/packages/workers-shared/router-worker/tests/index.test.ts
@@ -1076,7 +1076,7 @@ describe("inner entrypoint unit tests", () => {
 // ============================================================
 
 type InnerEntrypointOptions = {
-	props: Record<string, never>;
+	props: { timeToHandoff?: number };
 	version?: { cohort?: string };
 };
 
@@ -1252,6 +1252,7 @@ describe("gateway (outer entrypoint)", () => {
 
 		expect(capturedOptions).toHaveLength(1);
 		expect(capturedOptions[0].version).toEqual({ cohort: "ent" });
+		expect(capturedOptions[0].props.timeToHandoff).toBeGreaterThanOrEqual(0);
 	});
 
 	it("does not pass version when cohort is null", async ({ expect }) => {
@@ -1357,6 +1358,7 @@ describe("inner entrypoint analytics", () => {
 		const request = new Request("https://example.com");
 		const ctx = Object.assign(createExecutionContext(), {
 			version: { cohort: "ent" },
+			props: { timeToHandoff: 3 },
 		});
 
 		const env = {
@@ -1391,6 +1393,7 @@ describe("inner entrypoint analytics", () => {
 
 		expect(analyticsEvents).toHaveLength(1);
 		expect(analyticsEvents[0].doubles?.[9]).toBe(EntrypointType.Inner);
+		expect(analyticsEvents[0].doubles?.[10]).toBe(3); // double11 = timeToHandoff
 		expect(analyticsEvents[0].blobs?.[8]).toBe("ent");
 	});
 

--- a/packages/workers-shared/router-worker/tests/index.test.ts
+++ b/packages/workers-shared/router-worker/tests/index.test.ts
@@ -3,8 +3,18 @@ import {
 	createExecutionContext,
 	env as runtimeEnv,
 } from "cloudflare:test";
-import { describe, it } from "vitest";
-import { RouterInnerEntrypoint } from "../src/worker";
+import { describe, it, vi } from "vitest";
+import {
+	COHORT_LOOKUP_TIMEOUT_MS,
+	lookupCohort,
+} from "../../utils/cohort";
+import { EntrypointType } from "../src/analytics";
+import routerWorker, {
+	RouterInnerEntrypoint,
+	RouterPlatformError,
+} from "../src/worker";
+import type { AccountCohortQuerierBinding } from "../../utils/cohort";
+import type { ReadyAnalyticsEvent } from "../src/types";
 import type { Env } from "../src/worker";
 
 async function fetchFromInnerEntrypoint(
@@ -1058,5 +1068,371 @@ describe("inner entrypoint unit tests", () => {
 			const response = await fetchFromInnerEntrypoint(request, env, ctx);
 			expect(await response.text()).toEqual("hello from asset worker");
 		});
+	});
+});
+
+// ============================================================
+// Helper types and functions for gateway / analytics tests
+// ============================================================
+
+type InnerEntrypointOptions = {
+	props: Record<string, never>;
+	version?: { cohort?: string };
+};
+
+function createGatewayCtx(
+	innerFetch: (request: Request) => Promise<Response>,
+	optionsSink?: InnerEntrypointOptions[]
+): ExecutionContext {
+	return {
+		exports: {
+			RouterInnerEntrypoint(options: InnerEntrypointOptions) {
+				optionsSink?.push(options);
+				return { fetch: innerFetch };
+			},
+		},
+		waitUntil() {},
+		passThroughOnException() {},
+	} as unknown as ExecutionContext;
+}
+
+function createGatewayEnv(overrides?: Record<string, unknown>): {
+	env: Env;
+	analyticsEvents: ReadyAnalyticsEvent[];
+} {
+	const analyticsEvents: ReadyAnalyticsEvent[] = [];
+	return {
+		env: {
+			CONFIG: { account_id: 123, script_id: 456 },
+			COLO_METADATA: {
+				coloId: 1,
+				metalId: 2,
+				coloTier: 1,
+				coloRegion: "WEUR",
+			},
+			VERSION_METADATA: { tag: "v1" },
+			ANALYTICS: {
+				logEvent(event: ReadyAnalyticsEvent) {
+					analyticsEvents.push(event);
+				},
+			},
+			...overrides,
+		} as Env,
+		analyticsEvents,
+	};
+}
+
+// ============================================================
+// lookupCohort tests
+// ============================================================
+
+describe("lookupCohort", () => {
+	it("returns cohort on success", async ({ expect }) => {
+		const lookupMock = vi.fn().mockResolvedValue({
+			ok: true,
+			result: "ent",
+			meta: { workersVersion: "test" },
+		});
+
+		const result = await lookupCohort(
+			{ lookupAccountCohort: lookupMock } as AccountCohortQuerierBinding,
+			42
+		);
+
+		expect(result).toBe("ent");
+		expect(lookupMock).toHaveBeenCalledWith("42");
+	});
+
+	it("returns null when binding is unavailable", async ({ expect }) => {
+		const result = await lookupCohort(undefined, 42);
+		expect(result).toBeNull();
+	});
+
+	it("returns null when accountId is undefined", async ({ expect }) => {
+		const result = await lookupCohort(
+			{
+				lookupAccountCohort: () =>
+					Promise.resolve({
+						ok: true as const,
+						result: "ent",
+						meta: { workersVersion: "test" },
+					}),
+			},
+			undefined
+		);
+		expect(result).toBeNull();
+	});
+
+	it("returns null on RPC failure", async ({ expect }) => {
+		const result = await lookupCohort(
+			{
+				lookupAccountCohort: () => Promise.reject(new Error("rpc broke")),
+			},
+			42
+		);
+		expect(result).toBeNull();
+	});
+
+	it("returns null when ok:false", async ({ expect }) => {
+		const result = await lookupCohort(
+			{
+				lookupAccountCohort: () =>
+					Promise.resolve({
+						ok: false as const,
+						errors: [
+							{ name: "Error", message: "invalid account", code: "ERR" },
+						],
+					}),
+			},
+			42
+		);
+		expect(result).toBeNull();
+	});
+
+	it("returns null when result is null (cold cache)", async ({ expect }) => {
+		const result = await lookupCohort(
+			{
+				lookupAccountCohort: () =>
+					Promise.resolve({
+						ok: true as const,
+						result: null,
+						meta: { workersVersion: "test" },
+					}),
+			},
+			42
+		);
+		expect(result).toBeNull();
+	});
+
+	it("times out after COHORT_LOOKUP_TIMEOUT_MS", async ({ expect }) => {
+		const result = await lookupCohort(
+			{
+				lookupAccountCohort: () =>
+					new Promise((resolve) => {
+						setTimeout(
+							() =>
+								resolve({
+									ok: true as const,
+									result: "ent",
+									meta: { workersVersion: "test" },
+								}),
+							COHORT_LOOKUP_TIMEOUT_MS * 2
+						);
+					}),
+			},
+			42
+		);
+		expect(result).toBeNull();
+	});
+});
+
+// ============================================================
+// Gateway (outer entrypoint) tests
+// ============================================================
+
+describe("gateway (outer entrypoint)", () => {
+	it("passes cohort through ctx.version to inner", async ({ expect }) => {
+		const capturedOptions: InnerEntrypointOptions[] = [];
+		const ctx = createGatewayCtx(
+			async () => new Response("ok"),
+			capturedOptions
+		);
+		const { env } = createGatewayEnv({
+			ACCOUNT_COHORT_QUERIER: {
+				lookupAccountCohort: () =>
+					Promise.resolve({
+						ok: true as const,
+						result: "ent",
+						meta: { workersVersion: "test" },
+					}),
+			},
+		});
+
+		await routerWorker.fetch(new Request("https://example.com"), env, ctx);
+
+		expect(capturedOptions).toHaveLength(1);
+		expect(capturedOptions[0].version).toEqual({ cohort: "ent" });
+	});
+
+	it("does not pass version when cohort is null", async ({ expect }) => {
+		const capturedOptions: InnerEntrypointOptions[] = [];
+		const ctx = createGatewayCtx(
+			async () => new Response("ok"),
+			capturedOptions
+		);
+		// No ACCOUNT_COHORT_QUERIER — lookupCohort returns null
+		const { env } = createGatewayEnv();
+
+		await routerWorker.fetch(new Request("https://example.com"), env, ctx);
+
+		expect(capturedOptions).toHaveLength(1);
+		expect(capturedOptions[0].version).toBeUndefined();
+	});
+
+	it("writes entrypoint = Outer and cohort in analytics", async ({
+		expect,
+	}) => {
+		const ctx = createGatewayCtx(async () => new Response("ok"));
+		const { env, analyticsEvents } = createGatewayEnv({
+			ACCOUNT_COHORT_QUERIER: {
+				lookupAccountCohort: () =>
+					Promise.resolve({
+						ok: true as const,
+						result: "ent",
+						meta: { workersVersion: "test" },
+					}),
+			},
+		});
+
+		await routerWorker.fetch(new Request("https://example.com"), env, ctx);
+
+		expect(analyticsEvents).toHaveLength(1);
+		expect(analyticsEvents[0].doubles?.[9]).toBe(EntrypointType.Outer);
+		expect(analyticsEvents[0].blobs?.[8]).toBe("ent");
+	});
+
+	it("does not set error blob for user worker errors", async ({ expect }) => {
+		const userError = new Error("user code bug");
+		const ctx = createGatewayCtx(async () => {
+			throw userError;
+		});
+		const { env, analyticsEvents } = createGatewayEnv();
+
+		await expect(
+			routerWorker.fetch(new Request("https://example.com"), env, ctx)
+		).rejects.toThrow(userError);
+
+		expect(analyticsEvents).toHaveLength(1);
+		// blob3 (error) should not be set for user worker errors
+		expect(analyticsEvents[0].blobs?.[2]).toBeUndefined();
+	});
+
+	it("sets error blob for platform errors from inner", async ({ expect }) => {
+		const platformError = new RouterPlatformError(
+			new Error("platform boom")
+		);
+		const ctx = createGatewayCtx(async () => {
+			throw platformError;
+		});
+		const { env, analyticsEvents } = createGatewayEnv();
+
+		await expect(
+			routerWorker.fetch(new Request("https://example.com"), env, ctx)
+		).rejects.toThrow(RouterPlatformError);
+
+		expect(analyticsEvents).toHaveLength(1);
+		expect(analyticsEvents[0].blobs?.[2]).toBe("platform boom");
+	});
+
+	it("sets error blob for outer-originated errors", async ({ expect }) => {
+		const ctx = {
+			exports: {
+				RouterInnerEntrypoint() {
+					throw new Error("export setup failed");
+				},
+			},
+			waitUntil() {},
+			passThroughOnException() {},
+		} as unknown as ExecutionContext;
+		const { env, analyticsEvents } = createGatewayEnv();
+
+		await expect(
+			routerWorker.fetch(new Request("https://example.com"), env, ctx)
+		).rejects.toThrow("export setup failed");
+
+		expect(analyticsEvents).toHaveLength(1);
+		expect(analyticsEvents[0].blobs?.[2]).toBe("export setup failed");
+	});
+});
+
+// ============================================================
+// Inner entrypoint analytics tests
+// ============================================================
+
+describe("inner entrypoint analytics", () => {
+	it("writes entrypoint = Inner and cohort from ctx.version", async ({
+		expect,
+	}) => {
+		const analyticsEvents: ReadyAnalyticsEvent[] = [];
+		const request = new Request("https://example.com");
+		const ctx = Object.assign(createExecutionContext(), {
+			version: { cohort: "ent" },
+		});
+
+		const env = {
+			CONFIG: {
+				has_user_worker: false,
+				account_id: 123,
+				script_id: 456,
+			},
+			COLO_METADATA: {
+				coloId: 1,
+				metalId: 2,
+				coloTier: 1,
+				coloRegion: "WEUR",
+			},
+			VERSION_METADATA: { tag: "v1" },
+			ANALYTICS: {
+				logEvent(event: ReadyAnalyticsEvent) {
+					analyticsEvents.push(event);
+				},
+			},
+			ASSET_WORKER: {
+				async fetch() {
+					return new Response("ok");
+				},
+				async unstable_canFetch() {
+					return true;
+				},
+			},
+		} as unknown as Env;
+
+		await fetchFromInnerEntrypoint(request, env, ctx);
+
+		expect(analyticsEvents).toHaveLength(1);
+		expect(analyticsEvents[0].doubles?.[9]).toBe(EntrypointType.Inner);
+		expect(analyticsEvents[0].blobs?.[8]).toBe("ent");
+	});
+
+	it("writes cohort as 'unknown' when ctx.version has no cohort", async ({
+		expect,
+	}) => {
+		const analyticsEvents: ReadyAnalyticsEvent[] = [];
+		const request = new Request("https://example.com");
+		const ctx = createExecutionContext();
+
+		const env = {
+			CONFIG: {
+				has_user_worker: false,
+				account_id: 123,
+				script_id: 456,
+			},
+			COLO_METADATA: {
+				coloId: 1,
+				metalId: 2,
+				coloTier: 1,
+				coloRegion: "WEUR",
+			},
+			VERSION_METADATA: { tag: "v1" },
+			ANALYTICS: {
+				logEvent(event: ReadyAnalyticsEvent) {
+					analyticsEvents.push(event);
+				},
+			},
+			ASSET_WORKER: {
+				async fetch() {
+					return new Response("ok");
+				},
+				async unstable_canFetch() {
+					return true;
+				},
+			},
+		} as unknown as Env;
+
+		await fetchFromInnerEntrypoint(request, env, ctx);
+
+		expect(analyticsEvents).toHaveLength(1);
+		expect(analyticsEvents[0].doubles?.[9]).toBe(EntrypointType.Inner);
+		expect(analyticsEvents[0].blobs?.[8]).toBe("unknown");
 	});
 });

--- a/packages/workers-shared/router-worker/tests/index.test.ts
+++ b/packages/workers-shared/router-worker/tests/index.test.ts
@@ -3,14 +3,12 @@ import {
 	createExecutionContext,
 	env as runtimeEnv,
 } from "cloudflare:test";
-import { describe, it, vi } from "vitest";
-import { COHORT_LOOKUP_TIMEOUT_MS, lookupCohort } from "../../utils/cohort";
+import { describe, it } from "vitest";
 import { EntrypointType } from "../src/analytics";
 import routerWorker, {
 	RouterInnerEntrypoint,
 	RouterPlatformError,
 } from "../src/worker";
-import type { AccountCohortQuerierBinding } from "../../utils/cohort";
 import type { ReadyAnalyticsEvent } from "../src/types";
 import type { Env } from "../src/worker";
 
@@ -1118,110 +1116,6 @@ function createGatewayEnv(overrides?: Record<string, unknown>): {
 		analyticsEvents,
 	};
 }
-
-// ============================================================
-// lookupCohort tests
-// ============================================================
-
-describe("lookupCohort", () => {
-	it("returns cohort on success", async ({ expect }) => {
-		const lookupMock = vi.fn().mockResolvedValue({
-			ok: true,
-			result: "ent",
-			meta: { workersVersion: "test" },
-		});
-
-		const result = await lookupCohort(
-			{ lookupAccountCohort: lookupMock } as AccountCohortQuerierBinding,
-			42
-		);
-
-		expect(result).toBe("ent");
-		expect(lookupMock).toHaveBeenCalledWith("42");
-	});
-
-	it("returns null when binding is unavailable", async ({ expect }) => {
-		const result = await lookupCohort(undefined, 42);
-		expect(result).toBeNull();
-	});
-
-	it("returns null when accountId is undefined", async ({ expect }) => {
-		const result = await lookupCohort(
-			{
-				lookupAccountCohort: () =>
-					Promise.resolve({
-						ok: true as const,
-						result: "ent",
-						meta: { workersVersion: "test" },
-					}),
-			},
-			undefined
-		);
-		expect(result).toBeNull();
-	});
-
-	it("returns null on RPC failure", async ({ expect }) => {
-		const result = await lookupCohort(
-			{
-				lookupAccountCohort: () => Promise.reject(new Error("rpc broke")),
-			},
-			42
-		);
-		expect(result).toBeNull();
-	});
-
-	it("returns null when ok:false", async ({ expect }) => {
-		const result = await lookupCohort(
-			{
-				lookupAccountCohort: () =>
-					Promise.resolve({
-						ok: false as const,
-						errors: [
-							{ name: "Error", message: "invalid account", code: "ERR" },
-						],
-					}),
-			},
-			42
-		);
-		expect(result).toBeNull();
-	});
-
-	it("returns null when result is null (cold cache)", async ({ expect }) => {
-		const result = await lookupCohort(
-			{
-				lookupAccountCohort: () =>
-					Promise.resolve({
-						ok: true as const,
-						result: null,
-						meta: { workersVersion: "test" },
-					}),
-			},
-			42
-		);
-		expect(result).toBeNull();
-	});
-
-	it("times out after COHORT_LOOKUP_TIMEOUT_MS", async ({ expect }) => {
-		const result = await lookupCohort(
-			{
-				lookupAccountCohort: () =>
-					new Promise((resolve) => {
-						setTimeout(
-							() =>
-								resolve({
-									ok: true as const,
-									result: "ent",
-									meta: { workersVersion: "test" },
-								}),
-							COHORT_LOOKUP_TIMEOUT_MS * 2
-						);
-					}),
-			},
-			42
-		);
-		expect(result).toBeNull();
-	});
-});
 
 // ============================================================
 // Gateway (outer entrypoint) tests

--- a/packages/workers-shared/router-worker/tests/index.test.ts
+++ b/packages/workers-shared/router-worker/tests/index.test.ts
@@ -1281,9 +1281,10 @@ describe("inner entrypoint analytics", () => {
 		await fetchFromInnerEntrypoint(request, env, ctx);
 
 		expect(analyticsEvents).toHaveLength(1);
-		expect(analyticsEvents[0].doubles?.[9]).toBe(EntrypointType.Inner);
+		expect(analyticsEvents[0].doubles?.[8]).toBeGreaterThanOrEqual(0); // double9 = timeToDispatch
+		expect(analyticsEvents[0].doubles?.[9]).toBe(EntrypointType.Inner); // double10 = entrypoint
 		expect(analyticsEvents[0].doubles?.[10]).toBe(3); // double11 = timeToHandoff
-		expect(analyticsEvents[0].blobs?.[8]).toBe("ent");
+		expect(analyticsEvents[0].blobs?.[8]).toBe("ent"); // blob9 = cohort
 	});
 
 	it("writes cohort as 'unknown' when ctx.version has no cohort", async ({
@@ -1324,7 +1325,9 @@ describe("inner entrypoint analytics", () => {
 		await fetchFromInnerEntrypoint(request, env, ctx);
 
 		expect(analyticsEvents).toHaveLength(1);
-		expect(analyticsEvents[0].doubles?.[9]).toBe(EntrypointType.Inner);
-		expect(analyticsEvents[0].blobs?.[8]).toBe("unknown");
+		expect(analyticsEvents[0].doubles?.[8]).toBeGreaterThanOrEqual(0); // double9 = timeToDispatch
+		expect(analyticsEvents[0].doubles?.[9]).toBe(EntrypointType.Inner); // double10 = entrypoint
+		expect(analyticsEvents[0].doubles?.[10]).toBe(-1); // double11 = timeToHandoff (not passed)
+		expect(analyticsEvents[0].blobs?.[8]).toBe("unknown"); // blob9 = cohort
 	});
 });

--- a/packages/workers-shared/router-worker/worker-configuration.d.ts
+++ b/packages/workers-shared/router-worker/worker-configuration.d.ts
@@ -7,3 +7,13 @@ declare namespace Cloudflare {
 		mainModule: typeof RouterWorkerMainModule;
 	}
 }
+
+// Adds `version` from the experimental `enable_version_api` compat flag.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- generic must match the original declaration for interface merging
+interface ExecutionContext<Props = unknown> {
+	readonly version?: {
+		cohort?: string;
+		key?: string;
+		override?: string;
+	};
+}

--- a/packages/workers-shared/router-worker/wrangler.jsonc
+++ b/packages/workers-shared/router-worker/wrangler.jsonc
@@ -48,6 +48,13 @@
 				"name": "workers-router-worker",
 				"type": "internal_capability_grants",
 			},
+			{
+				"name": "ACCOUNT_COHORT_QUERIER",
+				"type": "service",
+				"service": "account-services-production",
+				"entrypoint": "AccountCohortQuerier",
+				"cross_account_grant": "workers-router-worker",
+			},
 		],
 		"metadata": {
 			"build_options": {
@@ -59,6 +66,14 @@
 	"env": {
 		"staging": {
 			"name": "router-worker-staging",
+			// enable_version_api is set per-environment (not top-level) because
+			// the local workerd in vitest-pool-workers does not support it yet.
+			"compatibility_flags": [
+				"nodejs_compat",
+				"no_nodejs_compat_v2",
+				"enable_ctx_exports",
+				"enable_version_api",
+			],
 			"version_metadata": {
 				"binding": "VERSION_METADATA",
 			},
@@ -82,6 +97,13 @@
 						"name": "workers-router-worker-staging",
 						"type": "internal_capability_grants",
 					},
+					{
+						"name": "ACCOUNT_COHORT_QUERIER",
+						"type": "service",
+						"service": "account-services-staging",
+						"entrypoint": "AccountCohortQuerier",
+						"cross_account_grant": "workers-router-worker-staging",
+					},
 				],
 				"metadata": {
 					"build_options": {
@@ -94,6 +116,14 @@
 		"fed-prod": {
 			"name": "router-worker-fed-prod",
 			"account_id": "fca6c231dc1d1780777997c5bce5a5e3", // workers assets
+			// enable_version_api is set per-environment (not top-level) because
+			// the local workerd in vitest-pool-workers does not support it yet.
+			"compatibility_flags": [
+				"nodejs_compat",
+				"no_nodejs_compat_v2",
+				"enable_ctx_exports",
+				"enable_version_api",
+			],
 			"version_metadata": {
 				"binding": "VERSION_METADATA",
 			},
@@ -117,6 +147,13 @@
 					{
 						"name": "workers-router-worker",
 						"type": "internal_capability_grants",
+					},
+					{
+						"name": "ACCOUNT_COHORT_QUERIER",
+						"type": "service",
+						"service": "account-services-production",
+						"entrypoint": "AccountCohortQuerier",
+						"cross_account_grant": "workers-router-worker",
 					},
 				],
 				"metadata": {

--- a/packages/workers-shared/utils/cohort.ts
+++ b/packages/workers-shared/utils/cohort.ts
@@ -1,0 +1,55 @@
+/**
+ * Minimal RPC binding type for the AccountCohortQuerier entrypoint
+ * in the account-services worker. Replace with the published type from
+ * `@cloudflare/workers-toolbox-types` once available with bundled deps.
+ */
+export interface AccountCohortQuerierBinding {
+	lookupAccountCohort(accountID: string): Promise<
+		| { ok: true; result: string | null; meta: { workersVersion: string } }
+		| {
+				ok: false;
+				errors: Array<{ name: string; message: string; code: string }>;
+		  }
+	>;
+}
+
+export const COHORT_LOOKUP_TIMEOUT_MS = 5;
+
+/**
+ * Resolves the deployment cohort for a customer account via the
+ * AccountCohortQuerier RPC binding. Returns null when the binding is
+ * unavailable, the RPC fails, times out, or the cohort is undetermined
+ * (cold cache). Intentionally fails open — a null cohort means the
+ * request runs under default routing.
+ */
+export async function lookupCohort(
+	querier: AccountCohortQuerierBinding | undefined,
+	accountId: number | undefined
+): Promise<string | null> {
+	if (!querier || !accountId) {
+		return null;
+	}
+	const ac = new AbortController();
+	try {
+		const rpc = querier.lookupAccountCohort(accountId.toString());
+		// Prevent unhandled rejection if timeout wins but RPC later rejects.
+		void rpc.catch(() => {});
+		const timeout = new Promise<never>((_, reject) => {
+			const id = setTimeout(() => {
+				reject(new Error("cohort lookup timed out"));
+			}, COHORT_LOOKUP_TIMEOUT_MS);
+			ac.signal.addEventListener("abort", () => clearTimeout(id));
+		});
+		const res = await Promise.race([rpc, timeout]);
+		if (!res.ok) {
+			console.error("cohort lookup failed", res.errors);
+			return null;
+		}
+		return res.result ?? null;
+	} catch (e: unknown) {
+		console.error("cohort lookup failed", e);
+		return null;
+	} finally {
+		ac.abort();
+	}
+}

--- a/packages/workers-shared/utils/tests/cohort.test.ts
+++ b/packages/workers-shared/utils/tests/cohort.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, vi } from "vitest";
-import { COHORT_LOOKUP_TIMEOUT_MS, lookupCohort } from "../../utils/cohort";
-import type { AccountCohortQuerierBinding } from "../../utils/cohort";
+import { COHORT_LOOKUP_TIMEOUT_MS, lookupCohort } from "../cohort";
+import type { AccountCohortQuerierBinding } from "../cohort";
 
-describe("[Asset Worker] lookupCohort", () => {
-	it("calls querier with account ID as string", async ({ expect }) => {
+describe("lookupCohort", () => {
+	it("returns cohort on success", async ({ expect }) => {
 		const lookupMock = vi.fn().mockResolvedValue({
 			ok: true,
 			result: "ent",
@@ -19,7 +19,37 @@ describe("[Asset Worker] lookupCohort", () => {
 		expect(lookupMock).toHaveBeenCalledWith("42");
 	});
 
-	it("returns null when result is ok:false", async ({ expect }) => {
+	it("returns null when binding is unavailable", async ({ expect }) => {
+		const result = await lookupCohort(undefined, 42);
+		expect(result).toBeNull();
+	});
+
+	it("returns null when accountId is undefined", async ({ expect }) => {
+		const result = await lookupCohort(
+			{
+				lookupAccountCohort: () =>
+					Promise.resolve({
+						ok: true as const,
+						result: "ent",
+						meta: { workersVersion: "test" },
+					}),
+			},
+			undefined
+		);
+		expect(result).toBeNull();
+	});
+
+	it("returns null on RPC failure", async ({ expect }) => {
+		const result = await lookupCohort(
+			{
+				lookupAccountCohort: () => Promise.reject(new Error("rpc broke")),
+			},
+			42
+		);
+		expect(result).toBeNull();
+	});
+
+	it("returns null when ok:false", async ({ expect }) => {
 		const result = await lookupCohort(
 			{
 				lookupAccountCohort: () =>
@@ -32,11 +62,10 @@ describe("[Asset Worker] lookupCohort", () => {
 			},
 			42
 		);
-
 		expect(result).toBeNull();
 	});
 
-	it("returns null when result is null", async ({ expect }) => {
+	it("returns null when result is null (cold cache)", async ({ expect }) => {
 		const result = await lookupCohort(
 			{
 				lookupAccountCohort: () =>
@@ -48,7 +77,6 @@ describe("[Asset Worker] lookupCohort", () => {
 			},
 			42
 		);
-
 		expect(result).toBeNull();
 	});
 
@@ -70,7 +98,6 @@ describe("[Asset Worker] lookupCohort", () => {
 			},
 			42
 		);
-
 		expect(result).toBeNull();
 	});
 });


### PR DESCRIPTION
Fixes WC-4890.

Adds cohort-based deployment support to the router worker by extracting shared cohort lookup utilities and wiring cohort resolution into the multi entrypoint flow.

What changed:
- utils/cohort.ts (new): Extracted AccountCohortQuerierBinding, COHORT_LOOKUP_TIMEOUT_MS, and lookupCohort() from asset-worker so both workers share the same implementation.
- asset-worker/src/worker.ts: Imports from shared utils/cohort rather than owning cohort lookup
- router-worker/src/worker.ts: Resolves cohort and passes to the inner entrypoint via ctx.version. Added RouterPlatformError to distinguish platform errors from user worker errors in the outer catch block. Passed timeToDispatch to distinguish total dispatch time from both entrypoints in a single queryable metric per request for analytics.
- router-worker/src/analytics.ts: Added EntrypointType enum (Outer/Inner), entrypoint field (double10), timetoDispatch, and cohort field (blob9).
- router-worker/worker-configuration.d.ts: Added ExecutionContext.version type augmentation for enable_version_api.
- router-worker/wrangler.jsonc: Added ACCOUNT_COHORT_QUERIER service binding and enable_version_api compat flag per environment

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change only

*A picture of a cute animal (not mandatory, but encouraged)*

<img width="1536" height="2048" alt="Messenger_creation_253419C6-4505-4B84-943F-85D9037302A1" src="https://github.com/user-attachments/assets/b6b4f54a-7a46-4318-9861-5b62aba59977" />


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
