### PR TITLE
[wrangler] Propagate assets binding to preview deployments

### DIFF
--- a/.changeset/tame-grapes-vanish.md
+++ b/.changeset/tame-grapes-vanish.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler preview` not propagating the `assets` binding to preview deployments
+
+Previously, `wrangler preview` would upload the asset manifest correctly but the resulting preview deployment had no `ASSETS` binding (or whatever name was configured under `assets.binding`). Workers reading from the binding would see `undefined` and fail at runtime.
+
+The fix emits the assets binding into the deployment's `env` map alongside other bindings, mirroring `wrangler deploy`. As a defense-in-depth measure, if Wrangler ever detects an inheritable binding (such as `assets`) missing from a preview deployment, it now logs a "this is likely a bug in Wrangler" warning instead of the previous advice to add the binding to the `previews` config — inheritable bindings are not valid under `previews`, so that advice was misleading.

--- a/.changeset/tame-grapes-vanish.md
+++ b/.changeset/tame-grapes-vanish.md
@@ -6,4 +6,4 @@ Fix `wrangler preview` not propagating the `assets` binding to preview deploymen
 
 Previously, `wrangler preview` would upload the asset manifest correctly but the resulting preview deployment had no `ASSETS` binding (or whatever name was configured under `assets.binding`). Workers reading from the binding would see `undefined` and fail at runtime.
 
-The fix emits the assets binding into the deployment's `env` map alongside other bindings, mirroring `wrangler deploy`. As a defense-in-depth measure, if Wrangler ever detects an inheritable binding (such as `assets`) missing from a preview deployment, it now logs a "this is likely a bug in Wrangler" warning instead of the previous advice to add the binding to the `previews` config — inheritable bindings are not valid under `previews`, so that advice was misleading.
+The fix emits the assets binding into the deployment's `env` map alongside other bindings, mirroring `wrangler deploy`.

--- a/packages/wrangler/src/__tests__/preview.test.ts
+++ b/packages/wrangler/src/__tests__/preview.test.ts
@@ -5,7 +5,6 @@ import { defaultWranglerConfig } from "@cloudflare/workers-utils";
 import { http, HttpResponse } from "msw";
 import { afterAll, afterEach, beforeEach, describe, test, vi } from "vitest";
 import { clearOutputFilePath } from "../output";
-import { logMissingPreviewsBindingsWarning } from "../preview/preview";
 import { extractConfigBindings, getBranchName } from "../preview/shared";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
@@ -17,11 +16,7 @@ import {
 	writeWranglerConfig,
 } from "./helpers/write-wrangler-config";
 import type { OutputEntry } from "../output";
-import type {
-	Binding,
-	Config,
-	PreviewsConfig,
-} from "@cloudflare/workers-utils";
+import type { Config, PreviewsConfig } from "@cloudflare/workers-utils";
 
 vi.mock("node:child_process", async () => {
 	const actual =
@@ -212,58 +207,6 @@ describe("wrangler preview", () => {
 				MY_STREAM: { type: "stream" },
 				MY_VERSION_METADATA: { type: "version_metadata" },
 			});
-		});
-	});
-
-	describe("logMissingPreviewsBindingsWarning", () => {
-		test("warns about a likely Wrangler bug when an inheritable binding is missing from the preview deployment", async ({
-			expect,
-		}) => {
-			const topLevelBindings: Record<string, Binding> = {
-				ASSETS: { type: "assets" },
-			};
-
-			await logMissingPreviewsBindingsWarning(topLevelBindings, undefined, {});
-
-			const normalizedWarningOutput = stripVTControlCharacters(
-				std.warn
-			).replace(/\s+/g, " ");
-
-			expect(normalizedWarningOutput).toContain(
-				"should have been inherited from your top-level Wrangler config but are missing from the Preview deployment"
-			);
-			expect(normalizedWarningOutput).toContain("ASSETS");
-			expect(normalizedWarningOutput).toContain(
-				"This is likely a bug in Wrangler."
-			);
-			expect(normalizedWarningOutput).not.toContain(
-				"Your configuration has diverged."
-			);
-		});
-
-		test("warns about diverged config when a non-inheritable binding is missing from the preview settings", async ({
-			expect,
-		}) => {
-			const topLevelBindings: Record<string, Binding> = {
-				IMPORTANT_BINDING: { type: "kv_namespace", id: "kv-id-123" },
-			};
-
-			await logMissingPreviewsBindingsWarning(topLevelBindings, undefined, {});
-
-			const normalizedWarningOutput = stripVTControlCharacters(
-				std.warn
-			).replace(/\s+/g, " ");
-
-			expect(normalizedWarningOutput).toContain(
-				"Your configuration has diverged."
-			);
-			expect(normalizedWarningOutput).toContain("IMPORTANT_BINDING");
-			expect(normalizedWarningOutput).toContain(
-				'Either include these bindings in the "previews" field'
-			);
-			expect(normalizedWarningOutput).not.toContain(
-				"This is likely a bug in Wrangler."
-			);
 		});
 	});
 

--- a/packages/wrangler/src/__tests__/preview.test.ts
+++ b/packages/wrangler/src/__tests__/preview.test.ts
@@ -5,6 +5,7 @@ import { defaultWranglerConfig } from "@cloudflare/workers-utils";
 import { http, HttpResponse } from "msw";
 import { afterAll, afterEach, beforeEach, describe, test, vi } from "vitest";
 import { clearOutputFilePath } from "../output";
+import { logMissingPreviewsBindingsWarning } from "../preview/preview";
 import { extractConfigBindings, getBranchName } from "../preview/shared";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
@@ -16,7 +17,11 @@ import {
 	writeWranglerConfig,
 } from "./helpers/write-wrangler-config";
 import type { OutputEntry } from "../output";
-import type { Config, PreviewsConfig } from "@cloudflare/workers-utils";
+import type {
+	Binding,
+	Config,
+	PreviewsConfig,
+} from "@cloudflare/workers-utils";
 
 vi.mock("node:child_process", async () => {
 	const actual =
@@ -207,6 +212,58 @@ describe("wrangler preview", () => {
 				MY_STREAM: { type: "stream" },
 				MY_VERSION_METADATA: { type: "version_metadata" },
 			});
+		});
+	});
+
+	describe("logMissingPreviewsBindingsWarning", () => {
+		test("warns about a likely Wrangler bug when an inheritable binding is missing from the preview deployment", async ({
+			expect,
+		}) => {
+			const topLevelBindings: Record<string, Binding> = {
+				ASSETS: { type: "assets" },
+			};
+
+			await logMissingPreviewsBindingsWarning(topLevelBindings, undefined, {});
+
+			const normalizedWarningOutput = stripVTControlCharacters(
+				std.warn
+			).replace(/\s+/g, " ");
+
+			expect(normalizedWarningOutput).toContain(
+				"should have been inherited from your top-level Wrangler config but are missing from the Preview deployment"
+			);
+			expect(normalizedWarningOutput).toContain("ASSETS");
+			expect(normalizedWarningOutput).toContain(
+				"This is likely a bug in Wrangler."
+			);
+			expect(normalizedWarningOutput).not.toContain(
+				"Your configuration has diverged."
+			);
+		});
+
+		test("warns about diverged config when a non-inheritable binding is missing from the preview settings", async ({
+			expect,
+		}) => {
+			const topLevelBindings: Record<string, Binding> = {
+				IMPORTANT_BINDING: { type: "kv_namespace", id: "kv-id-123" },
+			};
+
+			await logMissingPreviewsBindingsWarning(topLevelBindings, undefined, {});
+
+			const normalizedWarningOutput = stripVTControlCharacters(
+				std.warn
+			).replace(/\s+/g, " ");
+
+			expect(normalizedWarningOutput).toContain(
+				"Your configuration has diverged."
+			);
+			expect(normalizedWarningOutput).toContain("IMPORTANT_BINDING");
+			expect(normalizedWarningOutput).toContain(
+				'Either include these bindings in the "previews" field'
+			);
+			expect(normalizedWarningOutput).not.toContain(
+				"This is likely a bug in Wrangler."
+			);
 		});
 	});
 
@@ -1518,6 +1575,100 @@ describe("wrangler preview", () => {
 			});
 			expect(deploymentRequestBody?.main_module).toBeDefined();
 			expect(Array.isArray(deploymentRequestBody?.modules)).toBe(true);
+			// No assets binding configured, so no env entry should be emitted
+			const env = deploymentRequestBody?.env as
+				| Record<string, { type: string }>
+				| undefined;
+			const assetsEntries = Object.values(env ?? {}).filter(
+				(b) => b.type === "assets"
+			);
+			expect(assetsEntries).toHaveLength(0);
+		});
+
+		test("should include the assets binding in env using the configured binding name", async ({
+			expect,
+		}) => {
+			mkdirSync("public", { recursive: true });
+			writeFileSync("public/index.html", "<h1>Hello</h1>");
+			writeFileSync(
+				"wrangler.json",
+				JSON.stringify({
+					name: "test-worker",
+					main: "src/index.ts",
+					compatibility_date: "2025-01-01",
+					assets: { directory: "public", binding: "MY_ASSETS" },
+				})
+			);
+			let deploymentRequestBody: Record<string, unknown> | undefined;
+			msw.use(
+				http.get(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId`,
+					() =>
+						HttpResponse.json(
+							{
+								success: false,
+								result: null,
+								errors: [{ code: 10025, message: "Preview not found" }],
+							},
+							{ status: 404 }
+						)
+				),
+				http.post(
+					`*/accounts/:accountId/workers/workers/:workerId/previews`,
+					() =>
+						HttpResponse.json(
+							{
+								success: true,
+								result: {
+									id: "preview-id-custom-binding",
+									name: "test-preview",
+									slug: "test-preview",
+									urls: ["https://test-preview.test-worker.cloudflare.app"],
+									worker_name: "test-worker",
+									created_on: new Date().toISOString(),
+								},
+							},
+							{ status: 201 }
+						)
+				),
+				http.post(
+					`*/accounts/:accountId/workers/scripts/:workerId/assets-upload-session`,
+					() =>
+						HttpResponse.json({
+							success: true,
+							result: { buckets: [], jwt: "assets-jwt-from-session" },
+						})
+				),
+				http.post(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId/deployments`,
+					async ({ request }) => {
+						deploymentRequestBody = (await request.json()) as Record<
+							string,
+							unknown
+						>;
+						return HttpResponse.json(
+							{
+								success: true,
+								result: {
+									id: "deployment-id-custom-binding",
+									preview_id: "preview-id-custom-binding",
+									preview_name: "test-preview",
+									urls: ["https://custom-bind.test-worker.cloudflare.app"],
+									compatibility_date: "2025-01-01",
+									env: {},
+									created_on: new Date().toISOString(),
+								},
+							},
+							{ status: 201 }
+						);
+					}
+				)
+			);
+			await runWrangler("preview --name test-preview");
+			expect(deploymentRequestBody?.env).toMatchObject({
+				MY_ASSETS: { type: "assets" },
+			});
+			expect(deploymentRequestBody?.env).not.toHaveProperty("ASSETS");
 		});
 
 		test("should include source maps in deployment modules when upload_source_maps is enabled", async ({

--- a/packages/wrangler/src/preview/preview.ts
+++ b/packages/wrangler/src/preview/preview.ts
@@ -32,7 +32,6 @@ import {
 	visibleLength,
 } from "../utils/box";
 import { getRules } from "../utils/getRules";
-import { logPossibleBugMessage } from "../utils/logPossibleBugMessage";
 import { parseConfigPlacement } from "../utils/placement";
 import {
 	createPreview,
@@ -722,13 +721,7 @@ function formatDeploymentResource(
 	return drawConnectedChildBox(lines, { footerLines, indent: "  " });
 }
 
-function isInheritableBinding(
-	binding: Exclude<StartDevWorkerInput["bindings"], undefined>[string]
-) {
-	return binding.type === "assets";
-}
-
-export async function logMissingPreviewsBindingsWarning(
+function logMissingPreviewsBindingsWarning(
 	topLevelBindings: StartDevWorkerInput["bindings"],
 	remotePreviewDefaultBindings: Record<string, Binding> | undefined,
 	localPreviewBindings: Record<string, Binding>
@@ -737,44 +730,20 @@ export async function logMissingPreviewsBindingsWarning(
 		...Object.keys(remotePreviewDefaultBindings ?? {}),
 		...Object.keys(localPreviewBindings),
 	]);
-	const missingEntries = Object.entries(topLevelBindings ?? {}).filter(
-		([name]) => !availableBindingNames.has(name)
+	const missingBindings = Object.fromEntries(
+		Object.entries(topLevelBindings ?? {}).filter(
+			([name]) => !availableBindingNames.has(name)
+		)
 	);
 
-	if (missingEntries.length === 0) {
+	if (Object.keys(missingBindings).length === 0) {
 		return;
 	}
 
-	const missingInheritable = missingEntries.filter(([, binding]) =>
-		isInheritableBinding(binding)
-	);
-	const missingUserFixable = missingEntries.filter(
-		([, binding]) => !isInheritableBinding(binding)
-	);
-
-	if (missingInheritable.length > 0) {
-		// Inheritable bindings (e.g. `assets`) are not valid under the
-		// `previews` config block, so we cannot direct the user to fix this
-		// themselves. If one is missing here, it means Wrangler failed to
-		// propagate it to the preview deployment.
-		logger.warn(`The following bindings should have been inherited from your top-level Wrangler config but are missing from the Preview deployment:
-
-${missingInheritable
-	.map(
-		([name, binding]) =>
-			`  ${chalk.cyan(name)}  ${chalk.dim(getBindingTypeFriendlyName(binding.type))}`
-	)
-	.join("\n")}
-
-This is likely a bug in Wrangler.`);
-		await logPossibleBugMessage();
-	}
-
-	if (missingUserFixable.length > 0) {
-		logger.warn(`Your configuration has diverged.
+	logger.warn(`Your configuration has diverged.
 The following bindings are configured at the top level of your Wrangler config file, but are missing from the Previews settings of your Worker.
 
-${missingUserFixable
+${Object.entries(missingBindings)
 	.map(
 		([name, binding]) =>
 			`  ${chalk.cyan(name)}  ${chalk.dim(getBindingTypeFriendlyName(binding.type))}`
@@ -782,7 +751,6 @@ ${missingUserFixable
 	.join("\n")}
 
 Either include these bindings in the ${chalk.cyan(`"previews"`)} field of your Wrangler config or update the Previews settings of your Worker in the Cloudflare dashboard.`);
-	}
 }
 
 export async function handlePreviewCommand(
@@ -911,7 +879,7 @@ export async function handlePreviewCommand(
 			accountId,
 			workerName
 		);
-		await logMissingPreviewsBindingsWarning(
+		logMissingPreviewsBindingsWarning(
 			topLevelBindings,
 			previewDefaults.env,
 			extractConfigBindings(config)

--- a/packages/wrangler/src/preview/preview.ts
+++ b/packages/wrangler/src/preview/preview.ts
@@ -32,6 +32,7 @@ import {
 	visibleLength,
 } from "../utils/box";
 import { getRules } from "../utils/getRules";
+import { logPossibleBugMessage } from "../utils/logPossibleBugMessage";
 import { parseConfigPlacement } from "../utils/placement";
 import {
 	createPreview,
@@ -727,7 +728,7 @@ function isInheritableBinding(
 	return binding.type === "assets";
 }
 
-function logMissingPreviewsBindingsWarning(
+export async function logMissingPreviewsBindingsWarning(
 	topLevelBindings: StartDevWorkerInput["bindings"],
 	remotePreviewDefaultBindings: Record<string, Binding> | undefined,
 	localPreviewBindings: Record<string, Binding>
@@ -736,21 +737,44 @@ function logMissingPreviewsBindingsWarning(
 		...Object.keys(remotePreviewDefaultBindings ?? {}),
 		...Object.keys(localPreviewBindings),
 	]);
-	const missingBindings = Object.fromEntries(
-		Object.entries(topLevelBindings ?? {}).filter(
-			([name, binding]) =>
-				!availableBindingNames.has(name) && !isInheritableBinding(binding)
-		)
+	const missingEntries = Object.entries(topLevelBindings ?? {}).filter(
+		([name]) => !availableBindingNames.has(name)
 	);
 
-	if (Object.keys(missingBindings).length === 0) {
+	if (missingEntries.length === 0) {
 		return;
 	}
 
-	logger.warn(`Your configuration has diverged.
+	const missingInheritable = missingEntries.filter(([, binding]) =>
+		isInheritableBinding(binding)
+	);
+	const missingUserFixable = missingEntries.filter(
+		([, binding]) => !isInheritableBinding(binding)
+	);
+
+	if (missingInheritable.length > 0) {
+		// Inheritable bindings (e.g. `assets`) are not valid under the
+		// `previews` config block, so we cannot direct the user to fix this
+		// themselves. If one is missing here, it means Wrangler failed to
+		// propagate it to the preview deployment.
+		logger.warn(`The following bindings should have been inherited from your top-level Wrangler config but are missing from the Preview deployment:
+
+${missingInheritable
+	.map(
+		([name, binding]) =>
+			`  ${chalk.cyan(name)}  ${chalk.dim(getBindingTypeFriendlyName(binding.type))}`
+	)
+	.join("\n")}
+
+This is likely a bug in Wrangler.`);
+		await logPossibleBugMessage();
+	}
+
+	if (missingUserFixable.length > 0) {
+		logger.warn(`Your configuration has diverged.
 The following bindings are configured at the top level of your Wrangler config file, but are missing from the Previews settings of your Worker.
 
-${Object.entries(missingBindings)
+${missingUserFixable
 	.map(
 		([name, binding]) =>
 			`  ${chalk.cyan(name)}  ${chalk.dim(getBindingTypeFriendlyName(binding.type))}`
@@ -758,6 +782,7 @@ ${Object.entries(missingBindings)
 	.join("\n")}
 
 Either include these bindings in the ${chalk.cyan(`"previews"`)} field of your Wrangler config or update the Previews settings of your Worker in the Cloudflare dashboard.`);
+	}
 }
 
 export async function handlePreviewCommand(
@@ -886,7 +911,7 @@ export async function handlePreviewCommand(
 			accountId,
 			workerName
 		);
-		logMissingPreviewsBindingsWarning(
+		await logMissingPreviewsBindingsWarning(
 			topLevelBindings,
 			previewDefaults.env,
 			extractConfigBindings(config)

--- a/packages/wrangler/src/preview/shared.ts
+++ b/packages/wrangler/src/preview/shared.ts
@@ -301,6 +301,10 @@ export function extractConfigBindings(config: Config): EnvBindings {
 		env[previews.version_metadata.binding] = { type: "version_metadata" };
 	}
 
+	if (config.assets?.binding) {
+		env[config.assets.binding] = { type: "assets" };
+	}
+
 	return env;
 }
 


### PR DESCRIPTION
Previously, `wrangler preview` would upload the asset manifest correctly but the resulting preview deployment had no `ASSETS` binding (or whatever name was configured under `assets.binding`). Workers reading from the binding would see `undefined` and fail at runtime.

This PR emits the assets binding into the deployment's `env` map alongside other bindings, mirroring `wrangler deploy`.

As a defense-in-depth measure, when Wrangler detects an inheritable binding (e.g. `assets`) missing from a preview deployment, it now logs a "likely a Wrangler bug" warning instead of the previous "add it to the `previews` config" advice — inheritable bindings are not valid under the `previews` block, so the previous warning was misleading.

Split out from #13712.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix; no user-facing API change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->