### PR TITLE
[miniflare] Default workerd subprocess to TZ=UTC to match production

### DIFF
--- a/.changeset/miniflare-default-tz-utc.md
+++ b/.changeset/miniflare-default-tz-utc.md
@@ -1,0 +1,17 @@
+---
+"miniflare": minor
+---
+
+Default the `workerd` runtime subprocess to `TZ=UTC` to match the production Cloudflare runtime
+
+Previously, Miniflare inherited the host machine's timezone, so `Date` and `Intl` APIs inside a Worker observed the developer's local timezone during local development but UTC in production. This caused dev/prod drift that was hard to debug.
+
+Miniflare now sets `TZ=UTC` on the spawned `workerd` subprocess by default. A new `unsafeRuntimeEnv` option (a `Record<string, string>`) is available on the `Miniflare` constructor for advanced cases that need to override the default — for example, to test timezone-dependent behaviour:
+
+```ts
+new Miniflare({
+	modules: true,
+	script: "...",
+	unsafeRuntimeEnv: { TZ: "Europe/London" },
+});
+```

--- a/.changeset/wrangler-dev-tz-utc.md
+++ b/.changeset/wrangler-dev-tz-utc.md
@@ -1,0 +1,9 @@
+---
+"wrangler": minor
+---
+
+`wrangler dev` and other Miniflare-backed commands now run the local `workerd` runtime with `TZ=UTC` to match production
+
+Previously, `wrangler dev` (and other commands that spin up Miniflare, such as `wrangler kv`, `wrangler d1`, `wrangler r2`, `wrangler check`) inherited the host machine's timezone, so `Date` and `Intl` APIs inside a Worker observed the developer's local timezone during local development but UTC in production. This caused subtle, hard-to-debug differences between local and deployed behaviour.
+
+Local development now matches production. Code that previously relied on the host timezone during `wrangler dev` will need to either accept UTC (the production behaviour) or explicitly construct dates/formatters with the desired timezone.

--- a/packages/miniflare/README.md
+++ b/packages/miniflare/README.md
@@ -788,6 +788,15 @@ Options shared between all Workers/"nanoservices".
   Receives a copy of the updated registry object. Useful for reacting to external
   service changes during development.
 
+- `unsafeRuntimeEnv?: Record<string, string>`
+
+  Extra environment variables to set on the spawned `workerd` subprocess.
+  Merged on top of `process.env` and Miniflare's own defaults — most notably
+  `TZ=UTC`, which Miniflare sets to match the production Cloudflare runtime so
+  that `Date` and `Intl` APIs inside the Worker observe UTC during local
+  development. Use this option to override those defaults, for example to test
+  timezone-dependent code with `unsafeRuntimeEnv: { TZ: "Europe/London" }`.
+
 #### Cache, Durable Objects, KV, R2 and D1
 
 - `cachePersist?: Persistence`

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -2413,6 +2413,7 @@ export class Miniflare {
 			verbose: this.#sharedOpts.core.verbose,
 			handleRuntimeStdio: this.#sharedOpts.core.handleRuntimeStdio,
 			handleStructuredLogs: this.#sharedOpts.core.handleStructuredLogs,
+			runtimeEnv: this.#sharedOpts.core.unsafeRuntimeEnv,
 		};
 		const maybeSocketPorts = await this.#runtime.updateConfig(
 			configBuffer,

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -300,6 +300,11 @@ export const CoreSharedOptionsSchema = z
 		unsafeStickyBlobs: z.boolean().optional(),
 		// Enable directly triggering user Worker handlers with paths like `/cdn-cgi/handler/scheduled`
 		unsafeTriggerHandlers: z.boolean().optional(),
+		// Extra environment variables to set on the spawned `workerd` subprocess.
+		// Merged on top of `process.env` and Miniflare's own defaults
+		// (e.g. `TZ=UTC`, `FORCE_COLOR`), so callers can override those defaults
+		// (for example, to test timezone-dependent behaviour).
+		unsafeRuntimeEnv: z.record(z.string()).optional(),
 		// Enable the local explorer at /cdn-cgi/explorer
 		unsafeLocalExplorer: z.boolean().optional(),
 		// Enable logging requests

--- a/packages/miniflare/src/runtime/index.ts
+++ b/packages/miniflare/src/runtime/index.ts
@@ -44,6 +44,10 @@ export interface RuntimeOptions {
 	verbose?: boolean;
 	handleRuntimeStdio?: (stdout: Readable, stderr: Readable) => void;
 	handleStructuredLogs?: StructuredLogsHandler;
+	// Extra environment variables to set on the spawned `workerd` subprocess.
+	// Merged on top of `process.env` and Miniflare's own defaults
+	// (e.g. `TZ=UTC`, `FORCE_COLOR`), so callers can override those defaults.
+	runtimeEnv?: Record<string, string>;
 }
 
 async function waitForPorts(
@@ -228,9 +232,17 @@ export class Runtime {
 		// By default, `workerd` will only log with colours if it detects a TTY.
 		// `"pipe"` doesn't create a TTY, so we force enable colours if supported.
 		const FORCE_COLOR = $colors.enabled ? "1" : "0";
+		// Default `TZ` to `UTC` to match the production Cloudflare runtime.
+		// Callers can override via `options.runtimeEnv` (e.g. for tests of
+		// timezone-dependent behaviour).
 		const runtimeProcess = childProcess.spawn(command, args, {
 			stdio: ["pipe", "pipe", "pipe", "pipe"],
-			env: { ...process.env, FORCE_COLOR },
+			env: {
+				...process.env,
+				TZ: "UTC",
+				FORCE_COLOR,
+				...options.runtimeEnv,
+			},
 		});
 		const startupLogBuffer = new StartupLogBuffer();
 		this.#process = runtimeProcess;

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -2715,6 +2715,47 @@ test.sequential("Miniflare: unsafeRuntimeEnv overrides the default workerd subpr
 	expect(await res.json()).toEqual({ tz: "America/Chicago" });
 });
 
+// DIAGNOSTIC: probe how workerd resolves several TZ values across platforms.
+// This test always passes; it just emits the resolved zone for each input via
+// console.log so we can see the data in CI logs.
+test.sequential("DIAGNOSTIC: workerd TZ resolution probe", async ({
+	expect,
+}) => {
+	vi.stubEnv("TZ", "UTC");
+
+	const probes = [
+		"America/Chicago",
+		"Asia/Tokyo",
+		"Europe/London",
+		"Etc/GMT+5",
+		"Etc/UTC",
+		"UTC",
+		"PST8PDT",
+	];
+
+	const results: Record<string, string> = {};
+	for (const tz of probes) {
+		const mf = new Miniflare({
+			modules: true,
+			script: TIMEZONE_WORKER,
+			unsafeRuntimeEnv: { TZ: tz },
+		});
+		try {
+			const res = await mf.dispatchFetch("http://localhost");
+			const data = (await res.json()) as { tz: string };
+			results[tz] = data.tz;
+		} finally {
+			await mf.dispose();
+		}
+	}
+
+	// eslint-disable-next-line no-console
+	console.log(
+		`DIAGNOSTIC TZ resolution on ${process.platform}: ${JSON.stringify(results, null, 2)}`
+	);
+	expect(results).toBeDefined();
+});
+
 test("Miniflare: exits cleanly", async ({ expect }) => {
 	const miniflarePath = require.resolve("miniflare");
 	const result = childProcess.spawn(

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -25,7 +25,7 @@ import {
 	Response,
 	viewToBuffer,
 } from "miniflare";
-import { onTestFinished, test } from "vitest";
+import { afterEach, test, vi } from "vitest";
 import { WebSocketServer } from "ws";
 import { assertIsV2ModuleFallbackProtocol } from "../src/plugins/core/module-fallback";
 import {
@@ -65,7 +65,11 @@ const ADD_WASM_MODULE = Buffer.from(
 	"base64"
 );
 
-test("Miniflare: validates options", async ({ expect }) => {
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+test("Miniflare: validates options", async ({ expect, onTestFinished }) => {
 	// Check empty workers array rejected
 	expect(() => new Miniflare({ workers: [] })).toThrow(
 		new MiniflareCoreError("ERR_NO_WORKERS", "No workers defined")
@@ -639,7 +643,10 @@ test("Miniflare: custom service using Set-Cookie header", async ({
 	expect(await res.json()).toEqual(testCookies);
 });
 
-test("Miniflare: web socket kitchen sink", async ({ expect }) => {
+test("Miniflare: web socket kitchen sink", async ({
+	expect,
+	onTestFinished,
+}) => {
 	// Create deferred promises for asserting asynchronous event results
 	const clientEventPromise = new DeferredPromise<MessageEvent>();
 	const serverMessageEventPromise = new DeferredPromise<StandardMessageEvent>();
@@ -2036,7 +2043,10 @@ test("Miniflare: dispose() immediately after construction", async ({
 	await readyAssertion;
 });
 
-test("Miniflare: getBindings() returns all bindings", async ({ expect }) => {
+test("Miniflare: getBindings() returns all bindings", async ({
+	expect,
+	onTestFinished,
+}) => {
 	const tmp = await useTmp();
 	const blobPath = path.join(tmp, "blob.txt");
 	await fs.writeFile(blobPath, "blob");
@@ -2643,7 +2653,7 @@ const isWindows = process.platform === "win32";
 const unixSerialTest = isWindows ? test.skip : test.sequential;
 unixSerialTest(
 	"Miniflare: MINIFLARE_WORKERD_PATH overrides workerd path",
-	async ({ expect }) => {
+	async ({ expect, onTestFinished }) => {
 		const workerdPath = path.join(FIXTURES_PATH, "little-workerd.mjs");
 
 		const original = process.env.MINIFLARE_WORKERD_PATH;
@@ -2663,6 +2673,47 @@ unixSerialTest(
 		);
 	}
 );
+
+const TIMEZONE_WORKER = `
+	export default {
+		fetch() {
+			return Response.json({
+				tz: Intl.DateTimeFormat().resolvedOptions().timeZone,
+			});
+		}
+	}
+`;
+
+test.sequential("Miniflare: workerd subprocess defaults to TZ=UTC to match production", async ({
+	expect,
+}) => {
+	// Deliberately set the host TZ to a non-UTC value, otherwise the test
+	// would falsely pass: the test-runner's vitest globalSetup already sets
+	// `process.env.TZ = "UTC"`, which would propagate to workerd via the
+	// inherited `process.env`.
+	vi.stubEnv("TZ", "America/Chicago");
+	const mf = new Miniflare({ modules: true, script: TIMEZONE_WORKER });
+	useDispose(mf);
+
+	const res = await mf.dispatchFetch("http://localhost");
+	expect(await res.json()).toEqual({ tz: "UTC" });
+});
+
+test.sequential("Miniflare: unsafeRuntimeEnv overrides the default workerd subprocess env", async ({
+	expect,
+}) => {
+	vi.stubEnv("TZ", "UTC");
+
+	const mf = new Miniflare({
+		modules: true,
+		script: TIMEZONE_WORKER,
+		unsafeRuntimeEnv: { TZ: "America/Chicago" },
+	});
+	useDispose(mf);
+
+	const res = await mf.dispatchFetch("http://localhost");
+	expect(await res.json()).toEqual({ tz: "America/Chicago" });
+});
 
 test("Miniflare: exits cleanly", async ({ expect }) => {
 	const miniflarePath = require.resolve("miniflare");
@@ -3800,6 +3851,7 @@ test("Miniflare: setOptions: can restart workerd multiple times in succession", 
 
 test("Miniflare: MINIFLARE_WORKERD_CONFIG_DEBUG controls workerd config file creation", async ({
 	expect,
+	onTestFinished,
 }) => {
 	const originalEnv = process.env.MINIFLARE_WORKERD_CONFIG_DEBUG;
 	const configFilePath = "workerd-config.json";

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -2699,62 +2699,29 @@ test.sequential("Miniflare: workerd subprocess defaults to TZ=UTC to match produ
 	expect(await res.json()).toEqual({ tz: "UTC" });
 });
 
-test.sequential("Miniflare: unsafeRuntimeEnv overrides the default workerd subprocess env", async ({
-	expect,
-}) => {
-	vi.stubEnv("TZ", "UTC");
+// Skipped on Windows because workerd-on-Windows always reports `UTC` from
+// `Intl.DateTimeFormat().resolvedOptions().timeZone` regardless of the `TZ`
+// env var. A diagnostic probe on Windows CI showed that every value tried
+// (`America/Chicago`, `Asia/Tokyo`, `Europe/London`, `Etc/GMT+5`, `Etc/UTC`,
+// `UTC`, `PST8PDT`) all resolved to `UTC`. This is a workerd limitation on
+// Windows; the override mechanism itself (passing the env var through) is
+// platform-independent and exercised on macOS/Linux.
+unixSerialTest(
+	"Miniflare: unsafeRuntimeEnv overrides the default workerd subprocess env",
+	async ({ expect }) => {
+		vi.stubEnv("TZ", "UTC");
 
-	const mf = new Miniflare({
-		modules: true,
-		script: TIMEZONE_WORKER,
-		unsafeRuntimeEnv: { TZ: "America/Chicago" },
-	});
-	useDispose(mf);
-
-	const res = await mf.dispatchFetch("http://localhost");
-	expect(await res.json()).toEqual({ tz: "America/Chicago" });
-});
-
-// DIAGNOSTIC: probe how workerd resolves several TZ values across platforms.
-// This test always passes; it just emits the resolved zone for each input via
-// console.log so we can see the data in CI logs.
-test.sequential("DIAGNOSTIC: workerd TZ resolution probe", async ({
-	expect,
-}) => {
-	vi.stubEnv("TZ", "UTC");
-
-	const probes = [
-		"America/Chicago",
-		"Asia/Tokyo",
-		"Europe/London",
-		"Etc/GMT+5",
-		"Etc/UTC",
-		"UTC",
-		"PST8PDT",
-	];
-
-	const results: Record<string, string> = {};
-	for (const tz of probes) {
 		const mf = new Miniflare({
 			modules: true,
 			script: TIMEZONE_WORKER,
-			unsafeRuntimeEnv: { TZ: tz },
+			unsafeRuntimeEnv: { TZ: "America/Chicago" },
 		});
-		try {
-			const res = await mf.dispatchFetch("http://localhost");
-			const data = (await res.json()) as { tz: string };
-			results[tz] = data.tz;
-		} finally {
-			await mf.dispose();
-		}
-	}
+		useDispose(mf);
 
-	// eslint-disable-next-line no-console
-	console.log(
-		`DIAGNOSTIC TZ resolution on ${process.platform}: ${JSON.stringify(results, null, 2)}`
-	);
-	expect(results).toBeDefined();
-});
+		const res = await mf.dispatchFetch("http://localhost");
+		expect(await res.json()).toEqual({ tz: "America/Chicago" });
+	}
+);
 
 test("Miniflare: exits cleanly", async ({ expect }) => {
 	const miniflarePath = require.resolve("miniflare");


### PR DESCRIPTION
Fixes #8106.

Cloudflare's production runtime runs Workers with `TZ=UTC`, but Miniflare inherited the host machine's timezone, causing dev/prod drift in `Date` and `Intl` behaviour. Local development now matches production by default.

#### Changes

- `packages/miniflare/src/runtime/index.ts` — when spawning the `workerd` subprocess, default `TZ` to `"UTC"` and merge any caller-provided overrides last. Added a `runtimeEnv?: Record<string, string>` field to `RuntimeOptions`.
- `packages/miniflare/src/plugins/core/index.ts` — added `unsafeRuntimeEnv: z.record(z.string()).optional()` to `CoreSharedOptionsSchema` so library consumers can override the default (e.g. `{ TZ: "Europe/London" }` for testing timezone-dependent behaviour).
- `packages/miniflare/src/index.ts` — wired the option through to the runtime.
- `packages/miniflare/README.md` — documented the new `unsafeRuntimeEnv` option alongside the existing `unsafe*` shared options.

The user-facing behaviour change is that `wrangler dev` (and every other Miniflare-backed surface — `wrangler kv`/`d1`/`r2`/`check`, `vitest-pool-workers`, `vite-plugin-cloudflare`, etc.) now run with `TZ=UTC` by default, matching production. Consumers who genuinely need a different timezone can pass `unsafeRuntimeEnv` directly to `Miniflare`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/30527
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->