### PR TITLE
[wrangler] fix: throw clear error when _routes.json contains invalid JSON

### DIFF
--- a/.changeset/fix-pages-routes-json-parse-error.md
+++ b/.changeset/fix-pages-routes-json-parse-error.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: throw a clear error when _routes.json contains invalid JSON instead of silently skipping it

--- a/.changeset/fix-pages-routes-json-parse-error.md
+++ b/.changeset/fix-pages-routes-json-parse-error.md
@@ -2,4 +2,4 @@
 "wrangler": patch
 ---
 
-fix: throw a clear error when _routes.json contains invalid JSON instead of silently skipping it
+fix: throw a clear error when \_routes.json contains invalid JSON instead of silently skipping it

--- a/packages/wrangler/src/__tests__/pages/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deploy.test.ts
@@ -2931,7 +2931,6 @@ and that at least one include rule is provided.
 			expect(getProjectRequestCount).toEqual(2);
 		});
 
-
 		it("should surface a clear error when _routes.json contains invalid JSON (Functions)", async ({
 			expect,
 		}) => {
@@ -2939,26 +2938,65 @@ and that at least one include rule is provided.
 			writeFileSync("public/README.md", "This is a readme");
 			writeFileSync("public/_routes.json", `{ invalid json `);
 			mkdirSync("functions");
-			writeFileSync("functions/hello.js", `export async function onRequest() { return new Response("Hello, world!"); }`);
-			mockGetUploadTokenRequest(expect, "<<funfetti-auth-jwt>>", "some-account-id", "foo");
+			writeFileSync(
+				"functions/hello.js",
+				`export async function onRequest() { return new Response("Hello, world!"); }`
+			);
+			mockGetUploadTokenRequest(
+				expect,
+				"<<funfetti-auth-jwt>>",
+				"some-account-id",
+				"foo"
+			);
 			let getProjectRequestCount = 0;
 			msw.use(
-				http.post("*/pages/assets/check-missing", async ({ request }) => {
-					const body = (await request.json()) as { hashes: string[] };
-					expect(request.headers.get("Authorization")).toBe("Bearer <<funfetti-auth-jwt>>");
-					return HttpResponse.json({ success: true, errors: [], messages: [], result: body.hashes }, { status: 200 });
-				}, { once: true }),
-				http.post("*/pages/assets/upload", async ({ request }) => {
-					expect(request.headers.get("Authorization")).toBe("Bearer <<funfetti-auth-jwt>>");
-					return HttpResponse.json({ success: true, errors: [], messages: [], result: null }, { status: 200 });
-				}, { once: true }),
-				http.get("*/accounts/:accountId/pages/projects/foo", async ({ params }) => {
-					getProjectRequestCount++;
-					expect(params.accountId).toEqual("some-account-id");
-					return HttpResponse.json({ success: true, errors: [], messages: [], result: { deployment_configs: { production: {}, preview: {} } } }, { status: 200 });
-				})
+				http.post(
+					"*/pages/assets/check-missing",
+					async ({ request }) => {
+						const body = (await request.json()) as { hashes: string[] };
+						expect(request.headers.get("Authorization")).toBe(
+							"Bearer <<funfetti-auth-jwt>>"
+						);
+						return HttpResponse.json(
+							{ success: true, errors: [], messages: [], result: body.hashes },
+							{ status: 200 }
+						);
+					},
+					{ once: true }
+				),
+				http.post(
+					"*/pages/assets/upload",
+					async ({ request }) => {
+						expect(request.headers.get("Authorization")).toBe(
+							"Bearer <<funfetti-auth-jwt>>"
+						);
+						return HttpResponse.json(
+							{ success: true, errors: [], messages: [], result: null },
+							{ status: 200 }
+						);
+					},
+					{ once: true }
+				),
+				http.get(
+					"*/accounts/:accountId/pages/projects/foo",
+					async ({ params }) => {
+						getProjectRequestCount++;
+						expect(params.accountId).toEqual("some-account-id");
+						return HttpResponse.json(
+							{
+								success: true,
+								errors: [],
+								messages: [],
+								result: { deployment_configs: { production: {}, preview: {} } },
+							},
+							{ status: 200 }
+						);
+					}
+				)
 			);
-			await expect(runWrangler("pages deploy public --project-name=foo")).rejects.toThrow(/^Invalid _routes\.json file at .*_routes\.json: /);
+			await expect(
+				runWrangler("pages deploy public --project-name=foo")
+			).rejects.toThrow(/^Invalid _routes\.json file at .*_routes\.json: /);
 			expect(getProjectRequestCount).toEqual(2);
 		});
 
@@ -4058,33 +4096,71 @@ and that at least one include rule is provided.
 			expect(getProjectRequestCount).toEqual(2);
 		});
 
-
 		it("should surface a clear error when _routes.json contains invalid JSON (Advanced Mode)", async ({
 			expect,
 		}) => {
 			mkdirSync("public");
 			writeFileSync("public/README.md", "This is a readme");
 			writeFileSync("public/_routes.json", `{ invalid json `);
-			writeFileSync("public/_worker.js", `export default { async fetch(request, env) { const url = new URL(request.url); return url.pathname.startsWith('/api/') ? new Response('Ok') : env.ASSETS.fetch(request); } };`);
-			mockGetUploadTokenRequest(expect, "<<funfetti-auth-jwt>>", "some-account-id", "foo");
+			writeFileSync(
+				"public/_worker.js",
+				`export default { async fetch(request, env) { const url = new URL(request.url); return url.pathname.startsWith('/api/') ? new Response('Ok') : env.ASSETS.fetch(request); } };`
+			);
+			mockGetUploadTokenRequest(
+				expect,
+				"<<funfetti-auth-jwt>>",
+				"some-account-id",
+				"foo"
+			);
 			let getProjectRequestCount = 0;
 			msw.use(
-				http.post("*/pages/assets/check-missing", async ({ request }) => {
-					const body = (await request.json()) as { hashes: string[] };
-					expect(request.headers.get("Authorization")).toBe("Bearer <<funfetti-auth-jwt>>");
-					return HttpResponse.json({ success: true, errors: [], messages: [], result: body.hashes }, { status: 200 });
-				}, { once: true }),
-				http.post("*/pages/assets/upload", async ({ request }) => {
-					expect(request.headers.get("Authorization")).toBe("Bearer <<funfetti-auth-jwt>>");
-					return HttpResponse.json({ success: true, errors: [], messages: [], result: null }, { status: 200 });
-				}, { once: true }),
-				http.get("*/accounts/:accountId/pages/projects/foo", async ({ params }) => {
-					getProjectRequestCount++;
-					expect(params.accountId).toEqual("some-account-id");
-					return HttpResponse.json({ success: true, errors: [], messages: [], result: { deployment_configs: { production: {}, preview: {} } } }, { status: 200 });
-				})
+				http.post(
+					"*/pages/assets/check-missing",
+					async ({ request }) => {
+						const body = (await request.json()) as { hashes: string[] };
+						expect(request.headers.get("Authorization")).toBe(
+							"Bearer <<funfetti-auth-jwt>>"
+						);
+						return HttpResponse.json(
+							{ success: true, errors: [], messages: [], result: body.hashes },
+							{ status: 200 }
+						);
+					},
+					{ once: true }
+				),
+				http.post(
+					"*/pages/assets/upload",
+					async ({ request }) => {
+						expect(request.headers.get("Authorization")).toBe(
+							"Bearer <<funfetti-auth-jwt>>"
+						);
+						return HttpResponse.json(
+							{ success: true, errors: [], messages: [], result: null },
+							{ status: 200 }
+						);
+					},
+					{ once: true }
+				),
+				http.get(
+					"*/accounts/:accountId/pages/projects/foo",
+					async ({ params }) => {
+						getProjectRequestCount++;
+						expect(params.accountId).toEqual("some-account-id");
+						return HttpResponse.json(
+							{
+								success: true,
+								errors: [],
+								messages: [],
+								result: { deployment_configs: { production: {}, preview: {} } },
+							},
+							{ status: 200 }
+						);
+					}
+				)
 			);
-			await expect(runWrangler("pages deploy public --project-name=foo")).rejects.toThrow(/^Invalid _routes\.json file at .*_routes\.json: /);
+			await expect(
+				runWrangler("pages deploy public --project-name=foo")
+			).rejects.toThrow(/^Invalid _routes\.json file at .*_routes\.json: /);
 			expect(getProjectRequestCount).toEqual(2);
 		});
 

--- a/packages/wrangler/src/__tests__/pages/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deploy.test.ts
@@ -2958,7 +2958,7 @@ and that at least one include rule is provided.
 					return HttpResponse.json({ success: true, errors: [], messages: [], result: { deployment_configs: { production: {}, preview: {} } } }, { status: 200 });
 				})
 			);
-			await expect(runWrangler("pages deploy public --project-name=foo")).rejects.toThrow(/^Invalid _routes\\.json file at public: /);
+			await expect(runWrangler("pages deploy public --project-name=foo")).rejects.toThrow(/^Invalid _routes\.json file at .*_routes\.json: /);
 			expect(getProjectRequestCount).toEqual(2);
 		});
 
@@ -4084,7 +4084,7 @@ and that at least one include rule is provided.
 					return HttpResponse.json({ success: true, errors: [], messages: [], result: { deployment_configs: { production: {}, preview: {} } } }, { status: 200 });
 				})
 			);
-			await expect(runWrangler("pages deploy public --project-name=foo")).rejects.toThrow(/^Invalid _routes\\.json file at public: /);
+			await expect(runWrangler("pages deploy public --project-name=foo")).rejects.toThrow(/^Invalid _routes\.json file at .*_routes\.json: /);
 			expect(getProjectRequestCount).toEqual(2);
 		});
 

--- a/packages/wrangler/src/__tests__/pages/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deploy.test.ts
@@ -2931,6 +2931,37 @@ and that at least one include rule is provided.
 			expect(getProjectRequestCount).toEqual(2);
 		});
 
+
+		it("should surface a clear error when _routes.json contains invalid JSON (Functions)", async ({
+			expect,
+		}) => {
+			mkdirSync("public");
+			writeFileSync("public/README.md", "This is a readme");
+			writeFileSync("public/_routes.json", `{ invalid json `);
+			mkdirSync("functions");
+			writeFileSync("functions/hello.js", `export async function onRequest() { return new Response("Hello, world!"); }`);
+			mockGetUploadTokenRequest(expect, "<<funfetti-auth-jwt>>", "some-account-id", "foo");
+			let getProjectRequestCount = 0;
+			msw.use(
+				http.post("*/pages/assets/check-missing", async ({ request }) => {
+					const body = (await request.json()) as { hashes: string[] };
+					expect(request.headers.get("Authorization")).toBe("Bearer <<funfetti-auth-jwt>>");
+					return HttpResponse.json({ success: true, errors: [], messages: [], result: body.hashes }, { status: 200 });
+				}, { once: true }),
+				http.post("*/pages/assets/upload", async ({ request }) => {
+					expect(request.headers.get("Authorization")).toBe("Bearer <<funfetti-auth-jwt>>");
+					return HttpResponse.json({ success: true, errors: [], messages: [], result: null }, { status: 200 });
+				}, { once: true }),
+				http.get("*/accounts/:accountId/pages/projects/foo", async ({ params }) => {
+					getProjectRequestCount++;
+					expect(params.accountId).toEqual("some-account-id");
+					return HttpResponse.json({ success: true, errors: [], messages: [], result: { deployment_configs: { production: {}, preview: {} } } }, { status: 200 });
+				})
+			);
+			await expect(runWrangler("pages deploy public --project-name=foo")).rejects.toThrow(/^Invalid _routes\\.json file at public: /);
+			expect(getProjectRequestCount).toEqual(2);
+		});
+
 		it("should fail with the appropriate error message, if the deployment of the project failed", async ({
 			expect,
 		}) => {
@@ -4024,6 +4055,36 @@ Please make sure the JSON object has the following format:
 }
 and that at least one include rule is provided.
 		`);
+			expect(getProjectRequestCount).toEqual(2);
+		});
+
+
+		it("should surface a clear error when _routes.json contains invalid JSON (Advanced Mode)", async ({
+			expect,
+		}) => {
+			mkdirSync("public");
+			writeFileSync("public/README.md", "This is a readme");
+			writeFileSync("public/_routes.json", `{ invalid json `);
+			writeFileSync("public/_worker.js", `export default { async fetch(request, env) { const url = new URL(request.url); return url.pathname.startsWith('/api/') ? new Response('Ok') : env.ASSETS.fetch(request); } };`);
+			mockGetUploadTokenRequest(expect, "<<funfetti-auth-jwt>>", "some-account-id", "foo");
+			let getProjectRequestCount = 0;
+			msw.use(
+				http.post("*/pages/assets/check-missing", async ({ request }) => {
+					const body = (await request.json()) as { hashes: string[] };
+					expect(request.headers.get("Authorization")).toBe("Bearer <<funfetti-auth-jwt>>");
+					return HttpResponse.json({ success: true, errors: [], messages: [], result: body.hashes }, { status: 200 });
+				}, { once: true }),
+				http.post("*/pages/assets/upload", async ({ request }) => {
+					expect(request.headers.get("Authorization")).toBe("Bearer <<funfetti-auth-jwt>>");
+					return HttpResponse.json({ success: true, errors: [], messages: [], result: null }, { status: 200 });
+				}, { once: true }),
+				http.get("*/accounts/:accountId/pages/projects/foo", async ({ params }) => {
+					getProjectRequestCount++;
+					expect(params.accountId).toEqual("some-account-id");
+					return HttpResponse.json({ success: true, errors: [], messages: [], result: { deployment_configs: { production: {}, preview: {} } } }, { status: 200 });
+				})
+			);
+			await expect(runWrangler("pages deploy public --project-name=foo")).rejects.toThrow(/^Invalid _routes\\.json file at public: /);
 			expect(getProjectRequestCount).toEqual(2);
 		});
 

--- a/packages/wrangler/src/api/pages/deploy.ts
+++ b/packages/wrangler/src/api/pages/deploy.ts
@@ -403,7 +403,7 @@ export async function deploy({
 				if (err instanceof SyntaxError) {
 					throw new FatalError(
 						`Invalid _routes.json file at ${directory}: ${err.message}`,
-						1
+						{ telemetryMessage: "pages deploy routes json parse error" }
 					);
 				}
 			}
@@ -444,9 +444,10 @@ export async function deploy({
 				if (err instanceof SyntaxError) {
 					throw new FatalError(
 						`Invalid _routes.json file at ${directory}: ${err.message}`,
-						1
+						{ telemetryMessage: "pages deploy routes json parse error" }
 					);
 				}
+			}
 		} else if (routesOutputPath) {
 			// no custom _routes.json file found, so fallback to the generated one
 			try {

--- a/packages/wrangler/src/api/pages/deploy.ts
+++ b/packages/wrangler/src/api/pages/deploy.ts
@@ -6,6 +6,8 @@ import { cwd } from "node:process";
 import {
 	COMPLIANCE_REGION_CONFIG_PUBLIC,
 	FatalError,
+	ParseError,
+	parseJSON,
 } from "@cloudflare/workers-utils";
 import { FormData } from "undici";
 import { fetchResult } from "../../cfetch";
@@ -388,8 +390,9 @@ export async function deploy({
 		if (_routesCustom) {
 			// user provided a custom _routes.json file
 			try {
-				const routesCustomJSON = JSON.parse(_routesCustom);
-				validateRoutes(routesCustomJSON, join(directory, "_routes.json"));
+				const routesPath = join(directory, "_routes.json");
+				const routesCustomJSON = parseJSON(_routesCustom, routesPath);
+				validateRoutes(routesCustomJSON, routesPath);
 
 				formData.append(
 					"_routes.json",
@@ -400,12 +403,13 @@ export async function deploy({
 				if (err instanceof FatalError) {
 					throw err;
 				}
-				if (err instanceof SyntaxError) {
+				if (err instanceof ParseError) {
 					throw new FatalError(
-						`Invalid _routes.json file at ${directory}: ${err.message}`,
+						`Invalid _routes.json file at ${join(directory, "_routes.json")}: ${err.text}`,
 						{ telemetryMessage: "pages deploy routes json parse error" }
 					);
 				}
+				throw err;
 			}
 		}
 	}
@@ -418,7 +422,6 @@ export async function deploy({
 		const workerBundleContents = await createUploadWorkerBundleContents(
 			workerBundle as BundleResult,
 			config
-
 		);
 		formData.append(
 			"_worker.bundle",
@@ -429,8 +432,9 @@ export async function deploy({
 		if (_routesCustom) {
 			// user provided a custom _routes.json file
 			try {
-				const routesCustomJSON = JSON.parse(_routesCustom);
-				validateRoutes(routesCustomJSON, join(directory, "_routes.json"));
+				const routesPath = join(directory, "_routes.json");
+				const routesCustomJSON = parseJSON(_routesCustom, routesPath);
+				validateRoutes(routesCustomJSON, routesPath);
 
 				formData.append(
 					"_routes.json",
@@ -441,12 +445,13 @@ export async function deploy({
 				if (err instanceof FatalError) {
 					throw err;
 				}
-				if (err instanceof SyntaxError) {
+				if (err instanceof ParseError) {
 					throw new FatalError(
-						`Invalid _routes.json file at ${directory}: ${err.message}`,
+						`Invalid _routes.json file at ${join(directory, "_routes.json")}: ${err.text}`,
 						{ telemetryMessage: "pages deploy routes json parse error" }
 					);
 				}
+				throw err;
 			}
 		} else if (routesOutputPath) {
 			// no custom _routes.json file found, so fallback to the generated one

--- a/packages/wrangler/src/api/pages/deploy.ts
+++ b/packages/wrangler/src/api/pages/deploy.ts
@@ -410,7 +410,7 @@ export async function deploy({
 				if (err instanceof ParseError) {
 					throw new FatalError(
 						`Invalid _routes.json file at ${join(directory, "_routes.json")}: ${err.text}`,
-						{ telemetryMessage: "pages deploy routes json parse error" }
+						{ code: 1, telemetryMessage: "pages deploy invalid routes json" }
 					);
 				}
 				throw err;
@@ -455,7 +455,7 @@ export async function deploy({
 				if (err instanceof ParseError) {
 					throw new FatalError(
 						`Invalid _routes.json file at ${join(directory, "_routes.json")}: ${err.text}`,
-						{ telemetryMessage: "pages deploy routes json parse error" }
+						{ code: 1, telemetryMessage: "pages deploy invalid routes json" }
 					);
 				}
 				throw err;

--- a/packages/wrangler/src/api/pages/deploy.ts
+++ b/packages/wrangler/src/api/pages/deploy.ts
@@ -400,6 +400,12 @@ export async function deploy({
 				if (err instanceof FatalError) {
 					throw err;
 				}
+				if (err instanceof SyntaxError) {
+					throw new FatalError(
+						`Invalid _routes.json file at ${directory}: ${err.message}`,
+						1
+					);
+				}
 			}
 		}
 	}
@@ -412,8 +418,8 @@ export async function deploy({
 		const workerBundleContents = await createUploadWorkerBundleContents(
 			workerBundle as BundleResult,
 			config
-		);
 
+		);
 		formData.append(
 			"_worker.bundle",
 			new File([workerBundleContents], "_worker.bundle")
@@ -435,7 +441,12 @@ export async function deploy({
 				if (err instanceof FatalError) {
 					throw err;
 				}
-			}
+				if (err instanceof SyntaxError) {
+					throw new FatalError(
+						`Invalid _routes.json file at ${directory}: ${err.message}`,
+						1
+					);
+				}
 		} else if (routesOutputPath) {
 			// no custom _routes.json file found, so fallback to the generated one
 			try {

--- a/packages/wrangler/src/api/pages/deploy.ts
+++ b/packages/wrangler/src/api/pages/deploy.ts
@@ -35,6 +35,7 @@ import { getPagesTmpDir, truncateUtf8Bytes } from "../../pages/utils";
 import { validate } from "../../pages/validate";
 import { createUploadWorkerBundleContents } from "./create-worker-bundle-contents";
 import type { BundleResult } from "../../deployment-bundle/bundle";
+import type { RoutesJSONSpec } from "../../pages/functions/routes-transformation";
 import type { Deployment, Project } from "@cloudflare/types";
 import type { Config } from "@cloudflare/workers-utils";
 
@@ -391,7 +392,10 @@ export async function deploy({
 			// user provided a custom _routes.json file
 			try {
 				const routesPath = join(directory, "_routes.json");
-				const routesCustomJSON = parseJSON(_routesCustom, routesPath);
+				const routesCustomJSON = parseJSON(
+					_routesCustom,
+					routesPath
+				) as RoutesJSONSpec;
 				validateRoutes(routesCustomJSON, routesPath);
 
 				formData.append(
@@ -433,7 +437,10 @@ export async function deploy({
 			// user provided a custom _routes.json file
 			try {
 				const routesPath = join(directory, "_routes.json");
-				const routesCustomJSON = parseJSON(_routesCustom, routesPath);
+				const routesCustomJSON = parseJSON(
+					_routesCustom,
+					routesPath
+				) as RoutesJSONSpec;
 				validateRoutes(routesCustomJSON, routesPath);
 
 				formData.append(


### PR DESCRIPTION
Fixes #5308.

Previously, invalid JSON in `_routes.json` (e.g. trailing commas) was silently caught and ignored, causing the routes file to be skipped without any warning or error. The deployment would succeed but `_routes.json` wouldn't be uploaded.

Now a `SyntaxError` from `JSON.parse()` is re-thrown as a `FatalError` with a clear message pointing to the file location. Uses `parseJSON` from `@cloudflare/workers-utils` (which supports JSONC/comments) instead of raw `JSON.parse`.

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: this is a bug fix for silent error swallowing; no new API or configuration surface is introduced