### PR TITLE
fix(wrangler): propagate unsafe.bindings and cross_account_grant to worker previews

### DIFF
--- a/.changeset/small-rocks-live.md
+++ b/.changeset/small-rocks-live.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Propagate `unsafe.bindings` and service binding `cross_account_grant` to worker previews
+
+Worker previews now propagate `unsafe.bindings` declared on the `previews` config block to the deployment metadata, mirroring the deploy-time behavior. Without this, internal binding shapes that wrangler doesn't yet model (notably service bindings carrying `cross_account_grant`) were silently dropped on previews while working fine on regular deploys. The same change wires through `cross_account_grant` on typed `services` bindings.

--- a/packages/wrangler/src/__tests__/preview.test.ts
+++ b/packages/wrangler/src/__tests__/preview.test.ts
@@ -210,6 +210,58 @@ describe("wrangler preview", () => {
 				MY_FLAGS: { type: "flagship", app_id: "flagship-app-id" },
 			});
 		});
+
+		test("should pass cross_account_grant on service bindings", ({
+			expect,
+		}) => {
+			const config = configWithPreviews({
+				services: [
+					{
+						binding: "API",
+						service: "api-worker",
+						// cross_account_grant is internal/non-public-facing on
+						// the typed schema; mirror how callers set it at
+						// runtime (deploy path supports the same field).
+						cross_account_grant: "grant-target",
+					} as {
+						binding: string;
+						service: string;
+						cross_account_grant: string;
+					},
+				],
+			});
+			const bindings = extractConfigBindings(config);
+			expect(bindings).toMatchObject({
+				API: {
+					type: "service",
+					service: "api-worker",
+					cross_account_grant: "grant-target",
+				},
+			});
+		});
+
+		test("should fold unsafe.bindings into the previews env", ({ expect }) => {
+			const config = configWithPreviews({
+				unsafe: {
+					bindings: [
+						{
+							type: "service",
+							name: "VPC_BRIDGE",
+							service: "vpc-bridge-worker",
+							cross_account_grant: "grant-target",
+						},
+					],
+				},
+			});
+			const bindings = extractConfigBindings(config);
+			expect(bindings).toMatchObject({
+				VPC_BRIDGE: {
+					type: "service",
+					service: "vpc-bridge-worker",
+					cross_account_grant: "grant-target",
+				},
+			});
+		});
 	});
 
 	describe("preview command", () => {

--- a/packages/wrangler/src/preview/shared.ts
+++ b/packages/wrangler/src/preview/shared.ts
@@ -160,10 +160,17 @@ export function extractConfigBindings(config: Config): EnvBindings {
 	}
 
 	for (const service of previews?.services ?? []) {
+		// `cross_account_grant` is internal/non-public-facing, so we access it
+		// through the runtime shape instead of the public type.
+		const crossAccountGrant = (service as { cross_account_grant?: string })
+			.cross_account_grant;
 		env[service.binding] = {
 			type: "service",
 			service: service.service,
 			entrypoint: service.entrypoint,
+			...(crossAccountGrant !== undefined && {
+				cross_account_grant: crossAccountGrant,
+			}),
 		};
 	}
 
@@ -315,6 +322,11 @@ export function extractConfigBindings(config: Config): EnvBindings {
 
 	if (config.assets?.binding) {
 		env[config.assets.binding] = { type: "assets" };
+	}
+
+	for (const binding of previews?.unsafe?.bindings ?? []) {
+		const { name, type, ...rest } = binding;
+		env[name] = { type, ...rest } as Binding;
 	}
 
 	return env;


### PR DESCRIPTION
`wrangler preview` now folds `previews.unsafe.bindings` into the deployment's `env` map, mirroring the deploy-time behavior. Without this, internal binding shapes that wrangler doesn't yet model (notably service bindings carrying `cross_account_grant`) were silently dropped on previews while working fine on regular deploys. The same change wires through `cross_account_grant` on typed `services` bindings so callers don't have to drop into `unsafe.bindings` to get it.

This was originally part of #13712 and has been split out for easier review.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: `unsafe.bindings` and `cross_account_grant` are internal/non-public-facing.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->