### PR TITLE
[wrangler] fix: normalize legacy instance type aliases to prevent phantom EDIT diffs on deploy

### DIFF
--- a/.changeset/fix-containers-instance-type-phantom-diff.md
+++ b/.changeset/fix-containers-instance-type-phantom-diff.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: normalize legacy instance type aliases (standard/dev) to canonical names (standard-1/lite) to prevent phantom EDIT diffs on every deploy

--- a/.changeset/fix-containers-instance-type-phantom-diff.md
+++ b/.changeset/fix-containers-instance-type-phantom-diff.md
@@ -2,4 +2,4 @@
 "wrangler": patch
 ---
 
-fix: normalize legacy instance type aliases (standard/dev) to canonical names (standard-1/lite) to prevent phantom EDIT diffs on every deploy
+Normalize legacy instance type aliases (`standard` → `standard-1`, `dev` → `lite`) to prevent phantom EDIT diffs on every deploy

--- a/packages/wrangler/src/__tests__/cloudchamber/instance-type.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/instance-type.test.ts
@@ -1,0 +1,71 @@
+import { describe, it } from "vitest";
+import { inferInstanceType } from "../../cloudchamber/instance-type/instance-type";
+
+describe("inferInstanceType", () => {
+	it("returns 'lite' for lite specs (0.0625 vcpu, 256 MiB, 2 GB disk)", ({
+		expect,
+	}) => {
+		const result = inferInstanceType({
+			image: "cloudflare/hello-world:1.0",
+			vcpu: 0.0625,
+			memory_mib: 256,
+			disk: { size_mb: 2000 },
+		});
+		expect(result).toBe("lite");
+	});
+
+	it("normalizes legacy 'standard' alias to 'standard-1' (prevents phantom EDIT diffs)", ({
+		expect,
+	}) => {
+		// 'standard' and 'standard-1' share identical specs; Object.entries yields
+		// 'standard' first, so the API returning 'standard' specs must map to 'standard-1'.
+		const result = inferInstanceType({
+			image: "cloudflare/hello-world:1.0",
+			vcpu: 0.5,
+			memory_mib: 4096,
+			disk: { size_mb: 8000 },
+		});
+		expect(result).toBe("standard-1");
+	});
+
+	it("returns 'basic' for basic specs", ({ expect }) => {
+		const result = inferInstanceType({
+			image: "cloudflare/hello-world:1.0",
+			vcpu: 0.25,
+			memory_mib: 1024,
+			disk: { size_mb: 4000 },
+		});
+		expect(result).toBe("basic");
+	});
+
+	it("returns 'standard-2' for standard-2 specs", ({ expect }) => {
+		const result = inferInstanceType({
+			image: "cloudflare/hello-world:1.0",
+			vcpu: 1,
+			memory_mib: 6144,
+			disk: { size_mb: 12000 },
+		});
+		expect(result).toBe("standard-2");
+	});
+
+	it("returns undefined when config does not match any known instance type", ({
+		expect,
+	}) => {
+		const result = inferInstanceType({
+			image: "cloudflare/hello-world:1.0",
+			vcpu: 99,
+			memory_mib: 99999,
+			disk: { size_mb: 99999 },
+		});
+		expect(result).toBeUndefined();
+	});
+
+	it("returns undefined when disk is absent", ({ expect }) => {
+		const result = inferInstanceType({
+			image: "cloudflare/hello-world:1.0",
+			vcpu: 0.0625,
+			memory_mib: 256,
+		});
+		expect(result).toBeUndefined();
+	});
+});

--- a/packages/wrangler/src/cloudchamber/instance-type/instance-type.ts
+++ b/packages/wrangler/src/cloudchamber/instance-type/instance-type.ts
@@ -144,6 +144,15 @@ export function getInstanceTypeUsage(instanceType: InstanceType): {
 	return instanceTypes[instanceType];
 }
 
+// Legacy alias → canonical name mapping.
+// The API may return the legacy alias (e.g. "standard") for an instance
+// type configured as the canonical name ("standard-1"). Normalizing ensures
+// the deploy diff doesn't show a phantom EDIT for instance_type.
+const LEGACY_TO_CANONICAL: Record<string, string> = {
+	dev: "lite",
+	standard: "standard-1",
+};
+
 // infers the instance type from a given configuration
 export function inferInstanceType(
 	config: UserDeploymentConfiguration
@@ -154,7 +163,8 @@ export function inferInstanceType(
 			config.memory_mib === configuration.memory_mib &&
 			config.disk?.size_mb === configuration.disk_mb
 		) {
-			return instanceType as InstanceType;
+			const canonical = LEGACY_TO_CANONICAL[instanceType];
+			return (canonical ?? instanceType) as InstanceType;
 		}
 	}
 }

--- a/packages/wrangler/src/cloudchamber/instance-type/instance-type.ts
+++ b/packages/wrangler/src/cloudchamber/instance-type/instance-type.ts
@@ -148,7 +148,7 @@ export function getInstanceTypeUsage(instanceType: InstanceType): {
 // The API may return the legacy alias (e.g. "standard") for an instance
 // type configured as the canonical name ("standard-1"). Normalizing ensures
 // the deploy diff doesn't show a phantom EDIT for instance_type.
-const LEGACY_TO_CANONICAL: Record<string, string> = {
+const LEGACY_TO_CANONICAL: Record<"dev" | "standard", InstanceType> = {
 	dev: "lite",
 	standard: "standard-1",
 };
@@ -163,7 +163,12 @@ export function inferInstanceType(
 			config.memory_mib === configuration.memory_mib &&
 			config.disk?.size_mb === configuration.disk_mb
 		) {
-			const canonical = LEGACY_TO_CANONICAL[instanceType];
+			const canonical =
+				instanceType in LEGACY_TO_CANONICAL
+					? LEGACY_TO_CANONICAL[
+							instanceType as keyof typeof LEGACY_TO_CANONICAL
+						]
+					: undefined;
 			return (canonical ?? instanceType) as InstanceType;
 		}
 	}

--- a/packages/wrangler/src/cloudchamber/instance-type/instance-type.ts
+++ b/packages/wrangler/src/cloudchamber/instance-type/instance-type.ts
@@ -1,6 +1,6 @@
 import { inputPrompt } from "@cloudflare/cli-shared-helpers/interactive";
-import { UserError } from "@cloudflare/workers-utils";
 import { InstanceType } from "@cloudflare/containers-shared";
+import { UserError } from "@cloudflare/workers-utils";
 import type {
 	CreateApplicationRequest,
 	UserDeploymentConfiguration,

--- a/packages/wrangler/src/cloudchamber/instance-type/instance-type.ts
+++ b/packages/wrangler/src/cloudchamber/instance-type/instance-type.ts
@@ -1,8 +1,8 @@
 import { inputPrompt } from "@cloudflare/cli-shared-helpers/interactive";
 import { UserError } from "@cloudflare/workers-utils";
+import { InstanceType } from "@cloudflare/containers-shared";
 import type {
 	CreateApplicationRequest,
-	InstanceType,
 	UserDeploymentConfiguration,
 } from "@cloudflare/containers-shared";
 import type {
@@ -149,8 +149,8 @@ export function getInstanceTypeUsage(instanceType: InstanceType): {
 // type configured as the canonical name ("standard-1"). Normalizing ensures
 // the deploy diff doesn't show a phantom EDIT for instance_type.
 const LEGACY_TO_CANONICAL: Record<"dev" | "standard", InstanceType> = {
-	dev: "lite",
-	standard: "standard-1",
+	dev: InstanceType.LITE,
+	standard: InstanceType.STANDARD_1,
 };
 
 // infers the instance type from a given configuration


### PR DESCRIPTION
Fixes #13458.

Every `wrangler deploy` for a Worker with containers config and `instance_type: "standard-1"` showed a phantom EDIT diff with `- instance_type = "standard"` / `+ instance_type = "standard-1"`. This happened because:

- The API returns the legacy alias (`standard`) when reading stored configuration
- `inferInstanceType()` iterates the `instanceTypes` map in insertion order, and `standard` appeared before `standard-1`
- The first match was always the legacy alias, never matching the user's canonical config

**Fix:** Added a `LEGACY_TO_CANONICAL` mapping (`{ standard: InstanceType.STANDARD_1, dev: InstanceType.LITE }`) so `inferInstanceType` always returns the canonical name, aligning the API response with the user's config.

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: this is an internal bug fix — the user-visible behavior is that phantom EDIT diffs no longer appear; no API or config surface changed.