### PR TITLE
Enable require-description-when-disabling lint rule on miniflare

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -203,7 +203,6 @@
 		{
 			"files": [
 				"packages/local-explorer-ui/**",
-				"packages/miniflare/**",
 				"packages/quick-edit-extension/**",
 				"packages/vitest-pool-workers/**",
 				"packages/workers-editor-shared/**",

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -975,7 +975,7 @@ export class Miniflare {
 
 	// Store `#init()` `Promise`, so we can propagate initialisation errors in
 	// `ready`. We would have no way of catching these otherwise.
-	// eslint-disable-next-line no-unused-private-class-members — oxlint is wrong here, this variable _is_ used
+	// eslint-disable-next-line no-unused-private-class-members -- oxlint is wrong here, this variable _is_ used
 	readonly #initPromise: Promise<void>;
 
 	// Aborted when dispose() is called
@@ -1532,9 +1532,9 @@ export class Miniflare {
 					request
 				);
 			} else if (url.pathname === "/core/log") {
-				// Safety of `!`: `parseInt(null)` is `NaN`
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				const level = parseInt(request.headers.get(SharedHeaders.LOG_LEVEL)!);
+				const level = parseInt(
+					request.headers.get(SharedHeaders.LOG_LEVEL) ?? "NaN"
+				);
 				assert(
 					LogLevel.NONE <= level && level <= LogLevel.VERBOSE,
 					`Expected ${SharedHeaders.LOG_LEVEL} header to be log level, got ${level}`

--- a/packages/miniflare/src/plugins/core/errors/callsite.ts
+++ b/packages/miniflare/src/plugins/core/errors/callsite.ts
@@ -120,8 +120,7 @@ export class CallSite implements NodeJS.CallSite {
 	getTypeName(): string | null {
 		return this.opts.typeName;
 	}
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-	getFunction(): Function | undefined {
+	getFunction(): ((...args: unknown[]) => unknown) | undefined {
 		return undefined;
 	}
 	getFunctionName(): string | null {

--- a/packages/miniflare/src/plugins/core/errors/index.ts
+++ b/packages/miniflare/src/plugins/core/errors/index.ts
@@ -319,7 +319,7 @@ export async function handlePrettyErrorRequest(
 	}
 
 	// Lazily import `youch` when required
-	// eslint-disable-next-line typescript/consistent-type-imports, @typescript-eslint/no-require-imports
+	// eslint-disable-next-line typescript/consistent-type-imports, @typescript-eslint/no-require-imports -- lazy require to avoid loading youch until an error page is needed
 	const { Youch }: typeof import("youch") = require("youch");
 	const youch = new Youch();
 

--- a/packages/miniflare/src/plugins/core/errors/sourcemap.ts
+++ b/packages/miniflare/src/plugins/core/errors/sourcemap.ts
@@ -12,7 +12,7 @@ import type { Options } from "@cspotcode/source-map-support";
 //
 // ...load a fresh copy, by resetting then restoring the `require` cache, and
 // overriding `Symbol.for()` to return a unique symbol.
-// eslint-disable-next-line typescript/consistent-type-imports
+// eslint-disable-next-line typescript/consistent-type-imports -- dynamic import type used for return type annotation
 export function getFreshSourceMapSupport(): typeof import("@cspotcode/source-map-support") {
 	const resolvedSupportPath = require.resolve("@cspotcode/source-map-support");
 
@@ -30,7 +30,7 @@ export function getFreshSourceMapSupport(): typeof import("@cspotcode/source-map
 			return Symbol(key);
 		};
 		delete require.cache[resolvedSupportPath];
-		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		// eslint-disable-next-line @typescript-eslint/no-require-imports -- require needed to bypass module cache for fresh copy
 		return require(resolvedSupportPath);
 	} finally {
 		Symbol.for = originalSymbolFor;

--- a/packages/miniflare/src/plugins/core/proxy/client.ts
+++ b/packages/miniflare/src/plugins/core/proxy/client.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-function-type */
+/* eslint-disable @typescript-eslint/no-unsafe-function-type -- Proxy client uses Function type for dynamic RPC method proxying */
 import assert from "node:assert";
 import crypto from "node:crypto";
 import { ReadableStream, TransformStream } from "node:stream/web";

--- a/packages/miniflare/src/runtime/index.ts
+++ b/packages/miniflare/src/runtime/index.ts
@@ -93,9 +93,9 @@ function pipeOutput(stdout: Readable, stderr: Readable) {
 	// https://github.com/vadimdemedes/ink/blob/5d24ed8ada593a6c36ea5416f452158461e33ba5/readme.md#patchconsole
 	// Writing directly to `process.stdout/stderr` would result in graphical
 	// glitches.
-	// eslint-disable-next-line no-console
+	// eslint-disable-next-line no-console -- Intentional console.log to forward workerd stdout through Ink-patched console
 	rl.createInterface(stdout).on("line", (data) => console.log(data));
-	// eslint-disable-next-line no-console
+	// eslint-disable-next-line no-console -- Intentional console.error to forward workerd stderr through Ink-patched console
 	rl.createInterface(stderr).on("line", (data) => console.error(red(data)));
 	// stdout.pipe(process.stdout);
 	// stderr.pipe(process.stderr);

--- a/packages/miniflare/src/shared/log.ts
+++ b/packages/miniflare/src/shared/log.ts
@@ -128,7 +128,7 @@ export class Log {
 
 	protected log(message: string): void {
 		Log.#beforeLogHook?.();
-		// eslint-disable-next-line no-console
+		// eslint-disable-next-line no-console -- the logger itself needs to use console.log under the hood
 		console.log(message);
 		Log.#afterLogHook?.();
 	}

--- a/packages/miniflare/src/workers/cache/cache.worker.ts
+++ b/packages/miniflare/src/workers/cache/cache.worker.ts
@@ -357,9 +357,7 @@ export class CacheObject extends MiniflareDurableObject {
 
 		// If we know the size, avoid passing the body through a transform stream to
 		// count it (trusting `workerd` to send correct value here).
-		// Safety of `!`: `parseInt(null)` is `NaN`
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		const contentLength = parseInt(res.headers.get("Content-Length")!);
+		const contentLength = parseInt(res.headers.get("Content-Length") ?? "NaN");
 		let sizePromise: Promise<number>;
 		if (Number.isNaN(contentLength)) {
 			const stream = new SizingStream();

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -282,9 +282,7 @@ function maybeInjectLiveReload(
 	}
 
 	const headers = new Headers(response.headers);
-	// Safety of `!`: `parseInt(null)` is `NaN`
-	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	const contentLength = parseInt(headers.get("content-length")!);
+	const contentLength = parseInt(headers.get("content-length") ?? "NaN");
 	if (!isNaN(contentLength)) {
 		headers.set(
 			"content-length",

--- a/packages/miniflare/src/workers/d1/dumpSql.ts
+++ b/packages/miniflare/src/workers/d1/dumpSql.ts
@@ -65,7 +65,7 @@ export function* dumpSql(
 		}
 
 		if (noData) continue;
-		// eslint-disable-next-line workers-sdk/no-unsafe-command-execution
+		// eslint-disable-next-line workers-sdk/no-unsafe-command-execution -- input is escaped via escapeId() so this PRAGMA call is safe
 		const columns_cursor = db.exec(`PRAGMA table_info=${escapeId(table)}`);
 
 		const columns = Array.from(columns_cursor) as {

--- a/packages/miniflare/src/workers/kv/namespace.worker.ts
+++ b/packages/miniflare/src/workers/kv/namespace.worker.ts
@@ -216,9 +216,7 @@ export class KVNamespaceObject extends MiniflareDurableObject {
 		// through a transform stream to count it (trusting `workerd` to send
 		// correct value here).
 		let value = req.body;
-		// Safety of `!`: `parseInt(null)` is `NaN`
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		const contentLength = parseInt(req.headers.get("Content-Length")!);
+		const contentLength = parseInt(req.headers.get("Content-Length") ?? "NaN");
 		let valueLengthHint: number | undefined;
 		if (!Number.isNaN(contentLength)) valueLengthHint = contentLength;
 		else if (value === null) valueLengthHint = 0;

--- a/packages/miniflare/src/workers/kv/sites.worker.ts
+++ b/packages/miniflare/src/workers/kv/sites.worker.ts
@@ -69,7 +69,10 @@ async function* walkDirectory(
 }
 
 const encoder = new TextEncoder();
-function arrayCompare(a: Uint8Array, b: Uint8Array): number {
+function arrayCompare(
+	a: Uint8Array = new Uint8Array(),
+	b: Uint8Array = new Uint8Array()
+): number {
 	const minLength = Math.min(a.length, b.length);
 	for (let i = 0; i < minLength; i++) {
 		const aElement = a[i];
@@ -104,9 +107,7 @@ async function handleListRequest(
 		if (prefix !== undefined && !name.startsWith(prefix)) continue;
 		keys.push({ name, encodedName: encoder.encode(name) });
 	}
-	// Safety of `!`: all objects we just pushed to `keys` define `encodedName`
-	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	keys.sort((a, b) => arrayCompare(a.encodedName!, b.encodedName!));
+	keys.sort((a, b) => arrayCompare(a.encodedName, b.encodedName));
 	// Remove `encodedName`s, so they don't get returned
 	for (const key of keys) delete key.encodedName;
 

--- a/packages/miniflare/src/workers/r2/bucket.worker.ts
+++ b/packages/miniflare/src/workers/r2/bucket.worker.ts
@@ -145,9 +145,9 @@ function rangeOverlaps(a: InclusiveRange, b: InclusiveRange): boolean {
 }
 
 async function decodeMetadata(req: Request<unknown, unknown>) {
-	// Safety of `!`: `parseInt(null)` is `NaN`
-	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	const metadataSize = parseInt(req.headers.get(R2Headers.METADATA_SIZE)!);
+	const metadataSize = parseInt(
+		req.headers.get(R2Headers.METADATA_SIZE) ?? "NaN"
+	);
 	if (Number.isNaN(metadataSize)) throw new InvalidMetadata();
 
 	assert(req.body !== null);
@@ -1039,9 +1039,9 @@ export class R2BucketObject extends MiniflareDurableObject {
 			);
 			return new Response();
 		} else if (metadata.method === "put") {
-			// Safety of `!`: `parseInt(null)` is `NaN`
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			const contentLength = parseInt(req.headers.get("Content-Length")!);
+			const contentLength = parseInt(
+				req.headers.get("Content-Length") ?? "NaN"
+			);
 			// `workerd` requires a known value size for R2 put requests:
 			// - https://github.com/cloudflare/workerd/blob/e3479895a2ace28e4fd5f1399cea4c92291966ab/src/workerd/api/r2-rpc.c%2B%2B#L154-L156
 			// - https://github.com/cloudflare/workerd/blob/e3479895a2ace28e4fd5f1399cea4c92291966ab/src/workerd/api/r2-rpc.c%2B%2B#L188-L189
@@ -1061,9 +1061,9 @@ export class R2BucketObject extends MiniflareDurableObject {
 			);
 			return encodeJSONResult(result);
 		} else if (metadata.method === "uploadPart") {
-			// Safety of `!`: `parseInt(null)` is `NaN`
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			const contentLength = parseInt(req.headers.get("Content-Length")!);
+			const contentLength = parseInt(
+				req.headers.get("Content-Length") ?? "NaN"
+			);
 			// `workerd` requires a known value size for R2 put requests as above
 			assert(!isNaN(contentLength));
 			const valueSize = contentLength - metadataSize;

--- a/packages/miniflare/src/workers/r2/schemas.worker.ts
+++ b/packages/miniflare/src/workers/r2/schemas.worker.ts
@@ -316,7 +316,7 @@ export interface R2UploadPartResponse {
 
 export type R2CompleteMultipartUploadResponse = R2PutResponse;
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- empty interface is intentional; represents an R2 response with no body fields
 export interface R2AbortMultipartUploadResponse {}
 
 export interface R2ListResponse {
@@ -326,5 +326,5 @@ export interface R2ListResponse {
 	delimitedPrefixes: string[];
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- Empty interface is intentional; represents an R2 response with no body fields
 export interface R2DeleteResponse {}

--- a/packages/miniflare/src/workers/shared/blob.worker.ts
+++ b/packages/miniflare/src/workers/shared/blob.worker.ts
@@ -49,9 +49,7 @@ async function fetchSingleRange(
 	if (range !== undefined && res.status !== 206) {
 		// If we specified a range, but received full content, make sure the range
 		// covered the full content
-		// Safety of `!`: `parseInt(null)` is `NaN`
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		const contentLength = parseInt(res.headers.get("Content-Length")!);
+		const contentLength = parseInt(res.headers.get("Content-Length") ?? "NaN");
 		assert(!Number.isNaN(contentLength));
 		assertFullRangeRequest(range, contentLength);
 	}
@@ -120,9 +118,7 @@ async function fetchMultipleRanges(
 	if (res.status === 404) return null;
 	assert(res.ok);
 
-	// Safety of `!`: `parseInt(null)` is `NaN`
-	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	const contentLength = parseInt(res.headers.get("Content-Length")!);
+	const contentLength = parseInt(res.headers.get("Content-Length") ?? "NaN");
 	assert(!Number.isNaN(contentLength));
 
 	// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests#multipart_ranges

--- a/packages/miniflare/src/workers/shared/sync.ts
+++ b/packages/miniflare/src/workers/shared/sync.ts
@@ -14,19 +14,20 @@ export class DeferredPromise<T> extends Promise<T> {
 			reject: (reason?: any) => void
 		) => void = () => {}
 	) {
-		let promiseResolve: DeferredPromiseResolve<T>;
-		let promiseReject: DeferredPromiseReject;
+		let promiseResolve: DeferredPromiseResolve<T> | undefined = undefined;
+		let promiseReject: DeferredPromiseReject | undefined = undefined;
 		super((resolve, reject) => {
 			promiseResolve = resolve;
 			promiseReject = reject;
 			return executor(resolve, reject);
 		});
-		// Cannot access `this` until after `super`
-		// Safety of `!`: callback passed to `super()` is executed immediately
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		this.resolve = promiseResolve!;
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		this.reject = promiseReject!;
+		// Note: `promiseResolve` and `promiseReject` should be defined
+		//        since `super()` is executed immediately
+		assert(promiseResolve);
+		assert(promiseReject);
+		// Note: Cannot access `this` until after `super`
+		this.resolve = promiseResolve;
+		this.reject = promiseReject;
 	}
 }
 

--- a/packages/miniflare/types/webassembly.d.ts
+++ b/packages/miniflare/types/webassembly.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-function-type */
+/* eslint-disable @typescript-eslint/no-unsafe-function-type -- WebAssembly API type declarations use Function as a generic callable type */
 // Types adapted from https://github.com/microsoft/TypeScript/blob/main/lib/lib.webworker.d.ts
 //
 // Copyright (c) Microsoft Corporation. All rights reserved.


### PR DESCRIPTION
This PR enables the `require-description-when-disabling` lint rule on the miniflare package.

This is a followup PR for https://github.com/cloudflare/workers-sdk/pull/13698, https://github.com/cloudflare/workers-sdk/pull/13703, https://github.com/cloudflare/workers-sdk/pull/13710 and https://github.com/cloudflare/workers-sdk/pull/13741.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: internal linting change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal linting change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->