### PR TITLE
Enable require-description-when-disabling lint rule on shared packages

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -207,7 +207,6 @@
 				"packages/quick-edit-extension/**",
 				"packages/vitest-pool-workers/**",
 				"packages/workers-editor-shared/**",
-				"packages/workers-shared/**",
 				"packages/wrangler/**",
 			],
 			"rules": {

--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -206,7 +206,6 @@
 				"packages/miniflare/**",
 				"packages/quick-edit-extension/**",
 				"packages/vitest-pool-workers/**",
-				"packages/workers-editor-shared/**",
 				"packages/wrangler/**",
 			],
 			"rules": {

--- a/packages/workers-editor-shared/lib/ipc.ts
+++ b/packages/workers-editor-shared/lib/ipc.ts
@@ -37,7 +37,7 @@ interface SetEntryPoint {
 }
 
 // Sent on load to request sources for inflating a stack trace
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- interface used as a branded message type in the EditorMessage generic
 interface RequestSources {}
 
 export type WorkerLoadedMessage = EditorMessage<"WorkerLoaded", WorkerLoaded>;

--- a/packages/workers-editor-shared/lib/useRefreshableIframe.tsx
+++ b/packages/workers-editor-shared/lib/useRefreshableIframe.tsx
@@ -42,7 +42,7 @@ export function useRefreshableIframe(
 				second.removeEventListener("load", onLoadEvent);
 			};
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- refs are stable across renders and should not trigger re-subscription
 	}, [onLoad]);
 
 	function listen() {
@@ -72,7 +72,7 @@ export function useRefreshableIframe(
 		if (src) {
 			setUrl(src);
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- setUrl depends on mutable state that would cause infinite loops if included
 	}, [src]);
 	const isLoading = isLoadingContent;
 	return {

--- a/packages/workers-shared/asset-worker/src/assets-manifest.ts
+++ b/packages/workers-shared/asset-worker/src/assets-manifest.ts
@@ -96,16 +96,16 @@ function comparePathHashWithEntry(
 ) {
 	let pathHashOffset = HEADER_SIZE + entryIndex * ENTRY_SIZE + PATH_HASH_OFFSET;
 	for (let offset = 0; offset < PATH_HASH_SIZE; offset++, pathHashOffset++) {
-		// We know that both values could not be undefined
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		const s = searchValue[offset]!;
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		const e = manifest[pathHashOffset]!;
-		if (s < e) {
-			return -1;
-		}
-		if (s > e) {
-			return 1;
+		const s = searchValue[offset];
+		const e = manifest[pathHashOffset];
+		// Note: both values should be defined but we check just in case
+		if (s !== undefined && e !== undefined) {
+			if (s < e) {
+				return -1;
+			}
+			if (s > e) {
+				return 1;
+			}
 		}
 	}
 

--- a/packages/workers-shared/asset-worker/src/assets-manifest.ts
+++ b/packages/workers-shared/asset-worker/src/assets-manifest.ts
@@ -98,14 +98,16 @@ function comparePathHashWithEntry(
 	for (let offset = 0; offset < PATH_HASH_SIZE; offset++, pathHashOffset++) {
 		const s = searchValue[offset];
 		const e = manifest[pathHashOffset];
-		// Note: both values should be defined but we check just in case
-		if (s !== undefined && e !== undefined) {
-			if (s < e) {
-				return -1;
-			}
-			if (s > e) {
-				return 1;
-			}
+		if (s === undefined || e === undefined) {
+			throw new TypeError(
+				`Unexpected undefined value at offset ${offset} during path hash comparison`
+			);
+		}
+		if (s < e) {
+			return -1;
+		}
+		if (s > e) {
+			return 1;
 		}
 	}
 


### PR DESCRIPTION
This PR enables the `require-description-when-disabling` lint rule on the workers-shared and workers-editor-shared packages.

This is a followup PR for https://github.com/cloudflare/workers-sdk/pull/13698, https://github.com/cloudflare/workers-sdk/pull/13703, https://github.com/cloudflare/workers-sdk/pull/13710 and https://github.com/cloudflare/workers-sdk/pull/13741.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: internal linting change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal linting change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->