### PR TITLE
Stabilize secrets property

### DIFF
--- a/.changeset/stabilize-secrets-config.md
+++ b/.changeset/stabilize-secrets-config.md
@@ -1,0 +1,15 @@
+---
+"@cloudflare/workers-utils": minor
+---
+
+Stabilize the `secrets` configuration property
+
+The `secrets` property in the Wrangler config file is no longer experimental and will no longer emit an experimental warning when used. Required secrets are validated during local development and deploy, and used as the source of truth for type generation.
+
+```json
+{
+	"secrets": {
+		"required": ["API_KEY", "DB_PASSWORD"]
+	}
+}
+```

--- a/.changeset/stabilize-secrets-config.md
+++ b/.changeset/stabilize-secrets-config.md
@@ -1,5 +1,8 @@
 ---
 "@cloudflare/workers-utils": minor
+"wrangler": minor
+"@cloudflare/vite-plugin": minor
+"@cloudflare/vitest-pool-workers": minor
 ---
 
 Stabilize the `secrets` configuration property

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -763,7 +763,7 @@ export interface EnvironmentNonInheritable {
 	vars: Record<string, string | Json>;
 
 	/**
-	 * Secrets configuration (experimental).
+	 * Secrets configuration.
 	 *
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -768,6 +768,8 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#secrets-configuration-property
+	 *
 	 * @nonInheritable
 	 */
 	secrets?: {

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -1434,7 +1434,6 @@ function normalizeAndValidateEnvironment(
 	);
 
 	experimental(diagnostics, rawEnv, "unsafe");
-	experimental(diagnostics, rawEnv, "secrets");
 
 	const route = normalizeAndValidateRoute(diagnostics, topLevelEnv, rawEnv);
 

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -7425,11 +7425,7 @@ describe("normalizeAndValidateConfig()", () => {
 					required: ["API_KEY", "DATABASE_PASSWORD"],
 				});
 				expect(diagnostics.hasErrors()).toBe(false);
-				// Expect experimental warning
-				expect(diagnostics.hasWarnings()).toBe(true);
-				expect(diagnostics.renderWarnings()).toContain(
-					'"secrets" fields are experimental'
-				);
+				expect(diagnostics.hasWarnings()).toBe(false);
 			});
 
 			it("should error if secrets is not an object", ({ expect }) => {


### PR DESCRIPTION
Stabilize the `secrets` configuration property

The `secrets` property in the Wrangler config file is no longer experimental and will no longer emit an experimental warning when used. Required secrets are validated during local development and deploy, and used as the source of truth for type generation.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/30585
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
