### PR TITLE
run openapi generation and check diff in CI

### DIFF
--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -55,6 +55,23 @@ jobs:
           CI_OS: ${{ runner.os }}
           NODE_OPTIONS: "--max_old_space_size=8192"
 
+      - name: Filter changed paths
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        id: changes
+        with:
+          filters: |
+            miniflare_openapi:
+              - 'packages/miniflare/src/workers/local-explorer/openapi.local.json'
+              - 'packages/miniflare/src/workers/local-explorer/generated/**'
+              - 'packages/miniflare/scripts/openapi-filter-config.ts'
+              - 'packages/miniflare/scripts/filter-openapi.ts'
+              - 'packages/miniflare/scripts/check-generate-api.ts'
+              - 'packages/miniflare/openapi-ts.config.ts'
+
+      - name: Check generated OpenAPI types are up to date
+        if: steps.changes.outputs.miniflare_openapi == 'true'
+        run: pnpm -F miniflare check:generate-api
+
       # Check for old Node.js version warnings and errors
       - name: Use Node.js v20
         uses: actions/setup-node@v4

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -36,6 +36,7 @@
 	"scripts": {
 		"build": "node scripts/build.mjs && pnpm run types:build",
 		"capnp:workerd": "capnp-es node_modules/workerd/workerd.capnp -ots:src/runtime/config/generated --src-prefix=node_modules/workerd",
+		"check:generate-api": "node -r esbuild-register scripts/check-generate-api.ts",
 		"check:type": "tsc",
 		"clean": "node -r esbuild-register ../../tools/clean/clean.ts ./dist ./dist-types",
 		"dev": "concurrently -n esbuild,typechk,typewrk -c yellow,blue,blue.dim \"node scripts/build.mjs --watch\" \"node scripts/types.mjs tsconfig.json --bundle --watch\" \"node scripts/types.mjs src/workers/tsconfig.json --watch\"",

--- a/packages/miniflare/scripts/check-generate-api.ts
+++ b/packages/miniflare/scripts/check-generate-api.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env -S node -r esbuild-register
+/**
+ * CI check: verify that generated OpenAPI types are up-to-date.
+ *
+ * Downloads the Cloudflare OpenAPI spec from a pinned commit, runs the
+ * generate:api pipeline, and fails if any generated files differ from what
+ * is checked in.
+ *
+ * To update the pinned commit, change OPENAPI_COMMIT below and re-run
+ * `OPENAPI_INPUT_PATH=<path> pnpm generate:api` locally.
+ */
+import { execSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const OPENAPI_COMMIT = "5a81015dd2d335664a2dd2dcabd3fd666334c9c2";
+const OPENAPI_RAW_URL = `https://raw.githubusercontent.com/cloudflare/api-schemas/${OPENAPI_COMMIT}/openapi.json`;
+
+const GENERATED_PATHS = [
+	"src/workers/local-explorer/openapi.local.json",
+	"src/workers/local-explorer/generated",
+];
+
+async function main(): Promise<void> {
+	const miniflareRoot = join(__dirname, "..");
+
+	// 1. Download the pinned OpenAPI spec
+	console.log(`Downloading OpenAPI spec from pinned commit ${OPENAPI_COMMIT}…`);
+	const response = await fetch(OPENAPI_RAW_URL);
+	if (!response.ok) {
+		throw new Error(
+			`Failed to download OpenAPI spec: ${response.status} ${response.statusText}`
+		);
+	}
+	const specContent = await response.text();
+
+	const tmpDir = mkdtempSync(join(tmpdir(), "miniflare-openapi-"));
+	const specPath = join(tmpDir, "openapi.json");
+	writeFileSync(specPath, specContent, "utf-8");
+	console.log(`Wrote spec to ${specPath}`);
+
+	// 2. Run generate:api with the downloaded spec
+	console.log("Running generate:api…");
+	execSync(`pnpm generate:api`, {
+		cwd: miniflareRoot,
+		stdio: "inherit",
+		env: { ...process.env, OPENAPI_INPUT_PATH: specPath },
+	});
+
+	// 3. Check for uncommitted changes in generated files
+	console.log("Checking for uncommitted changes in generated files…");
+	const diffPaths = GENERATED_PATHS.map((p) => join("packages/miniflare", p));
+	try {
+		execSync(`git diff --exit-code -- ${diffPaths.join(" ")}`, {
+			cwd: join(miniflareRoot, "../.."),
+			stdio: "inherit",
+		});
+	} catch {
+		console.error(
+			"\n" +
+				"ERROR: Generated OpenAPI files are out of date.\n" +
+				"Run the following command locally and commit the result:\n" +
+				"\n" +
+				`  OPENAPI_INPUT_PATH=<path-to-openapi.json> pnpm -F miniflare generate:api\n` +
+				"\n" +
+				"See packages/miniflare/src/workers/local-explorer/README.md for details.\n" +
+				`The CI check uses the spec pinned at commit ${OPENAPI_COMMIT}.\n`
+		);
+		process.exit(1);
+	}
+
+	console.log("Generated OpenAPI files are up to date.");
+}
+
+void main();

--- a/packages/miniflare/scripts/check-generate-api.ts
+++ b/packages/miniflare/scripts/check-generate-api.ts
@@ -9,7 +9,7 @@
  * To update the pinned commit, change OPENAPI_COMMIT below and re-run
  * `OPENAPI_INPUT_PATH=<path> pnpm generate:api` locally.
  */
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -52,7 +52,7 @@ async function main(): Promise<void> {
 	console.log("Checking for uncommitted changes in generated files…");
 	const diffPaths = GENERATED_PATHS.map((p) => join("packages/miniflare", p));
 	try {
-		execSync(`git diff --exit-code -- ${diffPaths.join(" ")}`, {
+		execFileSync("git", ["diff", "--exit-code", "--", ...diffPaths], {
 			cwd: join(miniflareRoot, "../.."),
 			stdio: "inherit",
 		});

--- a/packages/miniflare/scripts/openapi-filter-config.ts
+++ b/packages/miniflare/scripts/openapi-filter-config.ts
@@ -1457,14 +1457,6 @@ const config = {
 						type: "string",
 						description: "Worker name from the dev registry",
 					},
-					port: {
-						type: "integer",
-						description: "Port the worker is running on",
-					},
-					protocol: {
-						type: "string",
-						description: "Protocol (http or https)",
-					},
 					bindings: {
 						$ref: "#/components/schemas/local-explorer_worker-bindings",
 						description: "Resource bindings for this worker",

--- a/packages/miniflare/src/workers/local-explorer/openapi.local.json
+++ b/packages/miniflare/src/workers/local-explorer/openapi.local.json
@@ -149,7 +149,7 @@
 								}
 							}
 						},
-						"description": "List a Namespace's Keys response."
+						"description": "List a Namespace'dafadsfasdfasdfdsfsds Keys response."
 					},
 					"4XX": {
 						"content": {

--- a/packages/miniflare/src/workers/local-explorer/openapi.local.json
+++ b/packages/miniflare/src/workers/local-explorer/openapi.local.json
@@ -149,7 +149,7 @@
 								}
 							}
 						},
-						"description": "List a Namespace'dafadsfasdfasdfdsfsds Keys response."
+						"description": "List a Namespace's Keys response."
 					},
 					"4XX": {
 						"content": {


### PR DESCRIPTION
Fixes n/a

This should make it clear that openapi.local.json is a generated file, and error if it goes out of sync.

e.g. port/protocal was removed from openapi.local.json, not in packages/miniflare/scripts/openapi-filter-config.ts, which we've cleaned up here.

We run the filter script on the full openapi spec (pinned to a specific commit) and make sure there is no diff when the downstream generated files have been touched.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: see commit history for test change that fails
  - [ ] Additional testing not necessary because: 
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: CI change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13817" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->