### PR TITLE
fix(wrangler): support Flagship bindings with `wrangler preview`

### DIFF
--- a/.changeset/quiet-flags-preview.md
+++ b/.changeset/quiet-flags-preview.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Support Flagship bindings in Worker Previews
+
+`wrangler preview` now accepts `flagship` entries in the `previews` block and includes them in Preview deployment bindings. This lets Workers that use Flagship bindings deploy Preview versions with preview-specific Flagship app IDs.

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -5160,6 +5160,7 @@ const validatePreviewsConfig =
 				"secrets_store_secrets",
 				"artifacts",
 				"unsafe_hello_world",
+				"flagship",
 				"worker_loaders",
 				"ratelimits",
 				"vpc_services",
@@ -5397,6 +5398,14 @@ const validatePreviewsConfig =
 				diagnostics,
 				`${field}.unsafe_hello_world`,
 				previews.unsafe_hello_world,
+				undefined
+			) && isValid;
+
+		isValid =
+			validateBindingArray(envName, validateFlagshipBinding)(
+				diagnostics,
+				`${field}.flagship`,
+				previews.flagship,
 				undefined
 			) && isValid;
 

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -9472,6 +9472,7 @@ describe("normalizeAndValidateConfig()", () => {
 						},
 						kv_namespaces: [{ binding: "MY_KV", id: "preview-kv-id" }],
 						r2_buckets: [{ binding: "MY_R2", bucket_name: "preview-bucket" }],
+						flagship: [{ binding: "FLAGS", app_id: "flagship-app-id" }],
 						observability: { enabled: true },
 						limits: { cpu_ms: 50 },
 					},

--- a/packages/wrangler/src/__tests__/preview.test.ts
+++ b/packages/wrangler/src/__tests__/preview.test.ts
@@ -196,6 +196,7 @@ describe("wrangler preview", () => {
 				browser: { binding: "MY_BROWSER" },
 				stream: { binding: "MY_STREAM" },
 				version_metadata: { binding: "MY_VERSION_METADATA" },
+				flagship: [{ binding: "MY_FLAGS", app_id: "flagship-app-id" }],
 			});
 			const bindings = extractConfigBindings(config);
 			expect(bindings).toMatchObject({
@@ -206,6 +207,7 @@ describe("wrangler preview", () => {
 				MY_BROWSER: { type: "browser" },
 				MY_STREAM: { type: "stream" },
 				MY_VERSION_METADATA: { type: "version_metadata" },
+				MY_FLAGS: { type: "flagship", app_id: "flagship-app-id" },
 			});
 		});
 	});
@@ -503,6 +505,90 @@ describe("wrangler preview", () => {
 			await runWrangler("preview --name test-preview");
 
 			expect(std.warn).not.toContain("IMPORTANT_BINDING");
+		});
+
+		test("should use flagship bindings from local previews config", async ({
+			expect,
+		}) => {
+			writeFileSync(
+				"wrangler.json",
+				JSON.stringify({
+					name: "test-worker",
+					main: "src/index.ts",
+					compatibility_date: "2025-01-01",
+					flagship: [{ binding: "FLAGS", app_id: "production-app-id" }],
+					previews: {
+						flagship: [{ binding: "FLAGS", app_id: "preview-app-id" }],
+					},
+				})
+			);
+
+			let deploymentRequestBody:
+				| {
+						env?: Record<string, { type: string; app_id?: string }>;
+				  }
+				| undefined;
+
+			msw.use(
+				http.get(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId`,
+					() =>
+						HttpResponse.json(
+							{
+								success: false,
+								result: null,
+								errors: [{ code: 10025, message: "Preview not found" }],
+							},
+							{ status: 404 }
+						)
+				),
+				http.post(
+					`*/accounts/:accountId/workers/workers/:workerId/previews`,
+					() =>
+						HttpResponse.json({
+							success: true,
+							result: {
+								id: "preview-id-flagship",
+								name: "test-preview",
+								slug: "test-preview",
+								urls: ["https://test-preview.test-worker.cloudflare.app"],
+								worker_name: "test-worker",
+								created_on: new Date().toISOString(),
+							},
+						})
+				),
+				http.post(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId/deployments`,
+					async ({ request }) => {
+						deploymentRequestBody =
+							(await request.json()) as typeof deploymentRequestBody;
+						return HttpResponse.json({
+							success: true,
+							result: {
+								id: "deployment-id-flagship",
+								preview_id: "preview-id-flagship",
+								preview_name: "test-preview",
+								urls: ["https://flags123.test-worker.cloudflare.app"],
+								compatibility_date: "2025-01-01",
+								env: deploymentRequestBody?.env ?? {},
+								created_on: new Date().toISOString(),
+							},
+						});
+					}
+				)
+			);
+
+			await runWrangler("preview --name test-preview");
+
+			expect(deploymentRequestBody?.env?.FLAGS).toMatchObject({
+				type: "flagship",
+				app_id: "preview-app-id",
+			});
+			expect(deploymentRequestBody?.env?.FLAGS).not.toMatchObject({
+				app_id: "production-app-id",
+			});
+			expect(std.out).toContain("preview-app-id");
+			expect(std.warn).not.toContain("FLAGS");
 		});
 
 		test("should not warn about inheritable top-level bindings missing from previews", async ({

--- a/packages/wrangler/src/preview/api.ts
+++ b/packages/wrangler/src/preview/api.ts
@@ -43,6 +43,7 @@ export interface Binding {
 	service_id?: string;
 	staging?: boolean;
 	enable_timer?: boolean;
+	app_id?: string;
 	entrypoint?: string;
 	class_name?: string;
 	script_name?: string;

--- a/packages/wrangler/src/preview/shared.ts
+++ b/packages/wrangler/src/preview/shared.ts
@@ -118,6 +118,8 @@ export function getBindingValue(binding: Binding): string {
 				: String(binding.store_id ?? "");
 		case "artifacts":
 			return String(binding.namespace ?? "");
+		case "flagship":
+			return String(binding.app_id ?? "");
 		case "ratelimit":
 			return String(binding.namespace_id ?? "");
 		case "vpc_service":
@@ -258,6 +260,13 @@ export function extractConfigBindings(config: Config): EnvBindings {
 		env[artifact.binding] = {
 			type: "artifacts",
 			namespace: artifact.namespace,
+		};
+	}
+
+	for (const flagship of previews?.flagship ?? []) {
+		env[flagship.binding] = {
+			type: "flagship",
+			app_id: flagship.app_id,
 		};
 	}
 


### PR DESCRIPTION
Fixes WC-5095.

Flagship bindings recently shipped for standard Worker deployments, but the Preview-specific config path was missed. This fixes `wrangler preview` so Workers with Flagship bindings can create Preview deployments and use preview-specific Flagship app IDs.
- Accept `flagship` bindings inside the `previews` block.
- Include Preview Flagship bindings in the Preview deployment `env` payload.
- Display the Flagship app ID in Preview deployment output.
- Add regression coverage for config validation and `wrangler preview` deployment behavior.

---
- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this fixes Preview support for an existing Wrangler config binding without changing the public configuration shape beyond making the existing `flagship` binding work in `previews`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->