### PR TITLE
Enable require-description-when-disabling lint rule on the local-explorer-ui package

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -202,7 +202,6 @@
 		// TODO: Remove the following overrides.
 		{
 			"files": [
-				"packages/local-explorer-ui/**",
 				"packages/quick-edit-extension/**",
 				"packages/vitest-pool-workers/**",
 				"packages/wrangler/**",

--- a/packages/local-explorer-ui/src/components/studio/index.tsx
+++ b/packages/local-explorer-ui/src/components/studio/index.tsx
@@ -481,10 +481,13 @@ export const Studio = forwardRef<StudioRef, StudioProps>(function Studio(
 	 */
 	const hasDirtyState = tabs.some((tab) => tab.isDirty);
 
+	const onBeforeLeaveRef = useRef(
+		() => "You have unsaved changes. Are you sure you want to leave?"
+	);
+
 	useLeaveGuard({
 		enabled: hasDirtyState,
-		onBeforeLeave: () =>
-			"You have unsaved changes. Are you sure you want to leave?",
+		onBeforeLeave: onBeforeLeaveRef.current,
 	});
 
 	const contextValues = useMemo(

--- a/packages/local-explorer-ui/src/hooks/leave-guard.ts
+++ b/packages/local-explorer-ui/src/hooks/leave-guard.ts
@@ -42,8 +42,10 @@ export function useLeaveGuard({
 	fallbackMessage = "You have unsaved changes. Are you sure you want to leave?",
 	onBeforeLeave,
 }: UseLeaveGuardOptions): void {
-	// eslint-disable-next-line react-hooks/exhaustive-deps
-	const handlerCallback = useCallback(onBeforeLeave, dependencies);
+	const handlerCallback = useCallback(onBeforeLeave, [
+		...dependencies,
+		onBeforeLeave,
+	]);
 
 	// Block tab close or refresh
 	useEffect(() => {


### PR DESCRIPTION
This PR enables the `require-description-when-disabling` lint rule on the local-explorer-ui package (by actually removing the only `eslint-disable-next-line` comment present in the package's code).

This is a followup PR for https://github.com/cloudflare/workers-sdk/pull/13698, https://github.com/cloudflare/workers-sdk/pull/13703, https://github.com/cloudflare/workers-sdk/pull/13710, https://github.com/cloudflare/workers-sdk/pull/13741, https://github.com/cloudflare/workers-sdk/pull/13803 and https://github.com/cloudflare/workers-sdk/pull/13804.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: internal linting change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal linting change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->