### PR TITLE
[wrangler] Fix container deployment being skipped for WfP user workers

### DIFF
--- a/.changeset/fix-wfp-container-deploy.md
+++ b/.changeset/fix-wfp-container-deploy.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix container deployment being skipped for Workers for Platforms user workers
+
+Previously, deploying a worker with `--dispatch-namespace` would early-exit before calling `deployContainers()`, meaning container-app registration that links the image to the Durable Object namespace was never executed for WfP user workers. Container deployment now runs before the WfP early exit.

--- a/packages/wrangler/src/__tests__/containers/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/containers/deploy.test.ts
@@ -14,6 +14,7 @@ import { afterEach, assert, beforeEach, describe, it, vi } from "vitest";
 import { clearCachedAccount } from "../../cloudchamber/locations";
 import * as user from "../../user";
 import { mockAccountV4 as mockContainersAccount } from "../cloudchamber/utils";
+import { mockServiceScriptData } from "../deploy/helpers";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockCLIOutput } from "../helpers/mock-cli-output";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -2462,6 +2463,72 @@ describe("wrangler deploy with containers dry run", () => {
 			--dry-run: exiting now."
 		`);
 		expect(cliStd.stdout).toMatchInlineSnapshot(`""`);
+	});
+});
+
+describe("wrangler deploy with containers and dispatch namespace", () => {
+	runInTempDir();
+	const std = mockConsoleMethods();
+	const cliStd = mockCLIOutput();
+	mockAccountId();
+	mockApiToken();
+	beforeEach(() => {
+		msw.use(...mswSuccessDeploymentScriptMetadata);
+		msw.use(...mswListNewDeploymentsLatestFull);
+		mockSubDomainRequest();
+		mockServiceScriptData({
+			script: { id: "test-name", migration_tag: "v1" },
+			dispatchNamespace: "test-namespace",
+		});
+		mockContainersAccount();
+		mockUploadWorkerRequest({
+			expectedBindings: [
+				{
+					class_name: "ExampleDurableObject",
+					name: "EXAMPLE_DO_BINDING",
+					type: "durable_object_namespace",
+				},
+			],
+			useOldUploadApi: true,
+			expectedDispatchNamespace: "test-namespace",
+			expectedContainers: [{ class_name: "ExampleDurableObject" }],
+		});
+		fs.writeFileSync(
+			"index.js",
+			`export class ExampleDurableObject {}; export default{};`
+		);
+		vi.stubEnv("WRANGLER_DOCKER_BIN", "/usr/bin/docker");
+	});
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("should deploy containers when using --dispatch-namespace", async ({
+		expect,
+	}) => {
+		mockGetVersion("Galaxy-Class");
+		writeWranglerConfig({
+			...DEFAULT_DURABLE_OBJECTS,
+			containers: [DEFAULT_CONTAINER_FROM_REGISTRY],
+		});
+
+		mockGetApplications([]);
+
+		mockCreateApplication(expect, {
+			name: "my-container",
+			max_instances: 10,
+			durable_objects: {
+				namespace_id: "1",
+			},
+		});
+
+		await runWrangler("deploy index.js --dispatch-namespace test-namespace");
+
+		expect(std.out).toContain("Uploaded test-name");
+		expect(std.out).toContain("Dispatch Namespace: test-namespace");
+		expect(std.out).toContain("Current Version ID: Galaxy-Class");
+		expect(cliStd.stdout).toContain("my-container");
+		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 });
 

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -1289,12 +1289,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 	logger.log("Uploaded", workerName, formatTime(uploadMs));
 
-	// Early exit for WfP since it doesn't need the below code
-	if (props.dispatchNamespace !== undefined) {
-		deployWfpUserWorker(props.dispatchNamespace, versionId);
-		return { versionId, workerTag };
-	}
-
 	if (normalisedContainerConfig.length) {
 		assert(versionId && accountId);
 		await deployContainers(config, normalisedContainerConfig, {
@@ -1302,6 +1296,12 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			accountId,
 			scriptName,
 		});
+	}
+
+	// Early exit for WfP since it doesn't need the below code
+	if (props.dispatchNamespace !== undefined) {
+		deployWfpUserWorker(props.dispatchNamespace, versionId);
+		return { versionId, workerTag };
 	}
 
 	// deploy triggers


### PR DESCRIPTION
The `wrangler deploy --dispatch-namespace` early-exits before calling `deployContainers()`, which means the container-app registration that links the image to the DO namespace is never executed for WfP user workers.

This PR moves the `deployContainers()` call above the WfP early exit so container deployment runs for all workers regardless of dispatch namespace usage.

Devin PR requested by @emily-shen

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is a bug fix to existing behavior, no new user-facing API or configuration changes.


Link to Devin session: https://app.devin.ai/sessions/b8e2546797a94d469c4bbaea5532897e