### PR TITLE
Show containers ssh in help output

### DIFF
--- a/.changeset/wrangler-containers-ssh-help-visible.md
+++ b/.changeset/wrangler-containers-ssh-help-visible.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Show `containers ssh` in `wrangler containers --help` and in `wrangler containers ssh --help`
+
+The `containers ssh` command was previously hidden, so it did not appear in the list of subcommands shown by `wrangler containers --help`, and its description was omitted from `wrangler containers ssh --help`. The command is now listed with its description in both places.

--- a/packages/wrangler/src/__tests__/containers/ssh.test.ts
+++ b/packages/wrangler/src/__tests__/containers/ssh.test.ts
@@ -24,6 +24,8 @@ describe("containers ssh", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"wrangler containers ssh <ID>
 
+			SSH into a container
+
 			POSITIONALS
 			  ID  ID of the container instance  [string] [required]
 

--- a/packages/wrangler/src/containers/ssh.ts
+++ b/packages/wrangler/src/containers/ssh.ts
@@ -344,7 +344,6 @@ export const containersSshCommand = createCommand({
 		description: "SSH into a container",
 		status: "stable",
 		owner: "Product: Cloudchamber",
-		hidden: true,
 	},
 	args: sshArgDefs,
 	positionalArgs: ["ID"],


### PR DESCRIPTION
Fixes CC-7636.

Ensure `wrangler containers ssh` is listed in `wrangler containers --help`.

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: This feature is already documented
