### PR TITLE
fix(vitest-pool-workers): filter benign "WebSocket peer disconnected" workerd noise

### DIFF
--- a/.changeset/filter-websocket-peer-disconnected.md
+++ b/.changeset/filter-websocket-peer-disconnected.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Filter benign `disconnected: WebSocket peer disconnected` workerd stderr noise during test runs.
+
+The `ignoreMessages` array in the pool already filters several benign workerd disconnect messages (e.g. `disconnected: WebSocket was aborted`). On recent workerd versions, tests that exercise the WebSocket API also surface `disconnected: WebSocket peer disconnected` warnings during normal teardown. These are not user-actionable and obscure real test failures. Add the message to the existing filter alongside the other `disconnected:` entries.

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -88,6 +88,7 @@ const ignoreMessages = [
 	"disconnected: operation canceled",
 	"disconnected: worker_do_not_log; Request failed due to internal error",
 	"disconnected: WebSocket was aborted",
+	"disconnected: WebSocket peer disconnected",
 	"CODE_MOVED for unknown code block",
 	"broken.outputGateBroken; jsg.Error: Instance dispose",
 ];


### PR DESCRIPTION
## What this changes

Adds `"disconnected: WebSocket peer disconnected"` to the existing `ignoreMessages` filter in `packages/vitest-pool-workers/src/pool/index.ts`, alongside the other benign `disconnected:` entries that are already filtered out.

## Why

The pool already filters several benign workerd stderr messages that fire during normal teardown — `disconnected: operation canceled`, `disconnected: worker_do_not_log; ...`, `disconnected: WebSocket was aborted`. On recent workerd versions, tests that exercise the WebSocket API (including normal lifecycle teardown of WebSocket-using Workers) also surface `workerd/api/web-socket.c++:NNN: disconnected: WebSocket peer disconnected` warnings. They are not user-actionable — tests pass, behavior is correct — and they obscure real regressions in CI logs.

In a real workspace running ~270 tests against an `apps/api` Worker, the message reproduces ~18 times per run during normal teardown. The fix is a one-line addition to the same `ignoreMessages` array.

## How verified

Applied the same one-line change as a local pnpm patch against `@cloudflare/vitest-pool-workers@0.16.0`; reran the full test suite — all tests still pass and the targeted stderr lines are now absent. No other warnings or errors are suppressed (the filter is an exact `message.includes(...)` substring match, identical in shape to the other entries).

## Changeset

`.changeset/filter-websocket-peer-disconnected.md` — `@cloudflare/vitest-pool-workers: patch`.

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This is a bug fix.
