### PR TITLE
[wrangler] Reduce Sentry noise by classifying user-environment errors correctly

### DIFF
--- a/.changeset/sentry-noise-reduction.md
+++ b/.changeset/sentry-noise-reduction.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: reduce Sentry noise by classifying user-environment errors correctly
+
+Converted common user-environment failures (missing build outputs, expired tokens, transient network issues, C3 process exits, invalid API tokens, missing assets directories, framework version detection, container SSH, D1 export limitations, and inline source maps) to `UserError` so they are no longer reported as crashes in Sentry. Also tightened top-level error filtering to recognise duck-typed `UserError`, `MiniflareError.isUserError()`, a broader set of authentication errors, transient network errors, and filesystem environment errors.

--- a/packages/wrangler/src/__tests__/autoconfig/frameworks/validate-framework-version.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/frameworks/validate-framework-version.test.ts
@@ -1,3 +1,4 @@
+import { UserError } from "@cloudflare/workers-utils";
 import { describe, it, vi } from "vitest";
 import { AutoConfigFrameworkConfigurationError } from "../../../autoconfig/errors";
 import { Framework } from "../../../autoconfig/frameworks/framework-class";
@@ -27,12 +28,15 @@ const PACKAGE_INFO: AutoConfigFrameworkPackageInfo = {
 describe("Framework.validateFrameworkVersion()", () => {
 	const std = mockConsoleMethods();
 
-	it("throws an AssertionError when the package version cannot be determined", ({
+	it("throws a UserError when the package version cannot be determined", ({
 		expect,
 	}) => {
 		vi.mocked(getInstalledPackageVersion).mockReturnValue(undefined);
 		const framework = new TestFramework({ id: "test", name: "Test" });
 
+		expect(() =>
+			framework.validateFrameworkVersion("/project", PACKAGE_INFO)
+		).toThrow(UserError);
 		expect(() =>
 			framework.validateFrameworkVersion("/project", PACKAGE_INFO)
 		).toThrow("Unable to detect the version of the `some-pkg` package");

--- a/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
+++ b/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { UserError } from "@cloudflare/workers-utils";
 import chalk from "chalk";
 import { DeferredPromise } from "miniflare";
 import remoteBindingsWorkerPath from "worker:remoteBindings/ProxyServerWorker";
@@ -59,9 +60,20 @@ export async function startRemoteProxySession(
 				errorMessage = startWorkerError.message;
 			}
 		}
-		throw new Error(
-			`Failed to start the remote proxy session, see the error details below:\n\n${errorMessage}`
-		);
+		const ErrorClass =
+			startWorkerError instanceof UserError ||
+			(startWorkerError instanceof Error &&
+				startWorkerError.cause instanceof UserError)
+				? UserError
+				: Error;
+		const message = `Failed to start the remote proxy session, see the error details below:\n\n${errorMessage}`;
+		if (ErrorClass === UserError) {
+			throw new UserError(message, {
+				cause: startWorkerError,
+				telemetryMessage: "remote proxy session start failed",
+			});
+		}
+		throw new Error(message, { cause: startWorkerError });
 	});
 
 	const maybeErrorPromise = new DeferredPromise<{ error: unknown }>();
@@ -76,12 +88,22 @@ export async function startRemoteProxySession(
 	]);
 
 	if (maybeError && maybeError.error) {
-		throw new Error(
-			"Failed to start the remote proxy session. There is likely additional logging output above.",
-			{
+		const ErrorClass =
+			maybeError instanceof UserError ||
+			(maybeError instanceof Error && maybeError.cause instanceof UserError)
+				? UserError
+				: Error;
+
+		const message = `Failed to start the remote proxy session. There is likely additional logging output above.`;
+		if (ErrorClass === UserError) {
+			throw new UserError(message, {
 				cause: maybeError.error,
-			}
-		);
+				telemetryMessage: "remote proxy session worker error",
+			});
+		}
+		throw new Error(message, {
+			cause: maybeError.error,
+		});
 	}
 
 	const remoteProxyConnectionString =

--- a/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
+++ b/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
@@ -89,8 +89,9 @@ export async function startRemoteProxySession(
 
 	if (maybeError && maybeError.error) {
 		const ErrorClass =
-			maybeError instanceof UserError ||
-			(maybeError instanceof Error && maybeError.cause instanceof UserError)
+			maybeError.error instanceof UserError ||
+			(maybeError.error instanceof Error &&
+				maybeError.error.cause instanceof UserError)
 				? UserError
 				: Error;
 

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -267,7 +267,27 @@ export const syncAssets = async (
 };
 
 export const buildAssetManifest = async (dir: string) => {
-	const files = await readdir(dir, { recursive: true });
+	let files: string[];
+	try {
+		files = await readdir(dir, { recursive: true });
+	} catch (e: unknown) {
+		if (
+			e &&
+			typeof e === "object" &&
+			"code" in e &&
+			(e as { code: string }).code === "ENOENT"
+		) {
+			throw new NonExistentAssetsDirError(
+				`The directory specified by the Assets configuration does not exist:\n` +
+					`${dir}`,
+				{
+					cause: e,
+					telemetryMessage: "assets directory does not exist",
+				}
+			);
+		}
+		throw e;
+	}
 	logReadFilesFromDirectory(dir, files);
 
 	const manifest: AssetManifest = {};

--- a/packages/wrangler/src/autoconfig/frameworks/framework-class.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/framework-class.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert";
+import { UserError } from "@cloudflare/workers-utils";
 import semiver from "semiver";
 import { logger } from "../../logger";
 import { AutoConfigFrameworkConfigurationError } from "../errors";
@@ -42,7 +43,7 @@ export abstract class Framework {
 	 *
 	 * @param projectPath - Path to the project root used to resolve the installed version.
 	 * @param frameworkPackageInfo - Package metadata including name and version bounds.
-	 * @throws {AssertionError} If the installed version cannot be determined.
+	 * @throws {UserError} If the installed version cannot be determined.
 	 * @throws {AutoConfigFrameworkConfigurationError} If the version is below `minimumVersion`.
 	 */
 	validateFrameworkVersion(
@@ -54,10 +55,12 @@ export abstract class Framework {
 			projectPath
 		);
 
-		assert(
-			frameworkVersion,
-			`Unable to detect the version of the \`${frameworkPackageInfo.name}\` package`
-		);
+		if (!frameworkVersion) {
+			throw new UserError(
+				`Unable to detect the version of the \`${frameworkPackageInfo.name}\` package`,
+				{ telemetryMessage: "autoconfig framework version not detected" }
+			);
+		}
 
 		if (semiver(frameworkVersion, frameworkPackageInfo.minimumVersion) < 0) {
 			throw new AutoConfigFrameworkConfigurationError(

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -314,6 +314,24 @@ export async function requireLoggedIn(
 	}
 }
 
+function setHeaderOrThrowForBadChars(
+	headers: Headers,
+	name: string,
+	value: string
+): void {
+	try {
+		headers.set(name, value);
+	} catch (e) {
+		if (e instanceof TypeError && String(e.message).includes("ByteString")) {
+			throw new UserError(
+				"Your API token contains an invalid character. API tokens must be plain text.",
+				{ telemetryMessage: "credential contains non-ascii characters" }
+			);
+		}
+		throw e;
+	}
+}
+
 export function addAuthorizationHeader(
 	headers: Headers,
 	auth: ApiCredentials,
@@ -321,10 +339,14 @@ export function addAuthorizationHeader(
 ): void {
 	if (!headers.has("Authorization") || overrideExisting) {
 		if ("apiToken" in auth) {
-			headers.set("Authorization", `Bearer ${auth.apiToken}`);
+			setHeaderOrThrowForBadChars(
+				headers,
+				"Authorization",
+				`Bearer ${auth.apiToken}`
+			);
 		} else {
-			headers.set("X-Auth-Key", auth.authKey);
-			headers.set("X-Auth-Email", auth.authEmail);
+			setHeaderOrThrowForBadChars(headers, "X-Auth-Key", auth.authKey);
+			setHeaderOrThrowForBadChars(headers, "X-Auth-Email", auth.authEmail);
 		}
 	}
 }
@@ -367,11 +389,12 @@ export async function fetchKVGetValue(
 	});
 	if (response.ok) {
 		return await response.arrayBuffer();
-	} else {
-		throw new Error(
-			`Failed to fetch ${resource} - ${response.status}: ${response.statusText});`
-		);
 	}
+	throw new APIError({
+		text: `Failed to fetch ${resource} - ${response.status}: ${response.statusText}`,
+		status: response.status,
+		telemetryMessage: false,
+	});
 }
 
 /**
@@ -435,6 +458,9 @@ export async function fetchR2Objects(
 		if (errorCode !== undefined) {
 			apiError.code = errorCode;
 		}
+		if (response.status >= 400 && response.status < 500) {
+			apiError.preventReport();
+		}
 		throw apiError;
 	}
 }
@@ -463,9 +489,18 @@ export async function fetchWorkerDefinitionFromDash(
 
 	if (!response.ok || !response.body) {
 		logger.error(response.ok, response.body);
-		throw new Error(
-			`Failed to fetch ${resource} - ${response.status}: ${response.statusText});`
-		);
+		const summary = `Failed to fetch ${resource} - ${response.status}: ${response.statusText});`;
+
+		if (response.status >= 400 && response.status < 500) {
+			throw new UserError(summary, {
+				telemetryMessage: `worker definition api ${response.status}`,
+			});
+		}
+		throw new APIError({
+			text: summary,
+			status: response.status,
+			telemetryMessage: false,
+		});
 	}
 
 	const usesModules = response.headers

--- a/packages/wrangler/src/containers/ssh.ts
+++ b/packages/wrangler/src/containers/ssh.ts
@@ -112,7 +112,10 @@ async function sshCommand(sshArgs: SshArgs, _config: Config) {
 	} catch (e) {
 		if (e instanceof ApiError) {
 			if (e.status === 404) {
-				throw new Error(`Instance ${sshArgs.ID} not found`);
+				throw new UserError(`Instance ${sshArgs.ID} not found`, {
+					cause: e,
+					telemetryMessage: "containers ssh instance not found",
+				});
 			}
 
 			let msg = `Error verifying SSH access`;
@@ -120,7 +123,14 @@ async function sshCommand(sshArgs: SshArgs, _config: Config) {
 				msg += `: ${e.body.error}`;
 			}
 
-			throw new Error(msg);
+			if (typeof e.status === "number" && e.status >= 400 && e.status < 500) {
+				throw new UserError(msg, {
+					cause: e,
+					telemetryMessage: `containers ssh verify ${e.status}`,
+				});
+			}
+
+			throw new Error(msg, { cause: e });
 		}
 
 		throw e;
@@ -172,11 +182,12 @@ async function sshCommand(sshArgs: SshArgs, _config: Config) {
 				resolve(undefined);
 			} else {
 				reject(
-					new Error(
+					new UserError(
 						[
 							"SSH exited unsuccessfully. Is the container running?",
 							`${bold("NOTE:")} SSH does not automatically wake a container or count as activity to keep a container alive`,
-						].join("\n")
+						].join("\n"),
+						{ telemetryMessage: "containers ssh exited 255" }
 					)
 				);
 			}

--- a/packages/wrangler/src/core/handle-errors.ts
+++ b/packages/wrangler/src/core/handle-errors.ts
@@ -194,20 +194,21 @@ function isCloudflareAPI(text: string): boolean {
 function isCloudflareAPIDNSError(e: unknown): boolean {
 	return (
 		visitErrorOrCause(e, (err) => {
-			if (hasErrorCode(e, new Set(["ENOTFOUND"]))) {
+			if (hasErrorCode(err, new Set(["ENOTFOUND"]))) {
 				const message = err instanceof Error ? err.message : String(err);
 				if (isCloudflareAPI(message)) {
 					return true;
 				}
 				if (
-					e &&
-					typeof e === "object" &&
-					"hostname" in e &&
+					err &&
+					typeof err === "object" &&
+					"hostname" in err &&
 					typeof (err as { hostname?: unknown }).hostname === "string" &&
 					isCloudflareAPI((err as { hostname: string }).hostname)
 				) {
 					return true;
 				}
+			}
 			}
 
 			return undefined;

--- a/packages/wrangler/src/core/handle-errors.ts
+++ b/packages/wrangler/src/core/handle-errors.ts
@@ -209,7 +209,6 @@ function isCloudflareAPIDNSError(e: unknown): boolean {
 					return true;
 				}
 			}
-			}
 
 			return undefined;
 		}) === true

--- a/packages/wrangler/src/core/handle-errors.ts
+++ b/packages/wrangler/src/core/handle-errors.ts
@@ -10,6 +10,7 @@ import {
 } from "@cloudflare/workers-utils";
 import chalk from "chalk";
 import { Cloudflare } from "cloudflare";
+import { MiniflareError } from "miniflare";
 import dedent from "ts-dedent";
 import { createCLIParser } from "..";
 import { renderError } from "../cfetch";
@@ -27,18 +28,66 @@ import type { ReadConfigCommandArgs } from "../config";
 import type { ComplianceConfig } from "@cloudflare/workers-utils";
 
 /**
+ * Check if an error has a Node.js error code matching one of the given codes,
+ * looking at both the error and its immediate cause.
+ */
+function hasErrorCode(e: unknown, codes: ReadonlySet<string>): boolean {
+	return (
+		visitErrorOrCause(e, (err) => {
+			if (
+				err !== null &&
+				typeof err === "object" &&
+				"code" in err &&
+				typeof (err as { code: unknown }).code === "string" &&
+				codes.has((err as { code: string }).code)
+			) {
+				return true;
+			}
+			return undefined;
+		}) === true
+	);
+}
+
+/**
+ * Check if a UserError-like object exists anywhere in the error chain.
+ * This duck-types the check so that `UserError` instances thrown from
+ * a different bundle (e.g. miniflare's bundled `@cloudflare/workers-utils`)
+ * are still recognised — `instanceof` fails across bundle boundaries because
+ * each bundle has its own copy of the class.
+ *
+ * We also recognise `MiniflareError.isUserError() === true`
+ */
+function isUserErrorLike(e: unknown): boolean {
+	return (
+		visitErrorOrCause(e, (err) => {
+			if (err instanceof UserError) {
+				return true;
+			}
+			if (
+				err instanceof Error &&
+				err.constructor?.name === "UserError" &&
+				"telemetryMessage" in err
+			) {
+				return true;
+			}
+			if (err instanceof MiniflareError && err.isUserError()) {
+				return true;
+			}
+			return undefined;
+		}) === true
+	);
+}
+
+/**
  * SSL/TLS certificate error messages that indicate a corporate proxy or VPN
  * may be intercepting HTTPS traffic with a custom root certificate.
  */
-const SSL_ERROR_SELF_SIGNED_CERT =
-	"self-signed certificate in certificate chain";
-const SSL_ERROR_UNABLE_TO_VERIFY = "unable to verify the first certificate";
-const SSL_ERROR_UNABLE_TO_GET_ISSUER = "unable to get local issuer certificate";
-
-const SSL_CERT_ERROR_MESSAGES = [
-	SSL_ERROR_SELF_SIGNED_CERT,
-	SSL_ERROR_UNABLE_TO_VERIFY,
-	SSL_ERROR_UNABLE_TO_GET_ISSUER,
+const SSL_CERT_ERROR_PATTERNS = [
+	"self-signed certificate in certificate chain",
+	"unable to verify the first certificate",
+	"unable to get local issuer certificate",
+	"does not match certificate's altnames",
+	"SSL routines:",
 ];
 
 /**
@@ -46,15 +95,18 @@ const SSL_CERT_ERROR_MESSAGES = [
  * which commonly occurs when a corporate proxy or VPN intercepts HTTPS traffic.
  */
 function isCertificateError(e: unknown): boolean {
-	const message = e instanceof Error ? e.message : String(e);
-	const causeMessage =
-		e instanceof Error && e.cause instanceof Error ? e.cause.message : "";
-
-	return SSL_CERT_ERROR_MESSAGES.some(
-		(errorText) =>
-			message.includes(errorText) || causeMessage.includes(errorText)
+	return (
+		visitErrorOrCause(e, (err) => {
+			const message = err instanceof Error ? err.message : String(err);
+			if (SSL_CERT_ERROR_PATTERNS.some((m) => message.includes(m))) {
+				return true;
+			}
+			return undefined;
+		}) === true
 	);
 }
+
+const PERMISSION_ERROR_CODES = new Set(["EPERM", "EACCES"]);
 
 /**
  * Permission errors (EPERM, EACCES) are caused by file system
@@ -65,50 +117,56 @@ function isCertificateError(e: unknown): boolean {
  * @returns `true` if the error is a permission error, `false` otherwise
  */
 function isPermissionError(e: unknown): boolean {
-	// Check for Node.js ErrnoException with EPERM or EACCES code
-	if (
-		e &&
-		typeof e === "object" &&
-		"code" in e &&
-		(e.code === "EPERM" || e.code === "EACCES") &&
-		"message" in e
-	) {
-		return true;
-	}
+	return hasErrorCode(e, PERMISSION_ERROR_CODES);
+}
 
-	// Check in the error cause as well
-	if (e instanceof Error && e.cause) {
-		return isPermissionError(e.cause);
-	}
-
-	return false;
+function isFileNotFoundError(e: unknown): boolean {
+	return hasErrorCode(e, new Set(["ENOENT"]));
 }
 
 /**
- * File not found errors (ENOENT) occur when users reference files or directories
- * that don't exist. We present a helpful message instead of reporting to Sentry.
- *
- * @param e - The error to check
- * @returns `true` if the error is a file not found error, `false` otherwise
+ * Visit an error and its immediate `cause` (one level only).
  */
-function isFileNotFoundError(e: unknown): boolean {
-	// Check for Node.js ErrnoException with ENOENT code
-	if (
-		e &&
-		typeof e === "object" &&
-		"code" in e &&
-		e.code === "ENOENT" &&
-		"message" in e
-	) {
-		return true;
+function visitErrorOrCause<T>(
+	e: unknown,
+	visit: (e: unknown) => T | undefined
+): T | undefined {
+	const direct = visit(e);
+	if (direct) {
+		return direct;
 	}
-
-	// Check in the error cause as well
-	if (e instanceof Error && e.cause) {
-		return isFileNotFoundError(e.cause);
+	if (e instanceof Error && e.cause !== undefined) {
+		return visit(e.cause);
 	}
+	return undefined;
+}
 
-	return false;
+/**
+ * Filesystem environmental errors (disk full, FD limit, system limits, file locks,
+ * read-only mounts, etc.) are not Wrangler bugs — they are properties of the
+ * user's environment that Wrangler can't fix.
+ *
+ * Unlike EPERM/EACCES (which are also handled separately above to log a more
+ * specific message), we only need to suppress these from Sentry.
+ */
+const FILESYSTEM_ENV_ERROR_CODES = new Set([
+	"EBUSY", // resource busy or locked (Windows file lock, AV scan)
+	"EISDIR", // illegal operation on a directory
+	"ENOTDIR", // path component is not a directory
+	"EEXIST", // file already exists
+	"ENOSPC", // no space left on device
+	"EMFILE", // too many open files (process FD limit)
+	"ENFILE", // too many open files in system
+	"ENAMETOOLONG", // name too long (Windows MAX_PATH, ext4 limits)
+	"EROFS", // read-only file system
+	"ELOOP", // too many symbolic links encountered
+	"ENXIO", // no such device or address
+	"EBADF", // bad file descriptor
+	"EINVAL", // invalid argument (often from `stat` on weird Windows reparse points)
+	"EFBIG", // file too large
+]);
+function isFileSystemEnvError(e: unknown): boolean {
+	return hasErrorCode(e, FILESYSTEM_ENV_ERROR_CODES);
 }
 
 /**
@@ -134,56 +192,27 @@ function isCloudflareAPI(text: string): boolean {
  * @returns `true` if the error is a DNS resolution failure to Cloudflare's API, `false` otherwise
  */
 function isCloudflareAPIDNSError(e: unknown): boolean {
-	// Only handle DNS errors to Cloudflare APIs
-
-	const hasDNSErrorCode = (obj: unknown): boolean => {
-		return (
-			obj !== null &&
-			typeof obj === "object" &&
-			"code" in obj &&
-			obj.code === "ENOTFOUND"
-		);
-	};
-
-	if (hasDNSErrorCode(e)) {
-		const message = e instanceof Error ? e.message : String(e);
-		if (isCloudflareAPI(message)) {
-			return true;
-		}
-		// Also check hostname property
-		if (
-			e &&
-			typeof e === "object" &&
-			"hostname" in e &&
-			typeof e.hostname === "string"
-		) {
-			if (isCloudflareAPI(e.hostname)) {
-				return true;
+	return (
+		visitErrorOrCause(e, (err) => {
+			if (hasErrorCode(e, new Set(["ENOTFOUND"]))) {
+				const message = err instanceof Error ? err.message : String(err);
+				if (isCloudflareAPI(message)) {
+					return true;
+				}
+				if (
+					e &&
+					typeof e === "object" &&
+					"hostname" in e &&
+					typeof (err as { hostname?: unknown }).hostname === "string" &&
+					isCloudflareAPI((err as { hostname: string }).hostname)
+				) {
+					return true;
+				}
 			}
-		}
-	}
 
-	// Errors are often wrapped, so check the cause chain as well
-	if (e instanceof Error && e.cause && hasDNSErrorCode(e.cause)) {
-		const causeMessage =
-			e.cause instanceof Error ? e.cause.message : String(e.cause);
-		const parentMessage = e.message;
-		if (isCloudflareAPI(causeMessage) || isCloudflareAPI(parentMessage)) {
-			return true;
-		}
-		// Check hostname in cause
-		if (
-			typeof e.cause === "object" &&
-			"hostname" in e.cause &&
-			typeof e.cause.hostname === "string"
-		) {
-			if (isCloudflareAPI(e.cause.hostname)) {
-				return true;
-			}
-		}
-	}
-
-	return false;
+			return undefined;
+		}) === true
+	);
 }
 
 /**
@@ -195,35 +224,165 @@ function isCloudflareAPIDNSError(e: unknown): boolean {
  * @returns `true` if the error is a connection timeout to Cloudflare's API, `false` otherwise
  */
 function isCloudflareAPIConnectionTimeoutError(e: unknown): boolean {
-	// Only handle timeouts to Cloudflare APIs - timeouts to user endpoints
-	// (e.g., in dev server or user's own APIs) may indicate actual bugs
-	const hasTimeoutCode = (obj: unknown): boolean => {
-		return (
-			obj !== null &&
-			typeof obj === "object" &&
-			"code" in obj &&
-			obj.code === "UND_ERR_CONNECT_TIMEOUT"
-		);
-	};
+	const hasTimeoutNode =
+		visitErrorOrCause(e, (err) => {
+			if (
+				err !== null &&
+				typeof err === "object" &&
+				"code" in err &&
+				(err as { code?: unknown }).code === "UND_ERR_CONNECT_TIMEOUT"
+			) {
+				return true;
+			}
+			if (
+				err instanceof Error &&
+				err.constructor?.name === "ConnectTimeoutError"
+			) {
+				return true;
+			}
+			return undefined;
+		}) === true;
 
-	if (hasTimeoutCode(e)) {
-		const message = e instanceof Error ? e.message : String(e);
-		if (isCloudflareAPI(message)) {
-			return true;
-		}
+	if (!hasTimeoutNode) {
+		return false;
 	}
 
-	// Errors are often wrapped, so check the cause chain as well
-	if (e instanceof Error && e.cause && hasTimeoutCode(e.cause)) {
-		const causeMessage =
-			e.cause instanceof Error ? e.cause.message : String(e.cause);
-		const parentMessage = e.message;
-		if (isCloudflareAPI(causeMessage) || isCloudflareAPI(parentMessage)) {
-			return true;
-		}
-	}
+	// The Cloudflare URL may live on any node in the chain — the leaf error
+	// (`ConnectTimeoutError`) often does not include the URL, while a parent
+	// wrapper (e.g., cfetch) does.
+	return (
+		visitErrorOrCause(e, (err) => {
+			const message = err instanceof Error ? err.message : String(err);
+			if (isCloudflareAPI(message)) {
+				return true;
+			}
+			if (
+				err !== null &&
+				typeof err === "object" &&
+				"hostname" in err &&
+				typeof (err as { hostname?: unknown }).hostname === "string" &&
+				isCloudflareAPI((err as { hostname: string }).hostname)
+			) {
+				return true;
+			}
+			return undefined;
+		}) === true
+	);
+}
 
-	return false;
+/**
+ * Transient network errors that have no actionable Wrangler bug.
+ *
+ * These are environmental issues (network glitches, server-side resets,
+ * proxy/VPN handshake failures, captive portals) that should be filtered
+ * from Sentry but reported to the user with a helpful message.
+ *
+ * Distinct from {@link isBenignWriteError}, which covers writes to peer-
+ * closed sockets/pipes (EPIPE/EOF/ECONNRESET-on-write).
+ */
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+	"ECONNRESET",
+	"ECONNREFUSED",
+	"EAI_AGAIN", // DNS temporary failure (different from ENOTFOUND)
+	"ETIMEDOUT", // OS-level connect timeout
+	"EHOSTUNREACH",
+	"ENETUNREACH",
+	"EAI_FAIL",
+	"UND_ERR_SOCKET", // undici "other side closed"
+	"UND_ERR_CLOSED",
+	"UND_ERR_BODY_TIMEOUT",
+	"UND_ERR_HEADERS_TIMEOUT",
+	// Note: UND_ERR_CONNECT_TIMEOUT is intentionally absent — that case is
+	// handled separately by `isCloudflareAPIConnectionTimeoutError` for
+	// Cloudflare-API URLs (the user gets a more specific message), and is
+	// otherwise allowed through (timeouts to the user's own endpoints can
+	// indicate real bugs).
+]);
+const TRANSIENT_NETWORK_ERROR_CLASSES = new Set([
+	"ConnectTimeoutError",
+	"SocketError",
+	"BodyTimeoutError",
+	"HeadersTimeoutError",
+]);
+const TRANSIENT_NETWORK_ERROR_MESSAGE_PATTERNS = [
+	"Client network socket disconnected before secure TLS connection was established",
+	"other side closed",
+];
+function isTransientNetworkError(e: unknown): boolean {
+	return (
+		visitErrorOrCause(e, (err) => {
+			if (err === null || typeof err !== "object") {
+				return undefined;
+			}
+			if (
+				"code" in err &&
+				typeof (err as { code: unknown }).code === "string" &&
+				TRANSIENT_NETWORK_ERROR_CODES.has((err as { code: string }).code)
+			) {
+				return true;
+			}
+			if (
+				err instanceof Error &&
+				err.constructor?.name &&
+				TRANSIENT_NETWORK_ERROR_CLASSES.has(err.constructor.name)
+			) {
+				return true;
+			}
+			if (err instanceof Error) {
+				const message = err.message;
+				if (
+					TRANSIENT_NETWORK_ERROR_MESSAGE_PATTERNS.some((m) =>
+						message.includes(m)
+					)
+				) {
+					return true;
+				}
+			}
+			return undefined;
+		}) === true
+	);
+}
+
+/**
+ * Writes to a closed pipe or socket (EPIPE / EOF / ECONNRESET-on-write)
+ * happen when the peer closes a stream while we still have writes in
+ * flight. Common causes: workerd dying with a separate (real) error and
+ * us trying to flush stderr to it, the user `Ctrl+C`-ing the terminal
+ * while wrangler streams to stdout, the user doing `wrangler tail | head`.
+ *
+ * These are never Wrangler bugs — the pipe/socket close already happened
+ * for some other reason and the underlying error (if any) will surface
+ * separately.
+ */
+const BENIGN_WRITE_ERROR_CODES = new Set([
+	"EPIPE",
+	"EOF",
+	"ERR_STREAM_WRITE_AFTER_END",
+	"ERR_STREAM_DESTROYED",
+]);
+function isBenignWriteError(e: unknown): boolean {
+	return (
+		visitErrorOrCause(e, (err) => {
+			if (err === null || typeof err !== "object") {
+				return undefined;
+			}
+			const code = "code" in err ? (err as { code: unknown }).code : undefined;
+			if (typeof code === "string" && BENIGN_WRITE_ERROR_CODES.has(code)) {
+				return true;
+			}
+			// `read ECONNRESET` is a transient network error; only `write ECONNRESET`
+			// (peer closed during our send) is benign-write.
+			if (
+				typeof code === "string" &&
+				code === "ECONNRESET" &&
+				"syscall" in err &&
+				(err as { syscall: unknown }).syscall === "write"
+			) {
+				return true;
+			}
+			return undefined;
+		}) === true
+	);
 }
 
 /**
@@ -235,42 +394,82 @@ function isCloudflareAPIConnectionTimeoutError(e: unknown): boolean {
  * @returns `true` if the error is a network fetch failure, `false` otherwise
  */
 function isNetworkFetchFailedError(e: unknown): boolean {
-	if (e instanceof TypeError) {
-		const message = e.message;
-		if (message.includes("fetch failed")) {
-			return true;
-		}
-	}
-
-	return false;
+	return (
+		visitErrorOrCause(e, (err) => {
+			if (err instanceof TypeError && err.message.includes("fetch failed")) {
+				return true;
+			}
+			return undefined;
+		}) === true
+	);
 }
 
 /**
  * Is this a Containers/Cloudchamber-based auth error?
  *
- * Containers uses custom OpenAPI-based generated client that throws an error that has a different structure to standard cfetch auth errors.
+ * Containers uses custom OpenAPI-based generated client that throws an error
+ * with a different structure to standard cfetch auth errors. We accept either
+ * a 401 or 403 because both indicate the user's credentials are insufficient.
  */
 function isContainersAuthenticationError(e: unknown): e is UserError {
 	return (
-		e instanceof UserError &&
-		e.cause instanceof ApiError &&
-		e.cause.status === 403
+		visitErrorOrCause(e, (err) => {
+			if (
+				err instanceof ApiError &&
+				(err.status === 401 || err.status === 403)
+			) {
+				return true;
+			}
+			return undefined;
+		}) === true
 	);
 }
 
 /**
- * @returns whether `e` is a standard Cloudflare API authentication error
+ * @returns whether `e` is a standard Cloudflare API authentication error.
+ *
+ * The legacy fingerprint is `ParseError` + `code === 10000`, but the auth
+ * stack returns several different envelope codes (10000, 9109, 10001, ...)
+ * with the same "Authentication error" semantic. Accept any 401/403 from
+ * a `ParseError` or `APIError`, plus the historical code-10000 case for
+ * non-status errors.
  */
 export function isAuthenticationError(e: unknown): e is ParseError {
-	return e instanceof ParseError && (e as { code?: number }).code === 10000;
+	return (
+		visitErrorOrCause(e, (err) => {
+			if (err instanceof ParseError) {
+				if ((err as { code?: number }).code === 10000) {
+					return true;
+				}
+				const status = (err as { status?: number }).status;
+				if (status === 401 || status === 403) {
+					return true;
+				}
+			}
+			if (err instanceof APIError) {
+				const status = (err as { status?: number }).status;
+				if (status === 401 || status === 403) {
+					return true;
+				}
+			}
+			return undefined;
+		}) === true
+	);
 }
 
 /**
  * Determines the error type for telemetry purposes, or `undefined` if it cannot be determined.
+ *
+ * Order matters: more specific predicates run before more generic ones so that
+ * (e.g.) a Cloudflare-API connection timeout is reported as `ConnectionTimeout`
+ * rather than the generic `TransientNetworkError`.
  */
 export function getErrorType(e: unknown): string | undefined {
 	if (isCloudflareAPIDNSError(e)) {
 		return "DNSError";
+	}
+	if (isCloudflareAPIConnectionTimeoutError(e)) {
+		return "ConnectionTimeout";
 	}
 	if (isPermissionError(e)) {
 		return "PermissionError";
@@ -278,8 +477,17 @@ export function getErrorType(e: unknown): string | undefined {
 	if (isFileNotFoundError(e)) {
 		return "FileNotFoundError";
 	}
-	if (isCloudflareAPIConnectionTimeoutError(e)) {
-		return "ConnectionTimeout";
+	if (isFileSystemEnvError(e)) {
+		return "FileSystemEnvError";
+	}
+	if (isBenignWriteError(e)) {
+		return "BenignWriteError";
+	}
+	if (isCertificateError(e)) {
+		return "CertificateError";
+	}
+	if (isTransientNetworkError(e)) {
+		return "TransientNetworkError";
 	}
 	if (isAuthenticationError(e) || isContainersAuthenticationError(e)) {
 		return "AuthenticationError";
@@ -305,13 +513,52 @@ export async function handleError(
 
 	logger.log(""); // Just adds a bit of space
 
+	// Unwrap StartDevEnv error envelopes early so all downstream predicates see
+	// the underlying user-recognisable error.
+	if (
+		e &&
+		typeof e === "object" &&
+		"type" in e &&
+		(e as { type?: unknown }).type === "error" &&
+		"cause" in e &&
+		(e as { cause?: unknown }).cause instanceof Error
+	) {
+		loggableException = (e as { cause: Error }).cause;
+	}
+
 	// Log a helpful warning for SSL certificate errors caused by corporate proxies/VPNs
 	if (isCertificateError(e)) {
+		mayReport = false;
 		logger.warn(
 			"Wrangler detected that a corporate proxy or VPN might be enabled on your machine, " +
 				"resulting in API calls failing due to a certificate mismatch. " +
 				"It is likely that you need to install the missing system roots provided by your corporate proxy vendor."
 		);
+	}
+
+	// Filter benign write-side stream errors (EPIPE/EOF/ECONNRESET-on-write).
+	// These are never Wrangler bugs — the underlying cause has already
+	// produced its own error somewhere else.
+	if (isBenignWriteError(e)) {
+		mayReport = false;
+		logger.debug(`Benign write error: ${e}`);
+	}
+
+	// Filter unactionable filesystem environment errors
+	// (EBUSY, EISDIR, ENOTDIR, EEXIST, ENOSPC, EMFILE, ENAMETOOLONG, EROFS, ELOOP, ...)
+	if (isFileSystemEnvError(e)) {
+		mayReport = false;
+		const message = e instanceof Error ? e.message : String(e);
+		logger.error(dedent`
+			A filesystem error occurred.
+
+			${message}
+
+			This is typically caused by your environment (disk full, file locked
+			by another process, system limits reached, read-only mount, etc.) and
+			is not a Wrangler bug.
+		`);
+		return;
 	}
 
 	// Handle DNS resolution errors to Cloudflare API with a user-friendly message
@@ -443,6 +690,25 @@ export async function handleError(
 		return;
 	}
 
+	// Filter transient network errors (ECONNRESET, ETIMEDOUT, EAI_AGAIN,
+	// SocketError "other side closed", TLS pre-handshake disconnects).
+	// Runs after `isCloudflareAPIConnectionTimeoutError` so that connection
+	// timeouts to Cloudflare's API get the more specific message.
+	if (isTransientNetworkError(e)) {
+		mayReport = false;
+		logger.error(dedent`
+			A network request failed due to a transient connectivity issue.
+
+			Common causes:
+			  - Intermittent internet connection
+			  - Captive portal / corporate proxy interfering with TLS
+			  - Server-side connection reset
+
+			Please check your network connection and try again.
+		`);
+		return;
+	}
+
 	// Handle generic "fetch failed" / "Failed to fetch" network errors
 	if (isNetworkFetchFailedError(e)) {
 		mayReport = false;
@@ -571,25 +837,19 @@ export async function handleError(
 		const error = new APIError({
 			text: `A request to the Cloudflare API failed.`,
 			notes: [...e.errors.map((err) => ({ text: renderError(err) }))],
+			status: e.status,
 			telemetryMessage: false,
 		});
+		// 4xx responses are user errors (bad credentials, missing perms, wrong
+		// resource id, malformed input). Don't report to Sentry.
+		if (typeof e.status === "number" && e.status >= 400 && e.status < 500) {
+			error.preventReport();
+		}
 		error.notes.push({
 			text: "\nIf you think this is a bug, please open an issue at: https://github.com/cloudflare/workers-sdk/issues/new/choose",
 		});
 		logger.error(error);
 	} else {
-		if (
-			// Is this a StartDevEnv error event? If so, unwrap the cause, which is usually the user-recognisable error
-			e &&
-			typeof e === "object" &&
-			"type" in e &&
-			e.type === "error" &&
-			"cause" in e &&
-			e.cause instanceof Error
-		) {
-			loggableException = e.cause;
-		}
-
 		logger.error(
 			loggableException instanceof Error
 				? loggableException.message
@@ -599,7 +859,7 @@ export async function handleError(
 			logger.debug(loggableException.stack);
 		}
 
-		if (!(loggableException instanceof UserError)) {
+		if (!isUserErrorLike(loggableException)) {
 			await logPossibleBugMessage();
 		}
 	}
@@ -607,8 +867,9 @@ export async function handleError(
 	if (
 		// Only report the error if we didn't just handle it
 		mayReport &&
-		// ...and it's not a user error
-		!(loggableException instanceof UserError) &&
+		// ...and it's not a user error (UserError, cross-bundle UserError, or
+		// MiniflareError.isUserError())
+		!isUserErrorLike(loggableException) &&
 		// ...and it's not an un-reportable API error
 		!(loggableException instanceof APIError && !loggableException.reportable)
 	) {

--- a/packages/wrangler/src/d1/export.ts
+++ b/packages/wrangler/src/d1/export.ts
@@ -275,7 +275,9 @@ async function pollExport(
 	);
 
 	if (!response.success) {
-		throw new Error(response.error);
+		throw new UserError(response.error, {
+			telemetryMessage: "d1 export api response not successful",
+		});
 	}
 
 	response.messages.forEach((line) => {

--- a/packages/wrangler/src/deployment-bundle/source-maps.ts
+++ b/packages/wrangler/src/deployment-bundle/source-maps.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { UserError } from "@cloudflare/workers-utils";
 import type { BundleResult, SourceMapMetadata } from "./bundle";
 import type { CfModule, CfWorkerSourceMap } from "@cloudflare/workers-utils";
 import type { RawSourceMap } from "source-map";
@@ -116,8 +117,9 @@ function getSourceMappingUrl(module: CfModule): string | undefined {
 	// generated file it appears in.
 	const commentPath = stripPrefix(commentPrefix, lastLine).trim();
 	if (commentPath.startsWith("data:")) {
-		throw new Error(
-			`Unsupported source map path in ${module.filePath}: expected file path but found data URL.`
+		throw new UserError(
+			`Unsupported source map path in ${module.filePath}: expected file path but found data URL.`,
+			{ telemetryMessage: "deploy bundle source map inline data url" }
 		);
 	}
 

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -150,11 +150,15 @@ export const init = createCommand({
 				await childProcess;
 			} catch (e: unknown) {
 				const execaError = e as ExecaError;
-				throw new Error(execaError.shortMessage, {
-					// We include the execaError as the cause, in this way this
-					// will be reflected in Sentry allowing us to better monitor
-					// C3 errors
+				// C3 (the create-cloudflare CLI) is responsible for handling its
+				// own errors and printing useful diagnostics for the user. By the
+				// time we get here, C3 has already piped its stderr to the user's
+				// terminal. Wrap the failure as a UserError so we don't report
+				// thousands of npm/pnpm/yarn warnings and Windows libuv asserts
+				// to Sentry as fake "Wrangler crashes".
+				throw new UserError(execaError.shortMessage, {
 					cause: execaError,
+					telemetryMessage: "init c3 delegation failed",
 				});
 			}
 		}


### PR DESCRIPTION
## Summary

Converted common user-environment failures to `UserError` so they are no longer reported as crashes in Sentry. Also tightened top-level error filtering.

## Changes

- `init.ts` — C3 child-process delegation failures → `UserError`
- `start-remote-proxy-session.ts` — preserves `UserError` identity across catch blocks
- `core/handle-errors.ts` — duck-typed `UserError` detection, broader auth error matching (401/403), new filters for transient network errors, benign write errors, filesystem environment errors, and SSL certificate errors
- `cfetch/internal.ts` — invalid API token characters (ByteString errors) caught and converted to `UserError`; KV/R2 4xx responses use `APIError`/`UserError`
- `assets.ts` — missing assets directory at upload time → `NonExistentAssetsDirError`
- `autoconfig/frameworks/framework-class.ts` — framework version detection failure → `UserError`
- `containers/ssh.ts` — SSH errors (instance not found, auth failures, exit 255) → `UserError`
- `d1/export.ts` — D1 export limitations → `UserError`
- `deployment-bundle/source-maps.ts` — inline data-URL source maps → `UserError`

## Author has addressed the following

- [ ] Tests included/updated
- [ ] Changeset included