### PR TITLE
EMAIL-1692 Support RFC5322 Name formats for To/Cc/Bcc Addresses

### DIFF
--- a/.changeset/email-address-names.md
+++ b/.changeset/email-address-names.md
@@ -1,0 +1,23 @@
+---
+"miniflare": minor
+---
+
+Support named recipients in the Email Sending API MessageBuilder
+
+The `send_email` binding's MessageBuilder now accepts `EmailAddress` objects for `to`, `cc`, and `bcc` in addition to plain strings. You can mix named and plain addresses in the same array:
+
+```js
+await env.SEND_EMAIL.send({
+	from: "sender@example.com",
+	to: [
+		"plain@example.com",
+		'"Name" <address@example.com>',
+		{ name: "Jane Doe", email: "jane@example.com" },
+	],
+	cc: [{ name: "CC Person", email: "cc@example.com" }],
+	subject: "Hello",
+	text: "...",
+});
+```
+
+Additionally, addresses in `"Name" <address>` format are now correctly parsed when checking `allowed_destination_addresses` and `allowed_sender_addresses` restrictions.

--- a/packages/miniflare/src/workers/email/send_email.worker.ts
+++ b/packages/miniflare/src/workers/email/send_email.worker.ts
@@ -22,10 +22,16 @@ function synthesizeMessageId(senderEmail: string): string {
 }
 
 /**
- * Extracts email address from string or EmailAddress object
+ * Extracts the bare email address from a string (which may be in
+ * `"Name" <address>` or plain address format) or EmailAddress object.
  */
 function extractEmailAddress(addr: string | EmailAddress): string {
-	return typeof addr === "string" ? addr : addr.email;
+	if (typeof addr !== "string") {
+		return addr.email;
+	}
+	// Match "Name" <address> or Name <address> or just address
+	const match = addr.match(/<([^>]+)>$/);
+	return match ? match[1].trim() : addr.trim();
 }
 
 /**

--- a/packages/miniflare/src/workers/email/types.ts
+++ b/packages/miniflare/src/workers/email/types.ts
@@ -23,11 +23,11 @@ export interface EmailAddress {
 
 export interface MessageBuilder {
 	from: string | EmailAddress;
-	to: string | string[];
+	to: string | EmailAddress | (string | EmailAddress)[];
 	subject: string;
 	replyTo?: string | EmailAddress;
-	cc?: string | string[];
-	bcc?: string | string[];
+	cc?: string | EmailAddress | (string | EmailAddress)[];
+	bcc?: string | EmailAddress | (string | EmailAddress)[];
 	headers?: Record<string, string>;
 	text?: string;
 	html?: string;

--- a/packages/miniflare/test/plugins/email/index.spec.ts
+++ b/packages/miniflare/test/plugins/email/index.spec.ts
@@ -1390,6 +1390,128 @@ test("MessageBuilder with EmailAddress objects", async ({ expect }) => {
 	);
 });
 
+test("MessageBuilder with named recipient arrays", async ({ expect }) => {
+	const log = new TestLog();
+	const mf = new Miniflare({
+		log,
+		modules: true,
+		script: MESSAGE_BUILDER_WORKER,
+		email: {
+			send_email: [{ name: "SEND_EMAIL" }],
+		},
+		compatibilityDate: "2025-03-17",
+	});
+
+	useDispose(mf);
+
+	const res = await mf.dispatchFetch("http://localhost", {
+		method: "POST",
+		body: JSON.stringify({
+			from: { name: "John Doe", email: "john@example.com" },
+			to: [
+				{ name: "Jane Smith", email: "jane@example.com" },
+				{ name: "Bob Wilson", email: "bob@example.com" },
+			],
+			cc: [{ name: "CC One", email: "cc1@example.com" }],
+			bcc: [
+				{ name: "BCC One", email: "bcc1@example.com" },
+				{ name: "BCC Two", email: "bcc2@example.com" },
+			],
+			subject: "Named Recipient Arrays Test",
+			text: "Hello",
+		}),
+	});
+
+	expect(await res.text()).toBe("ok");
+	expect(res.status).toBe(200);
+
+	await vi.waitFor(
+		async () => {
+			const entry = log.logs.find(
+				([type, message]) =>
+					type === LogLevel.INFO &&
+					message.includes("send_email binding called with MessageBuilder:")
+			);
+			if (!entry) {
+				throw new Error("send_email binding log not found");
+			}
+			const message = entry[1];
+
+			// Verify named recipient arrays are formatted correctly
+			expect(message).toContain(
+				'To: "Jane Smith" <jane@example.com>, "Bob Wilson" <bob@example.com>'
+			);
+			expect(message).toContain('Cc: "CC One" <cc1@example.com>');
+			expect(message).toContain(
+				'Bcc: "BCC One" <bcc1@example.com>, "BCC Two" <bcc2@example.com>'
+			);
+			expect(message).toContain("Subject: Named Recipient Arrays Test");
+		},
+		{ timeout: 5_000, interval: 100 }
+	);
+});
+
+test("MessageBuilder with mixed recipients", async ({ expect }) => {
+	const log = new TestLog();
+	const mf = new Miniflare({
+		log,
+		modules: true,
+		script: MESSAGE_BUILDER_WORKER,
+		email: {
+			send_email: [{ name: "SEND_EMAIL" }],
+		},
+		compatibilityDate: "2025-03-17",
+	});
+
+	useDispose(mf);
+
+	const res = await mf.dispatchFetch("http://localhost", {
+		method: "POST",
+		body: JSON.stringify({
+			from: "sender@example.com",
+			to: [
+				"plain@example.com",
+				{ name: "Jane Doe", email: "jane@example.com" },
+			],
+			cc: [
+				{ name: "CC Person", email: "cc@example.com" },
+				"plain-cc@example.com",
+			],
+			bcc: ["plain-bcc@example.com"],
+			subject: "Mixed Recipients Test",
+			text: "Hello",
+		}),
+	});
+
+	expect(await res.text()).toBe("ok");
+	expect(res.status).toBe(200);
+
+	await vi.waitFor(
+		async () => {
+			const entry = log.logs.find(
+				([type, message]) =>
+					type === LogLevel.INFO &&
+					message.includes("send_email binding called with MessageBuilder:")
+			);
+			if (!entry) {
+				throw new Error("send_email binding log not found");
+			}
+			const message = entry[1];
+
+			// Verify mixed recipients are formatted correctly
+			expect(message).toContain(
+				'To: plain@example.com, "Jane Doe" <jane@example.com>'
+			);
+			expect(message).toContain(
+				'Cc: "CC Person" <cc@example.com>, plain-cc@example.com'
+			);
+			expect(message).toContain("Bcc: plain-bcc@example.com");
+			expect(message).toContain("Subject: Mixed Recipients Test");
+		},
+		{ timeout: 5_000, interval: 100 }
+	);
+});
+
 test("MessageBuilder with multiple recipients", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
@@ -1538,6 +1660,198 @@ test("MessageBuilder respects allowed_sender_addresses", async ({ expect }) => {
 	expect(res.status).toBe(500);
 	const error = await res.text();
 	expect(error).toContain("not allowed");
+});
+
+test("MessageBuilder allowed_destination_addresses with named recipients", async ({
+	expect,
+}) => {
+	const mf = new Miniflare({
+		modules: true,
+		script: MESSAGE_BUILDER_WORKER,
+		email: {
+			send_email: [
+				{
+					name: "SEND_EMAIL",
+					allowed_destination_addresses: ["allowed@example.com"],
+				},
+			],
+		},
+		compatibilityDate: "2025-03-17",
+	});
+
+	useDispose(mf);
+
+	// Named allowed recipient should succeed
+	const resAllowed = await mf.dispatchFetch("http://localhost", {
+		method: "POST",
+		body: JSON.stringify({
+			from: "sender@example.com",
+			to: { name: "Allowed User", email: "allowed@example.com" },
+			subject: "Test",
+			text: "Test",
+		}),
+	});
+	expect(resAllowed.status).toBe(200);
+	expect(await resAllowed.text()).toBe("ok");
+
+	// Named disallowed recipient should fail
+	const resDisallowed = await mf.dispatchFetch("http://localhost", {
+		method: "POST",
+		body: JSON.stringify({
+			from: "sender@example.com",
+			to: { name: "Blocked User", email: "blocked@example.com" },
+			subject: "Test",
+			text: "Test",
+		}),
+	});
+	expect(resDisallowed.status).toBe(500);
+	expect(await resDisallowed.text()).toContain("not allowed");
+});
+
+test("MessageBuilder allowed_sender_addresses with named from", async ({
+	expect,
+}) => {
+	const mf = new Miniflare({
+		modules: true,
+		script: MESSAGE_BUILDER_WORKER,
+		email: {
+			send_email: [
+				{
+					name: "SEND_EMAIL",
+					allowed_sender_addresses: ["allowed@example.com"],
+				},
+			],
+		},
+		compatibilityDate: "2025-03-17",
+	});
+
+	useDispose(mf);
+
+	// Named allowed sender should succeed
+	const resAllowed = await mf.dispatchFetch("http://localhost", {
+		method: "POST",
+		body: JSON.stringify({
+			from: { name: "Allowed Sender", email: "allowed@example.com" },
+			to: "recipient@example.com",
+			subject: "Test",
+			text: "Test",
+		}),
+	});
+	expect(resAllowed.status).toBe(200);
+	expect(await resAllowed.text()).toBe("ok");
+
+	// Named disallowed sender should fail
+	const resDisallowed = await mf.dispatchFetch("http://localhost", {
+		method: "POST",
+		body: JSON.stringify({
+			from: { name: "Blocked Sender", email: "blocked@example.com" },
+			to: "recipient@example.com",
+			subject: "Test",
+			text: "Test",
+		}),
+	});
+	expect(resDisallowed.status).toBe(500);
+	expect(await resDisallowed.text()).toContain("not allowed");
+});
+
+test("MessageBuilder with RFC5322 string addresses", async ({ expect }) => {
+	const log = new TestLog();
+	const mf = new Miniflare({
+		log,
+		modules: true,
+		script: MESSAGE_BUILDER_WORKER,
+		email: {
+			send_email: [{ name: "SEND_EMAIL" }],
+		},
+		compatibilityDate: "2025-03-17",
+	});
+
+	useDispose(mf);
+
+	const res = await mf.dispatchFetch("http://localhost", {
+		method: "POST",
+		body: JSON.stringify({
+			from: '"John Doe" <john@example.com>',
+			to: ['"Jane Smith" <jane@example.com>', "plain@example.com"],
+			cc: '"CC Person" <cc@example.com>',
+			bcc: ['"BCC Person" <bcc@example.com>'],
+			subject: "RFC5322 Address Test",
+			text: "Hello",
+		}),
+	});
+
+	expect(await res.text()).toBe("ok");
+	expect(res.status).toBe(200);
+
+	await vi.waitFor(
+		async () => {
+			const entry = log.logs.find(
+				([type, message]) =>
+					type === LogLevel.INFO &&
+					message.includes("send_email binding called with MessageBuilder:")
+			);
+			if (!entry) {
+				throw new Error("send_email binding log not found");
+			}
+			const message = entry[1];
+
+			// Verify RFC5322 strings are passed through to the log as-is
+			expect(message).toContain('From: "John Doe" <john@example.com>');
+			expect(message).toContain(
+				'To: "Jane Smith" <jane@example.com>, plain@example.com'
+			);
+			expect(message).toContain('Cc: "CC Person" <cc@example.com>');
+			expect(message).toContain('Bcc: "BCC Person" <bcc@example.com>');
+			expect(message).toContain("Subject: RFC5322 Address Test");
+		},
+		{ timeout: 5_000, interval: 100 }
+	);
+});
+
+test("MessageBuilder allowed_destination_addresses with RFC5322 string recipients", async ({
+	expect,
+}) => {
+	const mf = new Miniflare({
+		modules: true,
+		script: MESSAGE_BUILDER_WORKER,
+		email: {
+			send_email: [
+				{
+					name: "SEND_EMAIL",
+					allowed_destination_addresses: ["allowed@example.com"],
+				},
+			],
+		},
+		compatibilityDate: "2025-03-17",
+	});
+
+	useDispose(mf);
+
+	// RFC5322-formatted allowed recipient should succeed
+	const resAllowed = await mf.dispatchFetch("http://localhost", {
+		method: "POST",
+		body: JSON.stringify({
+			from: "sender@example.com",
+			to: '"Allowed User" <allowed@example.com>',
+			subject: "Test",
+			text: "Test",
+		}),
+	});
+	expect(resAllowed.status).toBe(200);
+	expect(await resAllowed.text()).toBe("ok");
+
+	// RFC5322-formatted disallowed recipient should fail
+	const resDisallowed = await mf.dispatchFetch("http://localhost", {
+		method: "POST",
+		body: JSON.stringify({
+			from: "sender@example.com",
+			to: '"Blocked User" <blocked@example.com>',
+			subject: "Test",
+			text: "Test",
+		}),
+	});
+	expect(resDisallowed.status).toBe(500);
+	expect(await resDisallowed.text()).toContain("not allowed");
 });
 
 test("MessageBuilder backward compatibility - old EmailMessage API still works", async ({

--- a/packages/miniflare/test/plugins/email/index.spec.ts
+++ b/packages/miniflare/test/plugins/email/index.spec.ts
@@ -1394,6 +1394,9 @@ test("MessageBuilder with named recipient arrays", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: MESSAGE_BUILDER_WORKER,
 		email: {
@@ -1455,6 +1458,9 @@ test("MessageBuilder with mixed recipients", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: MESSAGE_BUILDER_WORKER,
 		email: {
@@ -1758,6 +1764,9 @@ test("MessageBuilder with RFC5322 string addresses", async ({ expect }) => {
 	const log = new TestLog();
 	const mf = new Miniflare({
 		log,
+		handleStructuredLogs({ message }: { message: string }) {
+			log.info(message);
+		},
 		modules: true,
 		script: MESSAGE_BUILDER_WORKER,
 		email: {


### PR DESCRIPTION
Fixes EMAIL-1692.

This change implements support for RFC5322 addresses in the to/cc/bcc fields of Email Sending, like we do for From/ReplyTo, as well as improving some of the test coverage around this.

It's broken into 2 commits:
- the first commit is the previously approved change from https://github.com/cloudflare/workers-sdk/pull/13738
- the second commit fixes the change to tests between the prior PR's CI run & it getting merged, which then caused failures on main

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Will be done after both this change and the corresponding change in the runtime are released

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->