### PR TITLE
[wrangler] fix: handle deleted entry point during hot-reload without unhandled rejection

### DIFF
--- a/.changeset/fix-unhandled-rejection-esbuild-entry-deleted.md
+++ b/.changeset/fix-unhandled-rejection-esbuild-entry-deleted.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix unhandled promise rejection when the worker entry point is deleted or moved during `wrangler dev` hot-reload — now logs a warning and skips the update instead of crashing

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -12,6 +12,7 @@ import {
 	getWrangler1xLegacyModuleReferences,
 	noopModuleCollector,
 } from "../deployment-bundle/module-collection";
+import { logger } from "../logger";
 import type { SourceMapMetadata } from "../deployment-bundle/bundle";
 import type {
 	CfModule,
@@ -139,9 +140,19 @@ export function runBuild(
 				...(moduleCollector?.modules ?? []),
 				...newAdditionalModules,
 			]);
+			let entrypointSource: string;
+			try {
+				entrypointSource = readFileSync(previousBundle.path, "utf8");
+			} catch (e) {
+				// Entry point was deleted or moved between builds — skip this update.
+				logger.warn(
+					`Could not read entrypoint "${previousBundle.path}": ${(e as NodeJS.ErrnoException).message}`
+				);
+				return previousBundle;
+			}
 			return {
 				...previousBundle,
-				entrypointSource: readFileSync(previousBundle.path, "utf8"),
+				entrypointSource,
 				id: previousBundle.id + 1,
 			};
 		});

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -136,10 +136,6 @@ export function runBuild(
 				previousBundle,
 				"Rebuild triggered with no previous build available"
 			);
-			previousBundle.modules = dedupeModulesByName([
-				...(moduleCollector?.modules ?? []),
-				...newAdditionalModules,
-			]);
 			let entrypointSource: string;
 			try {
 				entrypointSource = readFileSync(previousBundle.path, "utf8");
@@ -152,6 +148,10 @@ export function runBuild(
 			}
 			return {
 				...previousBundle,
+				modules: dedupeModulesByName([
+					...(moduleCollector?.modules ?? []),
+					...newAdditionalModules,
+				]),
 				entrypointSource,
 				id: previousBundle.id + 1,
 			};

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -141,7 +141,7 @@ export function runBuild(
 				entrypointSource = readFileSync(previousBundle.path, "utf8");
 			} catch (e) {
 				// Entry point was deleted or moved between builds — skip this update.
-				logger.warn(
+				logger.once.warn(
 					`Could not read entrypoint "${previousBundle.path}": ${(e as NodeJS.ErrnoException).message}`
 				);
 				return previousBundle;


### PR DESCRIPTION
Fixes #13122.

During `wrangler dev`, if the worker entry point is deleted or moved between builds, the `readFileSync` call inside the `updateBundle` callback throws synchronously and is promoted to an unhandled promise rejection, crashing the process.

**Fix:** Wrap the `readFileSync` call in a try/catch. On failure, log a warning and return the previous bundle unchanged, so the dev session stays alive.

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: internal dev-mode error handling, no user-facing API change