### PR TITLE
[wrangler] fix: show env-var hint when /memberships returns code 9106 (bad credentials)

### DIFF
--- a/.changeset/fix-auth-error-hint-env-var.md
+++ b/.changeset/fix-auth-error-hint-env-var.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: show actionable hint when `/memberships` returns a bad-credentials error (code 9106)
+
+Previously, `wrangler` threw a raw Cloudflare API error ("Missing X-Auth-Key, X-Auth-Email or Authorization headers") with no guidance. Now it emits a `UserError` explaining that an environment variable such as `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_API_KEY`, or `CLOUDFLARE_EMAIL` may be set to an invalid value, and suggests running `wrangler logout` / `wrangler login` to re-authenticate.

--- a/packages/wrangler/src/__tests__/kv/key.test.ts
+++ b/packages/wrangler/src/__tests__/kv/key.test.ts
@@ -1246,7 +1246,9 @@ describe("kv", () => {
 						runWrangler("kv key get --remote key --namespace-id=xxxx")
 					).rejects.toThrowErrorMatchingInlineSnapshot(`
 						[Error: Failed to automatically retrieve account IDs for the logged in user.
-						You may have incorrect permissions on your API token. You can skip this account check by adding an \`account_id\` in your Wrangler configuration file, or by setting the value of CLOUDFLARE_ACCOUNT_ID]
+						You may have incorrect permissions on your API token, or an environment variable such as CLOUDFLARE_API_TOKEN, CLOUDFLARE_API_KEY, or CLOUDFLARE_EMAIL may be set to an invalid value.
+						Check your environment and unset or correct any Cloudflare credential variables, or run \`wrangler logout\` followed by \`wrangler login\` to re-authenticate.
+						You can also skip this account check by adding an \`account_id\` in your Wrangler configuration file, or by setting the value of CLOUDFLARE_ACCOUNT_ID]
 					`);
 				});
 

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -1014,6 +1014,36 @@ describe("User", () => {
 			);
 		});
 
+		it("should include env-var hint when /memberships returns 9106 and /accounts is empty", async ({
+			expect,
+		}) => {
+			msw.use(
+				http.get("*/accounts", () => HttpResponse.json(createFetchResult([])), {
+					once: true,
+				}),
+				http.get(
+					"*/memberships",
+					() => {
+						return HttpResponse.json({
+							success: false,
+							errors: [
+								{
+									code: 9106,
+									message: "Authentication failed",
+								},
+							],
+							result: null,
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			await expect(fetchAllAccounts({})).rejects.toThrowError(
+				/CLOUDFLARE_API_TOKEN/
+			);
+		});
+
 		it("should propagate /memberships errors that are not 9106 or 10000", async ({
 			expect,
 		}) => {

--- a/packages/wrangler/src/user/fetch-accounts.ts
+++ b/packages/wrangler/src/user/fetch-accounts.ts
@@ -17,13 +17,13 @@ import type { ComplianceConfig } from "@cloudflare/workers-utils";
 //     auth (e.g. tokens missing the membership read scope).
 const MEMBERSHIPS_INACCESSIBLE_CODES = [9106, 10000];
 
-function isMembershipsInaccessible(err: unknown): boolean {
-	const code = (err as { code?: number } | undefined)?.code;
-	return code !== undefined && MEMBERSHIPS_INACCESSIBLE_CODES.includes(code);
+function getErrorCode(err: unknown): number | undefined {
+	return (err as { code?: number } | undefined)?.code;
 }
 
-function getMembershipsErrorCode(err: unknown): number | undefined {
-	return (err as { code?: number } | undefined)?.code;
+function isMembershipsInaccessible(err: unknown): boolean {
+	const code = getErrorCode(err);
+	return code !== undefined && MEMBERSHIPS_INACCESSIBLE_CODES.includes(code);
 }
 
 /**
@@ -78,9 +78,9 @@ export async function fetchAllAccounts(
 				// Fall back to `/accounts`, which is already scoped to what the auth can use.
 				return accountsRes.value;
 			}
-			// 9106 specifically can also be returned when an environment variable like
+			// 9106 specifically can be returned when an environment variable like
 			// CLOUDFLARE_API_TOKEN is set to an invalid value — surface that hint.
-			const errCode = getMembershipsErrorCode(membershipsRes.reason);
+			const errCode = getErrorCode(membershipsRes.reason);
 			if (errCode === 9106) {
 				throw new UserError(
 					`Failed to automatically retrieve account IDs for the logged in user.

--- a/packages/wrangler/src/user/fetch-accounts.ts
+++ b/packages/wrangler/src/user/fetch-accounts.ts
@@ -22,6 +22,10 @@ function isMembershipsInaccessible(err: unknown): boolean {
 	return code !== undefined && MEMBERSHIPS_INACCESSIBLE_CODES.includes(code);
 }
 
+function getMembershipsErrorCode(err: unknown): number | undefined {
+	return (err as { code?: number } | undefined)?.code;
+}
+
 /**
  * Fetches the set of accounts that the current login auth can actually use.
  *
@@ -73,6 +77,18 @@ export async function fetchAllAccounts(
 			if (accountsRes.status === "fulfilled" && accountsRes.value.length > 0) {
 				// Fall back to `/accounts`, which is already scoped to what the auth can use.
 				return accountsRes.value;
+			}
+			// 9106 specifically can also be returned when an environment variable like
+			// CLOUDFLARE_API_TOKEN is set to an invalid value — surface that hint.
+			const errCode = getMembershipsErrorCode(membershipsRes.reason);
+			if (errCode === 9106) {
+				throw new UserError(
+					`Failed to automatically retrieve account IDs for the logged in user.
+You may have incorrect permissions on your API token, or an environment variable such as CLOUDFLARE_API_TOKEN, CLOUDFLARE_API_KEY, or CLOUDFLARE_EMAIL may be set to an invalid value.
+Check your environment and unset or correct any Cloudflare credential variables, or run \`wrangler logout\` followed by \`wrangler login\` to re-authenticate.
+You can also skip this account check by adding an \`account_id\` in your ${configFileName(undefined)} file, or by setting the value of CLOUDFLARE_ACCOUNT_ID`,
+					{ telemetryMessage: "user account fetch permission denied" }
+				);
 			}
 			throw new UserError(
 				`Failed to automatically retrieve account IDs for the logged in user.


### PR DESCRIPTION
Fixes #13656.

When `/memberships` returns error code **9106** ("Authentication failed") and `/accounts` is also empty (no usable accounts), Wrangler previously showed a generic "incorrect permissions" message. This PR surfaces a more actionable hint that an environment variable like `CLOUDFLARE_API_TOKEN` may be set to an invalid value.

**Context:** PR #13858 added 9106 to `MEMBERSHIPS_INACCESSIBLE_CODES` — a valid Account API Token returns 9106 on `/memberships` since that endpoint is user-level. When `/accounts` has data, the existing fallback works correctly. This PR handles the edge case where 9106 is returned AND `/accounts` is also empty, which can happen when an env-var credential is malformed.

**Change:** Inside the `isMembershipsInaccessible` block, when code is specifically 9106 and no accounts are available, throw a `UserError` that names the env-var candidates (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_API_KEY`, `CLOUDFLARE_EMAIL`) and suggests `wrangler logout && wrangler login`.

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: error message improvement only, no public API or behavior change