### PR TITLE
[wrangler] Preserve placement on versions secret commands

### DIFF
--- a/.changeset/fix-versions-secrets-placement.md
+++ b/.changeset/fix-versions-secrets-placement.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler versions secret put/delete/bulk` to preserve the existing version's placement settings
+
+When creating a new version via `wrangler versions secret`, the previous code only re-emitted a bare `{ mode: "smart" }` placement when the API reported `placement_mode === "smart"`, dropping any other placement entirely. The new version is now created with the placement settings returned by the API, so placement settings survive a secret put/delete/bulk round-trip.

--- a/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
@@ -7,7 +7,9 @@ import { mockConsoleMethods } from "../../helpers/mock-console";
 import { clearDialogs } from "../../helpers/mock-dialogs";
 import { runInTempDir } from "../../helpers/run-in-tmp";
 import { runWrangler } from "../../helpers/run-wrangler";
-import { mockPostVersion, mockSetupApiCalls } from "./utils";
+import { mockGetVersion, mockPostVersion, mockSetupApiCalls } from "./utils";
+import type { VersionDetails } from "../../../versions/secrets";
+import type { CfPlacement } from "@cloudflare/workers-utils";
 import type { Interface } from "node:readline";
 
 describe("versions secret bulk", () => {
@@ -413,6 +415,92 @@ describe("versions secret bulk", () => {
 
 			await runWrangler(`versions secret bulk --name script-name --env=""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
+	});
+
+	describe("placement", () => {
+		function buildVersionInfo(placement: CfPlacement): VersionDetails {
+			return {
+				id: "ce15c78b-cc43-4f60-b5a9-15ce4f298c2a",
+				metadata: {} as VersionDetails["metadata"],
+				number: 2,
+				resources: {
+					bindings: [],
+					script: {
+						etag: "etag",
+						handlers: ["fetch"],
+						last_deployed_from: "api",
+						placement,
+					},
+					script_runtime: {
+						usage_model: "standard",
+						limits: {},
+					},
+				},
+			};
+		}
+
+		async function runBulk() {
+			await writeFile(
+				"secrets.json",
+				JSON.stringify({ SECRET_1: "secret-1" }),
+				{ encoding: "utf8" }
+			);
+			await runWrangler(`versions secret bulk secrets.json --name script-name`);
+		}
+
+		test("preserves smart placement on the new version", async ({ expect }) => {
+			const placement: CfPlacement = { mode: "smart" };
+			mockSetupApiCalls(expect);
+			mockGetVersion(expect, buildVersionInfo(placement));
+			mockPostVersion(expect, (metadata) => {
+				expect(metadata.placement).toStrictEqual(placement);
+			});
+			await runBulk();
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
+		test("preserves targeted placement with service targets on the new version", async ({
+			expect,
+		}) => {
+			const placement = {
+				mode: "targeted",
+				target: [{ hostname: "example.com", id: 410, type: "http" }],
+			} as unknown as CfPlacement;
+			mockSetupApiCalls(expect);
+			mockGetVersion(expect, buildVersionInfo(placement));
+			mockPostVersion(expect, (metadata) => {
+				expect(metadata.placement).toStrictEqual(placement);
+			});
+			await runBulk();
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
+		test("preserves targeted placement with region targets on the new version", async ({
+			expect,
+		}) => {
+			const placement = {
+				mode: "targeted",
+				target: [{ id: 12, region: "aws:ap-northeast-1", type: "region" }],
+			} as unknown as CfPlacement;
+			mockSetupApiCalls(expect);
+			mockGetVersion(expect, buildVersionInfo(placement));
+			mockPostVersion(expect, (metadata) => {
+				expect(metadata.placement).toStrictEqual(placement);
+			});
+			await runBulk();
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
+		test("omits placement when the existing version has none", async ({
+			expect,
+		}) => {
+			mockSetupApiCalls(expect);
+			mockPostVersion(expect, (metadata) => {
+				expect(metadata.placement).toBeUndefined();
+			});
+			await runBulk();
+			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
@@ -8,6 +8,8 @@ import { useMockIsTTY } from "../../helpers/mock-istty";
 import { runInTempDir } from "../../helpers/run-in-tmp";
 import { runWrangler } from "../../helpers/run-wrangler";
 import { mockGetVersion, mockPostVersion, mockSetupApiCalls } from "./utils";
+import type { VersionDetails } from "../../../versions/secrets";
+import type { CfPlacement } from "@cloudflare/workers-utils";
 
 describe("versions secret delete", () => {
 	const std = mockConsoleMethods();
@@ -225,6 +227,100 @@ describe("versions secret delete", () => {
 			);
 
 			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
+	});
+
+	describe("placement", () => {
+		function buildVersionInfo(placement: CfPlacement): VersionDetails {
+			return {
+				id: "ce15c78b-cc43-4f60-b5a9-15ce4f298c2a",
+				metadata: {} as VersionDetails["metadata"],
+				number: 2,
+				resources: {
+					bindings: [
+						{ type: "secret_text", name: "SECRET", text: "Secret shhh" },
+					],
+					script: {
+						etag: "etag",
+						handlers: ["fetch"],
+						last_deployed_from: "api",
+						placement,
+					},
+					script_runtime: {
+						usage_model: "standard",
+						limits: {},
+					},
+				},
+			};
+		}
+
+		// `versions secret delete` fetches the version twice (once directly, once
+		// inside copyWorkerVersionWithNewSecrets), so register the override twice.
+		function mockGetVersionTwice(
+			expect: Parameters<typeof mockGetVersion>[0],
+			versionInfo: VersionDetails
+		) {
+			mockGetVersion(expect, versionInfo);
+			mockGetVersion(expect, versionInfo);
+		}
+
+		test("preserves smart placement on the new version", async ({ expect }) => {
+			setIsTTY(false);
+			const placement: CfPlacement = { mode: "smart" };
+			mockSetupApiCalls(expect);
+			mockGetVersionTwice(expect, buildVersionInfo(placement));
+			mockPostVersion(expect, (metadata) => {
+				expect(metadata.placement).toStrictEqual(placement);
+			});
+			await runWrangler("versions secret delete SECRET --name script-name");
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
+		test("preserves targeted placement with service targets on the new version", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			const placement = {
+				mode: "targeted",
+				target: [{ hostname: "example.com", id: 410, type: "http" }],
+			} as unknown as CfPlacement;
+			mockSetupApiCalls(expect);
+			mockGetVersionTwice(expect, buildVersionInfo(placement));
+			mockPostVersion(expect, (metadata) => {
+				expect(metadata.placement).toStrictEqual(placement);
+			});
+			await runWrangler("versions secret delete SECRET --name script-name");
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
+		test("preserves targeted placement with region targets on the new version", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			const placement = {
+				mode: "targeted",
+				target: [{ id: 12, region: "aws:ap-northeast-1", type: "region" }],
+			} as unknown as CfPlacement;
+			mockSetupApiCalls(expect);
+			mockGetVersionTwice(expect, buildVersionInfo(placement));
+			mockPostVersion(expect, (metadata) => {
+				expect(metadata.placement).toStrictEqual(placement);
+			});
+			await runWrangler("versions secret delete SECRET --name script-name");
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
+		test("omits placement when the existing version has none", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			mockSetupApiCalls(expect);
+			mockGetVersion(expect);
+			mockPostVersion(expect, (metadata) => {
+				expect(metadata.placement).toBeUndefined();
+			});
+			await runWrangler("versions secret delete SECRET --name script-name");
+			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
@@ -11,7 +11,9 @@ import { useMockStdin } from "../../helpers/mock-stdin";
 import { msw } from "../../helpers/msw";
 import { runInTempDir } from "../../helpers/run-in-tmp";
 import { runWrangler } from "../../helpers/run-wrangler";
-import { mockPostVersion, mockSetupApiCalls } from "./utils";
+import { mockGetVersion, mockPostVersion, mockSetupApiCalls } from "./utils";
+import type { VersionDetails } from "../../../versions/secrets";
+import type { CfPlacement } from "@cloudflare/workers-utils";
 
 describe("versions secret put", () => {
 	const std = mockConsoleMethods();
@@ -574,6 +576,119 @@ describe("versions secret put", () => {
 			await runWrangler('versions secret put NEW_SECRET --env=""');
 
 			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
+	});
+
+	describe("placement", () => {
+		function buildVersionInfo(placement: CfPlacement): VersionDetails {
+			return {
+				id: "ce15c78b-cc43-4f60-b5a9-15ce4f298c2a",
+				metadata: {} as VersionDetails["metadata"],
+				number: 2,
+				resources: {
+					bindings: [],
+					script: {
+						etag: "etag",
+						handlers: ["fetch"],
+						last_deployed_from: "api",
+						placement,
+					},
+					script_runtime: {
+						usage_model: "standard",
+						limits: {},
+					},
+				},
+			};
+		}
+
+		test("preserves smart placement on the new version", async ({ expect }) => {
+			setIsTTY(true);
+
+			mockPrompt({
+				text: "Enter a secret value:",
+				options: { isSecret: true },
+				result: "the-secret",
+			});
+
+			const placement: CfPlacement = { mode: "smart" };
+			mockSetupApiCalls(expect);
+			mockGetVersion(expect, buildVersionInfo(placement));
+			mockPostVersion(expect, (metadata) => {
+				expect(metadata.placement).toStrictEqual(placement);
+			});
+			await runWrangler("versions secret put NEW_SECRET --name script-name");
+
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
+		test("preserves targeted placement with service targets on the new version", async ({
+			expect,
+		}) => {
+			setIsTTY(true);
+
+			mockPrompt({
+				text: "Enter a secret value:",
+				options: { isSecret: true },
+				result: "the-secret",
+			});
+
+			const placement = {
+				mode: "targeted",
+				target: [{ hostname: "example.com", id: 410, type: "http" }],
+			} as unknown as CfPlacement;
+			mockSetupApiCalls(expect);
+			mockGetVersion(expect, buildVersionInfo(placement));
+			mockPostVersion(expect, (metadata) => {
+				expect(metadata.placement).toStrictEqual(placement);
+			});
+			await runWrangler("versions secret put NEW_SECRET --name script-name");
+
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
+		test("preserves targeted placement with region targets on the new version", async ({
+			expect,
+		}) => {
+			setIsTTY(true);
+
+			mockPrompt({
+				text: "Enter a secret value:",
+				options: { isSecret: true },
+				result: "the-secret",
+			});
+
+			const placement = {
+				mode: "targeted",
+				target: [{ id: 12, region: "aws:ap-northeast-1", type: "region" }],
+			} as unknown as CfPlacement;
+			mockSetupApiCalls(expect);
+			mockGetVersion(expect, buildVersionInfo(placement));
+			mockPostVersion(expect, (metadata) => {
+				expect(metadata.placement).toStrictEqual(placement);
+			});
+			await runWrangler("versions secret put NEW_SECRET --name script-name");
+
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
+		test("omits placement when the existing version has none", async ({
+			expect,
+		}) => {
+			setIsTTY(true);
+
+			mockPrompt({
+				text: "Enter a secret value:",
+				options: { isSecret: true },
+				result: "the-secret",
+			});
+
+			mockSetupApiCalls(expect);
+			mockPostVersion(expect, (metadata) => {
+				expect(metadata.placement).toBeUndefined();
+			});
+			await runWrangler("versions secret put NEW_SECRET --name script-name");
+
+			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 	});
 });

--- a/packages/wrangler/src/versions/secrets/index.ts
+++ b/packages/wrangler/src/versions/secrets/index.ts
@@ -10,6 +10,7 @@ import { getMetricsUsageHeaders } from "../../metrics";
 import type { StartDevWorkerOptions } from "../../api";
 import type {
 	CfModule,
+	CfPlacement,
 	CfTailConsumer,
 	CfUserLimits,
 	CfWorkerInit,
@@ -61,6 +62,7 @@ export interface VersionDetails {
 			etag: string;
 			handlers: string[];
 			placement_mode?: "smart";
+			placement?: CfPlacement;
 			last_deployed_from: string;
 		};
 		script_runtime: {
@@ -180,9 +182,10 @@ export async function copyWorkerVersionWithNewSecrets({
 		keepBindings,
 		logpush: scriptSettings.logpush,
 		placement:
-			versionInfo.resources.script.placement_mode === "smart"
+			versionInfo.resources.script.placement ??
+			(versionInfo.resources.script.placement_mode === "smart"
 				? { mode: "smart" }
-				: undefined,
+				: undefined),
 		tail_consumers: scriptSettings.tail_consumers ?? undefined,
 		limits: versionInfo.resources.script_runtime.limits,
 		annotations: {


### PR DESCRIPTION
Fixes #13842.

When creating a new version via `wrangler versions secret`, the previous code only re-emitted a bare `{ mode: "smart" }` placement when the API reported `placement_mode === "smart"`, dropping any other placement entirely. The new version is now created with the placement settings returned by the API, so placement settings survive a secret put/delete/bulk round-trip.


For context, I checked the actual response from `/accounts/<account_id>/workers/scripts/<worker_name>/versions/<version_id>` and confirmed that the API currently returns the placement settings as expected:

```
$ curl https://api.cloudflare.com/client/v4/accounts/<account_id>/workers/scripts/<worker_name>/versions/<version_id> \
    -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
{
  "result": {
    "id": "redacted",
    "number": 11,
    "metadata": {
      "created_on": "2026-05-07T04:52:34.499684Z",
      "source": "dash",
      "author_id": "redacted",
      "author_email": "redacted",
      "has_preview": true
    },
    "annotations": {
      "workers/triggered_by": "version_upload"
    },
    "resources": {
      "script": {
        "etag": "e594a213def980a2febcac3bc35c2b627b7a22ac1264ccd5c6b05533f233e160",
        "handlers": [
          "fetch"
        ],
        "placement_mode": "targeted",
        "placement": {
          "mode": "targeted",
          "target": [
            {
              "id": 12,
              "region": "aws:ap-northeast-1",
              "type": "region"
            }
          ]
        },
        "last_deployed_from": "dash"
      },
      "script_runtime": {
        "compatibility_date": "2026-05-07",
        "compatibility_flags": [
          "nodejs_compat"
        ],
        "usage_model": "standard"
      },
      "bindings": [
        {
          "name": "test",
          "type": "secret_text"
        }
      ]
    }
  },
  "success": true,
  "errors": [],
  "messages": []
}
```

For reference, here are the response objects observed for each placement setting:

```
#  Placement: Smart

        "placement_mode": "smart",
        "placement": {
          "mode": "smart"
        },

# Placement: Region

        "placement_mode": "targeted",
        "placement": {
          "mode": "targeted",
          "target": [
            {
              "id": 12,
              "region": "aws:ap-northeast-1",
              "type": "region"
            }
          ]
        },

# Placement: Service

        "placement_mode": "targeted",
        "placement": {
          "mode": "targeted",
          "target": [
            {
              "hostname": "example.com",
              "id": 410,
              "type": "http"
            }
          ]
        },
```


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This is a bug fix of wrangler.

*A picture of a cute animal (not mandatory, but encouraged)*

<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/c64b1079-7cb0-4c3e-b516-996dc64b60b5" />

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
