### PR TITLE
Enable require-description-when-disabling lint rule on the vitest-pool-workers package

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -201,11 +201,7 @@
 		// Gradually rolling out require-description-when-disabling.
 		// TODO: Remove the following overrides.
 		{
-			"files": [
-				"packages/quick-edit-extension/**",
-				"packages/vitest-pool-workers/**",
-				"packages/wrangler/**",
-			],
+			"files": ["packages/quick-edit-extension/**", "packages/wrangler/**"],
 			"rules": {
 				"workers-sdk/require-description-when-disabling": "off",
 			},

--- a/packages/vitest-pool-workers/src/codemods/vitest-v3-to-v4.ts
+++ b/packages/vitest-pool-workers/src/codemods/vitest-v3-to-v4.ts
@@ -108,7 +108,7 @@ interface NodePath<T = ASTNode> {
 
 interface Collection {
 	find(type: ASTType, filter?: Record<string, unknown>): Collection;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- jscodeshift Collection.forEach accepts callbacks with narrowed NodePath types
 	forEach(callback: (path: NodePath<any>) => void): Collection;
 	at(index: number): Collection;
 	paths(): NodePath[];

--- a/packages/vitest-pool-workers/src/worker/index.ts
+++ b/packages/vitest-pool-workers/src/worker/index.ts
@@ -42,7 +42,7 @@ process.cwd = () => {
 
 globalThis.__console = console;
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- V8 stack trace API requires Function type for Error.captureStackTrace
 function getCallerFileName(of: Function): string | null {
 	const originalStackTraceLimit = Error.stackTraceLimit;
 	const originalPrepareStackTrace = Error.prepareStackTrace;

--- a/packages/vitest-pool-workers/src/worker/patch-ctx.ts
+++ b/packages/vitest-pool-workers/src/worker/patch-ctx.ts
@@ -64,8 +64,7 @@ export function isCtxExportsEnabled(
 	exports: Cloudflare.Exports | undefined
 ): exports is Cloudflare.Exports {
 	return (
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		(globalThis as any).Cloudflare?.compatibilityFlags.enable_ctx_exports &&
-		exports !== undefined
+		(globalThis as unknown as { Cloudflare: Cloudflare }).Cloudflare
+			?.compatibilityFlags.enable_ctx_exports && exports !== undefined
 	);
 }

--- a/packages/vitest-pool-workers/src/worker/types-ambient.d.ts
+++ b/packages/vitest-pool-workers/src/worker/types-ambient.d.ts
@@ -1,9 +1,15 @@
 interface UnsafeEval {
 	eval(code: string, name?: string): unknown;
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-	newFunction(script: string, name?: string, ...args: string[]): Function;
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-	newAsyncFunction(script: string, name?: string, ...args: string[]): Function;
+	newFunction(
+		script: string,
+		name?: string,
+		...args: string[]
+	): (...args: unknown[]) => unknown;
+	newAsyncFunction(
+		script: string,
+		name?: string,
+		...args: string[]
+	): (...args: unknown[]) => unknown;
 }
 
 namespace Cloudflare {
@@ -12,7 +18,7 @@ namespace Cloudflare {
 		__VITEST_POOL_WORKERS_UNSAFE_EVAL: UnsafeEval;
 	}
 	interface GlobalProps {
-		// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+		// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- typeof import() in ambient declarations requires inline import
 		mainModule: typeof import("./index");
 		durableNamespaces: "__VITEST_POOL_WORKERS_RUNNER_DURABLE_OBJECT__";
 	}

--- a/packages/vitest-pool-workers/test/helpers.ts
+++ b/packages/vitest-pool-workers/test/helpers.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-empty-pattern */
 import childProcess from "node:child_process";
 import events from "node:events";
 import fs from "node:fs/promises";
@@ -97,7 +96,7 @@ function wrap(proc: childProcess.ChildProcess): Process {
 	};
 }
 
-// eslint-disable-next-line jest/expect-expect, jest/no-disabled-tests
+// eslint-disable-next-line jest/expect-expect, jest/no-disabled-tests -- base test fixture definition, not an actual test
 export const test = baseTest.extend<{
 	tmpPath: string;
 	seed: (files: Record<string, string>) => Promise<void>;
@@ -108,6 +107,7 @@ export const test = baseTest.extend<{
 	vitestDev: (options?: { flags?: string[]; maxBuffer?: number }) => Process;
 }>({
 	// Fixture for creating a temporary directory
+	// eslint-disable-next-line no-empty-pattern -- Vitest requires the 1st argument to use object destructuring
 	async tmpPath({}, use) {
 		const tmpPoolInstallationPath = inject("tmpPoolInstallationPath");
 		const tmpPathBase = path.join(tmpPoolInstallationPath, "test-");

--- a/packages/vitest-pool-workers/types/cloudflare-test.d.ts
+++ b/packages/vitest-pool-workers/types/cloudflare-test.d.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 declare module "cloudflare:test" {
 	/**
 	 * @deprecated Instead, use `import { env } from "cloudflare:workers"`
@@ -88,7 +87,7 @@ declare module "cloudflare:test" {
 	 * `EventContext`s return by `createPagesEventContext()`.
 	 */
 	export function waitOnExecutionContext(
-		ctx: ExecutionContext | EventContext<Cloudflare.Env, string, any>
+		ctx: ExecutionContext | EventContext<Cloudflare.Env, string, unknown>
 	): Promise<void>;
 	/**
 	 * Creates an instance of `ScheduledController` for use as the 1st argument to
@@ -632,8 +631,8 @@ declare module "cloudflare:test" {
 		: { params: Record<Params, string | string[]> };
 	type EventContextInitData<Data> =
 		Data extends Record<string, never> ? { data?: Data } : { data: Data };
-	type EventContextInit<E extends EventContext<any, any, any>> =
-		E extends EventContext<any, infer Params, infer Data>
+	type EventContextInit<E extends EventContext<unknown, unknown, unknown>> =
+		E extends EventContext<unknown, infer Params, infer Data>
 			? EventContextInitBase &
 					EventContextInitParams<Params> &
 					EventContextInitData<Data>
@@ -644,6 +643,7 @@ declare module "cloudflare:test" {
 	 * Functions.
 	 */
 	export function createPagesEventContext<
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- any is required: PagesFunction wraps Data in a function parameter, which flips subtyping — unknown would reject PagesFunction types with specific Data
 		F extends PagesFunction<Cloudflare.Env, string, any>,
 	>(init: EventContextInit<Parameters<F>[0]>): Parameters<F>[0];
 


### PR DESCRIPTION
This PR enables the `require-description-when-disabling` lint rule on the vitest-pool-workers package.

This is a followup PR for https://github.com/cloudflare/workers-sdk/pull/13698, https://github.com/cloudflare/workers-sdk/pull/13703, https://github.com/cloudflare/workers-sdk/pull/13710, https://github.com/cloudflare/workers-sdk/pull/13741, https://github.com/cloudflare/workers-sdk/pull/13803, https://github.com/cloudflare/workers-sdk/pull/13804 and https://github.com/cloudflare/workers-sdk/pull/13819.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: internal linting change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal linting change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->