### PR TITLE
Migrate Workers AI references off deprecated models

### DIFF
--- a/.changeset/devprod-status-bot-ai-model-migration.md
+++ b/.changeset/devprod-status-bot-ai-model-migration.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/devprod-status-bot": patch
+---
+
+Migrate bot message generation off the deprecated `@cf/meta/llama-2-7b-chat-int8` Workers AI model
+
+Workers AI is deprecating Llama 2 7B chat (alongside several other older models) on May 30th 2026. The status bot now uses `@cf/google/gemma-4-26b-a4b-it` (Gemma 4) for generating its short, friendly chat messages.

--- a/.github/opencode.json
+++ b/.github/opencode.json
@@ -6,7 +6,7 @@
 		"cloudflare-ai-gateway": {
 			"models": {
 				"anthropic/claude-sonnet-4-5": {},
-				"workers-ai/@cf/moonshotai/kimi-k2.5": {}
+				"workers-ai/@cf/moonshotai/kimi-k2.6": {}
 			}
 		}
 	},

--- a/.github/workflows/changeset-review.yml
+++ b/.github/workflows/changeset-review.yml
@@ -56,7 +56,7 @@ jobs:
           DELETED_FILES: ${{ steps.changed-changesets.outputs.deleted_files }}
           ADDED_FILES: ${{ steps.changed-changesets.outputs.added_files }}
         run: |
-          opencode --model "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.5" run --print-logs \
+          opencode --model "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6" run --print-logs \
             "Review the changeset files in this PR.
 
             For \"Version Packages\" PRs, review: ${DELETED_FILES}

--- a/packages/devprod-status-bot/src/index.ts
+++ b/packages/devprod-status-bot/src/index.ts
@@ -21,7 +21,7 @@ async function getBotMessage(ai: Ai, prompt: string) {
 			},
 		] as RoleScopedChatInput[],
 	};
-	const message = await ai.run("@cf/meta/llama-2-7b-chat-int8", chat);
+	const message = await ai.run("@cf/google/gemma-4-26b-a4b-it", chat);
 	if (!("response" in message)) {
 		return "I'm feeling a bit poorly 🥲—try asking me for a message later!";
 	}

--- a/packages/vite-plugin-cloudflare/e2e/fixtures/remote-bindings-disabled/src/index.ts
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/remote-bindings-disabled/src/index.ts
@@ -1,6 +1,6 @@
 export default {
 	async fetch(_req, env) {
-		const content = await env.AI.run("@cf/meta/llama-2-7b-chat-fp16", {
+		const content = await env.AI.run("@cf/google/gemma-4-26b-a4b-it", {
 			messages: [],
 		});
 

--- a/packages/vite-plugin-cloudflare/playground/external-workers/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/external-workers/src/index.ts
@@ -16,7 +16,7 @@ async function waitForMutation(env: Env, mutationId: string) {
 export default {
 	async fetch(request: Request, env: Env): Promise<Response> {
 		const url = new URL(request.url);
-		const aiResponse = await env.AI.run("@cf/meta/llama-3-8b-instruct", {
+		const aiResponse = await env.AI.run("@cf/google/gemma-4-26b-a4b-it", {
 			prompt: "When I say PING, you say PONG. PING",
 		});
 

--- a/packages/wrangler/src/__tests__/ai-search.test.ts
+++ b/packages/wrangler/src/__tests__/ai-search.test.ts
@@ -25,7 +25,7 @@ const MOCK_INSTANCE = {
 	type: "r2",
 	status: "active",
 	namespace: "default",
-	ai_search_model: "@cf/meta/llama-3-8b",
+	ai_search_model: "@cf/google/gemma-4-26b-a4b-it",
 	embedding_model: "@cf/bge-base-en-v1.5",
 };
 
@@ -309,7 +309,7 @@ describe("ai-search commands", () => {
 				)
 			);
 			await runWrangler(
-				"ai-search create my-instance --namespace default --type r2 --source my-bucket --embedding-model @cf/bge-base-en-v1.5 --generation-model @cf/meta/llama-3-8b --chunk-size 512 --chunk-overlap 64 --max-num-results 10 --reranking --hybrid-search --cache --score-threshold 0.5"
+				"ai-search create my-instance --namespace default --type r2 --source my-bucket --embedding-model @cf/bge-base-en-v1.5 --generation-model @cf/google/gemma-4-26b-a4b-it --chunk-size 512 --chunk-overlap 64 --max-num-results 10 --reranking --hybrid-search --cache --score-threshold 0.5"
 			);
 			expect(capturedNamespace).toBe("default");
 			expect(capturedBody).toMatchObject({
@@ -317,7 +317,7 @@ describe("ai-search commands", () => {
 				source: "my-bucket",
 				type: "r2",
 				embedding_model: "@cf/bge-base-en-v1.5",
-				ai_search_model: "@cf/meta/llama-3-8b",
+				ai_search_model: "@cf/google/gemma-4-26b-a4b-it",
 				chunk_size: 512,
 				chunk_overlap: 64,
 				max_num_results: 10,


### PR DESCRIPTION
Migrates all references to Workers AI models slated for deprecation on May 30th 2026 (per the May 2026 deprecation announcement) to current recommended models from the Workers AI catalog.

### Changes

| File | Old model | New model |
|---|---|---|
| `.github/opencode.json` | `@cf/moonshotai/kimi-k2.5` | `@cf/moonshotai/kimi-k2.6` |
| `.github/workflows/changeset-review.yml` | `@cf/moonshotai/kimi-k2.5` | `@cf/moonshotai/kimi-k2.6` |
| `packages/devprod-status-bot/src/index.ts` | `@cf/meta/llama-2-7b-chat-int8` | `@cf/google/gemma-4-26b-a4b-it` |
| `packages/vite-plugin-cloudflare/playground/external-workers/src/index.ts` | `@cf/meta/llama-3-8b-instruct` | `@cf/google/gemma-4-26b-a4b-it` |
| `packages/vite-plugin-cloudflare/e2e/fixtures/remote-bindings-disabled/src/index.ts` | `@cf/meta/llama-2-7b-chat-fp16` | `@cf/google/gemma-4-26b-a4b-it` |
| `packages/wrangler/src/__tests__/ai-search.test.ts` (3 sites, mock data) | `@cf/meta/llama-3-8b` | `@cf/google/gemma-4-26b-a4b-it` |

Replacement model IDs verified against https://developers.cloudflare.com/workers-ai/models/.

The `kimi-k2.5` aliasing on May 10th means the changeset-review workflow would have kept working, but updating to the canonical ID avoids relying on the alias.

A patch changeset is included for `@cloudflare/devprod-status-bot` since it's a versioned private package whose deployed runtime behavior changes. The other touched packages (`vite-plugin-cloudflare` playground/e2e fixtures, `wrangler` test mocks, `.github/` config) don't ship to users, so they don't need changesets.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: All affected files are either CI configuration, internal Cloudflare bot code (`devprod-status-bot`), private playground/e2e fixtures, or unit-test mock data. No user-facing API or behavior changes. The `ai-search.test.ts` mock value is round-tripped through MSW handlers and asserted on, so the existing tests cover the change.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: No user-facing change — this is internal cleanup of references to deprecated Workers AI model IDs. Cloudflare's own model deprecation announcement covers the underlying change.