### PR TITLE
Hardcode asset worker cohort to 'ent' for latency testing

### DIFF
--- a/.changeset/hardcode-cohort-ent.md
+++ b/.changeset/hardcode-cohort-ent.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+Temporarily hardcode asset worker cohort to "ent" for latency testing
+
+Disables the `lookupCohort` RPC call and cohort-based version routing in the outer entrypoint while keeping all the glue code (analytics, bindings, types) in place for re-enablement.

--- a/packages/workers-shared/asset-worker/src/worker.ts
+++ b/packages/workers-shared/asset-worker/src/worker.ts
@@ -372,10 +372,12 @@ export default class AssetWorkerOuter<TEnv extends Env = Env>
 	 */
 	private async getCohort(): Promise<string | null> {
 		if (this.resolvedCohort === undefined) {
-			this.resolvedCohort = await lookupCohort(
-				this.env,
-				this.env.CONFIG?.account_id
-			);
+			// TODO: Hardcoding temporarily for latency testing.
+			// this.resolvedCohort = await lookupCohort(
+			// 	this.env,
+			// 	this.env.CONFIG?.account_id
+			// );
+			this.resolvedCohort = "ent";
 		}
 		return this.resolvedCohort;
 	}

--- a/packages/workers-shared/asset-worker/src/worker.ts
+++ b/packages/workers-shared/asset-worker/src/worker.ts
@@ -387,7 +387,7 @@ export default class AssetWorkerOuter<TEnv extends Env = Env>
 	 * When a cohort is provided, the runtime routes the inner entrypoint
 	 * to the version assigned to that cohort in the current deployment.
 	 */
-	private getInnerEntrypoint(cohort?: string | null): AssetWorkerMethods {
+	private getInnerEntrypoint(_cohort?: string | null): AssetWorkerMethods {
 		const loopbackCtx = this.ctx as AssetWorkerContext;
 		const entrypoint = loopbackCtx.exports?.AssetWorkerInner;
 		if (entrypoint === undefined) {

--- a/packages/workers-shared/asset-worker/src/worker.ts
+++ b/packages/workers-shared/asset-worker/src/worker.ts
@@ -399,7 +399,8 @@ export default class AssetWorkerOuter<TEnv extends Env = Env>
 		}
 		return entrypoint({
 			props: { traceContext: this.env.JAEGER.getSpanContext() },
-			...(cohort ? { version: { cohort } } : {}),
+			// TODO: Hardcoding temporarily for latency testing.
+			// ...(cohort ? { version: { cohort } } : {}),
 		});
 	}
 


### PR DESCRIPTION
Fixes #wc-4889.

Hardcodes the cohort determination temporarily to help narrow down latency issues.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal only

*A picture of a cute animal (not mandatory, but encouraged)*
<img width="4080" height="3072" alt="PXL_20240505_171719831" src="https://github.com/user-attachments/assets/b21107e8-5c24-4d63-9688-44f64ae7dd73" />

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
