### PR TITLE
[wrangler] Fix Account API Tokens failing on `/memberships`

### DIFF
--- a/.changeset/wrangler-memberships-9106-fallback.md
+++ b/.changeset/wrangler-memberships-9106-fallback.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler whoami` and account selection failing for Account API Tokens
+
+The `/memberships` fallback for Account API Tokens was checking for code 9109, but `/memberships` actually returns 9106 for that case. Correct the code so the fallback to `/accounts` triggers as intended.

--- a/packages/wrangler/src/__tests__/kv/key.test.ts
+++ b/packages/wrangler/src/__tests__/kv/key.test.ts
@@ -1232,8 +1232,8 @@ describe("kv", () => {
 								return HttpResponse.json(
 									createFetchResult(null, false, [
 										{
-											code: 9109,
-											message: "Uauthorized to access requested resource",
+											code: 9106,
+											message: "Authentication failed (status: 400)",
 										},
 									]),
 									{ status: 200 }

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -886,7 +886,7 @@ describe("User", () => {
 			);
 		});
 
-		it("should fall back to /accounts when /memberships returns 9109 (Account API Token path)", async ({
+		it("should fall back to /accounts when /memberships returns 9106 (Account API Token path)", async ({
 			expect,
 		}) => {
 			msw.use(
@@ -905,7 +905,12 @@ describe("User", () => {
 					() => {
 						return HttpResponse.json({
 							success: false,
-							errors: [{ code: 9109, message: "Insufficient permissions" }],
+							errors: [
+								{
+									code: 9106,
+									message: "Authentication failed (status: 400)",
+								},
+							],
 							result: null,
 						});
 					},
@@ -919,7 +924,7 @@ describe("User", () => {
 			]);
 		});
 
-		it("should throw a helpful error on 9109 when /accounts is also unusable", async ({
+		it("should throw a helpful error on 9106 when /accounts is also unusable", async ({
 			expect,
 		}) => {
 			msw.use(
@@ -931,7 +936,12 @@ describe("User", () => {
 					() => {
 						return HttpResponse.json({
 							success: false,
-							errors: [{ code: 9109, message: "Insufficient permissions" }],
+							errors: [
+								{
+									code: 9106,
+									message: "Authentication failed (status: 400)",
+								},
+							],
 							result: null,
 						});
 					},
@@ -1004,7 +1014,7 @@ describe("User", () => {
 			);
 		});
 
-		it("should propagate /memberships errors that are not 9109 or 10000", async ({
+		it("should propagate /memberships errors that are not 9106 or 10000", async ({
 			expect,
 		}) => {
 			msw.use(

--- a/packages/wrangler/src/__tests__/whoami.test.ts
+++ b/packages/wrangler/src/__tests__/whoami.test.ts
@@ -559,8 +559,8 @@ describe("whoami", () => {
 		expect,
 	}) => {
 		writeAuthConfigFile({ oauth_token: "some-oauth-token" });
-		// `fetchAllAccounts` only tolerates 9106 (Account API Token), 9109
-		// (Insufficient permissions) and 10000 (Authentication error) on
+		// `fetchAllAccounts` only tolerates 9106 (Account API Token) and
+		// 10000 (Authentication error) on
 		// `/memberships`. Any other failure is propagated and `whoami` fails.
 		// Use non-once handlers because `handleError` re-invokes `whoami` to
 		// display user info on auth errors, so `/user` and `/memberships` are

--- a/packages/wrangler/src/__tests__/whoami.test.ts
+++ b/packages/wrangler/src/__tests__/whoami.test.ts
@@ -490,7 +490,7 @@ describe("whoami", () => {
 	}) => {
 		writeAuthConfigFile({ oauth_token: "some-oauth-token" });
 		// `fetchAllAccounts` falls back to `/accounts` when `/memberships`
-		// fails with 9109 (Insufficient permissions) or 10000 (Authentication
+		// fails with 9106 (Account API Token) or 10000 (Authentication
 		// error), so the accounts table still renders. The separate
 		// `fetchMembershipRoles` call also fails with 10000 and surfaces the
 		// "Unable to get membership roles" hint to the user.
@@ -559,11 +559,12 @@ describe("whoami", () => {
 		expect,
 	}) => {
 		writeAuthConfigFile({ oauth_token: "some-oauth-token" });
-		// `fetchAllAccounts` only tolerates 9109 (Insufficient permissions) and
-		// 10000 (Authentication error) on `/memberships`. Any other failure is
-		// propagated and `whoami` fails. Use non-once handlers because
-		// `handleError` re-invokes `whoami` to display user info on auth
-		// errors, so `/user` and `/memberships` are each called twice.
+		// `fetchAllAccounts` only tolerates 9106 (Account API Token), 9109
+		// (Insufficient permissions) and 10000 (Authentication error) on
+		// `/memberships`. Any other failure is propagated and `whoami` fails.
+		// Use non-once handlers because `handleError` re-invokes `whoami` to
+		// display user info on auth errors, so `/user` and `/memberships` are
+		// each called twice.
 		msw.use(
 			http.get("*/user", () =>
 				HttpResponse.json(createFetchResult({ email: "user@example.com" }))

--- a/packages/wrangler/src/user/fetch-accounts.ts
+++ b/packages/wrangler/src/user/fetch-accounts.ts
@@ -5,12 +5,17 @@ import type { ComplianceConfig } from "@cloudflare/workers-utils";
 
 // Cloudflare API error codes returned by `/memberships` that mean "the
 // current auth cannot read memberships".
-//   - 9109 (Insufficient permissions): structural for Account API Tokens,
-//     which cannot read user-level memberships at all.
+//   - 9106 ("Authentication failed"): what `/memberships` returns for
+//     Account API Tokens. `/memberships` is a user-level endpoint and
+//     account-scoped tokens have no user identity, so the API rejects
+//     them at this endpoint even though a valid Bearer token was sent.
+//     (Note: `/user` returns 9109 "Insufficient permissions" for the
+//     same auth, but `/memberships` does not — see `getEmail` in
+//     `whoami.ts` for the 9109 case.)
 //   - 10000 (Authentication error): the token is not accepted by the
 //     `/memberships` endpoint, but `/accounts` may still work for the same
 //     auth (e.g. tokens missing the membership read scope).
-const MEMBERSHIPS_INACCESSIBLE_CODES = [9109, 10000];
+const MEMBERSHIPS_INACCESSIBLE_CODES = [9106, 10000];
 
 function isMembershipsInaccessible(err: unknown): boolean {
 	const code = (err as { code?: number } | undefined)?.code;
@@ -27,9 +32,9 @@ function isMembershipsInaccessible(err: unknown): boolean {
  * This avoids displaying accounts that the current credentials cannot meaningfully use.
  *
  * If `/memberships` returns a code that indicates it is inaccessible to the
- * current auth — 9109 (Insufficient permissions) or 10000 (Authentication
- * error) — we fall back to the `/accounts` response, which is itself scoped
- * to what the auth can access. Any other failure on either endpoint is
+ * current auth — 9106 (Account API Tokens) or 10000 (Authentication error)
+ * — we fall back to the `/accounts` response, which is itself scoped to
+ * what the auth can access. Any other failure on either endpoint is
  * propagated so the underlying API error reaches the user.
  *
  * @param complianceConfig - The compliance configuration for API requests


### PR DESCRIPTION
Fixes #13857.

PR #13770 added a fallback to `/accounts` when `/memberships` is inaccessible to the current auth, with code 9109 (Insufficient permissions) cited as the "structural Account API Token case". In practice, `/memberships` actually returns code 9106 (`Authentication failed`) for Account API Tokens — `/memberships` is a user-level endpoint and account-scoped tokens have no user identity, so the API rejects them at this endpoint even though a valid Bearer token is sent. (`/user` is the endpoint that returns 9109 for the same auth — see `getEmail` in `whoami.ts`.)

Result: any user authenticating with an Account API Token saw `wrangler whoami` (and any non-cached account selection) fail with `A request to the Cloudflare API (/memberships) failed. Authentication failed (status: 400) [code: 9106]` after upgrading to a Wrangler version with #13770.

This fixes the fallback by replacing 9109 with 9106 in `MEMBERSHIPS_INACCESSIBLE_CODES`. 10000 (Authentication error) is retained as-is. Tests are updated to assert the corrected code.

**Manual testing with account API tokens:**
- `CLOUDFLARE_API_TOKEN=... pnpx wrangler@4.88 whoami` ✅ 
- `CLOUDFLARE_API_TOKEN=... pnpx wrangler@4.89.1 whoami` ❌ 
- `CLOUDFLARE_API_TOKEN=... pnpx https://pkg.pr.new/wrangler@9b148fb whoami` ✅ 

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: bug fix; no public API or behaviour change beyond restoring pre-regression behaviour for Account API Tokens.