### PR TITLE
feat(miniflare,wrangler): cross-worker workflow bindings via dev registry

### DIFF
--- a/.changeset/getplatformproxy-cross-script-workflows.md
+++ b/.changeset/getplatformproxy-cross-script-workflows.md
@@ -1,0 +1,11 @@
+---
+"wrangler": minor
+---
+
+`getPlatformProxy()` now passes through workflow bindings that have a `script_name`
+
+Workflows without a `script_name` are still stripped (and warned about) because the engine for an internal workflow can't run inside the empty proxy worker that backs `getPlatformProxy()`. Workflows with a `script_name` are handed to miniflare unchanged; miniflare reroutes the engine's `USER_WORKFLOW` binding through the dev-registry-proxy when the target worker is running in another Miniflare instance — the same mechanism Durable Objects already use.
+
+This means SvelteKit/Remix (and similar split-process setups) can call `platform.env.MY_WORKFLOW.create({ ... })` directly from their server-side request handlers in dev, as long as the workflow class is exposed by another worker registered in the dev registry.
+
+Closes [#7459](https://github.com/cloudflare/workers-sdk/issues/7459).

--- a/.changeset/workflow-cross-worker-bindings.md
+++ b/.changeset/workflow-cross-worker-bindings.md
@@ -1,0 +1,13 @@
+---
+"miniflare": minor
+---
+
+Support cross-worker workflow bindings via the dev registry
+
+When a workflow binding has a `scriptName` that refers to a worker registered in another Miniflare instance (via `unsafeDevRegistryPath`), miniflare now reroutes the engine's `USER_WORKFLOW` binding through the dev-registry-proxy worker — the same mechanism Durable Objects already use for cross-worker `scriptName` bindings.
+
+Previously the workflow engine was bound directly to a local service `core:user:<scriptName>`, so workerd refused to start when that script lived in a different process.
+
+This unblocks `getPlatformProxy()` (and any other split-Miniflare setup) for users whose workflow class is defined in a separate worker — for example SvelteKit/Remix on Cloudflare, where `adapter-cloudflare`'s dev integration runs the user's worker in a sidecar.
+
+See [#7459](https://github.com/cloudflare/workers-sdk/issues/7459).

--- a/fixtures/get-platform-proxy/tests/get-platform-proxy.env.test.ts
+++ b/fixtures/get-platform-proxy/tests/get-platform-proxy.env.test.ts
@@ -293,16 +293,22 @@ describe("getPlatformProxy - env", () => {
 			expect(warn).not.toHaveBeenCalled();
 		});
 
-		it("warns about Workflows and doesn't crash", async ({ expect }) => {
+		it("warns only about internal Workflows, not cross-script ones, and doesn't crash", async ({
+			expect,
+		}) => {
 			await getPlatformProxy<Env>({
 				configPath: path.join(__dirname, "..", "wrangler_workflow.jsonc"),
 			});
+			// Only MY_WORKFLOW_INTERNAL (no script_name) is unsupported in
+			// getPlatformProxy(); MY_WORKFLOW_EXTERNAL (script_name set) is
+			// passed through to miniflare, which routes it via the dev-registry
+			// proxy to the named worker.
+			expect(warn).toHaveBeenCalledTimes(1);
 			expect(warn.mock.calls[0][0].replaceAll(/[\r\n]+/g, "\n"))
 				.toMatchInlineSnapshot(`
-					"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m				You have defined bindings to the following Workflows:[0m
-					  				- {"binding":"MY_WORKFLOW_INTERNAL","name":"my-workflow-internal","class_name":"MyWorkflowInternal"}
-					  - {"binding":"MY_WORKFLOW_EXTERNAL","name":"my-workflow-external","class_name":"MyWorkflowExternal","script_name":"OtherWorker"}
-					  				These are not available in local development, so you will not be able to bind to them when testing locally, but they should work in production.
+					"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mYou have defined bindings to the following Workflows without a script_name:[0m
+					  - {"binding":"MY_WORKFLOW_INTERNAL","name":"my-workflow-internal","class_name":"MyWorkflowInternal"}
+					  These are not available in local development, so you will not be able to bind to them when testing locally, but they should work in production.
 					"
 				`);
 		});

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -587,6 +587,31 @@ function getExternalServiceEntrypoints(allWorkerOpts: PluginWorkerOptions[]) {
 			}
 		}
 
+		// Cross-worker workflow bindings: when `scriptName` refers to a worker
+		// outside this Miniflare instance (registered in the dev registry), mark
+		// the workflow `external` so the workflows plugin reroutes the engine's
+		// USER_WORKFLOW binding through the dev-registry-proxy. Mirrors the DO
+		// block above. Without this, the engine binds to a non-existent local
+		// service `core:user:<scriptName>` and workerd refuses to start.
+		if (workerOpts.workflows.workflows) {
+			for (const [bindingName, workflow] of Object.entries(
+				workerOpts.workflows.workflows
+			)) {
+				const { scriptName, className, remoteProxyConnectionString } = workflow;
+				if (
+					remoteProxyConnectionString === undefined &&
+					scriptName &&
+					!allWorkerNames.includes(scriptName)
+				) {
+					workerOpts.workflows.workflows[bindingName] = {
+						...workflow,
+						external: true,
+					};
+					getEntrypoints(scriptName).entrypoints.add(className);
+				}
+			}
+		}
+
 		if (workerOpts.core.tails) {
 			for (let i = 0; i < workerOpts.core.tails.length; i++) {
 				const {

--- a/packages/miniflare/src/plugins/workflows/index.ts
+++ b/packages/miniflare/src/plugins/workflows/index.ts
@@ -8,6 +8,7 @@ import {
 	getUserBindingServiceName,
 	PersistenceSchema,
 	ProxyNodeBinding,
+	SERVICE_DEV_REGISTRY_PROXY,
 } from "../shared";
 import type { Service } from "../../runtime";
 import type { Plugin, RemoteProxyConnectionString } from "../shared";
@@ -19,6 +20,13 @@ export const WorkflowsOptionsSchema = z.object({
 				name: z.string(),
 				className: z.string(),
 				scriptName: z.string().optional(),
+				// When set, the workflow's `scriptName` refers to a worker that lives
+				// outside this Miniflare instance (registered in the wrangler dev
+				// registry). The engine's USER_WORKFLOW binding is rerouted through
+				// the dev-registry-proxy so calls reach the external worker. Set by
+				// `getExternalServiceEntrypoints` in `src/index.ts`; not part of the
+				// public API.
+				external: z.boolean().optional(),
 				remoteProxyConnectionString: z
 					.custom<RemoteProxyConnectionString>()
 					.optional(),
@@ -144,13 +152,27 @@ export const WORKFLOWS_PLUGIN: Plugin<
 								name: "ENGINE",
 								durableObjectNamespace: { className: "Engine" },
 							},
-							{
-								name: "USER_WORKFLOW",
-								service: {
-									name: getUserServiceName(workflow.scriptName),
-									entrypoint: workflow.className,
-								},
-							},
+							workflow.external && workflow.scriptName
+								? {
+										name: "USER_WORKFLOW",
+										service: {
+											name: getUserServiceName(SERVICE_DEV_REGISTRY_PROXY),
+											entrypoint: "ExternalServiceProxy",
+											props: {
+												json: JSON.stringify({
+													service: workflow.scriptName,
+													entrypoint: workflow.className,
+												}),
+											},
+										},
+									}
+								: {
+										name: "USER_WORKFLOW",
+										service: {
+											name: getUserServiceName(workflow.scriptName),
+											entrypoint: workflow.className,
+										},
+									},
 							{
 								name: "BINDING_NAME",
 								json: JSON.stringify(bindingName),

--- a/packages/miniflare/test/dev-registry.spec.ts
+++ b/packages/miniflare/test/dev-registry.spec.ts
@@ -845,6 +845,72 @@ describe.sequential("DevRegistry", () => {
 		);
 	});
 
+	test("workflow with cross-worker scriptName", async ({ expect }) => {
+		const unsafeDevRegistryPath = await useTmp();
+		const local = new Miniflare({
+			name: "local-worker",
+			unsafeDevRegistryPath,
+
+			workflows: {
+				MY_WORKFLOW: {
+					name: "MY_WORKFLOW",
+					className: "MyWorkflow",
+					scriptName: "remote-worker",
+				},
+			},
+			compatibilityDate: "2024-11-20",
+			modules: true,
+			script: `
+				export default {
+					async fetch(request, env, ctx) {
+						const instance = await env.MY_WORKFLOW.create({ id: "cross-worker-instance" });
+						return Response.json({ id: instance.id });
+					}
+				}
+			`,
+		});
+		useDispose(local);
+
+		const remote = new Miniflare({
+			name: "remote-worker",
+			unsafeDevRegistryPath,
+
+			workflows: {
+				MY_WORKFLOW: {
+					name: "MY_WORKFLOW",
+					className: "MyWorkflow",
+				},
+			},
+			compatibilityDate: "2024-11-20",
+			modules: true,
+			script: `
+				import { WorkflowEntrypoint } from "cloudflare:workers";
+				export class MyWorkflow extends WorkflowEntrypoint {
+					async run(event, step) {
+						return await step.do("hello", async () => "from remote workflow");
+					}
+				}
+				export default {
+					async fetch() { return new Response("ok"); }
+				}
+			`,
+		});
+		useDispose(remote);
+
+		await remote.ready;
+		// Workflow `create()` is queued asynchronously by the engine; routing
+		// goes engine (local) → ExternalServiceProxy → dev registry → remote
+		// MyWorkflow.run. Verify the instance is created with the expected id.
+		await vi.waitFor(
+			async () => {
+				const res = await local.dispatchFetch("http://placeholder");
+				expect(res.status).toBe(200);
+				expect(await res.json()).toEqual({ id: "cross-worker-instance" });
+			},
+			{ timeout: 10_000, interval: 100 }
+		);
+	});
+
 	test("DO RPC survives remote worker restart", async ({ expect }) => {
 		const unsafeDevRegistryPath = await useTmp();
 

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -257,16 +257,28 @@ async function getMiniflareOptionsFromConfig(args: {
 	}
 
 	if (config.workflows?.length > 0) {
-		logger.warn(dedent`
-				You have defined bindings to the following Workflows:
-				${config.workflows.map((b) => `- ${JSON.stringify(b)}`).join("\n")}
+		// Workflow bindings without a `script_name` aren't routable in
+		// `getPlatformProxy()` — the engine inside this Miniflare instance has
+		// nowhere to dispatch USER_WORKFLOW. Strip those (and warn).
+		// Cross-worker workflows (with `script_name` referring to another worker
+		// registered in the dev registry) are passed through; Miniflare's
+		// workflows plugin reroutes them via the dev-registry-proxy.
+		const localWorkflows = config.workflows.filter((w) => !w.script_name);
+		if (localWorkflows.length > 0) {
+			logger.warn(dedent`
+				You have defined bindings to the following Workflows without a script_name:
+				${localWorkflows.map((b) => `- ${JSON.stringify(b)}`).join("\n")}
 				These are not available in local development, so you will not be able to bind to them when testing locally, but they should work in production.
 				`);
 
-		// Remove workflows from bindings to prevent Miniflare from complaining
-		const workflowBindings = extractBindingsOfType("workflow", bindings);
-		for (const workflow of workflowBindings) {
-			delete bindings?.[workflow.binding];
+			// Remove only the local workflows from bindings.
+			const allWorkflowBindings = extractBindingsOfType("workflow", bindings);
+			const localBindingNames = new Set(localWorkflows.map((w) => w.binding));
+			for (const wf of allWorkflowBindings) {
+				if (localBindingNames.has(wf.binding)) {
+					delete bindings?.[wf.binding];
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Workflow bindings get stripped from `getPlatformProxy()` because miniflare can't run a workflow whose engine lives in another worker. That's fine inside a self-contained `wrangler dev`, but it kills the split-process model that `adapter-cloudflare` (SvelteKit, Remix) uses in dev — the user's `+server.ts` runs in Vite, the workflow class runs in a wrangler sidecar, and `platform.env.MY_WORKFLOW.create(...)` becomes `undefined.create(...)`.

DOs already work in this setup via `script_name` cross-worker routing through the dev registry. This PR adds the same for workflows.

- **miniflare**: when a workflow's `scriptName` doesn't refer to a local worker, route the engine's `USER_WORKFLOW` binding through the existing `ExternalServiceProxy` on the dev-registry-proxy worker. Same plumbing DOs use; no new proxy class needed because workflows talk to USER_WORKFLOW as a service binding.
- **wrangler**: `getPlatformProxy()` stops stripping workflows that have a `script_name` (it still strips local ones — the engine has nowhere to go for those).

Tested with a SvelteKit example end-to-end: `platform.env.BOT_WORKFLOW.create(...)` from a +server.ts now returns a real instance, runs in the sidecar, and a step inside the workflow can call back to a DO and reply over a WebSocket. Unit test added in `dev-registry.spec.ts` mirrors the existing cross-worker DO tests.

Closes #7459.


- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: only fixes a bug of an existing capability