### PR TITLE
Add telemetry for detecting whether AI coding agents have Cloudflare skills installed

### DIFF
--- a/.changeset/agent-skills-telemetry.md
+++ b/.changeset/agent-skills-telemetry.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add telemetry for detecting whether AI coding agents have Cloudflare skills installed
+
+Wrangler now includes a `currentAgentSkillsInstalled` property in telemetry events that reports whether the current AI coding agent has Cloudflare skills present on disk. The value distinguishes between skills installed automatically by Wrangler (`"automatic"`), skills installed manually by the user (`"manual"`), no skills present (`false`), or no supported agent detected (`null`). Skill names are fetched from the GitHub Contents API with a 24-hour disk cache to avoid rate limits.

--- a/packages/wrangler/src/__tests__/agents-skills-install.test.ts
+++ b/packages/wrangler/src/__tests__/agents-skills-install.test.ts
@@ -2,16 +2,24 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { getGlobalWranglerConfigPath } from "@cloudflare/workers-utils";
+import { detectAgenticEnvironment } from "am-i-vibing";
 import ci from "ci-info";
+import { http, HttpResponse } from "msw";
 import { afterEach, assert, beforeEach, describe, test, vi } from "vitest";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs, mockConfirm } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
+import { msw } from "./helpers/msw";
 import { runInTempDir } from "./helpers/run-in-tmp";
-import type { installCloudflareSkillsGlobally as InstallFnType } from "../agents-skills-install";
+import type {
+	installCloudflareSkillsGlobally as InstallFnType,
+	telemetryCurrentAgentSkillsInstalled as TelemetryFnType,
+} from "../agents-skills-install";
 
 // Undo the global no-op mock from vitest.setup.ts so we test the real implementation
 vi.unmock("../agents-skills-install");
+
+vi.mock("am-i-vibing");
 
 // Mock giget to avoid real network calls. The default downloadTemplate
 // implementation creates two fake skill directories; individual tests can
@@ -72,6 +80,19 @@ async function freshImport(): Promise<typeof InstallFnType> {
 	vi.resetModules();
 	const mod = await import("../agents-skills-install");
 	return mod.installCloudflareSkillsGlobally;
+}
+
+/**
+ * Like {@link freshImport} but returns the telemetry function instead.
+ * Each call resets the module graph (and hence the memoised promise) so
+ * that tests start with a clean state.
+ *
+ * @returns The `telemetryCurrentAgentSkillsInstalled` function from a fresh module import.
+ */
+async function freshTelemetryImport(): Promise<typeof TelemetryFnType> {
+	vi.resetModules();
+	const mod = await import("../agents-skills-install");
+	return mod.telemetryCurrentAgentSkillsInstalled;
 }
 
 describe("installCloudflareSkillsGlobally", () => {
@@ -530,5 +551,388 @@ describe("installCloudflareSkillsGlobally", () => {
 				])
 			);
 		});
+	});
+});
+
+/**
+ * MSW handler that returns a fake GitHub Contents API response.
+ *
+ * @param skillNames The skill directory names to include in the mocked response.
+ */
+function mockGitHubSkillsApi(skillNames: string[]) {
+	const entries = skillNames.map((name) => ({ name, type: "dir" }));
+	msw.use(
+		http.get(
+			"https://api.github.com/repos/cloudflare/skills/contents/skills",
+			() => {
+				return HttpResponse.json(entries);
+			}
+		)
+	);
+}
+
+/**
+ * MSW handler that makes the GitHub Contents API return an error.
+ *
+ * @param status The HTTP status code to return. Defaults to `403`.
+ */
+function mockGitHubSkillsApiError(status = 403) {
+	msw.use(
+		http.get(
+			"https://api.github.com/repos/cloudflare/skills/contents/skills",
+			() => {
+				return new HttpResponse(null, { status });
+			}
+		)
+	);
+}
+
+/** MSW handler that makes the GitHub Contents API throw a network error. */
+function mockGitHubSkillsApiNetworkError() {
+	msw.use(
+		http.get(
+			"https://api.github.com/repos/cloudflare/skills/contents/skills",
+			() => {
+				return HttpResponse.error();
+			}
+		)
+	);
+}
+
+describe("telemetryCurrentAgentSkillsInstalled", () => {
+	runInTempDir();
+	mockConsoleMethods();
+
+	beforeEach(() => {
+		// Default: no agent detected
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: false,
+			id: null,
+			name: null,
+			type: null,
+		});
+	});
+
+	test("resolves to null when no agent is detected", async ({ expect }) => {
+		const telemetryCurrentAgentSkillsInstalled = await freshTelemetryImport();
+
+		const result = await telemetryCurrentAgentSkillsInstalled();
+
+		expect(result).toBe(null);
+	});
+
+	test("resolves to null when detectAgenticEnvironment throws", async ({
+		expect,
+	}) => {
+		vi.mocked(detectAgenticEnvironment).mockImplementation(() => {
+			throw new Error("Detection failed");
+		});
+		const telemetryCurrentAgentSkillsInstalled = await freshTelemetryImport();
+
+		const result = await telemetryCurrentAgentSkillsInstalled();
+
+		expect(result).toBe(null);
+	});
+
+	test("resolves to null when agent is detected but not in supportedAgents", async ({
+		expect,
+	}) => {
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: true,
+			id: "jules",
+			name: "Jules",
+			type: "agent",
+		});
+		const telemetryCurrentAgentSkillsInstalled = await freshTelemetryImport();
+
+		const result = await telemetryCurrentAgentSkillsInstalled();
+
+		expect(result).toBe(null);
+	});
+
+	test("resolves to false when GitHub API fetch fails and no cache exists", async ({
+		expect,
+	}) => {
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: true,
+			id: "claude-code",
+			name: "Claude Code",
+			type: "agent",
+		});
+		createAgentDir(".claude");
+		mockGitHubSkillsApiNetworkError();
+		const telemetryCurrentAgentSkillsInstalled = await freshTelemetryImport();
+
+		const result = await telemetryCurrentAgentSkillsInstalled();
+
+		expect(result).toBe(false);
+	});
+
+	test("resolves to false when no skills are present in agent's globalSkillsPath", async ({
+		expect,
+	}) => {
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: true,
+			id: "claude-code",
+			name: "Claude Code",
+			type: "agent",
+		});
+		createAgentDir(".claude");
+		mockGitHubSkillsApi(["cloudflare", "wrangler"]);
+		const telemetryCurrentAgentSkillsInstalled = await freshTelemetryImport();
+
+		const result = await telemetryCurrentAgentSkillsInstalled();
+
+		expect(result).toBe(false);
+	});
+
+	test("resolves to 'manual' when some skills exist but no metadata file", async ({
+		expect,
+	}) => {
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: true,
+			id: "claude-code",
+			name: "Claude Code",
+			type: "agent",
+		});
+		createAgentDir(".claude");
+		const claudeSkills = path.join(os.homedir(), ".claude", "skills");
+		mkdirSync(path.join(claudeSkills, "cloudflare"), { recursive: true });
+		mockGitHubSkillsApi(["cloudflare", "wrangler"]);
+		const telemetryCurrentAgentSkillsInstalled = await freshTelemetryImport();
+
+		const result = await telemetryCurrentAgentSkillsInstalled();
+
+		expect(result).toBe("manual");
+	});
+
+	test("resolves to 'automatic' when skills exist and metadata confirms successful install", async ({
+		expect,
+	}) => {
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: true,
+			id: "claude-code",
+			name: "Claude Code",
+			type: "agent",
+		});
+		createAgentDir(".claude");
+		const claudeSkills = path.join(os.homedir(), ".claude", "skills");
+		mkdirSync(path.join(claudeSkills, "cloudflare"), { recursive: true });
+		const claudeGlobalSkillsPath = path.join(os.homedir(), ".claude", "skills");
+		writeMetadataFile({
+			accepted: true,
+			date: new Date().toISOString(),
+			agentsNeedingInstall: [
+				{
+					name: "Claude Code",
+					globalPath: path.join(os.homedir(), ".claude"),
+					globalSkillsPath: claudeGlobalSkillsPath,
+				},
+			],
+		});
+		mockGitHubSkillsApi(["cloudflare", "wrangler"]);
+		const telemetryCurrentAgentSkillsInstalled = await freshTelemetryImport();
+
+		const result = await telemetryCurrentAgentSkillsInstalled();
+
+		expect(result).toBe("automatic");
+	});
+
+	test("resolves to 'manual' when metadata says copy failed for this agent", async ({
+		expect,
+	}) => {
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: true,
+			id: "claude-code",
+			name: "Claude Code",
+			type: "agent",
+		});
+		createAgentDir(".claude");
+		const claudeSkills = path.join(os.homedir(), ".claude", "skills");
+		mkdirSync(path.join(claudeSkills, "cloudflare"), { recursive: true });
+		const claudeGlobalSkillsPath = path.join(os.homedir(), ".claude", "skills");
+		writeMetadataFile({
+			accepted: true,
+			date: new Date().toISOString(),
+			agentsNeedingInstall: [
+				{
+					name: "Claude Code",
+					globalPath: path.join(os.homedir(), ".claude"),
+					globalSkillsPath: claudeGlobalSkillsPath,
+				},
+			],
+			copyFailedFor: [
+				{
+					name: "Claude Code",
+					globalPath: path.join(os.homedir(), ".claude"),
+					globalSkillsPath: claudeGlobalSkillsPath,
+					error: "Permission denied",
+				},
+			],
+		});
+		mockGitHubSkillsApi(["cloudflare", "wrangler"]);
+		const telemetryCurrentAgentSkillsInstalled = await freshTelemetryImport();
+
+		const result = await telemetryCurrentAgentSkillsInstalled();
+
+		expect(result).toBe("manual");
+	});
+
+	test("resolves to 'manual' when agent is not in agentsNeedingInstall", async ({
+		expect,
+	}) => {
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: true,
+			id: "claude-code",
+			name: "Claude Code",
+			type: "agent",
+		});
+		createAgentDir(".claude");
+		const claudeSkills = path.join(os.homedir(), ".claude", "skills");
+		mkdirSync(path.join(claudeSkills, "cloudflare"), { recursive: true });
+		writeMetadataFile({
+			accepted: true,
+			date: new Date().toISOString(),
+			agentsNeedingInstall: [],
+		});
+		mockGitHubSkillsApi(["cloudflare", "wrangler"]);
+		const telemetryCurrentAgentSkillsInstalled = await freshTelemetryImport();
+
+		const result = await telemetryCurrentAgentSkillsInstalled();
+
+		expect(result).toBe("manual");
+	});
+
+	test("uses cached GitHub API response within TTL", async ({ expect }) => {
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: true,
+			id: "claude-code",
+			name: "Claude Code",
+			type: "agent",
+		});
+		createAgentDir(".claude");
+		const claudeSkills = path.join(os.homedir(), ".claude", "skills");
+		mkdirSync(path.join(claudeSkills, "cloudflare"), { recursive: true });
+
+		// Write a fresh cache file
+		const configDir = getGlobalWranglerConfigPath();
+		mkdirSync(configDir, { recursive: true });
+		writeFileSync(
+			path.join(configDir, "cloudflare-skills-repo-cache.json"),
+			JSON.stringify({
+				lastUpdate: Date.now(),
+				skillNames: ["cloudflare", "wrangler"],
+			})
+		);
+
+		writeMetadataFile({
+			accepted: true,
+			date: new Date().toISOString(),
+			agentsNeedingInstall: [
+				{
+					name: "Claude Code",
+					globalPath: path.join(os.homedir(), ".claude"),
+					globalSkillsPath: path.join(os.homedir(), ".claude", "skills"),
+				},
+			],
+		});
+
+		// Do NOT set up a GitHub API mock — if fetch is called, it would
+		// go unhandled. The test verifies the cache is used instead.
+		const telemetryCurrentAgentSkillsInstalled = await freshTelemetryImport();
+
+		const result = await telemetryCurrentAgentSkillsInstalled();
+
+		expect(result).toBe("automatic");
+	});
+
+	test("falls back to stale cache when GitHub API returns an error", async ({
+		expect,
+	}) => {
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: true,
+			id: "claude-code",
+			name: "Claude Code",
+			type: "agent",
+		});
+		createAgentDir(".claude");
+		const claudeSkills = path.join(os.homedir(), ".claude", "skills");
+		mkdirSync(path.join(claudeSkills, "cloudflare"), { recursive: true });
+
+		// Write an expired cache file (TTL is 24h, set lastUpdate to 48h ago)
+		const configDir = getGlobalWranglerConfigPath();
+		mkdirSync(configDir, { recursive: true });
+		writeFileSync(
+			path.join(configDir, "cloudflare-skills-repo-cache.json"),
+			JSON.stringify({
+				lastUpdate: Date.now() - 48 * 60 * 60 * 1000,
+				skillNames: ["cloudflare", "wrangler"],
+			})
+		);
+
+		writeMetadataFile({
+			accepted: true,
+			date: new Date().toISOString(),
+			agentsNeedingInstall: [
+				{
+					name: "Claude Code",
+					globalPath: path.join(os.homedir(), ".claude"),
+					globalSkillsPath: path.join(os.homedir(), ".claude", "skills"),
+				},
+			],
+		});
+
+		mockGitHubSkillsApiError(403);
+		const telemetryCurrentAgentSkillsInstalled = await freshTelemetryImport();
+
+		const result = await telemetryCurrentAgentSkillsInstalled();
+
+		expect(result).toBe("automatic");
+	});
+
+	test("works with cursor-agent amIVibingId mapping", async ({ expect }) => {
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: true,
+			id: "cursor-agent",
+			name: "Cursor Agent",
+			type: "agent",
+		});
+		createAgentDir(".cursor");
+		const cursorSkills = path.join(os.homedir(), ".cursor", "skills");
+		mkdirSync(path.join(cursorSkills, "cloudflare"), { recursive: true });
+		const cursorGlobalSkillsPath = path.join(os.homedir(), ".cursor", "skills");
+		writeMetadataFile({
+			accepted: true,
+			date: new Date().toISOString(),
+			agentsNeedingInstall: [
+				{
+					name: "Cursor",
+					globalPath: path.join(os.homedir(), ".cursor"),
+					globalSkillsPath: cursorGlobalSkillsPath,
+				},
+			],
+		});
+		mockGitHubSkillsApi(["cloudflare", "wrangler"]);
+		const telemetryCurrentAgentSkillsInstalled = await freshTelemetryImport();
+
+		const result = await telemetryCurrentAgentSkillsInstalled();
+
+		expect(result).toBe("automatic");
+	});
+
+	test("memoises the result across multiple calls", async ({ expect }) => {
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: false,
+			id: null,
+			name: null,
+			type: null,
+		});
+		const telemetryCurrentAgentSkillsInstalled = await freshTelemetryImport();
+
+		const first = telemetryCurrentAgentSkillsInstalled();
+		const second = telemetryCurrentAgentSkillsInstalled();
+
+		expect(first).toBe(second);
+		expect(await first).toBe(null);
 	});
 });

--- a/packages/wrangler/src/__tests__/metrics.test.ts
+++ b/packages/wrangler/src/__tests__/metrics.test.ts
@@ -106,7 +106,7 @@ describe("metrics", () => {
 				await allMetricsDispatchesCompleted();
 				expect(requests.count).toBe(1);
 				expect(std.debug).toMatchInlineSnapshot(
-					`"Metrics dispatcher: Posting data {"deviceId":"f82b1f46-eb7b-4154-aa9f-ce95f23b2288","event":"some-event","timestamp":1733961600000,"properties":{"amplitude_session_id":1733961600000,"amplitude_event_id":0,"wranglerVersion":"1.2.3","wranglerMajorVersion":1,"wranglerMinorVersion":2,"wranglerPatchVersion":3,"osPlatform":"mock platform","osVersion":"mock os version","nodeVersion":1,"packageManager":"npm","isFirstUsage":false,"configFileType":"none","isCI":false,"isPagesCI":false,"isWorkersCI":false,"isInteractive":true,"hasAssets":false,"agent":null,"category":"Workers","os":"foo:bar","a":1,"b":2}}"`
+					`"Metrics dispatcher: Posting data {"deviceId":"f82b1f46-eb7b-4154-aa9f-ce95f23b2288","event":"some-event","timestamp":1733961600000,"properties":{"amplitude_session_id":1733961600000,"amplitude_event_id":0,"wranglerVersion":"1.2.3","wranglerMajorVersion":1,"wranglerMinorVersion":2,"wranglerPatchVersion":3,"osPlatform":"mock platform","osVersion":"mock os version","nodeVersion":1,"packageManager":"npm","isFirstUsage":false,"configFileType":"none","isCI":false,"isPagesCI":false,"isWorkersCI":false,"isInteractive":true,"hasAssets":false,"agent":null,"category":"Workers","os":"foo:bar","a":1,"b":2,"currentAgentSkillsInstalled":null}}"`
 				);
 				expect(std.out).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
@@ -138,10 +138,11 @@ describe("metrics", () => {
 					sendMetrics: false,
 				});
 				dispatcher.sendAdhocEvent("some-event", { a: 1, b: 2 });
+				await allMetricsDispatchesCompleted();
 
 				expect(requests.count).toBe(0);
 				expect(std.debug).toMatchInlineSnapshot(
-					`"Metrics dispatcher: Dispatching disabled - would have sent {"deviceId":"f82b1f46-eb7b-4154-aa9f-ce95f23b2288","event":"some-event","timestamp":1733961600000,"properties":{"amplitude_session_id":1733961600000,"amplitude_event_id":0,"wranglerVersion":"1.2.3","wranglerMajorVersion":1,"wranglerMinorVersion":2,"wranglerPatchVersion":3,"osPlatform":"mock platform","osVersion":"mock os version","nodeVersion":1,"packageManager":"npm","isFirstUsage":false,"configFileType":"none","isCI":false,"isPagesCI":false,"isWorkersCI":false,"isInteractive":true,"hasAssets":false,"agent":null,"category":"Workers","os":"foo:bar","a":1,"b":2}}."`
+					`"Metrics dispatcher: Dispatching disabled - would have sent {"deviceId":"f82b1f46-eb7b-4154-aa9f-ce95f23b2288","event":"some-event","timestamp":1733961600000,"properties":{"amplitude_session_id":1733961600000,"amplitude_event_id":0,"wranglerVersion":"1.2.3","wranglerMajorVersion":1,"wranglerMinorVersion":2,"wranglerPatchVersion":3,"osPlatform":"mock platform","osVersion":"mock os version","nodeVersion":1,"packageManager":"npm","isFirstUsage":false,"configFileType":"none","isCI":false,"isPagesCI":false,"isWorkersCI":false,"isInteractive":true,"hasAssets":false,"agent":null,"category":"Workers","os":"foo:bar","a":1,"b":2,"currentAgentSkillsInstalled":null}}."`
 				);
 				expect(std.out).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
@@ -163,7 +164,7 @@ describe("metrics", () => {
 				await allMetricsDispatchesCompleted();
 
 				expect(std.debug).toMatchInlineSnapshot(`
-					"Metrics dispatcher: Posting data {"deviceId":"f82b1f46-eb7b-4154-aa9f-ce95f23b2288","event":"some-event","timestamp":1733961600000,"properties":{"amplitude_session_id":1733961600000,"amplitude_event_id":0,"wranglerVersion":"1.2.3","wranglerMajorVersion":1,"wranglerMinorVersion":2,"wranglerPatchVersion":3,"osPlatform":"mock platform","osVersion":"mock os version","nodeVersion":1,"packageManager":"npm","isFirstUsage":false,"configFileType":"none","isCI":false,"isPagesCI":false,"isWorkersCI":false,"isInteractive":true,"hasAssets":false,"agent":null,"category":"Workers","os":"foo:bar","a":1,"b":2}}
+					"Metrics dispatcher: Posting data {"deviceId":"f82b1f46-eb7b-4154-aa9f-ce95f23b2288","event":"some-event","timestamp":1733961600000,"properties":{"amplitude_session_id":1733961600000,"amplitude_event_id":0,"wranglerVersion":"1.2.3","wranglerMajorVersion":1,"wranglerMinorVersion":2,"wranglerPatchVersion":3,"osPlatform":"mock platform","osVersion":"mock os version","nodeVersion":1,"packageManager":"npm","isFirstUsage":false,"configFileType":"none","isCI":false,"isPagesCI":false,"isWorkersCI":false,"isInteractive":true,"hasAssets":false,"agent":null,"category":"Workers","os":"foo:bar","a":1,"b":2,"currentAgentSkillsInstalled":null}}
 					Metrics dispatcher: Failed to send request: Failed to fetch"
 				`);
 				expect(std.out).toMatchInlineSnapshot(`""`);
@@ -181,10 +182,11 @@ describe("metrics", () => {
 					sendMetrics: true,
 				});
 				dispatcher.sendAdhocEvent("some-event", { a: 1, b: 2 });
+				await allMetricsDispatchesCompleted();
 
 				expect(requests.count).toBe(0);
 				expect(std.debug).toMatchInlineSnapshot(
-					`"Metrics dispatcher: Source Key not provided. Be sure to initialize before sending events {"deviceId":"f82b1f46-eb7b-4154-aa9f-ce95f23b2288","event":"some-event","timestamp":1733961600000,"properties":{"amplitude_session_id":1733961600000,"amplitude_event_id":0,"wranglerVersion":"1.2.3","wranglerMajorVersion":1,"wranglerMinorVersion":2,"wranglerPatchVersion":3,"osPlatform":"mock platform","osVersion":"mock os version","nodeVersion":1,"packageManager":"npm","isFirstUsage":false,"configFileType":"none","isCI":false,"isPagesCI":false,"isWorkersCI":false,"isInteractive":true,"hasAssets":false,"agent":null,"category":"Workers","os":"foo:bar","a":1,"b":2}}"`
+					`"Metrics dispatcher: Source Key not provided. Be sure to initialize before sending events {"deviceId":"f82b1f46-eb7b-4154-aa9f-ce95f23b2288","event":"some-event","timestamp":1733961600000,"properties":{"amplitude_session_id":1733961600000,"amplitude_event_id":0,"wranglerVersion":"1.2.3","wranglerMajorVersion":1,"wranglerMinorVersion":2,"wranglerPatchVersion":3,"osPlatform":"mock platform","osVersion":"mock os version","nodeVersion":1,"packageManager":"npm","isFirstUsage":false,"configFileType":"none","isCI":false,"isPagesCI":false,"isWorkersCI":false,"isInteractive":true,"hasAssets":false,"agent":null,"category":"Workers","os":"foo:bar","a":1,"b":2,"currentAgentSkillsInstalled":null}}"`
 				);
 				expect(std.out).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);

--- a/packages/wrangler/src/__tests__/vitest.setup.ts
+++ b/packages/wrangler/src/__tests__/vitest.setup.ts
@@ -228,6 +228,9 @@ vi.mock("../agents-skills-install", async (importOriginal) => {
 		skipped: true,
 		reason: "Already prompted",
 	});
+	vi.spyOn(realModule, "telemetryCurrentAgentSkillsInstalled").mockReturnValue(
+		Promise.resolve(null)
+	);
 	return realModule;
 });
 

--- a/packages/wrangler/src/agents-skills-install.ts
+++ b/packages/wrangler/src/agents-skills-install.ts
@@ -14,8 +14,10 @@ import {
 	parseJSONC,
 	removeDir,
 } from "@cloudflare/workers-utils";
+import { detectAgenticEnvironment } from "am-i-vibing";
 import ci from "ci-info";
 import { downloadTemplate } from "giget";
+import { fetch } from "undici";
 import { confirm } from "./dialogs";
 import isInteractive from "./is-interactive";
 import { logger } from "./logger";
@@ -184,6 +186,8 @@ type AgentInfo = {
 	globalPath: string;
 	/** Absolute path to the directory where Cloudflare skill files should be copied for this agent. */
 	globalSkillsPath: string;
+	/** `am-i-vibing` provider IDs that map to this agent, used for telemetry detection. */
+	amIVibingIds?: string[];
 };
 
 /**
@@ -211,6 +215,16 @@ const SKILLS_INSTALL_METADATA_FILENAME = "agents-skills-install.jsonc";
 /** giget source for the skills subdirectory of the cloudflare/skills repo */
 const SKILLS_REPO_SOURCE = "gh:cloudflare/skills/skills";
 
+/** GitHub Contents API URL for listing skill directories in the cloudflare/skills repo. */
+const SKILLS_REPO_CONTENTS_URL =
+	"https://api.github.com/repos/cloudflare/skills/contents/skills";
+
+/** Cache filename for skill directory names fetched from the GitHub API. */
+const SKILLS_REPO_CACHE_FILENAME = "cloudflare-skills-repo-cache.json";
+
+/** Time-to-live for the cached skill names (24 hours in milliseconds). */
+const SKILLS_REPO_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
 /**
  * Returns the absolute path to the skills install config file within the global wrangler config directory.
  *
@@ -221,6 +235,196 @@ function getSkillsInstallMetadataFilePath(): string {
 		getGlobalWranglerConfigPath(),
 		SKILLS_INSTALL_METADATA_FILENAME
 	);
+}
+
+/**
+ * Returns the absolute path to the skills repo cache file within the global wrangler config directory.
+ *
+ * @returns Absolute path to the skills repo cache JSON file.
+ */
+function getSkillsRepoCachePath(): string {
+	return path.resolve(
+		getGlobalWranglerConfigPath(),
+		SKILLS_REPO_CACHE_FILENAME
+	);
+}
+
+/** On-disk cache for skill directory names fetched from the GitHub Contents API. */
+interface SkillsRepoCache {
+	/** Unix-epoch millisecond timestamp of when the cache was last written. */
+	lastUpdate: number;
+	/** Skill directory names from the `cloudflare/skills` repository. */
+	skillNames: string[];
+}
+
+/**
+ * Reads the cached skill names from disk, returning them only if the cache has not expired.
+ * Falls back to stale data when {@link allowStale} is true (e.g. after a failed network request).
+ *
+ * @param allowStale When `true`, returns cached data even if the TTL has expired.
+ * @returns Array of cached skill names, or `undefined` on cache miss.
+ */
+function readSkillsRepoCache(allowStale = false): string[] | undefined {
+	try {
+		const raw = readFileSync(getSkillsRepoCachePath(), "utf8");
+		const cache = JSON.parse(raw) as SkillsRepoCache;
+		if (
+			allowStale ||
+			cache.lastUpdate + SKILLS_REPO_CACHE_TTL_MS > Date.now()
+		) {
+			return cache.skillNames;
+		}
+	} catch {
+		// Cache file missing, corrupt, or unreadable — treat as cache miss.
+	}
+	return undefined;
+}
+
+/**
+ * Writes skill names to the disk cache with the current timestamp.
+ *
+ * @param skillNames The skill directory names to persist.
+ */
+function writeSkillsRepoCache(skillNames: string[]): void {
+	try {
+		const cachePath = getSkillsRepoCachePath();
+		mkdirSync(path.dirname(cachePath), { recursive: true });
+		const data: SkillsRepoCache = {
+			lastUpdate: Date.now(),
+			skillNames,
+		};
+		writeFileSync(cachePath, JSON.stringify(data));
+	} catch {
+		// Best-effort — cache write failure is non-fatal.
+	}
+}
+
+/**
+ * Fetches the list of skill directory names from the `cloudflare/skills` GitHub
+ * repository using the GitHub Contents API. Results are cached to disk for 24 hours
+ * to avoid hitting API rate limits.
+ *
+ * @returns Array of skill directory names, or `undefined` if both fetch and cache fail.
+ */
+async function fetchSkillNamesFromGitHub(): Promise<string[] | undefined> {
+	// Return fresh cached data if available.
+	const cached = readSkillsRepoCache();
+	if (cached) {
+		return cached;
+	}
+
+	try {
+		const res = await fetch(SKILLS_REPO_CONTENTS_URL, {
+			headers: {
+				Accept: "application/vnd.github.v3+json",
+				"User-Agent": "cloudflare-wrangler",
+			},
+		});
+		if (!res.ok) {
+			// API error (rate limited, 404, etc.) — fall back to stale cache.
+			return readSkillsRepoCache(true);
+		}
+		const entries = (await res.json()) as Array<{
+			name: string;
+			type: string;
+		}>;
+		const skillNames = entries
+			.filter((e) => e.type === "dir")
+			.map((e) => e.name);
+
+		writeSkillsRepoCache(skillNames);
+		return skillNames;
+	} catch {
+		// Network failure — fall back to stale cache.
+		return readSkillsRepoCache(true);
+	}
+}
+
+/**
+ * Result of checking whether the current AI agent has Cloudflare skills installed.
+ *
+ * - `null` — no agent detected or the agent is not in the supported list.
+ * - `false` — agent is supported but no skills are present on disk.
+ * - `"automatic"` — skills are present and the metadata file confirms Wrangler installed them.
+ * - `"manual"` — skills are present but were not installed by Wrangler (no metadata, agent not
+ *                listed in metadata, or the metadata records a copy failure for this agent).
+ */
+type AgentSkillsInstallStatus = "automatic" | "manual" | false | null;
+
+/**
+ * Determines whether the currently-running AI coding agent has Cloudflare
+ * skills installed. This runs asynchronously and is intended to be started
+ * eagerly on process startup so the result is available by the time
+ * telemetry events are dispatched.
+ *
+ * @returns The {@link AgentSkillsInstallStatus} for the current agent.
+ */
+async function computeTelemetryCurrentAgentSkillsInstalled(): Promise<AgentSkillsInstallStatus> {
+	let agentId: string | null = null;
+	try {
+		const detection = detectAgenticEnvironment(process.env, []);
+		agentId = detection.id;
+	} catch {
+		return null;
+	}
+	if (!agentId) {
+		return null;
+	}
+
+	const matchingAgent = supportedAgents.find((a) =>
+		a.amIVibingIds?.includes(agentId)
+	);
+	if (!matchingAgent) {
+		return null;
+	}
+
+	const skillNames = await fetchSkillNamesFromGitHub();
+	if (!skillNames || skillNames.length === 0) {
+		return false;
+	}
+
+	let localEntries: Set<string>;
+	try {
+		localEntries = new Set(readdirSync(matchingAgent.globalSkillsPath));
+	} catch {
+		return false;
+	}
+	const hasAnySkill = skillNames.some((name) => localEntries.has(name));
+	if (!hasAnySkill) {
+		return false;
+	}
+
+	const metadata = readSkillsInstallMetadataFile();
+	if (!metadata) {
+		return "manual";
+	}
+
+	const isInNeedingInstall = metadata.agentsNeedingInstall?.some(
+		(agent) => agent.globalSkillsPath === matchingAgent.globalSkillsPath
+	);
+	const isInCopyFailed = metadata.copyFailedFor?.some(
+		(agent) => agent.globalSkillsPath === matchingAgent.globalSkillsPath
+	);
+
+	if (metadata.accepted && isInNeedingInstall === true && !isInCopyFailed) {
+		return "automatic";
+	}
+	return "manual";
+}
+
+/** Lazily-initialised singleton promise used to memoise {@link telemetryCurrentAgentSkillsInstalled}. */
+let _telemetryPromise: Promise<AgentSkillsInstallStatus> | undefined;
+
+/**
+ * Returns a memoised promise that resolves to whether the current AI agent
+ * has Cloudflare skills installed. The promise is started lazily on first
+ * call and cached for the lifetime of the process.
+ *
+ * @returns A promise resolving to the {@link AgentSkillsInstallStatus} for the current agent.
+ */
+export function telemetryCurrentAgentSkillsInstalled(): Promise<AgentSkillsInstallStatus> {
+	_telemetryPromise ??= computeTelemetryCurrentAgentSkillsInstalled();
+	return _telemetryPromise;
 }
 
 /**
@@ -242,6 +446,7 @@ const supportedAgents: AgentInfo[] = [
 		name: "Amp, Kimi Code CLI, Replit, Universal",
 		globalPath: path.join(os.homedir(), ".config", "agents"),
 		globalSkillsPath: path.join(os.homedir(), ".config", "agents", "skills"),
+		amIVibingIds: ["replit", "replit-assistant"],
 	},
 	{
 		name: "Antigravity",
@@ -267,6 +472,7 @@ const supportedAgents: AgentInfo[] = [
 		name: "Claude Code",
 		globalPath: path.join(os.homedir(), ".claude"),
 		globalSkillsPath: path.join(os.homedir(), ".claude", "skills"),
+		amIVibingIds: ["claude-code"],
 	},
 	{
 		name: "OpenClaw",
@@ -277,6 +483,7 @@ const supportedAgents: AgentInfo[] = [
 		name: "Cline, Dexto, Warp",
 		globalPath: path.join(os.homedir(), ".agents"),
 		globalSkillsPath: path.join(os.homedir(), ".agents", "skills"),
+		amIVibingIds: ["warp"],
 	},
 	{
 		name: "CodeArts Agent",
@@ -302,6 +509,7 @@ const supportedAgents: AgentInfo[] = [
 		name: "Codex",
 		globalPath: path.join(os.homedir(), ".codex"),
 		globalSkillsPath: path.join(os.homedir(), ".codex", "skills"),
+		amIVibingIds: ["codex"],
 	},
 	{
 		name: "Command Code",
@@ -322,11 +530,13 @@ const supportedAgents: AgentInfo[] = [
 		name: "Crush",
 		globalPath: path.join(os.homedir(), ".config", "crush"),
 		globalSkillsPath: path.join(os.homedir(), ".config", "crush", "skills"),
+		amIVibingIds: ["crush"],
 	},
 	{
 		name: "Cursor",
 		globalPath: path.join(os.homedir(), ".cursor"),
 		globalSkillsPath: path.join(os.homedir(), ".cursor", "skills"),
+		amIVibingIds: ["cursor-agent", "cursor"],
 	},
 	{
 		name: "Deep Agents",
@@ -357,11 +567,13 @@ const supportedAgents: AgentInfo[] = [
 		name: "Gemini CLI",
 		globalPath: path.join(os.homedir(), ".gemini"),
 		globalSkillsPath: path.join(os.homedir(), ".gemini", "skills"),
+		amIVibingIds: ["gemini-agent"],
 	},
 	{
 		name: "GitHub Copilot",
 		globalPath: path.join(os.homedir(), ".copilot"),
 		globalSkillsPath: path.join(os.homedir(), ".copilot", "skills"),
+		amIVibingIds: ["vscode-copilot-agent"],
 	},
 	{
 		name: "Goose",
@@ -417,6 +629,7 @@ const supportedAgents: AgentInfo[] = [
 		name: "OpenCode",
 		globalPath: path.join(os.homedir(), ".config", "opencode"),
 		globalSkillsPath: path.join(os.homedir(), ".config", "opencode", "skills"),
+		amIVibingIds: ["opencode"],
 	},
 	{
 		name: "OpenHands",
@@ -467,6 +680,7 @@ const supportedAgents: AgentInfo[] = [
 		name: "Windsurf",
 		globalPath: path.join(os.homedir(), ".codeium", "windsurf"),
 		globalSkillsPath: path.join(os.homedir(), ".codeium", "windsurf", "skills"),
+		amIVibingIds: ["windsurf"],
 	},
 	{
 		name: "Zencoder",

--- a/packages/wrangler/src/metrics/metrics-dispatcher.ts
+++ b/packages/wrangler/src/metrics/metrics-dispatcher.ts
@@ -3,6 +3,7 @@ import { detectAgenticEnvironment } from "am-i-vibing";
 import chalk from "chalk";
 import ci from "ci-info";
 import { fetch } from "undici";
+import { telemetryCurrentAgentSkillsInstalled } from "../agents-skills-install";
 import isInteractive from "../is-interactive";
 import { logger } from "../logger";
 import { sniffUserAgent } from "../package-manager";
@@ -96,20 +97,31 @@ export function getMetricsDispatcher(options: MetricsConfigOptions) {
 		 *  - additional properties are camelCased
 		 */
 		sendAdhocEvent(name: string, properties: Properties = {}) {
-			dispatch({
-				name,
-				properties: {
-					...getCommonEventProperties(),
-					category: "Workers",
-					wranglerVersion,
-					wranglerMajorVersion,
-					wranglerMinorVersion,
-					wranglerPatchVersion,
-					os: getOS(),
-					agent,
-					...properties,
-				},
-			});
+			trackDispatch(
+				telemetryCurrentAgentSkillsInstalled()
+					.catch(() => null)
+					.then((currentAgentSkillsInstalled) => {
+						const baseProperties = {
+							...getCommonEventProperties(),
+							category: "Workers",
+							wranglerVersion,
+							wranglerMajorVersion,
+							wranglerMinorVersion,
+							wranglerPatchVersion,
+							os: getOS(),
+							agent,
+							...properties,
+						};
+
+						return dispatch({
+							name,
+							properties: {
+								...baseProperties,
+								currentAgentSkillsInstalled,
+							},
+						});
+					})
+			);
 		},
 
 		/**
@@ -146,20 +158,25 @@ export function getMetricsDispatcher(options: MetricsConfigOptions) {
 					argsCombination,
 				};
 
-				dispatch({
-					name,
-					properties: {
-						...commonCommandEventProperties,
-						...properties,
-					},
-				});
+				trackDispatch(
+					dispatch({
+						name,
+						properties: {
+							...commonCommandEventProperties,
+							...properties,
+						},
+					})
+				);
 			} catch (err) {
 				logger.debug("Error sending metrics event", err);
 			}
 		},
 	};
 
-	function dispatch(event: { name: string; properties: Properties }) {
+	function dispatch(event: {
+		name: string;
+		properties: Properties;
+	}): Promise<void> | void {
 		const metricsConfig = getMetricsConfig(options);
 		const body = {
 			deviceId: metricsConfig.deviceId,
@@ -191,7 +208,7 @@ export function getMetricsDispatcher(options: MetricsConfigOptions) {
 		// before exiting Wrangler. The exit handler in index.ts races
 		// allMetricsDispatchesCompleted() against a 1s timeout, which is the
 		// real protection against slow connections at shutdown.
-		const request = fetch(`${SPARROW_URL}/api/v1/event`, {
+		return fetch(`${SPARROW_URL}/api/v1/event`, {
 			method: "POST",
 			headers: {
 				Accept: "*/*",
@@ -215,12 +232,23 @@ export function getMetricsDispatcher(options: MetricsConfigOptions) {
 					"Metrics dispatcher: Failed to send request:",
 					(e as Error).message
 				);
-			})
-			.finally(() => {
-				pendingRequests.delete(request);
 			});
+	}
 
-		pendingRequests.add(request);
+	/**
+	 * Adds a dispatch promise (or promise chain) to `pendingRequests` so it
+	 * is awaited at process exit. Automatically removes itself once settled.
+	 *
+	 * @param maybePromise The dispatch promise to track, or `void` if no async work is needed.
+	 */
+	function trackDispatch(maybePromise: Promise<void> | void): void {
+		if (!maybePromise) {
+			return;
+		}
+		const tracked = maybePromise.finally(() => {
+			pendingRequests.delete(tracked);
+		});
+		pendingRequests.add(tracked);
 	}
 
 	/**

--- a/packages/wrangler/telemetry.md
+++ b/packages/wrangler/telemetry.md
@@ -27,6 +27,7 @@ Telemetry in Wrangler allows us to better identify bugs and gain visibility on u
 - Total session duration of the command run (e.g. 3 seconds, etc.)
 - Whether the Wrangler client is running in CI or in an interactive instance
 - Whether the command was executed by an AI coding agent (e.g. Claude Code, Cursor, GitHub Copilot), and if so, which agent
+- Whether the AI coding agent has Cloudflare skills installed, and if so, whether they were installed automatically by Wrangler or manually by the user
 - Error _type_ (e.g. `APIError` or `UserError`), and sanitised error messages that will not include user information like filepaths or stack traces (e.g. `Asset too large`).
 - General machine information such as OS and OS Version
 - local REST API usage (e.g. via the Local Explorer):


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-2608

Wrangler now includes a `currentAgentSkillsInstalled` property in telemetry events that reports whether the current AI coding agent has Cloudflare skills present on disk. The value distinguishes between skills installed automatically by Wrangler (`"automatic"`), skills installed manually by the user (`"manual"`), no skills present (`false`), or no supported agent detected (`null`). Skill names are fetched from the GitHub Contents API with a 24-hour disk cache to avoid rate limits.

> [!NOTE]
> This merges on top of the changes in https://github.com/cloudflare/workers-sdk/pull/13846, so 13846 needs to be merged first

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: included in `telemetry.md` (34c9efdbd7a91b456f8113f9290849bb13a6dcf2)

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
