### PR TITLE
Fix #13799 - Fix Svelte project init with Drizzle and/or Better Auth

### DIFF
--- a/packages/codemod/src/index.ts
+++ b/packages/codemod/src/index.ts
@@ -49,7 +49,12 @@ export function parseTs(src: string) {
 export function parseFile(filePath: string) {
 	const lang = path.extname(filePath).slice(1);
 	const parser = lang === "js" ? parseJs : parseTs;
-	const fileContents = readFileSync(path.resolve(filePath), "utf-8");
+	let fileContents: string
+	try {
+		fileContents = readFileSync(path.resolve(filePath), "utf-8");
+	} catch {
+		throw new Error(`Error reading file ${filePath} for parsing`);
+	}
 
 	if (fileContents) {
 		return parser(fileContents).program as Program;

--- a/packages/codemod/src/index.ts
+++ b/packages/codemod/src/index.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import * as recast from "recast";
-import * as esprimaParser from "recast/parsers/esprima";
+import * as babelParser from "recast/parsers/babel";
 import * as typescriptParser from "recast/parsers/typescript";
 import type { Program } from "esprima";
 
@@ -28,9 +28,9 @@ import type { Program } from "esprima";
 export function parseJs(src: string) {
 	src = src.trim();
 	try {
-		return recast.parse(src, { parser: esprimaParser });
-	} catch {
-		throw new Error("Error parsing js template.");
+		return recast.parse(src, { parser: babelParser });
+	} catch (e) {
+		throw new Error(`Error parsing JavaScript code: ${(e as Error).toString()}`);
 	}
 }
 
@@ -39,8 +39,8 @@ export function parseTs(src: string) {
 	src = src.trim();
 	try {
 		return recast.parse(src, { parser: typescriptParser });
-	} catch {
-		throw new Error("Error parsing ts template.");
+	} catch (e) {
+		throw new Error(`Error parsing TypeScript code: ${(e as Error).toString()}`);
 	}
 }
 
@@ -48,16 +48,11 @@ export function parseTs(src: string) {
 // Selects the correct parser based on the file extension
 export function parseFile(filePath: string) {
 	const lang = path.extname(filePath).slice(1);
-	const parser = lang === "js" ? esprimaParser : typescriptParser;
+	const parser = lang === "js" ? parseJs : parseTs;
+	const fileContents = readFileSync(path.resolve(filePath), "utf-8");
 
-	try {
-		const fileContents = readFileSync(path.resolve(filePath), "utf-8");
-
-		if (fileContents) {
-			return recast.parse(fileContents, { parser }).program as Program;
-		}
-	} catch {
-		throw new Error(`Error parsing file: ${filePath}`);
+	if (fileContents) {
+		return parser(fileContents).program as Program;
 	}
 
 	return null;

--- a/packages/codemod/tests/index.test.ts
+++ b/packages/codemod/tests/index.test.ts
@@ -1,7 +1,7 @@
 import * as recast from "recast";
 import parser from "recast/parsers/babel";
-import { describe, test } from "vitest";
-import { mergeObjectProperties } from "../src/index";
+import {describe, expect, test} from "vitest";
+import {mergeObjectProperties, parseJs, parseTs} from "../src/index";
 
 describe("mergeObjectProperties", () => {
 	const tests = [
@@ -127,3 +127,48 @@ const createObjectExpression = (
 		).declarations[0] as recast.types.namedTypes.VariableDeclarator
 	).init as recast.types.namedTypes.ObjectExpression;
 };
+
+
+/*
+	This code, auto-generated during SvelteKit project init with Drizzle and/or Better Auth options,
+	caused a parse failure with the ESPrima-based version of `codemod`,
+	causing failure during `npm create cloudflare`.
+ */
+const svConfigWithSpread = `
+import adapter from '@sveltejs/adapter-auto';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	compilerOptions: {
+		// Force runes mode for the project, except for libraries. Can be removed in svelte 6.
+		runes: ({ filename }) => filename.split(/[/\\\\]/).includes('node_modules') ? undefined : true
+	},
+	kit: {
+		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
+		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
+		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
+		adapter: adapter(),
+
+		typescript: {
+			config: (config) => ({
+				...config,
+				include: [...config.include, '../drizzle.config.ts']
+			})
+		}
+	}
+};
+
+export default config;
+`;
+
+describe("spread syntax parsing", () => {
+	test("can parse formerly failing svelte config file as TypeScript", () => {
+		const result = parseTs(svConfigWithSpread)
+		expect(result).toBe(result)
+	})
+
+	test("can parse formerly failing svelte config file as JavaScript", () => {
+		const result = parseJs(svConfigWithSpread)
+		expect(result).toBe(result)
+	})
+})

--- a/packages/codemod/tests/index.test.ts
+++ b/packages/codemod/tests/index.test.ts
@@ -1,6 +1,6 @@
 import * as recast from "recast";
 import parser from "recast/parsers/babel";
-import {describe, expect, test} from "vitest";
+import {describe, test} from "vitest";
 import {mergeObjectProperties, parseJs, parseTs} from "../src/index";
 
 describe("mergeObjectProperties", () => {
@@ -92,8 +92,8 @@ describe("mergeObjectProperties", () => {
 		expectedPropertiesObject: Record<string, unknown>;
 	}[];
 
-	tests.forEach(({ testName, ...testObjects }) =>
-		test(`${testName}`, ({ expect }) => {
+	tests.forEach(({testName, ...testObjects}) =>
+		test(`${testName}`, ({expect}) => {
 			const {
 				sourcePropertiesObject,
 				newPropertiesObject,
@@ -106,8 +106,8 @@ describe("mergeObjectProperties", () => {
 
 			mergeObjectProperties(sourceObj, newProperties);
 
-			expect(recast.prettyPrint(sourceObj, { parser }).code).toEqual(
-				recast.prettyPrint(expectedObj, { parser }).code
+			expect(recast.prettyPrint(sourceObj, {parser}).code).toEqual(
+				recast.prettyPrint(expectedObj, {parser}).code
 			);
 		})
 	);
@@ -122,7 +122,7 @@ const createObjectExpression = (
 				`const obj = {${Object.entries(sourceObj)
 					.map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
 					.join(",\n")}}`,
-				{ parser }
+				{parser}
 			).program.body[0] as recast.types.namedTypes.VariableDeclaration
 		).declarations[0] as recast.types.namedTypes.VariableDeclarator
 	).init as recast.types.namedTypes.ObjectExpression;
@@ -162,13 +162,13 @@ export default config;
 `;
 
 describe("spread syntax parsing", () => {
-	test("can parse formerly failing svelte config file as TypeScript", () => {
-		const result = parseTs(svConfigWithSpread)
-		expect(result).toBe(result)
-	})
+	test("can parse formerly failing svelte config file as TypeScript", ({ expect }) => {
+		const result = parseTs(svConfigWithSpread);
+		expect(result).toBeDefined();
+	});
 
-	test("can parse formerly failing svelte config file as JavaScript", () => {
-		const result = parseJs(svConfigWithSpread)
-		expect(result).toBe(result)
-	})
+	test("can parse formerly failing svelte config file as JavaScript", ({ expect }) => {
+		const result = parseJs(svConfigWithSpread);
+		expect(result).toBeDefined();
+	});
 })


### PR DESCRIPTION
Switch to use babel JS parsing in codemod to resolve Svelte project init failure when selecting Drizzle and/or Better Auth options.

Fixes #13799.

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Fix, not functional change.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13886" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->