### PR TITLE
[wrangler] Fix remote bindings hanging on shutdown

### DIFF
--- a/.changeset/mean-brooms-hope.md
+++ b/.changeset/mean-brooms-hope.md
@@ -2,4 +2,8 @@
 "wrangler": patch
 ---
 
-Fix remote bindings hanging on shutdown
+Fix `wrangler dev` hanging on shutdown when remote bindings are present
+
+startDev() registers dev hotkeys before authenticating the user. During interactive dev sessions, the auth callback re-registers hotkeys, which updates the local unregisterHotKeys variable to a new cleanup function. However, the unregisterHotKeys value returned to callers was captured as a direct reference to the initial registration, so it would call the stale cleanup function instead of the current one.
+
+This has been fixed by returning a wrapper function () => unregisterHotKeys?.() instead of the variable directly. The wrapper evaluates unregisterHotKeys at call time, ensuring it always invokes the latest cleanup function even after re-registration.

--- a/.changeset/mean-brooms-hope.md
+++ b/.changeset/mean-brooms-hope.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix remote bindings hanging on shutdown

--- a/packages/wrangler/src/__tests__/dev/start-dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev/start-dev.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert";
+import { beforeEach, describe, it, vi } from "vitest";
+import registerDevHotKeys from "../../dev/hotkeys";
+import { startDev } from "../../dev/start-dev";
+import { requireAuth } from "../../user";
+import type { StartDevWorkerInput } from "../../api";
+import type { StartDevOptions } from "../../dev";
+
+const mocks = vi.hoisted(() => {
+	const configSet = vi.fn();
+	const fakeDevEnv = {
+		config: { set: configSet },
+		proxy: { ready: { promise: new Promise(() => {}) } },
+		teardown: vi.fn(),
+	};
+
+	return {
+		configSet,
+		fakeDevEnv,
+	};
+});
+
+vi.mock("../../api", () => ({
+	DevEnv: vi.fn(function () {
+		return mocks.fakeDevEnv;
+	}),
+}));
+
+vi.mock("../../dev/hotkeys", () => ({
+	default: vi.fn(),
+}));
+
+vi.mock("../../is-interactive", () => ({
+	default: vi.fn(() => true),
+}));
+
+vi.mock("../../user", () => ({
+	requireApiToken: vi.fn(() => "test-api-token"),
+	requireAuth: vi.fn(async () => "test-account-id"),
+}));
+
+describe("startDev", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.configSet.mockResolvedValue(undefined);
+	});
+
+	it("unregisters the latest hotkey registration after auth re-registers hotkeys", async ({
+		expect,
+	}) => {
+		const unregisterHotKeys = [vi.fn(), vi.fn()];
+		vi.mocked(registerDevHotKeys)
+			.mockReturnValueOnce(unregisterHotKeys[0])
+			.mockReturnValueOnce(unregisterHotKeys[1]);
+
+		const result = await startDev({
+			disableDevRegistry: true,
+			showInteractiveDevSession: true,
+		} as StartDevOptions);
+
+		expect(registerDevHotKeys).toHaveBeenCalledTimes(1);
+
+		const startWorkerInput = mocks.configSet.mock
+			.calls[0][0] as StartDevWorkerInput;
+		const auth = startWorkerInput.dev?.auth;
+		assert(auth);
+		await (auth as (arg: { account_id?: string }) => Promise<unknown>)({});
+
+		expect(requireAuth).toHaveBeenCalledOnce();
+		expect(unregisterHotKeys[0]).toHaveBeenCalledOnce();
+		expect(registerDevHotKeys).toHaveBeenCalledTimes(2);
+
+		result.unregisterHotKeys?.();
+
+		expect(unregisterHotKeys[0]).toHaveBeenCalledOnce();
+		expect(unregisterHotKeys[1]).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/wrangler/src/dev/start-dev.ts
+++ b/packages/wrangler/src/dev/start-dev.ts
@@ -205,7 +205,7 @@ export async function startDev(args: StartDevOptions) {
 		return {
 			devEnv: primaryDevEnv,
 			secondary,
-			unregisterHotKeys,
+			unregisterHotKeys: () => unregisterHotKeys?.(),
 		};
 	} catch (e) {
 		await Promise.allSettled([


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/11254

startDev() registers dev hotkeys before authenticating the user. During interactive dev sessions, the auth callback re-registers hotkeys, which updates the local unregisterHotKeys variable to a new cleanup function. However, the unregisterHotKeys value returned to callers was captured as a direct reference to the initial registration, so it would call the stale cleanup function instead of the current one.

This PR fixes the bug by returning a wrapper function () => unregisterHotKeys?.() instead of the variable directly. The wrapper evaluates unregisterHotKeys at call time, ensuring it always invokes the latest cleanup function even after re-registration.

A unit test is added to verify that unregisterHotKeys() correctly calls the latest cleanup after auth triggers a re-registration.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: it's a bug fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
