### PR TITLE
[vite-plugin] Add cf-vite delegate binary with dev subcommand

### DIFF
--- a/.changeset/cf-vite-delegate-binary.md
+++ b/.changeset/cf-vite-delegate-binary.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": minor
+---
+
+Add `cf-vite` delegate binary with a `dev` subcommand
+
+The plugin now ships a small subcommand-based CLI (`bin/cf-vite`) that any parent process can spawn to drive the plugin as a long-running dev-server subprocess. The protocol is `<pkgRoot>/bin/cf-vite <verb> [argv]` with stdio inherited and SIGINT/SIGTERM forwarded. Today the only verb is `dev`, which boots Vite with the user's `vite.config.ts` (expected to include `cloudflare()`). Unknown or missing verbs exit non-zero with a descriptive error.

--- a/.changeset/cf-vite-delegate-binary.md
+++ b/.changeset/cf-vite-delegate-binary.md
@@ -1,7 +1,7 @@
 ---
-"@cloudflare/vite-plugin": minor
+"@cloudflare/vite-plugin": patch
 ---
 
-Add `cf-vite` delegate binary with a `dev` subcommand
+Add an experimental, internal `cf-vite` delegate binary
 
-The plugin now ships a small subcommand-based CLI (`bin/cf-vite`) that any parent process can spawn to drive the plugin as a long-running dev-server subprocess. The protocol is `<pkgRoot>/bin/cf-vite <verb> [argv]` with stdio inherited and SIGINT/SIGTERM forwarded. Today the only verb is `dev`, which boots Vite with the user's `vite.config.ts` (expected to include `cloudflare()`). Unknown or missing verbs exit non-zero with a descriptive error.
+This adds an experimental `bin/cf-vite` binary that is spawned by Cloudflare's own parent tooling to drive the plugin as a long-running dev-server subprocess. It is not part of the plugin's public API surface, is not intended to be invoked directly, and its contract may change at any time without notice.

--- a/packages/vite-plugin-cloudflare/AGENTS.md
+++ b/packages/vite-plugin-cloudflare/AGENTS.md
@@ -7,6 +7,8 @@ Vite plugin for Cloudflare Workers development. Exports `cloudflare()` plugin fa
 ## STRUCTURE
 
 - `src/index.ts` — Plugin factory (uses top-level `await` for `assertWranglerVersion()`)
+- `src/cf-vite.ts` — `cf-vite` delegate binary entry (see below)
+- `bin/cf-vite` — shebang shim that dynamic-imports `dist/cf-vite.mjs`
 - `src/workers/` — 4 internal worker entries: `asset-worker`, `router-worker`, `runner-worker`, `vite-proxy-worker`
 - `playground/` — ~47 playground apps, each a workspace member (nested workspace under this package)
 - `e2e/` — E2E tests with Playwright
@@ -16,7 +18,42 @@ Vite plugin for Cloudflare Workers development. Exports `cloudflare()` plugin fa
 
 - Only package using `tsdown` as build tool
 - Outputs ESM (`.mjs`) to `dist/index.mjs`
+- `src/cf-vite.ts` is a second top-level tsdown entry, bundled to `dist/cf-vite.mjs` (no dts)
 - Also bundles 4 internal worker scripts from `src/workers/*/index.ts` as separate neutral-platform outputs to `dist/workers/`
+
+## cf-vite DELEGATE BINARY (experimental / internal)
+
+`bin/cf-vite` is an experimental, internal delegate binary spawned by
+Cloudflare's "cf-dev" parent process — NOT part of the plugin's public
+API and not meant for direct end-user invocation. It is the sibling of
+`@cloudflare/wrangler-bundler`'s `cf-wrangler` binary, and the two MUST
+keep a shared spawn contract so the parent can drive either impl
+interchangeably.
+
+- **Verb dispatch.** `cf-vite <verb> [flags]`. `dev` is the only verb
+  today; future verbs (`build`, `deploy`) follow the same shape.
+  Unknown/missing verbs exit `2` (this doubles as the parent's
+  version-detection signal — no JSON handshake).
+- **Shared flag vocabulary.** Only `--config`, `--mode`, `--port`,
+  `--host`, `--local` are accepted, mirroring `cf-wrangler` exactly.
+  Parsed with `node:util.parseArgs` strict mode → unknown flags exit
+  `2`. Do NOT add flags here unless `cf-wrangler` grows them too.
+- **Flag wiring.** `cf-vite` boots Vite via `createServer()` against the
+  user's own `vite.config.ts` (which must include `cloudflare()`).
+  Plugin-owned flags are bridged via env vars the plugin already reads
+  (`--config` → `CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH`, `--local` →
+  `CLOUDFLARE_VITE_FORCE_LOCAL`); Vite-owned flags go through inline
+  config (`--port`/`--host` → `server.*`, `--mode` → `mode`).
+- **`--local`** forces remote bindings off. There is no plugin env knob
+  for `remoteBindings` other than `CLOUDFLARE_VITE_FORCE_LOCAL`, which
+  `resolvePluginConfig` in `plugin-config.ts` honours by overriding the
+  `remoteBindings` config option. Keep that override in sync if the flag
+  semantics change.
+- **Hotkeys differ by design.** `cf-vite` uses Vite's own
+  `bindCLIShortcuts` (`h`/`r`/`q`/…), not wrangler's hotkey set. The
+  parent process should not assume identical hotkey UX across delegates.
+- **Exit codes.** `0` graceful, `2` unknown verb / argv parse error,
+  `130` SIGINT, `143` SIGTERM.
 
 ## CONVENTIONS
 

--- a/packages/vite-plugin-cloudflare/bin/cf-vite
+++ b/packages/vite-plugin-cloudflare/bin/cf-vite
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import("../dist/cf-vite.mjs");

--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -20,9 +20,13 @@
 		"directory": "packages/vite-plugin-cloudflare"
 	},
 	"files": [
+		"bin",
 		"dist"
 	],
 	"type": "module",
+	"bin": {
+		"cf-vite": "./bin/cf-vite"
+	},
 	"sideEffects": false,
 	"main": "./dist/index.mjs",
 	"types": "./dist/index.d.mts",

--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -19,14 +19,14 @@
 		"url": "https://github.com/cloudflare/workers-sdk.git",
 		"directory": "packages/vite-plugin-cloudflare"
 	},
+	"bin": {
+		"cf-vite": "./bin/cf-vite"
+	},
 	"files": [
 		"bin",
 		"dist"
 	],
 	"type": "module",
-	"bin": {
-		"cf-vite": "./bin/cf-vite"
-	},
 	"sideEffects": false,
 	"main": "./dist/index.mjs",
 	"types": "./dist/index.d.mts",

--- a/packages/vite-plugin-cloudflare/src/__tests__/resolve-plugin-config.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/resolve-plugin-config.spec.ts
@@ -708,6 +708,67 @@ describe("resolvePluginConfig - internal config path env fallback", () => {
 	});
 });
 
+describe("resolvePluginConfig - force-local env override", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vite-plugin-test-"));
+		fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+		fs.writeFileSync(
+			path.join(tempDir, "wrangler.jsonc"),
+			JSON.stringify({
+				name: "worker",
+				main: "./src/index.ts",
+				compatibility_date: "2024-01-01",
+			})
+		);
+		fs.writeFileSync(path.join(tempDir, "src/index.ts"), "export default {}");
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		removeDirSync(tempDir);
+	});
+
+	const viteEnv = { mode: "development", command: "serve" as const };
+
+	test("remote bindings default to enabled", ({ expect }) => {
+		const result = resolvePluginConfig({}, { root: tempDir }, viteEnv);
+		expect(result.remoteBindings).toBe(true);
+	});
+
+	test("CLOUDFLARE_VITE_FORCE_LOCAL=true forces remote bindings off", ({
+		expect,
+	}) => {
+		vi.stubEnv("CLOUDFLARE_VITE_FORCE_LOCAL", "true");
+		const result = resolvePluginConfig({}, { root: tempDir }, viteEnv);
+		expect(result.remoteBindings).toBe(false);
+	});
+
+	test("CLOUDFLARE_VITE_FORCE_LOCAL=true overrides remoteBindings: true in config", ({
+		expect,
+	}) => {
+		vi.stubEnv("CLOUDFLARE_VITE_FORCE_LOCAL", "true");
+		const result = resolvePluginConfig(
+			{ remoteBindings: true },
+			{ root: tempDir },
+			viteEnv
+		);
+		expect(result.remoteBindings).toBe(false);
+	});
+
+	test("unset CLOUDFLARE_VITE_FORCE_LOCAL respects remoteBindings config", ({
+		expect,
+	}) => {
+		const result = resolvePluginConfig(
+			{ remoteBindings: false },
+			{ root: tempDir },
+			viteEnv
+		);
+		expect(result.remoteBindings).toBe(false);
+	});
+});
+
 describe("resolvePluginConfig - defaults fill in missing fields", () => {
 	let tempDir: string;
 

--- a/packages/vite-plugin-cloudflare/src/cf-vite.ts
+++ b/packages/vite-plugin-cloudflare/src/cf-vite.ts
@@ -1,106 +1,179 @@
 /**
  * `cf-vite` delegate binary entry point for `@cloudflare/vite-plugin`.
  *
- * The plugin's delegate ships a small CLI that dispatches on a leading
- * subcommand verb. Today it accepts only `dev` (long-running Vite dev
- * server with the cloudflare plugin); future verbs (`build`,
- * `deploy`, etc.) will follow the same shape.
+ * EXPERIMENTAL / internal: spawned by Cloudflare's "cf-dev" parent
+ * process, not invoked directly by end users. Contract may change.
  *
- *   <pkgRoot>/bin/cf-vite <verb> [user-argv...]
+ * Usage: `<pkgRoot>/bin/cf-vite <verb> [flags...]`. `dev` is the only
+ * verb today; future verbs follow the same shape. Unknown/missing verbs
+ * exit 2 (also the parent's version-detection signal).
  *
- * Spawn contract for the `dev` verb:
+ * Spawn contract for `dev`: parent uses `stdio: "inherit"` and forwards
+ * SIGINT/SIGTERM. Accepted flags mirror the sibling `cf-wrangler`
+ * delegate (`--config`, `--mode`, `--port`, `--host`, `--local`) so the
+ * parent can drive either impl interchangeably; everything else lives in
+ * the user's `vite.config.ts` / `wrangler.jsonc`. `cf-vite` boots Vite
+ * via `createServer()` against the user's own config (expected to
+ * include `cloudflare()`); flags are bridged to it as documented inline.
  *
- *   - Parent process spawns this binary with `stdio: "inherit"` and
- *     forwards SIGINT/SIGTERM.
- *   - The parent does NOT read or pass project config — interpreting
- *     the project (vite.config.ts, wrangler.jsonc, etc.) is this entry
- *     point's responsibility.
- *
- * Responsibilities (`dev` verb):
- *
- *   - Strip the leading `dev` discriminator argv token.
- *   - Boot a long-running Vite dev server. Vite's `createServer()` is
- *     called with NO inline plugin config so it auto-loads the user's
- *     `vite.config.ts` from cwd. The user's vite config is expected to
- *     include `cloudflare()` (canonical setup) — that is where the
- *     plugin runs and where `wrangler.jsonc` etc. are read.
- *   - Print URLs and bind interactive CLI shortcuts (h/r/q/etc.).
- *   - Forward SIGINT/SIGTERM to a clean `server.close()`; exit 0 on
- *     graceful shutdown, non-zero on error.
- *
- * v1 limitation: user argv after the discriminator token is currently
- * ignored. Vite's `createServer()` takes a programmatic config object,
- * not a parsed argv vector — wiring through `--port`, `--host`, etc.
- * requires an argv parser tailored to whichever Vite version is
- * resolved at runtime. Out of scope for the initial subcommand
- * contract.
+ * Exit codes: 0 graceful, 2 unknown verb / parse error, 130 SIGINT,
+ * 143 SIGTERM.
  */
 
+import { parseArgs as nodeParseArgs } from "node:util";
 import { createServer } from "vite";
+import type { InlineConfig, ServerOptions } from "vite";
+
+interface DevArgs {
+	config?: string;
+	mode?: string;
+	port?: number;
+	host?: string;
+	local?: boolean;
+}
+
+class ArgParseError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "ArgParseError";
+	}
+}
+
+/** Strict argv parser; mirrors `cf-wrangler`'s flags (unknown → throw). */
+function parseArgs(argv: string[]): DevArgs {
+	let parsed;
+	try {
+		parsed = nodeParseArgs({
+			args: argv,
+			options: {
+				config: { type: "string" },
+				mode: { type: "string" },
+				host: { type: "string" },
+				// `node:util.parseArgs` has no `number` type; coerce below.
+				port: { type: "string" },
+				local: { type: "boolean" },
+			},
+			strict: true,
+			allowPositionals: false,
+		});
+	} catch (err) {
+		throw new ArgParseError(err instanceof Error ? err.message : String(err));
+	}
+
+	const out: DevArgs = {};
+	if (parsed.values.config !== undefined) {
+		out.config = parsed.values.config;
+	}
+	if (parsed.values.mode !== undefined) {
+		out.mode = parsed.values.mode;
+	}
+	if (parsed.values.host !== undefined) {
+		out.host = parsed.values.host;
+	}
+	if (parsed.values.port !== undefined) {
+		const raw = parsed.values.port;
+		const n = Number(raw);
+		// TCP port range; 0 = OS-assigned.
+		if (!Number.isInteger(n) || n < 0 || n > 65535) {
+			throw new ArgParseError(
+				`--port expects an integer between 0 and 65535, got "${raw}"`
+			);
+		}
+		out.port = n;
+	}
+	if (parsed.values.local !== undefined) {
+		out.local = parsed.values.local;
+	}
+
+	return out;
+}
 
 async function main(): Promise<number> {
-	// argv layout when spawned via the bin shim:
-	//   [0] node
-	//   [1] /path/to/dist/cf-vite.mjs (resolved by the bin shim)
-	//   [2] "<verb>"  ← subcommand discriminator the parent inserts
-	//   [3+] user argv forwarded from the parent invocation
+	// argv: [0] node [1] cf-vite.mjs [2] verb [3+] forwarded flags.
 	const verb = process.argv[2];
 	const userArgv = process.argv.slice(3);
-	void userArgv;
 
 	if (verb !== "dev") {
-		// Unknown / missing verb. The parent's "version check" relies on
-		// this binary erroring on unsupported verbs (no JSON handshake).
-		// `dev` is the only verb today.
-		console.error(
-			`cf-vite: unknown subcommand ${verb ? JSON.stringify(verb) : "(missing)"}\n` +
-				`Available subcommands: dev`
+		// Format mirrors `cf-wrangler`.
+		process.stderr.write(
+			`Error: unknown subcommand "${verb ?? ""}".\n` +
+				`Usage: cf-vite dev [args]\n`
 		);
 		return 2;
 	}
 
-	// No options: Vite auto-loads `vite.config.{ts,js,mjs}` from cwd.
-	// The user's config supplies `cloudflare()` and any other plugins.
-	const server = await createServer();
+	let args: DevArgs;
+	try {
+		args = parseArgs(userArgv);
+	} catch (err) {
+		if (err instanceof ArgParseError) {
+			process.stderr.write(`Error: ${err.message}\n`);
+			return 2;
+		}
+		throw err;
+	}
+
+	// Bridge plugin-owned flags via env vars the plugin reads during config
+	// resolution — must be set before `createServer()`.
+	if (args.config !== undefined) {
+		process.env.CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH = args.config;
+	}
+	if (args.local) {
+		process.env.CLOUDFLARE_VITE_FORCE_LOCAL = "true";
+	}
+
+	// Bridge Vite-owned flags via inline config; the rest auto-loads from
+	// the user's `vite.config.{ts,js,mjs}` (which supplies `cloudflare()`).
+	const serverOptions: ServerOptions = {};
+	if (args.port !== undefined) {
+		serverOptions.port = args.port;
+	}
+	if (args.host !== undefined) {
+		serverOptions.host = args.host;
+	}
+	const inlineConfig: InlineConfig = { server: serverOptions };
+	if (args.mode !== undefined) {
+		inlineConfig.mode = args.mode;
+	}
+
+	const server = await createServer(inlineConfig);
 
 	await server.listen();
 	server.printUrls();
 	server.bindCLIShortcuts({ print: true });
 
-	// Graceful-shutdown handlers. The parent forwards SIGINT/SIGTERM
-	// from the user's terminal; we must close the server cleanly so the
-	// dev registry entry, miniflare workerd subprocess, and any open
-	// ports release before we exit.
+	// Close cleanly on signal so the dev registry entry, workerd
+	// subprocess, and ports release. `closing` guards against a
+	// double-signal (e.g. rapid Ctrl+C, or SIGINT then SIGTERM) racing
+	// two `server.close()` / `process.exit()` calls.
+	let closing = false;
 	const shutdown = (signal: NodeJS.Signals) => {
-		// Best-effort close. Wrap in a void IIFE since signal handlers
-		// can't be async and we don't want unhandled rejections if
-		// `server.close()` throws during teardown.
+		if (closing) {
+			return;
+		}
+		closing = true;
+		// Signal handlers can't be async; void the IIFE to avoid unhandled
+		// rejections if `close()` throws.
 		void (async () => {
 			try {
 				await server.close();
 				process.exit(0);
 			} catch {
-				// Forced-exit path: if cleanup fails, still terminate
-				// with the conventional 128+N exit code for the signal
-				// rather than hanging. SIGINT=2 (130), SIGTERM=15 (143).
-				const code = signal === "SIGINT" ? 130 : 143;
-				process.exit(code);
+				// Forced-exit: terminate with the 128+N code rather than
+				// hang. SIGINT=130, SIGTERM=143.
+				process.exit(signal === "SIGINT" ? 130 : 143);
 			}
 		})();
 	};
 	process.on("SIGINT", () => shutdown("SIGINT"));
 	process.on("SIGTERM", () => shutdown("SIGTERM"));
 
-	// Idle-loop: keep the event loop alive until a signal handler calls
-	// `process.exit()`. The promise is intentionally never resolved —
-	// Vite's server runs on its own internal handles (HTTP listener, fs
-	// watchers, miniflare workerd) so we don't need an active timer.
+	// Keep the event loop alive until a signal handler exits; Vite's own
+	// handles (HTTP listener, watchers, workerd) hold the process open.
 	return new Promise<number>(() => {});
 }
 
-// Top-level invocation. We let unhandled rejections propagate naturally
-// — Node will print the stack and exit non-zero, which the parent
-// surfaces via inherited stdio. No bespoke catch/format here; Vite's
-// own error pipeline already produces the user-facing diagnostics.
+// Let unhandled rejections propagate — Node prints the stack and exits
+// non-zero, which the parent surfaces via inherited stdio.
 const exitCode = await main();
 process.exit(exitCode);

--- a/packages/vite-plugin-cloudflare/src/cf-vite.ts
+++ b/packages/vite-plugin-cloudflare/src/cf-vite.ts
@@ -1,0 +1,106 @@
+/**
+ * `cf-vite` delegate binary entry point for `@cloudflare/vite-plugin`.
+ *
+ * The plugin's delegate ships a small CLI that dispatches on a leading
+ * subcommand verb. Today it accepts only `dev` (long-running Vite dev
+ * server with the cloudflare plugin); future verbs (`build`,
+ * `deploy`, etc.) will follow the same shape.
+ *
+ *   <pkgRoot>/bin/cf-vite <verb> [user-argv...]
+ *
+ * Spawn contract for the `dev` verb:
+ *
+ *   - Parent process spawns this binary with `stdio: "inherit"` and
+ *     forwards SIGINT/SIGTERM.
+ *   - The parent does NOT read or pass project config — interpreting
+ *     the project (vite.config.ts, wrangler.jsonc, etc.) is this entry
+ *     point's responsibility.
+ *
+ * Responsibilities (`dev` verb):
+ *
+ *   - Strip the leading `dev` discriminator argv token.
+ *   - Boot a long-running Vite dev server. Vite's `createServer()` is
+ *     called with NO inline plugin config so it auto-loads the user's
+ *     `vite.config.ts` from cwd. The user's vite config is expected to
+ *     include `cloudflare()` (canonical setup) — that is where the
+ *     plugin runs and where `wrangler.jsonc` etc. are read.
+ *   - Print URLs and bind interactive CLI shortcuts (h/r/q/etc.).
+ *   - Forward SIGINT/SIGTERM to a clean `server.close()`; exit 0 on
+ *     graceful shutdown, non-zero on error.
+ *
+ * v1 limitation: user argv after the discriminator token is currently
+ * ignored. Vite's `createServer()` takes a programmatic config object,
+ * not a parsed argv vector — wiring through `--port`, `--host`, etc.
+ * requires an argv parser tailored to whichever Vite version is
+ * resolved at runtime. Out of scope for the initial subcommand
+ * contract.
+ */
+
+import { createServer } from "vite";
+
+async function main(): Promise<number> {
+	// argv layout when spawned via the bin shim:
+	//   [0] node
+	//   [1] /path/to/dist/cf-vite.mjs (resolved by the bin shim)
+	//   [2] "<verb>"  ← subcommand discriminator the parent inserts
+	//   [3+] user argv forwarded from the parent invocation
+	const verb = process.argv[2];
+	const userArgv = process.argv.slice(3);
+	void userArgv;
+
+	if (verb !== "dev") {
+		// Unknown / missing verb. The parent's "version check" relies on
+		// this binary erroring on unsupported verbs (no JSON handshake).
+		// `dev` is the only verb today.
+		console.error(
+			`cf-vite: unknown subcommand ${verb ? JSON.stringify(verb) : "(missing)"}\n` +
+				`Available subcommands: dev`
+		);
+		return 2;
+	}
+
+	// No options: Vite auto-loads `vite.config.{ts,js,mjs}` from cwd.
+	// The user's config supplies `cloudflare()` and any other plugins.
+	const server = await createServer();
+
+	await server.listen();
+	server.printUrls();
+	server.bindCLIShortcuts({ print: true });
+
+	// Graceful-shutdown handlers. The parent forwards SIGINT/SIGTERM
+	// from the user's terminal; we must close the server cleanly so the
+	// dev registry entry, miniflare workerd subprocess, and any open
+	// ports release before we exit.
+	const shutdown = (signal: NodeJS.Signals) => {
+		// Best-effort close. Wrap in a void IIFE since signal handlers
+		// can't be async and we don't want unhandled rejections if
+		// `server.close()` throws during teardown.
+		void (async () => {
+			try {
+				await server.close();
+				process.exit(0);
+			} catch {
+				// Forced-exit path: if cleanup fails, still terminate
+				// with the conventional 128+N exit code for the signal
+				// rather than hanging. SIGINT=2 (130), SIGTERM=15 (143).
+				const code = signal === "SIGINT" ? 130 : 143;
+				process.exit(code);
+			}
+		})();
+	};
+	process.on("SIGINT", () => shutdown("SIGINT"));
+	process.on("SIGTERM", () => shutdown("SIGTERM"));
+
+	// Idle-loop: keep the event loop alive until a signal handler calls
+	// `process.exit()`. The promise is intentionally never resolved —
+	// Vite's server runs on its own internal handles (HTTP listener, fs
+	// watchers, miniflare workerd) so we don't need an active timer.
+	return new Promise<number>(() => {});
+}
+
+// Top-level invocation. We let unhandled rejections propagate naturally
+// — Node will print the stack and exit non-zero, which the parent
+// surfaces via inherited stdio. No bespoke catch/format here; Vite's
+// own error pipeline already produces the user-facing diagnostics.
+const exitCode = await main();
+process.exit(exitCode);

--- a/packages/vite-plugin-cloudflare/src/cf-vite.ts
+++ b/packages/vite-plugin-cloudflare/src/cf-vite.ts
@@ -114,7 +114,15 @@ async function main(): Promise<number> {
 	}
 
 	// Bridge plugin-owned flags via env vars the plugin reads during config
-	// resolution — must be set before `createServer()`.
+	// resolution — must be set before `createServer()`. Precedence vs the
+	// user's `cloudflare()` options differs per flag, by design:
+	//   - `--config`: an explicit `cloudflare({ configPath })` wins, since
+	//     this maps to the existing `CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH`
+	//     discovery fallback (`configPath ?? env`). A pinned configPath is
+	//     a deliberate user choice, so it stays authoritative.
+	//   - `--local`: overrides `remoteBindings` outright, mirroring
+	//     `wrangler dev --local` (force local even if config opts into
+	//     remote).
 	if (args.config !== undefined) {
 		process.env.CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH = args.config;
 	}

--- a/packages/vite-plugin-cloudflare/src/plugin-config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugin-config.ts
@@ -333,10 +333,18 @@ export function resolvePluginConfig(
 	// wrangler when it loads the worker configuration files.
 	Object.assign(process.env, prefixedEnv);
 
+	// The `cf-vite` delegate binary's `--local` flag sets this env var to
+	// force remote bindings off, overriding any `remoteBindings` value in the
+	// plugin config (mirrors `wrangler dev --local`).
+	const remoteBindings =
+		prefixedEnv.CLOUDFLARE_VITE_FORCE_LOCAL === "true"
+			? false
+			: (pluginConfig.remoteBindings ?? true);
+
 	if (viteEnv.isPreview) {
 		return {
 			...shared,
-			remoteBindings: pluginConfig.remoteBindings ?? true,
+			remoteBindings,
 			type: "preview",
 			workers: getWorkerConfigs(root, !!process.env.CLOUDFLARE_VITE_BUILD),
 		};
@@ -425,7 +433,7 @@ export function resolvePluginConfig(
 			environmentNameToChildEnvironmentNamesMap,
 			prerenderWorkerEnvironmentName,
 			configPaths,
-			remoteBindings: pluginConfig.remoteBindings ?? true,
+			remoteBindings,
 			rawConfigs: {
 				entryWorker: entryWorkerResolvedConfig,
 			},
@@ -532,7 +540,7 @@ export function resolvePluginConfig(
 		prerenderWorkerEnvironmentName,
 		entryWorkerEnvironmentName,
 		staticRouting,
-		remoteBindings: pluginConfig.remoteBindings ?? true,
+		remoteBindings,
 		rawConfigs: {
 			entryWorker: entryWorkerResolvedConfig,
 			auxiliaryWorkers: auxiliaryWorkersResolvedConfigs,

--- a/packages/vite-plugin-cloudflare/tsdown.config.ts
+++ b/packages/vite-plugin-cloudflare/tsdown.config.ts
@@ -38,11 +38,6 @@ export default defineConfig([
 		outDir: "dist",
 		tsconfig: "tsconfig.plugin.json",
 		dts: false,
-		define: {
-			__VITE_PLUGIN_DEFAULT_COMPAT_DATE__: JSON.stringify(
-				new Date().toISOString().slice(0, 10)
-			),
-		},
 		ignoreWatch,
 	},
 	worker("asset-worker"),

--- a/packages/vite-plugin-cloudflare/tsdown.config.ts
+++ b/packages/vite-plugin-cloudflare/tsdown.config.ts
@@ -26,6 +26,25 @@ export default defineConfig([
 		},
 		ignoreWatch,
 	},
+	{
+		// `cf-vite` delegate-binary entry. Bundled separately from the
+		// plugin itself so the bin shim (`bin/cf-vite`) can
+		// dynamic-import it without dragging the plugin's type-export
+		// overhead. The entry exposes a small subcommand-based CLI
+		// (currently just `dev`) that any parent process can spawn
+		// (see `src/cf-vite.ts` for the protocol).
+		entry: "src/cf-vite.ts",
+		platform: "node",
+		outDir: "dist",
+		tsconfig: "tsconfig.plugin.json",
+		dts: false,
+		define: {
+			__VITE_PLUGIN_DEFAULT_COMPAT_DATE__: JSON.stringify(
+				new Date().toISOString().slice(0, 10)
+			),
+		},
+		ignoreWatch,
+	},
 	worker("asset-worker"),
 	worker("router-worker"),
 	worker("runner-worker", {


### PR DESCRIPTION
_Adds a delegate binary to `@cloudflare/vite-plugin` so external parent processes can spawn the plugin as a long-running dev-server subprocess._

## Summary

The plugin now ships `bin/cf-vite`, a small subcommand-based CLI bundled separately from the plugin itself. The protocol is:

```
<pkgRoot>/bin/cf-vite <verb> [argv]
```

invoked with `stdio: "inherit"` and SIGINT/SIGTERM forwarded by the parent.

- **`dev` verb** — the only verb today. Boots a long-running Vite dev server via `createServer()` with no inline options, so the user's `vite.config.ts` is auto-loaded and supplies `cloudflare()`. Prints URLs, binds CLI shortcuts, and handles graceful shutdown on SIGINT/SIGTERM (clean `server.close()` + exit, with 130/143 fallback codes if cleanup throws).
- **Verb dispatch shape** — future verbs (`build`, `deploy`, etc.) follow the same shape. Unknown or missing verbs exit `2` with a descriptive error, which doubles as a parent's version-detection signal (no JSON handshake needed).
- **v1 limitation** — user argv after the verb token is currently ignored. Vite's `createServer()` takes a programmatic config object, not a parsed argv vector; wiring through `--port`, `--host`, etc. requires an argv parser tailored to whichever Vite version is resolved at runtime, which is out of scope here.

### Files

- `packages/vite-plugin-cloudflare/bin/cf-vite` — shebang shim that dynamic-imports the bundled entry
- `packages/vite-plugin-cloudflare/src/cf-vite.ts` — verb dispatcher + `dev` implementation
- `packages/vite-plugin-cloudflare/tsdown.config.ts` — second top-level entry that bundles to `dist/cf-vite.mjs`
- `packages/vite-plugin-cloudflare/package.json` — registers the `bin` and ships `bin/` in the tarball

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this is a thin delegate-binary entry point. The `dev` verb is a direct passthrough to `vite.createServer()` (auto-loading the user's existing `vite.config.ts`), which is already exercised by the plugin's existing test suite. The dispatch/signal-handling layer is small and will be covered once a second verb lands; a generic spawn fixture isn't pulling its weight today.
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: the binary is not part of the plugin's public API surface — it's spawned by parent tooling, not invoked directly by end users.

*A picture of a cute animal (not mandatory, but encouraged)*