### PR TITLE
Add automatic Cloudflare skills installation for AI coding agents

### DIFF
--- a/.changeset/agents-skills-install.md
+++ b/.changeset/agents-skills-install.md
@@ -4,4 +4,4 @@
 
 Add automatic Cloudflare skills installation for AI coding agents
 
-Wrangler now detects AI coding agents and offers to install Cloudflare skill files from the `cloudflare/skills` GitHub repository. Users are prompted once interactively; subsequent runs skip the prompt. Use `--experimental-force-skills-install` (alias `--x-force-skills-install`) to install without prompting.
+Wrangler now detects AI coding agents and offers to install Cloudflare skill files from the `cloudflare/skills` GitHub repository. Users are prompted once interactively; subsequent runs skip the prompt. Use `--install-skills` to install without prompting.

--- a/.changeset/agents-skills-install.md
+++ b/.changeset/agents-skills-install.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add automatic Cloudflare skills installation for AI coding agents
+
+Wrangler now detects AI coding agents and offers to install Cloudflare skill files from the `cloudflare/skills` GitHub repository. Users are prompted once interactively; subsequent runs skip the prompt. Use `--experimental-force-skills-install` (alias `--x-force-skills-install`) to install without prompting.

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -71,6 +71,7 @@
 		"esbuild": "catalog:default",
 		"miniflare": "workspace:*",
 		"path-to-regexp": "6.3.0",
+		"rosie-skills": "^0.6.3",
 		"unenv": "2.0.0-rc.24",
 		"workerd": "1.20260519.1"
 	},

--- a/packages/wrangler/scripts/deps.ts
+++ b/packages/wrangler/scripts/deps.ts
@@ -35,6 +35,10 @@ export const EXTERNAL_DEPENDENCIES = [
 
 	// workerd contains a native binary, so must be external. Wrangler depends on a pinned version.
 	"workerd",
+
+	// rosie-skills contains inlined WASM that is loaded at runtime via import.meta.url-relative
+	// path resolution, so it cannot be bundled.
+	"rosie-skills",
 ];
 
 const pathToPackageJson = path.resolve(__dirname, "..", "package.json");

--- a/packages/wrangler/src/__tests__/agents-skills-install.test.ts
+++ b/packages/wrangler/src/__tests__/agents-skills-install.test.ts
@@ -189,7 +189,7 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 				"Failed to install Cloudflare skills: network failure"
 			);
 			expect(std.warn).toContain(
-				"You can retry by running `wrangler --experimental-force-skills-install`, or install skills manually as described here: https://github.com/cloudflare/skills#installing"
+				"You can retry by running `wrangler --install-skills`, or install skills manually as described here: https://github.com/cloudflare/skills#installing"
 			);
 			expect(sendMetricsEvent).toHaveBeenCalledWith(
 				"skills_install_skipped",
@@ -409,7 +409,7 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 				"Failed to install Cloudflare skills: tarball download failed"
 			);
 			expect(std.warn).toContain(
-				"You can retry by running `wrangler --experimental-force-skills-install`, or install skills manually as described here: https://github.com/cloudflare/skills#installing"
+				"You can retry by running `wrangler --install-skills`, or install skills manually as described here: https://github.com/cloudflare/skills#installing"
 			);
 
 			const metadata = readMetadataFile();
@@ -460,7 +460,7 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 				"Skills installation failed for agents: cursor."
 			);
 			expect(std.warn).toContain(
-				"You can retry by running `wrangler --experimental-force-skills-install`, or install skills manually as described here: https://github.com/cloudflare/skills#installing"
+				"You can retry by running `wrangler --install-skills`, or install skills manually as described here: https://github.com/cloudflare/skills#installing"
 			);
 		});
 	});

--- a/packages/wrangler/src/__tests__/agents-skills-install.test.ts
+++ b/packages/wrangler/src/__tests__/agents-skills-install.test.ts
@@ -209,7 +209,10 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 			expect(mockRosieInstall).not.toHaveBeenCalled();
 			expect(sendMetricsEvent).toHaveBeenCalledWith(
 				"skills_install_skipped",
-				{ reason: "Failed to install skills", errorMessage: "WASM load failed" },
+				{
+					reason: "Failed to install skills",
+					errorMessage: "WASM load failed",
+				},
 				{}
 			);
 		});

--- a/packages/wrangler/src/__tests__/agents-skills-install.test.ts
+++ b/packages/wrangler/src/__tests__/agents-skills-install.test.ts
@@ -177,6 +177,24 @@ describe("installCloudflareSkillsGlobally", () => {
 			);
 		});
 
+		test("returns 'Failed to install skills' when rosie.agents() throws", async ({
+			expect,
+		}) => {
+			mockRosieAgents.mockRejectedValueOnce(new Error("WASM load failed"));
+			const installCloudflareSkillsGlobally = await freshImport();
+
+			const result = await installCloudflareSkillsGlobally(false);
+
+			expect(result).toEqual({
+				skipped: true,
+				reason: "Failed to install skills",
+			});
+			expect(std.warn).toContain(
+				"Failed to detect AI coding agents: WASM load failed"
+			);
+			expect(mockRosieInstall).not.toHaveBeenCalled();
+		});
+
 		test("returns 'Running in CI' when ci.isCI is true", async ({ expect }) => {
 			vi.mocked(ci).isCI = true;
 			const installCloudflareSkillsGlobally = await freshImport();
@@ -382,6 +400,60 @@ describe("installCloudflareSkillsGlobally", () => {
 			const metadata = readMetadataFile();
 			expect(metadata.accepted).toBe(true);
 			expect(metadata.installFailed).toBe(true);
+		});
+
+		test("success message and return value exclude agents that failed", async ({
+			expect,
+		}) => {
+			mockRosieAgents.mockResolvedValueOnce([
+				{
+					name: "claude",
+					display: "Claude Code",
+					detected: true,
+					installPath: "/fake/.claude/skills",
+				},
+				{
+					name: "cursor",
+					display: "Cursor",
+					detected: true,
+					installPath: "/fake/.cursor/skills",
+				},
+			]);
+			mockRosieInstall.mockResolvedValueOnce({
+				skills: [
+					{
+						name: "cloudflare",
+						kind: "skill",
+						installedAgents: ["claude"],
+						failedAgents: ["cursor"],
+					},
+				],
+				installedAgents: ["claude"],
+				failedAgents: ["cursor"],
+				installedInstruction: null,
+			});
+			const installCloudflareSkillsGlobally = await freshImport();
+
+			const result = await installCloudflareSkillsGlobally(true);
+
+			// Return value should only include succeeded agents
+			expect("skipped" in result).toBe(false);
+			if (!("skipped" in result)) {
+				const agentNames = result.targetedAgents.map((a) => a.name);
+				expect(agentNames).toContain("Claude Code");
+				expect(agentNames).not.toContain("Cursor");
+			}
+
+			// Success message should only mention succeeded agents
+			expect(std.out).toContain(
+				"Successfully installed Cloudflare skills for: Claude Code."
+			);
+			expect(std.out).not.toContain("Cursor");
+
+			// Warning should mention the failed agent
+			expect(std.warn).toContain(
+				"Skills installation failed for agents: cursor."
+			);
 		});
 	});
 

--- a/packages/wrangler/src/__tests__/agents-skills-install.test.ts
+++ b/packages/wrangler/src/__tests__/agents-skills-install.test.ts
@@ -3,11 +3,13 @@ import path from "node:path";
 import { getGlobalWranglerConfigPath } from "@cloudflare/workers-utils";
 import ci from "ci-info";
 import { afterEach, beforeEach, describe, test, vi } from "vitest";
+import { sendMetricsEvent } from "../metrics/send-event";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs, mockConfirm } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { runInTempDir } from "./helpers/run-in-tmp";
-import type { installCloudflareSkillsGlobally as InstallFnType } from "../agents-skills-install";
+import type { maybeInstallCloudflareSkillsGlobally as InstallFnType } from "../agents-skills-install";
+import type * as SendEventModule from "../metrics/send-event";
 
 // Undo the global no-op mock from vitest.setup.ts so we test the real implementation
 vi.unmock("../agents-skills-install");
@@ -19,6 +21,15 @@ vi.mock("rosie-skills", () => ({
 	install: mockRosieInstall,
 	agents: mockRosieAgents,
 }));
+
+// Mock sendMetricsEvent so we can verify metrics are sent for each code path.
+vi.mock("../metrics/send-event", async (importOriginal) => {
+	const original = await importOriginal<typeof SendEventModule>();
+	return {
+		...original,
+		sendMetricsEvent: vi.fn(),
+	};
+});
 
 /** Default rosie.agents() return value: Claude Code detected, Cursor not detected. */
 const DEFAULT_AGENTS = [
@@ -78,10 +89,10 @@ function readMetadataFile(): Record<string, unknown> {
 async function freshImport(): Promise<typeof InstallFnType> {
 	vi.resetModules();
 	const mod = await import("../agents-skills-install");
-	return mod.installCloudflareSkillsGlobally;
+	return mod.maybeInstallCloudflareSkillsGlobally;
 }
 
-describe("installCloudflareSkillsGlobally", () => {
+describe("maybeInstallCloudflareSkillsGlobally", () => {
 	runInTempDir();
 	const std = mockConsoleMethods();
 	const { setIsTTY } = useMockIsTTY();
@@ -97,34 +108,36 @@ describe("installCloudflareSkillsGlobally", () => {
 	});
 
 	describe("skip conditions", () => {
-		test("returns 'Already prompted' when metadata file exists", async ({
+		test("skips silently when metadata file exists and sends no metrics", async ({
 			expect,
 		}) => {
 			writeMetadataFile({ accepted: true, date: "2025-01-01T00:00:00Z" });
-			const installCloudflareSkillsGlobally = await freshImport();
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
 
-			const result = await installCloudflareSkillsGlobally(false);
+			await maybeInstallCloudflareSkillsGlobally(false);
 
-			expect(result).toEqual({
-				skipped: true,
-				reason: "Already prompted",
-			});
+			expect(mockRosieAgents).not.toHaveBeenCalled();
+			expect(mockRosieInstall).not.toHaveBeenCalled();
+			expect(sendMetricsEvent).not.toHaveBeenCalled();
 		});
 
 		test("force=true ignores existing metadata file", async ({ expect }) => {
 			writeMetadataFile({ accepted: true, date: "2025-01-01T00:00:00Z" });
-			const installCloudflareSkillsGlobally = await freshImport();
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
 
-			const result = await installCloudflareSkillsGlobally(true);
+			await maybeInstallCloudflareSkillsGlobally(true);
 
-			expect(result).toMatchObject({
-				targetedAgents: expect.arrayContaining([
-					expect.objectContaining({ name: "Claude Code" }),
-				]),
+			expect(mockRosieInstall).toHaveBeenCalledWith("cloudflare/skills", {
+				global: true,
+				agent: ["claude"],
+				lockfile: false,
 			});
+			expect(std.out).toContain(
+				"Successfully installed Cloudflare skills for: Claude Code."
+			);
 		});
 
-		test("returns 'No supported agents detected' when no agents are detected", async ({
+		test("skips and sends skills_install_skipped when no agents are detected", async ({
 			expect,
 		}) => {
 			mockRosieAgents.mockResolvedValueOnce([
@@ -135,94 +148,98 @@ describe("installCloudflareSkillsGlobally", () => {
 					installPath: null,
 				},
 			]);
-			const installCloudflareSkillsGlobally = await freshImport();
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
 
-			const result = await installCloudflareSkillsGlobally(false);
+			await maybeInstallCloudflareSkillsGlobally(false);
 
-			expect(result).toEqual({
-				skipped: true,
-				reason: "No supported agents detected",
-			});
-		});
-
-		test("returns 'No supported agents detected' when rosie.agents() returns empty", async ({
-			expect,
-		}) => {
-			mockRosieAgents.mockResolvedValueOnce([]);
-			const installCloudflareSkillsGlobally = await freshImport();
-
-			const result = await installCloudflareSkillsGlobally(false);
-
-			expect(result).toEqual({
-				skipped: true,
-				reason: "No supported agents detected",
-			});
-		});
-
-		test("returns 'Failed to install skills' when rosie.install() throws", async ({
-			expect,
-		}) => {
-			mockRosieInstall.mockRejectedValueOnce(new Error("network failure"));
-			const installCloudflareSkillsGlobally = await freshImport();
-
-			// force=true so we don't need to mock the confirm dialog
-			const result = await installCloudflareSkillsGlobally(true);
-
-			expect(result).toEqual({
-				skipped: true,
-				reason: "Failed to install skills",
-			});
-			expect(std.warn).toContain(
-				"Failed to install Cloudflare skills: network failure"
+			expect(mockRosieInstall).not.toHaveBeenCalled();
+			expect(sendMetricsEvent).toHaveBeenCalledWith(
+				"skills_install_skipped",
+				{ reason: "No supported agents detected" },
+				{}
 			);
 		});
 
-		test("returns 'Failed to install skills' when rosie.agents() throws", async ({
+		test("skips and sends skills_install_skipped when rosie.agents() returns empty", async ({
+			expect,
+		}) => {
+			mockRosieAgents.mockResolvedValueOnce([]);
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+
+			await maybeInstallCloudflareSkillsGlobally(false);
+
+			expect(mockRosieInstall).not.toHaveBeenCalled();
+			expect(sendMetricsEvent).toHaveBeenCalledWith(
+				"skills_install_skipped",
+				{ reason: "No supported agents detected" },
+				{}
+			);
+		});
+
+		test("warns and sends skills_install_skipped when rosie.install() throws", async ({
+			expect,
+		}) => {
+			mockRosieInstall.mockRejectedValueOnce(new Error("network failure"));
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+
+			// force=true so we don't need to mock the confirm dialog
+			await maybeInstallCloudflareSkillsGlobally(true);
+
+			expect(std.warn).toContain(
+				"Failed to install Cloudflare skills: network failure"
+			);
+			expect(sendMetricsEvent).toHaveBeenCalledWith(
+				"skills_install_skipped",
+				{ reason: "Failed to install skills" },
+				{}
+			);
+		});
+
+		test("warns and sends skills_install_skipped when rosie.agents() throws", async ({
 			expect,
 		}) => {
 			mockRosieAgents.mockRejectedValueOnce(new Error("WASM load failed"));
-			const installCloudflareSkillsGlobally = await freshImport();
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
 
-			const result = await installCloudflareSkillsGlobally(false);
+			await maybeInstallCloudflareSkillsGlobally(false);
 
-			expect(result).toEqual({
-				skipped: true,
-				reason: "Failed to install skills",
-			});
 			expect(std.warn).toContain(
 				"Failed to detect AI coding agents: WASM load failed"
 			);
 			expect(mockRosieInstall).not.toHaveBeenCalled();
+			expect(sendMetricsEvent).toHaveBeenCalledWith(
+				"skills_install_skipped",
+				{ reason: "Failed to install skills" },
+				{}
+			);
 		});
 
-		test("returns 'Running in CI' when ci.isCI is true", async ({ expect }) => {
+		test("skips in CI and sends skills_install_skipped when ci.isCI is true", async ({
+			expect,
+		}) => {
 			vi.mocked(ci).isCI = true;
-			const installCloudflareSkillsGlobally = await freshImport();
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
 
-			const result = await installCloudflareSkillsGlobally(false);
+			await maybeInstallCloudflareSkillsGlobally(false);
 
-			expect(result).toEqual({
-				skipped: true,
-				reason: "Running in CI",
-			});
 			// Verify neither agent detection nor install was attempted
 			expect(mockRosieAgents).not.toHaveBeenCalled();
 			expect(mockRosieInstall).not.toHaveBeenCalled();
+			expect(sendMetricsEvent).toHaveBeenCalledWith(
+				"skills_install_skipped",
+				{ reason: "Running in CI" },
+				{}
+			);
 		});
 
 		test("force=true bypasses CI check and installs skills", async ({
 			expect,
 		}) => {
 			vi.mocked(ci).isCI = true;
-			const installCloudflareSkillsGlobally = await freshImport();
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
 
-			const result = await installCloudflareSkillsGlobally(true);
+			await maybeInstallCloudflareSkillsGlobally(true);
 
-			expect(result).toMatchObject({
-				targetedAgents: expect.arrayContaining([
-					expect.objectContaining({ name: "Claude Code" }),
-				]),
-			});
 			expect(mockRosieInstall).toHaveBeenCalledWith("cloudflare/skills", {
 				global: true,
 				agent: ["claude"],
@@ -230,42 +247,38 @@ describe("installCloudflareSkillsGlobally", () => {
 			});
 		});
 
-		test("returns 'Non-interactive terminal' when TTY is false", async ({
+		test("logs info and sends skills_install_skipped when TTY is false", async ({
 			expect,
 		}) => {
 			setIsTTY(false);
-			const installCloudflareSkillsGlobally = await freshImport();
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
 
-			const result = await installCloudflareSkillsGlobally(false);
+			await maybeInstallCloudflareSkillsGlobally(false);
 
-			expect(result).toEqual({
-				skipped: true,
-				reason: "Non-interactive terminal",
-			});
 			expect(std.out).toContain(
 				"Cloudflare agent skills are available for: Claude Code"
 			);
 			// Verify no install call was made
 			expect(mockRosieInstall).not.toHaveBeenCalled();
+			expect(sendMetricsEvent).toHaveBeenCalledWith(
+				"skills_install_skipped",
+				{ reason: "Non-interactive terminal" },
+				{}
+			);
 		});
 	});
 
 	describe("user prompt interaction", () => {
-		test("returns 'User declined' and writes metadata when user declines", async ({
+		test("writes metadata, sends skills_install_skipped, and does not install when user declines", async ({
 			expect,
 		}) => {
 			mockConfirm({
 				text: expect.stringContaining("Claude Code") as unknown as string,
 				result: false,
 			});
-			const installCloudflareSkillsGlobally = await freshImport();
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
 
-			const result = await installCloudflareSkillsGlobally(false);
-
-			expect(result).toEqual({
-				skipped: true,
-				reason: "User declined",
-			});
+			await maybeInstallCloudflareSkillsGlobally(false);
 
 			// must not log a success message when the user declined
 			expect(std.out).not.toContain(
@@ -278,24 +291,24 @@ describe("installCloudflareSkillsGlobally", () => {
 			const metadata = readMetadataFile();
 			expect(metadata.accepted).toBe(false);
 			expect(metadata.date).toBeDefined();
+
+			expect(sendMetricsEvent).toHaveBeenCalledWith(
+				"skills_install_skipped",
+				{ reason: "User declined" },
+				{}
+			);
 		});
 
-		test("calls rosie.install and returns success when user accepts", async ({
+		test("calls rosie.install, logs success, and sends skills_install_completed when user accepts", async ({
 			expect,
 		}) => {
 			mockConfirm({
 				text: expect.stringContaining("Claude Code") as unknown as string,
 				result: true,
 			});
-			const installCloudflareSkillsGlobally = await freshImport();
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
 
-			const result = await installCloudflareSkillsGlobally(false);
-
-			expect(result).toMatchObject({
-				targetedAgents: expect.arrayContaining([
-					expect.objectContaining({ name: "Claude Code", rosieId: "claude" }),
-				]),
-			});
+			await maybeInstallCloudflareSkillsGlobally(false);
 
 			expect(mockRosieInstall).toHaveBeenCalledWith("cloudflare/skills", {
 				global: true,
@@ -306,19 +319,27 @@ describe("installCloudflareSkillsGlobally", () => {
 			expect(std.out).toContain(
 				"Successfully installed Cloudflare skills for: Claude Code."
 			);
+
+			expect(sendMetricsEvent).toHaveBeenCalledWith(
+				"skills_install_completed",
+				{
+					agents: [
+						{
+							name: "Claude Code",
+							rosieId: "claude",
+							globalSkillsPath: "/fake/.claude/skills",
+						},
+					],
+				},
+				{}
+			);
 		});
 
 		test("force=true installs skills without prompting", async ({ expect }) => {
 			// No mockConfirm — if a prompt fires, the test will fail with "Unexpected call to prompts"
-			const installCloudflareSkillsGlobally = await freshImport();
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
 
-			const result = await installCloudflareSkillsGlobally(true);
-
-			expect(result).toMatchObject({
-				targetedAgents: expect.arrayContaining([
-					expect.objectContaining({ name: "Claude Code" }),
-				]),
-			});
+			await maybeInstallCloudflareSkillsGlobally(true);
 
 			expect(mockRosieInstall).toHaveBeenCalledWith("cloudflare/skills", {
 				global: true,
@@ -354,16 +375,9 @@ describe("installCloudflareSkillsGlobally", () => {
 				text: expect.stringContaining("Claude Code") as unknown as string,
 				result: true,
 			});
-			const installCloudflareSkillsGlobally = await freshImport();
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
 
-			const result = await installCloudflareSkillsGlobally(false);
-
-			expect("skipped" in result).toBe(false);
-			if (!("skipped" in result)) {
-				const agentNames = result.targetedAgents.map((a) => a.name);
-				expect(agentNames).toContain("Claude Code");
-				expect(agentNames).toContain("Cursor");
-			}
+			await maybeInstallCloudflareSkillsGlobally(false);
 
 			expect(mockRosieInstall).toHaveBeenCalledWith("cloudflare/skills", {
 				global: true,
@@ -384,14 +398,9 @@ describe("installCloudflareSkillsGlobally", () => {
 			mockRosieInstall.mockRejectedValueOnce(
 				new Error("tarball download failed")
 			);
-			const installCloudflareSkillsGlobally = await freshImport();
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
 
-			const result = await installCloudflareSkillsGlobally(true);
-
-			expect(result).toEqual({
-				skipped: true,
-				reason: "Failed to install skills",
-			});
+			await maybeInstallCloudflareSkillsGlobally(true);
 
 			expect(std.warn).toContain(
 				"Failed to install Cloudflare skills: tarball download failed"
@@ -402,9 +411,7 @@ describe("installCloudflareSkillsGlobally", () => {
 			expect(metadata.installFailed).toBe(true);
 		});
 
-		test("success message and return value exclude agents that failed", async ({
-			expect,
-		}) => {
+		test("success message excludes agents that failed", async ({ expect }) => {
 			mockRosieAgents.mockResolvedValueOnce([
 				{
 					name: "claude",
@@ -432,17 +439,9 @@ describe("installCloudflareSkillsGlobally", () => {
 				failedAgents: ["cursor"],
 				installedInstruction: null,
 			});
-			const installCloudflareSkillsGlobally = await freshImport();
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
 
-			const result = await installCloudflareSkillsGlobally(true);
-
-			// Return value should only include succeeded agents
-			expect("skipped" in result).toBe(false);
-			if (!("skipped" in result)) {
-				const agentNames = result.targetedAgents.map((a) => a.name);
-				expect(agentNames).toContain("Claude Code");
-				expect(agentNames).not.toContain("Cursor");
-			}
+			await maybeInstallCloudflareSkillsGlobally(true);
 
 			// Success message should only mention succeeded agents
 			expect(std.out).toContain(
@@ -465,9 +464,9 @@ describe("installCloudflareSkillsGlobally", () => {
 				text: expect.stringContaining("Claude Code") as unknown as string,
 				result: true,
 			});
-			const installCloudflareSkillsGlobally = await freshImport();
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
 
-			await installCloudflareSkillsGlobally(false);
+			await maybeInstallCloudflareSkillsGlobally(false);
 
 			const metadata = readMetadataFile();
 			expect(metadata.accepted).toBe(true);
@@ -488,9 +487,9 @@ describe("installCloudflareSkillsGlobally", () => {
 				text: expect.stringContaining("Claude Code") as unknown as string,
 				result: false,
 			});
-			const installCloudflareSkillsGlobally = await freshImport();
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
 
-			await installCloudflareSkillsGlobally(false);
+			await maybeInstallCloudflareSkillsGlobally(false);
 
 			const metadata = readMetadataFile();
 			expect(metadata.accepted).toBe(false);
@@ -503,9 +502,9 @@ describe("installCloudflareSkillsGlobally", () => {
 				text: expect.stringContaining("Claude Code") as unknown as string,
 				result: false,
 			});
-			const installCloudflareSkillsGlobally = await freshImport();
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
 
-			await installCloudflareSkillsGlobally(false);
+			await maybeInstallCloudflareSkillsGlobally(false);
 
 			const metadata = readMetadataFile();
 			expect(metadata.installFailed).toBeUndefined();
@@ -515,9 +514,9 @@ describe("installCloudflareSkillsGlobally", () => {
 			expect,
 		}) => {
 			mockRosieInstall.mockRejectedValueOnce(new Error("download failed"));
-			const installCloudflareSkillsGlobally = await freshImport();
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
 
-			await installCloudflareSkillsGlobally(true);
+			await maybeInstallCloudflareSkillsGlobally(true);
 
 			const metadata = readMetadataFile();
 			expect(metadata.installFailed).toBe(true);
@@ -539,9 +538,9 @@ describe("installCloudflareSkillsGlobally", () => {
 				failedAgents: ["cursor"],
 				installedInstruction: null,
 			});
-			const installCloudflareSkillsGlobally = await freshImport();
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
 
-			await installCloudflareSkillsGlobally(true);
+			await maybeInstallCloudflareSkillsGlobally(true);
 
 			const metadata = readMetadataFile();
 			expect(metadata.accepted).toBe(true);
@@ -551,9 +550,9 @@ describe("installCloudflareSkillsGlobally", () => {
 		test("sets installFailed to false when all agents succeed", async ({
 			expect,
 		}) => {
-			const installCloudflareSkillsGlobally = await freshImport();
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
 
-			await installCloudflareSkillsGlobally(true);
+			await maybeInstallCloudflareSkillsGlobally(true);
 
 			const metadata = readMetadataFile();
 			expect(metadata.accepted).toBe(true);

--- a/packages/wrangler/src/__tests__/agents-skills-install.test.ts
+++ b/packages/wrangler/src/__tests__/agents-skills-install.test.ts
@@ -188,6 +188,9 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 			expect(std.warn).toContain(
 				"Failed to install Cloudflare skills: network failure"
 			);
+			expect(std.warn).toContain(
+				"You can retry by running `wrangler --experimental-force-skills-install`, or install skills manually as described here: https://github.com/cloudflare/skills#installing"
+			);
 			expect(sendMetricsEvent).toHaveBeenCalledWith(
 				"skills_install_skipped",
 				{ reason: "Failed to install skills" },
@@ -205,6 +208,9 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 
 			expect(std.warn).toContain(
 				"Failed to detect AI coding agents: WASM load failed"
+			);
+			expect(std.warn).toContain(
+				"You can retry by running `wrangler --experimental-force-skills-install`, or install skills manually as described here: https://github.com/cloudflare/skills#installing"
 			);
 			expect(mockRosieInstall).not.toHaveBeenCalled();
 			expect(sendMetricsEvent).toHaveBeenCalledWith(
@@ -405,6 +411,9 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 			expect(std.warn).toContain(
 				"Failed to install Cloudflare skills: tarball download failed"
 			);
+			expect(std.warn).toContain(
+				"You can retry by running `wrangler --experimental-force-skills-install`, or install skills manually as described here: https://github.com/cloudflare/skills#installing"
+			);
 
 			const metadata = readMetadataFile();
 			expect(metadata.accepted).toBe(true);
@@ -449,9 +458,12 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 			);
 			expect(std.out).not.toContain("Cursor");
 
-			// Warning should mention the failed agent
+			// Warning should mention the failed agent and retry hint
 			expect(std.warn).toContain(
 				"Skills installation failed for agents: cursor."
+			);
+			expect(std.warn).toContain(
+				"You can retry by running `wrangler --experimental-force-skills-install`, or install skills manually as described here: https://github.com/cloudflare/skills#installing"
 			);
 		});
 	});

--- a/packages/wrangler/src/__tests__/agents-skills-install.test.ts
+++ b/packages/wrangler/src/__tests__/agents-skills-install.test.ts
@@ -1,13 +1,13 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { getGlobalWranglerConfigPath } from "@cloudflare/workers-utils";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import ci from "ci-info";
 import { afterEach, beforeEach, describe, test, vi } from "vitest";
 import { sendMetricsEvent } from "../metrics/send-event";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs, mockConfirm } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import type { maybeInstallCloudflareSkillsGlobally as InstallFnType } from "../agents-skills-install";
 import type * as SendEventModule from "../metrics/send-event";
 

--- a/packages/wrangler/src/__tests__/agents-skills-install.test.ts
+++ b/packages/wrangler/src/__tests__/agents-skills-install.test.ts
@@ -1,0 +1,491 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { getGlobalWranglerConfigPath } from "@cloudflare/workers-utils";
+import ci from "ci-info";
+import { afterEach, beforeEach, describe, test, vi } from "vitest";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import { clearDialogs, mockConfirm } from "./helpers/mock-dialogs";
+import { useMockIsTTY } from "./helpers/mock-istty";
+import { runInTempDir } from "./helpers/run-in-tmp";
+import type { installCloudflareSkillsGlobally as InstallFnType } from "../agents-skills-install";
+
+// Undo the global no-op mock from vitest.setup.ts so we test the real implementation
+vi.unmock("../agents-skills-install");
+
+// Mock rosie-skills to avoid real network/WASM calls.
+const mockRosieInstall = vi.fn();
+const mockRosieAgents = vi.fn();
+vi.mock("rosie-skills", () => ({
+	install: mockRosieInstall,
+	agents: mockRosieAgents,
+}));
+
+/** Default rosie.agents() return value: Claude Code detected, Cursor not detected. */
+const DEFAULT_AGENTS = [
+	{
+		name: "claude",
+		display: "Claude Code",
+		detected: true,
+		installPath: "/fake/.claude/skills",
+	},
+	{
+		name: "cursor",
+		display: "Cursor",
+		detected: false,
+		installPath: null,
+	},
+];
+
+/** Default rosie.install() return value matching a successful single-agent install. */
+const DEFAULT_INSTALL_RESULT = {
+	skills: [
+		{
+			name: "cloudflare",
+			kind: "skill" as const,
+			installedAgents: ["claude"],
+			failedAgents: [],
+		},
+	],
+	installedAgents: ["claude"],
+	failedAgents: [],
+	installedInstruction: null,
+};
+
+/** Writes the skills-install metadata file to the global wrangler config path. */
+function writeMetadataFile(content: Record<string, unknown>): void {
+	const configDir = getGlobalWranglerConfigPath();
+	mkdirSync(configDir, { recursive: true });
+	writeFileSync(
+		path.join(configDir, "agents-skills-install.jsonc"),
+		JSON.stringify(content)
+	);
+}
+
+/** Reads and parses the skills-install metadata file. */
+function readMetadataFile(): Record<string, unknown> {
+	const filePath = path.join(
+		getGlobalWranglerConfigPath(),
+		"agents-skills-install.jsonc"
+	);
+	return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+/**
+ * Re-imports the agents-skills-install module with a fresh module graph.
+ * This is necessary because tests need a clean module state after mocks
+ * are reconfigured per test.
+ */
+async function freshImport(): Promise<typeof InstallFnType> {
+	vi.resetModules();
+	const mod = await import("../agents-skills-install");
+	return mod.installCloudflareSkillsGlobally;
+}
+
+describe("installCloudflareSkillsGlobally", () => {
+	runInTempDir();
+	const std = mockConsoleMethods();
+	const { setIsTTY } = useMockIsTTY();
+
+	beforeEach(() => {
+		setIsTTY(true);
+		mockRosieAgents.mockResolvedValue(DEFAULT_AGENTS);
+		mockRosieInstall.mockResolvedValue(DEFAULT_INSTALL_RESULT);
+	});
+
+	afterEach(() => {
+		clearDialogs();
+	});
+
+	describe("skip conditions", () => {
+		test("returns 'Already prompted' when metadata file exists", async ({
+			expect,
+		}) => {
+			writeMetadataFile({ accepted: true, date: "2025-01-01T00:00:00Z" });
+			const installCloudflareSkillsGlobally = await freshImport();
+
+			const result = await installCloudflareSkillsGlobally(false);
+
+			expect(result).toEqual({
+				skipped: true,
+				reason: "Already prompted",
+			});
+		});
+
+		test("force=true ignores existing metadata file", async ({ expect }) => {
+			writeMetadataFile({ accepted: true, date: "2025-01-01T00:00:00Z" });
+			const installCloudflareSkillsGlobally = await freshImport();
+
+			const result = await installCloudflareSkillsGlobally(true);
+
+			expect(result).toMatchObject({
+				targetedAgents: expect.arrayContaining([
+					expect.objectContaining({ name: "Claude Code" }),
+				]),
+			});
+		});
+
+		test("returns 'No supported agents detected' when no agents are detected", async ({
+			expect,
+		}) => {
+			mockRosieAgents.mockResolvedValueOnce([
+				{
+					name: "claude",
+					display: "Claude Code",
+					detected: false,
+					installPath: null,
+				},
+			]);
+			const installCloudflareSkillsGlobally = await freshImport();
+
+			const result = await installCloudflareSkillsGlobally(false);
+
+			expect(result).toEqual({
+				skipped: true,
+				reason: "No supported agents detected",
+			});
+		});
+
+		test("returns 'No supported agents detected' when rosie.agents() returns empty", async ({
+			expect,
+		}) => {
+			mockRosieAgents.mockResolvedValueOnce([]);
+			const installCloudflareSkillsGlobally = await freshImport();
+
+			const result = await installCloudflareSkillsGlobally(false);
+
+			expect(result).toEqual({
+				skipped: true,
+				reason: "No supported agents detected",
+			});
+		});
+
+		test("returns 'Failed to install skills' when rosie.install() throws", async ({
+			expect,
+		}) => {
+			mockRosieInstall.mockRejectedValueOnce(new Error("network failure"));
+			const installCloudflareSkillsGlobally = await freshImport();
+
+			// force=true so we don't need to mock the confirm dialog
+			const result = await installCloudflareSkillsGlobally(true);
+
+			expect(result).toEqual({
+				skipped: true,
+				reason: "Failed to install skills",
+			});
+			expect(std.warn).toContain(
+				"Failed to install Cloudflare skills: network failure"
+			);
+		});
+
+		test("returns 'Running in CI' when ci.isCI is true", async ({ expect }) => {
+			vi.mocked(ci).isCI = true;
+			const installCloudflareSkillsGlobally = await freshImport();
+
+			const result = await installCloudflareSkillsGlobally(false);
+
+			expect(result).toEqual({
+				skipped: true,
+				reason: "Running in CI",
+			});
+			// Verify neither agent detection nor install was attempted
+			expect(mockRosieAgents).not.toHaveBeenCalled();
+			expect(mockRosieInstall).not.toHaveBeenCalled();
+		});
+
+		test("force=true bypasses CI check and installs skills", async ({
+			expect,
+		}) => {
+			vi.mocked(ci).isCI = true;
+			const installCloudflareSkillsGlobally = await freshImport();
+
+			const result = await installCloudflareSkillsGlobally(true);
+
+			expect(result).toMatchObject({
+				targetedAgents: expect.arrayContaining([
+					expect.objectContaining({ name: "Claude Code" }),
+				]),
+			});
+			expect(mockRosieInstall).toHaveBeenCalledWith("cloudflare/skills", {
+				global: true,
+				agent: ["claude"],
+				lockfile: false,
+			});
+		});
+
+		test("returns 'Non-interactive terminal' when TTY is false", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			const installCloudflareSkillsGlobally = await freshImport();
+
+			const result = await installCloudflareSkillsGlobally(false);
+
+			expect(result).toEqual({
+				skipped: true,
+				reason: "Non-interactive terminal",
+			});
+			expect(std.out).toContain(
+				"Cloudflare agent skills are available for: Claude Code"
+			);
+			// Verify no install call was made
+			expect(mockRosieInstall).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("user prompt interaction", () => {
+		test("returns 'User declined' and writes metadata when user declines", async ({
+			expect,
+		}) => {
+			mockConfirm({
+				text: expect.stringContaining("Claude Code") as unknown as string,
+				result: false,
+			});
+			const installCloudflareSkillsGlobally = await freshImport();
+
+			const result = await installCloudflareSkillsGlobally(false);
+
+			expect(result).toEqual({
+				skipped: true,
+				reason: "User declined",
+			});
+
+			// must not log a success message when the user declined
+			expect(std.out).not.toContain(
+				"Successfully installed Cloudflare skills for:"
+			);
+
+			// must not call rosie.install when user declined
+			expect(mockRosieInstall).not.toHaveBeenCalled();
+
+			const metadata = readMetadataFile();
+			expect(metadata.accepted).toBe(false);
+			expect(metadata.date).toBeDefined();
+		});
+
+		test("calls rosie.install and returns success when user accepts", async ({
+			expect,
+		}) => {
+			mockConfirm({
+				text: expect.stringContaining("Claude Code") as unknown as string,
+				result: true,
+			});
+			const installCloudflareSkillsGlobally = await freshImport();
+
+			const result = await installCloudflareSkillsGlobally(false);
+
+			expect(result).toMatchObject({
+				targetedAgents: expect.arrayContaining([
+					expect.objectContaining({ name: "Claude Code", rosieId: "claude" }),
+				]),
+			});
+
+			expect(mockRosieInstall).toHaveBeenCalledWith("cloudflare/skills", {
+				global: true,
+				agent: ["claude"],
+				lockfile: false,
+			});
+
+			expect(std.out).toContain(
+				"Successfully installed Cloudflare skills for: Claude Code."
+			);
+		});
+
+		test("force=true installs skills without prompting", async ({ expect }) => {
+			// No mockConfirm — if a prompt fires, the test will fail with "Unexpected call to prompts"
+			const installCloudflareSkillsGlobally = await freshImport();
+
+			const result = await installCloudflareSkillsGlobally(true);
+
+			expect(result).toMatchObject({
+				targetedAgents: expect.arrayContaining([
+					expect.objectContaining({ name: "Claude Code" }),
+				]),
+			});
+
+			expect(mockRosieInstall).toHaveBeenCalledWith("cloudflare/skills", {
+				global: true,
+				agent: ["claude"],
+				lockfile: false,
+			});
+
+			expect(std.out).toContain(
+				"Successfully installed Cloudflare skills for: Claude Code."
+			);
+		});
+	});
+
+	describe("multiple agents", () => {
+		test("detects and installs skills for multiple agents", async ({
+			expect,
+		}) => {
+			mockRosieAgents.mockResolvedValueOnce([
+				{
+					name: "claude",
+					display: "Claude Code",
+					detected: true,
+					installPath: "/fake/.claude/skills",
+				},
+				{
+					name: "cursor",
+					display: "Cursor",
+					detected: true,
+					installPath: "/fake/.cursor/skills",
+				},
+			]);
+			mockConfirm({
+				text: expect.stringContaining("Claude Code") as unknown as string,
+				result: true,
+			});
+			const installCloudflareSkillsGlobally = await freshImport();
+
+			const result = await installCloudflareSkillsGlobally(false);
+
+			expect("skipped" in result).toBe(false);
+			if (!("skipped" in result)) {
+				const agentNames = result.targetedAgents.map((a) => a.name);
+				expect(agentNames).toContain("Claude Code");
+				expect(agentNames).toContain("Cursor");
+			}
+
+			expect(mockRosieInstall).toHaveBeenCalledWith("cloudflare/skills", {
+				global: true,
+				agent: ["claude", "cursor"],
+				lockfile: false,
+			});
+
+			expect(std.out).toContain(
+				"Successfully installed Cloudflare skills for: Claude Code, Cursor."
+			);
+		});
+	});
+
+	describe("install failure", () => {
+		test("writes metadata with installFailed when rosie.install() throws", async ({
+			expect,
+		}) => {
+			mockRosieInstall.mockRejectedValueOnce(
+				new Error("tarball download failed")
+			);
+			const installCloudflareSkillsGlobally = await freshImport();
+
+			const result = await installCloudflareSkillsGlobally(true);
+
+			expect(result).toEqual({
+				skipped: true,
+				reason: "Failed to install skills",
+			});
+
+			expect(std.warn).toContain(
+				"Failed to install Cloudflare skills: tarball download failed"
+			);
+
+			const metadata = readMetadataFile();
+			expect(metadata.accepted).toBe(true);
+			expect(metadata.installFailed).toBe(true);
+		});
+	});
+
+	describe("metadata file", () => {
+		test("writes metadata file with correct content when user accepts", async ({
+			expect,
+		}) => {
+			mockConfirm({
+				text: expect.stringContaining("Claude Code") as unknown as string,
+				result: true,
+			});
+			const installCloudflareSkillsGlobally = await freshImport();
+
+			await installCloudflareSkillsGlobally(false);
+
+			const metadata = readMetadataFile();
+			expect(metadata.accepted).toBe(true);
+			expect(metadata.date).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+			expect(metadata.detectedAgents).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						name: "Claude Code",
+						rosieId: "claude",
+					}),
+				])
+			);
+			expect(metadata.installFailed).toBe(false);
+		});
+
+		test("writes metadata file when user declines", async ({ expect }) => {
+			mockConfirm({
+				text: expect.stringContaining("Claude Code") as unknown as string,
+				result: false,
+			});
+			const installCloudflareSkillsGlobally = await freshImport();
+
+			await installCloudflareSkillsGlobally(false);
+
+			const metadata = readMetadataFile();
+			expect(metadata.accepted).toBe(false);
+		});
+
+		test("does not include installFailed in metadata when user declines", async ({
+			expect,
+		}) => {
+			mockConfirm({
+				text: expect.stringContaining("Claude Code") as unknown as string,
+				result: false,
+			});
+			const installCloudflareSkillsGlobally = await freshImport();
+
+			await installCloudflareSkillsGlobally(false);
+
+			const metadata = readMetadataFile();
+			expect(metadata.installFailed).toBeUndefined();
+		});
+
+		test("sets installFailed to true when rosie.install() throws", async ({
+			expect,
+		}) => {
+			mockRosieInstall.mockRejectedValueOnce(new Error("download failed"));
+			const installCloudflareSkillsGlobally = await freshImport();
+
+			await installCloudflareSkillsGlobally(true);
+
+			const metadata = readMetadataFile();
+			expect(metadata.installFailed).toBe(true);
+		});
+
+		test("sets installFailed to agent names on partial failure", async ({
+			expect,
+		}) => {
+			mockRosieInstall.mockResolvedValueOnce({
+				skills: [
+					{
+						name: "cloudflare",
+						kind: "skill",
+						installedAgents: ["claude"],
+						failedAgents: ["cursor"],
+					},
+				],
+				installedAgents: ["claude"],
+				failedAgents: ["cursor"],
+				installedInstruction: null,
+			});
+			const installCloudflareSkillsGlobally = await freshImport();
+
+			await installCloudflareSkillsGlobally(true);
+
+			const metadata = readMetadataFile();
+			expect(metadata.accepted).toBe(true);
+			expect(metadata.installFailed).toEqual(["cursor"]);
+		});
+
+		test("sets installFailed to false when all agents succeed", async ({
+			expect,
+		}) => {
+			const installCloudflareSkillsGlobally = await freshImport();
+
+			await installCloudflareSkillsGlobally(true);
+
+			const metadata = readMetadataFile();
+			expect(metadata.accepted).toBe(true);
+			expect(metadata.installFailed).toBe(false);
+		});
+	});
+});

--- a/packages/wrangler/src/__tests__/agents-skills-install.test.ts
+++ b/packages/wrangler/src/__tests__/agents-skills-install.test.ts
@@ -198,7 +198,7 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 			);
 		});
 
-		test("warns and sends skills_install_skipped when rosie.agents() throws", async ({
+		test("sends skills_install_skipped with errorMessage when rosie.agents() throws", async ({
 			expect,
 		}) => {
 			mockRosieAgents.mockRejectedValueOnce(new Error("WASM load failed"));
@@ -206,16 +206,10 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 
 			await maybeInstallCloudflareSkillsGlobally(false);
 
-			expect(std.warn).toContain(
-				"Failed to detect AI coding agents: WASM load failed"
-			);
-			expect(std.warn).toContain(
-				"You can retry by running `wrangler --experimental-force-skills-install`, or install skills manually as described here: https://github.com/cloudflare/skills#installing"
-			);
 			expect(mockRosieInstall).not.toHaveBeenCalled();
 			expect(sendMetricsEvent).toHaveBeenCalledWith(
 				"skills_install_skipped",
-				{ reason: "Failed to install skills" },
+				{ reason: "Failed to install skills", errorMessage: "WASM load failed" },
 				{}
 			);
 		});

--- a/packages/wrangler/src/__tests__/ai.test.ts
+++ b/packages/wrangler/src/__tests__/ai.test.ts
@@ -27,12 +27,13 @@ describe("ai help", () => {
 			  wrangler ai finetune  Interact with finetune files
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 
@@ -59,12 +60,13 @@ describe("ai help", () => {
 			  wrangler ai finetune  Interact with finetune files
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 
@@ -82,12 +84,13 @@ describe("ai help", () => {
 			  wrangler ai models schema <model>  Get model schema
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 
@@ -104,12 +107,13 @@ describe("ai help", () => {
 			  model  The model to fetch a schema for  [string] [required]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 });

--- a/packages/wrangler/src/__tests__/cert.test.ts
+++ b/packages/wrangler/src/__tests__/cert.test.ts
@@ -501,12 +501,13 @@ describe("wrangler", () => {
 						  wrangler cert delete  Delete an mTLS certificate
 
 						GLOBAL FLAGS
-						  -c, --config    Path to Wrangler configuration file  [string]
-						      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-						  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-						      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-						  -h, --help      Show help  [boolean]
-						  -v, --version   Show version number  [boolean]"
+						  -c, --config          Path to Wrangler configuration file  [string]
+						      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+						  -h, --help            Show help  [boolean]
+						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						  -v, --version         Show version number  [boolean]"
 					`);
 				});
 			});

--- a/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
@@ -81,12 +81,13 @@ describe("cloudchamber create", () => {
 			Create a new deployment [alpha]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
 			      --image          Image to use for your deployment  [string]

--- a/packages/wrangler/src/__tests__/cloudchamber/curl.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/curl.test.ts
@@ -38,12 +38,13 @@ describe("cloudchamber curl", () => {
 			  path  [string] [required] [default: "/"]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
 			  -H, --header              Add headers in the form of --header <name>:<value>  [array]

--- a/packages/wrangler/src/__tests__/cloudchamber/delete.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/delete.test.ts
@@ -34,12 +34,13 @@ describe("cloudchamber delete", () => {
 			  deploymentId  Deployment you want to delete  [string]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 

--- a/packages/wrangler/src/__tests__/cloudchamber/images.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/images.test.ts
@@ -36,12 +36,13 @@ describe("cloudchamber image", () => {
 			  wrangler cloudchamber registries list                  List registries configured for this account [alpha]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 
@@ -188,12 +189,13 @@ describe("cloudchamber image list", () => {
 			List images in the Cloudflare managed registry [alpha]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
 			      --filter  Regex to filter results  [string]
@@ -446,12 +448,13 @@ describe("cloudchamber image delete", () => {
 			  image  Image and tag to delete, of the form IMAGE:TAG  [string] [required]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 

--- a/packages/wrangler/src/__tests__/cloudchamber/list.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/list.test.ts
@@ -34,12 +34,13 @@ describe("cloudchamber list", () => {
 			  deploymentIdPrefix  Optional deploymentId to filter deployments. This means that 'list' will only showcase deployments that contain this ID prefix  [string]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
 			      --location  Filter deployments by location  [string]

--- a/packages/wrangler/src/__tests__/cloudchamber/modify.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/modify.test.ts
@@ -49,12 +49,13 @@ describe("cloudchamber modify", () => {
 			  deploymentId  The deployment you want to modify  [string]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
 			      --var                Container environment variables  [array]

--- a/packages/wrangler/src/__tests__/containers/delete.test.ts
+++ b/packages/wrangler/src/__tests__/containers/delete.test.ts
@@ -35,12 +35,13 @@ describe("containers delete", () => {
 			  ID  ID of the container to delete  [string] [required]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 

--- a/packages/wrangler/src/__tests__/containers/images.test.ts
+++ b/packages/wrangler/src/__tests__/containers/images.test.ts
@@ -39,12 +39,13 @@ describe("containers images list", () => {
 			List images in the Cloudflare managed registry
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
 			      --filter  Regex to filter results  [string]
@@ -209,12 +210,13 @@ describe("containers images delete", () => {
 			  image  Image and tag to delete, of the form IMAGE:TAG  [string] [required]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 

--- a/packages/wrangler/src/__tests__/containers/info.test.ts
+++ b/packages/wrangler/src/__tests__/containers/info.test.ts
@@ -34,12 +34,13 @@ describe("containers info", () => {
 			  ID  ID of the container to view  [string] [required]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 

--- a/packages/wrangler/src/__tests__/containers/instances.test.ts
+++ b/packages/wrangler/src/__tests__/containers/instances.test.ts
@@ -106,12 +106,13 @@ describe("containers instances", () => {
 			  ID  ID of the application to list instances for  [string] [required]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
 			      --per-page  Number of instances per page  [number] [default: 25]

--- a/packages/wrangler/src/__tests__/containers/list.test.ts
+++ b/packages/wrangler/src/__tests__/containers/list.test.ts
@@ -48,12 +48,13 @@ describe("containers list", () => {
 			List containers
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
 			      --per-page  Number of containers per page  [number] [default: 25]

--- a/packages/wrangler/src/__tests__/containers/push.test.ts
+++ b/packages/wrangler/src/__tests__/containers/push.test.ts
@@ -45,12 +45,13 @@ describe("containers push", () => {
 			  TAG  The tag of the local image to push  [string] [required]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
 			      --path-to-docker  Path to your docker binary if it's not on $PATH  [string] [default: "docker"]"

--- a/packages/wrangler/src/__tests__/containers/registries.test.ts
+++ b/packages/wrangler/src/__tests__/containers/registries.test.ts
@@ -35,12 +35,13 @@ describe("containers registries --help", () => {
 			  wrangler containers registries credentials [DOMAIN]  Get a temporary password for a specific domain
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 });

--- a/packages/wrangler/src/__tests__/containers/ssh.test.ts
+++ b/packages/wrangler/src/__tests__/containers/ssh.test.ts
@@ -30,12 +30,13 @@ describe("containers ssh", () => {
 			  ID  ID of the container instance  [string] [required]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 

--- a/packages/wrangler/src/__tests__/d1/d1.test.ts
+++ b/packages/wrangler/src/__tests__/d1/d1.test.ts
@@ -29,12 +29,13 @@ describe("d1", () => {
 			  wrangler d1 insights <name>     Get information about the queries run on a D1 database [experimental]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 
@@ -68,12 +69,13 @@ describe("d1", () => {
 			  wrangler d1 insights <name>     Get information about the queries run on a D1 database [experimental]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 
@@ -94,12 +96,13 @@ describe("d1", () => {
 			  wrangler d1 migrations apply <database>             Apply any unapplied D1 migrations
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 
@@ -118,12 +121,13 @@ describe("d1", () => {
 			  wrangler d1 time-travel restore <database>  Restore a database back to a specific point-in-time
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 });

--- a/packages/wrangler/src/__tests__/deployments.test.ts
+++ b/packages/wrangler/src/__tests__/deployments.test.ts
@@ -65,12 +65,13 @@ describe("deployments", () => {
 			  wrangler deployments status  View the current state of your production
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 

--- a/packages/wrangler/src/__tests__/docs.test.ts
+++ b/packages/wrangler/src/__tests__/docs.test.ts
@@ -46,12 +46,13 @@ describe("wrangler docs", () => {
 			  search  Enter search terms (e.g. the wrangler command) you want to know more about  [array] [default: []]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
 			  -y, --yes  Takes you to the docs, even if search fails  [boolean]"

--- a/packages/wrangler/src/__tests__/experimental-commands-api.test.ts
+++ b/packages/wrangler/src/__tests__/experimental-commands-api.test.ts
@@ -37,6 +37,13 @@ describe("experimental_getWranglerCommands", () => {
 			    "hidden": true,
 			    "type": "boolean",
 			  },
+			  "experimental-force-skills-install": {
+			    "alias": "x-force-skills-install",
+			    "default": false,
+			    "describe": "Install Cloudflare agents skills, if not already present, without asking the user for confirmation",
+			    "hidden": true,
+			    "type": "boolean",
+			  },
 			  "experimental-provision": {
 			    "alias": [
 			      "x-provision",

--- a/packages/wrangler/src/__tests__/experimental-commands-api.test.ts
+++ b/packages/wrangler/src/__tests__/experimental-commands-api.test.ts
@@ -37,12 +37,6 @@ describe("experimental_getWranglerCommands", () => {
 			    "hidden": true,
 			    "type": "boolean",
 			  },
-			  "install-skills": {
-			    "default": false,
-			    "describe": "Install Cloudflare agents skills, if not already present, without asking the user for confirmation",
-			    "hidden": true,
-			    "type": "boolean",
-			  },
 			  "experimental-provision": {
 			    "alias": [
 			      "x-provision",
@@ -50,6 +44,11 @@ describe("experimental_getWranglerCommands", () => {
 			    "default": true,
 			    "describe": "Experimental: Enable automatic resource provisioning",
 			    "hidden": true,
+			    "type": "boolean",
+			  },
+			  "install-skills": {
+			    "default": false,
+			    "describe": "Install Cloudflare agents skills, if not already present, without asking the user for confirmation",
 			    "type": "boolean",
 			  },
 			  "v": {

--- a/packages/wrangler/src/__tests__/experimental-commands-api.test.ts
+++ b/packages/wrangler/src/__tests__/experimental-commands-api.test.ts
@@ -37,8 +37,7 @@ describe("experimental_getWranglerCommands", () => {
 			    "hidden": true,
 			    "type": "boolean",
 			  },
-			  "experimental-force-skills-install": {
-			    "alias": "x-force-skills-install",
+			  "install-skills": {
 			    "default": false,
 			    "describe": "Install Cloudflare agents skills, if not already present, without asking the user for confirmation",
 			    "hidden": true,

--- a/packages/wrangler/src/__tests__/hyperdrive.test.ts
+++ b/packages/wrangler/src/__tests__/hyperdrive.test.ts
@@ -41,12 +41,13 @@ describe("hyperdrive help", () => {
 			  wrangler hyperdrive update <id>    Update a Hyperdrive config
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 
@@ -76,12 +77,13 @@ describe("hyperdrive help", () => {
 			  wrangler hyperdrive update <id>    Update a Hyperdrive config
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 });

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -89,12 +89,13 @@ describe("wrangler", () => {
 				  wrangler tunnel                 🚇 Manage Cloudflare Tunnels [experimental]
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]
 
 				Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose"
 			`);
@@ -167,12 +168,13 @@ describe("wrangler", () => {
 				  wrangler tunnel                 🚇 Manage Cloudflare Tunnels [experimental]
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]
 
 				Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose"
 			`);
@@ -264,12 +266,13 @@ describe("wrangler", () => {
 				  wrangler secret bulk [file]   Upload multiple secrets for a Worker at once
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 
@@ -290,12 +293,13 @@ describe("wrangler", () => {
 				  wrangler kv namespace rename [old-name]   Rename a KV namespace
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 
@@ -316,12 +320,13 @@ describe("wrangler", () => {
 				  wrangler kv key delete <key>       Remove a single key value pair from the given namespace
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 
@@ -341,12 +346,13 @@ describe("wrangler", () => {
 				  wrangler kv bulk delete <filename>  Delete multiple key-value pairs from a namespace
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 
@@ -366,12 +372,13 @@ describe("wrangler", () => {
 				  wrangler r2 sql     Send queries and manage R2 SQL [open beta]
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 	});

--- a/packages/wrangler/src/__tests__/kv/help.test.ts
+++ b/packages/wrangler/src/__tests__/kv/help.test.ts
@@ -38,12 +38,13 @@ describe("kv", () => {
 				  wrangler kv bulk       Interact with multiple Workers KV key-value pairs at once
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 
@@ -61,12 +62,13 @@ describe("kv", () => {
 				  wrangler kv bulk       Interact with multiple Workers KV key-value pairs at once
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 
@@ -93,12 +95,13 @@ describe("kv", () => {
 				  wrangler kv bulk       Interact with multiple Workers KV key-value pairs at once
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 	});

--- a/packages/wrangler/src/__tests__/kv/key.test.ts
+++ b/packages/wrangler/src/__tests__/kv/key.test.ts
@@ -372,12 +372,13 @@ describe("kv", () => {
 					  value  The value to write  [string]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
 					      --path          Read value from the file at a given path  [string]
@@ -421,12 +422,13 @@ describe("kv", () => {
 					  value  The value to write  [string]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
 					      --path          Read value from the file at a given path  [string]
@@ -472,12 +474,13 @@ describe("kv", () => {
 					  value  The value to write  [string]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
 					      --path          Read value from the file at a given path  [string]
@@ -521,12 +524,13 @@ describe("kv", () => {
 					  value  The value to write  [string]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
 					      --path          Read value from the file at a given path  [string]
@@ -567,12 +571,13 @@ describe("kv", () => {
 					  value  The value to write  [string]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
 					      --path          Read value from the file at a given path  [string]
@@ -618,12 +623,13 @@ describe("kv", () => {
 					  value  The value to write  [string]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
 					      --path          Read value from the file at a given path  [string]
@@ -1061,12 +1067,13 @@ describe("kv", () => {
 					  key  The key value to get.  [string] [required]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
 					      --text          Decode the returned value as a utf8 string  [boolean] [default: false]
@@ -1102,12 +1109,13 @@ describe("kv", () => {
 					  key  The key value to get.  [string] [required]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
 					      --text          Decode the returned value as a utf8 string  [boolean] [default: false]
@@ -1144,12 +1152,13 @@ describe("kv", () => {
 					  key  The key value to get.  [string] [required]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
 					      --text          Decode the returned value as a utf8 string  [boolean] [default: false]

--- a/packages/wrangler/src/__tests__/kv/namespace.test.ts
+++ b/packages/wrangler/src/__tests__/kv/namespace.test.ts
@@ -67,12 +67,13 @@ describe("kv", () => {
 					  namespace  The name of the new namespace  [string] [required]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
 					      --preview        Interact with a preview namespace  [boolean]
@@ -105,12 +106,13 @@ describe("kv", () => {
 					  namespace  The name of the new namespace  [string] [required]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
 					      --preview        Interact with a preview namespace  [boolean]
@@ -649,12 +651,13 @@ describe("kv", () => {
 					  old-name  The current name of the namespace to rename  [string]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
 					      --namespace-id  The id of the namespace to rename  [string]

--- a/packages/wrangler/src/__tests__/mtls-certificates.test.ts
+++ b/packages/wrangler/src/__tests__/mtls-certificates.test.ts
@@ -415,12 +415,13 @@ describe("wrangler", () => {
 						  wrangler mtls-certificate delete  Delete an mTLS certificate
 
 						GLOBAL FLAGS
-						  -c, --config    Path to Wrangler configuration file  [string]
-						      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-						  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-						      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-						  -h, --help      Show help  [boolean]
-						  -v, --version   Show version number  [boolean]"
+						  -c, --config          Path to Wrangler configuration file  [string]
+						      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+						  -h, --help            Show help  [boolean]
+						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						  -v, --version         Show version number  [boolean]"
 					`);
 				});
 			});

--- a/packages/wrangler/src/__tests__/pages/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deploy.test.ts
@@ -81,10 +81,11 @@ describe("pages deploy", () => {
 			  directory  The directory of static files to upload  [string]
 
 			GLOBAL FLAGS
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
 			      --project-name        The name of the project you want to deploy to  [string]

--- a/packages/wrangler/src/__tests__/pages/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages.test.ts
@@ -35,10 +35,11 @@ describe("pages", () => {
 			  wrangler pages download                   Download settings from your project
 
 			GLOBAL FLAGS
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 
@@ -58,10 +59,11 @@ describe("pages", () => {
 			  command    The proxy command to run  [deprecated]  [string]
 
 			GLOBAL FLAGS
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
 			      --compatibility-date                         Date to use for compatibility checks  [string]
@@ -107,10 +109,11 @@ describe("pages", () => {
 			  wrangler pages project delete <project-name>  Delete a Cloudflare Pages project
 
 			GLOBAL FLAGS
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 
@@ -134,10 +137,11 @@ describe("pages", () => {
 			  wrangler pages deployment delete <deployment-id>  Delete a deployment in your Cloudflare Pages project
 
 			GLOBAL FLAGS
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 
@@ -156,10 +160,11 @@ describe("pages", () => {
 			  directory  The directory of static files to upload  [string]
 
 			GLOBAL FLAGS
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
 			      --project-name        The name of the project you want to deploy to  [string]
@@ -191,10 +196,11 @@ describe("pages", () => {
 			  wrangler pages secret list          List all secrets for a Pages project
 
 			GLOBAL FLAGS
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 
@@ -213,10 +219,11 @@ describe("pages", () => {
 			  wrangler pages download config [projectName]  Download your Pages project config as a Wrangler configuration file [experimental]
 
 			GLOBAL FLAGS
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 

--- a/packages/wrangler/src/__tests__/queues/queues-subscription.test.ts
+++ b/packages/wrangler/src/__tests__/queues/queues-subscription.test.ts
@@ -74,12 +74,13 @@ describe("queues subscription", () => {
 				  queue  The name of the queue to create the subscription for  [string] [required]
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]
 
 				OPTIONS
 				      --source         The event source type  [string] [required] [choices: "kv", "r2", "superSlurper", "vectorize", "workersAi.model", "workersBuilds.worker", "workflows.workflow"]
@@ -252,12 +253,13 @@ describe("queues subscription", () => {
 				  queue  The name of the queue to list subscriptions for  [string] [required]
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]
 
 				OPTIONS
 				      --page      Page number for pagination  [number] [default: 1]
@@ -428,12 +430,13 @@ describe("queues subscription", () => {
 				  queue  The name of the queue  [string] [required]
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]
 
 				OPTIONS
 				      --id    The ID of the subscription to retrieve  [string] [required]
@@ -548,12 +551,13 @@ describe("queues subscription", () => {
 				  queue  The name of the queue  [string] [required]
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]
 
 				OPTIONS
 				      --id     The ID of the subscription to delete  [string] [required]

--- a/packages/wrangler/src/__tests__/queues/queues.test.ts
+++ b/packages/wrangler/src/__tests__/queues/queues.test.ts
@@ -46,12 +46,13 @@ describe("wrangler", () => {
 				  wrangler queues subscription            Manage event subscriptions for a queue
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 
@@ -94,12 +95,13 @@ describe("wrangler", () => {
 					List queues
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
 					      --page  Page number for pagination  [number]"
@@ -243,12 +245,13 @@ describe("wrangler", () => {
 					  name  The name of the queue  [string] [required]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
 					      --delivery-delay-secs            How long a published message should be delayed for, in seconds. Must be between 0 and 86400  [number]
@@ -484,12 +487,13 @@ describe("wrangler", () => {
 					  name  The name of the queue  [string] [required]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
 					      --delivery-delay-secs            How long a published message should be delayed for, in seconds. Must be between 0 and 86400  [number]
@@ -652,12 +656,13 @@ describe("wrangler", () => {
 					  name  The name of the queue  [string] [required]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]"
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]"
 				`);
 			});
 
@@ -726,12 +731,13 @@ describe("wrangler", () => {
 					  wrangler queues consumer worker                             Configure Queue Worker Consumers
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]"
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]"
 				`);
 			});
 
@@ -776,12 +782,13 @@ describe("wrangler", () => {
 						  script-name  Name of the consumer script  [string] [required]
 
 						GLOBAL FLAGS
-						  -c, --config    Path to Wrangler configuration file  [string]
-						      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-						  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-						      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-						  -h, --help      Show help  [boolean]
-						  -v, --version   Show version number  [boolean]
+						  -c, --config          Path to Wrangler configuration file  [string]
+						      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+						  -h, --help            Show help  [boolean]
+						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						  -v, --version         Show version number  [boolean]
 
 						OPTIONS
 						      --batch-size         Maximum number of messages per batch  [number]
@@ -1140,12 +1147,13 @@ describe("wrangler", () => {
 						  script-name  Name of the consumer script  [string] [required]
 
 						GLOBAL FLAGS
-						  -c, --config    Path to Wrangler configuration file  [string]
-						      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-						  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-						      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-						  -h, --help      Show help  [boolean]
-						  -v, --version   Show version number  [boolean]"
+						  -c, --config          Path to Wrangler configuration file  [string]
+						      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+						  -h, --help            Show help  [boolean]
+						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						  -v, --version         Show version number  [boolean]"
 					`);
 				});
 
@@ -1571,12 +1579,13 @@ describe("wrangler", () => {
 					  wrangler queues consumer http list <queue-name>    List HTTP pull consumers for a queue
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]"
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]"
 				`);
 			});
 
@@ -1620,12 +1629,13 @@ describe("wrangler", () => {
 						  queue-name  Name of the queue for the consumer  [string] [required]
 
 						GLOBAL FLAGS
-						  -c, --config    Path to Wrangler configuration file  [string]
-						      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-						  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-						      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-						  -h, --help      Show help  [boolean]
-						  -v, --version   Show version number  [boolean]
+						  -c, --config          Path to Wrangler configuration file  [string]
+						      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+						  -h, --help            Show help  [boolean]
+						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						  -v, --version         Show version number  [boolean]
 
 						OPTIONS
 						      --batch-size               Maximum number of messages per batch  [number]
@@ -1770,12 +1780,13 @@ describe("wrangler", () => {
 						  queue-name  Name of the queue for the consumer  [string] [required]
 
 						GLOBAL FLAGS
-						  -c, --config    Path to Wrangler configuration file  [string]
-						      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-						  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-						      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-						  -h, --help      Show help  [boolean]
-						  -v, --version   Show version number  [boolean]"
+						  -c, --config          Path to Wrangler configuration file  [string]
+						      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+						  -h, --help            Show help  [boolean]
+						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						  -v, --version         Show version number  [boolean]"
 					`);
 				});
 
@@ -1859,12 +1870,13 @@ describe("wrangler", () => {
 					  queue-name  Name of the queue  [string] [required]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
 					      --json  Output in JSON format  [boolean] [default: false]"
@@ -2089,12 +2101,13 @@ describe("wrangler", () => {
 					  queue-name  Name of the queue  [string] [required]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
 					      --json  Output in JSON format  [boolean] [default: false]"
@@ -2253,12 +2266,13 @@ describe("wrangler", () => {
 					  queue-name  Name of the queue  [string] [required]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
 					      --json  Output in JSON format  [boolean] [default: false]"
@@ -2437,12 +2451,13 @@ describe("wrangler", () => {
 					  name  The name of the queue  [string] [required]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]"
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]"
 				`);
 			});
 			it("should return queue info with worker producers when the queue has workers configured as producers", async ({
@@ -2616,12 +2631,13 @@ describe("wrangler", () => {
 				  name  The name of the queue  [string] [required]
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 
@@ -2732,12 +2748,13 @@ describe("wrangler", () => {
 				  name  The name of the queue  [string] [required]
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 
@@ -2840,12 +2857,13 @@ describe("wrangler", () => {
 				  name  The name of the queue  [string] [required]
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]
 
 				OPTIONS
 				      --force  Skip the confirmation dialog and forcefully purge the Queue  [boolean]"

--- a/packages/wrangler/src/__tests__/r2/bucket.test.ts
+++ b/packages/wrangler/src/__tests__/r2/bucket.test.ts
@@ -119,12 +119,13 @@ describe("r2", () => {
 				  wrangler r2 bucket lock             Manage lock rules for an R2 bucket
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 
@@ -162,12 +163,13 @@ describe("r2", () => {
 				  wrangler r2 bucket lock             Manage lock rules for an R2 bucket
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 
@@ -341,12 +343,13 @@ describe("r2", () => {
 					  name  The name of the new bucket  [string] [required]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
 					      --location       The optional location hint that determines geographic placement of the R2 bucket  [string] [choices: "weur", "eeur", "apac", "wnam", "enam", "oc"]
@@ -379,12 +382,13 @@ describe("r2", () => {
 					  name  The name of the new bucket  [string] [required]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
 					      --location       The optional location hint that determines geographic placement of the R2 bucket  [string] [choices: "weur", "eeur", "apac", "wnam", "enam", "oc"]
@@ -514,12 +518,13 @@ describe("r2", () => {
 					  wrangler r2 bucket update storage-class <name>  Update the default storage class of an existing R2 bucket
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]"
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]"
 				`);
 				expect(std.err).toMatchInlineSnapshot(`
 				            "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown argument: foo[0m
@@ -545,12 +550,13 @@ describe("r2", () => {
 						  name  The name of the existing bucket  [string] [required]
 
 						GLOBAL FLAGS
-						  -c, --config    Path to Wrangler configuration file  [string]
-						      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-						  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-						      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-						  -h, --help      Show help  [boolean]
-						  -v, --version   Show version number  [boolean]
+						  -c, --config          Path to Wrangler configuration file  [string]
+						      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+						  -h, --help            Show help  [boolean]
+						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						  -v, --version         Show version number  [boolean]
 
 						OPTIONS
 						  -J, --jurisdiction   The jurisdiction of the bucket to be updated  [string]
@@ -610,12 +616,13 @@ describe("r2", () => {
 					  bucket  The name of the bucket to delete  [string] [required]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
 					  -J, --jurisdiction  The jurisdiction where the bucket exists  [string]"
@@ -675,12 +682,13 @@ describe("r2", () => {
 					  bucket  The name of the bucket to delete  [string] [required]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
 					  -J, --jurisdiction  The jurisdiction where the bucket exists  [string]"
@@ -747,12 +755,13 @@ describe("r2", () => {
 					  wrangler r2 bucket sippy get <name>      Check the status of Sippy on an R2 bucket
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]"
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]"
 				`);
 			});
 
@@ -850,12 +859,13 @@ describe("r2", () => {
 						  name  The name of the bucket  [string] [required]
 
 						GLOBAL FLAGS
-						  -c, --config    Path to Wrangler configuration file  [string]
-						      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-						  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-						      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-						  -h, --help      Show help  [boolean]
-						  -v, --version   Show version number  [boolean]
+						  -c, --config          Path to Wrangler configuration file  [string]
+						      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+						  -h, --help            Show help  [boolean]
+						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						  -v, --version         Show version number  [boolean]
 
 						OPTIONS
 						  -J, --jurisdiction              The jurisdiction where the bucket exists  [string]
@@ -895,12 +905,13 @@ describe("r2", () => {
 						  name  The name of the bucket  [string] [required]
 
 						GLOBAL FLAGS
-						  -c, --config    Path to Wrangler configuration file  [string]
-						      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-						  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-						      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-						  -h, --help      Show help  [boolean]
-						  -v, --version   Show version number  [boolean]
+						  -c, --config          Path to Wrangler configuration file  [string]
+						      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+						  -h, --help            Show help  [boolean]
+						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						  -v, --version         Show version number  [boolean]
 
 						OPTIONS
 						  -J, --jurisdiction  The jurisdiction where the bucket exists  [string]"
@@ -953,12 +964,13 @@ describe("r2", () => {
 						  name  The name of the bucket  [string] [required]
 
 						GLOBAL FLAGS
-						  -c, --config    Path to Wrangler configuration file  [string]
-						      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-						  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-						      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-						  -h, --help      Show help  [boolean]
-						  -v, --version   Show version number  [boolean]
+						  -c, --config          Path to Wrangler configuration file  [string]
+						      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+						  -h, --help            Show help  [boolean]
+						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						  -v, --version         Show version number  [boolean]
 
 						OPTIONS
 						  -J, --jurisdiction  The jurisdiction where the bucket exists  [string]"
@@ -1028,12 +1040,13 @@ describe("r2", () => {
 					  wrangler r2 bucket catalog snapshot-expiration  Control settings for automatic snapshot expiration maintenance jobs for your R2 data catalog [open beta]
 
 					GLOBAL FLAGS
-					  -c, --config    Path to Wrangler configuration file  [string]
-					      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-					  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-					      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-					  -h, --help      Show help  [boolean]
-					  -v, --version   Show version number  [boolean]"
+					  -c, --config          Path to Wrangler configuration file  [string]
+					      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+					  -h, --help            Show help  [boolean]
+					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					  -v, --version         Show version number  [boolean]"
 				`);
 			});
 
@@ -1090,12 +1103,13 @@ describe("r2", () => {
 						  bucket  The name of the bucket to enable  [string] [required]
 
 						GLOBAL FLAGS
-						  -c, --config    Path to Wrangler configuration file  [string]
-						      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-						  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-						      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-						  -h, --help      Show help  [boolean]
-						  -v, --version   Show version number  [boolean]"
+						  -c, --config          Path to Wrangler configuration file  [string]
+						      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+						  -h, --help            Show help  [boolean]
+						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						  -v, --version         Show version number  [boolean]"
 					`);
 					expect(std.err).toMatchInlineSnapshot(`
 				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
@@ -1123,12 +1137,13 @@ describe("r2", () => {
 						  bucket  The name of the bucket to disable the data catalog for  [string] [required]
 
 						GLOBAL FLAGS
-						  -c, --config    Path to Wrangler configuration file  [string]
-						      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-						  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-						      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-						  -h, --help      Show help  [boolean]
-						  -v, --version   Show version number  [boolean]"
+						  -c, --config          Path to Wrangler configuration file  [string]
+						      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+						  -h, --help            Show help  [boolean]
+						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						  -v, --version         Show version number  [boolean]"
 					`);
 					expect(std.err).toMatchInlineSnapshot(`
 				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
@@ -1221,12 +1236,13 @@ describe("r2", () => {
 						  bucket  The name of the R2 bucket whose data catalog status to retrieve  [string] [required]
 
 						GLOBAL FLAGS
-						  -c, --config    Path to Wrangler configuration file  [string]
-						      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-						  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-						      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-						  -h, --help      Show help  [boolean]
-						  -v, --version   Show version number  [boolean]"
+						  -c, --config          Path to Wrangler configuration file  [string]
+						      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+						  -h, --help            Show help  [boolean]
+						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						  -v, --version         Show version number  [boolean]"
 					`);
 					expect(std.err).toMatchInlineSnapshot(`
 				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
@@ -1331,12 +1347,13 @@ describe("r2", () => {
 						  wrangler r2 bucket catalog compaction disable <bucket> [namespace] [table]  Disable automatic file compaction for your R2 data catalog or a specific table [open beta]
 
 						GLOBAL FLAGS
-						  -c, --config    Path to Wrangler configuration file  [string]
-						      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-						  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-						      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-						  -h, --help      Show help  [boolean]
-						  -v, --version   Show version number  [boolean]"
+						  -c, --config          Path to Wrangler configuration file  [string]
+						      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+						  -h, --help            Show help  [boolean]
+						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						  -v, --version         Show version number  [boolean]"
 					`);
 				});
 
@@ -1409,12 +1426,13 @@ describe("r2", () => {
 							  table      The name of the table (optional, for table-level compaction)  [string]
 
 							GLOBAL FLAGS
-							  -c, --config    Path to Wrangler configuration file  [string]
-							      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-							  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-							      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-							  -h, --help      Show help  [boolean]
-							  -v, --version   Show version number  [boolean]
+							  -c, --config          Path to Wrangler configuration file  [string]
+							      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+							  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+							      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+							  -h, --help            Show help  [boolean]
+							      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+							  -v, --version         Show version number  [boolean]
 
 							OPTIONS
 							      --target-size  The target size for compacted files in MB (allowed values: 64, 128, 256, 512)  [number] [default: 128]
@@ -1545,12 +1563,13 @@ describe("r2", () => {
 							  table      The name of the table (optional, for table-level compaction)  [string]
 
 							GLOBAL FLAGS
-							  -c, --config    Path to Wrangler configuration file  [string]
-							      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-							  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-							      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-							  -h, --help      Show help  [boolean]
-							  -v, --version   Show version number  [boolean]"
+							  -c, --config          Path to Wrangler configuration file  [string]
+							      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+							  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+							      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+							  -h, --help            Show help  [boolean]
+							      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+							  -v, --version         Show version number  [boolean]"
 						`);
 						expect(std.err).toMatchInlineSnapshot(`
 					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
@@ -1691,12 +1710,13 @@ describe("r2", () => {
 						  wrangler r2 bucket catalog snapshot-expiration disable <bucket> [namespace] [table]  Disable automatic snapshot expiration for your R2 data catalog or a specific table [open beta]
 
 						GLOBAL FLAGS
-						  -c, --config    Path to Wrangler configuration file  [string]
-						      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-						  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-						      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-						  -h, --help      Show help  [boolean]
-						  -v, --version   Show version number  [boolean]"
+						  -c, --config          Path to Wrangler configuration file  [string]
+						      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+						  -h, --help            Show help  [boolean]
+						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						  -v, --version         Show version number  [boolean]"
 					`);
 				});
 
@@ -1821,12 +1841,13 @@ describe("r2", () => {
 							  table      The name of the table (optional, for table-level snapshot expiration)  [string]
 
 							GLOBAL FLAGS
-							  -c, --config    Path to Wrangler configuration file  [string]
-							      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-							  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-							      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-							  -h, --help      Show help  [boolean]
-							  -v, --version   Show version number  [boolean]
+							  -c, --config          Path to Wrangler configuration file  [string]
+							      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+							  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+							      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+							  -h, --help            Show help  [boolean]
+							      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+							  -v, --version         Show version number  [boolean]
 
 							OPTIONS
 							      --older-than-days  Delete snapshots older than this many days, defaults to 30  [number]
@@ -1940,12 +1961,13 @@ describe("r2", () => {
 							  table      The name of the table (optional, for table-level snapshot expiration)  [string]
 
 							GLOBAL FLAGS
-							  -c, --config    Path to Wrangler configuration file  [string]
-							      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-							  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-							      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-							  -h, --help      Show help  [boolean]
-							  -v, --version   Show version number  [boolean]
+							  -c, --config          Path to Wrangler configuration file  [string]
+							      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+							  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+							      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+							  -h, --help            Show help  [boolean]
+							      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+							  -v, --version         Show version number  [boolean]
 
 							OPTIONS
 							      --force  Skip confirmation prompt  [boolean] [default: false]"
@@ -2243,12 +2265,13 @@ describe("r2", () => {
 						  bucket  The name of the R2 bucket to get event notification rules for  [string] [required]
 
 						GLOBAL FLAGS
-						  -c, --config    Path to Wrangler configuration file  [string]
-						      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-						  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-						      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-						  -h, --help      Show help  [boolean]
-						  -v, --version   Show version number  [boolean]
+						  -c, --config          Path to Wrangler configuration file  [string]
+						      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+						  -h, --help            Show help  [boolean]
+						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						  -v, --version         Show version number  [boolean]
 
 						OPTIONS
 						  -J, --jurisdiction  The jurisdiction where the bucket exists  [string]"
@@ -2617,12 +2640,13 @@ describe("r2", () => {
 						  bucket  The name of the R2 bucket to create an event notification rule for  [string] [required]
 
 						GLOBAL FLAGS
-						  -c, --config    Path to Wrangler configuration file  [string]
-						      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-						  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-						      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-						  -h, --help      Show help  [boolean]
-						  -v, --version   Show version number  [boolean]
+						  -c, --config          Path to Wrangler configuration file  [string]
+						      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+						  -h, --help            Show help  [boolean]
+						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						  -v, --version         Show version number  [boolean]
 
 						OPTIONS
 						      --event-types, --event-type  The type of event(s) that will emit event notifications  [array] [required] [choices: "object-create", "object-delete"]
@@ -2783,12 +2807,13 @@ describe("r2", () => {
 						  bucket  The name of the R2 bucket to delete an event notification rule for  [string] [required]
 
 						GLOBAL FLAGS
-						  -c, --config    Path to Wrangler configuration file  [string]
-						      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-						  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-						      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-						  -h, --help      Show help  [boolean]
-						  -v, --version   Show version number  [boolean]
+						  -c, --config          Path to Wrangler configuration file  [string]
+						      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+						  -h, --help            Show help  [boolean]
+						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						  -v, --version         Show version number  [boolean]
 
 						OPTIONS
 						      --queue         The name of the queue that corresponds to the event notification rule. If no rule is provided, all event notification rules associated with the bucket and queue will be deleted  [string] [required]

--- a/packages/wrangler/src/__tests__/r2/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/r2/bulk.test.ts
@@ -29,12 +29,13 @@ describe("r2", () => {
 				"wrangler r2 bulk
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 

--- a/packages/wrangler/src/__tests__/r2/help.test.ts
+++ b/packages/wrangler/src/__tests__/r2/help.test.ts
@@ -26,12 +26,13 @@ describe("r2", () => {
 				  wrangler r2 sql     Send queries and manage R2 SQL [open beta]
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 
@@ -59,12 +60,13 @@ describe("r2", () => {
 				  wrangler r2 sql     Send queries and manage R2 SQL [open beta]
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 	});

--- a/packages/wrangler/src/__tests__/r2/local-uploads.test.ts
+++ b/packages/wrangler/src/__tests__/r2/local-uploads.test.ts
@@ -33,12 +33,13 @@ describe("r2 bucket local-uploads", () => {
 				  wrangler r2 bucket local-uploads disable <bucket>  Disable local uploads for an R2 bucket
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 	});

--- a/packages/wrangler/src/__tests__/r2/object.test.ts
+++ b/packages/wrangler/src/__tests__/r2/object.test.ts
@@ -36,12 +36,13 @@ describe("r2", () => {
 				  wrangler r2 object delete <objectPath>  Delete an object in an R2 bucket
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 		describe("remote", () => {

--- a/packages/wrangler/src/__tests__/register-yargs-command-skills.test.ts
+++ b/packages/wrangler/src/__tests__/register-yargs-command-skills.test.ts
@@ -1,0 +1,119 @@
+import { seed } from "@cloudflare/workers-utils/test-helpers";
+import { beforeEach, describe, test, vi } from "vitest";
+import { installCloudflareSkillsGlobally } from "../agents-skills-install";
+import { sendMetricsEvent } from "../metrics/send-event";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import { runInTempDir } from "./helpers/run-in-tmp";
+import { runWrangler } from "./helpers/run-wrangler";
+import type * as SendEventModule from "../metrics/send-event";
+
+// The global vitest.setup.ts mock for installCloudflareSkillsGlobally is active
+// (returns { skipped: true, reason: "Already prompted" }), so we can spy on it
+// without making real network calls.
+
+vi.mock("../metrics/send-event", async (importOriginal) => {
+	const original = await importOriginal<typeof SendEventModule>();
+	return {
+		...original,
+		sendMetricsEvent: vi.fn(),
+	};
+});
+
+vi.mock("../package-manager", async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return {
+		...actual,
+		getPackageManager() {
+			return {
+				type: "npm",
+				npx: "npx",
+			};
+		},
+	};
+});
+
+describe("register-yargs-command skills integration", () => {
+	runInTempDir();
+	mockConsoleMethods();
+
+	beforeEach(async () => {
+		// Seed a wrangler config so `wrangler setup` skips autoconfig and
+		// returns quickly — we only care about the skills install call.
+		await seed({
+			"wrangler.jsonc": JSON.stringify({ name: "test-worker" }),
+		});
+	});
+
+	test("calls installCloudflareSkillsGlobally with false by default", async ({
+		expect,
+	}) => {
+		await runWrangler("setup");
+
+		expect(installCloudflareSkillsGlobally).toHaveBeenCalledWith(false);
+	});
+
+	test("calls installCloudflareSkillsGlobally with true when --x-force-skills-install is passed", async ({
+		expect,
+	}) => {
+		await runWrangler("setup --x-force-skills-install");
+
+		expect(installCloudflareSkillsGlobally).toHaveBeenCalledWith(true);
+	});
+
+	test("does not send skills_install metrics when result is 'Already prompted'", async ({
+		expect,
+	}) => {
+		// The global mock returns { skipped: true, reason: "Already prompted" }
+		await runWrangler("setup");
+
+		const metricsCalls = vi
+			.mocked(sendMetricsEvent)
+			.mock.calls.filter(
+				([event]) =>
+					event === "skills_install_skipped" ||
+					event === "skills_install_completed"
+			);
+
+		expect(metricsCalls).toHaveLength(0);
+	});
+
+	test("sends skills_install_skipped metric for non-'Already prompted' skip reasons", async ({
+		expect,
+	}) => {
+		vi.mocked(installCloudflareSkillsGlobally).mockResolvedValueOnce({
+			skipped: true,
+			reason: "No supported agents detected",
+		});
+
+		await runWrangler("setup");
+
+		expect(sendMetricsEvent).toHaveBeenCalledWith(
+			"skills_install_skipped",
+			{ reason: "No supported agents detected" },
+			{}
+		);
+	});
+
+	test("sends skills_install_completed metric when skills are installed", async ({
+		expect,
+	}) => {
+		const fakeAgents = [
+			{
+				name: "Claude Code",
+				rosieId: "claude",
+				globalSkillsPath: "/fake/.claude/skills",
+			},
+		];
+		vi.mocked(installCloudflareSkillsGlobally).mockResolvedValueOnce({
+			targetedAgents: fakeAgents,
+		});
+
+		await runWrangler("setup");
+
+		expect(sendMetricsEvent).toHaveBeenCalledWith(
+			"skills_install_completed",
+			{ agents: fakeAgents },
+			{}
+		);
+	});
+});

--- a/packages/wrangler/src/__tests__/register-yargs-command-skills.test.ts
+++ b/packages/wrangler/src/__tests__/register-yargs-command-skills.test.ts
@@ -1,23 +1,9 @@
 import { seed } from "@cloudflare/workers-utils/test-helpers";
 import { beforeEach, describe, test, vi } from "vitest";
-import { installCloudflareSkillsGlobally } from "../agents-skills-install";
-import { sendMetricsEvent } from "../metrics/send-event";
+import { maybeInstallCloudflareSkillsGlobally } from "../agents-skills-install";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
-import type * as SendEventModule from "../metrics/send-event";
-
-// The global vitest.setup.ts mock for installCloudflareSkillsGlobally is active
-// (returns { skipped: true, reason: "Already prompted" }), so we can spy on it
-// without making real network calls.
-
-vi.mock("../metrics/send-event", async (importOriginal) => {
-	const original = await importOriginal<typeof SendEventModule>();
-	return {
-		...original,
-		sendMetricsEvent: vi.fn(),
-	};
-});
 
 vi.mock("../package-manager", async (importOriginal) => {
 	const actual = (await importOriginal()) as Record<string, unknown>;
@@ -44,76 +30,19 @@ describe("register-yargs-command skills integration", () => {
 		});
 	});
 
-	test("calls installCloudflareSkillsGlobally with false by default", async ({
+	test("calls maybeInstallCloudflareSkillsGlobally with false by default", async ({
 		expect,
 	}) => {
 		await runWrangler("setup");
 
-		expect(installCloudflareSkillsGlobally).toHaveBeenCalledWith(false);
+		expect(maybeInstallCloudflareSkillsGlobally).toHaveBeenCalledWith(false);
 	});
 
-	test("calls installCloudflareSkillsGlobally with true when --x-force-skills-install is passed", async ({
+	test("calls maybeInstallCloudflareSkillsGlobally with true when --x-force-skills-install is passed", async ({
 		expect,
 	}) => {
 		await runWrangler("setup --x-force-skills-install");
 
-		expect(installCloudflareSkillsGlobally).toHaveBeenCalledWith(true);
-	});
-
-	test("does not send skills_install metrics when result is 'Already prompted'", async ({
-		expect,
-	}) => {
-		// The global mock returns { skipped: true, reason: "Already prompted" }
-		await runWrangler("setup");
-
-		const metricsCalls = vi
-			.mocked(sendMetricsEvent)
-			.mock.calls.filter(
-				([event]) =>
-					event === "skills_install_skipped" ||
-					event === "skills_install_completed"
-			);
-
-		expect(metricsCalls).toHaveLength(0);
-	});
-
-	test("sends skills_install_skipped metric for non-'Already prompted' skip reasons", async ({
-		expect,
-	}) => {
-		vi.mocked(installCloudflareSkillsGlobally).mockResolvedValueOnce({
-			skipped: true,
-			reason: "No supported agents detected",
-		});
-
-		await runWrangler("setup");
-
-		expect(sendMetricsEvent).toHaveBeenCalledWith(
-			"skills_install_skipped",
-			{ reason: "No supported agents detected" },
-			{}
-		);
-	});
-
-	test("sends skills_install_completed metric when skills are installed", async ({
-		expect,
-	}) => {
-		const fakeAgents = [
-			{
-				name: "Claude Code",
-				rosieId: "claude",
-				globalSkillsPath: "/fake/.claude/skills",
-			},
-		];
-		vi.mocked(installCloudflareSkillsGlobally).mockResolvedValueOnce({
-			targetedAgents: fakeAgents,
-		});
-
-		await runWrangler("setup");
-
-		expect(sendMetricsEvent).toHaveBeenCalledWith(
-			"skills_install_completed",
-			{ agents: fakeAgents },
-			{}
-		);
+		expect(maybeInstallCloudflareSkillsGlobally).toHaveBeenCalledWith(true);
 	});
 });

--- a/packages/wrangler/src/__tests__/register-yargs-command-skills.test.ts
+++ b/packages/wrangler/src/__tests__/register-yargs-command-skills.test.ts
@@ -37,10 +37,10 @@ describe("register-yargs-command skills integration", () => {
 		expect(maybeInstallCloudflareSkillsGlobally).toHaveBeenCalledWith(false);
 	});
 
-	test("calls maybeInstallCloudflareSkillsGlobally with true when --x-force-skills-install is passed", async ({
+	test("calls maybeInstallCloudflareSkillsGlobally with true when --install-skills is passed", async ({
 		expect,
 	}) => {
-		await runWrangler("setup --x-force-skills-install");
+		await runWrangler("setup --install-skills");
 
 		expect(maybeInstallCloudflareSkillsGlobally).toHaveBeenCalledWith(true);
 	});

--- a/packages/wrangler/src/__tests__/register-yargs-command-skills.test.ts
+++ b/packages/wrangler/src/__tests__/register-yargs-command-skills.test.ts
@@ -1,8 +1,7 @@
-import { seed } from "@cloudflare/workers-utils/test-helpers";
+import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import { beforeEach, describe, test, vi } from "vitest";
 import { maybeInstallCloudflareSkillsGlobally } from "../agents-skills-install";
 import { mockConsoleMethods } from "./helpers/mock-console";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 
 vi.mock("../package-manager", async (importOriginal) => {

--- a/packages/wrangler/src/__tests__/secrets-store.test.ts
+++ b/packages/wrangler/src/__tests__/secrets-store.test.ts
@@ -37,12 +37,13 @@ describe("secrets-store help", () => {
 			  wrangler secrets-store secret  🔐 Manage Secrets within the Secrets Store [open beta]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 
@@ -67,12 +68,13 @@ describe("secrets-store help", () => {
 			  wrangler secrets-store secret  🔐 Manage Secrets within the Secrets Store [open beta]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 });

--- a/packages/wrangler/src/__tests__/setup.test.ts
+++ b/packages/wrangler/src/__tests__/setup.test.ts
@@ -37,12 +37,13 @@ describe("wrangler setup", () => {
 			🪄 Setup a project to work on Cloudflare
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
 			  -y, --yes      Answer "yes" to any prompts for configuring your project  [boolean] [default: false]

--- a/packages/wrangler/src/__tests__/tunnel/tunnel.test.ts
+++ b/packages/wrangler/src/__tests__/tunnel/tunnel.test.ts
@@ -80,12 +80,13 @@ describe("tunnel help", () => {
 			  wrangler tunnel quick-start <url>  Start a free, temporary tunnel without an account (https://try.cloudflare.com) [experimental]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 

--- a/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
+++ b/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
@@ -41,12 +41,13 @@ describe("vectorize help", () => {
 			  wrangler vectorize delete-metadata-index <name>  Delete metadata indexes
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 
@@ -85,12 +86,13 @@ describe("vectorize help", () => {
 			  wrangler vectorize delete-metadata-index <name>  Delete metadata indexes
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 
@@ -116,12 +118,13 @@ describe("vectorize help", () => {
 			  name  The name of the Vectorize index.  [string] [required]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
 			      --json           Return output as JSON  [boolean] [default: false]
@@ -151,12 +154,13 @@ describe("vectorize help", () => {
 			  name  The name of the Vectorize index  [string] [required]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
 			      --vector           Vector to query the Vectorize Index  [number]
@@ -1081,12 +1085,13 @@ describe("vectorize commands", () => {
 			  name  The name of the Vectorize index  [string] [required]
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
 			      --count   Maximum number of vectors to return (1-1000)  [number]

--- a/packages/wrangler/src/__tests__/versions/versions.help.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.help.test.ts
@@ -24,12 +24,13 @@ describe("versions --help", () => {
 			  wrangler versions secret                    Generate a secret that can be referenced in a Worker
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 });
@@ -56,12 +57,13 @@ describe("versions subhelp", () => {
 			  wrangler versions secret                    Generate a secret that can be referenced in a Worker
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 });

--- a/packages/wrangler/src/__tests__/vitest.setup.ts
+++ b/packages/wrangler/src/__tests__/vitest.setup.ts
@@ -221,6 +221,16 @@ vi.mock("../metrics/metrics-config", async (importOriginal) => {
 	return realModule;
 });
 
+vi.mock("../agents-skills-install", async (importOriginal) => {
+	const realModule =
+		await importOriginal<typeof import("../agents-skills-install")>();
+	vi.spyOn(realModule, "installCloudflareSkillsGlobally").mockResolvedValue({
+		skipped: true,
+		reason: "Already prompted",
+	});
+	return realModule;
+});
+
 vi.mock("prompts", () => {
 	return {
 		__esModule: true,

--- a/packages/wrangler/src/__tests__/vitest.setup.ts
+++ b/packages/wrangler/src/__tests__/vitest.setup.ts
@@ -222,10 +222,7 @@ vi.mock("../metrics/metrics-config", async (importOriginal) => {
 });
 
 vi.mock("../agents-skills-install", () => ({
-	installCloudflareSkillsGlobally: vi.fn().mockResolvedValue({
-		skipped: true,
-		reason: "Already prompted",
-	}),
+	maybeInstallCloudflareSkillsGlobally: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("prompts", () => {

--- a/packages/wrangler/src/__tests__/vitest.setup.ts
+++ b/packages/wrangler/src/__tests__/vitest.setup.ts
@@ -221,15 +221,12 @@ vi.mock("../metrics/metrics-config", async (importOriginal) => {
 	return realModule;
 });
 
-vi.mock("../agents-skills-install", async (importOriginal) => {
-	const realModule =
-		await importOriginal<typeof import("../agents-skills-install")>();
-	vi.spyOn(realModule, "installCloudflareSkillsGlobally").mockResolvedValue({
+vi.mock("../agents-skills-install", () => ({
+	installCloudflareSkillsGlobally: vi.fn().mockResolvedValue({
 		skipped: true,
 		reason: "Already prompted",
-	});
-	return realModule;
-});
+	}),
+}));
 
 vi.mock("prompts", () => {
 	return {

--- a/packages/wrangler/src/__tests__/vpc.test.ts
+++ b/packages/wrangler/src/__tests__/vpc.test.ts
@@ -40,12 +40,13 @@ describe("vpc help", () => {
 			  wrangler vpc service  🔗 Manage VPC services
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 
@@ -69,12 +70,13 @@ describe("vpc help", () => {
 			  wrangler vpc service update <service-id>  Update a VPC service
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]"
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]"
 		`);
 	});
 });

--- a/packages/wrangler/src/__tests__/worker-namespace.test.ts
+++ b/packages/wrangler/src/__tests__/worker-namespace.test.ts
@@ -46,12 +46,13 @@ describe("dispatch-namespace", () => {
 			  wrangler dispatch-namespace rename <oldName> <newName>  Rename a dispatch namespace
 
 			GLOBAL FLAGS
-			  -c, --config    Path to Wrangler configuration file  [string]
-			      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-			  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-			      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-			  -h, --help      Show help  [boolean]
-			  -v, --version   Show version number  [boolean]",
+			  -c, --config          Path to Wrangler configuration file  [string]
+			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+			  -h, --help            Show help  [boolean]
+			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			  -v, --version         Show version number  [boolean]",
 			  "warn": "",
 			}
 		`);
@@ -100,12 +101,13 @@ describe("dispatch-namespace", () => {
 				  name  Name of the dispatch namespace  [string] [required]
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 
@@ -152,12 +154,13 @@ describe("dispatch-namespace", () => {
 				  name  Name of the dispatch namespace  [string] [required]
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 
@@ -213,12 +216,13 @@ describe("dispatch-namespace", () => {
 				  name  Name of the dispatch namespace  [string] [required]
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 
@@ -325,12 +329,13 @@ describe("dispatch-namespace", () => {
 				  newName  New name of the dispatch namespace  [string] [required]
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 

--- a/packages/wrangler/src/__tests__/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/workflows.test.ts
@@ -159,12 +159,13 @@ describe("wrangler workflows", () => {
 				  wrangler workflows instances                Manage Workflow instances
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`
 			);
 		});
@@ -194,12 +195,13 @@ describe("wrangler workflows", () => {
 				  wrangler workflows instances resume <name> <id>      Resume a workflow instance
 
 				GLOBAL FLAGS
-				  -c, --config    Path to Wrangler configuration file  [string]
-				      --cwd       Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
-				  -e, --env       Environment to use for operations, and for selecting .env and .dev.vars files  [string]
-				      --env-file  Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
-				  -h, --help      Show help  [boolean]
-				  -v, --version   Show version number  [boolean]"
+				  -c, --config          Path to Wrangler configuration file  [string]
+				      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
+				  -h, --help            Show help  [boolean]
+				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				  -v, --version         Show version number  [boolean]"
 			`);
 		});
 	});

--- a/packages/wrangler/src/agents-skills-install.ts
+++ b/packages/wrangler/src/agents-skills-install.ts
@@ -69,6 +69,7 @@ export async function maybeInstallCloudflareSkillsGlobally(
 		logger.warn(
 			`Failed to detect AI coding agents: ${err instanceof Error ? err.message : String(err)}`
 		);
+		logger.warn(SKILLS_INSTALL_RETRY_HINT);
 		sendResultMetricsEvent({
 			skippedBecause: "Failed to install skills",
 		});
@@ -134,6 +135,7 @@ export async function maybeInstallCloudflareSkillsGlobally(
 			logger.warn(
 				`Skills installation failed for agents: ${failedAgents.join(", ")}.`
 			);
+			logger.warn(SKILLS_INSTALL_RETRY_HINT);
 		}
 
 		writeSkillsInstallMetadataFile({
@@ -151,6 +153,7 @@ export async function maybeInstallCloudflareSkillsGlobally(
 		logger.warn(
 			`Failed to install Cloudflare skills: ${err instanceof Error ? err.message : String(err)}`
 		);
+		logger.warn(SKILLS_INSTALL_RETRY_HINT);
 
 		writeSkillsInstallMetadataFile({
 			accepted: true,
@@ -167,6 +170,10 @@ export async function maybeInstallCloudflareSkillsGlobally(
 
 /** The GitHub repo spec for Cloudflare skills, used with rosie.install(). */
 const SKILLS_REPO = "cloudflare/skills";
+
+/** Actionable hint appended to skills-install failure warnings, directing users to retry or install manually. */
+const SKILLS_INSTALL_RETRY_HINT =
+	"You can retry by running `wrangler --experimental-force-skills-install`, or install skills manually as described here: https://github.com/cloudflare/skills#installing";
 
 /**
  * Describes a detected AI coding agent.

--- a/packages/wrangler/src/agents-skills-install.ts
+++ b/packages/wrangler/src/agents-skills-install.ts
@@ -8,24 +8,12 @@ import ci from "ci-info";
 import { confirm } from "./dialogs";
 import isInteractive from "./is-interactive";
 import { logger } from "./logger";
-
-export type SkillsInstallSkipReason =
-	| "Already prompted"
-	| "No supported agents detected"
-	| "Failed to install skills"
-	| "Running in CI"
-	| "Non-interactive terminal"
-	| "User declined";
-
-export type SkillsInstallResult =
-	| { skipped: true; reason: SkillsInstallSkipReason }
-	| {
-			targetedAgents: AgentInfo[];
-	  };
+import { sendMetricsEvent } from "./metrics";
 
 /**
- * Detects AI coding agents installed on the user's machine and offers to
- * install Cloudflare skill files into their global skills directories.
+ * Detects AI coding agents installed on the user's machine and, if
+ * appropriate, offers to install Cloudflare skill files into their global
+ * skills directories.
  *
  * Skills are installed via the rosie-skills JS API, which handles
  * downloading from the `cloudflare/skills` GitHub repository, agent
@@ -34,18 +22,44 @@ export type SkillsInstallResult =
  * @param force - When `true` the interactive prompt is skipped and skills are
  *   installed unconditionally (used by `--experimental-force-skills-install`).
  */
-export async function installCloudflareSkillsGlobally(
+export async function maybeInstallCloudflareSkillsGlobally(
 	force: boolean
-): Promise<SkillsInstallResult> {
+): Promise<void> {
+	const sendResultMetricsEvent = (
+		result:
+			| { skippedBecause: string }
+			| {
+					targetedAgents: AgentInfo[];
+			  }
+	) => {
+		if ("skippedBecause" in result) {
+			sendMetricsEvent(
+				"skills_install_skipped",
+				{ reason: result.skippedBecause },
+				{}
+			);
+		} else {
+			sendMetricsEvent(
+				"skills_install_completed",
+				{
+					agents: result.targetedAgents,
+				},
+				{}
+			);
+		}
+	};
+
 	// If the user has already been prompted, don't ask again
 	const existingConfig = readSkillsInstallMetadataFile();
 	if (existingConfig !== undefined && !force) {
-		return { skipped: true, reason: "Already prompted" };
+		// Note: no metrics even is sent in this case
+		return;
 	}
 
 	if (ci.isCI && !force) {
 		// In CI environments, skip silently
-		return { skipped: true, reason: "Running in CI" };
+		sendResultMetricsEvent({ skippedBecause: "Running in CI" });
+		return;
 	}
 
 	let detectedAgents: AgentInfo[];
@@ -55,11 +69,17 @@ export async function installCloudflareSkillsGlobally(
 		logger.warn(
 			`Failed to detect AI coding agents: ${err instanceof Error ? err.message : String(err)}`
 		);
-		return { skipped: true, reason: "Failed to install skills" };
+		sendResultMetricsEvent({
+			skippedBecause: "Failed to install skills",
+		});
+		return;
 	}
 
 	if (detectedAgents.length === 0) {
-		return { skipped: true, reason: "No supported agents detected" };
+		sendResultMetricsEvent({
+			skippedBecause: "No supported agents detected",
+		});
+		return;
 	}
 
 	// In non-interactive terminals (but not CI), log a message
@@ -67,7 +87,10 @@ export async function installCloudflareSkillsGlobally(
 		logger.log(
 			`Cloudflare agent skills are available for: ${detectedAgents.map(({ name }) => name).join(", ")}. Run wrangler in an interactive terminal to install them, or use \`--experimental-force-skills-install\` to install without prompting.`
 		);
-		return { skipped: true, reason: "Non-interactive terminal" };
+		sendResultMetricsEvent({
+			skippedBecause: "Non-interactive terminal",
+		});
+		return;
 	}
 
 	const accepted =
@@ -83,19 +106,19 @@ export async function installCloudflareSkillsGlobally(
 			date: new Date().toISOString(),
 			detectedAgents,
 		});
-		return { skipped: true, reason: "User declined" };
+		sendResultMetricsEvent({ skippedBecause: "User declined" });
+		return;
 	}
 
 	try {
 		const rosie = await import("rosie-skills");
 		const agentNames = detectedAgents.map((a) => a.rosieId);
-		const result = await rosie.install(SKILLS_REPO, {
+		const { failedAgents } = await rosie.install(SKILLS_REPO, {
 			global: true,
 			agent: agentNames,
 			lockfile: false,
 		});
 
-		const { failedAgents } = result;
 		const failedSet = new Set(failedAgents);
 		const succeededAgents = detectedAgents.filter(
 			(a) => !failedSet.has(a.rosieId)
@@ -120,9 +143,10 @@ export async function installCloudflareSkillsGlobally(
 			installFailed: failedAgents.length > 0 ? failedAgents : false,
 		});
 
-		return {
+		sendResultMetricsEvent({
 			targetedAgents: succeededAgents,
-		};
+		});
+		return;
 	} catch (err) {
 		logger.warn(
 			`Failed to install Cloudflare skills: ${err instanceof Error ? err.message : String(err)}`
@@ -135,7 +159,9 @@ export async function installCloudflareSkillsGlobally(
 			installFailed: true,
 		});
 
-		return { skipped: true, reason: "Failed to install skills" };
+		sendResultMetricsEvent({
+			skippedBecause: "Failed to install skills",
+		});
 	}
 }
 

--- a/packages/wrangler/src/agents-skills-install.ts
+++ b/packages/wrangler/src/agents-skills-install.ts
@@ -55,7 +55,7 @@ export async function maybeInstallCloudflareSkillsGlobally(
 	// If the user has already been prompted, don't ask again
 	const existingConfig = readSkillsInstallMetadataFile();
 	if (existingConfig !== undefined && !force) {
-		// Note: no metrics even is sent in this case
+		// Note: no metrics event is sent in this case
 		return;
 	}
 

--- a/packages/wrangler/src/agents-skills-install.ts
+++ b/packages/wrangler/src/agents-skills-install.ts
@@ -20,7 +20,7 @@ import { sendMetricsEvent } from "./metrics";
  * detection, and file placement.
  *
  * @param force - When `true` the interactive prompt is skipped and skills are
- *   installed unconditionally (used by `--experimental-force-skills-install`).
+ *   installed unconditionally (used by `--install-skills`).
  */
 export async function maybeInstallCloudflareSkillsGlobally(
 	force: boolean
@@ -86,7 +86,7 @@ export async function maybeInstallCloudflareSkillsGlobally(
 	// In non-interactive terminals (but not CI), log a message
 	if (!force && !isInteractive()) {
 		logger.log(
-			`Cloudflare agent skills are available for: ${detectedAgents.map(({ name }) => name).join(", ")}. Run wrangler in an interactive terminal to install them, or use \`--experimental-force-skills-install\` to install without prompting.`
+			`Cloudflare agent skills are available for: ${detectedAgents.map(({ name }) => name).join(", ")}. Run wrangler in an interactive terminal to install them, or use \`--install-skills\` to install without prompting.`
 		);
 		sendResultMetricsEvent({
 			skippedBecause: "Non-interactive terminal",
@@ -173,7 +173,7 @@ const SKILLS_REPO = "cloudflare/skills";
 
 /** Actionable hint appended to skills-install failure warnings, directing users to retry or install manually. */
 const SKILLS_INSTALL_RETRY_HINT =
-	"You can retry by running `wrangler --experimental-force-skills-install`, or install skills manually as described here: https://github.com/cloudflare/skills#installing";
+	"You can retry by running `wrangler --install-skills`, or install skills manually as described here: https://github.com/cloudflare/skills#installing";
 
 /**
  * Describes a detected AI coding agent.

--- a/packages/wrangler/src/agents-skills-install.ts
+++ b/packages/wrangler/src/agents-skills-install.ts
@@ -1,0 +1,221 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import {
+	getGlobalWranglerConfigPath,
+	parseJSONC,
+} from "@cloudflare/workers-utils";
+import ci from "ci-info";
+import { confirm } from "./dialogs";
+import isInteractive from "./is-interactive";
+import { logger } from "./logger";
+
+export type SkillsInstallSkipReason =
+	| "Already prompted"
+	| "No supported agents detected"
+	| "Failed to install skills"
+	| "Running in CI"
+	| "Non-interactive terminal"
+	| "User declined";
+
+export type SkillsInstallResult =
+	| { skipped: true; reason: SkillsInstallSkipReason }
+	| {
+			targetedAgents: AgentInfo[];
+	  };
+
+/**
+ * Detects AI coding agents installed on the user's machine and offers to
+ * install Cloudflare skill files into their global skills directories.
+ *
+ * Skills are installed via the rosie-skills JS API, which handles
+ * downloading from the `cloudflare/skills` GitHub repository, agent
+ * detection, and file placement.
+ *
+ * @param force - When `true` the interactive prompt is skipped and skills are
+ *   installed unconditionally (used by `--experimental-force-skills-install`).
+ */
+export async function installCloudflareSkillsGlobally(
+	force: boolean
+): Promise<SkillsInstallResult> {
+	// If the user has already been prompted, don't ask again
+	const existingConfig = readSkillsInstallMetadataFile();
+	if (existingConfig !== undefined && !force) {
+		return { skipped: true, reason: "Already prompted" };
+	}
+
+	if (ci.isCI && !force) {
+		// In CI environments, skip silently
+		return { skipped: true, reason: "Running in CI" };
+	}
+
+	const detectedAgents = await getDetectedAgents();
+
+	if (detectedAgents.length === 0) {
+		return { skipped: true, reason: "No supported agents detected" };
+	}
+
+	// In non-interactive terminals (but not CI), log a message
+	if (!force && !isInteractive()) {
+		logger.log(
+			`Cloudflare agent skills are available for: ${detectedAgents.map(({ name }) => name).join(", ")}. Run wrangler in an interactive terminal to install them, or use \`--experimental-force-skills-install\` to install without prompting.`
+		);
+		return { skipped: true, reason: "Non-interactive terminal" };
+	}
+
+	const accepted =
+		force ||
+		(await confirm(
+			`Wrangler detected the following AI coding agents: ${detectedAgents.map(({ name }) => name).join(", ")}. Would you like to install Cloudflare skills for them?`,
+			{ defaultValue: true, fallbackValue: false }
+		));
+
+	if (!accepted) {
+		writeSkillsInstallMetadataFile({
+			accepted: false,
+			date: new Date().toISOString(),
+			detectedAgents,
+		});
+		return { skipped: true, reason: "User declined" };
+	}
+
+	try {
+		const rosie = await import("rosie-skills");
+		const agentNames = detectedAgents.map((a) => a.rosieId);
+		const result = await rosie.install(SKILLS_REPO, {
+			global: true,
+			agent: agentNames,
+			lockfile: false,
+		});
+
+		const { failedAgents } = result;
+
+		logger.log(
+			`Successfully installed Cloudflare skills for: ${detectedAgents.map(({ name }) => name).join(", ")}.`
+		);
+
+		if (failedAgents.length > 0) {
+			logger.warn(
+				`Skills installation failed for agents: ${failedAgents.join(", ")}.`
+			);
+		}
+
+		writeSkillsInstallMetadataFile({
+			accepted: true,
+			date: new Date().toISOString(),
+			detectedAgents,
+			installFailed: failedAgents.length > 0 ? failedAgents : false,
+		});
+
+		return {
+			targetedAgents: detectedAgents,
+		};
+	} catch (err) {
+		logger.warn(
+			`Failed to install Cloudflare skills: ${err instanceof Error ? err.message : String(err)}`
+		);
+
+		writeSkillsInstallMetadataFile({
+			accepted: true,
+			date: new Date().toISOString(),
+			detectedAgents,
+			installFailed: true,
+		});
+
+		return { skipped: true, reason: "Failed to install skills" };
+	}
+}
+
+/** The GitHub repo spec for Cloudflare skills, used with rosie.install(). */
+const SKILLS_REPO = "cloudflare/skills";
+
+/**
+ * Describes a detected AI coding agent.
+ */
+type AgentInfo = {
+	/** Human-readable display name of the agent (e.g. "Claude Code"). */
+	name: string;
+	/** Rosie's short identifier for the agent (e.g. "claude"). */
+	rosieId: string;
+	/** Absolute path to the agent's global skills directory. */
+	globalSkillsPath: string;
+};
+
+/**
+ * Persisted configuration that tracks whether the user has been prompted
+ * about installing Cloudflare agent skills globally.
+ */
+interface SkillsInstallMetadata {
+	/** Whether the user accepted the prompt to install skills. */
+	accepted: boolean;
+	/** ISO date string of when the user was prompted. */
+	date: string;
+	/** All agents detected on the user's machine. */
+	detectedAgents?: AgentInfo[];
+	/**
+	 * `true` when the entire `rosie.install()` call threw, or `string[]` with
+	 * the names of agents whose symlinks could not be created. `false` if
+	 * installation succeeded for all agents. Absent when no installation was
+	 * attempted (user declined or prompt was skipped).
+	 */
+	installFailed?: boolean | string[];
+}
+
+/** Jsonc metadata file created when Cloudflare agent skills are installed */
+const SKILLS_INSTALL_METADATA_FILENAME = "agents-skills-install.jsonc";
+
+/**
+ * Returns the absolute path to the skills install config file within the global wrangler config directory.
+ */
+function getSkillsInstallMetadataFilePath(): string {
+	return path.resolve(
+		getGlobalWranglerConfigPath(),
+		SKILLS_INSTALL_METADATA_FILENAME
+	);
+}
+
+/**
+ * Reads and parses the skills install metadata file.
+ *
+ * @returns The parsed metadata file, or `undefined` if the file doesn't exist or can't be parsed.
+ */
+function readSkillsInstallMetadataFile(): SkillsInstallMetadata | undefined {
+	try {
+		const content = readFileSync(getSkillsInstallMetadataFilePath(), "utf8");
+		return parseJSONC(content) as SkillsInstallMetadata;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Persists the skills install metadata to disk, creating parent directories as needed.
+ */
+function writeSkillsInstallMetadataFile(metadata: SkillsInstallMetadata): void {
+	const configPath = getSkillsInstallMetadataFilePath();
+	mkdirSync(path.dirname(configPath), { recursive: true });
+	writeFileSync(configPath, JSON.stringify(metadata, null, "\t"));
+}
+
+/**
+ * Queries rosie for detected agents on the user's machine.
+ *
+ * @returns Array of detected agents with their display names, rosie IDs, and skills paths.
+ */
+async function getDetectedAgents(): Promise<AgentInfo[]> {
+	const rosie = await import("rosie-skills");
+	const allAgents = await rosie.agents();
+	return allAgents
+		.filter(
+			(
+				agent
+			): agent is typeof agent & {
+				detected: true;
+				installPath: string;
+			} => agent.detected && agent.installPath !== null
+		)
+		.map((agent) => ({
+			name: agent.display,
+			rosieId: agent.name,
+			globalSkillsPath: agent.installPath,
+		}));
+}

--- a/packages/wrangler/src/agents-skills-install.ts
+++ b/packages/wrangler/src/agents-skills-install.ts
@@ -48,7 +48,15 @@ export async function installCloudflareSkillsGlobally(
 		return { skipped: true, reason: "Running in CI" };
 	}
 
-	const detectedAgents = await getDetectedAgents();
+	let detectedAgents: AgentInfo[];
+	try {
+		detectedAgents = await getDetectedAgents();
+	} catch (err) {
+		logger.warn(
+			`Failed to detect AI coding agents: ${err instanceof Error ? err.message : String(err)}`
+		);
+		return { skipped: true, reason: "Failed to install skills" };
+	}
 
 	if (detectedAgents.length === 0) {
 		return { skipped: true, reason: "No supported agents detected" };
@@ -88,10 +96,16 @@ export async function installCloudflareSkillsGlobally(
 		});
 
 		const { failedAgents } = result;
-
-		logger.log(
-			`Successfully installed Cloudflare skills for: ${detectedAgents.map(({ name }) => name).join(", ")}.`
+		const failedSet = new Set(failedAgents);
+		const succeededAgents = detectedAgents.filter(
+			(a) => !failedSet.has(a.rosieId)
 		);
+
+		if (succeededAgents.length > 0) {
+			logger.log(
+				`Successfully installed Cloudflare skills for: ${succeededAgents.map(({ name }) => name).join(", ")}.`
+			);
+		}
 
 		if (failedAgents.length > 0) {
 			logger.warn(
@@ -107,7 +121,7 @@ export async function installCloudflareSkillsGlobally(
 		});
 
 		return {
-			targetedAgents: detectedAgents,
+			targetedAgents: succeededAgents,
 		};
 	} catch (err) {
 		logger.warn(

--- a/packages/wrangler/src/agents-skills-install.ts
+++ b/packages/wrangler/src/agents-skills-install.ts
@@ -27,7 +27,7 @@ export async function maybeInstallCloudflareSkillsGlobally(
 ): Promise<void> {
 	const sendResultMetricsEvent = (
 		result:
-			| { skippedBecause: string }
+			| { skippedBecause: string; errorMessage?: string }
 			| {
 					targetedAgents: AgentInfo[];
 			  }
@@ -35,7 +35,10 @@ export async function maybeInstallCloudflareSkillsGlobally(
 		if ("skippedBecause" in result) {
 			sendMetricsEvent(
 				"skills_install_skipped",
-				{ reason: result.skippedBecause },
+				{
+					reason: result.skippedBecause,
+					...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
+				},
 				{}
 			);
 		} else {
@@ -66,12 +69,9 @@ export async function maybeInstallCloudflareSkillsGlobally(
 	try {
 		detectedAgents = await getDetectedAgents();
 	} catch (err) {
-		logger.warn(
-			`Failed to detect AI coding agents: ${err instanceof Error ? err.message : String(err)}`
-		);
-		logger.warn(SKILLS_INSTALL_RETRY_HINT);
 		sendResultMetricsEvent({
 			skippedBecause: "Failed to install skills",
+			errorMessage: err instanceof Error ? err.message : String(err),
 		});
 		return;
 	}

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -7,12 +7,13 @@ import {
 	UserError,
 } from "@cloudflare/workers-utils";
 import chalk from "chalk";
+import { installCloudflareSkillsGlobally } from "../agents-skills-install";
 import { fetchResult } from "../cfetch";
 import { createCloudflareClient } from "../cfetch/internal";
 import { readConfig } from "../config";
 import { run } from "../experimental-flags";
 import { logger } from "../logger";
-import { getMetricsDispatcher } from "../metrics";
+import { getMetricsDispatcher, sendMetricsEvent } from "../metrics";
 import {
 	COMMAND_ARG_ALLOW_LIST,
 	getAllowedArgs,
@@ -137,18 +138,42 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 				await printWranglerBanner();
 			}
 
-			// Suppress statusMessage when printBanner is a dynamic function that
-			// returned false (e.g. `--json` mode). When printBanner is the static
-			// boolean `false`, we preserve existing behaviour and still show
-			// status warnings — those commands opted out of the Wrangler banner,
-			// not necessarily the status message.
-			const statusMessageEnabled =
-				typeof shouldPrintBanner !== "function" || bannerEnabled;
+			const skillsInstallResult = await installCloudflareSkillsGlobally(
+				args.experimentalForceSkillsInstall
+			);
+			const alreadyPrompted =
+				"skipped" in skillsInstallResult &&
+				skillsInstallResult.reason === "Already prompted";
+			if (!alreadyPrompted) {
+				if ("skipped" in skillsInstallResult) {
+					sendMetricsEvent(
+						"skills_install_skipped",
+						{ reason: skillsInstallResult.reason },
+						{}
+					);
+				} else {
+					sendMetricsEvent(
+						"skills_install_completed",
+						{
+							agents: skillsInstallResult.targetedAgents,
+						},
+						{}
+					);
+				}
+			}
 
 			if (!getWranglerHideBanner()) {
 				if (def.metadata.deprecated) {
 					logger.warn(def.metadata.deprecatedMessage);
 				}
+
+				// Suppress statusMessage when printBanner is a dynamic function that
+				// returned false (e.g. `--json` mode). When printBanner is the static
+				// boolean `false`, we preserve existing behaviour and still show
+				// status warnings — those commands opted out of the Wrangler banner,
+				// not necessarily the status message.
+				const statusMessageEnabled =
+					typeof shouldPrintBanner !== "function" || bannerEnabled;
 
 				if (statusMessageEnabled && def.metadata.statusMessage) {
 					logger.warn(def.metadata.statusMessage);

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -7,13 +7,13 @@ import {
 	UserError,
 } from "@cloudflare/workers-utils";
 import chalk from "chalk";
-import { installCloudflareSkillsGlobally } from "../agents-skills-install";
+import { maybeInstallCloudflareSkillsGlobally } from "../agents-skills-install";
 import { fetchResult } from "../cfetch";
 import { createCloudflareClient } from "../cfetch/internal";
 import { readConfig } from "../config";
 import { run } from "../experimental-flags";
 import { logger } from "../logger";
-import { getMetricsDispatcher, sendMetricsEvent } from "../metrics";
+import { getMetricsDispatcher } from "../metrics";
 import {
 	COMMAND_ARG_ALLOW_LIST,
 	getAllowedArgs,
@@ -138,29 +138,9 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 				await printWranglerBanner();
 			}
 
-			const skillsInstallResult = await installCloudflareSkillsGlobally(
+			await maybeInstallCloudflareSkillsGlobally(
 				args.experimentalForceSkillsInstall
 			);
-			const alreadyPrompted =
-				"skipped" in skillsInstallResult &&
-				skillsInstallResult.reason === "Already prompted";
-			if (!alreadyPrompted) {
-				if ("skipped" in skillsInstallResult) {
-					sendMetricsEvent(
-						"skills_install_skipped",
-						{ reason: skillsInstallResult.reason },
-						{}
-					);
-				} else {
-					sendMetricsEvent(
-						"skills_install_completed",
-						{
-							agents: skillsInstallResult.targetedAgents,
-						},
-						{}
-					);
-				}
-			}
 
 			if (!getWranglerHideBanner()) {
 				if (def.metadata.deprecated) {

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -138,9 +138,7 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 				await printWranglerBanner();
 			}
 
-			await maybeInstallCloudflareSkillsGlobally(
-				args.experimentalForceSkillsInstall
-			);
+			await maybeInstallCloudflareSkillsGlobally(args.installSkills);
 
 			if (!getWranglerHideBanner()) {
 				if (def.metadata.deprecated) {

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -360,7 +360,10 @@ export type AdditionalDevProps = {
 	showInteractiveDevSession?: boolean;
 };
 
-type DevArguments = (typeof dev)["args"];
+type DevArguments = Omit<
+	(typeof dev)["args"],
+	"experimentalForceSkillsInstall"
+>;
 
 export type StartDevOptions = DevArguments &
 	// These options can be passed in directly when called with the `wrangler.dev()` API.

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -360,10 +360,7 @@ export type AdditionalDevProps = {
 	showInteractiveDevSession?: boolean;
 };
 
-type DevArguments = Omit<
-	(typeof dev)["args"],
-	"experimentalForceSkillsInstall"
->;
+type DevArguments = Omit<(typeof dev)["args"], "installSkills">;
 
 export type StartDevOptions = DevArguments &
 	// These options can be passed in directly when called with the `wrangler.dev()` API.

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -537,6 +537,16 @@ export function createCLIParser(argv: string[]) {
 			hidden: true,
 			alias: "x-auto-create",
 		},
+		"experimental-force-skills-install": {
+			describe:
+				"Install Cloudflare agents skills, if not already present, without asking the user for confirmation",
+			type: "boolean",
+			default: false,
+			// This flag is quite long and it wouldn't be great to show in all the wrangler help messages
+			// so we just hide it, we can unhide it in the future if this turns out not to be ok
+			hidden: true,
+			alias: "x-force-skills-install",
+		},
 	} as const;
 	// Type check result against CommonYargsOptions to make sure we've included
 	// all common options

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -537,15 +537,12 @@ export function createCLIParser(argv: string[]) {
 			hidden: true,
 			alias: "x-auto-create",
 		},
-		"experimental-force-skills-install": {
+		"install-skills": {
 			describe:
 				"Install Cloudflare agents skills, if not already present, without asking the user for confirmation",
 			type: "boolean",
 			default: false,
-			// This flag is quite long and it wouldn't be great to show in all the wrangler help messages
-			// so we just hide it, we can unhide it in the future if this turns out not to be ok
 			hidden: true,
-			alias: "x-force-skills-install",
 		},
 	} as const;
 	// Type check result against CommonYargsOptions to make sure we've included

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -542,7 +542,6 @@ export function createCLIParser(argv: string[]) {
 				"Install Cloudflare agents skills, if not already present, without asking the user for confirmation",
 			type: "boolean",
 			default: false,
-			hidden: true,
 		},
 	} as const;
 	// Type check result against CommonYargsOptions to make sure we've included
@@ -620,7 +619,7 @@ export function createCLIParser(argv: string[]) {
 		"Examples:": `${chalk.bold("EXAMPLES")}`,
 	});
 	wrangler.group(
-		["config", "cwd", "env", "env-file", "help", "version"],
+		["config", "cwd", "env", "env-file", "help", "install-skills", "version"],
 		`${chalk.bold("GLOBAL FLAGS")}`
 	);
 

--- a/packages/wrangler/src/metrics/send-event.ts
+++ b/packages/wrangler/src/metrics/send-event.ts
@@ -71,7 +71,8 @@ export type EventNames =
 	| "update pipeline"
 	| "show pipeline"
 	| "provision resources"
-	| AutoConfigEvent;
+	| AutoConfigEvent
+	| SkillsInstallEvent;
 
 /** Event related to the autoconfig flow */
 type AutoConfigEvent =
@@ -81,6 +82,9 @@ type AutoConfigEvent =
 	| "autoconfig_detection_completed"
 	| "autoconfig_configuration_started"
 	| "autoconfig_configuration_completed";
+
+/** Event related to the agent skills install flow */
+type SkillsInstallEvent = "skills_install_skipped" | "skills_install_completed";
 
 /**
  * Send a metrics event, with no extra properties, to Cloudflare, if usage tracking is enabled.

--- a/packages/wrangler/src/yargs-types.ts
+++ b/packages/wrangler/src/yargs-types.ts
@@ -12,6 +12,7 @@ export interface CommonYargsOptions {
 	"env-file": string[] | undefined;
 	"experimental-provision": boolean | undefined;
 	"experimental-auto-create": boolean;
+	"experimental-force-skills-install": boolean;
 }
 
 export type CommonYargsArgvSanitized<P = CommonYargsOptions> = OnlyCamelCase<

--- a/packages/wrangler/src/yargs-types.ts
+++ b/packages/wrangler/src/yargs-types.ts
@@ -12,7 +12,7 @@ export interface CommonYargsOptions {
 	"env-file": string[] | undefined;
 	"experimental-provision": boolean | undefined;
 	"experimental-auto-create": boolean;
-	"experimental-force-skills-install": boolean;
+	"install-skills": boolean;
 }
 
 export type CommonYargsArgvSanitized<P = CommonYargsOptions> = OnlyCamelCase<

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3942,6 +3942,9 @@ importers:
       path-to-regexp:
         specifier: 6.3.0
         version: 6.3.0
+      rosie-skills:
+        specifier: ^0.6.3
+        version: 0.6.3
       unenv:
         specifier: 2.0.0-rc.24
         version: 2.0.0-rc.24
@@ -13532,6 +13535,26 @@ packages:
   rollup@4.57.1:
     resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rosie-skills-darwin-arm64@0.6.3:
+    resolution: {integrity: sha512-DrgUIT+bEmGrGjZkomgnCfc1b1GwpM7r7Y4k8UjfkrOd0Zh1sDgd+X2ilGP12KUA8kIuUuqhzgX5TCEm83Fkbw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  rosie-skills-freebsd-x64@0.6.3:
+    resolution: {integrity: sha512-bm032ltYtn3aKVJo8VfxiUYZ5xCl23erxYsayNcLG3yUGOaNbWMtVR69wxct7RjUgtPKal87gRbFUA1zlvVSDg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  rosie-skills-linux-x64@0.6.3:
+    resolution: {integrity: sha512-eGdu8VBcmFV/uYIqJHdj/WSd2SRsJn3wmvsUmEc9AWWPzCT2WfSuRhJJAFssPLZ/Qyneg56G6mAke3A0Jrkwwg==}
+    cpu: [x64]
+    os: [linux]
+
+  rosie-skills@0.6.3:
+    resolution: {integrity: sha512-oIugHHNQHkW+LPbVrJTbE6Tx74dTSCQSXViVXBJ4MxGJkLnGZYZkVP7DRe0WwREx/Spah7V53UZncTlW0yfOWg==}
+    engines: {node: '>=18'}
     hasBin: true
 
   rou3@0.7.12:
@@ -24823,6 +24846,21 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.57.1
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
+
+  rosie-skills-darwin-arm64@0.6.3:
+    optional: true
+
+  rosie-skills-freebsd-x64@0.6.3:
+    optional: true
+
+  rosie-skills-linux-x64@0.6.3:
+    optional: true
+
+  rosie-skills@0.6.3:
+    optionalDependencies:
+      rosie-skills-darwin-arm64: 0.6.3
+      rosie-skills-freebsd-x64: 0.6.3
+      rosie-skills-linux-x64: 0.6.3
 
   rou3@0.7.12: {}
 


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-2607

Wrangler now detects AI coding agent configuration directories (e.g. Claude Code, Cursor, Cline, Gemini CLI, OpenCode) and offers to install Cloudflare skill files from the `cloudflare/skills` GitHub repository. Users are prompted once interactively; subsequent runs skip the prompt. Use `--experimental-force-skills-install` (alias `--x-force-skills-install`) to install without prompting.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: self-explanatory UX improvement

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->