### PR TITLE
Isolate fixture dev-registry paths to prevent cross-fixture test leakage

### DIFF
--- a/fixtures/shared/src/run-wrangler-long-lived.ts
+++ b/fixtures/shared/src/run-wrangler-long-lived.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert";
 import { fork } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
 import { createConnection } from "node:net";
+import os from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import treeKill from "tree-kill";
@@ -9,6 +11,37 @@ export const wranglerEntryPath = path.resolve(
 	__dirname,
 	"../../../packages/wrangler/bin/wrangler.js"
 );
+
+/**
+ * Returns a per-process temporary directory for the dev registry.
+ *
+ * When multiple fixture tests run in parallel (turbo `--concurrency=2`), each
+ * fixture's vitest process gets its own isolated registry directory. This
+ * prevents cross-fixture leakage — e.g. the local-explorer in one fixture
+ * picking up workers registered by a completely unrelated fixture.
+ *
+ * Within a single fixture process, all `runWranglerDev` / `runWranglerPagesDev`
+ * calls share the same registry so multi-worker setups (service bindings,
+ * durable objects across workers) continue to work.
+ *
+ * See `packages/miniflare/src/shared/DEV_REGISTRY.md` for registry architecture.
+ */
+let isolatedRegistryPath: string | undefined;
+function getIsolatedRegistryPath(): string {
+	if (isolatedRegistryPath === undefined) {
+		isolatedRegistryPath = mkdtempSync(
+			path.join(os.tmpdir(), "wrangler-fixture-registry-")
+		);
+		process.on("exit", () => {
+			try {
+				rmSync(isolatedRegistryPath!, { recursive: true, force: true });
+			} catch {
+				// Best-effort cleanup; the OS will reap tmp dirs eventually.
+			}
+		});
+	}
+	return isolatedRegistryPath;
+}
 
 /**
  * Runs the command `wrangler pages dev` in a child process.
@@ -71,10 +104,20 @@ async function runLongLivedWrangler(
 		rejectReadyPromise = reject;
 	});
 
+	// Ensure each fixture process uses an isolated dev registry unless the
+	// caller (or the environment) has already specified one explicitly.
+	const registryEnv: NodeJS.ProcessEnv = {};
+	if (!env?.WRANGLER_REGISTRY_PATH && !process.env.WRANGLER_REGISTRY_PATH) {
+		registryEnv.WRANGLER_REGISTRY_PATH = getIsolatedRegistryPath();
+	}
+	if (!env?.MINIFLARE_REGISTRY_PATH && !process.env.MINIFLARE_REGISTRY_PATH) {
+		registryEnv.MINIFLARE_REGISTRY_PATH = getIsolatedRegistryPath();
+	}
+
 	const wranglerProcess = fork(wranglerEntryPath, command, {
 		stdio: [/*stdin*/ "ignore", /*stdout*/ "pipe", /*stderr*/ "pipe", "ipc"],
 		cwd,
-		env: { ...process.env, ...env, PWD: cwd },
+		env: { ...process.env, ...registryEnv, ...env, PWD: cwd },
 	}).on("message", (message) => {
 		if (settledReadyPromise) {
 			return;


### PR DESCRIPTION
## What & why

When multiple fixture tests run in parallel via turbo (`--concurrency=2` in CI), they all share the default dev registry at `~/.wrangler/registry`. The local-explorer aggregates resources from **every worker** in the registry across all running miniflare instances, so a concurrent `browser-run` fixture leaks its `BROWSER_KV_DEMO` KV namespace into the `worker-with-resources` fixture's local-explorer results, causing assertion failures like:

```
expected result_info.count === 3, received 4
```

See e.g. https://github.com/cloudflare/workers-sdk/actions/runs/25725930967/job/75538563310?pr=13859.

## How

Lazily creates a per-process temporary registry directory inside the shared `runWranglerDev`/`runWranglerPagesDev` helper in `fixtures/shared/src/run-wrangler-long-lived.ts` and injects it as `WRANGLER_REGISTRY_PATH` + `MINIFLARE_REGISTRY_PATH` into the forked wrangler child process.

Key properties:

- **Per-process isolation** — each fixture's vitest process gets its own tmp registry, preventing cross-fixture leakage.
- **Intra-process sharing** — multiple `runWranglerDev` calls within the same fixture share the registry, so multi-worker setups (service bindings, durable objects across workers, e.g. `workers-with-assets-and-service-bindings`) continue to work.
- **Explicit overrides still win** — fixtures that already pass `WRANGLER_REGISTRY_PATH` / `MINIFLARE_REGISTRY_PATH` (like `dev-registry` and `entrypoints-rpc-tests`) are untouched.
- **Cleanup** — a `process.on("exit")` handler removes the tmp dir via `rmSync`.

## Verified locally

- `@fixture/worker-with-resources`: 16/16 tests pass
- `@fixture/browser-run`: 8/8 tests pass
- Both fixtures run concurrently with `--concurrency=2`: all 24 tests pass

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this is a test-infrastructure-only change to private `@fixture/shared` package; no published-package behaviour changes.