### PR TITLE
Enable require-description-when-disabling lint rule on the quick-edit-extension package

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -198,10 +198,9 @@
 				"workers-sdk/no-wrangler-named-imports": "error",
 			},
 		},
-		// Gradually rolling out require-description-when-disabling.
-		// TODO: Remove the following overrides.
+		// TODO: Remove the following wrangler override.
 		{
-			"files": ["packages/quick-edit-extension/**", "packages/wrangler/**"],
+			"files": ["packages/wrangler/**"],
 			"rules": {
 				"workers-sdk/require-description-when-disabling": "off",
 			},

--- a/packages/quick-edit-extension/src/cfs.ts
+++ b/packages/quick-edit-extension/src/cfs.ts
@@ -541,15 +541,16 @@ declare module "*.bin" {
 		});
 	}
 
+	/* eslint-disable no-useless-escape --
+		adapted from vscode-web-playground, see: https://github.com/microsoft/vscode-web-playground/blob/fde7a272cc7de/src/memfs.ts#L399-L401
+		escapes are redundant in a character class but harmless
+	*/
 	private _convertSimple2RegExpPattern(pattern: string): string {
-		return (
-			pattern
-				// eslint-disable-next-line
-				.replace(/[\-\\\{\}\+\?\|\^\$\.\,\[\]\(\)\#\s]/g, "\\$&")
-				// eslint-disable-next-line
-				.replace(/[\*]/g, ".*")
-		);
+		return pattern
+			.replace(/[\-\\\{\}\+\?\|\^\$\.\,\[\]\(\)\#\s]/g, "\\$&")
+			.replace(/[\*]/g, ".*");
 	}
+	/* eslint-enable no-useless-escape */
 
 	// --- search provider
 


### PR DESCRIPTION
This PR enables the `require-description-when-disabling` lint rule on the quick-edit-extension package.

This is a followup PR for https://github.com/cloudflare/workers-sdk/pull/13698, https://github.com/cloudflare/workers-sdk/pull/13703, https://github.com/cloudflare/workers-sdk/pull/13710, https://github.com/cloudflare/workers-sdk/pull/13741, https://github.com/cloudflare/workers-sdk/pull/13803, https://github.com/cloudflare/workers-sdk/pull/13804, https://github.com/cloudflare/workers-sdk/pull/13819 and https://github.com/cloudflare/workers-sdk/pull/13844.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: internal linting change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal linting change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->