### PR TITLE
[ci] Disable Turbo and pnpm caching on release builds

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -13,17 +13,28 @@ inputs:
     description: the api token for connecting to the turbo remote cache
   turbo-signature:
     description: the cache signature key for connecting to the turbo remote cache
+  disable-cache:
+    description: when "true", skip the pnpm store cache on setup-node (defense in depth for release builds)
+    default: "false"
 runs:
   using: "composite"
   steps:
     - name: Install pnpm
       uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
 
-    - name: Install Node.js ${{ inputs.node-version }}
+    - name: Install Node.js ${{ inputs.node-version }} (with pnpm cache)
+      if: inputs.disable-cache != 'true'
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: "pnpm"
+        registry-url: "https://registry.npmjs.org"
+
+    - name: Install Node.js ${{ inputs.node-version }} (without pnpm cache)
+      if: inputs.disable-cache == 'true'
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
         registry-url: "https://registry.npmjs.org"
 
     # Enable node compile cache (effective for Node 22+)

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -25,13 +25,14 @@ jobs:
           fetch-depth: 500
 
       - name: Install Dependencies
+        # Defense in depth: do not pass Turbo remote cache credentials and
+        # disable the pnpm store cache so release builds always resolve
+        # packages from the registry and rebuild every task from source,
+        # rather than restoring from a (potentially poisoned) cache.
         uses: ./.github/actions/install-dependencies
         with:
           node-version: 24
-          turbo-api: ${{ secrets.TURBO_API }}
-          turbo-team: ${{ secrets.TURBO_TEAM }}
-          turbo-token: ${{ secrets.TURBO_TOKEN }}
-          turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+          disable-cache: "true"
 
       - name: Check npm version
         run: node -r esbuild-register tools/deployments/check-npm-version.ts

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -50,12 +50,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Install Dependencies
+        # Defense in depth: do not pass Turbo remote cache credentials and
+        # disable the pnpm store cache so release builds always resolve
+        # packages from the registry and rebuild every task from source,
+        # rather than restoring from a (potentially poisoned) cache.
         uses: ./.github/actions/install-dependencies
         with:
-          turbo-api: ${{ secrets.TURBO_API }}
-          turbo-team: ${{ secrets.TURBO_TEAM }}
-          turbo-token: ${{ secrets.TURBO_TOKEN }}
-          turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+          disable-cache: "true"
 
       - name: Build all packages
         run: pnpm run build

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -28,12 +28,13 @@ jobs:
           fetch-depth: 1
 
       - name: Install Dependencies
+        # Defense in depth: do not pass Turbo remote cache credentials and
+        # disable the pnpm store cache so release builds always resolve
+        # packages from the registry and rebuild every task from source,
+        # rather than restoring from a (potentially poisoned) cache.
         uses: ./.github/actions/install-dependencies
         with:
-          turbo-api: ${{ secrets.TURBO_API }}
-          turbo-team: ${{ secrets.TURBO_TEAM }}
-          turbo-token: ${{ secrets.TURBO_TOKEN }}
-          turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+          disable-cache: "true"
 
       - run: echo ${{ github.head_ref }}
 


### PR DESCRIPTION
_Defense in depth for our release pipelines._

This makes our release workflows opt out of both layers of build-time caching:

1. **Turbo remote cache** — the `changesets`, `hotfix-release`, and `prerelease` workflows no longer pass the `TURBO_API` / `TURBO_TEAM` / `TURBO_TOKEN` / `TURBO_REMOTE_CACHE_SIGNATURE_KEY` secrets to the `install-dependencies` composite action. Because those env vars are never set, Turbo cannot read from or write to the remote cache for these runs — it falls back to local-only (which on a fresh CI runner is empty anyway).
2. **pnpm store cache** — `install-dependencies` now accepts a `disable-cache: "true"` input that omits `cache: "pnpm"` from `setup-node`, so the pnpm store is resolved freshly from the registry instead of being restored from the GitHub Actions cache.

The result: published artifacts are always built from source against packages freshly fetched from the npm registry, rather than being restored from a (potentially poisoned) local or remote cache entry.

Affected workflows:

- `.github/workflows/changesets.yml` — main release pipeline (publishes to npm + non-npm deployments)
- `.github/workflows/hotfix-release.yml` — manual hotfix publishes (wrangler / miniflare / create-cloudflare)
- `.github/workflows/prerelease.yml` — prereleases via `pkg-pr-new`

All other CI jobs (test / check / regular PR builds) keep both caches for performance — only release-publishing paths are affected.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: CI-only change. It removes inputs from a composite action invocation and adds a gated `setup-node` step. No package code changes.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal CI hardening with no user-facing impact.