### PR TITLE
fix(wrangler): stop rewriting query strings that contain the request Host

### DIFF
--- a/.changeset/fix-wrangler-dev-query-string-rewrite.md
+++ b/.changeset/fix-wrangler-dev-query-string-rewrite.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: stop rewriting query strings that happen to contain the request `Host`
+
+`wrangler dev` previously rewrote occurrences of the outer host inside `request.url`'s query string. For example, a request to `?echo=https%3A%2F%2Fdevelopment.test%2Fpath` with `Host: development.test` would be seen by the user worker as `?echo=https%3A%2F%2Fproduction.test%2Fpath`, silently mutating opaque application data such as `redirect_uri` values in OAuth flows.
+
+The proxy worker now sets the internal `MF-Original-URL` header *after* its blanket host-rewriting pass over request headers, so the URL passed to the user worker preserves the original query string.

--- a/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
@@ -129,7 +129,6 @@ export class ProxyWorker implements DurableObject {
 				proxyData.userWorkerInnerUrlOverrides ?? {},
 				request.url
 			);
-			headers.set("MF-Original-URL", innerUrl.href);
 
 			// Preserve client `Accept-Encoding`, rather than using Worker's default
 			// of `Accept-Encoding: br, gzip`
@@ -137,6 +136,11 @@ export class ProxyWorker implements DurableObject {
 			if (encoding !== undefined) headers.set("Accept-Encoding", encoding);
 
 			rewriteUrlRelatedHeaders(headers, outerUrl, innerUrl);
+
+			// Set after `rewriteUrlRelatedHeaders` so that any occurrences of the
+			// outer host inside the URL's query string (e.g. `?redirect_uri=`)
+			// are preserved in `request.url` inside the user worker.
+			headers.set("MF-Original-URL", innerUrl.href);
 
 			// merge proxyData headers with the request headers
 			for (const [key, value] of Object.entries(proxyData.headers ?? {})) {


### PR DESCRIPTION
Fixes #13871

`wrangler dev` previously rewrote occurrences of the outer hostname inside `request.url`'s query string when it appeared as URL-encoded application data (e.g. an OAuth `redirect_uri` value). The user worker's `request.url` would show `production.test` instead of the `development.test` the client actually sent.

## Root cause

In `packages/wrangler/templates/startDevWorker/ProxyWorker.ts#processQueue`:
1. `headers.set("MF-Original-URL", innerUrl.href)` was set *before* `rewriteUrlRelatedHeaders(headers, outerUrl, innerUrl)`.
2. `rewriteUrlRelatedHeaders` iterates **all** headers and does `value.replaceAll(from.host, to.host)` on any value containing `from.host`.
3. Since `innerUrl.href` contains the URL-encoded query string and that query string contains the outer host, the rewrite mutated the URL passed to the user worker via `MF-Original-URL`.

The user worker reads `MF-Original-URL` to construct `request.url`, which is why the rewritten query string surfaced inside the worker.

## Fix

Move `headers.set("MF-Original-URL", innerUrl.href)` to *after* `rewriteUrlRelatedHeaders`. `MF-Original-URL` is no longer in scope for the blanket rewrite, so the original query string is preserved.

## Notes on broader scope

The same class of bug could affect other URL-bearing headers (Cookie, Referer, etc.) that happen to contain the outer hostname as a substring in non-host position — `rewriteUrlRelatedHeaders` uses blanket `replaceAll`, not URL-aware rewriting. This PR targets the most visible symptom (URL passed to user worker). Happy to follow up with a broader fix to make `rewriteUrlRelatedHeaders` URL-aware if maintainers want.

---

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows:
    - Verified manually using the reporter's repro: https://github.com/dylanpyle/wrangler-rewrite-repro
    - A regression test would need e2e setup (a `wrangler dev` process + a worker that echoes `request.url`). Happy to add one in `packages/wrangler/e2e/dev.test.ts` if maintainers want.
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal bug fix, no public API change