### PR TITLE
[wrangler] fix: re-read refresh_token from disk to avoid 401 from sibling-process rotation

### DIFF
--- a/.changeset/fix-oauth-refresh-stale-token.md
+++ b/.changeset/fix-oauth-refresh-stale-token.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Fix `Failed to fetch auth token: 401 Unauthorized` from sibling-rotated refresh tokens
+
+`refreshToken` previously used the refresh token from module-level `localState`, which is populated once at startup and never re-read. OAuth refresh tokens are single-use, so when a sibling wrangler process (in another repo, another shell, or a parallel script) refreshes first, it rotates the token server-side and writes the new value to the shared config file (`~/Library/Preferences/.wrangler/config/default.toml` on macOS). The long-lived process — typically `wrangler dev` — then sends its stale in-memory token on the next refresh and gets `401 Unauthorized` from `https://dash.cloudflare.com/oauth2/token`, falling through to interactive login and timing out unattended.
+
+`refreshToken` now calls `reinitialiseAuthTokens()` before exchanging, picking up the latest refresh token written by any sibling process. The previously empty `catch {}` also now logs the underlying error at debug level so future refresh failures are diagnosable without source-diving.

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -445,6 +445,72 @@ describe("User", () => {
 			expect(std.out).toContain("access_token_success_mock");
 		});
 
+		it("should re-read refresh_token from disk before refreshing in case a sibling process rotated it", async ({
+			expect,
+		}) => {
+			// Bug repro: when a long-lived wrangler process (e.g. `wrangler dev`) holds a
+			// refresh_token in module-level localState, and a sibling wrangler invocation
+			// rotates the token on disk, the long-lived process's next refresh sends the
+			// stale RT and gets 401 Unauthorized — falling through to interactive login.
+			// See real-world logs: same RT sent by two processes 60min apart, second 401'd.
+			setIsTTY(false);
+
+			// Process startup state: both localState and disk have RT_A; access expired.
+			const pastDate = new Date(Date.now() - 100_000_000).toISOString();
+			writeAuthConfigFile({
+				oauth_token: "expired-access",
+				refresh_token: "RT_A",
+				expiration_time: pastDate,
+				scopes: ["account:read"],
+			});
+
+			// Sibling process refresh: rotates RT_A → RT_B on disk. Bypass
+			// writeAuthConfigFile (which would call reinitialiseAuthTokens and update
+			// OUR localState) by writing the file directly — this simulates what
+			// another wrangler process running concurrently actually does.
+			const fs = await import("node:fs");
+			const TOML = (await import("smol-toml")).default;
+			fs.writeFileSync(
+				getAuthConfigFilePath(),
+				TOML.stringify({
+					oauth_token: "sibling-fresh-access",
+					refresh_token: "RT_B",
+					expiration_time: new Date(Date.now() + 3600_000).toISOString(),
+					scopes: ["account:read"],
+				})
+			);
+
+			// CF token endpoint: rotated RT_A returns 401, current RT_B succeeds.
+			// Matches the exact failure mode observed in production logs.
+			msw.use(
+				http.post("*/oauth2/token", async ({ request }) => {
+					const body = new URLSearchParams(await request.text());
+					const rt = body.get("refresh_token");
+					if (rt === "RT_A") {
+						return new HttpResponse(null, {
+							status: 401,
+							statusText: "Unauthorized",
+						});
+					}
+					return HttpResponse.json({
+						access_token: "fresh-access-token",
+						expires_in: 3600,
+						refresh_token: "RT_B_NEXT",
+						scope: "account:read",
+						token_type: "bearer",
+					});
+				})
+			);
+
+			// With the fix, refreshToken() re-reads the file before exchanging,
+			// finds RT_B, and the command prints the fresh access token.
+			// Without the fix, the stale RT_A is sent, 401 is returned, the empty
+			// catch in refreshToken() swallows it, and the command falls through to
+			// interactive login — which in non-TTY mode throws.
+			await runWrangler("auth token");
+			expect(std.out).toContain("fresh-access-token");
+		});
+
 		it("should error when not logged in", async ({ expect }) => {
 			await expect(runWrangler("auth token")).rejects.toThrowError(
 				"Not logged in. Please run `wrangler login` to authenticate."

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -1,3 +1,4 @@
+import { writeFileSync } from "node:fs";
 import {
 	COMPLIANCE_REGION_CONFIG_UNKNOWN,
 	getGlobalWranglerConfigPath,
@@ -8,6 +9,7 @@ import {
 } from "@cloudflare/workers-utils/test-helpers";
 import ci from "ci-info";
 import { http, HttpResponse } from "msw";
+import TOML from "smol-toml";
 import { beforeEach, describe, it, vi } from "vitest";
 import { saveToConfigCache } from "../config-cache";
 import {
@@ -468,9 +470,7 @@ describe("User", () => {
 			// writeAuthConfigFile (which would call reinitialiseAuthTokens and update
 			// OUR localState) by writing the file directly — this simulates what
 			// another wrangler process running concurrently actually does.
-			const fs = await import("node:fs");
-			const TOML = (await import("smol-toml")).default;
-			fs.writeFileSync(
+			writeFileSync(
 				getAuthConfigFilePath(),
 				TOML.stringify({
 					oauth_token: "sibling-fresh-access",

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -1226,7 +1226,13 @@ function isAccessTokenExpired(): boolean {
 }
 
 async function refreshToken(): Promise<boolean> {
-	// refresh
+	// Re-read the auth config from disk before refreshing. OAuth refresh tokens are
+	// single-use: when a sibling wrangler process refreshes, it rotates the token
+	// server-side and writes the new value to the shared config file. A long-lived
+	// process (e.g. `wrangler dev`) that loaded its refresh_token at startup would
+	// otherwise send the stale value here and get a 401 from the token endpoint.
+	reinitialiseAuthTokens();
+
 	try {
 		const {
 			token: { value: oauth_token, expiry: expiration_time } = {
@@ -1243,7 +1249,10 @@ async function refreshToken(): Promise<boolean> {
 			scopes,
 		});
 		return true;
-	} catch {
+	} catch (e) {
+		logger.debug(
+			`Token refresh failed: ${e instanceof Error ? e.message : String(e)}`
+		);
 		return false;
 	}
 }


### PR DESCRIPTION
## Summary

`refreshToken` in `packages/wrangler/src/user/user.ts` uses the refresh token cached in module-level `localState`, which is populated once at process startup and never re-read. OAuth refresh tokens are single-use: when a sibling wrangler process (another repo, another shell, or a parallel script) refreshes first, it rotates the token server-side and writes the new value to the shared global config file (`~/Library/Preferences/.wrangler/config/default.toml` on macOS, equivalents elsewhere). The long-lived process — typically `wrangler dev` — then sends its stale in-memory token on the next refresh and gets `401 Unauthorized` from `https://dash.cloudflare.com/oauth2/token`, falling through to a fresh interactive OAuth login.

This matches every `Failed to fetch auth token: 401 Unauthorized` report I can find — and reproduces deterministically in a unit test.

## Evidence from a real failure

Two wrangler processes on the same machine, started 60 minutes apart in different repos, both sent the same `refresh_token=07RHxMHc…`:

```
01:13:36 UTC  wrangler dev (repo A)         reads default.toml → RT_A
                                            holds RT_A in module-level localState
02:13:28 UTC  wrangler deploy (repo B)      reads default.toml → also RT_A
                                            refreshes successfully, CF rotates → RT_B
                                            writes RT_B to default.toml
02:53:41 UTC  wrangler dev (repo A)         access token expired, refresh fires
                                            sends stale RT_A from localState
                                            ← 401 Unauthorized
                                            → empty catch{} swallows the error
                                            → falls through to OAuth login prompt
```

## Fix

Two changes inside `refreshToken()` (`packages/wrangler/src/user/user.ts`):

1. **Call `reinitialiseAuthTokens()` before exchanging.** Re-reads `default.toml` so the refresh request uses whatever value is currently on disk, not whatever was on disk when this process started. Cheap, idiomatic, eliminates the race for the realistic case where the sibling write lands seconds-to-hours before this refresh.
2. **Replace the empty `catch {}` with a `logger.debug` call.** The current swallowed error is *exactly* why this bug was hard to diagnose — `WRANGLER_LOG=debug` will now surface the failure mode.

A proper `flock`-style fix on `default.toml` is nicer but materially harder; this gets 99%+ of cases.

## Test plan

- [x] Added unit test in `packages/wrangler/src/__tests__/user.test.ts` (`should re-read refresh_token from disk before refreshing in case a sibling process rotated it`) — fails on `main`, passes with this change
- [x] Full `pnpm test -F wrangler src/__tests__/user.test.ts` — 51/51 pass
- [x] `pnpm test -F wrangler src/__tests__/deploy/core.test.ts` (other refresh-touching tests) — 48/48 pass
- [x] `pnpm check:type -F wrangler` clean
- [x] `oxlint --deny-warnings --type-aware` clean
- [x] `oxfmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): 
  - [x] Documentation not necessary because: bug fix
