### PR TITLE
devprod-status-bot: alert on api-labeled issues

### DIFF
--- a/.changeset/devprod-status-bot-api-issue-alerts.md
+++ b/.changeset/devprod-status-bot-api-issue-alerts.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/devprod-status-bot": minor
+---
+
+Post a Chat alert when an issue is opened with the `api` label, or when the `api` label is added to an existing issue
+
+Routes alerts to a new `API_ISSUES_WEBHOOK` so the team room watching the Workers SDK community channel gets realtime visibility into incoming api-tagged issues.

--- a/packages/devprod-status-bot/src/index.ts
+++ b/packages/devprod-status-bot/src/index.ts
@@ -299,6 +299,35 @@ function isRepositoryAdvisoryEvent(
 	return null;
 }
 
+/**
+ * Returns the issue event if a new issue was opened with the `api` label, or
+ * if the `api` label was just added to an existing issue. Returns null
+ * otherwise.
+ */
+function isApiLabeledIssueEvent(message: WebhookEvent): IssuesEvent | null {
+	if (!("issue" in message) || !("action" in message)) {
+		return null;
+	}
+	if ("pull_request" in message.issue) {
+		return null;
+	}
+
+	const event = message as IssuesEvent;
+
+	if (event.action === "opened") {
+		const hasApiLabel = event.issue.labels?.some(
+			(label) => label.name === "api"
+		);
+		return hasApiLabel ? event : null;
+	}
+
+	if (event.action === "labeled" && event.label?.name === "api") {
+		return event;
+	}
+
+	return null;
+}
+
 function isCheckRunCompleted(
 	message: WebhookEvent
 ): message is CheckRunCompletedEvent {
@@ -477,6 +506,55 @@ async function sendRepositoryAdvisoryAlert(
 			],
 		},
 		"-repository-advisory-" + advisory.ghsa_id
+	);
+}
+
+async function sendApiIssueAlert(webhookUrl: string, event: IssuesEvent) {
+	return sendMessage(
+		webhookUrl,
+		{
+			cardsV2: [
+				{
+					cardId: "api-issue-" + event.issue.number,
+					card: {
+						header: {
+							title: `🏷️ New api-labeled issue`,
+							subtitle: `#${event.issue.number} in ${event.repository.full_name}`,
+							imageUrl: event.issue.user.avatar_url,
+							imageType: "CIRCLE",
+							imageAltText: "Reporter Avatar",
+						},
+						sections: [
+							{
+								collapsible: false,
+								widgets: [
+									{
+										textParagraph: {
+											text: `<b>Title:</b> ${event.issue.title}\n\n<b>Reporter:</b> ${event.issue.user.login}`,
+										},
+									},
+									{
+										buttonList: {
+											buttons: [
+												{
+													text: "View Issue",
+													onClick: {
+														openLink: {
+															url: event.issue.html_url,
+														},
+													},
+												},
+											],
+										},
+									},
+								],
+							},
+						],
+					},
+				},
+			],
+		},
+		"-api-issue-" + event.issue.number
 	);
 }
 
@@ -749,6 +827,11 @@ export default {
 					env.ALERTS_WEBHOOK,
 					maybeVersionPackagesFailure
 				);
+			}
+			// Notifies when an issue is opened with the `api` label, or the `api` label is added to an existing issue
+			const maybeApiIssue = isApiLabeledIssueEvent(body);
+			if (maybeApiIssue) {
+				await sendApiIssueAlert(env.API_ISSUES_WEBHOOK, maybeApiIssue);
 			}
 		}
 

--- a/packages/devprod-status-bot/worker-configuration.d.ts
+++ b/packages/devprod-status-bot/worker-configuration.d.ts
@@ -3,6 +3,7 @@
 
 interface Env {
 	ALERTS_WEBHOOK: string;
+	API_ISSUES_WEBHOOK: string;
 	GITHUB_PAT: string;
 	PROD_TEAM_ONLY_WEBHOOK: string;
 	PROD_WEBHOOK: string;


### PR DESCRIPTION
Extends `devprod-status-bot` to post a Chat card when an issue is opened with the `api` label or when the `api` label is added to an existing issue. Used by the Workers SDK API triage group to get realtime visibility into incoming api-tagged community reports.

Routes through a new `API_ISSUES_WEBHOOK` secret on the deployed Worker (set via `wrangler secret put`), so no new repo secret is needed.

Originally drafted as a standalone GitHub Actions workflow; pivoted to extending the existing bot per maintainer feedback in chat - reuses the bot's `/github` webhook plumbing, `sendMessage` threading, and card patterns. Detection function is action-aware (`opened` with label vs. `labeled` with `api`), so adding unrelated labels to an already-api-tagged issue does not re-fire.

---

- Tests
  - [ ] Tests included/updated
  - [x] Additional testing not necessary because: internal team tooling
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal team tooling

*A picture of a cute animal (not mandatory, but encouraged)*
<img width="349" height="360" alt="image" src="https://github.com/user-attachments/assets/9be60a9b-a57e-46b9-9df9-5c7dde0212a4" />