### PR TITLE
[miniflare] Fix /cdn-cgi/* host validation incorrectly accepting subdomains of exact configured routes

### DIFF
--- a/.changeset/fix-cdn-cgi-host-validation.md
+++ b/.changeset/fix-cdn-cgi-host-validation.md
@@ -1,0 +1,11 @@
+---
+"miniflare": patch
+"wrangler": patch
+"@cloudflare/vite-plugin": patch
+---
+
+Fix `/cdn-cgi/*` host validation incorrectly accepting subdomains of exact configured routes
+
+Miniflare's `/cdn-cgi/*` host/origin validator was treating exact configured routes the same as wildcard configured routes, so a request whose `Host` or `Origin` hostname was a subdomain of an exact route (e.g. `sub.my-custom-site.com` for a `my-custom-site.com/*` route) was incorrectly accepted. Exact configured routes and the configured `upstream` hostname are now required to match the request hostname exactly. Subdomain matching is only applied to wildcard routes such as `*.example.com/*`. Localhost hostnames continue to be allowed as before.
+
+This affects `wrangler dev` and local development through `@cloudflare/vite-plugin`, both of which use Miniflare under the hood.

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -176,22 +176,30 @@ function validateCdnCgiRequest(
 		return;
 	}
 
-	// Build allowed hostnames set from localhost + user configured routes
-	const allowedHostnames = new Set<string>();
+	// Subdomain matching should only apply to wildcard routes (e.g.
+	// "*.example.com/*"). Exact routes and the configured upstream hostname
+	// must match the request hostname exactly.
+	const exactHostnames = new Set<string>();
+	const wildcardHostnames = new Set<string>();
 	for (const route of routes) {
 		// route.hostname has already had the leading "*" stripped by parseRoutes,
-		// but may have a leading "." for wildcard routes (e.g., "*.example.com" -> ".example.com")
+		// but wildcard routes still carry a leading "." (e.g., "*.example.com" -> ".example.com")
 		const hostname = route.hostname.replace(/^\./, "");
-		if (hostname) {
-			allowedHostnames.add(hostname);
+		if (!hostname) {
+			continue;
+		}
+		if (route.allowHostnamePrefix) {
+			wildcardHostnames.add(hostname);
+		} else {
+			exactHostnames.add(hostname);
 		}
 	}
-	// Add upstream hostname if configured (e.g., from --host or --local-upstream)
+	// Upstream is a single configured host, not a wildcard.
 	if (upstreamUrl) {
 		try {
 			const upstreamHostname = new URL(upstreamUrl).hostname;
 			if (upstreamHostname) {
-				allowedHostnames.add(upstreamHostname);
+				exactHostnames.add(upstreamHostname);
 			}
 		} catch {
 			// Ignore invalid upstream URL
@@ -206,7 +214,7 @@ function validateCdnCgiRequest(
 		} catch {
 			throw new HttpError(403, "Invalid Host header");
 		}
-		if (!isHostnameAllowed(hostHostname, allowedHostnames)) {
+		if (!isHostnameAllowed(hostHostname, exactHostnames, wildcardHostnames)) {
 			throw new HttpError(403, "Invalid Host header");
 		}
 	}
@@ -219,34 +227,36 @@ function validateCdnCgiRequest(
 		} catch {
 			throw new HttpError(403, "Invalid Origin header");
 		}
-		if (!isHostnameAllowed(originHostname, allowedHostnames)) {
+		if (!isHostnameAllowed(originHostname, exactHostnames, wildcardHostnames)) {
 			throw new HttpError(403, "Invalid Origin header");
 		}
 	}
 }
 
 /**
- * Check if a hostname is allowed.
- * - exactHostnames: must match exactly (localhost, upstream, non-wildcard routes)
- * - wildcardHostnames: allow subdomain matching (for wildcard routes like *.example.com)
+ * Checks whether a hostname is allowed.
+ * - exactHostnames: must match exactly (configured non-wildcard routes, upstream)
+ * - wildcardHostnames: also match any subdomain (for wildcard routes like *.example.com)
+ *
+ * Localhost hostnames are always allowed.
  */
 function isHostnameAllowed(
 	hostname: string,
-	allowedHostnames: Set<string>
+	exactHostnames: Set<string>,
+	wildcardHostnames: Set<string>
 ): boolean {
-	// Direct match against exact hostnames
 	if (LOCALHOST_HOSTNAMES.includes(hostname)) {
 		return true;
 	}
-
-	// Check for subdomain matches only against wildcard hostnames
-	for (const allowed of allowedHostnames) {
+	if (exactHostnames.has(hostname)) {
+		return true;
+	}
+	for (const allowed of wildcardHostnames) {
 		// Match the base domain or any subdomain
 		if (hostname === allowed || hostname.endsWith(`.${allowed}`)) {
 			return true;
 		}
 	}
-
 	return false;
 }
 

--- a/packages/miniflare/test/plugins/local-explorer/index.spec.ts
+++ b/packages/miniflare/test/plugins/local-explorer/index.spec.ts
@@ -395,6 +395,48 @@ describe("Local Explorer works with custom routes", () => {
 		expect(res.status).toBe(403);
 		await res.arrayBuffer();
 	});
+
+	// An exact configured route must not authorize subdomains of that route.
+	// Subdomain matching should only apply to wildcard routes.
+	test("blocks Origin that is a subdomain of an exact configured route", async ({
+		expect,
+	}) => {
+		const res = await mf.dispatchFetch(`${BASE_URL}/storage/kv/namespaces`, {
+			headers: { Origin: "https://sub.my-custom-site.com" },
+		});
+		expect(res.status).toBe(403);
+		await res.arrayBuffer();
+	});
+
+	test("blocks Host that is a subdomain of an exact configured route", async ({
+		expect,
+	}) => {
+		const url = await mf.ready;
+		const status = await new Promise<number>((resolve, reject) => {
+			const req = http.get(
+				`${url.origin}${CorePaths.EXPLORER}/api/storage/kv/namespaces`,
+				{ setHost: false, headers: { Host: "sub.my-custom-site.com" } },
+				(res) => {
+					res.resume();
+					resolve(res.statusCode ?? 0);
+				}
+			);
+			req.on("error", reject);
+		});
+		expect(status).toBe(403);
+	});
+
+	test("blocks look-alike hostname that ends with the exact route", async ({
+		expect,
+	}) => {
+		// Guards against a naive endsWith() bypass: `evilmy-custom-site.com`
+		// should NOT be accepted just because the suffix matches.
+		const res = await mf.dispatchFetch(`${BASE_URL}/storage/kv/namespaces`, {
+			headers: { Origin: "https://evilmy-custom-site.com" },
+		});
+		expect(res.status).toBe(403);
+		await res.arrayBuffer();
+	});
 });
 
 describe("Local Explorer works with wildcard routes", () => {
@@ -431,6 +473,107 @@ describe("Local Explorer works with wildcard routes", () => {
 			headers: { Origin: "https://sub.example.com" },
 		});
 		expect(res.status).toBe(200);
+		await res.arrayBuffer();
+	});
+
+	test("allows Origin that is a deep subdomain of a wildcard route", async ({
+		expect,
+	}) => {
+		const res = await mf.dispatchFetch(`${BASE_URL}/storage/kv/namespaces`, {
+			headers: { Origin: "https://a.b.example.com" },
+		});
+		expect(res.status).toBe(200);
+		await res.arrayBuffer();
+	});
+
+	test("blocks look-alike sibling hostname not under the wildcard route", async ({
+		expect,
+	}) => {
+		// `notexample.com` ends with `example.com` but is not a subdomain of it.
+		// Guards against a naive endsWith() match without a dot boundary.
+		const res = await mf.dispatchFetch(`${BASE_URL}/storage/kv/namespaces`, {
+			headers: { Origin: "https://notexample.com" },
+		});
+		expect(res.status).toBe(403);
+		await res.arrayBuffer();
+	});
+});
+
+// The configured `upstream` hostname is a single host, not a wildcard.
+// Subdomains of the upstream hostname must not be authorized for /cdn-cgi/*
+// requests.
+describe("Local Explorer works with upstream", () => {
+	let mf: Miniflare;
+
+	beforeAll(async () => {
+		mf = new Miniflare({
+			inspectorPort: 0,
+			compatibilityDate: "2025-01-01",
+			modules: true,
+			script: `export default { fetch() { return new Response("user worker"); } }`,
+			unsafeLocalExplorer: true,
+			kvNamespaces: {
+				TEST_KV: "test-kv-id",
+			},
+			upstream: "https://upstream-host.example/",
+		});
+	});
+
+	afterAll(async () => {
+		await disposeWithRetry(mf);
+	});
+
+	test("allows configured upstream host exactly", async ({ expect }) => {
+		const url = await mf.ready;
+		const status = await new Promise<number>((resolve, reject) => {
+			const req = http.get(
+				`${url.origin}${CorePaths.EXPLORER}/api/storage/kv/namespaces`,
+				{ setHost: false, headers: { Host: "upstream-host.example" } },
+				(res) => {
+					res.resume();
+					resolve(res.statusCode ?? 0);
+				}
+			);
+			req.on("error", reject);
+		});
+		expect(status).toBe(200);
+	});
+
+	test("blocks subdomain of configured upstream host (Host header)", async ({
+		expect,
+	}) => {
+		const url = await mf.ready;
+		const status = await new Promise<number>((resolve, reject) => {
+			const req = http.get(
+				`${url.origin}${CorePaths.EXPLORER}/api/storage/kv/namespaces`,
+				{ setHost: false, headers: { Host: "sub.upstream-host.example" } },
+				(res) => {
+					res.resume();
+					resolve(res.statusCode ?? 0);
+				}
+			);
+			req.on("error", reject);
+		});
+		expect(status).toBe(403);
+	});
+
+	test("blocks subdomain of configured upstream host (Origin header)", async ({
+		expect,
+	}) => {
+		const res = await mf.dispatchFetch(`${BASE_URL}/storage/kv/namespaces`, {
+			headers: { Origin: "https://sub.upstream-host.example" },
+		});
+		expect(res.status).toBe(403);
+		await res.arrayBuffer();
+	});
+
+	test("blocks unrelated external host even with upstream configured", async ({
+		expect,
+	}) => {
+		const res = await mf.dispatchFetch(`${BASE_URL}/storage/kv/namespaces`, {
+			headers: { Origin: "https://evil.com" },
+		});
+		expect(res.status).toBe(403);
 		await res.arrayBuffer();
 	});
 });


### PR DESCRIPTION
Miniflare's `/cdn-cgi/*` host/origin validator was treating exact configured routes the same as wildcard configured routes. A request whose `Host` or `Origin` hostname was a subdomain of an exact configured route (e.g. `sub.my-custom-site.com` for a `my-custom-site.com/*` route) was therefore incorrectly accepted on `/cdn-cgi/*` endpoints, including the local explorer API. The same applied to the configured `upstream` hostname.

The validator in `packages/miniflare/src/workers/core/entry.worker.ts` now keeps exact and wildcard hosts in separate buckets. Exact configured routes and the configured upstream hostname must match the request hostname exactly. Subdomain matching is only applied to wildcard routes such as `*.example.com/*`. Localhost hostnames continue to be allowed as before.

This also covers `wrangler dev` and local development through `@cloudflare/vite-plugin`, both of which use Miniflare under the hood.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is an internal change to `/cdn-cgi/*` host validation in Miniflare; there is no public API or user-facing configuration change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->