### PR TITLE
refactor deploy/versions upload (part 1)

### DIFF
--- a/.changeset/versions-upload-keep-vars.md
+++ b/.changeset/versions-upload-keep-vars.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Add `--keep-vars` flag to `wrangler versions upload`, matching the existing behavior in `wrangler deploy`. When set, environment variables configured via the dashboard are preserved rather than being deleted before the upload.

--- a/packages/wrangler/src/__tests__/deploy/config-args-merging.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/config-args-merging.test.ts
@@ -1187,7 +1187,38 @@ describe("config/args merging", () => {
 		});
 
 		describe("versions upload", () => {
-			// versions upload has no --keep-vars CLI flag; only config.keep_vars applies
+			it("without --keep-vars, keepVars is not set", async ({ expect }) => {
+				writeWranglerConfig({ main: "./index.js" });
+				writeWorkerSource();
+				mockGetScript();
+				const requests = mockUploadVersion();
+				await runWrangler("versions upload");
+				const metadata = await getMetadata(requests[requests.length - 1]);
+				expect(metadata.keep_bindings).toEqual(
+					expect.arrayContaining(["secret_text", "secret_key"])
+				);
+				expect(metadata.keep_bindings).not.toEqual(
+					expect.arrayContaining(["plain_text"])
+				);
+			});
+
+			it("--keep-vars alone enables keep_bindings", async ({ expect }) => {
+				writeWranglerConfig({ main: "./index.js", keep_vars: false });
+				writeWorkerSource();
+				mockGetScript();
+				const requests = mockUploadVersion();
+				await runWrangler("versions upload --keep-vars");
+				const metadata = await getMetadata(requests[requests.length - 1]);
+				expect(metadata.keep_bindings).toEqual(
+					expect.arrayContaining([
+						"plain_text",
+						"json",
+						"secret_text",
+						"secret_key",
+					])
+				);
+			});
+
 			it("config.keep_vars=true adds plain_text and json to keep_bindings", async ({
 				expect,
 			}) => {

--- a/packages/wrangler/src/deploy/autoconfig.ts
+++ b/packages/wrangler/src/deploy/autoconfig.ts
@@ -1,0 +1,335 @@
+import { statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import {
+	configFileName,
+	getTodaysCompatDate,
+	UserError,
+	type Config,
+} from "@cloudflare/workers-utils";
+import chalk from "chalk";
+import { getDetailsForAutoConfig } from "../autoconfig/details";
+import { runAutoConfig } from "../autoconfig/run";
+import {
+	sendAutoConfigProcessEndedMetricsEvent,
+	sendAutoConfigProcessStartedMetricsEvent,
+} from "../autoconfig/telemetry-utils";
+import { readConfig } from "../config";
+import { confirm, prompt } from "../dialogs";
+import { isNonInteractiveOrCI } from "../is-interactive";
+import { logger } from "../logger";
+import { writeOutput } from "../output";
+import { maybeDelegateToOpenNextDeployCommand } from "./open-next";
+import type { ReadConfigCommandArgs } from "../config";
+
+type AutoConfigArgs = ReadConfigCommandArgs & {
+	experimentalAutoconfig: boolean | undefined;
+	assets: string | undefined;
+	dryRun: boolean | undefined;
+	latest: boolean | undefined;
+	compatibilityDate: string | undefined;
+};
+
+/**
+ * Runs autoconfig if applicable, including open-next delegation and interactive
+ * prompts for missing config. Returns `{ aborted: true }` if deploy should not
+ * proceed (user declined or delegated to open-next), otherwise returns the
+ * potentially-updated config and args.
+ */
+export async function maybeRunAutoConfig<Args extends AutoConfigArgs>(
+	args: Args,
+	config: Config
+): Promise<{ args: Args; config: Config; aborted: boolean }> {
+	const shouldRunAutoConfig =
+		args.experimentalAutoconfig &&
+		// If there is a positional parameter, an assets directory specified via --assets, or an
+		// explicit --config path then we don't want to run autoconfig since we assume that the
+		// user knows what they are doing and that they are specifying what needs to be deployed
+		!args.script &&
+		!args.assets &&
+		!args.config;
+	if (
+		config.pages_build_output_dir &&
+		// Note: autoconfig handle Pages projects on its own, so we don't want to hard fail here if autoconfig run
+		!shouldRunAutoConfig
+	) {
+		throw new UserError(
+			"It looks like you've run a Workers-specific command in a Pages project.\n" +
+				"For Pages, please run `wrangler pages deploy` instead.",
+			{ telemetryMessage: "deploy command pages project mismatch" }
+		);
+	}
+	if (shouldRunAutoConfig) {
+		sendAutoConfigProcessStartedMetricsEvent({
+			command: "wrangler deploy",
+			dryRun: !!args.dryRun,
+		});
+
+		try {
+			const details = await getDetailsForAutoConfig({
+				wranglerConfig: config,
+			});
+
+			if (details.framework?.id === "cloudflare-pages") {
+				// If the project is a Pages project then warn the user but allow them to proceed if they wish so
+				logger.warn(
+					"It seems that you have run `wrangler deploy` on a Pages project, `wrangler pages deploy` should be used instead. Proceeding will likely produce unwanted results."
+				);
+				const proceedWithPagesProject = await confirm(
+					"Are you sure that you want to proceed?",
+					{
+						defaultValue: false,
+						fallbackValue: true,
+					}
+				);
+
+				if (!proceedWithPagesProject) {
+					sendAutoConfigProcessEndedMetricsEvent({
+						success: false,
+						command: "wrangler deploy",
+						dryRun: !!args.dryRun,
+					});
+					return { args, config, aborted: true };
+				}
+			} else if (!details.configured) {
+				// Only run auto config if the project is not already configured
+				const autoConfigSummary = await runAutoConfig(details);
+
+				writeOutput({
+					type: "autoconfig",
+					version: 1,
+					command: "deploy",
+					summary: autoConfigSummary,
+				});
+
+				// If autoconfig worked, there should now be a new config file, and so we need to read config again
+				config = readConfig(args, {
+					hideWarnings: false,
+					useRedirectIfAvailable: true,
+				});
+			}
+		} catch (error) {
+			sendAutoConfigProcessEndedMetricsEvent({
+				command: "wrangler deploy",
+				dryRun: !!args.dryRun,
+				success: false,
+				error,
+			});
+			throw error;
+		}
+
+		sendAutoConfigProcessEndedMetricsEvent({
+			success: true,
+			command: "wrangler deploy",
+			dryRun: !!args.dryRun,
+		});
+	}
+
+	// Note: the open-next delegation should happen after we run the auto-config logic so that we
+	//       make sure that the deployment of brand newly auto-configured Next.js apps is correctly
+	//       delegated here
+	const deploymentDelegatedToOpenNext =
+		// Currently the delegation to open-next is gated behind the autoconfig experimental flag, this is because
+		// this behavior is currently only necessary in the autoconfig flow and having it un-gated/stable in wrangler
+		// releases caused different issues. All the issues should have been fixed (by
+		// https://github.com/cloudflare/workers-sdk/pull/11694 and https://github.com/cloudflare/workers-sdk/pull/11710)
+		// but as a precaution we're gating the feature under the autoconfig flag for the time being
+		args.experimentalAutoconfig &&
+		// If the user explicitly provided a --config path, they are targeting a specific Worker config and we should not delegate to open-next
+		!args.config &&
+		!args.dryRun &&
+		(await maybeDelegateToOpenNextDeployCommand(process.cwd()));
+
+	if (deploymentDelegatedToOpenNext) {
+		return { args, config, aborted: true };
+	}
+
+	// Prompt for missing config (directory-as-assets, name, compat date, config file writing)
+	args = await promptForMissingConfig(args, config);
+
+	return { args, config, aborted: false };
+}
+
+/**
+ * Interactively prompts for missing deploy configuration. Handles two phases:
+ *
+ * 1. If the positional `script` arg is a directory and no config file exists,
+ *    asks whether the user intends to deploy static assets.
+ * 2. Prompts for missing name and compatibility date, and optionally writes a
+ *    new wrangler.jsonc config file.
+ *
+ * No-op in non-interactive / CI environments.
+ */
+async function promptForMissingConfig<Args extends AutoConfigArgs>(
+	args: Args,
+	config: { configPath?: string; compatibility_date?: string; name?: string }
+): Promise<Args> {
+	// Phase 1: detect `wrangler deploy <directory>` and offer to treat it as assets
+	let scriptIsDirectory = false;
+	if (!config.configPath && args.script) {
+		try {
+			const stats = statSync(args.script);
+			if (stats.isDirectory()) {
+				scriptIsDirectory = true;
+				args = await promptForMissingAssetFlag(args.script, args);
+			}
+		} catch (error) {
+			// If this is our UserError, re-throw it
+			if (error instanceof UserError) {
+				throw error;
+			}
+			// If stat fails, let the original flow handle the error
+		}
+	}
+
+	// Phase 2: prompt for name / compat-date / config file.
+	// Skip when the user was offered an assets deployment and declined (script is still a directory) —
+	// getEntry will produce the appropriate error about the directory entry point.
+	if (scriptIsDirectory && !args.assets) {
+		return args;
+	}
+
+	return promptForMissingDeployConfig(args, config);
+}
+
+/**
+ * Handles the case where a user provides a directory as a positional argument,
+ * probably intending to deploy static assets. e.g. `wrangler deploy ./public`.
+ * If the user confirms, sets `args.assets` and clears `args.script`.
+ */
+export async function promptForMissingAssetFlag<Args extends AutoConfigArgs>(
+	assetDirectory: string,
+	args: Args
+): Promise<Args> {
+	if (isNonInteractiveOrCI()) {
+		return args;
+	}
+
+	// Ask if user intended to deploy assets only
+	logger.log("");
+	if (!args.assets) {
+		const deployAssets = await confirm(
+			"It looks like you are trying to deploy a directory of static assets only. Is this correct?",
+			{ defaultValue: true }
+		);
+		logger.log("");
+		if (deployAssets) {
+			args.assets = assetDirectory;
+			args.script = undefined;
+		} else {
+			// let the usual error handling path kick in
+			return args;
+		}
+	}
+
+	return args;
+}
+
+/**
+ * Interactively prompts for missing deployment configuration (name, compatibility date,
+ * and optionally config file writing when no config file exists).
+ * No-op in non-interactive/CI environments or when all required config is already present.
+ */
+export async function promptForMissingDeployConfig<Args extends AutoConfigArgs>(
+	args: Args,
+	config: { configPath?: string; compatibility_date?: string; name?: string }
+): Promise<Args> {
+	if (isNonInteractiveOrCI()) {
+		return args;
+	}
+
+	let promptedForMissing = false;
+
+	// Prompt for name when missing from both CLI args and config
+	if (!args.name && !config.name) {
+		const defaultName = process
+			.cwd()
+			.split(path.sep)
+			.pop()
+			?.replaceAll("_", "-")
+			.trim();
+		const isValidName = defaultName && /^[a-zA-Z0-9-]+$/.test(defaultName);
+		const projectName = await prompt("What do you want to name your project?", {
+			defaultValue: isValidName ? defaultName : "my-project",
+		});
+		args.name = projectName;
+		logger.log("");
+		promptedForMissing = true;
+	}
+
+	// Prompt for compatibility date when missing
+	if (!args.latest && !args.compatibilityDate && !config.compatibility_date) {
+		const compatibilityDateStr = getTodaysCompatDate();
+
+		if (
+			await confirm(
+				`No compatibility date is set. Would you like to use today's date (${compatibilityDateStr})?`
+			)
+		) {
+			args.compatibilityDate = compatibilityDateStr;
+			promptedForMissing = true;
+			logger.log("");
+		} else {
+			throw new UserError(
+				`A compatibility_date is required when publishing. Add it to your ${configFileName(config.configPath)} file or pass \`--compatibility-date\` via CLI.\nSee https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`,
+				{ telemetryMessage: "missing compatibility date when deploying" }
+			);
+		}
+	}
+
+	const hasConfigFile = !!config.configPath;
+
+	// When no config file exists and we prompted for missing config, offer to write one
+	if (!hasConfigFile && promptedForMissing) {
+		// When --latest was used, the compat date prompt was skipped but we still
+		// need a concrete date in the config file for future deploys without --latest
+		const effectiveCompatDate =
+			args.compatibilityDate ??
+			(args.latest ? getTodaysCompatDate() : undefined);
+
+		const configContent: Record<string, unknown> = {
+			name: args.name,
+			compatibility_date: effectiveCompatDate,
+		};
+		if (args.script) {
+			configContent.main = args.script;
+		}
+		if (args.assets) {
+			configContent.assets = { directory: args.assets };
+		}
+
+		const writeConfigFile = await confirm(
+			`Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\n${chalk.dim(
+				"This will allow you to simply run `wrangler deploy` on future deployments."
+			)}`
+		);
+
+		if (writeConfigFile) {
+			const configPath = path.join(process.cwd(), "wrangler.jsonc");
+			const jsonString = JSON.stringify(configContent, null, 2);
+			writeFileSync(configPath, jsonString);
+			logger.log(`Wrote \n${jsonString}\n to ${chalk.bold(configPath)}.`);
+			logger.log(
+				`Simply run ${chalk.bold("`wrangler deploy`")} next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.`
+			);
+		} else {
+			const scriptPart = args.script ? `${args.script} ` : "";
+			const flagParts = [
+				args.name ? `--name ${args.name}` : "",
+				effectiveCompatDate
+					? `--compatibility-date ${effectiveCompatDate}`
+					: "",
+				args.assets ? `--assets ${args.assets}` : "",
+			]
+				.filter(Boolean)
+				.join(" ");
+			logger.log(
+				`You should run ${chalk.bold(
+					`wrangler deploy ${scriptPart}${flagParts}`
+				)} next time to deploy this Worker without going through this flow again.`
+			);
+		}
+		logger.log("\nProceeding with deployment...\n");
+	}
+
+	return args;
+}

--- a/packages/wrangler/src/deploy/autoconfig.ts
+++ b/packages/wrangler/src/deploy/autoconfig.ts
@@ -18,7 +18,6 @@ import { confirm, prompt } from "../dialogs";
 import { isNonInteractiveOrCI } from "../is-interactive";
 import { logger } from "../logger";
 import { writeOutput } from "../output";
-import { maybeDelegateToOpenNextDeployCommand } from "./open-next";
 import type { ReadConfigCommandArgs } from "../config";
 
 type AutoConfigArgs = ReadConfigCommandArgs & {
@@ -38,7 +37,7 @@ type AutoConfigArgs = ReadConfigCommandArgs & {
 export async function maybeRunAutoConfig<Args extends AutoConfigArgs>(
 	args: Args,
 	config: Config
-): Promise<{ args: Args; config: Config; aborted: boolean }> {
+): Promise<{ config: Config; aborted: boolean }> {
 	const shouldRunAutoConfig =
 		args.experimentalAutoconfig &&
 		// If there is a positional parameter, an assets directory specified via --assets, or an
@@ -88,7 +87,7 @@ export async function maybeRunAutoConfig<Args extends AutoConfigArgs>(
 						command: "wrangler deploy",
 						dryRun: !!args.dryRun,
 					});
-					return { args, config, aborted: true };
+					return { config, aborted: true };
 				}
 			} else if (!details.configured) {
 				// Only run auto config if the project is not already configured
@@ -124,29 +123,7 @@ export async function maybeRunAutoConfig<Args extends AutoConfigArgs>(
 		});
 	}
 
-	// Note: the open-next delegation should happen after we run the auto-config logic so that we
-	//       make sure that the deployment of brand newly auto-configured Next.js apps is correctly
-	//       delegated here
-	const deploymentDelegatedToOpenNext =
-		// Currently the delegation to open-next is gated behind the autoconfig experimental flag, this is because
-		// this behavior is currently only necessary in the autoconfig flow and having it un-gated/stable in wrangler
-		// releases caused different issues. All the issues should have been fixed (by
-		// https://github.com/cloudflare/workers-sdk/pull/11694 and https://github.com/cloudflare/workers-sdk/pull/11710)
-		// but as a precaution we're gating the feature under the autoconfig flag for the time being
-		args.experimentalAutoconfig &&
-		// If the user explicitly provided a --config path, they are targeting a specific Worker config and we should not delegate to open-next
-		!args.config &&
-		!args.dryRun &&
-		(await maybeDelegateToOpenNextDeployCommand(process.cwd()));
-
-	if (deploymentDelegatedToOpenNext) {
-		return { args, config, aborted: true };
-	}
-
-	// Prompt for missing config (directory-as-assets, name, compat date, config file writing)
-	args = await promptForMissingConfig(args, config);
-
-	return { args, config, aborted: false };
+	return { config, aborted: false };
 }
 
 /**
@@ -159,7 +136,7 @@ export async function maybeRunAutoConfig<Args extends AutoConfigArgs>(
  *
  * No-op in non-interactive / CI environments.
  */
-async function promptForMissingConfig<Args extends AutoConfigArgs>(
+export async function promptForMissingConfig<Args extends AutoConfigArgs>(
 	args: Args,
 	config: { configPath?: string; compatibility_date?: string; name?: string }
 ): Promise<Args> {

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -22,8 +22,9 @@ import { collectKeyValues } from "../utils/collectKeyValues";
 import { getRules } from "../utils/getRules";
 import { getScriptName } from "../utils/getScriptName";
 import { useServiceEnvironments } from "../utils/useServiceEnvironments";
-import { maybeRunAutoConfig } from "./autoconfig";
+import { maybeRunAutoConfig, promptForMissingConfig } from "./autoconfig";
 import deploy from "./deploy";
+import { maybeDelegateToOpenNextDeployCommand } from "./open-next";
 
 export const deployCommand = createCommand({
 	metadata: {
@@ -124,12 +125,23 @@ export const deployCommand = createCommand({
 		validateDeployVersionsArgs(args);
 	},
 	async handler(args, { config }) {
+		// --- Step 0. Auto-config --- //
 		const autoConfigResult = await maybeRunAutoConfig(args, config);
 		if (autoConfigResult.aborted) {
 			return;
 		}
-		args = autoConfigResult.args;
 		config = autoConfigResult.config;
+
+		// Interatively handle missing/incorrect --assets, --script, --name, --compatibility-date
+		args = await promptForMissingConfig(args, config);
+
+		// Needs to happen after auto-config logic to capture newly auto-configured open-next apps.
+		// As a precaution we're gating the feature under the autoconfig flag for the time being.
+		// If the user explicitly provided a --config path, they are targeting a specific Worker config and we should not delegate
+		if (args.experimentalAutoconfig && !args.config && !args.dryRun) {
+			await maybeDelegateToOpenNextDeployCommand(process.cwd());
+			return;
+		}
 
 		const entry = await getEntry(args, config, "deploy");
 		validateAssetsArgsAndConfig(args, config);

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -138,8 +138,12 @@ export const deployCommand = createCommand({
 		// Needs to happen after auto-config logic to capture newly auto-configured open-next apps.
 		// As a precaution we're gating the feature under the autoconfig flag for the time being.
 		// If the user explicitly provided a --config path, they are targeting a specific Worker config and we should not delegate
-		if (args.experimentalAutoconfig && !args.config && !args.dryRun) {
-			await maybeDelegateToOpenNextDeployCommand(process.cwd());
+		if (
+			args.experimentalAutoconfig &&
+			!args.config &&
+			!args.dryRun &&
+			(await maybeDelegateToOpenNextDeployCommand(process.cwd()))
+		) {
 			return;
 		}
 

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -1,29 +1,17 @@
 import assert from "node:assert";
-import { statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import {
-	configFileName,
 	getTodaysCompatDate,
 	getCIOverrideName,
 	UserError,
 } from "@cloudflare/workers-utils";
-import chalk from "chalk";
 import { getAssetsOptions, validateAssetsArgsAndConfig } from "../assets";
-import { getDetailsForAutoConfig } from "../autoconfig/details";
-import { runAutoConfig } from "../autoconfig/run";
-import {
-	sendAutoConfigProcessEndedMetricsEvent,
-	sendAutoConfigProcessStartedMetricsEvent,
-} from "../autoconfig/telemetry-utils";
-import { readConfig } from "../config";
 import { createCommand } from "../core/create-command";
 import {
 	sharedDeployVersionsArgs,
 	validateDeployVersionsArgs,
 } from "../deployment-bundle/deploy-args";
 import { getEntry } from "../deployment-bundle/entry";
-import { confirm, prompt } from "../dialogs";
-import { isNonInteractiveOrCI } from "../is-interactive";
 import { logger } from "../logger";
 import { verifyWorkerMatchesCITag } from "../match-tag";
 import * as metrics from "../metrics";
@@ -34,8 +22,8 @@ import { collectKeyValues } from "../utils/collectKeyValues";
 import { getRules } from "../utils/getRules";
 import { getScriptName } from "../utils/getScriptName";
 import { useServiceEnvironments } from "../utils/useServiceEnvironments";
+import { maybeRunAutoConfig } from "./autoconfig";
 import deploy from "./deploy";
-import { maybeDelegateToOpenNextDeployCommand } from "./open-next";
 
 export const deployCommand = createCommand({
 	metadata: {
@@ -136,139 +124,12 @@ export const deployCommand = createCommand({
 		validateDeployVersionsArgs(args);
 	},
 	async handler(args, { config }) {
-		const shouldRunAutoConfig =
-			args.experimentalAutoconfig &&
-			// If there is a positional parameter, an assets directory specified via --assets, or an
-			// explicit --config path then we don't want to run autoconfig since we assume that the
-			// user knows what they are doing and that they are specifying what needs to be deployed
-			!args.script &&
-			!args.assets &&
-			!args.config;
-
-		if (
-			config.pages_build_output_dir &&
-			// Note: autoconfig handle Pages projects on its own, so we don't want to hard fail here if autoconfig run
-			!shouldRunAutoConfig
-		) {
-			throw new UserError(
-				"It looks like you've run a Workers-specific command in a Pages project.\n" +
-					"For Pages, please run `wrangler pages deploy` instead.",
-				{ telemetryMessage: "deploy command pages project mismatch" }
-			);
-		}
-
-		if (shouldRunAutoConfig) {
-			sendAutoConfigProcessStartedMetricsEvent({
-				command: "wrangler deploy",
-				dryRun: !!args.dryRun,
-			});
-
-			try {
-				const details = await getDetailsForAutoConfig({
-					wranglerConfig: config,
-				});
-
-				if (details.framework?.id === "cloudflare-pages") {
-					// If the project is a Pages project then warn the user but allow them to proceed if they wish so
-					logger.warn(
-						"It seems that you have run `wrangler deploy` on a Pages project, `wrangler pages deploy` should be used instead. Proceeding will likely produce unwanted results."
-					);
-					const proceedWithPagesProject = await confirm(
-						"Are you sure that you want to proceed?",
-						{
-							defaultValue: false,
-							fallbackValue: true,
-						}
-					);
-
-					if (!proceedWithPagesProject) {
-						sendAutoConfigProcessEndedMetricsEvent({
-							success: false,
-							command: "wrangler deploy",
-							dryRun: !!args.dryRun,
-						});
-						return;
-					}
-				} else if (!details.configured) {
-					// Only run auto config if the project is not already configured
-					const autoConfigSummary = await runAutoConfig(details);
-
-					writeOutput({
-						type: "autoconfig",
-						version: 1,
-						command: "deploy",
-						summary: autoConfigSummary,
-					});
-
-					// If autoconfig worked, there should now be a new config file, and so we need to read config again
-					config = readConfig(args, {
-						hideWarnings: false,
-						useRedirectIfAvailable: true,
-					});
-				}
-			} catch (error) {
-				sendAutoConfigProcessEndedMetricsEvent({
-					command: "wrangler deploy",
-					dryRun: !!args.dryRun,
-					success: false,
-					error,
-				});
-				throw error;
-			}
-
-			sendAutoConfigProcessEndedMetricsEvent({
-				success: true,
-				command: "wrangler deploy",
-				dryRun: !!args.dryRun,
-			});
-		}
-
-		// Note: the open-next delegation should happen after we run the auto-config logic so that we
-		//       make sure that the deployment of brand newly auto-configured Next.js apps is correctly
-		//       delegated here
-		const deploymentDelegatedToOpenNext =
-			// Currently the delegation to open-next is gated behind the autoconfig experimental flag, this is because
-			// this behavior is currently only necessary in the autoconfig flow and having it un-gated/stable in wrangler
-			// releases caused different issues. All the issues should have been fixed (by
-			// https://github.com/cloudflare/workers-sdk/pull/11694 and https://github.com/cloudflare/workers-sdk/pull/11710)
-			// but as a precaution we're gating the feature under the autoconfig flag for the time being
-			args.experimentalAutoconfig &&
-			// If the user explicitly provided a --config path, they are targeting a specific Worker config and we should not delegate to open-next
-			!args.config &&
-			!args.dryRun &&
-			(await maybeDelegateToOpenNextDeployCommand(process.cwd()));
-
-		if (deploymentDelegatedToOpenNext) {
-			// We've delegated the deployment to open-next so we must not run any actual deployment logic now
+		const autoConfigResult = await maybeRunAutoConfig(args, config);
+		if (autoConfigResult.aborted) {
 			return;
 		}
-
-		let scriptIsDirectory = false;
-		if (!config.configPath) {
-			// Attempt to interactively handle `wrangler deploy <directory>`
-			if (args.script) {
-				try {
-					const stats = statSync(args.script);
-					if (stats.isDirectory()) {
-						scriptIsDirectory = true;
-						args = await promptForMissingAssetFlag(args.script, args);
-					}
-				} catch (error) {
-					// If this is our UserError, re-throw it
-					if (error instanceof UserError) {
-						throw error;
-					}
-					// If stat fails, let the original flow handle the error
-				}
-			}
-		}
-
-		// Interactively prompt for missing deployment config (compat date, and name + config file when no config exists).
-		// Skip when the user was offered an assets deployment and declined (script is still a directory) —
-		// getEntry will produce the appropriate error about the directory entry point.
-		if (!(scriptIsDirectory && !args.assets)) {
-			args = await promptForMissingDeployConfig(args, config);
-		}
+		args = autoConfigResult.args;
+		config = autoConfigResult.config;
 
 		const entry = await getEntry(args, config, "deploy");
 		validateAssetsArgsAndConfig(args, config);
@@ -396,154 +257,3 @@ export const deployCommand = createCommand({
 });
 
 export type DeployArgs = (typeof deployCommand)["args"];
-
-/**
- * Handles the case where a user provides a directory as a positional argument,
- * probably intending to deploy static assets. e.g. `wrangler deploy ./public`.
- * If the user confirms, sets `args.assets` and clears `args.script`.
- *
- * @param assetDirectory - The directory path the user provided as the positional argument
- * @param args - The current deploy command arguments (mutated in place)
- * @returns The updated deploy args with `assets` set and `script` cleared if the user confirmed
- */
-export async function promptForMissingAssetFlag(
-	assetDirectory: string,
-	args: DeployArgs
-): Promise<DeployArgs> {
-	if (isNonInteractiveOrCI()) {
-		return args;
-	}
-
-	// Ask if user intended to deploy assets only
-	logger.log("");
-	if (!args.assets) {
-		const deployAssets = await confirm(
-			"It looks like you are trying to deploy a directory of static assets only. Is this correct?",
-			{ defaultValue: true }
-		);
-		logger.log("");
-		if (deployAssets) {
-			args.assets = assetDirectory;
-			args.script = undefined;
-		} else {
-			// let the usual error handling path kick in
-			return args;
-		}
-	}
-
-	return args;
-}
-
-/**
- * Interactively prompts for missing deployment configuration (name, compatibility date,
- * and optionally config file writing when no config file exists).
- * No-op in non-interactive/CI environments or when all required config is already present.
- *
- * @param args - The current deploy command arguments (mutated in place)
- * @param config - The resolved wrangler config, used to check for existing configPath, name, and compatibility_date
- * @returns The updated deploy args with any prompted values filled in
- */
-export async function promptForMissingDeployConfig(
-	args: DeployArgs,
-	config: { configPath?: string; compatibility_date?: string; name?: string }
-): Promise<DeployArgs> {
-	if (isNonInteractiveOrCI()) {
-		return args;
-	}
-
-	let promptedForMissing = false;
-
-	// Prompt for name when missing from both CLI args and config
-	if (!args.name && !config.name) {
-		const defaultName = process
-			.cwd()
-			.split(path.sep)
-			.pop()
-			?.replaceAll("_", "-")
-			.trim();
-		const isValidName = defaultName && /^[a-zA-Z0-9-]+$/.test(defaultName);
-		const projectName = await prompt("What do you want to name your project?", {
-			defaultValue: isValidName ? defaultName : "my-project",
-		});
-		args.name = projectName;
-		logger.log("");
-		promptedForMissing = true;
-	}
-
-	// Prompt for compatibility date when missing
-	if (!args.latest && !args.compatibilityDate && !config.compatibility_date) {
-		const compatibilityDateStr = getTodaysCompatDate();
-
-		if (
-			await confirm(
-				`No compatibility date is set. Would you like to use today's date (${compatibilityDateStr})?`
-			)
-		) {
-			args.compatibilityDate = compatibilityDateStr;
-			promptedForMissing = true;
-			logger.log("");
-		} else {
-			throw new UserError(
-				`A compatibility_date is required when publishing. Add it to your ${configFileName(config.configPath)} file or pass \`--compatibility-date\` via CLI.\nSee https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`,
-				{ telemetryMessage: "missing compatibility date when deploying" }
-			);
-		}
-	}
-
-	const hasConfigFile = !!config.configPath;
-
-	// When no config file exists and we prompted for missing config, offer to write one
-	if (!hasConfigFile && promptedForMissing) {
-		// When --latest was used, the compat date prompt was skipped but we still
-		// need a concrete date in the config file for future deploys without --latest
-		const effectiveCompatDate =
-			args.compatibilityDate ??
-			(args.latest ? getTodaysCompatDate() : undefined);
-
-		const configContent: Record<string, unknown> = {
-			name: args.name,
-			compatibility_date: effectiveCompatDate,
-		};
-		if (args.script) {
-			configContent.main = args.script;
-		}
-		if (args.assets) {
-			configContent.assets = { directory: args.assets };
-		}
-
-		const writeConfigFile = await confirm(
-			`Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\n${chalk.dim(
-				"This will allow you to simply run `wrangler deploy` on future deployments."
-			)}`
-		);
-
-		if (writeConfigFile) {
-			const configPath = path.join(process.cwd(), "wrangler.jsonc");
-			const jsonString = JSON.stringify(configContent, null, 2);
-			writeFileSync(configPath, jsonString);
-			logger.log(`Wrote \n${jsonString}\n to ${chalk.bold(configPath)}.`);
-			logger.log(
-				`Simply run ${chalk.bold("`wrangler deploy`")} next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.`
-			);
-		} else {
-			const scriptPart = args.script ? `${args.script} ` : "";
-			const flagParts = [
-				args.name ? `--name ${args.name}` : "",
-				effectiveCompatDate
-					? `--compatibility-date ${effectiveCompatDate}`
-					: "",
-				args.assets ? `--assets ${args.assets}` : "",
-			]
-				.filter(Boolean)
-				.join(" ");
-			logger.log(
-				`You should run ${chalk.bold(
-					`wrangler deploy ${scriptPart}${flagParts}`
-				)} next time to deploy this Worker without going through this flow again.`
-			);
-		}
-		logger.log("\nProceeding with deployment...\n");
-	}
-
-	return args;
-}

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -63,15 +63,6 @@ export const deployCommand = createCommand({
 			type: "string",
 			coerce: (v: string) => (!v ? true : v),
 		},
-		"keep-vars": {
-			describe:
-				"When not used (or set to false), Wrangler will delete all vars before setting those found in the Wrangler configuration.\n" +
-				"When used (and set to true), the environment variables are not deleted before the deployment.\n" +
-				"If you set variables via the dashboard you probably want to use this flag.\n" +
-				"Note that secrets are never deleted by deployments.",
-			default: false,
-			type: "boolean",
-		},
 		"legacy-env": {
 			type: "boolean",
 			describe: "Use legacy environments",

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -17,6 +17,10 @@ import {
 } from "../autoconfig/telemetry-utils";
 import { readConfig } from "../config";
 import { createCommand } from "../core/create-command";
+import {
+	sharedDeployVersionsArgs,
+	validateDeployVersionsArgs,
+} from "../deployment-bundle/deploy-args";
 import { getEntry } from "../deployment-bundle/entry";
 import { confirm, prompt } from "../dialogs";
 import { isNonInteractiveOrCI } from "../is-interactive";
@@ -42,105 +46,7 @@ export const deployCommand = createCommand({
 	},
 	positionalArgs: ["script"],
 	args: {
-		script: {
-			describe: "The path to an entry point for your Worker",
-			type: "string",
-			requiresArg: true,
-		},
-		name: {
-			describe: "Name of the Worker",
-			type: "string",
-			requiresArg: true,
-		},
-		// We want to have a --no-bundle flag, but yargs requires that
-		// we also have a --bundle flag (that it adds the --no to by itself)
-		// So we make a --bundle flag, but hide it, and then add a --no-bundle flag
-		// that's visible to the user but doesn't "do" anything.
-		bundle: {
-			describe: "Run Wrangler's compilation step before publishing",
-			type: "boolean",
-			hidden: true,
-		},
-		"no-bundle": {
-			describe: "Skip internal build steps and directly deploy Worker",
-			type: "boolean",
-			default: false,
-		},
-		outdir: {
-			describe: "Output directory for the bundled Worker",
-			type: "string",
-			requiresArg: true,
-		},
-		outfile: {
-			describe: "Output file for the bundled worker",
-			type: "string",
-			requiresArg: true,
-		},
-		"compatibility-date": {
-			describe: "Date to use for compatibility checks",
-			type: "string",
-			requiresArg: true,
-		},
-		"compatibility-flags": {
-			describe: "Flags to use for compatibility checks",
-			alias: "compatibility-flag",
-			type: "string",
-			requiresArg: true,
-			array: true,
-		},
-		latest: {
-			describe: "Use the latest version of the Workers runtime",
-			type: "boolean",
-			default: false,
-		},
-		assets: {
-			describe: "Static assets to be served. Replaces Workers Sites.",
-			type: "string",
-			requiresArg: true,
-		},
-		site: {
-			describe: "Root folder of static assets for Workers Sites",
-			type: "string",
-			requiresArg: true,
-			hidden: true,
-			deprecated: true,
-		},
-		"site-include": {
-			describe:
-				"Array of .gitignore-style patterns that match file or directory names from the sites directory. Only matched items will be uploaded.",
-			type: "string",
-			requiresArg: true,
-			array: true,
-			hidden: true,
-			deprecated: true,
-		},
-		"site-exclude": {
-			describe:
-				"Array of .gitignore-style patterns that match file or directory names from the sites directory. Matched items will not be uploaded.",
-			type: "string",
-			requiresArg: true,
-			array: true,
-			hidden: true,
-			deprecated: true,
-		},
-		var: {
-			describe: "A key-value pair to be injected into the script as a variable",
-			type: "string",
-			requiresArg: true,
-			array: true,
-		},
-		define: {
-			describe: "A key-value pair to be substituted in the script",
-			type: "string",
-			requiresArg: true,
-			array: true,
-		},
-		alias: {
-			describe: "A module pair to be substituted in the script",
-			type: "string",
-			requiresArg: true,
-			array: true,
-		},
+		...sharedDeployVersionsArgs,
 		triggers: {
 			describe: "cron schedules to attach",
 			alias: ["schedule", "schedules"],
@@ -161,35 +67,6 @@ export const deployCommand = createCommand({
 			type: "string",
 			requiresArg: true,
 			array: true,
-		},
-		"jsx-factory": {
-			describe: "The function that is called for each JSX element",
-			type: "string",
-			requiresArg: true,
-		},
-		"jsx-fragment": {
-			describe: "The function that is called for each JSX fragment",
-			type: "string",
-			requiresArg: true,
-		},
-		tsconfig: {
-			describe: "Path to a custom tsconfig.json file",
-			type: "string",
-			requiresArg: true,
-		},
-		minify: {
-			describe: "Minify the Worker",
-			type: "boolean",
-		},
-		"node-compat": {
-			describe: "Enable Node.js compatibility",
-			type: "boolean",
-			hidden: true,
-			deprecated: true,
-		},
-		"dry-run": {
-			describe: "Don't actually deploy",
-			type: "boolean",
 		},
 		metafile: {
 			describe:
@@ -216,10 +93,6 @@ export const deployCommand = createCommand({
 			describe:
 				"Send Trace Events from this Worker to Workers Logpush.\nThis will not configure a corresponding Logpush job automatically.",
 		},
-		"upload-source-maps": {
-			type: "boolean",
-			describe: "Include source maps when uploading this Worker.",
-		},
 		"old-asset-ttl": {
 			describe:
 				"Expire old assets in given seconds rather than immediate deletion.",
@@ -235,16 +108,6 @@ export const deployCommand = createCommand({
 				"Rollout strategy for Containers changes. If set to immediate, it will override `rollout_percentage_steps` if configured and roll out to 100% of instances in one step. ",
 			choices: ["immediate", "gradual"] as const,
 		},
-		tag: {
-			describe: "A tag for this Worker Version",
-			type: "string",
-			requiresArg: true,
-		},
-		message: {
-			describe: "A descriptive message for this Worker Version and Deployment",
-			type: "string",
-			requiresArg: true,
-		},
 		strict: {
 			describe:
 				"Enables strict mode for the deploy command, this prevents deployments to occur when there are even small potential risks.",
@@ -258,12 +121,6 @@ export const deployCommand = createCommand({
 			type: "boolean",
 			default: true,
 		},
-		"secrets-file": {
-			describe:
-				"Path to a file containing secrets to upload with the deployment (JSON or .env format). Secrets from previous deployments will not be deleted - see `--keep-secrets`",
-			type: "string",
-			requiresArg: true,
-		},
 	},
 	behaviour: {
 		useConfigRedirectIfAvailable: true,
@@ -276,12 +133,7 @@ export const deployCommand = createCommand({
 		printMetricsBanner: true,
 	},
 	validateArgs(args) {
-		if (args.nodeCompat) {
-			throw new UserError(
-				"The --node-compat flag is no longer supported as of Wrangler v4. Instead, use the `nodejs_compat` compatibility flag. This includes the functionality from legacy `node_compat` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information.",
-				{ telemetryMessage: "deploy command node compat unsupported" }
-			);
-		}
+		validateDeployVersionsArgs(args);
 	},
 	async handler(args, { config }) {
 		const shouldRunAutoConfig =
@@ -425,14 +277,6 @@ export const deployCommand = createCommand({
 			args,
 			config,
 		});
-
-		if (args.latest) {
-			logger.warn(
-				`Using the latest version of the Workers runtime. To silence this warning, please choose a specific version of the runtime with --compatibility-date, or add a compatibility_date to your ${configFileName(
-					config.configPath
-				)} file.`
-			);
-		}
 
 		const cliVars = collectKeyValues(args.var);
 		const cliDefines = collectKeyValues(args.define);

--- a/packages/wrangler/src/deployment-bundle/deploy-args.ts
+++ b/packages/wrangler/src/deployment-bundle/deploy-args.ts
@@ -159,6 +159,15 @@ export const sharedDeployVersionsArgs = {
 		type: "string",
 		requiresArg: true,
 	},
+	"keep-vars": {
+		describe:
+			"When not used (or set to false), Wrangler will delete all vars before setting those found in the Wrangler configuration.\n" +
+			"When used (and set to true), the environment variables are not deleted before the deployment.\n" +
+			"If you set variables via the dashboard you probably want to use this flag.\n" +
+			"Note that secrets are never deleted by deployments.",
+		default: false,
+		type: "boolean",
+	},
 } as const satisfies NamedArgDefinitions;
 
 export function validateDeployVersionsArgs(args: {

--- a/packages/wrangler/src/deployment-bundle/deploy-args.ts
+++ b/packages/wrangler/src/deployment-bundle/deploy-args.ts
@@ -1,0 +1,180 @@
+import { UserError } from "@cloudflare/workers-utils";
+import { logger } from "../logger";
+import type { NamedArgDefinitions } from "../core/types";
+
+export const sharedDeployVersionsArgs = {
+	script: {
+		describe: "The path to an entry point for your Worker",
+		type: "string",
+		requiresArg: true,
+	},
+	name: {
+		describe: "Name of the Worker",
+		type: "string",
+		requiresArg: true,
+	},
+	tag: {
+		describe: "A tag for this Worker Version",
+		type: "string",
+		requiresArg: true,
+	},
+	message: {
+		describe: "A descriptive message for this Worker Version",
+		type: "string",
+		requiresArg: true,
+	},
+	// We want to have a --no-bundle flag, but yargs requires that
+	// we also have a --bundle flag (that it adds the --no to by itself)
+	// So we make a --bundle flag, but hide it, and then add a --no-bundle flag
+	// that's visible to the user but doesn't "do" anything.
+	bundle: {
+		describe: "Run Wrangler's compilation step before publishing",
+		type: "boolean",
+		hidden: true,
+	},
+	"no-bundle": {
+		describe: "Skip internal build steps and directly upload Worker",
+		type: "boolean",
+		default: false,
+	},
+	outdir: {
+		describe: "Output directory for the bundled Worker",
+		type: "string",
+		requiresArg: true,
+	},
+	outfile: {
+		describe: "Output file for the bundled worker",
+		type: "string",
+		requiresArg: true,
+	},
+	"compatibility-date": {
+		describe: "Date to use for compatibility checks",
+		type: "string",
+		requiresArg: true,
+	},
+	"compatibility-flags": {
+		describe: "Flags to use for compatibility checks",
+		alias: "compatibility-flag",
+		type: "string",
+		requiresArg: true,
+		array: true,
+	},
+	latest: {
+		describe: "Use the latest version of the Workers runtime",
+		type: "boolean",
+		default: false,
+	},
+	assets: {
+		describe: "Static assets to be served. Replaces Workers Sites.",
+		type: "string",
+		requiresArg: true,
+	},
+	site: {
+		describe: "Root folder of static assets for Workers Sites",
+		type: "string",
+		requiresArg: true,
+		hidden: true,
+		deprecated: true,
+	},
+	"site-include": {
+		describe:
+			"Array of .gitignore-style patterns that match file or directory names from the sites directory. Only matched items will be uploaded.",
+		type: "string",
+		requiresArg: true,
+		array: true,
+		hidden: true,
+		deprecated: true,
+	},
+	"site-exclude": {
+		describe:
+			"Array of .gitignore-style patterns that match file or directory names from the sites directory. Matched items will not be uploaded.",
+		type: "string",
+		requiresArg: true,
+		array: true,
+		hidden: true,
+		deprecated: true,
+	},
+	var: {
+		describe: "A key-value pair to be injected into the script as a variable",
+		type: "string",
+		requiresArg: true,
+		array: true,
+	},
+	define: {
+		describe: "A key-value pair to be substituted in the script",
+		type: "string",
+		requiresArg: true,
+		array: true,
+	},
+	alias: {
+		describe: "A module pair to be substituted in the script",
+		type: "string",
+		requiresArg: true,
+		array: true,
+	},
+	"jsx-factory": {
+		describe: "The function that is called for each JSX element",
+		type: "string",
+		requiresArg: true,
+	},
+	"jsx-fragment": {
+		describe: "The function that is called for each JSX fragment",
+		type: "string",
+		requiresArg: true,
+	},
+	tsconfig: {
+		describe: "Path to a custom tsconfig.json file",
+		type: "string",
+		requiresArg: true,
+	},
+	minify: {
+		describe: "Minify the Worker",
+		type: "boolean",
+	},
+	"upload-source-maps": {
+		describe: "Include source maps when uploading this Worker",
+		type: "boolean",
+	},
+	"node-compat": {
+		describe: "Enable Node.js compatibility",
+		type: "boolean",
+		hidden: true,
+		deprecated: true,
+	},
+	"dry-run": {
+		describe:
+			"Compile a project and run checks without actually uploading the Worker",
+		type: "boolean",
+	},
+	"experimental-auto-create": {
+		describe: "Automatically provision draft bindings with new resources",
+		type: "boolean",
+		default: true,
+		hidden: true,
+		alias: "x-auto-create",
+	},
+	"secrets-file": {
+		describe:
+			"Path to a file containing secrets to upload with the version (JSON or .env format). Secrets from previous deployments will not be deleted - see `--keep-secrets`",
+		type: "string",
+		requiresArg: true,
+	},
+} as const satisfies NamedArgDefinitions;
+
+export function validateDeployVersionsArgs(args: {
+	nodeCompat: boolean | undefined;
+	latest: boolean | undefined;
+}): void {
+	if (args.nodeCompat) {
+		throw new UserError(
+			"The --node-compat flag is no longer supported as of Wrangler v4. Instead, use the `nodejs_compat` compatibility flag. This includes the functionality from legacy `node_compat` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information.",
+			{ telemetryMessage: "deploy node compat unsupported" }
+		);
+	}
+
+	if (args.latest) {
+		logger.warn(
+			`Using the latest version of the Workers runtime. To silence this warning, please choose a specific version of the runtime with --compatibility-date, or add a compatibility_date to your configuration file.`
+		);
+	}
+}

--- a/packages/wrangler/src/deployment-bundle/deploy-args.ts
+++ b/packages/wrangler/src/deployment-bundle/deploy-args.ts
@@ -155,7 +155,7 @@ export const sharedDeployVersionsArgs = {
 	},
 	"secrets-file": {
 		describe:
-			"Path to a file containing secrets to upload with the version (JSON or .env format). Secrets from previous deployments will not be deleted - see `--keep-secrets`",
+			"Path to a file containing secrets to upload with the version (JSON or .env format). Applies additively with secrets from previous deployments - omitted secrets will not be deleted.",
 		type: "string",
 		requiresArg: true,
 	},

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -26,6 +26,10 @@ import { getBindings, provisionBindings } from "../deployment-bundle/bindings";
 import { bundleWorker } from "../deployment-bundle/bundle";
 import { printBundleSize } from "../deployment-bundle/bundle-reporter";
 import { createWorkerUploadForm } from "../deployment-bundle/create-worker-upload-form";
+import {
+	sharedDeployVersionsArgs,
+	validateDeployVersionsArgs,
+} from "../deployment-bundle/deploy-args";
 import { getEntry } from "../deployment-bundle/entry";
 import { logBuildOutput } from "../deployment-bundle/esbuild-plugins/log-build-output";
 import {
@@ -120,161 +124,9 @@ export const versionsUploadCommand = createCommand({
 	},
 	positionalArgs: ["script"],
 	args: {
-		script: {
-			describe: "The path to an entry point for your Worker",
-			type: "string",
-			requiresArg: true,
-		},
-		name: {
-			describe: "Name of the Worker",
-			type: "string",
-			requiresArg: true,
-		},
-		tag: {
-			describe: "A tag for this Worker Gradual Rollouts Version",
-			type: "string",
-			requiresArg: true,
-		},
-		message: {
-			describe:
-				"A descriptive message for this Worker Gradual Rollouts Version",
-			type: "string",
-			requiresArg: true,
-		},
+		...sharedDeployVersionsArgs,
 		"preview-alias": {
 			describe: "Name of an alias for this Worker version",
-			type: "string",
-			requiresArg: true,
-		},
-		bundle: {
-			describe: "Run Wrangler's compilation step before publishing",
-			type: "boolean",
-			hidden: true,
-		},
-		"no-bundle": {
-			describe: "Skip internal build steps and directly upload Worker",
-			type: "boolean",
-			default: false,
-		},
-		outdir: {
-			describe: "Output directory for the bundled Worker",
-			type: "string",
-			requiresArg: true,
-		},
-		outfile: {
-			describe: "Output file for the bundled worker",
-			type: "string",
-			requiresArg: true,
-		},
-		"compatibility-date": {
-			describe: "Date to use for compatibility checks",
-			type: "string",
-			requiresArg: true,
-		},
-		"compatibility-flags": {
-			describe: "Flags to use for compatibility checks",
-			alias: "compatibility-flag",
-			type: "string",
-			requiresArg: true,
-			array: true,
-		},
-		latest: {
-			describe: "Use the latest version of the Worker runtime",
-			type: "boolean",
-			default: false,
-		},
-		assets: {
-			describe: "Static assets to be served. Replaces Workers Sites.",
-			type: "string",
-			requiresArg: true,
-		},
-		site: {
-			describe: "Root folder of static assets for Workers Sites",
-			type: "string",
-			requiresArg: true,
-			hidden: true,
-			deprecated: true,
-		},
-		"site-include": {
-			describe:
-				"Array of .gitignore-style patterns that match file or directory names from the sites directory. Only matched items will be uploaded.",
-			type: "string",
-			requiresArg: true,
-			array: true,
-			hidden: true,
-			deprecated: true,
-		},
-		"site-exclude": {
-			describe:
-				"Array of .gitignore-style patterns that match file or directory names from the sites directory. Matched items will not be uploaded.",
-			type: "string",
-			requiresArg: true,
-			array: true,
-			hidden: true,
-			deprecated: true,
-		},
-		var: {
-			describe: "A key-value pair to be injected into the script as a variable",
-			type: "string",
-			requiresArg: true,
-			array: true,
-		},
-		define: {
-			describe: "A key-value pair to be substituted in the script",
-			type: "string",
-			requiresArg: true,
-			array: true,
-		},
-		alias: {
-			describe: "A module pair to be substituted in the script",
-			type: "string",
-			requiresArg: true,
-			array: true,
-		},
-		"jsx-factory": {
-			describe: "The function that is called for each JSX element",
-			type: "string",
-			requiresArg: true,
-		},
-		"jsx-fragment": {
-			describe: "The function that is called for each JSX fragment",
-			type: "string",
-			requiresArg: true,
-		},
-		tsconfig: {
-			describe: "Path to a custom tsconfig.json file",
-			type: "string",
-			requiresArg: true,
-		},
-		minify: {
-			describe: "Minify the Worker",
-			type: "boolean",
-		},
-		"upload-source-maps": {
-			describe:
-				"Include source maps when uploading this Worker Gradual Rollouts Version.",
-			type: "boolean",
-		},
-		"node-compat": {
-			describe: "Enable Node.js compatibility",
-			type: "boolean",
-			hidden: true,
-			deprecated: true,
-		},
-		"dry-run": {
-			describe: "Compile a project without actually uploading the version.",
-			type: "boolean",
-		},
-		"experimental-auto-create": {
-			describe: "Automatically provision draft bindings with new resources",
-			type: "boolean",
-			default: true,
-			hidden: true,
-			alias: "x-auto-create",
-		},
-		"secrets-file": {
-			describe:
-				"Path to a file containing secrets to upload with the version (JSON or .env format). Secrets from previous deployments will not be deleted - see `--keep-secrets`",
 			type: "string",
 			requiresArg: true,
 		},
@@ -288,6 +140,9 @@ export const versionsUploadCommand = createCommand({
 		}),
 		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
 	},
+	validateArgs(args) {
+		validateDeployVersionsArgs(args);
+	},
 	handler: async function versionsUploadHandler(args, { config }) {
 		const entry = await getEntry(args, config, "versions upload");
 		metrics.sendMetricsEvent(
@@ -299,13 +154,6 @@ export const versionsUploadCommand = createCommand({
 				sendMetrics: config.send_metrics,
 			}
 		);
-
-		if (args.nodeCompat) {
-			throw new UserError(
-				`The --node-compat flag is no longer supported as of Wrangler v4. Instead, use the \`nodejs_compat\` compatibility flag. This includes the functionality from legacy \`node_compat\` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information.`,
-				{ telemetryMessage: "versions upload node compat unsupported" }
-			);
-		}
 
 		if (args.site || config.site) {
 			throw new UserError(
@@ -327,12 +175,6 @@ export const versionsUploadCommand = createCommand({
 			args,
 			config,
 		});
-
-		if (args.latest) {
-			logger.warn(
-				`Using the latest version of the Workers runtime. To silence this warning, please choose a specific version of the runtime with --compatibility-date, or add a compatibility_date to your ${configFileName(config.configPath)} file.\n`
-			);
-		}
 
 		const cliVars = collectKeyValues(args.var);
 		const cliDefines = collectKeyValues(args.define);

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -242,7 +242,7 @@ export const versionsUploadCommand = createCommand({
 				outDir: args.outdir,
 				dryRun: args.dryRun,
 				noBundle: !(args.bundle ?? !config.no_bundle),
-				keepVars: config.keep_vars,
+				keepVars: args.keepVars || config.keep_vars,
 				projectRoot: entry.projectRoot,
 				tag: args.tag,
 				message: args.message,


### PR DESCRIPTION
Breaking this up into manageable PRs:

This PR:
- pulls out shared args for deploy and versions upload
- pulls out a shared validation function for args
- moves autoconfig and friends (opennext delegation, prompting for missing args) into a single function to make the main deploy path more readable).
- adds --keep-vars to versions upload for consistency with deploy (resolves https://github.com/cloudflare/workers-sdk/discussions/13907)
---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: refactor should just pass existing tests
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: refactor

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->