### PR TITLE
[vite-plugin-cloudflare] Honor X-Forwarded-Proto when constructing request.url

### DIFF
--- a/.changeset/vite-plugin-honor-upstream-protocol.md
+++ b/.changeset/vite-plugin-honor-upstream-protocol.md
@@ -1,0 +1,11 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Honor `X-Forwarded-Proto` when constructing the Worker's `request.url`
+
+When running the Vite dev server behind a TLS-terminating reverse proxy or tunnel, the Worker's `request.url` was always `http://...` even though the client reached the server over `https://...`. This caused frameworks that perform Origin/Host checks (e.g. CSRF protection) to reject requests with `403`.
+
+The Vite plugin now reads the `X-Forwarded-Proto` header from the incoming request and uses it to set the protocol of `request.url`. If the header is absent or invalid, the connection protocol is used as before. The same handling is applied to WebSocket upgrade URLs.
+
+Fixes [#13801](https://github.com/cloudflare/workers-sdk/issues/13801).

--- a/packages/vite-plugin-cloudflare/playground/worker-♫/__tests__/worker.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/worker-♫/__tests__/worker.spec.ts
@@ -68,6 +68,26 @@ test("receives the original Host header", async ({ expect }) => {
 	}, WAIT_FOR_OPTIONS);
 });
 
+// https://github.com/cloudflare/workers-sdk/issues/13801
+test("honors `X-Forwarded-Proto: https` when constructing `request.url`", async ({
+	expect,
+}) => {
+	const response = await fetch(`${viteTestUrl}/request-url`, {
+		headers: { "x-forwarded-proto": "https" },
+	});
+	const url = new URL(await response.text());
+	expect(url.protocol).toBe("https:");
+});
+
+test("falls back to `http://` for `request.url` when no proxy header is set", async ({
+	expect,
+}) => {
+	await vi.waitFor(async () => {
+		const url = new URL(await getTextResponse("/request-url"));
+		expect(url.protocol).toBe("http:");
+	}, WAIT_FOR_OPTIONS);
+});
+
 test("does not cause unhandled rejection", async ({ expect }) => {
 	expect(serverLogs.errors.join()).not.toContain("__unhandled rejection__");
 });

--- a/packages/vite-plugin-cloudflare/playground/worker-♫/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/worker-♫/src/index.ts
@@ -17,6 +17,10 @@ export default {
 			return new Response(request.headers.get("Host"));
 		}
 
+		if (url.pathname.endsWith("/request-url")) {
+			return new Response(request.url);
+		}
+
 		// return the pathname if the path parameter is present to test the base path
 		if (url.searchParams.has("path")) {
 			return new Response(url.pathname);

--- a/packages/vite-plugin-cloudflare/src/__tests__/utils.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/utils.spec.ts
@@ -1,6 +1,13 @@
+import http from "node:http";
 import * as path from "node:path";
-import { describe, test } from "vitest";
-import { getOutputDirectory } from "../utils";
+import { Response as MiniflareResponse } from "miniflare";
+import { afterEach, beforeEach, describe, test } from "vitest";
+import {
+	createRequestHandler,
+	getForwardedProto,
+	getOutputDirectory,
+} from "../utils";
+import type { AddressInfo } from "node:net";
 
 describe("getOutputDirectory", () => {
 	test("returns the correct output if `environments[environmentName].build.outDir` is defined", ({
@@ -37,5 +44,148 @@ describe("getOutputDirectory", () => {
 		expect(getOutputDirectory({}, "environment-name")).toBe(
 			path.join("dist", "environment-name")
 		);
+	});
+});
+
+describe("getForwardedProto", () => {
+	test("returns undefined when the header is missing", ({ expect }) => {
+		expect(getForwardedProto({ headers: {} })).toBeUndefined();
+	});
+
+	test("returns https: when the header is `https`", ({ expect }) => {
+		expect(
+			getForwardedProto({ headers: { "x-forwarded-proto": "https" } })
+		).toBe("https:");
+	});
+
+	test("returns http: when the header is `http`", ({ expect }) => {
+		expect(
+			getForwardedProto({ headers: { "x-forwarded-proto": "http" } })
+		).toBe("http:");
+	});
+
+	test("is case-insensitive", ({ expect }) => {
+		expect(
+			getForwardedProto({ headers: { "x-forwarded-proto": "HTTPS" } })
+		).toBe("https:");
+	});
+
+	test("trims surrounding whitespace", ({ expect }) => {
+		expect(
+			getForwardedProto({ headers: { "x-forwarded-proto": "  https  " } })
+		).toBe("https:");
+	});
+
+	test("uses the left-most value when the header is a comma-separated proxy chain", ({
+		expect,
+	}) => {
+		expect(
+			getForwardedProto({ headers: { "x-forwarded-proto": "https, http" } })
+		).toBe("https:");
+	});
+
+	test("returns undefined when the header is an unsupported value", ({
+		expect,
+	}) => {
+		expect(
+			getForwardedProto({ headers: { "x-forwarded-proto": "ws" } })
+		).toBeUndefined();
+	});
+
+	test("returns undefined when the header is an empty string", ({ expect }) => {
+		expect(
+			getForwardedProto({ headers: { "x-forwarded-proto": "" } })
+		).toBeUndefined();
+	});
+});
+
+describe("createRequestHandler", () => {
+	// Use a real HTTP server so that `req`, `res`, and `req.socket` look like
+	// what `createRequest` from `@remix-run/node-fetch-server` expects in
+	// production. This mirrors `websockets.spec.ts`.
+	let httpServer: http.Server;
+	let port: number;
+	let capturedUrls: string[];
+
+	beforeEach(async () => {
+		capturedUrls = [];
+	});
+
+	afterEach(async () => {
+		await new Promise<void>((resolve, reject) =>
+			httpServer?.close((e) => (e ? reject(e) : resolve()))
+		);
+	});
+
+	function startServer() {
+		const handler = createRequestHandler(async (request) => {
+			capturedUrls.push(request.url);
+			return new MiniflareResponse("OK");
+		});
+
+		httpServer = http.createServer((req, res) => {
+			void handler(
+				req as unknown as Parameters<typeof handler>[0],
+				res,
+				(error: unknown) => {
+					res.statusCode = 500;
+					res.end(error instanceof Error ? error.message : String(error));
+				}
+			);
+		});
+		return new Promise<void>((r) =>
+			httpServer.listen(0, "127.0.0.1", () => {
+				port = (httpServer.address() as AddressInfo).port;
+				r();
+			})
+		);
+	}
+
+	test("falls back to `http://` when no `X-Forwarded-Proto` header is set", async ({
+		expect,
+	}) => {
+		await startServer();
+		await fetch(`http://127.0.0.1:${port}/path`);
+		expect(capturedUrls[0]).toBe(`http://127.0.0.1:${port}/path`);
+	});
+
+	test("honors the `X-Forwarded-Proto` header set to `https`", async ({
+		expect,
+	}) => {
+		await startServer();
+		await fetch(`http://127.0.0.1:${port}/path`, {
+			headers: { "x-forwarded-proto": "https" },
+		});
+		expect(capturedUrls[0]).toBe(`https://127.0.0.1:${port}/path`);
+	});
+
+	test("honors the `X-Forwarded-Proto` header when it is case-insensitive", async ({
+		expect,
+	}) => {
+		await startServer();
+		await fetch(`http://127.0.0.1:${port}/path`, {
+			headers: { "x-forwarded-proto": "HTTPS" },
+		});
+		expect(capturedUrls[0]).toBe(`https://127.0.0.1:${port}/path`);
+	});
+
+	test("uses the left-most value when `X-Forwarded-Proto` is a proxy chain", async ({
+		expect,
+	}) => {
+		await startServer();
+		await fetch(`http://127.0.0.1:${port}/path`, {
+			headers: { "x-forwarded-proto": "https, http" },
+		});
+		expect(capturedUrls[0]).toBe(`https://127.0.0.1:${port}/path`);
+	});
+
+	test("ignores `X-Forwarded-Proto` when it holds an unsupported value", async ({
+		expect,
+	}) => {
+		await startServer();
+		await fetch(`http://127.0.0.1:${port}/path`, {
+			headers: { "x-forwarded-proto": "ws" },
+		});
+		expect(capturedUrls[0]).toBe(`http://127.0.0.1:${port}/path`);
 	});
 });

--- a/packages/vite-plugin-cloudflare/src/__tests__/websockets.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/websockets.spec.ts
@@ -1,7 +1,15 @@
 import http from "node:http";
 import net from "node:net";
 import { DeferredPromise, Miniflare, Response } from "miniflare";
-import { afterEach, assert, beforeEach, describe, test, vi } from "vitest";
+import {
+	afterEach,
+	assert,
+	beforeEach,
+	describe,
+	type ExpectStatic,
+	test,
+	vi,
+} from "vitest";
 import { handleWebSocket } from "../websockets";
 import type { AddressInfo } from "node:net";
 
@@ -22,10 +30,13 @@ describe("handleWebSocket", () => {
 				}
 			}`,
 		});
-		handleWebSocket(httpServer, miniflare);
+	});
+
+	async function listen(entryWorkerName?: string) {
+		handleWebSocket(httpServer, miniflare, entryWorkerName);
 		await new Promise<void>((r) => httpServer.listen(0, "127.0.0.1", r));
 		port = (httpServer.address() as AddressInfo).port;
-	});
+	}
 
 	afterEach(async () => {
 		await miniflare?.dispose();
@@ -36,6 +47,8 @@ describe("handleWebSocket", () => {
 
 	// https://github.com/cloudflare/workers-sdk/issues/12047
 	test("survives client disconnect during upgrade", async ({ expect }) => {
+		await listen();
+
 		// Mock dispatchFetch to simulate a slow response - the bug occurs when
 		// the client disconnects while dispatchFetch is pending
 		const deferred = new DeferredPromise<Response>();
@@ -64,6 +77,8 @@ describe("handleWebSocket", () => {
 	});
 
 	test("forwards sandbox requests", async ({ expect }) => {
+		await listen();
+
 		const deferred = new DeferredPromise<Response>();
 		const mockedDispatchFetch = vi
 			.spyOn(miniflare, "dispatchFetch")
@@ -109,5 +124,85 @@ describe("handleWebSocket", () => {
 		);
 		expect(init.headers.get("sec-websocket-protocol")).toBe("vite-hmr");
 		expect(init.headers.get("sec-websocket-version")).toBe("13");
+	});
+
+	/**
+	 * Performs a websocket upgrade with the given headers and returns the URL
+	 * that was dispatched to miniflare.
+	 */
+	async function dispatchUpgrade(
+		expect: ExpectStatic,
+		headers: Record<string, string>
+	) {
+		const deferred = new DeferredPromise<Response>();
+		const mockedDispatchFetch = vi
+			.spyOn(miniflare, "dispatchFetch")
+			.mockReturnValue(deferred);
+
+		const socket = net.connect(port, "127.0.0.1");
+		await new Promise<void>((r) => socket.on("connect", r));
+
+		const headerLines = Object.entries(headers)
+			.map(([k, v]) => `${k}: ${v}`)
+			.join("\r\n");
+		socket.write(
+			"GET / HTTP/1.1\r\n" +
+				`${headerLines}\r\n` +
+				"Upgrade: websocket\r\n" +
+				"Connection: Upgrade\r\n" +
+				"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+				"Sec-WebSocket-Version: 13\r\n\r\n"
+		);
+
+		await vi.waitFor(() => expect(miniflare.dispatchFetch).toHaveBeenCalled());
+
+		// Resolve the mock so miniflare.dispose() doesn't hang in afterEach
+		deferred.resolve(new Response(null));
+
+		socket.destroy();
+
+		assert(mockedDispatchFetch.mock.lastCall);
+		return mockedDispatchFetch.mock.lastCall[0];
+	}
+
+	test("falls back to `http://` when no `X-Forwarded-Proto` header is set", async ({
+		expect,
+	}) => {
+		await listen();
+		const url = await dispatchUpgrade(expect, { Host: `127.0.0.1:${port}` });
+		expect(`${url}`).toBe(`http://127.0.0.1:${port}/`);
+	});
+
+	test("honors the `X-Forwarded-Proto` header set to `https`", async ({
+		expect,
+	}) => {
+		await listen();
+		const url = await dispatchUpgrade(expect, {
+			Host: `127.0.0.1:${port}`,
+			"X-Forwarded-Proto": "https",
+		});
+		expect(`${url}`).toBe(`https://127.0.0.1:${port}/`);
+	});
+
+	test("uses the left-most value when `X-Forwarded-Proto` is a proxy chain", async ({
+		expect,
+	}) => {
+		await listen();
+		const url = await dispatchUpgrade(expect, {
+			Host: `127.0.0.1:${port}`,
+			"X-Forwarded-Proto": "https, http",
+		});
+		expect(`${url}`).toBe(`https://127.0.0.1:${port}/`);
+	});
+
+	test("ignores `X-Forwarded-Proto` when it holds an unsupported value", async ({
+		expect,
+	}) => {
+		await listen();
+		const url = await dispatchUpgrade(expect, {
+			Host: `127.0.0.1:${port}`,
+			"X-Forwarded-Proto": "ws",
+		});
+		expect(`${url}`).toBe(`http://127.0.0.1:${port}/`);
 	});
 });

--- a/packages/vite-plugin-cloudflare/src/utils.ts
+++ b/packages/vite-plugin-cloudflare/src/utils.ts
@@ -80,7 +80,24 @@ export function createRequestHandler(
 			if (req.originalUrl) {
 				req.url = req.originalUrl;
 			}
-			request = createRequest(req, res);
+			// Honor the `X-Forwarded-Proto` header on the incoming request so that
+			// `request.url` reflects the protocol the original client used, not the
+			// HTTP connection between the proxy and the dev server. This is needed
+			// when the Vite dev server sits behind a TLS-terminating reverse proxy
+			// or tunnel (cloudflared, ngrok, etc.) so that frameworks performing
+			// Origin/Host checks (e.g. CSRF protection) see a consistent origin.
+			//
+			// We trust this unconditionally because the Vite dev server is a
+			// local-only dev tool and this header is the de-facto standard set by
+			// reverse proxies. Browser-mediated CSRF attacks cannot reach here:
+			// `X-Forwarded-Proto` is not a CORS-safelisted header, so a `fetch()`
+			// that sets it triggers a CORS preflight, and simple form-submitted
+			// POSTs cannot include custom headers at all.
+			//
+			// If the header is absent or invalid, `createRequest` falls back to the
+			// connection protocol (`req.socket.encrypted`).
+			const protocol = getForwardedProto(req);
+			request = createRequest(req, res, protocol ? { protocol } : undefined);
 
 			let response = await handler(toMiniflareRequest(request), req);
 
@@ -139,3 +156,25 @@ function toMiniflareRequest(request: Request): MiniflareRequest {
 }
 
 export const isRolldown = "rolldownVersion" in vite;
+
+/**
+ * Parses the `X-Forwarded-Proto` header from an incoming Node.js request.
+ *
+ * If multiple proxies are in the chain, the header may be a comma-separated
+ * list — the left-most value is the original client-facing protocol.
+ * Returns `undefined` if the header is missing or holds an unsupported value.
+ */
+export function getForwardedProto(req: {
+	headers: http.IncomingHttpHeaders;
+}): "http:" | "https:" | undefined {
+	const raw = req.headers["x-forwarded-proto"];
+	const value = Array.isArray(raw) ? raw[0] : raw;
+	if (!value) {
+		return undefined;
+	}
+	const first = value.split(",")[0]?.trim().toLowerCase();
+	if (first === "http" || first === "https") {
+		return `${first}:`;
+	}
+	return undefined;
+}

--- a/packages/vite-plugin-cloudflare/src/websockets.ts
+++ b/packages/vite-plugin-cloudflare/src/websockets.ts
@@ -2,6 +2,7 @@ import { createHeaders } from "@remix-run/node-fetch-server";
 import { CoreHeaders, coupleWebSocket } from "miniflare";
 import { WebSocketServer } from "ws";
 import { UNKNOWN_HOST } from "./shared";
+import { getForwardedProto } from "./utils";
 import type { Headers, Miniflare } from "miniflare";
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
@@ -24,9 +25,13 @@ export function handleWebSocket(
 			socket.on("error", () => socket.destroy());
 
 			const rawHost = request.headers.host ?? UNKNOWN_HOST;
+			// Honor `X-Forwarded-Proto` so that the upgrade URL reflects the
+			// protocol the original client used (e.g. behind a TLS-terminating
+			// reverse proxy or tunnel). Matches `createRequestHandler` in utils.ts.
+			const protocol = getForwardedProto(request) ?? "http:";
 			const base = /^https?:\/\//i.test(rawHost)
 				? rawHost
-				: `http://${rawHost}`;
+				: `${protocol}//${rawHost}`;
 			const url = new URL(request.url ?? "", base);
 
 			const isViteRequest =


### PR DESCRIPTION
Fixes #13801.

When running the Vite dev server behind a TLS-terminating reverse proxy or tunnel (cloudflared, ngrok, etc.), the Worker's `request.url` was always `http://...` even though the client reached the server over `https://...`. This caused frameworks that perform Origin/Host checks (e.g. Astro's CSRF protection) to reject requests with `403`.

The Vite plugin now reads the `X-Forwarded-Proto` header from the incoming request and uses it to set the protocol of `request.url`. If the header is absent or invalid, the connection protocol is used as before. The same handling is applied to WebSocket upgrade URLs in `handleWebSocket`.

#### Security note

`X-Forwarded-Proto` is honored unconditionally rather than gated behind an opt-in flag. This is safe for the Vite dev server because:

- The Vite dev server is a local-only dev tool. The threat model here is much narrower than for a production server.
- Browser-mediated attacks cannot set this header in a CSRF-relevant way. `X-Forwarded-Proto` is **not** a CORS-safelisted header, so a `fetch()` carrying it triggers a CORS preflight (which the dev server does not permissively grant). Simple form-submitted POSTs (the one CSRF vector that bypasses preflight) cannot set custom headers at all — they are limited to `Content-Type: application/x-www-form-urlencoded | multipart/form-data | text/plain` and standard headers.
- The plugin already trusts the `Host` header from incoming requests on the same basis, so this does not introduce a new trust assumption.

If the dev server is exposed on an untrusted network (e.g. via `--host` without a host check, which Vite warns against), a direct non-browser client could spoof the protocol portion of `request.url`. This is dev-only behavior and consistent with the existing trust placed in the `Host` header.

#### What this PR does NOT do

The original issue also suggested honoring the `dev.upstream_protocol` setting from `wrangler.json`. That field is part of the `dev` config block that is designed for `wrangler dev` and is not generally consumed by the Vite plugin, so we are deliberately leaving it out of scope here. The `X-Forwarded-Proto` handling alone is sufficient to fix the reported bug for any reverse-proxy / tunnel deployment.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this restores conformance with the de-facto `X-Forwarded-Proto` convention set by reverse proxies and tunnels; no new public API surface.