### PR TITLE
MQ-1242: Removing a consumer from Wrangler config should detach that consumer

### DIFF
--- a/.changeset/clean-up-stale-queue-consumers-on-deploy.md
+++ b/.changeset/clean-up-stale-queue-consumers-on-deploy.md
@@ -1,0 +1,18 @@
+---
+"wrangler": patch
+---
+
+Clean up stale queue consumer registrations during `wrangler deploy`
+
+Previously, `wrangler deploy` only ever created or updated the queue consumers listed in `queues.consumers`. If a user removed a consumer from their config and redeployed, the stale consumer registration was left behind and the worker would keep receiving messages from a queue it no longer declared.
+
+Wrangler now sends the full, authoritative list of declared consumers to a single script-level endpoint on every deploy. Consumers that have been removed from the config are deleted, and the per-consumer outcome (created / updated / removed / failed) is reported inline with the rest of the trigger summary:
+
+```
+Deployed my-worker triggers (TIMINGS)
+  https://my-worker.workers.dev
+  Consumer for order-queue
+  Removed consumer for old-queue
+```
+
+If a consumer fails to configure, the error is printed both inline and to stderr, and the deploy exits with a non-zero status without aborting other trigger deployments.

--- a/packages/wrangler/src/__tests__/deploy/helpers.ts
+++ b/packages/wrangler/src/__tests__/deploy/helpers.ts
@@ -14,7 +14,12 @@ import {
 } from "../helpers/msw";
 import type { AssetManifest } from "../../assets";
 import type { CustomDomain, CustomDomainChangeset } from "../../deploy/deploy";
-import type { PostTypedConsumerBody, QueueResponse } from "../../queues/client";
+import type {
+	PostTypedConsumerBody,
+	QueueResponse,
+	SetScriptConsumersBody,
+	SetScriptConsumersResult,
+} from "../../queues/client";
 import type {
 	Config,
 	ServiceMetadataRes,
@@ -655,6 +660,38 @@ export function mockPostConsumerById(
 					errors: [],
 					messages: [],
 					result: {},
+				});
+			},
+			{ once: true }
+		)
+	);
+	return requests;
+}
+
+export function mockSetScriptConsumers(
+	expectedScriptName: string,
+	expectedBody: SetScriptConsumersBody,
+	result: SetScriptConsumersResult = {
+		created: [],
+		updated: [],
+		deleted: [],
+		failed: [],
+	}
+) {
+	const requests = { count: 0 };
+	msw.use(
+		http.put(
+			"*/accounts/:accountId/workers/scripts/:scriptName/queue-consumers",
+			async ({ request, params }) => {
+				requests.count += 1;
+				expect(params.accountId).toEqual("some-account-id");
+				expect(params.scriptName).toEqual(expectedScriptName);
+				expect(await request.json()).toEqual(expectedBody);
+				return HttpResponse.json({
+					success: true,
+					errors: [],
+					messages: [],
+					result,
 				});
 			},
 			{ once: true }

--- a/packages/wrangler/src/__tests__/deploy/queues.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/queues.test.ts
@@ -19,11 +19,9 @@ import { runWrangler } from "../helpers/run-wrangler";
 import {
 	mockDeploymentsListRequest,
 	mockGetQueueByName,
-	mockGetServiceByName,
 	mockLastDeploymentRequest,
 	mockPatchScriptSettings,
-	mockPostConsumerById,
-	mockPutQueueConsumerById,
+	mockSetScriptConsumers,
 } from "./helpers";
 import type { QueueResponse } from "../../queues/client";
 
@@ -186,7 +184,7 @@ describe("deploy", () => {
 			`);
 		});
 
-		it("should post worker queue consumers on deploy", async ({ expect }) => {
+		it("should set worker queue consumers on deploy", async ({ expect }) => {
 			writeWranglerConfig({
 				queues: {
 					consumers: [
@@ -215,17 +213,31 @@ describe("deploy", () => {
 				modified_on: "",
 			};
 			mockGetQueueByName(queueName, existingQueue);
-			mockPostConsumerById(queueId, {
-				dead_letter_queue: "myDLQ",
-				type: "worker",
-				script_name: "test-name",
-				settings: {
-					batch_size: 5,
-					max_retries: 10,
-					max_wait_time_ms: 3000,
-					retry_delay: 5,
+			mockSetScriptConsumers(
+				"test-name",
+				{
+					consumers: [
+						{
+							queue_id: queueId,
+							type: "worker",
+							script_name: "test-name",
+							dead_letter_queue: "myDLQ",
+							settings: {
+								batch_size: 5,
+								max_retries: 10,
+								max_wait_time_ms: 3000,
+								retry_delay: 5,
+							},
+						},
+					],
 				},
-			});
+				{
+					created: [{ queue_id: queueId, queue_name: queueName }],
+					updated: [],
+					deleted: [],
+					failed: [],
+				}
+			);
 			await runWrangler("deploy index.js");
 			expect(std.out).toMatchInlineSnapshot(`
 				"
@@ -241,7 +253,7 @@ describe("deploy", () => {
 			`);
 		});
 
-		it("should post worker queue consumers on deploy, using command line script name arg", async ({
+		it("should set worker queue consumers on deploy, using command line script name arg", async ({
 			expect,
 		}) => {
 			const expectedScriptName = "command-line-arg-script-name";
@@ -273,17 +285,31 @@ describe("deploy", () => {
 				modified_on: "",
 			};
 			mockGetQueueByName(queueName, existingQueue);
-			mockPostConsumerById(queueId, {
-				dead_letter_queue: "myDLQ",
-				type: "worker",
-				script_name: expectedScriptName,
-				settings: {
-					batch_size: 5,
-					max_retries: 10,
-					max_wait_time_ms: 3000,
-					retry_delay: 5,
+			mockSetScriptConsumers(
+				expectedScriptName,
+				{
+					consumers: [
+						{
+							queue_id: queueId,
+							type: "worker",
+							script_name: expectedScriptName,
+							dead_letter_queue: "myDLQ",
+							settings: {
+								batch_size: 5,
+								max_retries: 10,
+								max_wait_time_ms: 3000,
+								retry_delay: 5,
+							},
+						},
+					],
 				},
-			});
+				{
+					created: [{ queue_id: queueId, queue_name: queueName }],
+					updated: [],
+					deleted: [],
+					failed: [],
+				}
+			);
 			await runWrangler(`deploy index.js --name ${expectedScriptName}`);
 			expect(std.out).toMatchInlineSnapshot(`
 				"
@@ -299,82 +325,22 @@ describe("deploy", () => {
 			`);
 		});
 
-		it("should update worker queue consumers on deploy", async ({ expect }) => {
-			writeWranglerConfig({
-				queues: {
-					consumers: [
-						{
-							queue: queueName,
-							dead_letter_queue: "myDLQ",
-							max_batch_size: 5,
-							max_batch_timeout: 3,
-							max_retries: 10,
-							retry_delay: 5,
-						},
-					],
-				},
-			});
-			await fs.promises.writeFile("index.js", `export default {};`);
-			mockSubDomainRequest();
-			mockUploadWorkerRequest();
-			const expectedConsumerId = "consumerId";
-			const existingQueue: QueueResponse = {
-				queue_id: queueId,
-				queue_name: queueName,
-				created_on: "",
-				producers: [],
-				consumers: [
-					{
-						script: "test-name",
-						consumer_id: expectedConsumerId,
-						type: "worker",
-						settings: {},
-					},
-				],
-				producers_total_count: 1,
-				consumers_total_count: 1,
-				modified_on: "",
-			};
-			mockGetQueueByName(queueName, existingQueue);
-			mockPutQueueConsumerById(queueId, queueName, expectedConsumerId, {
-				dead_letter_queue: "myDLQ",
-				type: "worker",
-				script_name: "test-name",
-				settings: {
-					batch_size: 5,
-					max_retries: 10,
-					max_wait_time_ms: 3000,
-					retry_delay: 5,
-				},
-			});
-			await runWrangler("deploy index.js");
-			expect(std.out).toMatchInlineSnapshot(`
-				"
-				 ⛅️ wrangler x.x.x
-				──────────────────
-				Total Upload: xx KiB / gzip: xx KiB
-				Worker Startup Time: 100 ms
-				Uploaded test-name (TIMINGS)
-				Deployed test-name triggers (TIMINGS)
-				  https://test-name.test-sub-domain.workers.dev
-				  Consumer for queue1
-				Current Version ID: Galaxy-Class"
-			`);
-		});
-
-		it("should update worker (service) queue consumers with default environment on deploy", async ({
+		it("should send all configured consumers in a single request", async ({
 			expect,
 		}) => {
+			const secondQueueName = "queue2";
+			const secondQueueId = "queue2-id";
 			writeWranglerConfig({
 				queues: {
 					consumers: [
 						{
 							queue: queueName,
-							dead_letter_queue: "myDLQ",
 							max_batch_size: 5,
-							max_batch_timeout: 3,
-							max_retries: 10,
-							retry_delay: 5,
+						},
+						{
+							queue: secondQueueName,
+							max_batch_size: 10,
+							max_retries: 2,
 						},
 					],
 				},
@@ -382,41 +348,70 @@ describe("deploy", () => {
 			await fs.promises.writeFile("index.js", `export default {};`);
 			mockSubDomainRequest();
 			mockUploadWorkerRequest();
-			const expectedConsumerId = "consumerId";
-			const expectedConsumerName = "test-name";
-			const expectedEnvironment = "production";
-			const existingQueue: QueueResponse = {
-				queue_id: queueId,
-				queue_name: queueName,
-				created_on: "",
-				producers: [],
-				consumers: [
-					{
-						service: expectedConsumerName,
-						environment: "production",
-						consumer_id: expectedConsumerId,
-						type: "worker",
-						settings: {},
-					},
-				],
-				producers_total_count: 1,
-				consumers_total_count: 1,
-				modified_on: "",
-			};
-			mockGetQueueByName(queueName, existingQueue);
-			mockGetServiceByName(expectedConsumerName, expectedEnvironment);
-			mockPutQueueConsumerById(queueId, queueName, expectedConsumerId, {
-				dead_letter_queue: "myDLQ",
-				type: "worker",
-				script_name: "test-name",
-				settings: {
-					batch_size: 5,
-					max_retries: 10,
-					max_wait_time_ms: 3000,
-					retry_delay: 5,
+			// `ensureQueuesExistByConfig` batches the lookup, so the mock returns
+			// both queues from one call.
+			msw.use(
+				http.get("*/accounts/:accountId/queues?*", async ({ request }) => {
+					const url = new URL(request.url);
+					const names = url.searchParams.getAll("name");
+					expect(names).toEqual([queueName, secondQueueName]);
+					return HttpResponse.json({
+						success: true,
+						errors: [],
+						messages: [],
+						result: [
+							{
+								queue_id: queueId,
+								queue_name: queueName,
+								created_on: "",
+								producers: [],
+								consumers: [],
+								producers_total_count: 0,
+								consumers_total_count: 0,
+								modified_on: "",
+							},
+							{
+								queue_id: secondQueueId,
+								queue_name: secondQueueName,
+								created_on: "",
+								producers: [],
+								consumers: [],
+								producers_total_count: 0,
+								consumers_total_count: 0,
+								modified_on: "",
+							},
+						],
+					});
+				})
+			);
+			mockSetScriptConsumers(
+				"test-name",
+				{
+					consumers: [
+						{
+							queue_id: queueId,
+							type: "worker",
+							script_name: "test-name",
+							settings: { batch_size: 5 },
+						},
+						{
+							queue_id: secondQueueId,
+							type: "worker",
+							script_name: "test-name",
+							settings: { batch_size: 10, max_retries: 2 },
+						},
+					],
 				},
-			});
-
+				{
+					created: [
+						{ queue_id: queueId, queue_name: queueName },
+						{ queue_id: secondQueueId, queue_name: secondQueueName },
+					],
+					updated: [],
+					deleted: [],
+					failed: [],
+				}
+			);
 			await runWrangler("deploy index.js");
 			expect(std.out).toMatchInlineSnapshot(`
 				"
@@ -428,6 +423,7 @@ describe("deploy", () => {
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
 				  Consumer for queue1
+				  Consumer for queue2
 				Current Version ID: Galaxy-Class"
 			`);
 		});
@@ -472,36 +468,42 @@ describe("deploy", () => {
 			await fs.promises.writeFile("index.js", `export default {};`);
 			mockSubDomainRequest();
 			mockUploadWorkerRequest();
-			const consumerId = "consumer-id";
 			const existingQueue: QueueResponse = {
 				queue_id: queueId,
 				queue_name: queueName,
 				created_on: "",
 				producers: [],
-				consumers: [
-					{
-						type: "worker",
-						script: "test-name",
-						consumer_id: consumerId,
-						settings: {},
-					},
-				],
+				consumers: [],
 				producers_total_count: 0,
 				consumers_total_count: 0,
 				modified_on: "",
 			};
 			mockGetQueueByName(queueName, existingQueue);
-			mockPutQueueConsumerById(queueId, queueName, consumerId, {
-				dead_letter_queue: "myDLQ",
-				type: "worker",
-				script_name: "test-name",
-				settings: {
-					batch_size: 5,
-					max_retries: 10,
-					max_wait_time_ms: 3000,
-					max_concurrency: 5,
+			mockSetScriptConsumers(
+				"test-name",
+				{
+					consumers: [
+						{
+							queue_id: queueId,
+							type: "worker",
+							script_name: "test-name",
+							dead_letter_queue: "myDLQ",
+							settings: {
+								batch_size: 5,
+								max_retries: 10,
+								max_wait_time_ms: 3000,
+								max_concurrency: 5,
+							},
+						},
+					],
 				},
-			});
+				{
+					created: [{ queue_id: queueId, queue_name: queueName }],
+					updated: [],
+					deleted: [],
+					failed: [],
+				}
+			);
 			await runWrangler("deploy index.js");
 			expect(std.out).toMatchInlineSnapshot(`
 				"
@@ -538,35 +540,41 @@ describe("deploy", () => {
 			mockSubDomainRequest();
 			mockUploadWorkerRequest();
 
-			const consumerId = "consumer-id";
 			const existingQueue: QueueResponse = {
 				queue_id: queueId,
 				queue_name: queueName,
 				created_on: "",
 				producers: [],
-				consumers: [
-					{
-						type: "worker",
-						script: "test-name",
-						consumer_id: consumerId,
-						settings: {},
-					},
-				],
+				consumers: [],
 				producers_total_count: 0,
 				consumers_total_count: 0,
 				modified_on: "",
 			};
 			mockGetQueueByName(queueName, existingQueue);
-			mockPutQueueConsumerById(queueId, queueName, consumerId, {
-				dead_letter_queue: "myDLQ",
-				type: "worker",
-				script_name: "test-name",
-				settings: {
-					batch_size: 5,
-					max_retries: 10,
-					max_wait_time_ms: 3000,
+			mockSetScriptConsumers(
+				"test-name",
+				{
+					consumers: [
+						{
+							queue_id: queueId,
+							type: "worker",
+							script_name: "test-name",
+							dead_letter_queue: "myDLQ",
+							settings: {
+								batch_size: 5,
+								max_retries: 10,
+								max_wait_time_ms: 3000,
+							},
+						},
+					],
 				},
-			});
+				{
+					created: [{ queue_id: queueId, queue_name: queueName }],
+					updated: [],
+					deleted: [],
+					failed: [],
+				}
+			);
 
 			await runWrangler("deploy index.js");
 			expect(std.out).toMatchInlineSnapshot(`
@@ -604,35 +612,41 @@ describe("deploy", () => {
 			mockSubDomainRequest();
 			mockUploadWorkerRequest();
 
-			const consumerId = "consumer-id";
 			const existingQueue: QueueResponse = {
 				queue_id: queueId,
 				queue_name: queueName,
 				created_on: "",
 				producers: [],
-				consumers: [
-					{
-						type: "worker",
-						script: "test-name",
-						consumer_id: consumerId,
-						settings: {},
-					},
-				],
+				consumers: [],
 				producers_total_count: 0,
 				consumers_total_count: 0,
 				modified_on: "",
 			};
 			mockGetQueueByName(queueName, existingQueue);
-			mockPutQueueConsumerById(queueId, queueName, consumerId, {
-				dead_letter_queue: "myDLQ",
-				type: "worker",
-				script_name: "test-name",
-				settings: {
-					batch_size: 5,
-					max_retries: 10,
-					max_wait_time_ms: 0,
+			mockSetScriptConsumers(
+				"test-name",
+				{
+					consumers: [
+						{
+							queue_id: queueId,
+							type: "worker",
+							script_name: "test-name",
+							dead_letter_queue: "myDLQ",
+							settings: {
+								batch_size: 5,
+								max_retries: 10,
+								max_wait_time_ms: 0,
+							},
+						},
+					],
 				},
-			});
+				{
+					created: [{ queue_id: queueId, queue_name: queueName }],
+					updated: [],
+					deleted: [],
+					failed: [],
+				}
+			);
 
 			await runWrangler("deploy index.js");
 			expect(std.out).toMatchInlineSnapshot(`
@@ -697,6 +711,200 @@ describe("deploy", () => {
 			).rejects.toMatchInlineSnapshot(
 				`[Error: Queue "queue1" does not exist. To create it, run: wrangler queues create queue1]`
 			);
+		});
+
+		// Wrangler always calls the consumers endpoint so stale registrations
+		// from previous deploys get cleaned up — including the case where the
+		// user removes all consumers from their config.
+		it("should call the consumers endpoint with an empty list when no consumers are configured", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				queues: {
+					producers: [],
+					consumers: [],
+				},
+			});
+			await fs.promises.writeFile("index.js", `export default {};`);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest();
+			const requests = mockSetScriptConsumers("test-name", {
+				consumers: [],
+			});
+
+			await runWrangler("deploy index.js");
+
+			expect(requests.count).toBe(1);
+			expect(std.out).toMatchInlineSnapshot(`
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				Total Upload: xx KiB / gzip: xx KiB
+				Worker Startup Time: 100 ms
+				Uploaded test-name (TIMINGS)
+				Deployed test-name triggers (TIMINGS)
+				  https://test-name.test-sub-domain.workers.dev
+				Current Version ID: Galaxy-Class"
+			`);
+		});
+
+		it("should report cleanup of stale consumers when no consumers are configured", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				queues: {
+					producers: [],
+					consumers: [],
+				},
+			});
+			await fs.promises.writeFile("index.js", `export default {};`);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest();
+			mockSetScriptConsumers(
+				"test-name",
+				{ consumers: [] },
+				{
+					created: [],
+					updated: [],
+					deleted: [{ queue_id: "stale-id", queue_name: "stale-queue" }],
+					failed: [],
+				}
+			);
+
+			await runWrangler("deploy index.js");
+
+			expect(std.out).toMatchInlineSnapshot(`
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				Total Upload: xx KiB / gzip: xx KiB
+				Worker Startup Time: 100 ms
+				Uploaded test-name (TIMINGS)
+				Deployed test-name triggers (TIMINGS)
+				  https://test-name.test-sub-domain.workers.dev
+				  Removed consumer for stale-queue
+				Current Version ID: Galaxy-Class"
+			`);
+		});
+
+		it("should not block the deploy when the consumer sync request fails", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				queues: {
+					producers: [],
+					consumers: [],
+				},
+			});
+			await fs.promises.writeFile("index.js", `export default {};`);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest();
+			msw.use(
+				http.put(
+					"*/accounts/:accountId/workers/scripts/:scriptName/queue-consumers",
+					async () => {
+						return HttpResponse.json(
+							{
+								success: false,
+								errors: [{ code: 10000, message: "server unavailable" }],
+								messages: [],
+								result: null,
+							},
+							{ status: 500 }
+						);
+					},
+					{ once: true }
+				)
+			);
+
+			await runWrangler("deploy index.js");
+
+			expect(process.exitCode).toBe(1);
+			expect(std.err).toContain("Failed to configure queue consumers");
+
+			// Reset so it doesn't affect other tests
+			process.exitCode = 0;
+		});
+
+		it("should report a mix of created, updated, deleted, and failed consumers", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				queues: {
+					consumers: [
+						{
+							queue: queueName,
+							max_batch_size: 5,
+						},
+					],
+				},
+			});
+			await fs.promises.writeFile("index.js", `export default {};`);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest();
+			const existingQueue: QueueResponse = {
+				queue_id: queueId,
+				queue_name: queueName,
+				created_on: "",
+				producers: [],
+				consumers: [],
+				producers_total_count: 0,
+				consumers_total_count: 0,
+				modified_on: "",
+			};
+			mockGetQueueByName(queueName, existingQueue);
+			mockSetScriptConsumers(
+				"test-name",
+				{
+					consumers: [
+						{
+							queue_id: queueId,
+							type: "worker",
+							script_name: "test-name",
+							settings: {
+								batch_size: 5,
+							},
+						},
+					],
+				},
+				{
+					created: [{ queue_id: "id-a", queue_name: "order-queue" }],
+					updated: [{ queue_id: "id-b", queue_name: "notification-queue" }],
+					deleted: [{ queue_id: "id-c", queue_name: "old-queue" }],
+					failed: [
+						{
+							queue_id: "id-d",
+							queue_name: "broken-queue",
+							error: "broker unavailable",
+						},
+					],
+				}
+			);
+
+			await runWrangler("deploy index.js");
+
+			expect(process.exitCode).toBe(1);
+			expect(std.out).toMatchInlineSnapshot(`
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				Total Upload: xx KiB / gzip: xx KiB
+				Worker Startup Time: 100 ms
+				Uploaded test-name (TIMINGS)
+				Deployed test-name triggers (TIMINGS)
+				  https://test-name.test-sub-domain.workers.dev
+				  Consumer for order-queue
+				  Consumer for notification-queue
+				  Removed consumer for old-queue
+				  X Failed to configure consumer for broken-queue: broker unavailable
+				Current Version ID: Galaxy-Class"
+			`);
+			expect(std.err).toContain(
+				"Failed to configure consumer for broken-queue: broker unavailable"
+			);
+
+			// Reset so it doesn't affect other tests
+			process.exitCode = 0;
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/helpers/msw/index.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/index.ts
@@ -1,3 +1,4 @@
+import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { default as mswAccessHandlers } from "./handlers/access";
 import {
@@ -25,7 +26,29 @@ import {
 } from "./handlers/versions";
 import { default as mswZoneHandlers } from "./handlers/zones";
 
-export const msw = setupServer();
+// Default handler for the queue consumers sync endpoint. Wrangler calls this
+// on every deploy (even for workers that don't use queues) so stale consumer
+// registrations from previous deploys get cleaned up. Default handlers passed
+// to `setupServer` survive `resetHandlers()` between tests, so individual
+// tests don't need to mock this unless they want to assert specific behavior.
+const mswDefaultSetScriptConsumers = http.put(
+	"*/accounts/:accountId/workers/scripts/:scriptName/queue-consumers",
+	() => {
+		return HttpResponse.json({
+			success: true,
+			errors: [],
+			messages: [],
+			result: {
+				created: [],
+				updated: [],
+				deleted: [],
+				failed: [],
+			},
+		});
+	}
+);
+
+export const msw = setupServer(mswDefaultSetScriptConsumers);
 
 function createFetchResult(
 	result: unknown,

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -53,9 +53,7 @@ import { isNavigatorDefined } from "../navigator-user-agent";
 import { getWranglerTmpDir } from "../paths";
 import {
 	ensureQueuesExistByConfig,
-	getQueue,
-	postConsumer,
-	putConsumer,
+	setScriptConsumers,
 } from "../queues/client";
 import { parseBulkInputToObject } from "../secret";
 import { syncWorkersSite } from "../sites";
@@ -82,7 +80,7 @@ import { getConfigPatch, getRemoteConfigDiff } from "./config-diffs";
 import type { StartDevWorkerInput } from "../api/startDevWorker/types";
 import type { AssetsOptions } from "../assets";
 import type { Entry } from "../deployment-bundle/entry";
-import type { PostTypedConsumerBody } from "../queues/client";
+import type { SetScriptConsumerEntry } from "../queues/client";
 import type { LegacyAssetPaths } from "../sites";
 import type { RetrieveSourceMapFunction } from "../sourcemap";
 import type { ApiVersion, Percentage, VersionId } from "../versions/types";
@@ -1517,26 +1515,32 @@ async function publishRoutesFallback(
 	return deployedRoutes;
 }
 
-export async function updateQueueConsumers(
+export function updateQueueConsumers(
 	scriptName: string | undefined,
-	config: Config
-): Promise<Promise<string[]>[]> {
-	const consumers = config.queues.consumers || [];
-	const updateConsumers: Promise<string[]>[] = [];
-	for (const consumer of consumers) {
-		const queue = await getQueue(config, consumer.queue);
+	config: Config,
+	queueNameToId: Map<string, string>
+): Promise<string[]> {
+	if (scriptName === undefined) {
+		throw new UserError("Script name is required to update queue consumers", {
+			telemetryMessage: "deploy queue consumers missing script name",
+		});
+	}
 
-		if (scriptName === undefined) {
-			// TODO: how can we reliably get the current script name?
-			throw new UserError("Script name is required to update queue consumers", {
-				telemetryMessage: "deploy queue consumers missing script name",
-			});
+	const consumers = config.queues.consumers || [];
+	const entries: SetScriptConsumerEntry[] = consumers.map((consumer) => {
+		const queueId = queueNameToId.get(consumer.queue);
+		if (queueId === undefined) {
+			throw new UserError(
+				`Queue "${consumer.queue}" does not exist. To create it, run: wrangler queues create ${consumer.queue}`,
+				{ telemetryMessage: "queues config missing queue" }
+			);
 		}
 
-		const body: PostTypedConsumerBody = {
-			type: "worker",
-			dead_letter_queue: consumer.dead_letter_queue,
+		return {
+			queue_id: queueId,
+			type: "worker" as const,
 			script_name: scriptName,
+			dead_letter_queue: consumer.dead_letter_queue,
 			settings: {
 				batch_size: consumer.max_batch_size,
 				max_retries: consumer.max_retries,
@@ -1548,29 +1552,45 @@ export async function updateQueueConsumers(
 				retry_delay: consumer.retry_delay,
 			},
 		};
+	});
 
-		// Current script already assigned to queue?
-		const existingConsumer =
-			queue.consumers.filter(
-				(c) => c.script === scriptName || c.service === scriptName
-			).length > 0;
-		const envName = undefined; // TODO: script environment for wrangler deploy?
-		if (existingConsumer) {
-			updateConsumers.push(
-				putConsumer(config, consumer.queue, scriptName, envName, body).then(
-					() => [`Consumer for ${consumer.queue}`]
-				)
-			);
-			continue;
-		}
-		updateConsumers.push(
-			postConsumer(config, consumer.queue, body).then(() => [
-				`Consumer for ${consumer.queue}`,
-			])
-		);
-	}
+	return setScriptConsumers(config, scriptName, { consumers: entries })
+		.then((result) => {
+			const displayLines: string[] = [];
 
-	return updateConsumers;
+			for (const entry of result.created) {
+				displayLines.push(`Consumer for ${entry.queue_name}`);
+			}
+			for (const entry of result.updated) {
+				displayLines.push(`Consumer for ${entry.queue_name}`);
+			}
+			for (const entry of result.deleted) {
+				displayLines.push(`Removed consumer for ${entry.queue_name}`);
+			}
+			for (const entry of result.failed) {
+				displayLines.push(
+					`✘ Failed to configure consumer for ${entry.queue_name}: ${entry.error}`
+				);
+				logger.error(
+					`Failed to configure consumer for ${entry.queue_name}: ${entry.error}`
+				);
+			}
+
+			if (result.failed.length > 0) {
+				process.exitCode = 1;
+			}
+
+			return displayLines;
+		})
+		.catch((err) => {
+			// Don't fail the whole deploy if the consumer sync request fails;
+			// other triggers (routes, schedules, workflows) should still complete
+			// and be reported. Surface the failure with a non-zero exit code.
+			const message = err instanceof Error ? err.message : String(err);
+			logger.error(`Failed to configure queue consumers: ${message}`);
+			process.exitCode = 1;
+			return [`✘ Failed to configure queue consumers: ${message}`];
+		});
 }
 
 function getDeployConfirmFunction(

--- a/packages/wrangler/src/queues/client.ts
+++ b/packages/wrangler/src/queues/client.ts
@@ -98,6 +98,32 @@ export interface PurgeQueueResponse {
 	complete: boolean;
 }
 
+export interface SetScriptConsumersBody {
+	consumers: SetScriptConsumerEntry[];
+}
+
+export interface SetScriptConsumerEntry {
+	queue_id: string;
+	type: "worker";
+	script_name: string;
+	settings?: ConsumerSettings;
+	dead_letter_queue?: string;
+	environment?: string;
+}
+
+export interface SetScriptConsumersResultEntry {
+	queue_id: string;
+	queue_name: string;
+	error?: string;
+}
+
+export interface SetScriptConsumersResult {
+	created: SetScriptConsumersResultEntry[];
+	updated: SetScriptConsumersResultEntry[];
+	deleted: SetScriptConsumersResultEntry[];
+	failed: SetScriptConsumersResultEntry[];
+}
+
 const queuesUrl = (accountId: string, queueId?: string): string => {
 	let url = `/accounts/${accountId}/queues`;
 	if (queueId) {
@@ -117,6 +143,25 @@ const queueConsumersUrl = (
 	}
 	return url;
 };
+
+const scriptQueueConsumersUrl = (
+	accountId: string,
+	scriptName: string
+): string => {
+	return `/accounts/${accountId}/workers/scripts/${scriptName}/queue-consumers`;
+};
+
+export async function setScriptConsumers(
+	config: Config,
+	scriptName: string,
+	body: SetScriptConsumersBody
+): Promise<SetScriptConsumersResult> {
+	const accountId = await requireAuth(config);
+	return fetchResult(config, scriptQueueConsumersUrl(accountId, scriptName), {
+		method: "PUT",
+		body: JSON.stringify(body),
+	});
+}
 
 export async function createQueue(
 	config: Config,
@@ -201,7 +246,9 @@ export async function getQueue(
 	return queues[0];
 }
 
-export async function ensureQueuesExistByConfig(config: Config) {
+export async function ensureQueuesExistByConfig(
+	config: Config
+): Promise<Map<string, string>> {
 	const producers = (config.queues.producers || []).map(
 		(producer) => producer.queue
 	);
@@ -210,20 +257,25 @@ export async function ensureQueuesExistByConfig(config: Config) {
 	);
 
 	const queueNames = producers.concat(consumers);
-	await ensureQueuesExist(config, queueNames);
+	return ensureQueuesExist(config, queueNames);
 }
 
-async function ensureQueuesExist(config: Config, queueNames: string[]) {
+async function ensureQueuesExist(
+	config: Config,
+	queueNames: string[]
+): Promise<Map<string, string>> {
+	const queueNameToId = new Map<string, string>();
+
 	if (queueNames.length > 0) {
-		const existingQueues = (await listAllQueues(config, queueNames)).map(
-			(q) => q.queue_name
-		);
+		const existingQueues = await listAllQueues(config, queueNames);
+
+		for (const q of existingQueues) {
+			queueNameToId.set(q.queue_name, q.queue_id);
+		}
 
 		if (queueNames.length !== existingQueues.length) {
-			const queueSet = new Set(existingQueues);
-
 			for (const queue of queueNames) {
-				if (!queueSet.has(queue)) {
+				if (!queueNameToId.has(queue)) {
 					throw new UserError(
 						`Queue "${queue}" does not exist. To create it, run: wrangler queues create ${queue}`,
 						{ telemetryMessage: "queues config missing queue" }
@@ -232,6 +284,8 @@ async function ensureQueuesExist(config: Config, queueNames: string[]) {
 			}
 		}
 	}
+
+	return queueNameToId;
 }
 
 export async function getQueueById(
@@ -282,45 +336,6 @@ async function postConsumerById(
 		method: "POST",
 		body: JSON.stringify(body),
 	});
-}
-
-export async function putConsumerById(
-	config: Config,
-	queueId: string,
-	consumerId: string,
-	body: PostTypedConsumerBody
-): Promise<TypedConsumerResponse> {
-	const accountId = await requireAuth(config);
-	return fetchResult(
-		config,
-		queueConsumersUrl(accountId, queueId, consumerId),
-		{
-			method: "PUT",
-			body: JSON.stringify(body),
-		}
-	);
-}
-
-export async function putConsumer(
-	config: Config,
-	queueName: string,
-	scriptName: string,
-	envName: string | undefined,
-	body: PostTypedConsumerBody
-): Promise<TypedConsumerResponse> {
-	const queue = await getQueue(config, queueName);
-	const targetConsumer = await resolveWorkerConsumerByName(
-		config,
-		scriptName,
-		envName,
-		queue
-	);
-	return putConsumerById(
-		config,
-		queue.queue_id,
-		targetConsumer.consumer_id,
-		body
-	);
 }
 
 async function resolveWorkerConsumerByName(

--- a/packages/wrangler/src/triggers/deploy.ts
+++ b/packages/wrangler/src/triggers/deploy.ts
@@ -75,8 +75,9 @@ export default async function triggersDeploy(
 		? `/accounts/${accountId}/workers/services/${scriptName}/environments/${envName}`
 		: `/accounts/${accountId}/workers/scripts/${scriptName}`;
 
+	let queueNameToId = new Map<string, string>();
 	if (!props.dryRun) {
-		await ensureQueuesExistByConfig(config);
+		queueNameToId = await ensureQueuesExistByConfig(config);
 	}
 
 	if (props.dryRun) {
@@ -249,11 +250,9 @@ export default async function triggersDeploy(
 		);
 	}
 
-	if (config.queues.consumers && config.queues.consumers.length) {
-		const updateConsumers = await updateQueueConsumers(scriptName, config);
-
-		deployments.push(...updateConsumers);
-	}
+	// Always call so stale consumers from previous deploys are cleaned up,
+	// even when the user has removed all consumers from their config.
+	deployments.push(updateQueueConsumers(scriptName, config, queueNameToId));
 
 	if (config.workflows?.length) {
 		for (const workflow of config.workflows) {
@@ -299,13 +298,13 @@ export default async function triggersDeploy(
 	const targets = await Promise.all(deployments);
 	const deployMs = Date.now() - start - uploadMs;
 
-	if (deployments.length > 0) {
-		logger.log(`Deployed ${workerName} triggers`, formatTime(deployMs));
+	const flatTargets = targets.flat().map(
+		// Append protocol only on workers.dev domains
+		(target) => (target.endsWith("workers.dev") ? "https://" : "") + target
+	);
 
-		const flatTargets = targets.flat().map(
-			// Append protocol only on workers.dev domains
-			(target) => (target.endsWith("workers.dev") ? "https://" : "") + target
-		);
+	if (flatTargets.length > 0) {
+		logger.log(`Deployed ${workerName} triggers`, formatTime(deployMs));
 
 		for (const target of flatTargets) {
 			logger.log(" ", target);


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/MQ-1242

_Describe your change..._


`wrangler deploy` now cleans up stale queue consumer registrations.

Previously, when a user removed a queue consumer from their `wrangler.json` config and redeployed, Wrangler left the old consumer registration in place — the worker continued receiving messages from a queue it no longer declared. This was because deploy only ever called the create/update consumer endpoints for the consumers currently in the config list.

This PR replaces the per-consumer create/update calls with a single declarative call to EWC's new script-level endpoint (`PUT /accounts/{accountId}/workers/scripts/{scriptName}/queue-consumers`). Wrangler sends the full, authoritative list of declared consumers, and EWC creates, updates, or deletes registrations as needed.

The endpoint is called on every deploy (not just when consumers are declared) so stale registrations get cleaned up even if the user removes the entire `queues` section. This has to be done as wrangler doesn't track diffs between deploys but the cost for non-queue workers is a cheap no-op call to EWC per deploy.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
