### PR TITLE
Honor assetConfig.headers/redirects when no on-disk _headers/_redirects file is present

### DIFF
--- a/packages/miniflare/src/plugins/assets/index.ts
+++ b/packages/miniflare/src/plugins/assets/index.ts
@@ -174,8 +174,8 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 			compatibility_date: options.compatibilityDate,
 			compatibility_flags: options.compatibilityFlags,
 			...options.assets.assetConfig,
-			redirects: parsedRedirects,
-			headers: parsedHeaders,
+			redirects: parsedRedirects ?? options.assets.assetConfig?.redirects,
+			headers: parsedHeaders ?? options.assets.assetConfig?.headers,
 			debug: true,
 			has_static_routing: Boolean(options.assets.routerConfig?.static_routing),
 		};


### PR DESCRIPTION
### Describe your change

When a Miniflare consumer provides headers/redirects via the programmatic API:

```ts
new Miniflare({
  assets: {
    directory: '...',
    assetConfig: {
      headers: { version: 2, rules: { '/*': { set: { 'Cross-Origin-Opener-Policy': 'same-origin' } } } },
    },
  },
  // ...
});
```

…the values are silently discarded today. `AssetsOptionsSchema` advertises `assetConfig.headers` and `assetConfig.redirects` as part of the API surface (see `packages/miniflare/src/plugins/assets/schema.ts`), but `packages/miniflare/src/plugins/assets/index.ts` overwrites them unconditionally with `parsedHeaders` / `parsedRedirects`, which are populated **only** from the on-disk `_headers` / `_redirects` files. When no file is present, the user-supplied config is replaced with `undefined`:

```ts
const assetConfig: AssetConfig = {
  // ...
  ...options.assets.assetConfig,
  redirects: parsedRedirects,   // overwrites the spread, even when undefined
  headers: parsedHeaders,       // overwrites the spread, even when undefined
  // ...
};
```

This change keeps file-based config as the source of truth when a `_headers` / `_redirects` file exists, and falls back to `options.assets.assetConfig.headers` / `.redirects` otherwise. The schema already requires the programmatic value to be in the parsed shape (`HeadersSchema` / `RedirectsSchema`), so no extra parsing is needed.

Concrete impact: COOP/COEP headers configured programmatically now actually reach the browser, so `crossOriginIsolated` is true and `SharedArrayBuffer` transfers across workers succeed.