### PR TITLE
WOR-1251: provision workers.dev subdomain when a script has a workflo…

### DIFF
--- a/.changeset/workflows-workers-dev-subdomain.md
+++ b/.changeset/workflows-workers-dev-subdomain.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Prompt to provision a workers.dev subdomain before deploying Workflows
+
+Wrangler now checks for the account-level workers.dev subdomain when deploying Workflows, even if the Worker is not being published to workers.dev. If the subdomain has not been registered yet, Wrangler prompts to create one before calling the Workflows deploy API so users avoid an opaque server-side deployment failure.

--- a/packages/wrangler/src/__tests__/deploy/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/workflows.test.ts
@@ -175,6 +175,63 @@ describe("deploy", () => {
 			`);
 		});
 
+		it("should prompt to create a workers.dev subdomain before deploying owned Workflows", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				main: "index.js",
+				workers_dev: false,
+				workflows: [
+					{
+						binding: "WORKFLOW",
+						name: "my-workflow",
+						class_name: "MyWorkflow",
+					},
+				],
+			});
+			await fs.promises.writeFile(
+				"index.js",
+				`
+                import { WorkflowEntrypoint } from 'cloudflare:workers';
+                export default {};
+                export class MyWorkflow extends WorkflowEntrypoint {};
+            `
+			);
+
+			mockUploadWorkerRequest({
+				expectedBindings: [
+					{
+						type: "workflow",
+						name: "WORKFLOW",
+						workflow_name: "my-workflow",
+						class_name: "MyWorkflow",
+					},
+				],
+			});
+			mockSubDomainRequest("does-not-exist", false);
+			mockConfirm({
+				text: "Would you like to register a workers.dev subdomain now?",
+				result: false,
+			});
+			msw.use(
+				http.put("*/accounts/:accountId/workflows/:workflowName", () => {
+					throw new Error(
+						"Workflows API should not be called until the account has a workers.dev subdomain."
+					);
+				})
+			);
+
+			await expect(runWrangler("deploy")).rejects
+				.toThrowErrorMatchingInlineSnapshot(`
+				[Error: Workflows require your account to have a workers.dev subdomain. Register a workers.dev subdomain here:
+				https://dash.cloudflare.com/some-account-id/workers/onboarding]
+			`);
+
+			expect(std.warn).toContain(
+				"You need to register a workers.dev subdomain before deploying Workflows"
+			);
+		});
+
 		it("should deploy a workflow with limits", async ({ expect }) => {
 			writeWranglerConfig({
 				main: "index.js",

--- a/packages/wrangler/src/dev/create-worker-preview.ts
+++ b/packages/wrangler/src/dev/create-worker-preview.ts
@@ -218,9 +218,10 @@ export async function createPreviewSession(
 			const subdomain = await getWorkersDevSubdomain(
 				complianceConfig,
 				account.accountId,
-				undefined,
-				apiToken,
-				withTimeout(abortSignal)
+				{
+					apiToken,
+					abortSignal: withTimeout(abortSignal),
+				}
 			);
 			host = `${name ?? crypto.randomUUID()}.${subdomain}`;
 		}

--- a/packages/wrangler/src/routes.ts
+++ b/packages/wrangler/src/routes.ts
@@ -10,16 +10,30 @@ import { logger } from "./logger";
 import type { ApiCredentials } from "./user/user";
 import type { ComplianceConfig } from "@cloudflare/workers-utils";
 
+type WorkersDevSubdomainRegistrationContext = "workers_dev" | "workflows";
+
+type GetWorkersDevSubdomainOptions = {
+	configPath?: string | undefined;
+	apiToken?: ApiCredentials | undefined;
+	abortSignal?: AbortSignal | undefined;
+	registrationContext?: WorkersDevSubdomainRegistrationContext | undefined;
+};
+
 /**
  * Gets the <user-subdomain>.(fed.)workers.dev URL for the given account.
  */
 export async function getWorkersDevSubdomain(
 	complianceConfig: ComplianceConfig,
 	accountId: string,
-	configPath: string | undefined,
-	apiToken?: ApiCredentials,
-	abortSignal?: AbortSignal
+	options: GetWorkersDevSubdomainOptions = {}
 ): Promise<string> {
+	const {
+		configPath,
+		apiToken,
+		abortSignal,
+		registrationContext = "workers_dev",
+	} = options;
+
 	try {
 		// note: API docs say that this field is "name", but they're lying.
 		const { subdomain } = await fetchResult<{ subdomain: string }>(
@@ -33,30 +47,73 @@ export async function getWorkersDevSubdomain(
 		return `${subdomain}${getComplianceRegionSubdomain(complianceConfig)}.workers.dev`;
 	} catch (e) {
 		const error = e as { code?: number };
-		if (typeof error === "object" && !!error && error.code === 10007) {
-			// 10007 error code: not found
-			// https://api.cloudflare.com/#worker-subdomain-get-subdomain
-
-			logger.warn(
-				"You need to register a workers.dev subdomain before publishing to workers.dev"
-			);
-
-			const wantsToRegister = await confirm(
-				"Would you like to register a workers.dev subdomain now?",
-				{ fallbackValue: false }
-			);
-			if (!wantsToRegister) {
-				const solutionMessage = `You can either deploy your worker to one or more routes by specifying them in your ${configFileName(configPath)} file, or register a workers.dev subdomain here:`;
-				const onboardingLink = `https://dash.cloudflare.com/${accountId}/workers/onboarding`;
-
-				throw new UserError(`${solutionMessage}\n${onboardingLink}`, {
-					telemetryMessage: "routes workers dev registration declined",
-				});
-			}
-
-			return await registerSubdomain(complianceConfig, accountId, configPath);
-		} else {
+		if (typeof error !== "object" || !error || error.code !== 10007) {
 			throw e;
+		}
+
+		// 10007 error code: not found
+		// https://api.cloudflare.com/#worker-subdomain-get-subdomain
+		logger.warn(getRegistrationWarning(registrationContext));
+
+		const wantsToRegister = await confirm(
+			"Would you like to register a workers.dev subdomain now?",
+			{ fallbackValue: false }
+		);
+		if (!wantsToRegister) {
+			throw getRegistrationDeclinedError(
+				registrationContext,
+				accountId,
+				configPath
+			);
+		}
+
+		return await registerSubdomain(
+			complianceConfig,
+			accountId,
+			configPath,
+			registrationContext
+		);
+	}
+}
+
+function getRegistrationWarning(
+	registrationContext: WorkersDevSubdomainRegistrationContext
+): string {
+	switch (registrationContext) {
+		case "workflows":
+			return "You need to register a workers.dev subdomain before deploying Workflows";
+		case "workers_dev":
+			return "You need to register a workers.dev subdomain before publishing to workers.dev";
+		default: {
+			const _exhaustive: never = registrationContext;
+			return _exhaustive;
+		}
+	}
+}
+
+function getRegistrationDeclinedError(
+	registrationContext: WorkersDevSubdomainRegistrationContext,
+	accountId: string,
+	configPath: string | undefined
+): UserError {
+	const onboardingLink = `https://dash.cloudflare.com/${accountId}/workers/onboarding`;
+	switch (registrationContext) {
+		case "workflows":
+			return new UserError(
+				`Workflows require your account to have a workers.dev subdomain. Register a workers.dev subdomain here:\n${onboardingLink}`,
+				{
+					telemetryMessage: "workflows workers dev registration declined",
+				}
+			);
+		case "workers_dev": {
+			const solutionMessage = `You can either deploy your worker to one or more routes by specifying them in your ${configFileName(configPath)} file, or register a workers.dev subdomain here:`;
+			return new UserError(`${solutionMessage}\n${onboardingLink}`, {
+				telemetryMessage: "routes workers dev registration declined",
+			});
+		}
+		default: {
+			const _exhaustive: never = registrationContext;
+			return _exhaustive;
 		}
 	}
 }
@@ -64,7 +121,8 @@ export async function getWorkersDevSubdomain(
 async function registerSubdomain(
 	complianceConfig: ComplianceConfig,
 	accountId: string,
-	configPath: string | undefined
+	configPath: string | undefined,
+	registrationContext: WorkersDevSubdomainRegistrationContext
 ): Promise<string> {
 	let subdomain: string | undefined;
 
@@ -117,12 +175,11 @@ async function registerSubdomain(
 			)}. Ok to proceed?`
 		);
 		if (!ok) {
-			const solutionMessage = `You can either deploy your worker to one or more routes by specifying them in your ${configFileName(configPath)} file, or register a workers.dev subdomain here:`;
-			const onboardingLink = `https://dash.cloudflare.com/${accountId}/workers/onboarding`;
-
-			throw new UserError(`${solutionMessage}\n${onboardingLink}`, {
-				telemetryMessage: "routes workers dev registration declined",
-			});
+			throw getRegistrationDeclinedError(
+				registrationContext,
+				accountId,
+				configPath
+			);
 		}
 
 		try {

--- a/packages/wrangler/src/triggers/deploy.ts
+++ b/packages/wrangler/src/triggers/deploy.ts
@@ -92,6 +92,9 @@ export default async function triggersDeploy(
 
 	const uploadMs = Date.now() - start;
 	const deployments: Promise<string[]>[] = [];
+	const hasWorkflowsDefinedInThisScript = config.workflows.some((workflow) =>
+		isWorkflowDefinedInThisScript(workflow, scriptName)
+	);
 
 	const { wantWorkersDev, workersDevInSync } = await subdomainDeploy(
 		props,
@@ -198,6 +201,13 @@ export default async function triggersDeploy(
 		}
 	}
 
+	if (!wantWorkersDev && hasWorkflowsDefinedInThisScript) {
+		await getWorkersDevSubdomain(config, accountId, {
+			configPath: config.configPath,
+			registrationContext: "workflows",
+		});
+	}
+
 	// Update routing table for the script.
 	if (routesOnly.length > 0) {
 		deployments.push(
@@ -259,10 +269,7 @@ export default async function triggersDeploy(
 		for (const workflow of config.workflows) {
 			// NOTE: if the user provides a script_name thats not this script (aka bounds to another worker)
 			// we don't want to send this worker's config.
-			if (
-				workflow.script_name !== undefined &&
-				workflow.script_name !== scriptName
-			) {
+			if (!isWorkflowDefinedInThisScript(workflow, scriptName)) {
 				if (workflow.limits) {
 					throw new UserError(
 						`Workflow "${workflow.name}" has "limits" configured but references external script "${workflow.script_name}". ` +
@@ -398,11 +405,9 @@ async function validateSubdomainMixedState(
 		return after;
 	}
 
-	const userSubdomain = await getWorkersDevSubdomain(
-		config,
-		accountId,
-		config.configPath
-	);
+	const userSubdomain = await getWorkersDevSubdomain(config, accountId, {
+		configPath: config.configPath,
+	});
 	const previewUrl = `https://<VERSION_PREFIX>-${scriptName}.${userSubdomain}`;
 
 	// Scenario 1: User disables workers.dev while having preview URLs enabled
@@ -453,17 +458,15 @@ async function subdomainDeploy(
 
 	// workers.dev URL is only set if we want to deploy to workers.dev.
 
-	let workersDevURL: string | undefined;
 	if (wantWorkersDev) {
-		const userSubdomain = await getWorkersDevSubdomain(
-			config,
-			accountId,
-			config.configPath
-		);
-		workersDevURL =
+		const userSubdomain = await getWorkersDevSubdomain(config, accountId, {
+			configPath: config.configPath,
+		});
+		const workersDevURL =
 			!props.useServiceEnvironments || !props.env
 				? `${scriptName}.${userSubdomain}`
 				: `${envName}.${scriptName}.${userSubdomain}`;
+		deployments.push(Promise.resolve([workersDevURL]));
 	}
 
 	// Get current subdomain enablement status.
@@ -549,13 +552,19 @@ async function subdomainDeploy(
 
 	// Done.
 
-	if (workersDevURL) {
-		deployments.push(Promise.resolve([workersDevURL]));
-	}
 	return {
 		wantWorkersDev,
 		wantPreviews,
 		workersDevInSync: before.enabled === after.enabled,
 		previewsInSync: before.previews_enabled === after.previews_enabled,
 	};
+}
+
+function isWorkflowDefinedInThisScript(
+	workflow: Config["workflows"][number],
+	scriptName: string
+): boolean {
+	return (
+		workflow.script_name === undefined || workflow.script_name === scriptName
+	);
 }

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -975,11 +975,9 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			}>(config, `${workerUrl}/subdomain`);
 
 		if (previews_available_on_subdomain) {
-			const userSubdomain = await getWorkersDevSubdomain(
-				config,
-				accountId,
-				config.configPath
-			);
+			const userSubdomain = await getWorkersDevSubdomain(config, accountId, {
+				configPath: config.configPath,
+			});
 			const shortVersion = versionId.slice(0, 8);
 			versionPreviewUrl = `https://${shortVersion}-${workerName}.${userSubdomain}`;
 			logger.log(`Version Preview URL: ${versionPreviewUrl}`);


### PR DESCRIPTION
Fixes WOR-1242

Workflows hard codes the account `workers.dev` subdomain zone as the ownership zone.

Consider the following scenario:
```jsonc
   {
     "workers_dev": false,
     "workflows": [...]
   }
 ```

There could be a case here where the user's account doesn't have a `workers_dev` subdomain provisioned, neither will wrangler provision one on behalf of the user - `workers_dev` is explicitly false. In such scenarios the upstream workflows deployment fails because we rely on that zone to exist in the account.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not a customer-facing change - this is effectively a bugfix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->