### PR TITLE
[wrangler] sweep stale .wrangler/tmp/* dirs at startup

### DIFF
--- a/.changeset/wrangler-tmp-orphan-sweep.md
+++ b/.changeset/wrangler-tmp-orphan-sweep.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Sweep stale `.wrangler/tmp/*` dirs left behind by abnormal exits
+
+A `wrangler dev` session creates `.wrangler/tmp/bundle-*` and `.wrangler/tmp/dev-*` directories at startup and removes them via a `signal-exit` hook on graceful shutdown. When the process exited abnormally (SIGKILL, OOM, host crash) those directories were left behind and accumulated across sessions, slowing down dependency-walking tools that follow the bundle-emitted absolute-path imports.
+
+`wrangler` now sweeps entries in `.wrangler/tmp/` older than 24 hours when a new temporary directory is requested, bounding the leak regardless of how prior sessions exited.

--- a/packages/wrangler/src/__tests__/paths.test.ts
+++ b/packages/wrangler/src/__tests__/paths.test.ts
@@ -1,10 +1,13 @@
+import fs from "node:fs";
 import * as path from "node:path";
 import { describe, it } from "vitest";
 import {
 	getBasePath,
 	getWranglerHiddenDirPath,
 	readableRelative,
+	sweepStaleWranglerTmpDirs,
 } from "../paths";
+import { runInTempDir } from "./helpers/run-in-tmp";
 
 describe("paths", () => {
 	describe("getBasePath()", () => {
@@ -36,6 +39,54 @@ describe("paths", () => {
 				path.join(process.cwd(), ".wrangler")
 			);
 		});
+	});
+});
+
+describe("sweepStaleWranglerTmpDirs()", () => {
+	runInTempDir();
+
+	const ageDir = (dir: string, ageMs: number): void => {
+		const seconds = (Date.now() - ageMs) / 1000;
+		fs.utimesSync(dir, seconds, seconds);
+	};
+
+	it("removes orphaned dirs older than the staleness threshold", ({
+		expect,
+	}) => {
+		const tmpRoot = path.join(process.cwd(), ".wrangler", "tmp");
+		fs.mkdirSync(tmpRoot, { recursive: true });
+		const stale = path.join(tmpRoot, "bundle-stale");
+		const fresh = path.join(tmpRoot, "bundle-fresh");
+		fs.mkdirSync(stale);
+		fs.mkdirSync(fresh);
+		ageDir(stale, 2 * 24 * 60 * 60 * 1000);
+
+		sweepStaleWranglerTmpDirs(tmpRoot);
+
+		expect(fs.existsSync(stale)).toBe(false);
+		expect(fs.existsSync(fresh)).toBe(true);
+	});
+
+	it("does not throw when the tmp root is missing", ({ expect }) => {
+		const tmpRoot = path.join(process.cwd(), ".wrangler", "tmp");
+		expect(() => sweepStaleWranglerTmpDirs(tmpRoot)).not.toThrow();
+	});
+
+	it("only sweeps a given root once per process", ({ expect }) => {
+		const tmpRoot = path.join(process.cwd(), ".wrangler", "tmp");
+		fs.mkdirSync(tmpRoot, { recursive: true });
+		const orphan = path.join(tmpRoot, "bundle-orphan");
+		fs.mkdirSync(orphan);
+		ageDir(orphan, 2 * 24 * 60 * 60 * 1000);
+
+		sweepStaleWranglerTmpDirs(tmpRoot);
+		expect(fs.existsSync(orphan)).toBe(false);
+
+		// Recreate an equally stale entry; the cached root must skip rescanning.
+		fs.mkdirSync(orphan);
+		ageDir(orphan, 2 * 24 * 60 * 60 * 1000);
+		sweepStaleWranglerTmpDirs(tmpRoot);
+		expect(fs.existsSync(orphan)).toBe(true);
 	});
 });
 

--- a/packages/wrangler/src/paths.ts
+++ b/packages/wrangler/src/paths.ts
@@ -93,6 +93,55 @@ export function getWranglerHiddenDirPath(
 }
 
 /**
+ * Maximum age of a `.wrangler/tmp/*` entry before we treat it as orphaned and
+ * eligible for the startup sweep. Tuned to avoid touching any directory a
+ * concurrent wrangler session might still own.
+ */
+const STALE_WRANGLER_TMP_DIR_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Tracks tmp roots already swept by this process so repeated
+ * `getWranglerTmpDir` calls within one wrangler invocation only scan once.
+ */
+const sweptTmpRoots = new Set<string>();
+
+/**
+ * Removes stale `.wrangler/tmp/*` entries left behind by previous wrangler
+ * sessions that exited abnormally (SIGKILL, OOM, host crash) and so missed
+ * the `signal-exit` cleanup. Runs at most once per tmp root per process.
+ *
+ * Exported for tests.
+ */
+export function sweepStaleWranglerTmpDirs(tmpRoot: string): void {
+	if (sweptTmpRoots.has(tmpRoot)) {
+		return;
+	}
+	sweptTmpRoots.add(tmpRoot);
+
+	let entries: fs.Dirent[];
+	try {
+		entries = fs.readdirSync(tmpRoot, { withFileTypes: true });
+	} catch {
+		return;
+	}
+
+	const cutoff = Date.now() - STALE_WRANGLER_TMP_DIR_MS;
+	for (const entry of entries) {
+		if (!entry.isDirectory()) {
+			continue;
+		}
+		const entryPath = path.join(tmpRoot, entry.name);
+		try {
+			if (fs.statSync(entryPath).mtimeMs < cutoff) {
+				removeDirSync(entryPath);
+			}
+		} catch {
+			/* best effort — another process may have removed it first */
+		}
+	}
+}
+
+/**
  * Gets a temporary directory in the project's `.wrangler` folder with the
  * specified prefix. We create temporary directories in `.wrangler` as opposed
  * to the OS's temporary directory to avoid issues with different drive letters
@@ -106,6 +155,7 @@ export function getWranglerTmpDir(
 ): EphemeralDirectory {
 	const tmpRoot = path.join(getWranglerHiddenDirPath(projectRoot), "tmp");
 	fs.mkdirSync(tmpRoot, { recursive: true });
+	sweepStaleWranglerTmpDirs(tmpRoot);
 
 	const tmpPrefix = path.join(tmpRoot, `${prefix}-`);
 	const tmpDir = fs.realpathSync(fs.mkdtempSync(tmpPrefix));


### PR DESCRIPTION
Fixes #13872.

A `wrangler dev` session creates `.wrangler/tmp/bundle-*` and `.wrangler/tmp/dev-*` directories at startup and removes them via a `signal-exit` hook on graceful shutdown. On abnormal exit (SIGKILL, OOM-killer, host crash) the dirs survive and accumulate monotonically across sessions, slowing down (and eventually OOMing) tools that walk the worker package and follow the bundle-emitted absolute-path imports — dependency-cruiser, broader-scope `knip` configs, IDE indexers. The OP reported dependency-cruiser OOMing around ~110 orphans on an 8 GB Linux VM.

This PR adds a `sweepStaleWranglerTmpDirs(tmpRoot)` step that runs once per process on the first `getWranglerTmpDir(...)` call, removing entries in `.wrangler/tmp/` whose `mtime` is older than 24h. The window is deliberately wide enough that it never touches a directory an active concurrent wrangler session might still own; the per-process `Set<string>` guard prevents repeat scans within the same wrangler invocation.

Same approach as [`vitejs/vite#12252`](https://github.com/vitejs/vite/issues/12252) for `deps_temp_*`, just gated on `mtime` instead of a config flag.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is an internal `.wrangler/tmp` lifecycle fix with no user-facing CLI, config, or behavior change beyond removing junk left by killed sessions.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->