### PR TITLE
[miniflare] Deduplicate Workflow compatibility flags

### DIFF
--- a/.changeset/silent-workflows-tap.md
+++ b/.changeset/silent-workflows-tap.md
@@ -1,0 +1,8 @@
+---
+"miniflare": patch
+"wrangler": patch
+---
+
+Fix local Workflow startup when compatibility flags include `experimental`
+
+Miniflare now deduplicates compatibility flags for the internal Workflow engine service. This prevents `wrangler dev` from failing with `Compatibility flag specified multiple times: experimental` when the user's Worker already enables that flag.

--- a/packages/miniflare/src/plugins/workflows/index.ts
+++ b/packages/miniflare/src/plugins/workflows/index.ts
@@ -119,10 +119,9 @@ export const WORKFLOWS_PLUGIN: Plugin<
 					),
 					worker: {
 						compatibilityDate: "2024-10-22",
-						compatibilityFlags: [
-							"experimental",
-							...(workflow.compatibilityFlags ?? []),
-						],
+						compatibilityFlags: Array.from(
+							new Set(["experimental", ...(workflow.compatibilityFlags ?? [])])
+						),
 						modules: [
 							{
 								name: "workflows.mjs",

--- a/packages/miniflare/test/plugins/workflows/index.spec.ts
+++ b/packages/miniflare/test/plugins/workflows/index.spec.ts
@@ -22,6 +22,36 @@ export class MyWorkflow extends WorkflowEntrypoint {
 	},
   };`;
 
+test("starts Workflows with user-provided experimental compatibility flag", async ({
+	expect,
+}) => {
+	const tmp = await useTmp();
+	const mf = new Miniflare({
+		name: "workflow-compatibility-flags-worker",
+		compatibilityDate: "2024-11-20",
+		compatibilityFlags: [
+			"nodejs_compat",
+			"experimental",
+			"enhanced_error_serialization",
+		],
+		modules: true,
+		script: WORKFLOW_SCRIPT(),
+		workflows: {
+			MY_WORKFLOW: {
+				className: "MyWorkflow",
+				name: "MY_WORKFLOW",
+			},
+		},
+		workflowsPersist: tmp,
+	});
+	useDispose(mf);
+
+	const res = await mf.dispatchFetch("http://localhost");
+	expect(await res.text()).toBe(
+		'{"status":"complete","__LOCAL_DEV_STEP_OUTPUTS":["yes you are"],"output":"I\'m a output string"}'
+	);
+});
+
 test("persists Workflow data on file-system between runs", async ({
 	expect,
 }) => {

--- a/packages/miniflare/test/plugins/workflows/index.spec.ts
+++ b/packages/miniflare/test/plugins/workflows/index.spec.ts
@@ -29,17 +29,17 @@ test("starts Workflows with user-provided experimental compatibility flag", asyn
 	const mf = new Miniflare({
 		name: "workflow-compatibility-flags-worker",
 		compatibilityDate: "2024-11-20",
-		compatibilityFlags: [
-			"nodejs_compat",
-			"experimental",
-			"enhanced_error_serialization",
-		],
 		modules: true,
 		script: WORKFLOW_SCRIPT(),
 		workflows: {
 			MY_WORKFLOW: {
 				className: "MyWorkflow",
 				name: "MY_WORKFLOW",
+				compatibilityFlags: [
+					"nodejs_compat",
+					"experimental",
+					"enhanced_error_serialization",
+				],
 			},
 		},
 		workflowsPersist: tmp,


### PR DESCRIPTION
Deduplicate compatibility flags for the internal Miniflare Workflow engine service.

When a Worker using Workflows sets `compatibility_flags` containing `experimental`, `wrangler dev` passes those flags through to Miniflare. Miniflare also prepends `experimental` for the internal Workflow engine service, causing workerd startup to fail with a duplicate compatibility flag error.
This change preserves the required `experimental` flag while deduplicating the combined Workflow engine flags.

[repro](https://github.com/zebp/wrangler-workflows-experimental-repro-/blob/main/REPRO.md)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this fixes local development startup behavior and does not change public APIs or user-facing configuration.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->