### PR TITLE
[vitest-pool-workers] Stop externalizing devDependencies from the published bundle

### DIFF
--- a/.changeset/fix-vitest-pool-workers-external-list.md
+++ b/.changeset/fix-vitest-pool-workers-external-list.md
@@ -1,0 +1,11 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Derive bundler externals from `package.json` and shrink the published bundle
+
+The bundler's `external` list was previously hand-maintained and out of sync with `package.json` — `undici` and `semver` were both listed as external despite being only `devDependencies`. The published `dist/pool/index.mjs` consequently contained a top-level `import { fetch } from "undici"` that was only resolvable because pnpm happened to hoist `undici` from other packages' devDependencies during local development.
+
+The bundler now derives its `external` list from `dependencies` + `peerDependencies` in `package.json`, making it impossible for a `devDependency` to silently end up externalized.
+
+Combined with the new `"sideEffects": false` declaration in `@cloudflare/workers-utils`, the unused `cloudflared` / `tunnel` exports (and their transitive `undici` import) are now tree-shaken out of the pool entirely. `dist/pool/index.mjs` no longer references `undici` at all, and shrinks from ~489 KB to ~125 KB.

--- a/.changeset/fix-workers-utils-sideeffects-undici.md
+++ b/.changeset/fix-workers-utils-sideeffects-undici.md
@@ -1,0 +1,11 @@
+---
+"@cloudflare/workers-utils": patch
+---
+
+Mark `@cloudflare/workers-utils` as side-effect-free and properly declare `undici` as a runtime dependency
+
+The package now declares `"sideEffects": false` in its `package.json` so that downstream bundlers can tree-shake unused exports. In particular, consumers that only use a subset of the package (for example, `getTodaysCompatDate` from the main entry) will no longer carry the `cloudflared` / `tunnel` exports — or their transitive dependencies — in their final bundle.
+
+`undici` has been moved from `devDependencies` to `dependencies`. Previously it was incorrectly listed as a devDependency while the bundler config marked it as external, leaving the published `dist/index.mjs` with an unresolved `import { fetch } from "undici"` for anyone installing the package directly. `undici` is deliberately kept external (rather than bundled) so that downstream consumers don't end up with two copies of `undici` in their bundle — which would break `instanceof Request`/`Response`/`Headers` checks across the boundary and prevent `setGlobalDispatcher` / proxy configuration from applying to the bundled copy.
+
+`vitest` has been added as an optional `peerDependency` because the `./test-helpers` sub-export uses `vitest`'s `vi`, `beforeEach`, and `afterEach` APIs at runtime; consumers that import from `./test-helpers` must have `vitest` installed themselves.

--- a/packages/create-cloudflare/scripts/deps.ts
+++ b/packages/create-cloudflare/scripts/deps.ts
@@ -1,0 +1,19 @@
+/**
+ * Dependencies that _are not_ bundled along with create-cloudflare.
+ *
+ * create-cloudflare bundles all of its dependencies into a single CJS file,
+ * so this list is currently empty.
+ */
+export const EXTERNAL_DEPENDENCIES: string[] = [];
+
+/**
+ * Bare-specifier imports that legitimately appear in create-cloudflare's
+ * bundled output but should NOT be treated as missing runtime dependencies.
+ */
+export const IGNORED_DIST_IMPORTS = [
+	// `recast` (a bundled devDependency) attempts `require("babylon")` inside
+	// a try/catch as a fallback parser when `@babel/parser` is not available.
+	// We don't need to ship `babylon` because the primary `@babel/parser`
+	// path is bundled and always succeeds.
+	"babylon",
+];

--- a/packages/vitest-pool-workers/tsdown.config.ts
+++ b/packages/vitest-pool-workers/tsdown.config.ts
@@ -1,4 +1,4 @@
-import { readdirSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { defineConfig } from "tsdown";
 import { getBuiltinModules } from "./scripts/rtti/query.mjs";
@@ -23,6 +23,28 @@ const libPaths = [
 	...walk(path.join(pkgRoot, "src/worker/node")),
 ];
 
+// Derive bundler externals from package.json so devDependencies are always
+// bundled and runtime dependencies/peer dependencies are always external.
+// This prevents drift between package.json and the bundler config — the
+// previous hand-maintained list incorrectly externalized undici and semver
+// (both devDependencies), leaving the published bundle with unresolved
+// imports for users who don't have those packages installed transitively.
+const pkg = JSON.parse(
+	readFileSync(path.join(pkgRoot, "package.json"), "utf-8")
+) as {
+	dependencies?: Record<string, string>;
+	peerDependencies?: Record<string, string>;
+};
+const runtimeDeps = [
+	...Object.keys(pkg.dependencies ?? {}),
+	...Object.keys(pkg.peerDependencies ?? {}),
+];
+// Match the bare package name and any subpath import (e.g. `vitest/node`).
+const runtimeDepPatterns = runtimeDeps.flatMap((name) => [
+	name,
+	new RegExp(`^${name.replace(/[/\\^$+?.()|[\]{}]/g, "\\$&")}/`),
+]);
+
 const commonOptions: UserConfig = {
 	platform: "node",
 	target: "esnext",
@@ -36,22 +58,8 @@ const commonOptions: UserConfig = {
 		// Virtual/runtime modules
 		"__VITEST_POOL_WORKERS_DEFINES",
 		"__VITEST_POOL_WORKERS_USER_OBJECT",
-		// All npm packages (previously handled by packages: "external")
-		"cjs-module-lexer",
-		"esbuild",
-		"miniflare",
-		"semver",
-		"semver/*",
-		"wrangler",
-		"zod",
-		"undici",
-		"undici/*",
-		// Peer dependencies
-		"vitest",
-		"vitest/*",
-		"@vitest/runner",
-		"@vitest/snapshot",
-		"@vitest/snapshot/*",
+		// Runtime dependencies and peer dependencies (derived from package.json)
+		...runtimeDepPatterns,
 	],
 	sourcemap: true,
 	outDir: path.join(pkgRoot, "dist"),

--- a/packages/workers-utils/package.json
+++ b/packages/workers-utils/package.json
@@ -16,6 +16,7 @@
 	"files": [
 		"dist"
 	],
+	"sideEffects": false,
 	"exports": {
 		".": {
 			"browser": "./dist/browser.mjs",
@@ -40,6 +41,9 @@
 		"test:ci": "vitest run",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
 	},
+	"dependencies": {
+		"undici": "catalog:default"
+	},
 	"devDependencies": {
 		"@cloudflare/workers-shared": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
@@ -57,9 +61,16 @@
 		"tsdown": "^0.15.9",
 		"tsup": "8.3.0",
 		"typescript": "catalog:default",
-		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"xdg-app-paths": "^8.3.0"
+	},
+	"peerDependencies": {
+		"vitest": "^4.1.0"
+	},
+	"peerDependenciesMeta": {
+		"vitest": {
+			"optional": true
+		}
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/packages/workers-utils/scripts/deps.ts
+++ b/packages/workers-utils/scripts/deps.ts
@@ -1,0 +1,15 @@
+/**
+ * Dependencies that _are not_ bundled along with @cloudflare/workers-utils.
+ *
+ * These must be explicitly documented with a reason why they cannot be bundled.
+ * This list is validated by `tools/deployments/validate-package-dependencies.ts`.
+ */
+export const EXTERNAL_DEPENDENCIES = [
+	// Bundling `undici` would produce a duplicate copy in every downstream
+	// consumer that already depends on undici (e.g. wrangler), which breaks
+	// `instanceof Request`/`Response`/`Headers` checks across the boundary
+	// and prevents `setGlobalDispatcher` / proxy configuration from applying
+	// to the bundled copy. Keeping it external lets the package manager
+	// deduplicate undici to a single shared instance.
+	"undici",
+];

--- a/packages/workers-utils/tsup.config.ts
+++ b/packages/workers-utils/tsup.config.ts
@@ -20,6 +20,6 @@ export default defineConfig(() => [
 		define: {
 			"process.env.NODE_ENV": `'${"production"}'`,
 		},
-		external: ["@cloudflare/*", "vitest", "msw", "undici"],
+		external: ["@cloudflare/*", "vitest", "undici"],
 	},
 ]);

--- a/packages/wrangler/scripts/deps.ts
+++ b/packages/wrangler/scripts/deps.ts
@@ -37,6 +37,31 @@ export const EXTERNAL_DEPENDENCIES = [
 	"workerd",
 ];
 
+/**
+ * Bare-specifier imports that legitimately appear in wrangler's bundled
+ * output but should NOT be treated as missing runtime dependencies.
+ *
+ * Each entry must be justified — typically the import is guarded
+ * (try/catch, optional require) inside a bundled-in third-party library that
+ * probes for the consumer's environment.
+ */
+export const IGNORED_DIST_IMPORTS = [
+	// @netlify/build-info (bundled devDependency) tries to require these
+	// framework packages to detect what the user has installed. Each call
+	// is guarded by try/catch and used only for framework detection.
+	"@angular/ssr",
+	"@cloudflare/vite-plugin",
+	"isbot",
+	"react-dom",
+	"react-router",
+	"waku",
+
+	// @aws-sdk/client-s3 (bundled devDependency) optionally uses this native
+	// crypto implementation if installed; falls back to a JS implementation
+	// when missing.
+	"@aws-sdk/signature-v4-crt",
+];
+
 const pathToPackageJson = path.resolve(__dirname, "..", "package.json");
 const packageJson = fs.readFileSync(pathToPackageJson, { encoding: "utf-8" });
 const { dependencies, devDependencies } = JSON.parse(packageJson);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3826,6 +3826,10 @@ importers:
   packages/workers-tsconfig: {}
 
   packages/workers-utils:
+    dependencies:
+      undici:
+        specifier: catalog:default
+        version: 7.24.8
     devDependencies:
       '@cloudflare/workers-shared':
         specifier: workspace:*
@@ -3875,9 +3879,6 @@ importers:
       typescript:
         specifier: catalog:default
         version: 5.8.3
-      undici:
-        specifier: catalog:default
-        version: 7.24.8
       vitest:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.0.13(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))

--- a/tools/deployments/__tests__/validate-package-dependencies.test.ts
+++ b/tools/deployments/__tests__/validate-package-dependencies.test.ts
@@ -1,8 +1,13 @@
 import { describe, it } from "vitest";
 import {
+	extractBareImports,
 	getAllDependencies,
+	getEntryPointPaths,
 	getNonWorkspaceDependencies,
+	getPackageNameFromSpecifier,
 	getPublicPackages,
+	isBareSpecifier,
+	validateDistImports,
 	validatePackageDependencies,
 } from "../validate-package-dependencies";
 
@@ -307,6 +312,372 @@ describe("validatePackageDependencies()", () => {
 		expect(errors).toHaveLength(1);
 		expect(errors[0]).toContain('"esbuild"');
 		expect(errors[0]).toContain("not in dependencies or peerDependencies");
+	});
+});
+
+describe("getPackageNameFromSpecifier()", () => {
+	it("should return the package name from a bare specifier", ({ expect }) => {
+		expect(getPackageNameFromSpecifier("lodash")).toBe("lodash");
+	});
+
+	it("should strip subpath imports", ({ expect }) => {
+		expect(getPackageNameFromSpecifier("lodash/fp")).toBe("lodash");
+		expect(getPackageNameFromSpecifier("semver/functions/satisfies.js")).toBe(
+			"semver"
+		);
+	});
+
+	it("should preserve scoped package names", ({ expect }) => {
+		expect(getPackageNameFromSpecifier("@cloudflare/workers-utils")).toBe(
+			"@cloudflare/workers-utils"
+		);
+		expect(
+			getPackageNameFromSpecifier("@cloudflare/workers-utils/test-helpers")
+		).toBe("@cloudflare/workers-utils");
+	});
+});
+
+describe("isBareSpecifier()", () => {
+	it("should accept bare package names", ({ expect }) => {
+		expect(isBareSpecifier("lodash")).toBe(true);
+		expect(isBareSpecifier("@cloudflare/workers-utils")).toBe(true);
+		expect(isBareSpecifier("vitest/runtime")).toBe(true);
+	});
+
+	it("should reject relative paths", ({ expect }) => {
+		expect(isBareSpecifier("./foo")).toBe(false);
+		expect(isBareSpecifier("../bar")).toBe(false);
+		expect(isBareSpecifier("/abs/path")).toBe(false);
+	});
+
+	it("should reject empty specifiers", ({ expect }) => {
+		expect(isBareSpecifier("")).toBe(false);
+	});
+
+	it("should reject Node.js built-ins (with and without prefix)", ({
+		expect,
+	}) => {
+		expect(isBareSpecifier("node:fs")).toBe(false);
+		expect(isBareSpecifier("fs")).toBe(false);
+		expect(isBareSpecifier("node:child_process")).toBe(false);
+		expect(isBareSpecifier("child_process")).toBe(false);
+		expect(isBareSpecifier("assert")).toBe(false);
+	});
+
+	it("should reject Cloudflare/workerd built-ins", ({ expect }) => {
+		expect(isBareSpecifier("cloudflare:workers")).toBe(false);
+		expect(isBareSpecifier("workerd:unsafe")).toBe(false);
+	});
+
+	it("should reject bundler virtual modules", ({ expect }) => {
+		expect(isBareSpecifier("virtual:react-router")).toBe(false);
+		expect(isBareSpecifier("wrangler:modules-watch")).toBe(false);
+	});
+
+	it("should reject ALL_CAPS virtual modules", ({ expect }) => {
+		expect(isBareSpecifier("__VITEST_POOL_WORKERS_DEFINES")).toBe(false);
+		expect(isBareSpecifier("__BUILD_CONFIG")).toBe(false);
+	});
+
+	it("should reject template-literal expressions in specifiers", ({
+		expect,
+	}) => {
+		expect(isBareSpecifier("${moduleName}")).toBe(false);
+		expect(isBareSpecifier("foo/${bar}")).toBe(false);
+	});
+
+	it("should reject specifiers with wildcards", ({ expect }) => {
+		expect(isBareSpecifier("*")).toBe(false);
+		expect(isBareSpecifier("foo/*")).toBe(false);
+	});
+
+	it("should reject specifiers that are not package-name shaped", ({
+		expect,
+	}) => {
+		expect(isBareSpecifier(",")).toBe(false);
+		expect(isBareSpecifier("some random text")).toBe(false);
+		expect(isBareSpecifier("ASSERT.IN.MIXED-CASE")).toBe(false);
+	});
+});
+
+describe("extractBareImports()", () => {
+	it("should extract named imports", ({ expect }) => {
+		const imports = extractBareImports(`import { x } from "lodash";`);
+		expect([...imports]).toEqual(["lodash"]);
+	});
+
+	it("should extract default imports", ({ expect }) => {
+		const imports = extractBareImports(`import x from "lodash";`);
+		expect([...imports]).toEqual(["lodash"]);
+	});
+
+	it("should extract namespace imports", ({ expect }) => {
+		const imports = extractBareImports(`import * as x from "lodash";`);
+		expect([...imports]).toEqual(["lodash"]);
+	});
+
+	it("should extract side-effect imports", ({ expect }) => {
+		const imports = extractBareImports(`import "lodash";`);
+		expect([...imports]).toEqual(["lodash"]);
+	});
+
+	it("should extract re-exports", ({ expect }) => {
+		const imports = extractBareImports(`export { x } from "lodash";`);
+		expect([...imports]).toEqual(["lodash"]);
+	});
+
+	it("should extract require() calls", ({ expect }) => {
+		const imports = extractBareImports(
+			`const x = require("lodash"); require("foo");`
+		);
+		expect([...imports].sort()).toEqual(["foo", "lodash"]);
+	});
+
+	it("should extract dynamic import() calls with string literals", ({
+		expect,
+	}) => {
+		const imports = extractBareImports(`const x = await import("lodash");`);
+		expect([...imports]).toEqual(["lodash"]);
+	});
+
+	it("should strip subpath imports down to package name", ({ expect }) => {
+		const imports = extractBareImports(
+			`import x from "semver/functions/satisfies.js";`
+		);
+		expect([...imports]).toEqual(["semver"]);
+	});
+
+	it("should skip relative imports", ({ expect }) => {
+		const imports = extractBareImports(
+			`import x from "./foo"; import y from "../bar";`
+		);
+		expect([...imports]).toEqual([]);
+	});
+
+	it("should skip Node built-in imports", ({ expect }) => {
+		const imports = extractBareImports(
+			`import fs from "node:fs"; const path = require("node:path");`
+		);
+		expect([...imports]).toEqual([]);
+	});
+
+	it("should skip Cloudflare/workerd built-in imports", ({ expect }) => {
+		const imports = extractBareImports(
+			`import { env } from "cloudflare:workers"; import x from "workerd:unsafe";`
+		);
+		expect([...imports]).toEqual([]);
+	});
+
+	it("should skip imports inside line comments", ({ expect }) => {
+		const imports = extractBareImports(
+			`// import x from "lodash";\nimport y from "react";`
+		);
+		expect([...imports]).toEqual(["react"]);
+	});
+
+	it("should skip imports inside block comments", ({ expect }) => {
+		const imports = extractBareImports(
+			`/* import x from "lodash"; */\nimport y from "react";`
+		);
+		expect([...imports]).toEqual(["react"]);
+	});
+
+	it("should not match `from` keywords that aren't part of import/export", ({
+		expect,
+	}) => {
+		const imports = extractBareImports(
+			`function foo() { return "hello"; } const z = "from";`
+		);
+		expect([...imports]).toEqual([]);
+	});
+
+	it("should deduplicate imports", ({ expect }) => {
+		const imports = extractBareImports(
+			`import { x } from "lodash";\nimport { y } from "lodash";`
+		);
+		expect([...imports]).toEqual(["lodash"]);
+	});
+
+	it("should handle multiple imports in one file", ({ expect }) => {
+		const imports = extractBareImports(`
+			import { x } from "lodash";
+			import y from "react";
+			import "polyfill";
+			const z = require("commander");
+		`);
+		expect([...imports].sort()).toEqual([
+			"commander",
+			"lodash",
+			"polyfill",
+			"react",
+		]);
+	});
+});
+
+describe("validateDistImports()", () => {
+	it("should pass when all imports are declared dependencies", ({ expect }) => {
+		const errors = validateDistImports(
+			"test-package",
+			{
+				name: "test-package",
+				dependencies: { lodash: "^4.0.0", react: "^18.0.0" },
+			},
+			new Set(["lodash", "react"])
+		);
+		expect(errors).toEqual([]);
+	});
+
+	it("should pass when imports are peerDependencies", ({ expect }) => {
+		const errors = validateDistImports(
+			"test-package",
+			{
+				name: "test-package",
+				peerDependencies: { vitest: "^4.0.0" },
+			},
+			new Set(["vitest"])
+		);
+		expect(errors).toEqual([]);
+	});
+
+	it("should allow self-imports without error", ({ expect }) => {
+		const errors = validateDistImports(
+			"my-package",
+			{ name: "my-package" },
+			new Set(["my-package"])
+		);
+		expect(errors).toEqual([]);
+	});
+
+	it("should flag devDependency-only imports with a tailored message", ({
+		expect,
+	}) => {
+		const errors = validateDistImports(
+			"test-package",
+			{
+				name: "test-package",
+				devDependencies: { undici: "^7.0.0" },
+			},
+			new Set(["undici"])
+		);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain('"undici"');
+		expect(errors[0]).toContain("only a devDependency");
+		expect(errors[0]).toContain("IGNORED_DIST_IMPORTS");
+	});
+
+	it("should flag undeclared imports", ({ expect }) => {
+		const errors = validateDistImports(
+			"test-package",
+			{ name: "test-package" },
+			new Set(["mystery-package"])
+		);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain('"mystery-package"');
+		expect(errors[0]).toContain(
+			"not declared in dependencies or peerDependencies"
+		);
+	});
+
+	it("should skip imports in the ignored list", ({ expect }) => {
+		const errors = validateDistImports(
+			"test-package",
+			{
+				name: "test-package",
+				devDependencies: { "@netlify/build-info": "^1.0.0" },
+			},
+			new Set(["react-router", "@angular/ssr"]),
+			["react-router", "@angular/ssr"]
+		);
+		expect(errors).toEqual([]);
+	});
+
+	it("should still flag non-ignored imports when ignored list is non-empty", ({
+		expect,
+	}) => {
+		const errors = validateDistImports(
+			"test-package",
+			{
+				name: "test-package",
+				devDependencies: { undici: "^7.0.0" },
+			},
+			new Set(["undici", "react-router"]),
+			["react-router"]
+		);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain('"undici"');
+	});
+});
+
+describe("getEntryPointPaths()", () => {
+	it("should collect main field", ({ expect }) => {
+		const paths = getEntryPointPaths({
+			name: "p",
+			main: "dist/index.js",
+		});
+		expect(paths).toEqual(["dist/index.js"]);
+	});
+
+	it("should collect module field", ({ expect }) => {
+		const paths = getEntryPointPaths({
+			name: "p",
+			module: "dist/index.mjs",
+		});
+		expect(paths).toEqual(["dist/index.mjs"]);
+	});
+
+	it("should walk nested exports object", ({ expect }) => {
+		const paths = getEntryPointPaths({
+			name: "p",
+			exports: {
+				".": {
+					import: "./dist/index.mjs",
+					require: "./dist/index.cjs",
+					types: "./dist/index.d.ts",
+				},
+				"./test-helpers": {
+					import: "./dist/test-helpers/index.mjs",
+				},
+			},
+		});
+		expect(paths.sort()).toEqual([
+			"./dist/index.cjs",
+			"./dist/index.d.ts",
+			"./dist/index.mjs",
+			"./dist/test-helpers/index.mjs",
+		]);
+	});
+
+	it("should collect string bin entries", ({ expect }) => {
+		const paths = getEntryPointPaths({
+			name: "p",
+			bin: "./bin/cli.js",
+		});
+		expect(paths).toEqual(["./bin/cli.js"]);
+	});
+
+	it("should collect object bin entries", ({ expect }) => {
+		const paths = getEntryPointPaths({
+			name: "p",
+			bin: { foo: "./bin/foo.js", bar: "./bin/bar.js" },
+		});
+		expect(paths.sort()).toEqual(["./bin/bar.js", "./bin/foo.js"]);
+	});
+
+	it("should deduplicate paths across fields", ({ expect }) => {
+		const paths = getEntryPointPaths({
+			name: "p",
+			main: "./dist/index.js",
+			module: "./dist/index.js",
+			exports: { ".": "./dist/index.js" },
+		});
+		expect(paths).toEqual(["./dist/index.js"]);
+	});
+
+	it("should return empty array when no entry points are declared", ({
+		expect,
+	}) => {
+		const paths = getEntryPointPaths({ name: "p" });
+		expect(paths).toEqual([]);
 	});
 });
 

--- a/tools/deployments/validate-package-dependencies.ts
+++ b/tools/deployments/validate-package-dependencies.ts
@@ -11,15 +11,28 @@
  * 1. Listed in `dependencies` (or `peerDependencies`) in package.json
  * 2. Listed in `scripts/deps.ts` with EXTERNAL_DEPENDENCIES export
  * 3. Documented with a comment explaining WHY it can't be bundled
+ *
+ * In addition to validating the manifest, this script also scans the actual
+ * built/published files (from the `files` field in package.json) for bare
+ * import specifiers and checks they all resolve to a declared runtime
+ * dependency or peer dependency. This catches cases where a bundler config's
+ * `external` list drifts from `package.json` — for example, a devDependency
+ * being incorrectly externalized would leave the published bundle with an
+ * unresolved import.
  */
 
 import { existsSync, readFileSync } from "node:fs";
+import { isBuiltin } from "node:module";
 import { dirname, resolve } from "node:path";
 import { glob } from "tinyglobby";
 
 export interface PackageJSON {
 	name: string;
 	private?: boolean;
+	main?: string;
+	module?: string;
+	exports?: unknown;
+	bin?: string | Record<string, string>;
 	dependencies?: Record<string, string>;
 	devDependencies?: Record<string, string>;
 	peerDependencies?: Record<string, string>;
@@ -102,23 +115,47 @@ export function getNonWorkspaceDependencies(
  * Attempts to load EXTERNAL_DEPENDENCIES from a package's scripts/deps.ts
  */
 export function loadExternalDependencies(packageDir: string): string[] | null {
-	const depsFilePath = resolve(packageDir, "scripts/deps.ts");
+	const depsModule = loadDepsModule(packageDir);
+	if (!depsModule || !Array.isArray(depsModule.EXTERNAL_DEPENDENCIES)) {
+		return null;
+	}
+	return depsModule.EXTERNAL_DEPENDENCIES;
+}
 
+/**
+ * Attempts to load IGNORED_DIST_IMPORTS from a package's scripts/deps.ts.
+ *
+ * `IGNORED_DIST_IMPORTS` is an allowlist of package names that the dist-scan
+ * validator should not flag as missing dependencies. Use this for legitimate
+ * but unfixable patterns such as:
+ *   - Optional imports inside try/catch blocks in bundled libraries
+ *     (e.g. `@netlify/build-info` probing for installed frameworks)
+ *   - Optional native binaries (e.g. `@aws-sdk/signature-v4-crt`)
+ *   - Code paths that are only reachable when consumers also install the
+ *     listed package themselves
+ */
+export function loadIgnoredDistImports(packageDir: string): string[] {
+	const depsModule = loadDepsModule(packageDir);
+	if (!depsModule || !Array.isArray(depsModule.IGNORED_DIST_IMPORTS)) {
+		return [];
+	}
+	return depsModule.IGNORED_DIST_IMPORTS;
+}
+
+function loadDepsModule(packageDir: string): {
+	EXTERNAL_DEPENDENCIES?: string[];
+	IGNORED_DIST_IMPORTS?: string[];
+} | null {
+	const depsFilePath = resolve(packageDir, "scripts/deps.ts");
 	if (!existsSync(depsFilePath)) {
 		return null;
 	}
-
 	// Use require with esbuild-register (which is already loaded)
 	// eslint-disable-next-line @typescript-eslint/no-require-imports -- dynamic require needed for esbuild-register compatibility
-	const depsModule = require(depsFilePath) as {
+	return require(depsFilePath) as {
 		EXTERNAL_DEPENDENCIES?: string[];
+		IGNORED_DIST_IMPORTS?: string[];
 	};
-
-	if (!Array.isArray(depsModule.EXTERNAL_DEPENDENCIES)) {
-		return null;
-	}
-
-	return depsModule.EXTERNAL_DEPENDENCIES;
 }
 
 /**
@@ -192,6 +229,284 @@ export function validatePackageDependencies(
 }
 
 /**
+ * Given an import specifier, returns the package name part.
+ *
+ * Examples:
+ *   "lodash" -> "lodash"
+ *   "lodash/fp" -> "lodash"
+ *   "@cloudflare/workers-utils" -> "@cloudflare/workers-utils"
+ *   "@cloudflare/workers-utils/test-helpers" -> "@cloudflare/workers-utils"
+ *   "vitest/runtime" -> "vitest"
+ */
+export function getPackageNameFromSpecifier(spec: string): string {
+	if (spec.startsWith("@")) {
+		const parts = spec.split("/");
+		return parts.slice(0, 2).join("/");
+	}
+	return spec.split("/")[0];
+}
+
+/**
+ * Returns true if the specifier refers to an external bare package import
+ * (i.e. not a built-in, virtual module, or relative path).
+ */
+export function isBareSpecifier(spec: string): boolean {
+	if (!spec || spec.startsWith(".") || spec.startsWith("/")) {
+		return false;
+	}
+	// Node built-ins, both prefixed (node:fs) and unprefixed (fs).
+	if (isBuiltin(spec)) {
+		return false;
+	}
+	// Known non-package protocols used inside bundled user code / templates.
+	// These appear inside string literals in wrangler's shipped code templates,
+	// not as real imports of an npm package.
+	if (/^[a-z][a-z0-9+\-.]*:/.test(spec) && !spec.startsWith("@")) {
+		return false;
+	}
+	// Virtual / runtime-injected modules — anything in ALL_CAPS_WITH_UNDERSCORES
+	// is conventionally a build-time virtual module (e.g. __VITEST_POOL_WORKERS_DEFINES).
+	if (/^__[A-Z][A-Z0-9_]*$/.test(spec)) {
+		return false;
+	}
+	// Specifiers containing template-literal expressions are dynamic strings
+	// that appear inside source-code templates emitted by Wrangler, not real
+	// imports of the wrapping package.
+	if (spec.includes("${") || spec.includes("*")) {
+		return false;
+	}
+	// Specifier must look like a valid npm package name: lowercase letters/digits,
+	// hyphens, dots, underscores; optionally scoped (@scope/name). npm package
+	// names cannot contain uppercase letters per the npm naming rules.
+	const packageNameRe =
+		/^(?:@[a-z0-9._~-]+\/)?[a-z0-9][a-z0-9._~-]*(?:\/[a-z0-9._~-]+)*$/;
+	if (!packageNameRe.test(spec)) {
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Extracts all bare-specifier imports from a JS/CJS source file.
+ *
+ * Handles:
+ *   import x from "pkg"
+ *   import { x } from "pkg"
+ *   import * as x from "pkg"
+ *   import "pkg"
+ *   export ... from "pkg"
+ *   require("pkg")
+ *   await import("pkg")  (only when specifier is a string literal)
+ *
+ * Returns top-level package names (e.g. "vitest" for "vitest/runtime").
+ *
+ * This is a regex-based scanner, not a real parser — it can produce false
+ * positives when bundled output contains string literals that look like
+ * import statements (e.g. JavaScript parser libraries shipped inside the
+ * bundle). False positives are filtered downstream by `isBareSpecifier`
+ * (rejecting non-package-shaped strings) and the self-import guard in
+ * `validateDistImports`.
+ */
+export function extractBareImports(content: string): Set<string> {
+	const imports = new Set<string>();
+
+	// Strip line comments and block comments to avoid matching specs inside them.
+	// This is a deliberate approximation — sufficient for built/minified output.
+	const stripped = content
+		.replace(/\/\*[\s\S]*?\*\//g, "")
+		.replace(/\/\/[^\n]*/g, "");
+
+	const patterns: RegExp[] = [
+		// import ... from "spec" / export ... from "spec"
+		// Anchored to a statement boundary (start of file, newline, `;`, or `}`)
+		// to avoid matching `from "x"` inside string literals.
+		/(?:^|[\n;}])\s*(?:import|export)\b[^"';\n]*?\bfrom\s*["']([^"'\n]+)["']/g,
+		// import "spec" (side-effect import) — also statement-anchored.
+		/(?:^|[\n;}])\s*import\s*["']([^"'\n]+)["']/g,
+		// require("spec")
+		/\brequire\s*\(\s*["']([^"'\n]+)["']\s*\)/g,
+		// import("spec") — only matches string literals
+		/\bimport\s*\(\s*["']([^"'\n]+)["']\s*\)/g,
+	];
+
+	for (const re of patterns) {
+		let m: RegExpExecArray | null;
+		while ((m = re.exec(stripped)) !== null) {
+			const spec = m[1];
+			if (isBareSpecifier(spec)) {
+				imports.add(getPackageNameFromSpecifier(spec));
+			}
+		}
+	}
+
+	return imports;
+}
+
+/**
+ * Collects every path string referenced by the package's main/module/exports/bin
+ * fields. These are the entry points that Node.js will actually load when the
+ * package is imported or executed — and thus the surface that needs to have
+ * all of its imports resolvable from `dependencies`/`peerDependencies`.
+ *
+ * Other entries in `files` (e.g. user-facing scaffolding templates) are
+ * intentionally excluded because they aren't loaded by the package itself.
+ */
+export function getEntryPointPaths(packageJson: PackageJSON): string[] {
+	const paths = new Set<string>();
+	if (packageJson.main) {
+		paths.add(packageJson.main);
+	}
+	if (packageJson.module) {
+		paths.add(packageJson.module);
+	}
+	walkExportValue(packageJson.exports, paths);
+	if (typeof packageJson.bin === "string") {
+		paths.add(packageJson.bin);
+	} else if (packageJson.bin && typeof packageJson.bin === "object") {
+		for (const v of Object.values(packageJson.bin)) {
+			if (typeof v === "string") {
+				paths.add(v);
+			}
+		}
+	}
+	return [...paths];
+}
+
+function walkExportValue(value: unknown, paths: Set<string>): void {
+	if (!value) {
+		return;
+	}
+	if (typeof value === "string") {
+		paths.add(value);
+		return;
+	}
+	if (Array.isArray(value)) {
+		for (const v of value) {
+			walkExportValue(v, paths);
+		}
+		return;
+	}
+	if (typeof value === "object") {
+		for (const v of Object.values(value as Record<string, unknown>)) {
+			walkExportValue(v, paths);
+		}
+	}
+}
+
+/**
+ * Walks the package's runtime entry points (and any sibling files in the same
+ * output directories — to cover code-split chunks) and returns the union of
+ * all bare-specifier imports found across them.
+ */
+export async function scanDistForExternalImports(
+	packageDir: string,
+	packageJson: PackageJSON
+): Promise<Set<string>> {
+	const imports = new Set<string>();
+	const entryPaths = getEntryPointPaths(packageJson);
+
+	// Build the set of patterns to scan. For each entry-point path that points
+	// at a JS file, also scan its containing directory recursively to cover
+	// code-split chunks. (E.g. workers-utils' dist/index.mjs re-exports from
+	// dist/chunk-*.mjs, which we want to validate too.)
+	const patterns = new Set<string>();
+	for (const rawPath of entryPaths) {
+		const cleaned = rawPath.replace(/^\.\//, "");
+		if (!/\.(mjs|cjs|js)$/.test(cleaned)) {
+			continue;
+		}
+		const absPath = resolve(packageDir, cleaned);
+		if (!existsSync(absPath)) {
+			continue;
+		}
+		const containingDir = dirname(cleaned);
+		if (containingDir && containingDir !== ".") {
+			patterns.add(`${containingDir}/**/*.{mjs,cjs,js}`);
+		} else {
+			patterns.add(cleaned);
+		}
+	}
+
+	if (patterns.size === 0) {
+		return imports;
+	}
+
+	const matched = await glob([...patterns], {
+		cwd: packageDir,
+		absolute: true,
+	});
+
+	for (const file of matched) {
+		if (file.endsWith(".map") || file.endsWith(".d.ts")) {
+			continue;
+		}
+		const content = readFileSync(file, "utf-8");
+		for (const imp of extractBareImports(content)) {
+			imports.add(imp);
+		}
+	}
+
+	return imports;
+}
+
+/**
+ * Validates that every bare-specifier import found in a package's published
+ * files is declared as either a `dependency` or `peerDependency`.
+ *
+ * Catches drift between bundler config `external` lists and `package.json` —
+ * for example, a devDependency that's incorrectly marked external in the
+ * bundler config would leave the published bundle importing an undeclared
+ * runtime dependency.
+ */
+export function validateDistImports(
+	packageName: string,
+	packageJson: PackageJSON,
+	importedPackages: Set<string>,
+	ignoredImports: string[] = []
+): string[] {
+	const errors: string[] = [];
+
+	const declaredRuntimeDeps = new Set([
+		...getAllDependencies(packageJson.dependencies),
+		...getAllDependencies(packageJson.peerDependencies),
+	]);
+	const devDeps = new Set(getAllDependencies(packageJson.devDependencies));
+	const ignored = new Set(ignoredImports);
+
+	for (const imp of importedPackages) {
+		// A package importing itself by name is always fine — it's a
+		// self-reference inside the bundle (e.g. wrangler's bundled cli.js
+		// contains code that references "wrangler" as a string literal).
+		if (imp === packageName) {
+			continue;
+		}
+		if (declaredRuntimeDeps.has(imp)) {
+			continue;
+		}
+		if (ignored.has(imp)) {
+			continue;
+		}
+		if (devDeps.has(imp)) {
+			errors.push(
+				`Package "${packageName}" imports "${imp}" in its published files, but ` +
+					`"${imp}" is only a devDependency. Either:\n` +
+					`  1. Move "${imp}" to dependencies (and add to scripts/deps.ts if appropriate), or\n` +
+					`  2. Bundle "${imp}" by removing it from the bundler config's "external" list, or\n` +
+					`  3. Add "${imp}" to IGNORED_DIST_IMPORTS in scripts/deps.ts if it's a legitimate optional/try-catch import.`
+			);
+		} else {
+			errors.push(
+				`Package "${packageName}" imports "${imp}" in its published files, but ` +
+					`"${imp}" is not declared in dependencies or peerDependencies. ` +
+					`Add it to package.json or to IGNORED_DIST_IMPORTS in scripts/deps.ts.`
+			);
+		}
+	}
+
+	return errors;
+}
+
+/**
  * Validates that all packages properly declare their external dependencies
  */
 export async function checkPackageDependencies(): Promise<string[]> {
@@ -211,6 +526,30 @@ export async function checkPackageDependencies(): Promise<string[]> {
 			externalDeps
 		);
 		errors.push(...packageErrors);
+
+		// Scan the published runtime files (main/module/exports/bin) to catch
+		// drift between bundler `external` lists and `package.json`. This
+		// catches devDeps incorrectly marked as external — which would leave
+		// the published bundle with unresolvable imports for end users.
+		try {
+			const importedPackages = await scanDistForExternalImports(
+				dir,
+				packageJson
+			);
+			const ignoredImports = loadIgnoredDistImports(dir);
+			const distErrors = validateDistImports(
+				packageName,
+				packageJson,
+				importedPackages,
+				ignoredImports
+			);
+			errors.push(...distErrors);
+		} catch (e) {
+			errors.push(
+				`Package "${packageName}" dist scan failed: ${e instanceof Error ? e.message : String(e)}.\n` +
+					`  Make sure the package is built before running this check.`
+			);
+		}
 	}
 
 	return errors;


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/13807

## Summary

The bundler's `external` list for `@cloudflare/vitest-pool-workers` was hand-maintained and out of sync with `package.json`. `undici` and `semver` were both listed as external despite being only `devDependencies`, leaving `dist/pool/index.mjs` with a top-level `import { fetch } from "undici"` that only resolved at runtime because pnpm happened to hoist `undici` from other packages' devDependencies during local development. This PR fixes the bug at its source and adds a CI check to prevent it recurring.

### Changes

**`@cloudflare/vitest-pool-workers`**
- `tsdown.config.ts` now derives its `external` list from `dependencies` + `peerDependencies` in `package.json`. A devDependency can never silently end up externalized.

**`@cloudflare/workers-utils`**
- Declares `"sideEffects": false` so consumers can tree-shake unused exports. With this in place, `vitest-pool-workers` drops the unused `cloudflared` / `tunnel` exports (and their transitive `undici` import) entirely.
- Moves `undici` from `devDependencies` to `dependencies` — it was always a runtime dep, the manifest just didn't say so. Keeping it external (rather than bundling) avoids two-undici-instance issues for consumers like wrangler — `instanceof Request/Response/Headers` checks and `setGlobalDispatcher` / proxy configuration depend on there being a single shared undici instance.
- Adds `vitest` as an optional `peerDependency` because `./test-helpers` uses `vitest`'s `vi`/`beforeEach`/`afterEach` at runtime.
- Drops the stale `"msw"` entry from the tsup external list — never used.

**Validator (`tools/deployments/validate-package-dependencies.ts`)**
- Extended to scan each public package's runtime entry points (`main`/`module`/`exports`/`bin`) for bare-specifier imports and flag any that aren't declared in `dependencies` or `peerDependencies`.
- New `IGNORED_DIST_IMPORTS` allowlist convention in `scripts/deps.ts` for legitimate try/catch'd optional imports inside bundled libraries (e.g. `@netlify/build-info` probing for installed frameworks, `recast`'s `babylon` fallback).
- 53 new unit tests; 132/132 passing.

### Results

| | Before | After |
|---|---|---|
| `vitest-pool-workers/dist/pool/index.mjs` size | 489 KB | 125 KB |
| `vitest-pool-workers/dist/pool/index.mjs` undici references | 1 (unresolvable `import`) | 0 |
| `workers-utils/dist/index.mjs` undici references | 1 (unresolvable `import`) | 1 (resolvable via runtime dep) |
| `wrangler-dist/cli.js` undici copies | 1 | 1 (single shared instance) |
| Validator catches devDep externalization | no | yes |

Fixes a latent runtime resolution bug and prevents regressions.

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal build/packaging fix with no user-facing API or behavior changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13933" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->