### PR TITLE
[wrangler] fix: update remote proxy session error test snapshots

### DIFF
--- a/fixtures/get-platform-proxy-remote-bindings/tests/index.test.ts
+++ b/fixtures/get-platform-proxy-remote-bindings/tests/index.test.ts
@@ -246,8 +246,8 @@ if (auth) {
 					}>({
 						configPath: "./.tmp/config-with-invalid-account-id/wrangler.json",
 					})
-				).rejects.toThrowError(
-					/Failed to start the remote proxy session\. Failed to create a preview token/
+				).rejects.toMatchInlineSnapshot(
+					`[Error: Failed to start the remote proxy session. Error reloading remote server: A request to the Cloudflare API (/accounts/NOT a valid account id/workers/subdomain/edge-preview) failed.]`
 				);
 
 				expect(errorSpy).toHaveBeenCalledOnce();

--- a/packages/wrangler/e2e/remote-binding/remote-bindings-api.test.ts
+++ b/packages/wrangler/e2e/remote-binding/remote-bindings-api.test.ts
@@ -6,6 +6,7 @@ import {
 	importWrangler,
 	WranglerE2ETestHelper,
 } from "../helpers/e2e-wrangler-test";
+import { normalizeOutput } from "../helpers/normalize";
 import type {
 	MiniflareOptions,
 	Miniflare as MiniflareType,
@@ -82,8 +83,9 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 			});
 
 			test("user provided incorrect auth data", async ({ expect }) => {
-				await expect(
-					startRemoteProxySession(
+				let error: unknown;
+				try {
+					await startRemoteProxySession(
 						{
 							MY_SERVICE: {
 								type: "service",
@@ -98,9 +100,12 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 								},
 							},
 						}
-					)
-				).rejects.toThrowError(
-					/Failed to start the remote proxy session\. Failed to create a preview token/
+					);
+				} catch (e) {
+					error = e;
+				}
+				expect(normalizeOutput(`${error}`)).toMatchInlineSnapshot(
+					`"Error: Failed to start the remote proxy session. Error reloading remote server: A request to the Cloudflare API (/accounts/00000000000000000000000000000000/workers/subdomain/edge-preview) failed."`
 				);
 			});
 		});
@@ -137,8 +142,9 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 			});
 
 			test("user provided incorrect auth data", async ({ expect }) => {
-				await expect(
-					maybeStartOrUpdateRemoteProxySession(
+				let error: unknown;
+				try {
+					await maybeStartOrUpdateRemoteProxySession(
 						{
 							bindings: {
 								MY_SERVICE: {
@@ -155,9 +161,12 @@ describe.skipIf(!CLOUDFLARE_ACCOUNT_ID)(
 								apiToken: "This is an incorrect API TOKEN!",
 							},
 						}
-					)
-				).rejects.toThrowError(
-					/Failed to start the remote proxy session\. Failed to create a preview token/
+					);
+				} catch (e) {
+					error = e;
+				}
+				expect(normalizeOutput(`${error}`)).toMatchInlineSnapshot(
+					`"Error: Failed to start the remote proxy session. Error reloading remote server: A request to the Cloudflare API (/accounts/00000000000000000000000000000000/workers/subdomain/edge-preview) failed."`
 				);
 			});
 		});


### PR DESCRIPTION
Fixes the test regression introduced by #11896, which enriched the error thrown by `startRemoteProxySession` but pointed two real-API tests at a regex (`Failed to create a preview token`) that does not match the message that actually surfaces in CI:

> Failed to start the remote proxy session. Error reloading remote server: A request to the Cloudflare API (/accounts/`<id>`/workers/subdomain/edge-preview) failed.

This PR updates the two tests that exercise real API calls so their assertions reflect the actual error string:

- `fixtures/get-platform-proxy-remote-bindings/tests/index.test.ts` — back to `toMatchInlineSnapshot` (the invalid account id is a hard-coded literal here, so no normalization needed).
- `packages/wrangler/e2e/remote-binding/remote-bindings-api.test.ts` — capture via `try`/`catch` and assert against `normalizeOutput(...)` so the real `CLOUDFLARE_ACCOUNT_ID` is normalized in the snapshot.

The mocked unit test in `packages/wrangler/src/__tests__/dev/remote-bindings-errors.test.ts` and the loosely-asserting `packages/vite-plugin-cloudflare/e2e/remote-bindings.test.ts` are unaffected and were left alone.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test-only change; no user-facing behaviour change.

*A picture of a cute animal (not mandatory, but encouraged)*