### PR TITLE
docs: document experimental flag naming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,14 @@ We really appreciate your interest in making a contribution, and we want to make
 
 Thanks so much for helping us improve the [workers-sdk](https://github.com/cloudflare/workers-sdk), and we look forward to your contribution!
 
+## Naming experimental and unstable flags
+
+When adding Wrangler flags for behavior that is not yet stable, prefer an `experimental-` prefix for the long CLI flag name, such as `--experimental-autoconfig` or `--experimental-provision`. If the flag also needs a short opt-in alias, use the existing `x-` form, such as `--x-autoconfig` or `--x-provision`.
+
+Keep CLI flag names in kebab-case. Reserve `unstable_` and `experimental_` prefixes for exported JavaScript APIs rather than CLI flags, matching exports such as `unstable_dev` and `experimental_generateTypes`.
+
+If an experimental flag graduates or is no longer needed, keep the old flag hidden and deprecated while pointing users to the stable replacement, as with `--experimental-local` and `--experimental-include-runtime`.
+
 ## Getting started
 
 ### Set up your environment


### PR DESCRIPTION
Fixes #7873.

Adds a short contribution-guide note for experimental/unstable flag naming:

- use `experimental-` for long Wrangler CLI flags,
- use the existing `x-` form for short opt-in aliases,
- keep CLI flags kebab-case,
- reserve `unstable_` / `experimental_` prefixes for JavaScript API exports,
- keep graduated or removed experimental flags hidden/deprecated while pointing users to the stable replacement.

I checked the current Wrangler sources before writing this, including `--experimental-autoconfig`, `--experimental-provision`, `--experimental-local`, `--experimental-include-runtime`, and exported APIs such as `unstable_dev` and `experimental_generateTypes`.

Verification: `git diff --check`.

This was implemented with Codex assistance, with the patch kept focused and manually reviewed before sending.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: Markdown-only contribution guide update.
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This updates repository contribution docs, not product/user docs.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->