### PR TITLE
Pipelines: R2 Data Catalog sinks enforce minimum write  interval of 60 seconds

### DIFF
--- a/.changeset/pipelines-r2-data-catalog-min-interval.md
+++ b/.changeset/pipelines-r2-data-catalog-min-interval.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Enforce minimum 60 second interval for R2 Data Catalog sinks
+
+R2 Data Catalog sinks now require a minimum `--roll-interval` of 60 seconds to prevent compaction issues in the R2 Data Catalog. This validation is applied when creating sinks via `wrangler pipelines sinks create` with type `r2-data-catalog`, and during the interactive `wrangler pipelines setup` flow.
+
+Regular R2 sinks are not affected and can still use intervals as low as 10 seconds.

--- a/packages/wrangler/src/__tests__/pipelines.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines.test.ts
@@ -1720,6 +1720,34 @@ describe("wrangler pipelines", () => {
 				`[Error: --namespace is required for r2-data-catalog sinks]`
 			);
 		});
+
+		it("should error when r2-data-catalog has interval below minimum", async ({
+			expect,
+		}) => {
+			await expect(
+				runWrangler(
+					"pipelines sinks create my_sink --type r2-data-catalog --bucket catalog-bucket --namespace default --table my-table --catalog-token token123 --roll-interval 30"
+				)
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Pipeline frequency must be at least 60 seconds for R2 Data Catalog sinks to prevent compaction issues. Current value: 30 seconds.]`
+			);
+		});
+
+		it("should allow r2 sinks with interval below 60 seconds", async ({
+			expect,
+		}) => {
+			const createRequest = mockCreateSinkRequest(expect, {
+				name: "my_sink",
+				type: "r2",
+			});
+
+			await runWrangler(
+				"pipelines sinks create my_sink --type r2 --bucket my-bucket --access-key-id mykey --secret-access-key mysecret --roll-interval 30"
+			);
+
+			expect(createRequest.count).toBe(1);
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
 	});
 
 	describe("pipelines sinks list", () => {

--- a/packages/wrangler/src/pipelines/cli/setup.ts
+++ b/packages/wrangler/src/pipelines/cli/setup.ts
@@ -191,10 +191,14 @@ async function promptCompression(): Promise<string> {
 	});
 }
 
-async function promptRollingPolicy(): Promise<{
+async function promptRollingPolicy(options?: {
+	minIntervalSeconds?: number;
+}): Promise<{
 	fileSizeBytes: number;
 	intervalSeconds: number;
 }> {
+	const minInterval = options?.minIntervalSeconds ?? 10;
+
 	const fileSizeMB = await promptWithRetry(
 		() => "File size",
 		() =>
@@ -214,13 +218,13 @@ async function promptRollingPolicy(): Promise<{
 	const intervalSeconds = await promptWithRetry(
 		() => "Interval",
 		() =>
-			prompt("Roll file when time reaches (seconds, minimum 10):", {
+			prompt(`Roll file when time reaches (seconds, minimum ${minInterval}):`, {
 				defaultValue: String(SINK_DEFAULTS.rolling_policy.interval_seconds),
 			}),
 		(value) => {
 			const num = parseInt(value, 10);
-			if (isNaN(num) || num < 10) {
-				throw new UserError("Interval must be a number >= 10", {
+			if (isNaN(num) || num < minInterval) {
+				throw new UserError(`Interval must be a number >= ${minInterval}`, {
 					telemetryMessage: "pipelines setup invalid interval",
 				});
 			}
@@ -960,7 +964,10 @@ async function setupDataCatalogSink(
 	const token = await promptCatalogToken(config, accountId, bucket);
 
 	const compression = await promptCompression();
-	const rollingPolicy = await promptRollingPolicy();
+	// R2 Data Catalog sinks require minimum 60 second intervals to prevent compaction issues
+	const rollingPolicy = await promptRollingPolicy({
+		minIntervalSeconds: SINK_DEFAULTS.rolling_policy.min_interval_seconds,
+	});
 
 	setupConfig.sinkConfig = {
 		name: setupConfig.sinkName,

--- a/packages/wrangler/src/pipelines/cli/sinks/create.ts
+++ b/packages/wrangler/src/pipelines/cli/sinks/create.ts
@@ -144,6 +144,19 @@ export const pipelinesSinksCreateCommand = createCommand({
 					{ telemetryMessage: "pipelines sinks create invalid format" }
 				);
 			}
+			// Enforce minimum interval for R2 Data Catalog to prevent compaction issues
+			if (
+				args.rollInterval !== undefined &&
+				args.rollInterval < SINK_DEFAULTS.rolling_policy.min_interval_seconds
+			) {
+				throw new CommandLineArgsError(
+					`Pipeline frequency must be at least ${SINK_DEFAULTS.rolling_policy.min_interval_seconds} seconds for R2 Data Catalog sinks to prevent compaction issues. Current value: ${args.rollInterval} seconds.`,
+					{
+						telemetryMessage:
+							"pipelines r2 data catalog interval below minimum threshold",
+					}
+				);
+			}
 		}
 	},
 	async handler(args, { config }) {

--- a/packages/wrangler/src/pipelines/defaults.ts
+++ b/packages/wrangler/src/pipelines/defaults.ts
@@ -1,4 +1,3 @@
-import { UserError } from "@cloudflare/workers-utils";
 import type { ParquetFormat, Sink } from "./types";
 
 export const SINK_DEFAULTS = {
@@ -59,22 +58,6 @@ export function applyDefaultsToSink(sink: Sink): Sink {
 			withDefaults.config.rolling_policy.interval_seconds =
 				SINK_DEFAULTS.rolling_policy.interval_seconds;
 		}
-	}
-
-	// Enforce minimum interval for R2 Data Catalog to prevent compaction issues
-	if (
-		withDefaults.type === "r2_data_catalog" &&
-		withDefaults.config.rolling_policy &&
-		withDefaults.config.rolling_policy.interval_seconds <
-			SINK_DEFAULTS.rolling_policy.min_interval_seconds
-	) {
-		throw new UserError(
-			`Pipeline frequency must be at least ${SINK_DEFAULTS.rolling_policy.min_interval_seconds} seconds for R2 Data Catalog sinks to prevent compaction issues. Current value: ${withDefaults.config.rolling_policy.interval_seconds} seconds.`,
-			{
-				telemetryMessage:
-					"pipelines r2 data catalog interval below minimum threshold",
-			}
-		);
 	}
 
 	if (withDefaults.type === "r2") {

--- a/packages/wrangler/src/pipelines/defaults.ts
+++ b/packages/wrangler/src/pipelines/defaults.ts
@@ -1,3 +1,4 @@
+import { UserError } from "@cloudflare/workers-utils";
 import type { ParquetFormat, Sink } from "./types";
 
 export const SINK_DEFAULTS = {
@@ -9,6 +10,7 @@ export const SINK_DEFAULTS = {
 	rolling_policy: {
 		file_size_bytes: undefined,
 		interval_seconds: 300,
+		min_interval_seconds: 60,
 	},
 	r2: {
 		path: "",
@@ -57,6 +59,22 @@ export function applyDefaultsToSink(sink: Sink): Sink {
 			withDefaults.config.rolling_policy.interval_seconds =
 				SINK_DEFAULTS.rolling_policy.interval_seconds;
 		}
+	}
+
+	// Enforce minimum interval for R2 Data Catalog to prevent compaction issues
+	if (
+		withDefaults.type === "r2_data_catalog" &&
+		withDefaults.config.rolling_policy &&
+		withDefaults.config.rolling_policy.interval_seconds <
+			SINK_DEFAULTS.rolling_policy.min_interval_seconds
+	) {
+		throw new UserError(
+			`Pipeline frequency must be at least ${SINK_DEFAULTS.rolling_policy.min_interval_seconds} seconds for R2 Data Catalog sinks to prevent compaction issues. Current value: ${withDefaults.config.rolling_policy.interval_seconds} seconds.`,
+			{
+				telemetryMessage:
+					"pipelines r2 data catalog interval below minimum threshold",
+			}
+		);
 	}
 
 	if (withDefaults.type === "r2") {


### PR DESCRIPTION
- R2 Data Catalog sinks: Minimum interval is 60 seconds
- Regular R2 sinks: Minimum interval remains 10 seconds 
- The error message clearly explains: "Pipeline frequency must be at least 60 seconds for R2 Data Catalog sinks to prevent compaction issues"
---

- Tests
  - [x] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows:
<img width="742" height="561" alt="Screenshot 2026-05-19 at 12 12 27" src="https://github.com/user-attachments/assets/4d94b311-e8bf-46d5-96d7-692a938044d7" />
<img width="571" height="402" alt="Screenshot 2026-05-19 at 12 13 57" src="https://github.com/user-attachments/assets/4754c837-6164-4da3-a762-319e1e0f85f5" />

  - [x] Additional testing not necessary because: limited scope of changes
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/30883
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13951" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->