### PR TITLE
[wrangler] Read OAuth state from disk lazily so env auth takes priority

### DIFF
--- a/.changeset/lazy-auth-state-read.md
+++ b/.changeset/lazy-auth-state-read.md
@@ -1,0 +1,13 @@
+---
+"wrangler": patch
+---
+
+Read the on-disk OAuth state lazily so `CLOUDFLARE_API_TOKEN` from `.env` takes priority correctly
+
+Wrangler previously read its OAuth state from the user auth config file (for example `~/.config/.wrangler/config/default.toml`) eagerly at module-import time. That happens _before_ `.env` files are loaded, so the in-memory state would always hold the OAuth tokens even when the user only wanted to authenticate via `CLOUDFLARE_API_TOKEN`. If that stored OAuth token happened to be expired, Wrangler would try to refresh it (and fail), aborting the command with `Failed to fetch auth token: 400 Bad Request` and `Not logged in.` — even though a valid API token was in scope.
+
+Wrangler now reads the auth config file on demand, after `.env` has been loaded. When `CLOUDFLARE_API_TOKEN` (or `CLOUDFLARE_API_KEY` + `CLOUDFLARE_EMAIL`) is present, the OAuth state on disk is no longer consulted, the OAuth refresh endpoint is no longer called, and the env-based token is used directly. Sibling-process refresh-token rotation is also handled naturally because every check reads the current file contents.
+
+Internally, the exported `reinitialiseAuthTokens()` function is removed — there is no module-level OAuth cache left to invalidate.
+
+Fixes [#13744](https://github.com/cloudflare/workers-sdk/issues/13744).

--- a/packages/wrangler/src/__tests__/ai-search.test.ts
+++ b/packages/wrangler/src/__tests__/ai-search.test.ts
@@ -1,4 +1,5 @@
 import { writeFileSync } from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { endEventLoop } from "./helpers/end-event-loop";
@@ -12,7 +13,6 @@ import {
 } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { createFetchResult, msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 
 // ── Shared test data ──────────────────────────────────────────────────────────

--- a/packages/wrangler/src/__tests__/ai.test.ts
+++ b/packages/wrangler/src/__tests__/ai.test.ts
@@ -1,3 +1,4 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { endEventLoop } from "./helpers/end-event-loop";
@@ -6,7 +7,6 @@ import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { createFetchResult, msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 
 describe("ai help", () => {

--- a/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
@@ -1,12 +1,15 @@
 import path from "node:path";
-import { normalizeString, seed } from "@cloudflare/workers-utils/test-helpers";
+import {
+	normalizeString,
+	runInTempDir,
+	seed,
+} from "@cloudflare/workers-utils/test-helpers";
 import * as esbuild from "esbuild";
 import dedent from "ts-dedent";
 import { afterEach, beforeEach, describe, test, vi } from "vitest";
 import { BundlerController } from "../../../api/startDevWorker/BundlerController";
 import { FakeBus } from "../../helpers/fake-bus";
 import { mockConsoleMethods } from "../../helpers/mock-console";
-import { runInTempDir } from "../../helpers/run-in-tmp";
 import type { StartDevWorkerOptions } from "../../../api";
 
 // Find the bundled result of a particular source file

--- a/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { seed } from "@cloudflare/workers-utils/test-helpers";
+import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import dedent from "ts-dedent";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { ConfigController } from "../../../api/startDevWorker/ConfigController";
@@ -8,7 +8,6 @@ import { logger } from "../../../logger";
 import { FakeBus } from "../../helpers/fake-bus";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
-import { runInTempDir } from "../../helpers/run-in-tmp";
 import { runWrangler } from "../../helpers/run-wrangler";
 
 describe("ConfigController", () => {

--- a/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
@@ -4,6 +4,7 @@ import net from "node:net";
 import path from "node:path";
 import util from "node:util";
 import { removeDirSync } from "@cloudflare/workers-utils";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { DeferredPromise, Response } from "miniflare";
 import dedent from "ts-dedent";
 import { fetch } from "undici";
@@ -19,7 +20,6 @@ import { RuleTypeToModuleType } from "../../../deployment-bundle/module-collecti
 import { usingLocalSecretsStoreSecretAPI } from "../../../secrets-store/commands";
 import { FakeBus } from "../../helpers/fake-bus";
 import { mockConsoleMethods } from "../../helpers/mock-console";
-import { runInTempDir } from "../../helpers/run-in-tmp";
 import { useTeardown } from "../../helpers/teardown";
 import { unusable } from "../../helpers/unusable";
 import type { Bundle, File, StartDevWorkerOptions } from "../../../api";

--- a/packages/wrangler/src/__tests__/assets.test.ts
+++ b/packages/wrangler/src/__tests__/assets.test.ts
@@ -1,12 +1,12 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it } from "vitest";
 import {
 	NonDirectoryAssetsDirError,
 	NonExistentAssetsDirError,
 	getAssetsOptions,
 } from "../assets";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import type { Config } from "@cloudflare/workers-utils";
 
 /**

--- a/packages/wrangler/src/__tests__/autoconfig/details/framework-detection/basic-framework-detection.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/framework-detection/basic-framework-detection.test.ts
@@ -1,9 +1,7 @@
 import { writeFile } from "node:fs/promises";
-import { seed } from "@cloudflare/workers-utils/test-helpers";
+import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it } from "vitest";
 import { detectFramework } from "../../../../autoconfig/details/framework-detection";
-import { runInTempDir } from "../../../helpers/run-in-tmp";
-
 describe("detectFramework() / basic framework detection", () => {
 	runInTempDir();
 

--- a/packages/wrangler/src/__tests__/autoconfig/details/framework-detection/lock-file-warning.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/framework-detection/lock-file-warning.test.ts
@@ -1,9 +1,7 @@
-import { seed } from "@cloudflare/workers-utils/test-helpers";
+import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it } from "vitest";
 import { detectFramework } from "../../../../autoconfig/details/framework-detection";
 import { mockConsoleMethods } from "../../../helpers/mock-console";
-import { runInTempDir } from "../../../helpers/run-in-tmp";
-
 const noLockFileWarning =
 	"No lock file has been detected in the current working directory. This might indicate that the project is part of a workspace.";
 

--- a/packages/wrangler/src/__tests__/autoconfig/details/framework-detection/multiple-frameworks-detected.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/framework-detection/multiple-frameworks-detected.test.ts
@@ -1,8 +1,7 @@
-import { seed } from "@cloudflare/workers-utils/test-helpers";
+import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { detectFramework } from "../../../../autoconfig/details/framework-detection";
 import * as isInteractiveModule from "../../../../is-interactive";
-import { runInTempDir } from "../../../helpers/run-in-tmp";
 import type { MockInstance } from "vitest";
 
 describe("detectFramework() / multiple frameworks detected", () => {

--- a/packages/wrangler/src/__tests__/autoconfig/details/framework-detection/package-manager-detection.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/framework-detection/package-manager-detection.test.ts
@@ -1,4 +1,4 @@
-import { seed } from "@cloudflare/workers-utils/test-helpers";
+import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it } from "vitest";
 import { detectFramework } from "../../../../autoconfig/details/framework-detection";
 import {
@@ -7,8 +7,6 @@ import {
 	PnpmPackageManager,
 	YarnPackageManager,
 } from "../../../../package-manager";
-import { runInTempDir } from "../../../helpers/run-in-tmp";
-
 describe("detectFramework() / package manager detection", () => {
 	runInTempDir();
 

--- a/packages/wrangler/src/__tests__/autoconfig/details/framework-detection/pages-project-detection.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/framework-detection/pages-project-detection.test.ts
@@ -1,12 +1,11 @@
 import { join } from "node:path";
-import { seed } from "@cloudflare/workers-utils/test-helpers";
+import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { detectFramework } from "../../../../autoconfig/details/framework-detection";
 import * as configCache from "../../../../config-cache";
 import * as isInteractiveModule from "../../../../is-interactive";
 import { PAGES_CONFIG_CACHE_FILENAME } from "../../../../pages/constants";
 import { mockConfirm } from "../../../helpers/mock-dialogs";
-import { runInTempDir } from "../../../helpers/run-in-tmp";
 import type { Config } from "@cloudflare/workers-utils";
 import type { MockInstance } from "vitest";
 

--- a/packages/wrangler/src/__tests__/autoconfig/details/framework-detection/workspace-root-handling.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/framework-detection/workspace-root-handling.test.ts
@@ -1,8 +1,6 @@
-import { seed } from "@cloudflare/workers-utils/test-helpers";
+import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it } from "vitest";
 import { detectFramework } from "../../../../autoconfig/details/framework-detection";
-import { runInTempDir } from "../../../helpers/run-in-tmp";
-
 describe("detectFramework() / workspace root handling", () => {
 	runInTempDir();
 

--- a/packages/wrangler/src/__tests__/autoconfig/details/get-details-for-auto-config.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/get-details-for-auto-config.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { seed } from "@cloudflare/workers-utils/test-helpers";
+import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import * as details from "../../../autoconfig/details";
 import * as configCache from "../../../config-cache";
@@ -12,7 +12,6 @@ import { PAGES_CONFIG_CACHE_FILENAME } from "../../../pages/constants";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { mockConfirm } from "../../helpers/mock-dialogs";
 import { useMockIsTTY } from "../../helpers/mock-istty";
-import { runInTempDir } from "../../helpers/run-in-tmp";
 import type { Config } from "@cloudflare/workers-utils";
 import type { Mock, MockInstance } from "vitest";
 

--- a/packages/wrangler/src/__tests__/autoconfig/details/get-worker-name-from-project.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/get-worker-name-from-project.test.ts
@@ -1,9 +1,7 @@
 import { randomUUID } from "node:crypto";
-import { seed } from "@cloudflare/workers-utils/test-helpers";
+import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import { afterEach, describe, it, vi } from "vitest";
 import { getWorkerNameFromProject } from "../../../autoconfig/details";
-import { runInTempDir } from "../../helpers/run-in-tmp";
-
 describe("autoconfig details - getWorkerNameFromProject()", () => {
 	runInTempDir();
 

--- a/packages/wrangler/src/__tests__/autoconfig/frameworks/angular.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/frameworks/angular.test.ts
@@ -1,11 +1,10 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import * as cliPackages from "@cloudflare/cli-shared-helpers/packages";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { beforeEach, describe, it, vi } from "vitest";
 import { Angular } from "../../../autoconfig/frameworks/angular";
 import { NpmPackageManager } from "../../../package-manager";
-import { runInTempDir } from "../../helpers/run-in-tmp";
-
 const BASE_OPTIONS = {
 	projectPath: process.cwd(),
 	workerName: "my-angular-app",

--- a/packages/wrangler/src/__tests__/autoconfig/frameworks/vike.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/frameworks/vike.test.ts
@@ -1,11 +1,10 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import * as cliPackages from "@cloudflare/cli-shared-helpers/packages";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { beforeEach, describe, it, vi } from "vitest";
 import { Vike } from "../../../autoconfig/frameworks/vike";
 import { NpmPackageManager } from "../../../package-manager";
-import { runInTempDir } from "../../helpers/run-in-tmp";
-
 vi.mock("../../../autoconfig/frameworks/utils/packages", () => ({
 	isPackageInstalled: () => false,
 }));

--- a/packages/wrangler/src/__tests__/autoconfig/get-installed-package-version.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/get-installed-package-version.test.ts
@@ -1,8 +1,6 @@
-import { seed } from "@cloudflare/workers-utils/test-helpers";
+import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import { describe, test } from "vitest";
 import { getInstalledPackageVersion } from "../../autoconfig/frameworks/utils/packages";
-import { runInTempDir } from "../helpers/run-in-tmp";
-
 describe("getInstalledPackageVersion()", () => {
 	runInTempDir();
 	test("happy path", async ({ expect }) => {

--- a/packages/wrangler/src/__tests__/autoconfig/run.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/run.test.ts
@@ -6,7 +6,10 @@ import {
 	readFileSync,
 	getTodaysCompatDate,
 } from "@cloudflare/workers-utils";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import * as details from "../../autoconfig/details";
 import { Astro } from "../../autoconfig/frameworks/astro";
@@ -25,7 +28,6 @@ import {
 	mockSelect,
 } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { writeWorkerSource } from "../helpers/write-worker-source";
 import type { Framework } from "../../autoconfig/frameworks";

--- a/packages/wrangler/src/__tests__/autoconfig/vite-config.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/vite-config.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { beforeEach, describe, it } from "vitest";
 import {
 	checkIfViteConfigUsesCloudflarePlugin,
@@ -7,8 +8,6 @@ import {
 } from "../../autoconfig/frameworks/utils/vite-config";
 import { logger } from "../../logger";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import { runInTempDir } from "../helpers/run-in-tmp";
-
 describe("vite-config utils", () => {
 	runInTempDir();
 	const std = mockConsoleMethods();

--- a/packages/wrangler/src/__tests__/browser-run.test.ts
+++ b/packages/wrangler/src/__tests__/browser-run.test.ts
@@ -1,6 +1,7 @@
 import {
 	mockCreateDate,
 	mockStartDate,
+	runInTempDir,
 } from "@cloudflare/workers-utils/test-helpers";
 import ci from "ci-info";
 import { http, HttpResponse } from "msw";
@@ -11,7 +12,6 @@ import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs, mockSelect } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type {
 	BrowserAcquireResponse,

--- a/packages/wrangler/src/__tests__/cert.test.ts
+++ b/packages/wrangler/src/__tests__/cert.test.ts
@@ -1,5 +1,6 @@
 import { writeFileSync } from "node:fs";
 import { COMPLIANCE_REGION_CONFIG_UNKNOWN } from "@cloudflare/workers-utils";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, it, test } from "vitest";
 import {
@@ -17,7 +18,6 @@ import { mockConsoleMethods } from "./helpers/mock-console";
 import { mockConfirm } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 
 describe("wrangler", () => {

--- a/packages/wrangler/src/__tests__/cfetch-utils.test.ts
+++ b/packages/wrangler/src/__tests__/cfetch-utils.test.ts
@@ -1,10 +1,10 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { describe, it } from "vitest";
 import { extractAccountTag, hasMorePages } from "../cfetch";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { createFetchResult, msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 
 /**

--- a/packages/wrangler/src/__tests__/cloudchamber/apply.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/apply.test.ts
@@ -4,7 +4,10 @@ import {
 	SchedulingPolicy,
 	SecretAccessType,
 } from "@cloudflare/containers-shared";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, test } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
@@ -12,7 +15,6 @@ import { mockCLIOutput } from "../helpers/mock-cli-output";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { mockAccount } from "./utils";
 import type {

--- a/packages/wrangler/src/__tests__/cloudchamber/build.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/build.test.ts
@@ -8,10 +8,10 @@ import {
 	runDockerCmdWithOutput,
 } from "@cloudflare/containers-shared";
 import { UserError } from "@cloudflare/workers-utils";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { mockAccountV4 as mockAccount } from "./utils";
 

--- a/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import * as TOML from "smol-toml";
 import { afterEach, beforeEach, describe, it } from "vitest";
@@ -7,7 +8,6 @@ import { MOCK_DEPLOYMENTS_COMPLEX } from "../helpers/mock-cloudchamber";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { mockAccount, setWranglerConfig } from "./utils";
 import type { SSHPublicKeyItem } from "@cloudflare/containers-shared";

--- a/packages/wrangler/src/__tests__/cloudchamber/curl.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/curl.test.ts
@@ -1,3 +1,4 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { collectCLIOutput } from "../helpers/collect-cli-output";
@@ -6,7 +7,6 @@ import { MOCK_DEPLOYMENTS_COMPLEX } from "../helpers/mock-cloudchamber";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { mockAccount, setWranglerConfig } from "./utils";
 

--- a/packages/wrangler/src/__tests__/cloudchamber/delete.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/delete.test.ts
@@ -1,3 +1,4 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
@@ -5,7 +6,6 @@ import { MOCK_DEPLOYMENTS_COMPLEX } from "../helpers/mock-cloudchamber";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { mockAccount } from "./utils";
 

--- a/packages/wrangler/src/__tests__/cloudchamber/images.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/images.test.ts
@@ -1,11 +1,11 @@
 import { getCloudflareContainerRegistry } from "@cloudflare/containers-shared";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { mockAccount, setWranglerConfig } from "./utils";
 

--- a/packages/wrangler/src/__tests__/cloudchamber/list.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/list.test.ts
@@ -1,3 +1,4 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
@@ -5,7 +6,6 @@ import { MOCK_DEPLOYMENTS_COMPLEX } from "../helpers/mock-cloudchamber";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { mockAccount, setWranglerConfig } from "./utils";
 

--- a/packages/wrangler/src/__tests__/cloudchamber/modify.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/modify.test.ts
@@ -1,3 +1,4 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
@@ -5,7 +6,6 @@ import { MOCK_DEPLOYMENTS_COMPLEX } from "../helpers/mock-cloudchamber";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { mockAccount, setWranglerConfig } from "./utils";
 import type { ExpectStatic } from "vitest";

--- a/packages/wrangler/src/__tests__/complete.test.ts
+++ b/packages/wrangler/src/__tests__/complete.test.ts
@@ -1,7 +1,7 @@
 import { execSync } from "node:child_process";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { describe, test } from "vitest";
 import { mockConsoleMethods } from "./helpers/mock-console";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 
 function shellAvailable(shell: string): boolean {

--- a/packages/wrangler/src/__tests__/config-cache-wrangler-fallback.test.ts
+++ b/packages/wrangler/src/__tests__/config-cache-wrangler-fallback.test.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it } from "vitest";
 import {
 	getCacheFolder,
@@ -6,8 +7,6 @@ import {
 	saveToConfigCache,
 } from "../config-cache";
 import { mockConsoleMethods } from "./helpers/mock-console";
-import { runInTempDir } from "./helpers/run-in-tmp";
-
 interface PagesConfigCache {
 	account_id: string;
 	pages_project_name: string;

--- a/packages/wrangler/src/__tests__/config-cache.test.ts
+++ b/packages/wrangler/src/__tests__/config-cache.test.ts
@@ -1,5 +1,6 @@
 import { mkdirSync } from "node:fs";
 import * as path from "node:path";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import {
 	getCacheFolder,
@@ -7,8 +8,6 @@ import {
 	saveToConfigCache,
 } from "../config-cache";
 import { mockConsoleMethods } from "./helpers/mock-console";
-import { runInTempDir } from "./helpers/run-in-tmp";
-
 interface PagesConfigCache {
 	account_id: string;
 	pages_project_name: string;

--- a/packages/wrangler/src/__tests__/config/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.test.ts
@@ -1,13 +1,14 @@
 import * as fs from "node:fs";
 import { experimental_readRawConfig } from "@cloudflare/workers-utils";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { describe, it, vi } from "vitest";
 import { readConfig } from "../../config";
 import { updateCheck } from "../../update-check";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import { runInTempDir } from "../helpers/run-in-tmp";
-
 describe("readConfig() upgrade hint", () => {
 	runInTempDir();
 	const std = mockConsoleMethods();

--- a/packages/wrangler/src/__tests__/config/loadDotEnv.test.ts
+++ b/packages/wrangler/src/__tests__/config/loadDotEnv.test.ts
@@ -1,10 +1,8 @@
-import { seed } from "@cloudflare/workers-utils/test-helpers";
+import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { loadDotEnv } from "../../config/dot-env";
 import { logger } from "../../logger";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import { runInTempDir } from "../helpers/run-in-tmp";
-
 const isWindows = process.platform === "win32";
 
 describe("loadDotEnv()", () => {

--- a/packages/wrangler/src/__tests__/containers/config.test.ts
+++ b/packages/wrangler/src/__tests__/containers/config.test.ts
@@ -2,10 +2,10 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { getCloudflareContainerRegistry } from "@cloudflare/containers-shared";
 import { UserError } from "@cloudflare/workers-utils";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { beforeEach, describe, it, vi } from "vitest";
 import { getNormalizedContainerOptions } from "../../containers/config";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import type { Config } from "@cloudflare/workers-utils";
 
 describe("getNormalizedContainerOptions", () => {

--- a/packages/wrangler/src/__tests__/containers/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/containers/deploy.test.ts
@@ -8,7 +8,10 @@ import {
 	SchedulingPolicy,
 } from "@cloudflare/containers-shared";
 import { ApplicationAffinityHardwareGeneration } from "@cloudflare/containers-shared/src/client/models/ApplicationAffinityHardwareGeneration";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, assert, beforeEach, describe, it, vi } from "vitest";
 import { clearCachedAccount } from "../../cloudchamber/locations";
@@ -27,7 +30,6 @@ import {
 	mswSuccessDeploymentScriptMetadata,
 } from "../helpers/msw";
 import { mswListNewDeploymentsLatestFull } from "../helpers/msw/handlers/versions";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import type {
 	AccountRegistryToken,

--- a/packages/wrangler/src/__tests__/containers/images.test.ts
+++ b/packages/wrangler/src/__tests__/containers/images.test.ts
@@ -1,4 +1,5 @@
 import { getCloudflareContainerRegistry } from "@cloudflare/containers-shared";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { mockAccount, setWranglerConfig } from "../cloudchamber/utils";
@@ -6,7 +7,6 @@ import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 // Helper to wrap responses in v4 API schema format for containers endpoint

--- a/packages/wrangler/src/__tests__/custom-build.test.ts
+++ b/packages/wrangler/src/__tests__/custom-build.test.ts
@@ -1,12 +1,11 @@
 import { UserError } from "@cloudflare/workers-utils";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { assert, describe, it } from "vitest";
 import {
 	runCommand,
 	runCustomBuild,
 } from "../deployment-bundle/run-custom-build";
 import { mockConsoleMethods } from "./helpers/mock-console";
-import { runInTempDir } from "./helpers/run-in-tmp";
-
 describe("Custom Builds", () => {
 	runInTempDir();
 	const std = mockConsoleMethods();

--- a/packages/wrangler/src/__tests__/d1/create.test.ts
+++ b/packages/wrangler/src/__tests__/d1/create.test.ts
@@ -1,11 +1,13 @@
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { getMswSuccessMembershipHandlers, msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 describe("create", () => {

--- a/packages/wrangler/src/__tests__/d1/d1.test.ts
+++ b/packages/wrangler/src/__tests__/d1/d1.test.ts
@@ -1,7 +1,7 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 describe("d1", () => {

--- a/packages/wrangler/src/__tests__/d1/delete.test.ts
+++ b/packages/wrangler/src/__tests__/d1/delete.test.ts
@@ -1,3 +1,4 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
@@ -9,7 +10,6 @@ import {
 	getMswSuccessMembershipHandlers,
 	msw,
 } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import type { ExpectStatic } from "vitest";
 

--- a/packages/wrangler/src/__tests__/d1/execute.test.ts
+++ b/packages/wrangler/src/__tests__/d1/execute.test.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs";
 import { join } from "node:path";
 import { UserError } from "@cloudflare/workers-utils";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
@@ -9,7 +12,6 @@ import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { createFetchResult, msw } from "../helpers/msw";
 import { getMswSuccessMembershipHandlers } from "../helpers/msw/";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 describe("execute", () => {

--- a/packages/wrangler/src/__tests__/d1/export.test.ts
+++ b/packages/wrangler/src/__tests__/d1/export.test.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs";
 import { setTimeout } from "node:timers/promises";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
@@ -9,7 +12,6 @@ import { mockConfirm } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { getMswSuccessMembershipHandlers } from "../helpers/msw";
 import { msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 describe("export", () => {

--- a/packages/wrangler/src/__tests__/d1/info.test.ts
+++ b/packages/wrangler/src/__tests__/d1/info.test.ts
@@ -1,11 +1,13 @@
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { getMswSuccessMembershipHandlers, msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 describe("info", () => {

--- a/packages/wrangler/src/__tests__/d1/insights.test.ts
+++ b/packages/wrangler/src/__tests__/d1/insights.test.ts
@@ -1,4 +1,7 @@
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterAll, beforeAll, describe, it, vi } from "vitest";
 import { getDurationDates } from "../../d1/insights";
@@ -6,7 +9,6 @@ import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { getMswSuccessMembershipHandlers, msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 describe("getDurationDates()", () => {

--- a/packages/wrangler/src/__tests__/d1/list.test.ts
+++ b/packages/wrangler/src/__tests__/d1/list.test.ts
@@ -1,10 +1,10 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { getMswSuccessMembershipHandlers, msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 describe("list", () => {

--- a/packages/wrangler/src/__tests__/d1/migrate.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrate.test.ts
@@ -1,4 +1,7 @@
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { describe, it, vi } from "vitest";
 import * as d1Execute from "../../d1/execute";
@@ -8,7 +11,6 @@ import { mockConfirm } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { mockSetTimeout } from "../helpers/mock-set-timeout";
 import { getMswSuccessMembershipHandlers, msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 describe("migrate", () => {

--- a/packages/wrangler/src/__tests__/d1/migrate.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrate.test.ts
@@ -2,7 +2,6 @@ import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { describe, it, vi } from "vitest";
 import * as d1Execute from "../../d1/execute";
-import { reinitialiseAuthTokens } from "../../user";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { mockConfirm } from "../helpers/mock-dialogs";
@@ -316,7 +315,6 @@ Your database may not be available to serve requests during the migration, conti
 			expect,
 		}) => {
 			vi.stubEnv("CLOUDFLARE_API_TOKEN", "api-token");
-			reinitialiseAuthTokens();
 			setIsTTY(false);
 			writeWranglerConfig();
 			await expect(

--- a/packages/wrangler/src/__tests__/d1/migrations/helpers.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrations/helpers.test.ts
@@ -1,9 +1,8 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it } from "vitest";
 import { getMigrationNames } from "../../../d1/migrations/helpers";
-import { runInTempDir } from "../../helpers/run-in-tmp";
-
 describe("getMigrationNames", () => {
 	runInTempDir();
 

--- a/packages/wrangler/src/__tests__/d1/timeTravel.test.ts
+++ b/packages/wrangler/src/__tests__/d1/timeTravel.test.ts
@@ -1,5 +1,8 @@
 import { COMPLIANCE_REGION_CONFIG_UNKNOWN } from "@cloudflare/workers-utils";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { throwIfDatabaseIsAlpha } from "../../d1/timeTravel/utils";
@@ -7,7 +10,6 @@ import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { getMswSuccessMembershipHandlers, msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 describe("time-travel", () => {

--- a/packages/wrangler/src/__tests__/delete.test.ts
+++ b/packages/wrangler/src/__tests__/delete.test.ts
@@ -1,4 +1,7 @@
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
@@ -6,7 +9,6 @@ import { mockConsoleMethods } from "./helpers/mock-console";
 import { mockConfirm } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type { ServiceReferenceResponse, Tail } from "../delete";
 import type { KVNamespaceInfo } from "../kv/helpers";

--- a/packages/wrangler/src/__tests__/deploy/assets.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/assets.test.ts
@@ -1,5 +1,8 @@
 import * as fs from "node:fs";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import dedent from "ts-dedent";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
@@ -15,7 +18,6 @@ import { mockGetSettings } from "../helpers/mock-worker-settings";
 import { mockSubDomainRequest } from "../helpers/mock-workers-subdomain";
 import { createFetchResult, msw } from "../helpers/msw";
 import { mswListNewDeploymentsLatestFull } from "../helpers/msw/handlers/versions";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { writeWorkerSource } from "../helpers/write-worker-source";
 import {

--- a/packages/wrangler/src/__tests__/deploy/bindings.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/bindings.test.ts
@@ -1,7 +1,10 @@
 import { Buffer } from "node:buffer";
 import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { sync } from "command-exists";
 import { http, HttpResponse } from "msw";
 import * as TOML from "smol-toml";
@@ -19,7 +22,6 @@ import { mockGetSettings } from "../helpers/mock-worker-settings";
 import { mockSubDomainRequest } from "../helpers/mock-workers-subdomain";
 import { createFetchResult, msw } from "../helpers/msw";
 import { mswListNewDeploymentsLatestFull } from "../helpers/msw/handlers/versions";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { writeWorkerSource } from "../helpers/write-worker-source";
 import {

--- a/packages/wrangler/src/__tests__/deploy/build.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/build.test.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs";
 import { ParseError } from "@cloudflare/workers-utils";
 import {
 	normalizeString,
+	runInTempDir,
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
 import * as esbuild from "esbuild";
@@ -23,7 +24,6 @@ import { mockGetSettings } from "../helpers/mock-worker-settings";
 import { mockSubDomainRequest } from "../helpers/mock-workers-subdomain";
 import { createFetchResult, msw } from "../helpers/msw";
 import { mswListNewDeploymentsLatestFull } from "../helpers/msw/handlers/versions";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { writeWorkerSource } from "../helpers/write-worker-source";
 import {

--- a/packages/wrangler/src/__tests__/deploy/config-args-merging.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/config-args-merging.test.ts
@@ -11,7 +11,10 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { clearOutputFilePath } from "../../output";
@@ -31,7 +34,6 @@ import {
 import { mockGetZoneWorkerRoutes } from "../helpers/mock-zone-routes";
 import { createFetchResult, msw } from "../helpers/msw";
 import { mswListNewDeploymentsLatestFull } from "../helpers/msw/handlers/versions";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { toString } from "../helpers/serialize-form-data-entry";
 import { writeWorkerSource } from "../helpers/write-worker-source";

--- a/packages/wrangler/src/__tests__/deploy/config-remote.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/config-remote.test.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import { APIError } from "@cloudflare/workers-utils";
 import {
 	normalizeString,
+	runInTempDir,
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
@@ -22,7 +23,6 @@ import {
 	mswSuccessDeploymentScriptAPI,
 } from "../helpers/msw";
 import { mswListNewDeploymentsLatestFull } from "../helpers/msw/handlers/versions";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { writeWorkerSource } from "../helpers/write-worker-source";
 import {

--- a/packages/wrangler/src/__tests__/deploy/core.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/core.test.ts
@@ -1,7 +1,10 @@
 import * as fs from "node:fs";
 import { readFile } from "node:fs/promises";
 import * as path from "node:path";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import ci from "ci-info";
 import { http, HttpResponse } from "msw";
 import * as TOML from "smol-toml";
@@ -39,7 +42,6 @@ import {
 	mswSuccessUserHandlers,
 } from "../helpers/msw";
 import { mswListNewDeploymentsLatestFull } from "../helpers/msw/handlers/versions";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { writeWorkerSource } from "../helpers/write-worker-source";
 import {

--- a/packages/wrangler/src/__tests__/deploy/durable-objects.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/durable-objects.test.ts
@@ -1,5 +1,8 @@
 import * as fs from "node:fs";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { getInstalledPackageVersion } from "../../autoconfig/frameworks/utils/packages";
@@ -15,7 +18,6 @@ import { mockGetSettings } from "../helpers/mock-worker-settings";
 import { mockSubDomainRequest } from "../helpers/mock-workers-subdomain";
 import { createFetchResult, msw } from "../helpers/msw";
 import { mswListNewDeploymentsLatestFull } from "../helpers/msw/handlers/versions";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import {
 	mockDeploymentsListRequest,

--- a/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { findWranglerConfig } from "@cloudflare/workers-utils";
 import {
 	normalizeString,
+	runInTempDir,
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
 import * as esbuild from "esbuild";
@@ -25,7 +26,6 @@ import { mockGetSettings } from "../helpers/mock-worker-settings";
 import { mockSubDomainRequest } from "../helpers/mock-workers-subdomain";
 import { createFetchResult, msw } from "../helpers/msw";
 import { mswListNewDeploymentsLatestFull } from "../helpers/msw/handlers/versions";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { writeWorkerSource } from "../helpers/write-worker-source";
 import {

--- a/packages/wrangler/src/__tests__/deploy/environments.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/environments.test.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import {
+	runInTempDir,
 	writeRedirectedWranglerConfig,
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
@@ -25,7 +26,6 @@ import {
 	msw,
 } from "../helpers/msw";
 import { mswListNewDeploymentsLatestFull } from "../helpers/msw/handlers/versions";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { writeWorkerSource } from "../helpers/write-worker-source";
 import {

--- a/packages/wrangler/src/__tests__/deploy/formats.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/formats.test.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import {
 	normalizeString,
+	runInTempDir,
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
 import * as esbuild from "esbuild";
@@ -20,7 +21,6 @@ import { mockGetSettings } from "../helpers/mock-worker-settings";
 import { mockSubDomainRequest } from "../helpers/mock-workers-subdomain";
 import { createFetchResult, msw } from "../helpers/msw";
 import { mswListNewDeploymentsLatestFull } from "../helpers/msw/handlers/versions";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { writeWorkerSource } from "../helpers/write-worker-source";
 import {

--- a/packages/wrangler/src/__tests__/deploy/legacy-assets.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/legacy-assets.test.ts
@@ -1,5 +1,8 @@
 import * as fs from "node:fs";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { getInstalledPackageVersion } from "../../autoconfig/frameworks/utils/packages";
@@ -18,7 +21,6 @@ import { mockGetSettings } from "../helpers/mock-worker-settings";
 import { mockSubDomainRequest } from "../helpers/mock-workers-subdomain";
 import { createFetchResult, msw } from "../helpers/msw";
 import { mswListNewDeploymentsLatestFull } from "../helpers/msw/handlers/versions";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { writeWorkerSource } from "../helpers/write-worker-source";
 import {

--- a/packages/wrangler/src/__tests__/deploy/open-next.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/open-next.test.ts
@@ -1,5 +1,8 @@
 import * as fs from "node:fs";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import dedent from "ts-dedent";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
@@ -16,7 +19,6 @@ import { mockGetSettings } from "../helpers/mock-worker-settings";
 import { mockSubDomainRequest } from "../helpers/mock-workers-subdomain";
 import { createFetchResult, msw } from "../helpers/msw";
 import { mswListNewDeploymentsLatestFull } from "../helpers/msw/handlers/versions";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { writeWorkerSource } from "../helpers/write-worker-source";
 import {

--- a/packages/wrangler/src/__tests__/deploy/queues.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/queues.test.ts
@@ -1,5 +1,8 @@
 import * as fs from "node:fs";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { getInstalledPackageVersion } from "../../autoconfig/frameworks/utils/packages";
@@ -14,7 +17,6 @@ import { mockGetSettings } from "../helpers/mock-worker-settings";
 import { mockSubDomainRequest } from "../helpers/mock-workers-subdomain";
 import { createFetchResult, msw } from "../helpers/msw";
 import { mswListNewDeploymentsLatestFull } from "../helpers/msw/handlers/versions";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import {
 	mockDeploymentsListRequest,

--- a/packages/wrangler/src/__tests__/deploy/routes.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/routes.test.ts
@@ -1,4 +1,7 @@
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { getInstalledPackageVersion } from "../../autoconfig/frameworks/utils/packages";
@@ -25,7 +28,6 @@ import {
 } from "../helpers/mock-zone-routes";
 import { createFetchResult, msw } from "../helpers/msw";
 import { mswListNewDeploymentsLatestFull } from "../helpers/msw/handlers/versions";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { writeWorkerSource } from "../helpers/write-worker-source";
 import {

--- a/packages/wrangler/src/__tests__/deploy/secrets.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/secrets.test.ts
@@ -1,5 +1,8 @@
 import * as fs from "node:fs";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { getInstalledPackageVersion } from "../../autoconfig/frameworks/utils/packages";
@@ -15,7 +18,6 @@ import { mockGetSettings } from "../helpers/mock-worker-settings";
 import { mockSubDomainRequest } from "../helpers/mock-workers-subdomain";
 import { createFetchResult, msw } from "../helpers/msw";
 import { mswListNewDeploymentsLatestFull } from "../helpers/msw/handlers/versions";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { writeWorkerSource } from "../helpers/write-worker-source";
 import {

--- a/packages/wrangler/src/__tests__/deploy/workers-dev.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/workers-dev.test.ts
@@ -1,4 +1,7 @@
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 // eslint-disable-next-line no-restricted-imports
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -21,7 +24,6 @@ import {
 import { mockGetZoneWorkerRoutes } from "../helpers/mock-zone-routes";
 import { createFetchResult, msw } from "../helpers/msw";
 import { mswListNewDeploymentsLatestFull } from "../helpers/msw/handlers/versions";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { writeWorkerSource } from "../helpers/write-worker-source";
 import {

--- a/packages/wrangler/src/__tests__/deploy/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/workflows.test.ts
@@ -1,5 +1,8 @@
 import * as fs from "node:fs";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { getInstalledPackageVersion } from "../../autoconfig/frameworks/utils/packages";
@@ -15,7 +18,6 @@ import { mockGetSettings } from "../helpers/mock-worker-settings";
 import { mockSubDomainRequest } from "../helpers/mock-workers-subdomain";
 import { createFetchResult, msw } from "../helpers/msw";
 import { mswListNewDeploymentsLatestFull } from "../helpers/msw/handlers/versions";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import {
 	mockDeploymentsListRequest,

--- a/packages/wrangler/src/__tests__/deployments.test.ts
+++ b/packages/wrangler/src/__tests__/deployments.test.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs";
 import { thrownIsDoesNotExistError } from "@cloudflare/workers-shared";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { afterAll, afterEach, beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
@@ -14,7 +17,6 @@ import {
 	mswSuccessOauthHandlers,
 	mswSuccessUserHandlers,
 } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 
 // This is testing the old deployments behaviour, which is now deprecated

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -4,7 +4,10 @@ import {
 	FatalError,
 	getTodaysCompatDate,
 } from "@cloudflare/workers-utils";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import ci from "ci-info";
 import getPort from "get-port";
 import { http, HttpResponse } from "msw";
@@ -26,7 +29,6 @@ import {
 	mswSuccessUserHandlers,
 	mswZoneHandlers,
 } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type {
 	Binding,

--- a/packages/wrangler/src/__tests__/dev/get-local-persistence-path.test.ts
+++ b/packages/wrangler/src/__tests__/dev/get-local-persistence-path.test.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it } from "vitest";
 import { getLocalPersistencePath } from "../../dev/get-local-persistence-path";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import type { Config } from "@cloudflare/workers-utils";
 
 function makeConfig(userConfigPath?: string): Config {

--- a/packages/wrangler/src/__tests__/dev/remote-bindings-errors.test.ts
+++ b/packages/wrangler/src/__tests__/dev/remote-bindings-errors.test.ts
@@ -1,3 +1,4 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { assert, beforeEach, describe, it, vi } from "vitest";
 import { startRemoteProxySession } from "../../api";
 import {
@@ -7,8 +8,6 @@ import {
 import { mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { msw, mswSuccessUserHandlers } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
-
 vi.mock("../../dev/create-worker-preview", () => ({
 	createPreviewSession: vi.fn(),
 	createWorkerPreview: vi.fn(),

--- a/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
+++ b/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 import assert from "node:assert";
-import { seed } from "@cloudflare/workers-utils/test-helpers";
+import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import { fetch } from "undici";
 /* eslint-disable no-restricted-imports */
 import {
@@ -23,7 +23,6 @@ import {
 	mswSuccessUserHandlers,
 	mswZoneHandlers,
 } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import type { StartDevOptions } from "../../dev";
 import type { RawConfig } from "@cloudflare/workers-utils";

--- a/packages/wrangler/src/__tests__/docs.test.ts
+++ b/packages/wrangler/src/__tests__/docs.test.ts
@@ -1,9 +1,9 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, test, vi } from "vitest";
 import openInBrowser from "../open-in-browser";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 
 describe("wrangler docs", () => {

--- a/packages/wrangler/src/__tests__/email-routing.test.ts
+++ b/packages/wrangler/src/__tests__/email-routing.test.ts
@@ -1,4 +1,5 @@
 import { writeFileSync } from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { endEventLoop } from "./helpers/end-event-loop";
@@ -7,7 +8,6 @@ import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs, mockConfirm } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { createFetchResult, msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 
 // --- Mock data ---

--- a/packages/wrangler/src/__tests__/find-additional-modules.test.ts
+++ b/packages/wrangler/src/__tests__/find-additional-modules.test.ts
@@ -1,10 +1,10 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import dedent from "ts-dedent";
 import { describe, it } from "vitest";
 import { findAdditionalModules } from "../deployment-bundle/find-additional-modules";
 import { mockConsoleMethods } from "./helpers/mock-console";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import type { ConfigModuleRuleType } from "@cloudflare/workers-utils";
 
 /*

--- a/packages/wrangler/src/__tests__/friendly-validator-errors.test.ts
+++ b/packages/wrangler/src/__tests__/friendly-validator-errors.test.ts
@@ -1,13 +1,14 @@
 import { ParseError } from "@cloudflare/workers-utils";
-import { normalizeString } from "@cloudflare/workers-utils/test-helpers";
+import {
+	normalizeString,
+	runInTempDir,
+} from "@cloudflare/workers-utils/test-helpers";
 import { FormData } from "undici";
 import { beforeEach, describe, it, vi } from "vitest";
 import * as checkCommands from "../check/commands";
 import { logger } from "../logger";
 import { helpIfErrorIsSizeOrScriptStartup } from "../utils/friendly-validator-errors";
 import { mockConsoleMethods } from "./helpers/mock-console";
-import { runInTempDir } from "./helpers/run-in-tmp";
-
 vi.mock("../check/commands", () => ({ analyseBundle: vi.fn() }));
 const mockAnalyseBundle = vi.mocked(checkCommands.analyseBundle);
 

--- a/packages/wrangler/src/__tests__/get-entry.test.ts
+++ b/packages/wrangler/src/__tests__/get-entry.test.ts
@@ -1,11 +1,10 @@
 import path from "node:path";
 import { defaultWranglerConfig } from "@cloudflare/workers-utils";
-import { seed } from "@cloudflare/workers-utils/test-helpers";
+import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import dedent from "ts-dedent";
 import { describe, it } from "vitest";
 import { getEntry } from "../deployment-bundle/entry";
 import { mockConsoleMethods } from "./helpers/mock-console";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import type { Entry } from "../deployment-bundle/entry";
 
 function normalize(entry: Entry): Entry {

--- a/packages/wrangler/src/__tests__/guess-worker-format.test.ts
+++ b/packages/wrangler/src/__tests__/guess-worker-format.test.ts
@@ -1,10 +1,9 @@
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it } from "vitest";
 import { guessWorkerFormat } from "../deployment-bundle/guess-worker-format";
 import { mockConsoleMethods } from "./helpers/mock-console";
-import { runInTempDir } from "./helpers/run-in-tmp";
-
 describe("guess worker format", () => {
 	runInTempDir();
 	const std = mockConsoleMethods();

--- a/packages/wrangler/src/__tests__/hello-world.local.test.ts
+++ b/packages/wrangler/src/__tests__/hello-world.local.test.ts
@@ -1,6 +1,6 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it, vi } from "vitest";
 import { mockConsoleMethods } from "./helpers/mock-console";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 
 vi.unmock("undici");

--- a/packages/wrangler/src/__tests__/helpers/mock-account-id.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-account-id.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, vi } from "vitest";
-import { reinitialiseAuthTokens } from "../../user";
 
 /**
  * Mock the API token so that we don't need to read it from user configuration files.
@@ -19,8 +18,6 @@ export function mockApiToken({
 		} else {
 			vi.stubEnv("CLOUDFLARE_API_TOKEN", apiToken);
 		}
-		// Now we have updated the environment, we must reinitialize the user auth state.
-		reinitialiseAuthTokens();
 	});
 }
 
@@ -40,8 +37,6 @@ export function mockAccountId({
 		} else {
 			process.env.CLOUDFLARE_ACCOUNT_ID = accountId;
 		}
-		// Now we have updated the environment, we must reinitialize the user auth state.
-		reinitialiseAuthTokens();
 	});
 	afterEach(() => {
 		if (ORIGINAL_CLOUDFLARE_ACCOUNT_ID === undefined) {

--- a/packages/wrangler/src/__tests__/helpers/run-in-tmp.ts
+++ b/packages/wrangler/src/__tests__/helpers/run-in-tmp.ts
@@ -1,8 +1,0 @@
-import { runInTempDir as runInTempDirCommon } from "@cloudflare/workers-utils/test-helpers";
-
-export function runInTempDir(options?: { homedir: string }) {
-	runInTempDirCommon(options);
-	// Auth state is read on demand from the auth config file in the current
-	// home directory, so no module-level cache to invalidate after the temp
-	// directory has been swapped in.
-}

--- a/packages/wrangler/src/__tests__/helpers/run-in-tmp.ts
+++ b/packages/wrangler/src/__tests__/helpers/run-in-tmp.ts
@@ -1,11 +1,8 @@
 import { runInTempDir as runInTempDirCommon } from "@cloudflare/workers-utils/test-helpers";
-import { beforeEach } from "vitest";
-import { reinitialiseAuthTokens } from "../../user";
 
 export function runInTempDir(options?: { homedir: string }) {
 	runInTempDirCommon(options);
-	beforeEach(() => {
-		// Now that we have changed the home directory location, we must reinitialize the user auth state
-		reinitialiseAuthTokens();
-	});
+	// Auth state is read on demand from the auth config file in the current
+	// home directory, so no module-level cache to invalidate after the temp
+	// directory has been swapped in.
 }

--- a/packages/wrangler/src/__tests__/https-options.test.ts
+++ b/packages/wrangler/src/__tests__/https-options.test.ts
@@ -1,8 +1,7 @@
 import * as fs from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { assert, describe, it, vi } from "vitest";
 import { validateHttpsOptions } from "../https-options";
-import { runInTempDir } from "./helpers/run-in-tmp";
-
 describe("validateHttpsOptions()", () => {
 	runInTempDir();
 

--- a/packages/wrangler/src/__tests__/hyperdrive.test.ts
+++ b/packages/wrangler/src/__tests__/hyperdrive.test.ts
@@ -1,4 +1,7 @@
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { endEventLoop } from "./helpers/end-event-loop";
@@ -7,7 +10,6 @@ import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { createFetchResult, msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type {
 	CreateUpdateHyperdriveBody,

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -1,11 +1,13 @@
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { beforeEach, describe, it, vi } from "vitest";
 import { getPackageManager } from "../package-manager";
 import { updateCheck } from "../update-check";
 import { logPossibleBugMessage } from "../utils/logPossibleBugMessage";
 import { endEventLoop } from "./helpers/end-event-loop";
 import { mockConsoleMethods } from "./helpers/mock-console";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import { writeWorkerSource } from "./helpers/write-worker-source";
 import type { PackageManager } from "../package-manager";

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import path from "node:path";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { execa } from "execa";
 import { http, HttpResponse } from "msw";
 import * as TOML from "smol-toml";
@@ -16,7 +17,6 @@ import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type { PackageManager } from "../package-manager";
 import type { RawConfig, UserLimits } from "@cloudflare/workers-utils";

--- a/packages/wrangler/src/__tests__/kv/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/kv/bulk.test.ts
@@ -1,4 +1,5 @@
 import { writeFileSync } from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { BATCH_MAX_ERRORS_WARNINGS } from "../../kv/helpers";
@@ -7,7 +8,6 @@ import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs, mockConfirm } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { createFetchResult, msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import type { KeyValue } from "../../kv/helpers";
 import type { ExpectStatic } from "vitest";

--- a/packages/wrangler/src/__tests__/kv/help.test.ts
+++ b/packages/wrangler/src/__tests__/kv/help.test.ts
@@ -1,10 +1,10 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { afterEach, beforeEach, describe, it, test } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 describe("kv", () => {

--- a/packages/wrangler/src/__tests__/kv/key.test.ts
+++ b/packages/wrangler/src/__tests__/kv/key.test.ts
@@ -1,5 +1,8 @@
 import { writeFileSync } from "node:fs";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
@@ -9,7 +12,6 @@ import { useMockIsTTY } from "../helpers/mock-istty";
 import { mockProcess } from "../helpers/mock-process";
 import { createFetchResult, msw } from "../helpers/msw";
 import { getMswSuccessMembershipHandlers } from "../helpers/msw/handlers/user";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { wranglerKVConfig } from "./constant";
 import type { KeyValue, NamespaceKeyInfo } from "../../kv/helpers";

--- a/packages/wrangler/src/__tests__/kv/local.test.ts
+++ b/packages/wrangler/src/__tests__/kv/local.test.ts
@@ -1,7 +1,7 @@
 import { writeFileSync } from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it, vi } from "vitest";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 vi.unmock("undici");

--- a/packages/wrangler/src/__tests__/kv/namespace.test.ts
+++ b/packages/wrangler/src/__tests__/kv/namespace.test.ts
@@ -1,5 +1,8 @@
 import { readFile } from "node:fs/promises";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
@@ -7,7 +10,6 @@ import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs, mockConfirm, mockPrompt } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { wranglerKVConfig } from "./constant";
 import type { KVNamespaceInfo } from "../../kv/helpers";

--- a/packages/wrangler/src/__tests__/logout.test.ts
+++ b/packages/wrangler/src/__tests__/logout.test.ts
@@ -1,11 +1,13 @@
 import fs from "node:fs";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { describe, it } from "vitest";
 import { getAuthConfigFilePath, writeAuthConfigFile } from "../user";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 
 describe("logout", () => {

--- a/packages/wrangler/src/__tests__/match-tag.test.ts
+++ b/packages/wrangler/src/__tests__/match-tag.test.ts
@@ -1,13 +1,15 @@
 import { mkdir } from "node:fs/promises";
 import { COMPLIANCE_REGION_CONFIG_UNKNOWN } from "@cloudflare/workers-utils";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, it, vi } from "vitest";
 import { verifyWorkerMatchesCITag } from "../match-tag";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import { writeWorkerSource } from "./helpers/write-worker-source";
 

--- a/packages/wrangler/src/__tests__/metrics.test.ts
+++ b/packages/wrangler/src/__tests__/metrics.test.ts
@@ -1,5 +1,8 @@
 import * as fs from "node:fs";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { detectAgenticEnvironment } from "am-i-vibing";
 import ci from "ci-info";
 import { http, HttpResponse } from "msw";
@@ -26,7 +29,6 @@ import { sniffUserAgent } from "../package-manager";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type { ExpectStatic } from "vitest";
 

--- a/packages/wrangler/src/__tests__/middleware.scheduled.test.ts
+++ b/packages/wrangler/src/__tests__/middleware.scheduled.test.ts
@@ -1,8 +1,7 @@
 import * as fs from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { beforeEach, describe, it, vi } from "vitest";
 import { startWorker } from "../api/startDevWorker";
-import { runInTempDir } from "./helpers/run-in-tmp";
-
 vi.unmock("child_process");
 vi.unmock("undici");
 

--- a/packages/wrangler/src/__tests__/middleware.test.ts
+++ b/packages/wrangler/src/__tests__/middleware.test.ts
@@ -1,11 +1,11 @@
 import * as fs from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import dedent from "ts-dedent";
 import { beforeEach, describe, it, vi } from "vitest";
 import { startWorker } from "../api/startDevWorker";
 import { mockConsoleMethods } from "./helpers/mock-console";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 
 vi.unmock("child_process");

--- a/packages/wrangler/src/__tests__/mtls-certificates.test.ts
+++ b/packages/wrangler/src/__tests__/mtls-certificates.test.ts
@@ -1,5 +1,6 @@
 import { writeFileSync } from "node:fs";
 import { COMPLIANCE_REGION_CONFIG_UNKNOWN } from "@cloudflare/workers-utils";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, it, test } from "vitest";
 import {
@@ -15,7 +16,6 @@ import { mockConsoleMethods } from "./helpers/mock-console";
 import { mockConfirm } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type { MTlsCertificateResponse } from "../api/mtls-certificate";
 

--- a/packages/wrangler/src/__tests__/navigator-user-agent.test.ts
+++ b/packages/wrangler/src/__tests__/navigator-user-agent.test.ts
@@ -1,12 +1,12 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import dedent from "ts-dedent";
 import { afterEach, assert, describe, it, test, vi } from "vitest";
 import { bundleWorker } from "../deployment-bundle/bundle";
 import { noopModuleCollector } from "../deployment-bundle/module-collection";
 import { isNavigatorDefined } from "../navigator-user-agent";
 import { mockConsoleMethods } from "./helpers/mock-console";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import type { BundleOptions } from "../deployment-bundle/bundle";
 
 /*

--- a/packages/wrangler/src/__tests__/output.test.ts
+++ b/packages/wrangler/src/__tests__/output.test.ts
@@ -2,11 +2,11 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { FatalError } from "@cloudflare/workers-utils";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 // eslint-disable-next-line no-restricted-imports
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { clearOutputFilePath, writeOutput } from "../output";
 import { mockConsoleMethods } from "./helpers/mock-console";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type { OutputEntry } from "../output";
 

--- a/packages/wrangler/src/__tests__/package-manager.test.ts
+++ b/packages/wrangler/src/__tests__/package-manager.test.ts
@@ -1,9 +1,8 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { getPackageManager, getPackageManagerName } from "../package-manager";
 import { mockBinary } from "./helpers/mock-bin";
 import { mockConsoleMethods } from "./helpers/mock-console";
-import { runInTempDir } from "./helpers/run-in-tmp";
-
 vi.unmock("../package-manager");
 function mockUserAgent(userAgent = "npm") {
 	beforeEach(() => {

--- a/packages/wrangler/src/__tests__/pages/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deploy.test.ts
@@ -1,6 +1,9 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { chdir } from "node:process";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import ci from "ci-info";
 import { execa } from "execa";
 import { http, HttpResponse } from "msw";
@@ -26,7 +29,6 @@ import { useMockIsTTY } from "../helpers/mock-istty";
 import { mockSetTimeout } from "../helpers/mock-set-timeout";
 import { msw } from "../helpers/msw";
 import { normalizeProgressSteps } from "../helpers/normalize-progress";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import {
 	formDataToObject,

--- a/packages/wrangler/src/__tests__/pages/deployment-delete.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deployment-delete.test.ts
@@ -1,3 +1,4 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { saveToConfigCache } from "../../config-cache";
@@ -8,7 +9,6 @@ import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs, mockConfirm } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import type { PagesConfigCache } from "../../pages/types";
 import type { ExpectStatic } from "vitest";

--- a/packages/wrangler/src/__tests__/pages/deployment-list.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deployment-list.test.ts
@@ -1,3 +1,4 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, describe, it, vi } from "vitest";
 import { saveToConfigCache } from "../../config-cache";
@@ -6,7 +7,6 @@ import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { mockAccountId, mockApiToken } from "./../helpers/mock-account-id";
 import { msw } from "./../helpers/msw";
-import { runInTempDir } from "./../helpers/run-in-tmp";
 import { runWrangler } from "./../helpers/run-wrangler";
 import type { PagesConfigCache } from "../../pages/types";
 import type { Deployment } from "./../../pages/types";

--- a/packages/wrangler/src/__tests__/pages/dev.test.ts
+++ b/packages/wrangler/src/__tests__/pages/dev.test.ts
@@ -1,6 +1,6 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it } from "vitest";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 /**

--- a/packages/wrangler/src/__tests__/pages/filepath-routing.test.ts
+++ b/packages/wrangler/src/__tests__/pages/filepath-routing.test.ts
@@ -1,11 +1,11 @@
 import { mkdirSync, writeFileSync } from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it, test } from "vitest";
 import {
 	compareRoutes,
 	generateConfigFromFileTree,
 } from "../../pages/functions/filepath-routing";
 import { toUrlPath } from "../../paths";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import type { HTTPMethod, RouteConfig } from "../../pages/functions/routes";
 import type { UrlPath } from "../../paths";
 

--- a/packages/wrangler/src/__tests__/pages/functions-build.test.ts
+++ b/packages/wrangler/src/__tests__/pages/functions-build.test.ts
@@ -5,11 +5,11 @@ import {
 	readFileSync,
 	writeFileSync,
 } from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import dedent from "ts-dedent";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { replaceRandomWithConstantData } from "../helpers/string-dynamic-values-matcher";
 

--- a/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import {
 	normalizeString,
+	runInTempDir,
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
@@ -10,7 +11,6 @@ import {
 	EXIT_CODE_NO_CONFIG_FOUND,
 } from "../../pages/errors";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 describe("pages build env", () => {

--- a/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
@@ -1,5 +1,8 @@
 import { setTimeout } from "node:timers/promises";
-import { normalizeString } from "@cloudflare/workers-utils/test-helpers";
+import {
+	normalizeString,
+	runInTempDir,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { Headers, Request } from "undici";
 import { afterEach, describe, it, vi } from "vitest";
@@ -9,7 +12,6 @@ import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { MockWebSocket } from "../helpers/mock-web-socket";
 import { msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import type {
 	AlarmEvent,

--- a/packages/wrangler/src/__tests__/pages/pages-download-config.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-download-config.test.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { getTodaysCompatDate } from "@cloudflare/workers-utils";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterAll, beforeEach, describe, it, vi } from "vitest";
 import { saveToConfigCache } from "../../config-cache";
@@ -11,7 +14,6 @@ import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs, mockConfirm } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import type { PagesConfigCache } from "../../pages/types";
 import type { ExpectStatic } from "vitest";

--- a/packages/wrangler/src/__tests__/pages/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages.test.ts
@@ -1,7 +1,7 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { afterEach, describe, it } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 describe("pages", () => {

--- a/packages/wrangler/src/__tests__/pages/project-create.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-create.test.ts
@@ -1,10 +1,10 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, describe, it, vi } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "./../helpers/mock-account-id";
 import { mockConsoleMethods } from "./../helpers/mock-console";
 import { msw } from "./../helpers/msw";
-import { runInTempDir } from "./../helpers/run-in-tmp";
 import { runWrangler } from "./../helpers/run-wrangler";
 
 describe("pages project create", () => {

--- a/packages/wrangler/src/__tests__/pages/project-delete.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-delete.test.ts
@@ -1,3 +1,4 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
@@ -6,7 +7,6 @@ import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs, mockConfirm } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 describe("pages project delete", () => {

--- a/packages/wrangler/src/__tests__/pages/project-list.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-list.test.ts
@@ -1,10 +1,10 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, describe, it, vi } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { mockAccountId, mockApiToken } from "./../helpers/mock-account-id";
 import { msw } from "./../helpers/msw";
-import { runInTempDir } from "./../helpers/run-in-tmp";
 import { runWrangler } from "./../helpers/run-wrangler";
 import type { Project } from "./../../pages/types";
 import type { ExpectStatic } from "vitest";

--- a/packages/wrangler/src/__tests__/pages/project-upload.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-upload.test.ts
@@ -1,5 +1,6 @@
 // /* eslint-disable no-shadow */
 import { mkdirSync, writeFileSync } from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import ci from "ci-info";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
@@ -11,7 +12,6 @@ import { mockGetUploadTokenRequest } from "../helpers/mock-get-pages-upload-toke
 import { mockSetTimeout } from "../helpers/mock-set-timeout";
 import { msw } from "../helpers/msw";
 import { normalizeProgressSteps } from "../helpers/normalize-progress";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import type { UploadPayloadFile } from "../../pages/types";
 import type { StrictRequest } from "msw";

--- a/packages/wrangler/src/__tests__/pages/project-validate.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-validate.test.ts
@@ -1,10 +1,10 @@
 // /* eslint-disable no-shadow */
 import { writeFileSync } from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { afterEach, describe, it, vi } from "vitest";
 import { validate } from "../../pages/validate";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 vi.mock("../../pages/constants", async (importActual) => ({

--- a/packages/wrangler/src/__tests__/pages/routes-module.test.ts
+++ b/packages/wrangler/src/__tests__/pages/routes-module.test.ts
@@ -1,9 +1,8 @@
 import { UserError } from "@cloudflare/workers-utils";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it } from "vitest";
 import { writeRoutesModule } from "../../pages/functions/routes";
 import { toUrlPath } from "../../paths";
-import { runInTempDir } from "../helpers/run-in-tmp";
-
 describe("routes module", () => {
 	runInTempDir();
 

--- a/packages/wrangler/src/__tests__/pages/secret.test.ts
+++ b/packages/wrangler/src/__tests__/pages/secret.test.ts
@@ -1,5 +1,6 @@
 import { writeFileSync } from "node:fs";
 import readline from "node:readline";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { saveToConfigCache } from "../../config-cache";
@@ -16,7 +17,6 @@ import {
 	getMswSuccessMembershipHandlers,
 	msw,
 } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import type { PagesProject } from "../../pages/download-config";
 import type { PagesConfigCache } from "../../pages/types";

--- a/packages/wrangler/src/__tests__/paths.test.ts
+++ b/packages/wrangler/src/__tests__/paths.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import * as path from "node:path";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it } from "vitest";
 import {
 	getBasePath,
@@ -7,8 +8,6 @@ import {
 	readableRelative,
 	sweepStaleWranglerTmpDirs,
 } from "../paths";
-import { runInTempDir } from "./helpers/run-in-tmp";
-
 describe("paths", () => {
 	describe("getBasePath()", () => {
 		it("should return the path to the wrangler package", ({ expect }) => {

--- a/packages/wrangler/src/__tests__/pipelines-setup.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines-setup.test.ts
@@ -1,4 +1,5 @@
 import { writeFileSync } from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeAll, describe, it, vi } from "vitest";
 import {
@@ -15,7 +16,6 @@ import {
 } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { createFetchResult, msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type { Sink, Stream } from "../pipelines/types";
 import type { ExpectStatic } from "vitest";

--- a/packages/wrangler/src/__tests__/pipelines.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines.test.ts
@@ -1,4 +1,5 @@
 import { writeFileSync } from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
@@ -6,7 +7,6 @@ import { mockConsoleMethods } from "./helpers/mock-console";
 import { mockConfirm } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type { Pipeline, SchemaField, Sink, Stream } from "../pipelines/types";
 import type { ExpectStatic } from "vitest";

--- a/packages/wrangler/src/__tests__/preview.secret.test.ts
+++ b/packages/wrangler/src/__tests__/preview.secret.test.ts
@@ -1,11 +1,11 @@
 import { mkdirSync, writeFileSync } from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, test } from "vitest";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { useMockStdin } from "./helpers/mock-stdin";
 import { msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 
 describe("wrangler preview", () => {

--- a/packages/wrangler/src/__tests__/preview.settings.test.ts
+++ b/packages/wrangler/src/__tests__/preview.settings.test.ts
@@ -1,10 +1,10 @@
 import { mkdirSync, writeFileSync } from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, test } from "vitest";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 
 describe("wrangler preview", () => {

--- a/packages/wrangler/src/__tests__/preview.test.ts
+++ b/packages/wrangler/src/__tests__/preview.test.ts
@@ -2,6 +2,7 @@ import * as childProcess from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { stripVTControlCharacters } from "node:util";
 import { defaultWranglerConfig } from "@cloudflare/workers-utils";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterAll, afterEach, beforeEach, describe, test, vi } from "vitest";
 import { clearOutputFilePath } from "../output";
@@ -9,7 +10,6 @@ import { extractConfigBindings, getBranchName } from "../preview/shared";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import {
 	writeRedirectedWranglerConfig,

--- a/packages/wrangler/src/__tests__/provision.test.ts
+++ b/packages/wrangler/src/__tests__/provision.test.ts
@@ -1,6 +1,7 @@
 import { rmSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import {
+	runInTempDir,
 	writeRedirectedWranglerConfig,
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
@@ -23,7 +24,6 @@ import {
 	mswSuccessDeploymentScriptMetadata,
 } from "./helpers/msw";
 import { mswListNewDeploymentsLatestFull } from "./helpers/msw/handlers/versions";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import { writeWorkerSource } from "./helpers/write-worker-source";
 import type { DatabaseInfo } from "../d1/types";

--- a/packages/wrangler/src/__tests__/proxy-output.test.ts
+++ b/packages/wrangler/src/__tests__/proxy-output.test.ts
@@ -1,7 +1,6 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { beforeEach, describe, it, vi } from "vitest";
 import { mockConsoleMethods } from "./helpers/mock-console";
-import { runInTempDir } from "./helpers/run-in-tmp";
-
 describe("proxy startup output", () => {
 	runInTempDir();
 	const std = mockConsoleMethods();

--- a/packages/wrangler/src/__tests__/queues/queues-subscription.test.ts
+++ b/packages/wrangler/src/__tests__/queues/queues-subscription.test.ts
@@ -1,10 +1,10 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it } from "vitest";
 import { EventSourceType } from "../../queues/subscription-types";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { mockConfirm } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import {
 	mockCreateSubscriptionRequest,

--- a/packages/wrangler/src/__tests__/queues/queues.test.ts
+++ b/packages/wrangler/src/__tests__/queues/queues.test.ts
@@ -1,4 +1,7 @@
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
@@ -6,7 +9,6 @@ import { mockConsoleMethods } from "../helpers/mock-console";
 import { mockPrompt } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { mockGetQueueByNameRequest } from "./mock-utils";
 import type { PostTypedConsumerBody, QueueResponse } from "../../queues/client";

--- a/packages/wrangler/src/__tests__/r2/bucket.test.ts
+++ b/packages/wrangler/src/__tests__/r2/bucket.test.ts
@@ -1,5 +1,8 @@
 import * as fs from "node:fs";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 // eslint-disable-next-line no-restricted-imports
 import { beforeEach, describe, expect, it } from "vitest";
@@ -10,7 +13,6 @@ import { mockConsoleMethods } from "../helpers/mock-console";
 import { mockConfirm, mockPrompt } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { createFetchResult, msw, mswR2handlers } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import type { BucketLockRule } from "../../r2/helpers/bucket";
 import type {

--- a/packages/wrangler/src/__tests__/r2/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/r2/bulk.test.ts
@@ -1,5 +1,8 @@
 import fs from "node:fs";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, it } from "vitest";
 import { MAX_UPLOAD_SIZE_BYTES } from "../../r2/constants";
@@ -7,7 +10,6 @@ import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { createFetchResult, msw, mswR2handlers } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { createBigFile } from "./helper";
 

--- a/packages/wrangler/src/__tests__/r2/catalog-force.test.ts
+++ b/packages/wrangler/src/__tests__/r2/catalog-force.test.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
@@ -6,7 +7,6 @@ import { mockConsoleMethods } from "../helpers/mock-console";
 import { mockConfirm } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { createFetchResult, msw, mswR2handlers } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 describe("r2 data catalog force flag", () => {

--- a/packages/wrangler/src/__tests__/r2/errors.test.ts
+++ b/packages/wrangler/src/__tests__/r2/errors.test.ts
@@ -1,6 +1,6 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it } from "vitest";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 describe("r2 errors", () => {

--- a/packages/wrangler/src/__tests__/r2/help.test.ts
+++ b/packages/wrangler/src/__tests__/r2/help.test.ts
@@ -1,8 +1,8 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { beforeEach, describe, it } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { msw, mswR2handlers } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 describe("r2", () => {

--- a/packages/wrangler/src/__tests__/r2/local-uploads.test.ts
+++ b/packages/wrangler/src/__tests__/r2/local-uploads.test.ts
@@ -1,3 +1,4 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { describe, it } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
@@ -6,7 +7,6 @@ import { mockConsoleMethods } from "../helpers/mock-console";
 import { mockConfirm } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { createFetchResult, msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 describe("r2 bucket local-uploads", () => {

--- a/packages/wrangler/src/__tests__/r2/local.test.ts
+++ b/packages/wrangler/src/__tests__/r2/local.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it, vi } from "vitest";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 // Miniflare's use of undici doesn't play well with jest-mock-fetch

--- a/packages/wrangler/src/__tests__/r2/object.test.ts
+++ b/packages/wrangler/src/__tests__/r2/object.test.ts
@@ -1,5 +1,8 @@
 import * as fs from "node:fs";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, it } from "vitest";
 import { MAX_UPLOAD_SIZE_BYTES } from "../../r2/constants";
@@ -7,7 +10,6 @@ import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { createFetchResult, msw, mswR2handlers } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { createBigFile } from "./helper";
 

--- a/packages/wrangler/src/__tests__/r2/pipe.test.ts
+++ b/packages/wrangler/src/__tests__/r2/pipe.test.ts
@@ -1,7 +1,7 @@
 import { writeFileSync } from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { describe, it, vi } from "vitest";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 const decoder = new TextDecoder();

--- a/packages/wrangler/src/__tests__/r2/sql.test.ts
+++ b/packages/wrangler/src/__tests__/r2/sql.test.ts
@@ -1,10 +1,10 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, it, vi } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 describe("r2 sql", () => {

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -1,7 +1,10 @@
 import * as fs from "node:fs";
 import { writeFileSync } from "node:fs";
 import readline from "node:readline";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import * as TOML from "smol-toml";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
@@ -21,7 +24,6 @@ import {
 	mswFailAccountsHandler,
 	getMswSuccessMembershipHandlers,
 } from "./helpers/msw/handlers/user";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type { Interface } from "node:readline";
 import type { ExpectStatic } from "vitest";

--- a/packages/wrangler/src/__tests__/secrets-store.test.ts
+++ b/packages/wrangler/src/__tests__/secrets-store.test.ts
@@ -1,6 +1,7 @@
 import {
 	mockCreateDate,
 	mockModifiedDate,
+	runInTempDir,
 } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
@@ -10,7 +11,6 @@ import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs, mockConfirm, mockPrompt } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { createFetchResult, msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type {
 	CreateSecret,

--- a/packages/wrangler/src/__tests__/sentry.test.ts
+++ b/packages/wrangler/src/__tests__/sentry.test.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import * as Sentry from "@sentry/node";
 import { http, HttpResponse } from "msw";
 import { afterEach, assert, beforeEach, describe, it } from "vitest";
@@ -7,7 +8,6 @@ import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs, mockConfirm } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { createFetchResult, msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 
 declare const global: { SENTRY_DSN: string | undefined };

--- a/packages/wrangler/src/__tests__/setup.test.ts
+++ b/packages/wrangler/src/__tests__/setup.test.ts
@@ -1,11 +1,10 @@
 import { readFile } from "node:fs/promises";
 import * as cliPackages from "@cloudflare/cli-shared-helpers/packages";
-import { seed } from "@cloudflare/workers-utils/test-helpers";
+import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import { afterEach, assert, describe, test, vi } from "vitest";
 import * as run from "../autoconfig/run";
 import { clearOutputFilePath } from "../output";
 import { mockConsoleMethods } from "./helpers/mock-console";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type { OutputEntry } from "../output";
 

--- a/packages/wrangler/src/__tests__/startup-profiling.test.ts
+++ b/packages/wrangler/src/__tests__/startup-profiling.test.ts
@@ -1,12 +1,14 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { afterEach, beforeEach, describe, test } from "vitest";
 import { logger } from "../logger";
 import { collectCLIOutput } from "./helpers/collect-cli-output";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { useMockIsTTY } from "./helpers/mock-istty";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import { writeWorkerSource } from "./helpers/write-worker-source";
 

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -1,6 +1,7 @@
 import { setTimeout } from "node:timers/promises";
 import {
 	normalizeString,
+	runInTempDir,
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
@@ -13,7 +14,6 @@ import { clearDialogs } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { MockWebSocket } from "./helpers/mock-web-socket";
 import { createFetchResult, msw, mswSucessScriptHandlers } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type {
 	AlarmEvent,

--- a/packages/wrangler/src/__tests__/tunnel/tunnel.test.ts
+++ b/packages/wrangler/src/__tests__/tunnel/tunnel.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import { UserError } from "@cloudflare/workers-utils";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
@@ -8,7 +9,6 @@ import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs, mockConfirm } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { createFetchResult, msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import type { CloudflareTunnel } from "../../tunnel/client";
 

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterAll, beforeAll, beforeEach, describe, it, vi } from "vitest";
 import { experimental_generateTypes } from "../api";
@@ -23,7 +24,6 @@ import { dedent } from "../utils/dedent";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { createFetchResult, msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type { EnvironmentNonInheritable } from "@cloudflare/workers-utils";
 import type { MockInstance } from "vitest";

--- a/packages/wrangler/src/__tests__/update-config-file.test.ts
+++ b/packages/wrangler/src/__tests__/update-config-file.test.ts
@@ -1,13 +1,14 @@
 import { readFile } from "node:fs/promises";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { createdResourceConfig } from "../utils/add-created-resource-config";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs, mockConfirm, mockPrompt } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
-import { runInTempDir } from "./helpers/run-in-tmp";
-
 describe("createdResourceConfig()", () => {
 	mockAccountId();
 	mockApiToken();

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -1,4 +1,3 @@
-import { writeFileSync } from "node:fs";
 import {
 	COMPLIANCE_REGION_CONFIG_UNKNOWN,
 	getGlobalWranglerConfigPath,
@@ -9,13 +8,13 @@ import {
 } from "@cloudflare/workers-utils/test-helpers";
 import ci from "ci-info";
 import { http, HttpResponse } from "msw";
-import TOML from "smol-toml";
 import { beforeEach, describe, it, vi } from "vitest";
 import { saveToConfigCache } from "../config-cache";
 import {
 	fetchAllAccounts,
 	getAccountFromCache,
 	getActiveAccountId,
+	getAPIToken,
 	getAuthConfigFilePath,
 	getOAuthTokenFromLocalState,
 	getOrSelectAccountId,
@@ -347,6 +346,95 @@ describe("User", () => {
 		).resolves.toEqual(false);
 	});
 
+	describe("CLOUDFLARE_API_TOKEN priority over stored OAuth state", () => {
+		// Regression coverage for https://github.com/cloudflare/workers-sdk/issues/13744
+		//
+		// A user may legitimately have both:
+		//   - A `CLOUDFLARE_API_TOKEN` set in the environment (typically via `.env`)
+		//   - A stale OAuth token left over from a previous `wrangler login`
+		//
+		// The env-based API token should win unconditionally — the stored OAuth
+		// state should not even be consulted, let alone refreshed.
+
+		it("getAPIToken returns the env token even when a stored OAuth token also exists", ({
+			expect,
+		}) => {
+			writeAuthConfigFile({
+				oauth_token: "stale-oauth",
+				refresh_token: "stale-refresh",
+				expiration_time: new Date(Date.now() + 100_000 * 1000).toISOString(),
+				scopes: ["account:read"],
+			});
+			vi.stubEnv("CLOUDFLARE_API_TOKEN", "env-token");
+
+			expect(getAPIToken()).toEqual({ apiToken: "env-token" });
+		});
+
+		it("loginOrRefreshIfRequired does not attempt to refresh an expired OAuth token when env auth is set", async ({
+			expect,
+		}) => {
+			// Stored OAuth token is expired. Without the fix, wrangler would try to
+			// refresh it (and fail), aborting the command even though env auth is
+			// valid and available.
+			const pastDate = new Date(Date.now() - 100_000 * 1000).toISOString();
+			writeAuthConfigFile({
+				oauth_token: "expired-oauth",
+				refresh_token: "stale-refresh",
+				expiration_time: pastDate,
+				scopes: ["account:read"],
+			});
+			vi.stubEnv("CLOUDFLARE_API_TOKEN", "env-token");
+
+			let oauthRefreshCalled = false;
+			msw.use(
+				http.post("*/oauth2/token", () => {
+					oauthRefreshCalled = true;
+					return new HttpResponse(null, { status: 400 });
+				})
+			);
+
+			await expect(
+				loginOrRefreshIfRequired(COMPLIANCE_REGION_CONFIG_UNKNOWN)
+			).resolves.toEqual(true);
+			expect(oauthRefreshCalled).toBe(false);
+		});
+
+		it("wrangler whoami succeeds via env token when a stale OAuth token also exists on disk", async ({
+			expect,
+		}) => {
+			// End-to-end reproduction of issue #13744. With the bug, this command
+			// would fail with "Failed to fetch auth token: 400 Bad Request" /
+			// "Not logged in." Now it should succeed using the env token.
+			const pastDate = new Date(Date.now() - 100_000 * 1000).toISOString();
+			writeAuthConfigFile({
+				oauth_token: "expired-oauth",
+				refresh_token: "stale-refresh",
+				expiration_time: pastDate,
+				scopes: ["account:read"],
+			});
+			vi.stubEnv("CLOUDFLARE_API_TOKEN", "env-token");
+
+			let oauthRefreshCalled = false;
+			msw.use(
+				http.post("*/oauth2/token", () => {
+					oauthRefreshCalled = true;
+					return new HttpResponse(null, { status: 400 });
+				}),
+				http.get("*/user/tokens/verify", () =>
+					HttpResponse.json(createFetchResult([]))
+				)
+			);
+
+			await runWrangler("whoami");
+
+			expect(std.err).toBe("");
+			expect(std.out).toContain(
+				"The API Token is read from the CLOUDFLARE_API_TOKEN environment variable."
+			);
+			expect(oauthRefreshCalled).toBe(false);
+		});
+	});
+
 	it("should have auth per environment", async ({ expect }) => {
 		setIsTTY(false);
 		vi.stubEnv("WRANGLER_API_ENVIRONMENT", "staging");
@@ -451,36 +539,25 @@ describe("User", () => {
 			expect,
 		}) => {
 			// Bug repro: when a long-lived wrangler process (e.g. `wrangler dev`) holds a
-			// refresh_token in module-level localState, and a sibling wrangler invocation
-			// rotates the token on disk, the long-lived process's next refresh sends the
-			// stale RT and gets 401 Unauthorized — falling through to interactive login.
+			// refresh_token from a snapshot of disk, and a sibling wrangler invocation
+			// rotates the token on disk, the long-lived process's next refresh must
+			// pick up the rotated token rather than send the stale RT and get a 401.
 			// See real-world logs: same RT sent by two processes 60min apart, second 401'd.
 			setIsTTY(false);
 
-			// Process startup state: both localState and disk have RT_A; access expired.
+			// Sibling process has already rotated RT_A → RT_B on disk, but the access
+			// token written alongside is also expired (so a refresh is still needed).
+			// This simulates: our process started up with RT_A, time passes, the
+			// sibling rotates, then our process tries to refresh.
 			const pastDate = new Date(Date.now() - 100_000_000).toISOString();
 			writeAuthConfigFile({
 				oauth_token: "expired-access",
-				refresh_token: "RT_A",
+				refresh_token: "RT_B",
 				expiration_time: pastDate,
 				scopes: ["account:read"],
 			});
 
-			// Sibling process refresh: rotates RT_A → RT_B on disk. Bypass
-			// writeAuthConfigFile (which would call reinitialiseAuthTokens and update
-			// OUR localState) by writing the file directly — this simulates what
-			// another wrangler process running concurrently actually does.
-			writeFileSync(
-				getAuthConfigFilePath(),
-				TOML.stringify({
-					oauth_token: "sibling-fresh-access",
-					refresh_token: "RT_B",
-					expiration_time: new Date(Date.now() + 3600_000).toISOString(),
-					scopes: ["account:read"],
-				})
-			);
-
-			// CF token endpoint: rotated RT_A returns 401, current RT_B succeeds.
+			// CF token endpoint: stale RT_A returns 401, current RT_B succeeds.
 			// Matches the exact failure mode observed in production logs.
 			msw.use(
 				http.post("*/oauth2/token", async ({ request }) => {
@@ -502,11 +579,9 @@ describe("User", () => {
 				})
 			);
 
-			// With the fix, refreshToken() re-reads the file before exchanging,
-			// finds RT_B, and the command prints the fresh access token.
-			// Without the fix, the stale RT_A is sent, 401 is returned, the empty
-			// catch in refreshToken() swallows it, and the command falls through to
-			// interactive login — which in non-TTY mode throws.
+			// readStoredAuthState() reads the auth config file on every call, so
+			// exchangeRefreshTokenForAccessToken picks up RT_B written by the
+			// "sibling" process and the command prints the fresh access token.
 			await runWrangler("auth token");
 			expect(std.out).toContain("fresh-access-token");
 		});

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -4,6 +4,7 @@ import {
 } from "@cloudflare/workers-utils";
 import {
 	normalizeString,
+	runInTempDir,
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
 import ci from "ci-info";
@@ -37,7 +38,6 @@ import {
 	mswSuccessUserHandlers,
 } from "./helpers/msw";
 import { getMswSuccessMembershipHandlers } from "./helpers/msw/handlers/user";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type { UserAuthConfig } from "../user";
 import type { Config } from "@cloudflare/workers-utils";

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -586,6 +586,48 @@ describe("User", () => {
 			expect(std.out).toContain("fresh-access-token");
 		});
 
+		it("should preserve the stored refresh_token when the OAuth server omits one on refresh", async ({
+			expect,
+		}) => {
+			// RFC 6749 §6 allows the authorization server to return a successful
+			// refresh response without a new refresh_token; the previously issued
+			// refresh token then remains valid. Wrangler must keep that stored
+			// refresh token on disk rather than wiping it — otherwise the next
+			// refresh attempt fails with "No refresh token is present" and the
+			// user is effectively logged out.
+			setIsTTY(false);
+			const pastDate = new Date(Date.now() - 100_000_000).toISOString();
+			writeAuthConfigFile({
+				oauth_token: "expired-access",
+				refresh_token: "RT_A",
+				expiration_time: pastDate,
+				scopes: ["account:read"],
+			});
+
+			msw.use(
+				http.post("*/oauth2/token", () =>
+					HttpResponse.json({
+						access_token: "fresh-access-token",
+						expires_in: 3600,
+						// no refresh_token in the response
+						scope: "account:read",
+						token_type: "bearer",
+					})
+				)
+			);
+
+			await runWrangler("auth token");
+
+			expect(std.out).toContain("fresh-access-token");
+			expect(readAuthConfigFile()).toEqual<UserAuthConfig>({
+				api_token: undefined,
+				oauth_token: "fresh-access-token",
+				refresh_token: "RT_A",
+				expiration_time: expect.any(String),
+				scopes: ["account:read"],
+			});
+		});
+
 		it("should error when not logged in", async ({ expect }) => {
 			await expect(runWrangler("auth token")).rejects.toThrowError(
 				"Not logged in. Please run `wrangler login` to authenticate."

--- a/packages/wrangler/src/__tests__/utils/log-file.test.ts
+++ b/packages/wrangler/src/__tests__/utils/log-file.test.ts
@@ -8,6 +8,7 @@ import {
 import { utimes } from "node:fs/promises";
 import { join } from "node:path";
 import { removeDirSync } from "@cloudflare/workers-utils";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { beforeEach, describe, it, vi } from "vitest";
 import {
 	appendToDebugLogFile,
@@ -15,7 +16,6 @@ import {
 	debugLogFilepath,
 	tryCleanupLogs,
 } from "../../utils/log-file";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import type { ExpectStatic } from "vitest";
 
 describe("appendToDebugLogFile", () => {

--- a/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
+++ b/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
@@ -1,3 +1,4 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { validateQueryFilter } from "../../vectorize/query";
@@ -7,7 +8,6 @@ import { mockConsoleMethods } from "../helpers/mock-console";
 import { clearDialogs, mockConfirm } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { createFetchResult, msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import type { VectorizeQueryOptions } from "../../vectorize/types";
 

--- a/packages/wrangler/src/__tests__/vectorize/vectorize.upsert.test.ts
+++ b/packages/wrangler/src/__tests__/vectorize/vectorize.upsert.test.ts
@@ -1,11 +1,11 @@
 import crypto from "node:crypto";
 import { writeFileSync } from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { describe, it } from "vitest";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { toString } from "../helpers/serialize-form-data-entry";
 import type { VectorizeVector } from "../../vectorize/types";

--- a/packages/wrangler/src/__tests__/versions/deployments/deployments.list.test.ts
+++ b/packages/wrangler/src/__tests__/versions/deployments/deployments.list.test.ts
@@ -1,11 +1,13 @@
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { beforeEach, describe, test } from "vitest";
 import { normalizeOutput } from "../../../../e2e/helpers/normalize";
 import { collectCLIOutput } from "../../helpers/collect-cli-output";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { msw, mswGetVersion, mswListNewDeployments } from "../../helpers/msw";
-import { runInTempDir } from "../../helpers/run-in-tmp";
 import { runWrangler } from "../../helpers/run-wrangler";
 
 describe("deployments list", () => {

--- a/packages/wrangler/src/__tests__/versions/deployments/deployments.status.test.ts
+++ b/packages/wrangler/src/__tests__/versions/deployments/deployments.status.test.ts
@@ -1,11 +1,13 @@
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { beforeEach, describe, test } from "vitest";
 import { normalizeOutput } from "../../../../e2e/helpers/normalize";
 import { collectCLIOutput } from "../../helpers/collect-cli-output";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { msw, mswGetVersion, mswListNewDeployments } from "../../helpers/msw";
-import { runInTempDir } from "../../helpers/run-in-tmp";
 import { runWrangler } from "../../helpers/run-wrangler";
 
 describe("deployments list", () => {

--- a/packages/wrangler/src/__tests__/versions/secrets.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets.test.ts
@@ -1,4 +1,5 @@
 import { writeFileSync } from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, it } from "vitest";
 import { INVALID_INHERIT_BINDING_CODE } from "../../utils/error-codes";
@@ -6,7 +7,6 @@ import { captureRequestsFrom } from "../helpers/capture-requests-from";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { createFetchResult, msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { toString } from "../helpers/serialize-form-data-entry";
 import { writeWorkerSource } from "../helpers/write-worker-source";

--- a/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
@@ -1,11 +1,13 @@
 import { writeFile } from "node:fs/promises";
 import readline from "node:readline";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { afterEach, describe, it, test, vi } from "vitest";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { clearDialogs } from "../../helpers/mock-dialogs";
-import { runInTempDir } from "../../helpers/run-in-tmp";
 import { runWrangler } from "../../helpers/run-wrangler";
 import { mockGetVersion, mockPostVersion, mockSetupApiCalls } from "./utils";
 import type { VersionDetails } from "../../../versions/secrets";

--- a/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
@@ -1,11 +1,13 @@
 import { writeFile } from "node:fs/promises";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { afterEach, describe, it, test, vi } from "vitest";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { clearDialogs, mockConfirm } from "../../helpers/mock-dialogs";
 import { useMockIsTTY } from "../../helpers/mock-istty";
-import { runInTempDir } from "../../helpers/run-in-tmp";
 import { runWrangler } from "../../helpers/run-wrangler";
 import { mockGetVersion, mockPostVersion, mockSetupApiCalls } from "./utils";
 import type { VersionDetails } from "../../../versions/secrets";

--- a/packages/wrangler/src/__tests__/versions/secrets/list.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/list.test.ts
@@ -1,11 +1,13 @@
 import { writeFile } from "node:fs/promises";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { describe, test } from "vitest";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { createFetchResult, msw } from "../../helpers/msw";
-import { runInTempDir } from "../../helpers/run-in-tmp";
 import { runWrangler } from "../../helpers/run-wrangler";
 import type { ApiDeployment, ApiVersion } from "../../../versions/types";
 import type { ExpectStatic } from "vitest";

--- a/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
@@ -1,5 +1,8 @@
 import { writeFile } from "node:fs/promises";
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { FormData } from "undici";
 import { afterEach, describe, it, test, vi } from "vitest";
@@ -9,7 +12,6 @@ import { clearDialogs, mockPrompt } from "../../helpers/mock-dialogs";
 import { useMockIsTTY } from "../../helpers/mock-istty";
 import { useMockStdin } from "../../helpers/mock-stdin";
 import { msw } from "../../helpers/msw";
-import { runInTempDir } from "../../helpers/run-in-tmp";
 import { runWrangler } from "../../helpers/run-wrangler";
 import { mockGetVersion, mockPostVersion, mockSetupApiCalls } from "./utils";
 import type { VersionDetails } from "../../../versions/secrets";

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -1,4 +1,7 @@
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, it, test, vi } from "vitest";
 import { normalizeOutput } from "../../../e2e/helpers/normalize";
@@ -28,7 +31,6 @@ import {
 	mswSuccessDeploymentScriptMetadata,
 } from "../helpers/msw";
 import { mswListNewDeploymentsLatestFiftyFifty } from "../helpers/msw/handlers/versions";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { writeWorkerSource } from "../helpers/write-worker-source";
 

--- a/packages/wrangler/src/__tests__/versions/versions.list.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.list.test.ts
@@ -1,11 +1,13 @@
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { beforeEach, describe, test } from "vitest";
 import { normalizeOutput } from "../../../e2e/helpers/normalize";
 import { collectCLIOutput } from "../helpers/collect-cli-output";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { msw, mswListVersions } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 describe("versions list", () => {

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import {
+	runInTempDir,
 	writeRedirectedWranglerConfig,
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
@@ -19,7 +20,6 @@ import {
 	mockSubDomainRequest,
 } from "../helpers/mock-workers-subdomain";
 import { createFetchResult, msw } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { toString } from "../helpers/serialize-form-data-entry";
 import { writeWorkerSource } from "../helpers/write-worker-source";

--- a/packages/wrangler/src/__tests__/versions/versions.view.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.view.test.ts
@@ -1,11 +1,13 @@
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { beforeEach, describe, test } from "vitest";
 import { normalizeOutput } from "../../../e2e/helpers/normalize";
 import { collectCLIOutput } from "../helpers/collect-cli-output";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { msw, mswGetVersion } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
 describe("versions view", () => {

--- a/packages/wrangler/src/__tests__/vpc.test.ts
+++ b/packages/wrangler/src/__tests__/vpc.test.ts
@@ -1,3 +1,4 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { ServiceType } from "../vpc/index";
@@ -12,7 +13,6 @@ import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { createFetchResult, msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type {
 	ConnectivityService,

--- a/packages/wrangler/src/__tests__/whoami.test.ts
+++ b/packages/wrangler/src/__tests__/whoami.test.ts
@@ -1,4 +1,5 @@
 import { COMPLIANCE_REGION_CONFIG_UNKNOWN } from "@cloudflare/workers-utils";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, it, vi } from "vitest";
 import { writeAuthConfigFile } from "../user";
@@ -11,7 +12,6 @@ import {
 	mswSuccessOauthHandlers,
 	mswSuccessUserHandlers,
 } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 
 describe("getUserInfo(COMPLIANCE_REGION_CONFIG_UNKNOWN)", () => {

--- a/packages/wrangler/src/__tests__/worker-namespace.test.ts
+++ b/packages/wrangler/src/__tests__/worker-namespace.test.ts
@@ -1,3 +1,4 @@
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 // eslint-disable-next-line no-restricted-imports
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -9,7 +10,6 @@ import {
 	msw,
 	mswSuccessNamespacesHandlers,
 } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import type { Mock } from "vitest";
 

--- a/packages/wrangler/src/__tests__/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/workflows.test.ts
@@ -5,6 +5,7 @@ import {
 	mockModifiedDate,
 	mockQueuedDate,
 	mockStartDate,
+	runInTempDir,
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
@@ -14,7 +15,6 @@ import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs } from "./helpers/mock-dialogs";
 import { msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import { writeWorkerSource } from "./helpers/write-worker-source";
 import type { Instance, Workflow } from "../workflows/types";

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -410,12 +410,14 @@ export function validateScopeKeys(
 	return scopes.every((scope) => scope in DefaultScopes);
 }
 
-// Module-level state intentionally limited to the transient state shared
-// across the steps of one OAuth login flow. The on-disk OAuth tokens are NOT
-// cached here — they are read on demand by readStoredAuthState() so that env
-// vars loaded after module import (for example from `.env`) take priority
-// correctly. The selected-account cache is file-backed (wrangler-account.json)
-// and therefore naturally scoped to the current working directory.
+/**
+ * Module-level state intentionally limited to the transient state shared
+ * across the steps of one OAuth login flow. The on-disk OAuth tokens are NOT
+ * cached here — they are read on demand by readStoredAuthState() so that env
+ * vars loaded after module import (for example from `.env`) take priority
+ * correctly. The selected-account cache is file-backed (wrangler-account.json)
+ * and therefore naturally scoped to the current working directory.
+ */
 const oauthFlowState: OAuthFlowState = {};
 
 let hasWarnedAboutDeprecatedV1ApiToken = false;

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -970,7 +970,7 @@ export async function loginOrRefreshIfRequired(
 		// Not logged in.
 		// If we are not interactive, we cannot ask the user to login
 		return !isNonInteractiveOrCI() && (await login(complianceConfig, props));
-	} else if (isAccessTokenExpired()) {
+	} else if (isRefreshNeeded()) {
 		// We're logged in, but the refresh token seems to have expired,
 		// so let's try to refresh it
 		const didRefresh = await refreshToken();
@@ -1003,7 +1003,7 @@ export async function getOAuthTokenFromLocalState(): Promise<
 	}
 
 	// If the token is expired, try to refresh it
-	if (isAccessTokenExpired()) {
+	if (isRefreshNeeded()) {
 		const didRefresh = await refreshToken();
 		if (!didRefresh) {
 			return undefined;
@@ -1204,16 +1204,17 @@ export async function login(
 }
 
 /**
- * Checks to see if the locally stored OAuth access token has expired.
+ * Checks to see if we need to refresh the OAuth token.
  *
  * Returns `false` when env-based credentials are present: in that case the
  * env token is what will be used for API calls, and the stored OAuth state
- * is not consulted, so its expiry is irrelevant. Without this short-circuit,
- * the presence of a stale OAuth token on disk could spuriously trigger an
- * OAuth refresh that fails and aborts the command, even though a perfectly
- * valid env-based credential is in scope.
+ * is not consulted, so its expiry is irrelevant.
+ *
+ * Without this short-circuit, the presence of a stale OAuth token on disk
+ * could spuriously trigger an OAuth refresh that fails and aborts the command,
+ * even though a perfectly valid env-based credential is in scope.
  */
-function isAccessTokenExpired(): boolean {
+function isRefreshNeeded(): boolean {
 	if (getAuthFromEnv()) {
 		return false;
 	}

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -428,10 +428,10 @@ let hasWarnedAboutDeprecatedV1ApiToken = false;
  * being cached at module scope, so that environment-based credentials loaded
  * after module import are honoured.
  *
- * Returns an empty object when no auth config file exists or the file cannot
+ * @return an empty object when no auth config file exists or the file cannot
  * be parsed — the caller treats this as "not logged in via local OAuth".
  *
- * The optional `config` argument lets callers seed the state from an
+ * @param config The optional `config` argument lets callers seed the state from an
  * in-memory config (used by the OAuth login flow before it writes to disk).
  */
 function readStoredAuthState(config?: UserAuthConfig): StoredAuthState {

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -813,10 +813,17 @@ async function exchangeRefreshTokenForAccessToken(): Promise<AccessContext> {
 
 			// The caller (refreshToken) persists this via writeAuthConfigFile.
 			// No need to mirror the values into any module-level cache.
+			//
+			// The OAuth server is allowed to omit `refresh_token` from a successful
+			// refresh response, in which case the previously issued refresh token
+			// remains valid (RFC 6749 §6). Preserve the stored value so we don't
+			// wipe a still-valid refresh token from disk.
 			const accessContext: AccessContext = {
 				token: accessToken,
 				scopes,
-				refreshToken: refresh_token ? { value: refresh_token } : undefined,
+				refreshToken: refresh_token
+					? { value: refresh_token }
+					: storedRefreshToken,
 			};
 			return accessContext;
 		} catch (error) {

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -297,27 +297,30 @@ interface PKCECodes {
 }
 
 /**
- * The module level state of the authentication flow.
+ * Transient state that is shared across the steps of a single OAuth login flow
+ * within one Wrangler command. This state is not file-backed; it lives only for
+ * the duration of an interactive login.
  */
-interface State extends AuthTokens {
+interface OAuthFlowState {
 	authorizationCode?: string;
 	codeChallenge?: string;
 	codeVerifier?: string;
 	hasAuthCodeBeenExchangedForAccessToken?: boolean;
 	stateQueryParam?: string;
-	scopes?: Scope[];
-	account?: Account;
 }
 
 /**
- * The tokens related to authentication.
+ * The auth state that is stored on disk in the user auth config file (TOML).
+ * Read on demand by {@link readStoredAuthState} — never cached at module scope
+ * so that environment variables loaded after import (e.g. from `.env`) take
+ * priority correctly.
  */
-interface AuthTokens {
+interface StoredAuthState {
 	accessToken?: AccessToken;
 	refreshToken?: RefreshToken;
 	scopes?: Scope[];
 	/** @deprecated - this field was only provided by the deprecated v1 `wrangler config` command. */
-	apiToken?: string;
+	deprecatedApiToken?: string;
 }
 
 /**
@@ -407,82 +410,79 @@ export function validateScopeKeys(
 	return scopes.every((scope) => scope in DefaultScopes);
 }
 
-let localState: State = {
-	...getAuthTokens(),
-};
+// Module-level state intentionally limited to the transient state shared
+// across the steps of one OAuth login flow. The on-disk OAuth tokens are NOT
+// cached here — they are read on demand by readStoredAuthState() so that env
+// vars loaded after module import (for example from `.env`) take priority
+// correctly. The selected-account cache is file-backed (wrangler-account.json)
+// and therefore naturally scoped to the current working directory.
+const oauthFlowState: OAuthFlowState = {};
+
+let hasWarnedAboutDeprecatedV1ApiToken = false;
 
 /**
- * Compute the current auth tokens.
+ * Read the on-disk auth state. This is called on demand from every site that
+ * needs the stored OAuth tokens or the deprecated v1 `api_token`, rather than
+ * being cached at module scope, so that environment-based credentials loaded
+ * after module import are honoured.
+ *
+ * Returns an empty object when no auth config file exists or the file cannot
+ * be parsed — the caller treats this as "not logged in via local OAuth".
+ *
+ * The optional `config` argument lets callers seed the state from an
+ * in-memory config (used by the OAuth login flow before it writes to disk).
  */
-function getAuthTokens(config?: UserAuthConfig): AuthTokens | undefined {
-	// get refreshToken/accessToken from fs if exists
+function readStoredAuthState(config?: UserAuthConfig): StoredAuthState {
+	let parsed: UserAuthConfig;
 	try {
-		// if the environment variable is available, we don't need to do anything here
-		if (getAuthFromEnv()) {
-			return;
-		}
+		parsed = config ?? readAuthConfigFile();
+	} catch {
+		return {};
+	}
 
-		// otherwise try loading from the user auth config file.
-		const { oauth_token, refresh_token, expiration_time, scopes, api_token } =
-			config || readAuthConfigFile();
+	const { oauth_token, refresh_token, expiration_time, scopes, api_token } =
+		parsed;
 
-		if (oauth_token) {
-			return {
-				accessToken: {
-					value: oauth_token,
-					// If there is no `expiration_time` field then set it to an old date, to cause it to expire immediately.
-					expiry: expiration_time ?? "2000-01-01:00:00:00+00:00",
-				},
-				refreshToken: { value: refresh_token ?? "" },
-				scopes: scopes as Scope[],
-			};
-		} else if (api_token) {
+	if (oauth_token) {
+		return {
+			accessToken: {
+				value: oauth_token,
+				// If there is no `expiration_time` field then set it to an old date, to cause it to expire immediately.
+				expiry: expiration_time ?? "2000-01-01:00:00:00+00:00",
+			},
+			refreshToken: { value: refresh_token ?? "" },
+			scopes: scopes as Scope[] | undefined,
+		};
+	}
+
+	if (api_token) {
+		if (!hasWarnedAboutDeprecatedV1ApiToken) {
+			hasWarnedAboutDeprecatedV1ApiToken = true;
 			logger.warn(
 				"It looks like you have used Wrangler v1's `config` command to login with an API token\n" +
 					`from ${config === undefined ? getAuthConfigFilePath() : "in-memory config"}.\n` +
 					"This is no longer supported in the current version of Wrangler.\n" +
 					"If you wish to authenticate via an API token then please set the `CLOUDFLARE_API_TOKEN` environment variable."
 			);
-			return { apiToken: api_token };
 		}
-	} catch {
-		return undefined;
+		return { deprecatedApiToken: api_token };
 	}
-}
 
-/**
- * Run the initialization of the auth state, in the case that something changed.
- *
- * This runs automatically whenever `writeAuthConfigFile` is run, so generally
- * you won't need to call it yourself.
- */
-export function reinitialiseAuthTokens(): void;
-
-/**
- * Reinitialise auth state from an in-memory config, skipping
- * over the part where we write a file and then read it back into memory
- */
-export function reinitialiseAuthTokens(config: UserAuthConfig): void;
-
-export function reinitialiseAuthTokens(config?: UserAuthConfig): void {
-	localState = {
-		...getAuthTokens(config),
-	};
+	return {};
 }
 
 export function getAPIToken(): ApiCredentials | undefined {
-	if (localState.apiToken) {
-		return { apiToken: localState.apiToken };
+	const envAuth = getAuthFromEnv();
+	if (envAuth) {
+		return envAuth;
 	}
 
-	const localAPIToken = getAuthFromEnv();
-	if (localAPIToken) {
-		return localAPIToken;
+	const stored = readStoredAuthState();
+	if (stored.deprecatedApiToken) {
+		return { apiToken: stored.deprecatedApiToken };
 	}
-
-	const storedAccessToken = localState.accessToken?.value;
-	if (storedAccessToken) {
-		return { apiToken: storedAccessToken };
+	if (stored.accessToken?.value) {
+		return { apiToken: stored.accessToken.value };
 	}
 
 	return undefined;
@@ -706,10 +706,8 @@ function isReturningFromAuthServer(query: ParsedUrlQuery): boolean {
 		return false;
 	}
 
-	const state = localState;
-
 	const stateQueryParam = query.state;
-	if (stateQueryParam !== state.stateQueryParam) {
+	if (stateQueryParam !== oauthFlowState.stateQueryParam) {
 		logger.warn(
 			"Received query string parameter doesn't match the one sent! Possible malicious activity somewhere."
 		);
@@ -718,8 +716,8 @@ function isReturningFromAuthServer(query: ParsedUrlQuery): boolean {
 		});
 	}
 	assert(!Array.isArray(code));
-	state.authorizationCode = code;
-	state.hasAuthCodeBeenExchangedForAccessToken = false;
+	oauthFlowState.authorizationCode = code;
+	oauthFlowState.hasAuthCodeBeenExchangedForAccessToken = false;
 	return true;
 }
 
@@ -727,7 +725,7 @@ async function getAuthURL(scopes: string[], clientId: string): Promise<string> {
 	const { codeChallenge, codeVerifier } = await generatePKCECodes();
 	const stateQueryParam = generateRandomState(RECOMMENDED_STATE_LENGTH);
 
-	Object.assign(localState, {
+	Object.assign(oauthFlowState, {
 		codeChallenge,
 		codeVerifier,
 		stateQueryParam,
@@ -757,13 +755,16 @@ type TokenResponse =
  * Refresh an access token from the remote service.
  */
 async function exchangeRefreshTokenForAccessToken(): Promise<AccessContext> {
-	if (!localState.refreshToken) {
+	// Read the refresh token fresh from disk on every call so we always pick up
+	// the latest rotation written by a sibling Wrangler process.
+	const storedRefreshToken = readStoredAuthState().refreshToken;
+	if (!storedRefreshToken) {
 		logger.warn("No refresh token is present.");
 	}
 
 	const params = new URLSearchParams({
 		grant_type: "refresh_token",
-		refresh_token: localState.refreshToken?.value ?? "",
+		refresh_token: storedRefreshToken?.value ?? "",
 		client_id: getClientIdFromEnv(),
 	});
 
@@ -798,31 +799,22 @@ async function exchangeRefreshTokenForAccessToken(): Promise<AccessContext> {
 			}
 
 			const { access_token, expires_in, refresh_token, scope } = json;
-			let scopes: Scope[] = [];
 
 			const accessToken: AccessToken = {
 				value: access_token,
 				expiry: new Date(Date.now() + expires_in * 1000).toISOString(),
 			};
-			localState.accessToken = accessToken;
 
-			if (refresh_token) {
-				localState.refreshToken = {
-					value: refresh_token,
-				};
-			}
+			// Multiple scopes are passed and delimited by spaces,
+			// despite using the singular name "scope".
+			const scopes: Scope[] = scope ? (scope.split(" ") as Scope[]) : [];
 
-			if (scope) {
-				// Multiple scopes are passed and delimited by spaces,
-				// despite using the singular name "scope".
-				scopes = scope.split(" ") as Scope[];
-				localState.scopes = scopes;
-			}
-
+			// The caller (refreshToken) persists this via writeAuthConfigFile.
+			// No need to mirror the values into any module-level cache.
 			const accessContext: AccessContext = {
 				token: accessToken,
 				scopes,
-				refreshToken: localState.refreshToken,
+				refreshToken: refresh_token ? { value: refresh_token } : undefined,
 			};
 			return accessContext;
 		} catch (error) {
@@ -839,7 +831,7 @@ async function exchangeRefreshTokenForAccessToken(): Promise<AccessContext> {
  * Fetch an access token from the remote service.
  */
 async function exchangeAuthCodeForAccessToken(): Promise<AccessContext> {
-	const { authorizationCode, codeVerifier = "" } = localState;
+	const { authorizationCode, codeVerifier = "" } = oauthFlowState;
 
 	if (!codeVerifier) {
 		logger.warn("No code verifier is being sent.");
@@ -873,33 +865,24 @@ async function exchangeAuthCodeForAccessToken(): Promise<AccessContext> {
 		throw new Error(json.error);
 	}
 	const { access_token, expires_in, refresh_token, scope } = json;
-	let scopes: Scope[] = [];
-	localState.hasAuthCodeBeenExchangedForAccessToken = true;
+	oauthFlowState.hasAuthCodeBeenExchangedForAccessToken = true;
 
 	const expiryDate = new Date(Date.now() + expires_in * 1000);
 	const accessToken: AccessToken = {
 		value: access_token,
 		expiry: expiryDate.toISOString(),
 	};
-	localState.accessToken = accessToken;
 
-	if (refresh_token) {
-		localState.refreshToken = {
-			value: refresh_token,
-		};
-	}
+	// Multiple scopes are passed and delimited by spaces,
+	// despite using the singular name "scope".
+	const scopes: Scope[] = scope ? (scope.split(" ") as Scope[]) : [];
 
-	if (scope) {
-		// Multiple scopes are passed and delimited by spaces,
-		// despite using the singular name "scope".
-		scopes = scope.split(" ") as Scope[];
-		localState.scopes = scopes;
-	}
-
+	// The caller (login) persists this via writeAuthConfigFile.
+	// No need to mirror the values into any module-level cache.
 	const accessContext: AccessContext = {
 		token: accessToken,
 		scopes,
-		refreshToken: localState.refreshToken,
+		refreshToken: refresh_token ? { value: refresh_token } : undefined,
 	};
 	return accessContext;
 }
@@ -950,8 +933,10 @@ export function getAuthConfigFilePath() {
 }
 
 /**
- * Writes a a wrangler config file (auth credentials) to disk,
- * and updates the user auth state with the new credentials.
+ * Writes a wrangler config file (auth credentials) to disk.
+ *
+ * No in-memory cache to invalidate — auth state is read on demand by
+ * {@link readStoredAuthState} on every call site that needs it.
  */
 export function writeAuthConfigFile(config: UserAuthConfig) {
 	const configPath = getAuthConfigFilePath();
@@ -962,8 +947,6 @@ export function writeAuthConfigFile(config: UserAuthConfig) {
 	writeFileSync(path.join(configPath), TOML.stringify(config), {
 		encoding: "utf-8",
 	});
-
-	reinitialiseAuthTokens();
 }
 
 export function readAuthConfigFile(): UserAuthConfig {
@@ -1014,7 +997,8 @@ export async function getOAuthTokenFromLocalState(): Promise<
 	string | undefined
 > {
 	// Check if we have an OAuth token
-	if (!localState.accessToken) {
+	let stored = readStoredAuthState();
+	if (!stored.accessToken) {
 		return undefined;
 	}
 
@@ -1024,9 +1008,11 @@ export async function getOAuthTokenFromLocalState(): Promise<
 		if (!didRefresh) {
 			return undefined;
 		}
+		// Re-read after the refresh has persisted the new token to disk.
+		stored = readStoredAuthState();
 	}
 
-	return localState.accessToken?.value;
+	return stored.accessToken?.value;
 }
 
 export async function getOauthToken(options: {
@@ -1218,20 +1204,29 @@ export async function login(
 }
 
 /**
- * Checks to see if the access token has expired.
+ * Checks to see if the locally stored OAuth access token has expired.
+ *
+ * Returns `false` when env-based credentials are present: in that case the
+ * env token is what will be used for API calls, and the stored OAuth state
+ * is not consulted, so its expiry is irrelevant. Without this short-circuit,
+ * the presence of a stale OAuth token on disk could spuriously trigger an
+ * OAuth refresh that fails and aborts the command, even though a perfectly
+ * valid env-based credential is in scope.
  */
 function isAccessTokenExpired(): boolean {
-	const { accessToken } = localState;
+	if (getAuthFromEnv()) {
+		return false;
+	}
+	const { accessToken } = readStoredAuthState();
 	return Boolean(accessToken && new Date() >= new Date(accessToken.expiry));
 }
 
 async function refreshToken(): Promise<boolean> {
-	// Re-read the auth config from disk before refreshing. OAuth refresh tokens are
-	// single-use: when a sibling wrangler process refreshes, it rotates the token
-	// server-side and writes the new value to the shared config file. A long-lived
-	// process (e.g. `wrangler dev`) that loaded its refresh_token at startup would
-	// otherwise send the stale value here and get a 401 from the token endpoint.
-	reinitialiseAuthTokens();
+	// `exchangeRefreshTokenForAccessToken` reads the refresh token fresh from
+	// disk on every call, so we always pick up the latest rotation written by a
+	// sibling Wrangler process. Refresh tokens are single-use, so a long-lived
+	// process such as `wrangler dev` would otherwise send a stale value and get
+	// a 401 from the token endpoint.
 
 	try {
 		const {
@@ -1268,33 +1263,16 @@ export async function logout(): Promise<void> {
 		return;
 	}
 
-	if (!localState.accessToken) {
-		if (!localState.refreshToken) {
-			logger.log("Not logged in, exiting...");
-			return;
-		}
-
-		const body =
-			`client_id=${encodeURIComponent(getClientIdFromEnv())}&` +
-			`token_type_hint=refresh_token&` +
-			`token=${encodeURIComponent(localState.refreshToken?.value || "")}`;
-
-		const response = await fetch(getRevokeUrlFromEnv(), {
-			method: "POST",
-			body,
-			headers: {
-				"Content-Type": "application/x-www-form-urlencoded",
-			},
-		});
-		await response.text(); // blank text? would be nice if it was something meaningful
-		logger.log(
-			"💁  Wrangler is configured with an OAuth token. The token has been successfully revoked"
-		);
+	const storedRefreshToken = readStoredAuthState().refreshToken;
+	if (!storedRefreshToken) {
+		logger.log("Not logged in, exiting...");
+		return;
 	}
+
 	const body =
 		`client_id=${encodeURIComponent(getClientIdFromEnv())}&` +
 		`token_type_hint=refresh_token&` +
-		`token=${encodeURIComponent(localState.refreshToken?.value || "")}`;
+		`token=${encodeURIComponent(storedRefreshToken.value || "")}`;
 
 	const response = await fetch(getRevokeUrlFromEnv(), {
 		method: "POST",
@@ -1462,24 +1440,20 @@ export function requireApiToken(): ApiCredentials {
 }
 
 /**
- * Saves the given account details to the filesystem cache as well as the local state
+ * Saves the given account details to the filesystem cache.
  *
  * @param account The account to save
  */
 function saveAccountToCache(account: Account): void {
-	localState.account = account;
 	saveToConfigCache<{ account: Account }>("wrangler-account.json", { account });
 }
 
 /**
- * Retrieves the account details from either the local state or the filesystem cache (in that order)
+ * Retrieves the account details from the filesystem cache.
  *
  * @returns The cached account if present, `undefined` otherwise
  */
 export function getAccountFromCache(): undefined | Account {
-	if (localState.account) {
-		return localState.account;
-	}
 	return getConfigCache<{ account: Account }>("wrangler-account.json").account;
 }
 
@@ -1488,7 +1462,7 @@ export function getAccountFromCache(): undefined | Account {
  * if the token is an OAuth token.
  */
 export function getScopes(): Scope[] | undefined {
-	return localState.scopes;
+	return readStoredAuthState().scopes;
 }
 
 export function printScopes(scopes: Scope[]) {


### PR DESCRIPTION
Fixes #13744.

## What

Wrangler previously read its OAuth state from the user auth config file (e.g. `~/.config/.wrangler/config/default.toml`) eagerly at module-import time. That happens _before_ `.env` files are loaded, so the in-memory state would always hold the OAuth tokens even when the user only wanted to authenticate via `CLOUDFLARE_API_TOKEN`. If that stored OAuth token happened to be expired, Wrangler would try to refresh it (and fail), aborting the command with:

```
X [ERROR] Failed to fetch auth token: 400 Bad Request
X [ERROR] You are logged in with an API Token. Unset the CLOUDFLARE_API_TOKEN in the environment to log in via OAuth.
X [ERROR] Not logged in.
```

— even though a valid API token was in scope.

## How

Read the auth config file on demand from every site that needs it, rather than caching it at module scope. The key fix is in `isAccessTokenExpired()`: it now short-circuits to `false` when env-based credentials are present, so the OAuth refresh endpoint is no longer called when env auth is going to be used.

Sibling-process refresh-token rotation (the case PR #13910 partially addressed) is also handled naturally because every check reads the current file contents.

Two commits:

1. **`[wrangler] fix: read OAuth state from disk lazily so env auth takes priority`** — the actual fix in `packages/wrangler/src/user/user.ts`, plus three regression tests in `user.test.ts`. Includes several drive-by cleanups (dead `localState` mutations, dead `logout()` branch with accidental double-revoke, redundant `reinitialiseAuthTokens` in `refreshToken`, in-process selected-account cache).

2. **`[wrangler] refactor: import runInTempDir from workers-utils directly`** — pure mechanical cleanup: the local `packages/wrangler/src/__tests__/helpers/run-in-tmp.ts` wrapper only existed to call `reinitialiseAuthTokens()` between tests. With that function gone, every caller can import `runInTempDir` directly from `@cloudflare/workers-utils/test-helpers`. 163 test files updated by a one-shot script, then `oxfmt`-ed.

## Test plan

- 3 new regression tests in `user.test.ts` cover the issue scenario directly:
  - `getAPIToken` returns the env token even when a stored OAuth token also exists
  - `loginOrRefreshIfRequired` does not attempt OAuth refresh when env auth is set
  - End-to-end `wrangler whoami` succeeds via env token when a stale OAuth token also exists on disk (asserting no `oauth2/token` request is fired)
- Existing sibling-rotation regression test (#13910) updated to match the new lazy-read model — still validates the same invariant.
- Full wrangler unit test suite: **4059 passing**, 4 skipped, 9 todo (same shape as on `main`, plus the 3 new tests).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is a bug fix that restores documented behaviour — env-based auth already takes priority over OAuth state per `getAuthFromEnv()` documentation in user.ts.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13954" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->