### PR TITLE
[wrangler] Fix typos in comments and test names

### DIFF
--- a/packages/containers-shared/src/knobs.ts
+++ b/packages/containers-shared/src/knobs.ts
@@ -1,7 +1,7 @@
 import { MF_DEV_CONTAINER_PREFIX } from "./registry";
 
-// Will return the default cloudflare managed registry for either a staging or production envrionment
-// based on the env var WRANGLER_API_ENVIRONMENT. The default registry can be overriden with the env
+// Will return the default cloudflare managed registry for either a staging or production environment
+// based on the env var WRANGLER_API_ENVIRONMENT. The default registry can be overridden with the env
 // var CLOUDFLARE_CONTAINER_REGISTRY.
 export const getCloudflareContainerRegistry = () => {
 	// previously defaulted to registry.cloudchamber.cfdata.org

--- a/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
@@ -203,7 +203,7 @@ describe("pages build env", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	it("should throw an error if an invalid pages confg file is found", async ({
+	it("should throw an error if an invalid pages config file is found", async ({
 		expect,
 	}) => {
 		writeWranglerConfig({
@@ -229,7 +229,7 @@ describe("pages build env", () => {
 		`);
 	});
 
-	it("should exit if an unparseable pages confg file is found", async ({
+	it("should exit if an unparseable pages config file is found", async ({
 		expect,
 	}) => {
 		writeFileSync(

--- a/packages/wrangler/templates/pages-template-plugin.ts
+++ b/packages/wrangler/templates/pages-template-plugin.ts
@@ -157,7 +157,7 @@ export default function (pluginArgs: unknown) {
 						if (typeof value !== "object" || value === null) {
 							throw new Error("context.data must be an object");
 						}
-						// user has overriden context.data, so we need to merge it with the existing data
+						// user has overridden context.data, so we need to merge it with the existing data
 						data = value;
 					},
 					pluginArgs,

--- a/packages/wrangler/templates/pages-template-worker.ts
+++ b/packages/wrangler/templates/pages-template-worker.ts
@@ -148,7 +148,7 @@ export default {
 						if (typeof value !== "object" || value === null) {
 							throw new Error("context.data must be an object");
 						}
-						// user has overriden context.data, so we need to merge it with the existing data
+						// user has overridden context.data, so we need to merge it with the existing data
 						data = value;
 					},
 					env,

--- a/packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts
@@ -434,7 +434,7 @@ export class InspectorProxyWorker implements DurableObject {
 		// by default, sendRuntimeMessage waits for the runtime websocket to connect
 		// but we only want to send this message now or never
 		// if we schedule it to send later (like waiting for the websocket, by default)
-		// then we risk clearing logs that have occured since we scheduled it too
+		// then we risk clearing logs that have occurred since we scheduled it too
 		// which is worse than leaving logs from the previous version on screen
 		if (this.websockets.runtime) {
 			this.sendRuntimeMessage(


### PR DESCRIPTION
## Summary

Fixes a few spelling typos in handwritten comments and test names across Wrangler and containers-shared files.

## Files changed

- `packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts`: `occured` -> `occurred`
- `packages/wrangler/templates/pages-template-worker.ts`: `overriden` -> `overridden`
- `packages/wrangler/templates/pages-template-plugin.ts`: `overriden` -> `overridden`
- `packages/wrangler/src/__tests__/pages/pages-build-env.test.ts`: `confg` -> `config` in test names
- `packages/containers-shared/src/knobs.ts`: `envrionment` -> `environment`, `overriden` -> `overridden`

## Before / after

Before, these files contained misspellings in comments or test descriptions. After, the surrounding behavior is unchanged and only the text spelling is corrected.

## Verification

- Inspected the diff to confirm only comments and test names changed.
- Ran `rg "occured|overriden|confg|envrionment" packages/{wrangler,containers-shared}/**/*.{ts,md,js}` and confirmed no matches in the touched package areas.
- Attempted `corepack pnpm --filter wrangler test pages-build-env`, but this local checkout has no `node_modules` installed and the command failed before running Vitest because `dotenv` could not dispatch the repo-local `pnpm` command.

## Competing PR check

Checked for existing PRs with:

- `gh pr list --repo cloudflare/workers-sdk --search "occured InspectorProxyWorker" --state all --limit 10`
- `gh pr list --repo cloudflare/workers-sdk --search "overriden pages-template" --state all --limit 10`
- `gh pr list --repo cloudflare/workers-sdk --search "confg pages-build-env" --state all --limit 10`

No matching PRs were returned.