### PR TITLE
[wrangler] Accept creating Artifacts repo status

### DIFF
--- a/.changeset/real-wolves-create.md
+++ b/.changeset/real-wolves-create.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Recognize Artifacts repositories that are still being created
+
+Wrangler's Artifacts repo status type now accepts the `creating` lifecycle state alongside existing in-progress statuses.

--- a/packages/wrangler/src/artifacts/types.ts
+++ b/packages/wrangler/src/artifacts/types.ts
@@ -1,6 +1,10 @@
 export type ArtifactsTokenScope = "read" | "write";
 
-export type ArtifactsRepoStatus = "ready" | "importing" | "forking";
+export type ArtifactsRepoStatus =
+	| "creating"
+	| "ready"
+	| "importing"
+	| "forking";
 
 export interface ArtifactsNamespace {
 	namespace: string;


### PR DESCRIPTION
Adds `creating` to Wrangler's Artifacts repo status type so CLI/control-plane handling accepts the repository creation lifecycle state.

Implemented by Pi (GPT-5.5) with guidance from Dillon <dillon@cloudflare.com>.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this is a type-union expansion; validated with `pnpm check:type --filter=wrangler`.
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/30894
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
