### PR TITLE
[vitest-pool-workers] Preserve wrapped RPC call ordering

### DIFF
--- a/.changeset/quiet-rpc-ordering.md
+++ b/.changeset/quiet-rpc-ordering.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Preserve same-stub RPC call order for wrapped Worker and Durable Object entrypoints
+
+Previously, dynamically wrapped RPC methods could resolve and invoke out of order when many calls were fired without awaiting each individual call. This now queues method resolution per wrapper instance so calls begin in the order they were received.

--- a/.changeset/remote-proxy-session-errors.md
+++ b/.changeset/remote-proxy-session-errors.md
@@ -4,5 +4,4 @@
 
 Surface remote proxy session errors
 
-When remote bindings fail to start, include the controller reason and root
-cause in the error message to make failures like missing `cloudflared` clearer.
+When remote bindings fail to start, include the controller reason and root cause in the error message to make failures like missing `cloudflared` clearer.

--- a/fixtures/vitest-pool-workers-examples/rpc/src/index.ts
+++ b/fixtures/vitest-pool-workers-examples/rpc/src/index.ts
@@ -3,6 +3,7 @@ import { Counter } from "./counter";
 
 export class TestObject extends DurableObject<Env> {
 	#value: number = 0;
+	#log: string[] = [];
 
 	constructor(ctx: DurableObjectState, env: Env) {
 		super(ctx, env);
@@ -23,6 +24,27 @@ export class TestObject extends DurableObject<Env> {
 
 	scheduleReset(afterMillis: number) {
 		void this.ctx.storage.setAlarm(Date.now() + afterMillis);
+	}
+
+	record(value: string) {
+		this.#log.push(value);
+	}
+
+	getLog() {
+		return this.#log;
+	}
+
+	async recordFromDurableObject(targetName: string, calls: number) {
+		const id = this.env.TEST_OBJECT.idFromName(targetName);
+		const stub = this.env.TEST_OBJECT.get(id);
+		const promises: Promise<void>[] = [];
+
+		for (let i = 0; i < calls; i++) {
+			promises.push(stub.record(`call-${i}`));
+		}
+
+		await Promise.all(promises);
+		return stub.getLog();
 	}
 
 	async fetch(request: Request) {
@@ -80,6 +102,19 @@ export class TestNamedEntrypoint extends WorkerEntrypoint<Env> {
 
 	getCounter() {
 		return new Counter(0);
+	}
+
+	async recordFromWorkerEntrypoint(targetName: string, calls: number) {
+		const id = this.env.TEST_OBJECT.idFromName(targetName);
+		const stub = this.env.TEST_OBJECT.get(id);
+		const promises: Promise<void>[] = [];
+
+		for (let i = 0; i < calls; i++) {
+			promises.push(stub.record(`call-${i}`));
+		}
+
+		await Promise.all(promises);
+		return stub.getLog();
 	}
 }
 

--- a/fixtures/vitest-pool-workers-examples/rpc/test/unit.test.ts
+++ b/fixtures/vitest-pool-workers-examples/rpc/test/unit.test.ts
@@ -58,6 +58,16 @@ describe("named entrypoints", () => {
 });
 
 describe("Durable Object", () => {
+	const orderingAttempts = 5;
+	const orderingCalls = 100;
+
+	function expectedOrderingLog() {
+		return Array.from({ length: orderingCalls }, (_, i) => `call-${i}`);
+	}
+	function orderingTargetName(prefix: string, attempt: number) {
+		return `${prefix}-${crypto.randomUUID()}-${attempt}`;
+	}
+
 	it("dispatches fetch request", async ({ expect }) => {
 		const id = env.TEST_OBJECT.newUniqueId();
 		const stub = env.TEST_OBJECT.get(id);
@@ -151,6 +161,76 @@ describe("Durable Object", () => {
 		const stub = env.TEST_OBJECT.get(id);
 		using result = await stub.getObject();
 		expect(result).toMatchObject({ hello: "world" });
+	});
+
+	// Regression repro for https://github.com/cloudflare/workers-sdk/issues/13433.
+	it("preserves same-type RPC call order", async ({ expect }) => {
+		for (let attempt = 0; attempt < orderingAttempts; attempt++) {
+			const id = env.TEST_OBJECT.idFromName(
+				orderingTargetName("ordering", attempt)
+			);
+			const stub = env.TEST_OBJECT.get(id);
+			const promises: Promise<void>[] = [];
+
+			for (let i = 0; i < orderingCalls; i++) {
+				promises.push(stub.record(`call-${i}`));
+			}
+
+			await Promise.all(promises);
+
+			expect(await stub.getLog()).toEqual(expectedOrderingLog());
+		}
+	});
+
+	it("preserves same-type RPC call order after prewarming instance", async ({
+		expect,
+	}) => {
+		for (let attempt = 0; attempt < orderingAttempts; attempt++) {
+			const id = env.TEST_OBJECT.idFromName(
+				orderingTargetName("prewarmed-ordering", attempt)
+			);
+			const stub = env.TEST_OBJECT.get(id);
+			await stub.getLog();
+			const promises: Promise<void>[] = [];
+
+			for (let i = 0; i < orderingCalls; i++) {
+				promises.push(stub.record(`call-${i}`));
+			}
+
+			await Promise.all(promises);
+
+			expect(await stub.getLog()).toEqual(expectedOrderingLog());
+		}
+	});
+
+	it("preserves same-type RPC call order from a WorkerEntrypoint caller", async ({
+		expect,
+	}) => {
+		for (let attempt = 0; attempt < orderingAttempts; attempt++) {
+			expect(
+				await env.TEST_NAMED_ENTRYPOINT.recordFromWorkerEntrypoint(
+					orderingTargetName("worker-entrypoint-ordering", attempt),
+					orderingCalls
+				)
+			).toEqual(expectedOrderingLog());
+		}
+	});
+
+	it("preserves same-type RPC call order from a Durable Object caller", async ({
+		expect,
+	}) => {
+		for (let attempt = 0; attempt < orderingAttempts; attempt++) {
+			const id = env.TEST_OBJECT.idFromName(
+				orderingTargetName("do-caller", attempt)
+			);
+			const stub = env.TEST_OBJECT.get(id);
+			expect(
+				await stub.recordFromDurableObject(
+					orderingTargetName("do-caller-ordering", attempt),
+					orderingCalls
+				)
+			).toEqual(expectedOrderingLog());
+		}
 	});
 });
 

--- a/packages/vite-plugin-cloudflare/playground/durable-objects/__tests__/durable-objects.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/durable-objects/__tests__/durable-objects.spec.ts
@@ -1,5 +1,5 @@
 import { describe, test } from "vitest";
-import { getTextResponse } from "../../__test-utils__";
+import { getJsonResponse, getTextResponse, isBuild } from "../../__test-utils__";
 
 describe("in-worker defined durable objects", async () => {
 	test("can bind to a Durable Object that does not extend the `DurableObject` class", async ({
@@ -23,4 +23,14 @@ describe("in-worker defined durable objects", async () => {
 			"Durable Object 'my-do' count: 1"
 		);
 	});
+	test.skipIf(isBuild)(
+		"preserves same-type RPC call order in the dev runner",
+		async ({ expect }) => {
+			const result = await getJsonResponse(
+				`/rpc-ordering?name=${crypto.randomUUID()}`
+			);
+
+			expect(result).toMatchObject({ inOrder: true });
+		}
+	);
 });

--- a/packages/vite-plugin-cloudflare/playground/durable-objects/__tests__/durable-objects.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/durable-objects/__tests__/durable-objects.spec.ts
@@ -1,5 +1,9 @@
 import { describe, test } from "vitest";
-import { getJsonResponse, getTextResponse, isBuild } from "../../__test-utils__";
+import {
+	getJsonResponse,
+	getTextResponse,
+	isBuild,
+} from "../../__test-utils__";
 
 describe("in-worker defined durable objects", async () => {
 	test("can bind to a Durable Object that does not extend the `DurableObject` class", async ({

--- a/packages/vite-plugin-cloudflare/playground/durable-objects/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/durable-objects/src/index.ts
@@ -6,10 +6,20 @@ interface Env {
 }
 
 export class Counter extends DurableObject {
+	#log: string[] = [];
+
 	async getCounterValue() {
 		const value = ((await this.ctx.storage.get("value")) as number) || 0;
 
 		return value;
+	}
+
+	record(value: string) {
+		this.#log.push(value);
+	}
+
+	getLog() {
+		return this.#log;
 	}
 
 	async increment(amount = 1) {
@@ -45,6 +55,28 @@ export default {
 			const stub = env.LEGACY.get(id);
 
 			return stub.fetch(request);
+		}
+
+		if (url.pathname === "/rpc-ordering") {
+			const name = url.searchParams.get("name") ?? crypto.randomUUID();
+			const calls = 100;
+			const id = env.COUNTERS.idFromName(name);
+			const stub = env.COUNTERS.get(id);
+			const promises: Promise<void>[] = [];
+
+			for (let i = 0; i < calls; i++) {
+				promises.push(stub.record(`call-${i}`));
+			}
+
+			await Promise.all(promises);
+
+			const actual = await stub.getLog();
+			const expected = Array.from({ length: calls }, (_, i) => `call-${i}`);
+			return Response.json({
+				actual,
+				expected,
+				inOrder: JSON.stringify(actual) === JSON.stringify(expected),
+			});
 		}
 
 		const name = url.searchParams.get("name");

--- a/packages/vitest-pool-workers/src/worker/entrypoints.ts
+++ b/packages/vitest-pool-workers/src/worker/entrypoints.ts
@@ -113,6 +113,11 @@ function getRPCProperty(
 	return Reflect.get(/* target */ ctor.prototype, key, /* receiver */ instance);
 }
 
+type RPCInvocationQueueOwner =
+	| WorkerEntrypoint<Cloudflare.Env>
+	| DurableObjectClass<Cloudflare.Env>
+	| WorkflowEntrypoint<Cloudflare.Env>;
+
 /**
  * When calling RPC methods dynamically, we don't know whether the `property`
  * returned from `getSELFRPCProperty()` or `getDurableObjectRPCProperty()` below
@@ -131,20 +136,58 @@ function getRPCProperty(
  */
 function getRPCPropertyCallableThenable(
 	key: string,
-	property: Promise<unknown>
+	property: Promise<unknown>,
+	queueOwner: RPCInvocationQueueOwner
 ) {
 	const fn = async function (...args: unknown[]) {
-		const maybeFn = await property;
-		if (typeof maybeFn === "function") {
-			return maybeFn(...args);
-		} else {
-			throw new TypeError(`${JSON.stringify(key)} is not a function.`);
-		}
+		return enqueueRPCInvocation(queueOwner, async (release) => {
+			try {
+				const maybeFn = await property;
+				if (typeof maybeFn === "function") {
+					return maybeFn(...args);
+				} else {
+					throw new TypeError(`${JSON.stringify(key)} is not a function.`);
+				}
+			} finally {
+				release();
+			}
+		});
 	} as Promise<unknown> & ((...args: unknown[]) => Promise<unknown>);
 	fn.then = (onFulfilled, onRejected) => property.then(onFulfilled, onRejected);
 	fn.catch = (onRejected) => property.catch(onRejected);
 	fn.finally = (onFinally) => property.finally(onFinally);
 	return fn;
+}
+
+const rpcInvocationQueues = new WeakMap<RPCInvocationQueueOwner, Promise<void>>();
+
+/**
+ * Preserve the order in which dynamically-wrapped RPC methods begin executing.
+ *
+ * Resolving a property like `stub.method` may need to import user modules or
+ * instantiate wrapper objects. If several calls are fired synchronously, those
+ * async steps can otherwise complete out of order before the actual user method
+ * is invoked. The queue is released as soon as invocation starts, so async RPC
+ * completions can still run concurrently.
+ */
+async function enqueueRPCInvocation<T>(
+	owner: RPCInvocationQueueOwner,
+	callback: (release: () => void) => Promise<T>
+): Promise<T> {
+	const previous = rpcInvocationQueues.get(owner) ?? Promise.resolve();
+	let releaseStarted: (() => void) | undefined;
+	const started = new Promise<void>((resolve) => {
+		releaseStarted = resolve;
+	});
+	const release = () => {
+		const releaseStartedFn = releaseStarted;
+		if (releaseStartedFn !== undefined) {
+			releaseStartedFn();
+		}
+	};
+	const result = previous.catch(() => {}).then(() => callback(release));
+	rpcInvocationQueues.set(owner, started);
+	return result;
 }
 
 /**
@@ -297,7 +340,7 @@ export function createWorkerEntrypointWrapper(
 			}
 
 			const property = getWorkerEntrypointRPCProperty(this, entrypoint, key);
-			return getRPCPropertyCallableThenable(key, property);
+			return getRPCPropertyCallableThenable(key, property, this);
 		}
 	);
 
@@ -410,7 +453,7 @@ export function createDurableObjectWrapper(
 		}
 
 		const property = getDurableObjectRPCProperty(this, className, key);
-		return getRPCPropertyCallableThenable(key, property);
+		return getRPCPropertyCallableThenable(key, property, this);
 	});
 
 	Wrapper.prototype[kEnsureInstance] = async function (
@@ -526,7 +569,7 @@ export function createWorkflowEntrypointWrapper(entrypoint: string) {
 				entrypoint,
 				key
 			);
-			return getRPCPropertyCallableThenable(key, property);
+			return getRPCPropertyCallableThenable(key, property, this);
 		}
 	);
 

--- a/packages/vitest-pool-workers/src/worker/entrypoints.ts
+++ b/packages/vitest-pool-workers/src/worker/entrypoints.ts
@@ -159,7 +159,10 @@ function getRPCPropertyCallableThenable(
 	return fn;
 }
 
-const rpcInvocationQueues = new WeakMap<RPCInvocationQueueOwner, Promise<void>>();
+const rpcInvocationQueues = new WeakMap<
+	RPCInvocationQueueOwner,
+	Promise<void>
+>();
 
 /**
  * Preserve the order in which dynamically-wrapped RPC methods begin executing.


### PR DESCRIPTION
Fixes #13433.

This PR fixes a vitest-pool-specific ordering bug where many same-type RPC calls to a Durable Object could be observed out of order when the calls were fired synchronously without awaiting each individual call.

## What changed

`@cloudflare/vitest-pool-workers` wraps Worker, Durable Object, and Workflow entrypoints so RPC property accesses can be resolved dynamically through the Vitest module runner. The wrapper previously awaited dynamic property resolution independently for each call. In a burst of calls like `stub.record("call-0")`, `stub.record("call-1")`, etc., workerd entered the wrapper in the right order, but those wrapper continuations could resume from `await property` out of order before invoking the user method.

The fix adds a per-wrapper-instance queue around the dynamic property-resolution and method-invocation start section. The queue releases as soon as the user method invocation begins, rather than waiting for the returned promise to settle, so async RPC work can still complete concurrently.

## Investigation

I tried to reproduce this first in workerd with a focused Durable Object ordering test. That covered a normal Worker caller, a quiet Durable Object caller, and a noisy Durable Object caller, but it did not reproduce the same-type RPC reordering after repeated runs. That made this look less like a generic workerd input-gate or Durable Object scheduling issue.

I also checked the public repro behavior outside vitest: the same pure RPC ordering pattern did not reproduce in `wrangler dev`, and the Vite plugin dev-runner playground test added here also passed repeatedly before applying this fix. The issue appears specific to the vitest-pool wrapper path, where user module/property resolution goes through `runInRunnerObject(() => __vitest_mocker__.moduleRunner.import(...))`.

To confirm the root cause, I temporarily traced the wrapper call order. The wrapper callable was entered in order, but after `await property` the continuation order changed, for example from `..., call-8, call-9, call-10, ...` to `..., call-8, call-10, call-9, ...`. The Durable Object log matched the reordered post-await sequence. That is why the fix preserves ordering around that exact async boundary.

## Commit split

This is intentionally split into two commits:

1. `Add RPC ordering regression coverage`
   - Adds failing coverage for the vitest-pool RPC ordering bug.
   - Exercises direct test-code calls, prewarmed Durable Object instances, WorkerEntrypoint callers, and Durable Object callers.
   - Adds a Vite plugin dev-runner playground comparison test, which currently passes and documents that the similar Vite wrapper path does not reproduce this issue.

2. `Preserve wrapped RPC invocation order`
   - Adds the per-wrapper-instance invocation-start queue in `vitest-pool-workers`.
   - Adds the patch changeset for `@cloudflare/vitest-pool-workers`.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this fixes local test/dev wrapper ordering behavior and does not change public APIs or documented configuration.

*No picture this time; the repro was enough wildlife.*

Made with [Cursor](https://cursor.com)