### PR TITLE
[wrangler] Fix stream schema export workflow and R2 SQL auth docs URL

### DIFF
--- a/.changeset/r2-sql-auth-docs-url.md
+++ b/.changeset/r2-sql-auth-docs-url.md
@@ -2,6 +2,6 @@
 "wrangler": patch
 ---
 
-fix: Update R2 SQL error messages to link to correct authentication docs
+Update R2 SQL error messages to link to correct authentication docs
 
 The error messages shown when `WRANGLER_R2_SQL_AUTH_TOKEN` is missing or when a 403 is returned now link to the correct documentation page at `https://developers.cloudflare.com/r2-sql/query-data/#authentication`, which contains step-by-step token creation instructions. The previous URL pointed to a troubleshooting page that did not cover token creation.

--- a/.changeset/r2-sql-auth-docs-url.md
+++ b/.changeset/r2-sql-auth-docs-url.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Update R2 SQL error messages to link to correct authentication docs
+
+The error messages shown when `WRANGLER_R2_SQL_AUTH_TOKEN` is missing or when a 403 is returned now link to the correct documentation page at `https://developers.cloudflare.com/r2-sql/query-data/#authentication`, which contains step-by-step token creation instructions. The previous URL pointed to a troubleshooting page that did not cover token creation.

--- a/.changeset/stream-export-schema-flag.md
+++ b/.changeset/stream-export-schema-flag.md
@@ -1,0 +1,14 @@
+---
+"wrangler": minor
+---
+
+Add `--export-schema` flag to `pipelines streams get` command
+
+A new `--export-schema` flag on `wrangler pipelines streams get` outputs only the stream schema in a format directly compatible with `--schema-file` on `streams create`. This makes it easy to clone a stream's schema:
+
+```
+wrangler pipelines streams get <id> --export-schema > schema.json
+wrangler pipelines streams create new_stream --schema-file schema.json
+```
+
+For unstructured streams (no schema), a message is shown instead of empty output.

--- a/.changeset/stream-schema-export.md
+++ b/.changeset/stream-schema-export.md
@@ -1,0 +1,14 @@
+---
+"wrangler": patch
+---
+
+fix: Allow `streams create --schema-file` to accept full `streams get --json` output
+
+Previously, piping `wrangler pipelines streams get <id> --json` output into `--schema-file` for `streams create` would fail because the full stream JSON nests the schema under a `schema` key, while `--schema-file` only accepted `{ "fields": [...] }` at the top level.
+
+Now `--schema-file` accepts both formats: a direct schema object (`{ "fields": [...] }`) and the full stream JSON output from `streams get --json`. Additionally, a new `--export-schema` flag on `streams get` outputs only the schema portion, directly compatible with `--schema-file`:
+
+```
+wrangler pipelines streams get <id> --export-schema > schema.json
+wrangler pipelines streams create new_stream --schema-file schema.json
+```

--- a/.changeset/stream-schema-export.md
+++ b/.changeset/stream-schema-export.md
@@ -2,13 +2,8 @@
 "wrangler": patch
 ---
 
-fix: Allow `streams create --schema-file` to accept full `streams get --json` output
+Allow `streams create --schema-file` to accept full `streams get --json` output
 
 Previously, piping `wrangler pipelines streams get <id> --json` output into `--schema-file` for `streams create` would fail because the full stream JSON nests the schema under a `schema` key, while `--schema-file` only accepted `{ "fields": [...] }` at the top level.
 
-Now `--schema-file` accepts both formats: a direct schema object (`{ "fields": [...] }`) and the full stream JSON output from `streams get --json`. Additionally, a new `--export-schema` flag on `streams get` outputs only the schema portion, directly compatible with `--schema-file`:
-
-```
-wrangler pipelines streams get <id> --export-schema > schema.json
-wrangler pipelines streams create new_stream --schema-file schema.json
-```
+Now `--schema-file` accepts both formats: a direct schema object (`{ "fields": [...] }`) and the full stream JSON output from `streams get --json`.

--- a/packages/wrangler/src/__tests__/pipelines.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines.test.ts
@@ -1240,6 +1240,64 @@ describe("wrangler pipelines", () => {
 				└─┴─┴─┴─┘"
 			`);
 		});
+
+		it("should create stream using full stream JSON (from streams get --json) as schema file", async ({
+			expect,
+		}) => {
+			const schemaFile = "stream_export.json";
+			// This is the shape of the output from `wrangler pipelines streams get --json`
+			const fullStreamJson = {
+				id: "stream_456",
+				name: "existing_stream",
+				version: 1,
+				endpoint: "https://pipelines.cloudflare.com/stream_456",
+				format: { type: "json" },
+				schema: {
+					fields: [
+						{ name: "id", type: "string", required: true },
+						{
+							name: "timestamp",
+							type: "timestamp",
+							required: true,
+							unit: "millisecond",
+						},
+					],
+				},
+				http: { enabled: true, authentication: true },
+				worker_binding: { enabled: true },
+				created_at: "2024-01-01T00:00:00Z",
+				modified_at: "2024-01-01T00:00:00Z",
+			};
+			writeFileSync(schemaFile, JSON.stringify(fullStreamJson));
+
+			const createRequest = mockCreateStreamRequest(expect, {
+				name: "my_new_stream",
+				hasSchema: true,
+			});
+
+			await runWrangler(
+				`pipelines streams create my_new_stream --schema-file ${schemaFile}`
+			);
+
+			expect(createRequest.count).toBe(1);
+			expect(std.err).toMatchInlineSnapshot(`""`);
+			expect(std.out).toContain(
+				"Successfully created stream 'my_new_stream' with id 'stream_123'"
+			);
+		});
+
+		it("should error when schema file has no fields", async ({ expect }) => {
+			const schemaFile = "bad_schema.json";
+			writeFileSync(schemaFile, JSON.stringify({ something: "else" }));
+
+			await expect(
+				runWrangler(
+					`pipelines streams create my_stream --schema-file ${schemaFile}`
+				)
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Schema file must contain a 'fields' array, or be the JSON output of \`wrangler pipelines streams get --json\`]`
+			);
+		});
 	});
 
 	describe("pipelines streams list", () => {
@@ -1481,6 +1539,81 @@ describe("wrangler pipelines", () => {
 				  },
 				}
 			`);
+		});
+
+		it("should export schema with --export-schema for a structured stream", async ({
+			expect,
+		}) => {
+			const mockStream: Stream = {
+				id: "stream_123",
+				name: "my_stream",
+				version: 1,
+				endpoint: "https://pipelines.cloudflare.com/stream_123",
+				format: { type: "json" },
+				schema: {
+					fields: [
+						{ name: "id", type: "string", required: true },
+						{
+							name: "timestamp",
+							type: "timestamp",
+							required: true,
+							unit: "millisecond",
+						},
+					],
+				},
+				http: { enabled: true, authentication: true },
+				worker_binding: { enabled: true },
+				created_at: "2024-01-01T00:00:00Z",
+				modified_at: "2024-01-01T00:00:00Z",
+			};
+
+			mockGetStreamRequest("stream_123", mockStream);
+
+			await runWrangler("pipelines streams get stream_123 --export-schema");
+
+			expect(std.err).toMatchInlineSnapshot(`""`);
+			expect(JSON.parse(std.out)).toMatchInlineSnapshot(`
+				{
+				  "fields": [
+				    {
+				      "name": "id",
+				      "required": true,
+				      "type": "string",
+				    },
+				    {
+				      "name": "timestamp",
+				      "required": true,
+				      "type": "timestamp",
+				      "unit": "millisecond",
+				    },
+				  ],
+				}
+			`);
+		});
+
+		it("should show message for --export-schema on unstructured stream", async ({
+			expect,
+		}) => {
+			const mockStream: Stream = {
+				id: "stream_123",
+				name: "my_stream",
+				version: 1,
+				endpoint: "https://pipelines.cloudflare.com/stream_123",
+				format: { type: "json", unstructured: true },
+				schema: null,
+				http: { enabled: true, authentication: true },
+				worker_binding: { enabled: true },
+				created_at: "2024-01-01T00:00:00Z",
+				modified_at: "2024-01-01T00:00:00Z",
+			};
+
+			mockGetStreamRequest("stream_123", mockStream);
+
+			await runWrangler("pipelines streams get stream_123 --export-schema");
+
+			expect(std.out).toContain(
+				"This stream has no schema (unstructured JSON). There is no schema to export."
+			);
 		});
 	});
 

--- a/packages/wrangler/src/pipelines/cli/streams/create.ts
+++ b/packages/wrangler/src/pipelines/cli/streams/create.ts
@@ -68,10 +68,12 @@ export const pipelinesStreamsCreateCommand = createCommand({
 				);
 			}
 
+			let parsed: Record<string, unknown>;
 			try {
-				parsedSchema = parseJSON(schemaContent, args.schemaFile) as {
-					fields: SchemaField[];
-				};
+				parsed = parseJSON(schemaContent, args.schemaFile) as Record<
+					string,
+					unknown
+				>;
 			} catch (error) {
 				throw new UserError(
 					`Failed to parse schema file '${args.schemaFile}': ${error instanceof Error ? error.message : String(error)}`,
@@ -82,10 +84,25 @@ export const pipelinesStreamsCreateCommand = createCommand({
 				);
 			}
 
-			if (!parsedSchema || !Array.isArray(parsedSchema.fields)) {
-				throw new UserError("Schema file must contain a 'fields' array", {
-					telemetryMessage: "pipelines streams create invalid schema file",
-				});
+			// Accept both a direct schema object ({ fields: [...] }) and a full
+			// stream response from `streams get --json` (which nests the schema
+			// under a "schema" key).
+			if (
+				parsed &&
+				typeof parsed.schema === "object" &&
+				parsed.schema !== null &&
+				Array.isArray((parsed.schema as { fields?: unknown }).fields)
+			) {
+				parsedSchema = parsed.schema as { fields: SchemaField[] };
+			} else if (parsed && Array.isArray(parsed.fields)) {
+				parsedSchema = parsed as unknown as { fields: SchemaField[] };
+			} else {
+				throw new UserError(
+					"Schema file must contain a 'fields' array, or be the JSON output of `wrangler pipelines streams get --json`",
+					{
+						telemetryMessage: "pipelines streams create invalid schema file",
+					}
+				);
 			}
 
 			schema = parsedSchema;

--- a/packages/wrangler/src/pipelines/cli/streams/get.ts
+++ b/packages/wrangler/src/pipelines/cli/streams/get.ts
@@ -11,7 +11,7 @@ export const pipelinesStreamsGetCommand = createCommand({
 		status: "open beta",
 	},
 	behaviour: {
-		printBanner: (args) => !args.json,
+		printBanner: (args) => !args.json && !args.exportSchema,
 	},
 	positionalArgs: ["stream"],
 	args: {
@@ -25,11 +25,28 @@ export const pipelinesStreamsGetCommand = createCommand({
 			type: "boolean",
 			default: false,
 		},
+		"export-schema": {
+			describe:
+				"Output only the stream schema in a format compatible with --schema-file",
+			type: "boolean",
+			default: false,
+		},
 	},
 	async handler(args, { config }) {
 		await requireAuth(config);
 
 		const stream = await getStream(config, args.stream);
+
+		if (args.exportSchema) {
+			if (stream.schema) {
+				logger.json(stream.schema);
+			} else {
+				logger.log(
+					"This stream has no schema (unstructured JSON). There is no schema to export."
+				);
+			}
+			return;
+		}
 
 		if (args.json) {
 			logger.json(stream);

--- a/packages/wrangler/src/r2/sql.ts
+++ b/packages/wrangler/src/r2/sql.ts
@@ -99,9 +99,9 @@ export const r2SqlQueryCommand = createCommand({
 				throw new UserError(
 					"Missing WRANGLER_R2_SQL_AUTH_TOKEN environment variable. " +
 						"Tried to fallback to CLOUDFLARE_API_TOKEN, didn't find it either. " +
-						"Please follow instructions in https://developers.cloudflare.com/r2/sql/platform/troubleshooting/ to create a token. " +
+						"Please follow instructions in https://developers.cloudflare.com/r2-sql/query-data/#authentication to create a token. " +
 						"Once done, you can prefix the command with the variable definition like so: `WRANGLER_R2_SQL_AUTH_TOKEN=... wrangler r2 sql query ...`. " +
-						"There also other ways to provide the value of this variable, see https://developers.cloudflare.com/workers/wrangler/system-environment-variables/ for more details.",
+						"There are also other ways to provide the value of this variable, see https://developers.cloudflare.com/workers/wrangler/system-environment-variables/ for more details.",
 					{ telemetryMessage: "r2 sql query missing auth token" }
 				);
 			} else {
@@ -156,7 +156,7 @@ export const r2SqlQueryCommand = createCommand({
 		if (responseStatus === 403) {
 			logger.error(
 				"Please check that token in WRANGLER_R2_SQL_AUTH_TOKEN or CLOUDFLARE_API_TOKEN has the correct permissions. " +
-					"See https://developers.cloudflare.com/r2/sql/platform/troubleshooting/ for more details."
+					"See https://developers.cloudflare.com/r2-sql/query-data/#authentication for more details."
 			);
 		}
 


### PR DESCRIPTION
Fixes user-reported issues with Pipelines stream schema export and R2 SQL token docs.

**Stream schema export/import:**
- `--schema-file` now accepts both a direct schema (`{ "fields": [...] }`) and the full stream JSON output from `streams get --json`.
- Added `--export-schema` flag to `streams get` that outputs only the schema portion, directly compatible with `--schema-file`.

**R2 SQL auth docs URL:**
- Error messages for missing `WRANGLER_R2_SQL_AUTH_TOKEN` and 403 responses now link to `https://developers.cloudflare.com/r2-sql/query-data/#authentication` which has token creation instructions. The previous URL pointed to a troubleshooting page without that info.
- Fixed typo: "There also other ways" → "There are also other ways"

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: These changes fix CLI behavior and error messages to match existing docs. The `--export-schema` flag will be auto-documented by the wrangler commands docs generator.