### PR TITLE
containers: Make sure that dup'd image refernces in two different container applications do not conflict each other

### DIFF
--- a/.changeset/fair-cats-yell.md
+++ b/.changeset/fair-cats-yell.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/containers-shared": patch
+"wrangler": patch
+---
+
+Preserve sibling container image tags during local dev cleanup
+
+Wrangler now keeps other `cloudflare-dev` image tags from the same dev session when multiple containers share a Dockerfile. Previously, duplicate-image cleanup could remove earlier container tags if Docker BuildKit produced the same image ID for each build.

--- a/packages/containers-shared/src/utils.ts
+++ b/packages/containers-shared/src/utils.ts
@@ -396,12 +396,21 @@ export async function cleanupDuplicateImageTags(
 ): Promise<void> {
 	try {
 		const repoTags = await getImageRepoTags(dockerPath, imageTag);
-		// Remove all cloudflare-dev tags from previous sessions except the current one
+		const currentBuildId = getImageTag(imageTag);
+		// Remove all cloudflare-dev tags from previous sessions except the current dev session.
 		const tagsToRemove = repoTags.filter(
-			(tag) => tag !== imageTag && tag.startsWith("cloudflare-dev")
+			(tag) =>
+				tag.startsWith("cloudflare-dev") && getImageTag(tag) !== currentBuildId
 		);
 		if (tagsToRemove.length > 0) {
 			runDockerCmdWithOutput(dockerPath, ["rmi", ...tagsToRemove]);
 		}
 	} catch {}
+}
+
+function getImageTag(imageTag: string): string | undefined {
+	const tagSeparatorIndex = imageTag.lastIndexOf(":");
+	return tagSeparatorIndex === -1
+		? undefined
+		: imageTag.slice(tagSeparatorIndex + 1);
 }

--- a/packages/containers-shared/tests/utils.test.ts
+++ b/packages/containers-shared/tests/utils.test.ts
@@ -1,8 +1,11 @@
+import { execFileSync } from "node:child_process";
 import { beforeEach, describe, it, vi } from "vitest";
-import { checkExposedPorts } from "./../src/utils";
+import { checkExposedPorts, cleanupDuplicateImageTags } from "./../src/utils";
 import type { ContainerDevOptions } from "../src/types";
 
 let docketImageInspectResult = "0";
+
+vi.mock("node:child_process");
 
 vi.mock("../src/inspect", async (importOriginal) => {
 	const mod: object = await importOriginal();
@@ -19,6 +22,7 @@ const containerConfig = {
 describe("checkExposedPorts", () => {
 	beforeEach(() => {
 		docketImageInspectResult = "1";
+		vi.mocked(execFileSync).mockReset();
 	});
 
 	it("should not error when some ports are exported", async ({ expect }) => {
@@ -38,5 +42,52 @@ describe("checkExposedPorts", () => {
 				For additional information please see: https://developers.cloudflare.com/containers/local-dev/#exposing-ports.
 				]
 			`);
+	});
+});
+
+describe("cleanupDuplicateImageTags", () => {
+	beforeEach(() => {
+		docketImageInspectResult = "";
+		vi.mocked(execFileSync).mockReset();
+		vi.mocked(execFileSync).mockReturnValue("");
+	});
+
+	it("does not remove sibling container tags from the same dev session", async ({
+		expect,
+	}) => {
+		docketImageInspectResult = [
+			"cloudflare-dev/egresstestcontainer:build-123",
+			"cloudflare-dev/egresstest1container:build-123",
+		].join("\n");
+
+		await cleanupDuplicateImageTags(
+			"docker",
+			"cloudflare-dev/egresstest1container:build-123"
+		);
+
+		expect(execFileSync).not.toHaveBeenCalled();
+	});
+
+	it("removes stale cloudflare-dev tags from previous dev sessions", async ({
+		expect,
+	}) => {
+		docketImageInspectResult = [
+			"cloudflare-dev/egresstestcontainer:build-123",
+			"cloudflare-dev/egresstest1container:build-123",
+			"cloudflare-dev/egresstestcontainer:build-122",
+			"user/image:latest",
+		].join("\n");
+
+		await cleanupDuplicateImageTags(
+			"docker",
+			"cloudflare-dev/egresstest1container:build-123"
+		);
+
+		expect(execFileSync).toHaveBeenCalledOnce();
+		expect(execFileSync).toHaveBeenCalledWith(
+			"docker",
+			["rmi", "cloudflare-dev/egresstestcontainer:build-122"],
+			{ encoding: "utf8" }
+		);
 	});
 });

--- a/packages/wrangler/e2e/containers.dev.test.ts
+++ b/packages/wrangler/e2e/containers.dev.test.ts
@@ -341,6 +341,113 @@ for (const source of imageSource) {
 			}).toThrow();
 		});
 
+		it.runIf(source === "build")(
+			"preserves sibling image tags when containers share a Dockerfile",
+			async ({ expect }) => {
+				const dockerPath = getDockerPath();
+				const classNames = [
+					"E2ESharedDockerfileContainerA",
+					"E2ESharedDockerfileContainerB",
+				] as const;
+				const sharedBuildIdsBefore = getSharedContainerBuildIds(
+					dockerPath,
+					classNames
+				);
+
+				await helper.seed({
+					"wrangler.json": JSON.stringify({
+						...wranglerConfig,
+						containers: [
+							{
+								image: "./Dockerfile",
+								class_name: classNames[0],
+								name: `${workerName}-shared-container-a`,
+							},
+							{
+								image: "./Dockerfile",
+								class_name: classNames[1],
+								name: `${workerName}-shared-container-b`,
+							},
+						],
+						durable_objects: {
+							bindings: [
+								{
+									class_name: "E2EContainer",
+									name: "CONTAINER",
+								},
+								{
+									class_name: classNames[0],
+									name: "CONTAINER_A",
+								},
+								{
+									class_name: classNames[1],
+									name: "CONTAINER_B",
+								},
+							],
+						},
+						migrations: [
+							{
+								tag: "v1",
+								new_classes: ["E2EContainer", ...classNames],
+							},
+						],
+					}),
+					"src/index.ts": dedent`
+						import { DurableObject, WorkerEntrypoint } from "cloudflare:workers";
+
+						export class TestService extends WorkerEntrypoint {
+							async fetch(req: Request) {
+								return new Response("hello from worker");
+							}
+						}
+
+						export class E2EContainer extends DurableObject<Env> {
+							container: globalThis.Container;
+
+							constructor(ctx: DurableObjectState, env: Env) {
+								super(ctx, env);
+								this.container = ctx.container!;
+							}
+
+							async fetch(req: Request) {
+								const path = new URL(req.url).pathname;
+								switch (path) {
+									case "/status":
+										return new Response(JSON.stringify(this.container.running));
+
+									default:
+										return new Response("Hi from Container DO");
+								}
+							}
+						}
+
+						export class E2ESharedDockerfileContainerA extends E2EContainer {}
+						export class E2ESharedDockerfileContainerB extends E2EContainer {}
+
+						export default {
+							async fetch(request, env): Promise<Response> {
+								const id = env.CONTAINER.idFromName("container");
+								const stub = env.CONTAINER.get(id);
+								return stub.fetch(request);
+							},
+						} satisfies ExportedHandler<Env>;`,
+				});
+
+				const worker = helper.runLongLived("wrangler dev");
+				await worker.readUntil(/Container image\(s\) ready/, 30_000);
+
+				const sharedBuildIdsAfter = getSharedContainerBuildIds(
+					dockerPath,
+					classNames
+				);
+				const newSharedBuildIds = Array.from(sharedBuildIdsAfter).filter(
+					(buildId) => !sharedBuildIdsBefore.has(buildId)
+				);
+
+				expect(newSharedBuildIds).toHaveLength(1);
+			}
+		);
+
 		it("won't start the container service if no containers are present", async ({
 			expect,
 		}) => {
@@ -464,4 +571,33 @@ const getContainerIds = (class_name: string) => {
 		}
 	});
 	return ids.filter(Boolean);
+};
+
+const getSharedContainerBuildIds = (
+	dockerPath: string,
+	classNames: readonly string[]
+) => {
+	const [firstClassName, ...otherClassNames] = classNames;
+	if (firstClassName === undefined) {
+		return new Set<string>();
+	}
+
+	const sharedBuildIds = getContainerBuildIds(dockerPath, firstClassName);
+	for (const className of otherClassNames) {
+		const buildIds = getContainerBuildIds(dockerPath, className);
+		for (const buildId of sharedBuildIds) {
+			if (!buildIds.has(buildId)) {
+				sharedBuildIds.delete(buildId);
+			}
+		}
+	}
+	return sharedBuildIds;
+};
+
+const getContainerBuildIds = (dockerPath: string, className: string) => {
+	const output = execSync(
+		`${dockerPath} image ls cloudflare-dev/${className.toLowerCase()} --format "{{.Tag}}"`,
+		{ encoding: "utf8" }
+	);
+	return new Set(output.split("\n").filter((line) => line.trim()));
 };


### PR DESCRIPTION
There is this bug in wrangler dev with containers that when a user configures two container apps with the same image, the second application will work while the first one is just broken.

This commit fixes it by just using the build-id as the filtering parameter instead of the last imageTag.

Fixes https://github.com/cloudflare/containers/issues/211

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Existing feature
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->