### PR TITLE
fix(wrangler): warn when triggers.crons configured with --dispatch-namespace

### DIFF
--- a/.changeset/dispatch-namespace-crons-warning.md
+++ b/.changeset/dispatch-namespace-crons-warning.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Warn when `triggers.crons` are configured alongside `--dispatch-namespace`
+
+When deploying with `--dispatch-namespace`, cron triggers are not supported and were silently dropped. Wrangler now emits a warning in this situation so users are aware their cron configuration will be ignored.

--- a/packages/wrangler/src/__tests__/deploy/environments.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/environments.test.ts
@@ -257,7 +257,9 @@ describe("deploy", () => {
 			`);
 		});
 
-		it("should warn when crons are configured alongside --dispatch-namespace", async ({ expect }) => {
+		it("should warn when crons are configured alongside --dispatch-namespace", async ({
+			expect,
+		}) => {
 			writeWranglerConfig({
 				triggers: { crons: ["0 0 * * *"] },
 			});
@@ -284,7 +286,9 @@ describe("deploy", () => {
 			`);
 		});
 
-		it("should warn when --triggers flag is used alongside --dispatch-namespace", async ({ expect }) => {
+		it("should warn when --triggers flag is used alongside --dispatch-namespace", async ({
+			expect,
+		}) => {
 			writeWranglerConfig();
 			const scriptContent = `
       export default {

--- a/packages/wrangler/src/__tests__/deploy/environments.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/environments.test.ts
@@ -278,7 +278,29 @@ describe("deploy", () => {
 				"deploy --dispatch-namespace test-dispatch-namespace index.js"
 			);
 			expect(std.warn).toMatchInlineSnapshot(
-				`"[WARNING] Cron triggers are not supported with dispatch namespaces and will not be deployed."`
+				`"[WARNING] Cron triggers are not supported with --dispatch-namespace and will be ignored."`
+			);
+		});
+
+		it("should warn when --triggers flag is used alongside --dispatch-namespace", async ({ expect }) => {
+			const scriptContent = `
+      export default {
+				fetch() {
+					return new Response("Hello, World!");
+				}
+			}
+    `;
+			fs.writeFileSync("index.js", scriptContent);
+			mockUploadWorkerRequest({
+				expectedMainModule: "index.js",
+				expectedDispatchNamespace: "test-dispatch-namespace",
+			});
+
+			await runWrangler(
+				"deploy --dispatch-namespace test-dispatch-namespace --triggers '0 0 * * *' index.js"
+			);
+			expect(std.warn).toMatchInlineSnapshot(
+				`"[WARNING] Cron triggers are not supported with --dispatch-namespace and will be ignored."`
 			);
 		});
 	});

--- a/packages/wrangler/src/__tests__/deploy/environments.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/environments.test.ts
@@ -277,12 +277,15 @@ describe("deploy", () => {
 			await runWrangler(
 				"deploy --dispatch-namespace test-dispatch-namespace index.js"
 			);
-			expect(std.warn).toMatchInlineSnapshot(
-				`"[WARNING] Cron triggers are not supported with --dispatch-namespace and will be ignored."`
-			);
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mCron triggers are not supported with --dispatch-namespace and will be ignored.[0m
+
+				"
+			`);
 		});
 
 		it("should warn when --triggers flag is used alongside --dispatch-namespace", async ({ expect }) => {
+			writeWranglerConfig();
 			const scriptContent = `
       export default {
 				fetch() {
@@ -299,9 +302,11 @@ describe("deploy", () => {
 			await runWrangler(
 				"deploy --dispatch-namespace test-dispatch-namespace --triggers '0 0 * * *' index.js"
 			);
-			expect(std.warn).toMatchInlineSnapshot(
-				`"[WARNING] Cron triggers are not supported with --dispatch-namespace and will be ignored."`
-			);
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mCron triggers are not supported with --dispatch-namespace and will be ignored.[0m
+
+				"
+			`);
 		});
 	});
 	describe("[observability]", () => {

--- a/packages/wrangler/src/__tests__/deploy/environments.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/environments.test.ts
@@ -304,7 +304,7 @@ describe("deploy", () => {
 			});
 
 			await runWrangler(
-				"deploy --dispatch-namespace test-dispatch-namespace --triggers '0 0 * * *' index.js"
+				"deploy index.js --dispatch-namespace test-dispatch-namespace --triggers '0 0 * * *'"
 			);
 			expect(std.warn).toMatchInlineSnapshot(`
 				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mCron triggers are not supported with --dispatch-namespace and will be ignored.[0m

--- a/packages/wrangler/src/__tests__/deploy/environments.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/environments.test.ts
@@ -256,6 +256,31 @@ describe("deploy", () => {
 				Current Version ID: undefined"
 			`);
 		});
+
+		it("should warn when crons are configured alongside --dispatch-namespace", async ({ expect }) => {
+			writeWranglerConfig({
+				triggers: { crons: ["0 0 * * *"] },
+			});
+			const scriptContent = `
+      export default {
+				fetch() {
+					return new Response("Hello, World!");
+				}
+			}
+    `;
+			fs.writeFileSync("index.js", scriptContent);
+			mockUploadWorkerRequest({
+				expectedMainModule: "index.js",
+				expectedDispatchNamespace: "test-dispatch-namespace",
+			});
+
+			await runWrangler(
+				"deploy --dispatch-namespace test-dispatch-namespace index.js"
+			);
+			expect(std.warn).toMatchInlineSnapshot(
+				`"[WARNING] Cron triggers are not supported with dispatch namespaces and will not be deployed."`
+			);
+		});
 	});
 	describe("[observability]", () => {
 		it("should allow uploading workers with observability", async ({

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -1310,6 +1310,11 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 	// Early exit for WfP since it doesn't need the below code
 	if (props.dispatchNamespace !== undefined) {
+		if (props.triggers?.crons?.length) {
+			logger.warn(
+				"Cron triggers are not supported with dispatch namespaces and will not be deployed."
+			);
+		}
 		deployWfpUserWorker(props.dispatchNamespace, versionId);
 		return { versionId, workerTag };
 	}

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -1310,9 +1310,9 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 	// Early exit for WfP since it doesn't need the below code
 	if (props.dispatchNamespace !== undefined) {
-		if (props.triggers?.crons?.length) {
+		if (config.triggers?.crons?.length || props.triggers?.length) {
 			logger.warn(
-				"Cron triggers are not supported with dispatch namespaces and will not be deployed."
+				"Cron triggers are not supported with --dispatch-namespace and will be ignored."
 			);
 		}
 		deployWfpUserWorker(props.dispatchNamespace, versionId);


### PR DESCRIPTION
Fixes #13840.

When deploying with \`--dispatch-namespace\`, Wrangler returned early before calling \`triggersDeploy()\`, silently dropping any \`triggers.crons\` configuration. Users had no indication their cron triggers weren't being deployed.

## Changes

- Added warning when \`triggers.crons\` (wrangler.toml) or \`--triggers\` (CLI flags) are configured alongside \`--dispatch-namespace\`

---

- Tests
  - [x] Tests included/updated — added tests verifying the warning is emitted for both wrangler.toml crons and CLI \`--triggers\` flags alongside \`--dispatch-namespace\`
- Public documentation
  - [x] Documentation not necessary because: this is a warning message for an existing limitation; no new user-visible API or configuration surface changed.