### PR TITLE
fix(create-cloudflare): generate valid pnpm-workspace.yaml for pnpm 9/10

### DIFF
--- a/.changeset/create-cloudflare-pnpm-workspace-yaml.md
+++ b/.changeset/create-cloudflare-pnpm-workspace-yaml.md
@@ -1,0 +1,10 @@
+---
+"create-cloudflare": patch
+---
+
+Write `pnpm-workspace.yaml` before `pnpm install` to prevent `ERR_PNPM_IGNORED_BUILDS`
+
+pnpm 9+ blocks build scripts for packages like `esbuild`, `workerd`, and `sharp` by default
+unless they are explicitly allowed in `pnpm-workspace.yaml`. `create-cloudflare` now writes
+this file before running `pnpm install`, using `onlyBuiltDependencies` for pnpm 9.x and
+`allowBuilds` for pnpm 10+.

--- a/packages/create-cloudflare/src/helpers/__tests__/packages.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/packages.test.ts
@@ -1,7 +1,6 @@
 import { existsSync, writeFileSync } from "node:fs";
 import { writePnpmWorkspaceYaml } from "helpers/packages";
-import { beforeEach, describe, expect, test, vi } from "vitest";
-import whichPMRuns from "which-pm-runs";
+import { beforeEach, describe, test, vi } from "vitest";
 import { mockPackageManager } from "./mocks";
 
 vi.mock("node:fs");
@@ -14,26 +13,26 @@ describe("writePnpmWorkspaceYaml", () => {
 		vi.mocked(writeFileSync).mockImplementation(() => undefined);
 	});
 
-	test("does nothing for non-pnpm package managers", () => {
+	test("does nothing for non-pnpm package managers", ({ expect }) => {
 		mockPackageManager("npm");
 		writePnpmWorkspaceYaml("/some/project");
 		expect(writeFileSync).not.toHaveBeenCalled();
 	});
 
-	test("does nothing for pnpm < 9", () => {
+	test("does nothing for pnpm < 9", ({ expect }) => {
 		mockPackageManager("pnpm", "8.15.0");
 		writePnpmWorkspaceYaml("/some/project");
 		expect(writeFileSync).not.toHaveBeenCalled();
 	});
 
-	test("does nothing if pnpm-workspace.yaml already exists", () => {
+	test("does nothing if pnpm-workspace.yaml already exists", ({ expect }) => {
 		mockPackageManager("pnpm", "10.0.0");
 		vi.mocked(existsSync).mockReturnValue(true);
 		writePnpmWorkspaceYaml("/some/project");
 		expect(writeFileSync).not.toHaveBeenCalled();
 	});
 
-	test("writes onlyBuiltDependencies list for pnpm 9.x", () => {
+	test("writes onlyBuiltDependencies list for pnpm 9.x", ({ expect }) => {
 		mockPackageManager("pnpm", "9.5.0");
 		writePnpmWorkspaceYaml("/some/project");
 		expect(writeFileSync).toHaveBeenCalledOnce();
@@ -46,7 +45,7 @@ describe("writePnpmWorkspaceYaml", () => {
 		expect(written).not.toContain("allowBuilds:");
 	});
 
-	test("writes allowBuilds map with boolean values for pnpm 10+", () => {
+	test("writes allowBuilds map with boolean values for pnpm 10+", ({ expect }) => {
 		mockPackageManager("pnpm", "10.0.0");
 		writePnpmWorkspaceYaml("/some/project");
 		expect(writeFileSync).toHaveBeenCalledOnce();
@@ -61,7 +60,7 @@ describe("writePnpmWorkspaceYaml", () => {
 		expect(written).not.toContain("onlyBuiltDependencies:");
 	});
 
-	test("writes to the correct path", () => {
+	test("writes to the correct path", ({ expect }) => {
 		mockPackageManager("pnpm", "10.1.0");
 		writePnpmWorkspaceYaml("/my/project");
 		expect(writeFileSync).toHaveBeenCalledWith(

--- a/packages/create-cloudflare/src/helpers/__tests__/packages.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/packages.test.ts
@@ -1,0 +1,72 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { writePnpmWorkspaceYaml } from "helpers/packages";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import whichPMRuns from "which-pm-runs";
+import { mockPackageManager } from "./mocks";
+
+vi.mock("node:fs");
+vi.mock("which-pm-runs");
+
+describe("writePnpmWorkspaceYaml", () => {
+	beforeEach(() => {
+		mockPackageManager("npm");
+		vi.mocked(existsSync).mockReturnValue(false);
+		vi.mocked(writeFileSync).mockImplementation(() => undefined);
+	});
+
+	test("does nothing for non-pnpm package managers", () => {
+		mockPackageManager("npm");
+		writePnpmWorkspaceYaml("/some/project");
+		expect(writeFileSync).not.toHaveBeenCalled();
+	});
+
+	test("does nothing for pnpm < 9", () => {
+		mockPackageManager("pnpm", "8.15.0");
+		writePnpmWorkspaceYaml("/some/project");
+		expect(writeFileSync).not.toHaveBeenCalled();
+	});
+
+	test("does nothing if pnpm-workspace.yaml already exists", () => {
+		mockPackageManager("pnpm", "10.0.0");
+		vi.mocked(existsSync).mockReturnValue(true);
+		writePnpmWorkspaceYaml("/some/project");
+		expect(writeFileSync).not.toHaveBeenCalled();
+	});
+
+	test("writes onlyBuiltDependencies list for pnpm 9.x", () => {
+		mockPackageManager("pnpm", "9.5.0");
+		writePnpmWorkspaceYaml("/some/project");
+		expect(writeFileSync).toHaveBeenCalledOnce();
+		const written = vi.mocked(writeFileSync).mock.calls[0][1] as string;
+		expect(written).toContain("onlyBuiltDependencies:");
+		expect(written).toContain("- esbuild");
+		expect(written).toContain("- workerd");
+		expect(written).toContain("- sharp");
+		// Must not use YAML booleans (wrong for this format)
+		expect(written).not.toContain("allowBuilds:");
+	});
+
+	test("writes allowBuilds map with boolean values for pnpm 10+", () => {
+		mockPackageManager("pnpm", "10.0.0");
+		writePnpmWorkspaceYaml("/some/project");
+		expect(writeFileSync).toHaveBeenCalledOnce();
+		const written = vi.mocked(writeFileSync).mock.calls[0][1] as string;
+		expect(written).toContain("allowBuilds:");
+		expect(written).toContain("esbuild: true");
+		expect(written).toContain("workerd: true");
+		expect(written).toContain("sharp: true");
+		// Must not use quoted strings — pnpm 10 requires real YAML booleans
+		expect(written).not.toContain("esbuild: 'true'");
+		expect(written).not.toContain('esbuild: "true"');
+		expect(written).not.toContain("onlyBuiltDependencies:");
+	});
+
+	test("writes to the correct path", () => {
+		mockPackageManager("pnpm", "10.1.0");
+		writePnpmWorkspaceYaml("/my/project");
+		expect(writeFileSync).toHaveBeenCalledWith(
+			"/my/project/pnpm-workspace.yaml",
+			expect.any(String)
+		);
+	});
+});

--- a/packages/create-cloudflare/src/helpers/packageManagers.ts
+++ b/packages/create-cloudflare/src/helpers/packageManagers.ts
@@ -8,6 +8,7 @@ import {
 	testPackageManager,
 	testPackageManagerVersion,
 } from "../../e2e/helpers/constants";
+import { writePnpmWorkspaceYaml } from "./packages";
 import type { C3Context } from "types";
 
 /**
@@ -125,6 +126,10 @@ export const rectifyPmMismatch = async (ctx: C3Context) => {
 	const lockfilePath = nodePath.join(ctx.project.path, "package-lock.json");
 	if (existsSync(lockfilePath)) {
 		rmSync(lockfilePath);
+	}
+
+	if (npm === "pnpm") {
+		writePnpmWorkspaceYaml(ctx.project.path);
 	}
 
 	await runCommand([npm, "install"], {

--- a/packages/create-cloudflare/src/helpers/packages.ts
+++ b/packages/create-cloudflare/src/helpers/packages.ts
@@ -3,9 +3,61 @@ import nodePath from "node:path";
 import { brandColor, dim } from "@cloudflare/cli-shared-helpers/colors";
 import { runCommand } from "@cloudflare/cli-shared-helpers/command";
 import * as cliPackages from "@cloudflare/cli-shared-helpers/packages";
+import semver from "semver";
 import { fetch } from "undici";
+import { writeFile } from "./files";
 import { detectPackageManager } from "./packageManagers";
 import type { C3Context } from "types";
+
+const PNPM_BUILT_DEPENDENCIES = ["esbuild", "workerd", "sharp"];
+
+/**
+ * Writes a pnpm-workspace.yaml that allows build scripts for packages that
+ * require them. pnpm 10+ blocks all build scripts by default, causing
+ * ERR_PNPM_IGNORED_BUILDS during `pnpm install` without an explicit allow-list.
+ */
+export function writePnpmWorkspaceYaml(projectPath: string): void {
+	const { name, version } = detectPackageManager();
+	if (name !== "pnpm") {
+		return;
+	}
+
+	const workspaceYamlPath = nodePath.join(projectPath, "pnpm-workspace.yaml");
+	if (existsSync(workspaceYamlPath)) {
+		return;
+	}
+
+	let content: string;
+	if (semver.gte(version, "10.0.0")) {
+		// pnpm 10+: allowBuilds uses a map of package -> boolean
+		const entries = PNPM_BUILT_DEPENDENCIES.map((pkg) => `  ${pkg}: true`).join(
+			"\n"
+		);
+		content = [
+			"# Approve build scripts for packages that require them.",
+			"# See: https://pnpm.io/settings#allowbuilds",
+			"allowBuilds:",
+			entries,
+			"",
+		].join("\n");
+	} else if (semver.gte(version, "9.0.0")) {
+		// pnpm 9.x: onlyBuiltDependencies is a list
+		const entries = PNPM_BUILT_DEPENDENCIES.map((pkg) => `  - ${pkg}`).join(
+			"\n"
+		);
+		content = [
+			"# Approve build scripts for packages that require them.",
+			"# See: https://pnpm.io/package_json#pnpmonlybuiltdependencies",
+			"onlyBuiltDependencies:",
+			entries,
+			"",
+		].join("\n");
+	} else {
+		return;
+	}
+
+	writeFile(workspaceYamlPath, content);
+}
 
 type InstallConfig = {
 	startText?: string;
@@ -47,6 +99,8 @@ export const npmInstall = async (ctx: C3Context) => {
 	}
 
 	const { npm } = detectPackageManager();
+
+	writePnpmWorkspaceYaml(ctx.project.path);
 
 	await runCommand([npm, "install"], {
 		silent: true,


### PR DESCRIPTION
Fixes #13928.

`create-cloudflare` ran `pnpm install` without a `pnpm-workspace.yaml`. pnpm 10+ blocks build scripts by default, so installs failed with `ERR_PNPM_IGNORED_BUILDS` for packages like `esbuild`, `workerd`, and `sharp` that require build scripts.

## Changes

- `writePnpmWorkspaceYaml(projectPath)` is called before `pnpm install` in `npmInstall()`
- For pnpm 10+: writes `allowBuilds` with proper YAML boolean values (not quoted strings)
- For pnpm 9.x: writes `onlyBuiltDependencies` list
- Does nothing if the file already exists, the PM is not pnpm, or pnpm < 9

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: this is a fix for a scaffolding bug, no public API or user-facing CLI flags changed