### PR TITLE
[miniflare] Improve error diagnostics in the Browser Run binding worker

### DIFF
--- a/.changeset/improve-browser-run-binding-error-diagnostics.md
+++ b/.changeset/improve-browser-run-binding-error-diagnostics.md
@@ -1,0 +1,9 @@
+---
+"miniflare": patch
+---
+
+Improve error diagnostics in the Browser Run binding worker
+
+When the local Browser Run binding failed to reach an upstream — for example when Chrome failed to launch and miniflare's loopback `/browser/launch` endpoint returned a 500 with a stack-trace text body — the binding worker would call `response.json()` on the non-JSON body and throw an opaque `SyntaxError: Unexpected token X, "..." is not valid JSON`. The actual upstream error message (e.g. `Chrome readiness probe at ... timed out after 5000ms`) was discarded.
+
+The binding worker now reads the response body as text first, surfaces the HTTP status and body content in the thrown error, and chains the original `SyntaxError` via `cause` when the body was a 2xx response that didn't parse as JSON. This makes both local-dev failures and CI test flakes self-diagnosing.

--- a/packages/miniflare/src/workers/browser-rendering/binding.worker.ts
+++ b/packages/miniflare/src/workers/browser-rendering/binding.worker.ts
@@ -70,6 +70,46 @@ function isRetryableFetchError(error: unknown): boolean {
 	);
 }
 
+const MAX_BODY_PREVIEW = 2000;
+
+function truncateBody(text: string): string {
+	if (text.length <= MAX_BODY_PREVIEW) {
+		return text;
+	}
+	return `${text.slice(0, MAX_BODY_PREVIEW)}... (truncated, ${text.length} bytes total)`;
+}
+
+/**
+ * Read a JSON response with diagnostic error reporting.
+ *
+ * Standard `await resp.json()` produces opaque "Unexpected token X, ..."
+ * errors when an upstream returns non-JSON (e.g. a 500 with a stack-trace
+ * text body from the loopback `/browser/launch` handler when Chrome fails
+ * to start). This helper reads the body as text first, includes the status
+ * and (truncated) text in any thrown error, and chains the original
+ * `SyntaxError` via `cause` so the underlying parse failure is still
+ * inspectable.
+ */
+async function parseJsonResponse<T = unknown>(
+	resp: Response,
+	context: string
+): Promise<T> {
+	const text = await resp.text();
+	if (!resp.ok) {
+		throw new Error(
+			`${context}: upstream returned ${resp.status} ${resp.statusText}\n${truncateBody(text)}`
+		);
+	}
+	try {
+		return JSON.parse(text) as T;
+	} catch (cause) {
+		throw new Error(
+			`${context}: expected JSON, got non-JSON response (${resp.status} ${resp.statusText})\n${truncateBody(text)}`,
+			{ cause }
+		);
+	}
+}
+
 /**
  * Wrapper around `fetch` that retries on transient connection failures.
  *
@@ -445,11 +485,13 @@ class BrowserRenderingRouter extends Router {
 	}
 
 	async #acquireSession(): Promise<SessionInfo> {
-		const sessionInfo: SessionInfo = await this.env[
-			SharedBindings.MAYBE_SERVICE_LOOPBACK
-		]
-			.fetch("http://localhost/browser/launch")
-			.then((r) => r.json());
+		const resp = await this.env[SharedBindings.MAYBE_SERVICE_LOOPBACK].fetch(
+			"http://localhost/browser/launch"
+		);
+		const sessionInfo = await parseJsonResponse<SessionInfo>(
+			resp,
+			"Failed to launch local browser via miniflare loopback (/browser/launch)"
+		);
 		await this.#fetchSession(sessionInfo.sessionId, "/session-info", {
 			method: "POST",
 			body: JSON.stringify(sessionInfo),
@@ -458,9 +500,13 @@ class BrowserRenderingRouter extends Router {
 	}
 
 	async #getActiveSessions() {
-		const sessionIds = (await this.env[SharedBindings.MAYBE_SERVICE_LOOPBACK]
-			.fetch("http://localhost/browser/sessionIds")
-			.then((r) => r.json())) as string[];
+		const sessionIdsResp = await this.env[
+			SharedBindings.MAYBE_SERVICE_LOOPBACK
+		].fetch("http://localhost/browser/sessionIds");
+		const sessionIds = await parseJsonResponse<string[]>(
+			sessionIdsResp,
+			"Failed to list active browser sessions via miniflare loopback (/browser/sessionIds)"
+		);
 
 		const sessions = await Promise.all(
 			sessionIds.map(async (sessionId) => {
@@ -468,7 +514,10 @@ class BrowserRenderingRouter extends Router {
 				if (resp.status === 204) {
 					return null;
 				}
-				const sessionInfo: SessionInfo = await resp.json();
+				const sessionInfo = await parseJsonResponse<SessionInfo>(
+					resp,
+					`Failed to read session-info for browser session ${sessionId}`
+				);
 				return {
 					sessionId: sessionInfo.sessionId,
 					startTime: sessionInfo.startTime,


### PR DESCRIPTION
_No specific issue — this is a developer-experience improvement motivated by a recurring CI flake in `Tests (Windows, packages-and-tools)` where the underlying error from the local Browser Run binding is hidden behind an opaque `SyntaxError`._

## What

When the local Browser Run binding fails to reach an upstream — for example when Chrome fails to launch and miniflare's loopback `/browser/launch` endpoint returns a 500 with a stack-trace text body — the binding worker calls `response.json()` on the non-JSON body and throws a cryptic:

```
SyntaxError: Unexpected token "I", "Internal "... is not valid JSON
    at JSON.parse (<anonymous>)
    at parseJSONFromBytes (node:internal/deps/undici/...)
```

The actual upstream error message (e.g. `Chrome readiness probe at ... timed out after 5000ms` from the recently-added `waitForBrowserReady` probe) is **discarded** by `.json()` before the SyntaxError is thrown. This makes both local-dev failures and CI flakes nearly impossible to diagnose from logs alone.

## How

Add a `parseJsonResponse<T>(resp, context)` helper to `binding.worker.ts` that:

1. Reads the response body as text.
2. If `!resp.ok`, throws `Error("${context}: upstream returned ${status} ${statusText}\n${truncatedBody}")`.
3. Otherwise tries `JSON.parse(text)`. If it throws, rethrows with the same shape plus the original `SyntaxError` chained via `cause`.
4. Truncates bodies to 2000 chars with a `... (truncated, N bytes total)` suffix to avoid overwhelming CI logs.

Wire it into the three loopback JSON-parsing sites in the binding worker:

- `BrowserRenderingRouter.#acquireSession()` — `/browser/launch` (the Chrome-failed-to-launch path).
- `BrowserRenderingRouter.#getActiveSessions()` — `/browser/sessionIds`.
- The same method's per-DO session-info read.

The internal `setSessionInfoRoute` `req.json()` (line 172) is left alone — input is always JSON from `#acquireSession()` itself.

## Test plan

- All 21 existing miniflare browser tests still pass locally on macOS: `pnpm -F miniflare test:ci test/plugins/browser/index.spec.ts` ✅
- `pnpm -F miniflare check:type` ✅
- `pnpm check:lint` ✅
- `pnpm check:format` ✅
- `validate-changesets.ts` ✅

No new tests added — the helper is exercised by the existing passing tests on the happy path, and the failure path only matters when an upstream is broken (which is the diagnostic case we're improving, not a behavior we want to assert).

## What this looks like after the next CI flake

Before:
```
SyntaxError: Unexpected token "I", "Internal "... is not valid JSON
    at JSON.parse (<anonymous>)
    at parseJSONFromBytes (...)
```

After:
```
Failed to launch local browser via miniflare loopback (/browser/launch): upstream returned 500 Internal Server Error
Error: Chrome readiness probe at http://127.0.0.1:53198/json/version timed out after 5000ms
    at waitForBrowserReady (.../packages/miniflare/src/plugins/browser-rendering/index.ts:286:8)
    ...
```

…which immediately tells us whether bumping `waitForBrowserReady`'s 5s timeout is the right next fix, or whether something else is going on.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this is a pure-diagnostic change. The new helper has no behavioural effect on the happy path (all 21 existing browser-binding tests still pass), and the failure path it improves only fires when an upstream is broken — there's no stable error response to assert against, just the format of the rethrown error.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal diagnostic improvement to miniflare's embedded browser-binding worker. No public API or user-facing string changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->