### PR TITLE
[wrangler] Fix broken runInTempDir import in unstable-get-miniflare-worker-options test

### DIFF
--- a/packages/wrangler/src/__tests__/unstable-get-miniflare-worker-options.test.ts
+++ b/packages/wrangler/src/__tests__/unstable-get-miniflare-worker-options.test.ts
@@ -1,7 +1,9 @@
-import { writeWranglerConfig } from "@cloudflare/workers-utils/test-helpers";
+import {
+	runInTempDir,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
 import { describe, it } from "vitest";
 import { unstable_getMiniflareWorkerOptions } from "../api";
-import { runInTempDir } from "./helpers/run-in-tmp";
 
 describe("unstable_getMiniflareWorkerOptions", () => {
 	runInTempDir();


### PR DESCRIPTION
<!-- No tracked issue; this fixes a regression on `main`. -->

#13919 added `packages/wrangler/src/__tests__/unstable-get-miniflare-worker-options.test.ts` with `import { runInTempDir } from "./helpers/run-in-tmp"`. After it was rebased, #13954's helper refactor (`12e491e6e`) had already deleted that file and moved `runInTempDir` to `@cloudflare/workers-utils/test-helpers`, leaving an import on `main` that points at a non-existent module.

This PR updates the import to use `@cloudflare/workers-utils/test-helpers` like the rest of the wrangler test suite.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this PR _is_ the fix to the broken test import; running the affected test file under vitest verifies it.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: test-only fix, no user-facing behaviour change.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->