### PR TITLE
Bump ws to 8.20.1 to address GHSA-58qx-3vcg-4xpx

### DIFF
--- a/.changeset/bump-ws-8-20-1.md
+++ b/.changeset/bump-ws-8-20-1.md
@@ -1,0 +1,9 @@
+---
+"miniflare": patch
+"wrangler": patch
+"@cloudflare/vite-plugin": patch
+---
+
+Bump `ws` from 8.18.0 to 8.20.1 to address GHSA-58qx-3vcg-4xpx
+
+[GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx) / [CVE-2026-45736](https://www.cve.org/CVERecord?id=CVE-2026-45736) reports an uninitialized-memory disclosure in `ws@<8.20.1` when a `TypedArray` is passed as the reason argument to `WebSocket.close()`. The fix shipped in [ws@8.20.1](https://github.com/websockets/ws/commit/c0327ec15a54d701eb6ccefaa8bef328cfc03086) on 2026-05-12. This change bumps the workspace catalog entry so that `miniflare`, `wrangler`, and `@cloudflare/vite-plugin` all pick up the patched release.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ catalogs:
       specifier: 4.1.0
       version: 4.1.0
     ws:
-      specifier: 8.18.0
-      version: 8.18.0
+      specifier: 8.20.1
+      version: 8.20.1
 
 overrides:
   '@types/react-dom@18>@types/react': ^18
@@ -2017,7 +2017,7 @@ importers:
         version: 1.20260519.1
       ws:
         specifier: catalog:default
-        version: 8.18.0
+        version: 8.20.1
       youch:
         specifier: 4.1.0-beta.10
         version: 4.1.0-beta.10(patch_hash=3e73fc48581841f22ea1d2cf5a3560bde280fdba04940253073fb121a70a9269)
@@ -2364,7 +2364,7 @@ importers:
         version: link:../wrangler
       ws:
         specifier: catalog:default
-        version: 8.18.0
+        version: 8.20.1
     devDependencies:
       '@cloudflare/containers-shared':
         specifier: workspace:*
@@ -4215,7 +4215,7 @@ importers:
         version: 0.4.0(vitest@4.1.0)
       ws:
         specifier: catalog:default
-        version: 8.18.0
+        version: 8.20.1
       xxhash-wasm:
         specifier: ^1.0.1
         version: 1.0.1
@@ -14946,6 +14946,18 @@ packages:
 
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -26567,6 +26579,8 @@ snapshots:
       signal-exit: 4.1.0
 
   ws@8.18.0: {}
+
+  ws@8.20.1: {}
 
   wsl-utils@0.3.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -94,7 +94,7 @@ catalog:
   undici-types: "7.24.8"
   vitest: "4.1.0"
   vite: "^8.0.12"
-  "ws": "8.18.0"
+  "ws": "8.20.1"
   esbuild: "0.27.3"
   playwright-chromium: "^1.56.1"
   "@cloudflare/workers-types": "^4.20260519.1"


### PR DESCRIPTION
_Describe your change..._

Bumps the workspace catalog entry for [`ws`](https://github.com/websockets/ws) from `8.18.0` to `8.20.1` so that `miniflare`, `wrangler`, and `@cloudflare/vite-plugin` (the three workspace packages that consume `ws` via `catalog:default`) pick up the patched release for [GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx) / [CVE-2026-45736](https://www.cve.org/CVERecord?id=CVE-2026-45736).

The vulnerability is an uninitialized-memory disclosure in `WebSocket.close()` when a `TypedArray` is passed as the `reason` argument. The fix shipped upstream in [`ws@8.20.1` (commit `c0327ec`)](https://github.com/websockets/ws/commit/c0327ec15a54d701eb6ccefaa8bef328cfc03086) on 2026-05-12; this PR is the downstream propagation.

### Diff summary

- `pnpm-workspace.yaml`: catalog `ws: 8.18.0` → `8.20.1` (one line).
- `pnpm-lock.yaml`: regenerated via `pnpm install`.
- `.changeset/bump-ws-8-20-1.md`: patch changeset for `miniflare`, `wrangler`, `@cloudflare/vite-plugin`.

### Out of scope (separate upstreams)

The lockfile still resolves `ws@8.18.0` from two transitive paths that pin it directly rather than via the catalog:

- [`@cloudflare/puppeteer@1.0.4`](https://www.npmjs.com/package/@cloudflare/puppeteer) declares `ws@8.18.0` in its own published `package.json`.
- An older `miniflare@4.20260317.1` is pulled in via `node_modules/.pnpm/...` for some dev-dep path.

Both would need their own bumps in their respective repositories to fully clear the audit warning, and are outside the scope of a catalog change.

### Verification

- `pnpm install --filter "miniflare..."` produces a clean lockfile diff (only `ws` entries change).
- `pnpm run build --filter miniflare` succeeds (6/6 tasks, types bundled with 0 errors / 0 warnings).
- `pnpm test:ci --filter miniflare`: 787 tests pass; 20 failures all in `test/plugins/browser/index.spec.ts` (an `undici` JSON-parse failure in browser-rendering tests) — confirmed pre-existing on `main` at the same commit without this change, so unrelated to the bump.
- [`ws@8.20.1` release notes](https://github.com/websockets/ws/releases/tag/8.20.1) confirm the change is security-only with no breaking changes or behavior differences.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this is a dependency-only patch bump (`ws@8.18.0` → `8.20.1`); the patched release's notes confirm security-fix only with no API or behavior change, and the existing miniflare test suite (787 unrelated passes) covers the WebSocket surface.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: no user-facing behavior change; bump is transparent to consumers.

*A picture of a cute animal (not mandatory, but encouraged)*

🦊
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->