### PR TITLE
[wrangler] fix: warn when named env silently inherits custom_domain routes

### DIFF
--- a/.changeset/warn-custom-domain-route-inheritance.md
+++ b/.changeset/warn-custom-domain-route-inheritance.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix(wrangler): warn when a named environment silently inherits custom_domain routes from the top-level config
+
+When an `env.<name>` block does not override `routes`, it inherits the top-level `routes` array. If that array contains entries with `custom_domain: true`, every deploy to the named environment will silently reassign the custom domain away from the top-level Worker and towards the env Worker, causing routing drift. Wrangler now emits a warning in this situation and suggests adding `"routes": []` to the env block to prevent inheritance.

--- a/.changeset/warn-custom-domain-route-inheritance.md
+++ b/.changeset/warn-custom-domain-route-inheritance.md
@@ -2,6 +2,6 @@
 "wrangler": patch
 ---
 
-fix(wrangler): warn when a named environment silently inherits custom_domain routes from the top-level config
+Warn when a named environment silently inherits custom_domain routes from the top-level config
 
 When an `env.<name>` block does not override `routes`, it inherits the top-level `routes` array. If that array contains entries with `custom_domain: true`, every deploy to the named environment will silently reassign the custom domain away from the top-level Worker and towards the env Worker, causing routing drift. Wrangler now emits a warning in this situation and suggests adding `"routes": []` to the env block to prevent inheritance.

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -1156,7 +1156,7 @@ function validateRoutes(
 		if (customDomainRoutes && customDomainRoutes.length > 0) {
 			const customDomains = customDomainRoutes.map((r) => r.pattern).join(", ");
 			diagnostics.warnings.push(
-				`The "env.${envName}" environment inherits the top-level \`routes\` configuration, which includes the custom domain(s): ${customDomains}. Deploying this environment will reassign these custom domains away from the top-level Worker. Add \`"routes": []\` to "env.${envName}" to prevent inheritance.`
+				`The "env.${envName}" environment inherits the top-level \`routes\` configuration, which includes the custom domain(s): ${customDomains}. Deploying this environment will reassign these custom domains away from the top-level Worker. Add \`"routes": []\` to "env.${envName}" to prevent inheritance, or copy the route configuration from the top level to hide this warning.`
 			);
 		}
 	}

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -1132,7 +1132,7 @@ function validateRoutes(
 	diagnostics: Diagnostics,
 	topLevelEnv: Environment | undefined,
 	rawEnv: RawEnvironment,
-	envName = "top level"
+	envName?: string
 ): Config["routes"] {
 	const result = inheritable(
 		diagnostics,
@@ -1144,15 +1144,18 @@ function validateRoutes(
 	);
 
 	if (
-		envName !== "top level" &&
+		envName !== undefined &&
 		rawEnv.routes === undefined &&
 		topLevelEnv?.routes?.some(
 			(r) => typeof r === "object" && r !== null && r.custom_domain === true
 		)
 	) {
 		const customDomains = (topLevelEnv.routes ?? [])
-			.filter((r) => typeof r === "object" && r !== null && r.custom_domain)
-			.map((r) => (typeof r === "object" && r !== null && "pattern" in r ? r.pattern : String(r)))
+			.filter(
+				(r): r is { pattern: string; custom_domain?: boolean } =>
+					typeof r === "object" && r !== null && r.custom_domain === true
+			)
+			.map((r) => r.pattern)
 			.join(", ");
 		diagnostics.warnings.push(
 			`The "env.${envName}" environment inherits the top-level \`routes\` configuration, which includes the custom domain(s): ${customDomains}. Deploying this environment will reassign these custom domains away from the top-level Worker. Add \`"routes": []\` to "env.${envName}" to prevent inheritance.`
@@ -1472,7 +1475,12 @@ function normalizeAndValidateEnvironment(
 		undefined
 	);
 
-	const routes = validateRoutes(diagnostics, topLevelEnv, rawEnv, envName);
+	const routes = validateRoutes(
+		diagnostics,
+		topLevelEnv,
+		rawEnv,
+		topLevelEnv === undefined ? undefined : envName
+	);
 
 	const workers_dev = inheritable(
 		diagnostics,

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -1131,9 +1131,10 @@ function normalizeAndValidateRoute(
 function validateRoutes(
 	diagnostics: Diagnostics,
 	topLevelEnv: Environment | undefined,
-	rawEnv: RawEnvironment
+	rawEnv: RawEnvironment,
+	envName = "top level"
 ): Config["routes"] {
-	return inheritable(
+	const result = inheritable(
 		diagnostics,
 		topLevelEnv,
 		rawEnv,
@@ -1141,6 +1142,24 @@ function validateRoutes(
 		all(isRouteArray, isMutuallyExclusiveWith(rawEnv, "route")),
 		undefined
 	);
+
+	if (
+		envName !== "top level" &&
+		rawEnv.routes === undefined &&
+		topLevelEnv?.routes?.some(
+			(r) => typeof r === "object" && r !== null && r.custom_domain === true
+		)
+	) {
+		const customDomains = (topLevelEnv.routes ?? [])
+			.filter((r) => typeof r === "object" && r !== null && r.custom_domain)
+			.map((r) => (typeof r === "object" && r !== null && "pattern" in r ? r.pattern : String(r)))
+			.join(", ");
+		diagnostics.warnings.push(
+			`The "env.${envName}" environment inherits the top-level \`routes\` configuration, which includes the custom domain(s): ${customDomains}. Deploying this environment will reassign these custom domains away from the top-level Worker. Add \`"routes": []\` to "env.${envName}" to prevent inheritance.`
+		);
+	}
+
+	return result;
 }
 
 function normalizeAndValidatePlacement(
@@ -1453,7 +1472,7 @@ function normalizeAndValidateEnvironment(
 		undefined
 	);
 
-	const routes = validateRoutes(diagnostics, topLevelEnv, rawEnv);
+	const routes = validateRoutes(diagnostics, topLevelEnv, rawEnv, envName);
 
 	const workers_dev = inheritable(
 		diagnostics,

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -1145,22 +1145,20 @@ function validateRoutes(
 	);
 
 	if (
+		topLevelEnv !== undefined &&
 		envName !== undefined &&
-		rawEnv.routes === undefined &&
-		topLevelEnv?.routes?.some(
-			(r) => typeof r === "object" && r !== null && r.custom_domain === true
-		)
+		rawEnv.routes === undefined
 	) {
-		const customDomains = (topLevelEnv.routes ?? [])
-			.filter(
-				(r): r is CustomDomainRoute =>
-					typeof r === "object" && r !== null && r.custom_domain === true
-			)
-			.map((r) => r.pattern)
-			.join(", ");
-		diagnostics.warnings.push(
-			`The "env.${envName}" environment inherits the top-level \`routes\` configuration, which includes the custom domain(s): ${customDomains}. Deploying this environment will reassign these custom domains away from the top-level Worker. Add \`"routes": []\` to "env.${envName}" to prevent inheritance.`
+		const customDomainRoutes = topLevelEnv.routes?.filter(
+			(r): r is CustomDomainRoute =>
+				typeof r === "object" && r !== null && r.custom_domain === true
 		);
+		if (customDomainRoutes && customDomainRoutes.length > 0) {
+			const customDomains = customDomainRoutes.map((r) => r.pattern).join(", ");
+			diagnostics.warnings.push(
+				`The "env.${envName}" environment inherits the top-level \`routes\` configuration, which includes the custom domain(s): ${customDomains}. Deploying this environment will reassign these custom domains away from the top-level Worker. Add \`"routes": []\` to "env.${envName}" to prevent inheritance.`
+			);
+		}
 	}
 
 	return result;

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -42,6 +42,7 @@ import type {
 	Assets,
 	CacheOptions,
 	ContainerApp,
+	CustomDomainRoute,
 	DispatchNamespaceOutbound,
 	Environment,
 	Observability,
@@ -1152,7 +1153,7 @@ function validateRoutes(
 	) {
 		const customDomains = (topLevelEnv.routes ?? [])
 			.filter(
-				(r): r is { pattern: string; custom_domain?: boolean } =>
+				(r): r is CustomDomainRoute =>
 					typeof r === "object" && r !== null && r.custom_domain === true
 			)
 			.map((r) => r.pattern)

--- a/packages/wrangler/src/__tests__/config/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.test.ts
@@ -274,6 +274,7 @@ describe("readConfig() custom_domain inheritance warning", () => {
 		expect(std.warn).toContain(`api.example.com`);
 		expect(std.warn).toContain(`Add \`"routes": []\``);
 		expect(std.warn).toContain(`prevent`);
+		expect(std.warn).toContain(`copy the route configuration from the top level`);
 	});
 
 	it("should not warn when the env explicitly overrides routes", async ({

--- a/packages/wrangler/src/__tests__/config/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.test.ts
@@ -293,9 +293,7 @@ describe("readConfig() custom_domain inheritance warning", () => {
 		expect(std.warn).not.toContain("inherits the top-level `routes`");
 	});
 
-	it("should not warn for the top-level env itself", async ({
-		expect,
-	}) => {
+	it("should not warn for the top-level env itself", async ({ expect }) => {
 		writeWranglerConfig({
 			routes: [{ pattern: "api.example.com", custom_domain: true }],
 		});

--- a/packages/wrangler/src/__tests__/config/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.test.ts
@@ -248,3 +248,59 @@ compatibility_date = "2022-01-12"`;
 		expect(config.name).toBe("no-bom-test");
 	});
 });
+
+describe("readConfig() custom_domain inheritance warning", () => {
+	runInTempDir();
+	const std = mockConsoleMethods();
+
+	it("should warn when a named env inherits custom_domain routes from the top-level config", async ({
+		expect,
+	}) => {
+		writeWranglerConfig({
+			routes: [{ pattern: "api.example.com", custom_domain: true }],
+			env: {
+				staging: {
+					name: "my-worker-staging",
+					workers_dev: true,
+					// no `routes` override — will inherit top-level custom domain
+				},
+			},
+		});
+		readConfig({ config: "wrangler.toml", env: "staging" });
+		await endEventLoop();
+		expect(std.warn).toContain(
+			`"env.staging" environment inherits the top-level`
+		);
+		expect(std.warn).toContain(`api.example.com`);
+		expect(std.warn).toContain(`Add \`"routes": []\``);
+		expect(std.warn).toContain(`prevent`);
+	});
+
+	it("should not warn when the env explicitly overrides routes", async ({
+		expect,
+	}) => {
+		writeWranglerConfig({
+			routes: [{ pattern: "api.example.com", custom_domain: true }],
+			env: {
+				staging: {
+					name: "my-worker-staging",
+					routes: [],
+				},
+			},
+		});
+		readConfig({ config: "wrangler.toml", env: "staging" });
+		await endEventLoop();
+		expect(std.warn).not.toContain("inherits the top-level `routes`");
+	});
+
+	it("should not warn for the top-level env itself", async ({
+		expect,
+	}) => {
+		writeWranglerConfig({
+			routes: [{ pattern: "api.example.com", custom_domain: true }],
+		});
+		readConfig({ config: "wrangler.toml" });
+		await endEventLoop();
+		expect(std.warn).not.toContain("inherits the top-level `routes`");
+	});
+});

--- a/packages/wrangler/src/__tests__/config/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.test.ts
@@ -274,7 +274,9 @@ describe("readConfig() custom_domain inheritance warning", () => {
 		expect(std.warn).toContain(`api.example.com`);
 		expect(std.warn).toContain(`Add \`"routes": []\``);
 		expect(std.warn).toContain(`prevent`);
-		expect(std.warn).toContain(`copy the route configuration from the top level`);
+		expect(std.warn).toContain(
+			`copy the route configuration from the top level`
+		);
 	});
 
 	it("should not warn when the env explicitly overrides routes", async ({


### PR DESCRIPTION
Fixes #13925.

When an `env.<name>` block does not override `routes`, it inherits the top-level `routes` array. If that array contains entries with `custom_domain: true`, every deploy to the named environment silently reassigns the custom domain away from the top-level Worker, causing routing drift that is very hard to diagnose.

## Changes

- Modified `validateRoutes()` in `packages/workers-utils/src/config/validation.ts` to emit a warning when:
  - A named environment is active (not the top-level env)
  - The env block doesn't define its own `routes`
  - The inherited top-level `routes` contains at least one `{ custom_domain: true }` entry
- Warning message names the custom domain(s) and suggests adding `"routes": []` to the env block to prevent inheritance

## Example warning

```
▲ [WARNING] Processing wrangler.toml configuration:

    - "env.staging" environment configuration
      - The "env.staging" environment inherits the top-level `routes` configuration, which includes
        the custom domain(s): api.example.com. Deploying this environment will reassign these custom
        domains away from the top-level Worker. Add `"routes": []` to "env.staging" to prevent
        inheritance.
```

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: this is a warning for an existing undocumented footgun; no public API or CLI flags changed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->