### PR TITLE
[miniflare] Recover from corrupted @puppeteer/browsers cache in launchBrowser

### DIFF
--- a/.changeset/miniflare-recover-from-corrupted-chrome-cache.md
+++ b/.changeset/miniflare-recover-from-corrupted-chrome-cache.md
@@ -1,0 +1,11 @@
+---
+"miniflare": patch
+---
+
+Recover from corrupted `@puppeteer/browsers` cache when launching a Browser Run session
+
+When Miniflare's local Browser Run binding launches Chrome, it calls `@puppeteer/browsers`' `install()` to ensure the binary is present. If a previous `install()` was interrupted mid-extraction (test timeout, process kill, antivirus quarantine), the cache directory can be left partially populated — the folder exists but the executable inside it is missing. `install()` then throws `The browser folder (...) exists but the executable (...) is missing` on every subsequent call within the same process and the entire test session, breaking every later Browser Run operation until the cache is manually cleared.
+
+`launchBrowser` now catches that specific error, removes the corrupted cache directory, and retries `install()` once. If the corruption persists after cleanup, the original error is rethrown with a clearer message.
+
+This complements [#13971](https://github.com/cloudflare/workers-sdk/pull/13971), which surfaced the original error from inside the binding worker. With that diagnostic in place and this self-healing layer, the previously-intermittent "browser folder exists but executable missing" failure mode should no longer fail an entire CI run.

--- a/packages/miniflare/src/plugins/browser-rendering/index.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/index.ts
@@ -24,6 +24,7 @@ import {
 } from "../shared";
 import type { Log } from "../../shared";
 import type { Plugin, RemoteProxyConnectionString } from "../shared";
+import type { InstalledBrowser, InstallOptions } from "@puppeteer/browsers";
 
 const BrowserRenderingSchema = z.object({
 	binding: z.string(),
@@ -138,12 +139,12 @@ export async function launchBrowser({
 	const s = spinner();
 	let startedDownloading = false;
 
-	const { executablePath } = await install({
+	const installOptions = {
 		browser,
 		platform,
 		cacheDir: getGlobalWranglerCachePath(),
 		buildId: await resolveBuildId(browser, platform, browserVersion),
-		downloadProgressCallback: (downloadedBytes, totalBytes) => {
+		downloadProgressCallback: (downloadedBytes: number, totalBytes: number) => {
 			if (!startedDownloading) {
 				s.start(`Downloading browser...`);
 				startedDownloading = true;
@@ -151,7 +152,12 @@ export async function launchBrowser({
 			const progress = Math.round((downloadedBytes / totalBytes) * 100);
 			s.update(`Downloading browser... ${progress}%`);
 		},
-	});
+	};
+
+	const { executablePath } = await installWithCorruptedCacheRecovery(
+		installOptions,
+		log
+	);
 
 	if (startedDownloading) {
 		s.stop(`${brandColor("downloaded")} ${dim(`browser`)}`);
@@ -236,6 +242,57 @@ export async function launchBrowser({
 	await waitForBrowserReady(wsEndpoint, log);
 	const startTime = Date.now();
 	return { sessionId, browserProcess, startTime, wsEndpoint };
+}
+
+/**
+ * Regex matching the `@puppeteer/browsers` error thrown when its cache
+ * directory exists but the executable inside it is missing — typically
+ * because a previous `install()` was interrupted mid-extraction (test
+ * timeout, process kill) or because an external agent (Windows Defender,
+ * antivirus, disk cleanup) removed the executable from a previously-good
+ * install.
+ *
+ * @puppeteer/browsers source:
+ * https://github.com/puppeteer/puppeteer/blob/main/packages/browsers/src/install.ts
+ */
+const CORRUPTED_CACHE_ERROR_PATTERN =
+	/The browser folder \((.+?)\) exists but the executable .+? is missing/;
+
+/**
+ * Run `@puppeteer/browsers` `install()`, but if it fails with the
+ * "folder exists but executable is missing" error, clear the corrupted
+ * cache directory and retry once.
+ *
+ * Recovers from a known intermittent failure on CI runners (especially
+ * Windows) where the cache state can become partially populated and stay
+ * that way for the rest of the run, breaking every subsequent test until
+ * the runner is recycled.
+ */
+async function installWithCorruptedCacheRecovery(
+	installOptions: InstallOptions & { unpack?: true },
+	log: Log
+): Promise<InstalledBrowser> {
+	try {
+		return await install(installOptions);
+	} catch (e) {
+		const match = (e as Error)?.message?.match(CORRUPTED_CACHE_ERROR_PATTERN);
+		if (!match) {
+			throw e;
+		}
+		const corruptedPath = match[1];
+		log.warn(
+			`Detected corrupted Chrome cache at ${corruptedPath}; clearing and retrying install.`
+		);
+		try {
+			await removeDir(corruptedPath);
+		} catch (cleanupError) {
+			throw new Error(
+				`Failed to clear corrupted Chrome cache at ${corruptedPath} after detecting "${(e as Error).message}". Manual cleanup may be required.`,
+				{ cause: cleanupError }
+			);
+		}
+		return await install(installOptions);
+	}
 }
 
 /**

--- a/packages/miniflare/src/plugins/browser-rendering/index.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/index.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { brandColor } from "@cloudflare/cli-shared-helpers/colors";
+import { brandColor, dim, red } from "@cloudflare/cli-shared-helpers/colors";
 import { spinner } from "@cloudflare/cli-shared-helpers/interactive";
 import { removeDir } from "@cloudflare/workers-utils";
 import {
@@ -11,7 +11,6 @@ import {
 	launch,
 	resolveBuildId,
 } from "@puppeteer/browsers";
-import { dim } from "kleur/colors";
 import BROWSER_RENDERING_WORKER from "worker:browser-rendering/binding";
 import { z } from "zod";
 import { kVoid } from "../../runtime";
@@ -154,10 +153,18 @@ export async function launchBrowser({
 		},
 	};
 
-	const { executablePath } = await installWithCorruptedCacheRecovery(
-		installOptions,
-		log
-	);
+	let executablePath: string;
+	try {
+		({ executablePath } = await installWithCorruptedCacheRecovery(
+			installOptions,
+			log
+		));
+	} catch (e) {
+		if (startedDownloading) {
+			s.stop(`${red("failed")} ${dim(`browser download`)}`);
+		}
+		throw e;
+	}
 
 	if (startedDownloading) {
 		s.stop(`${brandColor("downloaded")} ${dim(`browser`)}`);
@@ -291,7 +298,14 @@ async function installWithCorruptedCacheRecovery(
 				{ cause: cleanupError }
 			);
 		}
-		return await install(installOptions);
+		try {
+			return await install(installOptions);
+		} catch (retryError) {
+			throw new Error(
+				`Chrome install failed after clearing corrupted cache at ${corruptedPath}: ${(retryError as Error).message}`,
+				{ cause: retryError }
+			);
+		}
 	}
 }
 


### PR DESCRIPTION
_No tracked issue; follow-up to [#13971](https://github.com/cloudflare/workers-sdk/pull/13971)._

## What

When Miniflare's local Browser Run binding launches Chrome, it calls `@puppeteer/browsers`' `install()` to ensure the binary is present. If a previous `install()` was interrupted mid-extraction (test timeout, process kill, antivirus quarantine), the cache directory can be left partially populated — the folder exists but the executable inside it is missing. `install()` then throws on every subsequent call within the same process for the rest of the test session:

```
Error: The browser folder (C:\Users\runneradmin\AppData\Local\xdg.cache\.wrangler\chrome\win64-126.0.6478.182) exists but the executable (...\chrome.exe) is missing
    at installUrl (...@puppeteer/browsers/src/install.ts:309:15)
    at install (...@puppeteer/browsers/src/install.ts:157:18)
    at launchBrowser (.../packages/miniflare/src/plugins/browser-rendering/index.ts:141:35)
```

This was visible on a previous CI run for #13971 ([job log](https://github.com/cloudflare/workers-sdk/actions/runs/26104552990/job/76764623218)) and recurs intermittently on Windows runners. With `retry: 3` configured on the affected tests, all four attempts hit the same corrupted state and all four fail.

## How

Wrap the `install()` call in `launchBrowser` with `installWithCorruptedCacheRecovery`, which:

1. Calls `install(options)`.
2. If it throws and the message matches `/The browser folder \((.+?)\) exists but the executable .+? is missing/`, captures the corrupted path.
3. Logs a warning, `removeDir`s the corrupted path, retries `install()` once.
4. If cleanup itself fails, rethrows with a clear message asking for manual intervention.
5. Any other install error rethrows unchanged.

The regex is matched against the literal error string from `@puppeteer/browsers@2.10.6/src/install.ts:309-311`. If `@puppeteer/browsers` ever rewords that error, this branch becomes a no-op (we'd rethrow the original error, just without recovery) — no risk of silently swallowing unrelated install failures.

## Test plan

- `pnpm -F miniflare check:type` ✅
- `pnpm check:lint` ✅
- `pnpm check:format` ✅
- `pnpm -F miniflare test:ci test/plugins/browser/index.spec.ts` ✅ — all 21 browser tests pass on the happy path
- **Manual recovery verification**: deleted the chrome executable from the local wrangler cache (`~/Library/Caches/.wrangler/chrome/mac_arm-126.0.6478.182/.../Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing`), then ran `pnpm -F miniflare test:ci test/plugins/browser/index.spec.ts -t "it creates a browser session"`. The test passed — the install error was detected, the cache directory was cleared, and Chrome was re-downloaded on the retry.

## Why no new tests

The recovery path is only hit when an external system (filesystem state, antivirus, OS) puts the cache into an invalid state. Writing a unit test that synthetically corrupts the cache would either (a) duplicate the @puppeteer/browsers state machine in mock code, or (b) actually invoke the real `install()` against a real cache, which makes it slow and flaky. The manual verification above exercises the real flow against a real corrupted cache, which is what we care about.

---

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: deleted the chrome executable from the local wrangler cache, ran `pnpm -F miniflare test:ci test/plugins/browser/index.spec.ts -t "it creates a browser session"`, confirmed the install error was detected, the cache directory was cleared, and Chrome was re-downloaded. See "Test plan" above.
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal recovery for a Miniflare-internal `@puppeteer/browsers` cache failure mode. No public API or user-facing behaviour change beyond a more helpful warning log when the recovery fires.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->