### PR TITLE
[ci] Cache Chrome binary across CI runs for Browser Run tests

### DIFF
--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -152,11 +152,12 @@ jobs:
         if: steps.changes.outputs.everything_but_markdown == 'true' && (matrix.suite == 'packages-and-tools' || (matrix.suite == 'fixtures' && matrix.os != 'ubuntu-latest'))
         uses: actions/cache@v4
         with:
-          # The Chrome version is hardcoded in `packages/miniflare/src/index.ts`
-          # (search for `browserVersion:`). Bump this key when that version
-          # changes — a cache miss only triggers a fresh download, no
+          # The Chrome version lives in
+          # `packages/miniflare/src/plugins/browser-rendering/browser-version.ts`.
+          # Bumping that constant invalidates this cache automatically via
+          # `hashFiles()` — a cache miss only triggers a fresh download, no
           # functional impact.
-          key: chrome-${{ runner.os }}-126.0.6478.182
+          key: chrome-${{ runner.os }}-${{ hashFiles('packages/miniflare/src/plugins/browser-rendering/browser-version.ts') }}
           path: |
             ~/.cache/.wrangler/chrome
             ~/Library/Caches/.wrangler/chrome

--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -136,6 +136,32 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
+      # Browser Run tests in `packages/miniflare/test/plugins/browser/index.spec.ts`
+      # and the `fixtures/browser-run` fixture use `@puppeteer/browsers` to
+      # download Chrome into the global Wrangler cache. Caching that binary
+      # across CI runs avoids ~150 MB of repeat downloads per run and reduces
+      # the surface area for the intermittent partial-extraction race that
+      # surfaces as `The browser folder (...) exists but the executable (...)
+      # is missing` (see #13971, #13980).
+      #
+      # The Browser Run fixture is skipped on Ubuntu (AppArmor), but the
+      # miniflare browser spec runs everywhere, so the cache is needed on all
+      # three OSes for `packages-and-tools` and on Windows + macOS for
+      # `fixtures`.
+      - name: Restore Chrome browser cache (Browser Run)
+        if: steps.changes.outputs.everything_but_markdown == 'true' && (matrix.suite == 'packages-and-tools' || (matrix.suite == 'fixtures' && matrix.os != 'ubuntu-latest'))
+        uses: actions/cache@v4
+        with:
+          # The Chrome version is hardcoded in `packages/miniflare/src/index.ts`
+          # (search for `browserVersion:`). Bump this key when that version
+          # changes — a cache miss only triggers a fresh download, no
+          # functional impact.
+          key: chrome-${{ runner.os }}-126.0.6478.182
+          path: |
+            ~/.cache/.wrangler/chrome
+            ~/Library/Caches/.wrangler/chrome
+            ~/AppData/Local/xdg.cache/.wrangler/chrome
+
       - name: Run tests (tools only)
         # tools _only_ needs to be tested on Linux because they're only intended to run in CI
         if: steps.changes.outputs.everything_but_markdown == 'true' && matrix.suite == 'packages-and-tools' && matrix.os == 'ubuntu-latest'

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -63,6 +63,7 @@ import {
 	WORKFLOWS_PLUGIN_NAME,
 } from "./plugins";
 import { RPC_PROXY_SERVICE_NAME } from "./plugins/assets/constants";
+import { BROWSER_VERSION } from "./plugins/browser-rendering/browser-version";
 import {
 	CUSTOM_SERVICE_KNOWN_OUTBOUND,
 	CustomServiceKind,
@@ -1550,13 +1551,7 @@ export class Miniflare {
 				);
 				const { sessionId, browserProcess, startTime, wsEndpoint } =
 					await launchBrowser({
-						// Puppeteer v22.13.1 supported chrome version:
-						// https://pptr.dev/supported-browsers#supported-browser-version-list
-						//
-						// It should match the supported chrome version for the upstream puppeteer
-						// version from which @cloudflare/puppeteer branched off, which is specified in:
-						// https://github.com/cloudflare/puppeteer/?tab=readme-ov-file#workers-version-of-puppeteer-core
-						browserVersion: "126.0.6478.182",
+						browserVersion: BROWSER_VERSION,
 						log: this.#log,
 						tmpPath: this.#tmpPath,
 						headful,

--- a/packages/miniflare/src/plugins/browser-rendering/browser-version.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/browser-version.ts
@@ -1,0 +1,14 @@
+/**
+ * The Chrome browser version downloaded by Miniflare's Browser Run binding.
+ *
+ * Puppeteer v22.13.1 supported chrome version:
+ * https://pptr.dev/supported-browsers#supported-browser-version-list
+ *
+ * It should match the supported chrome version for the upstream puppeteer
+ * version from which @cloudflare/puppeteer branched off, which is specified in:
+ * https://github.com/cloudflare/puppeteer/?tab=readme-ov-file#workers-version-of-puppeteer-core
+ *
+ * Bumping this value also invalidates the Chrome binary cache in
+ * `.github/workflows/test-and-check.yml` (which uses `hashFiles()` on this file).
+ */
+export const BROWSER_VERSION = "126.0.6478.182";


### PR DESCRIPTION
_No tracked issue; follow-up to [#13971](https://github.com/cloudflare/workers-sdk/pull/13971) and [#13980](https://github.com/cloudflare/workers-sdk/pull/13980)._

## What

Browser Run tests in `packages/miniflare/test/plugins/browser/index.spec.ts` and the `fixtures/browser-run` fixture call into `@puppeteer/browsers` to ensure Chrome is downloaded into the global Wrangler cache. Every CI run currently re-downloads ~150 MB of Chrome from scratch because the cache directory is per-runner-instance and not shared between runs.

Cache it across runs.

## How

Add an `actions/cache@v4` step keyed on the OS plus the Chrome version hardcoded in `packages/miniflare/src/index.ts` (`126.0.6478.182`), restoring/saving:

- `~/.cache/.wrangler/chrome` (Linux)
- `~/Library/Caches/.wrangler/chrome` (macOS)
- `~/AppData/Local/xdg.cache/.wrangler/chrome` (Windows)

`actions/cache@v4` silently skips paths that don't exist for the current OS, so listing all three in a single step keeps the workflow flat.

The cache step runs for the `packages-and-tools` suite on all three OSes (miniflare browser spec runs everywhere) and for the `fixtures` suite on macOS + Windows (the Browser Run fixture is excluded on Ubuntu because of AppArmor — [pptr.dev/troubleshooting](https://pptr.dev/troubleshooting#issues-with-apparmor-on-ubuntu)).

## Why

Two benefits:

1. **Cuts ~150 MB of repeat downloads off cold CI runs** for affected matrix jobs. Browser Run tests on Windows currently spend a meaningful chunk of their wall-clock time just downloading Chrome.
2. **Reduces the attack surface for the intermittent partial-extraction race** that surfaces as `The browser folder (...) exists but the executable (...) is missing` ([diagnostic in #13971](https://github.com/cloudflare/workers-sdk/pull/13971), [in-process recovery in #13980](https://github.com/cloudflare/workers-sdk/pull/13980)). When the cache is warm and the binary is already fully extracted, `install()` short-circuits and the race can't fire at all.

These two PRs are complementary, not alternatives:

- #13980 (recovery) — repairs the cache when it gets corrupted, regardless of how it got that way.
- This PR (caching) — populates the cache from main on every run, so it doesn't have to be re-extracted from scratch.

## Maintenance note

The cache key has the Chrome version literally in it: `chrome-${{ runner.os }}-126.0.6478.182`. When that version is bumped in `packages/miniflare/src/index.ts`, this key needs a manual bump too. The cost of forgetting is just one extra download (the new version misses the cache, downloads, then populates the new key) — no functional impact, no broken tests. Avoiding `hashFiles('packages/miniflare/src/index.ts')` because that file is ~3,200 lines and changes for unrelated reasons constantly, which would defeat the cache.

## Test plan

- `pnpm check:format` ✅
- Will rely on this PR's own CI to confirm the cache step parses and runs.

The first run on this PR will be a cache miss (no key exists yet). The cache populates from this run. Subsequent runs on this branch — and any PRs branched off main after this lands — will be cache hits.

---

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: this is a CI workflow change. Validation will be visible on this PR's own CI run — the cache step will appear in the job logs with "Cache not found" on first run (expected), then populate on save.
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: CI-only workflow change with no user-facing or API surface.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->