### PR TITLE
[wrangler] Pin timeago.js to exact version 4.0.2

### DIFF
--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -153,7 +153,7 @@
 		"smol-toml": "catalog:default",
 		"source-map": "^0.6.1",
 		"supports-color": "^9.2.2",
-		"timeago.js": "^4.0.2",
+		"timeago.js": "4.0.2",
 		"tree-kill": "catalog:default",
 		"ts-dedent": "^2.2.0",
 		"ts-json-schema-generator": "^1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4184,7 +4184,7 @@ importers:
         specifier: ^9.2.2
         version: 9.2.2
       timeago.js:
-        specifier: ^4.0.2
+        specifier: 4.0.2
         version: 4.0.2
       tree-kill:
         specifier: catalog:default


### PR DESCRIPTION
Pin the `timeago.js` devDependency in `packages/wrangler/package.json` to the exact version `4.0.2`, removing the `^` range specifier. This hardens the build against future accidental dependency poisoning attacks via a malicious patch or minor release of this package.

`timeago.js` is bundled into the wrangler distributable at build time, so this change has no observable runtime impact for end users — the lockfile was already resolved to `4.0.2`. The pin simply prevents `pnpm install` from picking up a different `4.x` version in the future without an explicit, reviewed lockfile update.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this only narrows the accepted version range for a dev/build-time dependency. The lockfile already resolved to `4.0.2`, so the bundled output is unchanged. `pnpm check` passes locally.
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal dependency hygiene change with no user-facing behaviour change.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->