### PR TITLE
[wrangler][vite-plugin] Print QR code for tunnel URLs

### DIFF
--- a/.changeset/tunnel-qr-code.md
+++ b/.changeset/tunnel-qr-code.md
@@ -1,0 +1,10 @@
+---
+"wrangler": minor
+"@cloudflare/vite-plugin": minor
+---
+
+Print a QR code alongside the tunnel URL when sharing via Cloudflare Tunnel
+
+When a tunnel is started (via `wrangler dev --tunnel` or the Vite plugin with `tunnel: true`), a scannable QR code is now printed to the terminal beneath the tunnel URL. This makes it easy to open the tunnel on a mobile device without manually copying the URL.
+
+The QR code uses Unicode block characters for a compact representation and is generated best-effort -- if generation fails for any reason, the tunnel URL is still displayed as before.

--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -68,6 +68,7 @@
 		"mlly": "^1.7.4",
 		"open": "catalog:default",
 		"picocolors": "^1.1.1",
+		"qr": "^0.6.0",
 		"semver": "^7.7.1",
 		"tinyglobby": "catalog:default",
 		"tree-kill": "catalog:default",

--- a/packages/vite-plugin-cloudflare/src/plugins/tunnel.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/tunnel.ts
@@ -541,11 +541,14 @@ function patchPrintUrls(server: vite.ViteDevServer | vite.PreviewServer) {
 		}
 
 		// Print a QR code for the first tunnel URL so it can be scanned from a mobile device
-		try {
-			const qrCode = encodeQR(publicUrls[0], "ascii", { border: 1 });
-			server.config.logger.info(`\n${qrCode}`);
-		} catch {
-			// QR generation is best-effort; don't disrupt the dev session if it fails
+		const primaryUrl = publicUrls[0];
+		if (primaryUrl) {
+			try {
+				const qrCode = encodeQR(primaryUrl, "ascii", { border: 1 });
+				server.config.logger.info(`\n${qrCode}`);
+			} catch {
+				// QR generation is best-effort; don't disrupt the dev session if it fails
+			}
 		}
 
 		// Add an extra newline after the URLs to improve readability

--- a/packages/vite-plugin-cloudflare/src/plugins/tunnel.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/tunnel.ts
@@ -2,6 +2,7 @@ import { startTunnel } from "@cloudflare/workers-utils";
 import getPort from "get-port";
 import { buildPublicUrl } from "miniflare";
 import colors from "picocolors";
+import encodeQR from "qr";
 import * as wrangler from "wrangler";
 import { assertIsNotPreview, assertIsPreview } from "../context";
 import { debuglog, createPlugin } from "../utils";
@@ -537,6 +538,14 @@ function patchPrintUrls(server: vite.ViteDevServer | vite.PreviewServer) {
 					`              ${colors.cyan(publicUrls[i])}`
 				);
 			}
+		}
+
+		// Print a QR code for the first tunnel URL so it can be scanned from a mobile device
+		try {
+			const qrCode = encodeQR(publicUrls[0], "ascii", { border: 1 });
+			server.config.logger.info(`\n${qrCode}`);
+		} catch {
+			// QR generation is best-effort; don't disrupt the dev session if it fails
 		}
 
 		// Add an extra newline after the URLs to improve readability

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -145,6 +145,7 @@
 		"patch-console": "^1.0.0",
 		"pretty-bytes": "^6.0.0",
 		"prompts": "^2.4.2",
+		"qr": "^0.6.0",
 		"recast": "0.23.11",
 		"resolve": "^1.22.8",
 		"semiver": "^1.1.0",

--- a/packages/wrangler/src/tunnel/dev.ts
+++ b/packages/wrangler/src/tunnel/dev.ts
@@ -1,6 +1,7 @@
 import { dim } from "@cloudflare/cli-shared-helpers/colors";
 import { startTunnel } from "@cloudflare/workers-utils";
 import chalk from "chalk";
+import encodeQR from "qr";
 import { formatHostname } from "../dev/start-dev";
 import { logger } from "../logger";
 import { resolveNamedTunnel } from "./client";
@@ -159,11 +160,23 @@ export class TunnelManager {
 			logger.log(
 				`⬣ Sharing via Cloudflare Tunnel: ${chalk.green(publicUrls[0])}`
 			);
+			this.printQrCode(publicUrls[0]);
 		} else if (publicUrls.length > 1) {
 			logger.log(
 				"⬣ Sharing via Cloudflare Tunnel:\n" +
 					publicUrls.map((url) => `   ${chalk.green(url)}`).join("\n")
 			);
+			// Print a QR code for the first URL when multiple are available
+			this.printQrCode(publicUrls[0]);
+		}
+	}
+
+	private printQrCode(url: string): void {
+		try {
+			const qrCode = encodeQR(url, "ascii", { border: 1 });
+			logger.log(`\n${qrCode}`);
+		} catch {
+			// QR generation is best-effort; don't disrupt the dev session if it fails
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2414,6 +2414,9 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      qr:
+        specifier: ^0.6.0
+        version: 0.6.0
       semver:
         specifier: ^7.7.1
         version: 7.7.3
@@ -4159,6 +4162,9 @@ importers:
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
+      qr:
+        specifier: ^0.6.0
+        version: 0.6.0
       recast:
         specifier: 0.23.11
         version: 0.23.11
@@ -13172,6 +13178,10 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  qr@0.6.0:
+    resolution: {integrity: sha512-P23VoX7SipHALdiIYG+D+LT/6n22dNKwV92FAb3d+Nlki/5WisSsfLt0UDFz2XEBtuwrECTznvu+chKKFCSYhA==}
+    engines: {node: '>= 20.19.0'}
 
   qs@6.10.3:
     resolution: {integrity: sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==}
@@ -24297,6 +24307,8 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
+
+  qr@0.6.0: {}
 
   qs@6.10.3:
     dependencies:


### PR DESCRIPTION
Print a scannable QR code alongside the tunnel URL when sharing via Cloudflare Tunnel, making it easy to open the tunnel on a mobile device.

When a tunnel starts (via `wrangler dev --tunnel` or the Vite plugin with `tunnel: true`), a compact QR code is printed to the terminal using Unicode block characters. Generation is best-effort -- if it fails, the tunnel URL is still displayed as before.

Changes:
- `packages/wrangler/src/tunnel/dev.ts` -- new `printQrCode` method on `TunnelManager`
- `packages/vite-plugin-cloudflare/src/plugins/tunnel.ts` -- QR code in `patchPrintUrls`
- New dependency: `qr` (0-dep, MIT/Apache-2.0, bundled into both packages)

<img width="792" height="890" alt="image" src="https://github.com/user-attachments/assets/cec3387b-94cd-41b4-bab0-9ddde3bd5ce4" />

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: QR generation is wrapped in try/catch and is additive display-only behaviour; the `qr` library has its own extensive test suite
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this is a cosmetic enhancement to existing tunnel output with no new configuration options