### PR TITLE
[wrangler] Improve asset upload retry log message

### DIFF
--- a/.changeset/improve-asset-upload-retry-log.md
+++ b/.changeset/improve-asset-upload-retry-log.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Improve the log message shown when an asset upload attempt fails and is retried
+
+The retry message now reports which attempt is being made (e.g. `Asset upload failed. Retrying... 1 of 5 attempts.`), making it easier to gauge how close Wrangler is to exhausting its retry budget. The raw error object is no longer appended to this user-facing message; it is instead logged at debug level (visible via `WRANGLER_LOG=debug`).

--- a/packages/wrangler/src/__tests__/deploy/assets.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/assets.test.ts
@@ -1326,5 +1326,76 @@ describe("deploy", () => {
 				`[Error: An unexpected response has been received from the Cloudflare API for assets upload. Please try again.]`
 			);
 		});
+
+		it("should retry asset uploads on failure and log a retry message including the attempt count", async ({
+			expect,
+		}) => {
+			vi.stubEnv("WRANGLER_LOG", "debug");
+
+			const assets = [{ filePath: "file-1.txt", content: "Content of file-1" }];
+			writeAssets(assets);
+			writeWranglerConfig({
+				assets: { directory: "assets" },
+			});
+
+			const mockBuckets = [["0de3dd5df907418e9730fd2bd747bd5e"]];
+			await mockAUSRequest([], mockBuckets, "<<aus-token>>");
+
+			// Fail the first upload attempt, succeed on the second.
+			const uploadAttempts: Request[] = [];
+			msw.use(
+				http.post(
+					"*/accounts/some-account-id/workers/assets/upload",
+					async ({ request }) => {
+						uploadAttempts.push(request);
+						if (uploadAttempts.length === 1) {
+							return HttpResponse.json(
+								{
+									success: false,
+									errors: [{ code: 1, message: "upload-boom-from-test" }],
+									messages: [],
+									result: null,
+								},
+								{ status: 500 }
+							);
+						}
+						return HttpResponse.json(
+							{
+								success: true,
+								errors: [],
+								messages: [],
+								result: { jwt: "<<aus-completion-token>>" },
+							},
+							{ status: 201 }
+						);
+					}
+				)
+			);
+
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedAssets: {
+					jwt: "<<aus-completion-token>>",
+					config: {},
+				},
+				expectedType: "none",
+			});
+
+			await runWrangler("deploy");
+
+			// The upload endpoint was hit twice: once failing, once succeeding.
+			expect(uploadAttempts.length).toBe(2);
+
+			// The new info message includes the attempt count.
+			expect(std.info).toContain(
+				"Asset upload failed. Retrying... 1 of 5 attempts."
+			);
+
+			// The error details no longer leak into the user-facing info log.
+			expect(std.info).not.toContain("upload-boom-from-test");
+
+			// The error is now logged at debug level instead.
+			expect(std.debug).toContain("upload-boom-from-test");
+		});
 	});
 });

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -193,7 +193,12 @@ export const syncAssets = async (
 				return res;
 			} catch (e) {
 				if (attempts < MAX_UPLOAD_ATTEMPTS) {
-					logger.info(chalk.dim(`Asset upload failed. Retrying...\n`, e));
+					logger.info(
+						chalk.dim(
+							`Asset upload failed. Retrying... ${attempts + 1} of ${MAX_UPLOAD_ATTEMPTS} attempts.\n`
+						)
+					);
+					logger.debug(e);
 					// Exponential backoff, 1 second first time, then 2 second, then 4 second etc.
 					await new Promise((resolvePromise) =>
 						setTimeout(resolvePromise, Math.pow(2, attempts) * 1000)


### PR DESCRIPTION
Improve the log message Wrangler emits when an asset upload attempt fails and is retried.

The previous message just said `Asset upload failed. Retrying...` and appended the raw error object to the user-facing info log. That made the output noisy and gave no indication of how many attempts had been made.

This change:

- Includes the attempt count in the info log, e.g.:

  ```
  Asset upload failed. Retrying... 1 of 5 attempts.
  ```

- Routes the underlying error to `logger.debug(e)` instead of including it in the info log, so the user-facing output stays clean and the error is still available with `WRANGLER_LOG=debug`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is a small change to a developer-facing log line; it does not affect documented behavior.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->