### PR TITLE
Fix autoconfig generated Worker name

### DIFF
--- a/.changeset/fuzzy-maps-travel.md
+++ b/.changeset/fuzzy-maps-travel.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Ensure framework-generated `wrangler.jsonc` uses the autoconfig Worker name.

--- a/packages/wrangler/src/__tests__/autoconfig/run.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/run.test.ts
@@ -498,6 +498,53 @@ describe("autoconfig (deploy)", () => {
 			`);
 		});
 
+		it("updates framework-generated wrangler.jsonc with the Worker name", async ({
+			expect,
+		}) => {
+			mockConfirm({
+				text: "Do you want to modify these settings?",
+				result: false,
+			});
+			mockConfirm({
+				text: "Proceed with setup?",
+				result: true,
+			});
+
+			await run.runAutoConfig({
+				projectPath: process.cwd(),
+				configured: false,
+				framework: {
+					id: "static",
+					name: "Static",
+					configure: async ({ dryRun }) => {
+						if (!dryRun) {
+							await writeFile(
+								"wrangler.jsonc",
+								JSON.stringify({
+									name: "example.org",
+									compatibility_date: "2026-05-20",
+								})
+							);
+						}
+
+						return { wranglerConfig: null };
+					},
+					isConfigured: () => false,
+				} as unknown as Framework,
+				workerName: "example-org",
+				outputDir: "dist",
+				packageManager: NpmPackageManager,
+			});
+
+			expect(readFileSync("wrangler.jsonc")).toMatchInlineSnapshot(`
+				"{
+				  \"name\": \"example-org\",
+				  \"compatibility_date\": \"2026-05-20\"
+				}
+				"
+			`);
+		});
+
 		it(".assetsignore should contain Wrangler files if outputDir === projectPath", async ({
 			expect,
 		}) => {

--- a/packages/wrangler/src/autoconfig/run.ts
+++ b/packages/wrangler/src/autoconfig/run.ts
@@ -240,6 +240,10 @@ export async function runAutoConfig(
 					...configurationResults.wranglerConfig,
 				})
 			);
+		} else if (getDirWranglerJsonConfigPath(autoConfigDetails.projectPath)) {
+			await saveWranglerJsonc(autoConfigDetails.projectPath, {
+				name: autoConfigDetails.workerName,
+			});
 		}
 
 		maybeAppendWranglerToGitIgnore(autoConfigDetails.projectPath);


### PR DESCRIPTION
## What

Ensure `wrangler deploy --x-autoconfig` applies the detected/autoconfig Worker name to a `wrangler.jsonc` generated by a framework setup command when the framework returns `wranglerConfig: null`.

This covers cases like Astro where the framework command can create `wrangler.jsonc` with a package/repo-derived name such as `example.org`, while Workers import has already normalized the Worker/project name to `example-org`.

## Checklist

- [x] Tests included/updated
- [x] Cloudflare docs PR(s): https://developers.cloudflare.com/workers/wrangler/configuration/#inheritable-keys

## Testing

- `pnpm --filter @cloudflare/workers-utils build`
- `pnpm --filter @cloudflare/cli-shared-helpers build`
- `pnpm --filter @cloudflare/local-explorer-ui build`
- `pnpm --filter miniflare build`
- `pnpm --filter @cloudflare/codemod build`
- `pnpm test src/__tests__/autoconfig/run.test.ts` from `packages/wrangler`

Note: an initial broad test invocation used a repo-root path from inside the package and ran the whole Wrangler suite; it failed on missing built local package outputs in this fresh clone before the targeted test could run. After building local dependencies and using the package-relative test path, the focused autoconfig test passes.
