### PR TITLE
[ci] Remove stray debug echo from prerelease workflow

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -36,8 +36,6 @@ jobs:
         with:
           disable-cache: "true"
 
-      - run: echo ${{ github.head_ref }}
-
       - name: Build
         run: pnpm build --filter="./packages/*"
         env:


### PR DESCRIPTION
Removes a leftover `echo ${{ github.head_ref }}` step from `.github/workflows/prerelease.yml`. The same value is already passed through as `WRANGLER_PRERELEASE_LABEL` in the Build step's env, so the echo is just noise.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: CI-only change, removing a no-op step from a workflow file.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal CI workflow change with no user-facing impact.