### PR TITLE
chore(deps): enforce 24h minimum release age

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
       day: "sunday"
       time: "06:00"
     versioning-strategy: increase
+    # Match the 24h minimumReleaseAge enforced by pnpm in pnpm-workspace.yaml
+    # so Dependabot doesn't open PRs that CI will then reject.
+    cooldown:
+      default-days: 1
     # the following is used to add the [C3] prefix to the PR title,
     # we override the commit message but setting a prefix like this
     # makes it so that also the PR title gets such prefix

--- a/packages/mock-npm-registry/src/index.ts
+++ b/packages/mock-npm-registry/src/index.ts
@@ -56,10 +56,6 @@ export async function startMockNpmRegistry(...targetPackages: string[]) {
 		dedent`
 			registry=http://localhost:${registryPort}
 			//localhost:${registryPort}/:_authToken=xxxx-xxxx-xxxx-xxxx
-			# Disable the workspace-level minimumReleaseAge for tests: fixtures install
-			# first-party packages (workerd, wrangler, the plugin under test...) seconds
-			# after publishing to the mock registry, so the 24h cooldown would block them.
-			minimum-release-age=0
 	`
 	);
 

--- a/packages/mock-npm-registry/src/index.ts
+++ b/packages/mock-npm-registry/src/index.ts
@@ -56,6 +56,10 @@ export async function startMockNpmRegistry(...targetPackages: string[]) {
 		dedent`
 			registry=http://localhost:${registryPort}
 			//localhost:${registryPort}/:_authToken=xxxx-xxxx-xxxx-xxxx
+			# Disable the workspace-level minimumReleaseAge for tests: fixtures install
+			# first-party packages (workerd, wrangler, the plugin under test...) seconds
+			# after publishing to the mock registry, so the 24h cooldown would block them.
+			minimum-release-age=0
 	`
 	);
 

--- a/packages/mock-npm-registry/src/index.ts
+++ b/packages/mock-npm-registry/src/index.ts
@@ -76,6 +76,15 @@ export async function startMockNpmRegistry(...targetPackages: string[]) {
 		"npm_config_registry",
 		`http://localhost:${registryPort}`
 	);
+	// `pnpm run` exports `npm_config_minimum_release_age` from the workspace
+	// pnpm-workspace.yaml to subprocess env vars, but does NOT export the
+	// matching `minimumReleaseAgeExclude` array. Tests using this mock registry
+	// install freshly-published first-party packages, so the 24h cooldown would
+	// reject them. Disable the constraint for the lifetime of the mock registry.
+	const revert_npm_config_minimum_release_age = overrideProcessEnv(
+		"npm_config_minimum_release_age",
+		"0"
+	);
 
 	if (debugLog.enabled) {
 		debugLog("Updated");
@@ -105,6 +114,7 @@ export async function startMockNpmRegistry(...targetPackages: string[]) {
 		revert_NPM_CONFIG_USERCONFIG();
 		revert_npm_config_registry();
 		revert_npm_config_userconfig();
+		revert_npm_config_minimum_release_age();
 		if (debugLog.enabled) {
 			debugLog("After");
 			debugLog(execSync("pnpm config list", { encoding: "utf8" }));

--- a/packages/mock-npm-registry/src/index.ts
+++ b/packages/mock-npm-registry/src/index.ts
@@ -80,10 +80,17 @@ export async function startMockNpmRegistry(...targetPackages: string[]) {
 	// pnpm-workspace.yaml to subprocess env vars, but does NOT export the
 	// matching `minimumReleaseAgeExclude` array. Tests using this mock registry
 	// install freshly-published first-party packages, so the 24h cooldown would
-	// reject them. Disable the constraint for the lifetime of the mock registry.
-	const revert_npm_config_minimum_release_age = overrideProcessEnv(
-		"npm_config_minimum_release_age",
-		"0"
+	// reject them. Set the exclude list as a comma-separated env var so the
+	// constraint still applies to other (third-party) deps pulled via uplinks.
+	const revert_npm_config_minimum_release_age_exclude = overrideProcessEnv(
+		"npm_config_minimum_release_age_exclude",
+		[
+			...pkgs.keys(),
+			// workerd is pulled in transitively (e.g. via miniflare) and may have
+			// been bumped same-day, so exempt it and its platform binaries too.
+			"workerd",
+			"@cloudflare/workerd-*",
+		].join(",")
 	);
 
 	if (debugLog.enabled) {
@@ -114,7 +121,7 @@ export async function startMockNpmRegistry(...targetPackages: string[]) {
 		revert_NPM_CONFIG_USERCONFIG();
 		revert_npm_config_registry();
 		revert_npm_config_userconfig();
-		revert_npm_config_minimum_release_age();
+		revert_npm_config_minimum_release_age_exclude();
 		if (debugLog.enabled) {
 			debugLog("After");
 			debugLog(execSync("pnpm config list", { encoding: "utf8" }));

--- a/packages/mock-npm-registry/src/index.ts
+++ b/packages/mock-npm-registry/src/index.ts
@@ -86,10 +86,12 @@ export async function startMockNpmRegistry(...targetPackages: string[]) {
 		"npm_config_minimum_release_age_exclude",
 		[
 			...pkgs.keys(),
-			// workerd is pulled in transitively (e.g. via miniflare) and may have
-			// been bumped same-day, so exempt it and its platform binaries too.
+			// workerd and @cloudflare/workers-types are pulled in transitively
+			// (e.g. via miniflare) and may have been bumped same-day. Keep this
+			// list in sync with `minimumReleaseAgeExclude` in pnpm-workspace.yaml.
 			"workerd",
 			"@cloudflare/workerd-*",
+			"@cloudflare/workers-types",
 		].join(",")
 	);
 

--- a/packages/vite-plugin-cloudflare/e2e/helpers.ts
+++ b/packages/vite-plugin-cloudflare/e2e/helpers.ts
@@ -240,12 +240,18 @@ export function runCommand(
 			return output;
 		} catch (e) {
 			attempts--;
+			const err = e as { stdout?: Buffer | string; stderr?: Buffer | string };
+			const stdout = err.stdout?.toString() ?? "";
+			const stderr = err.stderr?.toString() ?? "";
+			const details = `\nstdout:\n${stdout}\nstderr:\n${stderr}`;
 			if (attempts > 0) {
-				debuglog(`Retrying failed command (${e})`);
+				debuglog(`Retrying failed command (${e})${details}`);
 			} else if (canFail) {
-				debuglog(`Command failed but canFail is true, not throwing: ${e}`);
+				debuglog(
+					`Command failed but canFail is true, not throwing: ${e}${details}`
+				);
 			} else {
-				throw e;
+				throw new Error(`${e}${details}`);
 			}
 		}
 	}

--- a/packages/vite-plugin-cloudflare/e2e/helpers.ts
+++ b/packages/vite-plugin-cloudflare/e2e/helpers.ts
@@ -240,18 +240,12 @@ export function runCommand(
 			return output;
 		} catch (e) {
 			attempts--;
-			const err = e as { stdout?: Buffer | string; stderr?: Buffer | string };
-			const stdout = err.stdout?.toString() ?? "";
-			const stderr = err.stderr?.toString() ?? "";
-			const details = `\nstdout:\n${stdout}\nstderr:\n${stderr}`;
 			if (attempts > 0) {
-				debuglog(`Retrying failed command (${e})${details}`);
+				debuglog(`Retrying failed command (${e})`);
 			} else if (canFail) {
-				debuglog(
-					`Command failed but canFail is true, not throwing: ${e}${details}`
-				);
+				debuglog(`Command failed but canFail is true, not throwing: ${e}`);
 			} else {
-				throw new Error(`${e}${details}`);
+				throw e;
 			}
 		}
 	}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,6 +30,18 @@ gitChecks: false
 # URLs. Only direct dependencies may use exotic sources.
 blockExoticSubdeps: true
 
+# Require packages to be at least 24 hours old before they can be installed.
+# This mitigates supply-chain attacks where a malicious version is published and
+# yanked quickly, by ensuring there is a window for detection before adoption.
+# Value is in minutes (1440 = 24 hours).
+minimumReleaseAge: 1440
+
+# First-party Cloudflare packages are exempt from the cooldown so they can be
+# adopted same-day.
+minimumReleaseAgeExclude:
+  - "workerd"
+  - "@cloudflare/workers-types"
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Build scripts
 # pnpm 10 blocks lifecycle scripts by default. Only the packages listed here

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,12 +37,14 @@ blockExoticSubdeps: true
 minimumReleaseAge: 1440
 
 # First-party Cloudflare packages are exempt from the cooldown so they can be
-# adopted same-day.
+# adopted same-day. This also covers E2E fixture installs against the local
+# mock npm registry, which publishes our own packages seconds before installing
+# them in a temp project that inherits this workspace's settings.
 minimumReleaseAgeExclude:
+  - "@cloudflare/*"
+  - "miniflare"
+  - "wrangler"
   - "workerd"
-  # Platform-specific workerd binaries published in lock-step with workerd.
-  - "@cloudflare/workerd-*"
-  - "@cloudflare/workers-types"
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Build scripts

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,14 +37,12 @@ blockExoticSubdeps: true
 minimumReleaseAge: 1440
 
 # First-party Cloudflare packages are exempt from the cooldown so they can be
-# adopted same-day. This also covers E2E fixture installs against the local
-# mock npm registry, which publishes our own packages seconds before installing
-# them in a temp project that inherits this workspace's settings.
+# adopted same-day.
 minimumReleaseAgeExclude:
-  - "@cloudflare/*"
-  - "miniflare"
-  - "wrangler"
   - "workerd"
+  # Platform-specific workerd binaries published in lock-step with workerd.
+  - "@cloudflare/workerd-*"
+  - "@cloudflare/workers-types"
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Build scripts

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,6 +40,8 @@ minimumReleaseAge: 1440
 # adopted same-day.
 minimumReleaseAgeExclude:
   - "workerd"
+  # Platform-specific workerd binaries published in lock-step with workerd.
+  - "@cloudflare/workerd-*"
   - "@cloudflare/workers-types"
 
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Adds pnpm's `minimumReleaseAge` (1440 minutes) so neither local installs nor CI accept package versions less than 24 hours old, narrowing the window for fast-yanked supply-chain attacks. Adds a matching `cooldown` to the C3 framework Dependabot group so it doesn't open PRs CI would then reject.

`workerd` and `@cloudflare/workers-types` are exempted in both places so first-party updates land same-day. The miniflare Dependabot group is restricted via `allow` to those two packages, so it needs no cooldown.

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: config-only change; the behavior is enforced by pnpm and Dependabot themselves
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal repo policy, no user-facing surface