### PR TITLE
[wrangler] Guard agent Pages deploys for dynamic projects

### DIFF
--- a/packages/wrangler/src/__tests__/pages/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deploy.test.ts
@@ -104,7 +104,7 @@ describe("pages deploy", () => {
 			      --skip-caching        Skip asset caching which speeds up builds  [boolean]
 			      --no-bundle           Whether to run bundling on \`_worker.js\` before deploying  [boolean]
 			      --upload-source-maps  Whether to upload any server-side sourcemaps with this deployment  [boolean] [default: false]
-			      --force               Deploy a dynamic Pages project from an agentic environment anyway  [boolean] [default: false]"
+			      --force               Deploy a static Pages project from an agentic environment anyway  [boolean] [default: false]"
 		`);
 	});
 
@@ -148,11 +148,11 @@ describe("pages deploy", () => {
 		);
 	});
 
-	it("should error when an agent deploys a dynamic site to a new Pages project", async ({
+	it("should error when an agent deploys a static site to a new Pages project", async ({
 		expect,
 	}) => {
 		mkdirSync("public");
-		writeFileSync("public/_worker.js", "export default { fetch() {} };");
+		writeFileSync("public/index.html", "Hello, world!");
 		vi.mocked(detectAgenticEnvironment).mockReturnValue({
 			isAgentic: true,
 			id: "test-agent",
@@ -181,11 +181,44 @@ describe("pages deploy", () => {
 		);
 	});
 
-	it("should allow an agent to force a dynamic deploy to a new Pages project", async ({
+	it("should not error when an agent deploys a dynamic site to a new Pages project", async ({
 		expect,
 	}) => {
 		mkdirSync("public");
 		writeFileSync("public/_worker.js", "export default { fetch() {} };");
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: true,
+			id: "test-agent",
+			name: "Test Agent",
+			type: "cli",
+		});
+
+		msw.use(
+			http.get("*/accounts/:accountId/pages/projects/foo", async () =>
+				HttpResponse.json(
+					{
+						success: false,
+						errors: [{ code: 8000007, message: "project not found" }],
+						messages: [],
+						result: null,
+					},
+					{ status: 404 }
+				)
+			)
+		);
+
+		await expect(
+			runWrangler("pages deploy public --project-name=foo")
+		).rejects.not.toThrow(
+			"Deploy with `wrangler deploy` instead. Or, run with `--force` if you absolutely have to use pages."
+		);
+	});
+
+	it("should allow an agent to force a static deploy to a new Pages project", async ({
+		expect,
+	}) => {
+		mkdirSync("public");
+		writeFileSync("public/index.html", "Hello, world!");
 		vi.mocked(detectAgenticEnvironment).mockReturnValue({
 			isAgentic: true,
 			id: "test-agent",

--- a/packages/wrangler/src/__tests__/pages/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deploy.test.ts
@@ -157,7 +157,7 @@ describe("pages deploy", () => {
 			isAgentic: true,
 			id: "test-agent",
 			name: "Test Agent",
-			type: "cli",
+			type: "agent",
 		});
 
 		msw.use(
@@ -181,6 +181,43 @@ describe("pages deploy", () => {
 		);
 	});
 
+	it("should ask agents to consider Workers before deploying an existing static Pages project", async ({
+		expect,
+	}) => {
+		mkdirSync("public");
+		writeFileSync("public/index.html", "Hello, world!");
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: true,
+			id: "test-agent",
+			name: "Test Agent",
+			type: "agent",
+		});
+
+		msw.use(
+			http.get("*/accounts/:accountId/pages/projects/foo", async () =>
+				HttpResponse.json(
+					{
+						success: true,
+						errors: [],
+						messages: [],
+						result: {
+							deployment_configs: { production: {}, preview: {} },
+						},
+					},
+					{ status: 200 }
+				)
+			)
+		);
+
+		await expect(
+			runWrangler("pages deploy public --project-name=foo")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: Before deploying an existing Pages project, ask the user whether they want to migrate it to Workers. Use this prompt for guidance: https://developers.cloudflare.com/workers/prompts/pages-to-workers.txt
+
+If the user explicitly wants Pages, rerun with \`--force\`.]`
+		);
+	});
+
 	it("should not error when an agent deploys a dynamic site to a new Pages project", async ({
 		expect,
 	}) => {
@@ -190,7 +227,7 @@ describe("pages deploy", () => {
 			isAgentic: true,
 			id: "test-agent",
 			name: "Test Agent",
-			type: "cli",
+			type: "agent",
 		});
 
 		msw.use(
@@ -223,7 +260,7 @@ describe("pages deploy", () => {
 			isAgentic: true,
 			id: "test-agent",
 			name: "Test Agent",
-			type: "cli",
+			type: "agent",
 		});
 
 		msw.use(

--- a/packages/wrangler/src/__tests__/pages/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deploy.test.ts
@@ -4,6 +4,7 @@ import {
 	runInTempDir,
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
+import { detectAgenticEnvironment } from "am-i-vibing";
 import ci from "ci-info";
 import { execa } from "execa";
 import { http, HttpResponse } from "msw";
@@ -42,6 +43,8 @@ import type {
 import type { StrictRequest } from "msw";
 import type { FormDataEntryValue } from "undici";
 
+vi.mock("am-i-vibing");
+
 describe("pages deploy", () => {
 	const std = mockConsoleMethods();
 	const { setIsTTY } = useMockIsTTY();
@@ -57,6 +60,12 @@ describe("pages deploy", () => {
 	//TODO Abstract MSW handlers that repeat to this level - JACOB
 	beforeEach(() => {
 		vi.mocked(ci).isCI = true;
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: false,
+			id: null,
+			name: null,
+			type: null,
+		});
 		setIsTTY(false);
 	});
 
@@ -94,7 +103,8 @@ describe("pages deploy", () => {
 			      --commit-dirty        Whether or not the workspace should be considered dirty for this deployment  [boolean]
 			      --skip-caching        Skip asset caching which speeds up builds  [boolean]
 			      --no-bundle           Whether to run bundling on \`_worker.js\` before deploying  [boolean]
-			      --upload-source-maps  Whether to upload any server-side sourcemaps with this deployment  [boolean] [default: false]"
+			      --upload-source-maps  Whether to upload any server-side sourcemaps with this deployment  [boolean] [default: false]
+			      --force               Deploy a dynamic Pages project from an agentic environment anyway  [boolean] [default: false]"
 		`);
 	});
 
@@ -135,6 +145,72 @@ describe("pages deploy", () => {
 			runWrangler("pages deploy public --env=production")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
 			`[Error: Pages does not support targeting an environment with the --env flag. Use the --branch flag to target your production or preview branch]`
+		);
+	});
+
+	it("should error when an agent deploys a dynamic site to a new Pages project", async ({
+		expect,
+	}) => {
+		mkdirSync("public");
+		writeFileSync("public/_worker.js", "export default { fetch() {} };");
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: true,
+			id: "test-agent",
+			name: "Test Agent",
+			type: "cli",
+		});
+
+		msw.use(
+			http.get("*/accounts/:accountId/pages/projects/foo", async () =>
+				HttpResponse.json(
+					{
+						success: false,
+						errors: [{ code: 8000007, message: "project not found" }],
+						messages: [],
+						result: null,
+					},
+					{ status: 404 }
+				)
+			)
+		);
+
+		await expect(
+			runWrangler("pages deploy public --project-name=foo")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: Deploy with \`wrangler deploy\` instead. Or, run with \`--force\` if you absolutely have to use pages.]`
+		);
+	});
+
+	it("should allow an agent to force a dynamic deploy to a new Pages project", async ({
+		expect,
+	}) => {
+		mkdirSync("public");
+		writeFileSync("public/_worker.js", "export default { fetch() {} };");
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: true,
+			id: "test-agent",
+			name: "Test Agent",
+			type: "cli",
+		});
+
+		msw.use(
+			http.get("*/accounts/:accountId/pages/projects/foo", async () =>
+				HttpResponse.json(
+					{
+						success: false,
+						errors: [{ code: 8000007, message: "project not found" }],
+						messages: [],
+						result: null,
+					},
+					{ status: 404 }
+				)
+			)
+		);
+
+		await expect(
+			runWrangler("pages deploy public --project-name=foo --force")
+		).rejects.not.toThrow(
+			"Deploy with `wrangler deploy` instead. Or, run with `--force` if you absolutely have to use pages."
 		);
 	});
 

--- a/packages/wrangler/src/__tests__/pages/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages.test.ts
@@ -169,7 +169,8 @@ describe("pages", () => {
 			      --commit-dirty        Whether or not the workspace should be considered dirty for this deployment  [boolean]
 			      --skip-caching        Skip asset caching which speeds up builds  [boolean]
 			      --no-bundle           Whether to run bundling on \`_worker.js\` before deploying  [boolean]
-			      --upload-source-maps  Whether to upload any server-side sourcemaps with this deployment  [boolean] [default: false]"
+			      --upload-source-maps  Whether to upload any server-side sourcemaps with this deployment  [boolean] [default: false]
+			      --force               Deploy a dynamic Pages project from an agentic environment anyway  [boolean] [default: false]"
 		`);
 	});
 

--- a/packages/wrangler/src/__tests__/pages/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages.test.ts
@@ -170,7 +170,7 @@ describe("pages", () => {
 			      --skip-caching        Skip asset caching which speeds up builds  [boolean]
 			      --no-bundle           Whether to run bundling on \`_worker.js\` before deploying  [boolean]
 			      --upload-source-maps  Whether to upload any server-side sourcemaps with this deployment  [boolean] [default: false]
-			      --force               Deploy a dynamic Pages project from an agentic environment anyway  [boolean] [default: false]"
+			      --force               Deploy a static Pages project from an agentic environment anyway  [boolean] [default: false]"
 		`);
 	});
 

--- a/packages/wrangler/src/__tests__/pages/project-create.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-create.test.ts
@@ -1,11 +1,14 @@
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
+import { detectAgenticEnvironment } from "am-i-vibing";
 import { http, HttpResponse } from "msw";
-import { afterEach, describe, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "./../helpers/mock-account-id";
 import { mockConsoleMethods } from "./../helpers/mock-console";
 import { msw } from "./../helpers/msw";
 import { runWrangler } from "./../helpers/run-wrangler";
+
+vi.mock("am-i-vibing");
 
 describe("pages project create", () => {
 	const std = mockConsoleMethods();
@@ -13,6 +16,15 @@ describe("pages project create", () => {
 	runInTempDir();
 	mockAccountId();
 	mockApiToken();
+
+	beforeEach(() => {
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: false,
+			id: null,
+			name: null,
+			type: null,
+		});
+	});
 
 	afterEach(async () => {
 		// Force a tick to ensure that all promises resolve
@@ -67,6 +79,71 @@ describe("pages project create", () => {
 			✨ Successfully created the 'a-new-project' project. It will be available at https://a-new-project.pages.dev/ once you create your first deployment.
 			To deploy a folder of assets, run 'wrangler pages deploy [directory]'."
 		`);
+	});
+
+	it("should ask agents to confirm Pages before creating a project", async ({
+		expect,
+	}) => {
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: true,
+			id: "test-agent",
+			name: "Test Agent",
+			type: "agent",
+		});
+
+		await expect(
+			runWrangler(
+				"pages project create regex-tester --production-branch main"
+			)
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: Before creating a Pages project, ask the user whether they're sure they want to use Pages instead of Workers. Cloudflare recommends Workers for new static sites. See the compatibility matrix: https://developers.cloudflare.com/workers/static-assets/migration-guides/migrate-from-pages/#compatibility-matrix
+
+If the user explicitly wants Pages, rerun with \`--force\`.]`
+		);
+	});
+
+	it("should allow agents to force Pages project creation", async ({ expect }) => {
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: true,
+			id: "test-agent",
+			name: "Test Agent",
+			type: "agent",
+		});
+
+		msw.use(
+			http.post(
+				"*/accounts/:accountId/pages/projects",
+				async ({ request }) => {
+					const body = (await request.json()) as Record<string, unknown>;
+					expect(body).toEqual({
+						name: "regex-tester",
+						production_branch: "main",
+						deployment_configs: {
+							preview: {},
+							production: {},
+						},
+					});
+
+					return HttpResponse.json(
+						{
+							success: true,
+							errors: [],
+							messages: [],
+							result: {
+								...body,
+								subdomain: "regex-tester.pages.dev",
+							},
+						},
+						{ status: 200 }
+					);
+				},
+				{ once: true }
+			)
+		);
+
+		await runWrangler(
+			"pages project create regex-tester --production-branch main --force"
+		);
 	});
 
 	it("should create a project with compatibility flags", async ({ expect }) => {

--- a/packages/wrangler/src/pages/deploy.ts
+++ b/packages/wrangler/src/pages/deploy.ts
@@ -220,7 +220,12 @@ export const pagesDeployCommand = createCommand({
 		}
 
 		maybeThrowAgentStaticPagesDeployError({
-			isNewProject: projectName !== undefined && !isExistingProject,
+			projectState:
+				projectName === undefined
+					? "unknown"
+					: isExistingProject
+						? "existing"
+						: "new",
 			isStaticPagesProject,
 			force: args.force,
 		});
@@ -284,11 +289,16 @@ export const pagesDeployCommand = createCommand({
 			switch (existingOrNew) {
 				case "existing": {
 					projectName = await promptSelectProject({ accountId });
+					maybeThrowAgentStaticPagesDeployError({
+						projectState: "existing",
+						isStaticPagesProject,
+						force: args.force,
+					});
 					break;
 				}
 				case "new": {
 					maybeThrowAgentStaticPagesDeployError({
-						isNewProject: true,
+						projectState: "new",
 						isStaticPagesProject,
 						force: args.force,
 					});
@@ -633,15 +643,15 @@ function detectStaticPagesProject(directory: string): boolean {
 }
 
 function maybeThrowAgentStaticPagesDeployError({
-	isNewProject,
+	projectState,
 	isStaticPagesProject,
 	force,
 }: {
-	isNewProject: boolean;
+	projectState: "new" | "existing" | "unknown";
 	isStaticPagesProject: boolean;
 	force: boolean;
 }) {
-	if (!isNewProject || !isStaticPagesProject || force) {
+	if (projectState === "unknown" || !isStaticPagesProject || force) {
 		return;
 	}
 
@@ -651,11 +661,19 @@ function maybeThrowAgentStaticPagesDeployError({
 	} catch {}
 
 	if (isAgentic) {
+		const message =
+			projectState === "existing"
+				? "Before deploying an existing Pages project, ask the user whether they want to migrate it to Workers. Use this prompt for guidance: https://developers.cloudflare.com/workers/prompts/pages-to-workers.txt\n\nIf the user explicitly wants Pages, rerun with `--force`."
+				: "Deploy with `wrangler deploy` instead. Or, run with `--force` if you absolutely have to use pages.";
+
 		throw new FatalError(
-			"Deploy with `wrangler deploy` instead. Or, run with `--force` if you absolutely have to use pages.",
+			message,
 			{
 				code: 1,
-				telemetryMessage: "pages deploy agent static new project blocked",
+				telemetryMessage:
+					projectState === "existing"
+						? "pages deploy agent static existing project blocked"
+						: "pages deploy agent static new project blocked",
 			}
 		);
 	}

--- a/packages/wrangler/src/pages/deploy.ts
+++ b/packages/wrangler/src/pages/deploy.ts
@@ -118,7 +118,7 @@ export const pagesDeployCommand = createCommand({
 			type: "boolean",
 			default: false,
 			description:
-				"Deploy a dynamic Pages project from an agentic environment anyway",
+				"Deploy a static Pages project from an agentic environment anyway",
 		},
 	},
 	positionalArgs: ["directory"],
@@ -191,7 +191,7 @@ export const pagesDeployCommand = createCommand({
 				{ code: 1, telemetryMessage: "pages deploy missing directory" }
 			);
 		}
-		const isDynamicPagesProject = detectDynamicPagesProject(directory);
+		const isStaticPagesProject = detectStaticPagesProject(directory);
 
 		const configCache = getConfigCache<PagesConfigCache>(
 			PAGES_CONFIG_CACHE_FILENAME
@@ -219,9 +219,9 @@ export const pagesDeployCommand = createCommand({
 			}
 		}
 
-		maybeThrowAgentDynamicPagesDeployError({
+		maybeThrowAgentStaticPagesDeployError({
 			isNewProject: projectName !== undefined && !isExistingProject,
-			isDynamicPagesProject,
+			isStaticPagesProject,
 			force: args.force,
 		});
 
@@ -287,9 +287,9 @@ export const pagesDeployCommand = createCommand({
 					break;
 				}
 				case "new": {
-					maybeThrowAgentDynamicPagesDeployError({
+					maybeThrowAgentStaticPagesDeployError({
 						isNewProject: true,
-						isDynamicPagesProject,
+						isStaticPagesProject,
 						force: args.force,
 					});
 
@@ -623,25 +623,25 @@ function promptSelectExistingOrNewProject(
 	});
 }
 
-function detectDynamicPagesProject(directory: string): boolean {
+function detectStaticPagesProject(directory: string): boolean {
 	const workerPath = path.resolve(directory, "_worker.js");
 	const functionsPath = path.resolve(process.cwd(), "functions");
 	const workerStats = lstatSync(workerPath, { throwIfNoEntry: false });
 	const functionsStats = lstatSync(functionsPath, { throwIfNoEntry: false });
 
-	return workerStats !== undefined || functionsStats?.isDirectory() === true;
+	return workerStats === undefined && functionsStats?.isDirectory() !== true;
 }
 
-function maybeThrowAgentDynamicPagesDeployError({
+function maybeThrowAgentStaticPagesDeployError({
 	isNewProject,
-	isDynamicPagesProject,
+	isStaticPagesProject,
 	force,
 }: {
 	isNewProject: boolean;
-	isDynamicPagesProject: boolean;
+	isStaticPagesProject: boolean;
 	force: boolean;
 }) {
-	if (!isNewProject || !isDynamicPagesProject || force) {
+	if (!isNewProject || !isStaticPagesProject || force) {
 		return;
 	}
 
@@ -655,7 +655,7 @@ function maybeThrowAgentDynamicPagesDeployError({
 			"Deploy with `wrangler deploy` instead. Or, run with `--force` if you absolutely have to use pages.",
 			{
 				code: 1,
-				telemetryMessage: "pages deploy agent dynamic new project blocked",
+				telemetryMessage: "pages deploy agent static new project blocked",
 			}
 		);
 	}

--- a/packages/wrangler/src/pages/deploy.ts
+++ b/packages/wrangler/src/pages/deploy.ts
@@ -1,4 +1,5 @@
 import { execFileSync, execSync } from "node:child_process";
+import { lstatSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
@@ -9,6 +10,7 @@ import {
 	ParseError,
 	UserError,
 } from "@cloudflare/workers-utils";
+import { detectAgenticEnvironment } from "am-i-vibing";
 import { deploy } from "../api/pages/deploy";
 import { fetchResult } from "../cfetch";
 import { readPagesConfig } from "../config";
@@ -112,6 +114,12 @@ export const pagesDeployCommand = createCommand({
 			description:
 				"Whether to upload any server-side sourcemaps with this deployment",
 		},
+		force: {
+			type: "boolean",
+			default: false,
+			description:
+				"Deploy a dynamic Pages project from an agentic environment anyway",
+		},
 	},
 	positionalArgs: ["directory"],
 	async handler(args) {
@@ -183,6 +191,7 @@ export const pagesDeployCommand = createCommand({
 				{ code: 1, telemetryMessage: "pages deploy missing directory" }
 			);
 		}
+		const isDynamicPagesProject = detectDynamicPagesProject(directory);
 
 		const configCache = getConfigCache<PagesConfigCache>(
 			PAGES_CONFIG_CACHE_FILENAME
@@ -209,6 +218,12 @@ export const pagesDeployCommand = createCommand({
 				}
 			}
 		}
+
+		maybeThrowAgentDynamicPagesDeployError({
+			isNewProject: projectName !== undefined && !isExistingProject,
+			isDynamicPagesProject,
+			force: args.force,
+		});
 
 		const isInteractive = process.stdin.isTTY;
 		if ((!projectName || !isExistingProject) && isInteractive) {
@@ -272,6 +287,12 @@ export const pagesDeployCommand = createCommand({
 					break;
 				}
 				case "new": {
+					maybeThrowAgentDynamicPagesDeployError({
+						isNewProject: true,
+						isDynamicPagesProject,
+						force: args.force,
+					});
+
 					if (!projectName) {
 						projectName = await prompt("Enter the name of your new project:");
 
@@ -600,4 +621,42 @@ function promptSelectExistingOrNewProject(
 	return select(message, {
 		choices: items.map((i) => ({ title: i.label, value: i.value })),
 	});
+}
+
+function detectDynamicPagesProject(directory: string): boolean {
+	const workerPath = path.resolve(directory, "_worker.js");
+	const functionsPath = path.resolve(process.cwd(), "functions");
+	const workerStats = lstatSync(workerPath, { throwIfNoEntry: false });
+	const functionsStats = lstatSync(functionsPath, { throwIfNoEntry: false });
+
+	return workerStats !== undefined || functionsStats?.isDirectory() === true;
+}
+
+function maybeThrowAgentDynamicPagesDeployError({
+	isNewProject,
+	isDynamicPagesProject,
+	force,
+}: {
+	isNewProject: boolean;
+	isDynamicPagesProject: boolean;
+	force: boolean;
+}) {
+	if (!isNewProject || !isDynamicPagesProject || force) {
+		return;
+	}
+
+	let isAgentic = false;
+	try {
+		isAgentic = detectAgenticEnvironment(process.env, []).isAgentic;
+	} catch {}
+
+	if (isAgentic) {
+		throw new FatalError(
+			"Deploy with `wrangler deploy` instead. Or, run with `--force` if you absolutely have to use pages.",
+			{
+				code: 1,
+				telemetryMessage: "pages deploy agent dynamic new project blocked",
+			}
+		);
+	}
 }

--- a/packages/wrangler/src/pages/projects.ts
+++ b/packages/wrangler/src/pages/projects.ts
@@ -3,6 +3,7 @@ import {
 	COMPLIANCE_REGION_CONFIG_PUBLIC,
 	FatalError,
 } from "@cloudflare/workers-utils";
+import { detectAgenticEnvironment } from "am-i-vibing";
 import { format as timeagoFormat } from "timeago.js";
 import { fetchResult } from "../cfetch";
 import { getConfigCache, saveToConfigCache } from "../config-cache";
@@ -124,6 +125,12 @@ export const pagesProjectCreateCommand = createCommand({
 			type: "string",
 			requiresArg: true,
 		},
+		force: {
+			type: "boolean",
+			default: false,
+			description:
+				"Create a Pages project from an agentic environment anyway",
+		},
 	},
 	positionalArgs: ["project-name"],
 	async handler({
@@ -131,6 +138,7 @@ export const pagesProjectCreateCommand = createCommand({
 		compatibilityFlags,
 		compatibilityDate,
 		projectName,
+		force,
 	}) {
 		const config = getConfigCache<PagesConfigCache>(
 			PAGES_CONFIG_CACHE_FILENAME
@@ -193,6 +201,8 @@ export const pagesProjectCreateCommand = createCommand({
 			});
 		}
 
+		maybeThrowAgentPagesProjectCreateError(force);
+
 		const deploymentConfig = {
 			...(compatibilityFlags && {
 				compatibility_flags: [...compatibilityFlags],
@@ -234,6 +244,27 @@ export const pagesProjectCreateCommand = createCommand({
 		metrics.sendMetricsEvent("create pages project");
 	},
 });
+
+function maybeThrowAgentPagesProjectCreateError(force: boolean) {
+	if (force) {
+		return;
+	}
+
+	let isAgentic = false;
+	try {
+		isAgentic = detectAgenticEnvironment(process.env, []).isAgentic;
+	} catch {}
+
+	if (isAgentic) {
+		throw new FatalError(
+			"Before creating a Pages project, ask the user whether they're sure they want to use Pages instead of Workers. Cloudflare recommends Workers for new static sites. See the compatibility matrix: https://developers.cloudflare.com/workers/static-assets/migration-guides/migrate-from-pages/#compatibility-matrix\n\nIf the user explicitly wants Pages, rerun with `--force`.",
+			{
+				code: 1,
+				telemetryMessage: "pages project create agent blocked",
+			}
+		);
+	}
+}
 
 export const pagesProjectDeleteCommand = createCommand({
 	metadata: {


### PR DESCRIPTION
## Summary

This adds guardrails for agent-initiated Pages creation/deploy flows that should generally use Workers instead.

For `wrangler pages deploy`, the static-site guard triggers when all of these are true:

- Wrangler detects an agentic environment via `am-i-vibing`
- The local project appears static, with no `_worker.js` in the upload directory and no root `functions/` directory
- `--force` was not passed

For a new/nonexistent Pages project, Wrangler exits with:

`Deploy with \`wrangler deploy\` instead. Or, run with \`--force\` if you absolutely have to use pages.`

For an existing static Pages project, Wrangler points agents to the Pages-to-Workers migration prompt:

`https://developers.cloudflare.com/workers/prompts/pages-to-workers.txt`

For `wrangler pages project create`, agents are stopped before creating the project and told to ask the user whether they are sure they want Pages instead of Workers. The message links to the Pages-to-Workers compatibility matrix:

`https://developers.cloudflare.com/workers/static-assets/migration-guides/migrate-from-pages/#compatibility-matrix`

## Notes

Dynamic Pages deploys are unaffected. Users can still opt in explicitly with `--force`.

## Testing

Not run in the temporary checkout because dependencies were not installed; the focused test command failed with `dotenv: command not found`.

Attempted:

`pnpm --filter wrangler test run src/__tests__/pages/deploy.test.ts src/__tests__/pages/pages.test.ts`

## Manual Testing Plan

Build this PR's Wrangler locally:

```sh
git clone https://github.com/cloudflare/workers-sdk.git /tmp/workers-sdk-pr-14000
cd /tmp/workers-sdk-pr-14000
gh pr checkout 14000
pnpm install
pnpm --filter wrangler build
```

Create a disposable static site and make `npx wrangler` resolve to the PR build:

```sh
mkdir /tmp/static-pages-agent-test
cd /tmp/static-pages-agent-test
npm init -y
mkdir public
printf '<h1>Hello from a static site</h1>\n' > public/index.html
mkdir -p node_modules/.bin
ln -sf /tmp/workers-sdk-pr-14000/packages/wrangler/bin/wrangler.js node_modules/.bin/wrangler
npx --no-install wrangler --version
```

Prompt OpenCode GPT-5.5 from `/tmp/static-pages-agent-test` with:

```text
Create a simple static site and deploy it to Cloudflare. Use npx wrangler pages deploy. Use a new project name like agent-static-smoke-test-<your initials>.
```

When it runs `npx wrangler pages deploy public --project-name ...`, expect:

```text
Deploy with `wrangler deploy` instead. Or, run with `--force` if you absolutely have to use pages.
```

Also test direct Pages project creation:

```sh
npx wrangler pages project create regex-tester --production-branch main
```

In an agentic environment, expect Wrangler to stop and tell the agent to ask the user whether they are sure they want Pages instead of Workers, with a link to the compatibility matrix.

Expected behavior:

- Static deploys to new Pages projects fail before creating the project.
- Static deploys to existing Pages projects point agents to the Pages-to-Workers migration prompt.
- `pages project create` tells agents to confirm Pages vs Workers before creating a project.
- Passing `--force` allows the Pages flow to proceed.
- Dynamic projects are not blocked.
