### PR TITLE
[wrangler] Update bundle size warnings to use uncompressed size limit

### DIFF
--- a/.changeset/remove-compressed-size-warning.md
+++ b/.changeset/remove-compressed-size-warning.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Update bundle size warning thresholds to use uncompressed size instead of gzip size
+
+The compressed script size limits (3 MiB free / 10 MiB paid) have been removed server-side in favor of a single 64 MiB uncompressed limit. The bundle size reporter now compares the uncompressed bundle size against this 64 MiB limit for its color-coded warnings, instead of comparing gzip size against the old 3 MiB compressed limit.

--- a/packages/deploy-helpers/src/deploy/helpers/bundle-reporter.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/bundle-reporter.ts
@@ -5,9 +5,9 @@ import { logger } from "../../shared/context";
 import type { CfModule } from "@cloudflare/workers-utils";
 
 const ONE_KIB_BYTES = 1024;
-// Current max is 3 MiB for free accounts, 10 MiB for paid accounts.
+// Max uncompressed Worker size is 64 MiB for all accounts.
 // See https://developers.cloudflare.com/workers/platform/limits/#worker-size
-const MAX_GZIP_SIZE_BYTES = 3 * ONE_KIB_BYTES * ONE_KIB_BYTES;
+const MAX_UNCOMPRESSED_SIZE_BYTES = 64 * ONE_KIB_BYTES * ONE_KIB_BYTES;
 
 export interface BundleSize {
 	size: number;
@@ -30,7 +30,7 @@ export function printBundleSize({ size, gzipSize }: BundleSize) {
 		gzipSize / ONE_KIB_BYTES
 	).toFixed(2)} KiB`;
 
-	const percentage = (gzipSize / MAX_GZIP_SIZE_BYTES) * 100;
+	const percentage = (size / MAX_UNCOMPRESSED_SIZE_BYTES) * 100;
 
 	const colorizedReport =
 		percentage > 90

--- a/packages/wrangler/src/deployment-bundle/bundle-reporter.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle-reporter.ts
@@ -5,9 +5,9 @@ import { logger } from "../logger";
 import type { CfModule } from "@cloudflare/workers-utils";
 
 const ONE_KIB_BYTES = 1024;
-// Current max is 3 MiB for free accounts, 10 MiB for paid accounts.
+// Max uncompressed Worker size is 64 MiB for all accounts.
 // See https://developers.cloudflare.com/workers/platform/limits/#worker-size
-const MAX_GZIP_SIZE_BYTES = 3 * ONE_KIB_BYTES * ONE_KIB_BYTES;
+const MAX_UNCOMPRESSED_SIZE_BYTES = 64 * ONE_KIB_BYTES * ONE_KIB_BYTES;
 
 async function getSize(modules: Pick<CfModule, "content">[]) {
 	const gzipSize = gzipSync(
@@ -31,7 +31,7 @@ export async function printBundleSize(
 		gzipSize / ONE_KIB_BYTES
 	).toFixed(2)} KiB`;
 
-	const percentage = (gzipSize / MAX_GZIP_SIZE_BYTES) * 100;
+	const percentage = (size / MAX_UNCOMPRESSED_SIZE_BYTES) * 100;
 
 	const colorizedReport =
 		percentage > 90


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/WC-4489.

The compressed script size limits (3 MiB free / 10 MiB paid) are being removed server-side in favor of a single 64 MiB uncompressed limit ([EWC MR](https://gitlab.cfdata.org/cloudflare/ew/edgeworker-config-service/-/merge_requests/10880)).

This updates the bundle reporter to compare uncompressed size against the 64 MiB limit for its color-coded warnings, instead of comparing gzip size against the old 3 MiB compressed limit. The output format (`Total Upload: XX KiB / gzip: XX KiB`) is unchanged.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: docs update is tracked separately in WC-4489
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->