### PR TITLE
wrangler: report invalid API token header characters

### DIFF
--- a/.changeset/quiet-tokens-guard.md
+++ b/.changeset/quiet-tokens-guard.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Show a clear error for invalid API token header characters
+
+Wrangler now detects API tokens containing characters that cannot be sent in the HTTP Authorization header before making an API request. This avoids a low-level ByteString conversion error and helps users recreate or recopy the token without printing the token value.

--- a/packages/wrangler/src/__tests__/cfetch-internal.test.ts
+++ b/packages/wrangler/src/__tests__/cfetch-internal.test.ts
@@ -2,7 +2,11 @@ import { COMPLIANCE_REGION_CONFIG_UNKNOWN } from "@cloudflare/workers-utils";
 import { http, HttpResponse } from "msw";
 import { describe, it } from "vitest";
 import { fetchGraphqlResult } from "../cfetch";
-import { extractWAFBlockRayId, isWAFBlockResponse } from "../cfetch/internal";
+import {
+	addAuthorizationHeader,
+	extractWAFBlockRayId,
+	isWAFBlockResponse,
+} from "../cfetch/internal";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { msw } from "./helpers/msw";
 
@@ -34,6 +38,28 @@ describe("extractWAFBlockRayId", () => {
 	it("should return undefined when cf-ray header is absent", ({ expect }) => {
 		const headers = new Headers();
 		expect(extractWAFBlockRayId(headers)).toBeUndefined();
+	});
+});
+
+describe("addAuthorizationHeader", () => {
+	it("should throw a helpful error when the API token cannot be used in an Authorization header", ({
+		expect,
+	}) => {
+		expect(() =>
+			addAuthorizationHeader(new Headers(), { apiToken: "abcdefg…" })
+		).toThrow(
+			'The configured Cloudflare API token contains a character that cannot be used in an HTTP Authorization header: "…" (U+2026). Recreate or copy the token again, making sure it does not include characters such as ellipses.'
+		);
+	});
+
+	it("should set the Authorization header for an ASCII API token", ({
+		expect,
+	}) => {
+		const headers = new Headers();
+
+		addAuthorizationHeader(headers, { apiToken: "abcdefg" });
+
+		expect(headers.get("Authorization")).toBe("Bearer abcdefg");
 	});
 });
 

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -321,12 +321,62 @@ export function addAuthorizationHeader(
 ): void {
 	if (!headers.has("Authorization") || overrideExisting) {
 		if ("apiToken" in auth) {
-			headers.set("Authorization", `Bearer ${auth.apiToken}`);
+			const authorizationHeader = `Bearer ${auth.apiToken}`;
+			validateAuthorizationHeaderValue(authorizationHeader);
+			headers.set("Authorization", authorizationHeader);
 		} else {
 			headers.set("X-Auth-Key", auth.authKey);
 			headers.set("X-Auth-Email", auth.authEmail);
 		}
 	}
+}
+
+function validateAuthorizationHeaderValue(value: string): void {
+	for (const character of value) {
+		const codePoint = character.codePointAt(0);
+		if (codePoint === undefined || codePoint > 255) {
+			throw new UserError(
+				`The configured Cloudflare API token contains a character that cannot be used in an HTTP Authorization header: ${formatAuthorizationHeaderCharacter(character, codePoint)}. Recreate or copy the token again, making sure it does not include characters such as ellipses.`,
+				{
+					telemetryMessage: "cfetch auth invalid authorization header",
+				}
+			);
+		}
+	}
+}
+
+function formatAuthorizationHeaderCharacter(
+	character: string,
+	codePoint: number | undefined
+): string {
+	if (codePoint === undefined) {
+		return '"\\u{unknown}"';
+	}
+
+	const codePointLabel = `U+${codePoint.toString(16).toUpperCase().padStart(4, "0")}`;
+	const characterLabel = isPrintableCharacter(character)
+		? `"${character}"`
+		: `"${escapeCharacter(character)}"`;
+
+	return `${characterLabel} (${codePointLabel})`;
+}
+
+function isPrintableCharacter(character: string): boolean {
+	return !/[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u.test(character);
+}
+
+function escapeCharacter(character: string): string {
+	return Array.from(character)
+		.map((c) => {
+			const codePoint = c.codePointAt(0);
+			if (codePoint === undefined) {
+				return "";
+			}
+			return codePoint <= 0xffff
+				? `\\u${codePoint.toString(16).toUpperCase().padStart(4, "0")}`
+				: `\\u{${codePoint.toString(16).toUpperCase()}}`;
+		})
+		.join("");
 }
 
 export function addUserAgent(headers: Headers): void {


### PR DESCRIPTION
Fixes #13997

This reports a clearer error when `CLOUDFLARE_API_TOKEN` contains a character that cannot be used in the Authorization header.

I reproduced the original ByteString failure with a fake token containing `…`. Added coverage for that case and kept the ASCII token path unchanged.

- [x] Tests included/updated

Tests:
- `pnpm --filter wrangler test:ci -- cfetch-internal.test.ts`

- [x] Documentation not necessary because: this only changes the Wrangler error shown for an invalid local API token value.