### PR TITLE
[ci] Pass --repo to gh pr view in dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -45,13 +45,16 @@ jobs:
         if: steps.meta.outputs.dependency-group == 'workerd-and-workers-types'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
-          # Pull commits and changed files via the GitHub API.
-          commits_json=$(gh pr view "$PR_NUMBER" --json commits)
-          files_json=$(gh pr view "$PR_NUMBER" --json files)
+          # Pull commits and changed files via the GitHub API. `--repo` is
+          # required because this workflow runs without `actions/checkout`,
+          # so `gh` has no git remote to infer the repo from.
+          commits_json=$(gh pr view --repo "$REPO" "$PR_NUMBER" --json commits)
+          files_json=$(gh pr view --repo "$REPO" "$PR_NUMBER" --json files)
 
           fail() {
             echo "verified=false" >> "$GITHUB_OUTPUT"
@@ -83,7 +86,7 @@ jobs:
 
           # `gh pr view --json commits` doesn't expose signature info, so look
           # it up via the REST commit endpoint.
-          first_verified=$(gh api "repos/${{ github.repository }}/commits/$first_oid" --jq '.commit.verification.verified')
+          first_verified=$(gh api "repos/$REPO/commits/$first_oid" --jq '.commit.verification.verified')
           if [ "$first_verified" != "true" ]; then
             fail "first commit (Dependabot) does not have a verified signature"
           fi


### PR DESCRIPTION
The `dependabot-auto-merge` workflow ([originally landed in #13852](https://github.com/cloudflare/workers-sdk/pull/13852)) failed on its first real run against [PR #14003](https://github.com/cloudflare/workers-sdk/pull/14003) ([job log](https://github.com/cloudflare/workers-sdk/actions/runs/26271652095/job/77326289440?pr=14003)) with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1.
```

**Cause.** The verify step calls `gh pr view "$PR_NUMBER" --json commits`. When given a bare PR number, `gh` figures out the repo by shelling out to `git remote -v`. This workflow deliberately omits `actions/checkout` (per the security comment in the file — `pull_request_target` + checkout of PR code is the standard pwn vector), so there's no `.git` directory and `gh` exits 1. `set -euo pipefail` then aborts the script before the `fail()` helper can run, so the step turns red instead of cleanly skipping auto-merge with a warning annotation.

The downstream `gh pr merge "$PR_URL"` calls don't hit this because they're passed the full HTML URL.

**Fix.** Pass `--repo "$REPO"` explicitly to the two `gh pr view` calls, matching the convention used in `c3-e2e.yml`, `rerun-remote-tests.yml`, `rerun-codeowners-privileged.yml`, and `actions/check-remote-tests/action.yml`. Replaced the inline `${{ github.repository }}` expansion in the `gh api` URL with `$REPO` so the verify step has one source of truth.

---

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: The workflow only triggers on `pull_request_target`, so it can't be unit-tested. Once this lands, the next `dependabot[bot]` workerd-bump PR (daily, ~06:00 UTC) will exercise the fix. We can also force it sooner by triggering a `synchronize` event on #14003 (e.g. `@dependabot rebase`) — `pull_request_target` workflows use the workflow file from `main`, so the fix will be picked up automatically.
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Internal CI workflow change, no user-facing surface.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->