### PR TITLE
[wrangler] Fix Access Service Token authentication for service-auth-only apps

### DIFF
--- a/.changeset/fix-access-service-token-403.md
+++ b/.changeset/fix-access-service-token-403.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+Fix Access Service Token authentication for applications that only allow service tokens
+
+When using remote bindings against a Worker behind a Cloudflare Access application configured to only allow Service Auth tokens (no interactive user authentication), Wrangler previously ignored the `CLOUDFLARE_ACCESS_CLIENT_ID` and `CLOUDFLARE_ACCESS_CLIENT_SECRET` environment variables and the request would fail with a 403.
+
+This happened because Wrangler detects Access by looking for a 302 redirect to `cloudflareaccess.com`. A service-auth-only Access application has no interactive login path, so it responds with a hard 403 instead of redirecting. Wrangler concluded the domain was not behind Access and skipped attaching the service token headers entirely.
+
+The env-var check now runs before the Access detection step, so the configured service token credentials are always used when present.

--- a/packages/wrangler/src/__tests__/access.test.ts
+++ b/packages/wrangler/src/__tests__/access.test.ts
@@ -25,6 +25,20 @@ describe("access", () => {
 			expect(await domainUsesAccess("access-protected.com")).toBeTruthy();
 			expect(await domainUsesAccess("not-access-protected.com")).toBeFalsy();
 		});
+
+		it("should return false when the domain responds with a 403 (service-auth-only Access app)", async ({
+			expect,
+		}) => {
+			// When an Access application is configured to only allow Service
+			// Auth tokens, the domain responds with a hard 403 instead of
+			// redirecting to cloudflareaccess.com, so this detection method
+			// cannot recognise it as Access-protected. This is why
+			// `getAccessHeaders` must check the env vars before calling
+			// `domainUsesAccess`.
+			expect(
+				await domainUsesAccess("access-service-auth-only.com")
+			).toBeFalsy();
+		});
 	});
 
 	describe("getAccessHeaders", () => {
@@ -47,6 +61,26 @@ describe("access", () => {
 					"CF-Access-Client-Secret": "test-client-secret",
 				});
 				// No warning is presented since both env variables are set
+				expect(std.warn).toMatchInlineSnapshot(`""`);
+			});
+
+			it("should return service token headers for a service-auth-only domain (403 response)", async ({
+				expect,
+			}) => {
+				// Regression test: when the Access application is configured to
+				// only allow Service Auth tokens, the domain responds with a
+				// hard 403 instead of redirecting to cloudflareaccess.com.
+				// `domainUsesAccess` returns false in this case, so the env var
+				// check must happen first - otherwise Wrangler would return
+				// empty headers and the request would fail with a 403.
+				vi.stubEnv("CLOUDFLARE_ACCESS_CLIENT_ID", "test-client-id.access");
+				vi.stubEnv("CLOUDFLARE_ACCESS_CLIENT_SECRET", "test-client-secret");
+
+				const headers = await getAccessHeaders("access-service-auth-only.com");
+				expect(headers).toEqual({
+					"CF-Access-Client-Id": "test-client-id.access",
+					"CF-Access-Client-Secret": "test-client-secret",
+				});
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 

--- a/packages/wrangler/src/__tests__/helpers/msw/handlers/access.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/handlers/access.ts
@@ -10,4 +10,11 @@ export default [
 	http.get("https://not-access-protected.com/", () => {
 		return HttpResponse.json("OK", { status: 200 });
 	}),
+	// Simulates an Access application configured to only allow Service Auth
+	// tokens: the domain is behind Access but responds with a hard 403 instead
+	// of redirecting to cloudflareaccess.com, because there is no interactive
+	// login path for users.
+	http.get("https://access-service-auth-only.com/", () => {
+		return HttpResponse.json(null, { status: 403 });
+	}),
 ];

--- a/packages/wrangler/src/user/access.ts
+++ b/packages/wrangler/src/user/access.ts
@@ -75,16 +75,15 @@ export async function domainUsesAccess(domain: string): Promise<boolean> {
 export async function getAccessHeaders(
 	domain: string
 ): Promise<Record<string, string>> {
-	if (!(await domainUsesAccess(domain))) {
-		return {};
-	}
-	logger.debug("Getting Access headers for domain:", domain);
-	if (headersCache[domain]) {
-		logger.debug("Using cached Access headers for domain:", domain);
-		return headersCache[domain];
-	}
-
-	// 1. If Access Service Token credentials are provided, use them directly
+	// 1. If Access Service Token credentials are provided, use them directly.
+	//
+	// This check intentionally comes before `domainUsesAccess()`, which detects
+	// Access by looking for a 302 redirect to `cloudflareaccess.com`. When an
+	// Access application is configured to only allow Service Auth tokens (no
+	// interactive user authentication), the domain responds with a hard 403
+	// instead of redirecting, so `domainUsesAccess()` returns false. If we
+	// gated the env var check on `domainUsesAccess()` we would never attach
+	// the service token headers and the request would fail with a 403.
 	const clientId = getAccessClientIdFromEnv();
 	const clientSecret = getAccessClientSecretFromEnv();
 
@@ -108,6 +107,15 @@ export async function getAccessHeaders(
 						: "CLOUDFLARE_ACCESS_CLIENT_SECRET"
 				} was found.`
 		);
+	}
+
+	if (!(await domainUsesAccess(domain))) {
+		return {};
+	}
+	logger.debug("Getting Access headers for domain:", domain);
+	if (headersCache[domain]) {
+		logger.debug("Using cached Access headers for domain:", domain);
+		return headersCache[domain];
 	}
 
 	// 2. If non-interactive (CI), error with actionable message


### PR DESCRIPTION
When using remote bindings against a Worker behind a Cloudflare Access application configured to **only allow Service Auth tokens** (no interactive user authentication), Wrangler previously ignored the `CLOUDFLARE_ACCESS_CLIENT_ID` and `CLOUDFLARE_ACCESS_CLIENT_SECRET` env vars and the request would fail with a 403. This came up via reports from users using Wrangler for OpenNext pre-render uploads against a Worker behind Access, where the documented workaround of setting those env vars wasn't taking effect.

The detection method in `domainUsesAccess()` looks for a 302 redirect to `cloudflareaccess.com`. A service-auth-only Access app has no interactive login path, so it responds with a hard 403 instead of redirecting. Wrangler concluded the domain was not behind Access and skipped attaching the service token headers entirely.

The env-var check now runs **before** the Access detection step, so the configured service token credentials are always used when present. A code comment has been added explaining why the order matters to prevent regression.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is a bug fix that restores documented behaviour of `CLOUDFLARE_ACCESS_CLIENT_ID`/`CLOUDFLARE_ACCESS_CLIENT_SECRET` env vars for an additional Access configuration.

*A picture of a cute animal (not mandatory, but encouraged)*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->