### PR TITLE
Improve error messages for Pages CLI commands

### DIFF
--- a/.changeset/improve-pages-error-messages.md
+++ b/.changeset/improve-pages-error-messages.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+Improve error messages for Pages CLI commands
+
+Error messages across `wrangler pages` subcommands (deploy, dev, secret, project, etc.) now provide clearer descriptions and actionable guidance. For example, instead of "Must specify a project name.", you'll now see "Missing Pages project name. Use --project-name <name> or set the name in your wrangler.jsonc configuration file."
+

--- a/packages/wrangler/src/__tests__/pages/__snapshots__/deploy.test.ts.snap
+++ b/packages/wrangler/src/__tests__/pages/__snapshots__/deploy.test.ts.snap
@@ -30,7 +30,7 @@ exports[`pages deploy > with wrangler.json configuration > should support wrangl
 ✨ Deployment complete! Take a peek over at https://abcxyz.pages-is-awesome.pages.dev/"
 `;
 
-exports[`pages deploy > with wrangler.json configuration > should warn and ignore the config file, if it doesn't specify the \`pages_build_output_dir\` field 1`] = `[Error: Must specify a project name.]`;
+exports[`pages deploy > with wrangler.json configuration > should warn and ignore the config file, if it doesn't specify the \`pages_build_output_dir\` field 1`] = `[Error: Missing Pages project name. Use --project-name <name> or set the name in your Wrangler configuration file.]`;
 
 exports[`pages deploy > with wrangler.toml configuration > should always deploy to the Pages project specified by the top-level \`name\` configuration field, regardless of the corresponding env-level configuration 1`] = `"b5f53af7922efd0f0b73c7bf288f7e3f14df5c31e8b654e98027ddf85ea7e574"`;
 
@@ -62,4 +62,4 @@ exports[`pages deploy > with wrangler.toml configuration > should support wrangl
 ✨ Deployment complete! Take a peek over at https://abcxyz.pages-is-awesome.pages.dev/"
 `;
 
-exports[`pages deploy > with wrangler.toml configuration > should warn and ignore the config file, if it doesn't specify the \`pages_build_output_dir\` field 1`] = `[Error: Must specify a project name.]`;
+exports[`pages deploy > with wrangler.toml configuration > should warn and ignore the config file, if it doesn't specify the \`pages_build_output_dir\` field 1`] = `[Error: Missing Pages project name. Use --project-name <name> or set the name in your Wrangler configuration file.]`;

--- a/packages/wrangler/src/__tests__/pages/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deploy.test.ts
@@ -115,7 +115,7 @@ describe("pages deploy", () => {
 		await expect(
 			runWrangler("pages deploy public")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
-			`[Error: Must specify a project name.]`
+			`[Error: Missing Pages project name. Use --project-name <name> or set the name in your Wrangler configuration file.]`
 		);
 	});
 

--- a/packages/wrangler/src/__tests__/pages/dev.test.ts
+++ b/packages/wrangler/src/__tests__/pages/dev.test.ts
@@ -27,7 +27,7 @@ describe("pages dev", () => {
 		await expect(
 			runWrangler("pages dev public -- yarn dev")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
-			`[Error: Specify either a directory OR a proxy command, not both.]`
+			`[Error: Cannot specify both a directory and a proxy command. Provide either a directory of static assets or a proxy command, not both.]`
 		);
 	});
 
@@ -37,7 +37,7 @@ describe("pages dev", () => {
 		await expect(
 			runWrangler("pages dev public --config=/path/to/wrangler.toml")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
-			`[Error: Pages does not support custom paths for the Wrangler configuration file]`
+			`[Error: Pages does not support custom paths for the Wrangler configuration file. Remove the --config flag, or use a standard wrangler.jsonc in your project root.]`
 		);
 	});
 
@@ -47,7 +47,7 @@ describe("pages dev", () => {
 		await expect(
 			runWrangler("pages dev public --env=production")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
-			`[Error: Pages does not support targeting an environment with the --env flag during local development.]`
+			`[Error: Pages does not support the --env flag during local development. Use the --branch flag to target your production or preview environment instead.]`
 		);
 	});
 });

--- a/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
@@ -49,7 +49,7 @@ describe("pages build env", () => {
 		await expect(
 			runWrangler("pages functions build-env")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
-			`[Error: No Pages project location specified]`
+			`[Error: Missing Pages project location. Provide the project directory as a positional argument.]`
 		);
 	});
 
@@ -57,7 +57,7 @@ describe("pages build env", () => {
 		await expect(
 			runWrangler("pages functions build-env .")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
-			`[Error: No outfile specified]`
+			`[Error: Missing output file. Use --outfile <path> to specify where to write the build environment configuration.]`
 		);
 	});
 

--- a/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
@@ -79,7 +79,7 @@ describe("pages deployment tail", () => {
 			await expect(
 				runWrangler("pages deployment tail")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Must specify a deployment in non-interactive mode.]`
+				`[Error: Missing deployment. In non-interactive mode, provide the deployment ID or URL as a positional argument.]`
 			);
 			expect(api.requests.deployments.count).toStrictEqual(0);
 			await api.closeHelper();
@@ -146,7 +146,7 @@ describe("pages deployment tail", () => {
 			await expect(
 				runWrangler("pages deployment tail foo")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Must specify a project name in non-interactive mode.]`
+				`[Error: Missing Pages project name. In non-interactive mode, use --project-name <name> to specify which project to tail.]`
 			);
 		});
 

--- a/packages/wrangler/src/__tests__/pages/pages-download-config.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-download-config.test.ts
@@ -888,7 +888,7 @@ describe("pages download config", () => {
 		await expect(
 			runWrangler(`pages download config`)
 		).rejects.toThrowErrorMatchingInlineSnapshot(
-			`[Error: Must specify a project name.]`
+			`[Error: Missing Pages project name. Provide the project name as a positional argument: wrangler pages download config <name>.]`
 		);
 	});
 	it("should fail if project does not exist", async ({ expect }) => {

--- a/packages/wrangler/src/__tests__/pages/secret.test.ts
+++ b/packages/wrangler/src/__tests__/pages/secret.test.ts
@@ -161,7 +161,7 @@ describe("wrangler pages secret", () => {
 						"pages secret put the-key --project some-project-name --env some-env"
 					)
 				).rejects.toMatchInlineSnapshot(
-					`[Error: Pages does not support the "some-env" named environment. Please specify "production" (default) or "preview"]`
+					`[Error: Pages does not support the "some-env" environment. Only "production" and "preview" are valid. Use --env production or --env preview.]`
 				);
 			});
 
@@ -169,7 +169,7 @@ describe("wrangler pages secret", () => {
 				await expect(
 					runWrangler("pages secret put the-key")
 				).rejects.toMatchInlineSnapshot(
-					`[Error: Must specify a project name.]`
+					`[Error: Missing Pages project name. Use --project-name <name> to specify which project to manage secrets for.]`
 				);
 			});
 		});
@@ -398,14 +398,16 @@ describe("wrangler pages secret", () => {
 					"pages secret delete the-key --project some-project-name --env some-env"
 				)
 			).rejects.toMatchInlineSnapshot(
-				`[Error: Pages does not support the "some-env" named environment. Please specify "production" (default) or "preview"]`
+				`[Error: Pages does not support the "some-env" environment. Only "production" and "preview" are valid. Use --env production or --env preview.]`
 			);
 		});
 
 		it("should error without a project name", async ({ expect }) => {
 			await expect(
 				runWrangler("pages secret delete the-key")
-			).rejects.toMatchInlineSnapshot(`[Error: Must specify a project name.]`);
+			).rejects.toMatchInlineSnapshot(
+				`[Error: Missing Pages project name. Use --project-name <name> to specify which project to manage secrets for.]`
+			);
 		});
 	});
 
@@ -487,14 +489,16 @@ describe("wrangler pages secret", () => {
 					"pages secret list --project some-project-name --env some-env"
 				)
 			).rejects.toMatchInlineSnapshot(
-				`[Error: Pages does not support the "some-env" named environment. Please specify "production" (default) or "preview"]`
+				`[Error: Pages does not support the "some-env" environment. Only "production" and "preview" are valid. Use --env production or --env preview.]`
 			);
 		});
 
 		it("should error without a project name", async ({ expect }) => {
 			await expect(
 				runWrangler("pages secret list")
-			).rejects.toMatchInlineSnapshot(`[Error: Must specify a project name.]`);
+			).rejects.toMatchInlineSnapshot(
+				`[Error: Missing Pages project name. Use --project-name <name> to specify which project to manage secrets for.]`
+			);
 		});
 	});
 

--- a/packages/wrangler/src/pages/build-env.ts
+++ b/packages/wrangler/src/pages/build-env.ts
@@ -4,6 +4,7 @@ import {
 	configFileName,
 	FatalError,
 	findWranglerConfig,
+	UserError,
 } from "@cloudflare/workers-utils";
 import { readPagesConfig } from "../config";
 import { createCommand } from "../core/create-command";
@@ -37,14 +38,18 @@ export const pagesFunctionsBuildEnvCommand = createCommand({
 	positionalArgs: ["projectDir"],
 	async handler(args) {
 		if (!args.projectDir) {
-			throw new FatalError("No Pages project location specified", {
-				telemetryMessage: "pages build env missing project directory",
-			});
+			throw new UserError(
+				"Missing Pages project location. Provide the project directory as a positional argument.",
+				{
+					telemetryMessage: "pages build env missing project directory",
+				}
+			);
 		}
 		if (!args.outfile) {
-			throw new FatalError("No outfile specified", {
-				telemetryMessage: "pages build env missing outfile",
-			});
+			throw new UserError(
+				"Missing output file. Use --outfile <path> to specify where to write the build environment configuration.",
+				{ telemetryMessage: "pages build env missing outfile" }
+			);
 		}
 
 		logger.log(

--- a/packages/wrangler/src/pages/deploy.ts
+++ b/packages/wrangler/src/pages/deploy.ts
@@ -276,10 +276,12 @@ export const pagesDeployCommand = createCommand({
 						projectName = await prompt("Enter the name of your new project:");
 
 						if (!projectName) {
-							throw new FatalError("Must specify a project name.", {
-								code: 1,
-								telemetryMessage: "pages deploy missing project name",
-							});
+							throw new UserError(
+								"Missing Pages project name. Use --project-name <name> or set the name in your Wrangler configuration file.",
+								{
+									telemetryMessage: "pages deploy missing project name",
+								}
+							);
 						}
 					}
 
@@ -322,10 +324,12 @@ export const pagesDeployCommand = createCommand({
 					});
 
 					if (!productionBranch) {
-						throw new FatalError("Must specify a production branch.", {
-							code: 1,
-							telemetryMessage: "pages deploy missing production branch",
-						});
+						throw new UserError(
+							"Missing production branch. Specify the production branch for your new Pages project when prompted, or re-run with the required information.",
+							{
+								telemetryMessage: "pages deploy missing production branch",
+							}
+						);
 					}
 
 					await fetchResult<Project>(
@@ -353,10 +357,10 @@ export const pagesDeployCommand = createCommand({
 		}
 
 		if (!projectName) {
-			throw new FatalError("Must specify a project name.", {
-				code: 1,
-				telemetryMessage: "pages deploy missing project name",
-			});
+			throw new UserError(
+				"Missing Pages project name. Use --project-name <name> or set the name in your Wrangler configuration file.",
+				{ telemetryMessage: "pages deploy missing project name" }
+			);
 		}
 
 		// We infer git info by default is not passed in

--- a/packages/wrangler/src/pages/deployment-tails.ts
+++ b/packages/wrangler/src/pages/deployment-tails.ts
@@ -2,6 +2,7 @@ import { setTimeout } from "node:timers/promises";
 import {
 	COMPLIANCE_REGION_CONFIG_PUBLIC,
 	FatalError,
+	UserError,
 } from "@cloudflare/workers-utils";
 import onExit from "signal-exit";
 import { fetchResult } from "../cfetch";
@@ -149,20 +150,18 @@ export const pagesDeploymentTailCommand = createCommand({
 
 		if (!isInteractive()) {
 			if (!deploymentId) {
-				throw new FatalError(
-					"Must specify a deployment in non-interactive mode.",
+				throw new UserError(
+					"Missing deployment. In non-interactive mode, provide the deployment ID or URL as a positional argument.",
 					{
-						code: 1,
 						telemetryMessage: "pages deployment tail missing deployment",
 					}
 				);
 			}
 
 			if (!projectName) {
-				throw new FatalError(
-					"Must specify a project name in non-interactive mode.",
+				throw new UserError(
+					"Missing Pages project name. In non-interactive mode, use --project-name <name> to specify which project to tail.",
 					{
-						code: 1,
 						telemetryMessage: "pages deployment tail missing project name",
 					}
 				);
@@ -174,10 +173,10 @@ export const pagesDeploymentTailCommand = createCommand({
 		}
 
 		if (!deployment && !projectName) {
-			throw new FatalError("Must specify a project name or deployment.", {
-				code: 1,
-				telemetryMessage: "pages deployment tail missing target",
-			});
+			throw new UserError(
+				"Missing target. Provide a deployment ID or URL as a positional argument, or use --project-name <name> to specify which project to tail.",
+				{ telemetryMessage: "pages deployment tail missing target" }
+			);
 		}
 
 		const deployments: Array<Deployment> = await fetchResult(

--- a/packages/wrangler/src/pages/deployments.ts
+++ b/packages/wrangler/src/pages/deployments.ts
@@ -1,6 +1,6 @@
 import {
 	COMPLIANCE_REGION_CONFIG_PUBLIC,
-	FatalError,
+	UserError,
 } from "@cloudflare/workers-utils";
 import { format as timeagoFormat } from "timeago.js";
 import { fetchResult } from "../cfetch";
@@ -60,10 +60,10 @@ export const pagesDeploymentListCommand = createCommand({
 		}
 
 		if (!projectName) {
-			throw new FatalError("Must specify a project name.", {
-				code: 1,
-				telemetryMessage: "pages deployments list missing project name",
-			});
+			throw new UserError(
+				"Missing Pages project name. Use --project-name <name> to specify which project to list deployments for.",
+				{ telemetryMessage: "pages deployments list missing project name" }
+			);
 		}
 
 		const deployments: Array<Deployment> = await fetchResult(
@@ -160,10 +160,12 @@ export const pagesDeploymentDeleteCommand = createCommand({
 		}
 
 		if (!projectName) {
-			throw new FatalError("Must specify a project name.", {
-				code: 1,
-				telemetryMessage: "pages deployments delete missing project name",
-			});
+			throw new UserError(
+				"Missing Pages project name. Use --project-name <name> to specify which project to delete the deployment from.",
+				{
+					telemetryMessage: "pages deployments delete missing project name",
+				}
+			);
 		}
 
 		const confirmed =

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -325,16 +325,16 @@ export const pagesDevCommand = createCommand({
 		}
 
 		if (args.config && !Array.isArray(args.config)) {
-			throw new FatalError(
-				"Pages does not support custom paths for the Wrangler configuration file",
-				{ code: 1, telemetryMessage: "pages dev custom config unsupported" }
+			throw new UserError(
+				"Pages does not support custom paths for the Wrangler configuration file. Remove the --config flag, or use a standard wrangler.jsonc in your project root.",
+				{ telemetryMessage: "pages dev custom config unsupported" }
 			);
 		}
 
 		if (args.env) {
-			throw new FatalError(
-				"Pages does not support targeting an environment with the --env flag during local development.",
-				{ code: 1, telemetryMessage: "pages dev env unsupported" }
+			throw new UserError(
+				"Pages does not support the --env flag during local development. Use the --branch flag to target your production or preview environment instead.",
+				{ telemetryMessage: "pages dev env unsupported" }
 			);
 		}
 
@@ -357,9 +357,10 @@ export const pagesDevCommand = createCommand({
 			config.configPath &&
 			path.resolve(process.cwd(), args.config[0]) !== config.configPath
 		) {
-			throw new FatalError(
-				"The first `--config` argument must point to your Pages configuration file: " +
-					path.relative(process.cwd(), config.configPath),
+			throw new UserError(
+				"The first `--config` argument must point to your Pages configuration file. Expected: " +
+					path.relative(process.cwd(), config.configPath) +
+					". Ensure the file exists and is a valid Pages configuration.",
 				{ telemetryMessage: "pages dev config path mismatch" }
 			);
 		}
@@ -370,9 +371,9 @@ export const pagesDevCommand = createCommand({
 		let directory = resolvedDirectory;
 
 		if (directory !== undefined && command.length > 0) {
-			throw new FatalError(
-				"Specify either a directory OR a proxy command, not both.",
-				{ code: 1, telemetryMessage: "pages dev conflicting serve targets" }
+			throw new UserError(
+				"Cannot specify both a directory and a proxy command. Provide either a directory of static assets or a proxy command, not both.",
+				{ telemetryMessage: "pages dev conflicting serve targets" }
 			);
 		} else if (directory === undefined) {
 			proxyPort = await spawnProxyProcess({

--- a/packages/wrangler/src/pages/download-config.ts
+++ b/packages/wrangler/src/pages/download-config.ts
@@ -4,6 +4,7 @@ import {
 	COMPLIANCE_REGION_CONFIG_PUBLIC,
 	FatalError,
 	getTodaysCompatDate,
+	UserError,
 } from "@cloudflare/workers-utils";
 import chalk from "chalk";
 import TOML from "smol-toml";
@@ -325,10 +326,12 @@ export const pagesDownloadConfigCommand = createCommand({
 		projectName ??= projectConfig.project_name;
 
 		if (!projectName) {
-			throw new FatalError("Must specify a project name.", {
-				code: 1,
-				telemetryMessage: "pages download config missing project name",
-			});
+			throw new UserError(
+				"Missing Pages project name. Provide the project name as a positional argument: wrangler pages download config <name>.",
+				{
+					telemetryMessage: "pages download config missing project name",
+				}
+			);
 		}
 		const config = await downloadProject(accountId, projectName);
 		if (!force && existsSync("wrangler.toml")) {

--- a/packages/wrangler/src/pages/projects.ts
+++ b/packages/wrangler/src/pages/projects.ts
@@ -1,7 +1,7 @@
 import { execSync } from "node:child_process";
 import {
 	COMPLIANCE_REGION_CONFIG_PUBLIC,
-	FatalError,
+	UserError,
 } from "@cloudflare/workers-utils";
 import { format as timeagoFormat } from "timeago.js";
 import { fetchResult } from "../cfetch";
@@ -143,10 +143,10 @@ export const pagesProjectCreateCommand = createCommand({
 		}
 
 		if (!projectName) {
-			throw new FatalError("Must specify a project name.", {
-				code: 1,
-				telemetryMessage: "pages projects create missing project name",
-			});
+			throw new UserError(
+				"Missing Pages project name. Provide the project name as a positional argument: wrangler pages project create <name>.",
+				{ telemetryMessage: "pages projects create missing project name" }
+			);
 		}
 
 		if (!productionBranch && isInteractive) {
@@ -187,10 +187,12 @@ export const pagesProjectCreateCommand = createCommand({
 		}
 
 		if (!productionBranch) {
-			throw new FatalError("Must specify a production branch.", {
-				code: 1,
-				telemetryMessage: "pages projects create missing production branch",
-			});
+			throw new UserError(
+				"Missing production branch. Use --production-branch <branch> to specify the production branch for your Pages project.",
+				{
+					telemetryMessage: "pages projects create missing production branch",
+				}
+			);
 		}
 
 		const deploymentConfig = {

--- a/packages/wrangler/src/pages/secret/index.ts
+++ b/packages/wrangler/src/pages/secret/index.ts
@@ -3,6 +3,7 @@ import {
 	configFileName,
 	FatalError,
 	findWranglerConfig,
+	UserError,
 } from "@cloudflare/workers-utils";
 import chalk from "chalk";
 import { fetchResult } from "../../cfetch";
@@ -38,9 +39,9 @@ async function pagesProject(
 }> {
 	env ??= "production";
 	if (!isPagesEnv(env)) {
-		throw new FatalError(
-			`Pages does not support the "${env}" named environment. Please specify "production" (default) or "preview"`,
-			{ code: 1, telemetryMessage: "pages secret env unsupported" }
+		throw new UserError(
+			`Pages does not support the "${env}" environment. Only "production" and "preview" are valid. Use --env production or --env preview.`,
+			{ telemetryMessage: "pages secret env unsupported" }
 		);
 	}
 	let config: Config | undefined;
@@ -105,10 +106,10 @@ async function pagesProject(
 			throw err;
 		}
 	} else {
-		throw new FatalError("Must specify a project name.", {
-			code: 1,
-			telemetryMessage: "pages secret missing project name",
-		});
+		throw new UserError(
+			"Missing Pages project name. Use --project-name <name> to specify which project to manage secrets for.",
+			{ telemetryMessage: "pages secret missing project name" }
+		);
 	}
 	return { env, project, accountId, config };
 }

--- a/packages/wrangler/src/pages/upload.ts
+++ b/packages/wrangler/src/pages/upload.ts
@@ -5,6 +5,7 @@ import {
 	APIError,
 	COMPLIANCE_REGION_CONFIG_PUBLIC,
 	FatalError,
+	UserError,
 } from "@cloudflare/workers-utils";
 import PQueue from "p-queue";
 import { fetchResult } from "../cfetch";
@@ -53,10 +54,10 @@ export const pagesProjectUploadCommand = createCommand({
 	positionalArgs: ["directory"],
 	async handler({ directory, outputManifestPath, skipCaching }) {
 		if (!directory) {
-			throw new FatalError("Must specify a directory.", {
-				code: 1,
-				telemetryMessage: "pages upload missing directory",
-			});
+			throw new UserError(
+				"Missing directory. Provide the path to your build output directory as a positional argument.",
+				{ telemetryMessage: "pages upload missing directory" }
+			);
 		}
 
 		if (!process.env.CF_PAGES_UPLOAD_JWT) {

--- a/packages/wrangler/src/pages/validate.ts
+++ b/packages/wrangler/src/pages/validate.ts
@@ -1,6 +1,6 @@
 import { readdir, stat } from "node:fs/promises";
 import { join, relative, resolve, sep } from "node:path";
-import { FatalError } from "@cloudflare/workers-utils";
+import { FatalError, UserError } from "@cloudflare/workers-utils";
 import { getType } from "mime";
 import { Minimatch } from "minimatch";
 import prettyBytes from "pretty-bytes";
@@ -29,10 +29,10 @@ export const pagesProjectValidateCommand = createCommand({
 	positionalArgs: ["directory"],
 	async handler({ directory }) {
 		if (!directory) {
-			throw new FatalError("Must specify a directory.", {
-				code: 1,
-				telemetryMessage: "pages validate missing directory",
-			});
+			throw new UserError(
+				"Missing directory. Provide the path to the directory to validate as a positional argument.",
+				{ telemetryMessage: "pages validate missing directory" }
+			);
 		}
 
 		const fileCountLimit = process.env.CF_PAGES_UPLOAD_JWT


### PR DESCRIPTION
Error messages across `wrangler pages` subcommands (deploy, dev, secret, project, etc.) now provide clearer descriptions and actionable guidance. For example, instead of "Must specify a project name.", you'll now see "Missing Pages project name. Use --project-name <name> or set the name in your wrangler.jsonc configuration file."

Input validation errors also now use `UserError` instead of `FatalError` for more accurate error classification.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: just improving some error messages

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
