### PR TITLE
[wrangler] Show OAuth callback errors instead of hanging on `wrangler login`

### DIFF
--- a/.changeset/wrangler-login-oauth-callback-error-hang.md
+++ b/.changeset/wrangler-login-oauth-callback-error-hang.md
@@ -1,5 +1,6 @@
 ---
 "wrangler": patch
+"@cloudflare/workers-auth": patch
 ---
 
 Show the actual OAuth error instead of hanging when `wrangler login` is rejected by the OAuth provider (for example with `invalid_scope`).

--- a/.changeset/wrangler-login-oauth-callback-error-hang.md
+++ b/.changeset/wrangler-login-oauth-callback-error-hang.md
@@ -1,0 +1,16 @@
+---
+"wrangler": patch
+---
+
+Show the actual OAuth error instead of hanging when `wrangler login` is rejected by the OAuth provider (for example with `invalid_scope`).
+
+Previously, if the OAuth callback returned with an `error` other than `access_denied`, Wrangler would never respond to the browser. Because `server.close()`'s callback only fires once all open connections have ended, the login command would hang until the 120 second OAuth timeout — at which point it would print a generic timeout message rather than the actual OAuth failure. The same gap existed for the case where the OAuth provider redirected back without an authorisation code, and for failures during the auth-code-to-access-token exchange.
+
+The OAuth provider's `error_description` (RFC 6749 §4.1.2.1) is now also surfaced, so the message includes the specific reason for the failure rather than just the bare `error` code. For example, a misconfigured staging scope now surfaces as:
+
+```
+OAuth error: invalid_scope
+  The OAuth 2.0 Client is not allowed to request scope 'browser:write'.
+```
+
+instead of hanging silently.

--- a/packages/workers-auth/src/callback-server.ts
+++ b/packages/workers-auth/src/callback-server.ts
@@ -16,7 +16,7 @@ import assert from "node:assert";
 import http from "node:http";
 import url from "node:url";
 import { UserError } from "@cloudflare/workers-utils";
-import { ErrorAccessDenied, ErrorNoAuthCode } from "./errors";
+import { ErrorAccessDenied, ErrorNoAuthCode, ErrorOAuth2 } from "./errors";
 import {
 	exchangeAuthCodeForAccessToken,
 	getAuthURL,
@@ -85,6 +85,15 @@ export async function getOauthToken(
 			function finish(token: AccessContext): void;
 			function finish(token: AccessContext | null, error?: Error) {
 				clearTimeout(loginTimeoutHandle);
+				// Defensive: every code path that calls `finish()` should already
+				// have written a response, but if not, end the connection so that
+				// `server.close()` can complete (its callback only fires once all
+				// open connections have ended). Without this, a future code path
+				// that forgets to send a response could cause `wrangler login` to
+				// hang until the OAuth timeout.
+				if (!res.writableEnded) {
+					res.end();
+				}
 				server.close((closeErr?: Error) => {
 					if (error || closeErr) {
 						reject(error || closeErr);
@@ -93,6 +102,52 @@ export async function getOauthToken(
 						resolve(token);
 					}
 				});
+			}
+
+			function renderErrorPage(detail: {
+				code?: string;
+				description?: string;
+			}): void {
+				const escape = (s: string) =>
+					s.replace(
+						/[&<>"']/g,
+						(c) =>
+							({
+								"&": "&amp;",
+								"<": "&lt;",
+								">": "&gt;",
+								'"': "&quot;",
+								"'": "&#39;",
+							})[c] as string
+					);
+				const codeRow = detail.code
+					? `<p>Code: <code>${escape(detail.code)}</code></p>`
+					: "";
+				const descriptionRow = detail.description
+					? `<p class="detail">${escape(detail.description)}</p>`
+					: "";
+				const body = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Wrangler login failed</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; max-width: 720px; margin: 4rem auto; padding: 0 1rem; color: #1f2933; line-height: 1.5; }
+    h1 { color: #c12d3f; }
+    code { background: #f5f7fa; padding: 0.15em 0.3em; border-radius: 3px; }
+    p.detail { background: #f5f7fa; padding: 1rem; border-radius: 4px; white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <h1>Wrangler login failed</h1>
+  <p>The Cloudflare OAuth provider returned an error.</p>
+  ${codeRow}
+  ${descriptionRow}
+  <p>You can close this tab and return to your terminal for more details.</p>
+</body>
+</html>`;
+				res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
+				res.end(body);
 			}
 
 			assert(req.url, "This request doesn't have a URL"); // This should never happen
@@ -120,45 +175,58 @@ export async function getOauthToken(
 							});
 
 							return;
-						} else {
-							finish(null, err as Error);
-							return;
 						}
+						const oauthErr = err as ErrorOAuth2;
+						renderErrorPage({
+							code: oauthErr.code,
+							description: oauthErr.description ?? oauthErr.message,
+						});
+						finish(null, oauthErr);
+						return;
 					}
 					if (!hasAuthCode) {
-						// render an error page here
+						const noCodeMessage =
+							"The Cloudflare OAuth provider did not return an authorisation code.";
+						renderErrorPage({ description: noCodeMessage });
 						finish(
 							null,
-							new ErrorNoAuthCode("", {
+							new ErrorNoAuthCode(noCodeMessage, {
 								telemetryMessage: "user oauth missing auth code",
 							})
 						);
 						return;
-					} else {
-						// `exchangeAuthCodeForAccessToken` can reject (network error,
-						// invalid JSON, OAuth error response, etc.). Without this
-						// `try/catch` the rejection would become an unhandled promise
-						// rejection inside an `http.createServer` callback, which is
-						// not promise-aware — Node.js >= 15 terminates the process on
-						// unhandled rejection by default. Route the error through
-						// `finish` so the caller's promise rejects cleanly.
-						try {
-							const exchange = await exchangeAuthCodeForAccessToken(
-								state,
-								ctx.logger,
-								ctx.isNonInteractiveOrCI
-							);
-							res.writeHead(307, {
-								Location: options.granted.url,
-							});
-							res.end(() => {
-								finish(exchange);
-							});
-						} catch (err) {
-							finish(null, err as Error);
-						}
-						return;
 					}
+					// `exchangeAuthCodeForAccessToken` can reject (network error,
+					// invalid JSON, OAuth error response, etc.). Without this
+					// `try/catch` the rejection would become an unhandled promise
+					// rejection inside an `http.createServer` callback, which is
+					// not promise-aware — Node.js >= 15 terminates the process on
+					// unhandled rejection by default. Route the error through
+					// `finish` so the caller's promise rejects cleanly.
+					try {
+						const exchange = await exchangeAuthCodeForAccessToken(
+							state,
+							ctx.logger,
+							ctx.isNonInteractiveOrCI
+						);
+						res.writeHead(307, {
+							Location: options.granted.url,
+						});
+						res.end(() => {
+							finish(exchange);
+						});
+					} catch (err: unknown) {
+						const exchangeErr = err as ErrorOAuth2;
+						renderErrorPage({
+							code: exchangeErr.code,
+							description:
+								exchangeErr.description ??
+								exchangeErr.message ??
+								"Failed to exchange the authorisation code for an access token.",
+						});
+						finish(null, exchangeErr);
+					}
+					return;
 				}
 			}
 		});

--- a/packages/workers-auth/src/callback-server.ts
+++ b/packages/workers-auth/src/callback-server.ts
@@ -216,11 +216,17 @@ export async function getOauthToken(
 							finish(exchange);
 						});
 					} catch (err: unknown) {
-						const exchangeErr = err as ErrorOAuth2;
+						// `exchangeAuthCodeForAccessToken` can throw an `ErrorOAuth2`
+						// (for provider-side errors), or a plain `Error` (for JSON
+						// parse failures in `getJSONFromResponse`, network errors
+						// from `fetchAuthToken`, etc.). Only read the structured
+						// OAuth fields when we know we have them.
+						const exchangeErr = err as Error;
+						const isOAuthError = exchangeErr instanceof ErrorOAuth2;
 						renderErrorPage({
-							code: exchangeErr.code,
+							code: isOAuthError ? exchangeErr.code : undefined,
 							description:
-								exchangeErr.description ??
+								(isOAuthError ? exchangeErr.description : undefined) ??
 								exchangeErr.message ??
 								"Failed to exchange the authorisation code for an access token.",
 						});

--- a/packages/workers-auth/src/errors.ts
+++ b/packages/workers-auth/src/errors.ts
@@ -16,16 +16,26 @@ import { UserError } from "@cloudflare/workers-utils";
 
 /**
  * A list of OAuth2AuthCodePKCE errors.
+ *
+ * Instances may carry the structured details from the OAuth provider's
+ * `error`, `error_description` and `error_uri` query parameters (RFC 6749
+ * §4.1.2.1) so callers can render them — see {@link toErrorClass}.
  */
 // To "namespace" all errors.
 export class ErrorOAuth2 extends UserError {
+	/** The OAuth `error` code returned by the provider (e.g. `invalid_scope`). */
+	code?: string;
+	/** The OAuth `error_description` returned by the provider, if any. */
+	description?: string;
+	/** The OAuth `error_uri` returned by the provider, if any. */
+	uri?: string;
 	toString(): string {
 		return "ErrorOAuth2";
 	}
 }
 
 // Unclassified Oauth errors
-export class ErrorUnknown extends UserError {
+export class ErrorUnknown extends ErrorOAuth2 {
 	toString(): string {
 		return "ErrorUnknown";
 	}
@@ -125,61 +135,108 @@ export class ErrorUnsupportedGrantType extends ErrorAccessTokenResponse {
 }
 
 /**
- * Translate the raw error strings returned from the server into error classes.
+ * Format the parts of an OAuth provider error response into a single,
+ * user-facing message.
  */
-export function toErrorClass(rawError: string): ErrorOAuth2 | ErrorUnknown {
+function formatOAuthErrorMessage(
+	code: string,
+	description: string | undefined,
+	uri: string | undefined
+): string {
+	let message = `OAuth error: ${code}`;
+	if (description) {
+		message += `\n  ${description}`;
+	}
+	if (uri) {
+		message += `\n  See: ${uri}`;
+	}
+	return message;
+}
+
+/**
+ * Translate an OAuth error response from the provider into one of our error
+ * classes. The `error_description` and `error_uri` parameters (RFC 6749
+ * §4.1.2.1) are included in the message when present so the user sees the
+ * specific reason for the failure rather than just the bare error code, and
+ * are also attached as structured fields so the HTTP callback handler can
+ * render them on the browser-facing error page.
+ */
+export function toErrorClass(
+	rawError: string,
+	description?: string,
+	uri?: string
+): ErrorOAuth2 | ErrorUnknown {
+	const message = formatOAuthErrorMessage(rawError, description, uri);
+	let error: ErrorOAuth2 | ErrorUnknown;
 	switch (rawError) {
 		case "invalid_request":
-			return new ErrorInvalidRequest(rawError, {
+			error = new ErrorInvalidRequest(message, {
 				telemetryMessage: "user oauth invalid request",
 			});
+			break;
 		case "invalid_grant":
-			return new ErrorInvalidGrant(rawError, {
+			error = new ErrorInvalidGrant(message, {
 				telemetryMessage: "user oauth invalid grant",
 			});
+			break;
 		case "unauthorized_client":
-			return new ErrorUnauthorizedClient(rawError, {
+			error = new ErrorUnauthorizedClient(message, {
 				telemetryMessage: "user oauth unauthorized client",
 			});
+			break;
 		case "access_denied":
-			return new ErrorAccessDenied(rawError, {
+			error = new ErrorAccessDenied(message, {
 				telemetryMessage: "user oauth access denied",
 			});
+			break;
 		case "unsupported_response_type":
-			return new ErrorUnsupportedResponseType(rawError, {
+			error = new ErrorUnsupportedResponseType(message, {
 				telemetryMessage: "user oauth unsupported response type",
 			});
+			break;
 		case "invalid_scope":
-			return new ErrorInvalidScope(rawError, {
+			error = new ErrorInvalidScope(message, {
 				telemetryMessage: "user oauth invalid scope",
 			});
+			break;
 		case "server_error":
-			return new ErrorServerError(rawError, {
+			error = new ErrorServerError(message, {
 				telemetryMessage: "user oauth server error",
 			});
+			break;
 		case "temporarily_unavailable":
-			return new ErrorTemporarilyUnavailable(rawError, {
+			error = new ErrorTemporarilyUnavailable(message, {
 				telemetryMessage: "user oauth temporarily unavailable",
 			});
+			break;
 		case "invalid_client":
-			return new ErrorInvalidClient(rawError, {
+			error = new ErrorInvalidClient(message, {
 				telemetryMessage: "user oauth invalid client",
 			});
+			break;
 		case "unsupported_grant_type":
-			return new ErrorUnsupportedGrantType(rawError, {
+			error = new ErrorUnsupportedGrantType(message, {
 				telemetryMessage: "user oauth unsupported grant type",
 			});
+			break;
 		case "invalid_json":
-			return new ErrorInvalidJson(rawError, {
+			error = new ErrorInvalidJson(message, {
 				telemetryMessage: "user oauth invalid json",
 			});
+			break;
 		case "invalid_token":
-			return new ErrorInvalidToken(rawError, {
+			error = new ErrorInvalidToken(message, {
 				telemetryMessage: "user oauth invalid token",
 			});
+			break;
 		default:
-			return new ErrorUnknown(rawError, {
+			error = new ErrorUnknown(message, {
 				telemetryMessage: "user oauth unknown error",
 			});
+			break;
 	}
+	error.code = rawError;
+	error.description = description;
+	error.uri = uri;
+	return error;
 }

--- a/packages/workers-auth/src/token-exchange.ts
+++ b/packages/workers-auth/src/token-exchange.ts
@@ -64,10 +64,14 @@ export function isReturningFromAuthServer(
 	logger: OAuthFlowContext["logger"]
 ): boolean {
 	if (query.error) {
-		if (Array.isArray(query.error)) {
-			throw toErrorClass(query.error[0]);
-		}
-		throw toErrorClass(query.error);
+		const error = Array.isArray(query.error) ? query.error[0] : query.error;
+		const description = Array.isArray(query.error_description)
+			? query.error_description[0]
+			: query.error_description;
+		const uri = Array.isArray(query.error_uri)
+			? query.error_uri[0]
+			: query.error_uri;
+		throw toErrorClass(error, description, uri);
 	}
 
 	const code = query.code;

--- a/packages/workers-auth/src/token-exchange.ts
+++ b/packages/workers-auth/src/token-exchange.ts
@@ -257,7 +257,10 @@ export async function exchangeAuthCodeForAccessToken(
 	}
 	const json = (await getJSONFromResponse(response, logger)) as TokenResponse;
 	if ("error" in json) {
-		throw new Error(json.error);
+		// The token endpoint normally returns OAuth errors via a 4xx status
+		// (handled above), but be defensive: surface a 2xx-with-error-body as
+		// a structured OAuth error too so the catch site can render the code.
+		throw toErrorClass(json.error);
 	}
 	const { access_token, expires_in, refresh_token, scope } = json;
 	state.hasAuthCodeBeenExchangedForAccessToken = true;

--- a/packages/wrangler/src/__tests__/helpers/mock-http-server.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-http-server.ts
@@ -5,18 +5,33 @@ import type { Request } from "undici";
 /**
  * Setup a mock HTTP server that can be triggered directly without interacting with any network.
  *
+ * The mock mirrors production semantics for `server.close()`: its callback only
+ * fires once `res.end()` has been observed. A code path that forgets to send a
+ * response cannot rely on `server.close()` to clean up — exactly as in
+ * production — and tests for such code paths will fail at the vitest test
+ * timeout rather than passing by accident.
+ *
  * @returns a `fetch`-like function that will trigger the mock server to handle the request.
  */
 export function mockHttpServer() {
 	let listener: http.RequestListener;
+	let pendingCloseCallback: ((err?: Error) => void) | undefined;
+	let responseEnded = false;
 
 	beforeEach(() => {
+		pendingCloseCallback = undefined;
+		responseEnded = false;
+
 		vi.spyOn(http, "createServer").mockImplementation((...args: unknown[]) => {
 			listener = args.pop() as http.RequestListener;
 			return {
 				listen: vi.fn(),
 				close(callback?: (err?: Error) => void) {
-					callback?.();
+					if (responseEnded) {
+						callback?.();
+					} else {
+						pendingCloseCallback = callback;
+					}
 					return this;
 				},
 				// The OAuth callback server registers an `error` listener so it
@@ -34,16 +49,35 @@ export function mockHttpServer() {
 			req as unknown as http.IncomingMessage
 		);
 
-		// The listener will attache a callback to the response by calling `resp.end(callback)`.
-		// We want to capture that so that we can trigger it after the listener has completed its work.
+		// The listener may attach a callback to the response by calling `resp.end(callback)`.
+		// We capture that so we can trigger it once the listener has finished its async work,
+		// and then fire any pending `server.close()` callback (mirroring production semantics
+		// where `server.close()` only fires once all open connections have ended).
 		const endSpy = vi.spyOn(resp, "end");
 
-		// The `await` here is important to allow the listener to complete its async work before we end the response.
+		// The `await` here is important to allow the listener to complete its async work before
+		// we end the response.
 		await listener(req as unknown as http.IncomingMessage, resp);
 
-		// Now trigger the end callback.
-		const endCallback = endSpy.mock.calls[0].pop();
-		endCallback?.();
+		if (endSpy.mock.calls.length > 0) {
+			// Invoke the optional callback passed to `res.end()` (if any).
+			const lastCall = endSpy.mock.calls[endSpy.mock.calls.length - 1];
+			const lastArg = lastCall[lastCall.length - 1];
+			if (typeof lastArg === "function") {
+				(lastArg as () => void)();
+			}
+			// Mark the response as ended and fire the pending `server.close()` callback,
+			// if any. The close callback may have been registered synchronously by the
+			// `res.end()` callback above (e.g. via `finish()` in `getOauthToken`), so we
+			// read it after invoking that callback.
+			responseEnded = true;
+			const cb = pendingCloseCallback;
+			pendingCloseCallback = undefined;
+			cb?.();
+		}
+		// If `res.end()` was never called, this mimics production: `server.close()`'s
+		// callback never fires, and the caller will time out. Tests that hit this path
+		// will fail at the vitest test timeout.
 
 		return resp;
 	};

--- a/packages/wrangler/src/__tests__/helpers/mock-oauth-flow.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-oauth-flow.ts
@@ -191,10 +191,12 @@ export function mockExchangeRefreshTokenForAccessToken({
 type GrantResponseOptions = {
 	code?: string;
 	error?: ErrorType | ErrorType[];
+	error_description?: string;
+	error_uri?: string;
 };
 
 const toQueryParams = (
-	{ code, error }: GrantResponseOptions,
+	{ code, error, error_description, error_uri }: GrantResponseOptions,
 	wranglerRequestParams: URLSearchParams
 ): string => {
 	const queryParams = [];
@@ -204,6 +206,14 @@ const toQueryParams = (
 	if (error) {
 		const stringifiedErr = Array.isArray(error) ? error.join(",") : error;
 		queryParams.push(`error=${stringifiedErr}`);
+	}
+	if (error_description) {
+		queryParams.push(
+			`error_description=${encodeURIComponent(error_description)}`
+		);
+	}
+	if (error_uri) {
+		queryParams.push(`error_uri=${encodeURIComponent(error_uri)}`);
 	}
 
 	queryParams.push(`state=${wranglerRequestParams.get("state")}`);

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -360,6 +360,29 @@ describe("User", () => {
 					`[Error: OAuth error: invalid_grant]`
 				);
 			});
+
+			it("rejects with the provider error when /oauth2/token returns 2xx with an error body", async ({
+				expect,
+			}) => {
+				// Defensive handling of the (non-standard) case where the token
+				// endpoint returns a success status but the body still carries an
+				// OAuth `error` field. The error should still be surfaced via
+				// `toErrorClass` rather than as a plain `Error`.
+				mockOAuthServerCallback("success");
+				msw.use(
+					http.post(
+						"*/oauth2/token",
+						() => HttpResponse.json({ error: "invalid_token" }),
+						{ once: true }
+					)
+				);
+
+				await expect(
+					runWrangler("login")
+				).rejects.toThrowErrorMatchingInlineSnapshot(
+					`[Error: OAuth error: invalid_token]`
+				);
+			});
 		});
 	});
 

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -291,6 +291,76 @@ describe("User", () => {
 			Please use a Cloudflare API token (\`CLOUDFLARE_API_TOKEN\` environment variable) or remove the \`CLOUDFLARE_API_ENVIRONMENT\` environment variable.]
 		`);
 		});
+
+		// Regression coverage for the OAuth callback hang. When the OAuth
+		// provider redirected to `/oauth/callback?error=...` with any error
+		// other than `access_denied`, Wrangler used to never write a response,
+		// causing `server.close()` to wait forever for the connection to drain
+		// and the login command to hang until the 120s OAuth timeout. The
+		// tightened `mock-http-server.ts` faithfully reproduces those
+		// production semantics, so a regression would cause these tests to
+		// fail at the vitest test timeout rather than passing by accident.
+		describe("OAuth callback error handling", () => {
+			it("rejects with the bare OAuth error code when no description is provided", async ({
+				expect,
+			}) => {
+				mockOAuthServerCallback({ error: "invalid_scope" });
+
+				await expect(
+					runWrangler("login")
+				).rejects.toThrowErrorMatchingInlineSnapshot(
+					`[Error: OAuth error: invalid_scope]`
+				);
+			});
+
+			it("rejects with both the OAuth error code and error_description", async ({
+				expect,
+			}) => {
+				mockOAuthServerCallback({
+					error: "invalid_scope",
+					error_description:
+						"The OAuth 2.0 Client is not allowed to request scope 'browser:write'.",
+				});
+
+				await expect(runWrangler("login")).rejects
+					.toThrowErrorMatchingInlineSnapshot(`
+					[Error: OAuth error: invalid_scope
+					  The OAuth 2.0 Client is not allowed to request scope 'browser:write'.]
+				`);
+			});
+
+			it("rejects with the existing consent-denied message for access_denied", async ({
+				expect,
+			}) => {
+				mockOAuthServerCallback({ error: "access_denied" });
+
+				await expect(runWrangler("login")).rejects
+					.toThrowErrorMatchingInlineSnapshot(`
+					[Error: Error: Consent denied. You must grant consent to Wrangler in order to login.
+					If you don't want to do this consider passing an API token via the \`CLOUDFLARE_API_TOKEN\` environment variable]
+				`);
+			});
+
+			it("rejects with the provider error when /oauth2/token fails after a valid auth code", async ({
+				expect,
+			}) => {
+				mockOAuthServerCallback("success");
+				msw.use(
+					http.post(
+						"*/oauth2/token",
+						() =>
+							HttpResponse.json({ error: "invalid_grant" }, { status: 400 }),
+						{ once: true }
+					)
+				);
+
+				await expect(
+					runWrangler("login")
+				).rejects.toThrowErrorMatchingInlineSnapshot(
+					`[Error: OAuth error: invalid_grant]`
+				);
+			});
+		});
 	});
 
 	it("should handle errors for failed token refresh in a non-interactive environment", async ({


### PR DESCRIPTION
When `wrangler login` is rejected by the Cloudflare OAuth provider — for example when the provider doesn't support a scope Wrangler is requesting — the OAuth callback redirects to `http://localhost:8976/oauth/callback?error=...`. Previously, for any error other than `access_denied`, Wrangler:

1. Threw the OAuth error from inside the local HTTP callback handler without ever calling `res.end()`.
2. Called `server.close()`, which only fires its callback once all open connections have ended.
3. The browser tab was still waiting for a response, so `server.close()` never completed.
4. The login promise never settled, until the 120 second OAuth timeout fired with a generic _"Timed out waiting for authorization code"_ message.

Net effect: the real OAuth error was silently swallowed and Wrangler hung for two minutes.

This PR:

- Always writes an HTTP response on every OAuth callback exit path (a minimal inline HTML error page for non-`access_denied` errors, mirroring how `access_denied` already redirects to a hosted "consent denied" page). The same fix covers the previously-broken no-auth-code branch (`// render an error page here`) and a now-`try/catch`-wrapped token-exchange branch.
- Reads `error_description` and `error_uri` from the OAuth callback query string (RFC 6749 §4.1.2.1) and includes them in the surfaced error so the user sees the specific reason. For example a misconfigured scope now surfaces as:

  ```
  OAuth error: invalid_scope
    The OAuth 2.0 Client is not allowed to request scope 'browser:write'.
  ```

  instead of hanging silently.
- Adds a defensive `if (!res.writableEnded) res.end()` in `finish()` so a future code path that forgets to send a response can't reintroduce the hang.
- Tightens `mock-http-server.ts` to faithfully reproduce production `server.close()` semantics (its callback only fires once `res.end()` has been observed). Without this, tests for the broken behaviour would pass by accident because the mock's `close()` fired its callback unconditionally.
- Adds tests for `invalid_scope` (with and without `error_description`), `access_denied` (previously untested), and a token-exchange failure on the success path.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is a bug fix for an error message that was previously swallowed; no user-visible documented behaviour changes.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->