### PR TITLE
[vite-plugin] Expose /__scheduled alias for testing scheduled handlers

### DIFF
--- a/.changeset/vite-plugin-scheduled-alias.md
+++ b/.changeset/vite-plugin-scheduled-alias.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Expose `/__scheduled` for workers built by `@cloudflare/vite-plugin`
+
+The `/__scheduled` dev-only endpoint that Wrangler exposes via the `--test-scheduled` flag was unavailable when a worker was bundled by `@cloudflare/vite-plugin`, because Wrangler injects the supporting middleware at bundle time and that step does not run under Vite. Requests to `/__scheduled` fell through to the user's router and returned 404.
+
+The vite-plugin now serves `/__scheduled` as an alias for `/cdn-cgi/handler/scheduled` on its dev server, forwarding any `time` and `cron` query parameters to the worker's `scheduled` handler. The existing `/cdn-cgi/handler/scheduled` route continues to work unchanged.

--- a/packages/vite-plugin-cloudflare/playground/cron-triggers/__tests__/cron-triggers.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/cron-triggers/__tests__/cron-triggers.spec.ts
@@ -8,3 +8,13 @@ test("Supports testing Cron Triggers at '/cdn-cgi/handler/scheduled' route", asy
 	expect(cronResponse).toBe("ok");
 	expect(serverLogs.info.join()).toContain("Cron processed");
 });
+
+test("Supports testing Cron Triggers at the '/__scheduled' alias", async ({
+	expect,
+}) => {
+	const cronResponse = await getTextResponse(
+		"/__scheduled?time=0&cron=*+*+*+*+*"
+	);
+	expect(cronResponse).toBe("ok");
+	expect(serverLogs.info.join()).toContain("Cron processed");
+});

--- a/packages/vite-plugin-cloudflare/src/plugins/trigger-handlers.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/trigger-handlers.ts
@@ -1,8 +1,12 @@
-import { CoreHeaders } from "miniflare";
+import { CoreHeaders, CorePaths, Request as MiniflareRequest } from "miniflare";
 import { createPlugin, createRequestHandler } from "../utils";
 
 /**
- * Plugin to forward `/cdn-cgi/handler/*` routes to trigger handlers in development
+ * Plugin to forward `/cdn-cgi/handler/*` routes to trigger handlers in development.
+ *
+ * Also exposes `/__scheduled` as an alias for `/cdn-cgi/handler/scheduled` so workers
+ * built by this plugin honor the same dev-only contract that Wrangler's
+ * `--test-scheduled` flag exposes.
  */
 export const triggerHandlersPlugin = createPlugin("trigger-handlers", (ctx) => {
 	return {
@@ -15,14 +19,33 @@ export const triggerHandlersPlugin = createPlugin("trigger-handlers", (ctx) => {
 			}
 
 			const entryWorkerName = entryWorkerConfig.name;
-			const requestHandler = createRequestHandler((request) => {
+			// [LAW:single-enforcer] `dispatch` is the one place that forwards
+			// trigger-handler requests to the worker; both URL boundaries below
+			// funnel through it.
+			const dispatch = (request: MiniflareRequest) => {
 				request.headers.set(CoreHeaders.ROUTE_OVERRIDE, entryWorkerName);
 				return ctx.miniflare.dispatchFetch(request, {
 					redirect: "manual",
 				});
-			});
+			};
 
-			viteDevServer.middlewares.use("/cdn-cgi/handler/", requestHandler);
+			viteDevServer.middlewares.use(
+				"/cdn-cgi/handler/",
+				createRequestHandler((request) => dispatch(request))
+			);
+
+			// [LAW:dataflow-not-control-flow] `/__scheduled` is a legacy alias for
+			// `/cdn-cgi/handler/scheduled`. The variability is the URL value, not
+			// whether code runs — rewrite the pathname and reuse the single dispatch
+			// path so the scheduled-trigger contract stays in miniflare's entry worker.
+			viteDevServer.middlewares.use(
+				"/__scheduled",
+				createRequestHandler((request) => {
+					const aliasedUrl = new URL(request.url);
+					aliasedUrl.pathname = CorePaths.SCHEDULED;
+					return dispatch(new MiniflareRequest(aliasedUrl, request));
+				})
+			);
 		},
 	};
 });


### PR DESCRIPTION
Workers built by `@cloudflare/vite-plugin` had no way to trigger their `scheduled` handler locally via `/__scheduled`. That endpoint is normally supplied by a middleware that Wrangler injects at bundle time (`packages/wrangler/templates/middleware/middleware-scheduled.ts`), and Wrangler's bundler step does not run when Vite produces the worker bundle, so requests fall through to the user's router and 404. This was confirmed upstream in #9882.

This change forwards `/__scheduled` on the vite-plugin dev server to the same enforcer that already serves `/cdn-cgi/handler/scheduled` — Miniflare's entry worker. The path is a pure URL alias that preserves `time` and `cron` query parameters; no new dispatch logic is introduced and the existing `/cdn-cgi/handler/scheduled` route is untouched.

A new playground test in `cron-triggers` asserts that `GET /__scheduled?time=0&cron=*+*+*+*+*` returns `200 ok` and that the worker's `scheduled` handler observably runs.

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This restores parity with Wrangler's existing \`--test-scheduled\` dev contract that is already documented; behaviour for users of \`@cloudflare/vite-plugin\` now matches the documented Wrangler behaviour.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->