### PR TITLE
[wrangler] Make Wrangler compatible with the Bun runtime

### DIFF
--- a/.changeset/bun-compatibility.md
+++ b/.changeset/bun-compatibility.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Fix Bun compatibility issues in Wrangler when deploying assets and performing API requests
+
+- Replaced the platform-specific native WASM `blake3-wasm` dependency with the pure-JS `@noble/hashes` library for robust file hashing under Bun.
+- Added type-safe conditional fallbacks in the Cloudflare API fetch client to leverage native `globalThis.fetch` under the Bun runtime to prevent connection pool hanging and early process exits.
+- Implemented transparent FormData cloning to correctly serialize `undici` `FormData` instances as native `globalThis.FormData` bodies when running under Bun, ensuring correct API boundary headers.

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -67,7 +67,6 @@
 	"dependencies": {
 		"@cloudflare/kv-asset-handler": "workspace:*",
 		"@cloudflare/unenv-preset": "workspace:*",
-		"blake3-wasm": "2.1.5",
 		"esbuild": "catalog:default",
 		"miniflare": "workspace:*",
 		"path-to-regexp": "6.3.0",
@@ -90,6 +89,7 @@
 		"@cloudflare/workflows-shared": "workspace:*",
 		"@cspotcode/source-map-support": "0.8.1",
 		"@netlify/build-info": "^10.5.1",
+		"@noble/hashes": "^2.2.0",
 		"@sentry/node": "^7.86.0",
 		"@sentry/types": "^7.86.0",
 		"@sentry/utils": "^7.86.0",

--- a/packages/wrangler/scripts/deps.ts
+++ b/packages/wrangler/scripts/deps.ts
@@ -8,9 +8,6 @@ export const EXTERNAL_DEPENDENCIES = [
 	// Wrangler depends on a pinned version of esbuild.
 	"esbuild",
 
-	// This blows up when bundled, and has WASM dependencies. Wrangler depends on a pinned version.
-	"blake3-wasm",
-
 	// Wrangler depends on a pinned version of Miniflare.
 	"miniflare",
 

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -7,7 +7,31 @@ import {
 	UserError,
 } from "@cloudflare/workers-utils";
 import Cloudflare from "cloudflare";
-import { fetch, FormData, Headers, Request, Response } from "undici";
+import {
+	fetch as undiciFetch,
+	FormData as undiciFormData,
+	Headers as undiciHeaders,
+	Request as undiciRequest,
+	Response as undiciResponse,
+} from "undici";
+
+const isBun =
+	typeof (globalThis as unknown as { Bun: unknown }).Bun !== "undefined";
+
+const fetch = isBun ? globalThis.fetch : undiciFetch;
+const FormData = isBun
+	? (globalThis.FormData as typeof undiciFormData)
+	: undiciFormData;
+const Headers = isBun
+	? (globalThis.Headers as typeof undiciHeaders)
+	: undiciHeaders;
+const Request = isBun
+	? (globalThis.Request as typeof undiciRequest)
+	: undiciRequest;
+const Response = isBun
+	? (globalThis.Response as typeof undiciResponse)
+	: undiciResponse;
+
 import { version as wranglerVersion } from "../../package.json";
 import { logger } from "../logger";
 import { loginOrRefreshIfRequired, requireApiToken } from "../user";
@@ -114,10 +138,26 @@ export async function performApiFetch(
 	logHeaders(headers);
 
 	logger.debugWithSanitization("INIT:", JSON.stringify({ ...init }, null, 2));
-	if (init.body instanceof FormData) {
+
+	let body = init.body;
+	if (
+		isBun &&
+		body &&
+		typeof body === "object" &&
+		body.constructor.name === "FormData" &&
+		!(body instanceof globalThis.FormData)
+	) {
+		const nativeFormData = new globalThis.FormData();
+		for (const [key, value] of (body as any).entries()) {
+			nativeFormData.append(key, value);
+		}
+		body = nativeFormData;
+	}
+
+	if (body instanceof FormData) {
 		logger.debugWithSanitization(
 			"BODY:",
-			await new Response(init.body).text(),
+			await new Response(body).text(),
 			null,
 			2
 		);
@@ -128,6 +168,7 @@ export async function performApiFetch(
 		{
 			method,
 			...init,
+			body,
 			headers,
 			signal: abortSignal,
 		}

--- a/packages/wrangler/src/pages/hash.ts
+++ b/packages/wrangler/src/pages/hash.ts
@@ -1,13 +1,12 @@
 import { readFileSync } from "node:fs";
 import { extname } from "node:path";
-import { hash as blake3hash } from "blake3-wasm";
+import { blake3 } from "@noble/hashes/blake3.js";
 
 export const hashFile = (filepath: string) => {
 	const contents = readFileSync(filepath);
 	const base64Contents = contents.toString("base64");
 	const extension = extname(filepath).substring(1);
 
-	return blake3hash(base64Contents + extension)
-		.toString("hex")
-		.slice(0, 32);
+	const data = new TextEncoder().encode(base64Contents + extension);
+	return Buffer.from(blake3(data)).toString("hex").slice(0, 32);
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1608,7 +1608,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: catalog:default
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.0.13(@types/node@22.15.17)(esbuild@0.23.1)(jiti@2.6.1)(tsx@3.12.10)(yaml@2.8.1))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.0.13(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@3.12.10)(yaml@2.8.1))
 
   packages/containers-shared:
     devDependencies:
@@ -3934,6 +3934,9 @@ importers:
       '@cloudflare/unenv-preset':
         specifier: workspace:*
         version: link:../unenv-preset
+      '@noble/hashes':
+        specifier: ^2.2.0
+        version: 2.2.0
       blake3-wasm:
         specifier: 2.1.5
         version: 2.1.5
@@ -6545,6 +6548,10 @@ packages:
 
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -17718,6 +17725,8 @@ snapshots:
 
   '@noble/hashes@2.0.1': {}
 
+  '@noble/hashes@2.2.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -20049,14 +20058,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.1.0(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.0.13(@types/node@22.15.17)(esbuild@0.23.1)(jiti@2.6.1)(tsx@3.12.10)(yaml@2.8.1))':
+  '@vitest/mocker@4.1.0(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.0.13(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@3.12.10)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.4(@types/node@22.15.17)(typescript@5.8.3)
-      vite: 8.0.13(@types/node@22.15.17)(esbuild@0.23.1)(jiti@2.6.1)(tsx@3.12.10)(yaml@2.8.1)
+      vite: 8.0.13(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@3.12.10)(yaml@2.8.1)
 
   '@vitest/mocker@4.1.0(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.0.13(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
@@ -26319,7 +26328,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.1
 
-  vite@8.0.13(@types/node@22.15.17)(esbuild@0.23.1)(jiti@2.6.1)(tsx@3.12.10)(yaml@2.8.1):
+  vite@8.0.13(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@3.12.10)(yaml@2.8.1):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -26328,7 +26337,7 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 22.15.17
-      esbuild: 0.23.1
+      esbuild: 0.27.3
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 3.12.10
@@ -26355,10 +26364,10 @@ snapshots:
       mock-socket: 9.3.1
       vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.0.13(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
 
-  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.0.13(@types/node@22.15.17)(esbuild@0.23.1)(jiti@2.6.1)(tsx@3.12.10)(yaml@2.8.1)):
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.0.13(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@3.12.10)(yaml@2.8.1)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.0.13(@types/node@22.15.17)(esbuild@0.23.1)(jiti@2.6.1)(tsx@3.12.10)(yaml@2.8.1))
+      '@vitest/mocker': 4.1.0(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.0.13(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@3.12.10)(yaml@2.8.1))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -26375,7 +26384,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 8.0.13(@types/node@22.15.17)(esbuild@0.23.1)(jiti@2.6.1)(tsx@3.12.10)(yaml@2.8.1)
+      vite: 8.0.13(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@3.12.10)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1


### PR DESCRIPTION
- Replaced native WASM blake3-wasm dependency with pure-JS @noble/hashes/blake3.js in pages/hash.ts
- Added type-safe conditional fallbacks to globalThis.fetch under Bun in the cfetch client
- Added transparent FormData cloning to convert undici FormData to globalThis.FormData under Bun

This commit was made using Gemini 3.5 Flash.

---

I tested by doing `bun /home/codebam/Documents/git/workers-sdk/packages/wrangler/bin/wrangler.js deploy -e dev` with the newly built wrangler.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<img width="640" height="640" alt="photo_6336714012183170814_c" src="https://github.com/user-attachments/assets/4d20a78f-a2c9-4dda-b869-80e81f5df817" />

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
