### PR TITLE
fix: Preserve `--compatibility-flags` in the interactive deploy config flow

### DIFF
--- a/.changeset/fix-deploy-compatibility-flags-in-autoconfig.md
+++ b/.changeset/fix-deploy-compatibility-flags-in-autoconfig.md
@@ -1,0 +1,12 @@
+---
+"wrangler": patch
+---
+
+Preserve `--compatibility-flags` in the interactive deploy config flow
+
+When running `wrangler deploy` without a config file and going through the interactive setup flow, any `--compatibility-flags` passed on the command line (e.g. `--compatibility-flags=nodejs_compat`) were lost in two places:
+
+1. The generated `wrangler.jsonc` file did not include `compatibility_flags`.
+2. The suggested CLI command shown when declining the config file write did not include `--compatibility-flags`.
+
+Both are now fixed. Compatibility flags are persisted to the generated config and included in the suggested command.

--- a/packages/wrangler/src/__tests__/deploy/core.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/core.test.ts
@@ -1732,5 +1732,109 @@ describe("deploy", () => {
 			// Should NOT have been asked for a name
 			expect(std.out).not.toContain("What do you want to name your project?");
 		});
+
+		it("should include compatibility_flags in generated wrangler.jsonc when --compatibility-flags is passed", async ({
+			expect,
+		}) => {
+			vi.setSystemTime(new Date(2024, 5, 15));
+			setIsTTY(true);
+			writeWorkerSource();
+			// No writeWranglerConfig call — no config file exists
+			mockPrompt({
+				text: "What do you want to name your project?",
+				result: "test-worker",
+			});
+			mockConfirm({
+				text: "No compatibility date is set. Would you like to use today's date (2024-06-15)?",
+				result: true,
+			});
+			mockConfirm({
+				text: "Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
+				result: true,
+			});
+
+			await runWrangler(
+				"deploy ./index.js --compatibility-flags=nodejs_compat --dry-run"
+			);
+			expect(std.out).toContain("--dry-run: exiting now.");
+			const writtenConfig = JSON.parse(
+				fs.readFileSync("wrangler.jsonc", "utf-8")
+			);
+			expect(writtenConfig).toEqual({
+				name: "test-worker",
+				compatibility_date: "2024-06-15",
+				main: "./index.js",
+				compatibility_flags: ["nodejs_compat"],
+			});
+			expect(std.out).toContain("Proceeding with deployment...");
+		});
+
+		it("should include --compatibility-flags in suggested CLI command when user declines config file write", async ({
+			expect,
+		}) => {
+			vi.setSystemTime(new Date(2024, 5, 15));
+			setIsTTY(true);
+			writeWorkerSource();
+			// No writeWranglerConfig call — no config file exists
+			mockPrompt({
+				text: "What do you want to name your project?",
+				result: "test-worker",
+			});
+			mockConfirm({
+				text: "No compatibility date is set. Would you like to use today's date (2024-06-15)?",
+				result: true,
+			});
+			mockConfirm({
+				text: "Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
+				result: false,
+			});
+
+			await runWrangler(
+				"deploy ./index.js --compatibility-flags=nodejs_compat --compatibility-flags=disable_navigator_language --dry-run"
+			);
+			expect(std.out).toContain("--dry-run: exiting now.");
+			expect(fs.existsSync("wrangler.jsonc")).toBe(false);
+			// Suggested command should include the compat flags
+			expect(std.out).toContain(
+				"wrangler deploy ./index.js --name test-worker --compatibility-date 2024-06-15 --compatibility-flags nodejs_compat disable_navigator_language"
+			);
+			expect(std.out).toContain("Proceeding with deployment...");
+		});
+
+		it("should include multiple --compatibility-flags in suggested CLI command and config file", async ({
+			expect,
+		}) => {
+			vi.setSystemTime(new Date(2024, 5, 15));
+			setIsTTY(true);
+			writeWorkerSource();
+			// No writeWranglerConfig call — no config file exists
+			mockPrompt({
+				text: "What do you want to name your project?",
+				result: "test-worker",
+			});
+			mockConfirm({
+				text: "No compatibility date is set. Would you like to use today's date (2024-06-15)?",
+				result: true,
+			});
+			mockConfirm({
+				text: "Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
+				result: true,
+			});
+
+			await runWrangler(
+				"deploy ./index.js --compatibility-flags=nodejs_compat --compatibility-flags=url_standard --dry-run"
+			);
+			expect(std.out).toContain("--dry-run: exiting now.");
+			const writtenConfig = JSON.parse(
+				fs.readFileSync("wrangler.jsonc", "utf-8")
+			);
+			expect(writtenConfig).toEqual({
+				name: "test-worker",
+				compatibility_date: "2024-06-15",
+				main: "./index.js",
+				compatibility_flags: ["nodejs_compat", "url_standard"],
+			});
+			expect(std.out).toContain("Proceeding with deployment...");
+		});
 	});
 });

--- a/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
@@ -945,6 +945,7 @@ addEventListener('fetch', event => {});`
 					  }
 					}
 					 to <cwd>/wrangler.jsonc.
+
 					Simply run \`wrangler deploy\` next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.
 
 					Proceeding with deployment...
@@ -1029,6 +1030,7 @@ addEventListener('fetch', event => {});`
 					  }
 					}
 					 to <cwd>/wrangler.jsonc.
+
 					Simply run \`wrangler deploy\` next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.
 
 					Proceeding with deployment...
@@ -1101,6 +1103,7 @@ addEventListener('fetch', event => {});`
 					  }
 					}
 					 to <cwd>/wrangler.jsonc.
+
 					Simply run \`wrangler deploy\` next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.
 
 					Proceeding with deployment...
@@ -1180,6 +1183,7 @@ addEventListener('fetch', event => {});`
 					  }
 					}
 					 to <cwd>/wrangler.jsonc.
+
 					Simply run \`wrangler deploy\` next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.
 
 					Proceeding with deployment...
@@ -1266,6 +1270,7 @@ addEventListener('fetch', event => {});`
 					  }
 					}
 					 to <cwd>/wrangler.jsonc.
+
 					Simply run \`wrangler deploy\` next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.
 
 					Proceeding with deployment...
@@ -1382,6 +1387,7 @@ addEventListener('fetch', event => {});`
 					"
 					 ⛅️ wrangler x.x.x
 					──────────────────
+
 
 
 					You should run wrangler deploy --name test-name --compatibility-date 2024-01-01 --assets ./assets next time to deploy this Worker without going through this flow again.

--- a/packages/wrangler/src/deploy/autoconfig.ts
+++ b/packages/wrangler/src/deploy/autoconfig.ts
@@ -26,6 +26,7 @@ type AutoConfigArgs = ReadConfigCommandArgs & {
 	dryRun: boolean | undefined;
 	latest: boolean | undefined;
 	compatibilityDate: string | undefined;
+	compatibilityFlags: string[] | undefined;
 };
 
 /**
@@ -273,6 +274,9 @@ export async function promptForMissingDeployConfig<Args extends AutoConfigArgs>(
 		if (args.assets) {
 			configContent.assets = { directory: args.assets };
 		}
+		if (args.compatibilityFlags?.length) {
+			configContent.compatibility_flags = args.compatibilityFlags;
+		}
 
 		const writeConfigFile = await confirm(
 			`Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\n${chalk.dim(
@@ -286,7 +290,7 @@ export async function promptForMissingDeployConfig<Args extends AutoConfigArgs>(
 			writeFileSync(configPath, jsonString);
 			logger.log(`Wrote \n${jsonString}\n to ${chalk.bold(configPath)}.`);
 			logger.log(
-				`Simply run ${chalk.bold("`wrangler deploy`")} next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.`
+				`\nSimply run ${chalk.bold("`wrangler deploy`")} next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.`
 			);
 		} else {
 			const scriptPart = args.script ? `${args.script} ` : "";
@@ -296,11 +300,14 @@ export async function promptForMissingDeployConfig<Args extends AutoConfigArgs>(
 					? `--compatibility-date ${effectiveCompatDate}`
 					: "",
 				args.assets ? `--assets ${args.assets}` : "",
+				...(args.compatibilityFlags?.length
+					? [`--compatibility-flags ${args.compatibilityFlags.join(" ")}`]
+					: []),
 			]
 				.filter(Boolean)
 				.join(" ");
 			logger.log(
-				`You should run ${chalk.bold(
+				`\nYou should run ${chalk.bold(
 					`wrangler deploy ${scriptPart}${flagParts}`
 				)} next time to deploy this Worker without going through this flow again.`
 			);


### PR DESCRIPTION
Fixes #[insert GH or internal issue link(s)].

When running `wrangler deploy` without a config file and going through the interactive setup flow, any `--compatibility-flags` passed on the command line (e.g. `--compatibility-flags=nodejs_compat`) were lost in two places:

1. The generated `wrangler.jsonc` file did not include `compatibility_flags`.
2. The suggested CLI command shown when declining the config file write did not include `--compatibility-flags`.

Both are now fixed. Compatibility flags are persisted to the generated config and included in the suggested command.

| Before | After |
|--------|--------|
| <img width="965" height="527" alt="interactive wrangler deploy flow run before the changes" src="https://github.com/user-attachments/assets/5c95aebb-c69a-4093-a1bf-3859ae225201" /> | <img width="956" height="584" alt="interactive wrangler deploy flow run after the changes"  src="https://github.com/user-attachments/assets/d495a069-0fbe-45b5-87a0-1af23d0b233d" /> |


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: fixing incorrect behavior

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
