### PR TITLE
[wrangler] Add named-network VPC service targets

### DIFF
--- a/.changeset/add-vpc-named-network-services.md
+++ b/.changeset/add-vpc-named-network-services.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add named-network routing support to `wrangler vpc service`
+
+You can now create and update VPC services using `--network-id cf1:network` instead of a tunnel ID to connect through Cloudflare Mesh.

--- a/packages/wrangler/src/__tests__/vpc.test.ts
+++ b/packages/wrangler/src/__tests__/vpc.test.ts
@@ -185,7 +185,7 @@ describe("vpc service commands", () => {
 			──────────────────
 			📋 Listing VPC services
 			┌─┬─┬─┬─┬─┬─┬─┬─┐
-			│ id │ name │ type │ ports │ host │ tunnel │ created │ modified │
+			│ id │ name │ type │ ports │ host │ network │ created │ modified │
 			├─┼─┼─┼─┼─┼─┼─┼─┤
 			│ service-uuid │ test-web-service │ http │ HTTP:80, HTTPS:443 │ web.example.com │ tunnel-y... │ 1/1/2024, 12:00:00 AM │ 1/1/2024, 12:00:00 AM │
 			└─┴─┴─┴─┴─┴─┴─┴─┘"
@@ -466,7 +466,7 @@ describe("vpc service commands", () => {
 			──────────────────
 			📋 Listing VPC services
 			┌─┬─┬─┬─┬─┬─┬─┬─┐
-			│ id │ name │ type │ ports │ host │ tunnel │ created │ modified │
+			│ id │ name │ type │ ports │ host │ network │ created │ modified │
 			├─┼─┼─┼─┼─┼─┼─┼─┤
 			│ tcp-service-uuid │ test-tcp-service │ tcp │ TCP:5432 (postgresql) │ 10.0.0.5 │ 550e8400... │ 1/1/2024, 12:00:00 AM │ 1/1/2024, 12:00:00 AM │
 			└─┴─┴─┴─┴─┴─┴─┴─┘"
@@ -811,6 +811,184 @@ describe("vpc service commands", () => {
 		).rejects.toThrow(
 			"Conflicting TCP port: --hostname includes port 3306 but --tcp-port is 5432"
 		);
+	});
+
+	it("should handle creating a TCP service with --network-id", async ({
+		expect,
+	}) => {
+		const reqProm = mockWvpcServiceCreate();
+		await runWrangler(
+			"vpc service create test-pg-vnet --type tcp --tcp-port 5432 --ipv4 10.0.0.5 --network-id cf1:network"
+		);
+
+		await expect(reqProm).resolves.toMatchInlineSnapshot(`
+			{
+			  "host": {
+			    "ipv4": "10.0.0.5",
+			    "network": {
+			      "network_id": "cf1:network",
+			    },
+			  },
+			  "name": "test-pg-vnet",
+			  "tcp_port": 5432,
+			  "type": "tcp",
+			}
+		`);
+
+		expect(std.out).toMatchInlineSnapshot(`
+			"
+			 ⛅️ wrangler x.x.x
+			──────────────────
+			🚧 Creating VPC service 'test-pg-vnet'
+			✅ Created VPC service: service-uuid
+			   Name: test-pg-vnet
+			   Type: tcp
+			   TCP Port: 5432
+			   IPv4: 10.0.0.5
+			   Network ID: cf1:network"
+		`);
+	});
+
+	it("should handle updating a service with --network-id", async ({
+		expect,
+	}) => {
+		const reqProm = mockWvpcServiceUpdate();
+		await runWrangler(
+			"vpc service update service-uuid --name test-vnet-updated --type tcp --tcp-port 5432 --ipv4 10.0.0.5 --network-id cf1:network"
+		);
+
+		await expect(reqProm).resolves.toMatchInlineSnapshot(`
+			{
+			  "host": {
+			    "ipv4": "10.0.0.5",
+			    "network": {
+			      "network_id": "cf1:network",
+			    },
+			  },
+			  "name": "test-vnet-updated",
+			  "tcp_port": 5432,
+			  "type": "tcp",
+			}
+		`);
+	});
+
+	it("should display Network ID when service has a named network", async ({
+		expect,
+	}) => {
+		const networkService: ConnectivityService = {
+			service_id: "network-service-uuid",
+			type: ServiceType.Tcp,
+			name: "test-network-service",
+			tcp_port: 5432,
+			host: {
+				ipv4: "10.0.0.5",
+				network: { network_id: "cf1:network" },
+			},
+			created_at: "2024-01-01T00:00:00Z",
+			updated_at: "2024-01-01T00:00:00Z",
+		};
+
+		msw.use(
+			http.get(
+				"*/accounts/:accountId/connectivity/directory/services/:serviceId",
+				() => {
+					return HttpResponse.json(createFetchResult(networkService, true));
+				},
+				{ once: true }
+			)
+		);
+
+		await runWrangler("vpc service get network-service-uuid");
+
+		expect(std.out).toMatchInlineSnapshot(`
+			"
+			 ⛅️ wrangler x.x.x
+			──────────────────
+			🔍 Getting VPC service 'network-service-uuid'
+			✅ Retrieved VPC service: network-service-uuid
+			   Name: test-network-service
+			   Type: tcp
+			   TCP Port: 5432
+			   IPv4: 10.0.0.5
+			   Network ID: cf1:network
+			   Created: 1/1/2024, 12:00:00 AM
+			   Modified: 1/1/2024, 12:00:00 AM"
+		`);
+	});
+
+	it("should list services with a named network in table", async ({
+		expect,
+	}) => {
+		const networkService: ConnectivityService = {
+			service_id: "network-service-uuid",
+			type: ServiceType.Tcp,
+			name: "test-network-service",
+			tcp_port: 5432,
+			host: {
+				ipv4: "10.0.0.5",
+				network: { network_id: "cf1:network" },
+			},
+			created_at: "2024-01-01T00:00:00Z",
+			updated_at: "2024-01-01T00:00:00Z",
+		};
+
+		msw.use(
+			http.get(
+				"*/accounts/:accountId/connectivity/directory/services",
+				() => {
+					return HttpResponse.json(createFetchResult([networkService], true));
+				},
+				{ once: true }
+			)
+		);
+
+		await runWrangler("vpc service list");
+
+		expect(std.out).toMatchInlineSnapshot(`
+			"
+			 ⛅️ wrangler x.x.x
+			──────────────────
+			📋 Listing VPC services
+			┌─┬─┬─┬─┬─┬─┬─┬─┐
+			│ id │ name │ type │ ports │ host │ network │ created │ modified │
+			├─┼─┼─┼─┼─┼─┼─┼─┤
+			│ network-service-uuid │ test-network-service │ tcp │ TCP:5432 │ 10.0.0.5 │ cf1:netw... │ 1/1/2024, 12:00:00 AM │ 1/1/2024, 12:00:00 AM │
+			└─┴─┴─┴─┴─┴─┴─┴─┘"
+		`);
+	});
+
+	it("should reject --network-id with --hostname", async ({ expect }) => {
+		await expect(() =>
+			runWrangler(
+				"vpc service create test-invalid --type tcp --tcp-port 5432 --hostname db.internal --network-id cf1:network"
+			)
+		).rejects.toThrow("--network-id cannot be used with --hostname");
+	});
+
+	it("should reject creation without --tunnel-id or --network-id", async ({
+		expect,
+	}) => {
+		await expect(() =>
+			runWrangler(
+				"vpc service create test-missing --type tcp --tcp-port 5432 --ipv4 10.0.0.5"
+			)
+		).rejects.toThrow("Must specify either --tunnel-id or --network-id");
+	});
+});
+
+describe("vpc routing validation", () => {
+	it("should reject tunnel and named-network routing together", ({
+		expect,
+	}) => {
+		expect(() =>
+			validateRequest({
+				name: "test-invalid",
+				type: ServiceType.Http,
+				ipv4: "10.0.0.5",
+				tunnelId: "550e8400-e29b-41d4-a716-446655440000",
+				networkId: "cf1:network",
+			})
+		).toThrow("Specify only one of --tunnel-id or --network-id");
 	});
 });
 

--- a/packages/wrangler/src/vpc/index.ts
+++ b/packages/wrangler/src/vpc/index.ts
@@ -47,9 +47,7 @@ export interface HttpServiceConfig {
 	https_port?: number;
 }
 
-export interface Network {
-	tunnel_id: string;
-}
+export type Network = { tunnel_id: string } | { network_id: string };
 
 export interface ResolverNetwork {
 	tunnel_id: string;
@@ -159,9 +157,15 @@ export const serviceOptions = {
 	},
 	"tunnel-id": {
 		type: "string",
-		demandOption: true,
+		conflicts: ["network-id"],
 		group: "Required Configuration",
 		description: "UUID of the Cloudflare tunnel",
+	},
+	"network-id": {
+		type: "string",
+		conflicts: ["tunnel-id"],
+		group: "Required Configuration",
+		description: "Cloudflare network ID (e.g. 'cf1:network')",
 	},
 	"cert-verification-mode": {
 		type: "string",

--- a/packages/wrangler/src/vpc/shared.ts
+++ b/packages/wrangler/src/vpc/shared.ts
@@ -43,7 +43,11 @@ export function displayServiceDetails(service: ConnectivityService) {
 
 	// Display network details
 	if (service.host.network) {
-		logger.log(`   Tunnel ID: ${service.host.network.tunnel_id}`);
+		if ("tunnel_id" in service.host.network) {
+			logger.log(`   Tunnel ID: ${service.host.network.tunnel_id}`);
+		} else {
+			logger.log(`   Network ID: ${service.host.network.network_id}`);
+		}
 	} else if (service.host.resolver_network) {
 		logger.log(`   Tunnel ID: ${service.host.resolver_network.tunnel_id}`);
 		if (service.host.resolver_network.resolver_ips) {
@@ -90,11 +94,15 @@ export function formatServiceForTable(service: ConnectivityService) {
 		host = ips.join(", ");
 	}
 
-	// Get tunnel ID
-	const tunnelId =
-		service.host.network?.tunnel_id ||
-		service.host.resolver_network?.tunnel_id ||
-		"";
+	let networkDisplay = "";
+	if (service.host.network) {
+		networkDisplay =
+			"tunnel_id" in service.host.network
+				? service.host.network.tunnel_id
+				: service.host.network.network_id;
+	} else if (service.host.resolver_network) {
+		networkDisplay = service.host.resolver_network.tunnel_id;
+	}
 
 	return {
 		id: service.service_id,
@@ -102,7 +110,7 @@ export function formatServiceForTable(service: ConnectivityService) {
 		type: service.type,
 		ports,
 		host,
-		tunnel: tunnelId.substring(0, 8) + "...", // Truncate for table display
+		network: networkDisplay.substring(0, 8) + "...", // Truncate for table display
 		created: new Date(service.created_at).toLocaleString(),
 		modified: new Date(service.updated_at).toLocaleString(),
 	};

--- a/packages/wrangler/src/vpc/validation.ts
+++ b/packages/wrangler/src/vpc/validation.ts
@@ -17,9 +17,32 @@ export interface ServiceArgs {
 	ipv4?: string;
 	ipv6?: string;
 	hostname?: string;
-	tunnelId: string;
+	tunnelId?: string;
+	networkId?: string;
 	resolverIps?: string;
 	certVerificationMode?: string;
+}
+
+type ServiceRouting = { tunnelId: string } | { networkId: string };
+
+function getRouting(args: ServiceArgs): ServiceRouting {
+	if (args.tunnelId && args.networkId) {
+		throw new UserError("Specify only one of --tunnel-id or --network-id", {
+			telemetryMessage: "vpc validation conflicting network routing",
+		});
+	}
+
+	if (args.networkId) {
+		return { networkId: args.networkId };
+	}
+
+	if (args.tunnelId) {
+		return { tunnelId: args.tunnelId };
+	}
+
+	throw new UserError("Must specify either --tunnel-id or --network-id", {
+		telemetryMessage: "vpc validation missing network routing",
+	});
 }
 
 export function validateHostname(hostname: string): void {
@@ -126,7 +149,8 @@ export function toServiceArgs(args: {
 	ipv4?: string;
 	ipv6?: string;
 	hostname?: string;
-	tunnelId: string;
+	tunnelId?: string;
+	networkId?: string;
 	resolverIps?: string;
 	certVerificationMode?: string;
 }): ServiceArgs {
@@ -159,6 +183,7 @@ export function toServiceArgs(args: {
 		ipv6: args.ipv6,
 		hostname,
 		tunnelId: args.tunnelId,
+		networkId: args.networkId,
 		resolverIps: args.resolverIps,
 		certVerificationMode: args.certVerificationMode,
 	};
@@ -207,6 +232,15 @@ export function validateRequest(args: ServiceArgs) {
 		}
 	}
 
+	const routing = getRouting(args);
+
+	if ("networkId" in routing && hasHostname) {
+		throw new UserError(
+			"--network-id cannot be used with --hostname. Use --ipv4 or --ipv6 with --network-id.",
+			{ telemetryMessage: "vpc validation network-id with hostname" }
+		);
+	}
+
 	// Validate TCP services require a port
 	if (args.type === ServiceType.Tcp && !args.tcpPort) {
 		throw new UserError("TCP services require a --tcp-port to be specified", {
@@ -216,6 +250,8 @@ export function validateRequest(args: ServiceArgs) {
 }
 
 export function buildRequest(args: ServiceArgs): ConnectivityServiceRequest {
+	const routing = getRouting(args);
+
 	// Parse resolver IPs if provided
 	let resolverIpsList: string[] | undefined = undefined;
 	if (args.resolverIps) {
@@ -232,14 +268,16 @@ export function buildRequest(args: ServiceArgs): ConnectivityServiceRequest {
 		hostname: args.hostname,
 	};
 
-	if (args.hostname) {
+	if ("networkId" in routing) {
+		host.network = { network_id: routing.networkId };
+	} else if (args.hostname) {
 		host.resolver_network = {
-			tunnel_id: args.tunnelId,
+			tunnel_id: routing.tunnelId,
 			...(resolverIpsList && { resolver_ips: resolverIpsList }),
 		};
 	} else {
 		host.network = {
-			tunnel_id: args.tunnelId,
+			tunnel_id: routing.tunnelId,
 		};
 	}
 


### PR DESCRIPTION
Fixes WVPC-142.

Add named-network targets to `wrangler vpc service` via `--network-id`.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: This is part of the existing VPC services flow.
