### PR TITLE
Enable require-description-when-disabling lint rule on the wrangler package

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -198,12 +198,5 @@
 				"workers-sdk/no-wrangler-named-imports": "error",
 			},
 		},
-		// TODO: Remove the following wrangler override.
-		{
-			"files": ["packages/wrangler/**"],
-			"rules": {
-				"workers-sdk/require-description-when-disabling": "off",
-			},
-		},
 	],
 }

--- a/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
+++ b/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
@@ -22,12 +22,12 @@ import {
 import type { WranglerCommandOptions } from "./wrangler";
 import type { Awaitable } from "miniflare";
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- typeof requires a value import, not a type import
 export function importWrangler(): Promise<typeof import("../../src/cli")> {
 	return import(WRANGLER_IMPORT.href);
 }
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- typeof requires a value import, not a type import
 export function importMiniflare(): Promise<typeof import("miniflare")> {
 	return import(MINIFLARE_IMPORT.href);
 }

--- a/packages/wrangler/e2e/unenv-preset/worker/index.ts
+++ b/packages/wrangler/e2e/unenv-preset/worker/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import assert from "node:assert";
 
 export default {
@@ -40,7 +39,11 @@ export default {
 };
 
 function getRuntimeFlagValue(name: string): boolean | undefined {
-	const { compatibilityFlags } = (globalThis as any).Cloudflare;
+	const { compatibilityFlags } = (
+		globalThis as unknown as {
+			Cloudflare: { compatibilityFlags: Record<string, boolean> };
+		}
+	).Cloudflare;
 	return compatibilityFlags[name];
 }
 
@@ -454,12 +457,13 @@ export const WorkerdTests: Record<string, () => Promise<void>> = {
 			assert.ok(blob instanceof Blob);
 
 			// Old names in fs namespace
-			assert.strictEqual((fs as any).FileReadStream, fs.ReadStream);
-			assert.strictEqual((fs as any).FileWriteStream, fs.WriteStream);
-			assert.equal((fs as any).F_OK, 0);
-			assert.equal((fs as any).R_OK, 4);
-			assert.equal((fs as any).W_OK, 2);
-			assert.equal((fs as any).X_OK, 1);
+			const fsAsOld = fs as Record<string, unknown>;
+			assert.strictEqual(fsAsOld.FileReadStream, fs.ReadStream);
+			assert.strictEqual(fsAsOld.FileWriteStream, fs.WriteStream);
+			assert.equal(fsAsOld.F_OK, 0);
+			assert.equal(fsAsOld.R_OK, 4);
+			assert.equal(fsAsOld.W_OK, 2);
+			assert.equal(fsAsOld.X_OK, 1);
 		} else {
 			assert.throws(
 				() => fs.readFileSync("/tmp/file", "utf-8"),
@@ -549,7 +553,10 @@ export const WorkerdTests: Record<string, () => Promise<void>> = {
 			getRuntimeFlagValue("fetch_iterable_type_support_override_adjustment");
 
 		for (const p of [mProcess, gProcess]) {
-			assert.equal(typeof (p as any).binding, "function");
+			assert.equal(
+				typeof (p as unknown as { binding: unknown }).binding,
+				"function"
+			);
 			if (useV2) {
 				// workerd implementation only
 				assert.equal(p.arch, "x64");
@@ -852,8 +859,9 @@ export const WorkerdTests: Record<string, () => Promise<void>> = {
 		});
 
 		// builtinModules should be an array (not in TypeScript types but exported by both unenv and workerd)
-		assert.ok(Array.isArray((repl as any).builtinModules));
-		assert.ok((repl as any).builtinModules.length > 0);
+		const { builtinModules } = repl as unknown as { builtinModules: string[] };
+		assert.ok(Array.isArray(builtinModules));
+		assert.ok(builtinModules.length > 0);
 
 		// Both implementations throw when calling start()
 		assert.throws(
@@ -1113,7 +1121,7 @@ export const WorkerdTests: Record<string, () => Promise<void>> = {
  * Asserts that `target[property]` is of type `expectType`.
  */
 function assertTypeOf(target: unknown, property: string, expectType: string) {
-	const actualType = typeof (target as any)[property];
+	const actualType = typeof (target as Record<string, unknown>)[property];
 	assert.strictEqual(
 		actualType,
 		expectType,

--- a/packages/wrangler/e2e/vitest.setup.ts
+++ b/packages/wrangler/e2e/vitest.setup.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 // eslint-disable-next-line no-restricted-imports -- We need to import `expect` from "vitest" so that we can extend it
 import { expect } from "vitest";
 
@@ -7,8 +6,10 @@ interface CustomMatchers {
 }
 
 declare module "vitest" {
+	/* eslint-disable @typescript-eslint/no-empty-object-type -- Required for vitest module augmentation with empty interfaces */
 	interface Assertion extends CustomMatchers {}
 	interface AsymmetricMatchersContaining extends CustomMatchers {}
+	/* eslint-enable @typescript-eslint/no-empty-object-type */
 }
 
 expect.extend({

--- a/packages/wrangler/src/__tests__/browser-run.test.ts
+++ b/packages/wrangler/src/__tests__/browser-run.test.ts
@@ -5,7 +5,10 @@ import {
 } from "@cloudflare/workers-utils/test-helpers";
 import ci from "ci-info";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
+/* eslint-disable-next-line no-restricted-imports --
+ * Uses expect in MSW handlers outside test callbacks
+ * TODO: remove this `expect` import
+ */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";

--- a/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
@@ -253,7 +253,7 @@ describe("cloudchamber create", () => {
 			http.post(
 				"*/deployments/v2",
 				async ({ request }) => {
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any -- MSW handler parses untyped JSON request body
 					const r = (await request.json()) as Record<string, any>;
 					expect(r.instance_type).toEqual("lite");
 					return HttpResponse.json({});
@@ -329,7 +329,7 @@ describe("cloudchamber create", () => {
 			http.post(
 				"*/deployments/v2",
 				async ({ request }) => {
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any -- MSW handler parses untyped JSON request body
 					const r = (await request.json()) as Record<string, any>;
 					expect(r.instance_type).toEqual("lite");
 					return HttpResponse.json({});

--- a/packages/wrangler/src/__tests__/deploy/build.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/build.test.ts
@@ -213,8 +213,7 @@ describe("deploy", () => {
 			);
 
 			expect(fs.readFileSync("dist/index.js", "utf-8")).toContain(
-				// eslint-disable-next-line no-useless-escape
-				`console.log(\"https://www.abc.net.au/news/\");`
+				`console.log("https://www.abc.net.au/news/");`
 			);
 		});
 	});

--- a/packages/wrangler/src/__tests__/deploy/helpers.ts
+++ b/packages/wrangler/src/__tests__/deploy/helpers.ts
@@ -1,9 +1,11 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 import { Buffer } from "node:buffer";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
+/* eslint-disable-next-line no-restricted-imports --
+ * Helper used outside test callbacks, needs module-level expect
+ * TODO: remove this `expect` import
+ */
 import { expect } from "vitest";
 import { captureRequestsFrom } from "../helpers/capture-requests-from";
 import {
@@ -947,6 +949,8 @@ interface CustomMatchers {
 }
 
 declare module "vitest" {
+	/* eslint-disable @typescript-eslint/no-empty-object-type -- Type augmentation interfaces intentionally left empty */
 	interface Assertion extends CustomMatchers {}
 	interface AsymmetricMatchersContaining extends CustomMatchers {}
+	/* eslint-enable @typescript-eslint/no-empty-object-type */
 }

--- a/packages/wrangler/src/__tests__/deploy/workers-dev.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/workers-dev.test.ts
@@ -3,7 +3,10 @@ import {
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
+/* eslint-disable-next-line no-restricted-imports --
+ * Uses expect in MSW handlers outside test callbacks
+ * TODO: remove this `expect` import
+ */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getInstalledPackageVersion } from "../../autoconfig/frameworks/utils/packages";
 import { clearOutputFilePath } from "../../output";

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1931,7 +1931,7 @@ describe.sequential("wrangler dev", () => {
 			expect,
 		}) => {
 			fs.writeFileSync("index.js", `export default {};`);
-			// eslint-disable-next-line turbo/no-undeclared-env-vars
+			// eslint-disable-next-line turbo/no-undeclared-env-vars -- Test sets env var to simulate secret loaded from process.env
 			process.env.API_KEY = "from-process-env";
 			writeWranglerConfig({
 				main: "index.js",

--- a/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
+++ b/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
@@ -1,12 +1,12 @@
-/* eslint-disable @typescript-eslint/consistent-type-imports */
+/* eslint-disable @typescript-eslint/consistent-type-imports -- Test file uses dynamic imports where typeof requires value imports */
 import assert from "node:assert";
 import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import { fetch } from "undici";
-/* eslint-disable no-restricted-imports */
 import {
 	afterEach,
 	beforeEach,
 	describe,
+	// eslint-disable-next-line no-restricted-imports -- TODO: remove this `expect` import
 	expect,
 	it,
 	onTestFailed,

--- a/packages/wrangler/src/__tests__/helpers/mock-dialogs.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-dialogs.ts
@@ -1,5 +1,8 @@
 import prompts from "prompts";
-// eslint-disable-next-line no-restricted-imports
+/* eslint-disable-next-line no-restricted-imports --
+ * Helper used outside test callbacks, needs module-level expect
+ * TODO: remove this `expect` import
+ */
 import { expect } from "vitest";
 import type { Mock } from "vitest";
 

--- a/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
@@ -1,6 +1,9 @@
 import { ParseError } from "@cloudflare/workers-utils";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
+/* eslint-disable-next-line no-restricted-imports --
+ * Helper used outside test callbacks, needs module-level expect
+ * TODO: remove this `expect` import
+ */
 import { expect } from "vitest";
 import {
 	getSubdomainValues,

--- a/packages/wrangler/src/__tests__/hyperdrive.test.ts
+++ b/packages/wrangler/src/__tests__/hyperdrive.test.ts
@@ -2121,7 +2121,7 @@ function mockHyperdriveUpdate(
 							password: _,
 							access_client_secret: _2,
 							...reqOrigin
-							// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Destructuring untyped origin fields from API mock
 						} = reqBody.origin as any;
 						origin = { ...origin, ...reqOrigin };
 						if (reqOrigin.service_id) {
@@ -2178,7 +2178,7 @@ function mockHyperdriveCreate(): Promise<CreateUpdateHyperdriveBody> {
 
 					resolve(reqBody);
 
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Accessing untyped origin fields from API mock
 					const reqOrigin = reqBody.origin as any;
 					return HttpResponse.json(
 						createFetchResult(

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -7,7 +7,10 @@ import * as TOML from "smol-toml";
 import dedent from "ts-dedent";
 import { parseConfigFileTextToJson } from "typescript";
 import { FormData } from "undici";
-// eslint-disable-next-line no-restricted-imports
+/* eslint-disable-next-line no-restricted-imports --
+ * Uses expect in MSW handlers outside test callbacks
+ * TODO: remove this `expect` import
+ */
 import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
 import { downloadWorker } from "../init";
 import { writeMetricsConfig } from "../metrics/metrics-config";

--- a/packages/wrangler/src/__tests__/metrics.test.ts
+++ b/packages/wrangler/src/__tests__/metrics.test.ts
@@ -38,7 +38,7 @@ vi.mock("../metrics/send-event");
 vi.mock("../package-manager");
 vi.mocked(getMetricsConfig).mockReset();
 
-/* eslint-disable @typescript-eslint/no-namespace, no-shadow-restricted-names, no-unused-vars */
+/* eslint-disable @typescript-eslint/no-namespace, no-shadow-restricted-names, no-unused-vars -- Required for globalThis type augmentation in tests */
 declare namespace globalThis {
 	let ALGOLIA_APP_ID: string | undefined;
 	let ALGOLIA_PUBLIC_KEY: string | undefined;

--- a/packages/wrangler/src/__tests__/output.test.ts
+++ b/packages/wrangler/src/__tests__/output.test.ts
@@ -1,9 +1,12 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
+/* eslint-disable @typescript-eslint/no-empty-object-type -- Type augmentation interfaces intentionally left empty */
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { FatalError } from "@cloudflare/workers-utils";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
-// eslint-disable-next-line no-restricted-imports
+/* eslint-disable-next-line no-restricted-imports --
+ * Uses expect in MSW handlers outside test callbacks
+ * TODO: remove this `expect` import
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { clearOutputFilePath, writeOutput } from "../output";
 import { mockConsoleMethods } from "./helpers/mock-console";

--- a/packages/wrangler/src/__tests__/pages/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deploy.test.ts
@@ -9,7 +9,10 @@ import { execa } from "execa";
 import { http, HttpResponse } from "msw";
 import TOML from "smol-toml";
 import dedent from "ts-dedent";
-// eslint-disable-next-line no-restricted-imports
+/* eslint-disable-next-line no-restricted-imports --
+ * Uses expect in MSW handlers outside test callbacks
+ * TODO: remove this `expect` import
+ */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { version } from "../../../package.json";
 import { saveToConfigCache } from "../../config-cache";

--- a/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
@@ -26,7 +26,7 @@ import type { RequestInit } from "undici";
 import type WebSocket from "ws";
 
 vi.mock("ws", async (importOriginal) => {
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+	// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- typeof requires a value import in vi.mock importOriginal callback
 	const realModule = await importOriginal<typeof import("ws")>();
 	const module = {
 		__esModule: true,
@@ -1124,7 +1124,7 @@ function mockTailAPIs(
 			creation: [],
 			deployments: { count: 0, queryParams: [] },
 		},
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Initialized in beforeEach()
 		ws: null!, // will be set in the `beforeEach()`.
 
 		/**

--- a/packages/wrangler/src/__tests__/pages/project-validate.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-validate.test.ts
@@ -8,7 +8,7 @@ import { mockConsoleMethods } from "../helpers/mock-console";
 import { runWrangler } from "../helpers/run-wrangler";
 
 vi.mock("../../pages/constants", async (importActual) => ({
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+	// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- typeof requires a value import in vi.mock importActual callback
 	...(await importActual<typeof import("../../pages/constants")>()),
 	MAX_ASSET_SIZE: 1 * 1024 * 1024,
 	MAX_ASSET_COUNT_DEFAULT: 10,

--- a/packages/wrangler/src/__tests__/pages/routes-validation.test.ts
+++ b/packages/wrangler/src/__tests__/pages/routes-validation.test.ts
@@ -117,13 +117,13 @@ describe("routes-validation", () => {
 		it("should throw a fatal error if the routes are not a valid RoutesJSONSpec object", ({
 			expect,
 		}) => {
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- Intentionally testing invalid types
 			// @ts-ignore: sanity check
 			const routesWithoutVersion: RoutesJSONSpec = {
 				include: ["/*"],
 				exclude: [],
 			};
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- Intentionally testing invalid types
 			// @ts-ignore: sanity check
 			const routesWithoutInclude: RoutesJSONSpec = {
 				version: ROUTES_SPEC_VERSION,

--- a/packages/wrangler/src/__tests__/queues/mock-utils.ts
+++ b/packages/wrangler/src/__tests__/queues/mock-utils.ts
@@ -1,5 +1,8 @@
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
+/* eslint-disable-next-line no-restricted-imports --
+ * Helper used outside test callbacks, needs module-level expect
+ * TODO: remove this `expect` import
+ */
 import { expect } from "vitest";
 import { EventSourceType } from "../../queues/subscription-types";
 import { msw } from "../helpers/msw";

--- a/packages/wrangler/src/__tests__/r2/bucket.test.ts
+++ b/packages/wrangler/src/__tests__/r2/bucket.test.ts
@@ -4,7 +4,10 @@ import {
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
+/* eslint-disable-next-line no-restricted-imports --
+ * Uses expect in MSW handlers outside test callbacks
+ * TODO: remove this `expect` import
+ */
 import { beforeEach, describe, expect, it } from "vitest";
 import { actionsForEventCategories } from "../../r2/helpers/notification";
 import { endEventLoop } from "../helpers/end-event-loop";

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -32,7 +32,7 @@ import type { ExpectStatic } from "vitest";
 import type WebSocket from "ws";
 
 vi.mock("ws", async (importOriginal) => {
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+	// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- typeof requires a value import in vi.mock importOriginal callback
 	const realModule = await importOriginal<typeof import("ws")>();
 	const module = {
 		__esModule: true,
@@ -1211,7 +1211,7 @@ function mockWebsocketAPIs(
 			deletion: { count: 0 },
 			creation: [],
 		},
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Initialized in beforeEach()
 		ws: null!, // will be set in the `beforeEach()` below.
 
 		/**

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -1279,8 +1279,7 @@ describe("generate types - CLI", () => {
 				name: "test-name",
 				main: "./index.ts",
 				vars: bindingsConfigMock.vars,
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			} as any),
+			}),
 			"utf-8"
 		);
 		await runWrangler("types");

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -5,7 +5,10 @@ import {
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
+/* eslint-disable-next-line no-restricted-imports --
+ * Uses assert/expect in MSW handlers and top-level mock setup
+ * TODO: remove this `expect` import
+ */
 import { assert, beforeEach, describe, expect, it, test, vi } from "vitest";
 import { dedent } from "../../utils/dedent";
 import { generatePreviewAlias } from "../../versions/upload";
@@ -1930,7 +1933,7 @@ const mockExecSync = vi.fn();
 describe("generatePreviewAlias", () => {
 	mockConsoleMethods();
 	vi.mock("child_process", () => ({
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- vi.mock callback needs untyped rest args to forward to mock
 		execSync: (...args: any[]) => mockExecSync(...args),
 	}));
 

--- a/packages/wrangler/src/__tests__/vitest.setup.ts
+++ b/packages/wrangler/src/__tests__/vitest.setup.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/consistent-type-imports */
+/* eslint-disable @typescript-eslint/consistent-type-imports -- Setup file uses dynamic imports where typeof requires value imports */
 import { PassThrough } from "node:stream";
 import chalk from "chalk";
 import { passthrough } from "msw";
@@ -10,7 +10,7 @@ chalk.level = 0;
 
 // In general we don't want the ConfigController to watch the config files
 // as this tends to make the tests flaky.
-// eslint-disable-next-line turbo/no-undeclared-env-vars
+// eslint-disable-next-line turbo/no-undeclared-env-vars -- Test-only env var to prevent flaky config file watching
 process.env.WRANGLER_CI_DISABLE_CONFIG_WATCHING = "true";
 
 /**

--- a/packages/wrangler/src/__tests__/worker-namespace.test.ts
+++ b/packages/wrangler/src/__tests__/worker-namespace.test.ts
@@ -1,6 +1,9 @@
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
+/* eslint-disable-next-line no-restricted-imports --
+ * Uses expect in MSW handlers outside test callbacks
+ * TODO: remove this `expect` import
+ */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { printWranglerBanner } from "../wrangler-banner";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";

--- a/packages/wrangler/src/__tests__/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/workflows.test.ts
@@ -18,6 +18,7 @@ import { msw } from "./helpers/msw";
 import { runWrangler } from "./helpers/run-wrangler";
 import { writeWorkerSource } from "./helpers/write-worker-source";
 import type { Instance, Workflow } from "../workflows/types";
+import type { RawConfig } from "@cloudflare/workers-utils";
 import type { ExpectStatic } from "vitest";
 
 describe("wrangler workflows", () => {
@@ -916,9 +917,9 @@ describe("wrangler workflows", () => {
 				workflows: [
 					{
 						binding: "MY_WORKFLOW",
-					} as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+					},
 				],
-			});
+			} as RawConfig);
 
 			await expect(runWrangler("deploy --dry-run")).rejects.toThrow();
 			expect(std.err).toContain('should have a string "name" field');
@@ -955,9 +956,9 @@ describe("wrangler workflows", () => {
 						binding: 123, // should be string
 						name: "my-workflow",
 						class_name: "MyWorkflow",
-					} as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+					},
 				],
-			});
+			} as unknown as RawConfig);
 
 			await expect(runWrangler("deploy --dry-run")).rejects.toThrow();
 			expect(std.err).toContain('should have a string "binding" field');
@@ -967,8 +968,8 @@ describe("wrangler workflows", () => {
 			expect,
 		}) => {
 			writeWranglerConfig({
-				workflows: ["invalid-workflow-config"] as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-			});
+				workflows: ["invalid-workflow-config"],
+			} as unknown as RawConfig);
 
 			await expect(runWrangler("deploy --dry-run")).rejects.toThrow();
 			expect(std.err).toContain('"workflows" bindings should be objects');
@@ -1053,9 +1054,9 @@ describe("wrangler workflows", () => {
 						name: "my-workflow",
 						class_name: "MyWorkflow",
 						limits: { steps: 0 },
-					} as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+					},
 				],
-			});
+			} as RawConfig);
 
 			await expect(runWrangler("deploy --dry-run")).rejects.toThrow();
 			expect(std.err).toContain(
@@ -1073,9 +1074,9 @@ describe("wrangler workflows", () => {
 						name: "my-workflow",
 						class_name: "MyWorkflow",
 						limits: { steps: 1.5 },
-					} as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+					},
 				],
-			});
+			} as unknown as RawConfig);
 
 			await expect(runWrangler("deploy --dry-run")).rejects.toThrow();
 			expect(std.err).toContain(
@@ -1093,7 +1094,7 @@ describe("wrangler workflows", () => {
 						name: "my-workflow",
 						class_name: "MyWorkflow",
 						limits: { steps: -1 },
-					} as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+					},
 				],
 			});
 
@@ -1113,9 +1114,9 @@ describe("wrangler workflows", () => {
 						name: "my-workflow",
 						class_name: "MyWorkflow",
 						limits: "invalid",
-					} as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+					},
 				],
-			});
+			} as RawConfig);
 
 			await expect(runWrangler("deploy --dry-run")).rejects.toThrow();
 			expect(std.err).toContain(
@@ -1133,9 +1134,9 @@ describe("wrangler workflows", () => {
 						name: "my-workflow",
 						class_name: "MyWorkflow",
 						limits: [1, 2, 3],
-					} as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+					},
 				],
-			});
+			} as RawConfig);
 
 			await expect(runWrangler("deploy --dry-run")).rejects.toThrow();
 			expect(std.err).toContain(

--- a/packages/wrangler/src/__tests__/zones.test.ts
+++ b/packages/wrangler/src/__tests__/zones.test.ts
@@ -1,6 +1,9 @@
 import { COMPLIANCE_REGION_CONFIG_UNKNOWN } from "@cloudflare/workers-utils";
 import { http, HttpResponse } from "msw";
-// eslint-disable-next-line no-restricted-imports
+/* eslint-disable-next-line no-restricted-imports --
+ * Uses expect in MSW handlers outside test callbacks
+ * TODO: remove this `expect` import
+ */
 import { describe, expect, it, test } from "vitest";
 import { getHostFromUrl, getZoneForRoute, getZoneFromRoute } from "../zones";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";

--- a/packages/wrangler/src/api/integrations/platform/executionContext.ts
+++ b/packages/wrangler/src/api/integrations/platform/executionContext.ts
@@ -1,5 +1,5 @@
 export class ExecutionContext {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any, unused-imports/no-unused-vars
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any, unused-imports/no-unused-vars -- Matches the Workers runtime ExecutionContext API signature
 	waitUntil(promise: Promise<any>): void {
 		if (!(this instanceof ExecutionContext)) {
 			throw new Error("Illegal invocation");
@@ -10,6 +10,6 @@ export class ExecutionContext {
 			throw new Error("Illegal invocation");
 		}
 	}
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Matches the Workers runtime ExecutionContext API signature
 	props: any = {};
 }

--- a/packages/wrangler/src/cli-hotkeys.ts
+++ b/packages/wrangler/src/cli-hotkeys.ts
@@ -114,7 +114,10 @@ export default function (
 	function printInstructions() {
 		const bottomFloat = formatInstructions();
 		if (bottomFloat) {
-			// eslint-disable-next-line no-console
+			/* eslint-disable-next-line no-console --
+				here we are intentionally using a console.log instead of using the logger to
+				ensure that the text is always present regardless on the current log level
+			*/
 			console.log(bottomFloat);
 		}
 	}

--- a/packages/wrangler/src/cli.ts
+++ b/packages/wrangler/src/cli.ts
@@ -101,9 +101,6 @@ export { splitSqlQuery as unstable_splitSqlQuery } from "./d1/splitter";
 // `@cloudflare/pages-shared/environment-polyfills/types.ts` defines `global`
 // augmentations that pollute the `import`-site's typing environment.
 //
-// We `require` instead of `import`ing here to avoid polluting the main
-// `wrangler` TypeScript project with the `global` augmentations. This
-// relies on the fact that `require` is untyped.
 export interface Unstable_ASSETSBindingsOptions {
 	log: Logger;
 	proxyPort?: number;
@@ -113,7 +110,11 @@ export interface Unstable_ASSETSBindingsOptions {
 export const unstable_generateASSETSBinding: (
 	opts: Unstable_ASSETSBindingsOptions
 ) => (request: Request) => Promise<Response> =
-	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	/* eslint-disable-next-line @typescript-eslint/no-require-imports --
+	   We `require` instead of `import`ing here to avoid polluting the main
+	   `wrangler` TypeScript project with the `global` augmentations. This
+	   relies on the fact that `require` is untyped.
+	*/
 	require("./miniflare-cli/assets").default;
 
 export {

--- a/packages/wrangler/src/core/types.ts
+++ b/packages/wrangler/src/core/types.ts
@@ -38,9 +38,9 @@ type CamelCaseKey<K extends PropertyKey> = K extends string
 type Alias<O extends Options | PositionalOptions> = O extends { alias: infer T }
 	? T extends Exclude<string, T>
 		? { [key in T]: InferredOptionType<O> }
-		: // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+		: // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- Vendored yargs type requires empty object fallback
 			{}
-	: // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+	: // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- Vendored yargs type requires empty object fallback
 		{};
 
 type StringKeyOf<T> = Extract<keyof T, string>;

--- a/packages/wrangler/src/dev/start-dev.ts
+++ b/packages/wrangler/src/dev/start-dev.ts
@@ -302,15 +302,15 @@ async function getPagesAssetsFetcher(
 	options: EnablePagesAssetsServiceBindingOptions | undefined
 ): Promise<StartDevWorkerInput["bindings"] | undefined> {
 	if (options !== undefined) {
-		// `./miniflare-cli/assets` dynamically imports`@cloudflare/pages-shared/environment-polyfills`.
-		// `@cloudflare/pages-shared/environment-polyfills/types.ts` defines `global`
-		// augmentations that pollute the `import`-site's typing environment.
-		//
-		// We `require` instead of `import`ing here to avoid polluting the main
-		// `wrangler` TypeScript project with the `global` augmentations. This
-		// relies on the fact that `require` is untyped.
-		//
-		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		/* eslint-disable-next-line @typescript-eslint/no-require-imports --
+		  `./miniflare-cli/assets` dynamically imports`@cloudflare/pages-shared/environment-polyfills`.
+		  `@cloudflare/pages-shared/environment-polyfills/types.ts` defines `global`
+		  augmentations that pollute the `import`-site's typing environment.
+
+		  We `require` instead of `import`ing here to avoid polluting the main
+		  `wrangler` TypeScript project with the `global` augmentations. This
+		  relies on the fact that `require` is untyped.
+		*/
 		const generateASSETSBinding = require("../miniflare-cli/assets").default;
 		return {
 			ASSETS: {

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -2402,7 +2402,7 @@ export async function main(argv: string[]): Promise<void> {
 			// Only re-throw if we haven't already re-thrown an exception from a
 			// command handler.
 			if (!cliHandlerThrew) {
-				// eslint-disable-next-line no-unsafe-finally
+				// eslint-disable-next-line no-unsafe-finally -- Intentionally re-throw in finally when the CLI handler did not throw
 				throw e;
 			}
 		}

--- a/packages/wrangler/src/logger.ts
+++ b/packages/wrangler/src/logger.ts
@@ -122,7 +122,7 @@ export class Logger {
 	columns = process.stdout.columns;
 
 	json = (data: unknown) => {
-		// eslint-disable-next-line no-console
+		// eslint-disable-next-line no-console -- The logger implementation has to use console directly
 		console.log(JSON.stringify(data, null, 4));
 	};
 
@@ -175,7 +175,7 @@ export class Logger {
 		method: M,
 		...args: Parameters<Console[M]>
 	) {
-		// eslint-disable-next-line no-console
+		// eslint-disable-next-line no-console -- Logger implementation must use console directly
 		if (typeof console[method] !== "function") {
 			throw new Error(`console.${method}() is not a function`);
 		}
@@ -185,7 +185,7 @@ export class Logger {
 			LOGGER_LEVELS[consoleMethodToLoggerLevel(method)]
 		) {
 			Logger.#beforeLogHook?.();
-			// eslint-disable-next-line no-console
+			// eslint-disable-next-line no-console -- Logger implementation must use console directly
 			(console[method] as (...args: unknown[]) => unknown).apply(console, args);
 			Logger.#afterLogHook?.();
 		}
@@ -230,7 +230,7 @@ export class Logger {
 		// only send logs to the terminal if their level is at least the configured log-level
 		if (LOGGER_LEVELS[this.loggerLevel] >= LOGGER_LEVELS[messageLevel]) {
 			Logger.#beforeLogHook?.();
-			// eslint-disable-next-line no-console
+			// eslint-disable-next-line no-console -- Logger implementation must use console directly
 			console[messageLevel](message);
 			Logger.#afterLogHook?.();
 		}

--- a/packages/wrangler/src/pages/build-env.ts
+++ b/packages/wrangler/src/pages/build-env.ts
@@ -71,7 +71,7 @@ export const pagesFunctionsBuildEnvCommand = createCommand({
 			config = readPagesConfig({
 				...args,
 				config: configPath,
-				// eslint-disable-next-line turbo/no-undeclared-env-vars
+				// eslint-disable-next-line turbo/no-undeclared-env-vars -- PAGES_ENVIRONMENT is set by the Pages CI environment
 				env: process.env.PAGES_ENVIRONMENT,
 			});
 		} catch (err) {

--- a/packages/wrangler/src/pages/build.ts
+++ b/packages/wrangler/src/pages/build.ts
@@ -385,7 +385,7 @@ async function maybeReadPagesConfig(
 		const config = readPagesConfig({
 			...args,
 			config: configPath,
-			// eslint-disable-next-line turbo/no-undeclared-env-vars
+			// eslint-disable-next-line turbo/no-undeclared-env-vars -- PAGES_ENVIRONMENT is set by the Pages CI environment
 			env: process.env.PAGES_ENVIRONMENT,
 		});
 

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -405,7 +405,9 @@ export const pagesDevCommand = createCommand({
 			ai,
 		} = getBindingsFromArgs(args);
 
-		let scriptReadyResolve: () => void;
+		// Note: we initialize scriptReadyResolve to an no-op function, mainly for making
+		//       typescript happy, it will be properly re-assigned before used
+		let scriptReadyResolve: () => void = () => {};
 		const scriptReadyPromise = new Promise<void>(
 			(promiseResolve) => (scriptReadyResolve = promiseResolve)
 		);
@@ -814,8 +816,7 @@ export const pagesDevCommand = createCommand({
 		// Depending on the result of building Functions, we may not actually be using
 		// Functions even if the directory exists.
 		if (!usingFunctions && !usingWorkerScript) {
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			scriptReadyResolve!();
+			scriptReadyResolve();
 
 			logger.log("No Functions. Shimming...");
 			scriptPath = resolve(getBasePath(), "templates/pages-shim.ts");

--- a/packages/wrangler/src/paths.ts
+++ b/packages/wrangler/src/paths.ts
@@ -69,7 +69,7 @@ declare const __RELATIVE_PACKAGE_PATH__: string;
  * no matter whether the code has been bundled or not.
  */
 export function getBasePath(): string {
-	// eslint-disable-next-line no-restricted-globals
+	// eslint-disable-next-line no-restricted-globals -- __dirname is the correct baseline for resolving the package root at runtime
 	return path.resolve(__dirname, __RELATIVE_PACKAGE_PATH__);
 }
 

--- a/packages/wrangler/src/secrets-store/commands.ts
+++ b/packages/wrangler/src/secrets-store/commands.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import { FatalError, UserError } from "@cloudflare/workers-utils";
 import { Miniflare } from "miniflare";
 import { createCommand } from "../core/create-command";
@@ -247,17 +248,19 @@ export const secretsStoreSecretListCommand = createCommand({
 					"",
 					(api) => api.list()
 				)
-			).map((key) => ({
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				id: key.metadata!.uuid,
-				store_id: args.storeId,
-				name: key.name,
-				comment: "",
-				scopes: [],
-				created: new Date().toISOString(),
-				modified: new Date().toISOString(),
-				status: "active",
-			}));
+			).map((key) => {
+				assert(key.metadata, "metadata is always present in API list response");
+				return {
+					id: key.metadata.uuid,
+					store_id: args.storeId,
+					name: key.name,
+					comment: "",
+					scopes: [],
+					created: new Date().toISOString(),
+					modified: new Date().toISOString(),
+					status: "active",
+				};
+			});
 		}
 
 		if (secrets.length === 0) {

--- a/packages/wrangler/src/sourcemap.ts
+++ b/packages/wrangler/src/sourcemap.ts
@@ -67,7 +67,7 @@ function getSourceMappingPrepareStackTrace(
 		return sourceMappingPrepareStackTrace;
 	}
 
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+	// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- typeof requires a value import, not a type import
 	const support: typeof import("@cspotcode/source-map-support") =
 		getFreshSourceMapSupport();
 	const originalPrepareStackTrace = Error.prepareStackTrace;
@@ -190,7 +190,7 @@ export function getSourceMappedString(
 const CALL_SITE_REGEXP =
 	// Validation errors from `wrangler deploy` have a 2 space indent, whereas
 	// regular stack traces have a 4 space indent.
-	// eslint-disable-next-line no-control-regex
+	// eslint-disable-next-line no-control-regex -- Intentionally matches ANSI escape sequences in stack traces
 	/^(?:\s+(?:\x1B\[\d+m)?'?)? {2,4}at (?:(.+?)\s+\()?(?:(.+?):(\d+)(?::(\d+))?|([^)]+))\)?/gm;
 function lineMatchToCallSite(lineMatch: RegExpMatchArray): CallSite {
 	let object: string | null = null;
@@ -271,7 +271,7 @@ class CallSite implements NodeJS.CallSite {
 	getTypeName(): string | null {
 		return this.opts.typeName;
 	}
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- V8 CallSite interface requires Function return type
 	getFunction(): Function | undefined {
 		return undefined;
 	}

--- a/packages/wrangler/src/utils/box.ts
+++ b/packages/wrangler/src/utils/box.ts
@@ -33,7 +33,7 @@ const BOX = {
  * Remove ANSI escape codes from a string.
  */
 export function stripAnsi(str: string): string {
-	// eslint-disable-next-line no-control-regex
+	// eslint-disable-next-line no-control-regex -- Intentionally matches ANSI escape sequences
 	return str.replace(/\x1b\[[0-9;]*m/g, "");
 }
 

--- a/packages/wrangler/src/workflows/commands/instances/describe.ts
+++ b/packages/wrangler/src/workflows/commands/instances/describe.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import { logRaw } from "@cloudflare/cli-shared-helpers";
 import { red, white } from "@cloudflare/cli-shared-helpers/colors";
 import {
@@ -211,9 +212,11 @@ function logStep(
 			const latestAttempt = step.attempts.at(-1);
 			let delay = step.config.retries.delay;
 			if (latestAttempt !== undefined && latestAttempt.success === false) {
-				// SAFETY: It's okay because end date must always exist in the API, otherwise it's okay to fail
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				const endDate = new Date(latestAttempt.end!);
+				assert(
+					latestAttempt.end,
+					"end date always exists in the API for completed attempts"
+				);
+				const endDate = new Date(latestAttempt.end);
 				if (typeof delay === "string") {
 					delay = ms(delay);
 				}

--- a/packages/wrangler/vitest.config.mts
+++ b/packages/wrangler/vitest.config.mts
@@ -63,7 +63,7 @@ export default defineConfig({
 		pool: "forks",
 		retry: 0,
 		include: ["**/__tests__/**/*.test.ts", "**/__tests__/**/*.test.tsx"],
-		// eslint-disable-next-line turbo/no-undeclared-env-vars
+		// eslint-disable-next-line turbo/no-undeclared-env-vars -- TEST_REPORT_PATH is optionally set by CI
 		outputFile: process.env.TEST_REPORT_PATH ?? ".e2e-test-report/index.html",
 		setupFiles: path.resolve(__dirname, "src/__tests__/vitest.setup.ts"),
 		globalSetup: path.resolve(__dirname, "src/__tests__/vitest.global.ts"),


### PR DESCRIPTION
This PR enables the `require-description-when-disabling` lint rule on the wrangler package.

This is a followup PR for https://github.com/cloudflare/workers-sdk/pull/13698, https://github.com/cloudflare/workers-sdk/pull/13703, https://github.com/cloudflare/workers-sdk/pull/13710, https://github.com/cloudflare/workers-sdk/pull/13741, https://github.com/cloudflare/workers-sdk/pull/13803, https://github.com/cloudflare/workers-sdk/pull/13804, https://github.com/cloudflare/workers-sdk/pull/13819, https://github.com/cloudflare/workers-sdk/pull/13844 and https://github.com/cloudflare/workers-sdk/pull/13900.

And this PR completely removes the `require-description-when-disabling` lint rule override 🥳 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: internal linting change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal linting change

*A picture of a cute animal (not mandatory, but encouraged)*
