### PR TITLE
[wrangler] Rename Workflows schedule property to schedules

### DIFF
--- a/.changeset/workflows-schedules-rename.md
+++ b/.changeset/workflows-schedules-rename.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Rename Workflow binding `schedule` property to `schedules`
+
+The `schedule` property on Workflow bindings introduced in [#13467](https://github.com/cloudflare/workers-sdk/pull/13467) has been renamed to `schedules` to match the control plane API.
+
+> **Note:** This remains a configuration-only change. Scheduled triggering of Workflow instances is not yet available — adding `schedules` to a Workflow binding will not result in scheduled invocations at this time.

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -729,7 +729,7 @@ export type WorkflowBinding = {
 		steps?: number;
 	};
 	/** Optional cron schedule(s) for automatically triggering workflow instances */
-	schedule?: string | string[];
+	schedules?: string | string[];
 };
 
 /**

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -2699,36 +2699,38 @@ const validateWorkflowBinding: ValidatorFn = (diagnostics, field, value) => {
 		isValid = false;
 	}
 
-	if (hasProperty(value, "schedule") && value.schedule !== undefined) {
-		if (typeof value.schedule === "string") {
-			if (value.schedule.length === 0) {
+	if (hasProperty(value, "schedules") && value.schedules !== undefined) {
+		if (typeof value.schedules === "string") {
+			if (value.schedules.length === 0) {
 				diagnostics.errors.push(
-					`"${field}" bindings "schedule" field must not be an empty string.`
+					`"${field}" bindings "schedules" field must not be an empty string.`
 				);
 				isValid = false;
 			}
-		} else if (Array.isArray(value.schedule)) {
-			if (value.schedule.length === 0) {
+		} else if (Array.isArray(value.schedules)) {
+			if (value.schedules.length === 0) {
 				diagnostics.errors.push(
-					`"${field}" bindings "schedule" field must not be an empty array.`
+					`"${field}" bindings "schedules" field must not be an empty array.`
 				);
 				isValid = false;
-			} else if (!value.schedule.every((s: unknown) => typeof s === "string")) {
+			} else if (
+				!value.schedules.every((s: unknown) => typeof s === "string")
+			) {
 				diagnostics.errors.push(
-					`"${field}" bindings should, optionally, have a string or array of strings "schedule" field but got ${JSON.stringify(
+					`"${field}" bindings should, optionally, have a string or array of strings "schedules" field but got ${JSON.stringify(
 						value
 					)}.`
 				);
 				isValid = false;
-			} else if (value.schedule.some((s: unknown) => s === "")) {
+			} else if (value.schedules.some((s: unknown) => s === "")) {
 				diagnostics.errors.push(
-					`"${field}" bindings "schedule" field must not contain empty strings.`
+					`"${field}" bindings "schedules" field must not contain empty strings.`
 				);
 				isValid = false;
 			}
 		} else {
 			diagnostics.errors.push(
-				`"${field}" bindings should, optionally, have a string or array of strings "schedule" field but got ${JSON.stringify(
+				`"${field}" bindings should, optionally, have a string or array of strings "schedules" field but got ${JSON.stringify(
 					value
 				)}.`
 			);
@@ -2784,7 +2786,7 @@ const validateWorkflowBinding: ValidatorFn = (diagnostics, field, value) => {
 		"script_name",
 		"remote",
 		"limits",
-		"schedule",
+		"schedules",
 	]);
 
 	return isValid;

--- a/packages/workers-utils/src/worker.ts
+++ b/packages/workers-utils/src/worker.ts
@@ -192,7 +192,7 @@ export interface CfWorkflow {
 	limits?: {
 		steps?: number;
 	};
-	schedule?: string | string[];
+	schedules?: string | string[];
 }
 
 export interface CfQueue {

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -5204,7 +5204,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBe(false);
 			});
 
-			it("should accept valid workflow bindings with schedule as a string", ({
+			it("should accept valid workflow bindings with schedules as a string", ({
 				expect,
 			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
@@ -5214,7 +5214,7 @@ describe("normalizeAndValidateConfig()", () => {
 								binding: "MY_WORKFLOW",
 								name: "my-workflow",
 								class_name: "MyWorkflow",
-								schedule: "*/5 * * * *",
+								schedules: "*/5 * * * *",
 							},
 						],
 					} as unknown as RawConfig,
@@ -5227,7 +5227,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBe(false);
 			});
 
-			it("should accept valid workflow bindings with schedule as an array of strings", ({
+			it("should accept valid workflow bindings with schedules as an array of strings", ({
 				expect,
 			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
@@ -5237,7 +5237,7 @@ describe("normalizeAndValidateConfig()", () => {
 								binding: "MY_WORKFLOW",
 								name: "my-workflow",
 								class_name: "MyWorkflow",
-								schedule: ["*/5 * * * *", "0 9 * * 1"],
+								schedules: ["*/5 * * * *", "0 9 * * 1"],
 							},
 						],
 					} as unknown as RawConfig,
@@ -5330,7 +5330,7 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
-			it("should error if schedule has wrong type", ({ expect }) => {
+			it("should error if schedules has wrong type", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						workflows: [
@@ -5338,7 +5338,7 @@ describe("normalizeAndValidateConfig()", () => {
 								binding: "MY_WORKFLOW",
 								name: "my-workflow",
 								class_name: "MyWorkflow",
-								schedule: 123,
+								schedules: 123,
 							},
 						],
 					} as unknown as RawConfig,
@@ -5350,11 +5350,11 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(true);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
-					  - "workflows[0]" bindings should, optionally, have a string or array of strings "schedule" field but got {"binding":"MY_WORKFLOW","name":"my-workflow","class_name":"MyWorkflow","schedule":123}."
+					  - "workflows[0]" bindings should, optionally, have a string or array of strings "schedules" field but got {"binding":"MY_WORKFLOW","name":"my-workflow","class_name":"MyWorkflow","schedules":123}."
 				`);
 			});
 
-			it("should error if schedule is an empty string", ({ expect }) => {
+			it("should error if schedules is an empty string", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						workflows: [
@@ -5362,7 +5362,7 @@ describe("normalizeAndValidateConfig()", () => {
 								binding: "MY_WORKFLOW",
 								name: "my-workflow",
 								class_name: "MyWorkflow",
-								schedule: "",
+								schedules: "",
 							},
 						],
 					} as unknown as RawConfig,
@@ -5374,11 +5374,11 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(true);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
-					  - "workflows[0]" bindings "schedule" field must not be an empty string."
+					  - "workflows[0]" bindings "schedules" field must not be an empty string."
 				`);
 			});
 
-			it("should error if schedule is an empty array", ({ expect }) => {
+			it("should error if schedules is an empty array", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{
 						workflows: [
@@ -5386,7 +5386,7 @@ describe("normalizeAndValidateConfig()", () => {
 								binding: "MY_WORKFLOW",
 								name: "my-workflow",
 								class_name: "MyWorkflow",
-								schedule: [],
+								schedules: [],
 							},
 						],
 					} as unknown as RawConfig,
@@ -5398,11 +5398,11 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(true);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
-					  - "workflows[0]" bindings "schedule" field must not be an empty array."
+					  - "workflows[0]" bindings "schedules" field must not be an empty array."
 				`);
 			});
 
-			it("should error if schedule is an array containing non-strings", ({
+			it("should error if schedules is an array containing non-strings", ({
 				expect,
 			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
@@ -5412,7 +5412,7 @@ describe("normalizeAndValidateConfig()", () => {
 								binding: "MY_WORKFLOW",
 								name: "my-workflow",
 								class_name: "MyWorkflow",
-								schedule: ["*/5 * * * *", 123],
+								schedules: ["*/5 * * * *", 123],
 							},
 						],
 					} as unknown as RawConfig,
@@ -5424,11 +5424,11 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(true);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
-					  - "workflows[0]" bindings should, optionally, have a string or array of strings "schedule" field but got {"binding":"MY_WORKFLOW","name":"my-workflow","class_name":"MyWorkflow","schedule":["*/5 * * * *",123]}."
+					  - "workflows[0]" bindings should, optionally, have a string or array of strings "schedules" field but got {"binding":"MY_WORKFLOW","name":"my-workflow","class_name":"MyWorkflow","schedules":["*/5 * * * *",123]}."
 				`);
 			});
 
-			it("should error if schedule is an array containing empty strings", ({
+			it("should error if schedules is an array containing empty strings", ({
 				expect,
 			}) => {
 				const { diagnostics } = normalizeAndValidateConfig(
@@ -5438,7 +5438,7 @@ describe("normalizeAndValidateConfig()", () => {
 								binding: "MY_WORKFLOW",
 								name: "my-workflow",
 								class_name: "MyWorkflow",
-								schedule: ["*/5 * * * *", ""],
+								schedules: ["*/5 * * * *", ""],
 							},
 						],
 					} as unknown as RawConfig,
@@ -5450,7 +5450,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(true);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
-					  - "workflows[0]" bindings "schedule" field must not contain empty strings."
+					  - "workflows[0]" bindings "schedules" field must not contain empty strings."
 				`);
 			});
 

--- a/packages/wrangler/src/__tests__/deploy/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/workflows.test.ts
@@ -289,7 +289,7 @@ describe("deploy", () => {
 			expect(std.out).toContain("workflow: my-workflow");
 		});
 
-		it("should deploy a workflow with schedule", async ({ expect }) => {
+		it("should deploy a workflow with schedules", async ({ expect }) => {
 			writeWranglerConfig({
 				main: "index.js",
 				workflows: [
@@ -297,7 +297,7 @@ describe("deploy", () => {
 						binding: "WORKFLOW",
 						name: "my-workflow",
 						class_name: "MyWorkflow",
-						schedule: "0 * * * *",
+						schedules: "0 * * * *",
 					},
 				],
 			});
@@ -318,7 +318,7 @@ describe("deploy", () => {
 					expect(body).toEqual({
 						script_name: "test-name",
 						class_name: "MyWorkflow",
-						schedule: "0 * * * *",
+						schedules: "0 * * * *",
 					});
 					return HttpResponse.json(
 						createFetchResult({ id: "mock-new-workflow-id" })
@@ -344,7 +344,7 @@ describe("deploy", () => {
 			expect(std.out).toContain("workflow: my-workflow");
 		});
 
-		it("should deploy a workflow with schedule as an array of cron expressions", async ({
+		it("should deploy a workflow with schedules as an array of cron expressions", async ({
 			expect,
 		}) => {
 			writeWranglerConfig({
@@ -354,7 +354,7 @@ describe("deploy", () => {
 						binding: "WORKFLOW",
 						name: "my-workflow",
 						class_name: "MyWorkflow",
-						schedule: ["0 * * * *", "0 9 * * 1"],
+						schedules: ["0 * * * *", "0 9 * * 1"],
 					},
 				],
 			});
@@ -375,7 +375,7 @@ describe("deploy", () => {
 					expect(body).toEqual({
 						script_name: "test-name",
 						class_name: "MyWorkflow",
-						schedule: ["0 * * * *", "0 9 * * 1"],
+						schedules: ["0 * * * *", "0 9 * * 1"],
 					});
 					return HttpResponse.json(
 						createFetchResult({ id: "mock-new-workflow-id" })
@@ -401,7 +401,7 @@ describe("deploy", () => {
 			expect(std.out).toContain("workflow: my-workflow");
 		});
 
-		it("should deploy a workflow with both limits and schedule", async ({
+		it("should deploy a workflow with both limits and schedules", async ({
 			expect,
 		}) => {
 			writeWranglerConfig({
@@ -412,7 +412,7 @@ describe("deploy", () => {
 						name: "my-workflow",
 						class_name: "MyWorkflow",
 						limits: { steps: 5000 },
-						schedule: "*/15 * * * *",
+						schedules: "*/15 * * * *",
 					},
 				],
 			});
@@ -434,7 +434,7 @@ describe("deploy", () => {
 						script_name: "test-name",
 						class_name: "MyWorkflow",
 						limits: { steps: 5000 },
-						schedule: "*/15 * * * *",
+						schedules: "*/15 * * * *",
 					});
 					return HttpResponse.json(
 						createFetchResult({ id: "mock-new-workflow-id" })
@@ -568,7 +568,7 @@ describe("deploy", () => {
 			);
 		});
 
-		it("should error when deploying a workflow with schedule that references an external script", async ({
+		it("should error when deploying a workflow with schedules that references an external script", async ({
 			expect,
 		}) => {
 			writeWranglerConfig({
@@ -580,7 +580,7 @@ describe("deploy", () => {
 						name: "my-workflow",
 						class_name: "MyWorkflow",
 						script_name: "another-script",
-						schedule: "0 * * * *",
+						schedules: "0 * * * *",
 					},
 				],
 			});
@@ -606,7 +606,7 @@ describe("deploy", () => {
 			);
 
 			await expect(runWrangler("deploy")).rejects.toThrow(
-				'Workflow "my-workflow" has "schedule" configured but references external script "another-script"'
+				'Workflow "my-workflow" has "schedules" configured but references external script "another-script"'
 			);
 		});
 
@@ -749,7 +749,7 @@ describe("deploy", () => {
 				expect(std.out).toContain("Uploaded my-app-staging");
 			});
 
-			it("should error when script_name matches top-level name but not env-suffixed name and schedule is set", async ({
+			it("should error when script_name matches top-level name but not env-suffixed name and schedules is set", async ({
 				expect,
 			}) => {
 				writeWranglerConfig({
@@ -763,7 +763,7 @@ describe("deploy", () => {
 									name: "my-workflow",
 									class_name: "MyWorkflow",
 									script_name: "my-app",
-									schedule: "0 * * * *",
+									schedules: "0 * * * *",
 								},
 							],
 						},
@@ -777,11 +777,11 @@ describe("deploy", () => {
 				});
 
 				await expect(runWrangler("deploy --env staging")).rejects.toThrow(
-					'Workflow "my-workflow" has "schedule" configured but references external script "my-app"'
+					'Workflow "my-workflow" has "schedules" configured but references external script "my-app"'
 				);
 			});
 
-			it("should allow schedule when script_name matches the env-suffixed name", async ({
+			it("should allow schedules when script_name matches the env-suffixed name", async ({
 				expect,
 			}) => {
 				writeWranglerConfig({
@@ -795,7 +795,7 @@ describe("deploy", () => {
 									name: "my-workflow",
 									class_name: "MyWorkflow",
 									script_name: "my-app-staging",
-									schedule: "0 * * * *",
+									schedules: "0 * * * *",
 								},
 							],
 						},
@@ -818,7 +818,7 @@ describe("deploy", () => {
 						expect(body).toEqual({
 							script_name: "my-app-staging",
 							class_name: "MyWorkflow",
-							schedule: "0 * * * *",
+							schedules: "0 * * * *",
 						});
 						return HttpResponse.json(
 							createFetchResult({ id: "mock-new-workflow-id" })
@@ -837,7 +837,7 @@ describe("deploy", () => {
 				expect(std.out).toContain("workflow: my-workflow");
 			});
 
-			it("should deploy external script_name under env without schedule", async ({
+			it("should deploy external script_name under env without schedules", async ({
 				expect,
 			}) => {
 				writeWranglerConfig({

--- a/packages/wrangler/src/dev/miniflare/index.ts
+++ b/packages/wrangler/src/dev/miniflare/index.ts
@@ -798,11 +798,11 @@ export function buildMiniflareBindingOptions(
 							{ telemetryMessage: "workflow limits on external script" }
 						);
 					}
-					if (workflow.schedule) {
+					if (workflow.schedules) {
 						throw new UserError(
-							`Workflow "${workflow.name}" has "schedule" configured but references external script "${workflow.script_name}". ` +
-								`Configure schedule on the worker that defines the workflow.`,
-							{ telemetryMessage: "workflow schedule on external script" }
+							`Workflow "${workflow.name}" has "schedules" configured but references external script "${workflow.script_name}". ` +
+								`Configure schedules on the worker that defines the workflow.`,
+							{ telemetryMessage: "workflow schedules on external script" }
 						);
 					}
 				}

--- a/packages/wrangler/src/triggers/deploy.ts
+++ b/packages/wrangler/src/triggers/deploy.ts
@@ -280,13 +280,13 @@ export default async function triggersDeploy(
 						}
 					);
 				}
-				if (workflow.schedule) {
+				if (workflow.schedules) {
 					throw new UserError(
-						`Workflow "${workflow.name}" has "schedule" configured but references external script "${workflow.script_name}". ` +
-							`Configure schedule on the worker that defines the workflow.`,
+						`Workflow "${workflow.name}" has "schedules" configured but references external script "${workflow.script_name}". ` +
+							`Configure schedules on the worker that defines the workflow.`,
 						{
 							telemetryMessage:
-								"triggers deploy workflow schedule external script",
+								"triggers deploy workflow schedules external script",
 						}
 					);
 				}
@@ -303,7 +303,7 @@ export default async function triggersDeploy(
 							script_name: scriptName,
 							class_name: workflow.class_name,
 							...(workflow.limits && { limits: workflow.limits }),
-							...(workflow.schedule && { schedule: workflow.schedule }),
+							...(workflow.schedules && { schedules: workflow.schedules }),
 						}),
 						headers: {
 							"Content-Type": "application/json",


### PR DESCRIPTION
Fixes WOR-1221.

Renames the `schedule` Workflow binding property (added in #13467) to `schedules` to match the control plane API.
The field is still non-functional - scheduled triggering of Workflow instances is not yet available.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: the field is not yet documented externally and remains non-functional

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
