### PR TITLE
Remove most `@ts-ignore` directives from the codebase

### DIFF
--- a/packages/containers-shared/src/client/core/request.ts
+++ b/packages/containers-shared/src/client/core/request.ts
@@ -53,7 +53,6 @@ const base64 = (str: string): string => {
 	try {
 		return btoa(str);
 	} catch (err) {
-		// @ts-ignore
 		return Buffer.from(str).toString("base64");
 	}
 };
@@ -268,7 +267,7 @@ export const sendRequest = async (
 		// :(
 		// The vite-plugin is attempting to typecheck everything with worker types, which does not support request.credentials
 		// Also note this is always set to "omit".
-		// @ts-ignore
+		// @ts-ignore -- request.credentials not in Workers types
 		request.credentials = config.CREDENTIALS;
 	}
 

--- a/packages/miniflare/src/http/response.ts
+++ b/packages/miniflare/src/http/response.ts
@@ -61,7 +61,7 @@ export class Response extends BaseResponse {
 	get status() {
 		// When passing a WebSocket, we validate that the passed status was actually
 		// 101, but we can't store this because `undici` rightfully complains.
-		// @ts-ignore
+		// @ts-expect-error -- super.status in the overridden getter
 		return this[kWebSocket] ? 101 : super.status;
 	}
 

--- a/packages/miniflare/src/workers/d1/dumpSql.ts
+++ b/packages/miniflare/src/workers/d1/dumpSql.ts
@@ -40,7 +40,7 @@ export function* dumpSql(
 	const { noData, noSchema } = options || {};
 
 	// Taken from SQLite shell.c.in https://github.com/sqlite/sqlite/blob/105c20648e1b05839fd0638686b95f2e3998abcb/src/shell.c.in#L8463-L8469
-	// @ts-ignore (SqlStorageStatement needs to be callable)
+	// @ts-expect-error -- SqlStorageStatement needs to be callable
 	const tables_cursor = db.prepare(`
     SELECT name, type, sql
       FROM sqlite_schema AS o

--- a/packages/wrangler/src/__tests__/pages/routes-validation.test.ts
+++ b/packages/wrangler/src/__tests__/pages/routes-validation.test.ts
@@ -117,14 +117,12 @@ describe("routes-validation", () => {
 		it("should throw a fatal error if the routes are not a valid RoutesJSONSpec object", ({
 			expect,
 		}) => {
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- Intentionally testing invalid types
-			// @ts-ignore: sanity check
+			// @ts-expect-error -- Intentionally testing invalid types
 			const routesWithoutVersion: RoutesJSONSpec = {
 				include: ["/*"],
 				exclude: [],
 			};
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- Intentionally testing invalid types
-			// @ts-ignore: sanity check
+			// @ts-expect-error -- Intentionally testing invalid types
 			const routesWithoutInclude: RoutesJSONSpec = {
 				version: ROUTES_SPEC_VERSION,
 				exclude: [],

--- a/packages/wrangler/templates/__tests__/pages-dev-util.test.ts
+++ b/packages/wrangler/templates/__tests__/pages-dev-util.test.ts
@@ -93,14 +93,12 @@ describe("isRoutingRuleMatch", () => {
 	it("should throw an error if pathname or routing rule params are missing", () => {
 		// MISSING PATHNAME
 		expect(() =>
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore: sanity check
+			// @ts-expect-error -- Intentionally testing invalid types
 			isRoutingRuleMatch(undefined, "/*")
 		).toThrow("Pathname is undefined.");
 
 		expect(() =>
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore: sanity check
+			// @ts-expect-error -- Intentionally testing invalid types
 			isRoutingRuleMatch(null, "/*")
 		).toThrow("Pathname is undefined.");
 
@@ -110,14 +108,12 @@ describe("isRoutingRuleMatch", () => {
 
 		// MISSING ROUTING RULE
 		expect(() =>
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore: sanity check
+			// @ts-expect-error -- Intentionally testing invalid types
 			isRoutingRuleMatch("/foo", undefined)
 		).toThrow("Routing rule is undefined.");
 
 		expect(() =>
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore: sanity check
+			// @ts-expect-error -- Intentionally testing invalid types
 			isRoutingRuleMatch("/foo", null)
 		).toThrow("Routing rule is undefined.");
 

--- a/packages/wrangler/templates/pages-dev-pipeline.ts
+++ b/packages/wrangler/templates/pages-dev-pipeline.ts
@@ -1,11 +1,9 @@
-// @ts-ignore entry point will get replaced
 import worker from "__ENTRY_POINT__";
 import { isRoutingRuleMatch } from "./pages-dev-util";
 
-// @ts-ignore entry point will get replaced
 export * from "__ENTRY_POINT__";
 
-// @ts-ignore routes are injected
+// @ts-expect-error -- routes are injected
 const routes = __ROUTES__;
 
 export default <ExportedHandler<{ ASSETS: Fetcher }>>{


### PR DESCRIPTION
This PR removes most `@ts-ignore` directives from the codebase (all besides one which isn't trivial to remove).

In some places by removing them entirely and in others by replacing them with the more correct `@ts-expect-error`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: just ts directive changes
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: just ts directive changes

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
