### PR TITLE
Remove pointelss `// /* eslint-disable no-shadow */` comments

### DIFF
--- a/packages/wrangler/src/__tests__/pages/project-upload.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-upload.test.ts
@@ -1,4 +1,3 @@
-// /* eslint-disable no-shadow */
 import { mkdirSync, writeFileSync } from "node:fs";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import ci from "ci-info";

--- a/packages/wrangler/src/__tests__/pages/project-validate.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-validate.test.ts
@@ -1,4 +1,3 @@
-// /* eslint-disable no-shadow */
 import { writeFileSync } from "node:fs";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { afterEach, describe, it, vi } from "vitest";


### PR DESCRIPTION
I noticed these two `// /* eslint-disable no-shadow */` comments which as far as I can tell I completely pointless (note that the leading `// ` makes the eslint-disable directive not take any effect). This PR is simply removing them.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: just removing code comment
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: just removing code comment

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
