### PR TITLE
Set `disallowTypeAnnotations` to `false` in `@typescript-eslint/consistent-type-imports` config

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -32,7 +32,10 @@
 		"prefer-const": "error",
 		"prefer-rest-params": "error",
 		"prefer-spread": "error",
-		"@typescript-eslint/consistent-type-imports": ["error"],
+		"@typescript-eslint/consistent-type-imports": [
+			"error",
+			{ "disallowTypeAnnotations": false },
+		],
 		"no-var": "error",
 		"no-regex-spaces": "error",
 		"@typescript-eslint/no-empty-object-type": "error",

--- a/packages/miniflare/src/plugins/core/errors/index.ts
+++ b/packages/miniflare/src/plugins/core/errors/index.ts
@@ -319,7 +319,7 @@ export async function handlePrettyErrorRequest(
 	}
 
 	// Lazily import `youch` when required
-	// eslint-disable-next-line typescript/consistent-type-imports, @typescript-eslint/no-require-imports -- lazy require to avoid loading youch until an error page is needed
+	// eslint-disable-next-line @typescript-eslint/no-require-imports -- lazy require to avoid loading youch until an error page is needed
 	const { Youch }: typeof import("youch") = require("youch");
 	const youch = new Youch();
 

--- a/packages/miniflare/src/plugins/core/errors/sourcemap.ts
+++ b/packages/miniflare/src/plugins/core/errors/sourcemap.ts
@@ -13,7 +13,6 @@ import type { Options } from "@cspotcode/source-map-support";
 //
 // ...load a fresh copy, by resetting then restoring the `require` cache, and
 // overriding `Symbol.for()` to return a unique symbol.
-// eslint-disable-next-line typescript/consistent-type-imports -- dynamic import type used for return type annotation
 export function getFreshSourceMapSupport(): typeof import("@cspotcode/source-map-support") {
 	// Under Yarn PnP, Node's ESM->CJS bridge (`loadCJSModule` in
 	// `node:internal/modules/esm/translators`) hands this module a re-invented

--- a/packages/vitest-pool-workers/src/worker/types-ambient.d.ts
+++ b/packages/vitest-pool-workers/src/worker/types-ambient.d.ts
@@ -18,7 +18,6 @@ namespace Cloudflare {
 		__VITEST_POOL_WORKERS_UNSAFE_EVAL: UnsafeEval;
 	}
 	interface GlobalProps {
-		// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- typeof import() in ambient declarations requires inline import
 		mainModule: typeof import("./index");
 		durableNamespaces: "__VITEST_POOL_WORKERS_RUNNER_DURABLE_OBJECT__";
 	}

--- a/packages/workers-shared/asset-worker/worker-configuration.d.ts
+++ b/packages/workers-shared/asset-worker/worker-configuration.d.ts
@@ -2,7 +2,6 @@
 // bindings derived from the main module's exports.
 declare namespace Cloudflare {
 	interface GlobalProps {
-		// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- Cloudflare typegen requires `typeof import()` for mainModule
 		mainModule: typeof import("./src/worker");
 	}
 }

--- a/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
+++ b/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
@@ -22,12 +22,10 @@ import {
 import type { WranglerCommandOptions } from "./wrangler";
 import type { Awaitable } from "miniflare";
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- typeof requires a value import, not a type import
 export function importWrangler(): Promise<typeof import("../../src/cli")> {
 	return import(WRANGLER_IMPORT.href);
 }
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- typeof requires a value import, not a type import
 export function importMiniflare(): Promise<typeof import("miniflare")> {
 	return import(MINIFLARE_IMPORT.href);
 }

--- a/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
+++ b/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-imports -- Test file uses dynamic imports where typeof requires value imports */
 import assert from "node:assert";
 import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import { fetch } from "undici";
@@ -12,8 +11,6 @@ import {
 	onTestFailed,
 	vi,
 } from "vitest";
-/* eslint-enable no-restricted-imports */
-import { Binding, StartRemoteProxySessionOptions } from "../../api";
 import { unwrapHook } from "../../api/startDevWorker/utils";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -24,6 +21,7 @@ import {
 	mswZoneHandlers,
 } from "../helpers/msw";
 import { runWrangler } from "../helpers/run-wrangler";
+import type { Binding, StartRemoteProxySessionOptions } from "../../api";
 import type { StartDevOptions } from "../../dev";
 import type { RawConfig } from "@cloudflare/workers-utils";
 import type { RemoteProxyConnectionString, WorkerOptions } from "miniflare";

--- a/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
@@ -26,7 +26,6 @@ import type { RequestInit } from "undici";
 import type WebSocket from "ws";
 
 vi.mock("ws", async (importOriginal) => {
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- typeof requires a value import in vi.mock importOriginal callback
 	const realModule = await importOriginal<typeof import("ws")>();
 	const module = {
 		__esModule: true,

--- a/packages/wrangler/src/__tests__/pages/project-validate.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-validate.test.ts
@@ -7,7 +7,6 @@ import { mockConsoleMethods } from "../helpers/mock-console";
 import { runWrangler } from "../helpers/run-wrangler";
 
 vi.mock("../../pages/constants", async (importActual) => ({
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- typeof requires a value import in vi.mock importActual callback
 	...(await importActual<typeof import("../../pages/constants")>()),
 	MAX_ASSET_SIZE: 1 * 1024 * 1024,
 	MAX_ASSET_COUNT_DEFAULT: 10,

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -32,7 +32,6 @@ import type { ExpectStatic } from "vitest";
 import type WebSocket from "ws";
 
 vi.mock("ws", async (importOriginal) => {
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- typeof requires a value import in vi.mock importOriginal callback
 	const realModule = await importOriginal<typeof import("ws")>();
 	const module = {
 		__esModule: true,

--- a/packages/wrangler/src/__tests__/vitest.setup.ts
+++ b/packages/wrangler/src/__tests__/vitest.setup.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-imports -- Setup file uses dynamic imports where typeof requires value imports */
 import { PassThrough } from "node:stream";
 import chalk from "chalk";
 import { passthrough } from "msw";

--- a/packages/wrangler/src/sourcemap.ts
+++ b/packages/wrangler/src/sourcemap.ts
@@ -67,7 +67,6 @@ function getSourceMappingPrepareStackTrace(
 		return sourceMappingPrepareStackTrace;
 	}
 
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- typeof requires a value import, not a type import
 	const support: typeof import("@cspotcode/source-map-support") =
 		getFreshSourceMapSupport();
 	const originalPrepareStackTrace = Error.prepareStackTrace;


### PR DESCRIPTION
In the codebase we pretty consistently do:
```ts
typeof import(/*...*/)
```
each time disabling the `@typescript-eslint/no-require-imports` rule, in this PR I am instead setting the rule's `disallowTypeAnnotations` option to `false` so that we don't need to add the eslint disabling directive anymore

Note: an alternative to this would be to use standard type imports: https://github.com/cloudflare/workers-sdk/compare/dario/typeof-import-fix?expand=1 instead

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: linting refactoring
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: linting refactoring

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
