### PR TITLE
[wrangler] fix(containers): add --json flag to `wrangler containers info`

### DIFF
--- a/.changeset/containers-info-json-flag.md
+++ b/.changeset/containers-info-json-flag.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Add `--json` flag to `wrangler containers info` for consistent JSON output with sibling commands `list` and `instances`

--- a/.changeset/containers-info-json-flag.md
+++ b/.changeset/containers-info-json-flag.md
@@ -1,5 +1,5 @@
 ---
-"wrangler": patch
+"wrangler": minor
 ---
 
 Add `--json` flag to `wrangler containers info` for consistent JSON output with sibling commands `list` and `instances`

--- a/packages/wrangler/src/__tests__/containers/info.test.ts
+++ b/packages/wrangler/src/__tests__/containers/info.test.ts
@@ -76,8 +76,8 @@ describe("containers info", () => {
 				{ once: true }
 			)
 		);
-		expect(std.err).toMatchInlineSnapshot(`""`);
 		await runWrangler("containers info asdf --json");
+		expect(std.err).toMatchInlineSnapshot(`""`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"{
 			    "id": "asdf",
@@ -136,6 +136,8 @@ describe("containers info", () => {
 		await expect(runWrangler("containers info asdf --json")).rejects.toThrow(
 			/There has been an internal error/
 		);
+		expect(() => JSON.parse(std.out)).not.toThrow();
+		expect(JSON.parse(std.out)).toHaveProperty("error");
 	});
 
 	it("should show a single container when given an ID (json)", async ({
@@ -155,8 +157,8 @@ describe("containers info", () => {
 				{ once: true }
 			)
 		);
-		expect(std.err).toMatchInlineSnapshot(`""`);
 		await runWrangler("containers info asdf");
+		expect(std.err).toMatchInlineSnapshot(`""`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"{
 			    "id": "asdf",

--- a/packages/wrangler/src/__tests__/containers/info.test.ts
+++ b/packages/wrangler/src/__tests__/containers/info.test.ts
@@ -112,6 +112,32 @@ describe("containers info", () => {
 		`);
 	});
 
+	it("should throw JsonFriendlyFatalError on unexpected API error with --json", async ({
+		expect,
+	}) => {
+		setIsTTY(true);
+		setWranglerConfig({});
+		msw.use(
+			http.get(
+				"*/applications/asdf",
+				async () => {
+					return HttpResponse.json(
+						{
+							success: false,
+							result: null,
+							errors: [{ code: 2000, message: "boom" }],
+						},
+						{ status: 500 }
+					);
+				},
+				{ once: true }
+			)
+		);
+		await expect(runWrangler("containers info asdf --json")).rejects.toThrow(
+			/There has been an internal error/
+		);
+	});
+
 	it("should show a single container when given an ID (json)", async ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/__tests__/containers/info.test.ts
+++ b/packages/wrangler/src/__tests__/containers/info.test.ts
@@ -41,7 +41,10 @@ describe("containers info", () => {
 			  -h, --help            Show help  [boolean]
 			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			      --profile         Use a specific auth profile  [string]
-			  -v, --version         Show version number  [boolean]"
+			  -v, --version         Show version number  [boolean]
+
+			OPTIONS
+			      --json  Return output as JSON  [boolean] [default: false]"
 		`);
 	});
 
@@ -56,6 +59,57 @@ describe("containers info", () => {
 		).rejects.toThrowErrorMatchingInlineSnapshot(
 			`[Error: You need 'containers:write', try logging in again or creating an appropiate API token]`
 		);
+	});
+
+	it("should output JSON via --json flag in TTY mode", async ({ expect }) => {
+		setIsTTY(true);
+		setWranglerConfig({});
+		msw.use(
+			http.get(
+				"*/applications/asdf",
+				async ({ request }) => {
+					expect(await request.text()).toEqual("");
+					return HttpResponse.json(
+						`{"success": true, "result": ${MOCK_APPLICATION_SINGLE}}`
+					);
+				},
+				{ once: true }
+			)
+		);
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		await runWrangler("containers info asdf --json");
+		expect(std.out).toMatchInlineSnapshot(`
+			"{
+			    "id": "asdf",
+			    "created_at": "2025-02-14T18:03:13.268999936Z",
+			    "account_id": "test-account",
+			    "name": "app-test",
+			    "version": 1,
+			    "configuration": {
+			        "image": "registry.test.cfdata.org/test-app:v1",
+			        "network": {
+			            "mode": "private"
+			        }
+			    },
+			    "scheduling_policy": "regional",
+			    "instances": 2,
+			    "jobs": false,
+			    "constraints": {
+			        "region": "WNAM"
+			    },
+			    "durable_objects": {
+			        "namespace_id": "test-id"
+			    },
+			    "health": {
+			        "instances": {
+			            "healthy": 2,
+			            "failed": 0,
+			            "scheduling": 0,
+			            "starting": 0
+			        }
+			    }
+			}"
+		`);
 	});
 
 	it("should show a single container when given an ID (json)", async ({

--- a/packages/wrangler/src/containers/containers.ts
+++ b/packages/wrangler/src/containers/containers.ts
@@ -135,7 +135,7 @@ export const containersInfoCommand = createCommand({
 		owner: "Product: Cloudchamber",
 	},
 	behaviour: {
-		printBanner: () => !isNonInteractiveOrCI(),
+		printBanner: (args) => !args.json && !isNonInteractiveOrCI(),
 	},
 	args: {
 		ID: {
@@ -143,10 +143,20 @@ export const containersInfoCommand = createCommand({
 			type: "string",
 			demandOption: true,
 		},
+		json: {
+			describe: "Return output as JSON",
+			type: "boolean",
+			default: false,
+		},
 	},
 	positionalArgs: ["ID"],
 	async handler(args, { config }) {
 		await fillOpenAPIConfiguration(config, containersScope);
+		if (args.json) {
+			const application = await ApplicationsService.getApplication(args.ID);
+			logger.json(application);
+			return;
+		}
 		await infoCommand(args, config);
 	},
 });

--- a/packages/wrangler/src/containers/containers.ts
+++ b/packages/wrangler/src/containers/containers.ts
@@ -5,7 +5,7 @@ import {
 } from "@cloudflare/cli-shared-helpers";
 import { inputPrompt } from "@cloudflare/cli-shared-helpers/interactive";
 import { ApiError, ApplicationsService } from "@cloudflare/containers-shared";
-import { UserError } from "@cloudflare/workers-utils";
+import { JsonFriendlyFatalError, UserError } from "@cloudflare/workers-utils";
 import { isNonInteractiveOrCI } from "@cloudflare/workers-utils";
 import YAML from "yaml";
 import { fillOpenAPIConfiguration } from "../cloudchamber/common";
@@ -153,9 +153,19 @@ export const containersInfoCommand = createCommand({
 	async handler(args, { config }) {
 		await fillOpenAPIConfiguration(config, containersScope);
 		if (args.json) {
-			const application = await ApplicationsService.getApplication(args.ID);
-			logger.json(application);
-			return;
+			try {
+				const application = await ApplicationsService.getApplication(args.ID);
+				logger.json(application);
+				return;
+			} catch (err) {
+				if (err instanceof UserError) {
+					throw err;
+				}
+				const message = err instanceof Error ? err.message : "Unknown error";
+				throw new JsonFriendlyFatalError(JSON.stringify({ error: message }), {
+					telemetryMessage: "containers info json output failed",
+				});
+			}
 		}
 		await infoCommand(args, config);
 	},


### PR DESCRIPTION
Fixes #14035.

`wrangler containers list` and `wrangler containers instances` both expose a `--json` flag, but `wrangler containers info` does not. JSON output was reachable only implicitly via `CI=true` or non-TTY detection — the flag was absent from `--help` and the command wasn't composable with tools like `jq` when running in a TTY.

This adds an explicit `--json` boolean flag following the same pattern used by `list` and `instances`.

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: exposes existing behavior via an explicit flag; behavior is already documented for sibling commands
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->