### PR TITLE
[wrangler] fix(secret): don't create Worker for delete-only `secret bulk` payload

### DIFF
--- a/.changeset/secret-bulk-delete-only-guard.md
+++ b/.changeset/secret-bulk-delete-only-guard.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler secret bulk` creating a new Worker when the input is delete-only (all values `null`)

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -1594,6 +1594,32 @@ describe("wrangler secret", () => {
 			`);
 		});
 
+		it("should not create a new Worker when bulk input is delete-only (all null values)", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			writeFileSync(
+				"secret.json",
+				JSON.stringify({
+					"secret-to-delete": null,
+				})
+			);
+			mockNoWorkerFound({ isBulk: true });
+
+			await expect(
+				runWrangler("secret bulk ./secret.json --name non-existent-worker")
+			).rejects.toThrow();
+			expect(std.out).toMatchInlineSnapshot(`
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				🌀 Processing the secrets for the Worker "non-existent-worker"
+
+				🚨 Secrets failed to upload
+				"
+			`);
+		});
+
 		describe("multi-env warning", () => {
 			it("should warn if the wrangler config contains environments but none was specified in the command", async ({
 				expect,

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -1608,7 +1608,9 @@ describe("wrangler secret", () => {
 
 			await expect(
 				runWrangler("secret bulk ./secret.json --name non-existent-worker")
-			).rejects.toThrow();
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[APIError: A request to the Cloudflare API (/accounts/some-account-id/workers/scripts/non-existent-worker/secrets-bulk) failed.]`
+			);
 			expect(std.out).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -503,6 +503,10 @@ export const secretBulkCommand = createCommand({
 				if (!isWorkerNotFoundError(e)) {
 					throw e;
 				}
+				// Delete-only payloads (all values null) should not create a new Worker
+				if (Object.values(content).every((v) => v === null)) {
+					throw e;
+				}
 				// Worker doesn't exist yet — create a draft worker, then retry
 				const draftWorkerResult = await createDraftWorker({
 					config,


### PR DESCRIPTION
Fixes #14052.

`wrangler secret bulk` now supports `null` values to delete secrets. However, when the payload is **delete-only** (all values are `null`) and the named Worker doesn't exist, the command incorrectly falls through to the Worker-not-found recovery path — which prompts to create a draft Worker. In non-interactive/CI contexts this auto-accepts, silently creating a Worker under a mistyped name.

This fix guards the `createDraftWorker` fallback: if every value in the bulk payload is `null`, the Worker-not-found error propagates unchanged instead of triggering Worker creation.

**Before:** `echo '{"OLD_SECRET": null}' | wrangler secret bulk --name typo-worker` → creates `typo-worker`  
**After:** same command → fails with the original Worker-not-found error

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: bug fix for edge case introduced by the recently-merged delete support; no user-visible API change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14058" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->