### PR TITLE
[vitest-pool-workers] Preserve Durable Object handler order (for hibernated DOs)

### DIFF
--- a/.changeset/sharp-dogs-relax.md
+++ b/.changeset/sharp-dogs-relax.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Preserve Durable Object WebSocket handler invocation order
+
+Durable Object WebSocket events could begin executing out of order in the Workers Vitest integration when several events arrived while the test wrapper was resolving user code.
+
+Handler invocation now preserves arrival order while still allowing asynchronous handler completion to run concurrently.

--- a/fixtures/vitest-pool-workers-examples/durable-objects/src/index.ts
+++ b/fixtures/vitest-pool-workers-examples/durable-objects/src/index.ts
@@ -2,6 +2,7 @@ import { DurableObject } from "cloudflare:workers";
 
 export class Counter extends DurableObject {
 	count: number = 0;
+	#webSocketMessages: string[] = [];
 
 	constructor(ctx: DurableObjectState, env: Env) {
 		super(ctx, env);
@@ -17,6 +18,14 @@ export class Counter extends DurableObject {
 
 	fetch(request: Request) {
 		const url = new URL(request.url);
+		if (url.pathname === "/websocket-order") {
+			const { 0: client, 1: server } = new WebSocketPair();
+			this.ctx.acceptWebSocket(server);
+			return new Response(null, { status: 101, webSocket: client });
+		}
+		if (url.pathname === "/websocket-order-log") {
+			return Response.json(this.#webSocketMessages);
+		}
 		if (url.pathname === "/redirect") {
 			return Response.redirect("https://example.com/redirected", 302);
 		}
@@ -32,6 +41,17 @@ export class Counter extends DurableObject {
 	scheduleReset(afterMillis: number) {
 		void this.ctx.storage.setAlarm(Date.now() + afterMillis);
 	}
+
+	webSocketMessage(ws: WebSocket, message: string | ArrayBuffer) {
+		const value =
+			typeof message === "string" ? message : new TextDecoder().decode(message);
+		this.#webSocketMessages.push(value);
+		ws.send(value);
+	}
+
+	webSocketClose() {}
+
+	webSocketError() {}
 }
 
 export class SQLiteDurableObject extends DurableObject {

--- a/fixtures/vitest-pool-workers-examples/durable-objects/test/websockets.test.ts
+++ b/fixtures/vitest-pool-workers-examples/durable-objects/test/websockets.test.ts
@@ -1,0 +1,79 @@
+import { env } from "cloudflare:workers";
+import { it } from "vitest";
+
+const orderingAttempts = 5;
+const orderingMessages = 100;
+
+function expectedOrderingMessages() {
+	return Array.from({ length: orderingMessages }, (_, i) => `message-${i}`);
+}
+
+function getMessageData(event: MessageEvent) {
+	if (typeof event.data === "string") {
+		return event.data;
+	}
+	if (event.data instanceof ArrayBuffer) {
+		return new TextDecoder().decode(event.data);
+	}
+	throw new TypeError(
+		`Unexpected WebSocket message type: ${typeof event.data}`
+	);
+}
+
+function waitForMessages(socket: WebSocket, count: number) {
+	return new Promise<string[]>((resolve, reject) => {
+		const messages: string[] = [];
+		const timeout = setTimeout(() => {
+			reject(new Error(`Timed out waiting for ${count} WebSocket messages`));
+		}, 10_000);
+
+		socket.addEventListener("message", (event) => {
+			messages.push(getMessageData(event));
+			if (messages.length === count) {
+				clearTimeout(timeout);
+				resolve(messages);
+			}
+		});
+		socket.addEventListener("error", () => {
+			clearTimeout(timeout);
+			reject(new Error("WebSocket error while waiting for messages"));
+		});
+	});
+}
+
+function getResponseWebSocket(response: Response) {
+	const socket = response.webSocket;
+	if (socket === null || socket === undefined) {
+		throw new TypeError("Expected WebSocket response");
+	}
+	return socket;
+}
+
+it("preserves hibernatable WebSocket message order", async ({ expect }) => {
+	for (let attempt = 0; attempt < orderingAttempts; attempt++) {
+		const id = env.COUNTER.idFromName(
+			`websocket-ordering-${crypto.randomUUID()}-${attempt}`
+		);
+		const stub = env.COUNTER.get(id);
+		const response = await stub.fetch("https://example.com/websocket-order", {
+			headers: { Upgrade: "websocket" },
+		});
+		const socket = getResponseWebSocket(response);
+		const expected = expectedOrderingMessages();
+		const messagesPromise = waitForMessages(socket, orderingMessages);
+
+		socket.accept();
+		for (const message of expected) {
+			socket.send(message);
+		}
+
+		expect(await messagesPromise).toEqual(expected);
+
+		const logResponse = await stub.fetch(
+			"https://example.com/websocket-order-log"
+		);
+		expect(await logResponse.json()).toEqual(expected);
+
+		socket.close(1000, "done");
+	}
+});

--- a/packages/vitest-pool-workers/src/worker/entrypoints.ts
+++ b/packages/vitest-pool-workers/src/worker/entrypoints.ts
@@ -173,12 +173,12 @@ const invocationQueues = new WeakMap<InvocationQueueOwner, Promise<void>>();
 /**
  * Preserve the order in which async wrapper invocations begin executing.
  *
- * Resolving a property like `stub.method` may need to import user modules or
- * ensuring a Durable Object handler instance may need to import user modules or
- * instantiate wrapper objects. If several calls are fired synchronously, those
- * async steps can otherwise complete out of order before the actual user code is
- * invoked. The queue is released as soon as invocation starts, so async
- * completions can still run concurrently.
+ * Resolving a property like `stub.method`, or ensuring a Durable Object handler
+ * instance, may need to import user modules or instantiate wrapper objects. If
+ * several calls are fired synchronously, those async steps can otherwise
+ * complete out of order before the actual user code is invoked. The queue is
+ * released as soon as invocation starts, so async completions can still run
+ * concurrently.
  */
 async function enqueueInvocation<T>(
 	owner: InvocationQueueOwner,

--- a/packages/vitest-pool-workers/src/worker/entrypoints.ts
+++ b/packages/vitest-pool-workers/src/worker/entrypoints.ts
@@ -122,7 +122,7 @@ function getRPCProperty(
 	return Reflect.get(/* target */ ctor.prototype, key, /* receiver */ instance);
 }
 
-type RPCInvocationQueueOwner =
+type InvocationQueueOwner =
 	| WorkerEntrypoint<Cloudflare.Env>
 	| DurableObjectClass<Cloudflare.Env>
 	| WorkflowEntrypoint<Cloudflare.Env>;
@@ -146,10 +146,10 @@ type RPCInvocationQueueOwner =
 function getRPCPropertyCallableThenable(
 	key: string,
 	property: Promise<unknown>,
-	queueOwner: RPCInvocationQueueOwner
+	queueOwner: InvocationQueueOwner
 ) {
 	const fn = async function (...args: unknown[]) {
-		return enqueueRPCInvocation(queueOwner, async (release) => {
+		return enqueueInvocation(queueOwner, async (release) => {
 			try {
 				const maybeFn = await property;
 				if (typeof maybeFn === "function") {
@@ -168,25 +168,23 @@ function getRPCPropertyCallableThenable(
 	return fn;
 }
 
-const rpcInvocationQueues = new WeakMap<
-	RPCInvocationQueueOwner,
-	Promise<void>
->();
+const invocationQueues = new WeakMap<InvocationQueueOwner, Promise<void>>();
 
 /**
- * Preserve the order in which dynamically-wrapped RPC methods begin executing.
+ * Preserve the order in which async wrapper invocations begin executing.
  *
  * Resolving a property like `stub.method` may need to import user modules or
+ * ensuring a Durable Object handler instance may need to import user modules or
  * instantiate wrapper objects. If several calls are fired synchronously, those
- * async steps can otherwise complete out of order before the actual user method
- * is invoked. The queue is released as soon as invocation starts, so async RPC
+ * async steps can otherwise complete out of order before the actual user code is
+ * invoked. The queue is released as soon as invocation starts, so async
  * completions can still run concurrently.
  */
-async function enqueueRPCInvocation<T>(
-	owner: RPCInvocationQueueOwner,
+async function enqueueInvocation<T>(
+	owner: InvocationQueueOwner,
 	callback: (release: () => void) => Promise<T>
 ): Promise<T> {
-	const previous = rpcInvocationQueues.get(owner) ?? Promise.resolve();
+	const previous = invocationQueues.get(owner) ?? Promise.resolve();
 	let releaseStarted: (() => void) | undefined;
 	const started = new Promise<void>((resolve) => {
 		releaseStarted = resolve;
@@ -198,7 +196,7 @@ async function enqueueRPCInvocation<T>(
 		}
 	};
 	const result = previous.catch(() => {}).then(() => callback(release));
-	rpcInvocationQueues.set(owner, started);
+	invocationQueues.set(owner, started);
 	return result;
 }
 
@@ -551,14 +549,20 @@ export function createDurableObjectWrapper(
 			this: DurableObjectWrapper,
 			...args: unknown[]
 		) {
-			const { mainPath, instance } = await this[kEnsureInstance]();
-			const maybeFn = instance[key];
-			if (typeof maybeFn === "function") {
-				return (maybeFn as (...a: unknown[]) => void).apply(instance, args);
-			} else {
-				const message = `${className} exported by ${mainPath} does not define a \`${key}()\` method`;
-				throw new TypeError(message);
-			}
+			return enqueueInvocation(this, async (release) => {
+				try {
+					const { mainPath, instance } = await this[kEnsureInstance]();
+					const maybeFn = instance[key];
+					if (typeof maybeFn === "function") {
+						return (maybeFn as (...a: unknown[]) => void).apply(instance, args);
+					} else {
+						const message = `${className} exported by ${mainPath} does not define a \`${key}()\` method`;
+						throw new TypeError(message);
+					}
+				} finally {
+					release();
+				}
+			});
 		};
 	}
 


### PR DESCRIPTION
Preserves invocation order for Durable Object WebSocket handlers in `@cloudflare/vitest-pool-workers` when the wrapper has to resolve user code before calling the handler.

This extends the existing queued invocation behavior used for dynamic RPC wrappers to hibernatable Durable Object WebSocket handlers. The queue is released once the user handler starts, so asynchronous handler completion can still overlap.

Related context: #13433

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this fixes test runtime behavior and is covered by a regression test and changeset.

Validation:
- `pnpm --filter @fixture/vitest-pool-workers test:ci durable-objects/test/websockets.test.ts`
- `pnpm --filter @fixture/vitest-pool-workers test:ci durable-objects`
- `pnpm --filter @fixture/vitest-pool-workers test:ci rpc/test/unit.test.ts`
- `pnpm --filter @fixture/vitest-pool-workers check:type`
- `pnpm --filter @cloudflare/vitest-pool-workers check:type`
- `pnpm run check:format -- .changeset/sharp-dogs-relax.md packages/vitest-pool-workers/src/worker/entrypoints.ts fixtures/vitest-pool-workers-examples/durable-objects/src/index.ts fixtures/vitest-pool-workers-examples/durable-objects/test/websockets.test.ts`
- `pnpm run check:lint -- packages/vitest-pool-workers/src/worker/entrypoints.ts fixtures/vitest-pool-workers-examples/durable-objects/src/index.ts fixtures/vitest-pool-workers-examples/durable-objects/test/websockets.test.ts`

The new regression test fails without the source change: `webSocketMessage` invocations can observe adjacent message swaps. With the fix restored, the same test passes.

Note: `pnpm --filter @cloudflare/vitest-pool-workers test:ci` still has unrelated local failures in stdout/output expectation tests (`chunking`, `console`, and `filtering`).

Disclosure: Cursor with GPT-5.5 Extra High was used to help investigate the ordering bug, port the fix, and draft the regression test. I reviewed the generated changes before publishing.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->