### PR TITLE
[wrangler] Add OAuth 2.0 Device Authorization Grant support

### DIFF
--- a/.changeset/wrangler-login-device-flow.md
+++ b/.changeset/wrangler-login-device-flow.md
@@ -1,0 +1,18 @@
+---
+"@cloudflare/workers-auth": minor
+"wrangler": minor
+---
+
+Add support for OAuth 2.0 Device Authorization Grant to `wrangler login`
+
+Run `wrangler login --device` to authenticate without a local callback server. Useful in containers, remote SSH sessions, Codespaces, and any other environment where `localhost:8976` is unreachable from your browser.
+
+The new flow:
+
+- prints the verification URL and user code to the terminal,
+- attempts to open the verification URL in your default browser automatically (suppressed via `--browser=false`),
+- and polls the token endpoint until you approve the request (with a 5-minute hard cap).
+
+The verification URL is supplied by the authorization server, so it is rejected unless it is an `https` URL on the same auth domain the device code was requested from — it is never printed or opened otherwise.
+
+`--callback-host` and `--callback-port` cannot be combined with `--device`, since this flow does not start a local callback server.

--- a/packages/workers-auth/AGENTS.md
+++ b/packages/workers-auth/AGENTS.md
@@ -19,6 +19,8 @@ CLIs. Internal-only — published as `prerelease: true`.
 - `src/state.ts` — `readStoredAuthState()` + `StoredAuthState` shape
 - `src/token-exchange.ts` — auth-code → token + refresh-token rotation + `fetchAuthToken`
 - `src/callback-server.ts` — local HTTP server for the OAuth callback (listens on the host/port from the consumer's `redirectUri`)
+- `src/device-flow.ts` — `getOauthTokenViaDeviceFlow(options, ctx)`: the OAuth 2.0 Device Authorization Grant (RFC 8628) used by `login({device: true})` when the browser cannot reach the local callback URL. No callback server; prints the verification URL + user code and polls `/oauth2/token`. Every user-facing string is parameterised by `ctx.displayName` / `ctx.deviceLoginCommand` so the module carries no per-CLI branding. Both endpoints' bodies are narrowed before use (`asDeviceAuthorizationResponse`, `pollDeviceToken`'s `DevicePollResult`) rather than cast — an intermediary's envelope or a 2xx without a grant must produce a reportable `unexpected`/unusable-response error, never `undefined` arithmetic. `slow_down` / 5xx / 429 / unparseable bodies keep the loop alive; the last such failure is reported in place of the generic timeout if the deadline passes
+- `src/generate-device-auth-url.ts` — `generateVerificationUrl` (fallback `verification_uri_complete` builder for servers that omit it, RFC 8628 §3.3.1) + `assertTrustedVerificationUrl`, which rejects any server-supplied verification URL that is not `https:` on exactly the resolved auth domain (with no embedded credentials) before it is printed or handed to `openInBrowser` — the device flow is the only place this package opens a URL it did not build itself (RFC 8628 §5.4, remote phishing)
 - `src/flow.ts` — `createOAuthFlow(ctx)` factory wiring everything together
 - `src/context.ts` — `OAuthFlowContext` interface (DI surface)
 - `src/credential-store/` — opt-in OS-keyring-backed credential persistence (see below)
@@ -62,6 +64,11 @@ files and its own encryption key.
 - `clientId` (required) — the consumer's registered OAuth app ID; `string` or
   `() => string` for lazy (e.g. env-driven prod/staging) resolution
 - `consent` (required) — the consumer's branded granted/denied consent pages
+- `displayName` (required) — the consumer's branded name (`"Wrangler"`, `"cf"`),
+  interpolated into the device flow's "To authorize \<name\>…" copy
+- `deviceLoginCommand` (required) — the command that restarts the device flow
+  (`"wrangler login --device"`), quoted when a device code is denied, expires,
+  or the flow times out
 - `redirectUri` (required) — the registered redirect URI / local callback URL.
   The callback server's listen host/port and route path are all derived from it
   (per-call bind overrides via `LoginProps.callbackHost`/`callbackPort`)
@@ -75,10 +82,10 @@ files and its own encryption key.
 - `generateAuthUrl?` / `generateRandomState?` — test overrides for deterministic
   snapshot tests (defaults pull from `./generate-auth-url` / `./generate-random-state`)
 
-`clientId`, `consent`, `redirectUri`, and `storageFactory` are consumer-specific,
-so they are required rather than defaulted here. Wrangler's values live in the
-in-package wrangler layer (`src/wrangler/`, see below) rather than in the
-`wrangler` package itself.
+`clientId`, `consent`, `displayName`, `deviceLoginCommand`, `redirectUri`, and
+`storageFactory` are consumer-specific, so they are required rather than
+defaulted here. Wrangler's values live in the in-package wrangler layer
+(`src/wrangler/`, see below) rather than in the `wrangler` package itself.
 
 The wrangler layer (`src/wrangler/index.ts`, `createWranglerAuth`) wires the
 credential-storage layer once via `createCredentialStorageContext(...)` and
@@ -99,7 +106,9 @@ Cloudflare CLI built on this package. It lives in `src/core/`:
   only `@cloudflare/workers-utils`.
 - `types.ts` — `AuthContext` (the injected primitives: `logger`, `userAgent`,
   interactive `prompt` / `select`, `isNoDefaultValueProvidedError`) and
-  `CliDescriptor` (everything that varies per CLI: `cliName`, auth command names, `keyringServiceName`,
+  `CliDescriptor` (everything that varies per CLI: `cliName` (the executable),
+  `displayName` (branded name used in prose), auth command names
+  (`login` / `whoami` / `createProfile` / `deviceLogin`), `keyringServiceName`,
   `clientId`, `consent`, `redirectUri`, `getConfigPath`, `fileFormat`,
   `accountCachePrefix`, `cacheNamespace`, `getConfigFileLabel`,
   `getDefaultScopeKeys`, …).

--- a/packages/workers-auth/src/cf/constants.ts
+++ b/packages/workers-auth/src/cf/constants.ts
@@ -12,6 +12,9 @@ export const CF_KEYRING_SERVICE_NAME = "cloudflare";
 /** CLI name used for keyring install-dir scoping and user-facing messaging. */
 export const CF_CLI_NAME = "cf";
 
+/** cf's branded name, used in prose addressed to the user. */
+export const CF_DISPLAY_NAME = "cf";
+
 /**
  * The `redirect_uri` registered on cf's OAuth app; also the local callback URL.
  * cf uses the fixed local callback port 8877 (from its historical 8877–8886

--- a/packages/workers-auth/src/cf/index.ts
+++ b/packages/workers-auth/src/cf/index.ts
@@ -14,6 +14,7 @@ import { createCloudflareProfileStore } from "../core/profile-store";
 import {
 	CF_CLI_NAME,
 	CF_CONSENT_PAGES,
+	CF_DISPLAY_NAME,
 	CF_KEYRING_SERVICE_NAME,
 	CF_OAUTH_CALLBACK_URL,
 } from "./constants";
@@ -66,10 +67,12 @@ export type { UserPreferences } from "../core/preferences";
  */
 export const CF_CLI: CliDescriptor = {
 	cliName: CF_CLI_NAME,
+	displayName: CF_DISPLAY_NAME,
 	commands: {
 		login: "cf auth login",
 		whoami: "cf auth whoami",
 		createProfile: "cf auth create",
+		deviceLogin: "cf auth login --device",
 	},
 	keyringServiceName: CF_KEYRING_SERVICE_NAME,
 	clientId: getClientIdFromEnv,

--- a/packages/workers-auth/src/context.ts
+++ b/packages/workers-auth/src/context.ts
@@ -94,6 +94,20 @@ export interface OAuthFlowContext {
 	consent: OAuthConsentPages;
 
 	/**
+	 * The consuming CLI's branded name (e.g. `"Wrangler"`, `"cf"`), interpolated
+	 * into the copy the flow prints to the user — "To authorize <name>, please
+	 * visit ...". Consumer-specific, so it is required.
+	 */
+	displayName: string;
+
+	/**
+	 * The command that restarts the device authorization flow (e.g.
+	 * `"wrangler login --device"`), quoted when a device code is denied,
+	 * expires, or the flow times out. Consumer-specific, so it is required.
+	 */
+	deviceLoginCommand: string;
+
+	/**
 	 * The `redirect_uri` registered on the consumer's OAuth app
 	 */
 	redirectUri: string;

--- a/packages/workers-auth/src/core/factory.ts
+++ b/packages/workers-auth/src/core/factory.ts
@@ -63,6 +63,13 @@ export interface CloudflareLoginProps {
 	callbackHost?: string;
 	callbackPort?: number;
 	profile?: string;
+	/**
+	 * When `true`, authenticate using the OAuth 2.0 Device Authorization Grant
+	 * (RFC 8628) instead of the authorization-code-with-PKCE callback flow. The
+	 * device flow does not start a local callback server, so `callbackHost` and
+	 * `callbackPort` are ignored when this is set.
+	 */
+	device?: boolean;
 }
 
 /** A Cloudflare CLI's auth layer, returned by {@link createCloudflareAuth}. */
@@ -236,6 +243,8 @@ export function createCloudflareAuth(
 		purgeOnLoginOrLogout: configCache.purgeConfigCaches,
 		clientId: descriptor.clientId,
 		consent: descriptor.consent,
+		displayName: descriptor.displayName,
+		deviceLoginCommand: descriptor.commands.deviceLogin,
 		redirectUri: descriptor.redirectUri,
 		storageFactory: credentialStorage.storageFactory,
 		allowGlobalAuthKey,
@@ -286,6 +295,7 @@ export function createCloudflareAuth(
 			callbackHost: props?.callbackHost,
 			callbackPort: props?.callbackPort,
 			profile: props?.profile,
+			device: props?.device,
 		};
 	}
 

--- a/packages/workers-auth/src/core/types.ts
+++ b/packages/workers-auth/src/core/types.ts
@@ -45,14 +45,31 @@ export interface AuthContext {
  * rather than a fork of the factory.
  */
 export interface CliDescriptor {
-	/** CLI name used in user-facing messaging and keyring install-dir scoping (e.g. `"wrangler"`). */
+	/**
+	 * The CLI's invocation name, used for keyring install-dir scoping and in
+	 * messaging that refers to the executable (e.g. `"wrangler"`, `"cf"`).
+	 */
 	cliName: string;
+
+	/**
+	 * The CLI's branded name, used in prose addressed to the user (e.g.
+	 * `"Wrangler"` for wrangler, `"cf"` for cf). Distinct from
+	 * {@link CliDescriptor.cliName}, which names the executable.
+	 */
+	displayName: string;
 
 	/** Commands surfaced in auth guidance. */
 	commands: {
 		login: string;
 		whoami: string;
 		createProfile: string;
+		/**
+		 * The command that restarts the OAuth 2.0 Device Authorization Grant,
+		 * surfaced when a device code is denied, expires, or times out. Spelled
+		 * out per CLI rather than derived from {@link CliDescriptor.commands.login}
+		 * so the flag name stays the CLI's business.
+		 */
+		deviceLogin: string;
 	};
 
 	/**

--- a/packages/workers-auth/src/device-flow.ts
+++ b/packages/workers-auth/src/device-flow.ts
@@ -1,0 +1,587 @@
+import { UserError } from "@cloudflare/workers-utils";
+import dedent from "ts-dedent";
+import { fetch } from "undici";
+import { domainUsesAccess, getCloudflareAccessHeaders } from "./access";
+import { getAuthDomainFromEnv, getDeviceAuthUrl } from "./env-vars";
+import { toErrorClass } from "./errors";
+import {
+	assertTrustedVerificationUrl,
+	generateVerificationUrl,
+} from "./generate-device-auth-url";
+import { fetchAuthToken } from "./token-exchange";
+import type { OAuthFlowContext } from "./context";
+import type { AccessContext } from "./token-exchange";
+import type { Response } from "undici";
+
+/**
+ * Maximum time (in seconds) the CLI polls the token endpoint while waiting for
+ * the user to approve a device authorization request.
+ *
+ * RFC 8628 §3.2 lets the server set `expires_in`, but we apply our own
+ * hard cap on top of that to:
+ *   - keep login feeling fast and finite to the user, and
+ *   - shorten the window in which a leaked user code could be abused
+ *     (RFC 8628 §5.4 — remote phishing).
+ */
+const DEVICE_FLOW_MAX_DURATION_SECONDS = 300;
+
+/**
+ * Minimum polling interval (in seconds) used between token requests when the
+ * authorization server does not provide one or sends a value below this floor.
+ * The server's `interval` is always respected when it is larger than this
+ * value.
+ *
+ * RFC 8628 §3.5 mandates a default of 5 seconds when the server omits
+ * `interval`. We deviate to 1 second because:
+ *   - the server can still throttle us via the `slow_down` error code
+ *     (which adds 5 seconds per RFC 8628 §3.5), and
+ *   - a 5 second baseline feels unacceptably slow for an interactive CLI
+ *     login on a developer's primary workstation.
+ *
+ * If the server explicitly returns a value (e.g. `interval: 5`), that value
+ * is honoured rather than this floor.
+ */
+const DEVICE_FLOW_MIN_POLL_INTERVAL_SECONDS = 1;
+
+/** Per-login options for {@link getOauthTokenViaDeviceFlow}. */
+export interface GetOauthTokenViaDeviceFlowOptions {
+	browser: boolean;
+	scopes: string[];
+	clientId: string;
+}
+
+interface DeviceAuthorizationResponse {
+	device_code: string;
+	user_code: string;
+	verification_uri: string;
+	verification_uri_complete?: string;
+	expires_in: number;
+	interval?: number;
+}
+
+interface DeviceTokenGrant {
+	access_token: string;
+	expires_in: number;
+	refresh_token?: string;
+	scope?: string;
+}
+
+/**
+ * The outcome of a single poll, classified so the loop never has to guess.
+ *
+ * `unexpected` exists because neither the HTTP status nor the body shape can be
+ * trusted: an intermediary (corporate proxy, WAF) or a Cloudflare API envelope
+ * (`{"success": false, "errors": [...]}`) can arrive in place of the RFC 8628
+ * response. Those bodies carry no `error` code, so without this case they would
+ * fall through to the success path and be read as a token grant.
+ */
+type DevicePollResult =
+	| { kind: "token"; grant: DeviceTokenGrant }
+	| { kind: "oauth-error"; error: string }
+	| { kind: "unexpected"; detail: string; retryable: boolean };
+
+/**
+ * Read a non-empty string member from a parsed JSON body. Anything else
+ * (missing, wrong type, empty) is reported as absent so callers can treat the
+ * response as unusable rather than trusting `undefined` into a template.
+ */
+function getStringMember(body: unknown, key: string): string | undefined {
+	if (typeof body !== "object" || body === null) {
+		return undefined;
+	}
+	const value = (body as Record<string, unknown>)[key];
+	return typeof value === "string" && value !== "" ? value : undefined;
+}
+
+/**
+ * Read a positive, finite number member from a parsed JSON body. Guards the
+ * arithmetic that turns `expires_in` into a timestamp — `undefined * 1000` is
+ * `NaN`, and `new Date(NaN).toISOString()` throws a `RangeError`.
+ */
+function getPositiveNumberMember(
+	body: unknown,
+	key: string
+): number | undefined {
+	if (typeof body !== "object" || body === null) {
+		return undefined;
+	}
+	const value = (body as Record<string, unknown>)[key];
+	return typeof value === "number" && Number.isFinite(value) && value > 0
+		? value
+		: undefined;
+}
+
+/**
+ * A short, user-safe summary of a response we could not interpret: the status
+ * line, plus the standard OAuth `error_description` when the server sent one.
+ * The full body is logged at `debug` by the caller.
+ */
+function describeUnusableResponse(response: Response, body: unknown): string {
+	const status = `HTTP ${response.status} ${response.statusText}`.trim();
+	const description = getStringMember(body, "error_description");
+	return description ? `${status}: ${description}` : status;
+}
+
+/**
+ * Whether a status that carried no usable OAuth payload is worth another poll.
+ * 5xx and 429 are the conventional "try again" signals; any other 4xx means the
+ * request itself was rejected, so repeating it until the deadline would only
+ * delay the error the user needs to see.
+ */
+function isRetryableStatus(status: number): boolean {
+	return status >= 500 || status === 429;
+}
+
+/**
+ * Narrow a parsed device-authorization body to the members the flow relies on.
+ *
+ * Optional members are dropped unless correctly typed, so a bogus `interval`
+ * falls back to our floor and a bogus `verification_uri_complete` falls back to
+ * the URL we build ourselves.
+ */
+function asDeviceAuthorizationResponse(
+	body: unknown
+): DeviceAuthorizationResponse | undefined {
+	const deviceCode = getStringMember(body, "device_code");
+	const userCode = getStringMember(body, "user_code");
+	const verificationUri = getStringMember(body, "verification_uri");
+	const expiresIn = getPositiveNumberMember(body, "expires_in");
+
+	if (!deviceCode || !userCode || !verificationUri || expiresIn === undefined) {
+		return undefined;
+	}
+
+	return {
+		device_code: deviceCode,
+		user_code: userCode,
+		verification_uri: verificationUri,
+		verification_uri_complete: getStringMember(
+			body,
+			"verification_uri_complete"
+		),
+		expires_in: expiresIn,
+		interval: getPositiveNumberMember(body, "interval"),
+	};
+}
+
+/**
+ * Parse a JSON body from an `undici` response. Device-flow endpoints are
+ * expected to respond with JSON (both on success and on the RFC 8628 §3.5
+ * error codes), so a parse failure is thrown.
+ */
+async function readJson(
+	response: Response,
+	logger: OAuthFlowContext["logger"]
+): Promise<unknown> {
+	const text = await response.text();
+	try {
+		return JSON.parse(text);
+	} catch (e) {
+		// Sometimes we get a response where the body is HTML rather than JSON.
+		if (text.match(/<!DOCTYPE html>/)) {
+			logger.debug(
+				"The body of the response was HTML rather than JSON. Check the debug logs to see the full body of the response."
+			);
+			if (text.match(/challenge-platform/)) {
+				logger.debug(
+					`It looks like you might have hit a bot challenge page. This may be transient but if not, please contact Cloudflare to find out what can be done. When you contact Cloudflare, please provide your Ray ID: ${response.headers.get(
+						"cf-ray"
+					)}`
+				);
+			}
+		}
+		logger.debug("Full body of response\n\n", text);
+		throw new Error(
+			`Invalid JSON in response: status: ${response.status} ${response.statusText}`,
+			{ cause: e }
+		);
+	}
+}
+
+/**
+ * Build the headers for a request to the OAuth provider's device-authorization
+ * endpoint. Mirrors `fetchAuthToken` in `token-exchange.ts`: when the auth
+ * domain is behind Cloudflare Access (typically staging), the request needs
+ * Access service-token / cookie headers.
+ */
+async function buildDeviceAuthHeaders(
+	logger: OAuthFlowContext["logger"],
+	isNonInteractiveOrCI: OAuthFlowContext["isNonInteractiveOrCI"]
+): Promise<Record<string, string>> {
+	const headers: Record<string, string> = {
+		"Content-Type": "application/x-www-form-urlencoded",
+	};
+	if (await domainUsesAccess(getAuthDomainFromEnv(), logger)) {
+		logger.debug(
+			"Using Cloudflare Access to get an access token for the device authorization request"
+		);
+		Object.assign(
+			headers,
+			await getCloudflareAccessHeaders({ logger, isNonInteractiveOrCI })
+		);
+	}
+	return headers;
+}
+
+/**
+ * Request a `device_code` and `user_code` from the authorization server's
+ * device authorization endpoint (RFC 8628 §3.1, §3.2).
+ */
+async function requestDeviceAuthorization(
+	scopes: string[],
+	clientId: string,
+	logger: OAuthFlowContext["logger"],
+	isNonInteractiveOrCI: OAuthFlowContext["isNonInteractiveOrCI"]
+): Promise<DeviceAuthorizationResponse> {
+	// `offline_access` is appended unconditionally so the eventual token
+	// response includes a refresh token, matching the behaviour of the
+	// authorization-code flow (see generate-auth-url.ts).
+	const params = new URLSearchParams({
+		client_id: clientId,
+		scope: [...scopes, "offline_access"].join(" "),
+	});
+
+	const headers = await buildDeviceAuthHeaders(logger, isNonInteractiveOrCI);
+	const deviceAuthUrl = getDeviceAuthUrl();
+	logger.debug("Fetching device authorization from", deviceAuthUrl);
+	const response = await fetch(deviceAuthUrl, {
+		method: "POST",
+		body: params.toString(),
+		headers,
+	});
+
+	if (!response.ok) {
+		const body = await readJson(response, logger).catch(() => undefined);
+		const rawError =
+			body && typeof body === "object" && "error" in body
+				? String((body as { error: unknown }).error)
+				: `HTTP ${response.status} ${response.statusText}`;
+		throw toErrorClass(rawError);
+	}
+
+	const body = await readJson(response, logger);
+	const deviceAuth = asDeviceAuthorizationResponse(body);
+	if (deviceAuth === undefined) {
+		// Without this the missing members flow onwards as `undefined`: a bogus
+		// `expires_in` makes the poll deadline `NaN`, which skips the loop
+		// entirely and reports a timeout "after NaN minutes".
+		logger.debug("Unusable device authorization response body:", body);
+		throw new UserError(
+			`The device authorization endpoint returned a response that could not be interpreted (${describeUnusableResponse(response, body)}).\n` +
+				"Enable debug logging to see the full response.",
+			{
+				telemetryMessage:
+					"user device-flow unusable device authorization response",
+			}
+		);
+	}
+	return deviceAuth;
+}
+
+/**
+ * Send a single poll request to the token endpoint with grant type
+ * `urn:ietf:params:oauth:grant-type:device_code` (RFC 8628 §3.4) and classify
+ * the reply into a {@link DevicePollResult}. The caller decides what each
+ * classification means for the loop; nothing here is assumed to be a token.
+ *
+ * The `error` member is authoritative over the HTTP status, because RFC 8628
+ * §3.5 delivers `authorization_pending` / `slow_down` as an `error` with HTTP
+ * 400 on every poll while the user is still approving.
+ *
+ * Reuses `fetchAuthToken`, which logs non-2xx responses at `debug` level only.
+ * That matters here for the same reason: those 400s are expected, non-terminal
+ * states, not errors, so they must not produce user-visible error logging.
+ *
+ * This can reject if the network request fails or the body is not valid JSON
+ * (e.g. a transient HTML 5xx or bot-challenge page from the Cloudflare edge).
+ * The polling loop catches those rejections and treats them as transient, so a
+ * single bad poll does not abort the whole login.
+ */
+async function pollDeviceToken(
+	deviceCode: string,
+	clientId: string,
+	logger: OAuthFlowContext["logger"],
+	isNonInteractiveOrCI: OAuthFlowContext["isNonInteractiveOrCI"]
+): Promise<DevicePollResult> {
+	const params = new URLSearchParams({
+		grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+		device_code: deviceCode,
+		client_id: clientId,
+	});
+
+	const response = await fetchAuthToken(params, logger, isNonInteractiveOrCI);
+	const body = await readJson(response, logger);
+
+	const error = getStringMember(body, "error");
+	if (error !== undefined) {
+		return { kind: "oauth-error", error };
+	}
+
+	const accessToken = getStringMember(body, "access_token");
+	const expiresIn = getPositiveNumberMember(body, "expires_in");
+	if (!response.ok || accessToken === undefined || expiresIn === undefined) {
+		logger.debug("Unusable token response body:", body);
+		return {
+			kind: "unexpected",
+			detail: describeUnusableResponse(response, body),
+			// A 2xx that carries no usable grant is not going to become one on the
+			// next attempt, so only the retryable statuses keep the loop alive.
+			retryable: !response.ok && isRetryableStatus(response.status),
+		};
+	}
+
+	return {
+		kind: "token",
+		grant: {
+			access_token: accessToken,
+			expires_in: expiresIn,
+			refresh_token: getStringMember(body, "refresh_token"),
+			scope: getStringMember(body, "scope"),
+		},
+	};
+}
+
+/**
+ * Wait `seconds` seconds, then resolve. Extracted so tests can mock it
+ * via vi.useFakeTimers().
+ */
+function sleep(seconds: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
+}
+
+/**
+ * Acquire an access token via the OAuth 2.0 Device Authorization Grant
+ * (RFC 8628).
+ *
+ * High-level flow:
+ *   1. POST to the device authorization endpoint to get `device_code`,
+ *      `user_code`, and a verification URL.
+ *   2. Display the verification URL and the user code to the user. Attempt
+ *      to open the URL in the default browser.
+ *   3. Poll the token endpoint with `grant_type=device_code` until the user
+ *      approves the request, denies it, or the device code expires. The
+ *      first poll is sent immediately to minimise perceived latency for
+ *      users who approve quickly.
+ *
+ * The polling loop applies a hard cap
+ * ({@link DEVICE_FLOW_MAX_DURATION_SECONDS}) on top of the server-provided
+ * `expires_in` to limit any leaked-code abuse window. Whichever expires
+ * first wins.
+ *
+ * Every consumer-specific string the flow prints (the CLI's branded name and
+ * the command that restarts the flow) comes from the injected context, so this
+ * module stays CLI-agnostic.
+ */
+export async function getOauthTokenViaDeviceFlow(
+	options: GetOauthTokenViaDeviceFlowOptions,
+	ctx: OAuthFlowContext
+): Promise<AccessContext> {
+	const { logger, openInBrowser, isNonInteractiveOrCI } = ctx;
+
+	const deviceAuth = await requestDeviceAuthorization(
+		options.scopes,
+		options.clientId,
+		logger,
+		isNonInteractiveOrCI
+	);
+
+	// The verification URLs are chosen by the server, and we both print them and
+	// hand one to the OS browser opener. Prove they belong to the auth domain we
+	// asked for the device code *before* anything is displayed or opened —
+	// see `assertTrustedVerificationUrl` for the threat this closes.
+	const authDomain = getAuthDomainFromEnv();
+	assertTrustedVerificationUrl(deviceAuth.verification_uri, {
+		field: "verification_uri",
+		authDomain,
+	});
+	if (deviceAuth.verification_uri_complete !== undefined) {
+		assertTrustedVerificationUrl(deviceAuth.verification_uri_complete, {
+			field: "verification_uri_complete",
+			authDomain,
+		});
+	}
+
+	// Prefer the server-provided verification_uri_complete (RFC 8628 §3.3.1).
+	// Otherwise synthesise one ourselves so the browser we open pre-fills the
+	// user_code. Appending a query param cannot change the origin, so the
+	// fallback inherits the check above.
+	const verificationUrl =
+		deviceAuth.verification_uri_complete ??
+		generateVerificationUrl({
+			verificationUri: deviceAuth.verification_uri,
+			userCode: deviceAuth.user_code,
+		});
+
+	// Effective overall timeout is the smaller of the server's expires_in and
+	// our hard cap. Computed before display so the message below quotes the
+	// real deadline rather than always advertising the hard cap.
+	const maxDurationSeconds = Math.min(
+		deviceAuth.expires_in,
+		DEVICE_FLOW_MAX_DURATION_SECONDS
+	);
+
+	// Always show the bare verification URI and the user code, even when we
+	// have a complete URL. RFC 8628 §3.3.1: "Clients MUST still display
+	// the user_code, as the authorization server will require the user to
+	// confirm it to disambiguate devices or as remote phishing mitigation".
+	logger.log(
+		dedent`
+		To authorize ${ctx.displayName}, please visit:
+
+		  ${deviceAuth.verification_uri}
+
+		and enter the code:
+
+		  ${deviceAuth.user_code}
+
+		You have ${toHumanPeriod(maxDurationSeconds)} to approve this request.
+	`
+	);
+
+	if (options.browser) {
+		logger.log(`\nOpening a link in your default browser: ${verificationUrl}`);
+		await openInBrowser(verificationUrl);
+	}
+
+	const deadline = Date.now() + maxDurationSeconds * 1000;
+
+	// Start with the server-provided interval, but floor it so we don't sit
+	// idle for 5+ seconds between polls if the user approves quickly.
+	let intervalSeconds = Math.max(
+		deviceAuth.interval ?? DEVICE_FLOW_MIN_POLL_INTERVAL_SECONDS,
+		DEVICE_FLOW_MIN_POLL_INTERVAL_SECONDS
+	);
+
+	// Send the first poll immediately rather than waiting `interval` seconds.
+	// In the common case the user approves quickly, so the perceived login
+	// latency drops from 1-5s to ~the network RTT.
+	let firstPoll = true;
+
+	// Set whenever a poll produces nothing we can interpret, cleared as soon as
+	// one does. If it survives to the end of the loop, the run ended on failed
+	// polls rather than on a user who never approved — reporting a timeout in
+	// that case would send the user looking in the wrong place.
+	let lastPollFailure: string | undefined;
+
+	while (Date.now() < deadline) {
+		if (!firstPoll) {
+			await sleep(intervalSeconds);
+		}
+		firstPoll = false;
+
+		let result: DevicePollResult;
+		try {
+			result = await pollDeviceToken(
+				deviceAuth.device_code,
+				options.clientId,
+				logger,
+				isNonInteractiveOrCI
+			);
+		} catch (e) {
+			// A single poll can fail transiently: a network blip, or the
+			// Cloudflare edge returning a non-JSON body (an HTML 5xx or a
+			// bot-challenge page) instead of the expected RFC 8628 response.
+			// Because we poll repeatedly over several minutes, one bad poll
+			// must not abort the whole login.
+			logger.debug("Ignoring transient error while polling for token:", e);
+			lastPollFailure = e instanceof Error ? e.message : String(e);
+			continue;
+		}
+
+		if (result.kind === "unexpected") {
+			if (!result.retryable) {
+				throw new UserError(
+					`The token endpoint returned a response that could not be interpreted (${result.detail}).\n` +
+						"Enable debug logging to see the full response.",
+					{ telemetryMessage: "user device-flow unusable token response" }
+				);
+			}
+			logger.debug(
+				"Ignoring transient response while polling for token:",
+				result.detail
+			);
+			lastPollFailure = result.detail;
+			continue;
+		}
+
+		// The server said something we understand, so any earlier transient
+		// failure is no longer the story of this login.
+		lastPollFailure = undefined;
+
+		if (result.kind === "oauth-error") {
+			switch (result.error) {
+				case "authorization_pending":
+					continue;
+				case "slow_down":
+					// RFC 8628 §3.5: increase the polling interval by 5 seconds
+					// for this and all subsequent requests.
+					intervalSeconds += 5;
+					continue;
+				case "access_denied":
+					throw new UserError(
+						`Consent denied. You must grant consent to ${ctx.displayName} in order to login.\n` +
+							"If you don't want to do this consider passing an API token via the `CLOUDFLARE_API_TOKEN` environment variable.",
+						{ telemetryMessage: "user device-flow consent denied" }
+					);
+				case "expired_token":
+					throw new UserError(
+						`Device code expired before the request was approved. Please run \`${ctx.deviceLoginCommand}\` again to obtain a new code.`,
+						{ telemetryMessage: "user device-flow code expired" }
+					);
+				default:
+					throw toErrorClass(result.error);
+			}
+		}
+
+		// Success — we have an access token.
+		const { grant } = result;
+		const accessToken = {
+			value: grant.access_token,
+			expiry: new Date(Date.now() + grant.expires_in * 1000).toISOString(),
+		};
+		const scopes: string[] = grant.scope ? grant.scope.split(" ") : [];
+		return {
+			token: accessToken,
+			scopes,
+			refreshToken: grant.refresh_token
+				? { value: grant.refresh_token }
+				: undefined,
+		};
+	}
+
+	if (lastPollFailure !== undefined) {
+		throw new UserError(
+			`Gave up waiting for device authorization: the token endpoint kept returning responses that could not be interpreted (last: ${lastPollFailure}).\n` +
+				`Enable debug logging to see the full response, then run \`${ctx.deviceLoginCommand}\` to try again.`,
+			{ telemetryMessage: "user device-flow poll failed" }
+		);
+	}
+
+	throw new UserError(
+		`Device authorization timed out after ${toHumanPeriod(maxDurationSeconds)}. Please run \`${ctx.deviceLoginCommand}\` again to obtain a new code.`,
+		{ telemetryMessage: "user device-flow authorization timeout" }
+	);
+}
+
+/**
+ * Converts a duration in seconds to a human-readable string.
+ * @param seconds - The duration in seconds.
+ * @returns A human-readable string representing the duration.
+ */
+function toHumanPeriod(seconds: number): string {
+	if (seconds < 60) {
+		return `${seconds} seconds`;
+	}
+	const minutes = Math.floor(seconds / 60);
+	const minutesPostfix = minutes === 1 ? "minute" : "minutes";
+	const remainingSeconds = seconds % 60;
+	const secondsPostfix = remainingSeconds === 1 ? "second" : "seconds";
+	if (remainingSeconds === 0) {
+		return `${minutes} ${minutesPostfix}`;
+	}
+	if (remainingSeconds == 59) {
+		// Let's round "x mins and 59 seconds" up to "x+1 mins" for better readability.
+		return `${minutes + 1} ${minutesPostfix}`;
+	}
+	return `${minutes} ${minutesPostfix} and ${remainingSeconds} ${secondsPostfix}`;
+}

--- a/packages/workers-auth/src/env-vars.ts
+++ b/packages/workers-auth/src/env-vars.ts
@@ -90,6 +90,29 @@ export function getCloudflareAccountIdFromEnv(): string | undefined {
 }
 
 /**
+ * The path used by the OAuth provider for the OAuth 2.0 Device Authorization
+ * endpoint (RFC 8628 §3.1).
+ */
+const DEVICE_AUTH_PATH = "/oauth2/device/auth";
+
+/**
+ * The URL used to obtain a device code and user code from the OAuth 2.0 Device
+ * Authorization endpoint (RFC 8628 §3.1).
+ *
+ * Deliberately **not** environment-overridable (there is no
+ * `WRANGLER_DEVICE_AUTH_URL`): the device authorization endpoint must live on
+ * the same auth domain as the token endpoint it is paired with (the flow polls
+ * `/oauth2/token` on the same host), and the device flow is a phishing-sensitive
+ * surface — the user is told to visit the verification URL this endpoint
+ * returns. It therefore derives strictly from the resolved auth domain
+ * (production vs. staging, selected by `WRANGLER_API_ENVIRONMENT`), exactly
+ * like {@link getTokenUrlFromEnv}.
+ */
+export function getDeviceAuthUrl(): string {
+	return `https://${getAuthDomainFromEnv()}${DEVICE_AUTH_PATH}`;
+}
+
+/**
  * `CLOUDFLARE_ACCESS_CLIENT_ID` is the Client ID of a Cloudflare Access Service Token.
  * Used together with `CLOUDFLARE_ACCESS_CLIENT_SECRET` to authenticate with
  * Access-protected domains in non-interactive environments (e.g. CI).

--- a/packages/workers-auth/src/flow.ts
+++ b/packages/workers-auth/src/flow.ts
@@ -6,6 +6,7 @@ import dedent from "ts-dedent";
 import { fetch } from "undici";
 import { getOauthToken } from "./callback-server";
 import { getAPIToken, requireApiToken } from "./credentials";
+import { getOauthTokenViaDeviceFlow } from "./device-flow";
 import { getRevokeUrlFromEnv } from "./env-vars";
 import { generateAuthUrl as defaultGenerateAuthUrl } from "./generate-auth-url";
 import { generateRandomState as defaultGenerateRandomState } from "./generate-random-state";
@@ -70,6 +71,16 @@ export interface LoginProps {
 	 * Only for use by 'auth create', not exposed to the user
 	 */
 	profile?: string;
+	/**
+	 * When `true`, authenticate using the OAuth 2.0 Device Authorization Grant
+	 * (RFC 8628) instead of the authorization-code-with-PKCE callback flow. The
+	 * device flow does not start a local callback server and works in
+	 * environments where the consumer's loopback callback URL
+	 * ({@link OAuthFlowContext.redirectUri}) is unreachable from the user's
+	 * browser (containers, remote SSH sessions, Codespaces). `callbackHost` and
+	 * `callbackPort` are ignored when this is set.
+	 */
+	device?: boolean;
 }
 
 /**
@@ -251,23 +262,38 @@ export function createOAuthFlow(ctx: OAuthFlowContext): OAuthFlowAPI {
 			);
 		}
 
-		ctx.logger.log("Attempting to login via OAuth...");
+		let oauth;
+		if (props.device) {
+			ctx.logger.log(
+				"Attempting to login via OAuth Device Authorization Grant..."
+			);
+			oauth = await getOauthTokenViaDeviceFlow(
+				{
+					browser: props.browser ?? true,
+					scopes: props.scopes,
+					clientId: getClientId(),
+				},
+				ctx
+			);
+		} else {
+			ctx.logger.log("Attempting to login via OAuth...");
 
-		const oauth = await getOauthToken(
-			{
-				browser: props.browser ?? true,
-				scopes: props.scopes,
-				clientId: getClientId(),
-				redirectUri: ctx.redirectUri,
-				denied: consent.denied,
-				granted: consent.granted,
-				callbackHost: props.callbackHost ?? defaultCallbackHost,
-				callbackPort: props.callbackPort ?? defaultCallbackPort,
-			},
-			oauthFlowState,
-			ctx,
-			generators
-		);
+			oauth = await getOauthToken(
+				{
+					browser: props.browser ?? true,
+					scopes: props.scopes,
+					clientId: getClientId(),
+					redirectUri: ctx.redirectUri,
+					denied: consent.denied,
+					granted: consent.granted,
+					callbackHost: props.callbackHost ?? defaultCallbackHost,
+					callbackPort: props.callbackPort ?? defaultCallbackPort,
+				},
+				oauthFlowState,
+				ctx,
+				generators
+			);
+		}
 
 		getStorage(props.profile).write({
 			oauth_token: oauth.token?.value ?? "",

--- a/packages/workers-auth/src/generate-device-auth-url.ts
+++ b/packages/workers-auth/src/generate-device-auth-url.ts
@@ -1,0 +1,87 @@
+import { UserError } from "@cloudflare/workers-utils";
+
+/**
+ * Build the URL the user should visit to approve a device authorization
+ * request, with the `user_code` embedded as a query parameter so the user
+ * does not have to type it manually.
+ *
+ * Per RFC 8628 §3.3.1, this is the "verification_uri_complete" optimization
+ * for non-textual transmission (such as QR codes). Authorization servers may
+ * return their own `verification_uri_complete` in the device authorization
+ * response — prefer that when it is provided. Use this helper as a fallback
+ * when only `verification_uri` is available.
+ *
+ * Extracted into its own module (mirroring `generate-auth-url.ts`) so that
+ * tests can mock the generated URL deterministically.
+ */
+export const generateVerificationUrl = ({
+	verificationUri,
+	userCode,
+}: {
+	verificationUri: string;
+	userCode: string;
+}): string => {
+	const url = new URL(verificationUri);
+	url.searchParams.set("user_code", userCode);
+	return url.toString();
+};
+
+function parseUrl(value: string): URL | undefined {
+	try {
+		return new URL(value);
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Assert that a verification URL supplied by the authorization server is safe
+ * to show the user and hand to the OS browser opener.
+ *
+ * Unlike the authorization-code flow — which builds its authorize URL itself
+ * from the resolved auth domain — the device flow is *told* where to send the
+ * user. That URL is printed to the terminal and passed to `openInBrowser`,
+ * which shells out to the platform opener and will happily launch a `file:`
+ * path or a registered custom-scheme handler. An off-domain URL is exactly the
+ * remote-phishing scenario RFC 8628 §5.4 warns about: the user is instructed to
+ * enter their `user_code` on whatever page opens.
+ *
+ * So a URL is only trusted when it
+ *   - parses,
+ *   - uses `https:`,
+ *   - carries no embedded credentials (`https://real-looking@evil.example`),
+ *   - and sits on exactly the auth domain we asked for the device code.
+ *
+ * @param verificationUrl the server-supplied URL to check
+ * @param options `field` names the response member for the error message;
+ *   `authDomain` is the resolved auth domain (`getAuthDomainFromEnv()`),
+ *   with or without a port
+ * @throws {UserError} when the URL fails any of the above
+ */
+export function assertTrustedVerificationUrl(
+	verificationUrl: string,
+	options: {
+		field: "verification_uri" | "verification_uri_complete";
+		authDomain: string;
+	}
+): void {
+	const url = parseUrl(verificationUrl);
+	const expected = parseUrl(`https://${options.authDomain}`);
+
+	const trusted =
+		url !== undefined &&
+		expected !== undefined &&
+		url.protocol === "https:" &&
+		url.username === "" &&
+		url.password === "" &&
+		// `host` rather than `hostname` so a port in either value is significant.
+		url.host === expected.host;
+
+	if (!trusted) {
+		throw new UserError(
+			`The authorization server returned an untrusted \`${options.field}\`: ${verificationUrl}\n` +
+				`Expected an \`https\` URL on \`${options.authDomain}\`. Refusing to display or open it.`,
+			{ telemetryMessage: "user device-flow untrusted verification url" }
+		);
+	}
+}

--- a/packages/workers-auth/src/index.ts
+++ b/packages/workers-auth/src/index.ts
@@ -39,6 +39,8 @@ export type {
 
 export { generateAuthUrl } from "./generate-auth-url";
 
+export { generateVerificationUrl } from "./generate-device-auth-url";
+
 export { generateRandomState } from "./generate-random-state";
 export { TEMPORARY_TERMS_NOTICE, TEMPORARY_TERMS_PROMPT } from "./temporary";
 export { PKCE_CHARSET } from "./pkce";

--- a/packages/workers-auth/src/wrangler/constants.ts
+++ b/packages/workers-auth/src/wrangler/constants.ts
@@ -16,6 +16,9 @@ export const WRANGLER_KEYRING_SERVICE_NAME = "wrangler";
 /** CLI name used for keyring install-dir scoping and user-facing messaging. */
 export const WRANGLER_CLI_NAME = "wrangler";
 
+/** Wrangler's branded name, used in prose addressed to the user. */
+export const WRANGLER_DISPLAY_NAME = "Wrangler";
+
 /** The `redirect_uri` registered on Wrangler's OAuth app. */
 export const OAUTH_CALLBACK_URL = "http://localhost:8976/oauth/callback";
 

--- a/packages/workers-auth/src/wrangler/index.ts
+++ b/packages/workers-auth/src/wrangler/index.ts
@@ -18,6 +18,7 @@ import {
 	OAUTH_CALLBACK_URL,
 	WRANGLER_CLI_NAME,
 	WRANGLER_CONSENT_PAGES,
+	WRANGLER_DISPLAY_NAME,
 	WRANGLER_KEYRING_SERVICE_NAME,
 } from "./constants";
 import { getClientIdFromEnv } from "./env";
@@ -68,10 +69,12 @@ export type WranglerLoginProps = CloudflareLoginProps;
  */
 export const WRANGLER_CLI: CliDescriptor = {
 	cliName: WRANGLER_CLI_NAME,
+	displayName: WRANGLER_DISPLAY_NAME,
 	commands: {
 		login: "wrangler login",
 		whoami: "wrangler whoami",
 		createProfile: "wrangler auth create",
+		deviceLogin: "wrangler login --device",
 	},
 	keyringServiceName: WRANGLER_KEYRING_SERVICE_NAME,
 	clientId: getClientIdFromEnv,

--- a/packages/workers-auth/tests/cf/index.test.ts
+++ b/packages/workers-auth/tests/cf/index.test.ts
@@ -45,7 +45,9 @@ describe("cf auth layer", () => {
 			login: "cf auth login",
 			whoami: "cf auth whoami",
 			createProfile: "cf auth create",
+			deviceLogin: "cf auth login --device",
 		});
+		expect(CF_CLI.displayName).toBe("cf");
 	});
 
 	it("resolves its config directory to `cloudflare` (no leading dot, not `.wrangler`)", ({

--- a/packages/workers-auth/tests/device-flow.test.ts
+++ b/packages/workers-auth/tests/device-flow.test.ts
@@ -1,0 +1,424 @@
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	it,
+} from "vitest";
+import { clearAccessCaches } from "../src/access";
+import { createOAuthFlow } from "../src/flow";
+import type { UserAuthConfig } from "../src/config-file/auth";
+import type { OAuthFlowContext } from "../src/context";
+import type { ComplianceConfig } from "@cloudflare/workers-utils";
+
+const msw = setupServer();
+
+beforeAll(() => msw.listen({ onUnhandledRequest: "error" }));
+afterEach(() => {
+	msw.restoreHandlers();
+	msw.resetHandlers();
+});
+afterAll(() => msw.close());
+
+const COMPLIANCE_CONFIG: ComplianceConfig = { compliance_region: undefined };
+
+/**
+ * A CLI identity that shares nothing with wrangler's, so any copy that leaks
+ * wrangler branding back into the shared device flow shows up as a failure
+ * here rather than being invisible in wrangler's own test suite.
+ */
+const TEST_CLI = {
+	displayName: "TestCLI",
+	deviceLoginCommand: "testcli auth login --device",
+};
+
+function createTestContext(): {
+	ctx: OAuthFlowContext;
+	logs: string[];
+	opened: string[];
+	stored: () => UserAuthConfig | undefined;
+} {
+	const logs: string[] = [];
+	const opened: string[] = [];
+	const record =
+		(...prefix: unknown[]) =>
+		(...args: unknown[]) => {
+			logs.push([...prefix, ...args].join(" "));
+		};
+
+	let stored: UserAuthConfig | undefined;
+
+	return {
+		logs,
+		opened,
+		stored: () => stored,
+		ctx: {
+			logger: {
+				// Debug output is not user-facing copy, so it is not recorded.
+				debug: () => {},
+				info: record(),
+				log: record(),
+				warn: record(),
+				error: record(),
+			},
+			isNonInteractiveOrCI: () => false,
+			openInBrowser: async (url: string) => {
+				opened.push(url);
+			},
+			hasEnvCredentials: () => false,
+			clientId: "test-client-id",
+			consent: {
+				granted: { url: "https://example.com/granted" },
+				denied: {
+					url: "https://example.com/denied",
+					error: "consent denied page copy",
+				},
+			},
+			displayName: TEST_CLI.displayName,
+			deviceLoginCommand: TEST_CLI.deviceLoginCommand,
+			redirectUri: "http://localhost:9999/oauth/callback",
+			storageFactory: () => ({
+				read: () => stored,
+				write: (config: UserAuthConfig) => {
+					stored = config;
+				},
+				clear: () => {
+					const existed = stored !== undefined;
+					stored = undefined;
+					return existed;
+				},
+				path: () => "<in-memory>",
+			}),
+			allowGlobalAuthKey: true,
+			temporary: undefined,
+		},
+	};
+}
+
+/** Handle the Cloudflare Access probe the OAuth requests make first. */
+function mockAccessProbe() {
+	return http.get(
+		"https://dash.cloudflare.com/",
+		() => new HttpResponse(null, { status: 200 })
+	);
+}
+
+function mockDeviceAuth(overrides: Record<string, unknown> = {}) {
+	return http.post("*/oauth2/device/auth", () =>
+		HttpResponse.json({
+			device_code: "test-device-code",
+			user_code: "WDJB-MJHT",
+			verification_uri: "https://dash.cloudflare.com/oauth2/device",
+			expires_in: 600,
+			interval: 5,
+			...overrides,
+		})
+	);
+}
+
+function mockPoll(
+	status: number,
+	body: Record<string, unknown>,
+	counter?: { calls: number }
+) {
+	return http.post("*/oauth2/token", () => {
+		if (counter) {
+			counter.calls += 1;
+		}
+		return HttpResponse.json(body, { status });
+	});
+}
+
+beforeEach(() => {
+	clearAccessCaches();
+	msw.use(mockAccessProbe());
+});
+
+describe("device flow copy", () => {
+	beforeEach(() => {
+		msw.use(mockDeviceAuth());
+	});
+
+	it("addresses the user with the consumer's display name, not wrangler's", async ({
+		expect,
+	}) => {
+		msw.use(
+			mockPoll(200, {
+				access_token: "test-access-token",
+				expires_in: 100000,
+				refresh_token: "test-refresh-token",
+				scope: "account:read",
+			})
+		);
+
+		const { ctx, logs, opened, stored } = createTestContext();
+		const flow = createOAuthFlow(ctx);
+
+		expect(
+			await flow.login({
+				complianceConfig: COMPLIANCE_CONFIG,
+				scopes: ["account:read"],
+				device: true,
+			})
+		).toBe(true);
+
+		const output = logs.join("\n");
+		expect(output).toContain("To authorize TestCLI, please visit:");
+		expect(output.toLowerCase()).not.toContain("wrangler");
+		expect(opened).toEqual([
+			"https://dash.cloudflare.com/oauth2/device?user_code=WDJB-MJHT",
+		]);
+		expect(stored()?.oauth_token).toBe("test-access-token");
+	});
+
+	it("names the consumer in the consent-denied error", async ({ expect }) => {
+		msw.use(mockPoll(400, { error: "access_denied" }));
+
+		const { ctx } = createTestContext();
+		const flow = createOAuthFlow(ctx);
+
+		await expect(
+			flow.login({
+				complianceConfig: COMPLIANCE_CONFIG,
+				scopes: ["account:read"],
+				device: true,
+			})
+		).rejects.toThrow(
+			"Consent denied. You must grant consent to TestCLI in order to login."
+		);
+	});
+
+	it("quotes the consumer's device-login command when the code expires", async ({
+		expect,
+	}) => {
+		msw.use(mockPoll(400, { error: "expired_token" }));
+
+		const { ctx } = createTestContext();
+		const flow = createOAuthFlow(ctx);
+
+		await expect(
+			flow.login({
+				complianceConfig: COMPLIANCE_CONFIG,
+				scopes: ["account:read"],
+				device: true,
+			})
+		).rejects.toThrow(
+			"Device code expired before the request was approved. Please run `testcli auth login --device` again to obtain a new code."
+		);
+	});
+});
+
+async function login(ctx: OAuthFlowContext): Promise<boolean> {
+	return createOAuthFlow(ctx).login({
+		complianceConfig: COMPLIANCE_CONFIG,
+		scopes: ["account:read"],
+		device: true,
+	});
+}
+
+describe("device flow verification URL trust", () => {
+	beforeEach(() => {
+		// Should the trust check ever stop firing, the flow would fall through to
+		// polling; this handler makes that regression fail fast with a distinctly
+		// different error instead of retrying until the test times out.
+		msw.use(mockPoll(400, { error: "access_denied" }));
+	});
+
+	it("refuses an off-domain `verification_uri_complete`, without printing or opening it", async ({
+		expect,
+	}) => {
+		msw.use(
+			mockDeviceAuth({
+				verification_uri_complete:
+					"https://evil.example.com/oauth2/device?user_code=WDJB-MJHT",
+			})
+		);
+
+		const { ctx, logs, opened } = createTestContext();
+
+		await expect(login(ctx)).rejects.toThrow(
+			"The authorization server returned an untrusted `verification_uri_complete`: https://evil.example.com/oauth2/device?user_code=WDJB-MJHT"
+		);
+		expect(opened).toEqual([]);
+		expect(logs.join("\n")).not.toContain("evil.example.com");
+	});
+
+	it("refuses a subdomain of the auth domain", async ({ expect }) => {
+		msw.use(
+			mockDeviceAuth({
+				verification_uri: "https://oauth2.dash.cloudflare.com/device",
+				verification_uri_complete: undefined,
+			})
+		);
+
+		const { ctx, opened } = createTestContext();
+
+		await expect(login(ctx)).rejects.toThrow(
+			"The authorization server returned an untrusted `verification_uri`: https://oauth2.dash.cloudflare.com/device"
+		);
+		expect(opened).toEqual([]);
+	});
+
+	it("refuses a non-https `verification_uri`", async ({ expect }) => {
+		msw.use(
+			mockDeviceAuth({
+				verification_uri: "http://dash.cloudflare.com/oauth2/device",
+				verification_uri_complete: undefined,
+			})
+		);
+
+		const { ctx, opened } = createTestContext();
+
+		await expect(login(ctx)).rejects.toThrow(
+			"Expected an `https` URL on `dash.cloudflare.com`. Refusing to display or open it."
+		);
+		expect(opened).toEqual([]);
+	});
+
+	it("refuses embedded credentials even on the right host", async ({
+		expect,
+	}) => {
+		// Browsers de-emphasise or strip userinfo, so `user:pw@host` is a display
+		// spoofing vector rather than anything the auth server needs.
+		msw.use(
+			mockDeviceAuth({
+				verification_uri_complete:
+					"https://dash.cloudflare.com:pw@dash.cloudflare.com/oauth2/device",
+			})
+		);
+
+		const { ctx, opened } = createTestContext();
+
+		await expect(login(ctx)).rejects.toThrow(
+			"The authorization server returned an untrusted `verification_uri_complete`"
+		);
+		expect(opened).toEqual([]);
+	});
+});
+
+describe("device flow unusable responses", () => {
+	it("reports a non-2xx token response that carries no OAuth error code", async ({
+		expect,
+	}) => {
+		msw.use(mockDeviceAuth());
+		// The Cloudflare API envelope, as an intermediary or a misrouted request
+		// might produce. There is no top-level `error` member to switch on.
+		msw.use(
+			mockPoll(400, {
+				success: false,
+				errors: [{ code: 10000, message: "Authentication error" }],
+			})
+		);
+
+		const { ctx } = createTestContext();
+
+		await expect(login(ctx)).rejects.toThrow(
+			"The token endpoint returned a response that could not be interpreted (HTTP 400 Bad Request)."
+		);
+	});
+
+	it("reports a 2xx token response with no usable grant instead of crashing", async ({
+		expect,
+	}) => {
+		msw.use(mockDeviceAuth());
+		// Reading this as a token grant is what produced
+		// `RangeError: Invalid time value` from `expires_in` being `undefined`.
+		msw.use(mockPoll(200, { success: true }));
+
+		const { ctx, stored } = createTestContext();
+
+		await expect(login(ctx)).rejects.toThrow(
+			"The token endpoint returned a response that could not be interpreted (HTTP 200 OK)."
+		);
+		expect(stored()).toBeUndefined();
+	});
+
+	it("surfaces the standard `error_description` when the server sends one", async ({
+		expect,
+	}) => {
+		msw.use(mockDeviceAuth());
+		msw.use(
+			mockPoll(200, { error_description: "token issuance is disabled here" })
+		);
+
+		const { ctx } = createTestContext();
+
+		await expect(login(ctx)).rejects.toThrow(
+			"(HTTP 200 OK: token issuance is disabled here)"
+		);
+	});
+
+	it("keeps polling through retryable statuses, then reports them rather than a timeout", async ({
+		expect,
+	}) => {
+		// `expires_in` bounds the run: polls at t=0s and t=1s, then the deadline
+		// passes. `interval` is the server's own floor-respecting value.
+		msw.use(mockDeviceAuth({ expires_in: 2, interval: 1 }));
+		const poll = { calls: 0 };
+		msw.use(mockPoll(503, { message: "upstream unavailable" }, poll));
+
+		const { ctx } = createTestContext();
+
+		await expect(login(ctx)).rejects.toThrow(
+			"Gave up waiting for device authorization: the token endpoint kept returning responses that could not be interpreted (last: HTTP 503 Service Unavailable).\nEnable debug logging to see the full response, then run `testcli auth login --device` to try again."
+		);
+		expect(poll.calls).toBeGreaterThan(1);
+	});
+
+	it("still reports a plain timeout when the user simply never approves", async ({
+		expect,
+	}) => {
+		msw.use(mockDeviceAuth({ expires_in: 2, interval: 1 }));
+		// One transient failure followed by well-formed `authorization_pending`
+		// replies must not be mistaken for a broken endpoint.
+		let firstPoll = true;
+		msw.use(
+			http.post("*/oauth2/token", () => {
+				if (firstPoll) {
+					firstPoll = false;
+					return HttpResponse.text("<!DOCTYPE html><html></html>", {
+						status: 502,
+					});
+				}
+				return HttpResponse.json(
+					{ error: "authorization_pending" },
+					{
+						status: 400,
+					}
+				);
+			})
+		);
+
+		const { ctx } = createTestContext();
+
+		await expect(login(ctx)).rejects.toThrow(
+			"Device authorization timed out after 2 seconds. Please run `testcli auth login --device` again to obtain a new code."
+		);
+	});
+
+	it("reports an unusable device authorization response instead of timing out after `NaN`", async ({
+		expect,
+	}) => {
+		// `expires_in` missing: the deadline arithmetic used to yield `NaN`, which
+		// skips the poll loop entirely and reports "timed out after NaN minutes".
+		msw.use(
+			http.post("*/oauth2/device/auth", () =>
+				HttpResponse.json({
+					device_code: "test-device-code",
+					user_code: "WDJB-MJHT",
+					verification_uri: "https://dash.cloudflare.com/oauth2/device",
+				})
+			)
+		);
+
+		const { ctx, opened } = createTestContext();
+
+		await expect(login(ctx)).rejects.toThrow(
+			"The device authorization endpoint returned a response that could not be interpreted (HTTP 200 OK)."
+		);
+		expect(opened).toEqual([]);
+	});
+});

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -7,6 +7,7 @@ import {
 import {
 	COMPLIANCE_REGION_CONFIG_UNKNOWN,
 	getGlobalConfigPath,
+	openInBrowser,
 	UserError,
 } from "@cloudflare/workers-utils";
 import {
@@ -1166,6 +1167,445 @@ describe("User", () => {
 		).resolves.toEqual({
 			loggedIn: false,
 			reason: "no-credentials-non-interactive",
+		});
+	});
+
+	describe("login (device flow)", () => {
+		/**
+		 * Register an MSW handler for `POST /oauth2/device/auth` that returns
+		 * a successful device authorization response.
+		 */
+		function mockDeviceAuthSuccess(
+			overrides: {
+				verification_uri_complete?: string | null;
+				interval?: number;
+				expires_in?: number;
+			} = {}
+		) {
+			let calls = 0;
+			msw.use(
+				http.post(
+					"*/oauth2/device/auth",
+					() => {
+						calls += 1;
+						const body: Record<string, unknown> = {
+							device_code: "test-device-code",
+							user_code: "WDJB-MJHT",
+							verification_uri: "https://dash.cloudflare.com/oauth2/device",
+							expires_in: overrides.expires_in ?? 600,
+							interval: overrides.interval ?? 5,
+						};
+						// `null` means "deliberately omit this field"; undefined means
+						// "use the default".
+						if (overrides.verification_uri_complete === undefined) {
+							body.verification_uri_complete =
+								"https://dash.cloudflare.com/oauth2/device?user_code=WDJB-MJHT";
+						} else if (overrides.verification_uri_complete !== null) {
+							body.verification_uri_complete =
+								overrides.verification_uri_complete;
+						}
+						return HttpResponse.json(body);
+					},
+					{ once: true }
+				)
+			);
+			return {
+				get calls() {
+					return calls;
+				},
+			};
+		}
+
+		/**
+		 * Register an MSW handler for `POST /oauth2/token` that returns the
+		 * supplied sequence of responses in order. After exhausting the
+		 * sequence the handler is removed.
+		 */
+		function mockDevicePollSequence(
+			responses: Array<{ status: number; body: Record<string, unknown> }>
+		) {
+			let i = 0;
+			const counts = { calls: 0 };
+			msw.use(
+				http.post("*/oauth2/token", async () => {
+					counts.calls += 1;
+					const response = responses[Math.min(i, responses.length - 1)];
+					i += 1;
+					return HttpResponse.json(response.body, {
+						status: response.status,
+					});
+				})
+			);
+			return counts;
+		}
+
+		beforeEach(() => {
+			// Reset openInBrowser to a no-op for device flow tests. The
+			// `mockOAuthFlow()` helper used elsewhere in this file installs a
+			// callback-flow-specific implementation that tries to parse a
+			// `redirect_uri` out of the URL — which the device flow URL does
+			// not have. mockReset clears both the implementation and call
+			// history.
+			vi.mocked(openInBrowser).mockReset();
+		});
+
+		// Tear down the keyring test seam so the stubbed `KeyProvider`
+		// factory installed by the credential-storage regression test below
+		// cannot leak into other tests. No-op when never installed.
+		afterEach(() => {
+			setKeyProviderFactoryForTesting(undefined);
+			resetCredentialStorageState();
+		});
+
+		it("should complete login on the first successful poll", async ({
+			expect,
+		}) => {
+			mockDeviceAuthSuccess();
+			const poll = mockDevicePollSequence([
+				{
+					status: 200,
+					body: {
+						access_token: "test-access-token",
+						expires_in: 100000,
+						refresh_token: "test-refresh-token",
+						scope: "account:read",
+					},
+				},
+			]);
+
+			await runWrangler("login --device");
+
+			expect(poll.calls).toBe(1);
+			expect(openInBrowser).toHaveBeenCalledWith(
+				"https://dash.cloudflare.com/oauth2/device?user_code=WDJB-MJHT",
+				expect.anything()
+			);
+			expect(std.out).toMatchInlineSnapshot(`
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				Attempting to login via OAuth Device Authorization Grant...
+				To authorize Wrangler, please visit:
+
+				  https://dash.cloudflare.com/oauth2/device
+
+				and enter the code:
+
+				  WDJB-MJHT
+
+				You have 5 minutes to approve this request.
+
+				Opening a link in your default browser: https://dash.cloudflare.com/oauth2/device?user_code=WDJB-MJHT
+				Successfully logged in."
+			`);
+			expect(readAuthConfigFile()).toEqual<UserAuthConfig>({
+				api_token: undefined,
+				oauth_token: "test-access-token",
+				refresh_token: "test-refresh-token",
+				expiration_time: expect.any(String),
+				scopes: ["account:read"],
+			});
+		});
+
+		it("should display the effective timeout when the server's `expires_in` is shorter than the 5-minute cap", async ({
+			expect,
+		}) => {
+			// Server grants only 2 minutes; the displayed timeout must reflect
+			// that, not the 5-minute hard cap.
+			mockDeviceAuthSuccess({ expires_in: 120 });
+			mockDevicePollSequence([
+				{
+					status: 200,
+					body: {
+						access_token: "test-access-token",
+						expires_in: 100000,
+						refresh_token: "test-refresh-token",
+						scope: "account:read",
+					},
+				},
+			]);
+
+			await runWrangler("login --device");
+
+			expect(std.out).toContain("You have 2 minutes to approve this request.");
+			expect(std.out).not.toContain("You have 5 minutes");
+		});
+
+		it("should fall back to constructing a verification URL when the server omits `verification_uri_complete`", async ({
+			expect,
+		}) => {
+			mockDeviceAuthSuccess({ verification_uri_complete: null });
+			mockDevicePollSequence([
+				{
+					status: 200,
+					body: {
+						access_token: "test-access-token",
+						expires_in: 100000,
+						refresh_token: "test-refresh-token",
+						scope: "account:read",
+					},
+				},
+			]);
+
+			await runWrangler("login --device");
+
+			// We synthesised the verification URL by appending the user code
+			// because the server didn't give us a complete one.
+			expect(openInBrowser).toHaveBeenCalledWith(
+				"https://dash.cloudflare.com/oauth2/device?user_code=WDJB-MJHT",
+				expect.anything()
+			);
+		});
+
+		it("should not open the browser when `--browser=false`", async ({
+			expect,
+		}) => {
+			mockDeviceAuthSuccess();
+			mockDevicePollSequence([
+				{
+					status: 200,
+					body: {
+						access_token: "test-access-token",
+						expires_in: 100000,
+						refresh_token: "test-refresh-token",
+						scope: "account:read",
+					},
+				},
+			]);
+
+			await runWrangler("login --device --browser=false");
+
+			expect(openInBrowser).not.toHaveBeenCalled();
+			expect(std.out).not.toContain("Opening a link in your default browser");
+		});
+
+		it("should keep polling while the server returns `authorization_pending`, then succeed", async ({
+			expect,
+		}) => {
+			// Use fake timers so the polling sleep is instant.
+			vi.useFakeTimers();
+			try {
+				mockDeviceAuthSuccess({ interval: 1 });
+				const poll = mockDevicePollSequence([
+					{ status: 400, body: { error: "authorization_pending" } },
+					{ status: 400, body: { error: "authorization_pending" } },
+					{
+						status: 200,
+						body: {
+							access_token: "test-access-token",
+							expires_in: 100000,
+							refresh_token: "test-refresh-token",
+							scope: "account:read",
+						},
+					},
+				]);
+
+				const runPromise = runWrangler("login --device");
+				// Drain microtasks + fake-timer waits until the polling loop
+				// completes. `runAllTimersAsync` cycles until no pending timers.
+				await vi.runAllTimersAsync();
+				await runPromise;
+
+				expect(poll.calls).toBe(3);
+				expect(readAuthConfigFile()).toMatchObject({
+					oauth_token: "test-access-token",
+					refresh_token: "test-refresh-token",
+				});
+				// RFC 8628 §3.5: HTTP 400 with `authorization_pending` is the
+				// expected polling-control mechanism, not an error. Verify that
+				// the polling loop does NOT log spurious "Failed to fetch auth
+				// token" errors to stderr while the user is approving.
+				expect(std.err).toBe("");
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("should keep polling when a poll fails transiently (non-JSON body), then succeed", async ({
+			expect,
+		}) => {
+			// Use fake timers so the polling sleep is instant.
+			vi.useFakeTimers();
+			try {
+				mockDeviceAuthSuccess({ interval: 1 });
+
+				// The token endpoint sits behind the Cloudflare edge, which can
+				// occasionally return a transient HTML 5xx or bot-challenge page
+				// instead of JSON. A single such poll must not abort the login —
+				// it should be treated like `authorization_pending` and polling
+				// should continue.
+				let calls = 0;
+				msw.use(
+					http.post("*/oauth2/token", () => {
+						calls += 1;
+						if (calls === 1) {
+							return new HttpResponse(
+								"<!DOCTYPE html><html><body>challenge-platform</body></html>",
+								{
+									status: 503,
+									headers: {
+										"content-type": "text/html",
+										"cf-ray": "test-ray",
+									},
+								}
+							);
+						}
+						return HttpResponse.json({
+							access_token: "test-access-token",
+							expires_in: 100000,
+							refresh_token: "test-refresh-token",
+							scope: "account:read",
+						});
+					})
+				);
+
+				const runPromise = runWrangler("login --device");
+				await vi.runAllTimersAsync();
+				await runPromise;
+
+				// First poll failed transiently, second succeeded.
+				expect(calls).toBe(2);
+				expect(readAuthConfigFile()).toMatchObject({
+					oauth_token: "test-access-token",
+					refresh_token: "test-refresh-token",
+				});
+				// A transient poll failure is not a user-facing error: nothing
+				// should be logged to stderr while we keep polling.
+				expect(std.err).toBe("");
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("should time out with a message reflecting the server's `expires_in` when shorter than the cap", async ({
+			expect,
+		}) => {
+			// Use fake timers so the polling sleeps are instant.
+			vi.useFakeTimers();
+			try {
+				// Server grants 2 minutes and never approves; the timeout error
+				// must quote the effective 2-minute window, not the 5-minute cap.
+				mockDeviceAuthSuccess({ interval: 1, expires_in: 120 });
+				mockDevicePollSequence([
+					{ status: 400, body: { error: "authorization_pending" } },
+				]);
+
+				const runPromise = runWrangler("login --device");
+				const assertion = expect(runPromise).rejects.toThrow(
+					"Device authorization timed out after 2 minutes. Please run `wrangler login --device` again to obtain a new code."
+				);
+				await vi.runAllTimersAsync();
+				await assertion;
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("should error with a clear message when the user denies consent", async ({
+			expect,
+		}) => {
+			mockDeviceAuthSuccess();
+			mockDevicePollSequence([
+				{ status: 400, body: { error: "access_denied" } },
+			]);
+
+			await expect(
+				runWrangler("login --device")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`
+				[Error: Consent denied. You must grant consent to Wrangler in order to login.
+				If you don't want to do this consider passing an API token via the \`CLOUDFLARE_API_TOKEN\` environment variable.]
+			`
+			);
+		});
+
+		it("should error with a clear message when the device code expires", async ({
+			expect,
+		}) => {
+			mockDeviceAuthSuccess();
+			mockDevicePollSequence([
+				{ status: 400, body: { error: "expired_token" } },
+			]);
+
+			await expect(
+				runWrangler("login --device")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Device code expired before the request was approved. Please run \`wrangler login --device\` again to obtain a new code.]`
+			);
+		});
+
+		it("should error when `--callback-host` is passed alongside `--device`", async ({
+			expect,
+		}) => {
+			await expect(
+				runWrangler("login --device --callback-host=0.0.0.0")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: \`--callback-host\` and \`--callback-port\` cannot be used with \`--device\`; the device authorization flow does not use a local callback server.]`
+			);
+		});
+
+		it("should error when `--callback-port` is passed alongside `--device`", async ({
+			expect,
+		}) => {
+			await expect(
+				runWrangler("login --device --callback-port=9999")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: \`--callback-host\` and \`--callback-port\` cannot be used with \`--device\`; the device authorization flow does not use a local callback server.]`
+			);
+		});
+
+		it("should reject the incompatible flag combination before `--no-use-keyring` mutates any credential-storage state", async ({
+			expect,
+		}) => {
+			// Regression: the incompatibility guard used to live in the
+			// command handler, *after* `setKeyringPreference(...)` had
+			// already persisted the preference and scrubbed every
+			// encrypted profile. Combining the invalid flags with
+			// `--no-use-keyring` therefore destroyed stored credentials
+			// before the command errored. The guard now runs in
+			// `validateArgs`, which executes before the handler, so an
+			// invalid invocation must be inert.
+			const {
+				getEncryptedAuthConfigFilePath,
+				readUserPreferences,
+				updateUserPreferences,
+			} = await import("@cloudflare/workers-auth/wrangler");
+			const keyringStore = new Map<string, Uint8Array>();
+			setKeyProviderFactoryForTesting((serviceName) => ({
+				getKey: () => keyringStore.get(`${serviceName}::default`),
+				setKey: (key) => {
+					keyringStore.set(`${serviceName}::default`, key);
+				},
+				deleteKey: () => {
+					keyringStore.delete(`${serviceName}::default`);
+				},
+				describe: () => "in-memory test keyring",
+			}));
+			// Seed the persistent opt-in plus encrypted credentials so the
+			// opt-out scrub has something real to destroy if it runs.
+			updateUserPreferences({ keyring_enabled: true });
+			writeAuthCredentials({
+				oauth_token: "existing-encrypted-token",
+				refresh_token: "existing-encrypted-refresh",
+			});
+			expect(fs.existsSync(getEncryptedAuthConfigFilePath())).toBe(true);
+			expect(keyringStore.size).toBe(1);
+
+			await expect(
+				runWrangler("login --device --callback-host=0.0.0.0 --no-use-keyring")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: \`--callback-host\` and \`--callback-port\` cannot be used with \`--device\`; the device authorization flow does not use a local callback server.]`
+			);
+
+			// Nothing may have been scrubbed, migrated, or re-persisted.
+			expect(fs.existsSync(getEncryptedAuthConfigFilePath())).toBe(true);
+			expect(keyringStore.size).toBe(1);
+			expect(readUserPreferences().keyring_enabled).toBe(true);
+			// The credentials must remain readable and unchanged.
+			expect(readAuthCredentials()).toMatchObject({
+				oauth_token: "existing-encrypted-token",
+				refresh_token: "existing-encrypted-refresh",
+			});
 		});
 	});
 

--- a/packages/wrangler/src/user/commands.ts
+++ b/packages/wrangler/src/user/commands.ts
@@ -83,6 +83,12 @@ export const loginCommand = createCommand({
 			// touches the persisted preference when the user actually opts in
 			// or out.
 		},
+		device: {
+			describe:
+				"Use the OAuth 2.0 Device Authorization Grant (RFC 8628) instead of the localhost callback flow. Useful in containers, remote SSH sessions, or other environments where localhost:8976 is unreachable from your browser.",
+			type: "boolean",
+			default: false,
+		},
 	},
 	validateArgs(args) {
 		if (args.profile) {
@@ -90,6 +96,25 @@ export const loginCommand = createCommand({
 				"--profile cannot be used with the login command, as `wrangler login` is reserved for default, global auth. If you want to create or activate a named profile, run `wrangler auth create` or `wrangler auth activate`.",
 				{
 					telemetryMessage: "profile flag with login",
+				}
+			);
+		}
+
+		// `--callback-host` / `--callback-port` configure the temporary local
+		// callback server used by the authorization-code flow. The device
+		// authorization flow has no callback server, so the combination is
+		// invalid rather than merely ignored. This is validated here rather
+		// than in the handler so the command fails before `--use-keyring` /
+		// `--no-use-keyring` has persisted any credential-storage state.
+		if (
+			args.device &&
+			(args.callbackHost !== "localhost" || args.callbackPort !== 8976)
+		) {
+			throw new CommandLineArgsError(
+				"`--callback-host` and `--callback-port` cannot be used with `--device`; the device authorization flow does not use a local callback server.",
+				{
+					telemetryMessage:
+						"user login callback args incompatible with device flow",
 				}
 			);
 		}
@@ -121,6 +146,7 @@ export const loginCommand = createCommand({
 		// call (and a single `sendMetricsEvent("login user", ...)` site) between
 		// the scoped and unscoped paths.
 		let scopes: typeof DefaultScopeKeys | undefined;
+
 		if (args.scopes) {
 			if (args.scopes.length === 0) {
 				// don't allow no scopes to be passed, that would be weird
@@ -143,6 +169,7 @@ export const loginCommand = createCommand({
 			callbackHost: args.callbackHost,
 			callbackPort: args.callbackPort,
 			profile: "default",
+			device: args.device,
 		});
 		metrics.sendMetricsEvent("login user", {
 			sendMetrics: config.send_metrics,

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -180,6 +180,11 @@ type WranglerLoginProps = {
 	callbackHost?: string;
 	callbackPort?: number;
 	profile?: string;
+	/**
+	 * When `true`, use the OAuth 2.0 Device Authorization Grant (RFC 8628)
+	 * instead of the authorization-code-with-PKCE flow.
+	 */
+	device?: boolean;
 };
 
 export async function login(


### PR DESCRIPTION
_Adds a `--device` flag to `wrangler login` that uses the OAuth 2.0 Device Authorization Grant ([RFC 8628](https://www.rfc-editor.org/rfc/rfc8628)) instead of the existing localhost callback flow._

Replaces https://github.com/cloudflare/workers-sdk/pull/13130 with an industry standard approach.
Fixes https://github.com/cloudflare/workers-sdk/discussions/13117
Fixes https://github.com/cloudflare/workers-sdk/issues/10935

### What this changes

`wrangler login --device` runs a new flow that:

- requests a device code + user code from the OAuth device authorization endpoint,
- prints the verification URL and user code to the terminal,
- attempts to open the verification URL in the user's default browser,
- polls the token endpoint with `grant_type=urn:ietf:params:oauth:grant-type:device_code` until the user approves the request, denies it, or the device code expires.

This is useful in containers, remote SSH sessions, Codespaces, and any other environment where `localhost:8976` is unreachable from the user's browser.

### Where the code lives

Since this PR was first opened, wrangler's OAuth machinery was extracted into the `@cloudflare/workers-auth` package (#14185). This PR is rebased onto that structure:

- The device-flow primitives live in **`@cloudflare/workers-auth`**, exposed through the existing `createOAuthFlow(...)` API as a new `device` login option. Other Cloudflare CLIs that consume the package get the flow for free.
- **wrangler** wires up the `--device` flag and injects its client config into the flow context.

### Behaviour details

- **Initial poll is sent immediately** with no wait, so logins that complete quickly feel instantaneous.
- **Subsequent polls** respect the server's `interval` field (RFC 8628 §3.5), with a minimum floor of 1s. If the server sends `slow_down`, we add +5s as required by the RFC.
- **Wrangler-side hard cap of 5 minutes** on top of the server's `expires_in`, to limit the abuse window if a user code is ever leaked (RFC 8628 §5.4).
- **`--callback-host` and `--callback-port` are rejected** (hard error) when `--experimental-device` is set — this flow has no local callback server.
- **`offline_access` scope is appended unconditionally**, same as the auth-code flow, so refresh tokens still work end-to-end.
- **Polling does not spam stderr**: HTTP 400 with `authorization_pending` / `slow_down` is the expected RFC 8628 §3.5 control mechanism, so the poll path logs non-2xx responses at `debug` level only — a normal pending login produces no error output.
- The device authorization endpoint is **not** environment-overridable; it derives from the same auth domain as the token endpoint (production vs. staging), so the device-auth and token endpoints can never desync.

---

- Tests
  - [x] Tests included/updated (device-flow tests in `packages/wrangler/src/__tests__/user.test.ts`; flow primitives in `@cloudflare/workers-auth`)
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/31091
