### PR TITLE
[wrangler] Fix Pages dev config bindings without package.json

### DIFF
--- a/.changeset/fix-pages-dev-config-path.md
+++ b/.changeset/fix-pages-dev-config-path.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler pages dev` ignoring config bindings in projects without a `package.json`
+
+Previously, Pages local development could fail to apply bindings from Wrangler configuration when the project did not include a `package.json`. `pages dev` now passes the already-discovered configuration path into the dev runtime so bindings from `wrangler.json`, `wrangler.jsonc`, and `wrangler.toml` continue to be loaded correctly.

--- a/packages/wrangler/src/__tests__/pages/dev.test.ts
+++ b/packages/wrangler/src/__tests__/pages/dev.test.ts
@@ -6,6 +6,7 @@ import {
 import { describe, it, vi } from "vitest";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runWrangler } from "../helpers/run-wrangler";
+import type { ExpectStatic } from "vitest";
 
 const startDevMock = vi.hoisted(() => vi.fn());
 
@@ -19,6 +20,30 @@ vi.mock("../../dev/start-dev", async () => {
 		}),
 	};
 });
+
+async function expectPagesDevToPassConfigPath(
+	expect: ExpectStatic,
+	files: Record<string, string> = {}
+) {
+	await seed({ "public/index.html": "", ...files });
+	writeWranglerConfig({ pages_build_output_dir: "public" });
+	const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+		throw new Error("process.exit");
+	}) as typeof process.exit);
+
+	try {
+		await expect(runWrangler("pages dev")).rejects.toThrow("process.exit");
+
+		expect(exitSpy).toHaveBeenCalledWith(0);
+		expect(startDevMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				config: expect.stringMatching(/wrangler\.toml$/),
+			})
+		);
+	} finally {
+		exitSpy.mockRestore();
+	}
+}
 
 /**
  * Given that `runWrangler()` mocks out the underlying implementation
@@ -68,22 +93,37 @@ describe("pages dev", () => {
 		);
 	});
 
-	it("should pass the discovered config path to startDev", async ({
+	it("should pass the discovered config path to startDev without package.json", async ({
+		expect,
+	}) => {
+		await expectPagesDevToPassConfigPath(expect);
+	});
+
+	it("should pass the discovered config path to startDev with package.json", async ({
+		expect,
+	}) => {
+		await expectPagesDevToPassConfigPath(expect, { "package.json": "{}" });
+	});
+
+	it("should not pass a config path to startDev when no config exists", async ({
 		expect,
 	}) => {
 		await seed({ "public/index.html": "" });
-		writeWranglerConfig({ pages_build_output_dir: "public" });
 		const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
 			throw new Error("process.exit");
 		}) as typeof process.exit);
 
-		await expect(runWrangler("pages dev")).rejects.toThrow("process.exit");
+		try {
+			await expect(runWrangler("pages dev public")).rejects.toThrow(
+				"process.exit"
+			);
 
-		expect(exitSpy).toHaveBeenCalledWith(0);
-		expect(startDevMock).toHaveBeenCalledWith(
-			expect.objectContaining({
-				config: expect.stringMatching(/wrangler\.toml$/),
-			})
-		);
+			expect(exitSpy).toHaveBeenCalledWith(0);
+			expect(startDevMock).toHaveBeenCalledWith(
+				expect.objectContaining({ config: undefined })
+			);
+		} finally {
+			exitSpy.mockRestore();
+		}
 	});
 });

--- a/packages/wrangler/src/__tests__/pages/dev.test.ts
+++ b/packages/wrangler/src/__tests__/pages/dev.test.ts
@@ -6,7 +6,6 @@ import {
 import { describe, it, vi } from "vitest";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runWrangler } from "../helpers/run-wrangler";
-import type { ExpectStatic } from "vitest";
 
 const startDevMock = vi.hoisted(() => vi.fn());
 
@@ -20,30 +19,6 @@ vi.mock("../../dev/start-dev", async () => {
 		}),
 	};
 });
-
-async function expectPagesDevToPassConfigPath(
-	expect: ExpectStatic,
-	files: Record<string, string> = {}
-) {
-	await seed({ "public/index.html": "", ...files });
-	writeWranglerConfig({ pages_build_output_dir: "public" });
-	const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
-		throw new Error("process.exit");
-	}) as typeof process.exit);
-
-	try {
-		await expect(runWrangler("pages dev")).rejects.toThrow("process.exit");
-
-		expect(exitSpy).toHaveBeenCalledWith(0);
-		expect(startDevMock).toHaveBeenCalledWith(
-			expect.objectContaining({
-				config: expect.stringMatching(/wrangler\.toml$/),
-			})
-		);
-	} finally {
-		exitSpy.mockRestore();
-	}
-}
 
 /**
  * Given that `runWrangler()` mocks out the underlying implementation
@@ -96,13 +71,47 @@ describe("pages dev", () => {
 	it("should pass the discovered config path to startDev without package.json", async ({
 		expect,
 	}) => {
-		await expectPagesDevToPassConfigPath(expect);
+		await seed({ "public/index.html": "" });
+		writeWranglerConfig({ pages_build_output_dir: "public" });
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+			throw new Error("process.exit");
+		}) as typeof process.exit);
+
+		try {
+			await expect(runWrangler("pages dev")).rejects.toThrow("process.exit");
+
+			expect(exitSpy).toHaveBeenCalledWith(0);
+			expect(startDevMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					config: expect.stringMatching(/wrangler\.toml$/),
+				})
+			);
+		} finally {
+			exitSpy.mockRestore();
+		}
 	});
 
 	it("should pass the discovered config path to startDev with package.json", async ({
 		expect,
 	}) => {
-		await expectPagesDevToPassConfigPath(expect, { "package.json": "{}" });
+		await seed({ "public/index.html": "", "package.json": "{}" });
+		writeWranglerConfig({ pages_build_output_dir: "public" });
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+			throw new Error("process.exit");
+		}) as typeof process.exit);
+
+		try {
+			await expect(runWrangler("pages dev")).rejects.toThrow("process.exit");
+
+			expect(exitSpy).toHaveBeenCalledWith(0);
+			expect(startDevMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					config: expect.stringMatching(/wrangler\.toml$/),
+				})
+			);
+		} finally {
+			exitSpy.mockRestore();
+		}
 	});
 
 	it("should not pass a config path to startDev when no config exists", async ({

--- a/packages/wrangler/src/__tests__/pages/dev.test.ts
+++ b/packages/wrangler/src/__tests__/pages/dev.test.ts
@@ -1,7 +1,24 @@
-import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
-import { describe, it } from "vitest";
+import {
+	runInTempDir,
+	seed,
+	writeWranglerConfig,
+} from "@cloudflare/workers-utils/test-helpers";
+import { describe, it, vi } from "vitest";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runWrangler } from "../helpers/run-wrangler";
+
+const startDevMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../dev/start-dev", async () => {
+	const { EventEmitter } = await import("node:events");
+	return {
+		startDev: startDevMock.mockImplementation(async () => {
+			const devEnv = new EventEmitter();
+			setTimeout(() => devEnv.emit("teardown"), 0);
+			return { devEnv, secondary: [], unregisterHotKeys: vi.fn() };
+		}),
+	};
+});
 
 /**
  * Given that `runWrangler()` mocks out the underlying implementation
@@ -48,6 +65,25 @@ describe("pages dev", () => {
 			runWrangler("pages dev public --env=production")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
 			`[Error: Pages does not support the --env flag during local development. Use the --branch flag to target your production or preview environment instead.]`
+		);
+	});
+
+	it("should pass the discovered config path to startDev", async ({
+		expect,
+	}) => {
+		await seed({ "public/index.html": "" });
+		writeWranglerConfig({ pages_build_output_dir: "public" });
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+			throw new Error("process.exit");
+		}) as typeof process.exit);
+
+		await expect(runWrangler("pages dev")).rejects.toThrow("process.exit");
+
+		expect(exitSpy).toHaveBeenCalledWith(0);
+		expect(startDevMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				config: expect.stringMatching(/wrangler\.toml$/),
+			})
 		);
 	});
 });

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -1029,7 +1029,7 @@ export const pagesDevCommand = createCommand({
 					experimentalProvision: undefined,
 					experimentalAutoCreate: false,
 					enableIpc: true,
-					config: Array.isArray(args.config) ? args.config : undefined,
+					config: Array.isArray(args.config) ? args.config : config.configPath,
 					site: undefined,
 					siteInclude: undefined,
 					siteExclude: undefined,


### PR DESCRIPTION
Fixes https://discord.com/channels/595317990191398933/1508733813466075146/1509184728908173465.

Pass the Pages config path that `wrangler pages dev` already discovered into the dev runtime. This prevents the runtime from rediscovering config from generated `.wrangler/tmp` entrypoints, which could miss config bindings in projects without a `package.json`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this restores existing config binding behavior in local development.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->