### PR TITLE
move triggers deploy into deploy-helpers 

### DIFF
--- a/packages/deploy-helpers/package.json
+++ b/packages/deploy-helpers/package.json
@@ -32,13 +32,17 @@
 		"test:ci": "vitest run",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
 	},
+	"dependencies": {
+		"@cloudflare/workers-utils": "workspace:*"
+	},
 	"devDependencies": {
 		"@cloudflare/containers-shared": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-utils": "workspace:*",
 		"@types/node": "catalog:default",
+		"chalk": "^5.2.0",
 		"concurrently": "^8.2.2",
 		"miniflare": "workspace:*",
+		"p-queue": "^9.0.0",
 		"tsup": "8.3.0",
 		"typescript": "catalog:default",
 		"vitest": "catalog:default"

--- a/packages/deploy-helpers/scripts/deps.ts
+++ b/packages/deploy-helpers/scripts/deps.ts
@@ -1,0 +1,11 @@
+/**
+ * Dependencies that _are not_ bundled along with @cloudflare/deploy-helpers.
+ *
+ * These must be explicitly documented with a reason why they cannot be bundled.
+ * This list is validated by `tools/deployments/validate-package-dependencies.ts`.
+ */
+export const EXTERNAL_DEPENDENCIES = [
+	// Workspace package kept external so consumers share a single copy of
+	// workers-utils types and runtime code (e.g. ParseError instanceof checks).
+	"@cloudflare/workers-utils",
+];

--- a/packages/deploy-helpers/src/index.ts
+++ b/packages/deploy-helpers/src/index.ts
@@ -1,1 +1,6 @@
 export * from "./shared/types";
+export * from "./triggers/deploy";
+export * from "./triggers/subdomain";
+export * from "./triggers/zones";
+export * from "./triggers/publish-routes";
+export * from "./triggers/queue-consumers";

--- a/packages/deploy-helpers/src/shared/types.ts
+++ b/packages/deploy-helpers/src/shared/types.ts
@@ -132,3 +132,19 @@ export type VersionsUploadProps = SharedDeployVersionsProps & {
 	/** CLI-only (--preview-alias), or auto-generated from CI branch name. */
 	previewAlias: string | undefined;
 };
+
+export interface TriggerDeployment {
+	targets: string[];
+	error?: Error;
+}
+
+export type TriggerProps = {
+	config: Config;
+	accountId: string;
+	scriptName: string;
+	env: string | undefined;
+	crons: string[] | undefined;
+	routes: Route[];
+	useServiceEnvironments: boolean;
+	firstDeploy: boolean;
+};

--- a/packages/deploy-helpers/src/shared/types.ts
+++ b/packages/deploy-helpers/src/shared/types.ts
@@ -29,6 +29,7 @@ export type DeployHelpersContext = {
 		text: string,
 		options?: { defaultValue?: string }
 	) => Promise<string>;
+	isNonInteractiveOrCI: () => boolean;
 };
 
 /**

--- a/packages/deploy-helpers/src/shared/types.ts
+++ b/packages/deploy-helpers/src/shared/types.ts
@@ -6,6 +6,7 @@ import type {
 	Config,
 	EphemeralDirectory,
 	FetchResultFetcher,
+	FetchListResultFetcher,
 	Logger,
 	Route,
 	Entry,
@@ -18,7 +19,16 @@ import type { NodeJSCompatMode } from "miniflare";
  */
 export type DeployHelpersContext = {
 	fetchResult: FetchResultFetcher;
+	fetchListResult: FetchListResultFetcher;
 	logger: Logger;
+	confirm: (
+		text: string,
+		options?: { defaultValue?: boolean; fallbackValue?: boolean }
+	) => Promise<boolean>;
+	prompt: (
+		text: string,
+		options?: { defaultValue?: string }
+	) => Promise<string>;
 };
 
 /**

--- a/packages/deploy-helpers/src/triggers/deploy.ts
+++ b/packages/deploy-helpers/src/triggers/deploy.ts
@@ -1,56 +1,37 @@
 import {
+	formatTime,
 	getSubdomainMixedStateCheckDisabled,
+	isNonInteractiveOrCI,
+	retryOnAPIFailure,
 	UserError,
 } from "@cloudflare/workers-utils";
 import chalk from "chalk";
 import PQueue from "p-queue";
-import { fetchListResult, fetchResult } from "../cfetch";
 import {
-	formatTime,
 	publishCustomDomains,
 	publishRoutes,
 	renderRoute,
-	updateQueueConsumers,
-	validateRoutes,
-} from "../deploy/deploy";
-import { isNonInteractiveOrCI } from "../is-interactive";
-import { logger } from "../logger";
-import { ensureQueuesExistByConfig } from "../queues/client";
-import { getWorkersDevSubdomain } from "../routes";
-import { retryOnAPIFailure } from "../utils/retry";
-import { getZoneForRoute } from "../zones";
-import type { RouteObject } from "../deploy/deploy";
-import type { AssetsOptions, Config, Route } from "@cloudflare/workers-utils";
+} from "./publish-routes";
+import { updateQueueConsumers } from "./queue-consumers";
+import { getWorkersDevSubdomain } from "./subdomain";
+import { getZoneForRoute } from "./zones";
+import type {
+	DeployHelpersContext,
+	TriggerDeployment,
+	TriggerProps,
+} from "../shared/types";
+import type { RouteObject } from "./publish-routes";
+import type { Config, Route } from "@cloudflare/workers-utils";
 
-type Props = {
-	config: Config;
-	accountId: string | undefined;
-	name: string | undefined;
-	env: string | undefined;
-	triggers: string[] | undefined;
-	routes: Route[] | undefined;
-	useServiceEnvironments: boolean | undefined;
-	dryRun: boolean | undefined;
-	assetsOptions: AssetsOptions | undefined;
-	firstDeploy: boolean;
-};
-
-export interface TriggerDeployment {
-	targets: string[];
-	error?: Error;
-}
-
-export default async function triggersDeploy(
-	props: Props
+export async function triggersDeploy(
+	props: TriggerProps,
+	ctx: DeployHelpersContext
 ): Promise<string[] | void> {
-	const { config, accountId, name: scriptName } = props;
+	const { config, accountId, scriptName, routes, crons } = props;
 
-	const schedules = props.triggers || config.triggers?.crons;
-	const routes =
-		props.routes ?? config.routes ?? (config.route ? [config.route] : []) ?? [];
 	const routesOnly: Array<Route> = [];
 	const customDomainsOnly: Array<RouteObject> = [];
-	validateRoutes(routes, props.assetsOptions);
+
 	for (const route of routes) {
 		if (typeof route !== "string" && route.custom_domain) {
 			customDomainsOnly.push(route);
@@ -59,40 +40,13 @@ export default async function triggersDeploy(
 		}
 	}
 
-	if (!scriptName) {
-		throw new UserError(
-			'You need to provide a name when uploading a Worker Version. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`',
-			{ telemetryMessage: "triggers deploy missing worker name" }
-		);
-	}
-
 	const envName = props.env ?? "production";
 
 	const start = Date.now();
-	const useServiceEnvironments = Boolean(
-		props.useServiceEnvironments && props.env
-	);
-	const workerName = useServiceEnvironments
-		? `${scriptName} (${envName})`
-		: scriptName;
-	const workerUrl = useServiceEnvironments
+
+	const workerUrl = props.useServiceEnvironments
 		? `/accounts/${accountId}/workers/services/${scriptName}/environments/${envName}`
 		: `/accounts/${accountId}/workers/scripts/${scriptName}`;
-
-	if (!props.dryRun) {
-		await ensureQueuesExistByConfig(config);
-	}
-
-	if (props.dryRun) {
-		logger.log(`--dry-run: exiting now.`);
-		return;
-	}
-
-	if (!accountId) {
-		throw new UserError("Missing accountId", {
-			telemetryMessage: "triggers deploy missing account id",
-		});
-	}
 
 	const uploadMs = Date.now() - start;
 	const deployments: Promise<TriggerDeployment>[] = [];
@@ -108,7 +62,8 @@ export default async function triggersDeploy(
 		workerUrl,
 		routes,
 		deployments,
-		props.firstDeploy
+		props.firstDeploy,
+		ctx
 	);
 
 	if (!wantWorkersDev && workersDevInSync && routes.length !== 0) {
@@ -145,6 +100,7 @@ export default async function triggersDeploy(
 					const zone = await getZoneForRoute(
 						config,
 						{ route, accountId },
+						ctx,
 						zoneIdCache
 					);
 					if (!zone) {
@@ -156,11 +112,13 @@ export default async function triggersDeploy(
 
 					let routesInZone = zoneRoutesCache.get(zone.id);
 					if (!routesInZone) {
-						routesInZone = retryOnAPIFailure(() =>
-							fetchListResult<{
-								pattern: string;
-								script: string;
-							}>(config, `/zones/${zone.id}/workers/routes`)
+						routesInZone = retryOnAPIFailure(
+							() =>
+								ctx.fetchListResult<{
+									pattern: string;
+									script: string;
+								}>(config, `/zones/${zone.id}/workers/routes`),
+							ctx.logger
 						);
 						zoneRoutesCache.set(zone.id, routesInZone);
 					}
@@ -206,7 +164,7 @@ export default async function triggersDeploy(
 	}
 
 	if (!wantWorkersDev && hasWorkflowsDefinedInThisScript) {
-		await getWorkersDevSubdomain(config, accountId, {
+		await getWorkersDevSubdomain(config, accountId, ctx, {
 			configPath: config.configPath,
 			registrationContext: "workflows",
 		});
@@ -215,12 +173,17 @@ export default async function triggersDeploy(
 	// Update routing table for the script.
 	if (routesOnly.length > 0) {
 		deployments.push(
-			publishRoutes(config, routesOnly, {
-				workerUrl,
-				scriptName,
-				useServiceEnvironments,
-				accountId,
-			}).then(
+			publishRoutes(
+				config,
+				routesOnly,
+				{
+					workerUrl,
+					scriptName,
+					useServiceEnvironments: props.useServiceEnvironments,
+					accountId,
+				},
+				ctx
+			).then(
 				() => {
 					if (routesOnly.length > 10) {
 						return {
@@ -244,7 +207,8 @@ export default async function triggersDeploy(
 				config,
 				workerUrl,
 				accountId,
-				customDomainsOnly
+				customDomainsOnly,
+				ctx
 			).catch((error) => ({ targets: [], error }))
 		);
 	}
@@ -252,21 +216,23 @@ export default async function triggersDeploy(
 	// Configure any schedules for the script.
 	// If schedules is not defined then we just leave whatever is previously deployed alone.
 	// If it is an empty array we will remove all schedules.
-	if (schedules) {
+	if (crons) {
 		deployments.push(
-			fetchResult(config, `${workerUrl}/schedules`, {
-				// Note: PUT will override previous schedules on this script.
-				method: "PUT",
-				body: JSON.stringify(schedules.map((cron) => ({ cron }))),
-				headers: {
-					"Content-Type": "application/json",
-				},
-			}).then(
-				() => ({
-					targets: schedules.map((trigger) => `schedule: ${trigger}`),
-				}),
-				(error) => ({ targets: [], error })
-			)
+			ctx
+				.fetchResult(config, `${workerUrl}/schedules`, {
+					// Note: PUT will override previous schedules on this script.
+					method: "PUT",
+					body: JSON.stringify(crons.map((cron) => ({ cron }))),
+					headers: {
+						"Content-Type": "application/json",
+					},
+				})
+				.then(
+					() => ({
+						targets: crons.map((trigger) => `schedule: ${trigger}`),
+					}),
+					(error) => ({ targets: [], error })
+				)
 		);
 	}
 
@@ -279,15 +245,21 @@ export default async function triggersDeploy(
 	}
 
 	if (config.queues.consumers && config.queues.consumers.length) {
-		const updateConsumers = await updateQueueConsumers(scriptName, config);
-
-		deployments.push(...updateConsumers);
+		const consumerUpdates = await updateQueueConsumers(
+			config,
+			accountId,
+			scriptName,
+			config,
+			ctx
+		);
+		deployments.push(...consumerUpdates);
 	}
 
 	if (config.workflows?.length) {
+		// NOTE: if the user provides a script_name thats not this script (aka bounds to another worker)
+		// we don't want to send this worker's config.
+		// TODO: move this earlier.
 		for (const workflow of config.workflows) {
-			// NOTE: if the user provides a script_name thats not this script (aka bounds to another worker)
-			// we don't want to send this worker's config.
 			if (!isWorkflowDefinedInThisScript(workflow, scriptName)) {
 				if (workflow.limits) {
 					throw new UserError(
@@ -313,36 +285,42 @@ export default async function triggersDeploy(
 			}
 
 			deployments.push(
-				fetchResult(
-					config,
-					`/accounts/${accountId}/workflows/${workflow.name}`,
-					{
-						method: "PUT",
-						body: JSON.stringify({
-							script_name: scriptName,
-							class_name: workflow.class_name,
-							...(workflow.limits && { limits: workflow.limits }),
-							...(workflow.schedules && {
-								schedules: (Array.isArray(workflow.schedules)
-									? workflow.schedules
-									: [workflow.schedules]
-								).map((cron) => ({ cron })),
+				ctx
+					.fetchResult(
+						config,
+						`/accounts/${accountId}/workflows/${workflow.name}`,
+						{
+							method: "PUT",
+							body: JSON.stringify({
+								script_name: scriptName,
+								class_name: workflow.class_name,
+								...(workflow.limits && { limits: workflow.limits }),
+								...(workflow.schedules && {
+									schedules: (Array.isArray(workflow.schedules)
+										? workflow.schedules
+										: [workflow.schedules]
+									).map((cron) => ({ cron })),
+								}),
 							}),
-						}),
-						headers: {
-							"Content-Type": "application/json",
-						},
-					}
-				).then(
-					() => ({ targets: [`workflow: ${workflow.name}`] }),
-					(error) => ({ targets: [], error })
-				)
+							headers: {
+								"Content-Type": "application/json",
+							},
+						}
+					)
+					.then(
+						() => ({ targets: [`workflow: ${workflow.name}`] }),
+						(error) => ({ targets: [], error })
+					)
 			);
 		}
 	}
 
 	const completedDeployments = await Promise.all(deployments);
 	const deployMs = Date.now() - start - uploadMs;
+
+	const workerName = props.useServiceEnvironments
+		? `${scriptName} (${envName})`
+		: scriptName;
 
 	const targets = completedDeployments
 		.flatMap((deployment) => deployment.targets)
@@ -351,12 +329,12 @@ export default async function triggersDeploy(
 			(target) => (target.endsWith("workers.dev") ? "https://" : "") + target
 		);
 	if (targets.length > 0) {
-		logger.log(`Deployed ${workerName} triggers`, formatTime(deployMs));
+		ctx.logger.log(`Deployed ${workerName} triggers`, formatTime(deployMs));
 		for (const target of targets) {
-			logger.log(" ", target);
+			ctx.logger.log(" ", target);
 		}
 	} else {
-		logger.log("No targets deployed for", workerName, formatTime(deployMs));
+		ctx.logger.log("No targets deployed for", workerName, formatTime(deployMs));
 	}
 
 	const errors = completedDeployments
@@ -437,12 +415,13 @@ export function getSubdomainValuesAPIMock(
 }
 
 async function validateSubdomainMixedState(
-	props: Props,
+	props: TriggerProps,
 	accountId: string,
 	scriptName: string,
 	before: { workers_dev: boolean; preview_urls: boolean },
 	after: { workers_dev: boolean; preview_urls: boolean },
-	firstDeploy: boolean
+	firstDeploy: boolean,
+	ctx: DeployHelpersContext
 ): Promise<{
 	workers_dev: boolean;
 	preview_urls: boolean;
@@ -478,14 +457,14 @@ async function validateSubdomainMixedState(
 		return after;
 	}
 
-	const userSubdomain = await getWorkersDevSubdomain(config, accountId, {
+	const userSubdomain = await getWorkersDevSubdomain(config, accountId, ctx, {
 		configPath: config.configPath,
 	});
 	const previewUrl = `https://<VERSION_PREFIX>-${scriptName}.${userSubdomain}`;
 
 	// Scenario 1: User disables workers.dev while having preview URLs enabled
 	if (!after.workers_dev && after.preview_urls) {
-		logger.warn(
+		ctx.logger.warn(
 			[
 				"You are disabling the 'workers.dev' subdomain for this Worker, but Preview URLs are still enabled.",
 				"Preview URLs will automatically generate a unique, shareable link for each new version which will be accessible at:",
@@ -498,7 +477,7 @@ async function validateSubdomainMixedState(
 
 	// Scenario 2: User enables workers.dev when Preview URLs are off
 	if (after.workers_dev && !after.preview_urls) {
-		logger.warn(
+		ctx.logger.warn(
 			[
 				"You are enabling the 'workers.dev' subdomain for this Worker, but Preview URLs are still disabled.",
 				"Preview URLs will automatically generate a unique, shareable link for each new version which will be accessible at:",
@@ -513,14 +492,15 @@ async function validateSubdomainMixedState(
 }
 
 async function subdomainDeploy(
-	props: Props,
+	props: TriggerProps,
 	accountId: string,
 	scriptName: string,
 	envName: string,
 	workerUrl: string,
 	routes: Route[],
 	deployments: Promise<TriggerDeployment>[],
-	firstDeploy: boolean
+	firstDeploy: boolean,
+	ctx: DeployHelpersContext
 ) {
 	const { config } = props;
 
@@ -530,9 +510,8 @@ async function subdomainDeploy(
 		getSubdomainValues(config.workers_dev, config.preview_urls, routes);
 
 	// workers.dev URL is only set if we want to deploy to workers.dev.
-
 	if (wantWorkersDev) {
-		const userSubdomain = await getWorkersDevSubdomain(config, accountId, {
+		const userSubdomain = await getWorkersDevSubdomain(config, accountId, ctx, {
 			configPath: config.configPath,
 		});
 		const workersDevURL =
@@ -543,8 +522,7 @@ async function subdomainDeploy(
 	}
 
 	// Get current subdomain enablement status.
-
-	const before = await fetchResult<{
+	const before = await ctx.fetchResult<{
 		enabled: boolean;
 		previews_enabled: boolean;
 	}>(config, `${workerUrl}/subdomain`);
@@ -552,26 +530,26 @@ async function subdomainDeploy(
 	// Update subdomain status.
 	// Occasionally this update to the subdomain endpoint fails due to some internal API error,
 	// we retry this request a few times to mitigate that.
-
-	const after = await retryOnAPIFailure(async () =>
-		fetchResult<{
-			enabled: boolean;
-			previews_enabled: boolean;
-		}>(config, `${workerUrl}/subdomain`, {
-			method: "POST",
-			body: JSON.stringify({
-				enabled: wantWorkersDev,
-				previews_enabled: wantPreviews,
+	const after = await retryOnAPIFailure(
+		async () =>
+			ctx.fetchResult<{
+				enabled: boolean;
+				previews_enabled: boolean;
+			}>(config, `${workerUrl}/subdomain`, {
+				method: "POST",
+				body: JSON.stringify({
+					enabled: wantWorkersDev,
+					previews_enabled: wantPreviews,
+				}),
+				headers: {
+					"Content-Type": "application/json",
+					"Cloudflare-Workers-Script-Api-Date": "2025-08-01",
+				},
 			}),
-			headers: {
-				"Content-Type": "application/json",
-				"Cloudflare-Workers-Script-Api-Date": "2025-08-01",
-			},
-		})
+		ctx.logger
 	);
 
 	// Warn about mismatching config and current values.
-
 	if (
 		!firstDeploy &&
 		config.workers_dev == undefined &&
@@ -584,7 +562,7 @@ async function subdomainDeploy(
 				return enabled ? "enable" : "disable";
 			}
 		};
-		logger.warn(
+		ctx.logger.warn(
 			[
 				`Because 'workers_dev' is not in your Wrangler file, it will be ${status(after.enabled, true)} for this deployment by default.`,
 				`To override this setting, you can ${status(before.enabled, false)} workers.dev by explicitly setting 'workers_dev = ${before.enabled}' in your Wrangler file.`,
@@ -604,7 +582,7 @@ async function subdomainDeploy(
 				return enabled ? "enable" : "disable";
 			}
 		};
-		logger.warn(
+		ctx.logger.warn(
 			[
 				`Because your 'workers.dev' route is ${status(after.enabled, true)} and your 'preview_urls' setting is not in your Wrangler file, Preview URLs will be ${status(after.previews_enabled, true)} for this deployment by default.`,
 				`To override this setting, you can ${status(before.previews_enabled, false)} Preview URLs by explicitly setting 'preview_urls = ${before.previews_enabled}' in your Wrangler file.`,
@@ -613,17 +591,15 @@ async function subdomainDeploy(
 	}
 
 	// Warn about mixed status.
-
 	await validateSubdomainMixedState(
 		props,
 		accountId,
 		scriptName,
 		{ workers_dev: before.enabled, preview_urls: before.previews_enabled },
 		{ workers_dev: after.enabled, preview_urls: after.previews_enabled },
-		firstDeploy
+		firstDeploy,
+		ctx
 	);
-
-	// Done.
 
 	return {
 		wantWorkersDev,

--- a/packages/deploy-helpers/src/triggers/deploy.ts
+++ b/packages/deploy-helpers/src/triggers/deploy.ts
@@ -1,7 +1,6 @@
 import {
 	formatTime,
 	getSubdomainMixedStateCheckDisabled,
-	isNonInteractiveOrCI,
 	retryOnAPIFailure,
 	UserError,
 } from "@cloudflare/workers-utils";
@@ -443,7 +442,7 @@ async function validateSubdomainMixedState(
 	}
 
 	// Early return if non-interactive or CI
-	if (isNonInteractiveOrCI()) {
+	if (ctx.isNonInteractiveOrCI()) {
 		return after;
 	}
 

--- a/packages/deploy-helpers/src/triggers/publish-routes.ts
+++ b/packages/deploy-helpers/src/triggers/publish-routes.ts
@@ -1,0 +1,375 @@
+import { ParseError, UserError } from "@cloudflare/workers-utils";
+import PQueue from "p-queue";
+import { getZoneForRoute } from "./zones";
+import type { DeployHelpersContext, TriggerDeployment } from "../shared/types";
+import type {
+	ComplianceConfig,
+	CustomDomainRoute,
+	Route,
+	ZoneIdRoute,
+	ZoneNameRoute,
+} from "@cloudflare/workers-utils";
+
+export type RouteObject = ZoneIdRoute | ZoneNameRoute | CustomDomainRoute;
+
+export type CustomDomain = {
+	id: string;
+	zone_id: string;
+	zone_name: string;
+	hostname: string;
+	service: string;
+	environment: string;
+	enabled: boolean;
+	previews_enabled: boolean;
+};
+
+type UpdatedCustomDomain = CustomDomain & { modified: boolean };
+type ConflictingCustomDomain = CustomDomain & {
+	external_dns_record_id?: string | null;
+	external_cert_id?: string;
+};
+
+export type CustomDomainChangeset = {
+	added: CustomDomain[];
+	removed: CustomDomain[];
+	updated: UpdatedCustomDomain[];
+	conflicting: ConflictingCustomDomain[];
+};
+
+export function renderRoute(route: Route): string {
+	let result = "";
+	if (typeof route === "string") {
+		result = route;
+	} else {
+		result = route.pattern;
+		const isCustomDomain = Boolean(
+			"custom_domain" in route && route.custom_domain
+		);
+		if (isCustomDomain && "zone_id" in route) {
+			result += ` (custom domain - zone id: ${route.zone_id})`;
+		} else if (isCustomDomain && "zone_name" in route) {
+			result += ` (custom domain - zone name: ${route.zone_name})`;
+		} else if (isCustomDomain) {
+			result += ` (custom domain)`;
+		} else if ("zone_id" in route) {
+			result += ` (zone id: ${route.zone_id})`;
+		} else if ("zone_name" in route) {
+			result += ` (zone name: ${route.zone_name})`;
+		}
+
+		if (isCustomDomain) {
+			const flags: string[] = [];
+			if ("enabled" in route && route.enabled !== undefined) {
+				flags.push(route.enabled ? "enabled" : "disabled");
+			}
+			if ("previews_enabled" in route && route.previews_enabled !== undefined) {
+				flags.push(
+					route.previews_enabled ? "previews: enabled" : "previews: disabled"
+				);
+			}
+			if (flags.length > 0) {
+				result += ` [${flags.join(", ")}]`;
+			}
+		}
+	}
+	return result;
+}
+
+function isAuthenticationError(e: unknown): e is ParseError {
+	return e instanceof ParseError && (e as { code?: number }).code === 10000;
+}
+
+/**
+ * Associate the newly deployed Worker with the given routes.
+ */
+export async function publishRoutes(
+	complianceConfig: ComplianceConfig,
+	routes: Route[],
+	{
+		workerUrl,
+		scriptName,
+		useServiceEnvironments,
+		accountId,
+	}: {
+		workerUrl: string;
+		scriptName: string;
+		useServiceEnvironments: boolean;
+		accountId: string;
+	},
+	ctx: DeployHelpersContext
+): Promise<string[]> {
+	try {
+		return await ctx.fetchResult(complianceConfig, `${workerUrl}/routes`, {
+			// Note: PUT will delete previous routes on this script.
+			method: "PUT",
+			body: JSON.stringify(
+				routes.map((route) =>
+					typeof route !== "object" ? { pattern: route } : route
+				)
+			),
+			headers: {
+				"Content-Type": "application/json",
+			},
+		});
+	} catch (e) {
+		if (isAuthenticationError(e)) {
+			// An authentication error is probably due to a known issue,
+			// where the user is logged in via an API token that does not have "All Zones".
+			return await publishRoutesFallback(
+				complianceConfig,
+				routes,
+				{
+					scriptName,
+					useServiceEnvironments,
+					accountId,
+				},
+				ctx
+			);
+		} else {
+			throw e;
+		}
+	}
+}
+/**
+ * Try updating routes for the Worker using a less optimal zone-based API.
+ *
+ * Compute match zones to the routes, then for each route attempt to connect it to the Worker via the zone.
+ */
+async function publishRoutesFallback(
+	complianceConfig: ComplianceConfig,
+	routes: Route[],
+	{
+		scriptName,
+		useServiceEnvironments,
+		accountId,
+	}: { scriptName: string; useServiceEnvironments: boolean; accountId: string },
+	ctx: DeployHelpersContext
+) {
+	if (useServiceEnvironments) {
+		throw new UserError(
+			"Service environments combined with an API token that doesn't have 'All Zones' permissions is not supported.\n" +
+				"Either turn off service environments by setting `legacy_env = true`, creating an API token with 'All Zones' permissions, or logging in via OAuth",
+			{
+				telemetryMessage:
+					"deploy service environments require all zones permission",
+			}
+		);
+	}
+	ctx.logger.info(
+		"The current authentication token does not have 'All Zones' permissions.\n" +
+			"Falling back to using the zone-based API endpoint to update each route individually.\n" +
+			"Note that there is no access to routes associated with zones that the API token does not have permission for.\n" +
+			"Existing routes for this Worker in such zones will not be deleted."
+	);
+
+	const deployedRoutes: string[] = [];
+
+	const queue = new PQueue({ concurrency: 10 });
+	const queuePromises: Array<Promise<void>> = [];
+	const zoneIdCache = new Map();
+
+	// Collect the routes (and their zones) that will be deployed.
+	const activeZones = new Map<string, string>();
+	const routesToDeploy = new Map<string, string>();
+	for (const route of routes) {
+		queuePromises.push(
+			queue.add(async () => {
+				const zone = await getZoneForRoute(
+					complianceConfig,
+					{ route, accountId },
+					ctx,
+					zoneIdCache
+				);
+				if (zone) {
+					activeZones.set(zone.id, zone.host);
+					routesToDeploy.set(
+						typeof route === "string" ? route : route.pattern,
+						zone.id
+					);
+				}
+			})
+		);
+	}
+	await Promise.all(queuePromises.splice(0, queuePromises.length));
+
+	// Collect the routes that are already deployed.
+	const allRoutes = new Map<string, string>();
+	const alreadyDeployedRoutes = new Set<string>();
+	for (const [zone, host] of activeZones) {
+		queuePromises.push(
+			queue.add(async () => {
+				try {
+					for (const { pattern, script } of await ctx.fetchListResult<{
+						pattern: string;
+						script: string;
+					}>(complianceConfig, `/zones/${zone}/workers/routes`)) {
+						allRoutes.set(pattern, script);
+						if (script === scriptName) {
+							alreadyDeployedRoutes.add(pattern);
+						}
+					}
+				} catch (e) {
+					if (isAuthenticationError(e)) {
+						e.notes.push({
+							text: `This could be because the API token being used does not have permission to access the zone "${host}" (${zone}).`,
+						});
+					}
+					throw e;
+				}
+			})
+		);
+	}
+	// using Promise.all() here instead of queue.onIdle() to ensure
+	// we actually throw errors that occur within queued promises.
+	await Promise.all(queuePromises);
+
+	// Deploy each route that is not already deployed.
+	for (const [routePattern, zoneId] of routesToDeploy.entries()) {
+		if (allRoutes.has(routePattern)) {
+			const knownScript = allRoutes.get(routePattern);
+			if (knownScript === scriptName) {
+				// This route is already associated with this worker, so no need to hit the API.
+				alreadyDeployedRoutes.delete(routePattern);
+				continue;
+			} else {
+				throw new UserError(
+					`The route with pattern "${routePattern}" is already associated with another worker called "${knownScript}".`,
+					{ telemetryMessage: "route already associated with another worker" }
+				);
+			}
+		}
+
+		const { pattern } = await ctx.fetchResult<{ pattern: string }>(
+			complianceConfig,
+			`/zones/${zoneId}/workers/routes`,
+			{
+				method: "POST",
+				body: JSON.stringify({
+					pattern: routePattern,
+					script: scriptName,
+				}),
+				headers: {
+					"Content-Type": "application/json",
+				},
+			}
+		);
+
+		deployedRoutes.push(pattern);
+	}
+
+	if (alreadyDeployedRoutes.size) {
+		ctx.logger.warn(
+			"Previously deployed routes:\n" +
+				"The following routes were already associated with this worker, and have not been deleted:\n" +
+				[...alreadyDeployedRoutes.values()].map((route) => ` - "${route}"\n`) +
+				"If these routes are not wanted then you can remove them in the dashboard."
+		);
+	}
+
+	return deployedRoutes;
+}
+
+export async function publishCustomDomains(
+	complianceConfig: ComplianceConfig,
+	workerUrl: string,
+	accountId: string,
+	domains: Array<RouteObject>,
+	ctx: DeployHelpersContext
+): Promise<TriggerDeployment> {
+	const options = {
+		override_scope: true,
+		override_existing_origin: false,
+		override_existing_dns_record: false,
+	};
+	const origins = domains.map((domainRoute) => {
+		return {
+			hostname: domainRoute.pattern,
+			zone_id: "zone_id" in domainRoute ? domainRoute.zone_id : undefined,
+			zone_name: "zone_name" in domainRoute ? domainRoute.zone_name : undefined,
+			enabled: "enabled" in domainRoute ? domainRoute.enabled : undefined,
+			previews_enabled:
+				"previews_enabled" in domainRoute
+					? domainRoute.previews_enabled
+					: undefined,
+		};
+	});
+
+	const fail = (): TriggerDeployment => {
+		return {
+			targets: [],
+			error: new UserError(
+				domains.length > 1
+					? `Publishing to ${domains.length} Custom Domains was skipped, fix conflicts and try again`
+					: `Publishing to Custom Domain "${domains[0].pattern}" was skipped, fix conflict and try again`,
+				{ telemetryMessage: "deploy custom domains skipped" }
+			),
+		};
+	};
+
+	if (!process.stdout.isTTY) {
+		options.override_existing_origin = true;
+		options.override_existing_dns_record = true;
+	} else {
+		const changeset = await ctx.fetchResult<CustomDomainChangeset>(
+			complianceConfig,
+			`${workerUrl}/domains/changeset?replace_state=true`,
+			{
+				method: "POST",
+				body: JSON.stringify(origins),
+				headers: {
+					"Content-Type": "application/json",
+				},
+			}
+		);
+
+		const updatesRequired = changeset.updated.filter(
+			(domain) => domain.modified
+		);
+		if (updatesRequired.length > 0) {
+			const existing = await Promise.all(
+				updatesRequired.map((domain) =>
+					ctx.fetchResult<CustomDomain>(
+						complianceConfig,
+						`/accounts/${accountId}/workers/domains/records/${domain.id}`
+					)
+				)
+			);
+			const existingRendered = existing
+				.map(
+					(domain) =>
+						`\t• ${domain.hostname} (used as a domain for "${domain.service}")`
+				)
+				.join("\n");
+			const message = `Custom Domains already exist for these domains:
+${existingRendered}
+Update them to point to this script instead?`;
+			if (!(await ctx.confirm(message))) {
+				return fail();
+			}
+			options.override_existing_origin = true;
+		}
+
+		if (changeset.conflicting.length > 0) {
+			const conflicitingRendered = changeset.conflicting
+				.map((domain) => `\t• ${domain.hostname}`)
+				.join("\n");
+			const message = `You already have DNS records that conflict for these Custom Domains:
+${conflicitingRendered}
+Update them to point to this script instead?`;
+			if (!(await ctx.confirm(message))) {
+				return fail();
+			}
+			options.override_existing_dns_record = true;
+		}
+	}
+
+	await ctx.fetchResult(complianceConfig, `${workerUrl}/domains/records`, {
+		method: "PUT",
+		body: JSON.stringify({ ...options, origins }),
+		headers: {
+			"Content-Type": "application/json",
+		},
+	});
+
+	return { targets: domains.map((domain) => renderRoute(domain)) };
+}

--- a/packages/deploy-helpers/src/triggers/queue-consumers.ts
+++ b/packages/deploy-helpers/src/triggers/queue-consumers.ts
@@ -1,0 +1,433 @@
+import { UserError } from "@cloudflare/workers-utils";
+import type { DeployHelpersContext, TriggerDeployment } from "../shared/types";
+import type { Config, ComplianceConfig } from "@cloudflare/workers-utils";
+
+export interface PostQueueBody {
+	queue_name: string;
+	settings?: QueueSettings;
+}
+
+export interface QueueSettings {
+	delivery_delay?: number;
+	delivery_paused?: boolean;
+	message_retention_period?: number;
+}
+
+export interface PostQueueResponse {
+	queue_id: string;
+	queue_name: string;
+	settings?: QueueSettings;
+	created_on: string;
+	modified_on: string;
+}
+
+export interface QueueResponse {
+	queue_id: string;
+	queue_name: string;
+	created_on: string;
+	modified_on: string;
+	producers: Producer[];
+	producers_total_count: number;
+	consumers: Consumer[];
+	consumers_total_count: number;
+	settings?: QueueSettings;
+}
+
+export interface ScriptReference {
+	namespace?: string;
+	script?: string;
+	service?: string;
+	environment?: string;
+}
+
+export type Producer = ScriptReference & {
+	type: string;
+	bucket_name?: string;
+};
+
+export type Consumer = ScriptReference & {
+	dead_letter_queue?: string;
+	settings: ConsumerSettings;
+	consumer_id: string;
+	bucket_name?: string;
+	type: string;
+};
+
+export interface TypedConsumerResponse extends Consumer {
+	queue_name: string;
+	created_on: string;
+}
+
+export interface PostTypedConsumerBody {
+	type: string;
+	script_name?: string;
+	environment_name?: string;
+	settings: ConsumerSettings;
+	dead_letter_queue?: string;
+}
+
+export interface ConsumerSettings {
+	batch_size?: number;
+	max_retries?: number;
+	max_wait_time_ms?: number;
+	max_concurrency?: number | null;
+	visibility_timeout_ms?: number;
+	retry_delay?: number;
+}
+
+export interface PurgeQueueBody {
+	delete_messages_permanently: boolean;
+}
+
+export interface PurgeQueueResponse {
+	started_at: string;
+	complete: boolean;
+}
+
+export async function listQueues(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	ctx: DeployHelpersContext,
+	page?: number,
+	name?: string
+): Promise<QueueResponse[]> {
+	page = page ?? 1;
+	const params = new URLSearchParams({ page: page.toString() });
+
+	if (name) {
+		params.append("name", name);
+	}
+
+	return ctx.fetchResult<QueueResponse[]>(
+		complianceConfig,
+		`/accounts/${accountId}/queues`,
+		{},
+		params
+	);
+}
+
+export async function getQueue(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	queueName: string,
+	ctx: DeployHelpersContext
+): Promise<QueueResponse> {
+	const queues = await listQueues(
+		complianceConfig,
+		accountId,
+		ctx,
+		1,
+		queueName
+	);
+	if (queues.length === 0) {
+		throw new UserError(
+			`Queue "${queueName}" does not exist. To create it, run: wrangler queues create ${queueName}`,
+			{ telemetryMessage: "queues lookup missing queue" }
+		);
+	}
+	return queues[0];
+}
+
+export async function postConsumer(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	queueName: string,
+	body: PostTypedConsumerBody,
+	ctx: DeployHelpersContext
+): Promise<TypedConsumerResponse> {
+	const queue = await getQueue(complianceConfig, accountId, queueName, ctx);
+	return postConsumerById(
+		complianceConfig,
+		accountId,
+		ctx,
+		queue.queue_id,
+		body
+	);
+}
+
+async function postConsumerById(
+	config: ComplianceConfig,
+	accountId: string,
+	ctx: DeployHelpersContext,
+	queueId: string,
+	body: PostTypedConsumerBody
+): Promise<TypedConsumerResponse> {
+	return ctx.fetchResult(
+		config,
+		`/accounts/${accountId}/queues/${queueId}/consumers`,
+		{
+			method: "POST",
+			body: JSON.stringify(body),
+		}
+	);
+}
+
+export async function putConsumerById(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	queueId: string,
+	consumerId: string,
+	body: PostTypedConsumerBody,
+	ctx: DeployHelpersContext
+): Promise<TypedConsumerResponse> {
+	return ctx.fetchResult(
+		complianceConfig,
+		`/accounts/${accountId}/queues/${queueId}/consumers/${consumerId}`,
+		{
+			method: "PUT",
+			body: JSON.stringify(body),
+		}
+	);
+}
+
+export async function putConsumer(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	queueName: string,
+	scriptName: string,
+	envName: string | undefined,
+	body: PostTypedConsumerBody,
+	ctx: DeployHelpersContext
+): Promise<TypedConsumerResponse> {
+	const queue = await getQueue(complianceConfig, accountId, queueName, ctx);
+	const targetConsumer = await resolveWorkerConsumerByName(
+		complianceConfig,
+		accountId,
+		scriptName,
+		envName,
+		queue,
+		ctx
+	);
+	return putConsumerById(
+		complianceConfig,
+		accountId,
+		queue.queue_id,
+		targetConsumer.consumer_id,
+		body,
+		ctx
+	);
+}
+
+async function resolveWorkerConsumerByName(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	consumerName: string,
+	envName: string | undefined,
+	queue: QueueResponse,
+	ctx: DeployHelpersContext
+): Promise<Consumer> {
+	const queueName = queue.queue_name;
+	const consumers = queue.consumers.filter(
+		(c) =>
+			c.type === "worker" &&
+			(c.script === consumerName || c.service === consumerName)
+	);
+
+	if (consumers.length === 0) {
+		throw new UserError(
+			`No worker consumer '${consumerName}' exists for queue ${queue.queue_name}`,
+			{ telemetryMessage: "queues worker consumer missing" }
+		);
+	}
+
+	// If more than a consumer with the same name is found, it should be
+	// a service+environment combination
+	if (consumers.length > 1) {
+		const targetEnv =
+			envName ??
+			(await getDefaultService(complianceConfig, accountId, consumerName, ctx));
+		const targetConsumers = consumers.filter(
+			(c) => c.environment === targetEnv
+		);
+
+		if (targetConsumers.length === 0) {
+			throw new UserError(
+				`No worker consumer '${consumerName}' exists for queue ${queueName}`,
+				{ telemetryMessage: "queues worker consumer missing environment" }
+			);
+		}
+		return consumers[0];
+	}
+
+	if (consumers[0].service) {
+		const targetEnv =
+			envName ??
+			(await getDefaultService(complianceConfig, accountId, consumerName, ctx));
+		if (targetEnv != consumers[0].environment) {
+			throw new UserError(
+				`No worker consumer '${consumerName}' exists for queue ${queueName}`,
+				{ telemetryMessage: "queues worker consumer environment mismatch" }
+			);
+		}
+	}
+	return consumers[0];
+}
+
+interface WorkerService {
+	id: string;
+	default_environment: {
+		environment: string;
+	};
+}
+
+async function getDefaultService(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	serviceName: string,
+	ctx: DeployHelpersContext
+): Promise<string> {
+	const service = await ctx.fetchResult<WorkerService>(
+		complianceConfig,
+		`/accounts/${accountId}/workers/services/${serviceName}`,
+		{
+			method: "GET",
+		}
+	);
+
+	ctx.logger.info(service);
+
+	return service.default_environment.environment;
+}
+
+async function deleteConsumerById(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	queueId: string,
+	consumerId: string,
+	ctx: DeployHelpersContext
+): Promise<void> {
+	return ctx.fetchResult(
+		complianceConfig,
+		`/accounts/${accountId}/queues/${queueId}/consumers/${consumerId}`,
+		{
+			method: "DELETE",
+		}
+	);
+}
+
+export async function deletePullConsumer(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	queueName: string,
+	ctx: DeployHelpersContext
+): Promise<void> {
+	const queue = await getQueue(complianceConfig, accountId, queueName, ctx);
+	const consumer = queue.consumers[0];
+	if (consumer?.type !== "http_pull") {
+		throw new UserError(`No http_pull consumer exists for queue ${queueName}`, {
+			telemetryMessage: "queues http pull consumer missing",
+		});
+	}
+	return deleteConsumerById(
+		complianceConfig,
+		accountId,
+		queue.queue_id,
+		consumer.consumer_id,
+		ctx
+	);
+}
+
+export async function listConsumers(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	queueName: string,
+	ctx: DeployHelpersContext
+): Promise<Consumer[]> {
+	const queue = await getQueue(complianceConfig, accountId, queueName, ctx);
+	return queue.consumers;
+}
+
+export async function deleteWorkerConsumer(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	queueName: string,
+	scriptName: string,
+	envName: string | undefined,
+	ctx: DeployHelpersContext
+): Promise<void> {
+	const queue = await getQueue(complianceConfig, accountId, queueName, ctx);
+	const targetConsumer = await resolveWorkerConsumerByName(
+		complianceConfig,
+		accountId,
+		scriptName,
+		envName,
+		queue,
+		ctx
+	);
+	return deleteConsumerById(
+		complianceConfig,
+		accountId,
+		queue.queue_id,
+		targetConsumer.consumer_id,
+		ctx
+	);
+}
+
+export async function updateQueueConsumers(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	scriptName: string,
+	config: Config,
+	ctx: DeployHelpersContext
+): Promise<Promise<TriggerDeployment>[]> {
+	const consumers = config.queues.consumers || [];
+	const updateConsumers: Promise<TriggerDeployment>[] = [];
+	for (const consumer of consumers) {
+		const queue = await getQueue(
+			complianceConfig,
+			accountId,
+			consumer.queue,
+			ctx
+		);
+
+		const body: PostTypedConsumerBody = {
+			type: "worker",
+			dead_letter_queue: consumer.dead_letter_queue,
+			script_name: scriptName,
+			settings: {
+				batch_size: consumer.max_batch_size,
+				max_retries: consumer.max_retries,
+				max_wait_time_ms:
+					consumer.max_batch_timeout !== undefined
+						? 1000 * consumer.max_batch_timeout
+						: undefined,
+				max_concurrency: consumer.max_concurrency,
+				retry_delay: consumer.retry_delay,
+			},
+		};
+
+		// Current script already assigned to queue?
+		const existingConsumer =
+			queue.consumers.filter(
+				(c) => c.script === scriptName || c.service === scriptName
+			).length > 0;
+		const envName = undefined; // TODO: script environment for wrangler deploy?
+		if (existingConsumer) {
+			updateConsumers.push(
+				putConsumer(
+					complianceConfig,
+					accountId,
+					consumer.queue,
+					scriptName,
+					envName,
+					body,
+					ctx
+				).then(
+					() => ({ targets: [`Consumer for ${consumer.queue}`] }),
+					(error) => ({ targets: [], error })
+				)
+			);
+			continue;
+		}
+		updateConsumers.push(
+			postConsumer(complianceConfig, accountId, consumer.queue, body, ctx).then(
+				() => ({
+					targets: [`Consumer for ${consumer.queue}`],
+				}),
+				(error) => ({ targets: [], error })
+			)
+		);
+	}
+
+	return updateConsumers;
+}

--- a/packages/deploy-helpers/src/triggers/queue-consumers.ts
+++ b/packages/deploy-helpers/src/triggers/queue-consumers.ts
@@ -246,7 +246,7 @@ async function resolveWorkerConsumerByName(
 				{ telemetryMessage: "queues worker consumer missing environment" }
 			);
 		}
-		return consumers[0];
+		return targetConsumers[0];
 	}
 
 	if (consumers[0].service) {

--- a/packages/deploy-helpers/src/triggers/subdomain.ts
+++ b/packages/deploy-helpers/src/triggers/subdomain.ts
@@ -4,19 +4,13 @@ import {
 	UserError,
 } from "@cloudflare/workers-utils";
 import chalk from "chalk";
-import { fetchResult } from "./cfetch";
-import { confirm, prompt } from "./dialogs";
-import { logger } from "./logger";
-import type {
-	ComplianceConfig,
-	ApiCredentials,
-} from "@cloudflare/workers-utils";
+import type { DeployHelpersContext } from "../shared/types";
+import type { ComplianceConfig } from "@cloudflare/workers-utils";
 
 type WorkersDevSubdomainRegistrationContext = "workers_dev" | "workflows";
 
 type GetWorkersDevSubdomainOptions = {
 	configPath?: string | undefined;
-	apiToken?: ApiCredentials | undefined;
 	abortSignal?: AbortSignal | undefined;
 	registrationContext?: WorkersDevSubdomainRegistrationContext | undefined;
 };
@@ -27,24 +21,23 @@ type GetWorkersDevSubdomainOptions = {
 export async function getWorkersDevSubdomain(
 	complianceConfig: ComplianceConfig,
 	accountId: string,
+	ctx: DeployHelpersContext,
 	options: GetWorkersDevSubdomainOptions = {}
 ): Promise<string> {
 	const {
 		configPath,
-		apiToken,
 		abortSignal,
 		registrationContext = "workers_dev",
 	} = options;
 
 	try {
 		// note: API docs say that this field is "name", but they're lying.
-		const { subdomain } = await fetchResult<{ subdomain: string }>(
+		const { subdomain } = await ctx.fetchResult<{ subdomain: string }>(
 			complianceConfig,
 			`/accounts/${accountId}/workers/subdomain`,
 			undefined,
 			undefined,
-			abortSignal,
-			apiToken
+			abortSignal
 		);
 		return `${subdomain}${getComplianceRegionSubdomain(complianceConfig)}.workers.dev`;
 	} catch (e) {
@@ -55,9 +48,9 @@ export async function getWorkersDevSubdomain(
 
 		// 10007 error code: not found
 		// https://api.cloudflare.com/#worker-subdomain-get-subdomain
-		logger.warn(getRegistrationWarning(registrationContext));
+		ctx.logger.warn(getRegistrationWarning(registrationContext));
 
-		const wantsToRegister = await confirm(
+		const wantsToRegister = await ctx.confirm(
 			"Would you like to register a workers.dev subdomain now?",
 			{ fallbackValue: false }
 		);
@@ -73,7 +66,8 @@ export async function getWorkersDevSubdomain(
 			complianceConfig,
 			accountId,
 			configPath,
-			registrationContext
+			registrationContext,
+			ctx
 		);
 	}
 }
@@ -124,24 +118,25 @@ async function registerSubdomain(
 	complianceConfig: ComplianceConfig,
 	accountId: string,
 	configPath: string | undefined,
-	registrationContext: WorkersDevSubdomainRegistrationContext
+	registrationContext: WorkersDevSubdomainRegistrationContext,
+	ctx: DeployHelpersContext
 ): Promise<string> {
 	let subdomain: string | undefined;
 
 	while (subdomain === undefined) {
-		const potentialName = await prompt(
+		const potentialName = await ctx.prompt(
 			"What would you like your workers.dev subdomain to be? It will be accessible at https://<subdomain>.workers.dev"
 		);
 
 		if (!/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/.test(potentialName)) {
-			logger.warn(
+			ctx.logger.warn(
 				`${potentialName} is invalid, please choose another subdomain.`
 			);
 			continue;
 		}
 
 		try {
-			await fetchResult<{ subdomain: string }>(
+			await ctx.fetchResult<{ subdomain: string }>(
 				complianceConfig,
 				`/accounts/${accountId}/workers/subdomains/${potentialName}`
 			);
@@ -156,20 +151,18 @@ async function registerSubdomain(
 					// oddly enough, this is a `subdomain_unavailable` error, meaning...that the subdomain
 					// doesn't exist. and we can register it. this is exactly how the dashboard does it.
 				} else if (subdomainAvailabilityCheckError.code === 10031) {
-					logger.error(
+					ctx.logger.error(
 						"Subdomain is unavailable, please try a different subdomain"
 					);
-
 					continue;
 				} else {
-					logger.error("An unexpected error occurred, please try again.");
-
+					ctx.logger.error("An unexpected error occurred, please try again.");
 					continue;
 				}
 			}
 		}
 
-		const ok = await confirm(
+		const ok = await ctx.confirm(
 			`Creating a workers.dev subdomain for your account at ${chalk.blue(
 				chalk.underline(
 					`https://${potentialName}${getComplianceRegionSubdomain(complianceConfig)}.workers.dev`
@@ -185,7 +178,7 @@ async function registerSubdomain(
 		}
 
 		try {
-			const result = await fetchResult<{ subdomain: string }>(
+			const result = await ctx.fetchResult<{ subdomain: string }>(
 				complianceConfig,
 				`/accounts/${accountId}/workers/subdomain`,
 				{
@@ -193,7 +186,6 @@ async function registerSubdomain(
 					body: JSON.stringify({ subdomain: potentialName }),
 				}
 			);
-
 			subdomain = result.subdomain;
 		} catch (err) {
 			const subdomainCreationError = err as { code?: number };
@@ -204,20 +196,22 @@ async function registerSubdomain(
 			) {
 				switch (subdomainCreationError.code) {
 					case 10031:
-						logger.error(
+						ctx.logger.error(
 							"Subdomain is unavailable, please try a different subdomain."
 						);
 						break;
 					default:
-						logger.error("An unexpected error occurred, please try again.");
+						ctx.logger.error("An unexpected error occurred, please try again.");
 						break;
 				}
 			}
 		}
 	}
 
-	logger.log("Success! It may take a few minutes for DNS records to update.");
-	logger.log(
+	ctx.logger.log(
+		"Success! It may take a few minutes for DNS records to update."
+	);
+	ctx.logger.log(
 		`Visit ${chalk.blue(
 			chalk.underline(
 				`https://dash.cloudflare.com/${accountId}/workers/subdomain`

--- a/packages/deploy-helpers/src/triggers/zones.ts
+++ b/packages/deploy-helpers/src/triggers/zones.ts
@@ -1,0 +1,95 @@
+import { getHostFromRoute, UserError } from "@cloudflare/workers-utils";
+import type { DeployHelpersContext } from "../shared/types";
+import type { ComplianceConfig, Route } from "@cloudflare/workers-utils";
+
+export interface Zone {
+	id: string;
+	host: string;
+}
+
+export type ZoneIdCache = Map<string, Promise<string | null>>;
+
+export async function getZoneForRoute(
+	complianceConfig: ComplianceConfig,
+	from: {
+		route: Route;
+		accountId: string;
+	},
+	ctx: DeployHelpersContext,
+	zoneIdCache: ZoneIdCache = new Map()
+): Promise<Zone | undefined> {
+	const { route, accountId } = from;
+	const host = getHostFromRoute(route);
+	let id: string | undefined;
+
+	if (typeof route === "object" && "zone_id" in route) {
+		id = route.zone_id;
+	} else if (typeof route === "object" && "zone_name" in route) {
+		id = await getZoneIdFromHost(
+			complianceConfig,
+			{ host: route.zone_name, accountId },
+			ctx,
+			zoneIdCache
+		);
+	} else if (host) {
+		id = await getZoneIdFromHost(
+			complianceConfig,
+			{ host, accountId },
+			ctx,
+			zoneIdCache
+		);
+	}
+
+	return id && host ? { id, host } : undefined;
+}
+
+/**
+ * Given something that resembles a host, try to infer a zone id from it.
+ *
+ * It's hard to get a 'valid' domain from a string, so we don't even try to validate TLDs, etc.
+ * For each domain-like part of the host (e.g. w.x.y.z) try to get a zone id for it by
+ * lopping off subdomains until we get a hit from the API.
+ */
+export async function getZoneIdFromHost(
+	complianceConfig: ComplianceConfig,
+	from: {
+		host: string;
+		accountId: string;
+	},
+	ctx: DeployHelpersContext,
+	zoneIdCache: ZoneIdCache = new Map()
+): Promise<string> {
+	const hostPieces = from.host.split(".");
+
+	while (hostPieces.length > 1) {
+		const cacheKey = `${from.accountId}:${hostPieces.join(".")}`;
+		if (!zoneIdCache.has(cacheKey)) {
+			zoneIdCache.set(
+				cacheKey,
+				ctx
+					.fetchListResult<{ id: string }>(
+						complianceConfig,
+						`/zones`,
+						{},
+						new URLSearchParams({
+							name: hostPieces.join("."),
+							"account.id": from.accountId,
+						})
+					)
+					.then((zones) => zones[0]?.id ?? null)
+			);
+		}
+
+		const cachedZone = await zoneIdCache.get(cacheKey);
+		if (cachedZone) {
+			return cachedZone;
+		}
+
+		hostPieces.shift();
+	}
+
+	throw new UserError(
+		`Could not find zone for \`${from.host}\`. Make sure the domain is set up to be proxied by Cloudflare.\nFor more details, refer to https://developers.cloudflare.com/workers/configuration/routing/routes/#set-up-a-route`,
+		{ telemetryMessage: "zones route zone not found" }
+	);
+}

--- a/packages/deploy-helpers/src/triggers/zones.ts
+++ b/packages/deploy-helpers/src/triggers/zones.ts
@@ -1,4 +1,8 @@
-import { getHostFromRoute, UserError } from "@cloudflare/workers-utils";
+import {
+	getHostFromRoute,
+	retryOnAPIFailure,
+	UserError,
+} from "@cloudflare/workers-utils";
 import type { DeployHelpersContext } from "../shared/types";
 import type { ComplianceConfig, Route } from "@cloudflare/workers-utils";
 
@@ -66,17 +70,19 @@ export async function getZoneIdFromHost(
 		if (!zoneIdCache.has(cacheKey)) {
 			zoneIdCache.set(
 				cacheKey,
-				ctx
-					.fetchListResult<{ id: string }>(
-						complianceConfig,
-						`/zones`,
-						{},
-						new URLSearchParams({
-							name: hostPieces.join("."),
-							"account.id": from.accountId,
-						})
-					)
-					.then((zones) => zones[0]?.id ?? null)
+				retryOnAPIFailure(
+					() =>
+						ctx.fetchListResult<{ id: string }>(
+							complianceConfig,
+							`/zones`,
+							{},
+							new URLSearchParams({
+								name: hostPieces.join("."),
+								"account.id": from.accountId,
+							})
+						),
+					ctx.logger
+				).then((zones) => zones[0]?.id ?? null)
 			);
 		}
 

--- a/packages/deploy-helpers/tsup.config.ts
+++ b/packages/deploy-helpers/tsup.config.ts
@@ -12,6 +12,6 @@ export default defineConfig(() => [
 		tsconfig: "tsconfig.json",
 		metafile: true,
 		sourcemap: process.env.SOURCEMAPS !== "false",
-		external: ["@cloudflare/*"],
+		external: [/^@cloudflare\//],
 	},
 ]);

--- a/packages/workers-utils/src/cfetch/index.ts
+++ b/packages/workers-utils/src/cfetch/index.ts
@@ -37,6 +37,13 @@ export type FetchResultFetcher = <ResponseType>(
 	abortSignal?: AbortSignal
 ) => Promise<ResponseType>;
 
+export type FetchListResultFetcher = <ResponseType>(
+	complianceConfig: ComplianceConfig,
+	resource: string,
+	init?: RequestInit,
+	queryParams?: URLSearchParams
+) => Promise<ResponseType[]>;
+
 function logHeaders(headers: Headers, logger: Logger): void {
 	const clone = cloneHeaders(headers);
 	clone.delete("Authorization");

--- a/packages/workers-utils/src/format-time.ts
+++ b/packages/workers-utils/src/format-time.ts
@@ -1,0 +1,3 @@
+export function formatTime(duration: number): string {
+	return `(${(duration / 1000).toFixed(2)} sec)`;
+}

--- a/packages/workers-utils/src/index.ts
+++ b/packages/workers-utils/src/index.ts
@@ -117,3 +117,6 @@ export { fetchLatestNpmVersion } from "./update-check";
 export type { NpmVersionCheckResult } from "./update-check";
 
 export type { Logger } from "./logger";
+
+export { retryOnAPIFailure } from "./retry";
+export { formatTime } from "./format-time";

--- a/packages/workers-utils/src/index.ts
+++ b/packages/workers-utils/src/index.ts
@@ -120,3 +120,8 @@ export type { Logger } from "./logger";
 
 export { retryOnAPIFailure } from "./retry";
 export { formatTime } from "./format-time";
+export {
+	getHostFromRoute,
+	getHostFromUrl,
+	getZoneFromRoute,
+} from "./route-utils";

--- a/packages/workers-utils/src/retry.ts
+++ b/packages/workers-utils/src/retry.ts
@@ -1,0 +1,45 @@
+import { setTimeout } from "node:timers/promises";
+import { APIError } from "./parse";
+import type { Logger } from "./logger";
+
+const MAX_ATTEMPTS = 3;
+
+export async function retryOnAPIFailure<T>(
+	action: () => T | Promise<T>,
+	logger: Logger,
+	backoff = 0,
+	attempts = MAX_ATTEMPTS,
+	abortSignal?: AbortSignal
+): Promise<T> {
+	try {
+		return await action();
+	} catch (err) {
+		if (err instanceof APIError) {
+			if (!err.isRetryable()) {
+				throw err;
+			}
+		} else if (err instanceof DOMException && err.name === "TimeoutError") {
+			// Per-request timeouts (from AbortSignal.timeout()) are transient
+			// and should be retried, but user-initiated aborts (AbortError)
+			// should not.
+		} else if (!(err instanceof TypeError)) {
+			throw err;
+		}
+
+		logger.debug(`Retrying API call after error...`);
+		logger.debug(err);
+
+		if (attempts <= 1) {
+			throw err;
+		}
+
+		await setTimeout(backoff, undefined, { signal: abortSignal });
+		return retryOnAPIFailure(
+			action,
+			logger,
+			backoff + 1000,
+			attempts - 1,
+			abortSignal
+		);
+	}
+}

--- a/packages/workers-utils/src/route-utils.ts
+++ b/packages/workers-utils/src/route-utils.ts
@@ -1,0 +1,84 @@
+import type { Route } from "./config/environment";
+
+/**
+ * Get the hostname on which to run a Worker.
+ *
+ * The most accurate place is usually
+ * `route.pattern`, as that includes any subdomains. For example:
+ * ```js
+ * {
+ * 	pattern: foo.example.com
+ * 	zone_name: example.com
+ * }
+ * ```
+ * However, in the case of patterns that _can't_ be parsed as a hostname
+ * (primarily the pattern `*/ /*`), we fall back to the `zone_name`
+ * (and in the absence of that return undefined).
+ * @param route
+ */
+export function getHostFromRoute(route: Route): string | undefined {
+	let host: string | undefined;
+
+	if (typeof route === "string") {
+		host = getHostFromUrl(route);
+	} else if (typeof route === "object") {
+		host = getHostFromUrl(route.pattern);
+
+		if (host === undefined && "zone_name" in route) {
+			host = getHostFromUrl(route.zone_name);
+		}
+	}
+
+	return host;
+}
+
+/**
+ * Best-effort derivation of the Cloudflare zone name that owns a given route,
+ * for use as the `CF-Worker` header value on outbound subrequests in local
+ * development (see https://developers.cloudflare.com/fundamentals/reference/http-headers/#cf-worker).
+ *
+ * In production, `CF-Worker` is set to the zone name — for a route
+ * `foo.example.com/*` on zone `example.com`, the header is `example.com`.
+ * When the user has explicitly told us the zone name in their route config
+ * (`zone_name`), use it. Otherwise, fall back to {@link getHostFromRoute},
+ * which returns the route pattern's hostname — this is the closest local
+ * approximation without performing an API lookup, and matches the behaviour
+ * users see when their route's hostname is already the apex (e.g.
+ * `example.com/*`).
+ */
+export function getZoneFromRoute(route: Route): string | undefined {
+	if (typeof route === "object" && "zone_name" in route && route.zone_name) {
+		return route.zone_name;
+	}
+	return getHostFromRoute(route);
+}
+
+/**
+ * Given something that resembles a URL, try to extract a host from it.
+ */
+export function getHostFromUrl(urlLike: string): string | undefined {
+	// if the urlLike-pattern uses a splat for the entire host and is only concerned with the pathname, we cannot infer a host
+	if (
+		urlLike.startsWith("*/") ||
+		urlLike.startsWith("http://*/") ||
+		urlLike.startsWith("https://*/")
+	) {
+		return undefined;
+	}
+
+	// if the urlLike-pattern uses a splat for the sub-domain (*.example.com) or for the root-domain (*example.com), remove the wildcard parts
+	urlLike = urlLike.replace(/\*(\.)?/g, "");
+
+	// prepend a protocol if the pattern did not specify one
+	if (!(urlLike.startsWith("http://") || urlLike.startsWith("https://"))) {
+		urlLike = "http://" + urlLike;
+	}
+
+	// now we've done our best to make urlLike a valid url string which we can pass to `new URL()` to get the host
+	// if it still isn't, return undefined to indicate we couldn't infer a host
+	try {
+		return new URL(urlLike).host;
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/wrangler/src/__tests__/deploy/helpers.ts
+++ b/packages/wrangler/src/__tests__/deploy/helpers.ts
@@ -15,8 +15,11 @@ import {
 	mswSuccessDeploymentScriptMetadata,
 } from "../helpers/msw";
 import type { AssetManifest } from "../../assets";
-import type { CustomDomain, CustomDomainChangeset } from "../../deploy/deploy";
 import type { PostTypedConsumerBody, QueueResponse } from "../../queues/client";
+import type {
+	CustomDomain,
+	CustomDomainChangeset,
+} from "@cloudflare/deploy-helpers";
 import type {
 	Config,
 	ServiceMetadataRes,

--- a/packages/wrangler/src/__tests__/deploy/workers-dev.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/workers-dev.test.ts
@@ -1,3 +1,4 @@
+import { getSubdomainValues } from "@cloudflare/deploy-helpers";
 import {
 	runInTempDir,
 	writeWranglerConfig,
@@ -10,7 +11,6 @@ import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getInstalledPackageVersion } from "../../autoconfig/frameworks/utils/packages";
 import { clearOutputFilePath } from "../../output";
-import { getSubdomainValues } from "../../triggers/deploy";
 import { fetchSecrets } from "../../utils/fetch-secrets";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";

--- a/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
@@ -1,3 +1,7 @@
+import {
+	getSubdomainValues,
+	getSubdomainValuesAPIMock,
+} from "@cloudflare/deploy-helpers";
 import { ParseError } from "@cloudflare/workers-utils";
 import { http, HttpResponse } from "msw";
 /* eslint-disable-next-line no-restricted-imports --
@@ -5,10 +9,6 @@ import { http, HttpResponse } from "msw";
  * TODO: remove this `expect` import
  */
 import { expect } from "vitest";
-import {
-	getSubdomainValues,
-	getSubdomainValuesAPIMock,
-} from "../../triggers/deploy";
 import {
 	mockGetWorkerSubdomain,
 	mockUpdateWorkerSubdomain,

--- a/packages/wrangler/src/__tests__/zones.test.ts
+++ b/packages/wrangler/src/__tests__/zones.test.ts
@@ -1,3 +1,4 @@
+import { getZoneForRoute } from "@cloudflare/deploy-helpers";
 import { COMPLIANCE_REGION_CONFIG_UNKNOWN } from "@cloudflare/workers-utils";
 import { http, HttpResponse } from "msw";
 /* eslint-disable-next-line no-restricted-imports --
@@ -5,7 +6,8 @@ import { http, HttpResponse } from "msw";
  * TODO: remove this `expect` import
  */
 import { describe, expect, it, test } from "vitest";
-import { getHostFromUrl, getZoneForRoute, getZoneFromRoute } from "../zones";
+import { createDeployHelpersContext } from "../core/deploy-helpers-context";
+import { getHostFromUrl, getZoneFromRoute } from "../zones";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { msw } from "./helpers/msw";
 
@@ -81,10 +83,14 @@ describe("Zones", () => {
 		test("string route", async () => {
 			mockGetZones("example.com", [{ id: "example-id" }]);
 			expect(
-				await getZoneForRoute(COMPLIANCE_REGION_CONFIG_UNKNOWN, {
-					route: "example.com/*",
-					accountId: "some-account-id",
-				})
+				await getZoneForRoute(
+					COMPLIANCE_REGION_CONFIG_UNKNOWN,
+					{
+						route: "example.com/*",
+						accountId: "some-account-id",
+					},
+					createDeployHelpersContext()
+				)
 			).toEqual({
 				host: "example.com",
 				id: "example-id",
@@ -94,10 +100,14 @@ describe("Zones", () => {
 		test("string route (not a zone)", async () => {
 			mockGetZones("wrong.com", []);
 			await expect(
-				getZoneForRoute(COMPLIANCE_REGION_CONFIG_UNKNOWN, {
-					route: "wrong.com/*",
-					accountId: "some-account-id",
-				})
+				getZoneForRoute(
+					COMPLIANCE_REGION_CONFIG_UNKNOWN,
+					{
+						route: "wrong.com/*",
+						accountId: "some-account-id",
+					},
+					createDeployHelpersContext()
+				)
 			).rejects.toMatchInlineSnapshot(`
 				[Error: Could not find zone for \`wrong.com\`. Make sure the domain is set up to be proxied by Cloudflare.
 				For more details, refer to https://developers.cloudflare.com/workers/configuration/routing/routes/#set-up-a-route]
@@ -108,10 +118,14 @@ describe("Zones", () => {
 			// when a zone_id is provided in the route
 			mockGetZones("example.com", [{ id: "example-id" }]);
 			expect(
-				await getZoneForRoute(COMPLIANCE_REGION_CONFIG_UNKNOWN, {
-					route: { pattern: "example.com/*", zone_id: "other-id" },
-					accountId: "some-account-id",
-				})
+				await getZoneForRoute(
+					COMPLIANCE_REGION_CONFIG_UNKNOWN,
+					{
+						route: { pattern: "example.com/*", zone_id: "other-id" },
+						accountId: "some-account-id",
+					},
+					createDeployHelpersContext()
+				)
 			).toEqual({
 				host: "example.com",
 				id: "other-id",
@@ -122,13 +136,17 @@ describe("Zones", () => {
 			// when a zone_id is provided in the route
 			mockGetZones("example.com", [{ id: "example-id" }]);
 			expect(
-				await getZoneForRoute(COMPLIANCE_REGION_CONFIG_UNKNOWN, {
-					route: {
-						pattern: "some.third-party.com/*",
-						zone_id: "other-id",
+				await getZoneForRoute(
+					COMPLIANCE_REGION_CONFIG_UNKNOWN,
+					{
+						route: {
+							pattern: "some.third-party.com/*",
+							zone_id: "other-id",
+						},
+						accountId: "some-account-id",
 					},
-					accountId: "some-account-id",
-				})
+					createDeployHelpersContext()
+				)
 			).toEqual({
 				host: "some.third-party.com",
 				id: "other-id",
@@ -138,13 +156,17 @@ describe("Zones", () => {
 		test("zone_name route (apex)", async () => {
 			mockGetZones("example.com", [{ id: "example-id" }]);
 			expect(
-				await getZoneForRoute(COMPLIANCE_REGION_CONFIG_UNKNOWN, {
-					route: {
-						pattern: "example.com/*",
-						zone_name: "example.com",
+				await getZoneForRoute(
+					COMPLIANCE_REGION_CONFIG_UNKNOWN,
+					{
+						route: {
+							pattern: "example.com/*",
+							zone_name: "example.com",
+						},
+						accountId: "some-account-id",
 					},
-					accountId: "some-account-id",
-				})
+					createDeployHelpersContext()
+				)
 			).toEqual({
 				host: "example.com",
 				id: "example-id",
@@ -153,13 +175,17 @@ describe("Zones", () => {
 		test("zone_name route (subdomain)", async () => {
 			mockGetZones("example.com", [{ id: "example-id" }]);
 			expect(
-				await getZoneForRoute(COMPLIANCE_REGION_CONFIG_UNKNOWN, {
-					route: {
-						pattern: "subdomain.example.com/*",
-						zone_name: "example.com",
+				await getZoneForRoute(
+					COMPLIANCE_REGION_CONFIG_UNKNOWN,
+					{
+						route: {
+							pattern: "subdomain.example.com/*",
+							zone_name: "example.com",
+						},
+						accountId: "some-account-id",
 					},
-					accountId: "some-account-id",
-				})
+					createDeployHelpersContext()
+				)
 			).toEqual({
 				host: "subdomain.example.com",
 				id: "example-id",
@@ -168,13 +194,17 @@ describe("Zones", () => {
 		test("zone_name route (custom hostname)", async () => {
 			mockGetZones("example.com", [{ id: "example-id" }]);
 			expect(
-				await getZoneForRoute(COMPLIANCE_REGION_CONFIG_UNKNOWN, {
-					route: {
-						pattern: "some.third-party.com/*",
-						zone_name: "example.com",
+				await getZoneForRoute(
+					COMPLIANCE_REGION_CONFIG_UNKNOWN,
+					{
+						route: {
+							pattern: "some.third-party.com/*",
+							zone_name: "example.com",
+						},
+						accountId: "some-account-id",
 					},
-					accountId: "some-account-id",
-				})
+					createDeployHelpersContext()
+				)
 			).toEqual({
 				host: "some.third-party.com",
 				id: "example-id",
@@ -278,6 +308,7 @@ describe("Zones", () => {
 						},
 						accountId: "some-account-id",
 					},
+					createDeployHelpersContext(),
 					zoneIdCache
 				)
 			).toEqual({
@@ -301,6 +332,7 @@ describe("Zones", () => {
 						},
 						accountId: "some-account-id",
 					},
+					createDeployHelpersContext(),
 					zoneIdCache
 				)
 			).toEqual({

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -16,12 +16,12 @@ import {
 	normalizeFilePath,
 } from "@cloudflare/workers-shared/utils/helpers";
 import { APIError, FatalError, UserError } from "@cloudflare/workers-utils";
+import { formatTime } from "@cloudflare/workers-utils";
 import chalk from "chalk";
 import PQueue from "p-queue";
 import prettyBytes from "pretty-bytes";
 import { FormData } from "undici";
 import { fetchResult } from "./cfetch";
-import { formatTime } from "./deploy/deploy";
 import { logger, LOGGER_LEVELS } from "./logger";
 import { hashFile } from "./pages/hash";
 import { isJwtExpired } from "./pages/upload";

--- a/packages/wrangler/src/core/deploy-helpers-context.ts
+++ b/packages/wrangler/src/core/deploy-helpers-context.ts
@@ -1,0 +1,35 @@
+import { fetchListResult, fetchResult } from "../cfetch";
+import { confirm, prompt } from "../dialogs";
+import { logger } from "../logger";
+import type { DeployHelpersContext } from "@cloudflare/deploy-helpers";
+import type { ApiCredentials } from "@cloudflare/workers-utils";
+
+/**
+ * Builds a `DeployHelpersContext` from Wrangler's singletons (logger, auth'd
+ * fetchers and interactive prompts) so that `@cloudflare/deploy-helpers`
+ * functions can be called from code paths that don't have easy access to command
+ * `HandlerContext`.
+ *
+ * An optional `apiToken` can be provided to override the credentials used by
+ * `fetchResult` (e.g. for remote preview sessions that authenticate with a
+ * per-request token rather than the global account credentials).
+ */
+export function createDeployHelpersContext(options?: {
+	apiToken?: ApiCredentials;
+}): DeployHelpersContext {
+	return {
+		fetchResult: (complianceConfig, resource, init, queryParams, abortSignal) =>
+			fetchResult(
+				complianceConfig,
+				resource,
+				init,
+				queryParams,
+				abortSignal,
+				options?.apiToken
+			),
+		fetchListResult,
+		logger,
+		confirm,
+		prompt,
+	};
+}

--- a/packages/wrangler/src/core/deploy-helpers-context.ts
+++ b/packages/wrangler/src/core/deploy-helpers-context.ts
@@ -1,5 +1,6 @@
 import { fetchListResult, fetchResult } from "../cfetch";
 import { confirm, prompt } from "../dialogs";
+import { isNonInteractiveOrCI } from "../is-interactive";
 import { logger } from "../logger";
 import type { DeployHelpersContext } from "@cloudflare/deploy-helpers";
 import type { ApiCredentials } from "@cloudflare/workers-utils";
@@ -31,5 +32,6 @@ export function createDeployHelpersContext(options?: {
 		logger,
 		confirm,
 		prompt,
+		isNonInteractiveOrCI,
 	};
 }

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -12,6 +12,7 @@ import { fetchResult, fetchListResult } from "../cfetch";
 import { createCloudflareClient } from "../cfetch/internal";
 import { readConfig } from "../config";
 import { confirm, prompt } from "../dialogs";
+import { isNonInteractiveOrCI } from "../is-interactive";
 import { run } from "../experimental-flags";
 import { logger } from "../logger";
 import { getMetricsDispatcher } from "../metrics";
@@ -269,6 +270,7 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 						fetchListResult,
 						prompt,
 						confirm,
+						isNonInteractiveOrCI,
 					});
 
 					const durationMs = Date.now() - startTime;

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -8,9 +8,10 @@ import {
 } from "@cloudflare/workers-utils";
 import chalk from "chalk";
 import { maybeInstallCloudflareSkillsGlobally } from "../agents-skills-install";
-import { fetchResult } from "../cfetch";
+import { fetchResult, fetchListResult } from "../cfetch";
 import { createCloudflareClient } from "../cfetch/internal";
 import { readConfig } from "../config";
+import { confirm, prompt } from "../dialogs";
 import { run } from "../experimental-flags";
 import { logger } from "../logger";
 import { getMetricsDispatcher } from "../metrics";
@@ -265,6 +266,9 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 						errors: { UserError, FatalError },
 						logger,
 						fetchResult,
+						fetchListResult,
+						prompt,
+						confirm,
 					});
 
 					const durationMs = Date.now() - startTime;

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -12,8 +12,8 @@ import { fetchResult, fetchListResult } from "../cfetch";
 import { createCloudflareClient } from "../cfetch/internal";
 import { readConfig } from "../config";
 import { confirm, prompt } from "../dialogs";
-import { isNonInteractiveOrCI } from "../is-interactive";
 import { run } from "../experimental-flags";
+import { isNonInteractiveOrCI } from "../is-interactive";
 import { logger } from "../logger";
 import { getMetricsDispatcher } from "../metrics";
 import {

--- a/packages/wrangler/src/core/types.ts
+++ b/packages/wrangler/src/core/types.ts
@@ -1,4 +1,5 @@
-import type { fetchResult } from "../cfetch";
+import type { fetchResult, fetchListResult } from "../cfetch";
+import type { confirm, prompt } from "../dialogs";
 import type { ExperimentalFlags } from "../experimental-flags";
 import type { Logger } from "../logger";
 import type { CommonYargsOptions, RemoveIndex } from "../yargs-types";
@@ -109,6 +110,14 @@ export type HandlerContext = {
 	 * Use fetchResult to make *auth'd* requests to the Cloudflare API.
 	 */
 	fetchResult: typeof fetchResult;
+	fetchListResult: typeof fetchListResult;
+
+	/**
+	 * Interactive prompts
+	 */
+	confirm: typeof confirm;
+	prompt: typeof prompt;
+
 	/**
 	 * Error classes provided to the command implementor as a convenience
 	 * to aid discoverability and to encourage their usage.

--- a/packages/wrangler/src/core/types.ts
+++ b/packages/wrangler/src/core/types.ts
@@ -119,6 +119,11 @@ export type HandlerContext = {
 	prompt: typeof prompt;
 
 	/**
+	 * Whether the process is non-interactive or running in CI.
+	 */
+	isNonInteractiveOrCI: () => boolean;
+
+	/**
 	 * Error classes provided to the command implementor as a convenience
 	 * to aid discoverability and to encourage their usage.
 	 */

--- a/packages/wrangler/src/deploy/config-diffs.ts
+++ b/packages/wrangler/src/deploy/config-diffs.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import { getSubdomainValuesAPIMock } from "../triggers/deploy";
+import { getSubdomainValuesAPIMock } from "@cloudflare/deploy-helpers";
 import {
 	diffJsonObjects,
 	isModifiedDiffValue,

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { URLSearchParams } from "node:url";
 import { cancel } from "@cloudflare/cli-shared-helpers";
 import { verifyDockerInstalled } from "@cloudflare/containers-shared";
+import { triggersDeploy } from "@cloudflare/deploy-helpers";
 import {
 	APIError,
 	configFileName,
@@ -16,14 +17,12 @@ import {
 	UserError,
 	formatTime,
 } from "@cloudflare/workers-utils";
-import PQueue from "p-queue";
 import { Response } from "undici";
 import { buildAssetManifest, syncAssets } from "../assets";
-import { fetchListResult, fetchResult } from "../cfetch";
+import { fetchResult } from "../cfetch";
 import { buildContainer } from "../containers/build";
 import { getNormalizedContainerOptions } from "../containers/config";
 import { deployContainers } from "../containers/deploy";
-import { isAuthenticationError } from "../core/handle-errors";
 import { getBindings, provisionBindings } from "../deployment-bundle/bindings";
 import { bundleWorker } from "../deployment-bundle/bundle";
 import { printBundleSize } from "../deployment-bundle/bundle-reporter";
@@ -35,6 +34,7 @@ import {
 } from "../deployment-bundle/module-collection";
 import { noBundleWorker } from "../deployment-bundle/no-bundle-worker";
 import { validateNodeCompatMode } from "../deployment-bundle/node-compat";
+import { validateRoutes } from "../deployment-bundle/resolve-config-args";
 import {
 	addRequiredSecretsInheritBindings,
 	handleMissingSecretsError,
@@ -52,19 +52,13 @@ import isInteractive, { isNonInteractiveOrCI } from "../is-interactive";
 import { logger } from "../logger";
 import { getMetricsUsageHeaders } from "../metrics";
 import { isNavigatorDefined } from "../navigator-user-agent";
-import {
-	ensureQueuesExistByConfig,
-	getQueue,
-	postConsumer,
-	putConsumer,
-} from "../queues/client";
+import { ensureQueuesExistByConfig } from "../queues/client";
 import { parseBulkInputToObject } from "../secret";
 import { syncWorkersSite } from "../sites";
 import {
 	getSourceMappedString,
 	maybeRetrieveFileSourceMap,
 } from "../sourcemap";
-import triggersDeploy from "../triggers/deploy";
 import { downloadWorkerConfig } from "../utils/download-worker-config";
 import { helpIfErrorIsSizeOrScriptStartup } from "../utils/friendly-validator-errors";
 import { parseConfigPlacement } from "../utils/placement";
@@ -76,29 +70,22 @@ import {
 	patchNonVersionedScriptSettings,
 } from "../versions/api";
 import { confirmLatestDeploymentOverwrite } from "../versions/deploy";
-import { getZoneForRoute } from "../zones";
 import { checkRemoteSecretsOverride } from "./check-remote-secrets-override";
 import { checkWorkflowConflicts } from "./check-workflow-conflicts";
 import { getConfigPatch, getRemoteConfigDiff } from "./config-diffs";
 import type { StartDevWorkerInput } from "../api/startDevWorker/types";
-import type { PostTypedConsumerBody } from "../queues/client";
+import type { HandlerContext } from "../core/types";
 import type { RetrieveSourceMapFunction } from "../sourcemap";
-import type { TriggerDeployment } from "../triggers/deploy";
 import type { ApiVersion, Percentage, VersionId } from "../versions/types";
 import type {
 	AssetsOptions,
 	CfModule,
 	CfScriptFormat,
 	CfWorkerInit,
-	ComplianceConfig,
 	Config,
-	CustomDomainRoute,
 	Entry,
 	LegacyAssetPaths,
 	RawConfig,
-	Route,
-	ZoneIdRoute,
-	ZoneNameRoute,
 } from "@cloudflare/workers-utils";
 import type { FormData } from "undici";
 
@@ -145,262 +132,6 @@ type Props = {
 	secretsFile: string | undefined;
 };
 
-export type RouteObject = ZoneIdRoute | ZoneNameRoute | CustomDomainRoute;
-
-export type CustomDomain = {
-	id: string;
-	zone_id: string;
-	zone_name: string;
-	hostname: string;
-	service: string;
-	environment: string;
-	enabled: boolean;
-	previews_enabled: boolean;
-};
-type UpdatedCustomDomain = CustomDomain & { modified: boolean };
-type ConflictingCustomDomain = CustomDomain & {
-	external_dns_record_id?: string;
-	external_cert_id?: string;
-};
-
-export type CustomDomainChangeset = {
-	added: CustomDomain[];
-	removed: CustomDomain[];
-	updated: UpdatedCustomDomain[];
-	conflicting: ConflictingCustomDomain[];
-};
-
-export const validateRoutes = (routes: Route[], assets?: AssetsOptions) => {
-	const invalidRoutes: Record<string, string[]> = {};
-	const mountedAssetRoutes: string[] = [];
-
-	for (const route of routes) {
-		if (typeof route !== "string" && route.custom_domain) {
-			if (route.pattern.includes("*")) {
-				invalidRoutes[route.pattern] ??= [];
-				invalidRoutes[route.pattern].push(
-					`Wildcard operators (*) are not allowed in Custom Domains`
-				);
-			}
-			if (route.pattern.includes("/")) {
-				invalidRoutes[route.pattern] ??= [];
-				invalidRoutes[route.pattern].push(
-					`Paths are not allowed in Custom Domains`
-				);
-			}
-		} else if (
-			// If we have Assets but we're not always hitting the Worker then validate
-			assets?.directory !== undefined &&
-			assets.routerConfig.invoke_user_worker_ahead_of_assets !== true
-		) {
-			const pattern = typeof route === "string" ? route : route.pattern;
-			const components = pattern.split("/");
-
-			// If this isn't `domain.com/*` then we're mounting to a path
-			if (!(components.length === 2 && components[1] === "*")) {
-				mountedAssetRoutes.push(pattern);
-			}
-		}
-	}
-	if (Object.keys(invalidRoutes).length > 0) {
-		throw new UserError(
-			`Invalid Routes:\n` +
-				Object.entries(invalidRoutes)
-					.map(([route, errors]) => `${route}:\n` + errors.join("\n"))
-					.join(`\n\n`),
-			{ telemetryMessage: "deploy invalid routes" }
-		);
-	}
-
-	if (mountedAssetRoutes.length > 0 && assets?.directory !== undefined) {
-		const relativeAssetsDir = path.relative(process.cwd(), assets.directory);
-
-		logger.once.warn(
-			`Warning: The following routes will attempt to serve Assets on a configured path:\n${mountedAssetRoutes
-				.map((route) => {
-					const routeNoScheme = route.replace(/https?:\/\//g, "");
-					const assetPath = path.join(
-						relativeAssetsDir,
-						routeNoScheme.substring(routeNoScheme.indexOf("/"))
-					);
-					return `  • ${route} (Will match assets: ${assetPath})`;
-				})
-				.join("\n")}` +
-				(assets?.routerConfig.has_user_worker
-					? "\n\nRequests not matching an asset will be forwarded to the Worker's code."
-					: "")
-		);
-	}
-};
-
-export function renderRoute(route: Route): string {
-	let result = "";
-	if (typeof route === "string") {
-		result = route;
-	} else {
-		result = route.pattern;
-		const isCustomDomain = Boolean(
-			"custom_domain" in route && route.custom_domain
-		);
-		if (isCustomDomain && "zone_id" in route) {
-			result += ` (custom domain - zone id: ${route.zone_id})`;
-		} else if (isCustomDomain && "zone_name" in route) {
-			result += ` (custom domain - zone name: ${route.zone_name})`;
-		} else if (isCustomDomain) {
-			result += ` (custom domain)`;
-		} else if ("zone_id" in route) {
-			result += ` (zone id: ${route.zone_id})`;
-		} else if ("zone_name" in route) {
-			result += ` (zone name: ${route.zone_name})`;
-		}
-
-		if (isCustomDomain) {
-			const flags: string[] = [];
-			if ("enabled" in route && route.enabled !== undefined) {
-				flags.push(route.enabled ? "enabled" : "disabled");
-			}
-			if ("previews_enabled" in route && route.previews_enabled !== undefined) {
-				flags.push(
-					route.previews_enabled ? "previews: enabled" : "previews: disabled"
-				);
-			}
-			if (flags.length > 0) {
-				result += ` [${flags.join(", ")}]`;
-			}
-		}
-	}
-	return result;
-}
-
-// publishing to custom domains involves a few more steps than just updating
-// the routing table, and thus the api implementing it is fairly defensive -
-// it will error eagerly on conflicts against existing domains or existing
-// managed DNS records
-
-// however, you can pass params to override the errors. to know if we should
-// override the current state, we generate a "changeset" of required actions
-// to get to the state we want (specified by the list of custom domains). the
-// changeset returns an "updated" collection (existing custom domains
-// connected to other scripts) and a "conflicting" collection (the requested
-// custom domains that have a managed, conflicting DNS record preventing the
-// host's use as a custom domain). with this information, we can prompt to
-// the user what will occur if we create the custom domains requested, and
-// add the override param if they confirm the action
-//
-// if a user does not confirm that they want to override, we skip publishing
-// to these custom domains, but continue on through the rest of the
-// deploy stage
-export async function publishCustomDomains(
-	complianceConfig: ComplianceConfig,
-	workerUrl: string,
-	accountId: string,
-	domains: Array<RouteObject>
-): Promise<TriggerDeployment> {
-	const options = {
-		override_scope: true,
-		override_existing_origin: false,
-		override_existing_dns_record: false,
-	};
-	const origins = domains.map((domainRoute) => {
-		return {
-			hostname: domainRoute.pattern,
-			zone_id: "zone_id" in domainRoute ? domainRoute.zone_id : undefined,
-			zone_name: "zone_name" in domainRoute ? domainRoute.zone_name : undefined,
-			enabled: "enabled" in domainRoute ? domainRoute.enabled : undefined,
-			previews_enabled:
-				"previews_enabled" in domainRoute
-					? domainRoute.previews_enabled
-					: undefined,
-		};
-	});
-
-	const fail = (): TriggerDeployment => {
-		return {
-			targets: [],
-			error: new UserError(
-				domains.length > 1
-					? `Publishing to ${domains.length} Custom Domains was skipped, fix conflicts and try again`
-					: `Publishing to Custom Domain "${domains[0].pattern}" was skipped, fix conflict and try again`,
-				{ telemetryMessage: "deploy custom domains skipped" }
-			),
-		};
-	};
-
-	if (!process.stdout.isTTY) {
-		// running in non-interactive mode.
-		// existing origins / dns records are not indicative of errors,
-		// so we aggressively update rather than aggressively fail
-		options.override_existing_origin = true;
-		options.override_existing_dns_record = true;
-	} else {
-		// get a changeset for operations required to achieve a state with the requested domains
-		const changeset = await fetchResult<CustomDomainChangeset>(
-			complianceConfig,
-			`${workerUrl}/domains/changeset?replace_state=true`,
-			{
-				method: "POST",
-				body: JSON.stringify(origins),
-				headers: {
-					"Content-Type": "application/json",
-				},
-			}
-		);
-
-		const updatesRequired = changeset.updated.filter(
-			(domain) => domain.modified
-		);
-		if (updatesRequired.length > 0) {
-			// find out which scripts the conflict domains are already attached to
-			// so we can provide that in the confirmation prompt
-			const existing = await Promise.all(
-				updatesRequired.map((domain) =>
-					fetchResult<CustomDomain>(
-						complianceConfig,
-						`/accounts/${accountId}/workers/domains/records/${domain.id}`
-					)
-				)
-			);
-			const existingRendered = existing
-				.map(
-					(domain) =>
-						`\t• ${domain.hostname} (used as a domain for "${domain.service}")`
-				)
-				.join("\n");
-			const message = `Custom Domains already exist for these domains:
-${existingRendered}
-Update them to point to this script instead?`;
-			if (!(await confirm(message))) {
-				return fail();
-			}
-			options.override_existing_origin = true;
-		}
-
-		if (changeset.conflicting.length > 0) {
-			const conflicitingRendered = changeset.conflicting
-				.map((domain) => `\t• ${domain.hostname}`)
-				.join("\n");
-			const message = `You already have DNS records that conflict for these Custom Domains:
-${conflicitingRendered}
-Update them to point to this script instead?`;
-			if (!(await confirm(message))) {
-				return fail();
-			}
-			options.override_existing_dns_record = true;
-		}
-	}
-
-	// deploy to domains
-	await fetchResult(complianceConfig, `${workerUrl}/domains/records`, {
-		method: "PUT",
-		body: JSON.stringify({ ...options, origins }),
-		headers: {
-			"Content-Type": "application/json",
-		},
-	});
-
-	return { targets: domains.map((domain) => renderRoute(domain)) };
-}
-
 /**
  * Inject bindings into the Worker to support Workers Sites. These are injected at the last minute so that
  * they don't display in the output of `printBindings()`
@@ -432,7 +163,10 @@ function addWorkersSitesBindings(
 	return withSites;
 }
 
-export default async function deploy(props: Props): Promise<{
+export default async function deploy(
+	props: Props,
+	ctx: Omit<HandlerContext, "config">
+): Promise<{
 	sourceMapSize?: number;
 	versionId: string | null;
 	workerTag: string | null;
@@ -1321,16 +1055,19 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 	}
 	assert(accountId);
 	// deploy triggers
-	const targets = await triggersDeploy({
-		config,
-		accountId,
-		scriptName,
-		env: props.env,
-		crons: props.triggers,
-		useServiceEnvironments,
-		firstDeploy: !workerExists,
-		routes: allDeploymentRoutes,
-	});
+	const targets = await triggersDeploy(
+		{
+			config,
+			accountId,
+			scriptName,
+			env: props.env,
+			crons: props.triggers || config.triggers?.crons,
+			useServiceEnvironments,
+			firstDeploy: !workerExists,
+			routes: allDeploymentRoutes,
+		},
+		ctx
+	);
 
 	logger.log("Current Version ID:", versionId);
 
@@ -1349,249 +1086,6 @@ function deployWfpUserWorker(
 	// Will go under the "Uploaded" text
 	logger.log("  Dispatch Namespace:", dispatchNamespace);
 	logger.log("Current Version ID:", versionId);
-}
-
-/**
- * Associate the newly deployed Worker with the given routes.
- */
-export async function publishRoutes(
-	complianceConfig: ComplianceConfig,
-	routes: Route[],
-	{
-		workerUrl,
-		scriptName,
-		useServiceEnvironments,
-		accountId,
-	}: {
-		workerUrl: string;
-		scriptName: string;
-		useServiceEnvironments: boolean;
-		accountId: string;
-	}
-): Promise<string[]> {
-	try {
-		return await fetchResult(complianceConfig, `${workerUrl}/routes`, {
-			// Note: PUT will delete previous routes on this script.
-			method: "PUT",
-			body: JSON.stringify(
-				routes.map((route) =>
-					typeof route !== "object" ? { pattern: route } : route
-				)
-			),
-			headers: {
-				"Content-Type": "application/json",
-			},
-		});
-	} catch (e) {
-		if (isAuthenticationError(e)) {
-			// An authentication error is probably due to a known issue,
-			// where the user is logged in via an API token that does not have "All Zones".
-			return await publishRoutesFallback(complianceConfig, routes, {
-				scriptName,
-				useServiceEnvironments,
-				accountId,
-			});
-		} else {
-			throw e;
-		}
-	}
-}
-
-/**
- * Try updating routes for the Worker using a less optimal zone-based API.
- *
- * Compute match zones to the routes, then for each route attempt to connect it to the Worker via the zone.
- */
-async function publishRoutesFallback(
-	complianceConfig: ComplianceConfig,
-	routes: Route[],
-	{
-		scriptName,
-		useServiceEnvironments,
-		accountId,
-	}: { scriptName: string; useServiceEnvironments: boolean; accountId: string }
-) {
-	if (useServiceEnvironments) {
-		throw new UserError(
-			"Service environments combined with an API token that doesn't have 'All Zones' permissions is not supported.\n" +
-				"Either turn off service environments by setting `legacy_env = true`, creating an API token with 'All Zones' permissions, or logging in via OAuth",
-			{
-				telemetryMessage:
-					"deploy service environments require all zones permission",
-			}
-		);
-	}
-	logger.info(
-		"The current authentication token does not have 'All Zones' permissions.\n" +
-			"Falling back to using the zone-based API endpoint to update each route individually.\n" +
-			"Note that there is no access to routes associated with zones that the API token does not have permission for.\n" +
-			"Existing routes for this Worker in such zones will not be deleted."
-	);
-
-	const deployedRoutes: string[] = [];
-
-	const queue = new PQueue({ concurrency: 10 });
-	const queuePromises: Array<Promise<void>> = [];
-	const zoneIdCache = new Map();
-
-	// Collect the routes (and their zones) that will be deployed.
-	const activeZones = new Map<string, string>();
-	const routesToDeploy = new Map<string, string>();
-	for (const route of routes) {
-		queuePromises.push(
-			queue.add(async () => {
-				const zone = await getZoneForRoute(
-					complianceConfig,
-					{ route, accountId },
-					zoneIdCache
-				);
-				if (zone) {
-					activeZones.set(zone.id, zone.host);
-					routesToDeploy.set(
-						typeof route === "string" ? route : route.pattern,
-						zone.id
-					);
-				}
-			})
-		);
-	}
-	await Promise.all(queuePromises.splice(0, queuePromises.length));
-
-	// Collect the routes that are already deployed.
-	const allRoutes = new Map<string, string>();
-	const alreadyDeployedRoutes = new Set<string>();
-	for (const [zone, host] of activeZones) {
-		queuePromises.push(
-			queue.add(async () => {
-				try {
-					for (const { pattern, script } of await fetchListResult<{
-						pattern: string;
-						script: string;
-					}>(complianceConfig, `/zones/${zone}/workers/routes`)) {
-						allRoutes.set(pattern, script);
-						if (script === scriptName) {
-							alreadyDeployedRoutes.add(pattern);
-						}
-					}
-				} catch (e) {
-					if (isAuthenticationError(e)) {
-						e.notes.push({
-							text: `This could be because the API token being used does not have permission to access the zone "${host}" (${zone}).`,
-						});
-					}
-					throw e;
-				}
-			})
-		);
-	}
-	// using Promise.all() here instead of queue.onIdle() to ensure
-	// we actually throw errors that occur within queued promises.
-	await Promise.all(queuePromises);
-
-	// Deploy each route that is not already deployed.
-	for (const [routePattern, zoneId] of routesToDeploy.entries()) {
-		if (allRoutes.has(routePattern)) {
-			const knownScript = allRoutes.get(routePattern);
-			if (knownScript === scriptName) {
-				// This route is already associated with this worker, so no need to hit the API.
-				alreadyDeployedRoutes.delete(routePattern);
-				continue;
-			} else {
-				throw new UserError(
-					`The route with pattern "${routePattern}" is already associated with another worker called "${knownScript}".`,
-					{ telemetryMessage: "route already associated with another worker" }
-				);
-			}
-		}
-
-		const { pattern } = await fetchResult<{ pattern: string }>(
-			complianceConfig,
-			`/zones/${zoneId}/workers/routes`,
-			{
-				method: "POST",
-				body: JSON.stringify({
-					pattern: routePattern,
-					script: scriptName,
-				}),
-				headers: {
-					"Content-Type": "application/json",
-				},
-			}
-		);
-
-		deployedRoutes.push(pattern);
-	}
-
-	if (alreadyDeployedRoutes.size) {
-		logger.warn(
-			"Previously deployed routes:\n" +
-				"The following routes were already associated with this worker, and have not been deleted:\n" +
-				[...alreadyDeployedRoutes.values()].map((route) => ` - "${route}"\n`) +
-				"If these routes are not wanted then you can remove them in the dashboard."
-		);
-	}
-
-	return deployedRoutes;
-}
-
-export async function updateQueueConsumers(
-	scriptName: string | undefined,
-	config: Config
-): Promise<Promise<TriggerDeployment>[]> {
-	const consumers = config.queues.consumers || [];
-	const updateConsumers: Promise<TriggerDeployment>[] = [];
-	for (const consumer of consumers) {
-		const queue = await getQueue(config, consumer.queue);
-
-		if (scriptName === undefined) {
-			// TODO: how can we reliably get the current script name?
-			throw new UserError("Script name is required to update queue consumers", {
-				telemetryMessage: "deploy queue consumers missing script name",
-			});
-		}
-
-		const body: PostTypedConsumerBody = {
-			type: "worker",
-			dead_letter_queue: consumer.dead_letter_queue,
-			script_name: scriptName,
-			settings: {
-				batch_size: consumer.max_batch_size,
-				max_retries: consumer.max_retries,
-				max_wait_time_ms:
-					consumer.max_batch_timeout !== undefined
-						? 1000 * consumer.max_batch_timeout
-						: undefined,
-				max_concurrency: consumer.max_concurrency,
-				retry_delay: consumer.retry_delay,
-			},
-		};
-
-		// Current script already assigned to queue?
-		const existingConsumer =
-			queue.consumers.filter(
-				(c) => c.script === scriptName || c.service === scriptName
-			).length > 0;
-		const envName = undefined; // TODO: script environment for wrangler deploy?
-		if (existingConsumer) {
-			updateConsumers.push(
-				putConsumer(config, consumer.queue, scriptName, envName, body).then(
-					() => ({ targets: [`Consumer for ${consumer.queue}`] }),
-					(error) => ({ targets: [], error })
-				)
-			);
-			continue;
-		}
-		updateConsumers.push(
-			postConsumer(config, consumer.queue, body).then(
-				() => ({
-					targets: [`Consumer for ${consumer.queue}`],
-				}),
-				(error) => ({ targets: [], error })
-			)
-		);
-	}
-
-	return updateConsumers;
 }
 
 function getDeployConfirmFunction(

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -1318,10 +1318,15 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		deployWfpUserWorker(props.dispatchNamespace, versionId);
 		return { versionId, workerTag };
 	}
-
+	assert(accountId);
 	// deploy triggers
 	const targets = await triggersDeploy({
-		...props,
+		config,
+		accountId,
+		scriptName,
+		env: props.env,
+		crons: props.triggers,
+		useServiceEnvironments,
 		firstDeploy: !workerExists,
 		routes: allDeploymentRoutes,
 	});

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -14,6 +14,7 @@ import {
 	parseNonHyphenedUuid,
 	getWranglerTmpDir,
 	UserError,
+	formatTime,
 } from "@cloudflare/workers-utils";
 import PQueue from "p-queue";
 import { Response } from "undici";
@@ -1348,10 +1349,6 @@ function deployWfpUserWorker(
 	// Will go under the "Uploaded" text
 	logger.log("  Dispatch Namespace:", dispatchNamespace);
 	logger.log("Current Version ID:", versionId);
-}
-
-export function formatTime(duration: number) {
-	return `(${(duration / 1000).toFixed(2)} sec)`;
 }
 
 /**

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -115,7 +115,7 @@ export const deployCommand = createCommand({
 	validateArgs(args) {
 		validateDeployVersionsArgs(args);
 	},
-	async handler(args, { config }) {
+	async handler(args, { config, ...ctx }) {
 		// --- Step 0. Auto-config --- //
 		const autoConfigResult = await maybeRunAutoConfig(args, config);
 		if (autoConfigResult.aborted) {
@@ -194,49 +194,52 @@ export const deployCommand = createCommand({
 		const projectRoot =
 			config.userConfigPath && path.dirname(config.userConfigPath);
 
-		const { sourceMapSize, versionId, workerTag, targets } = await deploy({
-			config,
-			accountId,
-			name,
-			rules: getRules(config),
-			entry,
-			env: args.env,
-			compatibilityDate: args.latest
-				? getTodaysCompatDate()
-				: args.compatibilityDate,
-			compatibilityFlags: args.compatibilityFlags,
-			vars: cliVars,
-			defines: cliDefines,
-			alias: cliAlias,
-			triggers: args.triggers,
-			jsxFactory: args.jsxFactory,
-			jsxFragment: args.jsxFragment,
-			tsconfig: args.tsconfig,
-			routes: args.routes,
-			domains: args.domains,
-			assetsOptions,
-			legacyAssetPaths: siteAssetPaths,
-			useServiceEnvironments: useServiceEnvironments(config),
-			minify: args.minify,
-			isWorkersSite: Boolean(args.site || config.site),
-			outDir: args.outdir,
-			outFile: args.outfile,
-			dryRun: args.dryRun,
-			metafile: args.metafile,
-			noBundle: !(args.bundle ?? !config.no_bundle),
-			keepVars: args.keepVars,
-			logpush: args.logpush,
-			uploadSourceMaps: args.uploadSourceMaps,
-			oldAssetTtl: args.oldAssetTtl,
-			projectRoot,
-			dispatchNamespace: args.dispatchNamespace,
-			experimentalAutoCreate: args.experimentalAutoCreate,
-			containersRollout: args.containersRollout,
-			strict: args.strict,
-			tag: args.tag,
-			message: args.message,
-			secretsFile: args.secretsFile,
-		});
+		const { sourceMapSize, versionId, workerTag, targets } = await deploy(
+			{
+				config,
+				accountId,
+				name,
+				rules: getRules(config),
+				entry,
+				env: args.env,
+				compatibilityDate: args.latest
+					? getTodaysCompatDate()
+					: args.compatibilityDate,
+				compatibilityFlags: args.compatibilityFlags,
+				vars: cliVars,
+				defines: cliDefines,
+				alias: cliAlias,
+				triggers: args.triggers,
+				jsxFactory: args.jsxFactory,
+				jsxFragment: args.jsxFragment,
+				tsconfig: args.tsconfig,
+				routes: args.routes,
+				domains: args.domains,
+				assetsOptions,
+				legacyAssetPaths: siteAssetPaths,
+				useServiceEnvironments: useServiceEnvironments(config),
+				minify: args.minify,
+				isWorkersSite: Boolean(args.site || config.site),
+				outDir: args.outdir,
+				outFile: args.outfile,
+				dryRun: args.dryRun,
+				metafile: args.metafile,
+				noBundle: !(args.bundle ?? !config.no_bundle),
+				keepVars: args.keepVars,
+				logpush: args.logpush,
+				uploadSourceMaps: args.uploadSourceMaps,
+				oldAssetTtl: args.oldAssetTtl,
+				projectRoot,
+				dispatchNamespace: args.dispatchNamespace,
+				experimentalAutoCreate: args.experimentalAutoCreate,
+				containersRollout: args.containersRollout,
+				strict: args.strict,
+				tag: args.tag,
+				message: args.message,
+				secretsFile: args.secretsFile,
+			},
+			ctx
+		);
 
 		writeOutput({
 			type: "deploy",

--- a/packages/wrangler/src/deployment-bundle/resolve-config-args.ts
+++ b/packages/wrangler/src/deployment-bundle/resolve-config-args.ts
@@ -1,0 +1,118 @@
+import path from "node:path";
+import { UserError } from "@cloudflare/workers-utils";
+import { getAssetsOptions } from "../assets";
+import { logger } from "../logger";
+import { getScriptName } from "../utils/getScriptName";
+import { useServiceEnvironmentApi } from "../utils/useServiceEnvironments";
+import type { triggersDeployCommand } from "../triggers";
+import type { AssetsOptions, Config, Route } from "@cloudflare/workers-utils";
+
+/**
+ * for wrangler triggers deploy - non dry-run/API calling validation and resolution
+ */
+export function resolveTriggersInput(
+	args: (typeof triggersDeployCommand)["args"] & { domains?: string[] },
+	config: Config
+) {
+	const assetsOptions = getAssetsOptions({
+		args: { assets: undefined },
+		config,
+	});
+	const scriptName = getScriptName(args, config);
+	if (!scriptName) {
+		throw new UserError(
+			'You need to provide a name when uploading a Worker Version. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`',
+			{ telemetryMessage: "triggers deploy missing worker name" }
+		);
+	}
+	const useServiceEnvironments = useServiceEnvironmentApi(args, config);
+	return {
+		crons: resolveCronTriggers(args, config),
+		useServiceEnvironments,
+		routes: resolveRoutes(args, config, assetsOptions) ?? [],
+		scriptName,
+	};
+}
+
+function resolveRoutes(
+	args: { routes?: string[]; domains?: string[] },
+	config: Config,
+	assetsOptions: AssetsOptions | undefined
+): Route[] {
+	const domainRoutes = (args.domains || []).map((domain) => ({
+		pattern: domain,
+		custom_domain: true,
+	}));
+	const routes =
+		args.routes ?? config.routes ?? (config.route ? [config.route] : []);
+	const allDeploymentRoutes = [...routes, ...domainRoutes];
+	validateRoutes(allDeploymentRoutes, assetsOptions);
+	return allDeploymentRoutes;
+}
+
+function resolveCronTriggers(args: { triggers?: string[] }, config: Config) {
+	return args.triggers ?? config.triggers?.crons;
+}
+
+const validateRoutes = (routes: Route[], assets?: AssetsOptions) => {
+	const invalidRoutes: Record<string, string[]> = {};
+	const mountedAssetRoutes: string[] = [];
+
+	for (const route of routes) {
+		if (typeof route !== "string" && route.custom_domain) {
+			if (route.pattern.includes("*")) {
+				invalidRoutes[route.pattern] ??= [];
+				invalidRoutes[route.pattern].push(
+					`Wildcard operators (*) are not allowed in Custom Domains`
+				);
+			}
+			if (route.pattern.includes("/")) {
+				invalidRoutes[route.pattern] ??= [];
+				invalidRoutes[route.pattern].push(
+					`Paths are not allowed in Custom Domains`
+				);
+			}
+		} else if (
+			// If we have Assets but we're not always hitting the Worker then validate
+			assets?.directory !== undefined &&
+			assets.routerConfig.invoke_user_worker_ahead_of_assets !== true
+		) {
+			const pattern = typeof route === "string" ? route : route.pattern;
+			const components = pattern.split("/");
+
+			// If this isn't `domain.com/*` then we're mounting to a path
+			if (!(components.length === 2 && components[1] === "*")) {
+				mountedAssetRoutes.push(pattern);
+			}
+		}
+	}
+	if (Object.keys(invalidRoutes).length > 0) {
+		throw new UserError(
+			`Invalid Routes:\n` +
+				Object.entries(invalidRoutes)
+					.map(([route, errors]) => `${route}:\n` + errors.join("\n"))
+					.join(`\n\n`),
+			{ telemetryMessage: "deploy invalid routes" }
+		);
+	}
+
+	if (mountedAssetRoutes.length > 0 && assets?.directory !== undefined) {
+		const relativeAssetsDir = path.relative(process.cwd(), assets.directory);
+
+		logger.once.warn(
+			`Warning: The following routes will attempt to serve Assets on a configured path:\n${mountedAssetRoutes
+				.map((route) => {
+					const routeNoScheme = route.replace(/https?:\/\//g, "");
+					const assetPath = path.join(
+						relativeAssetsDir,
+						routeNoScheme.substring(routeNoScheme.indexOf("/"))
+					);
+					return `  • ${route} (Will match assets: ${assetPath})`;
+				})
+				.join("\n")}` +
+				(assets?.routerConfig.has_user_worker
+					? "\n\nRequests not matching an asset will be forwarded to the Worker's code."
+					: "")
+		);
+	}
+};

--- a/packages/wrangler/src/deployment-bundle/resolve-config-args.ts
+++ b/packages/wrangler/src/deployment-bundle/resolve-config-args.ts
@@ -54,7 +54,7 @@ function resolveCronTriggers(args: { triggers?: string[] }, config: Config) {
 	return args.triggers ?? config.triggers?.crons;
 }
 
-const validateRoutes = (routes: Route[], assets?: AssetsOptions) => {
+export const validateRoutes = (routes: Route[], assets?: AssetsOptions) => {
 	const invalidRoutes: Record<string, string[]> = {};
 	const mountedAssetRoutes: string[] = [];
 

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -5,15 +5,15 @@ import {
 	formatConfigSnippet,
 	UserError,
 } from "@cloudflare/workers-utils";
+import { getHostFromRoute } from "@cloudflare/workers-utils";
 import { isWebContainer } from "@webcontainer/env";
 import { convertConfigToBindings } from "./api/startDevWorker/utils";
 import { getAssetsOptions } from "./assets";
 import { createCommand } from "./core/create-command";
-import { validateRoutes } from "./deploy/deploy";
+import { validateRoutes } from "./deployment-bundle/resolve-config-args";
 import { getVarsForDev } from "./dev/dev-vars";
 import { startDev } from "./dev/start-dev";
 import { logger } from "./logger";
-import { getHostFromRoute } from "./zones";
 import type { StartDevWorkerInput, Trigger } from "./api";
 import type { EnablePagesAssetsServiceBindingOptions } from "./miniflare-cli/types";
 import type {

--- a/packages/wrangler/src/dev/create-worker-preview.ts
+++ b/packages/wrangler/src/dev/create-worker-preview.ts
@@ -1,11 +1,12 @@
 import crypto from "node:crypto";
 import { URL } from "node:url";
+import { getWorkersDevSubdomain } from "@cloudflare/deploy-helpers";
 import { ParseError, parseJSON, UserError } from "@cloudflare/workers-utils";
 import { fetch } from "undici";
 import { fetchResult } from "../cfetch";
+import { createDeployHelpersContext } from "../core/deploy-helpers-context";
 import { createWorkerUploadForm } from "../deployment-bundle/create-worker-upload-form";
 import { logger } from "../logger";
-import { getWorkersDevSubdomain } from "../routes";
 import { getAccessHeaders } from "../user/access";
 import type { CfWorkerInitWithName } from "./remote";
 import type {
@@ -218,8 +219,8 @@ export async function createPreviewSession(
 			const subdomain = await getWorkersDevSubdomain(
 				complianceConfig,
 				account.accountId,
+				createDeployHelpersContext({ apiToken }),
 				{
-					apiToken,
 					abortSignal: withTimeout(abortSignal),
 				}
 			);

--- a/packages/wrangler/src/pages/upload.ts
+++ b/packages/wrangler/src/pages/upload.ts
@@ -5,6 +5,7 @@ import {
 	APIError,
 	COMPLIANCE_REGION_CONFIG_PUBLIC,
 	FatalError,
+	formatTime,
 	UserError,
 } from "@cloudflare/workers-utils";
 import PQueue from "p-queue";
@@ -447,10 +448,6 @@ export const maxFileCountAllowedFromClaims = (token: string): number => {
 		return MAX_ASSET_COUNT_DEFAULT;
 	}
 };
-
-function formatTime(duration: number) {
-	return `(${(duration / 1000).toFixed(2)} sec)`;
-}
 
 function renderProgress(done: number, total: number) {
 	const s = spinner();

--- a/packages/wrangler/src/queues/client.ts
+++ b/packages/wrangler/src/queues/client.ts
@@ -1,119 +1,54 @@
 import { URLSearchParams } from "node:url";
+import {
+	deletePullConsumer as deletePullConsumerImpl,
+	deleteWorkerConsumer as deleteWorkerConsumerImpl,
+	getQueue as getQueueImpl,
+	listConsumers as listConsumersImpl,
+	listQueues as listQueuesImpl,
+	postConsumer as postConsumerImpl,
+	putConsumer as putConsumerImpl,
+	putConsumerById as putConsumerByIdImpl,
+} from "@cloudflare/deploy-helpers";
 import { UserError } from "@cloudflare/workers-utils";
 import { fetchPagedListResult, fetchResult } from "../cfetch";
-import { logger } from "../logger";
+import { createDeployHelpersContext } from "../core/deploy-helpers-context";
 import { requireAuth } from "../user";
 import type {
 	CreateEventSubscriptionRequest,
 	EventSubscription,
 } from "./subscription-types";
+import type {
+	Consumer,
+	PostQueueBody,
+	PostQueueResponse,
+	PostTypedConsumerBody,
+	PurgeQueueBody,
+	QueueResponse,
+	TypedConsumerResponse,
+} from "@cloudflare/deploy-helpers";
 import type { Config } from "@cloudflare/workers-utils";
 
-export interface PostQueueBody {
-	queue_name: string;
-	settings?: QueueSettings;
-}
-
-interface WorkerService {
-	id: string;
-	default_environment: {
-		environment: string;
-	};
-}
-
-export interface QueueSettings {
-	delivery_delay?: number;
-	delivery_paused?: boolean;
-	message_retention_period?: number;
-}
-
-export interface PostQueueResponse {
-	queue_id: string;
-	queue_name: string;
-	settings?: QueueSettings;
-	created_on: string;
-	modified_on: string;
-}
-
-export interface QueueResponse {
-	queue_id: string;
-	queue_name: string;
-	created_on: string;
-	modified_on: string;
-	producers: Producer[];
-	producers_total_count: number;
-	consumers: Consumer[];
-	consumers_total_count: number;
-	settings?: QueueSettings;
-}
-
-export interface ScriptReference {
-	namespace?: string;
-	script?: string;
-	service?: string;
-	environment?: string;
-}
-
-export type Producer = ScriptReference & {
-	type: string;
-	bucket_name?: string;
-};
-
-export type Consumer = ScriptReference & {
-	dead_letter_queue?: string;
-	settings: ConsumerSettings;
-	consumer_id: string;
-	bucket_name?: string;
-	type: string;
-};
-
-export interface TypedConsumerResponse extends Consumer {
-	queue_name: string;
-	created_on: string;
-}
-
-export interface PostTypedConsumerBody {
-	type: string;
-	script_name?: string;
-	environment_name?: string;
-	settings: ConsumerSettings;
-	dead_letter_queue?: string;
-}
-
-export interface ConsumerSettings {
-	batch_size?: number;
-	max_retries?: number;
-	max_wait_time_ms?: number;
-	max_concurrency?: number | null;
-	visibility_timeout_ms?: number;
-	retry_delay?: number;
-}
-
-export interface PurgeQueueBody {
-	delete_messages_permanently: boolean;
-}
-
-export interface PurgeQueueResponse {
-	started_at: string;
-	complete: boolean;
-}
+// Queue types now live in `@cloudflare/deploy-helpers`; re-export them here so
+// existing `../client` imports across the queue commands keep working.
+export type {
+	Consumer,
+	ConsumerSettings,
+	PostQueueBody,
+	PostQueueResponse,
+	PostTypedConsumerBody,
+	Producer,
+	PurgeQueueBody,
+	PurgeQueueResponse,
+	QueueResponse,
+	QueueSettings,
+	ScriptReference,
+	TypedConsumerResponse,
+} from "@cloudflare/deploy-helpers";
 
 const queuesUrl = (accountId: string, queueId?: string): string => {
 	let url = `/accounts/${accountId}/queues`;
 	if (queueId) {
 		url += `/${queueId}`;
-	}
-	return url;
-};
-
-const queueConsumersUrl = (
-	accountId: string,
-	queueId: string,
-	consumerId?: string
-): string => {
-	let url = `${queuesUrl(accountId, queueId)}/consumers`;
-	if (consumerId) {
-		url += `/${consumerId}`;
 	}
 	return url;
 };
@@ -162,15 +97,15 @@ export async function listQueues(
 	page?: number,
 	name?: string
 ): Promise<QueueResponse[]> {
-	page = page ?? 1;
 	const accountId = await requireAuth(config);
-	const params = new URLSearchParams({ page: page.toString() });
 
-	if (name) {
-		params.append("name", name);
-	}
-
-	return fetchResult(config, queuesUrl(accountId), {}, params);
+	return listQueuesImpl(
+		config,
+		accountId,
+		createDeployHelpersContext(),
+		page,
+		name
+	);
 }
 
 async function listAllQueues(
@@ -191,14 +126,13 @@ export async function getQueue(
 	config: Config,
 	queueName: string
 ): Promise<QueueResponse> {
-	const queues = await listQueues(config, 1, queueName);
-	if (queues.length === 0) {
-		throw new UserError(
-			`Queue "${queueName}" does not exist. To create it, run: wrangler queues create ${queueName}`,
-			{ telemetryMessage: "queues lookup missing queue" }
-		);
-	}
-	return queues[0];
+	const accountId = await requireAuth(config);
+	return getQueueImpl(
+		config,
+		accountId,
+		queueName,
+		createDeployHelpersContext()
+	);
 }
 
 export async function ensureQueuesExistByConfig(config: Config) {
@@ -268,20 +202,14 @@ export async function postConsumer(
 	queueName: string,
 	body: PostTypedConsumerBody
 ): Promise<TypedConsumerResponse> {
-	const queue = await getQueue(config, queueName);
-	return postConsumerById(config, queue.queue_id, body);
-}
-
-async function postConsumerById(
-	config: Config,
-	queueId: string,
-	body: PostTypedConsumerBody
-): Promise<TypedConsumerResponse> {
 	const accountId = await requireAuth(config);
-	return fetchResult(config, queueConsumersUrl(accountId, queueId), {
-		method: "POST",
-		body: JSON.stringify(body),
-	});
+	return postConsumerImpl(
+		config,
+		accountId,
+		queueName,
+		body,
+		createDeployHelpersContext()
+	);
 }
 
 export async function putConsumerById(
@@ -291,13 +219,13 @@ export async function putConsumerById(
 	body: PostTypedConsumerBody
 ): Promise<TypedConsumerResponse> {
 	const accountId = await requireAuth(config);
-	return fetchResult(
+	return putConsumerByIdImpl(
 		config,
-		queueConsumersUrl(accountId, queueId, consumerId),
-		{
-			method: "PUT",
-			body: JSON.stringify(body),
-		}
+		accountId,
+		queueId,
+		consumerId,
+		body,
+		createDeployHelpersContext()
 	);
 }
 
@@ -308,84 +236,15 @@ export async function putConsumer(
 	envName: string | undefined,
 	body: PostTypedConsumerBody
 ): Promise<TypedConsumerResponse> {
-	const queue = await getQueue(config, queueName);
-	const targetConsumer = await resolveWorkerConsumerByName(
+	const accountId = await requireAuth(config);
+	return putConsumerImpl(
 		config,
+		accountId,
+		queueName,
 		scriptName,
 		envName,
-		queue
-	);
-	return putConsumerById(
-		config,
-		queue.queue_id,
-		targetConsumer.consumer_id,
-		body
-	);
-}
-
-async function resolveWorkerConsumerByName(
-	config: Config,
-	consumerName: string,
-	envName: string | undefined,
-	queue: QueueResponse
-): Promise<Consumer> {
-	const queueName = queue.queue_name;
-	const consumers = queue.consumers.filter(
-		(c) =>
-			c.type === "worker" &&
-			(c.script === consumerName || c.service === consumerName)
-	);
-
-	if (consumers.length === 0) {
-		throw new UserError(
-			`No worker consumer '${consumerName}' exists for queue ${queue.queue_name}`,
-			{ telemetryMessage: "queues worker consumer missing" }
-		);
-	}
-
-	// If more than a consumer with the same name is found, it should be
-	// a service+environment combination
-	if (consumers.length > 1) {
-		const targetEnv =
-			envName ?? (await getDefaultService(config, consumerName));
-		const targetConsumers = consumers.filter(
-			(c) => c.environment === targetEnv
-		);
-
-		if (targetConsumers.length === 0) {
-			throw new UserError(
-				`No worker consumer '${consumerName}' exists for queue ${queueName}`,
-				{ telemetryMessage: "queues worker consumer missing environment" }
-			);
-		}
-		return consumers[0];
-	}
-
-	if (consumers[0].service) {
-		const targetEnv =
-			envName ?? (await getDefaultService(config, consumerName));
-		if (targetEnv != consumers[0].environment) {
-			throw new UserError(
-				`No worker consumer '${consumerName}' exists for queue ${queueName}`,
-				{ telemetryMessage: "queues worker consumer environment mismatch" }
-			);
-		}
-	}
-	return consumers[0];
-}
-
-async function deleteConsumerById(
-	config: Config,
-	queueId: string,
-	consumerId: string
-): Promise<void> {
-	const accountId = await requireAuth(config);
-	return fetchResult(
-		config,
-		queueConsumersUrl(accountId, queueId, consumerId),
-		{
-			method: "DELETE",
-		}
+		body,
+		createDeployHelpersContext()
 	);
 }
 
@@ -393,40 +252,26 @@ export async function deletePullConsumer(
 	config: Config,
 	queueName: string
 ): Promise<void> {
-	const queue = await getQueue(config, queueName);
-	const consumer = queue.consumers[0];
-	if (consumer?.type !== "http_pull") {
-		throw new UserError(`No http_pull consumer exists for queue ${queueName}`, {
-			telemetryMessage: "queues http pull consumer missing",
-		});
-	}
-	return deleteConsumerById(config, queue.queue_id, consumer.consumer_id);
-}
-
-async function getDefaultService(
-	config: Config,
-	serviceName: string
-): Promise<string> {
 	const accountId = await requireAuth(config);
-	const service = await fetchResult<WorkerService>(
+	return deletePullConsumerImpl(
 		config,
-		`/accounts/${accountId}/workers/services/${serviceName}`,
-		{
-			method: "GET",
-		}
+		accountId,
+		queueName,
+		createDeployHelpersContext()
 	);
-
-	logger.info(service);
-
-	return service.default_environment.environment;
 }
 
 export async function listConsumers(
 	config: Config,
 	queueName: string
 ): Promise<Consumer[]> {
-	const queue = await getQueue(config, queueName);
-	return queue.consumers;
+	const accountId = await requireAuth(config);
+	return listConsumersImpl(
+		config,
+		accountId,
+		queueName,
+		createDeployHelpersContext()
+	);
 }
 
 export async function deleteWorkerConsumer(
@@ -435,14 +280,15 @@ export async function deleteWorkerConsumer(
 	scriptName: string,
 	envName?: string
 ): Promise<void> {
-	const queue = await getQueue(config, queueName);
-	const targetConsumer = await resolveWorkerConsumerByName(
+	const accountId = await requireAuth(config);
+	return deleteWorkerConsumerImpl(
 		config,
+		accountId,
+		queueName,
 		scriptName,
 		envName,
-		queue
+		createDeployHelpersContext()
 	);
-	return deleteConsumerById(config, queue.queue_id, targetConsumer.consumer_id);
 }
 
 export async function purgeQueue(

--- a/packages/wrangler/src/triggers/index.ts
+++ b/packages/wrangler/src/triggers/index.ts
@@ -1,10 +1,10 @@
+import { triggersDeploy } from "@cloudflare/deploy-helpers";
 import { createCommand, createNamespace } from "../core/create-command";
 import { resolveTriggersInput } from "../deployment-bundle/resolve-config-args";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { ensureQueuesExistByConfig } from "../queues/client";
 import { requireAuth } from "../user";
-import triggersDeploy from "./deploy";
 
 export const triggersNamespace = createNamespace({
 	metadata: {
@@ -61,7 +61,7 @@ export const triggersDeployCommand = createCommand({
 	behaviour: {
 		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
 	},
-	async handler(args, { config }) {
+	async handler(args, { config, ...ctx }) {
 		metrics.sendMetricsEvent("deploy worker triggers", {
 			sendMetrics: config.send_metrics,
 		});
@@ -72,15 +72,19 @@ export const triggersDeployCommand = createCommand({
 			return;
 		}
 
+		// Any validation that requires auth goes below
 		const accountId = await requireAuth(config);
 		await ensureQueuesExistByConfig(config);
 
-		await triggersDeploy({
-			config,
-			accountId,
-			env: args.env,
-			firstDeploy: false,
-			...props,
-		});
+		await triggersDeploy(
+			{
+				config,
+				accountId,
+				env: args.env,
+				firstDeploy: false,
+				...props,
+			},
+			ctx
+		);
 	},
 });

--- a/packages/wrangler/src/triggers/index.ts
+++ b/packages/wrangler/src/triggers/index.ts
@@ -1,9 +1,9 @@
-import { getAssetsOptions } from "../assets";
 import { createCommand, createNamespace } from "../core/create-command";
+import { resolveTriggersInput } from "../deployment-bundle/resolve-config-args";
+import { logger } from "../logger";
 import * as metrics from "../metrics";
+import { ensureQueuesExistByConfig } from "../queues/client";
 import { requireAuth } from "../user";
-import { getScriptName } from "../utils/getScriptName";
-import { useServiceEnvironments } from "../utils/useServiceEnvironments";
 import triggersDeploy from "./deploy";
 
 export const triggersNamespace = createNamespace({
@@ -62,27 +62,25 @@ export const triggersDeployCommand = createCommand({
 		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
 	},
 	async handler(args, { config }) {
-		const assetsOptions = getAssetsOptions({
-			args: { assets: undefined },
-			config,
-		});
 		metrics.sendMetricsEvent("deploy worker triggers", {
 			sendMetrics: config.send_metrics,
 		});
+		const props = resolveTriggersInput(args, config);
 
-		const accountId = args.dryRun ? undefined : await requireAuth(config);
+		if (args.dryRun) {
+			logger.log(`--dry-run: exiting now.`);
+			return;
+		}
+
+		const accountId = await requireAuth(config);
+		await ensureQueuesExistByConfig(config);
 
 		await triggersDeploy({
 			config,
 			accountId,
-			name: getScriptName(args, config),
 			env: args.env,
-			triggers: args.triggers,
-			routes: args.routes,
-			useServiceEnvironments: useServiceEnvironments(config),
-			dryRun: args.dryRun,
-			assetsOptions,
-			firstDeploy: false, // at this point the Worker should already exist.
+			firstDeploy: false,
+			...props,
 		});
 	},
 });

--- a/packages/wrangler/src/utils/useServiceEnvironments.ts
+++ b/packages/wrangler/src/utils/useServiceEnvironments.ts
@@ -21,3 +21,13 @@ export function useServiceEnvironments(
 		? !config.legacy_env
 		: Boolean(config.legacy.useServiceEnvironments);
 }
+
+/**
+ * even though service environments might be enabled, we might not need to use the service environments api
+ */
+export function useServiceEnvironmentApi(
+	args: { env: string | undefined },
+	config: Config
+) {
+	return Boolean(useServiceEnvironments(config) && args.env);
+}

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -14,6 +14,7 @@ import {
 	getWranglerTmpDir,
 	ParseError,
 	UserError,
+	formatTime,
 } from "@cloudflare/workers-utils";
 import { Response } from "undici";
 import {
@@ -847,10 +848,6 @@ Changes to triggers (routes, custom domains, cron schedules, etc) must be applie
 	);
 
 	return { versionId, workerTag, versionPreviewUrl, versionPreviewAliasUrl };
-}
-
-function formatTime(duration: number) {
-	return `(${(duration / 1000).toFixed(2)} sec)`;
 }
 
 // Constants for DNS label constraints and hash configuration

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { blue, gray } from "@cloudflare/cli-shared-helpers/colors";
+import { getWorkersDevSubdomain } from "@cloudflare/deploy-helpers";
 import {
 	configFileName,
 	getTodaysCompatDate,
@@ -24,6 +25,7 @@ import {
 } from "../assets";
 import { fetchResult } from "../cfetch";
 import { createCommand } from "../core/create-command";
+import { createDeployHelpersContext } from "../core/deploy-helpers-context";
 import { getBindings, provisionBindings } from "../deployment-bundle/bindings";
 import { bundleWorker } from "../deployment-bundle/bundle";
 import { printBundleSize } from "../deployment-bundle/bundle-reporter";
@@ -60,7 +62,6 @@ import * as metrics from "../metrics";
 import { isNavigatorDefined } from "../navigator-user-agent";
 import { writeOutput } from "../output";
 import { ensureQueuesExistByConfig } from "../queues/client";
-import { getWorkersDevSubdomain } from "../routes";
 import { parseBulkInputToObject } from "../secret";
 import {
 	getSourceMappedString,
@@ -821,9 +822,14 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			}>(config, `${workerUrl}/subdomain`);
 
 		if (previews_available_on_subdomain) {
-			const userSubdomain = await getWorkersDevSubdomain(config, accountId, {
-				configPath: config.configPath,
-			});
+			const userSubdomain = await getWorkersDevSubdomain(
+				config,
+				accountId,
+				createDeployHelpersContext(),
+				{
+					configPath: config.configPath,
+				}
+			);
 			const shortVersion = versionId.slice(0, 8);
 			versionPreviewUrl = `https://${shortVersion}-${workerName}.${userSubdomain}`;
 			logger.log(`Version Preview URL: ${versionPreviewUrl}`);

--- a/packages/wrangler/src/zones.ts
+++ b/packages/wrangler/src/zones.ts
@@ -1,139 +1,16 @@
+import { getZoneForRoute, getZoneIdFromHost } from "@cloudflare/deploy-helpers";
 import { configFileName, UserError } from "@cloudflare/workers-utils";
 import { fetchListResult } from "./cfetch";
-import { retryOnAPIFailure } from "./utils/retry";
+import { createDeployHelpersContext } from "./core/deploy-helpers-context";
+import type { ZoneIdCache } from "@cloudflare/deploy-helpers";
 import type { ComplianceConfig, Route } from "@cloudflare/workers-utils";
 
-/**
- * An object holding information about a zone for publishing.
- */
-export interface Zone {
-	id: string;
-	host: string;
-}
+export {
+	getHostFromRoute,
+	getHostFromUrl,
+	getZoneFromRoute,
+} from "@cloudflare/workers-utils";
 
-/**
- * Get the hostname on which to run a Worker.
- *
- * The most accurate place is usually
- * `route.pattern`, as that includes any subdomains. For example:
- * ```js
- * {
- * 	pattern: foo.example.com
- * 	zone_name: example.com
- * }
- * ```
- * However, in the case of patterns that _can't_ be parsed as a hostname
- * (primarily the pattern `*/ /*`), we fall back to the `zone_name`
- * (and in the absence of that return undefined).
- * @param route
- */
-export function getHostFromRoute(route: Route): string | undefined {
-	let host: string | undefined;
-
-	if (typeof route === "string") {
-		host = getHostFromUrl(route);
-	} else if (typeof route === "object") {
-		host = getHostFromUrl(route.pattern);
-
-		if (host === undefined && "zone_name" in route) {
-			host = getHostFromUrl(route.zone_name);
-		}
-	}
-
-	return host;
-}
-
-/**
- * Best-effort derivation of the Cloudflare zone name that owns a given route,
- * for use as the `CF-Worker` header value on outbound subrequests in local
- * development (see https://developers.cloudflare.com/fundamentals/reference/http-headers/#cf-worker).
- *
- * In production, `CF-Worker` is set to the zone name — for a route
- * `foo.example.com/*` on zone `example.com`, the header is `example.com`.
- * When the user has explicitly told us the zone name in their route config
- * (`zone_name`), use it. Otherwise, fall back to {@link getHostFromRoute},
- * which returns the route pattern's hostname — this is the closest local
- * approximation without performing an API lookup, and matches the behaviour
- * users see when their route's hostname is already the apex (e.g.
- * `example.com/*`).
- */
-export function getZoneFromRoute(route: Route): string | undefined {
-	if (typeof route === "object" && "zone_name" in route && route.zone_name) {
-		return route.zone_name;
-	}
-	return getHostFromRoute(route);
-}
-
-/**
- * Try to compute the a zone ID and host name for a route.
- *
- * When we're given a route, we do 2 things:
- * - We try to extract a host from it
- * - We try to get a zone id from the host
- */
-export async function getZoneForRoute(
-	complianceConfig: ComplianceConfig,
-	from: {
-		route: Route;
-		accountId: string;
-	},
-	zoneIdCache: ZoneIdCache = new Map()
-): Promise<Zone | undefined> {
-	const { route, accountId } = from;
-	const host = getHostFromRoute(route);
-	let id: string | undefined;
-
-	if (typeof route === "object" && "zone_id" in route) {
-		id = route.zone_id;
-	} else if (typeof route === "object" && "zone_name" in route) {
-		id = await getZoneIdFromHost(
-			complianceConfig,
-			{
-				host: route.zone_name,
-				accountId,
-			},
-			zoneIdCache
-		);
-	} else if (host) {
-		id = await getZoneIdFromHost(
-			complianceConfig,
-			{ host, accountId },
-			zoneIdCache
-		);
-	}
-
-	return id && host ? { id, host } : undefined;
-}
-
-/**
- * Given something that resembles a URL, try to extract a host from it.
- */
-export function getHostFromUrl(urlLike: string): string | undefined {
-	// if the urlLike-pattern uses a splat for the entire host and is only concerned with the pathname, we cannot infer a host
-	if (
-		urlLike.startsWith("*/") ||
-		urlLike.startsWith("http://*/") ||
-		urlLike.startsWith("https://*/")
-	) {
-		return undefined;
-	}
-
-	// if the urlLike-pattern uses a splat for the sub-domain (*.example.com) or for the root-domain (*example.com), remove the wildcard parts
-	urlLike = urlLike.replace(/\*(\.)?/g, "");
-
-	// prepend a protocol if the pattern did not specify one
-	if (!(urlLike.startsWith("http://") || urlLike.startsWith("https://"))) {
-		urlLike = "http://" + urlLike;
-	}
-
-	// now we've done our best to make urlLike a valid url string which we can pass to `new URL()` to get the host
-	// if it still isn't, return undefined to indicate we couldn't infer a host
-	try {
-		return new URL(urlLike).host;
-	} catch {
-		return undefined;
-	}
-}
 export async function getZoneIdForPreview(
 	complianceConfig: ComplianceConfig,
 	from: {
@@ -142,6 +19,7 @@ export async function getZoneIdForPreview(
 		accountId: string;
 	}
 ) {
+	const ctx = createDeployHelpersContext();
 	const zoneIdCache: ZoneIdCache = new Map();
 	const { host, routes, accountId } = from;
 	let zoneId: string | undefined;
@@ -149,6 +27,7 @@ export async function getZoneIdForPreview(
 		zoneId = await getZoneIdFromHost(
 			complianceConfig,
 			{ host, accountId },
+			ctx,
 			zoneIdCache
 		);
 	}
@@ -160,6 +39,7 @@ export async function getZoneIdForPreview(
 				route: firstRoute,
 				accountId,
 			},
+			ctx,
 			zoneIdCache
 		);
 		if (zone) {
@@ -167,61 +47,6 @@ export async function getZoneIdForPreview(
 		}
 	}
 	return zoneId;
-}
-
-/**
- * A mapping from account:host to zone id.
- */
-export type ZoneIdCache = Map<string, Promise<string | null>>;
-
-/**
- * Given something that resembles a host, try to infer a zone id from it.
- *
- * It's hard to get a 'valid' domain from a string, so we don't even try to validate TLDs, etc.
- * For each domain-like part of the host (e.g. w.x.y.z) try to get a zone id for it by
- * lopping off subdomains until we get a hit from the API.
- */
-async function getZoneIdFromHost(
-	complianceConfig: ComplianceConfig,
-	from: {
-		host: string;
-		accountId: string;
-	},
-	zoneIdCache: ZoneIdCache
-): Promise<string> {
-	const hostPieces = from.host.split(".");
-
-	while (hostPieces.length > 1) {
-		const cacheKey = `${from.accountId}:${hostPieces.join(".")}`;
-		if (!zoneIdCache.has(cacheKey)) {
-			zoneIdCache.set(
-				cacheKey,
-				retryOnAPIFailure(() =>
-					fetchListResult<{ id: string }>(
-						complianceConfig,
-						`/zones`,
-						{},
-						new URLSearchParams({
-							name: hostPieces.join("."),
-							"account.id": from.accountId,
-						})
-					)
-				).then((zones) => zones[0]?.id ?? null)
-			);
-		}
-
-		const cachedZone = await zoneIdCache.get(cacheKey);
-		if (cachedZone) {
-			return cachedZone;
-		}
-
-		hostPieces.shift();
-	}
-
-	throw new UserError(
-		`Could not find zone for \`${from.host}\`. Make sure the domain is set up to be proxied by Cloudflare.\nFor more details, refer to https://developers.cloudflare.com/workers/configuration/routing/routes/#set-up-a-route`,
-		{ telemetryMessage: "zones route zone not found" }
-	);
 }
 
 /**
@@ -300,10 +125,14 @@ export async function getWorkerForZone(
 	configPath: string | undefined
 ) {
 	const { worker, accountId } = from;
-	const zone = await getZoneForRoute(complianceConfig, {
-		route: worker,
-		accountId,
-	});
+	const zone = await getZoneForRoute(
+		complianceConfig,
+		{
+			route: worker,
+			accountId,
+		},
+		createDeployHelpersContext()
+	);
 	if (!zone) {
 		throw new UserError(
 			`The route '${worker}' is not part of one of your zones. Either add this zone from the Cloudflare dashboard, or try using a route within one of your existing zones.`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1801,12 +1801,18 @@ importers:
       '@types/node':
         specifier: 22.15.17
         version: 22.15.17
+      chalk:
+        specifier: ^5.2.0
+        version: 5.3.0
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
       miniflare:
         specifier: workspace:*
         version: link:../miniflare
+      p-queue:
+        specifier: ^9.0.0
+        version: 9.0.0
       tsup:
         specifier: 8.3.0
         version: 8.3.0(@microsoft/api-extractor@7.52.8(@types/node@22.15.17))(jiti@2.6.1)(postcss@8.5.14)(supports-color@9.2.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.1)
@@ -3888,6 +3894,9 @@ importers:
       '@vitest/ui':
         specifier: catalog:default
         version: 4.1.0(vitest@4.1.0)
+      ci-info:
+        specifier: catalog:default
+        version: 4.4.0
       cloudflare:
         specifier: ^5.2.0
         version: 5.2.0(encoding@0.1.13)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1788,6 +1788,10 @@ importers:
         version: 17.7.2
 
   packages/deploy-helpers:
+    dependencies:
+      '@cloudflare/workers-utils':
+        specifier: workspace:*
+        version: link:../workers-utils
     devDependencies:
       '@cloudflare/containers-shared':
         specifier: workspace:*
@@ -1795,9 +1799,6 @@ importers:
       '@cloudflare/workers-tsconfig':
         specifier: workspace:*
         version: link:../workers-tsconfig
-      '@cloudflare/workers-utils':
-        specifier: workspace:*
-        version: link:../workers-utils
       '@types/node':
         specifier: 22.15.17
         version: 22.15.17

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3895,9 +3895,6 @@ importers:
       '@vitest/ui':
         specifier: catalog:default
         version: 4.1.0(vitest@4.1.0)
-      ci-info:
-        specifier: catalog:default
-        version: 4.4.0
       cloudflare:
         specifier: ^5.2.0
         version: 5.2.0(encoding@0.1.13)


### PR DESCRIPTION
Extract wrangler deploy's trigger-deployment logic out of wrangler into the internal @cloudflare/deploy-helpers package, and move the shared primitives it needs into @cloudflare/workers-utils.

Move triggersDeploy and everything it depends on out of wrangler and into @cloudflare/deploy-helpers. The logger, auth'd fetchResult/fetchListResult, and interactive confirm/prompts are injected through a DeployHelpersContext. Wrangler builds that context from its existing command HandlerContext (which is now structurally compatible) or, for the handful of non-command call sites, via a small createDeployHelpersContext() glue helper.

What moved to @cloudflare/deploy-helpers:
- triggersDeploy and its private helpers (subdomainDeploy, validateSubdomainMixedState, getSubdomainValues/getSubdomainValuesAPIMock)
- Route publishing (publishRoutes, publishRoutesFallback, publishCustomDomains, renderRoute, RouteObject/CustomDomain/CustomDomainChangeset types)
- workers.dev subdomain registration (getWorkersDevSubdomain)
- Zone resolution (getZoneForRoute, getZoneIdFromHost, Zone, ZoneIdCache)
- Queue consumer operations the deploy path and queue commands share (getQueue, listQueues, postConsumer, putConsumer, putConsumerById, listConsumers, deletePullConsumer, deleteWorkerConsumer, updateQueueConsumers) plus the queue types
- DeployHelpersContext and TriggerProps/SharedDeployVersionsProps types


What moved to @cloudflare/workers-utils:
- The shared Cloudflare API fetcher type shapes (FetchResultFetcher, FetchListResultFetcher)
- retryOnAPIFailure (now takes a logger argument rather than importing wrangler's)
- formatTime
- Pure route/zone helpers with no API or logger dependency (getHostFromRoute, getHostFromUrl, getZoneFromRoute)
- The shared Logger type

What stays in wrangler:
- All yargs commands (deploy, triggers deploy, queues *, etc.)
- Auth acquisition (requireAuth, requireApiToken) and the concrete fetchResult/fetchListResult/fetchPagedListResult, logger, confirm/prompt singletons
- The full queue client (packages/wrangler/src/queues/client.ts), now thin config + requireAuth wrappers that delegate to the deploy-helpers implementations
- The wrangler-only zone helpers (getZoneIdForPreview, getWorkerForZone) and arg/config resolution (resolveTriggersInput, validateRoutes, useServiceEnvironmentApi)

How wrangler wires it up:
- HandlerContext exposes fetchResult, fetchListResult, logger, confirm, prompt, isNonInteractiveOrCI so a command handler can pass ctx straight into deploy-helpers
- createDeployHelpersContext() builds an equivalent context from wrangler singletons for code paths that don't have a HandlerContext (e.g. zones.ts, versions/upload.ts, create-worker-preview.ts), with an optional apiToken override for the remote-preview flow

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: refactor, should pass existing tests
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: refactor

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
