### PR TITLE
[wrangler] Add confirmation prompt to `containers images delete`

### DIFF
--- a/.changeset/nine-mangos-camp.md
+++ b/.changeset/nine-mangos-camp.md
@@ -1,0 +1,9 @@
+---
+"wrangler": minor
+---
+
+Add confirmation prompt to `wrangler containers images delete`
+
+Previously, running `wrangler containers images delete IMAGE:TAG` would delete the image immediately with no confirmation. The command now prompts
+for confirmation before deleting.
+Use `-y` or `--skip-confirmation` to bypass the prompt in non-interactive or scripted environments.

--- a/.changeset/nine-mangos-camp.md
+++ b/.changeset/nine-mangos-camp.md
@@ -4,6 +4,4 @@
 
 Add confirmation prompt to `wrangler containers images delete`
 
-Previously, running `wrangler containers images delete IMAGE:TAG` would delete the image immediately with no confirmation. The command now prompts
-for confirmation before deleting.
-Use `-y` or `--skip-confirmation` to bypass the prompt in non-interactive or scripted environments.
+Previously, running `wrangler containers images delete IMAGE:TAG` would delete the image immediately with no confirmation. The command now prompts for confirmation before deleting. Use `-y` or `--skip-confirmation` to bypass the prompt in non-interactive or scripted environments.

--- a/packages/wrangler/src/__tests__/containers/images.test.ts
+++ b/packages/wrangler/src/__tests__/containers/images.test.ts
@@ -2,7 +2,6 @@ import { getCloudflareContainerRegistry } from "@cloudflare/containers-shared";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it } from "vitest";
-import type { ExpectStatic } from "vitest";
 import { mockAccount, setWranglerConfig } from "../cloudchamber/utils";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockCLIOutput } from "../helpers/mock-cli-output";
@@ -11,6 +10,7 @@ import { clearDialogs, mockConfirm } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { msw } from "../helpers/msw";
 import { runWrangler } from "../helpers/run-wrangler";
+import type { ExpectStatic } from "vitest";
 
 // Helper to wrap responses in v4 API schema format for containers endpoint
 function wrapV4Response<T>(result: T) {

--- a/packages/wrangler/src/__tests__/containers/images.test.ts
+++ b/packages/wrangler/src/__tests__/containers/images.test.ts
@@ -2,9 +2,12 @@ import { getCloudflareContainerRegistry } from "@cloudflare/containers-shared";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, it } from "vitest";
+import type { ExpectStatic } from "vitest";
 import { mockAccount, setWranglerConfig } from "../cloudchamber/utils";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
+import { mockCLIOutput } from "../helpers/mock-cli-output";
 import { mockConsoleMethods } from "../helpers/mock-console";
+import { clearDialogs, mockConfirm } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { msw } from "../helpers/msw";
 import { runWrangler } from "../helpers/run-wrangler";
@@ -184,6 +187,7 @@ describe("containers images list", () => {
 
 describe("containers images delete", () => {
 	const std = mockConsoleMethods();
+	const cliStd = mockCLIOutput();
 	const { setIsTTY } = useMockIsTTY();
 
 	const REGISTRY = getCloudflareContainerRegistry();
@@ -194,6 +198,7 @@ describe("containers images delete", () => {
 	runInTempDir();
 	afterEach(() => {
 		msw.resetHandlers();
+		clearDialogs();
 	});
 
 	it("should help", async ({ expect }) => {
@@ -216,59 +221,29 @@ describe("containers images delete", () => {
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
 			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
-			  -v, --version         Show version number  [boolean]"
+			  -v, --version         Show version number  [boolean]
+
+			OPTIONS
+			  -y, --skip-confirmation  Skip confirmation prompt for deleting an image  [boolean] [default: false]"
 		`);
 	});
 
 	it("should delete images", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
-
-		msw.use(
-			http.post("*/registries/:domain/credentials", async ({ params }) => {
-				expect(params.domain).toEqual(REGISTRY);
-				return HttpResponse.json(
-					wrapV4Response({
-						account_id: "1234",
-						registry_host: REGISTRY,
-						username: "foo",
-						password: "bar",
-					})
-				);
-			}),
-			http.head("*/v2/:accountId/:image/manifests/:tag", async ({ params }) => {
-				expect(params.accountId).toEqual("some-account-id");
-				expect(params.image).toEqual("one");
-				expect(params.tag).toEqual("hundred");
-				return new HttpResponse("", {
-					status: 200,
-					headers: { "Docker-Content-Digest": "some-digest" },
-				});
-			}),
-			http.delete(
-				"*/v2/:accountId/:image/manifests/:tag",
-				async ({ params }) => {
-					expect(params.accountId).toEqual("some-account-id");
-					expect(params.image).toEqual("one");
-					expect(params.tag).toEqual("hundred");
-					return new HttpResponse("", { status: 200 });
-				}
-			),
-			http.put("*/v2/gc/layers", async () => {
-				return new HttpResponse("", { status: 200 });
-			})
-		);
+		mockDeleteImage(expect, REGISTRY);
 		await runWrangler("containers images delete one:hundred");
 		expect(std.err).toMatchInlineSnapshot(`""`);
-		expect(std.out).toMatchInlineSnapshot(
-			`"Deleted one:hundred (some-digest)"`
-		);
+		expect(std.out).toMatchInlineSnapshot(`
+			"? Are you sure you want to delete one:hundred? This action cannot be undone.
+			🤖 Using fallback value in non-interactive context: yes
+			Deleted one:hundred (some-digest)"
+		`);
 	});
 
 	it("should error when provided a repo without a tag", async ({ expect }) => {
 		setIsTTY(false);
 		setWranglerConfig({});
-
 		msw.use(
 			http.post("*/registries/:domain/credentials", async ({ params }) => {
 				expect(params.domain).toEqual(REGISTRY);
@@ -287,4 +262,102 @@ describe("containers images delete", () => {
 				[Error: Invalid image format. Expected IMAGE:TAG]
 			`);
 	});
+
+	it("should prompt for confirmation and proceed when confirmed", async ({
+		expect,
+	}) => {
+		setIsTTY(true);
+		setWranglerConfig({});
+		mockConfirm({
+			text: "Are you sure you want to delete one:hundred? This action cannot be undone.",
+			result: true,
+		});
+		mockDeleteImage(expect, REGISTRY);
+		await runWrangler("containers images delete one:hundred");
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`
+			"
+			 ⛅️ wrangler x.x.x
+			──────────────────
+			Deleted one:hundred (some-digest)"
+		`);
+	});
+
+	it("should cancel deletion when user declines", async ({ expect }) => {
+		setIsTTY(true);
+		setWranglerConfig({});
+		mockConfirm({
+			text: "Are you sure you want to delete one:hundred? This action cannot be undone.",
+			result: false,
+		});
+		await runWrangler("containers images delete one:hundred");
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		expect(cliStd.stdout).toContain("The operation has been cancelled");
+	});
+
+	it("should skip confirmation with --skip-confirmation flag", async ({
+		expect,
+	}) => {
+		setIsTTY(true);
+		setWranglerConfig({});
+		mockDeleteImage(expect, REGISTRY);
+		await runWrangler(
+			"containers images delete one:hundred --skip-confirmation"
+		);
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`
+			"
+			 ⛅️ wrangler x.x.x
+			──────────────────
+			Deleted one:hundred (some-digest)"
+		`);
+	});
+
+	it("should skip confirmation with -y flag", async ({ expect }) => {
+		setIsTTY(true);
+		setWranglerConfig({});
+		mockDeleteImage(expect, REGISTRY);
+		await runWrangler("containers images delete one:hundred -y");
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`
+			"
+			 ⛅️ wrangler x.x.x
+			──────────────────
+			Deleted one:hundred (some-digest)"
+		`);
+	});
 });
+
+function mockDeleteImage(expect: ExpectStatic, registry: string) {
+	msw.use(
+		http.post("*/registries/:domain/credentials", async ({ params }) => {
+			expect(params.domain).toEqual(registry);
+			return HttpResponse.json(
+				wrapV4Response({
+					account_id: "1234",
+					registry_host: registry,
+					username: "foo",
+					password: "bar",
+				})
+			);
+		}),
+		http.head("*/v2/:accountId/:image/manifests/:tag", async ({ params }) => {
+			expect(params.accountId).toEqual("some-account-id");
+			expect(params.image).toEqual("one");
+			expect(params.tag).toEqual("hundred");
+			return new HttpResponse("", {
+				status: 200,
+				headers: { "Docker-Content-Digest": "some-digest" },
+			});
+		}),
+		http.delete("*/v2/:accountId/:image/manifests/:tag", async ({ params }) => {
+			expect(params.accountId).toEqual("some-account-id");
+			expect(params.image).toEqual("one");
+			expect(params.tag).toEqual("hundred");
+			return new HttpResponse("", { status: 200 });
+		}),
+		http.put("*/v2/gc/layers", async () => {
+			return new HttpResponse("", { status: 200 });
+		})
+	);
+}

--- a/packages/wrangler/src/containers/images.ts
+++ b/packages/wrangler/src/containers/images.ts
@@ -1,3 +1,4 @@
+import { cancel } from "@cloudflare/cli-shared-helpers";
 import {
 	getCloudflareContainerRegistry,
 	ImageRegistriesService,
@@ -8,6 +9,7 @@ import {
 	promiseSpinner,
 } from "../cloudchamber/common";
 import { createCommand, createNamespace } from "../core/create-command";
+import { confirm } from "../dialogs";
 import { isNonInteractiveOrCI } from "../is-interactive";
 import { logger } from "../logger";
 import { getOrSelectAccountId } from "../user";
@@ -73,6 +75,12 @@ export const containersImagesDeleteCommand = createCommand({
 			description: "Image and tag to delete, of the form IMAGE:TAG",
 			demandOption: true,
 		},
+		"skip-confirmation": {
+			type: "boolean",
+			description: "Skip confirmation prompt for deleting an image",
+			alias: "y",
+			default: false,
+		},
 	},
 	positionalArgs: ["image"],
 	async handler(args, { config }) {
@@ -84,9 +92,19 @@ export const containersImagesDeleteCommand = createCommand({
 // --- Handler functions ---
 
 async function handleDeleteImageCommand(
-	args: { image: string },
+	args: { image: string; skipConfirmation: boolean },
 	config: Config
 ) {
+	if (!args.skipConfirmation) {
+		const yes = await confirm(
+			`Are you sure you want to delete ${args.image}? This action cannot be undone.`
+		);
+		if (!yes) {
+			cancel("The operation has been cancelled");
+			return;
+		}
+	}
+
 	if (!args.image.includes(":")) {
 		throw new Error("Invalid image format. Expected IMAGE:TAG");
 	}

--- a/packages/wrangler/src/containers/images.ts
+++ b/packages/wrangler/src/containers/images.ts
@@ -95,6 +95,10 @@ async function handleDeleteImageCommand(
 	args: { image: string; skipConfirmation: boolean },
 	config: Config
 ) {
+	if (!args.image.includes(":")) {
+		throw new Error("Invalid image format. Expected IMAGE:TAG");
+	}
+
 	if (!args.skipConfirmation) {
 		const yes = await confirm(
 			`Are you sure you want to delete ${args.image}? This action cannot be undone.`
@@ -103,10 +107,6 @@ async function handleDeleteImageCommand(
 			cancel("The operation has been cancelled");
 			return;
 		}
-	}
-
-	if (!args.image.includes(":")) {
-		throw new Error("Invalid image format. Expected IMAGE:TAG");
 	}
 
 	const digest = await promiseSpinner(


### PR DESCRIPTION
Fixes [CC-6324](https://jira.cfdata.org/browse/CC-6324) - wrangler: confirmation prompt before deleting an image from the registry

Add a confirmation prompt to `wrangler containers images delete` before deleting an image from the Cloudflare managed registry. Previously the command would delete immediately with no confirmation.

Users can bypass the prompt with `--skip-confirmation` or `-y` for scripted/non-interactive environments.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: confirmation prompt is self-explanatory from the CLI help output
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->