### PR TITLE
[wrangler] Detect configless Vite apps in autoconfig

### DIFF
--- a/.changeset/bright-lamps-sip.md
+++ b/.changeset/bright-lamps-sip.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Detect configless Vite projects during automatic configuration
+
+Wrangler now recognizes Vite from `package.json` when no more specific framework is detected, including before dependencies are installed. It also creates a minimal `vite.config` with the Cloudflare Vite plugin when the project does not already have one.

--- a/packages/wrangler/src/__tests__/autoconfig/details/framework-detection/basic-framework-detection.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/framework-detection/basic-framework-detection.test.ts
@@ -34,6 +34,7 @@ describe("detectFramework() / basic framework detection", () => {
 		expect,
 	}) => {
 		await seed({
+			"index.html": `<div id="app"></div>`,
 			"package.json": JSON.stringify({
 				scripts: {
 					build: "tsc && vite build",
@@ -57,6 +58,7 @@ describe("detectFramework() / basic framework detection", () => {
 		expect,
 	}) => {
 		await seed({
+			"index.html": `<div id="app"></div>`,
 			"package.json": JSON.stringify({
 				scripts: {
 					build: "tsc && vite build --outDir build",
@@ -78,6 +80,7 @@ describe("detectFramework() / basic framework detection", () => {
 		expect,
 	}) => {
 		await seed({
+			"index.html": `<div id="app"></div>`,
 			"package.json": JSON.stringify({
 				scripts: {
 					build: "tsc --outDir lib && vite build",
@@ -93,6 +96,26 @@ describe("detectFramework() / basic framework detection", () => {
 
 		expect(result.detectedFramework?.framework.id).toBe("vite");
 		expect(result.detectedFramework?.dist).toBe("dist");
+	});
+
+	it("does not detect configless vite without a root index.html", async ({
+		expect,
+	}) => {
+		await seed({
+			"package.json": JSON.stringify({
+				scripts: {
+					build: "vite build",
+				},
+				devDependencies: {
+					vite: "^8.0.12",
+				},
+			}),
+			"package-lock.json": JSON.stringify({ lockfileVersion: 3 }),
+		});
+
+		const result = await detectFramework(process.cwd());
+
+		expect(result.detectedFramework?.framework.id).toBe("static");
 	});
 
 	it("does not detect vite from package.json without a Vite script", async ({

--- a/packages/wrangler/src/__tests__/autoconfig/details/framework-detection/basic-framework-detection.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/framework-detection/basic-framework-detection.test.ts
@@ -53,6 +53,85 @@ describe("detectFramework() / basic framework detection", () => {
 		expect(result.detectedFramework?.dist).toBe("dist");
 	});
 
+	it("detects a custom Vite output directory from the build script", async ({
+		expect,
+	}) => {
+		await seed({
+			"package.json": JSON.stringify({
+				scripts: {
+					build: "tsc && vite build --outDir build",
+				},
+				devDependencies: {
+					vite: "^8.0.12",
+				},
+			}),
+			"package-lock.json": JSON.stringify({ lockfileVersion: 3 }),
+		});
+
+		const result = await detectFramework(process.cwd());
+
+		expect(result.detectedFramework?.framework.id).toBe("vite");
+		expect(result.detectedFramework?.dist).toBe("build");
+	});
+
+	it("does not use output directories from non-Vite commands", async ({
+		expect,
+	}) => {
+		await seed({
+			"package.json": JSON.stringify({
+				scripts: {
+					build: "tsc --outDir lib && vite build",
+				},
+				devDependencies: {
+					vite: "^8.0.12",
+				},
+			}),
+			"package-lock.json": JSON.stringify({ lockfileVersion: 3 }),
+		});
+
+		const result = await detectFramework(process.cwd());
+
+		expect(result.detectedFramework?.framework.id).toBe("vite");
+		expect(result.detectedFramework?.dist).toBe("dist");
+	});
+
+	it("does not detect vite from package.json without a Vite script", async ({
+		expect,
+	}) => {
+		await seed({
+			"package.json": JSON.stringify({
+				devDependencies: {
+					vite: "^8.0.12",
+				},
+			}),
+			"package-lock.json": JSON.stringify({ lockfileVersion: 3 }),
+		});
+
+		const result = await detectFramework(process.cwd());
+
+		expect(result.detectedFramework?.framework.id).toBe("static");
+	});
+
+	it("does not detect vite from package.json peerDependencies", async ({
+		expect,
+	}) => {
+		await seed({
+			"package.json": JSON.stringify({
+				scripts: {
+					build: "vite build",
+				},
+				peerDependencies: {
+					vite: "^8.0.12",
+				},
+			}),
+			"package-lock.json": JSON.stringify({ lockfileVersion: 3 }),
+		});
+
+		const result = await detectFramework(process.cwd());
+
+		expect(result.detectedFramework?.framework.id).toBe("static");
+	});
+
 	it("includes buildCommand in detectedFramework when available", async ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/__tests__/autoconfig/details/framework-detection/basic-framework-detection.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/framework-detection/basic-framework-detection.test.ts
@@ -30,6 +30,29 @@ describe("detectFramework() / basic framework detection", () => {
 		expect(result.detectedFramework?.framework.name).toBe("Astro");
 	});
 
+	it("detects vite from package.json when no framework is otherwise detected", async ({
+		expect,
+	}) => {
+		await seed({
+			"package.json": JSON.stringify({
+				scripts: {
+					build: "tsc && vite build",
+				},
+				devDependencies: {
+					vite: "^8.0.12",
+				},
+			}),
+			"package-lock.json": JSON.stringify({ lockfileVersion: 3 }),
+		});
+
+		const result = await detectFramework(process.cwd());
+
+		expect(result.detectedFramework?.framework.id).toBe("vite");
+		expect(result.detectedFramework?.framework.name).toBe("Vite");
+		expect(result.detectedFramework?.buildCommand).toBe("npm run build");
+		expect(result.detectedFramework?.dist).toBe("dist");
+	});
+
 	it("includes buildCommand in detectedFramework when available", async ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/__tests__/autoconfig/details/get-details-for-auto-config.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/details/get-details-for-auto-config.test.ts
@@ -198,6 +198,34 @@ describe("autoconfig details - getDetailsForAutoConfig()", () => {
 		});
 	});
 
+	it("should detect a Vite project from package.json when no Vite config exists", async ({
+		expect,
+	}) => {
+		await seed({
+			"index.html": '<div id="app"></div>',
+			"package-lock.json": JSON.stringify({ lockfileVersion: 3 }),
+			"package.json": JSON.stringify({
+				name: "vite-project",
+				scripts: {
+					build: "tsc && vite build",
+				},
+				devDependencies: {
+					vite: "^8.0.12",
+				},
+			}),
+		});
+
+		await expect(details.getDetailsForAutoConfig()).resolves.toMatchObject({
+			buildCommand: "npm run build",
+			configured: false,
+			framework: {
+				id: "vite",
+				name: "Vite",
+			},
+			outputDir: "dist",
+		});
+	});
+
 	it("an error should be thrown if no output dir can be detected", async ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/__tests__/autoconfig/frameworks/utils/vite-plugin.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/frameworks/utils/vite-plugin.test.ts
@@ -1,11 +1,15 @@
 import * as cliPackages from "@cloudflare/cli-shared-helpers/packages";
 import { beforeEach, describe, it, vi } from "vitest";
-import { getInstalledPackageVersion } from "../../../../autoconfig/frameworks/utils/packages";
+import {
+	getInstalledPackageVersion,
+	getPackageJsonDependencyVersion,
+} from "../../../../autoconfig/frameworks/utils/packages";
 import { installCloudflareVitePlugin } from "../../../../autoconfig/frameworks/utils/vite-plugin";
 import type { MockInstance } from "vitest";
 
 vi.mock("../../../../autoconfig/frameworks/utils/packages", () => ({
 	getInstalledPackageVersion: vi.fn(),
+	getPackageJsonDependencyVersion: vi.fn(),
 }));
 
 describe("installCloudflareVitePlugin", () => {
@@ -15,6 +19,7 @@ describe("installCloudflareVitePlugin", () => {
 		installSpy = vi
 			.spyOn(cliPackages, "installPackages")
 			.mockImplementation(async () => {});
+		vi.mocked(getPackageJsonDependencyVersion).mockReturnValue(undefined);
 	});
 
 	describe("when Vite is not installed/detected", () => {
@@ -101,6 +106,27 @@ describe("installCloudflareVitePlugin", () => {
 				2,
 				"npm",
 				["@cloudflare/vite-plugin"],
+				expect.objectContaining({ dev: true })
+			);
+		});
+
+		it("upgrades Vite when only package.json declares version 6.0.0", async ({
+			expect,
+		}) => {
+			vi.mocked(getInstalledPackageVersion).mockReturnValue(undefined);
+			vi.mocked(getPackageJsonDependencyVersion).mockReturnValue("6.0.0");
+
+			await installCloudflareVitePlugin({
+				packageManager: "npm",
+				projectPath: "/test/project",
+				isWorkspaceRoot: false,
+			});
+
+			expect(installSpy).toHaveBeenCalledTimes(2);
+			expect(installSpy).toHaveBeenNthCalledWith(
+				1,
+				"npm",
+				["vite@^6.1.0"],
 				expect.objectContaining({ dev: true })
 			);
 		});
@@ -281,7 +307,8 @@ describe("installCloudflareVitePlugin", () => {
 
 			expect(getInstalledPackageVersion).toHaveBeenCalledWith(
 				"vite",
-				"/custom/path"
+				"/custom/path",
+				{ stopAtProjectPath: true }
 			);
 		});
 	});

--- a/packages/wrangler/src/__tests__/autoconfig/frameworks/vite.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/frameworks/vite.test.ts
@@ -1,7 +1,9 @@
+import { existsSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
-import { describe, it, vi } from "vitest";
+import { beforeEach, describe, it, vi } from "vitest";
 import { AutoConfigFrameworkConfigurationError } from "../../../autoconfig/errors";
+import { getPackageJsonDependencyVersion } from "../../../autoconfig/frameworks/utils/packages";
 import { installCloudflareVitePlugin } from "../../../autoconfig/frameworks/utils/vite-plugin";
 import { Vite } from "../../../autoconfig/frameworks/vite";
 import { NpmPackageManager } from "../../../package-manager";
@@ -12,6 +14,7 @@ vi.mock("../../../autoconfig/frameworks/utils/vite-plugin", () => ({
 
 vi.mock("../../../autoconfig/frameworks/utils/packages", () => ({
 	getInstalledPackageVersion: vi.fn(() => undefined),
+	getPackageJsonDependencyVersion: vi.fn(() => undefined),
 }));
 
 const VITE_PACKAGE_INFO = {
@@ -34,17 +37,15 @@ function getBaseOptions() {
 describe("Vite framework", () => {
 	runInTempDir();
 
-	it("validates the Vite version from package.json when dependencies are not installed", async ({
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(getPackageJsonDependencyVersion).mockReturnValue(undefined);
+	});
+
+	it("validates the Vite version from package.json when dependencies are not installed", ({
 		expect,
 	}) => {
-		await writeFile(
-			"package.json",
-			JSON.stringify({
-				devDependencies: {
-					vite: "^8.0.12",
-				},
-			})
-		);
+		vi.mocked(getPackageJsonDependencyVersion).mockReturnValue("8.0.12");
 
 		const framework = new Vite({ id: "vite", name: "Vite" });
 		expect(() =>
@@ -53,17 +54,10 @@ describe("Vite framework", () => {
 		expect(framework.frameworkVersion).toBe("8.0.12");
 	});
 
-	it("rejects unsupported Vite versions declared in package.json", async ({
+	it("rejects unsupported Vite versions declared in package.json", ({
 		expect,
 	}) => {
-		await writeFile(
-			"package.json",
-			JSON.stringify({
-				devDependencies: {
-					vite: "^5.4.0",
-				},
-			})
-		);
+		vi.mocked(getPackageJsonDependencyVersion).mockReturnValue("5.4.0");
 
 		const framework = new Vite({ id: "vite", name: "Vite" });
 		expect(() =>
@@ -89,5 +83,28 @@ describe("Vite framework", () => {
 			isWorkspaceRoot: false,
 			projectPath: process.cwd(),
 		});
+	});
+
+	it("does not create a duplicate Vite config when an unsupported config exists", async ({
+		expect,
+	}) => {
+		await writeFile(
+			"vite.config.cjs",
+			`
+const { defineConfig } = require("vite");
+
+module.exports = defineConfig({
+  plugins: [],
+});
+`
+		);
+
+		const framework = new Vite({ id: "vite", name: "Vite" });
+		await expect(framework.configure(getBaseOptions())).rejects.toThrow(
+			/Cannot modify Vite config: CommonJS Vite config files are not supported/
+		);
+		expect(installCloudflareVitePlugin).not.toHaveBeenCalled();
+		expect(existsSync("vite.config.ts")).toBe(false);
+		expect(existsSync("vite.config.js")).toBe(false);
 	});
 });

--- a/packages/wrangler/src/__tests__/autoconfig/frameworks/vite.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/frameworks/vite.test.ts
@@ -1,0 +1,93 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
+import { describe, it, vi } from "vitest";
+import { AutoConfigFrameworkConfigurationError } from "../../../autoconfig/errors";
+import { installCloudflareVitePlugin } from "../../../autoconfig/frameworks/utils/vite-plugin";
+import { Vite } from "../../../autoconfig/frameworks/vite";
+import { NpmPackageManager } from "../../../package-manager";
+
+vi.mock("../../../autoconfig/frameworks/utils/vite-plugin", () => ({
+	installCloudflareVitePlugin: vi.fn(async () => {}),
+}));
+
+vi.mock("../../../autoconfig/frameworks/utils/packages", () => ({
+	getInstalledPackageVersion: vi.fn(() => undefined),
+}));
+
+const VITE_PACKAGE_INFO = {
+	name: "vite",
+	minimumVersion: "6.0.0",
+	maximumKnownMajorVersion: "8",
+};
+
+function getBaseOptions() {
+	return {
+		projectPath: process.cwd(),
+		workerName: "my-vite-app",
+		outputDir: "dist",
+		dryRun: false,
+		packageManager: NpmPackageManager,
+		isWorkspaceRoot: false,
+	};
+}
+
+describe("Vite framework", () => {
+	runInTempDir();
+
+	it("validates the Vite version from package.json when dependencies are not installed", async ({
+		expect,
+	}) => {
+		await writeFile(
+			"package.json",
+			JSON.stringify({
+				devDependencies: {
+					vite: "^8.0.12",
+				},
+			})
+		);
+
+		const framework = new Vite({ id: "vite", name: "Vite" });
+		expect(() =>
+			framework.validateFrameworkVersion(process.cwd(), VITE_PACKAGE_INFO)
+		).not.toThrow();
+		expect(framework.frameworkVersion).toBe("8.0.12");
+	});
+
+	it("rejects unsupported Vite versions declared in package.json", async ({
+		expect,
+	}) => {
+		await writeFile(
+			"package.json",
+			JSON.stringify({
+				devDependencies: {
+					vite: "^5.4.0",
+				},
+			})
+		);
+
+		const framework = new Vite({ id: "vite", name: "Vite" });
+		expect(() =>
+			framework.validateFrameworkVersion(process.cwd(), VITE_PACKAGE_INFO)
+		).toThrow(AutoConfigFrameworkConfigurationError);
+	});
+
+	it("creates a Vite config when the project does not have one", async ({
+		expect,
+	}) => {
+		await writeFile("tsconfig.json", JSON.stringify({}));
+
+		const framework = new Vite({ id: "vite", name: "Vite" });
+		await framework.configure(getBaseOptions());
+
+		const result = await readFile("vite.config.ts", "utf8");
+		expect(result).toContain(
+			'import { cloudflare } from "@cloudflare/vite-plugin";'
+		);
+		expect(result).toContain("plugins: [cloudflare()]");
+		expect(installCloudflareVitePlugin).toHaveBeenCalledWith({
+			packageManager: "npm",
+			isWorkspaceRoot: false,
+			projectPath: process.cwd(),
+		});
+	});
+});

--- a/packages/wrangler/src/__tests__/autoconfig/get-installed-package-version.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/get-installed-package-version.test.ts
@@ -1,6 +1,11 @@
+import { join } from "node:path";
 import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import { describe, test } from "vitest";
-import { getInstalledPackageVersion } from "../../autoconfig/frameworks/utils/packages";
+import {
+	getInstalledPackageVersion,
+	getPackageJsonDependencyVersion,
+	hasPackageJsonDependency,
+} from "../../autoconfig/frameworks/utils/packages";
 describe("getInstalledPackageVersion()", () => {
 	runInTempDir();
 	test("happy path", async ({ expect }) => {
@@ -21,5 +26,66 @@ describe("getInstalledPackageVersion()", () => {
 		expect(
 			getInstalledPackageVersion("react-router", process.cwd())
 		).toBeUndefined();
+	});
+
+	test("can ignore packages installed outside the project path", async ({
+		expect,
+	}) => {
+		await seed({
+			"app/package.json": JSON.stringify({ name: "app" }),
+			"node_modules/vite/package.json": JSON.stringify({
+				name: "vite",
+				version: "8.0.13",
+				main: "index.js",
+			}),
+			"node_modules/vite/index.js": "console.log(1)",
+		});
+
+		const appPath = join(process.cwd(), "app");
+
+		expect(getInstalledPackageVersion("vite", appPath)).toBe("8.0.13");
+		expect(
+			getInstalledPackageVersion("vite", appPath, {
+				stopAtProjectPath: true,
+			})
+		).toBeUndefined();
+	});
+
+	test("gets package.json dependency versions", async ({ expect }) => {
+		await seed({
+			"package.json": JSON.stringify({
+				dependencies: {
+					vite: "^8.0.12",
+				},
+				devDependencies: {
+					astro: "~5.1",
+				},
+			}),
+		});
+
+		expect(getPackageJsonDependencyVersion("vite", process.cwd())).toBe(
+			"8.0.12"
+		);
+		expect(getPackageJsonDependencyVersion("astro", process.cwd())).toBe(
+			"5.1.0"
+		);
+		expect(hasPackageJsonDependency("vite", process.cwd())).toBe(true);
+	});
+
+	test("does not treat peerDependencies as application dependencies", async ({
+		expect,
+	}) => {
+		await seed({
+			"package.json": JSON.stringify({
+				peerDependencies: {
+					vite: "^8.0.12",
+				},
+			}),
+		});
+
+		expect(
+			getPackageJsonDependencyVersion("vite", process.cwd())
+		).toBeUndefined();
+		expect(hasPackageJsonDependency("vite", process.cwd())).toBe(false);
 	});
 });

--- a/packages/wrangler/src/__tests__/autoconfig/vite-config.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/vite-config.test.ts
@@ -4,6 +4,7 @@ import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { beforeEach, describe, it } from "vitest";
 import {
 	checkIfViteConfigUsesCloudflarePlugin,
+	createViteConfigWithCloudflarePlugin,
 	transformViteConfig,
 } from "../../autoconfig/frameworks/utils/vite-config";
 import { logger } from "../../logger";
@@ -17,6 +18,11 @@ describe("vite-config utils", () => {
 	});
 
 	describe("checkIfViteConfigUsesCloudflarePlugin", () => {
+		it("should return false when there is no Vite config", ({ expect }) => {
+			const result = checkIfViteConfigUsesCloudflarePlugin(".");
+			expect(result).toBe(false);
+		});
+
 		it("should detect cloudflare plugin in function-based defineConfig", async ({
 			expect,
 		}) => {
@@ -90,6 +96,36 @@ export default defineConfig({
 
 			const result = checkIfViteConfigUsesCloudflarePlugin(".");
 			expect(result).toBe(true);
+		});
+	});
+
+	describe("createViteConfigWithCloudflarePlugin", () => {
+		it("should create a TypeScript Vite config when the project uses TypeScript", async ({
+			expect,
+		}) => {
+			await writeFile("tsconfig.json", JSON.stringify({}));
+
+			createViteConfigWithCloudflarePlugin(".");
+
+			expect(readFileSync("vite.config.ts", "utf-8")).toMatchInlineSnapshot(`
+				"import { cloudflare } from "@cloudflare/vite-plugin";
+				import { defineConfig } from "vite";
+
+				export default defineConfig({
+				\tplugins: [cloudflare()],
+				});
+				"
+			`);
+		});
+
+		it("should create a JavaScript Vite config when the project does not use TypeScript", ({
+			expect,
+		}) => {
+			createViteConfigWithCloudflarePlugin(".");
+
+			expect(readFileSync("vite.config.js", "utf-8")).toContain(
+				"plugins: [cloudflare()]"
+			);
 		});
 	});
 

--- a/packages/wrangler/src/__tests__/autoconfig/vite-config.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/vite-config.test.ts
@@ -130,6 +130,45 @@ export default defineConfig({
 	});
 
 	describe("transformViteConfig", () => {
+		it("should transform existing vite.config.mjs files", async ({
+			expect,
+		}) => {
+			await writeFile(
+				"vite.config.mjs",
+				`
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: []
+});
+`
+			);
+
+			expect(() => transformViteConfig(".")).not.toThrow();
+			const result = readFileSync("vite.config.mjs", "utf-8");
+			expect(result).toContain(
+				'import { cloudflare } from "@cloudflare/vite-plugin"'
+			);
+			expect(result).toContain("cloudflare()");
+		});
+
+		it("should throw for CommonJS Vite config files", async ({ expect }) => {
+			await writeFile(
+				"vite.config.cjs",
+				`
+const { defineConfig } = require('vite');
+
+module.exports = defineConfig({
+  plugins: []
+});
+`
+			);
+
+			expect(() => transformViteConfig(".")).toThrowError(
+				/Cannot modify Vite config: CommonJS Vite config files are not supported/
+			);
+		});
+
 		it("should successfully transform function-based defineConfig with arrow expression body", async ({
 			expect,
 		}) => {

--- a/packages/wrangler/src/autoconfig/details/framework-detection.ts
+++ b/packages/wrangler/src/autoconfig/details/framework-detection.ts
@@ -261,6 +261,11 @@ function maybeGetVitePackageJsonDefaults(
 		return undefined;
 	}
 
+	const viteConfigExists = hasViteConfig(projectPath);
+	if (!viteConfigExists && !hasRootIndexHtml(projectPath)) {
+		return undefined;
+	}
+
 	if (
 		!hasPackageJsonDependency("vite", projectPath) ||
 		!hasViteScript(packageJson)
@@ -304,6 +309,15 @@ function getViteOutputDir(buildScript: unknown): string {
 	return (
 		outputDirMatch?.[1] ?? outputDirMatch?.[2] ?? outputDirMatch?.[3] ?? "dist"
 	);
+}
+
+function hasRootIndexHtml(projectPath: string): boolean {
+	const indexHtmlPath = join(projectPath, "index.html");
+	if (!existsSync(indexHtmlPath)) {
+		return false;
+	}
+
+	return statSync(indexHtmlPath).isFile();
 }
 
 class MultipleFrameworksCIError extends FatalError {

--- a/packages/wrangler/src/autoconfig/details/framework-detection.ts
+++ b/packages/wrangler/src/autoconfig/details/framework-detection.ts
@@ -24,6 +24,8 @@ import {
 import { PAGES_CONFIG_CACHE_FILENAME } from "../../pages/constants";
 import { isKnownFramework } from "../frameworks";
 import { staticFramework } from "../frameworks/all-frameworks";
+import { hasPackageJsonDependency } from "../frameworks/utils/packages";
+import { hasViteConfig } from "../frameworks/utils/vite-config";
 import type { PackageManager } from "../../package-manager";
 import type {
 	Config,
@@ -186,11 +188,6 @@ function convertDetectedPackageManager(
 	}
 }
 
-type PackageJsonWithAdditionalDependencies = PackageJSON & {
-	optionalDependencies?: Record<string, unknown>;
-	peerDependencies?: Record<string, unknown>;
-};
-
 function maybeDetectViteFromPackageJson(
 	projectPath: string,
 	packageManager: PackageManager
@@ -228,14 +225,23 @@ function maybeApplyVitePackageJsonDefaults(
 	);
 
 	if (!vitePackageJsonDefaults) {
-		return detectedFramework;
+		if (hasViteConfig(projectPath)) {
+			return detectedFramework;
+		}
+
+		// @netlify/build-info can detect Vite from a package dependency alone.
+		// Without a Vite script or config, that is too weak a signal for autoconfig.
+		return undefined;
 	}
 
 	return {
 		...detectedFramework,
 		buildCommand:
 			detectedFramework.buildCommand ?? vitePackageJsonDefaults.buildCommand,
-		dist: detectedFramework.dist ?? vitePackageJsonDefaults.dist,
+		dist:
+			vitePackageJsonDefaults.dist === "dist"
+				? (detectedFramework.dist ?? vitePackageJsonDefaults.dist)
+				: vitePackageJsonDefaults.dist,
 	};
 }
 
@@ -245,17 +251,20 @@ function maybeGetVitePackageJsonDefaults(
 ): Pick<DetectedFramework, "buildCommand" | "dist"> | undefined {
 	const packageJsonPath = join(projectPath, "package.json");
 
-	let packageJson: PackageJsonWithAdditionalDependencies;
+	let packageJson: PackageJSON;
 	try {
 		packageJson = parsePackageJSON(
 			readFileSync(packageJsonPath),
 			packageJsonPath
-		) as PackageJsonWithAdditionalDependencies;
+		);
 	} catch {
 		return undefined;
 	}
 
-	if (!hasPackageJsonDependency(packageJson, "vite")) {
+	if (
+		!hasPackageJsonDependency("vite", projectPath) ||
+		!hasViteScript(packageJson)
+	) {
 		return undefined;
 	}
 
@@ -264,22 +273,36 @@ function maybeGetVitePackageJsonDefaults(
 			typeof packageJson.scripts?.build === "string"
 				? `${packageManager.type} run build`
 				: "vite build",
-		dist: "dist",
+		dist: getViteOutputDir(packageJson.scripts?.build),
 	};
 }
 
-function hasPackageJsonDependency(
-	packageJson: PackageJsonWithAdditionalDependencies,
-	packageName: string
-): boolean {
+function hasViteScript(packageJson: PackageJSON): boolean {
 	return [
-		packageJson.dependencies,
-		packageJson.devDependencies,
-		packageJson.optionalDependencies,
-		packageJson.peerDependencies,
-	].some(
-		(dependencies) =>
-			dependencies !== undefined && Object.hasOwn(dependencies, packageName)
+		packageJson.scripts?.build,
+		packageJson.scripts?.dev,
+		packageJson.scripts?.preview,
+	].some((script) => typeof script === "string" && /\bvite\b/.test(script));
+}
+
+function getViteOutputDir(buildScript: unknown): string {
+	if (typeof buildScript !== "string") {
+		return "dist";
+	}
+	const viteBuildCommand = buildScript
+		.split(/&&|;/)
+		.find((command) => /\bvite\s+build\b/.test(command));
+
+	if (!viteBuildCommand) {
+		return "dist";
+	}
+
+	const outputDirMatch = viteBuildCommand.match(
+		/--outDir(?:=|\s+)(?:"([^"]+)"|'([^']+)'|([^\s]+))/
+	);
+
+	return (
+		outputDirMatch?.[1] ?? outputDirMatch?.[2] ?? outputDirMatch?.[3] ?? "dist"
 	);
 }
 

--- a/packages/wrangler/src/autoconfig/details/framework-detection.ts
+++ b/packages/wrangler/src/autoconfig/details/framework-detection.ts
@@ -1,6 +1,11 @@
 import { existsSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { FatalError, UserError } from "@cloudflare/workers-utils";
+import {
+	FatalError,
+	parsePackageJSON,
+	readFileSync,
+	UserError,
+} from "@cloudflare/workers-utils";
 import { Project } from "@netlify/build-info";
 import { NodeFS } from "@netlify/build-info/node";
 import { captureException } from "@sentry/node";
@@ -20,7 +25,11 @@ import { PAGES_CONFIG_CACHE_FILENAME } from "../../pages/constants";
 import { isKnownFramework } from "../frameworks";
 import { staticFramework } from "../frameworks/all-frameworks";
 import type { PackageManager } from "../../package-manager";
-import type { Config, TelemetryMessage } from "@cloudflare/workers-utils";
+import type {
+	Config,
+	PackageJSON,
+	TelemetryMessage,
+} from "@cloudflare/workers-utils";
 import type { Settings } from "@netlify/build-info";
 
 /**
@@ -94,10 +103,15 @@ export async function detectFramework(
 		existsSync(join(projectPath, lockFile))
 	);
 
-	const maybeDetectedFramework = maybeFindDetectedFramework(buildSettings);
+	const detectedFrameworkFromBuildSettings =
+		maybeFindDetectedFramework(buildSettings);
 
 	if (
-		await isPagesProject(projectPath, wranglerConfig, maybeDetectedFramework)
+		await isPagesProject(
+			projectPath,
+			wranglerConfig,
+			detectedFrameworkFromBuildSettings
+		)
 	) {
 		return {
 			detectedFramework: {
@@ -110,6 +124,13 @@ export async function detectFramework(
 			packageManager,
 		};
 	}
+
+	const maybeDetectedFramework =
+		maybeApplyVitePackageJsonDefaults(
+			detectedFrameworkFromBuildSettings,
+			projectPath,
+			packageManager
+		) ?? maybeDetectViteFromPackageJson(projectPath, packageManager);
 
 	const detectedFramework = maybeDetectedFramework ?? {
 		framework: {
@@ -163,6 +184,103 @@ function convertDetectedPackageManager(
 		default:
 			return NpmPackageManager;
 	}
+}
+
+type PackageJsonWithAdditionalDependencies = PackageJSON & {
+	optionalDependencies?: Record<string, unknown>;
+	peerDependencies?: Record<string, unknown>;
+};
+
+function maybeDetectViteFromPackageJson(
+	projectPath: string,
+	packageManager: PackageManager
+): DetectedFramework | undefined {
+	const vitePackageJsonDefaults = maybeGetVitePackageJsonDefaults(
+		projectPath,
+		packageManager
+	);
+
+	if (!vitePackageJsonDefaults) {
+		return undefined;
+	}
+
+	return {
+		framework: {
+			id: "vite",
+			name: "Vite",
+		},
+		...vitePackageJsonDefaults,
+	};
+}
+
+function maybeApplyVitePackageJsonDefaults(
+	detectedFramework: DetectedFramework | undefined,
+	projectPath: string,
+	packageManager: PackageManager
+): DetectedFramework | undefined {
+	if (detectedFramework?.framework.id !== "vite") {
+		return detectedFramework;
+	}
+
+	const vitePackageJsonDefaults = maybeGetVitePackageJsonDefaults(
+		projectPath,
+		packageManager
+	);
+
+	if (!vitePackageJsonDefaults) {
+		return detectedFramework;
+	}
+
+	return {
+		...detectedFramework,
+		buildCommand:
+			detectedFramework.buildCommand ?? vitePackageJsonDefaults.buildCommand,
+		dist: detectedFramework.dist ?? vitePackageJsonDefaults.dist,
+	};
+}
+
+function maybeGetVitePackageJsonDefaults(
+	projectPath: string,
+	packageManager: PackageManager
+): Pick<DetectedFramework, "buildCommand" | "dist"> | undefined {
+	const packageJsonPath = join(projectPath, "package.json");
+
+	let packageJson: PackageJsonWithAdditionalDependencies;
+	try {
+		packageJson = parsePackageJSON(
+			readFileSync(packageJsonPath),
+			packageJsonPath
+		) as PackageJsonWithAdditionalDependencies;
+	} catch {
+		return undefined;
+	}
+
+	if (!hasPackageJsonDependency(packageJson, "vite")) {
+		return undefined;
+	}
+
+	return {
+		buildCommand:
+			typeof packageJson.scripts?.build === "string"
+				? `${packageManager.type} run build`
+				: "vite build",
+		dist: "dist",
+	};
+}
+
+function hasPackageJsonDependency(
+	packageJson: PackageJsonWithAdditionalDependencies,
+	packageName: string
+): boolean {
+	return [
+		packageJson.dependencies,
+		packageJson.devDependencies,
+		packageJson.optionalDependencies,
+		packageJson.peerDependencies,
+	].some(
+		(dependencies) =>
+			dependencies !== undefined && Object.hasOwn(dependencies, packageName)
+	);
 }
 
 class MultipleFrameworksCIError extends FatalError {

--- a/packages/wrangler/src/autoconfig/frameworks/framework-class.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/framework-class.ts
@@ -59,6 +59,13 @@ export abstract class Framework {
 			`Unable to detect the version of the \`${frameworkPackageInfo.name}\` package`
 		);
 
+		this.validateAndSetFrameworkVersion(frameworkVersion, frameworkPackageInfo);
+	}
+
+	protected validateAndSetFrameworkVersion(
+		frameworkVersion: string,
+		frameworkPackageInfo: AutoConfigFrameworkPackageInfo
+	): void {
 		if (semiver(frameworkVersion, frameworkPackageInfo.minimumVersion) < 0) {
 			throw new AutoConfigFrameworkConfigurationError(
 				`The version of ${this.name} used in the project (${JSON.stringify(

--- a/packages/wrangler/src/autoconfig/frameworks/utils/packages.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/utils/packages.ts
@@ -1,6 +1,11 @@
 import path from "node:path";
 import { parsePackageJSON, readFileSync } from "@cloudflare/workers-utils";
 import * as find from "empathic/find";
+import type { PackageJSON } from "@cloudflare/workers-utils";
+
+type PackageJsonWithAdditionalDependencies = PackageJSON & {
+	optionalDependencies?: Record<string, unknown>;
+};
 
 /**
  * Checks wether a package is installed in a target project or not
@@ -36,6 +41,15 @@ export function getInstalledPackageVersion(
 		if (!packagePath) {
 			return undefined;
 		}
+		if (opts.stopAtProjectPath === true) {
+			const relativePackagePath = path.relative(projectPath, packagePath);
+			if (
+				relativePackagePath.startsWith("..") ||
+				path.isAbsolute(relativePackagePath)
+			) {
+				return undefined;
+			}
+		}
 		const packageJsonPath = find.file("package.json", {
 			cwd: packagePath,
 			last: opts.stopAtProjectPath === true ? projectPath : undefined,
@@ -49,6 +63,77 @@ export function getInstalledPackageVersion(
 		);
 		return packageJson.version;
 	} catch {}
+}
+
+export function getPackageJsonDependencyVersion(
+	packageName: string,
+	projectPath: string
+): string | undefined {
+	const packageJson = getPackageJson(projectPath);
+	if (!packageJson) {
+		return undefined;
+	}
+
+	return getVersionFromSpecifier(
+		getPackageJsonDependency(packageJson, packageName)
+	);
+}
+
+export function hasPackageJsonDependency(
+	packageName: string,
+	projectPath: string
+): boolean {
+	const packageJson = getPackageJson(projectPath);
+	if (!packageJson) {
+		return false;
+	}
+
+	return getPackageJsonDependency(packageJson, packageName) !== undefined;
+}
+
+function getPackageJson(
+	projectPath: string
+): PackageJsonWithAdditionalDependencies | undefined {
+	const packageJsonPath = path.join(projectPath, "package.json");
+
+	try {
+		return parsePackageJSON(
+			readFileSync(packageJsonPath),
+			packageJsonPath
+		) as PackageJsonWithAdditionalDependencies;
+	} catch {
+		return undefined;
+	}
+}
+
+function getPackageJsonDependency(
+	packageJson: PackageJsonWithAdditionalDependencies,
+	packageName: string
+): unknown {
+	return (
+		packageJson.dependencies?.[packageName] ??
+		packageJson.devDependencies?.[packageName] ??
+		packageJson.optionalDependencies?.[packageName]
+	);
+}
+
+function getVersionFromSpecifier(
+	versionSpecifier: unknown
+): string | undefined {
+	if (typeof versionSpecifier !== "string") {
+		return undefined;
+	}
+
+	const versionMatch = versionSpecifier.match(
+		/(\d+)(?:\.(\d+))?(?:\.(\d+))?(-[0-9A-Za-z.-]+)?/
+	);
+
+	if (!versionMatch) {
+		return undefined;
+	}
+
+	const [, major, minor = "0", patch = "0", prerelease = ""] = versionMatch;
+	return `${major}.${minor}.${patch}${prerelease}`;
 }
 
 /**

--- a/packages/wrangler/src/autoconfig/frameworks/utils/vite-config.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/utils/vite-config.ts
@@ -11,6 +11,18 @@ import type { types } from "recast";
 const b = recast.types.builders;
 const t = recast.types.namedTypes;
 
+const transformableViteConfigFileNames = [
+	"vite.config.ts",
+	"vite.config.mts",
+	"vite.config.js",
+	"vite.config.mjs",
+];
+const unsupportedViteConfigFileNames = ["vite.config.cts", "vite.config.cjs"];
+const viteConfigFileNames = [
+	...transformableViteConfigFileNames,
+	...unsupportedViteConfigFileNames,
+];
+
 /**
  * Extracts the ObjectExpression from the first argument of defineConfig().
  *
@@ -65,7 +77,10 @@ function extractFromBlockStatement(
 export function checkIfViteConfigUsesCloudflarePlugin(
 	projectPath: string
 ): boolean {
-	const filePath = maybeGetViteConfigPath(projectPath);
+	const filePath = maybeGetViteConfigPath(
+		projectPath,
+		transformableViteConfigFileNames
+	);
 
 	if (!filePath) {
 		return false;
@@ -133,32 +148,51 @@ export function checkIfViteConfigUsesCloudflarePlugin(
 }
 
 export function hasViteConfig(projectPath: string): boolean {
-	return maybeGetViteConfigPath(projectPath) !== undefined;
+	return maybeGetViteConfigPath(projectPath, viteConfigFileNames) !== undefined;
 }
 
-function maybeGetViteConfigPath(projectPath: string): string | undefined {
-	const filePathTS = path.join(projectPath, `vite.config.ts`);
-	const filePathJS = path.join(projectPath, `vite.config.js`);
+export function assertCanTransformViteConfig(projectPath: string): void {
+	getViteConfigPath(projectPath);
+}
 
-	if (existsSync(filePathTS)) {
-		return filePathTS;
-	}
-
-	if (existsSync(filePathJS)) {
-		return filePathJS;
+function maybeGetViteConfigPath(
+	projectPath: string,
+	fileNames: string[]
+): string | undefined {
+	for (const fileName of fileNames) {
+		const filePath = path.join(projectPath, fileName);
+		if (existsSync(filePath)) {
+			return filePath;
+		}
 	}
 
 	return undefined;
 }
 
 function getViteConfigPath(projectPath: string): string {
-	const filePath = maybeGetViteConfigPath(projectPath);
+	const filePath = maybeGetViteConfigPath(
+		projectPath,
+		transformableViteConfigFileNames
+	);
 
-	if (!filePath) {
-		throw new Error("Could not find Vite config file to modify");
+	if (filePath) {
+		return filePath;
 	}
 
-	return filePath;
+	const unsupportedFilePath = maybeGetViteConfigPath(
+		projectPath,
+		unsupportedViteConfigFileNames
+	);
+	if (unsupportedFilePath) {
+		throw new UserError(
+			"Cannot modify Vite config: CommonJS Vite config files are not supported. Please manually add the Cloudflare plugin or convert the config to vite.config.ts, vite.config.mts, vite.config.js, or vite.config.mjs.",
+			{
+				telemetryMessage: "autoconfig vite config extension unsupported",
+			}
+		);
+	}
+
+	throw new Error("Could not find Vite config file to modify");
 }
 
 export function createViteConfigWithCloudflarePlugin(

--- a/packages/wrangler/src/autoconfig/frameworks/utils/vite-config.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/utils/vite-config.ts
@@ -1,10 +1,11 @@
-import { existsSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { transformFile } from "@cloudflare/codemod";
 import { UserError } from "@cloudflare/workers-utils";
 import * as recast from "recast";
 import dedent from "ts-dedent";
 import { logger } from "../../../logger";
+import { usesTypescript } from "../../uses-typescript";
 import type { types } from "recast";
 
 const b = recast.types.builders;
@@ -64,7 +65,11 @@ function extractFromBlockStatement(
 export function checkIfViteConfigUsesCloudflarePlugin(
 	projectPath: string
 ): boolean {
-	const filePath = getViteConfigPath(projectPath);
+	const filePath = maybeGetViteConfigPath(projectPath);
+
+	if (!filePath) {
+		return false;
+	}
 
 	let importsCloudflarePlugin = false;
 	let usesCloudflarePlugin = false;
@@ -127,21 +132,58 @@ export function checkIfViteConfigUsesCloudflarePlugin(
 	return importsCloudflarePlugin && usesCloudflarePlugin;
 }
 
-function getViteConfigPath(projectPath: string): string {
+export function hasViteConfig(projectPath: string): boolean {
+	return maybeGetViteConfigPath(projectPath) !== undefined;
+}
+
+function maybeGetViteConfigPath(projectPath: string): string | undefined {
 	const filePathTS = path.join(projectPath, `vite.config.ts`);
 	const filePathJS = path.join(projectPath, `vite.config.js`);
 
-	let filePath: string;
-
 	if (existsSync(filePathTS)) {
-		filePath = filePathTS;
-	} else if (existsSync(filePathJS)) {
-		filePath = filePathJS;
-	} else {
+		return filePathTS;
+	}
+
+	if (existsSync(filePathJS)) {
+		return filePathJS;
+	}
+
+	return undefined;
+}
+
+function getViteConfigPath(projectPath: string): string {
+	const filePath = maybeGetViteConfigPath(projectPath);
+
+	if (!filePath) {
 		throw new Error("Could not find Vite config file to modify");
 	}
 
 	return filePath;
+}
+
+export function createViteConfigWithCloudflarePlugin(
+	projectPath: string,
+	options: { viteEnvironmentName?: string } = {}
+): void {
+	const filePath = path.join(
+		projectPath,
+		`vite.config.${usesTypescript(projectPath) ? "ts" : "js"}`
+	);
+	const cloudflarePluginOptions = options.viteEnvironmentName
+		? `{ viteEnvironment: { name: ${JSON.stringify(options.viteEnvironmentName)} } }`
+		: undefined;
+
+	writeFileSync(
+		filePath,
+		dedent`
+			import { cloudflare } from "@cloudflare/vite-plugin";
+			import { defineConfig } from "vite";
+
+			export default defineConfig({
+				plugins: [cloudflare(${cloudflarePluginOptions ?? ""})],
+			});
+		` + "\n"
+	);
 }
 
 /**

--- a/packages/wrangler/src/autoconfig/frameworks/utils/vite-plugin.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/utils/vite-plugin.ts
@@ -1,7 +1,10 @@
 import { brandColor, dim } from "@cloudflare/cli-shared-helpers/colors";
 import { installPackages } from "@cloudflare/cli-shared-helpers/packages";
 import semiver from "semiver";
-import { getInstalledPackageVersion } from "./packages";
+import {
+	getInstalledPackageVersion,
+	getPackageJsonDependencyVersion,
+} from "./packages";
 import type { PackageManager } from "../../../package-manager";
 
 /**
@@ -23,7 +26,10 @@ export async function installCloudflareVitePlugin({
 	projectPath: string;
 	isWorkspaceRoot: boolean;
 }): Promise<void> {
-	const viteVersion = getInstalledPackageVersion("vite", projectPath);
+	const viteVersion =
+		getInstalledPackageVersion("vite", projectPath, {
+			stopAtProjectPath: true,
+		}) ?? getPackageJsonDependencyVersion("vite", projectPath);
 
 	if (
 		viteVersion &&

--- a/packages/wrangler/src/autoconfig/frameworks/vite.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/vite.ts
@@ -1,8 +1,10 @@
-import { join } from "node:path";
-import { parsePackageJSON, readFileSync } from "@cloudflare/workers-utils";
 import { Framework } from "./framework-class";
-import { getInstalledPackageVersion } from "./utils/packages";
 import {
+	getInstalledPackageVersion,
+	getPackageJsonDependencyVersion,
+} from "./utils/packages";
+import {
+	assertCanTransformViteConfig,
 	checkIfViteConfigUsesCloudflarePlugin,
 	createViteConfigWithCloudflarePlugin,
 	hasViteConfig,
@@ -14,7 +16,6 @@ import type {
 	ConfigurationOptions,
 	ConfigurationResults,
 } from "./framework-class";
-import type { PackageJSON } from "@cloudflare/workers-utils";
 
 export class Vite extends Framework {
 	isConfigured(projectPath: string): boolean {
@@ -25,23 +26,28 @@ export class Vite extends Framework {
 		projectPath: string,
 		frameworkPackageInfo: AutoConfigFrameworkPackageInfo
 	): void {
-		const installedVersion = getInstalledPackageVersion(
+		const declaredVersion = getPackageJsonDependencyVersion(
 			frameworkPackageInfo.name,
 			projectPath
 		);
 
-		if (installedVersion) {
+		if (declaredVersion) {
 			this.validateAndSetFrameworkVersion(
-				installedVersion,
+				declaredVersion,
 				frameworkPackageInfo
 			);
 			return;
 		}
 
-		const declaredVersion = getDeclaredViteVersion(projectPath);
-		if (declaredVersion) {
+		const installedVersion = getInstalledPackageVersion(
+			frameworkPackageInfo.name,
+			projectPath,
+			{ stopAtProjectPath: true }
+		);
+
+		if (installedVersion) {
 			this.validateAndSetFrameworkVersion(
-				declaredVersion,
+				installedVersion,
 				frameworkPackageInfo
 			);
 			return;
@@ -57,13 +63,18 @@ export class Vite extends Framework {
 		isWorkspaceRoot,
 	}: ConfigurationOptions): Promise<ConfigurationResults> {
 		if (!dryRun) {
+			const viteConfigExists = hasViteConfig(projectPath);
+			if (viteConfigExists) {
+				assertCanTransformViteConfig(projectPath);
+			}
+
 			await installCloudflareVitePlugin({
 				packageManager: packageManager.type,
 				isWorkspaceRoot,
 				projectPath,
 			});
 
-			if (hasViteConfig(projectPath)) {
+			if (viteConfigExists) {
 				transformViteConfig(projectPath);
 			} else {
 				createViteConfigWithCloudflarePlugin(projectPath);
@@ -78,49 +89,4 @@ export class Vite extends Framework {
 			},
 		};
 	}
-}
-
-type PackageJsonWithAdditionalDependencies = PackageJSON & {
-	optionalDependencies?: Record<string, unknown>;
-	peerDependencies?: Record<string, unknown>;
-};
-
-function getDeclaredViteVersion(projectPath: string): string | undefined {
-	const packageJsonPath = join(projectPath, "package.json");
-
-	let packageJson: PackageJsonWithAdditionalDependencies;
-	try {
-		packageJson = parsePackageJSON(
-			readFileSync(packageJsonPath),
-			packageJsonPath
-		) as PackageJsonWithAdditionalDependencies;
-	} catch {
-		return undefined;
-	}
-
-	return getVersionFromSpecifier(
-		packageJson.dependencies?.vite ??
-			packageJson.devDependencies?.vite ??
-			packageJson.optionalDependencies?.vite ??
-			packageJson.peerDependencies?.vite
-	);
-}
-
-function getVersionFromSpecifier(
-	versionSpecifier: unknown
-): string | undefined {
-	if (typeof versionSpecifier !== "string") {
-		return undefined;
-	}
-
-	const versionMatch = versionSpecifier.match(
-		/(\d+)(?:\.(\d+))?(?:\.(\d+))?(-[0-9A-Za-z.-]+)?/
-	);
-
-	if (!versionMatch) {
-		return undefined;
-	}
-
-	const [, major, minor = "0", patch = "0", prerelease = ""] = versionMatch;
-	return `${major}.${minor}.${patch}${prerelease}`;
 }

--- a/packages/wrangler/src/autoconfig/frameworks/vite.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/vite.ts
@@ -1,17 +1,53 @@
+import { join } from "node:path";
+import { parsePackageJSON, readFileSync } from "@cloudflare/workers-utils";
 import { Framework } from "./framework-class";
+import { getInstalledPackageVersion } from "./utils/packages";
 import {
 	checkIfViteConfigUsesCloudflarePlugin,
+	createViteConfigWithCloudflarePlugin,
+	hasViteConfig,
 	transformViteConfig,
 } from "./utils/vite-config";
 import { installCloudflareVitePlugin } from "./utils/vite-plugin";
+import type { AutoConfigFrameworkPackageInfo } from ".";
 import type {
 	ConfigurationOptions,
 	ConfigurationResults,
 } from "./framework-class";
+import type { PackageJSON } from "@cloudflare/workers-utils";
 
 export class Vite extends Framework {
 	isConfigured(projectPath: string): boolean {
 		return checkIfViteConfigUsesCloudflarePlugin(projectPath);
+	}
+
+	validateFrameworkVersion(
+		projectPath: string,
+		frameworkPackageInfo: AutoConfigFrameworkPackageInfo
+	): void {
+		const installedVersion = getInstalledPackageVersion(
+			frameworkPackageInfo.name,
+			projectPath
+		);
+
+		if (installedVersion) {
+			this.validateAndSetFrameworkVersion(
+				installedVersion,
+				frameworkPackageInfo
+			);
+			return;
+		}
+
+		const declaredVersion = getDeclaredViteVersion(projectPath);
+		if (declaredVersion) {
+			this.validateAndSetFrameworkVersion(
+				declaredVersion,
+				frameworkPackageInfo
+			);
+			return;
+		}
+
+		super.validateFrameworkVersion(projectPath, frameworkPackageInfo);
 	}
 
 	async configure({
@@ -27,7 +63,11 @@ export class Vite extends Framework {
 				projectPath,
 			});
 
-			transformViteConfig(projectPath);
+			if (hasViteConfig(projectPath)) {
+				transformViteConfig(projectPath);
+			} else {
+				createViteConfigWithCloudflarePlugin(projectPath);
+			}
 		}
 
 		return {
@@ -38,4 +78,49 @@ export class Vite extends Framework {
 			},
 		};
 	}
+}
+
+type PackageJsonWithAdditionalDependencies = PackageJSON & {
+	optionalDependencies?: Record<string, unknown>;
+	peerDependencies?: Record<string, unknown>;
+};
+
+function getDeclaredViteVersion(projectPath: string): string | undefined {
+	const packageJsonPath = join(projectPath, "package.json");
+
+	let packageJson: PackageJsonWithAdditionalDependencies;
+	try {
+		packageJson = parsePackageJSON(
+			readFileSync(packageJsonPath),
+			packageJsonPath
+		) as PackageJsonWithAdditionalDependencies;
+	} catch {
+		return undefined;
+	}
+
+	return getVersionFromSpecifier(
+		packageJson.dependencies?.vite ??
+			packageJson.devDependencies?.vite ??
+			packageJson.optionalDependencies?.vite ??
+			packageJson.peerDependencies?.vite
+	);
+}
+
+function getVersionFromSpecifier(
+	versionSpecifier: unknown
+): string | undefined {
+	if (typeof versionSpecifier !== "string") {
+		return undefined;
+	}
+
+	const versionMatch = versionSpecifier.match(
+		/(\d+)(?:\.(\d+))?(?:\.(\d+))?(-[0-9A-Za-z.-]+)?/
+	);
+
+	if (!versionMatch) {
+		return undefined;
+	}
+
+	const [, major, minor = "0", patch = "0", prerelease = ""] = versionMatch;
+	return `${major}.${minor}.${patch}${prerelease}`;
 }


### PR DESCRIPTION
Detects Vite projects from `package.json` during automatic configuration when no more specific framework is found. For configless Vite apps, Wrangler now creates a minimal `vite.config` with `@cloudflare/vite-plugin` and can validate declared Vite versions before dependencies are installed.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This improves automatic detection/configuration behavior without changing user-facing docs or adding new commands/config options.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->