### PR TITLE
[wrangler] Fix autoconfig for Vite projects without a config file

### DIFF
--- a/.changeset/fix-autoconfig-vite-no-config.md
+++ b/.changeset/fix-autoconfig-vite-no-config.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler setup` failing for Vite projects without a config file
+
+`wrangler setup` (and `wrangler deploy --experimental-autoconfig`) crashed with "Could not find Vite config file to modify" for Vite projects that don't have a `vite.config.js` or `vite.config.ts`. This affected 6 of the 16 `create-vite` templates: `vanilla`, `vanilla-ts`, `react-swc`, `react-swc-ts`, `lit`, and `lit-ts`.
+
+Autoconfig now creates a minimal Vite config with the Cloudflare plugin when no config file exists, instead of failing. The file extension (`.ts` or `.js`) is chosen based on whether the project has a `tsconfig.json`.

--- a/packages/wrangler/src/__tests__/autoconfig/frameworks/vite.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/frameworks/vite.test.ts
@@ -1,0 +1,107 @@
+import { existsSync, readFileSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import * as cliPackages from "@cloudflare/cli-shared-helpers/packages";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
+import { beforeEach, describe, it, vi } from "vitest";
+import { Vite } from "../../../autoconfig/frameworks/vite";
+import { NpmPackageManager } from "../../../package-manager";
+
+const BASE_OPTIONS = {
+	projectPath: ".",
+	workerName: "my-vite-app",
+	outputDir: "dist",
+	dryRun: false,
+	packageManager: NpmPackageManager,
+	isWorkspaceRoot: false,
+};
+
+describe("Vite framework", () => {
+	runInTempDir();
+
+	beforeEach(() => {
+		vi.spyOn(cliPackages, "installPackages").mockImplementation(async () => {});
+	});
+
+	describe("isConfigured()", () => {
+		it("returns false when no vite config file exists", ({ expect }) => {
+			const framework = new Vite({ id: "vite", name: "Vite" });
+			expect(framework.isConfigured(".")).toBe(false);
+		});
+	});
+
+	describe("configure()", () => {
+		it("creates a vite config with the cloudflare plugin when no config file exists", async ({
+			expect,
+		}) => {
+			const framework = new Vite({ id: "vite", name: "Vite" });
+			const result = await framework.configure(BASE_OPTIONS);
+
+			expect(existsSync("vite.config.js")).toBe(true);
+			const content = readFileSync("vite.config.js", "utf-8");
+			expect(content).toContain(
+				'import { cloudflare } from "@cloudflare/vite-plugin"'
+			);
+			expect(content).toContain("plugins: [cloudflare()]");
+
+			expect(result.wranglerConfig).toEqual({
+				assets: {
+					not_found_handling: "single-page-application",
+				},
+			});
+		});
+
+		it("uses .ts extension when the project has a tsconfig.json", async ({
+			expect,
+		}) => {
+			await writeFile("tsconfig.json", "{}");
+
+			const framework = new Vite({ id: "vite", name: "Vite" });
+			await framework.configure(BASE_OPTIONS);
+
+			expect(existsSync("vite.config.ts")).toBe(true);
+			expect(existsSync("vite.config.js")).toBe(false);
+		});
+
+		it("transforms existing vite config instead of creating a new one", async ({
+			expect,
+		}) => {
+			await writeFile(
+				"vite.config.ts",
+				`
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});
+`
+			);
+
+			const framework = new Vite({ id: "vite", name: "Vite" });
+			await framework.configure(BASE_OPTIONS);
+
+			const content = readFileSync("vite.config.ts", "utf-8");
+			expect(content).toContain("cloudflare()");
+			// Existing plugins should be preserved
+			expect(content).toContain("react()");
+		});
+
+		it("does not create or modify files in dry-run mode", async ({
+			expect,
+		}) => {
+			const framework = new Vite({ id: "vite", name: "Vite" });
+			const result = await framework.configure({
+				...BASE_OPTIONS,
+				dryRun: true,
+			});
+
+			expect(existsSync("vite.config.ts")).toBe(false);
+			expect(existsSync("vite.config.js")).toBe(false);
+			expect(result.wranglerConfig).toEqual({
+				assets: {
+					not_found_handling: "single-page-application",
+				},
+			});
+		});
+	});
+});

--- a/packages/wrangler/src/autoconfig/frameworks/utils/vite-config.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/utils/vite-config.ts
@@ -127,6 +127,17 @@ export function checkIfViteConfigUsesCloudflarePlugin(
 	return importsCloudflarePlugin && usesCloudflarePlugin;
 }
 
+/**
+ * Returns whether a Vite config file (`vite.config.ts` or `vite.config.js`)
+ * exists in the given project directory.
+ */
+export function hasViteConfig(projectPath: string): boolean {
+	return (
+		existsSync(path.join(projectPath, "vite.config.ts")) ||
+		existsSync(path.join(projectPath, "vite.config.js"))
+	);
+}
+
 function getViteConfigPath(projectPath: string): string {
 	const filePathTS = path.join(projectPath, `vite.config.ts`);
 	const filePathJS = path.join(projectPath, `vite.config.js`);

--- a/packages/wrangler/src/autoconfig/frameworks/vite.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/vite.ts
@@ -1,6 +1,10 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { usesTypescript } from "../uses-typescript";
 import { Framework } from "./framework-class";
 import {
 	checkIfViteConfigUsesCloudflarePlugin,
+	hasViteConfig,
 	transformViteConfig,
 } from "./utils/vite-config";
 import { installCloudflareVitePlugin } from "./utils/vite-plugin";
@@ -11,6 +15,9 @@ import type {
 
 export class Vite extends Framework {
 	isConfigured(projectPath: string): boolean {
+		if (!hasViteConfig(projectPath)) {
+			return false;
+		}
 		return checkIfViteConfigUsesCloudflarePlugin(projectPath);
 	}
 
@@ -27,7 +34,11 @@ export class Vite extends Framework {
 				projectPath,
 			});
 
-			transformViteConfig(projectPath);
+			if (hasViteConfig(projectPath)) {
+				transformViteConfig(projectPath);
+			} else {
+				createViteConfig(projectPath);
+			}
 		}
 
 		return {
@@ -38,4 +49,25 @@ export class Vite extends Framework {
 			},
 		};
 	}
+}
+
+/**
+ * Creates a minimal `vite.config` file with the Cloudflare plugin already
+ * configured. Used when a Vite project has no config file (e.g. projects
+ * scaffolded with `npm create vite@latest --template vanilla`).
+ *
+ * The file extension (`.ts` or `.js`) is chosen based on whether the project
+ * has a `tsconfig.json`.
+ */
+function createViteConfig(projectPath: string): void {
+	const ext = usesTypescript(projectPath) ? "ts" : "js";
+	const filePath = join(projectPath, `vite.config.${ext}`);
+	const content = `import { cloudflare } from "@cloudflare/vite-plugin";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+\tplugins: [cloudflare()],
+});
+`;
+	writeFileSync(filePath, content);
 }


### PR DESCRIPTION
`wrangler setup` crashed with "Could not find Vite config file to modify" for Vite projects that have no `vite.config.js` or `vite.config.ts`. Vite does not require a config file for simple projects, so several `create-vite` templates omit it entirely.

When no config file exists, autoconfig now creates a minimal one with the Cloudflare plugin already configured. `isConfigured()` also returns `false` instead of throwing.

The fix is scoped to the `Vite` framework class only. Other frameworks that use the shared `transformViteConfig` utility (React Router, TanStack) are unaffected -- they always have a config file, and the existing throw behaviour is correct for them.

**Affected templates (6 of 16):** `vanilla`, `vanilla-ts`, `react-swc`, `react-swc-ts`, `lit`, `lit-ts`

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this is a bug fix to existing behaviour, no new user-facing configuration

<details>
<summary>Known issue: <code>create-vite --template solid</code> detected as Static instead of Vite</summary>

`@netlify/build-info` correctly identifies plain Solid projects as `solid-js` (distinct from `solid-start`). However, wrangler's `allKnownFrameworks` list has `solid-start` but not `solid-js`, so `getFrameworkClassInstance` falls back to the `Static` handler. This means plain Solid SPAs get `assets.directory` without `not_found_handling: "single-page-application"`, which would cause 404s on client-side routes.

This is a separate issue from the config file fix in this PR. A follow-up could add fallback logic in the autoconfig layer: when an unknown framework is detected but the project has `vite` as a dependency and uses `vite build`, route it through the `Vite` handler instead of `Static`.
</details>