### PR TITLE
feat(miniflare): add json output to `/cdn-cgi/handler/scheduled`

### DIFF
--- a/.changeset/stale-shoes-learn.md
+++ b/.changeset/stale-shoes-learn.md
@@ -1,5 +1,5 @@
 ---
-"miniflare": patch
+"miniflare": minor
 ---
 
 Add JSON output to `/cdn-cgi/handler/scheduled`

--- a/.changeset/stale-shoes-learn.md
+++ b/.changeset/stale-shoes-learn.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Add JSON output to `/cdn-cgi/handler/scheduled`
+
+The `/cdn-cgi/handler/scheduled` endpoint now accepts `?format=json` to return the scheduled handler result as JSON, including whether the handler called `controller.noRetry()`. Requests without `format=json` still return the existing text outcome for backward compatibility.

--- a/packages/miniflare/src/workers/core/scheduled.ts
+++ b/packages/miniflare/src/workers/core/scheduled.ts
@@ -5,11 +5,17 @@ export async function handleScheduled(
 	const time = params.get("time");
 	const scheduledTime = time ? new Date(parseInt(time)) : undefined;
 	const cron = params.get("cron") ?? undefined;
-
+	const format = params.get("format");
 	const result = await service.scheduled({
 		scheduledTime,
 		cron,
 	});
+
+	if (format === "json") {
+		return Response.json(result, {
+			status: result.outcome === "ok" ? 200 : 500,
+		});
+	}
 
 	return new Response(result.outcome, {
 		status: result.outcome === "ok" ? 200 : 500,

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -1712,8 +1712,9 @@ test("Miniflare: manually triggered scheduled events", async ({ expect }) => {
 				fetch() {
 					return new Response(scheduledRun);
 				},
-				scheduled() {
+				scheduled(controller) {
 					scheduledRun = true;
+					controller.noRetry();
 				}
 			}`,
 		unsafeTriggerHandlers: true,
@@ -1725,6 +1726,11 @@ test("Miniflare: manually triggered scheduled events", async ({ expect }) => {
 
 	res = await mf.dispatchFetch("http://localhost/cdn-cgi/handler/scheduled");
 	expect(await res.text()).toBe("ok");
+
+	res = await mf.dispatchFetch(
+		"http://localhost/cdn-cgi/handler/scheduled?format=json"
+	);
+	expect(await res.json()).toEqual({ outcome: "ok", noRetry: true });
 
 	res = await mf.dispatchFetch("http://localhost");
 	expect(await res.text()).toBe("true");


### PR DESCRIPTION
Fixes n/a.

There was no way to know if `controller.noRetry()` is called from the endpoint. This adds a `?format=json` query so miniflare can return the full result, while keeping the default unchanged for backward compatibility.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
