### PR TITLE
Detect early workerd exit instead of hanging indefinitely

### DIFF
--- a/.changeset/fix-miniflare-hang-on-workerd-exit.md
+++ b/.changeset/fix-miniflare-hang-on-workerd-exit.md
@@ -1,0 +1,9 @@
+---
+"miniflare": patch
+---
+
+Detect early workerd exit instead of hanging indefinitely
+
+When `workerd` exits during startup before writing all expected listen events to the control file descriptor (e.g. due to an IPv6 bind failure, permission error, or missing library), Miniflare's `waitForPorts()` would block forever. This caused `wrangler dev` to stall at "Starting local server..." with no error and no timeout.
+
+The fix races `waitForPorts()` against the child process exit event so that any unexpected `workerd` termination is detected immediately. When `workerd` exits early, Miniflare now throws `ERR_RUNTIME_FAILURE` with the runtime's stderr output included in the error message, making the root cause diagnosable without external tools.

--- a/packages/miniflare/src/runtime/index.ts
+++ b/packages/miniflare/src/runtime/index.ts
@@ -209,6 +209,17 @@ class StartupLogBuffer {
 				`Address already in use (${match[1]}:${match[2]}). Please check that you are not already running a server on this address or specify a different port with --port.`
 			);
 		}
+
+		// If stderr contains any output, surface it so the user can diagnose
+		// the failure (e.g. bind errors on IPv6 addresses, permission denied,
+		// missing libraries, etc.)
+		const stderr = this.stderrBuffer.join("").trim();
+		if (stderr.length > 0) {
+			throw new MiniflareCoreError(
+				"ERR_RUNTIME_FAILURE",
+				`The Workers runtime failed to start. There was likely a problem with the workerd binary or your configuration.\nRuntime stderr:\n${stderr}`
+			);
+		}
 	}
 }
 
@@ -246,7 +257,8 @@ export class Runtime {
 		});
 		const startupLogBuffer = new StartupLogBuffer();
 		this.#process = runtimeProcess;
-		this.#processExitPromise = waitForExit(runtimeProcess);
+		const processExitPromise = waitForExit(runtimeProcess);
+		this.#processExitPromise = processExitPromise;
 
 		const handleRuntimeStdio =
 			options.handleRuntimeStdio ??
@@ -279,8 +291,15 @@ export class Runtime {
 		runtimeProcess.stdin.end();
 		await once(runtimeProcess.stdin, "finish");
 
-		// 4. Wait for sockets to start listening
-		const ports = await waitForPorts(controlPipe, options);
+		// 4. Wait for sockets to start listening, racing against the process
+		// exiting early. If workerd exits before all required sockets report
+		// their ports (e.g. due to a bind failure), `waitForPorts()` would
+		// hang indefinitely. Racing against the exit promise ensures we
+		// detect this and return `undefined` promptly.
+		const ports = await Promise.race([
+			waitForPorts(controlPipe, options),
+			processExitPromise.then(() => undefined),
+		]);
 		if (ports?.has(kInspectorSocket) && process.env.VSCODE_INSPECTOR_OPTIONS) {
 			// We have an inspector socket and we're in a VSCode Debug Terminal.
 			// Let's startup a watchdog service to register ourselves as a debuggable target

--- a/packages/miniflare/test/fixtures/crashing-workerd.mjs
+++ b/packages/miniflare/test/fixtures/crashing-workerd.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+// A fake workerd that exits immediately without writing any control messages.
+// Used to test that Miniflare detects early workerd exits instead of hanging.
+
+import { arrayBuffer } from "stream/consumers";
+
+// Consume stdin (config passed via stdin) to avoid EPIPE
+await arrayBuffer(process.stdin);
+
+// Write an error to stderr to simulate a startup failure
+process.stderr.write("error: bind(::1, 0): Address not available\n");
+
+// Exit with non-zero code without writing any listen events to FD3
+process.exit(1);

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -2746,6 +2746,32 @@ unixSerialTest(
 	}
 );
 
+// When workerd exits before sending all listen events on FD3, Miniflare should
+// detect this and throw ERR_RUNTIME_FAILURE instead of hanging indefinitely.
+// See https://github.com/cloudflare/workers-sdk/issues/14077
+unixSerialTest(
+	"Miniflare: throws ERR_RUNTIME_FAILURE when workerd exits before all sockets are ready",
+	async ({ expect, onTestFinished }) => {
+		const workerdPath = path.join(FIXTURES_PATH, "crashing-workerd.mjs");
+
+		const original = process.env.MINIFLARE_WORKERD_PATH;
+		process.env.MINIFLARE_WORKERD_PATH = workerdPath;
+		onTestFinished(() => {
+			if (original === undefined) {
+				delete process.env.MINIFLARE_WORKERD_PATH;
+			} else {
+				process.env.MINIFLARE_WORKERD_PATH = original;
+			}
+		});
+
+		const mf = new Miniflare({ script: "" });
+		onTestFinished(() => mf.dispose().catch(() => {}));
+
+		await expect(mf.ready).rejects.toThrow(MiniflareCoreError);
+		await expect(mf.ready).rejects.toThrow(/Workers runtime failed to start/);
+	}
+);
+
 const TIMEZONE_WORKER = `
 	export default {
 		fetch() {


### PR DESCRIPTION
When `workerd` exits during startup before writing all expected listen events to the control file descriptor (e.g. due to an IPv6 bind failure, permission error, or missing library), Miniflare's `waitForPorts()` would block forever. This caused `wrangler dev` to stall at "Starting local server..." with no error and no timeout.

The fix races `waitForPorts()` against the child process exit event so that any unexpected `workerd` termination is detected immediately. When `workerd` exits early, Miniflare now throws `ERR_RUNTIME_FAILURE` with the runtime's stderr output included in the error message, making the root cause diagnosable without external tools.

> [!IMPORTANT]
> I've created this PR as an attempt to address https://github.com/cloudflare/workers-sdk/issues/14077, it however does not fix that issue.
> But in any case this seems looks like an improvement to me that makes miniflare a bit more robust (and it could potentially save some user some pain?)... although it might be completely unnecessary... I'll leave this to the discretion of the reviewer.... I am totally ok proceeding with this PR or scrapping it entirely

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
