### PR TITLE
Support wrangler containers ssh with ProxyCommand

### DIFF
--- a/.changeset/sharp-containers-proxy.md
+++ b/.changeset/sharp-containers-proxy.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add ProxyCommand support for `wrangler containers ssh`
+
+`wrangler containers ssh` now automatically switches to a stdio proxy when invoked by OpenSSH's `ProxyCommand`, and `--stdio` can force this mode. This lets users connect with `ssh <instance_id>` when their SSH config uses Wrangler as the proxy command.

--- a/packages/wrangler/src/__tests__/containers/ssh.test.ts
+++ b/packages/wrangler/src/__tests__/containers/ssh.test.ts
@@ -1,14 +1,50 @@
+import { PassThrough } from "node:stream";
 import { http, HttpResponse } from "msw";
-import { afterEach, beforeEach, describe, it } from "vitest";
-import MockWebSocketServer from "vitest-websocket-mock";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
+import { WebSocketServer } from "ws";
 import { mockAccount, setWranglerConfig } from "../cloudchamber/utils";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { msw } from "../helpers/msw";
 import { runWrangler } from "../helpers/run-wrangler";
+import type * as childProcess from "node:child_process";
+import type * as nodeEvents from "node:events";
+import type { WebSocket } from "ws";
+
+vi.mock("node:child_process", async () => {
+	const actual =
+		await vi.importActual<typeof childProcess>("node:child_process");
+	const { EventEmitter } =
+		await vi.importActual<typeof nodeEvents>("node:events");
+
+	return {
+		...actual,
+		spawn: vi.fn((...args: Parameters<typeof actual.spawn>) => {
+			const [command, commandArgs] = args;
+			if (command !== "ssh") {
+				return actual.spawn(...args);
+			}
+
+			const child = new EventEmitter() as ReturnType<typeof actual.spawn>;
+			const sshArgs = Array.isArray(commandArgs)
+				? commandArgs.map((arg) => arg.toString())
+				: [];
+			const exitCode = sshArgs.length === 1 && sshArgs[0] === "-V" ? 0 : 255;
+
+			setImmediate(() => {
+				child.emit("exit", exitCode, null);
+				child.emit("close", exitCode, null);
+			});
+
+			return child;
+		}),
+	};
+});
 
 describe("containers ssh", () => {
 	const std = mockConsoleMethods();
+	const originalStdin = process.stdin;
+	const originalStdout = process.stdout;
 
 	mockAccountId();
 	mockApiToken();
@@ -16,6 +52,14 @@ describe("containers ssh", () => {
 
 	afterEach(() => {
 		msw.resetHandlers();
+		Object.defineProperty(process, "stdin", {
+			value: originalStdin,
+			configurable: true,
+		});
+		Object.defineProperty(process, "stdout", {
+			value: originalStdout,
+			configurable: true,
+		});
 	});
 
 	it("should help", async ({ expect }) => {
@@ -36,7 +80,10 @@ describe("containers ssh", () => {
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
 			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
-			  -v, --version         Show version number  [boolean]"
+			  -v, --version         Show version number  [boolean]
+
+			OPTIONS
+			      --stdio  Proxy SSH traffic over stdin/stdout  [boolean]"
 		`);
 	});
 
@@ -79,27 +126,157 @@ describe("containers ssh", () => {
 	// against, but everything up until that point is covered.
 	it("should try ssh'ing into a container", async ({ expect }) => {
 		const instanceId = "a".repeat(64);
-		const wsUrl = "ws://localhost:1234";
 		const sshJwt = "asd";
+		const server = await createWsServer();
+		mockStdio({ stdinIsTTY: true, stdoutIsTTY: true });
+
+		try {
+			setWranglerConfig({});
+			msw.use(
+				http.get(`*/instances/:instanceId/ssh`, async () => {
+					return HttpResponse.json(
+						{ success: true, result: { url: server.url, token: sshJwt } },
+						{ status: 200 }
+					);
+				})
+			);
+
+			const wrangler = runWrangler(`containers ssh ${instanceId}`);
+			const expectedFailure = expect(wrangler).rejects.toMatchInlineSnapshot(`
+				[Error: SSH exited unsuccessfully. Is the container running?
+				NOTE: SSH does not automatically wake a container or count as activity to keep a container alive]
+			`);
+			const socket = await server.connection;
+			socket.close();
+			await expectedFailure;
+		} finally {
+			server.ws.close();
+		}
+	});
+
+	it("should proxy stdin and stdout when stdio is forced", async ({
+		expect,
+	}) => {
+		const instanceId = "a".repeat(64);
+		const sshJwt = "asd";
+		const server = await createWsServer();
+		const { stdin, stdout } = mockStdio({
+			stdinIsTTY: true,
+			stdoutIsTTY: true,
+		});
 
 		setWranglerConfig({});
 		msw.use(
 			http.get(`*/instances/:instanceId/ssh`, async () => {
 				return HttpResponse.json(
-					{ success: true, result: { url: wsUrl, token: sshJwt } },
+					{ success: true, result: { url: server.url, token: sshJwt } },
 					{ status: 200 }
 				);
 			})
 		);
 
-		const mockWebSocket = new MockWebSocketServer(wsUrl);
-		await expect(runWrangler(`containers ssh ${instanceId}`)).rejects
-			.toMatchInlineSnapshot(`
-			[Error: SSH exited unsuccessfully. Is the container running?
-			NOTE: SSH does not automatically wake a container or count as activity to keep a container alive]
-		`);
+		const stdoutData = new Promise<string>((resolve) => {
+			stdout.on("data", (chunk: Buffer) => resolve(chunk.toString()));
+		});
+		const serverMessage = new Promise<string>((resolve) => {
+			void server.connection.then((socket) => {
+				socket.on("message", (chunk) => resolve(chunk.toString()));
+			});
+		});
+		const wrangler = runWrangler(`containers ssh --stdio ${instanceId}`);
 
-		// We got a connection
-		expect(mockWebSocket.connected).toBeTruthy();
+		const socket = await server.connection;
+		stdin.write("client-data");
+		await expect(serverMessage).resolves.toBe("client-data");
+
+		socket.send("server-data");
+		await expect(stdoutData).resolves.toBe("server-data");
+
+		stdin.end();
+		socket.close();
+		await wrangler;
+		server.ws.close();
+		expect(std.out).toBe("");
+		expect(stdin.listenerCount("data")).toBe(0);
+		expect(stdin.listenerCount("end")).toBe(0);
+		expect(stdin.listenerCount("error")).toBe(0);
+	});
+
+	it("should auto-detect proxy mode with extra args when stdin and stdout are not TTYs", async ({
+		expect,
+	}) => {
+		const instanceId = "a".repeat(64);
+		const sshJwt = "asd";
+		const server = await createWsServer();
+		const { stdin, stdout } = mockStdio({});
+
+		setWranglerConfig({});
+		msw.use(
+			http.get(`*/instances/:instanceId/ssh`, async () => {
+				return HttpResponse.json(
+					{ success: true, result: { url: server.url, token: sshJwt } },
+					{ status: 200 }
+				);
+			})
+		);
+
+		const stdoutData = new Promise<string>((resolve) => {
+			stdout.on("data", (chunk: Buffer) => resolve(chunk.toString()));
+		});
+		const serverMessage = new Promise<string>((resolve) => {
+			void server.connection.then((socket) => {
+				socket.on("message", (chunk) => resolve(chunk.toString()));
+			});
+		});
+		const wrangler = runWrangler(`containers ssh ${instanceId} -- 22`);
+
+		const socket = await server.connection;
+		stdin.write("client-data");
+		await expect(serverMessage).resolves.toBe("client-data");
+
+		socket.send("server-data");
+		await expect(stdoutData).resolves.toBe("server-data");
+
+		stdin.end();
+		socket.close();
+		await wrangler;
+		server.ws.close();
+		expect(std.out).toBe("");
 	});
 });
+
+async function createWsServer() {
+	const ws = new WebSocketServer({ port: 0 });
+	await new Promise<void>((resolve) => ws.on("listening", resolve));
+	const address = ws.address();
+	if (address === null || typeof address === "string") {
+		throw new Error("Expected WebSocket server to listen on a TCP port");
+	}
+	const connection = new Promise<WebSocket>((resolve) => {
+		ws.on("connection", resolve);
+	});
+	return { ws, connection, url: `ws://127.0.0.1:${address.port}` };
+}
+
+function mockStdio({
+	stdinIsTTY,
+	stdoutIsTTY,
+}: {
+	stdinIsTTY?: boolean;
+	stdoutIsTTY?: boolean;
+}) {
+	const stdin = new PassThrough();
+	const stdout = new PassThrough();
+	if (stdinIsTTY !== undefined) {
+		Object.defineProperty(stdin, "isTTY", { value: stdinIsTTY });
+	}
+	if (stdoutIsTTY !== undefined) {
+		Object.defineProperty(stdout, "isTTY", { value: stdoutIsTTY });
+	}
+	Object.defineProperty(process, "stdin", { value: stdin, configurable: true });
+	Object.defineProperty(process, "stdout", {
+		value: stdout,
+		configurable: true,
+	});
+	return { stdin, stdout };
+}

--- a/packages/wrangler/src/containers/ssh.ts
+++ b/packages/wrangler/src/containers/ssh.ts
@@ -16,6 +16,7 @@ import type { HandlerArgs, NamedArgDefinitions } from "../core/types";
 import type { WranglerSSHResponse } from "@cloudflare/containers-shared";
 import type { Config } from "@cloudflare/workers-utils";
 import type { Server } from "node:net";
+import type { RawData } from "ws";
 
 // Deprecated SSH flags are hidden because a future SSH implementation
 // will not use OpenSSH, at which point these options will not work.
@@ -91,6 +92,10 @@ const sshArgDefs = {
 		hidden: true,
 		deprecated: true,
 	},
+	stdio: {
+		describe: "Proxy SSH traffic over stdin/stdout",
+		type: "boolean",
+	},
 } as const satisfies NamedArgDefinitions;
 
 type SshArgs = HandlerArgs<typeof sshArgDefs>;
@@ -102,13 +107,19 @@ async function sshCommand(sshArgs: SshArgs, _config: Config) {
 		});
 	}
 
+	// Get arguments passed to the SSH command itself. yargs includes
+	// "containers" and "ssh" as the first two elements of the array, which
+	// we don't want, so we don't include those.
+	const [, , ...rest] = sshArgs._;
+	const useStdio = shouldUseStdio(sshArgs);
+
 	// Check that ssh is enabled
 	let sshResponse: WranglerSSHResponse;
 	try {
-		sshResponse = await promiseSpinner(
-			DeploymentsService.containerWranglerSsh(sshArgs.ID),
-			{ message: "Authenticating" }
-		);
+		const sshPromise = DeploymentsService.containerWranglerSsh(sshArgs.ID);
+		sshResponse = useStdio
+			? await sshPromise
+			: await promiseSpinner(sshPromise, { message: "Authenticating" });
 	} catch (e) {
 		if (e instanceof ApiError) {
 			if (e.status === 404) {
@@ -126,7 +137,21 @@ async function sshCommand(sshArgs: SshArgs, _config: Config) {
 		throw e;
 	}
 
-	const proxy = createSshTcpProxy(sshResponse);
+	const ws = new WebSocket(sshResponse.url, {
+		headers: {
+			authorization: `Bearer ${sshResponse.token}`,
+			"user-agent": "wrangler",
+		},
+	});
+
+	ws.binaryType = "arraybuffer";
+
+	if (useStdio) {
+		await stdioProxy(ws);
+		return;
+	}
+
+	const proxy = tcpProxy(ws);
 	const proxyController = new AbortController();
 	proxy.listen({ port: 0, signal: proxyController.signal });
 
@@ -136,11 +161,6 @@ async function sshCommand(sshArgs: SshArgs, _config: Config) {
 	}
 
 	await verifySshInstalled("ssh");
-
-	// Get arguments passed to the SSH command itself. yargs includes
-	// "containers" and "ssh" as the first two elements of the array, which
-	// we don't want, so we don't include those.
-	const [, , ...rest] = sshArgs._;
 
 	const child = spawn(
 		"ssh",
@@ -221,7 +241,7 @@ export function verifySshInstalled(sshPath: string): Promise<undefined> {
  * Creates a local TCP proxy that wraps data sent in a websocket binary
  * websocket message
  */
-export function createSshTcpProxy(sshResponse: WranglerSSHResponse): Server {
+function tcpProxy(ws: WebSocket): Server {
 	let hasConnection = false;
 	const proxy = createServer((inbound) => {
 		if (hasConnection) {
@@ -235,15 +255,6 @@ export function createSshTcpProxy(sshResponse: WranglerSSHResponse): Server {
 			logger.error("Proxy error: ", err);
 		});
 
-		const ws = new WebSocket(sshResponse.url, {
-			headers: {
-				authorization: `Bearer ${sshResponse.token}`,
-				"user-agent": "wrangler",
-			},
-		});
-
-		ws.binaryType = "arraybuffer";
-
 		ws.addEventListener("error", (err) => {
 			logger.error("Web socket error:", err.message);
 			inbound.end();
@@ -251,9 +262,7 @@ export function createSshTcpProxy(sshResponse: WranglerSSHResponse): Server {
 		});
 
 		ws.addEventListener("open", () => {
-			inbound.on("data", (data) => {
-				ws.send(data);
-			});
+			inbound.on("data", (data) => ws.send(data));
 
 			inbound.on("close", () => {
 				ws.close();
@@ -273,6 +282,57 @@ export function createSshTcpProxy(sshResponse: WranglerSSHResponse): Server {
 	});
 
 	return proxy;
+}
+
+function stdioProxy(ws: WebSocket): Promise<void> {
+	return new Promise<void>((resolve, reject) => {
+		const onData = (data: Buffer | string) => ws.send(data);
+		const onEnd = () => ws.close();
+		const onError = (err: Error) => {
+			ws.close();
+			reject(err);
+		};
+		const cleanup = () => {
+			process.stdin.off("data", onData);
+			process.stdin.off("end", onEnd);
+			process.stdin.off("error", onError);
+		};
+
+		ws.addEventListener("error", (err) => {
+			cleanup();
+			reject(new Error(`Web socket error: ${err.message}`));
+		});
+
+		ws.addEventListener("open", () => {
+			process.stdin.on("data", onData);
+			process.stdin.on("end", onEnd);
+			process.stdin.on("error", onError);
+			process.stdin.resume();
+		});
+
+		ws.on("message", (data: RawData) => {
+			process.stdout.write(formatWebSocketData(data));
+		});
+
+		ws.addEventListener("close", () => {
+			cleanup();
+			resolve(undefined);
+		});
+	});
+}
+
+function formatWebSocketData(data: RawData) {
+	if (Array.isArray(data)) {
+		return Buffer.concat(data);
+	}
+	return data instanceof ArrayBuffer ? new Uint8Array(data) : data;
+}
+
+function shouldUseStdio(sshArgs: SshArgs) {
+	return (
+		sshArgs.stdio === true ||
+		(process.stdin.isTTY !== true && process.stdout.isTTY !== true)
+	);
 }
 
 function buildSshArgs(sshArgs: SshArgs): string[] {
@@ -344,6 +404,9 @@ export const containersSshCommand = createCommand({
 		description: "SSH into a container",
 		status: "stable",
 		owner: "Product: Cloudchamber",
+	},
+	behaviour: {
+		printBanner: (args) => !shouldUseStdio(args),
 	},
 	args: sshArgDefs,
 	positionalArgs: ["ID"],

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -2398,7 +2398,7 @@ export async function main(argv: string[]): Promise<void> {
 			// needed, so we can cleanly exit. Note, we don't want to disconnect if
 			// this file was imported in Vitest, as that would stop communication with
 			// the test runner.
-			if (typeof vitest === "undefined") {
+			if (typeof vitest === "undefined" && process.connected) {
 				process.disconnect?.();
 			}
 


### PR DESCRIPTION
When neither stdin or stdout is a TTY (or with the `--stdio` flag), make `wrangler containers ssh` act as a simple pipe that forwards data between stdio and the websocket (where it is forwarded to the SSH server running in the VM). This allows users to use "plain" SSH with the `ProxyCommand` ssh option.

For example, with the following SSH config:

```
Host *.cloudflare
    User cloudchamber
    ProxyCommand wrangler containers ssh %h
```

a user can use `ssh abcdef1234.cloudflare` to SSH to the container `abcdef1234`.

Fixes CC-7801.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/31117
  - [ ] Documentation not necessary because:
