### PR TITLE
[wrangler] Honor anonymous auth interactively

### DIFF
--- a/.changeset/anonymous-terms-acceptance.md
+++ b/.changeset/anonymous-terms-acceptance.md
@@ -4,4 +4,4 @@
 
 Require explicit Terms of Service acceptance for `--allow-anonymous`
 
-Wrangler now prompts users to type `yes` before continuing with `--allow-anonymous`, including in non-interactive environments. The prompt links to Cloudflare's Terms of Service and Privacy Policy.
+Wrangler now prompts users to type `yes` before continuing with `--allow-anonymous`, including in non-interactive environments. The prompt links to Cloudflare's Terms of Service and Privacy Policy, and the flag now uses a temporary preview account in interactive terminals instead of starting OAuth.

--- a/packages/wrangler/src/__tests__/deploy/core.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/core.test.ts
@@ -781,39 +781,53 @@ describe("deploy", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		it("still starts OAuth in interactive mode when --allow-anonymous is passed", async ({
+		it("creates an anonymous preview account in interactive mode when --allow-anonymous is passed", async ({
 			expect,
 		}) => {
 			setIsTTY(true);
 			mockAnonymousTermsAcceptance();
 			writeWranglerConfig();
 			writeWorkerSource();
-			mockDomainUsesAccess({ usesAccess: false });
-			mockSubDomainRequest();
-			mockUploadWorkerRequest();
-			mockExchangeRefreshTokenForAccessToken({ respondWith: "refreshSuccess" });
-			mockOAuthServerCallback("success");
+			mockSubDomainRequest("test-sub-domain", true, false);
+			mockUploadWorkerRequest({
+				expectedAccountId: "preview-account-id",
+			});
 
 			let previewAccountRequests = 0;
-			let contentTypeHeader: string | null = null;
 			msw.use(
-				http.post(anonymousPreviewAccountUrl, async ({ request }) => {
+				http.get(
+					"*/accounts/preview-account-id/workers/services/:scriptName",
+					() => {
+						return HttpResponse.json(
+							createFetchResult({
+								default_environment: {
+									script: { last_deployed_from: "wrangler" },
+								},
+							})
+						);
+					}
+				),
+				http.post(anonymousPreviewAccountUrl, async () => {
 					previewAccountRequests += 1;
-					contentTypeHeader = request.headers.get("Content-Type");
 					return HttpResponse.json({
-						account: {
-							id: "preview-account-id",
-							name: "Preview Account Alpha",
-							type: "standard",
-							apiToken: "preview-account-token",
-							tokenId: "preview-token-id",
-							expiresAt: "2027-01-01T00:00:00.000Z",
+						success: true,
+						result: {
+							account: {
+								id: "preview-account-id",
+								name: "Preview Account Alpha",
+								type: "standard",
+								apiToken: "preview-account-token",
+								tokenId: "preview-token-id",
+								expiresAt: "2027-01-01T00:00:00.000Z",
+							},
+							claim: {
+								token: "claim-token",
+								url: "https://dash.cloudflare.com/claim-preview?claimToken=claim-token",
+								expiresAt: "2027-01-02T00:00:00.000Z",
+							},
 						},
-						claim: {
-							token: "claim-token",
-							url: "https://dash.cloudflare.com/claim-preview?claimToken=claim-token",
-							expiresAt: "2027-01-02T00:00:00.000Z",
-						},
+						errors: [],
+						messages: [],
 					});
 				})
 			);
@@ -822,10 +836,10 @@ describe("deploy", () => {
 				runWrangler("deploy index.js --allow-anonymous")
 			).resolves.toBeUndefined();
 
-			expect(previewAccountRequests).toBe(0);
-			expect(contentTypeHeader).toBeNull();
-			expect(std.out).toContain("Attempting to login via OAuth...");
-			expect(std.out).not.toContain("Temporary account ready:");
+			expect(previewAccountRequests).toBe(1);
+			expect(std.out).not.toContain("Attempting to login via OAuth...");
+			expect(std.out).toContain("Temporary account ready:");
+			expect(std.out).toContain("Account: Preview Account Alpha (created)");
 		});
 
 		describe("with an alternative auth domain", () => {

--- a/packages/wrangler/src/__tests__/experimental-commands-api.test.ts
+++ b/packages/wrangler/src/__tests__/experimental-commands-api.test.ts
@@ -9,7 +9,7 @@ describe("experimental_getWranglerCommands", () => {
 			{
 			  "allow-anonymous": {
 			    "default": false,
-			    "describe": "Create a temporary preview account when a command needs authentication in non-interactive mode",
+			    "describe": "Create a temporary preview account when a command needs authentication",
 			    "hidden": true,
 			    "type": "boolean",
 			  },

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -527,7 +527,7 @@ export function createCLIParser(argv: string[]) {
 		},
 		"allow-anonymous": {
 			describe:
-				"Create a temporary preview account when a command needs authentication in non-interactive mode",
+				"Create a temporary preview account when a command needs authentication",
 			type: "boolean",
 			default: false,
 			hidden: true,

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -1035,14 +1035,19 @@ type LoginProps = {
 
 export async function loginOrRefreshIfRequired(
 	complianceConfig: ComplianceConfig,
-	props?: LoginProps
+	props?: LoginProps,
+	{ allowLogin = true }: { allowLogin?: boolean } = {}
 ): Promise<boolean> {
 	// TODO: if there already is a token, then try refreshing
 	// TODO: ask permission before opening browser
 	if (!getAPIToken()) {
 		// Not logged in.
 		// If we are not interactive, we cannot ask the user to login
-		return !isNonInteractiveOrCI() && (await login(complianceConfig, props));
+		return (
+			allowLogin &&
+			!isNonInteractiveOrCI() &&
+			(await login(complianceConfig, props))
+		);
 	} else if (isRefreshNeeded()) {
 		// We're logged in, but the refresh token seems to have expired,
 		// so let's try to refresh it
@@ -1052,7 +1057,11 @@ export async function loginOrRefreshIfRequired(
 			return true;
 		} else {
 			// If the refresh token isn't valid, then we ask the user to login again
-			return !isNonInteractiveOrCI() && (await login(complianceConfig, props));
+			return (
+				allowLogin &&
+				!isNonInteractiveOrCI() &&
+				(await login(complianceConfig, props))
+			);
 		}
 	} else {
 		return true;
@@ -1483,22 +1492,24 @@ export async function requireAuth(
 		account_id?: string;
 	}
 ): Promise<string> {
-	const loggedIn = await loginOrRefreshIfRequired(config);
+	const loggedIn = await loginOrRefreshIfRequired(config, undefined, {
+		allowLogin: !shouldAllowAnonymous(),
+	});
 	if (!loggedIn) {
-		if (isNonInteractiveOrCI()) {
-			if (shouldAllowAnonymous()) {
-				const { account: anonymousPreviewAccount, cached } =
-					await getOrCreateAnonymousPreviewAccount();
-				setAuthOverride({
-					accountId: anonymousPreviewAccount.account.id,
-					apiToken: {
-						apiToken: anonymousPreviewAccount.account.apiToken,
-					},
-				});
-				logAnonymousPreviewAccount(anonymousPreviewAccount, cached);
-				return anonymousPreviewAccount.account.id;
-			}
+		if (shouldAllowAnonymous()) {
+			const { account: anonymousPreviewAccount, cached } =
+				await getOrCreateAnonymousPreviewAccount();
+			setAuthOverride({
+				accountId: anonymousPreviewAccount.account.id,
+				apiToken: {
+					apiToken: anonymousPreviewAccount.account.apiToken,
+				},
+			});
+			logAnonymousPreviewAccount(anonymousPreviewAccount, cached);
+			return anonymousPreviewAccount.account.id;
+		}
 
+		if (isNonInteractiveOrCI()) {
 			throw new UserError(
 				"In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/fundamentals/api/get-started/create-token/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN.\n\nTo continue without logging in, rerun this command with `--allow-anonymous`. Wrangler will use a temporary account and print a claim URL.",
 				{ telemetryMessage: "user auth missing api token non interactive" }


### PR DESCRIPTION
Updates the `--allow-anonymous` auth flow so unauthenticated interactive Wrangler commands use a temporary preview account instead of starting OAuth. Existing authenticated users still use their configured auth, but when no usable auth is present the explicit flag is respected regardless of TTY mode.

This is stacked on #14092.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: `--allow-anonymous` is a hidden Wrangler flag, and the changeset text has been updated for release notes.

*A picture of a cute animal (not mandatory, but encouraged)*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->