### PR TITLE
In C3 hide non-framework categories when `--platform=pages` is specified

### DIFF
--- a/.changeset/filter-categories-by-platform.md
+++ b/.changeset/filter-categories-by-platform.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": minor
+---
+
+Hide non-framework categories when `--platform=pages` is specified
+
+When running C3 with `--platform=pages`, the "Hello World example" and "Application Starter" categories are now hidden since they only produce Workers projects. The framework list is also filtered to only show frameworks that support the Pages platform. This makes it clear that C3 can only create Pages projects when using a framework.

--- a/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
+++ b/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
@@ -740,7 +740,7 @@ describe("Create Cloudflare CLI", () => {
 	});
 
 	describe("frameworks related", () => {
-		["solid", "next"].forEach((framework) =>
+		["solid", "next", "react-router", "analog"].forEach((framework) =>
 			test(`error when trying to create a ${framework} app on Pages`, async ({
 				expect,
 				logStream,
@@ -838,6 +838,99 @@ describe("Create Cloudflare CLI", () => {
 			expect(output).toContain("--template react-ts");
 			expect(output).not.toContain("Select a variant");
 		});
+	});
+
+	describe.skipIf(isExperimental)("platform filtering", () => {
+		test.skipIf(isWindows)(
+			"--platform=pages hides non-framework categories",
+			async ({ expect, logStream, project }) => {
+				const { output } = await runC3(
+					[project.path, "--platform=pages"],
+					[
+						{
+							matcher: /What would you like to start with\?/,
+							input: {
+								type: "select",
+								target: "Framework Starter",
+								// "Framework Starter" should be the default (first visible)
+								// option since "Hello World example" is hidden
+								assertDefaultSelection: "Framework Starter",
+							},
+						},
+						{
+							matcher: /Which development framework do you want to use\?/,
+							input: {
+								type: "select",
+								target: "Angular",
+							},
+						},
+						{
+							matcher: /Do you want to use git for version control/,
+							input: ["n"],
+						},
+						{
+							matcher: /Do you want to deploy your application/,
+							input: ["n"],
+						},
+					],
+					logStream
+				);
+
+				expect(output).toContain("category Framework Starter");
+				expect(output).not.toContain("Hello World");
+				expect(output).not.toContain("Application Starter");
+			}
+		);
+
+		test.skipIf(isWindows)(
+			"--platform=pages filters out workers-only frameworks",
+			async ({ expect, logStream, project }) => {
+				const { output } = await runC3(
+					[project.path, "--platform=pages", "--category=web-framework"],
+					[
+						{
+							matcher: /Which development framework do you want to use\?/,
+							input: {
+								type: "select",
+								target: "Angular",
+							},
+						},
+						{
+							matcher: /Do you want to use git for version control/,
+							input: ["n"],
+						},
+						{
+							matcher: /Do you want to deploy your application/,
+							input: ["n"],
+						},
+					],
+					logStream
+				);
+
+				// Workers-only frameworks should not appear in the output
+				expect(output).not.toContain("Next");
+				expect(output).not.toContain("SolidStart");
+				expect(output).not.toContain("React Router");
+				expect(output).not.toContain("Analog");
+			}
+		);
+
+		["hello-world", "demo"].forEach((category) =>
+			test(`--platform=pages --category=${category} errors for workers-only category`, async ({
+				expect,
+				logStream,
+				project,
+			}) => {
+				const { errors } = await runC3(
+					[project.path, "--platform=pages", `--category=${category}`],
+					[],
+					logStream
+				);
+				expect(errors).toContain(
+					`The "${category}" category is not available for the "pages" platform`
+				);
+			})
+		);
 	});
 });
 

--- a/packages/create-cloudflare/src/helpers/args.ts
+++ b/packages/create-cloudflare/src/helpers/args.ts
@@ -69,8 +69,18 @@ export const cliDefinition: ArgumentsDefinition = {
 			description: `Specifies the kind of templates that should be created`,
 			values(args) {
 				const experimental = Boolean(args?.["experimental"]);
+				const platform = args?.["platform"] as string | undefined;
 				if (experimental) {
 					return [{ name: "web-framework", description: "Framework Starter" }];
+				} else if (platform === "pages") {
+					// Only framework starters can produce Pages projects
+					return [
+						{ name: "web-framework", description: "Framework Starter" },
+						{
+							name: "remote-template",
+							description: "Template from a GitHub repo",
+						},
+					];
 				} else {
 					return [
 						{ name: "hello-world", description: "Hello World Starter" },

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -478,7 +478,9 @@ export const createContext = async (
 	});
 
 	const categoryOptions = [];
-	if (Object.keys(helloWorldTemplateMap).length) {
+	// Hello World and Application Starter templates are all Workers-only,
+	// so hide them when the user has explicitly targeted the Pages platform
+	if (args.platform !== "pages" && Object.keys(helloWorldTemplateMap).length) {
 		categoryOptions.push({
 			label: "Hello World example",
 			value: "hello-world",
@@ -492,7 +494,7 @@ export const createContext = async (
 			description: "Select from the most popular full-stack web frameworks",
 		});
 	}
-	if (Object.keys(otherTemplateMap).length) {
+	if (args.platform !== "pages" && Object.keys(otherTemplateMap).length) {
 		categoryOptions.push({
 			label: "Application Starter",
 			value: "demo",
@@ -501,6 +503,9 @@ export const createContext = async (
 		});
 	}
 	categoryOptions.push(
+		// TODO: hide "Template from a GitHub repo" when a --platform arg is
+		// provided (whether workers or pages), since remote templates have no
+		// platform validation and would ignore the user's platform choice
 		{
 			label: "Template from a GitHub repo",
 			value: "remote-template",
@@ -524,6 +529,19 @@ export const createContext = async (
 		return goBack("category");
 	}
 
+	// Validate that the selected category is compatible with the target platform.
+	// This catches the case where a user passes e.g. --platform=pages --category=hello-world
+	// directly via CLI args, bypassing the interactive prompt filtering.
+	if (
+		args.platform === "pages" &&
+		category !== "web-framework" &&
+		category !== "remote-template"
+	) {
+		throw new Error(
+			`The "${category}" category is not available for the "pages" platform`
+		);
+	}
+
 	let template: TemplateConfig;
 
 	if (category === "web-framework") {
@@ -532,6 +550,18 @@ export const createContext = async (
 				// only hide if we're going to show the options - otherwise, the
 				// result will show up as (skipped) instead of the actual value
 				if (!config.hidden || args.framework) {
+					// When a platform is specified, filter out frameworks that don't
+					// support that platform (e.g. workers-only frameworks when
+					// --platform=pages)
+					if (args.platform && !args.framework) {
+						const supportsTargetPlatform =
+							"platformVariants" in config
+								? args.platform in config.platformVariants
+								: config.platform === args.platform;
+						if (!supportsTargetPlatform) {
+							return acc;
+						}
+					}
 					acc.push({
 						label: config.displayName,
 						value: key,


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-2432

When running C3 with `--platform=pages`, the "Hello World example" and "Application Starter" categories are now hidden since they only produce Workers projects. The framework list is also filtered to only show frameworks that support the Pages platform. This makes it clear that C3 can only create Pages projects when using a framework.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/31119
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
