### PR TITLE
[C3] Migrate TanStack Start scaffolding to @tanstack/cli

### DIFF
--- a/.changeset/c3-tanstack-cli-migration.md
+++ b/.changeset/c3-tanstack-cli-migration.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": minor
+---
+
+Migrate TanStack Start scaffolding from `@tanstack/create-start` to `@tanstack/cli`
+
+TanStack has consolidated their project scaffolding into a unified CLI package (`@tanstack/cli`) with a `create` subcommand, replacing the previous `@tanstack/create-start` package. This updates C3 to use the new CLI while preserving the same Cloudflare deployment target and React framework options.

--- a/packages/create-cloudflare/src/frameworks/package.json
+++ b/packages/create-cloudflare/src/frameworks/package.json
@@ -2,7 +2,7 @@
 	"name": "frameworks_clis_info",
 	"dependencies": {
 		"@angular/create": "21.2.12",
-		"@tanstack/create-start": "0.59.32",
+		"@tanstack/cli": "0.68.0",
 		"create-analog": "2.5.2",
 		"create-astro": "5.0.6",
 		"create-docusaurus": "3.10.1",

--- a/packages/create-cloudflare/templates/tanstack-start/c3.ts
+++ b/packages/create-cloudflare/templates/tanstack-start/c3.ts
@@ -8,6 +8,8 @@ const { npm } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, [
+		// @tanstack/cli uses `create` as a subcommand
+		"create",
 		ctx.project.name,
 		"--deployment",
 		"cloudflare",
@@ -24,7 +26,7 @@ const config: TemplateConfig = {
 	configVersion: 1,
 	id: "tanstack-start",
 	platform: "workers",
-	frameworkCli: "@tanstack/create-start",
+	frameworkCli: "@tanstack/cli",
 	displayName: "TanStack Start",
 	generate,
 	transformPackageJson: async () => ({


### PR DESCRIPTION
TanStack has consolidated their project scaffolding into a unified CLI package (`@tanstack/cli`) with a `create` subcommand, replacing the previous `@tanstack/create-start` package. The old package prints a deprecation warning at runtime directing users to the new CLI ([ref](https://github.com/TanStack/router/discussions/6712)).

This updates C3 to use `npx @tanstack/cli create` instead of `npx @tanstack/create-start`, preserving the same `--deployment cloudflare --framework react --no-git` flags which the new CLI continues to support.

Changes:
- `templates/tanstack-start/c3.ts` – updated `frameworkCli` to `@tanstack/cli` and added `"create"` subcommand to the args array
- `src/frameworks/package.json` – replaced `@tanstack/create-start` with `@tanstack/cli@0.68.0` for Dependabot version tracking

Other framework CLIs (`@angular/create`, `create-astro`, `create-docusaurus`, `create-hono`, `create-next-app`, `create-qwik`, `create-react-router`, `create-rwsdk`, `create-solid`, `create-vike`, `create-vite`, `create-vue`, `create-waku`, `gatsby`, `nuxi`, `sv`) were checked and none have deprecations or CLI interface changes requiring updates at this time.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: the framework unit tests pass and E2E testing requires running the actual TanStack CLI which is covered by CI
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this is an internal scaffolding tool change with no user-facing documentation impact