### PR TITLE
[wrangler] fix: clear error when API token contains non-ASCII characters

### DIFF
--- a/.changeset/api-token-ascii-validation.md
+++ b/.changeset/api-token-ascii-validation.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix cryptic "Cannot convert argument to a ByteString" error when API token contains non-ASCII characters
+
+Previously, if `CLOUDFLARE_API_TOKEN` contained non-ASCII characters (for example an ellipsis `…` instead of three dots `...`, which can happen when copy-pasting tokens from some web pages or terminals that auto-substitute punctuation), wrangler would crash with an opaque undici internal error that gave no hint that the token itself was the problem. Wrangler now detects this case in `requireApiToken()` and throws a clear `UserError` explaining the problem and how to fix it.

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -21,6 +21,7 @@ import {
 	getOrSelectAccountId,
 	loginOrRefreshIfRequired,
 	readAuthConfigFile,
+	requireApiToken,
 	requireAuth,
 	writeAuthConfigFile,
 } from "../user";
@@ -1324,6 +1325,51 @@ describe("User", () => {
 				id: "api-account",
 				name: "API Account",
 			});
+		});
+	});
+
+	describe("requireApiToken", () => {
+		it("returns credentials when the token is valid ASCII", ({ expect }) => {
+			vi.stubEnv("CLOUDFLARE_API_TOKEN", "valid-ascii-token-1234");
+
+			expect(requireApiToken()).toEqual({ apiToken: "valid-ascii-token-1234" });
+		});
+
+		it("throws a helpful UserError when the token contains non-ASCII characters", ({
+			expect,
+		}) => {
+			// U+2026 HORIZONTAL ELLIPSIS — common when pasting tokens from rich-text sources
+			vi.stubEnv("CLOUDFLARE_API_TOKEN", "abc…def");
+
+			expect(() => requireApiToken()).toThrowError(
+				"Your API token contains invalid characters (non-ASCII). " +
+					"Run `wrangler login` to re-authenticate, or check that CLOUDFLARE_API_TOKEN is set correctly."
+			);
+		});
+
+		it("throws a UserError when the token contains emoji (surrogate pair)", ({
+			expect,
+		}) => {
+			vi.stubEnv("CLOUDFLARE_API_TOKEN", "tok😀en");
+
+			expect(() => requireApiToken()).toThrowError(
+				"Your API token contains invalid characters (non-ASCII)."
+			);
+		});
+
+		it("throws the missing-token UserError when no credentials exist", ({
+			expect,
+		}) => {
+			expect(() => requireApiToken()).toThrowError("No API token found.");
+		});
+
+		it("does not throw when using authKey/authEmail credentials", ({
+			expect,
+		}) => {
+			vi.stubEnv("CLOUDFLARE_API_KEY", "my-auth-key");
+			vi.stubEnv("CLOUDFLARE_EMAIL", "user@example.com");
+
+			expect(() => requireApiToken()).not.toThrow();
 		});
 	});
 });

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -1447,7 +1447,7 @@ export function requireApiToken(): ApiCredentials {
 			telemetryMessage: "user auth missing api token",
 		});
 	}
-	if ("apiToken" in credentials && /[^\x00-\x7F]/.test(credentials.apiToken)) {
+	if ("apiToken" in credentials && /[-￿]/.test(credentials.apiToken)) {
 		throw new UserError(
 			"Your API token contains invalid characters (non-ASCII). " +
 				"Run `wrangler login` to re-authenticate, or check that CLOUDFLARE_API_TOKEN is set correctly.",

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -1447,6 +1447,13 @@ export function requireApiToken(): ApiCredentials {
 			telemetryMessage: "user auth missing api token",
 		});
 	}
+	if ("apiToken" in credentials && /[^\x00-\x7F]/.test(credentials.apiToken)) {
+		throw new UserError(
+			"Your API token contains invalid characters (non-ASCII). " +
+				"Run `wrangler login` to re-authenticate, or check that CLOUDFLARE_API_TOKEN is set correctly.",
+			{ telemetryMessage: "user auth invalid api token characters" }
+		);
+	}
 	return credentials;
 }
 


### PR DESCRIPTION
Fixes #13997.

When `CLOUDFLARE_API_TOKEN` (or a stored OAuth token) contained non-ASCII characters — e.g. an ellipsis `…` (U+2026) pasted from a web page that auto-substitutes punctuation — wrangler crashed with an opaque undici internal error:

```
✘ [ERROR] Cannot convert argument to a ByteString because the character at
  index 7 has a value of 8230 which is greater than 255.
```

The error originated in `addAuthorizationHeader` when calling `headers.set("Authorization", \`Bearer ${token}\`)`. Since `Headers.set` enforces ByteString semantics (all char codes ≤ 255 per the Fetch spec), any token with a non-ASCII character throws this internal message with no mention of the token.

#### Fix

`requireApiToken()` now checks that the `apiToken` is ASCII-safe before returning credentials. If it contains non-ASCII characters, it throws a `UserError` with an actionable message:

```
Your API token contains invalid characters (non-ASCII). Run `wrangler login`
to re-authenticate, or check that CLOUDFLARE_API_TOKEN is set correctly.
```

`requireApiToken()` is the single enforcement point for all API calls in wrangler, so the check fires regardless of which command triggers authentication.

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: bug fix with no new user-facing API surface; the error message is self-describing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->