### PR TITLE
Add Chrome browser caching to test-and-check-other-node workflow and add timeout to waitForLineOutput call

### DIFF
--- a/.changeset/browser-launch-timeout.md
+++ b/.changeset/browser-launch-timeout.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Add timeout to browser-rendering browser launch to prevent infinite hangs
+
+The browser-rendering plugin's `launchBrowser()` function now passes a 5-minute timeout to `waitForLineOutput()` when waiting for Chrome to print its DevTools WebSocket URL. Previously, if Chrome failed to start or crashed before printing the URL, the promise would hang forever. This could cause CI pipelines and local dev sessions to get stuck indefinitely.

--- a/.github/workflows/test-and-check-other-node.yml
+++ b/.github/workflows/test-and-check-other-node.yml
@@ -69,6 +69,18 @@ jobs:
           turbo-token: ${{ secrets.TURBO_TOKEN }}
           turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
 
+      # The miniflare browser-rendering tests download Chrome (~150 MB) via
+      # @puppeteer/browsers at runtime. Caching the binary avoids repeat
+      # downloads and reduces the chance of tests hanging while waiting for
+      # the download to finish within their timeout window.
+      - name: Restore Chrome browser cache (Browser Run)
+        if: steps.should_run.outputs.result == 'true'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          key: chrome-${{ runner.os }}-${{ hashFiles('packages/miniflare/src/plugins/browser-rendering/browser-version.ts') }}
+          path: |
+            ~/.cache/.wrangler/chrome
+
       - name: Run tests (packages)
         # We are running the package tests first be able to get early feedback on changes.
         # There is no point in running the fixtures if a package is broken.

--- a/packages/miniflare/src/plugins/browser-rendering/index.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/index.ts
@@ -238,7 +238,10 @@ export async function launchBrowser({
 		},
 	});
 	const wsEndpoint = await browserProcess.waitForLineOutput(
-		CDP_WEBSOCKET_ENDPOINT_REGEX
+		CDP_WEBSOCKET_ENDPOINT_REGEX,
+		// Note: we pass an explicit timeout so the promise rejects instead of hanging forever
+		//       when Chrome fails to start or crashes before printing the DevTools URL
+		10_000
 	);
 	// On Windows in particular, Chrome may print the DevTools URL slightly
 	// before its listening socket is fully ready to accept connections.

--- a/packages/miniflare/src/plugins/browser-rendering/index.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/index.ts
@@ -240,8 +240,10 @@ export async function launchBrowser({
 	const wsEndpoint = await browserProcess.waitForLineOutput(
 		CDP_WEBSOCKET_ENDPOINT_REGEX,
 		// Note: we pass an explicit timeout so the promise rejects instead of hanging forever
-		//       when Chrome fails to start or crashes before printing the DevTools URL
-		10_000
+		//       when Chrome fails to start or crashes before printing the DevTools URL.
+		//       Five minutes is generous enough to cover on-demand browser downloads on slow
+		//       connections while still failing within a reasonable window.
+		5 * 60 * 1_000
 	);
 	// On Windows in particular, Chrome may print the DevTools URL slightly
 	// before its listening socket is fully ready to accept connections.


### PR DESCRIPTION
The test-and-check-other-node GitHub workflow is constantly getting stuck (I assume) because of Chrome browser downloads (e.g. https://github.com/cloudflare/workers-sdk/actions/runs/26635076139/job/78493207646?pr=14082), this PR tries to fix such issue.

It also adds a timeout to the `waitForLineOutput` call that `launchBrowser` makes (just to make sure that it doesn't get stuck)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: fixes a CI issue
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->