### PR TITLE
chore: add `create-server-example` fixture

### DIFF
--- a/fixtures/create-server-example/README.md
+++ b/fixtures/create-server-example/README.md
@@ -1,0 +1,30 @@
+# `createServer()` example
+
+This fixture shows how to use the `createServer()` API as an integration-test harness for a multi-Worker app. It includes examples for both Wrangler and Vite projects.
+
+The example app has two Workers:
+
+| Worker       | Route               | Role                                                                          |
+| ------------ | ------------------- | ----------------------------------------------------------------------------- |
+| `web-worker` | `example.com/*`     | Handles user-facing routes and calls the API Worker over a service binding.   |
+| `api-worker` | `example.com/api/*` | Fetches upstream user data, caches it in KV, and generates scheduled reports. |
+
+The tests demonstrate:
+
+- Starting Workers from Wrangler config files with `createServer()`.
+- Using `server.fetch()` to dispatch through configured routes.
+- Using `server.getWorker(name)` to call a specific Worker's `fetch()` or `scheduled()` handler directly.
+- Mocking Worker outbound requests with MSW.
+- Calling `server.clearStorage()` between tests to reuse a server while keeping local storage isolated.
+
+## Files
+
+| File                                                               | Purpose                                        |
+| ------------------------------------------------------------------ | ---------------------------------------------- |
+| [`tests/wrangler-project.test.ts`](tests/wrangler-project.test.ts) | Example for testing Wrangler projects.         |
+| [`tests/vite-project.test.ts`](tests/vite-project.test.ts)         | Example for testing Vite projects.             |
+| [`src/web.ts`](src/web.ts)                                         | User-facing Worker.                            |
+| [`src/api.ts`](src/api.ts)                                         | API Worker with KV and scheduled job behavior. |
+| [`wrangler.web.jsonc`](wrangler.web.jsonc)                         | Web Worker config.                             |
+| [`wrangler.api.jsonc`](wrangler.api.jsonc)                         | API Worker config.                             |
+| [`vite.config.ts`](vite.config.ts)                                 | Builds Vite-generated Worker configs.          |

--- a/fixtures/create-server-example/package.json
+++ b/fixtures/create-server-example/package.json
@@ -13,7 +13,6 @@
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "catalog:default",
-		"@fixture/shared": "workspace:*",
 		"@types/node": "catalog:default",
 		"msw": "catalog:default",
 		"typescript": "catalog:default",

--- a/fixtures/create-server-example/package.json
+++ b/fixtures/create-server-example/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "@fixture/create-server-example",
+	"private": true,
+	"description": "Integration tests with createServer API",
+	"type": "module",
+	"scripts": {
+		"check:type": "tsc",
+		"build": "vite build",
+		"test:ci": "vitest run",
+		"type:tests": "tsc -p ./tests/tsconfig.json"
+	},
+	"devDependencies": {
+		"@cloudflare/vite-plugin": "workspace:*",
+		"@cloudflare/workers-tsconfig": "workspace:*",
+		"@cloudflare/workers-types": "catalog:default",
+		"@fixture/shared": "workspace:*",
+		"@types/node": "catalog:default",
+		"msw": "catalog:default",
+		"typescript": "catalog:default",
+		"vite": "catalog:default",
+		"vitest": "catalog:default",
+		"wrangler": "workspace:*"
+	},
+	"volta": {
+		"extends": "../../package.json"
+	}
+}

--- a/fixtures/create-server-example/src/api.ts
+++ b/fixtures/create-server-example/src/api.ts
@@ -1,0 +1,82 @@
+import { WorkerEntrypoint } from "cloudflare:workers";
+
+type Env = {
+	STORE: KVNamespace;
+};
+
+type User = {
+	id: string;
+	name: string;
+};
+
+/**
+ * API Worker: fetches users from an upstream service, caches them in KV, and generates daily reports on a schedule.
+ */
+export default class ApiWorker extends WorkerEntrypoint<Env> {
+	async fetch(request: Request) {
+		const url = new URL(request.url);
+		const userPathPrefix = "/api/users/";
+		if (url.pathname.startsWith(userPathPrefix)) {
+			const userId = url.pathname.slice(userPathPrefix.length);
+			return Response.json(await this.getUser(userId));
+		}
+
+		const reportPathPrefix = "/api/reports/";
+		if (url.pathname.startsWith(reportPathPrefix)) {
+			const date = url.pathname.slice(reportPathPrefix.length);
+			const report = await this.getDailyReport(date);
+
+			if (report === null) {
+				return Response.json({ error: "No report" }, { status: 404 });
+			}
+
+			return Response.json(report);
+		}
+
+		return new Response("Not Found", { status: 404 });
+	}
+
+	async scheduled(event: ScheduledController) {
+		if (event.cron !== "0 0 * * *") {
+			throw new Error(`Unexpected cron: ${event.cron}`);
+		}
+
+		const date = new Date(event.scheduledTime).toISOString().slice(0, 10);
+		const list = await this.env.STORE.list({ prefix: "user/" });
+		const userIds = list.keys.map((key) => key.name.slice("user/".length));
+
+		await this.env.STORE.put(`daily-report/${date}`, JSON.stringify(userIds), {
+			expirationTtl: 60 * 60,
+		});
+
+		for (const key of list.keys) {
+			await this.env.STORE.delete(key.name);
+		}
+	}
+
+	async getUser(userId: string): Promise<User> {
+		const key = `user/${userId}`;
+		const cachedUser = await this.env.STORE.get<User>(key, {
+			type: "json",
+		});
+
+		if (cachedUser !== null) {
+			return cachedUser;
+		}
+
+		const upstreamResponse = await fetch(
+			`http://upstream.example.com/users/${userId}`
+		);
+		const user = await upstreamResponse.json<User>();
+
+		await this.env.STORE.put(key, JSON.stringify(user));
+
+		return user;
+	}
+
+	async getDailyReport(date: string) {
+		return await this.env.STORE.get<string[]>(`daily-report/${date}`, {
+			type: "json",
+		});
+	}
+}

--- a/fixtures/create-server-example/src/web.ts
+++ b/fixtures/create-server-example/src/web.ts
@@ -1,0 +1,39 @@
+type Env = {
+	API: Service<typeof import("./api").default>;
+};
+
+/**
+ * Web Worker: renders user profiles and reports by calling the API Worker over a service binding.
+ */
+export default {
+	async fetch(request, env) {
+		const url = new URL(request.url);
+
+		if (url.pathname === "/") {
+			return new Response("Hello World");
+		}
+
+		const userPathPrefix = "/users/";
+		if (url.pathname.startsWith(userPathPrefix)) {
+			const userId = url.pathname.slice(userPathPrefix.length);
+			const { name } = await env.API.getUser(userId);
+			return new Response(`Profile: ${name}`);
+		}
+
+		const reportsPathPrefix = "/reports/";
+		if (url.pathname.startsWith(reportsPathPrefix)) {
+			const date = url.pathname.slice(reportsPathPrefix.length);
+			const report = await env.API.getDailyReport(date);
+
+			if (report === null) {
+				return new Response("No report", { status: 404 });
+			}
+
+			return new Response(
+				`Daily report (${date}): active users ${report.join(", ")}`
+			);
+		}
+
+		return new Response("Not Found", { status: 404 });
+	},
+} satisfies ExportedHandler<Env>;

--- a/fixtures/create-server-example/tests/tsconfig.json
+++ b/fixtures/create-server-example/tests/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "@cloudflare/workers-tsconfig/tsconfig.json",
+	"compilerOptions": {
+		"module": "esnext",
+		"types": ["node"]
+	},
+	"include": ["**/*.ts"],
+	"exclude": []
+}

--- a/fixtures/create-server-example/tests/vite-project.test.ts
+++ b/fixtures/create-server-example/tests/vite-project.test.ts
@@ -1,0 +1,111 @@
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, test } from "vitest";
+import { createServer } from "wrangler";
+
+// Vite builds each Worker to a generated Wrangler config. Test those generated
+// configs instead of the source configs you pass to the Vite plugin.
+const server = createServer({
+	workers: [
+		{ configPath: "./dist/web_worker/wrangler.json" },
+		{ configPath: "./dist/api_worker/wrangler.json" },
+	],
+});
+
+// server.getWorker() would return the first Worker, but naming it makes it explicit.
+const webWorker = server.getWorker("web-worker");
+const apiWorker = server.getWorker("api-worker");
+
+// createServer's default outboundService forwards Worker outbound fetches to globalThis.fetch().
+// You can use libraries like MSW to intercept those requests.
+const mock = setupServer();
+
+describe("createServer: vite project setup", () => {
+	beforeAll(async () => {
+		mock.listen({ onUnhandledRequest: "error" });
+		await server.listen();
+	});
+
+	afterAll(async () => {
+		mock.close();
+		await server.close();
+	});
+
+	afterEach(async () => {
+		// Keep tests isolated while reusing the same running server.
+		mock.resetHandlers();
+		await server.clearStorage();
+	});
+
+	test("fetches the primary Worker with a relative URL", async ({ expect }) => {
+		// Relative URLs are dispatched to the primary Worker (the first one listed).
+		const response = await server.fetch("/");
+		expect(await response.text()).toBe("Hello World");
+	});
+
+	test("mocks outbound requests", async ({ expect }) => {
+		mock.use(
+			http.get("http://upstream.example.com/users/:id", ({ params }) => {
+				return HttpResponse.json({ id: params.id, name: "Ada Lovelace" });
+			})
+		);
+
+		const userResponse = await apiWorker.fetch(
+			"http://example.com/api/users/123"
+		);
+		expect(await userResponse.json()).toEqual({
+			id: "123",
+			name: "Ada Lovelace",
+		});
+	});
+
+	test("dispatches requests using configured routes", async ({ expect }) => {
+		mock.use(
+			http.get("http://upstream.example.com/users/:id", ({ params }) => {
+				return HttpResponse.json({ id: params.id, name: "Ada Lovelace" });
+			})
+		);
+
+		// server.fetch() matches requests to workers based on routes.
+		const apiResponse = await server.fetch("http://example.com/api/users/123");
+		expect(await apiResponse.json()).toEqual({
+			id: "123",
+			name: "Ada Lovelace",
+		});
+
+		const webResponse = await server.fetch("http://example.com/users/123");
+		expect(await webResponse.text()).toBe("Profile: Ada Lovelace");
+	});
+
+	test("runs scheduled jobs and stores the result", async ({ expect }) => {
+		mock.use(
+			http.get("http://upstream.example.com/users/:id", ({ params }) => {
+				return HttpResponse.json({ id: params.id, name: "Ada Lovelace" });
+			})
+		);
+
+		// Seed user data that the scheduled job will read to generate a report.
+		await apiWorker.fetch("http://example.com/api/users/123");
+		await apiWorker.fetch("http://example.com/api/users/456");
+
+		const initialResponse = await webWorker.fetch(
+			"http://example.com/reports/2026-05-29"
+		);
+		expect(initialResponse.status).toBe(404);
+		expect(await initialResponse.text()).toBe("No report");
+
+		expect(
+			await apiWorker.scheduled({
+				cron: "0 0 * * *",
+				scheduledTime: new Date("2026-05-29T00:00:00.000Z"),
+			})
+		).toEqual({ outcome: "ok", noRetry: false });
+
+		const webResponse = await webWorker.fetch(
+			"http://example.com/reports/2026-05-29"
+		);
+		expect(await webResponse.text()).toBe(
+			"Daily report (2026-05-29): active users 123, 456"
+		);
+	});
+});

--- a/fixtures/create-server-example/tests/wrangler-project.test.ts
+++ b/fixtures/create-server-example/tests/wrangler-project.test.ts
@@ -1,0 +1,110 @@
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, test } from "vitest";
+import { createServer } from "wrangler";
+
+// Point each worker to the Wrangler config you want to test.
+const server = createServer({
+	workers: [
+		{ configPath: "./wrangler.web.jsonc" },
+		{ configPath: "./wrangler.api.jsonc" },
+	],
+});
+
+// server.getWorker() would return the first Worker, but naming it makes it explicit.
+const webWorker = server.getWorker("web-worker");
+const apiWorker = server.getWorker("api-worker");
+
+// createServer's default outboundService forwards Worker outbound fetches to globalThis.fetch().
+// You can use libraries like MSW to intercept those requests.
+const mock = setupServer();
+
+describe("createServer: wrangler project setup", () => {
+	beforeAll(async () => {
+		mock.listen({ onUnhandledRequest: "error" });
+		await server.listen();
+	});
+
+	afterAll(async () => {
+		mock.close();
+		await server.close();
+	});
+
+	afterEach(async () => {
+		// Keep tests isolated while reusing the same running server.
+		mock.resetHandlers();
+		await server.clearStorage();
+	});
+
+	test("fetches the primary Worker with a relative URL", async ({ expect }) => {
+		// Relative URLs are dispatched to the primary Worker (the first one listed).
+		const response = await server.fetch("/");
+		expect(await response.text()).toBe("Hello World");
+	});
+
+	test("mocks outbound requests", async ({ expect }) => {
+		mock.use(
+			http.get("http://upstream.example.com/users/:id", ({ params }) => {
+				return HttpResponse.json({ id: params.id, name: "Ada Lovelace" });
+			})
+		);
+
+		const userResponse = await apiWorker.fetch(
+			"http://example.com/api/users/123"
+		);
+		expect(await userResponse.json()).toEqual({
+			id: "123",
+			name: "Ada Lovelace",
+		});
+	});
+
+	test("dispatches requests using configured routes", async ({ expect }) => {
+		mock.use(
+			http.get("http://upstream.example.com/users/:id", ({ params }) => {
+				return HttpResponse.json({ id: params.id, name: "Ada Lovelace" });
+			})
+		);
+
+		// server.fetch() matches requests to workers based on routes.
+		const apiResponse = await server.fetch("http://example.com/api/users/123");
+		expect(await apiResponse.json()).toEqual({
+			id: "123",
+			name: "Ada Lovelace",
+		});
+
+		const webResponse = await server.fetch("http://example.com/users/123");
+		expect(await webResponse.text()).toBe("Profile: Ada Lovelace");
+	});
+
+	test("runs scheduled jobs and stores the result", async ({ expect }) => {
+		mock.use(
+			http.get("http://upstream.example.com/users/:id", ({ params }) => {
+				return HttpResponse.json({ id: params.id, name: "Ada Lovelace" });
+			})
+		);
+
+		// Seed user data that the scheduled job will read to generate a report.
+		await apiWorker.fetch("http://example.com/api/users/123");
+		await apiWorker.fetch("http://example.com/api/users/456");
+
+		const initialResponse = await webWorker.fetch(
+			"http://example.com/reports/2026-05-29"
+		);
+		expect(initialResponse.status).toBe(404);
+		expect(await initialResponse.text()).toBe("No report");
+
+		expect(
+			await apiWorker.scheduled({
+				cron: "0 0 * * *",
+				scheduledTime: new Date("2026-05-29T00:00:00.000Z"),
+			})
+		).toEqual({ outcome: "ok", noRetry: false });
+
+		const webResponse = await webWorker.fetch(
+			"http://example.com/reports/2026-05-29"
+		);
+		expect(await webResponse.text()).toBe(
+			"Daily report (2026-05-29): active users 123, 456"
+		);
+	});
+});

--- a/fixtures/create-server-example/tsconfig.json
+++ b/fixtures/create-server-example/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"isolatedModules": true,
+		"esModuleInterop": true,
+		"allowSyntheticDefaultImports": true,
+		"moduleResolution": "bundler",
+		"resolveJsonModule": true,
+		"target": "esnext",
+		"strict": true,
+		"noEmit": true,
+		"types": ["@cloudflare/workers-types", "node"],
+		"lib": ["esnext"],
+		"skipLibCheck": true
+	},
+	"include": ["**/*.ts"],
+	"exclude": ["tests"]
+}

--- a/fixtures/create-server-example/turbo.json
+++ b/fixtures/create-server-example/turbo.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "http://turbo.build/schema.json",
+	"extends": ["//"],
+	"tasks": {
+		"build": {
+			"outputs": ["dist/**"]
+		}
+	}
+}

--- a/fixtures/create-server-example/vite.config.ts
+++ b/fixtures/create-server-example/vite.config.ts
@@ -1,0 +1,13 @@
+import { cloudflare } from "@cloudflare/vite-plugin";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+	plugins: [
+		cloudflare({
+			configPath: "./wrangler.web.jsonc",
+			auxiliaryWorkers: [{ configPath: "./wrangler.api.jsonc" }],
+			inspectorPort: false,
+			persistState: false,
+		}),
+	],
+});

--- a/fixtures/create-server-example/vitest.config.ts
+++ b/fixtures/create-server-example/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../vitest.shared";
+
+export default mergeConfig(
+	configShared,
+	defineProject({
+		test: {},
+	})
+);

--- a/fixtures/create-server-example/wrangler.api.jsonc
+++ b/fixtures/create-server-example/wrangler.api.jsonc
@@ -1,0 +1,7 @@
+{
+	"name": "api-worker",
+	"main": "src/api.ts",
+	"compatibility_date": "2024-09-23",
+	"routes": ["example.com/api/*"],
+	"kv_namespaces": [{ "binding": "STORE", "id": "shared-store" }],
+}

--- a/fixtures/create-server-example/wrangler.web.jsonc
+++ b/fixtures/create-server-example/wrangler.web.jsonc
@@ -1,0 +1,7 @@
+{
+	"name": "web-worker",
+	"main": "src/web.ts",
+	"compatibility_date": "2024-09-23",
+	"routes": ["example.com/*"],
+	"services": [{ "binding": "API", "service": "api-worker" }],
+}

--- a/packages/wrangler/e2e/create-server.test.ts
+++ b/packages/wrangler/e2e/create-server.test.ts
@@ -1,0 +1,947 @@
+import path from "node:path";
+import { setTimeout } from "node:timers/promises";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import dedent from "ts-dedent";
+import { beforeEach, describe, it, onTestFinished, vi } from "vitest";
+import {
+	importWrangler,
+	WranglerE2ETestHelper,
+} from "./helpers/e2e-wrangler-test";
+
+const { createServer } = await importWrangler();
+
+describe("createServer", { sequential: true }, () => {
+	let helper: WranglerE2ETestHelper;
+
+	beforeEach(() => {
+		helper = new WranglerE2ETestHelper();
+	});
+
+	it("starts with default server options", async ({ expect }) => {
+		await helper.seed({
+			"wrangler.jsonc": dedent`
+				{
+					"name": "hello-worker",
+					"main": "src/index.ts",
+					"compatibility_date": "2026-05-20"
+				}
+			`,
+			"src/index.ts": dedent`
+				export default {
+					fetch(request) {
+						if (new URL(request.url).pathname === "/url") {
+							return new Response(request.url);
+						}
+						return new Response("Hello World");
+					}
+				};
+			`,
+		});
+
+		const server = createServer({
+			workers: [
+				{ configPath: path.resolve(helper.tmpPath, "./wrangler.jsonc") },
+			],
+		});
+		onTestFinished(server.close);
+
+		const { url, inspectorUrl } = await server.listen();
+
+		expect(url.protocol).toBe("http:");
+		expect(url.hostname).toBe("127.0.0.1");
+		expect(Number(url.port)).toBeGreaterThan(0);
+		expect(inspectorUrl).toBeUndefined();
+
+		const response1 = await fetch(url);
+		await expect(response1.text()).resolves.toBe("Hello World");
+
+		const relativeServerResponse = await server.fetch("/url");
+		await expect(relativeServerResponse.text()).resolves.toBe(
+			new URL("/url", url).href
+		);
+
+		const relativeWorkerResponse = await server.getWorker().fetch("/url");
+		await expect(relativeWorkerResponse.text()).resolves.toBe(
+			new URL("/url", url).href
+		);
+	});
+
+	it("support fetching different workers from the same session", async ({
+		expect,
+	}) => {
+		await helper.seed({
+			"wrangler.primary.jsonc": dedent`
+				{
+					"name": "primary-worker",
+					"main": "src/primary.ts",
+					"compatibility_date": "2026-05-20"
+				}
+			`,
+			"wrangler.auxiliary.jsonc": dedent`
+				{
+					"name": "auxiliary-worker",
+					"main": "src/auxiliary.ts",
+					"compatibility_date": "2026-05-20"
+				}
+			`,
+			"src/primary.ts": dedent`
+				export default {
+					fetch() {
+						return new Response("Hello from Primary Worker");
+					}
+				};
+			`,
+			"src/auxiliary.ts": dedent`
+				export default {
+					fetch() {
+						return new Response("Hello from Auxiliary Worker");
+					}
+				};
+			`,
+		});
+
+		const server = createServer({
+			root: helper.tmpPath,
+			workers: [
+				{ configPath: "./wrangler.primary.jsonc" },
+				{ configPath: "./wrangler.auxiliary.jsonc" },
+			],
+		});
+		onTestFinished(server.close);
+
+		await server.listen();
+
+		const defaultServerResponse = await server.fetch("/");
+		await expect(defaultServerResponse.text()).resolves.toBe(
+			"Hello from Primary Worker"
+		);
+
+		const defaultWorkerResponse = await server.getWorker().fetch("/");
+		await expect(defaultWorkerResponse.text()).resolves.toBe(
+			"Hello from Primary Worker"
+		);
+
+		const primaryResponse = await server.getWorker("primary-worker").fetch("/");
+		await expect(primaryResponse.text()).resolves.toBe(
+			"Hello from Primary Worker"
+		);
+
+		const auxiliaryResponse = await server
+			.getWorker("auxiliary-worker")
+			.fetch("/");
+		await expect(auxiliaryResponse.text()).resolves.toBe(
+			"Hello from Auxiliary Worker"
+		);
+	});
+
+	it("routes fetches based on worker routes", async ({ expect }) => {
+		await helper.seed({
+			"wrangler.primary.jsonc": dedent`
+				{
+					"name": "primary-worker",
+					"main": "src/primary.ts",
+					"compatibility_date": "2026-05-20",
+					"routes": ["primary.example.com/*"]
+				}
+			`,
+			"src/primary.ts": dedent`
+				export default {
+					fetch(request) {
+						return Response.json({ name: "primary", url: request.url });
+					}
+				};
+			`,
+			"src/auxiliary.ts": dedent`
+				export default {
+					fetch(request) {
+						return Response.json({ name: "auxiliary", url: request.url });
+					}
+				};
+			`,
+		});
+
+		const server = createServer({
+			root: helper.tmpPath,
+			workers: [
+				{ configPath: "./wrangler.primary.jsonc" },
+				{
+					config: {
+						name: "auxiliary-worker",
+						main: "src/auxiliary.ts",
+						compatibility_date: "2026-05-20",
+						routes: ["auxiliary.example.com/*"],
+					},
+				},
+			],
+		});
+		onTestFinished(server.close);
+
+		await server.listen();
+
+		const primaryResponse = await server.fetch(
+			"http://primary.example.com/path?value=1"
+		);
+		await expect(primaryResponse.json()).resolves.toEqual({
+			name: "primary",
+			url: "http://primary.example.com/path?value=1",
+		});
+
+		const auxiliaryResponse = await server.fetch(
+			"http://auxiliary.example.com/path?value=2"
+		);
+		await expect(auxiliaryResponse.json()).resolves.toEqual({
+			name: "auxiliary",
+			url: "http://auxiliary.example.com/path?value=2",
+		});
+
+		await server.update({
+			root: helper.tmpPath,
+			workers: [
+				{ configPath: "./wrangler.primary.jsonc" },
+				{
+					config: {
+						name: "auxiliary-worker",
+						main: "src/auxiliary.ts",
+						compatibility_date: "2026-05-20",
+						routes: ["updated-auxiliary.example.com/*"],
+					},
+				},
+			],
+		});
+
+		const updatedAuxiliaryResponse = await server.fetch(
+			"http://updated-auxiliary.example.com/path?value=3"
+		);
+		await expect(updatedAuxiliaryResponse.json()).resolves.toEqual({
+			name: "auxiliary",
+			url: "http://updated-auxiliary.example.com/path?value=3",
+		});
+	});
+
+	it("rejects updates that change the number of workers", async ({
+		expect,
+	}) => {
+		await helper.seed({
+			"src/primary.ts": dedent`
+				export default {
+					fetch() {
+						return new Response("primary");
+					}
+				};
+			`,
+			"src/auxiliary.ts": dedent`
+				export default {
+					fetch() {
+						return new Response("auxiliary");
+					}
+				};
+			`,
+		});
+
+		const server = createServer({
+			root: helper.tmpPath,
+			workers: [
+				{
+					config: {
+						name: "primary-worker",
+						main: "src/primary.ts",
+						compatibility_date: "2026-05-20",
+					},
+				},
+			],
+		});
+		onTestFinished(server.close);
+
+		await server.listen();
+
+		await expect(
+			server.update((options) => ({
+				...options,
+				workers: [
+					...options.workers,
+					{
+						config: {
+							name: "auxiliary-worker",
+							main: "src/auxiliary.ts",
+							compatibility_date: "2026-05-20",
+						},
+					},
+				],
+			}))
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: Updating the number of workers running in the server is not supported.]`
+		);
+	});
+
+	it("returns a 404 response for missing workers", async ({ expect }) => {
+		await helper.seed({
+			"wrangler.jsonc": dedent`
+				{
+					"name": "primary-worker",
+					"main": "src/index.ts",
+					"compatibility_date": "2026-05-20"
+				}
+			`,
+			"src/index.ts": dedent`
+				export default {
+					fetch() {
+						return new Response("primary");
+					}
+				};
+			`,
+		});
+
+		const server = createServer({
+			root: helper.tmpPath,
+			workers: [{ configPath: "./wrangler.jsonc" }],
+		});
+		onTestFinished(server.close);
+
+		await server.listen();
+
+		const response = await server.getWorker("missing-worker").fetch("/");
+		expect(response.status).toBe(404);
+		await expect(response.text()).resolves.toBe("No entrypoint worker found");
+	});
+
+	it("supports overriding fetch for outbound requests", async ({ expect }) => {
+		await helper.seed({
+			"wrangler.jsonc": dedent`
+				{
+					"name": "hello-example",
+					"main": "src/index.ts",
+					"compatibility_date": "2026-05-20"
+				}
+			`,
+			"src/index.ts": dedent`
+				export default {
+					fetch() {
+						return fetch("http://example.com");
+					}
+				};
+			`,
+		});
+
+		const server = createServer({
+			root: helper.tmpPath,
+			workers: [{ configPath: "./wrangler.jsonc" }],
+			outboundService(request) {
+				if (request.url === "http://example.com/") {
+					return new Response("Mocked response from example.com");
+				}
+
+				throw new Error(`Unexpected outbound request to ${request.url}`);
+			},
+		});
+		onTestFinished(server.close);
+
+		await server.listen();
+
+		const response = await server.fetch("/");
+		await expect(response.text()).resolves.toBe(
+			"Mocked response from example.com"
+		);
+	});
+
+	it("uses the current Node process fetch for outbound requests by default", async ({
+		expect,
+	}) => {
+		const mockServer = setupServer(
+			http.get("http://example.com/", () => {
+				return HttpResponse.text("Mocked by MSW");
+			})
+		);
+		mockServer.listen({ onUnhandledRequest: "error" });
+		onTestFinished(() => mockServer.close());
+
+		await helper.seed({
+			"wrangler.jsonc": dedent`
+				{
+					"name": "default-outbound-worker",
+					"main": "src/index.ts",
+					"compatibility_date": "2026-05-20"
+				}
+			`,
+			"src/index.ts": dedent`
+				export default {
+					fetch() {
+						return fetch("http://example.com");
+					}
+				};
+			`,
+		});
+
+		const server = createServer({
+			root: helper.tmpPath,
+			workers: [{ configPath: "./wrangler.jsonc" }],
+		});
+		onTestFinished(server.close);
+
+		await server.listen();
+
+		const response = await server.fetch("/");
+		await expect(response.text()).resolves.toBe("Mocked by MSW");
+	});
+
+	it("starts workers from inline config", async ({ expect }) => {
+		await helper.seed({
+			"src/index.ts": dedent`
+				export default {
+					fetch() {
+						return new Response("Hello from inline config");
+					}
+				};
+			`,
+		});
+
+		const server = createServer({
+			workers: [
+				{
+					root: helper.tmpPath,
+					config: {
+						main: "src/index.ts",
+						compatibility_date: "2026-05-20",
+					},
+				},
+			],
+		});
+		onTestFinished(server.close);
+
+		await server.listen();
+
+		const response = await server.fetch("/");
+		await expect(response.text()).resolves.toBe("Hello from inline config");
+	});
+
+	it("loads default .env files for config path workers", async ({ expect }) => {
+		await helper.seed({
+			"wrangler.jsonc": dedent`
+				{
+					"name": "env-worker",
+					"main": "src/index.ts",
+					"compatibility_date": "2026-05-20",
+					"vars": { "CONFIG_VAR": "from-config" }
+				}
+			`,
+			".env": dedent`
+				ENV_SECRET=from-env
+			`,
+			"src/index.ts": dedent`
+				export default {
+					fetch(request, env) {
+						return Response.json({
+							CONFIG_VAR: env.CONFIG_VAR,
+							ENV_SECRET: env.ENV_SECRET,
+						});
+					}
+				};
+			`,
+		});
+
+		const server = createServer({
+			root: helper.tmpPath,
+			workers: [{ configPath: "./wrangler.jsonc" }],
+		});
+		onTestFinished(server.close);
+
+		await server.listen();
+
+		const response = await server.fetch("/");
+		await expect(response.json()).resolves.toEqual({
+			CONFIG_VAR: "from-config",
+			ENV_SECRET: "from-env",
+		});
+	});
+
+	it("loads default .dev.vars files for config path workers", async ({
+		expect,
+	}) => {
+		await helper.seed({
+			"wrangler.jsonc": dedent`
+				{
+					"name": "dev-vars-worker",
+					"main": "src/index.ts",
+					"compatibility_date": "2026-05-20",
+					"vars": { "CONFIG_VAR": "from-config" }
+				}
+			`,
+			".env": dedent`
+				SECRET=from-env
+			`,
+			".dev.vars": dedent`
+				SECRET=from-dev-vars
+			`,
+			"src/index.ts": dedent`
+				export default {
+					fetch(request, env) {
+						return Response.json({
+							CONFIG_VAR: env.CONFIG_VAR,
+							SECRET: env.SECRET,
+						});
+					}
+				};
+			`,
+		});
+
+		const server = createServer({
+			root: helper.tmpPath,
+			workers: [{ configPath: "./wrangler.jsonc" }],
+		});
+		onTestFinished(server.close);
+
+		await server.listen();
+
+		const response = await server.fetch("/");
+		await expect(response.json()).resolves.toEqual({
+			CONFIG_VAR: "from-config",
+			SECRET: "from-dev-vars",
+		});
+	});
+
+	it("overrides vars and secrets for config path workers", async ({
+		expect,
+	}) => {
+		await helper.seed({
+			"wrangler.jsonc": dedent`
+				{
+					"name": "var-overrides-worker",
+					"main": "src/index.ts",
+					"compatibility_date": "2026-05-20",
+					"vars": { "CONFIG_VAR": "from-config" },
+					"secrets": { "required": ["API_TOKEN", "SECRET_FROM_FILE"] }
+				}
+			`,
+			".dev.vars": dedent`
+				API_TOKEN=from-dev-vars
+				SECRET_FROM_FILE=from-dev-vars
+			`,
+			"src/index.ts": dedent`
+				export default {
+					fetch(request, env) {
+						return Response.json({
+							CONFIG_VAR: env.CONFIG_VAR,
+							API_TOKEN: env.API_TOKEN,
+							SECRET_FROM_FILE: env.SECRET_FROM_FILE,
+							ADDED_VAR: env.ADDED_VAR,
+							NULL_VAR: env.NULL_VAR,
+						});
+					}
+				};
+			`,
+		});
+
+		const server = createServer({
+			root: helper.tmpPath,
+			workers: [
+				{
+					configPath: "./wrangler.jsonc",
+					overrides: {
+						vars: {
+							CONFIG_VAR: "from-override",
+							ADDED_VAR: "from-override",
+							NULL_VAR: null,
+						},
+						secrets: {
+							API_TOKEN: "from-override",
+						},
+					},
+				},
+			],
+		});
+		onTestFinished(server.close);
+
+		await server.listen();
+
+		const response = await server.fetch("/");
+		await expect(response.json()).resolves.toEqual({
+			CONFIG_VAR: "from-override",
+			API_TOKEN: "from-override",
+			SECRET_FROM_FILE: "from-dev-vars",
+			ADDED_VAR: "from-override",
+			NULL_VAR: null,
+		});
+
+		await server.update({
+			root: helper.tmpPath,
+			workers: [
+				{
+					configPath: "./wrangler.jsonc",
+					overrides: {
+						vars: {
+							CONFIG_VAR: "from-updated-override",
+							ADDED_VAR: "from-updated-override",
+							NULL_VAR: null,
+						},
+						secrets: {
+							API_TOKEN: "from-updated-override",
+						},
+					},
+				},
+			],
+		});
+
+		const updatedResponse = await server.fetch("/");
+		await expect(updatedResponse.json()).resolves.toEqual({
+			CONFIG_VAR: "from-updated-override",
+			API_TOKEN: "from-updated-override",
+			SECRET_FROM_FILE: "from-dev-vars",
+			ADDED_VAR: "from-updated-override",
+			NULL_VAR: null,
+		});
+	});
+
+	it(`supports "nodejs_compat" flag`, async ({ expect }) => {
+		await helper.seed({
+			"wrangler.jsonc": dedent`
+				{
+					"name": "nodejs-compat-worker",
+					"main": "src/index.ts",
+					"compatibility_date": "2026-05-20",
+					"compatibility_flags": ["nodejs_compat"]
+				}
+			`,
+			"src/index.ts": dedent`
+				import { Stream } from "node:stream";
+
+				export default {
+					fetch() {
+						return new Response(String(typeof Stream));
+					}
+				};
+			`,
+		});
+
+		const server = createServer({
+			root: helper.tmpPath,
+			workers: [{ configPath: "./wrangler.jsonc" }],
+		});
+		onTestFinished(server.close);
+
+		await server.listen();
+
+		const response = await server.fetch("/");
+		await expect(response.text()).resolves.toBe("function");
+	});
+
+	it("supports Workers Sites", async ({ expect }) => {
+		await helper.seed({
+			"public/hello.txt": "Hello from Workers Sites",
+			"src/index.ts": dedent`
+				import manifestJSON from "__STATIC_CONTENT_MANIFEST";
+
+				const manifest = JSON.parse(manifestJSON);
+
+				export default {
+					async fetch(request, env) {
+						const key = manifest[new URL(request.url).pathname.slice(1)];
+						const value = key ? await env.__STATIC_CONTENT.get(key) : null;
+						return new Response(value ?? "missing");
+					}
+				};
+			`,
+		});
+
+		const server = createServer({
+			root: helper.tmpPath,
+			workers: [
+				{
+					config: {
+						main: "src/index.ts",
+						compatibility_date: "2026-05-20",
+						site: { bucket: "public" },
+					},
+				},
+			],
+		});
+		onTestFinished(server.close);
+
+		await server.listen();
+
+		const response = await server.fetch("/hello.txt");
+		await expect(response.text()).resolves.toBe("Hello from Workers Sites");
+	});
+
+	it("uses ephemeral storage by default", async ({ expect }) => {
+		await helper.seed({
+			"wrangler.jsonc": dedent`
+				{
+					"name": "ephemeral-storage-worker",
+					"main": "src/index.ts",
+					"compatibility_date": "2026-05-20",
+					"kv_namespaces": [
+						{ "binding": "STORE", "id": "test-store" }
+					]
+				}
+			`,
+			"src/index.ts": dedent`
+				export default {
+					async fetch(request, env) {
+						const url = new URL(request.url);
+						if (url.pathname === "/set") {
+							await env.STORE.put("key", "value");
+							return new Response("stored");
+						}
+						return new Response((await env.STORE.get("key")) ?? "missing");
+					}
+				};
+			`,
+		});
+
+		const firstServer = createServer({
+			root: helper.tmpPath,
+			workers: [{ configPath: "./wrangler.jsonc" }],
+		});
+		onTestFinished(firstServer.close);
+
+		await firstServer.listen();
+
+		const setResponse = await firstServer.fetch("/set");
+		await expect(setResponse.text()).resolves.toBe("stored");
+
+		const storedResponse = await firstServer.fetch("/");
+		await expect(storedResponse.text()).resolves.toBe("value");
+
+		await firstServer.close();
+
+		const secondServer = createServer({
+			root: helper.tmpPath,
+			workers: [{ configPath: "./wrangler.jsonc" }],
+		});
+		onTestFinished(secondServer.close);
+
+		await secondServer.listen();
+
+		const resetResponse = await secondServer.fetch("/");
+		await expect(resetResponse.text()).resolves.toBe("missing");
+	});
+
+	it("clears local storage", async ({ expect }) => {
+		await helper.seed({
+			"wrangler.jsonc": dedent`
+				{
+					"name": "storage-worker",
+					"main": "src/index.ts",
+					"compatibility_date": "2026-05-20",
+					"kv_namespaces": [
+						{ "binding": "STORE", "id": "test-store" }
+					]
+				}
+			`,
+			"src/index.ts": dedent`
+				export default {
+					async fetch(request, env) {
+						const url = new URL(request.url);
+						if (url.pathname === "/set") {
+							await env.STORE.put("key", "value");
+							return new Response("stored");
+						}
+						return new Response((await env.STORE.get("key")) ?? "missing");
+					}
+				};
+			`,
+		});
+
+		const server = createServer({
+			root: helper.tmpPath,
+			workers: [{ configPath: "./wrangler.jsonc" }],
+		});
+		onTestFinished(server.close);
+
+		await expect(server.clearStorage()).rejects.toThrow(
+			"Worker server has not been started. Start it with server.listen() before calling this method."
+		);
+
+		await server.listen();
+
+		const setResponse = await server.fetch("/set");
+		await expect(setResponse.text()).resolves.toBe("stored");
+		const storedResponse = await server.fetch("/");
+		await expect(storedResponse.text()).resolves.toBe("value");
+		await server.close();
+
+		const persistentServer = createServer({
+			root: helper.tmpPath,
+			persist: "state",
+			workers: [{ configPath: "./wrangler.jsonc" }],
+		});
+		onTestFinished(persistentServer.close);
+
+		await persistentServer.listen();
+		const persistentSetResponse = await persistentServer.fetch("/set");
+		await expect(persistentSetResponse.text()).resolves.toBe("stored");
+		await persistentServer.close();
+
+		const nextPersistentServer = createServer({
+			root: helper.tmpPath,
+			persist: "state",
+			workers: [{ configPath: "./wrangler.jsonc" }],
+		});
+		onTestFinished(nextPersistentServer.close);
+
+		await nextPersistentServer.listen();
+		const persistentStoredResponse = await nextPersistentServer.fetch("/");
+		await expect(persistentStoredResponse.text()).resolves.toBe("value");
+
+		await nextPersistentServer.clearStorage();
+
+		const persistentClearedResponse = await nextPersistentServer.fetch("/");
+		await expect(persistentClearedResponse.text()).resolves.toBe("missing");
+		await nextPersistentServer.close();
+
+		const defaultPersistentServer = createServer({
+			root: helper.tmpPath,
+			persist: true,
+			workers: [{ configPath: "./wrangler.jsonc" }],
+		});
+		onTestFinished(defaultPersistentServer.close);
+		await defaultPersistentServer.listen();
+
+		await expect(defaultPersistentServer.clearStorage()).rejects.toThrow(
+			"clearStorage() cannot clear storage when persist is true."
+		);
+	});
+
+	it("exposes the inspector URL when enabled", async ({ expect }) => {
+		await helper.seed({
+			"wrangler.jsonc": dedent`
+				{
+					"name": "inspector-worker",
+					"main": "src/index.ts",
+					"compatibility_date": "2026-05-20"
+				}
+			`,
+			"src/index.ts": dedent`
+				export default {
+					fetch() {
+						return new Response("Hello World");
+					}
+				};
+			`,
+		});
+
+		const server = createServer({
+			root: helper.tmpPath,
+			workers: [{ configPath: "./wrangler.jsonc" }],
+			inspector: { port: 0 },
+		});
+		onTestFinished(server.close);
+
+		const { inspectorUrl } = await server.listen();
+
+		expect(inspectorUrl).toBeDefined();
+		const inspectorResponse = await fetch(`http://${inspectorUrl?.host}/json`);
+		expect(inspectorResponse.ok).toBe(true);
+	});
+
+	it("triggers scheduled handlers", async ({ expect }) => {
+		await helper.seed({
+			"wrangler.jsonc": dedent`
+				{
+					"name": "scheduled-worker",
+					"main": "src/index.ts",
+					"compatibility_date": "2026-05-20"
+				}
+			`,
+			"src/index.ts": dedent`
+				let lastCron = "missing";
+
+				export default {
+					fetch() {
+						return new Response(lastCron);
+					},
+					scheduled(event) {
+						lastCron = event.cron;
+					}
+				};
+			`,
+		});
+
+		const server = createServer({
+			root: helper.tmpPath,
+			workers: [{ configPath: "./wrangler.jsonc" }],
+		});
+		onTestFinished(server.close);
+
+		await server.listen();
+
+		const beforeScheduled = await server.fetch("/");
+		await expect(beforeScheduled.text()).resolves.toBe("missing");
+
+		await expect(
+			server.getWorker().scheduled({
+				cron: "* * * * *",
+				scheduledTime: new Date(1_700_000_100_000),
+			})
+		).resolves.toEqual({ outcome: "ok", noRetry: false });
+
+		const afterScheduled = await server.fetch("/");
+		await expect(afterScheduled.text()).resolves.toBe("* * * * *");
+	});
+
+	it("does not reload on source changes by default", async ({ expect }) => {
+		await helper.seed({
+			"wrangler.jsonc": dedent`
+				{
+					"name": "create-server-test",
+					"main": "src/index.ts",
+					"compatibility_date": "2026-05-20"
+				}
+			`,
+			"src/index.ts": dedent`
+				export default {
+					fetch() {
+						return new Response("Hello World");
+					}
+				};
+			`,
+		});
+
+		const server = createServer({
+			root: helper.tmpPath,
+			workers: [{ configPath: "./wrangler.jsonc" }],
+		});
+		onTestFinished(server.close);
+
+		await server.listen();
+
+		const response1 = await server.fetch("/");
+		await expect(response1.text()).resolves.toBe("Hello World");
+
+		await helper.seed({
+			"src/index.ts": dedent`
+				export default {
+					fetch() {
+						return new Response("Greeting");
+					}
+				};
+			`,
+		});
+
+		// Wait a moment to ensure that if the server were going to reload, it would have done so by now
+		await setTimeout(1000);
+
+		const response2 = await server.fetch("/");
+		await expect(response2.text()).resolves.toBe("Hello World");
+
+		await server.update((options) => ({ ...options, watch: true }));
+
+		const response3 = await server.fetch("/");
+		await expect(response3.text()).resolves.toBe("Greeting");
+
+		await helper.seed({
+			"src/index.ts": dedent`
+				export default {
+					fetch() {
+						return new Response("Bonjour");
+					}
+				};
+			`,
+		});
+
+		await vi.waitFor(async () => {
+			const response4 = await server.fetch("/");
+			expect(await response4.text()).toBe("Bonjour");
+		});
+	});
+});

--- a/packages/wrangler/src/api/index.ts
+++ b/packages/wrangler/src/api/index.ts
@@ -58,6 +58,10 @@ export type {
 } from "./startDevWorker/events";
 export type { DevToolsEvent } from "./startDevWorker/devtools";
 
+// Exports from ./server
+export { createServer } from "./server";
+export type { ServerOptions, WorkerHandle, WorkerServer } from "./server";
+
 // Exports from ./integrations
 export {
 	unstable_getVarsForDev,

--- a/packages/wrangler/src/api/server.ts
+++ b/packages/wrangler/src/api/server.ts
@@ -1,0 +1,659 @@
+import assert from "node:assert";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+	normalizeAndValidateConfig,
+	removeDir,
+	UserError,
+} from "@cloudflare/workers-utils";
+import { Headers, Request } from "miniflare";
+import { validateNodeCompatMode } from "../deployment-bundle/node-compat";
+import { logger } from "../logger";
+import { getSiteAssetPaths } from "../sites";
+import { requireApiToken, requireAuth } from "../user";
+import { DevEnv } from "./startDevWorker/DevEnv";
+import { MultiworkerRuntimeController } from "./startDevWorker/MultiworkerRuntimeController";
+import { NoOpProxyController } from "./startDevWorker/NoOpProxyController";
+import { convertConfigToBindings } from "./startDevWorker/utils";
+import type { CfAccount } from "../dev/create-worker-preview";
+import type {
+	LogLevel,
+	ServiceFetch,
+	StartDevWorkerInput,
+} from "./startDevWorker/types";
+import type {
+	FetcherScheduledOptions,
+	FetcherScheduledResult,
+} from "@cloudflare/workers-types/experimental";
+import type { Config, RawConfig } from "@cloudflare/workers-utils";
+import type { DispatchFetch, Json, Miniflare, RequestInfo } from "miniflare";
+
+export type ServerOptions = {
+	/**
+	 * Base directory used to resolve relative worker config paths and persist paths.
+	 * Defaults to `process.cwd()`.
+	 */
+	root?: string | undefined;
+	/**
+	 * Workers to run in this server. The first worker is the primary worker.
+	 */
+	workers: WorkerInput[];
+	/**
+	 * Host, port, and protocol options for the public server.
+	 * Defaults to `{ hostname: "127.0.0.1", port: 0 }`.
+	 */
+	server?: DevServerOptions | undefined;
+	/**
+	 * Inspector options for debugging Workers. Set to `false` to disable.
+	 * Defaults to `false`.
+	 */
+	inspector?: InspectorOptions | undefined;
+	/**
+	 * Controls local storage persistence.
+	 * Defaults to `false` for ephemeral storage. Set to a path to persist storage there.
+	 */
+	persist?: boolean | string | undefined;
+	/**
+	 * Whether to watch worker source/config files and reload on changes.
+	 * Defaults to `false`.
+	 */
+	watch?: boolean | undefined;
+	/**
+	 * Minimum Wrangler log level emitted while running the server.
+	 * Defaults to `"error"`.
+	 */
+	logLevel?: LogLevel | undefined;
+	/**
+	 * Cloudflare account ID used when an operation requires account context.
+	 * Defaults to the account selected by Wrangler auth when needed.
+	 */
+	accountId?: string | undefined;
+	/**
+	 * Handles outbound `fetch()` calls from Workers.
+	 * Defaults to the current process `fetch`.
+	 */
+	outboundService?: ServiceFetch | undefined;
+};
+
+export type WorkerHandle = {
+	/**
+	 * Dispatches a fetch event directly to this worker.
+	 * Relative URL inputs are resolved against the current server URL.
+	 *
+	 * @example
+	 * ```ts
+	 * const response = await worker.fetch("/", {
+	 *   method: "POST",
+	 *   body: "Hello, world!"
+	 * });
+	 * ```
+	 */
+	fetch: DispatchFetch;
+	/**
+	 * Dispatches a scheduled event directly to this Worker.
+	 *
+	 * @example
+	 * ```ts
+	 * const result = await worker.scheduled({
+	 *   cron: "0 * * * *",
+	 *   scheduledTime: new Date(),
+	 * });
+	 * ```
+	 */
+	scheduled(options: FetcherScheduledOptions): Promise<FetcherScheduledResult>;
+};
+
+export type WorkerServer = {
+	/**
+	 * Starts the server and returns its current URL.
+	 * Calling this more than once returns the same running server session until
+	 * the server is closed or reset by an operation such as `clearStorage()`.
+	 */
+	listen(): Promise<{
+		url: URL;
+		inspectorUrl: URL | undefined;
+	}>;
+	/**
+	 * Dispatches a fetch request through the server.
+	 *
+	 * - Relative URLs are resolved against the current server URL. Absolute URLs
+	 * are also accepted, and can be used to control the hostname seen by the Worker.
+	 * - Requests are matched against each Worker's configured routes and dispatched to
+	 * the first matching Worker, or to the primary Worker if no routes match.
+	 * - To dispatch directly to a specific Worker, use `server.getWorker(name).fetch()`.
+	 *
+	 * @example
+	 * ```ts
+	 * const server = createServer({
+	 *   workers: [
+	 *     { configPath: "./wrangler.dashboard.jsonc" }, // No route pattern
+	 *     { configPath: "./wrangler.api.jsonc" }, // Route pattern: "example.com/api/*"
+	 *     { configPath: "./wrangler.admin.jsonc" }, // Route pattern: "admin.example.com/*"
+	 *   ]
+	 * });
+	 *
+	 * await server.fetch("/users");
+	 * // Dispatches a request to the dashboard Worker (the first Worker) with URL "http://localhost:{port}/users"
+	 *
+	 * await server.fetch("http://admin.example.com/accounts");
+	 * // Dispatches a request to the admin Worker with URL "http://admin.example.com/accounts"
+	 *
+	 * await server.fetch("http://example.com/api/data");
+	 * // Dispatches a request to the API Worker with URL "http://example.com/api/data"
+	 * ```
+	 */
+	fetch: DispatchFetch;
+	/**
+	 * Returns a handle for dispatching events directly to a Worker.
+	 * When no name is provided, this returns the primary Worker, which is the first
+	 * Worker in the server's `workers` options.
+	 */
+	getWorker(name?: string): WorkerHandle;
+	/**
+	 * Updates the server configuration and reloads the running Workers.
+	 *
+	 * @example
+	 * ```ts
+	 * await server.update((options) => ({
+	 *   ...options,
+	 *   outboundService(request) {
+	 *     if (request.url === "http://example.com/api/data") {
+	 *       return Response.json([
+	 *         { id: 1, name: "Alice" },
+	 *         { id: 2, name: "Bob" }
+	 *       ]);
+	 *     }
+	 *
+	 *     throw new Error(`Unexpected request to ${request.url}`);
+	 *   },
+	 * }));
+	 * ```
+	 */
+	update(
+		options: ServerOptions | ((currentOptions: ServerOptions) => ServerOptions)
+	): Promise<void>;
+	/**
+	 * Clears local storage and restarts the server session.
+	 * The server URL may change after storage is cleared.
+	 */
+	clearStorage(): Promise<void>;
+	/**
+	 * Stops the server and releases all runtime resources.
+	 */
+	close(): Promise<void>;
+};
+
+type InlineConfig = Omit<RawConfig, "env">;
+
+type ConfigOverrides = {
+	vars?: Record<string, Json>;
+	secrets?: Record<string, string>;
+};
+
+type WorkerInput =
+	| {
+			root?: string;
+			configPath: string | URL;
+			env?: string;
+			overrides?: ConfigOverrides;
+	  }
+	| {
+			root?: string;
+			config: InlineConfig;
+	  };
+
+type DevServerOptions = Exclude<
+	NonNullable<StartDevWorkerInput["dev"]>["server"],
+	undefined
+>;
+
+type InspectorOptions = Exclude<
+	NonNullable<StartDevWorkerInput["dev"]>["inspector"],
+	undefined
+>;
+
+type ServerSession = {
+	primaryDevEnv: DevEnv;
+	devEnvs: DevEnv[];
+};
+
+/**
+ * Creates a server that runs Workers locally.
+ *
+ * The server can run one or more Workers from Wrangler config files, including
+ * generated configs from Vite, or from inline configuration objects.
+ *
+ * @example
+ * ```ts
+ * const server = createServer({
+ *   workers: [{ configPath: "./wrangler.jsonc" }],
+ * });
+ * await server.listen();
+ * const response = await server.fetch("/api/users");
+ * await server.close();
+ * ```
+ */
+export function createServer(options: ServerOptions): WorkerServer {
+	let currentOptions = options;
+	let desiredAccountId = options.accountId;
+	let serverSession: ServerSession | undefined;
+	let startPromise: Promise<ServerSession> | undefined;
+
+	function resolvePath(basePath: string, maybePath: string | URL): string {
+		if (maybePath instanceof URL) {
+			return fileURLToPath(maybePath);
+		}
+
+		return path.isAbsolute(maybePath)
+			? maybePath
+			: path.resolve(basePath, maybePath);
+	}
+
+	function normalizeInlineWorkerConfig(
+		config: InlineConfig,
+		root: string
+	): Config {
+		const configPath = path.join(root, "wrangler.jsonc");
+		const { config: normalizedConfig, diagnostics } =
+			normalizeAndValidateConfig(config, configPath, configPath, {});
+
+		if (diagnostics.hasWarnings()) {
+			logger.warn(diagnostics.renderWarnings());
+		}
+
+		if (diagnostics.hasErrors()) {
+			throw new UserError(diagnostics.renderErrors(), {
+				telemetryMessage: "create server inline config validation failed",
+			});
+		}
+
+		return normalizedConfig;
+	}
+
+	function resolvePersistOption(
+		root: string,
+		persist: ServerOptions["persist"]
+	): string | false | undefined {
+		if (persist === true) {
+			return undefined;
+		}
+		if (typeof persist === "string") {
+			return resolvePath(root, persist);
+		}
+		return persist ?? false;
+	}
+
+	function resolveWorkerInputs(
+		serverOptions: ServerOptions
+	): StartDevWorkerInput[] {
+		if (serverOptions.workers.length === 0) {
+			throw new Error("Worker server requires at least one worker.");
+		}
+
+		const cwd = process.cwd();
+		const serverRoot = serverOptions.root ?? cwd;
+
+		return serverOptions.workers.map((input, index, list) => {
+			const isPrimaryWorker = index === 0;
+			const isMultiworker = list.length > 1;
+			const root = input.root ?? serverOptions.root ?? cwd;
+			const inlineConfig =
+				"config" in input
+					? normalizeInlineWorkerConfig(input.config, root)
+					: undefined;
+			const overrides = "configPath" in input ? input.overrides : undefined;
+			const bindings = convertConfigToBindings(
+				{ vars: overrides?.vars },
+				{ usePreviewIds: true }
+			);
+			for (const [key, value] of Object.entries(overrides?.secrets ?? {})) {
+				bindings[key] = { type: "secret_text", value };
+			}
+
+			return {
+				config:
+					"configPath" in input
+						? resolvePath(root, input.configPath)
+						: inlineConfig,
+				env: "configPath" in input ? input.env : undefined,
+				bindings,
+				dev: {
+					auth: serverAuthHook,
+					server: serverOptions.server ?? { hostname: "127.0.0.1", port: 0 },
+					logLevel: serverOptions.logLevel ?? "error",
+					watch: serverOptions.watch ?? false,
+					persist: resolvePersistOption(serverRoot, serverOptions.persist),
+					inspector: serverOptions.inspector ?? false,
+					registry: undefined,
+					outboundService:
+						serverOptions.outboundService ??
+						((request) => {
+							return globalThis.fetch(request.url, request);
+						}),
+					multiworkerPrimary: isMultiworker ? isPrimaryWorker : undefined,
+					inferOriginFromRoutes: false,
+				},
+				build: {
+					nodejsCompatMode: (config) => {
+						return validateNodeCompatMode(
+							config.compatibility_date,
+							config.compatibility_flags ?? [],
+							{ noBundle: config.no_bundle }
+						);
+					},
+				},
+				legacy: {
+					site: (config) => {
+						const legacyAssetPaths = getSiteAssetPaths(config);
+
+						if (!legacyAssetPaths) {
+							return undefined;
+						}
+
+						return {
+							bucket: path.join(
+								legacyAssetPaths.baseDirectory,
+								legacyAssetPaths.assetDirectory
+							),
+							include: legacyAssetPaths.includePatterns,
+							exclude: legacyAssetPaths.excludePatterns,
+						};
+					},
+				},
+			};
+		});
+	}
+
+	async function createSession(
+		serverOptions: ServerOptions
+	): Promise<ServerSession> {
+		const inputs = resolveWorkerInputs(serverOptions);
+		const [, ...auxiliaryWorkers] = inputs;
+		const isMultiworker = auxiliaryWorkers.length > 0;
+		const primaryDevEnv = isMultiworker
+			? new DevEnv({
+					runtimeFactories: [
+						(devEnv) => new MultiworkerRuntimeController(devEnv, inputs.length),
+					],
+				})
+			: new DevEnv();
+		const auxiliaryDevEnvs = auxiliaryWorkers.map(
+			() =>
+				new DevEnv({
+					runtimeFactories: [() => primaryDevEnv.runtimes[0]],
+					proxyFactory: (devEnv) => new NoOpProxyController(devEnv),
+				})
+		);
+		const session: ServerSession = {
+			primaryDevEnv,
+			devEnvs: [primaryDevEnv, ...auxiliaryDevEnvs],
+		};
+
+		try {
+			await updateConfig(session, inputs);
+			await waitForProxyReady(session);
+			return session;
+		} catch (error) {
+			await teardownSession(session);
+			throw error;
+		}
+	}
+
+	async function updateConfig(
+		session: ServerSession,
+		inputs: StartDevWorkerInput[]
+	) {
+		for (const [index, workerInput] of inputs.entries()) {
+			const devEnv = session.devEnvs[index];
+			await devEnv.config.set(workerInput, true);
+		}
+	}
+
+	async function resolveSession() {
+		if (startPromise) {
+			return await startPromise;
+		}
+
+		assert(
+			serverSession,
+			"Worker server has not been started. Start it with server.listen() before calling this method."
+		);
+
+		return serverSession;
+	}
+
+	async function serverAuthHook(
+		config: Pick<Config, "account_id">
+	): Promise<CfAccount> {
+		desiredAccountId ??= await requireAuth(config);
+
+		return {
+			accountId: desiredAccountId,
+			apiToken: requireApiToken(),
+		};
+	}
+
+	async function teardownSession(session: ServerSession) {
+		try {
+			await Promise.all(session.devEnvs.map((devEnv) => devEnv.teardown()));
+		} finally {
+			if (session === serverSession) {
+				serverSession = undefined;
+			}
+		}
+	}
+
+	async function startServerSession() {
+		if (!startPromise) {
+			startPromise = createSession(currentOptions)
+				.then((session) => {
+					serverSession = session;
+					return session;
+				})
+				.finally(() => {
+					startPromise = undefined;
+				});
+		}
+
+		return await startPromise;
+	}
+
+	async function waitForProxyReady(session: ServerSession) {
+		return new Promise<
+			Awaited<typeof session.primaryDevEnv.proxy.ready.promise>
+		>((resolve, reject) => {
+			const onError = (error: unknown) => {
+				session.primaryDevEnv.off("error", onError);
+				reject(error);
+			};
+
+			session.primaryDevEnv.once("error", onError);
+			void session.primaryDevEnv.proxy.ready.promise.then(
+				(ready) => {
+					session.primaryDevEnv.off("error", onError);
+					resolve(ready);
+				},
+				(error: unknown) => {
+					session.primaryDevEnv.off("error", onError);
+					reject(error);
+				}
+			);
+		});
+	}
+
+	async function waitForReloadComplete(session: ServerSession) {
+		return new Promise<void>((resolve, reject) => {
+			const cleanup = () => {
+				session.primaryDevEnv.off("error", onError);
+				session.primaryDevEnv.off("reloadComplete", onReloadComplete);
+			};
+			const onError = (error: unknown) => {
+				cleanup();
+				reject(error);
+			};
+			const onReloadComplete = () => {
+				cleanup();
+				resolve();
+			};
+
+			session.primaryDevEnv.once("error", onError);
+			session.primaryDevEnv.once("reloadComplete", onReloadComplete);
+		});
+	}
+
+	async function getRuntimeMiniflare(session: ServerSession) {
+		await session.primaryDevEnv.proxy.runtimeMessageMutex.drained();
+		const miniflare = session.primaryDevEnv.runtimes[0].mf;
+		assert(miniflare, "Worker runtime is not available.");
+		return miniflare;
+	}
+
+	async function dispatchFetch(
+		miniflare: Miniflare,
+		input: RequestInfo,
+		init?: RequestInit,
+		worker?: string
+	) {
+		if (typeof input === "string") {
+			const session = await resolveSession();
+			const { url } = await waitForProxyReady(session);
+			const baseUrl = new URL(url);
+
+			if (
+				baseUrl.hostname === "0.0.0.0" ||
+				baseUrl.hostname === "::" ||
+				baseUrl.hostname === "[::]" ||
+				baseUrl.hostname === "*"
+			) {
+				baseUrl.hostname = "localhost";
+			}
+
+			input = new URL(input, baseUrl);
+		}
+
+		if (worker === undefined) {
+			return miniflare.dispatchFetch(input, init);
+		}
+
+		const request = new Request(input, init);
+		const headers = new Headers(request.headers);
+
+		headers.set("MF-Route-Override", worker);
+
+		return miniflare.dispatchFetch(request, { headers });
+	}
+
+	return {
+		async listen() {
+			const session = serverSession ?? (await startServerSession());
+			const ready = await waitForProxyReady(session);
+
+			return {
+				url: ready.url,
+				inspectorUrl: ready.inspectorUrl,
+			};
+		},
+		async fetch(input, init) {
+			const session = await resolveSession();
+			const miniflare = session.primaryDevEnv.proxy.proxyWorker;
+			assert(
+				miniflare,
+				"The proxy worker is not available yet. Did you call server.listen()?"
+			);
+
+			return dispatchFetch(miniflare, input, init);
+		},
+		getWorker(name?: string) {
+			return {
+				async fetch(input, init) {
+					const session = await resolveSession();
+					const miniflare = await getRuntimeMiniflare(session);
+
+					return dispatchFetch(miniflare, input, init, name);
+				},
+				async scheduled(scheduledOptions) {
+					const session = await resolveSession();
+					const miniflare = await getRuntimeMiniflare(session);
+					const url = new URL(
+						"http://localhost/cdn-cgi/handler/scheduled?format=json"
+					);
+
+					if (scheduledOptions?.cron !== undefined) {
+						url.searchParams.set("cron", scheduledOptions.cron);
+					}
+
+					if (scheduledOptions?.scheduledTime !== undefined) {
+						url.searchParams.set(
+							"time",
+							String(scheduledOptions.scheduledTime.getTime())
+						);
+					}
+
+					const response = await dispatchFetch(miniflare, url, undefined, name);
+					const result = await response.json();
+
+					return result as FetcherScheduledResult;
+				},
+			};
+		},
+		async update(updateInput) {
+			currentOptions =
+				typeof updateInput === "function"
+					? updateInput(currentOptions)
+					: updateInput;
+			desiredAccountId = currentOptions.accountId ?? desiredAccountId;
+
+			if (serverSession) {
+				const nextInputs = resolveWorkerInputs(currentOptions);
+
+				if (nextInputs.length !== serverSession.devEnvs.length) {
+					throw new Error(
+						`Updating the number of workers running in the server is not supported.`
+					);
+				}
+
+				try {
+					await Promise.all([
+						waitForReloadComplete(serverSession),
+						updateConfig(serverSession, nextInputs),
+					]);
+				} catch (error) {
+					await teardownSession(serverSession);
+					throw error;
+				}
+			}
+		},
+		async clearStorage() {
+			const session = await resolveSession();
+
+			if (currentOptions.persist === true) {
+				throw new Error(
+					"clearStorage() cannot clear storage when persist is true. Omit persist or set it to false for ephemeral storage, or set persist to a path to clear that directory."
+				);
+			}
+
+			await teardownSession(session);
+
+			if (typeof currentOptions.persist === "string") {
+				const persistPath = resolvePath(
+					currentOptions.root ?? process.cwd(),
+					currentOptions.persist
+				);
+
+				await removeDir(persistPath);
+			}
+
+			await startServerSession();
+		},
+		async close() {
+			if (startPromise) {
+				// Wait for it to start before tearing down
+				// ignoring any errors since we're closing the server anyway
+				await startPromise.catch(() => undefined);
+			}
+			if (serverSession) {
+				await teardownSession(serverSession);
+			}
+		},
+	};
+}

--- a/packages/wrangler/src/api/startDevWorker/BaseController.ts
+++ b/packages/wrangler/src/api/startDevWorker/BaseController.ts
@@ -9,6 +9,7 @@ import type {
 	ReloadCompleteEvent,
 	ReloadStartEvent,
 } from "./events";
+import type { Miniflare } from "miniflare";
 
 export type ControllerEvent =
 	| ErrorEvent
@@ -56,6 +57,11 @@ export abstract class RuntimeController extends Controller {
 	abstract onBundleStart(_: BundleStartEvent): void;
 	abstract onBundleComplete(_: BundleCompleteEvent): void;
 	abstract onPreviewTokenExpired(_: PreviewTokenExpiredEvent): void;
+
+	// *********************
+	//   Runtime Accessors
+	// *********************
+	mf: Miniflare | undefined;
 
 	// *********************
 	//   Event Dispatchers

--- a/packages/wrangler/src/api/startDevWorker/BundlerController.ts
+++ b/packages/wrangler/src/api/startDevWorker/BundlerController.ts
@@ -184,6 +184,7 @@ export class BundlerController extends Controller {
 
 	async #startCustomBuild(config: StartDevWorkerOptions) {
 		await this.#customBuildWatcher?.close();
+		this.#customBuildWatcher = undefined;
 		this.#customBuildAborter?.abort();
 
 		if (!config.build?.custom?.command) {
@@ -194,6 +195,11 @@ export class BundlerController extends Controller {
 
 		// This is always present if a custom command is provided, defaulting to `./src`
 		assert(pathsToWatch, "config.build.custom.watch");
+
+		if (config.dev.watch === false) {
+			await this.#runCustomBuild(config, String(pathsToWatch));
+			return;
+		}
 
 		this.#customBuildWatcher = watch(pathsToWatch, {
 			persistent: true,
@@ -277,6 +283,7 @@ export class BundlerController extends Controller {
 					config.compatibilityDate,
 					config.compatibilityFlags
 				),
+				watch: config.dev.watch ?? true,
 				defineNavigatorUserAgent: isNavigatorDefined(
 					config.compatibilityDate,
 					config.compatibilityFlags
@@ -307,6 +314,7 @@ export class BundlerController extends Controller {
 	#assetsWatcher?: ReturnType<typeof watch>;
 	async #ensureWatchingAssets(config: StartDevWorkerOptions) {
 		await this.#assetsWatcher?.close();
+		this.#assetsWatcher = undefined;
 
 		const debouncedRefreshBundle = debounce(() => {
 			if (this.#currentBundle) {
@@ -314,7 +322,7 @@ export class BundlerController extends Controller {
 			}
 		});
 
-		if (config.assets?.directory) {
+		if (config.dev.watch !== false && config.assets?.directory) {
 			this.#assetsWatcher = watch(config.assets.directory, {
 				persistent: true,
 				ignoreInitial: true,

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -149,14 +149,21 @@ async function resolveDevConfig(
 		origin: {
 			secure:
 				input.dev?.origin?.secure ?? config.dev.upstream_protocol === "https",
-			hostname: host ?? getInferredHost(routes, config.configPath),
+			hostname:
+				host ??
+				(input.dev?.inferOriginFromRoutes
+					? getInferredHost(routes, config.configPath)
+					: undefined),
 		},
+		watch: input.dev?.watch,
 		liveReload: input.dev?.liveReload || false,
 		testScheduled: input.dev?.testScheduled,
+		outboundService: input.dev?.outboundService,
 		// absolute resolved path
 		persist: localPersistencePath,
 		registry: input.dev?.registry,
 		multiworkerPrimary: input.dev?.multiworkerPrimary,
+		inferOriginFromRoutes: input.dev?.inferOriginFromRoutes,
 		enableContainers:
 			input.dev?.enableContainers ?? config.dev.enable_containers,
 		dockerPath: input.dev?.dockerPath ?? getDockerPath(),
@@ -565,33 +572,39 @@ export class ConfigController extends Controller {
 		const signal = this.#abortController.signal;
 		this.latestInput = input;
 		try {
-			const fileConfig = readConfig(
-				{
-					script: input.entrypoint,
-					config: input.config,
-					env: input.env,
-					"dispatch-namespace": undefined,
-					"legacy-env": !input.legacy?.useServiceEnvironments,
-					remote: !!input.dev?.remote,
-					upstreamProtocol:
-						input.dev?.origin?.secure === undefined
-							? undefined
-							: input.dev?.origin?.secure
-								? "https"
-								: "http",
-					localProtocol:
-						input.dev?.server?.secure === undefined
-							? undefined
-							: input.dev?.server?.secure
-								? "https"
-								: "http",
-					generateTypes: input.dev?.generateTypes,
-				},
-				{ useRedirectIfAvailable: true }
-			);
+			const fileConfig =
+				typeof input.config === "object"
+					? input.config
+					: readConfig(
+							{
+								script: input.entrypoint,
+								config: input.config,
+								env: input.env,
+								"dispatch-namespace": undefined,
+								"legacy-env": !input.legacy?.useServiceEnvironments,
+								remote: !!input.dev?.remote,
+								upstreamProtocol:
+									input.dev?.origin?.secure === undefined
+										? undefined
+										: input.dev?.origin?.secure
+											? "https"
+											: "http",
+								localProtocol:
+									input.dev?.server?.secure === undefined
+										? undefined
+										: input.dev?.server?.secure
+											? "https"
+											: "http",
+								generateTypes: input.dev?.generateTypes,
+							},
+							{ useRedirectIfAvailable: true }
+						);
 
-			if (!getDisableConfigWatching()) {
+			if (!getDisableConfigWatching() && input.dev?.watch !== false) {
 				await this.#ensureWatchingConfig(fileConfig.configPath);
+			} else {
+				await this.#configWatcher?.close();
+				this.#configWatcher = undefined;
 			}
 
 			const { config: resolvedConfig, printCurrentBindings } =

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -112,10 +112,13 @@ export async function convertToConfigBundle(
 	const bindings: Record<string, Binding> = { ...event.config.bindings };
 
 	const crons = [];
+	const routes = [];
 	const queueConsumers = [];
 	for (const trigger of event.config.triggers ?? []) {
 		if (trigger.type === "cron") {
 			crons.push(trigger.cron);
+		} else if (trigger.type === "route") {
+			routes.push(trigger.pattern);
 		} else if (trigger.type === "queue-consumer") {
 			const { type: _, ...consumer } = trigger;
 			queueConsumers.push(consumer);
@@ -191,7 +194,9 @@ export async function convertToConfigBundle(
 		localPersistencePath: event.config.dev.persist,
 		liveReload: event.config.dev?.liveReload ?? false,
 		crons,
+		routes,
 		queueConsumers,
+		outboundService: event.config.dev.outboundService,
 		localProtocol: event.config.dev?.server?.secure ? "https" : "http",
 		httpsCertPath: event.config.dev?.server?.httpsCertPath,
 		httpsKeyPath: event.config.dev?.server?.httpsKeyPath,
@@ -235,7 +240,6 @@ export class LocalRuntimeController extends RuntimeController {
 	// updates were submitted, the second may apply before the first. Therefore,
 	// wrap updates in a mutex, so they're always applied in invocation order.
 	#mutex = new Mutex();
-	#mf?: Miniflare;
 
 	#remoteProxySessionData: {
 		session: RemoteProxySession;
@@ -362,13 +366,13 @@ export class LocalRuntimeController extends RuntimeController {
 				}
 			);
 			options.liveReload = false; // TODO: set in buildMiniflareOptions once old code path is removed
-			if (this.#mf === undefined) {
+			if (this.mf === undefined) {
 				logger.log(chalk.dim("⎔ Starting local server..."));
-				this.#mf = new Miniflare(options);
+				this.mf = new Miniflare(options);
 			} else {
 				logger.log(chalk.dim("⎔ Reloading local server..."));
 
-				await this.#mf.setOptions(options);
+				await this.mf.setOptions(options);
 
 				logger.log(chalk.dim("⎔ Local server updated and ready"));
 			}
@@ -376,14 +380,14 @@ export class LocalRuntimeController extends RuntimeController {
 			// calls to complete before resolving. To ensure we get the `url` and
 			// `inspectorUrl` for this set of `options`, we protect `#mf` with a mutex,
 			// so only one update can happen at a time.
-			const userWorkerUrl = await this.#mf.ready;
+			const userWorkerUrl = await this.mf.ready;
 			// TODO: Miniflare should itself return undefined on
 			//       `getInspectorURL` when no inspector is in use
 			//       (currently the function just hangs)
 			const userWorkerInspectorUrl =
 				options.inspectorPort === undefined
 					? undefined
-					: await this.#mf.getInspectorURL();
+					: await this.mf.getInspectorURL();
 			// If we received a new `bundleComplete` event before we were able to
 			// dispatch a `reloadComplete` for this bundle, ignore this bundle.
 			if (id !== this.#currentBundleId) {
@@ -482,12 +486,12 @@ export class LocalRuntimeController extends RuntimeController {
 		process.off("exit", this.cleanupContainers);
 		this.cleanupContainers();
 
-		if (this.#mf) {
+		if (this.mf) {
 			logger.log(chalk.dim("⎔ Shutting down local server..."));
 		}
 
-		await this.#mf?.dispose();
-		this.#mf = undefined;
+		await this.mf?.dispose();
+		this.mf = undefined;
 
 		if (this.#remoteProxySessionData) {
 			logger.log(chalk.dim("⎔ Shutting down remote connection..."));

--- a/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
@@ -68,7 +68,6 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 	// updates were submitted, the second may apply before the first. Therefore,
 	// wrap updates in a mutex, so they're always applied in invocation order.
 	#mutex = new Mutex();
-	#mf?: Miniflare;
 
 	#options = new Map<string, { options: MF.Options; primary: boolean }>();
 
@@ -200,13 +199,13 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 			if (this.#canStartMiniflare()) {
 				const mergedMfOptions = ensureMatchingSql(this.#mergedMfOptions());
 
-				if (this.#mf === undefined) {
+				if (this.mf === undefined) {
 					logger.log(chalk.dim("⎔ Starting local server..."));
-					this.#mf = new Miniflare(mergedMfOptions);
+					this.mf = new Miniflare(mergedMfOptions);
 				} else {
 					logger.log(chalk.dim("⎔ Reloading local server..."));
 
-					await this.#mf.setOptions(mergedMfOptions);
+					await this.mf.setOptions(mergedMfOptions);
 
 					logger.log(chalk.dim("⎔ Local server updated and ready"));
 				}
@@ -215,8 +214,11 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 				// calls to complete before resolving. To ensure we get the `url` and
 				// `inspectorUrl` for this set of `options`, we protect `#mf` with a mutex,
 				// so only one update can happen at a time.
-				const userWorkerUrl = await this.#mf.ready;
-				const userWorkerInspectorUrl = await this.#mf.getInspectorURL();
+				const userWorkerUrl = await this.mf.ready;
+				const userWorkerInspectorUrl =
+					mergedMfOptions.inspectorPort !== undefined
+						? await this.mf.getInspectorURL()
+						: null;
 				// If we received a new `bundleComplete` event before we were able to
 				// dispatch a `reloadComplete` for this bundle, ignore this bundle.
 				if (id !== this.#currentBundleId) {
@@ -233,12 +235,14 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 							hostname: userWorkerUrl.hostname,
 							port: userWorkerUrl.port,
 						},
-						userWorkerInspectorUrl: {
-							protocol: userWorkerInspectorUrl.protocol,
-							hostname: userWorkerInspectorUrl.hostname,
-							port: userWorkerInspectorUrl.port,
-							pathname: `/core:user:${data.config.name}`,
-						},
+						userWorkerInspectorUrl: userWorkerInspectorUrl
+							? {
+									protocol: userWorkerInspectorUrl.protocol,
+									hostname: userWorkerInspectorUrl.hostname,
+									port: userWorkerInspectorUrl.port,
+									pathname: `/core:user:${data.config.name}`,
+								}
+							: undefined,
 						userWorkerInnerUrlOverrides: getUserWorkerInnerUrlOverrides(
 							data.config
 						),
@@ -301,12 +305,12 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 
 	#teardown = async (): Promise<void> => {
 		logger.debug("MultiworkerRuntimeController teardown beginning...");
-		if (this.#mf) {
+		if (this.mf) {
 			logger.log(chalk.dim("⎔ Shutting down local server..."));
 		}
 
-		await this.#mf?.dispose();
-		this.#mf = undefined;
+		await this.mf?.dispose();
+		this.mf = undefined;
 
 		if (this.#remoteProxySessionsData.size > 0) {
 			logger.log(chalk.dim("⎔ Shutting down remote connections..."));

--- a/packages/wrangler/src/api/startDevWorker/types.ts
+++ b/packages/wrangler/src/api/startDevWorker/types.ts
@@ -46,8 +46,8 @@ export interface StartDevWorkerInput {
 	 * This is the `main` property of a Wrangler configuration file.
 	 */
 	entrypoint?: string;
-	/** The configuration path of the worker. */
-	config?: string;
+	/** The configuration path of the worker, or a normalized configuration object. */
+	config?: string | Config;
 
 	/** The compatibility date for the workerd runtime. */
 	compatibilityDate?: string;
@@ -173,6 +173,8 @@ export interface StartDevWorkerInput {
 
 		/** Treat this as the primary worker in a multiworker setup (i.e. the first Worker in Miniflare's options) */
 		multiworkerPrimary?: boolean;
+		/** Whether to infer the local request origin from configured routes. */
+		inferOriginFromRoutes?: boolean;
 
 		containerBuildId?: string;
 		/** Whether to build and connect to containers during local dev. Requires Docker daemon to be running. Defaults to true. */
@@ -208,8 +210,10 @@ export interface StartDevWorkerInput {
 
 export type StartDevWorkerOptions = Omit<
 	StartDevWorkerInput,
-	"assets" | "containers" | "dev"
+	"assets" | "config" | "containers" | "dev"
 > & {
+	/** The configuration path of the worker */
+	config?: string;
 	/** A worker's directory. Usually where the Wrangler configuration file is located */
 	projectRoot: string;
 	build: StartDevWorkerInput["build"] & {

--- a/packages/wrangler/src/cli.ts
+++ b/packages/wrangler/src/cli.ts
@@ -15,6 +15,7 @@ import {
 	startRemoteProxySession,
 	startWorker,
 	unstable_dev,
+	createServer,
 	experimental_generateTypes,
 	unstable_getDevCompatibilityDate,
 	unstable_getDurableObjectClassNameToUseSQLiteMap,
@@ -40,6 +41,7 @@ import type {
 	Unstable_MiniflareWorkerOptions,
 	Unstable_RawConfig,
 	Unstable_RawEnvironment,
+	WorkerServer,
 } from "./api";
 import type { Logger } from "./logger";
 import type { Request, Response } from "miniflare";
@@ -67,6 +69,7 @@ export {
 	unstable_pages,
 	DevEnv as unstable_DevEnv,
 	startWorker as unstable_startWorker,
+	createServer,
 	unstable_getVarsForDev,
 	unstable_readConfig,
 	experimental_generateTypes,
@@ -89,6 +92,7 @@ export type {
 	Unstable_MiniflareWorkerOptions,
 	Experimental_GenerateTypesOptions,
 	Experimental_GenerateTypesResult,
+	WorkerServer,
 };
 
 export { printBindings as unstable_printBindings } from "./utils/print-bindings";

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -525,13 +525,21 @@ export function getBindings(
 	// getVarsForDev returns typed bindings: config vars are plain_text/json,
 	// while .dev.vars/.env vars are secret_text.
 	// When secrets is defined, only declared secret keys are loaded from files.
+	const secrets = configParam.secrets
+		? {
+				...configParam.secrets,
+				required: configParam.secrets?.required?.filter(
+					(secret) => inputBindings?.[secret]?.type !== "secret_text"
+				),
+			}
+		: undefined;
 	const vars = getVarsForDev(
 		configParam.userConfigPath,
 		envFiles,
 		configParam.vars,
 		env,
 		false,
-		configParam.secrets
+		secrets
 	);
 	for (const [name, binding] of Object.entries(vars)) {
 		// Only override plain_text/json/secret_text vars, not other binding types like kv_namespace

--- a/packages/wrangler/src/dev/miniflare/index.ts
+++ b/packages/wrangler/src/dev/miniflare/index.ts
@@ -37,6 +37,7 @@ import type {
 	Config,
 	ContainerEngine,
 	LegacyAssetPaths,
+	ServiceFetch,
 } from "@cloudflare/workers-utils";
 import type {
 	DOContainerOptions,
@@ -85,6 +86,7 @@ export interface ConfigBundle {
 	localPersistencePath: string | false;
 	liveReload: boolean;
 	crons: Config["triggers"]["crons"];
+	routes: string[] | undefined;
 	queueConsumers: Config["queues"]["consumers"];
 	localProtocol: "http" | "https";
 	httpsKeyPath: string | undefined;
@@ -92,6 +94,7 @@ export interface ConfigBundle {
 	localUpstream: string | undefined;
 	upstreamProtocol: "http" | "https";
 	inspect: boolean;
+	outboundService: ServiceFetch | undefined;
 	tails: Config["tail_consumers"] | undefined;
 	streamingTails: Config["streaming_tail_consumers"] | undefined;
 	testScheduled: boolean;
@@ -1123,6 +1126,8 @@ export async function buildMiniflareOptions(
 				...bindingOptions,
 				...sitesOptions,
 				...assetOptions,
+				routes: config.routes,
+				outboundService: config.outboundService,
 				containerEngine: config.containerEngine,
 				zone: config.zone,
 			},

--- a/packages/wrangler/src/dev/start-dev.ts
+++ b/packages/wrangler/src/dev/start-dev.ts
@@ -265,6 +265,7 @@ async function setupDevEnv(
 				logLevel: args.logLevel,
 				registry: args.disableDevRegistry ? undefined : getRegistryPath(),
 				multiworkerPrimary: args.multiworkerPrimary,
+				inferOriginFromRoutes: true,
 				enableContainers: args.enableContainers,
 				dockerPath: args.dockerPath,
 				// initialise with a random id

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import { readFileSync, realpathSync } from "node:fs";
 import path from "node:path";
-import { watch } from "chokidar";
+import { watch as watchPaths } from "chokidar";
 import { bundleWorker } from "../deployment-bundle/bundle";
 import { getBundleType } from "../deployment-bundle/bundle-type";
 import { dedupeModulesByName } from "../deployment-bundle/dedupe-modules";
@@ -58,6 +58,7 @@ export function runBuild(
 		local,
 		targetConsumer,
 		testScheduled,
+		watch,
 		projectRoot,
 		onStart,
 		defineNavigatorUserAgent,
@@ -86,6 +87,7 @@ export function runBuild(
 		local: boolean;
 		targetConsumer: "dev" | "deploy";
 		testScheduled: boolean;
+		watch: boolean;
 		projectRoot: string | undefined;
 		onStart: () => void;
 		defineNavigatorUserAgent: boolean;
@@ -161,7 +163,7 @@ export function runBuild(
 						additionalModules: newAdditionalModules,
 						jsxFactory,
 						jsxFragment,
-						watch: true,
+						watch,
 						tsconfig,
 						minify,
 						keepNames,
@@ -198,9 +200,9 @@ export function runBuild(
 
 		// if "noBundle" is true, then we need to manually watch all modules and
 		// trigger "builds" when any change
-		if (noBundle) {
+		if (noBundle && watch) {
 			const watching = [path.resolve(entry.moduleRoot)];
-			const watcher = watch(watching, {
+			const watcher = watchPaths(watching, {
 				persistent: true,
 				// Ignore VCS dirs, dependencies, and the .wrangler dir (which
 				// contains miniflare state/cache files written by workerd at

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,39 @@ importers:
         specifier: workspace:*
         version: link:../../packages/wrangler
 
+  fixtures/create-server-example:
+    devDependencies:
+      '@cloudflare/vite-plugin':
+        specifier: workspace:*
+        version: link:../../packages/vite-plugin-cloudflare
+      '@cloudflare/workers-tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/workers-tsconfig
+      '@cloudflare/workers-types':
+        specifier: catalog:default
+        version: 4.20260528.1
+      '@fixture/shared':
+        specifier: workspace:*
+        version: link:../shared
+      '@types/node':
+        specifier: ^22.10.1
+        version: 22.15.17
+      msw:
+        specifier: catalog:default
+        version: 2.12.4(@types/node@22.15.17)(typescript@5.8.3)
+      typescript:
+        specifier: catalog:default
+        version: 5.8.3
+      vite:
+        specifier: catalog:default
+        version: 8.0.13(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1)
+      vitest:
+        specifier: catalog:default
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.15.17)(@vitest/ui@4.1.0)(msw@2.12.4(@types/node@22.15.17)(typescript@5.8.3))(vite@8.0.13(@types/node@22.15.17)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.1))
+      wrangler:
+        specifier: workspace:*
+        version: link:../../packages/wrangler
+
   fixtures/d1-read-replication-app:
     devDependencies:
       '@cloudflare/workers-tsconfig':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,9 +243,6 @@ importers:
       '@cloudflare/workers-types':
         specifier: catalog:default
         version: 4.20260528.1
-      '@fixture/shared':
-        specifier: workspace:*
-        version: link:../shared
       '@types/node':
         specifier: ^22.10.1
         version: 22.15.17


### PR DESCRIPTION
Fixes n/a.

This adds a fixture we will reference in the Cloudflare docs to act as recipes of the new `createServer()` API, covering both Wrangler and Vite projects.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
