### PR TITLE
ci: do not run codeowners checks on PR that do not target main

### DIFF
--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -25,22 +25,27 @@ jobs:
   codeowners:
     name: "Run Codeowners Plus"
     runs-on: ubuntu-latest
+    # Each step is skipped when:
+    #   - the PR head is the changeset-release branch (auto-generated changeset PRs), or
+    #   - the PR base is not `main` (PRs against feature branches don't need formal review).
+    # Note: if we ever introduce a maintenance branch (e.g. a long-lived release branch),
+    # it would need to be added to the base branch allowlist below.
     steps:
       - name: "Checkout Base Branch"
-        if: github.event.pull_request.head.ref != 'changeset-release/main'
+        if: github.event.pull_request.head.ref != 'changeset-release/main' && github.event.pull_request.base.ref == 'main'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: "Fetch PR Head (for diff computation)"
-        if: github.event.pull_request.head.ref != 'changeset-release/main'
+        if: github.event.pull_request.head.ref != 'changeset-release/main' && github.event.pull_request.base.ref == 'main'
         run: git fetch origin +refs/pull/${{ github.event.pull_request.number }}/head
         env:
           GITHUB_TOKEN: "${{ secrets.CODEOWNERS_GITHUB_PAT }}"
 
       - name: "Codeowners Plus"
-        if: github.event.pull_request.head.ref != 'changeset-release/main'
+        if: github.event.pull_request.head.ref != 'changeset-release/main' && github.event.pull_request.base.ref == 'main'
         uses: multimediallc/codeowners-plus@ff02aa993a92e8efe01642916d0877beb9439e9f # v1.9.0
         with:
           github-token: "${{ secrets.CODEOWNERS_GITHUB_PAT }}"


### PR DESCRIPTION
When a PR is created against a side branch (i.e. not `main`) it is not necessary to run the codeowners workflow and assign reviewers.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: ci change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ci change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->