### PR TITLE
[workers-utils] Fix cloudflared macOS checksum: verify extracted binary, not tarball

### DIFF
--- a/.changeset/fix-cloudflared-macos-checksum.md
+++ b/.changeset/fix-cloudflared-macos-checksum.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/workers-utils": patch
+---
+
+Fix cloudflared SHA256 checksum mismatch on macOS
+
+The update service (`update.argotunnel.com`) returns a checksum for the extracted binary, not the `.tgz` tarball. We were computing the SHA256 of the tarball itself, which always mismatched on macOS where cloudflared is distributed as a compressed archive.
+
+This aligns with cloudflared's own auto-updater (`cmd/cloudflared/updater/workers_update.go`), which decompresses the tarball first, then checksums the resulting binary. We now do the same: extract, then verify.

--- a/packages/workers-utils/src/cloudflared.ts
+++ b/packages/workers-utils/src/cloudflared.ts
@@ -14,6 +14,7 @@ import {
 	constants,
 	existsSync,
 	mkdirSync,
+	readFileSync,
 	renameSync,
 	unlinkSync,
 	writeFileSync,
@@ -516,7 +517,13 @@ async function downloadCloudflared(
 }
 
 /**
- * Download and extract a tarball (for macOS)
+ * Download and extract a tarball (for macOS).
+ *
+ * The update service checksum is for the extracted binary, not the tarball
+ * itself. This matches cloudflared's own auto-update behavior — see
+ * cloudflared/cmd/cloudflared/updater/workers_update.go: the download()
+ * function decompresses .tgz into the raw binary, then Apply() checksums
+ * the resulting file. We do the same: extract first, then verify.
  */
 async function downloadAndExtractTarball(
 	response: Response,
@@ -527,17 +534,6 @@ async function downloadAndExtractTarball(
 	const tempTarPath = join(cacheDir, "cloudflared.tgz");
 
 	const buffer = Buffer.from(await response.arrayBuffer());
-	if (expectedChecksum) {
-		const actualSha256 = sha256Hex(buffer);
-		if (actualSha256 !== expectedChecksum) {
-			throw new UserError(
-				`[cloudflared] SHA256 mismatch for downloaded cloudflared tarball.\n\n` +
-					`Expected: ${expectedChecksum}\n` +
-					`Actual:   ${actualSha256}`,
-				{ telemetryMessage: "tunnel cloudflared tarball checksum mismatch" }
-			);
-		}
-	}
 	writeFileSync(tempTarPath, buffer);
 
 	try {
@@ -548,6 +544,24 @@ async function downloadAndExtractTarball(
 		const extractedPath = join(cacheDir, "cloudflared");
 		if (extractedPath !== binPath && existsSync(extractedPath)) {
 			renameSync(extractedPath, binPath);
+		}
+
+		// Verify checksum against the extracted binary, not the tarball.
+		// The update service provides checksums for the uncompressed binary.
+		if (expectedChecksum) {
+			const extractedBinary = readFileSync(binPath);
+			const actualSha256 = sha256Hex(extractedBinary);
+			if (actualSha256 !== expectedChecksum) {
+				throw new UserError(
+					`[cloudflared] SHA256 mismatch for downloaded cloudflared binary.\n\n` +
+						`Expected: ${expectedChecksum}\n` +
+						`Actual:   ${actualSha256}`,
+					{
+						telemetryMessage:
+							"tunnel cloudflared extracted binary checksum mismatch",
+					}
+				);
+			}
 		}
 	} finally {
 		try {


### PR DESCRIPTION
The cloudflared update service (`update.argotunnel.com`) returns a SHA256 checksum for the **extracted binary**, not the `.tgz` tarball. On macOS, where cloudflared is distributed as a compressed archive, we were computing the checksum of the tarball itself — which always mismatched.

This aligns with cloudflared's own auto-updater ([`workers_update.go`](https://github.com/cloudflare/cloudflared/blob/master/cmd/cloudflared/updater/workers_update.go#L102-L112)), which decompresses the tarball first via `download()`, then checksums the resulting binary in `Apply()`. We now do the same: extract first, then verify.

Before this fix, macOS users hit:
```
Error: [cloudflared] SHA256 mismatch for downloaded cloudflared tarball.
Expected: cd9f764abfd06757b4def10ee5ba3d862381ed9fc02d6c1f06086c23d88695c6
Actual: ba94054c9fd4297645093d59d514425e546d07bb0516120e694a13d5b216d38
```

---

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: Removed all system cloudflared binaries, cleared `~/.wrangler/cloudflared` cache, ran `wrangler tunnel quick-start` which triggered a fresh download of `cloudflared-darwin-arm64.tgz`, checksum passed, tunnel started successfully.
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: Bug fix with no user-facing API or config changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->