### PR TITLE
[vite-plugin] Forward response headers on WebSocket upgrade

### DIFF
--- a/.changeset/vite-plugin-websocket-upgrade-headers.md
+++ b/.changeset/vite-plugin-websocket-upgrade-headers.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Forward response headers from the Worker on WebSocket upgrade responses
+
+Headers set on a `new Response(null, { status: 101, webSocket, headers })` returned from the Worker are now propagated to the upgrade response sent to the browser during `vite dev`. Previously the headers were dropped, so cookies (`Set-Cookie`) and custom headers (`X-*`) on WebSocket handshake responses were invisible client-side — even though they were delivered correctly by `wrangler dev`.

--- a/packages/vite-plugin-cloudflare/src/__tests__/websockets.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/websockets.spec.ts
@@ -207,6 +207,71 @@ describe("handleWebSocket", () => {
 	});
 
 	// https://github.com/cloudflare/workers-sdk/issues/10390
+	test("does not forward framing headers from the Worker response", async ({
+		expect,
+	}) => {
+		// Defense in depth: even if a Worker returns framing headers, they
+		// must not leak onto the 101 response (no body, so they're nonsensical).
+		// Handshake headers (`Sec-WebSocket-*`, `Connection`, `Upgrade`) are
+		// rejected upstream by miniflare's own validation before reaching the
+		// forwarding code, so they're not exercised here.
+		await miniflare.dispose();
+		miniflare = new Miniflare({
+			modules: true,
+			script: `export default {
+				fetch() {
+					const [client, server] = Object.values(new WebSocketPair());
+					server.accept();
+					const headers = new Headers({
+						"X-Hello": "testing",
+						"Transfer-Encoding": "chunked",
+						"Content-Length": "42",
+					});
+					return new Response(null, {
+						status: 101,
+						webSocket: client,
+						headers,
+					});
+				}
+			}`,
+		});
+		await listen();
+
+		const socket = net.connect(port, "127.0.0.1");
+		await new Promise<void>((r) => socket.on("connect", r));
+
+		const chunks: Buffer[] = [];
+		socket.on("data", (chunk) => chunks.push(chunk));
+
+		socket.write(
+			"GET / HTTP/1.1\r\n" +
+				`Host: 127.0.0.1:${port}\r\n` +
+				"Upgrade: websocket\r\n" +
+				"Connection: Upgrade\r\n" +
+				"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+				"Sec-WebSocket-Version: 13\r\n\r\n"
+		);
+
+		await vi.waitFor(() => {
+			const raw = Buffer.concat(chunks).toString("utf8");
+			expect(raw).toContain("HTTP/1.1 101");
+			expect(raw).toContain("\r\n\r\n");
+		});
+
+		const raw = Buffer.concat(chunks).toString("utf8");
+		const headerBlock = raw.slice(0, raw.indexOf("\r\n\r\n"));
+
+		// Non-excluded header still forwarded.
+		expect(headerBlock).toContain("x-hello: testing");
+
+		// Excluded framing headers must NOT appear on the 101 response.
+		expect(headerBlock).not.toMatch(/Transfer-Encoding: chunked/i);
+		expect(headerBlock).not.toMatch(/Content-Length: 42/i);
+
+		socket.destroy();
+	});
+
+	// https://github.com/cloudflare/workers-sdk/issues/10390
 	test("forwards response headers from the Worker on the 101 upgrade response", async ({
 		expect,
 	}) => {

--- a/packages/vite-plugin-cloudflare/src/__tests__/websockets.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/websockets.spec.ts
@@ -205,4 +205,64 @@ describe("handleWebSocket", () => {
 		});
 		expect(`${url}`).toBe(`http://127.0.0.1:${port}/`);
 	});
+
+	// https://github.com/cloudflare/workers-sdk/issues/10390
+	test("forwards response headers from the Worker on the 101 upgrade response", async ({
+		expect,
+	}) => {
+		// Override the default Miniflare instance with a Worker that returns
+		// custom headers (including two Set-Cookie entries) on the upgrade
+		// response.
+		await miniflare.dispose();
+		miniflare = new Miniflare({
+			modules: true,
+			script: `export default {
+				fetch() {
+					const [client, server] = Object.values(new WebSocketPair());
+					server.accept();
+					const headers = new Headers({ "X-Hello": "testing" });
+					headers.append("Set-Cookie", "session=abc; Path=/");
+					headers.append("Set-Cookie", "theme=dark; Path=/; HttpOnly");
+					return new Response(null, {
+						status: 101,
+						webSocket: client,
+						headers,
+					});
+				}
+			}`,
+		});
+		await listen();
+
+		const socket = net.connect(port, "127.0.0.1");
+		await new Promise<void>((r) => socket.on("connect", r));
+
+		const chunks: Buffer[] = [];
+		socket.on("data", (chunk) => chunks.push(chunk));
+
+		socket.write(
+			"GET / HTTP/1.1\r\n" +
+				`Host: 127.0.0.1:${port}\r\n` +
+				"Upgrade: websocket\r\n" +
+				"Connection: Upgrade\r\n" +
+				"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+				"Sec-WebSocket-Version: 13\r\n\r\n"
+		);
+
+		await vi.waitFor(() => {
+			const raw = Buffer.concat(chunks).toString("utf8");
+			expect(raw).toContain("HTTP/1.1 101");
+			expect(raw).toContain("\r\n\r\n");
+		});
+
+		const raw = Buffer.concat(chunks).toString("utf8");
+		const headerBlock = raw.slice(0, raw.indexOf("\r\n\r\n"));
+
+		// Fetch `Headers` normalize names to lowercase; `Set-Cookie` keeps its
+		// canonical casing because it is appended manually via `getSetCookie()`.
+		expect(headerBlock).toContain("x-hello: testing");
+		expect(headerBlock).toContain("Set-Cookie: session=abc; Path=/");
+		expect(headerBlock).toContain("Set-Cookie: theme=dark; Path=/; HttpOnly");
+
+		socket.destroy();
+	});
 });

--- a/packages/vite-plugin-cloudflare/src/websockets.ts
+++ b/packages/vite-plugin-cloudflare/src/websockets.ts
@@ -60,6 +60,17 @@ export function handleWebSocket(
 				return;
 			}
 
+			// Forward response headers (e.g. Set-Cookie, custom auth headers) from
+			// the Worker's 101 response onto the upgrade response sent to the
+			// client. Without this, headers set on a `new Response(null, { status:
+			// 101, webSocket, headers })` are silently dropped during `vite dev`,
+			// even though they are delivered correctly by `wrangler dev`.
+			// See cloudflare/workers-sdk#10390.
+			const onHeaders = (responseHeaders: string[]) => {
+				appendWorkerResponseHeaders(responseHeaders, response.headers);
+			};
+			nodeWebSocket.once("headers", onHeaders);
+
 			nodeWebSocket.handleUpgrade(
 				request,
 				socket,
@@ -71,6 +82,47 @@ export function handleWebSocket(
 			);
 		}
 	);
+}
+
+/**
+ * Headers that must not be forwarded on the 101 upgrade response — they are
+ * either part of the WebSocket handshake managed by `ws` or irrelevant on a
+ * response with no body.
+ */
+const EXCLUDED_RESPONSE_HEADERS = new Set([
+	"connection",
+	"content-length",
+	"sec-websocket-accept",
+	"sec-websocket-extensions",
+	"sec-websocket-protocol",
+	"transfer-encoding",
+	"upgrade",
+]);
+
+function appendWorkerResponseHeaders(
+	responseHeaders: string[],
+	workerHeaders: Headers
+) {
+	// `Set-Cookie` can appear multiple times in a single response.
+	// `Headers.forEach` collapses them into a single comma-joined value, which
+	// breaks cookies that themselves contain commas (e.g. Expires).
+	// `getSetCookie` returns them as a string array.
+	if (typeof workerHeaders.getSetCookie === "function") {
+		for (const cookie of workerHeaders.getSetCookie()) {
+			responseHeaders.push(`Set-Cookie: ${cookie}`);
+		}
+	}
+
+	workerHeaders.forEach((value, name) => {
+		const lower = name.toLowerCase();
+		if (lower === "set-cookie") {
+			return;
+		}
+		if (EXCLUDED_RESPONSE_HEADERS.has(lower)) {
+			return;
+		}
+		responseHeaders.push(`${name}: ${value}`);
+	});
 }
 
 /**

--- a/packages/vite-plugin-cloudflare/src/websockets.ts
+++ b/packages/vite-plugin-cloudflare/src/websockets.ts
@@ -18,6 +18,27 @@ export function handleWebSocket(
 ) {
 	const nodeWebSocket = new WebSocketServer({ noServer: true });
 
+	// Stash Worker 101-response headers keyed by the upgrade request so a single
+	// persistent `headers` listener can apply them when `ws` emits the upgrade
+	// response. Matches the pattern in `packages/miniflare/src/index.ts`.
+	//
+	// Using `once()` per upgrade is unsafe: if `ws.handleUpgrade` aborts before
+	// emitting `headers` (e.g. malformed `Sec-WebSocket-Key`/`Sec-WebSocket-
+	// Version`), the listener stays attached and fires on the next successful
+	// upgrade with stale headers leaked from the previous Worker response. The
+	// WeakMap entry is GC'd if the request never completes.
+	const workerResponseHeaders = new WeakMap<IncomingMessage, Headers>();
+	nodeWebSocket.on(
+		"headers",
+		(responseHeaders: string[], request: IncomingMessage) => {
+			const extra = workerResponseHeaders.get(request);
+			workerResponseHeaders.delete(request);
+			if (extra) {
+				appendWorkerResponseHeaders(responseHeaders, extra);
+			}
+		}
+	);
+
 	httpServer.on(
 		"upgrade",
 		async (request: IncomingMessage, socket: Duplex, head: Buffer) => {
@@ -66,10 +87,7 @@ export function handleWebSocket(
 			// 101, webSocket, headers })` are silently dropped during `vite dev`,
 			// even though they are delivered correctly by `wrangler dev`.
 			// See cloudflare/workers-sdk#10390.
-			const onHeaders = (responseHeaders: string[]) => {
-				appendWorkerResponseHeaders(responseHeaders, response.headers);
-			};
-			nodeWebSocket.once("headers", onHeaders);
+			workerResponseHeaders.set(request, response.headers);
 
 			nodeWebSocket.handleUpgrade(
 				request,


### PR DESCRIPTION
Fixes #10390.

When a Worker responds to a WebSocket upgrade with custom headers — for example `Set-Cookie` or a custom `X-*` auth header on a `new Response(null, { status: 101, webSocket, headers })` — the headers never reach the browser under `vite dev`. The same Worker behaves correctly under `wrangler dev`. The issue tracks the bug with a minimal repro at [cloudkite/websocket-handshake](https://github.com/cloudkite/websocket-handshake).

`handleWebSocket` in `packages/vite-plugin-cloudflare/src/websockets.ts` consumed `response.webSocket` and called `nodeWebSocket.handleUpgrade(...)` without ever propagating `response.headers`, so anything the Worker put on its 101 response was discarded before the handshake completed.

This PR attaches a one-shot `headers` listener to the `ws` `WebSocketServer` right before each `handleUpgrade` call and appends the Worker's response headers to the upgrade response. Excluded:

- `connection`, `upgrade`, `sec-websocket-accept`, `sec-websocket-extensions`, `sec-websocket-protocol` — owned by the handshake managed by `ws`.
- `transfer-encoding`, `content-length` — irrelevant to a body-less 101.

`Set-Cookie` is handled separately via `Headers.getSetCookie()` so multiple cookies are preserved verbatim instead of being collapsed by `Headers.forEach` into a single comma-joined value.

A regression test (`forwards response headers from the Worker on the 101 upgrade response`) drives a real WebSocket upgrade against a mock Miniflare that returns `X-Hello` plus two `Set-Cookie` entries, reads the raw 101 response from the socket, and asserts each header is present.

`pnpm check:lint`, `pnpm check:format`, and `pnpm -F @cloudflare/vite-plugin check:type` are clean. The repo-level `pnpm check` does fail on a pre-existing `wrangler` → `vite` `check:package-deps` warning that reproduces on upstream `main` before any of these changes.

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this is a bug fix that aligns `vite dev` behaviour with `wrangler dev`; no externally documented behaviour changes.