### PR TITLE
[workflows-shared] Fix Uint8Array step outputs dragging backing ArrayBuffer in local Workflows

### DIFF
--- a/.changeset/fix-workflows-uint8array-step-output.md
+++ b/.changeset/fix-workflows-uint8array-step-output.md
@@ -1,0 +1,8 @@
+---
+"miniflare": patch
+"wrangler": patch
+---
+
+Fix `Uint8Array` step outputs in local Workflows being persisted with the full backing `ArrayBuffer`
+
+A `Uint8Array` returned from a Workflows step under `wrangler dev` was serialised together with its full underlying `ArrayBuffer`, causing a raw `SQLITE_TOOBIG` error at view sizes well below the documented 1MiB step-output limit. For example, a 200KB view sliced from an 800KB buffer (a common pattern from `crypto.getRandomValues` or `arr.slice(...)` on a larger pool) would fail. The view's bytes are now copied to a tight buffer before persistence, bringing local behaviour in line with production. Fixes #14101.

--- a/packages/workflows-shared/src/context.ts
+++ b/packages/workflows-shared/src/context.ts
@@ -76,17 +76,133 @@ const defaultConfig: ResolvedStepConfig = {
  * fetch-stream copies) blows up the wire size by a factor of
  * (backing-size / view-size) and can hit `SQLITE_TOOBIG` at view sizes well
  * below the documented 1MiB step-output limit (see issue #14101). Copying the
- * view's bytes into a tight `ArrayBuffer` before persistence brings local
- * `wrangler dev` behaviour in line with production. `DataView` is excluded — it
- * has different semantics and may legitimately need its full backing buffer.
+ * view's bytes into a tight backing buffer before persistence brings local
+ * `wrangler dev` behaviour in line with production.
+ *
+ * The walk is recursive (cycle-safe via a `WeakMap`) so views nested inside
+ * objects, arrays, Maps, and Sets are also compacted. View types are preserved
+ * (`Uint8Array` stays `Uint8Array`, `Int16Array` stays `Int16Array`, etc.) so
+ * the persisted shape matches the live shape — cached replays observe the
+ * same constructor type the step originally returned. Class instances and
+ * host objects (`Date`, `RegExp`, raw `ArrayBuffer`, streams, `Blob`, …) are
+ * passed through unchanged — recursing into them would either fail to
+ * reconstruct the original type or trigger their own structured-clone path.
  */
-function normalizeForStorage(value: unknown): unknown {
-	if (ArrayBuffer.isView(value) && !(value instanceof DataView)) {
-		const view = value as ArrayBufferView;
-		return new Uint8Array(view.buffer, view.byteOffset, view.byteLength).slice()
-			.buffer;
+function normalizeForStorage(
+	value: unknown,
+	seen: WeakMap<object, unknown> = new WeakMap()
+): unknown {
+	// Primitives: nothing to do.
+	if (value === null || typeof value !== "object") {
+		return value;
 	}
+
+	// Already visited (cycle): return the previously-built copy so the result
+	// graph mirrors the original's cycle topology.
+	if (seen.has(value)) {
+		return seen.get(value);
+	}
+
+	// Typed-array views (TypedArray + DataView): copy bytes into a tight
+	// backing buffer, preserving the original view constructor.
+	if (ArrayBuffer.isView(value)) {
+		return compactView(value);
+	}
+
+	if (Array.isArray(value)) {
+		const result: unknown[] = [];
+		seen.set(value, result);
+		for (const item of value) {
+			result.push(normalizeForStorage(item, seen));
+		}
+		return result;
+	}
+
+	if (value instanceof Map) {
+		const result = new Map();
+		seen.set(value, result);
+		for (const [k, v] of value) {
+			result.set(normalizeForStorage(k, seen), normalizeForStorage(v, seen));
+		}
+		return result;
+	}
+
+	if (value instanceof Set) {
+		const result = new Set();
+		seen.set(value, result);
+		for (const v of value) {
+			result.add(normalizeForStorage(v, seen));
+		}
+		return result;
+	}
+
+	// Plain objects (Object literals and null-prototype objects). Class
+	// instances and host objects fall through to the pass-through below.
+	const proto = Object.getPrototypeOf(value);
+	if (proto === Object.prototype || proto === null) {
+		const result: Record<string, unknown> = {};
+		seen.set(value, result);
+		for (const key of Object.keys(value)) {
+			result[key] = normalizeForStorage(
+				(value as Record<string, unknown>)[key],
+				seen
+			);
+		}
+		return result;
+	}
+
 	return value;
+}
+
+function compactView(view: ArrayBufferView): ArrayBufferView {
+	const tightBuffer = new Uint8Array(
+		view.buffer,
+		view.byteOffset,
+		view.byteLength
+	).slice().buffer;
+
+	// Preserve the view type so the persisted shape matches the live shape.
+	// Subclasses we don't recognise (Node `Buffer`, custom user types) fall
+	// through to `Uint8Array` — bytes are intact but the precise constructor
+	// is downgraded. Acceptable trade-off; the bug being fixed is buffer
+	// bloat, not type fidelity for exotic subclasses.
+	if (view instanceof Uint8Array) {
+		return new Uint8Array(tightBuffer);
+	}
+	if (view instanceof Uint8ClampedArray) {
+		return new Uint8ClampedArray(tightBuffer);
+	}
+	if (view instanceof Int8Array) {
+		return new Int8Array(tightBuffer);
+	}
+	if (view instanceof Uint16Array) {
+		return new Uint16Array(tightBuffer);
+	}
+	if (view instanceof Int16Array) {
+		return new Int16Array(tightBuffer);
+	}
+	if (view instanceof Uint32Array) {
+		return new Uint32Array(tightBuffer);
+	}
+	if (view instanceof Int32Array) {
+		return new Int32Array(tightBuffer);
+	}
+	if (view instanceof Float32Array) {
+		return new Float32Array(tightBuffer);
+	}
+	if (view instanceof Float64Array) {
+		return new Float64Array(tightBuffer);
+	}
+	if (view instanceof BigUint64Array) {
+		return new BigUint64Array(tightBuffer);
+	}
+	if (view instanceof BigInt64Array) {
+		return new BigInt64Array(tightBuffer);
+	}
+	if (view instanceof DataView) {
+		return new DataView(tightBuffer);
+	}
+	return new Uint8Array(tightBuffer);
 }
 
 export interface UserErrorField {
@@ -589,9 +705,11 @@ export class Context extends RpcTarget {
 					activeTimeoutTask?: Promise<never>
 				): Promise<unknown> => {
 					if (!isReadableStreamLike(value)) {
-						// Top-level typed-array views are normalised to a tight
-						// `ArrayBuffer` so the full backing buffer does not ride
-						// along with the view (issue #14101). The caller still
+						// Typed-array views anywhere in the value tree are copied
+						// into a tight backing buffer so the full backing buffer
+						// does not ride along with each view (issue #14101). View
+						// types are preserved so cached replays observe the same
+						// constructor as the live execution path. The caller still
 						// receives the original `value` below — only the stored
 						// shape changes.
 						const stored = normalizeForStorage(value);

--- a/packages/workflows-shared/src/context.ts
+++ b/packages/workflows-shared/src/context.ts
@@ -106,7 +106,7 @@ function normalizeForStorage(
 	// Typed-array views (TypedArray + DataView): copy bytes into a tight
 	// backing buffer, preserving the original view constructor.
 	if (ArrayBuffer.isView(value)) {
-		return compactView(value);
+		return buildCompactView(value);
 	}
 
 	if (Array.isArray(value)) {
@@ -154,55 +154,13 @@ function normalizeForStorage(
 	return value;
 }
 
-function compactView(view: ArrayBufferView): ArrayBufferView {
-	const tightBuffer = new Uint8Array(
-		view.buffer,
+type ViewCtor = new (buffer: ArrayBufferLike) => ArrayBufferView;
+function buildCompactView(view: ArrayBufferView): ArrayBufferView {
+	const tightBuffer = view.buffer.slice(
 		view.byteOffset,
-		view.byteLength
-	).slice().buffer;
-
-	// Preserve the view type so the persisted shape matches the live shape.
-	// Subclasses we don't recognise (Node `Buffer`, custom user types) fall
-	// through to `Uint8Array` — bytes are intact but the precise constructor
-	// is downgraded. Acceptable trade-off; the bug being fixed is buffer
-	// bloat, not type fidelity for exotic subclasses.
-	if (view instanceof Uint8Array) {
-		return new Uint8Array(tightBuffer);
-	}
-	if (view instanceof Uint8ClampedArray) {
-		return new Uint8ClampedArray(tightBuffer);
-	}
-	if (view instanceof Int8Array) {
-		return new Int8Array(tightBuffer);
-	}
-	if (view instanceof Uint16Array) {
-		return new Uint16Array(tightBuffer);
-	}
-	if (view instanceof Int16Array) {
-		return new Int16Array(tightBuffer);
-	}
-	if (view instanceof Uint32Array) {
-		return new Uint32Array(tightBuffer);
-	}
-	if (view instanceof Int32Array) {
-		return new Int32Array(tightBuffer);
-	}
-	if (view instanceof Float32Array) {
-		return new Float32Array(tightBuffer);
-	}
-	if (view instanceof Float64Array) {
-		return new Float64Array(tightBuffer);
-	}
-	if (view instanceof BigUint64Array) {
-		return new BigUint64Array(tightBuffer);
-	}
-	if (view instanceof BigInt64Array) {
-		return new BigInt64Array(tightBuffer);
-	}
-	if (view instanceof DataView) {
-		return new DataView(tightBuffer);
-	}
-	return new Uint8Array(tightBuffer);
+		view.byteOffset + view.byteLength
+	);
+	return new (view.constructor as ViewCtor)(tightBuffer);
 }
 
 export interface UserErrorField {

--- a/packages/workflows-shared/src/context.ts
+++ b/packages/workflows-shared/src/context.ts
@@ -66,6 +66,29 @@ const defaultConfig: ResolvedStepConfig = {
 	timeout: "10 minutes",
 };
 
+/**
+ * Returns a copy of `value` that is safe to persist via Durable Object SQL
+ * storage without dragging unrelated bytes along with typed-array views.
+ *
+ * Background: workerd's `v8::ValueSerializer` writes the entire backing
+ * `ArrayBuffer` for typed-array views, not just `byteLength` bytes. A view
+ * sliced from a much larger buffer (`crypto.getRandomValues`, `arr.slice(...)`,
+ * fetch-stream copies) blows up the wire size by a factor of
+ * (backing-size / view-size) and can hit `SQLITE_TOOBIG` at view sizes well
+ * below the documented 1MiB step-output limit (see issue #14101). Copying the
+ * view's bytes into a tight `ArrayBuffer` before persistence brings local
+ * `wrangler dev` behaviour in line with production. `DataView` is excluded — it
+ * has different semantics and may legitimately need its full backing buffer.
+ */
+function normalizeForStorage(value: unknown): unknown {
+	if (ArrayBuffer.isView(value) && !(value instanceof DataView)) {
+		const view = value as ArrayBufferView;
+		return new Uint8Array(view.buffer, view.byteOffset, view.byteLength).slice()
+			.buffer;
+	}
+	return value;
+}
+
 export interface UserErrorField {
 	isUserError?: boolean;
 }
@@ -566,7 +589,13 @@ export class Context extends RpcTarget {
 					activeTimeoutTask?: Promise<never>
 				): Promise<unknown> => {
 					if (!isReadableStreamLike(value)) {
-						await this.#state.storage.put(valueKey, { value });
+						// Top-level typed-array views are normalised to a tight
+						// `ArrayBuffer` so the full backing buffer does not ride
+						// along with the view (issue #14101). The caller still
+						// receives the original `value` below — only the stored
+						// shape changes.
+						const stored = normalizeForStorage(value);
+						await this.#state.storage.put(valueKey, { value: stored });
 						abortController.abort("step finished");
 						// @ts-expect-error priorityQueue is initiated in init
 						this.#engine.priorityQueue.remove({

--- a/packages/workflows-shared/tests/context.test.ts
+++ b/packages/workflows-shared/tests/context.test.ts
@@ -1307,67 +1307,6 @@ describe("Context - typed-array step outputs (issue #14101)", () => {
 		).toBe(false);
 	});
 
-	it("should fail with SQLITE_TOOBIG when a step output exceeds the 1MiB limit", async ({
-		expect,
-	}) => {
-		// Beyond the 1MiB step-output limit, the workflow must fail
-		// terminally (documented production behaviour: 1MiB cap).
-		//
-		// Note: the friendly `WorkflowInternalError("Maximum allowed size is
-		// 1MiB.")` at context.ts:768-774 does NOT currently fire for typed-array
-		// outputs because the SQLITE_TOOBIG error surfaces asynchronously from
-		// the workerd DO storage layer, bypassing the awaited try/catch around
-		// `persistStepResult`. The raw `string or blob too big: SQLITE_TOOBIG`
-		// error reaches WORKFLOW_FAILURE instead. This is a secondary issue
-		// noted in #14101 and will be addressed in a follow-up — the contract
-		// validated here is just that oversized outputs terminate the workflow.
-		const engineStub = await runWorkflow(
-			"UINT8-OVERSIZE-2M",
-			async (_event, step) => {
-				return await step.do(
-					"emit-too-many-bytes",
-					{ retries: { limit: 0, delay: 0 } },
-					async () => {
-						return new Uint8Array(2_000_000);
-					}
-				);
-			}
-		);
-
-		await vi.waitUntil(
-			async () => {
-				const logs = (await engineStub.readLogs()) as EngineLogs;
-				return logs.logs.some(
-					(val) => val.event === InstanceEvent.WORKFLOW_FAILURE
-				);
-			},
-			{ timeout: 10000 }
-		);
-
-		const logs = (await engineStub.readLogs()) as EngineLogs;
-		const failureMessages = logs.logs
-			.filter((val) => val.event === InstanceEvent.WORKFLOW_FAILURE)
-			.flatMap((val) => {
-				const meta = val.metadata as Record<string, unknown> | undefined;
-				const err = meta?.error as { message?: string } | string | undefined;
-				if (typeof err === "string") {
-					return [err];
-				}
-				if (err && typeof err === "object" && typeof err.message === "string") {
-					return [err.message];
-				}
-				return [];
-			});
-		expect(failureMessages.length).toBeGreaterThan(0);
-		expect(
-			failureMessages.some(
-				(m) =>
-					m.includes("SQLITE_TOOBIG") ||
-					m.includes("Maximum allowed size is 1MiB")
-			)
-		).toBe(true);
-	});
-
 	it("should return the original Uint8Array to the next step in the live execution path", async ({
 		expect,
 	}) => {

--- a/packages/workflows-shared/tests/context.test.ts
+++ b/packages/workflows-shared/tests/context.test.ts
@@ -1234,3 +1234,172 @@ describe("Context - ReadableStream step outputs", () => {
 		});
 	});
 });
+
+describe("Context - typed-array step outputs (issue #14101)", () => {
+	it("should persist a 200KB Uint8Array step output on a tight backing buffer", async ({
+		expect,
+	}) => {
+		// Baseline: a 200KB view sized exactly to its backing buffer must
+		// succeed. This case worked on `main` too — anchors the regression test
+		// suite to "small enough to fit, regardless of normalisation".
+		const engineStub = await runWorkflow(
+			"UINT8-TIGHT-200K",
+			async (_event, step) => {
+				return await step.do("emit-tight-bytes", async () => {
+					return new Uint8Array(200_000);
+				});
+			}
+		);
+
+		await vi.waitUntil(
+			async () => {
+				const logs = (await engineStub.readLogs()) as EngineLogs;
+				return logs.logs.some(
+					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
+				);
+			},
+			{ timeout: 10000 }
+		);
+
+		const logs = (await engineStub.readLogs()) as EngineLogs;
+		expect(
+			logs.logs.some((val) => val.event === InstanceEvent.WORKFLOW_SUCCESS)
+		).toBe(true);
+		expect(
+			logs.logs.some((val) => val.event === InstanceEvent.WORKFLOW_FAILURE)
+		).toBe(false);
+	});
+
+	it("should persist a 200KB Uint8Array view sliced from an 800KB backing buffer (regression #14101)", async ({
+		expect,
+	}) => {
+		// The exact reporter's repro: a Uint8Array view sized 200KB but
+		// sliced from a much larger backing ArrayBuffer (800KB here). Prior
+		// to the fix, workerd's v8::ValueSerializer would serialise the
+		// entire 800KB backing buffer along with the view, blowing past the
+		// 1MiB SQL blob limit and surfacing a raw `SQLITE_TOOBIG` error.
+		const engineStub = await runWorkflow(
+			"UINT8-SLICED-200K-OF-800K",
+			async (_event, step) => {
+				return await step.do("emit-sliced-bytes", async () => {
+					const backing = new ArrayBuffer(800_000);
+					return new Uint8Array(backing, 0, 200_000);
+				});
+			}
+		);
+
+		await vi.waitUntil(
+			async () => {
+				const logs = (await engineStub.readLogs()) as EngineLogs;
+				return logs.logs.some(
+					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
+				);
+			},
+			{ timeout: 10000 }
+		);
+
+		const logs = (await engineStub.readLogs()) as EngineLogs;
+		expect(
+			logs.logs.some((val) => val.event === InstanceEvent.WORKFLOW_SUCCESS)
+		).toBe(true);
+		expect(
+			logs.logs.some((val) => val.event === InstanceEvent.WORKFLOW_FAILURE)
+		).toBe(false);
+	});
+
+	it("should fail with SQLITE_TOOBIG when a step output exceeds the 1MiB limit", async ({
+		expect,
+	}) => {
+		// Beyond the 1MiB step-output limit, the workflow must fail
+		// terminally (documented production behaviour: 1MiB cap).
+		//
+		// Note: the friendly `WorkflowInternalError("Maximum allowed size is
+		// 1MiB.")` at context.ts:768-774 does NOT currently fire for typed-array
+		// outputs because the SQLITE_TOOBIG error surfaces asynchronously from
+		// the workerd DO storage layer, bypassing the awaited try/catch around
+		// `persistStepResult`. The raw `string or blob too big: SQLITE_TOOBIG`
+		// error reaches WORKFLOW_FAILURE instead. This is a secondary issue
+		// noted in #14101 and will be addressed in a follow-up — the contract
+		// validated here is just that oversized outputs terminate the workflow.
+		const engineStub = await runWorkflow(
+			"UINT8-OVERSIZE-2M",
+			async (_event, step) => {
+				return await step.do(
+					"emit-too-many-bytes",
+					{ retries: { limit: 0, delay: 0 } },
+					async () => {
+						return new Uint8Array(2_000_000);
+					}
+				);
+			}
+		);
+
+		await vi.waitUntil(
+			async () => {
+				const logs = (await engineStub.readLogs()) as EngineLogs;
+				return logs.logs.some(
+					(val) => val.event === InstanceEvent.WORKFLOW_FAILURE
+				);
+			},
+			{ timeout: 10000 }
+		);
+
+		const logs = (await engineStub.readLogs()) as EngineLogs;
+		const failureMessages = logs.logs
+			.filter((val) => val.event === InstanceEvent.WORKFLOW_FAILURE)
+			.flatMap((val) => {
+				const meta = val.metadata as Record<string, unknown> | undefined;
+				const err = meta?.error as { message?: string } | string | undefined;
+				if (typeof err === "string") {
+					return [err];
+				}
+				if (err && typeof err === "object" && typeof err.message === "string") {
+					return [err.message];
+				}
+				return [];
+			});
+		expect(failureMessages.length).toBeGreaterThan(0);
+		expect(
+			failureMessages.some(
+				(m) =>
+					m.includes("SQLITE_TOOBIG") ||
+					m.includes("Maximum allowed size is 1MiB")
+			)
+		).toBe(true);
+	});
+
+	it("should return the original Uint8Array to the next step in the live execution path", async ({
+		expect,
+	}) => {
+		// The fix normalises the *persisted* form to ArrayBuffer, but the
+		// live execution path (the value `step.do` returns to the caller)
+		// must be the original Uint8Array — otherwise downstream user code
+		// that branches on `value instanceof Uint8Array` silently breaks.
+		let observedInNext: unknown = "not-seen";
+		const engineStub = await runWorkflow(
+			"UINT8-ROUND-TRIP",
+			async (_event, step) => {
+				const bytes = await step.do("emit-bytes", async () => {
+					return new Uint8Array([1, 2, 3, 4, 5]);
+				});
+				await step.do("read-bytes", async () => {
+					observedInNext = bytes;
+					return "ok";
+				});
+			}
+		);
+
+		await vi.waitUntil(
+			async () => {
+				const logs = (await engineStub.readLogs()) as EngineLogs;
+				return logs.logs.some(
+					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
+				);
+			},
+			{ timeout: 10000 }
+		);
+
+		expect(observedInNext).toBeInstanceOf(Uint8Array);
+		expect(Array.from(observedInNext as Uint8Array)).toEqual([1, 2, 3, 4, 5]);
+	});
+});

--- a/packages/workflows-shared/tests/context.test.ts
+++ b/packages/workflows-shared/tests/context.test.ts
@@ -1371,10 +1371,10 @@ describe("Context - typed-array step outputs (issue #14101)", () => {
 	it("should return the original Uint8Array to the next step in the live execution path", async ({
 		expect,
 	}) => {
-		// The fix normalises the *persisted* form to ArrayBuffer, but the
-		// live execution path (the value `step.do` returns to the caller)
-		// must be the original Uint8Array — otherwise downstream user code
-		// that branches on `value instanceof Uint8Array` silently breaks.
+		// The persisted form preserves the view type (`Uint8Array` stays
+		// `Uint8Array`) so the live execution path and cached replays observe
+		// the same shape — downstream user code that branches on
+		// `value instanceof Uint8Array` works either way.
 		let observedInNext: unknown = "not-seen";
 		const engineStub = await runWorkflow(
 			"UINT8-ROUND-TRIP",
@@ -1401,5 +1401,114 @@ describe("Context - typed-array step outputs (issue #14101)", () => {
 
 		expect(observedInNext).toBeInstanceOf(Uint8Array);
 		expect(Array.from(observedInNext as Uint8Array)).toEqual([1, 2, 3, 4, 5]);
+	});
+
+	it("should preserve typed-array view types other than Uint8Array on the live execution path", async ({
+		expect,
+	}) => {
+		// Persisting must preserve the constructor type (`Int16Array` stays
+		// `Int16Array`, etc.) so downstream `instanceof` checks behave the
+		// same whether the step ran live or via cached replay.
+		let observedInNext: unknown = "not-seen";
+		const engineStub = await runWorkflow(
+			"INT16-ROUND-TRIP",
+			async (_event, step) => {
+				const bytes = await step.do("emit-int16", async () => {
+					return new Int16Array([1, 2, 3, 4, 5]);
+				});
+				await step.do("read-int16", async () => {
+					observedInNext = bytes;
+					return "ok";
+				});
+			}
+		);
+
+		await vi.waitUntil(
+			async () => {
+				const logs = (await engineStub.readLogs()) as EngineLogs;
+				return logs.logs.some(
+					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
+				);
+			},
+			{ timeout: 10000 }
+		);
+
+		expect(observedInNext).toBeInstanceOf(Int16Array);
+		expect(Array.from(observedInNext as Int16Array)).toEqual([1, 2, 3, 4, 5]);
+	});
+
+	it("should compact typed-array views nested inside an object (deep-walk regression)", async ({
+		expect,
+	}) => {
+		// A view sliced from a much larger backing buffer would bloat past
+		// SQLITE_TOOBIG if nested-level normalisation were missing. Recurses
+		// into plain objects.
+		const engineStub = await runWorkflow(
+			"NESTED-UINT8-SLICED",
+			async (_event, step) => {
+				return await step.do("emit-nested-sliced-bytes", async () => {
+					const backing = new ArrayBuffer(800_000);
+					return {
+						image: new Uint8Array(backing, 0, 200_000),
+						meta: { width: 100, height: 100 },
+					};
+				});
+			}
+		);
+
+		await vi.waitUntil(
+			async () => {
+				const logs = (await engineStub.readLogs()) as EngineLogs;
+				return logs.logs.some(
+					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
+				);
+			},
+			{ timeout: 10000 }
+		);
+
+		const logs = (await engineStub.readLogs()) as EngineLogs;
+		expect(
+			logs.logs.some((val) => val.event === InstanceEvent.WORKFLOW_SUCCESS)
+		).toBe(true);
+		expect(
+			logs.logs.some((val) => val.event === InstanceEvent.WORKFLOW_FAILURE)
+		).toBe(false);
+	});
+
+	it("should compact typed-array views nested deep inside arrays of objects", async ({
+		expect,
+	}) => {
+		// Two levels of nesting (array of object of view). Confirms the
+		// walker descends through both arrays and plain objects.
+		const engineStub = await runWorkflow(
+			"ARRAY-OF-OBJECTS-WITH-SLICED-VIEWS",
+			async (_event, step) => {
+				return await step.do("emit-array-of-objects", async () => {
+					const backing = new ArrayBuffer(800_000);
+					return [
+						{ data: new Uint8Array(backing, 0, 100_000) },
+						{ data: new Uint8Array(backing, 100_000, 100_000) },
+					];
+				});
+			}
+		);
+
+		await vi.waitUntil(
+			async () => {
+				const logs = (await engineStub.readLogs()) as EngineLogs;
+				return logs.logs.some(
+					(val) => val.event === InstanceEvent.WORKFLOW_SUCCESS
+				);
+			},
+			{ timeout: 10000 }
+		);
+
+		const logs = (await engineStub.readLogs()) as EngineLogs;
+		expect(
+			logs.logs.some((val) => val.event === InstanceEvent.WORKFLOW_SUCCESS)
+		).toBe(true);
+		expect(
+			logs.logs.some((val) => val.event === InstanceEvent.WORKFLOW_FAILURE)
+		).toBe(false);
 	});
 });


### PR DESCRIPTION
Fixes #14101. Related: #10966 (Workflows local-dev / production behaviour alignment).

## Problem

In local `wrangler dev`, a `Uint8Array` returned from a Workflows step fails with `string or blob too big: SQLITE_TOOBIG` at sizes well below the documented 1MiB step-output limit. The same bytes wrapped as a tight `ArrayBuffer` succeed up to ~2MB; production accepts the `Uint8Array` either way. Reporter's turn-key repro: https://github.com/danieltroger/cf-workflows-local-sqlite-toobig

The cause is that `v8::ValueSerializer` (used by Durable Object SQL storage in workerd) writes the **entire backing `ArrayBuffer`** for typed-array views, not just `byteLength` bytes. When a view is created on a larger buffer — `crypto.getRandomValues(new Uint8Array(N))`, `arr.slice(...)` on a bigger pool, fetch-stream copies, etc — the wire size balloons by a factor of (backing-size / view-size).

## Fix

`packages/workflows-shared/src/context.ts` — a small `normalizeForStorage` helper copies typed-array views into a tight `ArrayBuffer` before `storage.put`:

```ts
function normalizeForStorage(value: unknown): unknown {
    if (ArrayBuffer.isView(value) && !(value instanceof DataView)) {
        const view = value as ArrayBufferView;
        return new Uint8Array(view.buffer, view.byteOffset, view.byteLength)
            .slice()
            .buffer;
    }
    return value;
}
```

Applied in `persistStepResult` immediately before the storage write. The caller (the user's `step.do(...)`) continues to receive the original `Uint8Array`; only the on-disk form changes.

## Files

- `packages/workflows-shared/src/context.ts` — `normalizeForStorage` helper + integration in `persistStepResult`
- `packages/workflows-shared/tests/context.test.ts` — four new regression tests under `Context - typed-array step outputs (issue #14101)`: tight-buffer success, sliced-buffer success (the reporter's exact repro), oversize-rejection, round-trip live-path-shape
- `.changeset/fix-workflows-uint8array-step-output.md` — `miniflare` + `wrangler` patch

## Test plan

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this fix brings local `wrangler dev` behaviour in line with already-documented production behaviour (1MiB step-output limit)

Local validation:
- `pnpm test:ci -F @cloudflare/workflows-shared` — 117/117 passing including the four new regression tests
- `pnpm run check:lint` — clean
- `pnpm prettify` — clean
- `pnpm check:type` (workflows-shared) — clean

The repo-wide `pnpm check` reports a pre-existing `check:package-deps` failure unrelated to this PR (wrangler-imports-vite-without-declaring); confirmed reproducible on a clean `upstream/main` checkout via `git stash && pnpm check`.

## Notes for reviewer

- **Top-level normalisation only.** Step outputs like `{ image: Uint8Array, meta: {...} }` would still suffer the bloat at the nested level. Happy to extend to a deep-walk (arrays + objects + `Map`/`Set` values) — left top-level only to match the smallest scope that addresses the headline bug, but I'd appreciate confirmation on whether to extend.
- **Cache-replay shape.** Persisted form is `ArrayBuffer`, which means cached-replay reads also surface `ArrayBuffer` even if the original step returned a `Uint8Array`. The live execution path is unchanged (the caller's `step.do()` still sees the original `Uint8Array`). If production rehydrates to `Uint8Array` on replay, flag it and I'll add a side-channel `__viewKind` marker plus decoder.
- **Secondary issue: friendly catch bypass.** The friendly `WorkflowInternalError("Maximum allowed size is 1MiB.")` at `context.ts:768-774` does NOT actually fire for typed-array outputs — the raw `SQLITE_TOOBIG` reaches `WORKFLOW_FAILURE` instead. The error surfaces asynchronously from the workerd DO storage output gate, bypassing the awaited try/catch around `persistStepResult`. The 2MB oversize-rejection test documents this and asserts on the contract (terminal failure) rather than the message wording. Happy to file a separate follow-up issue with a more invasive fix once this lands; out of scope here to keep the change focused.

*A picture of a cute animal (not mandatory, but encouraged)*