### PR TITLE
[ci] Add macOS to C3 frameworks E2E test matrix

### DIFF
--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -122,7 +122,9 @@ jobs:
       fail-fast: false
       matrix:
         experimental: [false]
-        os: [{ name: ubuntu-latest, description: Linux }]
+        os:
+          - { name: ubuntu-latest, description: Linux }
+          - { name: macos-latest, description: macOS }
         pm:
           - { name: pnpm, version: "10.33.0" }
           - { name: npm, version: "0.0.0" }


### PR DESCRIPTION
This is a CI-only experimental change to verify whether [issue #13928](https://github.com/cloudflare/workers-sdk/issues/13928) (`create-cloudflare` fails with `ERR_PNPM_IGNORED_BUILDS` on pnpm 10/11) can be reproduced in CI on macOS.

Adds `macos-latest` to the `frameworks-e2e` matrix in `.github/workflows/c3-e2e.yml`, so the C3 frameworks E2E tests will run on both Linux and macOS (with both `pnpm` and `npm`).

This PR is kept in draft because it is purely an investigative CI run - we want to see how the existing C3 frameworks tests behave on macOS before deciding what (if anything) to ship.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this PR only modifies the CI workflow matrix - the workflow itself is the test, exercised by this PR run.
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is a CI-only change with no user-facing impact.
