### PR TITLE
[wrangler] Fix secret bulk stdin env parsing

### DIFF
--- a/.changeset/tame-wrangler-secrets.md
+++ b/.changeset/tame-wrangler-secrets.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler secret bulk` dropping newlines from `.env` input read from stdin
+
+Previously, `.env` input piped through stdin was concatenated without line breaks, so only the first secret could be parsed correctly. Stdin input now preserves line separators before parsing.

--- a/packages/wrangler/src/__tests__/pages/secret.test.ts
+++ b/packages/wrangler/src/__tests__/pages/secret.test.ts
@@ -23,6 +23,12 @@ import type { PagesConfigCache } from "../../pages/types";
 import type { Interface } from "node:readline";
 import type { ExpectStatic } from "vitest";
 
+function mockReadlineInput(input: string) {
+	vi.spyOn(readline, "createInterface").mockImplementation(
+		() => input.split(/\r?\n/) as unknown as Interface
+	);
+}
+
 describe("wrangler pages secret", () => {
 	const std = mockConsoleMethods();
 	const { setIsTTY } = useMockIsTTY();
@@ -561,13 +567,11 @@ describe("wrangler pages secret", () => {
 		});
 
 		it("should use secret bulk w/ pipe input", async ({ expect }) => {
-			vi.spyOn(readline, "createInterface").mockImplementation(
-				() =>
-					// `readline.Interface` is an async iterator: `[Symbol.asyncIterator](): AsyncIterableIterator<string>`
-					JSON.stringify({
-						secret1: "secret-value",
-						password: "hunter2",
-					}) as unknown as Interface
+			mockReadlineInput(
+				JSON.stringify({
+					secret1: "secret-value",
+					password: "hunter2",
+				})
 			);
 
 			mockProjectRequests(expect, [

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -79,6 +79,12 @@ function mockNoWorkerFound({ isBulk = false } = {}) {
 	}
 }
 
+function mockReadlineInput(input: string) {
+	vi.spyOn(readline, "createInterface").mockImplementation(
+		() => input.split(/\r?\n/) as unknown as Interface
+	);
+}
+
 describe("wrangler secret", () => {
 	const std = mockConsoleMethods();
 	const { setIsTTY } = useMockIsTTY();
@@ -1136,13 +1142,11 @@ describe("wrangler secret", () => {
 		});
 
 		it("should use secret bulk w/ pipe input", async ({ expect }) => {
-			vi.spyOn(readline, "createInterface").mockImplementation(
-				() =>
-					// `readline.Interface` is an async iterator: `[Symbol.asyncIterator](): AsyncIterableIterator<string>`
-					JSON.stringify({
-						secret1: "secret-value",
-						password: "hunter2",
-					}) as unknown as Interface
+			mockReadlineInput(
+				JSON.stringify({
+					secret1: "secret-value",
+					password: "hunter2",
+				})
 			);
 			mockBulkRequest(expect);
 
@@ -1154,6 +1158,27 @@ describe("wrangler secret", () => {
 				🌀 Processing the secrets for the Worker "script-name"
 				✨ Successfully created secret for key: secret1
 				✨ Successfully created secret for key: password
+
+				Finished processing secrets file:
+				✨ 2 secrets successfully created"
+			`);
+			expect(std.err).toMatchInlineSnapshot(`""`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
+
+		it("should create secrets from env stdin", async ({ expect }) => {
+			mockReadlineInput("SECRET_NAME_1=secret_text\nSECRET_NAME_2=secret_text");
+			mockBulkRequest(expect);
+
+			await runWrangler("secret bulk --name script-name");
+
+			expect(std.out).toMatchInlineSnapshot(`
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				🌀 Processing the secrets for the Worker "script-name"
+				✨ Successfully created secret for key: SECRET_NAME_1
+				✨ Successfully created secret for key: SECRET_NAME_2
 
 				Finished processing secrets file:
 				✨ 2 secrets successfully created"

--- a/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
@@ -14,6 +14,12 @@ import type { VersionDetails } from "../../../versions/secrets";
 import type { CfPlacement } from "@cloudflare/workers-utils";
 import type { Interface } from "node:readline";
 
+function mockReadlineInput(input: string) {
+	vi.spyOn(readline, "createInterface").mockImplementation(
+		() => input.split(/\r?\n/) as unknown as Interface
+	);
+}
+
 describe("versions secret bulk", () => {
 	const std = mockConsoleMethods();
 	runInTempDir();
@@ -124,14 +130,49 @@ describe("versions secret bulk", () => {
 	});
 
 	test("uploading secrets from stdin", async ({ expect }) => {
-		vi.spyOn(readline, "createInterface").mockImplementation(
-			() =>
-				// `readline.Interface` is an async iterator: `[Symbol.asyncIterator](): AsyncIterableIterator<string>`
-				JSON.stringify({
-					SECRET_1: "secret-1",
-					SECRET_2: "secret-2",
-					SECRET_3: "secret-3",
-				}) as unknown as Interface
+		mockReadlineInput(
+			JSON.stringify({
+				SECRET_1: "secret-1",
+				SECRET_2: "secret-2",
+				SECRET_3: "secret-3",
+			})
+		);
+
+		mockSetupApiCalls(expect);
+		mockPostVersion(expect, (metadata) => {
+			expect(metadata.bindings).toStrictEqual([
+				{ type: "inherit", name: "do-binding" },
+				{ type: "secret_text", name: "SECRET_1", text: "secret-1" },
+				{ type: "secret_text", name: "SECRET_2", text: "secret-2" },
+				{ type: "secret_text", name: "SECRET_3", text: "secret-3" },
+			]);
+			expect(metadata.keep_bindings).toStrictEqual([
+				"secret_key",
+				"secret_text",
+			]);
+			expect(metadata.keep_assets).toBeTruthy();
+		});
+
+		await runWrangler(`versions secret bulk --name script-name`);
+		expect(std.out).toMatchInlineSnapshot(
+			`
+			"
+			 ⛅️ wrangler x.x.x
+			──────────────────
+			🌀 Creating the secrets for the Worker "script-name"
+			✨ Successfully created secret for key: SECRET_1
+			✨ Successfully created secret for key: SECRET_2
+			✨ Successfully created secret for key: SECRET_3
+			✨ Success! Created version id with 3 secrets.
+			➡️  To deploy this version to production traffic use the command "wrangler versions deploy"."
+		`
+		);
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+
+	test("uploading secrets from env stdin", async ({ expect }) => {
+		mockReadlineInput(
+			"SECRET_1=secret-1\nSECRET_2=secret-2\nSECRET_3=secret-3"
 		);
 
 		mockSetupApiCalls(expect);
@@ -177,11 +218,7 @@ describe("versions secret bulk", () => {
 	});
 
 	test("should error on invalid json stdin", async ({ expect }) => {
-		vi.spyOn(readline, "createInterface").mockImplementation(
-			() =>
-				// `readline.Interface` is an async iterator: `[Symbol.asyncIterator](): AsyncIterableIterator<string>`
-				"hello world" as unknown as Interface
-		);
+		mockReadlineInput("hello world");
 
 		mockSetupApiCalls(expect);
 		mockPostVersion(expect, (metadata) => {
@@ -317,12 +354,10 @@ describe("versions secret bulk", () => {
 		it("should warn if the wrangler config contains environments but none was specified in the command", async ({
 			expect,
 		}) => {
-			vi.spyOn(readline, "createInterface").mockImplementation(
-				() =>
-					// `readline.Interface` is an async iterator: `[Symbol.asyncIterator](): AsyncIterableIterator<string>`
-					JSON.stringify({
-						SECRET_1: "secret-1",
-					}) as unknown as Interface
+			mockReadlineInput(
+				JSON.stringify({
+					SECRET_1: "secret-1",
+				})
 			);
 
 			writeWranglerConfig({ env: { test: {} } });
@@ -345,12 +380,10 @@ describe("versions secret bulk", () => {
 		it("should not warn if the wrangler config contains environments and one was specified in the command", async ({
 			expect,
 		}) => {
-			vi.spyOn(readline, "createInterface").mockImplementation(
-				() =>
-					// `readline.Interface` is an async iterator: `[Symbol.asyncIterator](): AsyncIterableIterator<string>`
-					JSON.stringify({
-						SECRET_1: "secret-1",
-					}) as unknown as Interface
+			mockReadlineInput(
+				JSON.stringify({
+					SECRET_1: "secret-1",
+				})
 			);
 
 			writeWranglerConfig({ env: { test: {} } });
@@ -364,12 +397,10 @@ describe("versions secret bulk", () => {
 		it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async ({
 			expect,
 		}) => {
-			vi.spyOn(readline, "createInterface").mockImplementation(
-				() =>
-					// `readline.Interface` is an async iterator: `[Symbol.asyncIterator](): AsyncIterableIterator<string>`
-					JSON.stringify({
-						SECRET_1: "secret-1",
-					}) as unknown as Interface
+			mockReadlineInput(
+				JSON.stringify({
+					SECRET_1: "secret-1",
+				})
 			);
 
 			writeWranglerConfig();
@@ -384,12 +415,10 @@ describe("versions secret bulk", () => {
 			expect,
 		}) => {
 			vi.stubEnv("CLOUDFLARE_ENV", "test");
-			vi.spyOn(readline, "createInterface").mockImplementation(
-				() =>
-					// `readline.Interface` is an async iterator: `[Symbol.asyncIterator](): AsyncIterableIterator<string>`
-					JSON.stringify({
-						SECRET_1: "secret-1",
-					}) as unknown as Interface
+			mockReadlineInput(
+				JSON.stringify({
+					SECRET_1: "secret-1",
+				})
 			);
 
 			writeWranglerConfig({ env: { test: {} } });
@@ -403,12 +432,10 @@ describe("versions secret bulk", () => {
 		it('should not warn if --env="" is passed to explicitly target the top-level environment', async ({
 			expect,
 		}) => {
-			vi.spyOn(readline, "createInterface").mockImplementation(
-				() =>
-					// `readline.Interface` is an async iterator: `[Symbol.asyncIterator](): AsyncIterableIterator<string>`
-					JSON.stringify({
-						SECRET_1: "secret-1",
-					}) as unknown as Interface
+			mockReadlineInput(
+				JSON.stringify({
+					SECRET_1: "secret-1",
+				})
 			);
 
 			writeWranglerConfig({ env: { test: {} } });

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -657,10 +657,11 @@ export async function parseBulkInputToObject(
 		secretSource = "stdin";
 		try {
 			const rl = readline.createInterface({ input: process.stdin });
-			let pipedInput = "";
+			const pipedInputLines: string[] = [];
 			for await (const line of rl) {
-				pipedInput += line;
+				pipedInputLines.push(line);
 			}
+			const pipedInput = pipedInputLines.join("\n");
 			try {
 				content = parseJSON(pipedInput) as Record<string, string | null>;
 				secretFormat = "json";


### PR DESCRIPTION

Preserve line separators when reading bulk secret input from stdin so dotenv-formatted secrets parse the same way as file input.

Previously, `wrangler secret bulk < secrets.env` read stdin line-by-line and concatenated the lines without restoring newlines. This meant input such as:

```env
A=1
B=2
```

was parsed like `A=1B=2`, so only the first secret was handled correctly.

This change preserves line separators before parsing stdin input, matching the behavior of `wrangler secret bulk secrets.env`.

Regression coverage was added for `wrangler secret bulk` and `wrangler versions secret bulk`. Related stdin test mocks were also adjusted to better match `readline`'s line-oriented iterator behavior.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This fixes stdin parsing to match the existing documented `wrangler secret bulk [FILE]` behavior and does not add or change user-facing options.

Tested with:

- `corepack pnpm -w test:ci -F wrangler -- secret.test.ts`
- `corepack pnpm -w test:ci -F wrangler -- versions/secrets/bulk.test.ts`
- `corepack pnpm -w test:ci -F wrangler -- pages/secret.test.ts`


*A picture of a cute animal (not mandatory, but encouraged)*

<img width="500" alt="a sleeping cat" src="https://github.com/user-attachments/assets/0f961378-a61e-4123-8fb7-92026950a6bc" />

↑This is my cat.