### PR TITLE
Bump `rosie-skills` from `0.7.6` to `0.8.1` and bundle it into the Wrangler output

### DIFF
--- a/.changeset/angry-carrots-switch.md
+++ b/.changeset/angry-carrots-switch.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Bump `rosie-skills` from `0.7.6` to `0.8.1` and bundle it into the Wrangler output
+
+The new version of `rosie-skills` is a [pure-TypeScript rewrite](https://github.com/withastro/rosie/pull/21) that removes the previously necessary ~600kb WASM binary. The package now ships only JavaScript with two minimal dependencies (`modern-tar` and `diff`).
+
+Additionally, `rosie-skills` is now bundled directly into Wrangler's distributable rather than kept as an external runtime dependency. This eliminates the supply chain concern raised in [#14110](https://github.com/cloudflare/workers-sdk/issues/14110): there is no separate package to resolve at install time, since all code is inlined into Wrangler's build output.

--- a/.changeset/angry-carrots-switch.md
+++ b/.changeset/angry-carrots-switch.md
@@ -4,6 +4,6 @@
 
 Bump `rosie-skills` from `0.7.6` to `0.8.1` and bundle it into the Wrangler output
 
-The new version of `rosie-skills` is a [pure-TypeScript rewrite](https://github.com/withastro/rosie/pull/21) that removes the previously necessary ~600kb WASM binary. The package now ships only JavaScript with two minimal dependencies (`modern-tar` and `diff`).
+The new version of `rosie-skills` is a [pure-TypeScript rewrite](https://github.com/withastro/rosie/pull/21) that removes the previously necessary ~600kb WASM binary. The package now ships only JavaScript with one minimal dependencies (`modern-tar`).
 
 Additionally, `rosie-skills` is now bundled directly into Wrangler's distributable rather than kept as an external runtime dependency. This eliminates the supply chain concern raised in [#14110](https://github.com/cloudflare/workers-sdk/issues/14110): there is no separate package to resolve at install time, since all code is inlined into Wrangler's build output.

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -71,7 +71,6 @@
 		"esbuild": "catalog:default",
 		"miniflare": "workspace:*",
 		"path-to-regexp": "6.3.0",
-		"rosie-skills": "^0.7.6",
 		"unenv": "2.0.0-rc.24",
 		"workerd": "1.20260529.1"
 	},
@@ -150,6 +149,7 @@
 		"qr": "^0.6.0",
 		"recast": "0.23.11",
 		"resolve": "^1.22.8",
+		"rosie-skills": "^0.8.1",
 		"semiver": "^1.1.0",
 		"shell-quote": "^1.8.1",
 		"signal-exit": "catalog:default",

--- a/packages/wrangler/scripts/deps.ts
+++ b/packages/wrangler/scripts/deps.ts
@@ -35,10 +35,6 @@ export const EXTERNAL_DEPENDENCIES = [
 
 	// workerd contains a native binary, so must be external. Wrangler depends on a pinned version.
 	"workerd",
-
-	// rosie-skills contains inlined WASM that is loaded at runtime via import.meta.url-relative
-	// path resolution, so it cannot be bundled.
-	"rosie-skills",
 ];
 
 /**

--- a/packages/wrangler/src/__tests__/agents-skills-install.test.ts
+++ b/packages/wrangler/src/__tests__/agents-skills-install.test.ts
@@ -24,8 +24,12 @@ vi.unmock("../agents-skills-install");
 vi.mock("am-i-vibing");
 
 // Mock rosie-skills to avoid real network/WASM calls.
-const mockRosieInstall = vi.fn();
-const mockRosieAgents = vi.fn();
+// vi.hoisted() is required because vi.mock() factories are hoisted above normal
+// variable declarations, so plain `const` variables would still be in the TDZ.
+const { mockRosieInstall, mockRosieAgents } = vi.hoisted(() => ({
+	mockRosieInstall: vi.fn(),
+	mockRosieAgents: vi.fn(),
+}));
 vi.mock("rosie-skills", () => ({
 	install: mockRosieInstall,
 	agents: mockRosieAgents,

--- a/packages/wrangler/src/agents-skills-install.ts
+++ b/packages/wrangler/src/agents-skills-install.ts
@@ -7,6 +7,7 @@ import {
 } from "@cloudflare/workers-utils";
 import { detectAgenticEnvironment } from "am-i-vibing";
 import ci from "ci-info";
+import { install as rosieInstall, agents as rosieAgents } from "rosie-skills";
 import { fetch } from "undici";
 import { confirm } from "./dialogs";
 import isInteractive from "./is-interactive";
@@ -116,9 +117,8 @@ export async function maybeInstallCloudflareSkillsGlobally(
 	}
 
 	try {
-		const rosie = await import("rosie-skills");
 		const agentNames = detectedAgents.map((a) => a.rosie.id);
-		const { failedAgents } = await rosie.install(SKILLS_REPO, {
+		const { failedAgents } = await rosieInstall(SKILLS_REPO, {
 			global: true,
 			agent: agentNames,
 			lockfile: false,
@@ -733,8 +733,7 @@ export function telemetryCurrentAgentSkillsInstalled(): Promise<AgentSkillsInsta
  * @returns Array of detected agents with their display names, rosie IDs, and skills paths.
  */
 async function getDetectedAgents(): Promise<AgentInfo[]> {
-	const rosie = await import("rosie-skills");
-	const allAgents = await rosie.agents();
+	const allAgents = await rosieAgents();
 	return allAgents
 		.filter(
 			(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3988,9 +3988,6 @@ importers:
       path-to-regexp:
         specifier: 6.3.0
         version: 6.3.0
-      rosie-skills:
-        specifier: ^0.7.6
-        version: 0.7.6
       unenv:
         specifier: 2.0.0-rc.24
         version: 2.0.0-rc.24
@@ -4220,6 +4217,9 @@ importers:
       resolve:
         specifier: ^1.22.8
         version: 1.22.8
+      rosie-skills:
+        specifier: ^0.8.1
+        version: 0.8.1
       semiver:
         specifier: ^1.1.0
         version: 1.1.0
@@ -12215,6 +12215,10 @@ packages:
     resolution: {integrity: sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==}
     engines: {node: '>= 8'}
 
+  modern-tar@0.7.6:
+    resolution: {integrity: sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==}
+    engines: {node: '>=18.0.0'}
+
   mongodb-connection-string-url@7.0.1:
     resolution: {integrity: sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==}
     engines: {node: '>=20.19.0'}
@@ -13620,23 +13624,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rosie-skills-darwin-arm64@0.7.6:
-    resolution: {integrity: sha512-EIOMS53cpOvorb2v2QI40MGdVwLlvsYXRdwKMj0GrEPStfsChlmN3EIy0IqLHFRkLpMUTkqUz46wXftNG/rWyA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  rosie-skills-freebsd-x64@0.7.6:
-    resolution: {integrity: sha512-M26M0QjTbIIpK1G013M5N+3k80sjsVWloC7XowgCVigViojvCfaIbnjCeh+/8GAIx4yYFltf4Fem3GWsyK/17w==}
-    cpu: [x64]
-    os: [freebsd]
-
-  rosie-skills-linux-x64@0.7.6:
-    resolution: {integrity: sha512-jlMa48A9c8XssiiNvBcJ1w8RBOOVbTHYzcRaXmqgO3zFLc0R8VTrIpIfmc7KC8dlL313qYerPCrq6LAtGwD0fQ==}
-    cpu: [x64]
-    os: [linux]
-
-  rosie-skills@0.7.6:
-    resolution: {integrity: sha512-B/3CcJlOH3KPNvbyl20VJJmah1ZLQTPjd2hAFIMs1Rn9KY2QN0GqZr0FJ5V+uFtUg3L6WEDGX/i5phIWRnl+BQ==}
+  rosie-skills@0.8.1:
+    resolution: {integrity: sha512-byhpM6YcmlQfjPiOBL+6TGW9Wur3DHH4OcVFcGyRhjxeLLRfZg7dEfI2fFKmc6al/eNEPLQ7pSe+JNETk55Fzw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -23373,6 +23362,8 @@ snapshots:
 
   mock-socket@9.3.1: {}
 
+  modern-tar@0.7.6: {}
+
   mongodb-connection-string-url@7.0.1:
     dependencies:
       '@types/whatwg-url': 13.0.0
@@ -24946,20 +24937,9 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
 
-  rosie-skills-darwin-arm64@0.7.6:
-    optional: true
-
-  rosie-skills-freebsd-x64@0.7.6:
-    optional: true
-
-  rosie-skills-linux-x64@0.7.6:
-    optional: true
-
-  rosie-skills@0.7.6:
-    optionalDependencies:
-      rosie-skills-darwin-arm64: 0.7.6
-      rosie-skills-freebsd-x64: 0.7.6
-      rosie-skills-linux-x64: 0.7.6
+  rosie-skills@0.8.1:
+    dependencies:
+      modern-tar: 0.7.6
 
   rou3@0.7.12: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,6 +43,10 @@ minimumReleaseAgeExclude:
   # Platform-specific workerd binaries published in lock-step with workerd.
   - "@cloudflare/workerd-*"
   - "@cloudflare/workers-types"
+  # The below is to install the rosie-skills package and remove the problematic
+  # wasm module it brings as soon as possible
+  # TODO(dario): remove in a few days
+  - "rosie-skills"
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Build scripts


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/14110

The new version of `rosie-skills` is a [pure-TypeScript rewrite](https://github.com/withastro/rosie/pull/21) that removes the previously necessary ~600kb WASM binary. The package now ships only JavaScript with two minimal dependencies (`modern-tar` and `diff`).

Additionally, `rosie-skills` is now bundled directly into Wrangler's distributable rather than kept as an external runtime dependency. This eliminates the supply chain concern raised in [#14110](https://github.com/cloudflare/workers-sdk/issues/14110): there is no separate package to resolve at install time, since all code is inlined into Wrangler's build output.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: all of this is already test covered
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not something needing documentation

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
