### PR TITLE
Update React Router autoconfig to use `cloudflare:workers` env pattern and enable v8 future flags

### DIFF
--- a/.changeset/react-router-autoconfig-v8-flags.md
+++ b/.changeset/react-router-autoconfig-v8-flags.md
@@ -1,0 +1,17 @@
+---
+"wrangler": patch
+---
+
+Update React Router autoconfig to use `cloudflare:workers` env pattern and enable v8 future flags
+
+The upstream React Router templates added v8 future flags in [remix-run/react-router-templates#210](https://github.com/remix-run/react-router-templates/pull/210), including `v8_middleware` which changes the context API from `AppLoadContext` to `RouterContextProvider`. This broke the autoconfig-generated `workers/app.ts` which relied on the old `AppLoadContext` pattern.
+
+The React Router autoconfig (`wrangler setup`) now generates a simpler `workers/app.ts` that no longer uses the `AppLoadContext` module augmentation pattern. Instead, Cloudflare Worker bindings are accessible via `import { env } from "cloudflare:workers"` in loaders and actions. This aligns with the [upstream Cloudflare template](https://github.com/remix-run/react-router-templates/tree/main/cloudflare) and is compatible with all v8 future flags.
+
+Additionally, the autoconfig now enables all applicable v8 future flags in `react-router.config.ts` based on the installed React Router version:
+
+- `v8_middleware`, `v8_splitRouteModules`, `v8_viteEnvironmentApi` (>= 7.10.0)
+- `v8_passThroughRequests` (>= 7.15.0)
+- `v8_trailingSlashAwareDataRequests` (>= 7.16.0)
+
+This prepares new projects for the upcoming React Router v8 release.

--- a/packages/wrangler/src/__tests__/autoconfig/frameworks/react-router.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/frameworks/react-router.test.ts
@@ -1,0 +1,364 @@
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import * as cliPackages from "@cloudflare/cli-shared-helpers/packages";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
+import { beforeEach, describe, it, vi } from "vitest";
+import {
+	getV8FutureFlags,
+	ReactRouter,
+} from "../../../autoconfig/frameworks/react-router";
+import * as packagesUtils from "../../../autoconfig/frameworks/utils/packages";
+import { NpmPackageManager } from "../../../package-manager";
+
+vi.mock("../../../autoconfig/frameworks/utils/vite-config", () => ({
+	transformViteConfig: vi.fn(),
+}));
+
+vi.mock("../../../autoconfig/frameworks/utils/vite-plugin", () => ({
+	installCloudflareVitePlugin: vi.fn(),
+}));
+
+vi.mock("../../../autoconfig/frameworks/utils/packages", () => ({
+	getInstalledPackageVersion: vi.fn(),
+	isPackageInstalled: vi.fn(() => true),
+}));
+
+function getBaseOptions() {
+	return {
+		projectPath: process.cwd(),
+		outputDir: "build/",
+		workerName: "my-react-router-app",
+		dryRun: false,
+		packageManager: NpmPackageManager,
+		isWorkspaceRoot: false,
+	};
+}
+
+function createFramework(version: string): ReactRouter {
+	vi.mocked(packagesUtils.getInstalledPackageVersion).mockReturnValue(version);
+
+	const framework = new ReactRouter({
+		id: "react-router",
+		name: "React Router",
+	});
+
+	framework.validateFrameworkVersion(".", {
+		name: "react-router",
+		minimumVersion: "7.0.0",
+		maximumKnownMajorVersion: "7",
+	});
+
+	return framework;
+}
+
+async function seedProjectFiles() {
+	await mkdir(resolve("app"), { recursive: true });
+	await writeFile(
+		resolve("react-router.config.ts"),
+		`import type { Config } from "@react-router/dev/config";
+export default {
+  ssr: true,
+} satisfies Config;
+`
+	);
+	await writeFile(
+		resolve("vite.config.ts"),
+		`import { defineConfig } from 'vite';
+export default defineConfig({ plugins: [] });
+`
+	);
+}
+
+describe("React Router framework configure()", () => {
+	runInTempDir();
+
+	beforeEach(() => {
+		vi.spyOn(cliPackages, "installPackages").mockImplementation(async () => {});
+	});
+
+	describe("workers/app.ts generation", () => {
+		beforeEach(async () => {
+			await seedProjectFiles();
+		});
+
+		it("creates workers/app.ts without AppLoadContext augmentation", async ({
+			expect,
+		}) => {
+			const framework = createFramework("7.16.0");
+			await framework.configure(getBaseOptions());
+
+			const content = readFileSync(resolve("workers/app.ts"), "utf-8");
+			expect(content).not.toContain("AppLoadContext");
+			expect(content).not.toContain("declare module");
+			expect(content).toContain(
+				'import { createRequestHandler } from "react-router"'
+			);
+			expect(content).toContain("requestHandler(request)");
+			expect(content).toContain("satisfies ExportedHandler<Env>");
+		});
+
+		it("creates workers/app.ts with a simple fetch handler", async ({
+			expect,
+		}) => {
+			const framework = createFramework("7.16.0");
+			await framework.configure(getBaseOptions());
+
+			const content = readFileSync(resolve("workers/app.ts"), "utf-8");
+			// The fetch handler should accept only `request`, not `env` or `ctx`
+			expect(content).toContain("async fetch(request)");
+			expect(content).not.toContain("env, ctx");
+			expect(content).not.toContain("cloudflare: { env, ctx }");
+		});
+	});
+
+	describe("entry.server.tsx generation", () => {
+		beforeEach(async () => {
+			await seedProjectFiles();
+		});
+
+		it("creates entry.server.tsx without AppLoadContext", async ({
+			expect,
+		}) => {
+			const framework = createFramework("7.16.0");
+			await framework.configure(getBaseOptions());
+
+			const content = readFileSync(resolve("app/entry.server.tsx"), "utf-8");
+			expect(content).not.toContain("AppLoadContext");
+			expect(content).not.toContain("_loadContext");
+			expect(content).toContain(
+				'import type { EntryContext } from "react-router"'
+			);
+			expect(content).toContain("ServerRouter");
+			expect(content).toContain("renderToReadableStream");
+		});
+
+		it("does not overwrite existing entry.server.tsx", async ({ expect }) => {
+			const existingContent = "// existing entry server";
+			await mkdir(resolve("app"), { recursive: true });
+			await writeFile(resolve("app/entry.server.tsx"), existingContent);
+
+			const framework = createFramework("7.16.0");
+			await framework.configure(getBaseOptions());
+
+			const content = readFileSync(resolve("app/entry.server.tsx"), "utf-8");
+			expect(content).toBe(existingContent);
+		});
+	});
+
+	describe("react-router.config.ts transformation", () => {
+		beforeEach(async () => {
+			await mkdir(resolve("app"), { recursive: true });
+			await writeFile(
+				resolve("vite.config.ts"),
+				`import { defineConfig } from 'vite';
+export default defineConfig({ plugins: [] });
+`
+			);
+		});
+
+		it("adds all v8 future flags to config without existing future block", async ({
+			expect,
+		}) => {
+			await writeFile(
+				resolve("react-router.config.ts"),
+				`import type { Config } from "@react-router/dev/config";
+export default {
+  ssr: true,
+} satisfies Config;
+`
+			);
+
+			const framework = createFramework("7.16.0");
+			await framework.configure(getBaseOptions());
+
+			const content = readFileSync(resolve("react-router.config.ts"), "utf-8");
+			expect(content).toContain("v8_middleware: true");
+			expect(content).toContain("v8_passThroughRequests: true");
+			expect(content).toContain("v8_splitRouteModules: true");
+			expect(content).toContain("v8_trailingSlashAwareDataRequests: true");
+			expect(content).toContain("v8_viteEnvironmentApi: true");
+		});
+
+		it("preserves existing future flags and adds missing ones", async ({
+			expect,
+		}) => {
+			await writeFile(
+				resolve("react-router.config.ts"),
+				`import type { Config } from "@react-router/dev/config";
+export default {
+  ssr: true,
+  future: {
+    v8_middleware: true,
+    v8_viteEnvironmentApi: true,
+  },
+} satisfies Config;
+`
+			);
+
+			const framework = createFramework("7.16.0");
+			await framework.configure(getBaseOptions());
+
+			const content = readFileSync(resolve("react-router.config.ts"), "utf-8");
+			// Existing flags preserved
+			expect(content).toContain("v8_middleware: true");
+			expect(content).toContain("v8_viteEnvironmentApi: true");
+			// New flags added
+			expect(content).toContain("v8_passThroughRequests: true");
+			expect(content).toContain("v8_splitRouteModules: true");
+			expect(content).toContain("v8_trailingSlashAwareDataRequests: true");
+		});
+
+		it("uses unstable_viteEnvironmentApi for React Router < 7.10.0", async ({
+			expect,
+		}) => {
+			await writeFile(
+				resolve("react-router.config.ts"),
+				`import type { Config } from "@react-router/dev/config";
+export default {
+  ssr: true,
+} satisfies Config;
+`
+			);
+
+			const framework = createFramework("7.9.0");
+			await framework.configure(getBaseOptions());
+
+			const content = readFileSync(resolve("react-router.config.ts"), "utf-8");
+			expect(content).toContain("unstable_viteEnvironmentApi: true");
+			expect(content).not.toContain("v8_viteEnvironmentApi");
+			expect(content).not.toContain("v8_middleware");
+		});
+
+		it("handles config with plain object export (no satisfies)", async ({
+			expect,
+		}) => {
+			await writeFile(
+				resolve("react-router.config.ts"),
+				`export default {
+  ssr: true,
+};
+`
+			);
+
+			const framework = createFramework("7.16.0");
+			await framework.configure(getBaseOptions());
+
+			const content = readFileSync(resolve("react-router.config.ts"), "utf-8");
+			expect(content).toContain("v8_viteEnvironmentApi: true");
+			expect(content).toContain("v8_middleware: true");
+		});
+	});
+
+	describe("dry run", () => {
+		it("does not create files in dry run mode", async ({ expect }) => {
+			const framework = createFramework("7.16.0");
+			const result = await framework.configure({
+				...getBaseOptions(),
+				dryRun: true,
+			});
+
+			expect(result.wranglerConfig).toEqual({
+				main: "./workers/app.ts",
+			});
+			expect(existsSync(resolve("workers/app.ts"))).toBe(false);
+			expect(existsSync(resolve("app/entry.server.tsx"))).toBe(false);
+		});
+	});
+
+	describe("wrangler config", () => {
+		beforeEach(async () => {
+			await seedProjectFiles();
+		});
+
+		it("returns wrangler config with main pointing to workers/app.ts", async ({
+			expect,
+		}) => {
+			const framework = createFramework("7.16.0");
+			const result = await framework.configure(getBaseOptions());
+
+			expect(result.wranglerConfig).toEqual({
+				main: "./workers/app.ts",
+			});
+		});
+	});
+
+	describe("package installation", () => {
+		beforeEach(async () => {
+			await seedProjectFiles();
+		});
+
+		it("installs isbot as a dev dependency", async ({ expect }) => {
+			const framework = createFramework("7.16.0");
+			await framework.configure(getBaseOptions());
+
+			expect(cliPackages.installPackages).toHaveBeenCalledWith(
+				NpmPackageManager.type,
+				["isbot"],
+				expect.objectContaining({ dev: true })
+			);
+		});
+	});
+});
+
+describe("getV8FutureFlags()", () => {
+	it("returns all flags for unknown version", ({ expect }) => {
+		expect(getV8FutureFlags("")).toEqual([
+			"v8_middleware",
+			"v8_passThroughRequests",
+			"v8_splitRouteModules",
+			"v8_trailingSlashAwareDataRequests",
+			"v8_viteEnvironmentApi",
+		]);
+	});
+
+	it("returns unstable flag for versions < 7.10.0", ({ expect }) => {
+		expect(getV8FutureFlags("7.9.0")).toEqual(["unstable_viteEnvironmentApi"]);
+		expect(getV8FutureFlags("7.0.0")).toEqual(["unstable_viteEnvironmentApi"]);
+	});
+
+	it("returns 3 flags for versions >= 7.10.0 and < 7.15.0", ({ expect }) => {
+		expect(getV8FutureFlags("7.10.0")).toEqual([
+			"v8_middleware",
+			"v8_splitRouteModules",
+			"v8_viteEnvironmentApi",
+		]);
+		expect(getV8FutureFlags("7.14.2")).toEqual([
+			"v8_middleware",
+			"v8_splitRouteModules",
+			"v8_viteEnvironmentApi",
+		]);
+	});
+
+	it("returns 4 flags for versions >= 7.15.0 and < 7.16.0", ({ expect }) => {
+		expect(getV8FutureFlags("7.15.0")).toEqual([
+			"v8_middleware",
+			"v8_passThroughRequests",
+			"v8_splitRouteModules",
+			"v8_viteEnvironmentApi",
+		]);
+		expect(getV8FutureFlags("7.15.1")).toEqual([
+			"v8_middleware",
+			"v8_passThroughRequests",
+			"v8_splitRouteModules",
+			"v8_viteEnvironmentApi",
+		]);
+	});
+
+	it("returns all 5 flags for versions >= 7.16.0", ({ expect }) => {
+		expect(getV8FutureFlags("7.16.0")).toEqual([
+			"v8_middleware",
+			"v8_passThroughRequests",
+			"v8_splitRouteModules",
+			"v8_trailingSlashAwareDataRequests",
+			"v8_viteEnvironmentApi",
+		]);
+		expect(getV8FutureFlags("7.20.0")).toEqual([
+			"v8_middleware",
+			"v8_passThroughRequests",
+			"v8_splitRouteModules",
+			"v8_trailingSlashAwareDataRequests",
+			"v8_viteEnvironmentApi",
+		]);
+	});
+});

--- a/packages/wrangler/src/autoconfig/frameworks/react-router.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/react-router.ts
@@ -18,9 +18,41 @@ import type {
 
 const b = recast.types.builders;
 
+/**
+ * Ensures a future flag property exists in the `future` object expression and is set to `true`.
+ * If the property already exists, its value is set to `true`. Otherwise, a new property is added.
+ *
+ * @param futureObject - The AST `ObjectExpression` node representing the `future` config block.
+ * @param flagName - The name of the future flag to ensure (e.g. `"v8_middleware"`).
+ */
+function ensureFutureFlag(
+	futureObject: recast.types.namedTypes.ObjectExpression,
+	flagName: string
+) {
+	const existingIndex = futureObject.properties.findIndex(
+		(p) =>
+			p.type === "ObjectProperty" &&
+			p.key.type === "Identifier" &&
+			p.key.name === flagName &&
+			p.value.type === "BooleanLiteral"
+	);
+
+	if (existingIndex !== -1) {
+		const prop = futureObject.properties[existingIndex];
+		assert(
+			prop.type === "ObjectProperty" && prop.value.type === "BooleanLiteral"
+		);
+		prop.value.value = true;
+	} else {
+		futureObject.properties.push(
+			b.objectProperty(b.identifier(flagName), b.booleanLiteral(true))
+		);
+	}
+}
+
 function transformReactRouterConfig(
 	projectPath: string,
-	viteEnvironmentKey: ReturnType<typeof configPropertyName>
+	futureFlags: string[]
 ) {
 	const filePathTS = path.join(projectPath, `react-router.config.ts`);
 	const filePathJS = path.join(projectPath, `react-router.config.js`);
@@ -35,6 +67,8 @@ function transformReactRouterConfig(
 		throw new Error("Could not find React Router config file to modify");
 	}
 
+	const flagList = futureFlags.join(", ");
+
 	transformFile(filePath, {
 		/**
 		 * Visit an export default declaration of the form:
@@ -43,13 +77,9 @@ function transformReactRouterConfig(
 		 *     ...
 		 *   }
 		 *
-		 * and add or modify the `future` property to look like:
+		 * and add or modify the `future` property to include the required v8 future flags.
 		 *
-		 *   future: {
-		 *     unstable_viteEnvironmentApi: true // v8_viteEnvironment depending on the React Router version
-		 *   }
-		 *
-		 * For some extra complexity, this also supports TS `as` and `satisfies` expressions
+		 * For some extra complexity, this also supports TS `as` and `satisfies` expressions.
 		 */
 		visitExportDefaultDeclaration(n) {
 			let node: recast.types.namedTypes.ObjectExpression;
@@ -63,61 +93,39 @@ function transformReactRouterConfig(
 				node = n.node.declaration;
 			} else {
 				throw new Error(
-					`Could not parse React Router config file. Please add the following snippet manually:\n  future: {\n    ${viteEnvironmentKey}: true,\n  }`
+					`Could not parse React Router config file. Please add the following snippet manually:\n  future: {\n    ${flagList}: true,\n  }`
 				);
 			}
 
 			assert(node.type === "ObjectExpression");
 
 			// Is there an existing `future` key? If there is, we should modify it rather than creating a new one
-			const futureKey = node.properties.findIndex(
+			const futureKeyIndex = node.properties.findIndex(
 				(p) =>
 					p.type === "ObjectProperty" &&
 					p.key.type === "Identifier" &&
 					p.key.name === "future" &&
 					p.value.type === "ObjectExpression"
 			);
-			if (futureKey !== -1) {
-				const future = node.properties[futureKey];
+			if (futureKeyIndex !== -1) {
+				const future = node.properties[futureKeyIndex];
 				assert(
 					future.type === "ObjectProperty" &&
 						future.value.type === "ObjectExpression"
 				);
 
-				// Does the `future` key already have a property called `unstable_viteEnvironmentApi`?
-				const viteEnvironment = future.value.properties.findIndex(
-					(p) =>
-						p.type === "ObjectProperty" &&
-						p.key.type === "Identifier" &&
-						p.key.name === viteEnvironmentKey &&
-						p.value.type === "BooleanLiteral"
-				);
-
-				// If there's already a unstable_viteEnvironmentApi key, set the value to true
-				if (viteEnvironment !== -1) {
-					const prop = future.value.properties[viteEnvironment];
-					assert(
-						prop.type === "ObjectProperty" &&
-							prop.value.type === "BooleanLiteral"
-					);
-					prop.value.value = true;
-				} else {
-					const prop = b.objectProperty(
-						b.identifier(viteEnvironmentKey),
-						b.booleanLiteral(true)
-					);
-					future.value.properties.push(prop);
+				for (const flag of futureFlags) {
+					ensureFutureFlag(future.value, flag);
 				}
 			} else {
 				node.properties.push(
 					b.objectProperty(
 						b.identifier("future"),
-						b.objectExpression([
-							b.objectProperty(
-								b.identifier(viteEnvironmentKey),
-								b.booleanLiteral(true)
-							),
-						])
+						b.objectExpression(
+							futureFlags.map((flag) =>
+								b.objectProperty(b.identifier(flag), b.booleanLiteral(true))
+							)
+						)
 					)
 				);
 			}
@@ -127,17 +135,49 @@ function transformReactRouterConfig(
 	});
 }
 
-function configPropertyName(reactRouterVersion: string) {
+/**
+ * Returns the list of v8 future flags to enable based on the installed React Router version.
+ *
+ * Version gates:
+ * - < 7.10.0: unstable_viteEnvironmentApi only
+ * - >= 7.10.0: v8_viteEnvironmentApi, v8_splitRouteModules, v8_middleware
+ * - >= 7.15.0: adds v8_passThroughRequests
+ * - >= 7.16.0: adds v8_trailingSlashAwareDataRequests (all 5 stable v8 flags)
+ */
+export function getV8FutureFlags(reactRouterVersion: string): string[] {
 	if (!reactRouterVersion) {
-		return "v8_viteEnvironmentApi";
+		// Default to the full set of flags when version is unknown
+		return [
+			"v8_middleware",
+			"v8_passThroughRequests",
+			"v8_splitRouteModules",
+			"v8_trailingSlashAwareDataRequests",
+			"v8_viteEnvironmentApi",
+		];
 	}
 
 	// version less than 7.10.0
 	if (semiver(reactRouterVersion, "7.10.0") === -1) {
-		return "unstable_viteEnvironmentApi";
-	} else {
-		return "v8_viteEnvironmentApi";
+		return ["unstable_viteEnvironmentApi"];
 	}
+
+	const flags = [
+		"v8_middleware",
+		"v8_splitRouteModules",
+		"v8_viteEnvironmentApi",
+	];
+
+	// v8_passThroughRequests was stabilized in 7.15.0
+	if (semiver(reactRouterVersion, "7.15.0") >= 0) {
+		flags.push("v8_passThroughRequests");
+	}
+
+	// v8_trailingSlashAwareDataRequests was stabilized in 7.16.0
+	if (semiver(reactRouterVersion, "7.16.0") >= 0) {
+		flags.push("v8_trailingSlashAwareDataRequests");
+	}
+
+	return flags.sort();
 }
 
 export class ReactRouter extends Framework {
@@ -147,7 +187,7 @@ export class ReactRouter extends Framework {
 		packageManager,
 		isWorkspaceRoot,
 	}: ConfigurationOptions): Promise<ConfigurationResults> {
-		const viteEnvironmentKey = configPropertyName(this.frameworkVersion);
+		const futureFlags = getV8FutureFlags(this.frameworkVersion);
 		if (!dryRun) {
 			await installCloudflareVitePlugin({
 				packageManager: packageManager.type,
@@ -162,25 +202,14 @@ export class ReactRouter extends Framework {
 				dedent /* javascript */ `
 					import { createRequestHandler } from "react-router";
 
-					declare module "react-router" {
-						export interface AppLoadContext {
-							cloudflare: {
-								env: Env;
-								ctx: ExecutionContext;
-							};
-						}
-					}
-
 					const requestHandler = createRequestHandler(
 						() => import("virtual:react-router/server-build"),
-						import.meta.env.MODE
+						import.meta.env.MODE,
 					);
 
 					export default {
-						async fetch(request, env, ctx) {
-							return requestHandler(request, {
-								cloudflare: { env, ctx },
-							});
+						async fetch(request) {
+							return requestHandler(request);
 						},
 					} satisfies ExportedHandler<Env>;
 				`
@@ -197,7 +226,7 @@ export class ReactRouter extends Framework {
 				writeFileSync(
 					`app/entry.server.tsx`,
 					dedent /* javascript */ `
-					import type { AppLoadContext, EntryContext } from "react-router";
+					import type { EntryContext } from "react-router";
 					import { ServerRouter } from "react-router";
 					import { isbot } from "isbot";
 					import { renderToReadableStream } from "react-dom/server";
@@ -207,7 +236,6 @@ export class ReactRouter extends Framework {
 						responseStatusCode: number,
 						responseHeaders: Headers,
 						routerContext: EntryContext,
-						_loadContext: AppLoadContext
 					) {
 						let shellRendered = false;
 						const userAgent = request.headers.get("user-agent");
@@ -224,7 +252,7 @@ export class ReactRouter extends Framework {
 										console.error(error);
 									}
 								},
-							}
+							},
 						);
 						shellRendered = true;
 
@@ -253,7 +281,7 @@ export class ReactRouter extends Framework {
 				incompatibleVitePlugins: ["netlifyReactRouter"],
 			});
 
-			transformReactRouterConfig(projectPath, viteEnvironmentKey);
+			transformReactRouterConfig(projectPath, futureFlags);
 		}
 
 		return {


### PR DESCRIPTION
Fixes the broken C3 React Router experimental E2E.

The upstream React Router templates added v8 future flags in [remix-run/react-router-templates#210](https://github.com/remix-run/react-router-templates/pull/210), including `v8_middleware` which changes the context API from `AppLoadContext` to `RouterContextProvider`. This broke the autoconfig-generated `workers/app.ts` which relied on the old `AppLoadContext` pattern.

The React Router autoconfig (`wrangler setup`) now generates a simpler `workers/app.ts` that no longer uses the `AppLoadContext` module augmentation pattern. Instead, Cloudflare Worker bindings are accessible via `import { env } from "cloudflare:workers"` in loaders and actions. This aligns with the [upstream Cloudflare template](https://github.com/remix-run/react-router-templates/tree/main/cloudflare) and is compatible with all v8 future flags.

Additionally, the autoconfig now enables all applicable v8 future flags in `react-router.config.ts` based on the installed React Router version:

- `v8_middleware`, `v8_splitRouteModules`, `v8_viteEnvironmentApi` (>= 7.10.0)
- `v8_passThroughRequests` (>= 7.15.0)
- `v8_trailingSlashAwareDataRequests` (>= 7.16.0)

This prepares new projects for the upcoming React Router v8 release.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: self-documenting change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
