### PR TITLE
Adapt React Router autoconfig based on `v8_middleware` future flag

### DIFF
--- a/.changeset/react-router-autoconfig-v8-middleware.md
+++ b/.changeset/react-router-autoconfig-v8-middleware.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Adapt React Router autoconfig based on `v8_middleware` future flag
+
+The React Router autoconfig (`wrangler setup`) now detects whether `v8_middleware: true` is set in the user's `react-router.config.ts`. When it is, the generated `workers/app.ts` uses a simplified fetch handler without `AppLoadContext` module augmentation, and the generated `app/entry.server.tsx` omits the `_loadContext` parameter. When `v8_middleware` is not set, the existing `AppLoadContext` pattern with `env`/`ctx` params is preserved.
+
+This avoids breaking projects that use the `v8_middleware` future flag (which changes the context API from `AppLoadContext` to `RouterContextProvider`), while keeping the traditional pattern for projects that haven't opted in.

--- a/packages/wrangler/src/__tests__/autoconfig/frameworks/fixtures/react-router/config-future-no-middleware.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/frameworks/fixtures/react-router/config-future-no-middleware.ts
@@ -1,0 +1,7 @@
+import type { Config } from "@react-router/dev/config";
+export default {
+	ssr: true,
+	future: {
+		v8_splitRouteModules: true,
+	},
+} satisfies Config;

--- a/packages/wrangler/src/__tests__/autoconfig/frameworks/fixtures/react-router/config-middleware-and-split.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/frameworks/fixtures/react-router/config-middleware-and-split.ts
@@ -1,0 +1,8 @@
+import type { Config } from "@react-router/dev/config";
+export default {
+	ssr: true,
+	future: {
+		v8_middleware: true,
+		v8_splitRouteModules: true,
+	},
+} satisfies Config;

--- a/packages/wrangler/src/__tests__/autoconfig/frameworks/fixtures/react-router/config-middleware-false.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/frameworks/fixtures/react-router/config-middleware-false.ts
@@ -1,0 +1,7 @@
+import type { Config } from "@react-router/dev/config";
+export default {
+	ssr: true,
+	future: {
+		v8_middleware: false,
+	},
+} satisfies Config;

--- a/packages/wrangler/src/__tests__/autoconfig/frameworks/fixtures/react-router/config-middleware-true.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/frameworks/fixtures/react-router/config-middleware-true.ts
@@ -1,0 +1,7 @@
+import type { Config } from "@react-router/dev/config";
+export default {
+	ssr: true,
+	future: {
+		v8_middleware: true,
+	},
+} satisfies Config;

--- a/packages/wrangler/src/__tests__/autoconfig/frameworks/fixtures/react-router/config-no-future.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/frameworks/fixtures/react-router/config-no-future.ts
@@ -1,0 +1,4 @@
+import type { Config } from "@react-router/dev/config";
+export default {
+	ssr: true,
+} satisfies Config;

--- a/packages/wrangler/src/__tests__/autoconfig/frameworks/fixtures/react-router/config-plain-object-middleware.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/frameworks/fixtures/react-router/config-plain-object-middleware.ts
@@ -1,0 +1,6 @@
+export default {
+	ssr: true,
+	future: {
+		v8_middleware: true,
+	},
+};

--- a/packages/wrangler/src/__tests__/autoconfig/frameworks/fixtures/react-router/vite-config-basic.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/frameworks/fixtures/react-router/vite-config-basic.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from "vite";
+export default defineConfig({ plugins: [] });

--- a/packages/wrangler/src/__tests__/autoconfig/frameworks/react-router.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/frameworks/react-router.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import * as cliPackages from "@cloudflare/cli-shared-helpers/packages";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { beforeEach, describe, it, vi } from "vitest";
@@ -10,6 +10,13 @@ import {
 } from "../../../autoconfig/frameworks/react-router";
 import * as packagesUtils from "../../../autoconfig/frameworks/utils/packages";
 import { NpmPackageManager } from "../../../package-manager";
+
+function fixture(name: string): string {
+	return readFileSync(
+		join(__dirname, "fixtures/react-router", name),
+		"utf-8"
+	);
+}
 
 vi.mock("../../../autoconfig/frameworks/utils/vite-config", () => ({
 	transformViteConfig: vi.fn(),
@@ -60,57 +67,35 @@ describe("hasV8MiddlewareFlag()", () => {
 	});
 
 	it("returns false when config has no future block", async ({ expect }) => {
-		const config = `
-			import type { Config } from "@react-router/dev/config";
-			export default {
-			ssr: true,
-			} satisfies Config;
-		`;
-		await writeFile(resolve("react-router.config.ts"), config);
+		await writeFile(
+			resolve("react-router.config.ts"),
+			fixture("config-no-future.ts")
+		);
 		expect(hasV8MiddlewareFlag(process.cwd())).toBe(false);
 	});
 
 	it("returns false when future block does not contain v8_middleware", async ({
 		expect,
 	}) => {
-		const config = `
-			import type { Config } from "@react-router/dev/config";
-			export default {
-				ssr: true,
-				future: {
-					v8_splitRouteModules: true,
-				},
-			} satisfies Config;
-		`;
-		await writeFile(resolve("react-router.config.ts"), config);
+		await writeFile(
+			resolve("react-router.config.ts"),
+			fixture("config-future-no-middleware.ts")
+		);
 		expect(hasV8MiddlewareFlag(process.cwd())).toBe(false);
 	});
 
 	it("returns true when v8_middleware is set to true", async ({ expect }) => {
-		const config = `
-			import type { Config } from "@react-router/dev/config";
-			export default {
-				ssr: true,
-				future: {
-					v8_middleware: true,
-				},
-			} satisfies Config;
-		`;
-		await writeFile(resolve("react-router.config.ts"), config);
+		await writeFile(
+			resolve("react-router.config.ts"),
+			fixture("config-middleware-true.ts")
+		);
 		expect(hasV8MiddlewareFlag(process.cwd())).toBe(true);
 	});
 
 	it("returns false when v8_middleware is set to false", async ({ expect }) => {
 		await writeFile(
 			resolve("react-router.config.ts"),
-			`import type { Config } from "@react-router/dev/config";
-export default {
-  ssr: true,
-  future: {
-    v8_middleware: false,
-  },
-} satisfies Config;
-`
+			fixture("config-middleware-false.ts")
 		);
 		expect(hasV8MiddlewareFlag(process.cwd())).toBe(false);
 	});
@@ -118,13 +103,7 @@ export default {
 	it("handles plain object export without satisfies", async ({ expect }) => {
 		await writeFile(
 			resolve("react-router.config.ts"),
-			`export default {
-  ssr: true,
-  future: {
-    v8_middleware: true,
-  },
-};
-`
+			fixture("config-plain-object-middleware.ts")
 		);
 		expect(hasV8MiddlewareFlag(process.cwd())).toBe(true);
 	});
@@ -132,7 +111,7 @@ export default {
 	it("returns false when config file has syntax errors", async ({ expect }) => {
 		await writeFile(
 			resolve("react-router.config.ts"),
-			`export default { this is not valid syntax`
+			"export default { this is not valid syntax"
 		);
 		expect(hasV8MiddlewareFlag(process.cwd())).toBe(false);
 	});
@@ -142,15 +121,7 @@ export default {
 	}) => {
 		await writeFile(
 			resolve("react-router.config.ts"),
-			`import type { Config } from "@react-router/dev/config";
-export default {
-  ssr: true,
-  future: {
-    v8_middleware: true,
-    v8_splitRouteModules: true,
-  },
-} satisfies Config;
-`
+			fixture("config-middleware-and-split.ts")
 		);
 		expect(hasV8MiddlewareFlag(process.cwd())).toBe(true);
 	});
@@ -165,22 +136,16 @@ describe("React Router framework configure()", () => {
 		await mkdir(resolve("app"), { recursive: true });
 		await writeFile(
 			resolve("vite.config.ts"),
-			`
-			import { defineConfig } from 'vite';
-			export default defineConfig({ plugins: [] });
-		`
+			fixture("vite-config-basic.ts")
 		);
 	});
 
 	describe("workers/app.ts generation — without v8_middleware", () => {
 		beforeEach(async () => {
-			const config = `
-				import type { Config } from "@react-router/dev/config";
-				export default {
-				ssr: true,
-				} satisfies Config;
-			`;
-			await writeFile(resolve("react-router.config.ts"), config);
+			await writeFile(
+				resolve("react-router.config.ts"),
+				fixture("config-no-future.ts")
+			);
 		});
 
 		it("creates workers/app.ts with AppLoadContext augmentation", async ({
@@ -200,16 +165,10 @@ describe("React Router framework configure()", () => {
 
 	describe("workers/app.ts generation — with v8_middleware", () => {
 		beforeEach(async () => {
-			const config = `
-				import type { Config } from "@react-router/dev/config";
-				export default {
-					ssr: true,
-					future: {
-						v8_middleware: true,
-					},
-				} satisfies Config;
-			`;
-			await writeFile(resolve("react-router.config.ts"), config);
+			await writeFile(
+				resolve("react-router.config.ts"),
+				fixture("config-middleware-true.ts")
+			);
 		});
 
 		it("creates workers/app.ts without AppLoadContext augmentation", async ({
@@ -243,13 +202,10 @@ describe("React Router framework configure()", () => {
 
 	describe("entry.server.tsx generation — without v8_middleware", () => {
 		beforeEach(async () => {
-			const config = `
-				import type { Config } from "@react-router/dev/config";
-				export default {
-				ssr: true,
-				} satisfies Config;
-			`;
-			await writeFile(resolve("react-router.config.ts"), config);
+			await writeFile(
+				resolve("react-router.config.ts"),
+				fixture("config-no-future.ts")
+			);
 		});
 
 		it("creates entry.server.tsx with AppLoadContext", async ({ expect }) => {
@@ -267,16 +223,10 @@ describe("React Router framework configure()", () => {
 
 	describe("entry.server.tsx generation — with v8_middleware", () => {
 		beforeEach(async () => {
-			const config = `
-				import type { Config } from "@react-router/dev/config";
-				export default {
-					ssr: true,
-					future: {
-						v8_middleware: true,
-					},
-				} satisfies Config;
-			`;
-			await writeFile(resolve("react-router.config.ts"), config);
+			await writeFile(
+				resolve("react-router.config.ts"),
+				fixture("config-middleware-true.ts")
+			);
 		});
 
 		it("creates entry.server.tsx without AppLoadContext", async ({
@@ -298,16 +248,10 @@ describe("React Router framework configure()", () => {
 
 	describe("entry.server.tsx — existing file not overwritten", () => {
 		beforeEach(async () => {
-			const config = `
-				import type { Config } from "@react-router/dev/config";
-				export default {
-					ssr: true,
-					future: {
-						v8_middleware: true,
-					},
-				} satisfies Config;
-			`;
-			await writeFile(resolve("react-router.config.ts"), config);
+			await writeFile(
+				resolve("react-router.config.ts"),
+				fixture("config-middleware-true.ts")
+			);
 		});
 
 		it("does not overwrite existing entry.server.tsx", async ({ expect }) => {
@@ -327,13 +271,10 @@ describe("React Router framework configure()", () => {
 		it("adds v8_viteEnvironmentApi for React Router >= 7.10.0", async ({
 			expect,
 		}) => {
-			const config = `
-				import type { Config } from "@react-router/dev/config";
-				export default {
-				ssr: true,
-				} satisfies Config;
-			`;
-			await writeFile(resolve("react-router.config.ts"), config);
+			await writeFile(
+				resolve("react-router.config.ts"),
+				fixture("config-no-future.ts")
+			);
 
 			const framework = createFramework("7.16.0");
 			await framework.configure(getBaseOptions());
@@ -350,13 +291,10 @@ describe("React Router framework configure()", () => {
 		it("uses unstable_viteEnvironmentApi for React Router < 7.10.0", async ({
 			expect,
 		}) => {
-			const config = `
-				import type { Config } from "@react-router/dev/config";
-				export default {
-				ssr: true,
-				} satisfies Config;
-			`;
-			await writeFile(resolve("react-router.config.ts"), config);
+			await writeFile(
+				resolve("react-router.config.ts"),
+				fixture("config-no-future.ts")
+			);
 
 			const framework = createFramework("7.9.0");
 			await framework.configure(getBaseOptions());
@@ -369,16 +307,10 @@ describe("React Router framework configure()", () => {
 		it("preserves existing future flags when adding viteEnvironmentApi", async ({
 			expect,
 		}) => {
-			const config = `
-				import type { Config } from "@react-router/dev/config";
-				export default {
-					ssr: true,
-					future: {
-						v8_middleware: true,
-					},
-				} satisfies Config;
-			`;
-			await writeFile(resolve("react-router.config.ts"), config);
+			await writeFile(
+				resolve("react-router.config.ts"),
+				fixture("config-middleware-true.ts")
+			);
 
 			const framework = createFramework("7.16.0");
 			await framework.configure(getBaseOptions());
@@ -409,13 +341,10 @@ describe("React Router framework configure()", () => {
 
 	describe("wrangler config", () => {
 		beforeEach(async () => {
-			const config = `
-				import type { Config } from "@react-router/dev/config";
-				export default {
-				ssr: true,
-				} satisfies Config;
-			`;
-			await writeFile(resolve("react-router.config.ts"), config);
+			await writeFile(
+				resolve("react-router.config.ts"),
+				fixture("config-no-future.ts")
+			);
 		});
 
 		it("returns wrangler config with main pointing to workers/app.ts", async ({
@@ -432,13 +361,10 @@ describe("React Router framework configure()", () => {
 
 	describe("package installation", () => {
 		beforeEach(async () => {
-			const config = `
-				import type { Config } from "@react-router/dev/config";
-				export default {
-				ssr: true,
-				} satisfies Config;
-			`;
-			await writeFile(resolve("react-router.config.ts"), config);
+			await writeFile(
+				resolve("react-router.config.ts"),
+				fixture("config-no-future.ts")
+			);
 		});
 
 		it("installs isbot as a dev dependency", async ({ expect }) => {

--- a/packages/wrangler/src/__tests__/autoconfig/frameworks/react-router.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/frameworks/react-router.test.ts
@@ -12,10 +12,7 @@ import * as packagesUtils from "../../../autoconfig/frameworks/utils/packages";
 import { NpmPackageManager } from "../../../package-manager";
 
 function fixture(name: string): string {
-	return readFileSync(
-		join(__dirname, "fixtures/react-router", name),
-		"utf-8"
-	);
+	return readFileSync(join(__dirname, "fixtures/react-router", name), "utf-8");
 }
 
 vi.mock("../../../autoconfig/frameworks/utils/vite-config", () => ({
@@ -134,10 +131,7 @@ describe("React Router framework configure()", () => {
 		vi.spyOn(cliPackages, "installPackages").mockImplementation(async () => {});
 
 		await mkdir(resolve("app"), { recursive: true });
-		await writeFile(
-			resolve("vite.config.ts"),
-			fixture("vite-config-basic.ts")
-		);
+		await writeFile(resolve("vite.config.ts"), fixture("vite-config-basic.ts"));
 	});
 
 	describe("workers/app.ts generation — without v8_middleware", () => {

--- a/packages/wrangler/src/__tests__/autoconfig/frameworks/react-router.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/frameworks/react-router.test.ts
@@ -52,48 +52,6 @@ function createFramework(version: string): ReactRouter {
 	return framework;
 }
 
-async function seedProjectFiles(options?: {
-	withMiddlewareFlag?: boolean;
-	withFutureBlock?: boolean;
-}) {
-	await mkdir(resolve("app"), { recursive: true });
-
-	let configContent: string;
-	if (options?.withMiddlewareFlag) {
-		configContent = `import type { Config } from "@react-router/dev/config";
-export default {
-  ssr: true,
-  future: {
-    v8_middleware: true,
-  },
-} satisfies Config;
-`;
-	} else if (options?.withFutureBlock) {
-		configContent = `import type { Config } from "@react-router/dev/config";
-export default {
-  ssr: true,
-  future: {
-    v8_splitRouteModules: true,
-  },
-} satisfies Config;
-`;
-	} else {
-		configContent = `import type { Config } from "@react-router/dev/config";
-export default {
-  ssr: true,
-} satisfies Config;
-`;
-	}
-
-	await writeFile(resolve("react-router.config.ts"), configContent);
-	await writeFile(
-		resolve("vite.config.ts"),
-		`import { defineConfig } from 'vite';
-export default defineConfig({ plugins: [] });
-`
-	);
-}
-
 describe("hasV8MiddlewareFlag()", () => {
 	runInTempDir();
 
@@ -102,19 +60,43 @@ describe("hasV8MiddlewareFlag()", () => {
 	});
 
 	it("returns false when config has no future block", async ({ expect }) => {
-		await seedProjectFiles();
+		const config = `
+			import type { Config } from "@react-router/dev/config";
+			export default {
+			ssr: true,
+			} satisfies Config;
+		`;
+		await writeFile(resolve("react-router.config.ts"), config);
 		expect(hasV8MiddlewareFlag(process.cwd())).toBe(false);
 	});
 
 	it("returns false when future block does not contain v8_middleware", async ({
 		expect,
 	}) => {
-		await seedProjectFiles({ withFutureBlock: true });
+		const config = `
+			import type { Config } from "@react-router/dev/config";
+			export default {
+				ssr: true,
+				future: {
+					v8_splitRouteModules: true,
+				},
+			} satisfies Config;
+		`;
+		await writeFile(resolve("react-router.config.ts"), config);
 		expect(hasV8MiddlewareFlag(process.cwd())).toBe(false);
 	});
 
 	it("returns true when v8_middleware is set to true", async ({ expect }) => {
-		await seedProjectFiles({ withMiddlewareFlag: true });
+		const config = `
+			import type { Config } from "@react-router/dev/config";
+			export default {
+				ssr: true,
+				future: {
+					v8_middleware: true,
+				},
+			} satisfies Config;
+		`;
+		await writeFile(resolve("react-router.config.ts"), config);
 		expect(hasV8MiddlewareFlag(process.cwd())).toBe(true);
 	});
 
@@ -177,13 +159,28 @@ export default {
 describe("React Router framework configure()", () => {
 	runInTempDir();
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		vi.spyOn(cliPackages, "installPackages").mockImplementation(async () => {});
+
+		await mkdir(resolve("app"), { recursive: true });
+		await writeFile(
+			resolve("vite.config.ts"),
+			`
+			import { defineConfig } from 'vite';
+			export default defineConfig({ plugins: [] });
+		`
+		);
 	});
 
 	describe("workers/app.ts generation — without v8_middleware", () => {
 		beforeEach(async () => {
-			await seedProjectFiles();
+			const config = `
+				import type { Config } from "@react-router/dev/config";
+				export default {
+				ssr: true,
+				} satisfies Config;
+			`;
+			await writeFile(resolve("react-router.config.ts"), config);
 		});
 
 		it("creates workers/app.ts with AppLoadContext augmentation", async ({
@@ -203,7 +200,16 @@ describe("React Router framework configure()", () => {
 
 	describe("workers/app.ts generation — with v8_middleware", () => {
 		beforeEach(async () => {
-			await seedProjectFiles({ withMiddlewareFlag: true });
+			const config = `
+				import type { Config } from "@react-router/dev/config";
+				export default {
+					ssr: true,
+					future: {
+						v8_middleware: true,
+					},
+				} satisfies Config;
+			`;
+			await writeFile(resolve("react-router.config.ts"), config);
 		});
 
 		it("creates workers/app.ts without AppLoadContext augmentation", async ({
@@ -237,7 +243,13 @@ describe("React Router framework configure()", () => {
 
 	describe("entry.server.tsx generation — without v8_middleware", () => {
 		beforeEach(async () => {
-			await seedProjectFiles();
+			const config = `
+				import type { Config } from "@react-router/dev/config";
+				export default {
+				ssr: true,
+				} satisfies Config;
+			`;
+			await writeFile(resolve("react-router.config.ts"), config);
 		});
 
 		it("creates entry.server.tsx with AppLoadContext", async ({ expect }) => {
@@ -255,7 +267,16 @@ describe("React Router framework configure()", () => {
 
 	describe("entry.server.tsx generation — with v8_middleware", () => {
 		beforeEach(async () => {
-			await seedProjectFiles({ withMiddlewareFlag: true });
+			const config = `
+				import type { Config } from "@react-router/dev/config";
+				export default {
+					ssr: true,
+					future: {
+						v8_middleware: true,
+					},
+				} satisfies Config;
+			`;
+			await writeFile(resolve("react-router.config.ts"), config);
 		});
 
 		it("creates entry.server.tsx without AppLoadContext", async ({
@@ -277,7 +298,16 @@ describe("React Router framework configure()", () => {
 
 	describe("entry.server.tsx — existing file not overwritten", () => {
 		beforeEach(async () => {
-			await seedProjectFiles({ withMiddlewareFlag: true });
+			const config = `
+				import type { Config } from "@react-router/dev/config";
+				export default {
+					ssr: true,
+					future: {
+						v8_middleware: true,
+					},
+				} satisfies Config;
+			`;
+			await writeFile(resolve("react-router.config.ts"), config);
 		});
 
 		it("does not overwrite existing entry.server.tsx", async ({ expect }) => {
@@ -297,7 +327,13 @@ describe("React Router framework configure()", () => {
 		it("adds v8_viteEnvironmentApi for React Router >= 7.10.0", async ({
 			expect,
 		}) => {
-			await seedProjectFiles();
+			const config = `
+				import type { Config } from "@react-router/dev/config";
+				export default {
+				ssr: true,
+				} satisfies Config;
+			`;
+			await writeFile(resolve("react-router.config.ts"), config);
 
 			const framework = createFramework("7.16.0");
 			await framework.configure(getBaseOptions());
@@ -314,7 +350,13 @@ describe("React Router framework configure()", () => {
 		it("uses unstable_viteEnvironmentApi for React Router < 7.10.0", async ({
 			expect,
 		}) => {
-			await seedProjectFiles();
+			const config = `
+				import type { Config } from "@react-router/dev/config";
+				export default {
+				ssr: true,
+				} satisfies Config;
+			`;
+			await writeFile(resolve("react-router.config.ts"), config);
 
 			const framework = createFramework("7.9.0");
 			await framework.configure(getBaseOptions());
@@ -327,7 +369,16 @@ describe("React Router framework configure()", () => {
 		it("preserves existing future flags when adding viteEnvironmentApi", async ({
 			expect,
 		}) => {
-			await seedProjectFiles({ withMiddlewareFlag: true });
+			const config = `
+				import type { Config } from "@react-router/dev/config";
+				export default {
+					ssr: true,
+					future: {
+						v8_middleware: true,
+					},
+				} satisfies Config;
+			`;
+			await writeFile(resolve("react-router.config.ts"), config);
 
 			const framework = createFramework("7.16.0");
 			await framework.configure(getBaseOptions());
@@ -358,7 +409,13 @@ describe("React Router framework configure()", () => {
 
 	describe("wrangler config", () => {
 		beforeEach(async () => {
-			await seedProjectFiles();
+			const config = `
+				import type { Config } from "@react-router/dev/config";
+				export default {
+				ssr: true,
+				} satisfies Config;
+			`;
+			await writeFile(resolve("react-router.config.ts"), config);
 		});
 
 		it("returns wrangler config with main pointing to workers/app.ts", async ({
@@ -375,7 +432,13 @@ describe("React Router framework configure()", () => {
 
 	describe("package installation", () => {
 		beforeEach(async () => {
-			await seedProjectFiles();
+			const config = `
+				import type { Config } from "@react-router/dev/config";
+				export default {
+				ssr: true,
+				} satisfies Config;
+			`;
+			await writeFile(resolve("react-router.config.ts"), config);
 		});
 
 		it("installs isbot as a dev dependency", async ({ expect }) => {

--- a/packages/wrangler/src/__tests__/autoconfig/frameworks/react-router.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/frameworks/react-router.test.ts
@@ -1,0 +1,392 @@
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import * as cliPackages from "@cloudflare/cli-shared-helpers/packages";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
+import { beforeEach, describe, it, vi } from "vitest";
+import {
+	hasV8MiddlewareFlag,
+	ReactRouter,
+} from "../../../autoconfig/frameworks/react-router";
+import * as packagesUtils from "../../../autoconfig/frameworks/utils/packages";
+import { NpmPackageManager } from "../../../package-manager";
+
+vi.mock("../../../autoconfig/frameworks/utils/vite-config", () => ({
+	transformViteConfig: vi.fn(),
+}));
+
+vi.mock("../../../autoconfig/frameworks/utils/vite-plugin", () => ({
+	installCloudflareVitePlugin: vi.fn(),
+}));
+
+vi.mock("../../../autoconfig/frameworks/utils/packages", () => ({
+	getInstalledPackageVersion: vi.fn(),
+	isPackageInstalled: vi.fn(() => true),
+}));
+
+function getBaseOptions() {
+	return {
+		projectPath: process.cwd(),
+		outputDir: "build/",
+		workerName: "my-react-router-app",
+		dryRun: false,
+		packageManager: NpmPackageManager,
+		isWorkspaceRoot: false,
+	};
+}
+
+function createFramework(version: string): ReactRouter {
+	vi.mocked(packagesUtils.getInstalledPackageVersion).mockReturnValue(version);
+
+	const framework = new ReactRouter({
+		id: "react-router",
+		name: "React Router",
+	});
+
+	framework.validateFrameworkVersion(".", {
+		name: "react-router",
+		minimumVersion: "7.0.0",
+		maximumKnownMajorVersion: "7",
+	});
+
+	return framework;
+}
+
+async function seedProjectFiles(options?: {
+	withMiddlewareFlag?: boolean;
+	withFutureBlock?: boolean;
+}) {
+	await mkdir(resolve("app"), { recursive: true });
+
+	let configContent: string;
+	if (options?.withMiddlewareFlag) {
+		configContent = `import type { Config } from "@react-router/dev/config";
+export default {
+  ssr: true,
+  future: {
+    v8_middleware: true,
+  },
+} satisfies Config;
+`;
+	} else if (options?.withFutureBlock) {
+		configContent = `import type { Config } from "@react-router/dev/config";
+export default {
+  ssr: true,
+  future: {
+    v8_splitRouteModules: true,
+  },
+} satisfies Config;
+`;
+	} else {
+		configContent = `import type { Config } from "@react-router/dev/config";
+export default {
+  ssr: true,
+} satisfies Config;
+`;
+	}
+
+	await writeFile(resolve("react-router.config.ts"), configContent);
+	await writeFile(
+		resolve("vite.config.ts"),
+		`import { defineConfig } from 'vite';
+export default defineConfig({ plugins: [] });
+`
+	);
+}
+
+describe("hasV8MiddlewareFlag()", () => {
+	runInTempDir();
+
+	it("returns false when no config file exists", ({ expect }) => {
+		expect(hasV8MiddlewareFlag(process.cwd())).toBe(false);
+	});
+
+	it("returns false when config has no future block", async ({ expect }) => {
+		await seedProjectFiles();
+		expect(hasV8MiddlewareFlag(process.cwd())).toBe(false);
+	});
+
+	it("returns false when future block does not contain v8_middleware", async ({
+		expect,
+	}) => {
+		await seedProjectFiles({ withFutureBlock: true });
+		expect(hasV8MiddlewareFlag(process.cwd())).toBe(false);
+	});
+
+	it("returns true when v8_middleware is set to true", async ({ expect }) => {
+		await seedProjectFiles({ withMiddlewareFlag: true });
+		expect(hasV8MiddlewareFlag(process.cwd())).toBe(true);
+	});
+
+	it("returns false when v8_middleware is set to false", async ({ expect }) => {
+		await writeFile(
+			resolve("react-router.config.ts"),
+			`import type { Config } from "@react-router/dev/config";
+export default {
+  ssr: true,
+  future: {
+    v8_middleware: false,
+  },
+} satisfies Config;
+`
+		);
+		expect(hasV8MiddlewareFlag(process.cwd())).toBe(false);
+	});
+
+	it("handles plain object export without satisfies", async ({ expect }) => {
+		await writeFile(
+			resolve("react-router.config.ts"),
+			`export default {
+  ssr: true,
+  future: {
+    v8_middleware: true,
+  },
+};
+`
+		);
+		expect(hasV8MiddlewareFlag(process.cwd())).toBe(true);
+	});
+
+	it("returns false when config file has syntax errors", async ({ expect }) => {
+		await writeFile(
+			resolve("react-router.config.ts"),
+			`export default { this is not valid syntax`
+		);
+		expect(hasV8MiddlewareFlag(process.cwd())).toBe(false);
+	});
+
+	it("detects v8_middleware inside a `satisfies Config` expression", async ({
+		expect,
+	}) => {
+		await writeFile(
+			resolve("react-router.config.ts"),
+			`import type { Config } from "@react-router/dev/config";
+export default {
+  ssr: true,
+  future: {
+    v8_middleware: true,
+    v8_splitRouteModules: true,
+  },
+} satisfies Config;
+`
+		);
+		expect(hasV8MiddlewareFlag(process.cwd())).toBe(true);
+	});
+});
+
+describe("React Router framework configure()", () => {
+	runInTempDir();
+
+	beforeEach(() => {
+		vi.spyOn(cliPackages, "installPackages").mockImplementation(async () => {});
+	});
+
+	describe("workers/app.ts generation — without v8_middleware", () => {
+		beforeEach(async () => {
+			await seedProjectFiles();
+		});
+
+		it("creates workers/app.ts with AppLoadContext augmentation", async ({
+			expect,
+		}) => {
+			const framework = createFramework("7.16.0");
+			await framework.configure(getBaseOptions());
+
+			const content = readFileSync(resolve("workers/app.ts"), "utf-8");
+			expect(content).toContain("AppLoadContext");
+			expect(content).toContain("declare module");
+			expect(content).toContain("cloudflare: { env, ctx }");
+			expect(content).toContain("async fetch(request, env, ctx)");
+			expect(content).toContain("satisfies ExportedHandler<Env>");
+		});
+	});
+
+	describe("workers/app.ts generation — with v8_middleware", () => {
+		beforeEach(async () => {
+			await seedProjectFiles({ withMiddlewareFlag: true });
+		});
+
+		it("creates workers/app.ts without AppLoadContext augmentation", async ({
+			expect,
+		}) => {
+			const framework = createFramework("7.16.0");
+			await framework.configure(getBaseOptions());
+
+			const content = readFileSync(resolve("workers/app.ts"), "utf-8");
+			expect(content).not.toContain("AppLoadContext");
+			expect(content).not.toContain("declare module");
+			expect(content).toContain(
+				'import { createRequestHandler } from "react-router"'
+			);
+			expect(content).toContain("requestHandler(request)");
+			expect(content).toContain("satisfies ExportedHandler<Env>");
+		});
+
+		it("creates workers/app.ts with a simple fetch handler", async ({
+			expect,
+		}) => {
+			const framework = createFramework("7.16.0");
+			await framework.configure(getBaseOptions());
+
+			const content = readFileSync(resolve("workers/app.ts"), "utf-8");
+			expect(content).toContain("async fetch(request)");
+			expect(content).not.toContain("env, ctx");
+			expect(content).not.toContain("cloudflare: { env, ctx }");
+		});
+	});
+
+	describe("entry.server.tsx generation — without v8_middleware", () => {
+		beforeEach(async () => {
+			await seedProjectFiles();
+		});
+
+		it("creates entry.server.tsx with AppLoadContext", async ({ expect }) => {
+			const framework = createFramework("7.16.0");
+			await framework.configure(getBaseOptions());
+
+			const content = readFileSync(resolve("app/entry.server.tsx"), "utf-8");
+			expect(content).toContain("AppLoadContext");
+			expect(content).toContain("_loadContext: AppLoadContext");
+			expect(content).toContain(
+				'import type { AppLoadContext, EntryContext } from "react-router"'
+			);
+		});
+	});
+
+	describe("entry.server.tsx generation — with v8_middleware", () => {
+		beforeEach(async () => {
+			await seedProjectFiles({ withMiddlewareFlag: true });
+		});
+
+		it("creates entry.server.tsx without AppLoadContext", async ({
+			expect,
+		}) => {
+			const framework = createFramework("7.16.0");
+			await framework.configure(getBaseOptions());
+
+			const content = readFileSync(resolve("app/entry.server.tsx"), "utf-8");
+			expect(content).not.toContain("AppLoadContext");
+			expect(content).not.toContain("_loadContext");
+			expect(content).toContain(
+				'import type { EntryContext } from "react-router"'
+			);
+			expect(content).toContain("ServerRouter");
+			expect(content).toContain("renderToReadableStream");
+		});
+	});
+
+	describe("entry.server.tsx — existing file not overwritten", () => {
+		beforeEach(async () => {
+			await seedProjectFiles({ withMiddlewareFlag: true });
+		});
+
+		it("does not overwrite existing entry.server.tsx", async ({ expect }) => {
+			const existingContent = "// existing entry server";
+			await mkdir(resolve("app"), { recursive: true });
+			await writeFile(resolve("app/entry.server.tsx"), existingContent);
+
+			const framework = createFramework("7.16.0");
+			await framework.configure(getBaseOptions());
+
+			const content = readFileSync(resolve("app/entry.server.tsx"), "utf-8");
+			expect(content).toBe(existingContent);
+		});
+	});
+
+	describe("react-router.config.ts transformation", () => {
+		it("adds v8_viteEnvironmentApi for React Router >= 7.10.0", async ({
+			expect,
+		}) => {
+			await seedProjectFiles();
+
+			const framework = createFramework("7.16.0");
+			await framework.configure(getBaseOptions());
+
+			const content = readFileSync(resolve("react-router.config.ts"), "utf-8");
+			expect(content).toContain("v8_viteEnvironmentApi: true");
+			// Should NOT add other v8 flags
+			expect(content).not.toContain("v8_middleware");
+			expect(content).not.toContain("v8_splitRouteModules");
+			expect(content).not.toContain("v8_passThroughRequests");
+			expect(content).not.toContain("v8_trailingSlashAwareDataRequests");
+		});
+
+		it("uses unstable_viteEnvironmentApi for React Router < 7.10.0", async ({
+			expect,
+		}) => {
+			await seedProjectFiles();
+
+			const framework = createFramework("7.9.0");
+			await framework.configure(getBaseOptions());
+
+			const content = readFileSync(resolve("react-router.config.ts"), "utf-8");
+			expect(content).toContain("unstable_viteEnvironmentApi: true");
+			expect(content).not.toContain("v8_viteEnvironmentApi");
+		});
+
+		it("preserves existing future flags when adding viteEnvironmentApi", async ({
+			expect,
+		}) => {
+			await seedProjectFiles({ withMiddlewareFlag: true });
+
+			const framework = createFramework("7.16.0");
+			await framework.configure(getBaseOptions());
+
+			const content = readFileSync(resolve("react-router.config.ts"), "utf-8");
+			// Existing flag preserved
+			expect(content).toContain("v8_middleware: true");
+			// New flag added
+			expect(content).toContain("v8_viteEnvironmentApi: true");
+		});
+	});
+
+	describe("dry run", () => {
+		it("does not create files in dry run mode", async ({ expect }) => {
+			const framework = createFramework("7.16.0");
+			const result = await framework.configure({
+				...getBaseOptions(),
+				dryRun: true,
+			});
+
+			expect(result.wranglerConfig).toEqual({
+				main: "./workers/app.ts",
+			});
+			expect(existsSync(resolve("workers/app.ts"))).toBe(false);
+			expect(existsSync(resolve("app/entry.server.tsx"))).toBe(false);
+		});
+	});
+
+	describe("wrangler config", () => {
+		beforeEach(async () => {
+			await seedProjectFiles();
+		});
+
+		it("returns wrangler config with main pointing to workers/app.ts", async ({
+			expect,
+		}) => {
+			const framework = createFramework("7.16.0");
+			const result = await framework.configure(getBaseOptions());
+
+			expect(result.wranglerConfig).toEqual({
+				main: "./workers/app.ts",
+			});
+		});
+	});
+
+	describe("package installation", () => {
+		beforeEach(async () => {
+			await seedProjectFiles();
+		});
+
+		it("installs isbot as a dev dependency", async ({ expect }) => {
+			const framework = createFramework("7.16.0");
+			await framework.configure(getBaseOptions());
+
+			expect(cliPackages.installPackages).toHaveBeenCalledWith(
+				NpmPackageManager.type,
+				["isbot"],
+				expect.objectContaining({ dev: true })
+			);
+		});
+	});
+});

--- a/packages/wrangler/src/__tests__/tsconfig.json
+++ b/packages/wrangler/src/__tests__/tsconfig.json
@@ -5,5 +5,6 @@
 		"types": ["node"],
 		"jsx": "preserve"
 	},
-	"include": ["../*.d.ts", "**/*.ts", "**/*.tsx", "**/*.js"]
+	"include": ["../*.d.ts", "**/*.ts", "**/*.tsx", "**/*.js"],
+	"exclude": ["**/fixtures"]
 }

--- a/packages/wrangler/src/autoconfig/frameworks/react-router.ts
+++ b/packages/wrangler/src/autoconfig/frameworks/react-router.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { brandColor, dim } from "@cloudflare/cli-shared-helpers/colors";
 import { installPackages } from "@cloudflare/cli-shared-helpers/packages";
-import { transformFile } from "@cloudflare/codemod";
+import { parseFile, transformFile } from "@cloudflare/codemod";
 import * as recast from "recast";
 import semiver from "semiver";
 import dedent from "ts-dedent";
@@ -15,23 +15,123 @@ import type {
 	ConfigurationOptions,
 	ConfigurationResults,
 } from "./framework-class";
+import type { Program } from "esprima";
 
 const b = recast.types.builders;
 
+/**
+ * Resolves the path to the React Router config file (`react-router.config.ts` or `.js`)
+ * in the given project directory.
+ *
+ * @param projectPath - Absolute path to the project root.
+ * @returns The resolved config file path, or `null` if neither `.ts` nor `.js` variant exists.
+ */
+function getReactRouterConfigPath(projectPath: string): string | null {
+	const filePathTS = path.join(projectPath, "react-router.config.ts");
+	const filePathJS = path.join(projectPath, "react-router.config.js");
+
+	if (existsSync(filePathTS)) {
+		return filePathTS;
+	}
+
+	if (existsSync(filePathJS)) {
+		return filePathJS;
+	}
+
+	return null;
+}
+
+/**
+ * Checks whether the user's `react-router.config.ts` (or `.js`) has `v8_middleware: true`
+ * set in its `future` block. This determines which code pattern to generate:
+ * - With middleware: simplified fetch handler using `cloudflare:workers` env pattern
+ * - Without middleware: traditional `AppLoadContext` pattern with `env`/`ctx` params
+ *
+ * Parses the config file read-only (via `parseFile`) without writing anything to disk.
+ * Handles both TS `satisfies`/`as` expressions and plain object exports.
+ *
+ * @param projectPath - Absolute path to the project root containing the React Router config file.
+ * @returns `true` if `future.v8_middleware` is explicitly set to `true`, `false` otherwise
+ *   (including when the config file is missing or has no `future` block).
+ */
+export function hasV8MiddlewareFlag(projectPath: string): boolean {
+	const filePath = getReactRouterConfigPath(projectPath);
+	if (!filePath) {
+		return false;
+	}
+
+	let ast: Program | null = null;
+	try {
+		ast = parseFile(filePath);
+	} catch {}
+
+	if (!ast) {
+		return false;
+	}
+
+	let found = false;
+	recast.visit(ast, {
+		visitExportDefaultDeclaration(n) {
+			let node: recast.types.namedTypes.ObjectExpression | null = null;
+			if (
+				(n.node.declaration.type === "TSAsExpression" ||
+					n.node.declaration.type === "TSSatisfiesExpression") &&
+				n.node.declaration.expression.type === "ObjectExpression"
+			) {
+				node = n.node.declaration.expression;
+			} else if (n.node.declaration.type === "ObjectExpression") {
+				node = n.node.declaration;
+			}
+
+			if (node) {
+				const futureProp = node.properties.find(
+					(p) =>
+						p.type === "ObjectProperty" &&
+						p.key.type === "Identifier" &&
+						p.key.name === "future" &&
+						p.value.type === "ObjectExpression"
+				);
+				if (
+					futureProp?.type === "ObjectProperty" &&
+					futureProp.value.type === "ObjectExpression"
+				) {
+					found = futureProp.value.properties.some(
+						(p) =>
+							p.type === "ObjectProperty" &&
+							p.key.type === "Identifier" &&
+							p.key.name === "v8_middleware" &&
+							p.value.type === "BooleanLiteral" &&
+							p.value.value === true
+					);
+				}
+			}
+			return false;
+		},
+	});
+
+	return found;
+}
+
+/**
+ * Transforms the user's `react-router.config.ts` (or `.js`) to ensure the
+ * `future.unstable_viteEnvironmentApi` or `future.v8_viteEnvironmentApi` flag
+ * is set to `true`. If a `future` block already exists, the flag is added or
+ * updated in place; otherwise a new `future` block is created.
+ *
+ * Supports TS `as` and `satisfies` expressions wrapping the default export object.
+ *
+ * @param projectPath - Absolute path to the project root containing the React Router config file.
+ * @param viteEnvironmentKey - The config property name to set, either
+ *   `"unstable_viteEnvironmentApi"` (React Router < 7.10.0) or `"v8_viteEnvironmentApi"`.
+ * @throws {Error} If no `react-router.config.ts` or `.js` file exists in the project.
+ * @throws {Error} If the default export cannot be parsed as an object expression.
+ */
 function transformReactRouterConfig(
 	projectPath: string,
 	viteEnvironmentKey: ReturnType<typeof configPropertyName>
 ) {
-	const filePathTS = path.join(projectPath, `react-router.config.ts`);
-	const filePathJS = path.join(projectPath, `react-router.config.js`);
-
-	let filePath: string;
-
-	if (existsSync(filePathTS)) {
-		filePath = filePathTS;
-	} else if (existsSync(filePathJS)) {
-		filePath = filePathJS;
-	} else {
+	const filePath = getReactRouterConfigPath(projectPath);
+	if (!filePath) {
 		throw new Error("Could not find React Router config file to modify");
 	}
 
@@ -127,6 +227,15 @@ function transformReactRouterConfig(
 	});
 }
 
+/**
+ * Returns the correct future flag property name for enabling the Vite Environment API
+ * based on the installed React Router version.
+ *
+ * @param reactRouterVersion - The installed React Router semver version string (e.g. `"7.16.0"`).
+ *   When empty, defaults to the stable `"v8_viteEnvironmentApi"` name.
+ * @returns `"unstable_viteEnvironmentApi"` for versions before 7.10.0,
+ *   or `"v8_viteEnvironmentApi"` for 7.10.0 and later.
+ */
 function configPropertyName(reactRouterVersion: string) {
 	if (!reactRouterVersion) {
 		return "v8_viteEnvironmentApi";
@@ -140,6 +249,184 @@ function configPropertyName(reactRouterVersion: string) {
 	}
 }
 
+/**
+ * Writes the `workers/app.ts` Worker entry point. When `v8_middleware` is enabled,
+ * generates a simplified fetch handler that delegates directly to the request handler.
+ * Otherwise generates the traditional pattern with `AppLoadContext` module augmentation
+ * and explicit `env`/`ctx` forwarding.
+ *
+ * @param useMiddlewarePattern - Whether `v8_middleware` is enabled in the user's config.
+ */
+function writeAppTs(useMiddlewarePattern: boolean) {
+	if (useMiddlewarePattern) {
+		writeFileSync(
+			"workers/app.ts",
+			dedent /* javascript */ `
+				import { createRequestHandler } from "react-router";
+
+				const requestHandler = createRequestHandler(
+					() => import("virtual:react-router/server-build"),
+					import.meta.env.MODE,
+				);
+
+				export default {
+					async fetch(request) {
+						return requestHandler(request);
+					},
+				} satisfies ExportedHandler<Env>;
+			`
+		);
+		return;
+	}
+
+	writeFileSync(
+		"workers/app.ts",
+		dedent /* javascript */ `
+				import { createRequestHandler } from "react-router";
+
+				declare module "react-router" {
+					export interface AppLoadContext {
+						cloudflare: {
+							env: Env;
+							ctx: ExecutionContext;
+						};
+					}
+				}
+
+				const requestHandler = createRequestHandler(
+					() => import("virtual:react-router/server-build"),
+					import.meta.env.MODE
+				);
+
+				export default {
+					async fetch(request, env, ctx) {
+						return requestHandler(request, {
+							cloudflare: { env, ctx },
+						});
+					},
+				} satisfies ExportedHandler<Env>;
+			`
+	);
+}
+
+/**
+ * Writes `app/entry.server.tsx` if it does not already exist. When `v8_middleware`
+ * is enabled, the generated file omits the `AppLoadContext` import and `_loadContext`
+ * parameter. Otherwise uses the traditional signature that includes both.
+ *
+ * If the file already exists on disk it is left untouched and a warning is logged.
+ *
+ * @param useMiddlewarePattern - Whether `v8_middleware` is enabled in the user's config.
+ */
+function writeEntryServerTsx(useMiddlewarePattern: boolean) {
+	if (existsSync("app/entry.server.tsx")) {
+		logger.warn(
+			"The file `app/entry.server.tsx` already exists on disk, and so we're not modifying it. This may lead to deployment failures if `app/entry.server.tsx` is not set up correctly."
+		);
+		return;
+	}
+
+	if (useMiddlewarePattern) {
+		writeFileSync(
+			`app/entry.server.tsx`,
+			dedent /* javascript */ `
+			import type { EntryContext } from "react-router";
+			import { ServerRouter } from "react-router";
+			import { isbot } from "isbot";
+			import { renderToReadableStream } from "react-dom/server";
+
+			export default async function handleRequest(
+				request: Request,
+				responseStatusCode: number,
+				responseHeaders: Headers,
+				routerContext: EntryContext,
+			) {
+				let shellRendered = false;
+				const userAgent = request.headers.get("user-agent");
+
+				const body = await renderToReadableStream(
+					<ServerRouter context={routerContext} url={request.url} />,
+					{
+						onError(error: unknown) {
+							responseStatusCode = 500;
+							// Log streaming rendering errors from inside the shell.  Don't log
+							// errors encountered during initial shell rendering since they'll
+							// reject and get logged in handleDocumentRequest.
+							if (shellRendered) {
+								console.error(error);
+							}
+						},
+					},
+				);
+				shellRendered = true;
+
+				// Ensure requests from bots and SPA Mode renders wait for all content to load before responding
+				// https://react.dev/reference/react-dom/server/renderToPipeableStream#waiting-for-all-content-to-load-for-crawlers-and-static-generation
+				if ((userAgent && isbot(userAgent)) || routerContext.isSpaMode) {
+					await body.allReady;
+				}
+
+				responseHeaders.set("Content-Type", "text/html");
+				return new Response(body, {
+					headers: responseHeaders,
+					status: responseStatusCode,
+				});
+			}
+		`
+		);
+		return;
+	}
+
+	writeFileSync(
+		`app/entry.server.tsx`,
+		dedent /* javascript */ `
+			import type { AppLoadContext, EntryContext } from "react-router";
+			import { ServerRouter } from "react-router";
+			import { isbot } from "isbot";
+			import { renderToReadableStream } from "react-dom/server";
+
+			export default async function handleRequest(
+				request: Request,
+				responseStatusCode: number,
+				responseHeaders: Headers,
+				routerContext: EntryContext,
+				_loadContext: AppLoadContext
+			) {
+				let shellRendered = false;
+				const userAgent = request.headers.get("user-agent");
+
+				const body = await renderToReadableStream(
+					<ServerRouter context={routerContext} url={request.url} />,
+					{
+						onError(error: unknown) {
+							responseStatusCode = 500;
+							// Log streaming rendering errors from inside the shell.  Don't log
+							// errors encountered during initial shell rendering since they'll
+							// reject and get logged in handleDocumentRequest.
+							if (shellRendered) {
+								console.error(error);
+							}
+						},
+					}
+				);
+				shellRendered = true;
+
+				// Ensure requests from bots and SPA Mode renders wait for all content to load before responding
+				// https://react.dev/reference/react-dom/server/renderToPipeableStream#waiting-for-all-content-to-load-for-crawlers-and-static-generation
+				if ((userAgent && isbot(userAgent)) || routerContext.isSpaMode) {
+					await body.allReady;
+				}
+
+				responseHeaders.set("Content-Type", "text/html");
+				return new Response(body, {
+					headers: responseHeaders,
+					status: responseStatusCode,
+				});
+			}
+		`
+	);
+}
+
 export class ReactRouter extends Framework {
 	async configure({
 		dryRun,
@@ -148,6 +435,7 @@ export class ReactRouter extends Framework {
 		isWorkspaceRoot,
 	}: ConfigurationOptions): Promise<ConfigurationResults> {
 		const viteEnvironmentKey = configPropertyName(this.frameworkVersion);
+		const useMiddlewarePattern = hasV8MiddlewareFlag(projectPath);
 		if (!dryRun) {
 			await installCloudflareVitePlugin({
 				packageManager: packageManager.type,
@@ -157,34 +445,7 @@ export class ReactRouter extends Framework {
 
 			mkdirSync("workers");
 
-			writeFileSync(
-				"workers/app.ts",
-				dedent /* javascript */ `
-					import { createRequestHandler } from "react-router";
-
-					declare module "react-router" {
-						export interface AppLoadContext {
-							cloudflare: {
-								env: Env;
-								ctx: ExecutionContext;
-							};
-						}
-					}
-
-					const requestHandler = createRequestHandler(
-						() => import("virtual:react-router/server-build"),
-						import.meta.env.MODE
-					);
-
-					export default {
-						async fetch(request, env, ctx) {
-							return requestHandler(request, {
-								cloudflare: { env, ctx },
-							});
-						},
-					} satisfies ExportedHandler<Env>;
-				`
-			);
+			writeAppTs(useMiddlewarePattern);
 
 			await installPackages(packageManager.type, ["isbot"], {
 				dev: true,
@@ -193,60 +454,7 @@ export class ReactRouter extends Framework {
 				isWorkspaceRoot,
 			});
 
-			if (!existsSync("app/entry.server.tsx")) {
-				writeFileSync(
-					`app/entry.server.tsx`,
-					dedent /* javascript */ `
-					import type { AppLoadContext, EntryContext } from "react-router";
-					import { ServerRouter } from "react-router";
-					import { isbot } from "isbot";
-					import { renderToReadableStream } from "react-dom/server";
-
-					export default async function handleRequest(
-						request: Request,
-						responseStatusCode: number,
-						responseHeaders: Headers,
-						routerContext: EntryContext,
-						_loadContext: AppLoadContext
-					) {
-						let shellRendered = false;
-						const userAgent = request.headers.get("user-agent");
-
-						const body = await renderToReadableStream(
-							<ServerRouter context={routerContext} url={request.url} />,
-							{
-								onError(error: unknown) {
-									responseStatusCode = 500;
-									// Log streaming rendering errors from inside the shell.  Don't log
-									// errors encountered during initial shell rendering since they'll
-									// reject and get logged in handleDocumentRequest.
-									if (shellRendered) {
-										console.error(error);
-									}
-								},
-							}
-						);
-						shellRendered = true;
-
-						// Ensure requests from bots and SPA Mode renders wait for all content to load before responding
-						// https://react.dev/reference/react-dom/server/renderToPipeableStream#waiting-for-all-content-to-load-for-crawlers-and-static-generation
-						if ((userAgent && isbot(userAgent)) || routerContext.isSpaMode) {
-							await body.allReady;
-						}
-
-						responseHeaders.set("Content-Type", "text/html");
-						return new Response(body, {
-							headers: responseHeaders,
-							status: responseStatusCode,
-						});
-					}
-				`
-				);
-			} else {
-				logger.warn(
-					"The file `app/entry.server.tsx` already exists on disk, and so we're not modifying it. This may lead to deployment failures if `app/entry.server.tsx` is not set up correctly."
-				);
-			}
+			writeEntryServerTsx(useMiddlewarePattern);
 
 			transformViteConfig(projectPath, {
 				viteEnvironmentName: "ssr",


### PR DESCRIPTION
Fixes the broken C3 React Router experimental E2E.
(The E2E was broken because ReactRouter introduced the use of the flag in their starter templates in https://github.com/remix-run/react-router-templates/pull/210 which breaks the Cloudflare integration)

The React Router autoconfig (`wrangler setup`) now detects whether `v8_middleware: true` is set in the user's `react-router.config.ts`. When it is, the generated `workers/app.ts` uses a simplified fetch handler without `AppLoadContext` module augmentation, and the generated `app/entry.server.tsx` omits the `_loadContext` parameter. When `v8_middleware` is not set, the existing `AppLoadContext` pattern with `env`/`ctx` params is preserved.

This avoids breaking projects that use the `v8_middleware` future flag (which changes the context API from `AppLoadContext` to `RouterContextProvider`), while keeping the traditional pattern for projects that haven't opted in.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: self-explanatory fix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
