### PR TITLE
[wrangler] fix: remove trailing period after api-tokens URL in wrangler whoami output

### DIFF
--- a/.changeset/whoami-trailing-period.md
+++ b/.changeset/whoami-trailing-period.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler whoami` printing a trailing period after the api-tokens URL
+
+The message `To see token permissions visit https://...api-tokens.` ended with
+a period that became part of the URL when clicked in terminals or GitHub Actions
+output, causing a 404. The period is removed and a comma added before "visit"
+so the sentence reads naturally without a trailing period on the URL.

--- a/packages/wrangler/src/__tests__/deploy/core.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/core.test.ts
@@ -529,7 +529,7 @@ describe("deploy", () => {
 			├─┼─┤
 			│ Account Three │ account-3 │
 			└─┴─┘
-			🔓 To see token permissions visit https://dash.cloudflare.com/profile/api-tokens.",
+			🔓 To see token permissions, visit https://dash.cloudflare.com/profile/api-tokens",
 			  "warn": "",
 			}
 		`);

--- a/packages/wrangler/src/user/whoami.ts
+++ b/packages/wrangler/src/user/whoami.ts
@@ -170,7 +170,7 @@ function printTokenPermissions(user: UserInfo) {
 		user.tokenPermissions?.map((scope) => scope.split(":")) ?? [];
 	if (user.authType !== "OAuth Token") {
 		return void logger.log(
-			`🔓 To see token permissions visit https://dash.cloudflare.com/${user.authType === "User API Token" ? "profile" : user.accounts[0].id}/api-tokens.`
+			`🔓 To see token permissions, visit https://dash.cloudflare.com/${user.authType === "User API Token" ? "profile" : user.accounts[0].id}/api-tokens`
 		);
 	}
 	logger.log(`🔓 Token Permissions:`);


### PR DESCRIPTION
Fixes #14102.

## What this does

`wrangler whoami` was printing:

```
🔓 To see token permissions visit https://dash.cloudflare.com/.../api-tokens.
```

The trailing `.` became part of the URL when clicked in terminals and
GitHub Actions output, causing a 404.

**Before:** `...api-tokens.` (period is part of the clickable URL)
**After:** `...api-tokens` (period removed; comma added before "visit")

## Tests
- [x] Tests included/updated — updated inline snapshot in `deploy/core.test.ts`; all 20 `whoami.test.ts` tests pass

## Documentation
- [x] Documentation not necessary because: single-character output fix, no new API surface