### PR TITLE
tools: use esbuild to extract bare imports in dist validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"check:fixtures": "node -r esbuild-register tools/deployments/validate-fixtures.ts",
 		"check:format": "oxfmt --check",
 		"check:lint": "oxlint --deny-warnings --type-aware",
-		"check:package-deps": "node -r esbuild-register tools/deployments/validate-package-dependencies.ts",
+		"check:package-deps": "pnpm build && node -r esbuild-register tools/deployments/validate-package-dependencies.ts",
 		"check:private-packages": "node -r esbuild-register tools/deployments/validate-private-packages.ts",
 		"check:type": "dotenv -- turbo check:type type:tests",
 		"check:workflows": "node -r esbuild-register tools/github-workflow-helpers/validate-action-pinning.ts",

--- a/tools/deployments/__tests__/validate-package-dependencies.test.ts
+++ b/tools/deployments/__tests__/validate-package-dependencies.test.ts
@@ -379,18 +379,6 @@ describe("isBareSpecifier()", () => {
 		expect(isBareSpecifier("__BUILD_CONFIG")).toBe(false);
 	});
 
-	it("should reject template-literal expressions in specifiers", ({
-		expect,
-	}) => {
-		expect(isBareSpecifier("${moduleName}")).toBe(false);
-		expect(isBareSpecifier("foo/${bar}")).toBe(false);
-	});
-
-	it("should reject specifiers with wildcards", ({ expect }) => {
-		expect(isBareSpecifier("*")).toBe(false);
-		expect(isBareSpecifier("foo/*")).toBe(false);
-	});
-
 	it("should reject specifiers that are not package-name shaped", ({
 		expect,
 	}) => {
@@ -401,105 +389,146 @@ describe("isBareSpecifier()", () => {
 });
 
 describe("extractBareImports()", () => {
-	it("should extract named imports", ({ expect }) => {
-		const imports = extractBareImports(`import { x } from "lodash";`);
+	it("should extract named imports", async ({ expect }) => {
+		const imports = await extractBareImports(`import { x } from "lodash";`);
 		expect([...imports]).toEqual(["lodash"]);
 	});
 
-	it("should extract default imports", ({ expect }) => {
-		const imports = extractBareImports(`import x from "lodash";`);
+	it("should extract default imports", async ({ expect }) => {
+		const imports = await extractBareImports(`import x from "lodash";`);
 		expect([...imports]).toEqual(["lodash"]);
 	});
 
-	it("should extract namespace imports", ({ expect }) => {
-		const imports = extractBareImports(`import * as x from "lodash";`);
+	it("should extract namespace imports", async ({ expect }) => {
+		const imports = await extractBareImports(`import * as x from "lodash";`);
 		expect([...imports]).toEqual(["lodash"]);
 	});
 
-	it("should extract side-effect imports", ({ expect }) => {
-		const imports = extractBareImports(`import "lodash";`);
+	it("should extract side-effect imports", async ({ expect }) => {
+		const imports = await extractBareImports(`import "lodash";`);
 		expect([...imports]).toEqual(["lodash"]);
 	});
 
-	it("should extract re-exports", ({ expect }) => {
-		const imports = extractBareImports(`export { x } from "lodash";`);
+	it("should extract re-exports", async ({ expect }) => {
+		const imports = await extractBareImports(`export { x } from "lodash";`);
 		expect([...imports]).toEqual(["lodash"]);
 	});
 
-	it("should extract require() calls", ({ expect }) => {
-		const imports = extractBareImports(
+	it("should extract require() calls", async ({ expect }) => {
+		const imports = await extractBareImports(
 			`const x = require("lodash"); require("foo");`
 		);
 		expect([...imports].sort()).toEqual(["foo", "lodash"]);
 	});
 
-	it("should extract dynamic import() calls with string literals", ({
+	it("should extract dynamic import() calls with string literals", async ({
 		expect,
 	}) => {
-		const imports = extractBareImports(`const x = await import("lodash");`);
+		const imports = await extractBareImports(
+			`const x = await import("lodash");`
+		);
 		expect([...imports]).toEqual(["lodash"]);
 	});
 
-	it("should strip subpath imports down to package name", ({ expect }) => {
-		const imports = extractBareImports(
+	it("should strip subpath imports down to package name", async ({
+		expect,
+	}) => {
+		const imports = await extractBareImports(
 			`import x from "semver/functions/satisfies.js";`
 		);
 		expect([...imports]).toEqual(["semver"]);
 	});
 
-	it("should skip relative imports", ({ expect }) => {
-		const imports = extractBareImports(
+	it("should skip relative imports", async ({ expect }) => {
+		const imports = await extractBareImports(
 			`import x from "./foo"; import y from "../bar";`
 		);
 		expect([...imports]).toEqual([]);
 	});
 
-	it("should skip Node built-in imports", ({ expect }) => {
-		const imports = extractBareImports(
+	it("should skip Node built-in imports", async ({ expect }) => {
+		const imports = await extractBareImports(
 			`import fs from "node:fs"; const path = require("node:path");`
 		);
 		expect([...imports]).toEqual([]);
 	});
 
-	it("should skip Cloudflare/workerd built-in imports", ({ expect }) => {
-		const imports = extractBareImports(
+	it("should skip Cloudflare/workerd built-in imports", async ({ expect }) => {
+		const imports = await extractBareImports(
 			`import { env } from "cloudflare:workers"; import x from "workerd:unsafe";`
 		);
 		expect([...imports]).toEqual([]);
 	});
 
-	it("should skip imports inside line comments", ({ expect }) => {
-		const imports = extractBareImports(
+	it("should skip imports inside line comments", async ({ expect }) => {
+		const imports = await extractBareImports(
 			`// import x from "lodash";\nimport y from "react";`
 		);
 		expect([...imports]).toEqual(["react"]);
 	});
 
-	it("should skip imports inside block comments", ({ expect }) => {
-		const imports = extractBareImports(
+	it("should skip imports inside block comments", async ({ expect }) => {
+		const imports = await extractBareImports(
 			`/* import x from "lodash"; */\nimport y from "react";`
 		);
 		expect([...imports]).toEqual(["react"]);
 	});
 
-	it("should not match `from` keywords that aren't part of import/export", ({
+	it("should skip imports inside template literals (regression: createViteConfig)", async ({
 		expect,
 	}) => {
-		const imports = extractBareImports(
+		// Regression test: wrangler's createViteConfig bundles the literal text
+		// of a vite.config.ts into a template literal. The regex-based scanner
+		// used to match `import { defineConfig } from "vite"` as a real import.
+		const imports = await extractBareImports(
+			[
+				"function createViteConfig() {",
+				'  const content = `import { cloudflare } from "@cloudflare/vite-plugin";',
+				'import { defineConfig } from "vite";',
+				"",
+				"export default defineConfig({",
+				"\tplugins: [cloudflare()],",
+				"});",
+				"`;",
+				"  return content;",
+				"}",
+				'import real from "react";',
+			].join("\n")
+		);
+		expect([...imports]).toEqual(["react"]);
+	});
+
+	it("should skip imports inside single- and double-quoted strings", async ({
+		expect,
+	}) => {
+		const imports = await extractBareImports(
+			[
+				'const a = "import { x } from \\"lodash\\";";',
+				"const b = 'import { y } from \"react\";';",
+				'import real from "commander";',
+			].join("\n")
+		);
+		expect([...imports]).toEqual(["commander"]);
+	});
+
+	it("should not match `from` keywords that aren't part of import/export", async ({
+		expect,
+	}) => {
+		const imports = await extractBareImports(
 			`function foo() { return "hello"; } const z = "from";`
 		);
 		expect([...imports]).toEqual([]);
 	});
 
-	it("should deduplicate imports", ({ expect }) => {
-		const imports = extractBareImports(
+	it("should deduplicate imports", async ({ expect }) => {
+		const imports = await extractBareImports(
 			`import { x } from "lodash";\nimport { y } from "lodash";`
 		);
 		expect([...imports]).toEqual(["lodash"]);
 	});
 
-	it("should handle multiple imports in one file", ({ expect }) => {
-		const imports = extractBareImports(`
+	it("should handle multiple imports in one file", async ({ expect }) => {
+		const imports = await extractBareImports(`
 			import { x } from "lodash";
 			import y from "react";
 			import "polyfill";

--- a/tools/deployments/validate-package-dependencies.ts
+++ b/tools/deployments/validate-package-dependencies.ts
@@ -24,6 +24,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { isBuiltin } from "node:module";
 import { dirname, resolve } from "node:path";
+import * as esbuild from "esbuild";
 import { glob } from "tinyglobby";
 
 export interface PackageJSON {
@@ -269,12 +270,6 @@ export function isBareSpecifier(spec: string): boolean {
 	if (/^__[A-Z][A-Z0-9_]*$/.test(spec)) {
 		return false;
 	}
-	// Specifiers containing template-literal expressions are dynamic strings
-	// that appear inside source-code templates emitted by Wrangler, not real
-	// imports of the wrapping package.
-	if (spec.includes("${") || spec.includes("*")) {
-		return false;
-	}
 	// Specifier must look like a valid npm package name: lowercase letters/digits,
 	// hyphens, dots, underscores; optionally scoped (@scope/name). npm package
 	// names cannot contain uppercase letters per the npm naming rules.
@@ -300,41 +295,44 @@ export function isBareSpecifier(spec: string): boolean {
  *
  * Returns top-level package names (e.g. "vitest" for "vitest/runtime").
  *
- * This is a regex-based scanner, not a real parser — it can produce false
- * positives when bundled output contains string literals that look like
- * import statements (e.g. JavaScript parser libraries shipped inside the
- * bundle). False positives are filtered downstream by `isBareSpecifier`
- * (rejecting non-package-shaped strings) and the self-import guard in
- * `validateDistImports`.
+ * Uses esbuild's parser (via a `bundle: true` build with everything marked
+ * external) so that specifiers found inside string literals, template
+ * literals, comments, etc. are correctly ignored. `bundle: true` is required
+ * to surface `require()` calls in the metafile — `bundle: false` only
+ * reports ESM `import` statements. The `externalize-all` plugin short-
+ * circuits resolution so esbuild never has to find the imports on disk.
  */
-export function extractBareImports(content: string): Set<string> {
+export async function extractBareImports(
+	content: string
+): Promise<Set<string>> {
 	const imports = new Set<string>();
 
-	// Strip line comments and block comments to avoid matching specs inside them.
-	// This is a deliberate approximation — sufficient for built/minified output.
-	const stripped = content
-		.replace(/\/\*[\s\S]*?\*\//g, "")
-		.replace(/\/\/[^\n]*/g, "");
+	const result = await esbuild.build({
+		stdin: { contents: content, loader: "js" },
+		metafile: true,
+		bundle: true,
+		write: false,
+		logLevel: "silent",
+		platform: "neutral",
+		plugins: [
+			{
+				name: "externalize-all",
+				setup(build) {
+					build.onResolve({ filter: /.*/ }, (args) => {
+						if (args.kind === "entry-point") {
+							return undefined;
+						}
+						return { path: args.path, external: true };
+					});
+				},
+			},
+		],
+	});
 
-	const patterns: RegExp[] = [
-		// import ... from "spec" / export ... from "spec"
-		// Anchored to a statement boundary (start of file, newline, `;`, or `}`)
-		// to avoid matching `from "x"` inside string literals.
-		/(?:^|[\n;}])\s*(?:import|export)\b[^"';\n]*?\bfrom\s*["']([^"'\n]+)["']/g,
-		// import "spec" (side-effect import) — also statement-anchored.
-		/(?:^|[\n;}])\s*import\s*["']([^"'\n]+)["']/g,
-		// require("spec")
-		/\brequire\s*\(\s*["']([^"'\n]+)["']\s*\)/g,
-		// import("spec") — only matches string literals
-		/\bimport\s*\(\s*["']([^"'\n]+)["']\s*\)/g,
-	];
-
-	for (const re of patterns) {
-		let m: RegExpExecArray | null;
-		while ((m = re.exec(stripped)) !== null) {
-			const spec = m[1];
-			if (isBareSpecifier(spec)) {
-				imports.add(getPackageNameFromSpecifier(spec));
+	for (const input of Object.values(result.metafile.inputs)) {
+		for (const imp of input.imports) {
+			if (isBareSpecifier(imp.path)) {
+				imports.add(getPackageNameFromSpecifier(imp.path));
 			}
 		}
 	}
@@ -441,7 +439,7 @@ export async function scanDistForExternalImports(
 			continue;
 		}
 		const content = readFileSync(file, "utf-8");
-		for (const imp of extractBareImports(content)) {
+		for (const imp of await extractBareImports(content)) {
 			imports.add(imp);
 		}
 	}


### PR DESCRIPTION
_The `check:package-deps` validator was reporting a false positive: it claimed `wrangler` imports `vite` in its published files. The "import" was actually inside a template literal — `createViteConfig()` in `packages/wrangler/src/autoconfig/frameworks/vite.ts` bundles the literal text of a `vite.config.ts` (including `import { defineConfig } from "vite"`) as a string to write out to disk. The regex-based scanner has no understanding of string contexts and treated it as a real import._

_Replace the regex scanner in `extractBareImports()` with an esbuild metafile-based parser, mirroring the existing pattern used by `guess-exports.ts` (vitest-pool-workers) and `guess-worker-format.ts` (wrangler). esbuild parses real JavaScript so string literals, template literals, comments, etc. are correctly ignored. Also tightens `check:package-deps` to run `pnpm build` first so the dist files actually exist when the validator scans them._

_One non-obvious gotcha discovered along the way: `bundle: false` only records ESM `import` statements in the metafile. To capture `require()` calls too, we need `bundle: true` with an `externalize-all` plugin that short-circuits resolution so esbuild never tries to find anything on disk. Documented in the function's JSDoc._

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal CI tooling only — no user-facing changes.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
