### PR TITLE
[vite-plugin] fix: resolve temp dir to long form in E2E tests (Windows)

### DIFF
--- a/packages/vite-plugin-cloudflare/e2e/global-setup.ts
+++ b/packages/vite-plugin-cloudflare/e2e/global-setup.ts
@@ -21,8 +21,14 @@ export default async function ({ provide }: TestProject) {
 		"@cloudflare/vite-plugin"
 	);
 
-	// Create temporary directory to host projects used for testing
-	const root = await fs.mkdtemp(path.join(os.tmpdir(), "vite-plugin-"));
+	// Create temporary directory to host projects used for testing.
+	// On Windows GitHub Actions runners, `os.tmpdir()` returns a path containing
+	// the 8.3 short name "RUNNER~1". Vite 8.0.16 (and the backports to v6/v7)
+	// rejects paths containing "~" or ":" as a security fix
+	// (https://github.com/vitejs/vite/pull/22572, GHSA-fx2h-pf6j-xcff), so we
+	// resolve the temp dir to its real long-form path first.
+	const tmpdir = await fs.realpath(os.tmpdir());
+	const root = await fs.mkdtemp(path.join(tmpdir, "vite-plugin-"));
 	debuglog("Created temporary directory at " + root);
 
 	// The type of the provided `root` is defined in the `ProvidedContent` type above.


### PR DESCRIPTION
_No tracking issue; surfaced via the Windows Vite Plugin E2E job spiking to ~100% failure rate on 2026-06-01._

Vite [8.0.16](https://github.com/vitejs/vite/releases/tag/v8.0.16) (published 2026-06-01 09:50 UTC) and its v6/v7 backports introduced a security fix ([vitejs/vite#22572](https://github.com/vitejs/vite/pull/22572), GHSA-fx2h-pf6j-xcff) that **rejects paths containing `~` or `:`** to prevent path traversal via NTFS Alternate Data Streams and Windows 8.3 short names.

On Windows GitHub Actions runners, `os.tmpdir()` returns:

```
C:\Users\RUNNER~1\AppData\Local\Temp
```

(`RUNNER~1` is the 8.3 short form of `runneradmin`.) Our Vite plugin E2E suite seeds every fixture under that path via `fs.mkdtemp(path.join(os.tmpdir(), "vite-plugin-"))` in `e2e/global-setup.ts`, so every Windows E2E test now fails immediately with:

```
Error: Failed to load url /api/index.ts
  (resolved id: C:/Users/RUNNER~1/AppData/Local/Temp/vite-plugin-j5N8yD/basic/pnpm/api/index.ts) in
```

Counts at the time of writing:

| Day | Successes | Failures |
| --- | ---: | ---: |
| May 31 | 9 | 0 |
| Jun 1 (so far) | 11* | 12 |

*the "passes" on Jun 1 after the regression are turbo remote-cache hits, not real runs.

This change resolves the temp dir to its real long-form path with `fs.realpath()` before passing it to `fs.mkdtemp()`. The expanded path no longer contains `~`, so Vite accepts it. No behaviour change on macOS/Linux (where `realpath(os.tmpdir())` either returns the same path or follows the `/var`→`/private/var` symlink on macOS, which is the correct full path anyway).

This matches the existing pattern in `packages/workers-utils/src/test-helpers/run-in-tmp.ts`, which already wraps `mkdtempSync` in `realpathSync`.

---

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: this fixes the E2E test harness itself — the existing E2E suite is the test. The CI run on this PR (Windows job in particular) is the verification. No new test could meaningfully cover "the test harness chooses a path Vite accepts" beyond running the suite.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal CI/test infrastructure fix with no user-visible behaviour change.
