### PR TITLE
[wrangler] Add re-authentication hint to account fetch errors

### DIFF
--- a/.changeset/add-reauth-hint-to-account-errors.md
+++ b/.changeset/add-reauth-hint-to-account-errors.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Add re-authentication hint to account fetch error messages
+
+When Wrangler fails to automatically retrieve account IDs, the error messages now suggest running `wrangler login` as a troubleshooting step. This addresses confusion for users who encounter these errors after OAuth system changes or other authentication issues.

--- a/packages/wrangler/src/__tests__/deploy/core.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/core.test.ts
@@ -1033,6 +1033,7 @@ describe("deploy", () => {
 
 					  In a non-interactive environment, it is mandatory to specify an account ID, either by assigning
 					  its value to CLOUDFLARE_ACCOUNT_ID, or as \`account_id\` in your Wrangler configuration file.
+					  Alternatively, try running \`wrangler login\` to re-authenticate.
 
 					"
 				`);

--- a/packages/wrangler/src/__tests__/kv/key.test.ts
+++ b/packages/wrangler/src/__tests__/kv/key.test.ts
@@ -1258,7 +1258,7 @@ describe("kv", () => {
 					).rejects.toThrowErrorMatchingInlineSnapshot(`
 						[Error: Failed to automatically retrieve account IDs for the logged in user.
 						You may have incorrect permissions on your API token, or an environment variable such as CLOUDFLARE_API_TOKEN, CLOUDFLARE_API_KEY, or CLOUDFLARE_EMAIL may be set to an invalid value.
-						Check your environment and unset or correct any Cloudflare credential variables, or run \`wrangler logout\` followed by \`wrangler login\` to re-authenticate.
+						Check your environment and unset or correct any Cloudflare credential variables, or run \`wrangler login\` to re-authenticate.
 						You can also skip this account check by adding an \`account_id\` in your Wrangler configuration file, or by setting the value of CLOUDFLARE_ACCOUNT_ID]
 					`);
 				});

--- a/packages/wrangler/src/__tests__/pages/secret.test.ts
+++ b/packages/wrangler/src/__tests__/pages/secret.test.ts
@@ -278,7 +278,8 @@ describe("wrangler pages secret", () => {
 						runWrangler("pages secret put the-key --project some-project-name")
 					).rejects.toThrowErrorMatchingInlineSnapshot(`
 						[Error: Failed to automatically retrieve account IDs for the logged in user.
-						In a non-interactive environment, it is mandatory to specify an account ID, either by assigning its value to CLOUDFLARE_ACCOUNT_ID, or as \`account_id\` in your Wrangler configuration file.]
+						In a non-interactive environment, it is mandatory to specify an account ID, either by assigning its value to CLOUDFLARE_ACCOUNT_ID, or as \`account_id\` in your Wrangler configuration file.
+						Alternatively, try running \`wrangler login\` to re-authenticate.]
 					`);
 				});
 

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -431,7 +431,8 @@ describe("wrangler secret", () => {
 					await expect(runWrangler("secret put the-key --name script-name"))
 						.rejects.toThrowErrorMatchingInlineSnapshot(`
 						[Error: Failed to automatically retrieve account IDs for the logged in user.
-						In a non-interactive environment, it is mandatory to specify an account ID, either by assigning its value to CLOUDFLARE_ACCOUNT_ID, or as \`account_id\` in your Wrangler configuration file.]
+						In a non-interactive environment, it is mandatory to specify an account ID, either by assigning its value to CLOUDFLARE_ACCOUNT_ID, or as \`account_id\` in your Wrangler configuration file.
+						Alternatively, try running \`wrangler login\` to re-authenticate.]
 					`);
 				});
 

--- a/packages/wrangler/src/user/fetch-accounts.ts
+++ b/packages/wrangler/src/user/fetch-accounts.ts
@@ -85,14 +85,14 @@ export async function fetchAllAccounts(
 				throw new UserError(
 					`Failed to automatically retrieve account IDs for the logged in user.
 You may have incorrect permissions on your API token, or an environment variable such as CLOUDFLARE_API_TOKEN, CLOUDFLARE_API_KEY, or CLOUDFLARE_EMAIL may be set to an invalid value.
-Check your environment and unset or correct any Cloudflare credential variables, or run \`wrangler logout\` followed by \`wrangler login\` to re-authenticate.
+Check your environment and unset or correct any Cloudflare credential variables, or run \`wrangler login\` to re-authenticate.
 You can also skip this account check by adding an \`account_id\` in your ${configFileName(undefined)} file, or by setting the value of CLOUDFLARE_ACCOUNT_ID`,
 					{ telemetryMessage: "user account fetch permission denied" }
 				);
 			}
 			throw new UserError(
 				`Failed to automatically retrieve account IDs for the logged in user.
-You may have incorrect permissions on your API token. You can skip this account check by adding an \`account_id\` in your ${configFileName(undefined)} file, or by setting the value of CLOUDFLARE_ACCOUNT_ID`,
+You may have incorrect permissions on your API token, or your authentication may have expired. Try running \`wrangler login\` to re-authenticate. You can also skip this account check by adding an \`account_id\` in your ${configFileName(undefined)} file, or by setting the value of CLOUDFLARE_ACCOUNT_ID`,
 				{ telemetryMessage: "user account fetch permission denied" }
 			);
 		} else {
@@ -108,7 +108,8 @@ You may have incorrect permissions on your API token. You can skip this account 
 	if (usableAccounts.length === 0 && throwOnEmpty) {
 		throw new UserError(
 			`Failed to automatically retrieve account IDs for the logged in user.
-In a non-interactive environment, it is mandatory to specify an account ID, either by assigning its value to CLOUDFLARE_ACCOUNT_ID, or as \`account_id\` in your ${configFileName(undefined)} file.`,
+In a non-interactive environment, it is mandatory to specify an account ID, either by assigning its value to CLOUDFLARE_ACCOUNT_ID, or as \`account_id\` in your ${configFileName(undefined)} file.
+Alternatively, try running \`wrangler login\` to re-authenticate.`,
 			{ telemetryMessage: "user account fetch empty" }
 		);
 	}


### PR DESCRIPTION
Improves the error messages shown when Wrangler fails to automatically retrieve account IDs for the logged-in user. The messages now suggest running `wrangler login` to re-authenticate, which helps users recover after OAuth system changes or expired authentication.

Changes in `packages/wrangler/src/user/fetch-accounts.ts`:
- Simplified the permission-denied hint from "run `wrangler logout` followed by `wrangler login`" to just "run `wrangler login`".
- Added an "authentication may have expired. Try running `wrangler login`" hint to the generic permission error.
- Added an "Alternatively, try running `wrangler login` to re-authenticate." line to the non-interactive empty-accounts error.

Test snapshots updated accordingly.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): 
  - [x] Documentation not necessary because: These are CLI error-message wording changes only; no documented behaviour changes.
