### PR TITLE
Simplify `constructWranglerConfig` to accept a single worker instead of an array

### DIFF
--- a/.changeset/simplify-construct-wrangler-config.md
+++ b/.changeset/simplify-construct-wrangler-config.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/workers-utils": minor
+---
+
+Simplify `constructWranglerConfig` to accept a single worker instead of an array
+
+The `constructWranglerConfig` function now accepts a single `APIWorkerConfig` object instead of `APIWorkerConfig | APIWorkerConfig[]`. The multi-environment array support has been removed since the array use-case was removed and now the only call site already passes a single worker object. This is a breaking change to the function's public signature.

--- a/packages/workers-utils/src/construct-wrangler-config.ts
+++ b/packages/workers-utils/src/construct-wrangler-config.ts
@@ -1,5 +1,4 @@
 import { getTodaysCompatDate } from "./compatibility-date";
-import { ENVIRONMENT_TAG_PREFIX, SERVICE_TAG_PREFIX } from "./constants";
 import { mapWorkerMetadataBindings } from "./map-worker-metadata-bindings";
 import type { RawConfig } from "./config";
 import type {
@@ -48,7 +47,14 @@ interface APIWorkerConfig {
 	};
 }
 
-function convertWorkerToWranglerConfig(config: APIWorkerConfig): RawConfig {
+/**
+ * Given information about a Worker,
+ * construct a Wrangler config file for the application.
+ *
+ * @param config - The Worker configuration sourced from the Cloudflare API
+ * @returns A Wrangler-compatible raw config object
+ */
+export function constructWranglerConfig(config: APIWorkerConfig): RawConfig {
 	const mappedBindings = mapWorkerMetadataBindings(config.bindings);
 
 	const durableObjectClassNames = config.bindings
@@ -108,52 +114,4 @@ function convertWorkerToWranglerConfig(config: APIWorkerConfig): RawConfig {
 		observability: config.observability,
 		...mappedBindings,
 	};
-}
-
-/**
- * Given the information of multiple Workers (representing different environments),
- * construct a Wrangler config file for the application.
- */
-export function constructWranglerConfig(
-	workerOrWorkers: APIWorkerConfig | APIWorkerConfig[]
-): RawConfig {
-	let workers: APIWorkerConfig[];
-	if (Array.isArray(workerOrWorkers)) {
-		workers = workerOrWorkers;
-	} else {
-		workers = [workerOrWorkers];
-	}
-
-	const topLevelEnv = workers.find(
-		(w) => !w.tags?.some((t) => t.startsWith(ENVIRONMENT_TAG_PREFIX))
-	);
-	const workerName = topLevelEnv?.name ?? workers[0].name;
-	const entrypoint = topLevelEnv?.entrypoint ?? workers[0].entrypoint;
-	let combinedConfig: RawConfig;
-	if (topLevelEnv) {
-		combinedConfig = convertWorkerToWranglerConfig(topLevelEnv);
-	} else {
-		// Make a synthetic top level environment
-		combinedConfig = {
-			name: workerName,
-			main: entrypoint,
-		};
-	}
-
-	for (const env of workers) {
-		const serviceTag = env.tags?.find(
-			(t) => t === `${SERVICE_TAG_PREFIX}${workerName}`
-		);
-		const envTag = env.tags?.find((t) => t.startsWith(ENVIRONMENT_TAG_PREFIX));
-		if (
-			serviceTag !== `${SERVICE_TAG_PREFIX}${workerName}` ||
-			envTag === undefined
-		) {
-			continue;
-		}
-		const [_, envName] = envTag.split("=");
-		combinedConfig.env ??= {};
-		combinedConfig.env[envName] = convertWorkerToWranglerConfig(env);
-	}
-	return combinedConfig;
 }

--- a/packages/workers-utils/tests/construct-wrangler-config.test.ts
+++ b/packages/workers-utils/tests/construct-wrangler-config.test.ts
@@ -1,9 +1,7 @@
 import { describe, it } from "vitest";
-import { ENVIRONMENT_TAG_PREFIX, SERVICE_TAG_PREFIX } from "../src/constants";
 import { constructWranglerConfig } from "../src/construct-wrangler-config";
 
-type APIWorkerConfigOrArray = Parameters<typeof constructWranglerConfig>[0];
-type APIWorkerConfig = Exclude<APIWorkerConfigOrArray, unknown[]>;
+type APIWorkerConfig = Parameters<typeof constructWranglerConfig>[0];
 
 /**
  * Factory for a minimal valid APIWorkerConfig.
@@ -36,22 +34,6 @@ function makeWorkerConfig(
 }
 
 describe("constructWranglerConfig", () => {
-	describe("input normalization", () => {
-		it("accepts a single worker (non-array)", ({ expect }) => {
-			const config = makeWorkerConfig();
-			const result = constructWranglerConfig(config);
-			expect(result.name).toBe("my-worker");
-			expect(result.main).toBe("index.js");
-		});
-
-		it("accepts an array with one worker", ({ expect }) => {
-			const config = makeWorkerConfig();
-			const result = constructWranglerConfig([config]);
-			expect(result.name).toBe("my-worker");
-			expect(result.main).toBe("index.js");
-		});
-	});
-
 	describe("basic field mapping", () => {
 		it("maps core fields correctly", ({ expect }) => {
 			const config = makeWorkerConfig({
@@ -389,129 +371,6 @@ describe("constructWranglerConfig", () => {
 			expect(result.vars).toEqual({ MY_VAR: "hello" });
 			// secret_text should not appear anywhere in the output
 			expect(JSON.stringify(result)).not.toContain("s3cret");
-		});
-	});
-
-	describe("multi-environment support", () => {
-		it("uses top-level worker as base config and tagged workers as environments", ({
-			expect,
-		}) => {
-			const topLevel = makeWorkerConfig({
-				name: "my-worker",
-				entrypoint: "index.js",
-				tags: [],
-				compatibility_date: "2025-01-01",
-			});
-			const staging = makeWorkerConfig({
-				name: "my-worker-staging",
-				entrypoint: "index.js",
-				tags: [
-					`${SERVICE_TAG_PREFIX}my-worker`,
-					`${ENVIRONMENT_TAG_PREFIX}staging`,
-				],
-				compatibility_date: "2025-02-01",
-			});
-			const production = makeWorkerConfig({
-				name: "my-worker-production",
-				entrypoint: "index.js",
-				tags: [
-					`${SERVICE_TAG_PREFIX}my-worker`,
-					`${ENVIRONMENT_TAG_PREFIX}production`,
-				],
-				compatibility_date: "2025-03-01",
-			});
-
-			const result = constructWranglerConfig([topLevel, staging, production]);
-
-			expect(result.name).toBe("my-worker");
-			expect(result.compatibility_date).toBe("2025-01-01");
-			expect(result.env).toBeDefined();
-			expect(result.env?.staging).toBeDefined();
-			expect(result.env?.staging?.compatibility_date).toBe("2025-02-01");
-			expect(result.env?.production).toBeDefined();
-			expect(result.env?.production?.compatibility_date).toBe("2025-03-01");
-		});
-
-		it("creates synthetic top-level when no untagged worker exists", ({
-			expect,
-		}) => {
-			const staging = makeWorkerConfig({
-				name: "my-worker-staging",
-				entrypoint: "src/index.ts",
-				tags: [
-					`${ENVIRONMENT_TAG_PREFIX}staging`,
-					`${SERVICE_TAG_PREFIX}my-worker-staging`,
-				],
-			});
-			const production = makeWorkerConfig({
-				name: "my-worker-prod",
-				entrypoint: "src/index.ts",
-				tags: [
-					`${ENVIRONMENT_TAG_PREFIX}production`,
-					`${SERVICE_TAG_PREFIX}my-worker-staging`,
-				],
-			});
-
-			const result = constructWranglerConfig([staging, production]);
-
-			// Synthetic top-level should use workers[0] for name and entrypoint
-			expect(result.name).toBe("my-worker-staging");
-			expect(result.main).toBe("src/index.ts");
-			// Should not have compatibility_date etc. since it's synthetic
-			expect(result.compatibility_date).toBeUndefined();
-		});
-
-		it("skips workers with mismatched service tags", ({ expect }) => {
-			const topLevel = makeWorkerConfig({
-				name: "my-worker",
-				tags: [],
-			});
-			const matchingEnv = makeWorkerConfig({
-				name: "my-worker-staging",
-				tags: [
-					`${SERVICE_TAG_PREFIX}my-worker`,
-					`${ENVIRONMENT_TAG_PREFIX}staging`,
-				],
-			});
-			const mismatchedEnv = makeWorkerConfig({
-				name: "other-worker-prod",
-				tags: [
-					`${SERVICE_TAG_PREFIX}other-worker`,
-					`${ENVIRONMENT_TAG_PREFIX}production`,
-				],
-			});
-
-			const result = constructWranglerConfig([
-				topLevel,
-				matchingEnv,
-				mismatchedEnv,
-			]);
-
-			expect(result.env?.staging).toBeDefined();
-			expect(result.env?.production).toBeUndefined();
-		});
-
-		it("skips workers without an environment tag", ({ expect }) => {
-			const topLevel = makeWorkerConfig({
-				name: "my-worker",
-				tags: [],
-			});
-			const noEnvTag = makeWorkerConfig({
-				name: "my-worker-noenv",
-				tags: [`${SERVICE_TAG_PREFIX}my-worker`],
-			});
-
-			const result = constructWranglerConfig([topLevel, noEnvTag]);
-			expect(result.env).toBeUndefined();
-		});
-
-		it("handles null tags by treating worker as top-level", ({ expect }) => {
-			const config = makeWorkerConfig({ tags: null });
-			const result = constructWranglerConfig(config);
-			// Worker with null tags is treated as having no tags,
-			// so it becomes the top-level environment
-			expect(result.name).toBe("my-worker");
-			expect(result.main).toBe("index.js");
 		});
 	});
 });


### PR DESCRIPTION
Followup from https://github.com/cloudflare/workers-sdk/pull/14084#discussion_r3323566016 (cc. @petebacondarwin)

`constructWranglerConfig` accepts an array of workers, I believe that this functionality was introduced for a specific use case which is no longer present, so I don't think that the function needs to accept an array of workers anymore.

For the sake of simplicity and YAGNI I'm proposing to remove it here.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: changes to not a public facing utility

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
