### PR TITLE
[wrangler] fix: don't assume sourceMappingURL is on the last line

### DIFF
--- a/.changeset/fix-sourcemappingurl-detection-trailing-magic-comments.md
+++ b/.changeset/fix-sourcemappingurl-detection-trailing-magic-comments.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler deploy --upload-source-maps` silently skipping source maps when the entry file ends with magic comments after `//# sourceMappingURL=`
+
+Wrangler previously assumed the `//# sourceMappingURL=` comment was the last non-empty line of a module. Tools like `sentry-cli sourcemaps inject` append a `//# debugId=` comment after it, which silently caused source maps to be omitted from the upload form, most commonly when deploying with `--no-bundle --upload-source-maps`. Wrangler now scans trailing magic comments (lines starting with `//#` or `//@`) and detects the `//# sourceMappingURL=` comment regardless of which other magic comments follow it.

--- a/packages/wrangler/src/__tests__/deploy/build.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/build.test.ts
@@ -1341,6 +1341,49 @@ export default { fetch() { return new Response(mod); } };`;
 			await runWrangler("deploy");
 		});
 
+		it("should include source maps when a //# debugId= comment follows the //# sourceMappingURL= comment", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({
+				no_bundle: true,
+				main: "index.js",
+				upload_source_maps: true,
+				build: {
+					command: `echo "custom build script"`,
+				},
+			});
+			// Mirrors the output of `sentry-cli sourcemaps inject`, which appends
+			// a `//# debugId=` comment on a new line after `//# sourceMappingURL=`.
+			fs.writeFileSync(
+				"index.js",
+				`export default { fetch() { return new Response("Hello World"); } }\n` +
+					"//# sourceMappingURL=index.js.map\n" +
+					"\n" +
+					"//# debugId=7f1ca8ac-1725-5ca5-b961-279f0ab7279a\n"
+			);
+			fs.writeFileSync(
+				"index.js.map",
+				JSON.stringify({
+					version: 3,
+					sources: ["index.ts"],
+					sourceRoot: "",
+					file: "index.js",
+				})
+			);
+
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedMainModule: "index.js",
+				expectedModules: {
+					"index.js.map": expect.stringMatching(
+						/"sources":\["index.ts"\],"sourceRoot":"".*"file":"index.js"/
+					),
+				},
+			});
+
+			await runWrangler("deploy");
+		});
+
 		it("should not include source maps emitted by custom build when upload_source_maps = false", async () => {
 			writeWranglerConfig({
 				no_bundle: true,

--- a/packages/wrangler/src/deployment-bundle/source-maps.ts
+++ b/packages/wrangler/src/deployment-bundle/source-maps.ts
@@ -97,31 +97,37 @@ function getSourceMappingUrl(module: CfModule): string | undefined {
 			? module.content
 			: new TextDecoder().decode(module.content);
 
-	const trimmed = content.trimEnd();
-	const lines = trimmed.split("\n");
-
-	// Some build steps generate empty last lines after the sourceMappingURL, so we'll need to
-	// trim so we can check for the sourcemap url.
-	while (lines.at(-1)?.trim().length === 0) {
-		lines.pop();
-	}
-
 	const commentPrefix = "//# sourceMappingURL=";
-	const lastLine = lines.pop();
-	if (lastLine === undefined || !lastLine.startsWith(commentPrefix)) {
-		return undefined;
+
+	// Scan trailing lines from the bottom up so that the `//# sourceMappingURL=`
+	// comment is still detected when other magic comments (e.g.
+	// `//# debugId=` injected by `sentry-cli sourcemaps inject`) follow it.
+	const lines = content.split("\n");
+	for (let i = lines.length - 1; i >= 0; i--) {
+		const line = lines[i].trim();
+		if (line.length === 0) {
+			continue;
+		}
+		if (line.startsWith(commentPrefix)) {
+			// Assume the source map path in the comment is relative to the
+			// generated file it appears in.
+			const commentPath = stripPrefix(commentPrefix, line).trim();
+			if (commentPath.startsWith("data:")) {
+				throw new Error(
+					`Unsupported source map path in ${module.filePath}: expected file path but found data URL.`
+				);
+			}
+			return commentPath;
+		}
+		// Skip past other trailing magic comments (`//# debugId=`, `//# sourceURL=`,
+		// etc.) and keep looking for the sourceMappingURL above them. Stop as
+		// soon as we hit any non-magic-comment content.
+		if (!line.startsWith("//#") && !line.startsWith("//@")) {
+			return undefined;
+		}
 	}
 
-	// Assume the source map path in the comment is relative to the
-	// generated file it appears in.
-	const commentPath = stripPrefix(commentPrefix, lastLine).trim();
-	if (commentPath.startsWith("data:")) {
-		throw new Error(
-			`Unsupported source map path in ${module.filePath}: expected file path but found data URL.`
-		);
-	}
-
-	return commentPath;
+	return undefined;
 }
 
 function sourceMapForModule(module: CfModule): CfWorkerSourceMap | undefined {


### PR DESCRIPTION
`getSourceMappingUrl` assumed the `//# sourceMappingURL=` comment was the last non-empty line of the module. Tools like `sentry-cli sourcemaps inject` append a trailing `//# debugId=` comment, which silently defeated detection and caused source maps to be omitted from the upload form when deploying with `--no-bundle --upload-source-maps`.

Scan trailing lines from the bottom up, skipping blank lines and other trailing magic comments (lines starting with `//#` or `//@`), until the `sourceMappingURL` comment is found or non-magic-comment content is hit.

Fixes https://jira.cfdata.org/browse/CC-7824

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: only fixes a bug of an existing capability

*A picture of a cute animal (not mandatory, but encouraged)*

<img width="1932" height="1449" alt="image" src="https://github.com/user-attachments/assets/9d7ba6b2-7a0b-47ef-b29e-9ce0ce098d79" />

