### PR TITLE
[wrangler] fix: send Workflows schedules as { cron } objects on deploy

### DIFF
--- a/.changeset/fix-workflow-schedules-cron-mapping.md
+++ b/.changeset/fix-workflow-schedules-cron-mapping.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix Workflows `schedules` deploy payload to match the control plane API
+
+When deploying a Workflow with a `schedules` binding property, Wrangler sent the cron expressions as a list of strings. The Workflows API expects a list of objects of the form `{ cron: string }`, so the request was rejected. Wrangler now maps each configured cron expression to `{ cron }` (normalizing a single string or an array) when building the request. The user-facing config still accepts a string or an array of strings.

--- a/packages/wrangler/src/__tests__/deploy/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/workflows.test.ts
@@ -318,7 +318,7 @@ describe("deploy", () => {
 					expect(body).toEqual({
 						script_name: "test-name",
 						class_name: "MyWorkflow",
-						schedules: "0 * * * *",
+						schedules: [{ cron: "0 * * * *" }],
 					});
 					return HttpResponse.json(
 						createFetchResult({ id: "mock-new-workflow-id" })
@@ -375,7 +375,7 @@ describe("deploy", () => {
 					expect(body).toEqual({
 						script_name: "test-name",
 						class_name: "MyWorkflow",
-						schedules: ["0 * * * *", "0 9 * * 1"],
+						schedules: [{ cron: "0 * * * *" }, { cron: "0 9 * * 1" }],
 					});
 					return HttpResponse.json(
 						createFetchResult({ id: "mock-new-workflow-id" })
@@ -434,7 +434,7 @@ describe("deploy", () => {
 						script_name: "test-name",
 						class_name: "MyWorkflow",
 						limits: { steps: 5000 },
-						schedules: "*/15 * * * *",
+						schedules: [{ cron: "*/15 * * * *" }],
 					});
 					return HttpResponse.json(
 						createFetchResult({ id: "mock-new-workflow-id" })
@@ -818,7 +818,7 @@ describe("deploy", () => {
 						expect(body).toEqual({
 							script_name: "my-app-staging",
 							class_name: "MyWorkflow",
-							schedules: "0 * * * *",
+							schedules: [{ cron: "0 * * * *" }],
 						});
 						return HttpResponse.json(
 							createFetchResult({ id: "mock-new-workflow-id" })

--- a/packages/wrangler/src/triggers/deploy.ts
+++ b/packages/wrangler/src/triggers/deploy.ts
@@ -322,7 +322,12 @@ export default async function triggersDeploy(
 							script_name: scriptName,
 							class_name: workflow.class_name,
 							...(workflow.limits && { limits: workflow.limits }),
-							...(workflow.schedules && { schedules: workflow.schedules }),
+							...(workflow.schedules && {
+								schedules: (Array.isArray(workflow.schedules)
+									? workflow.schedules
+									: [workflow.schedules]
+								).map((cron) => ({ cron })),
+							}),
 						}),
 						headers: {
 							"Content-Type": "application/json",


### PR DESCRIPTION
Deploying a Workflow with a `schedules` binding fails with `400` on `PUT /accounts/:id/workflows/:name`: the control plane expects `schedules` as `{ cron: string }[]`, but Wrangler sent bare strings.

`triggers/deploy.ts` now maps each cron expression to `{ cron }` (normalizing `string | string[]`). User config is unchanged — `schedules` still accepts a string or array of strings; only the request shape changes.

- Tests
    - [x] Tests included/updated
- Public documentation
    - [x] Documentation not necessary because: the `schedules` field is hidden/non-functional until cron-trigger Workflows GA; this only corrects the request shape to match the control plane API.