### PR TITLE
[vitest-pool-workers] Fix module resolution for paths with spaces

### DIFF
--- a/.changeset/fix-space-in-path-double-encoding.md
+++ b/.changeset/fix-space-in-path-double-encoding.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Fix module resolution failing when project path contains spaces
+
+When a project lived under a directory with spaces (e.g. `/Users/me/Documents/Master CMS/project`), the vitest pool would fail with `No such module "threads.js"` before any test executed. The module fallback service now uses the `rawSpecifier` from workerd's fallback request to correctly decode `file://` URLs, avoiding the double-encoding of spaces (`%20` → `%2520`) that occurred when workerd resolved these URLs as relative paths.

--- a/packages/vitest-pool-workers/src/pool/module-fallback.ts
+++ b/packages/vitest-pool-workers/src/pool/module-fallback.ts
@@ -510,16 +510,6 @@ export async function handleModuleFallbackRequest(
 	let referrer = url.searchParams.get("referrer");
 	assert(target !== null, "Expected specifier search param");
 	assert(referrer !== null, "Expected referrer search param");
-
-	// When the raw specifier is a `file://` URL (e.g. from vitest's dynamic
-	// imports using `import.meta.url`), workerd may double-encode spaces in the
-	// resolved `specifier` (%20 → %2520). Use the raw specifier to recover the
-	// correct filesystem path. See https://github.com/cloudflare/workers-sdk/issues/14107
-	const rawSpecifier = url.searchParams.get("rawSpecifier");
-	if (rawSpecifier?.startsWith("file:")) {
-		target = ensurePosixLikePath(fileURLToPath(rawSpecifier));
-	}
-
 	const referrerDir = posixPath.dirname(referrer);
 	let specifier = getApproximateSpecifier(target, referrerDir);
 
@@ -528,6 +518,18 @@ export async function handleModuleFallbackRequest(
 	// TODO(soon): remove this code once the new modules refactor lands
 	if (specifier.startsWith("file:")) {
 		specifier = fileURLToPath(specifier);
+	}
+
+	// When the raw specifier is a `file://` URL (e.g. from vitest's dynamic
+	// imports using `import.meta.url`), workerd may double-encode spaces in the
+	// resolved `specifier` (%20 → %2520). Use the raw specifier to recover the
+	// correct filesystem path for resolution. We override `specifier` (not
+	// `target`) so that `buildModuleResponse` still uses the original module name
+	// that workerd expects, and the mismatch triggers a redirect.
+	// See https://github.com/cloudflare/workers-sdk/issues/14107
+	const rawSpecifier = url.searchParams.get("rawSpecifier");
+	if (rawSpecifier?.startsWith("file:")) {
+		specifier = ensurePosixLikePath(fileURLToPath(rawSpecifier));
 	}
 
 	if (isWindows) {

--- a/packages/vitest-pool-workers/src/pool/module-fallback.ts
+++ b/packages/vitest-pool-workers/src/pool/module-fallback.ts
@@ -510,6 +510,16 @@ export async function handleModuleFallbackRequest(
 	let referrer = url.searchParams.get("referrer");
 	assert(target !== null, "Expected specifier search param");
 	assert(referrer !== null, "Expected referrer search param");
+
+	// When the raw specifier is a `file://` URL (e.g. from vitest's dynamic
+	// imports using `import.meta.url`), workerd may double-encode spaces in the
+	// resolved `specifier` (%20 → %2520). Use the raw specifier to recover the
+	// correct filesystem path. See https://github.com/cloudflare/workers-sdk/issues/14107
+	const rawSpecifier = url.searchParams.get("rawSpecifier");
+	if (rawSpecifier?.startsWith("file:")) {
+		target = ensurePosixLikePath(fileURLToPath(rawSpecifier));
+	}
+
 	const referrerDir = posixPath.dirname(referrer);
 	let specifier = getApproximateSpecifier(target, referrerDir);
 

--- a/packages/vitest-pool-workers/test/file-url-import.test.ts
+++ b/packages/vitest-pool-workers/test/file-url-import.test.ts
@@ -1,0 +1,36 @@
+import dedent from "ts-dedent";
+import { test, vitestConfig } from "./helpers";
+
+test(
+	"resolves dynamic file:// URL imports in paths with spaces",
+	{ timeout: 45_000 },
+	async ({ expect, seed, vitestRun }) => {
+		// Regression test for https://github.com/cloudflare/workers-sdk/issues/14107
+		// When the project path contains spaces, dynamic imports using file:// URLs
+		// (e.g. constructed via import.meta.url) would double-encode %20 → %2520,
+		// causing workerd to fail with "No such module".
+		await seed({
+			"vitest.config.mts": vitestConfig({
+				miniflare: {
+					compatibilityDate: "2025-12-02",
+					compatibilityFlags: ["nodejs_compat"],
+				},
+			}),
+			"helper.ts": dedent`
+				export const value = 42;
+			`,
+			"index.test.ts": dedent`
+				import { it, expect } from "vitest";
+				it("can dynamically import via file:// URL", async () => {
+					const helperUrl = new URL("./helper.ts", import.meta.url);
+					expect(helperUrl.protocol).toBe("file:");
+					const mod = await import(helperUrl.href);
+					expect(mod.value).toBe(42);
+				});
+			`,
+		});
+		const result = await vitestRun();
+		expect(result.stderr).not.toContain("%2520");
+		expect(await result.exitCode).toBe(0);
+	}
+);


### PR DESCRIPTION
Fixes #14107.

When a project lives under a directory with spaces (e.g. `/Users/me/Documents/Master CMS/project`), `vitest-pool-workers` fails with `No such module "threads.js"` before any test executes.

**Root cause:** workerd treats `file://` URLs (constructed via `import.meta.url`) as relative paths, producing a mangled `specifier` where `%20` gets double-encoded to `%2520`. The module fallback service then can't resolve the mangled path on disk.

**Fix:** When `rawSpecifier` (the original import specifier from workerd) is a `file://` URL, decode it via `fileURLToPath()` and use it as the resolution `specifier`. Crucially, `target` (used for module naming) is left unchanged so that the `target ≠ filePath` mismatch triggers a redirect — workerd then follows the redirect with the correct specifier. This mirrors the approach used in `vite-plugin-cloudflare`.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal module resolution fix, no user-facing API change

Devin PR requested by petebacondarwin@cloudflare.com

Link to Devin session: https://app.devin.ai/sessions/609d6c4488ca4b6aa04ffdf8fc84550c
Requested by: @petebacondarwin