### PR TITLE
Generalize `wrangler deploy` positional argument from `[script]` to `[path]`

### DIFF
--- a/.changeset/deploy-path-positional.md
+++ b/.changeset/deploy-path-positional.md
@@ -2,11 +2,16 @@
 "wrangler": minor
 ---
 
-Generalize `wrangler deploy` positional argument from `[script]` to `[path]`
+Generalize `wrangler deploy` and `wrangler versions upload` positional argument from `[script]` to `[path]`
 
-The `wrangler deploy` command now accepts a generic `[path]` positional argument that can point to either a Worker entry-point file or a directory of static assets. The type is auto-detected:
+Both `wrangler deploy` and `wrangler versions upload` now accept a generic `[path]` positional argument that can point to either a Worker entry-point file or a directory of static assets. The type is auto-detected:
 
 - **File**: `wrangler deploy ./src/index.ts` deploys a Worker (same as before)
 - **Directory**: `wrangler deploy ./public` deploys a static assets site (no interactive confirmation prompt)
 
-The `--script` named option is now hidden and deprecated for the deploy command. It continues to work for backwards compatibility but only accepts file paths. Passing a directory to `--script` now produces a clear error message suggesting the positional `path` argument or `--assets` flag instead.
+The same applies to `wrangler versions upload`:
+
+- **File**: `wrangler versions upload ./src/index.ts` uploads a Worker version
+- **Directory**: `wrangler versions upload ./public` uploads a static assets version
+
+The `--script` named option is now hidden and deprecated for both commands. It continues to work for backwards compatibility but only accepts file paths. Passing a directory to `--script` now produces a clear error message suggesting the positional `path` argument or `--assets` flag instead.

--- a/.changeset/deploy-path-positional.md
+++ b/.changeset/deploy-path-positional.md
@@ -1,0 +1,12 @@
+---
+"wrangler": minor
+---
+
+Generalize `wrangler deploy` positional argument from `[script]` to `[path]`
+
+The `wrangler deploy` command now accepts a generic `[path]` positional argument that can point to either a Worker entry-point file or a directory of static assets. The type is auto-detected:
+
+- **File**: `wrangler deploy ./src/index.ts` deploys a Worker (same as before)
+- **Directory**: `wrangler deploy ./public` deploys a static assets site (no interactive confirmation prompt)
+
+The `--script` named option is now hidden and deprecated for the deploy command. It continues to work for backwards compatibility but only accepts file paths. Passing a directory to `--script` now produces a clear error message suggesting the positional `path` argument or `--assets` flag instead.

--- a/.changeset/deploy-path-positional.md
+++ b/.changeset/deploy-path-positional.md
@@ -4,14 +4,9 @@
 
 Generalize `wrangler deploy` and `wrangler versions upload` positional argument from `[script]` to `[path]`
 
-Both `wrangler deploy` and `wrangler versions upload` now accept a generic `[path]` positional argument that can point to either a Worker entry-point file or a directory of static assets. The type is auto-detected:
+Both `wrangler deploy` and `wrangler versions upload` now accept a generic `[path]` positional argument that can point to either a Worker entry-point file or a directory of static assets. The type is auto-detected. For example:
 
 - **File**: `wrangler deploy ./src/index.ts` deploys a Worker (same as before)
 - **Directory**: `wrangler deploy ./public` deploys a static assets site (no interactive confirmation prompt)
-
-The same applies to `wrangler versions upload`:
-
-- **File**: `wrangler versions upload ./src/index.ts` uploads a Worker version
-- **Directory**: `wrangler versions upload ./public` uploads a static assets version
 
 The `--script` named option is now hidden and deprecated for both commands. It continues to work for backwards compatibility but only accepts file paths. Passing a directory to `--script` now produces a clear error message suggesting the positional `path` argument or `--assets` flag instead.

--- a/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
@@ -887,10 +887,6 @@ addEventListener('fetch', event => {});`
 
 			// TODO: remove this test once autoconfig goes GA and its experimental opt-in flag is removed
 			it("should handle `wrangler deploy <directory>`", async ({ expect }) => {
-				mockConfirm({
-					text: "It looks like you are trying to deploy a directory of static assets only. Is this correct?",
-					result: true,
-				});
 				mockPrompt({
 					text: "What do you want to name your project?",
 					options: { defaultValue: "my-site" },
@@ -934,8 +930,6 @@ addEventListener('fetch', event => {});`
 					──────────────────
 
 
-
-
 					Wrote
 					{
 					  "name": "test-name",
@@ -972,10 +966,6 @@ addEventListener('fetch', event => {});`
 				const runAutoConfigSpy = (await import("../../autoconfig/run"))
 					.runAutoConfig;
 
-				mockConfirm({
-					text: "It looks like you are trying to deploy a directory of static assets only. Is this correct?",
-					result: true,
-				});
 				mockPrompt({
 					text: "What do you want to name your project?",
 					options: { defaultValue: "my-site" },
@@ -1017,8 +1007,6 @@ addEventListener('fetch', event => {});`
 					"
 					 ⛅️ wrangler x.x.x
 					──────────────────
-
-
 
 
 					Wrote
@@ -1199,7 +1187,7 @@ addEventListener('fetch', event => {});`
 				expect(runAutoConfigSpy).not.toHaveBeenCalled();
 			});
 
-			it("should not trigger autoconfig on `wrangler deploy <script>` when called with `--x-autoconfig`", async ({
+			it("should not trigger autoconfig on `wrangler deploy <directory>` when called with `--x-autoconfig`", async ({
 				expect,
 			}) => {
 				vi.mock(import("../../autoconfig/details"), { spy: true });
@@ -1212,10 +1200,6 @@ addEventListener('fetch', event => {});`
 				const runAutoConfigSpy = (await import("../../autoconfig/run"))
 					.runAutoConfig;
 
-				mockConfirm({
-					text: "It looks like you are trying to deploy a directory of static assets only. Is this correct?",
-					result: true,
-				});
 				mockPrompt({
 					text: "What do you want to name your project?",
 					options: { defaultValue: "my-site" },
@@ -1257,8 +1241,6 @@ addEventListener('fetch', event => {});`
 					"
 					 ⛅️ wrangler x.x.x
 					──────────────────
-
-
 
 
 					Wrote
@@ -1333,22 +1315,14 @@ addEventListener('fetch', event => {});`
 					`);
 			});
 
-			it("should bail if the user denies that they are trying to deploy a directory", async ({
+			it("should error when --script points to a directory", async ({
 				expect,
 			}) => {
-				mockConfirm({
-					text: "It looks like you are trying to deploy a directory of static assets only. Is this correct?",
-					result: false,
-				});
-
-				await expect(runWrangler("deploy ./assets")).rejects
+				await expect(runWrangler("deploy --script ./assets")).rejects
 					.toThrowErrorMatchingInlineSnapshot(`
-					[Error: The provided entry-point path, "assets", points to a directory, rather than a file.
-
-					 If you want to deploy a directory of static assets, you can do so by using the \`--assets\` flag. For example:
-
-					wrangler deploy --assets=./assets
-					]
+					[Error: The --script option must point to a Worker entry-point file, not a directory. To deploy a directory of static assets, use the positional path argument or the --assets flag instead:
+					  wrangler deploy ./assets
+					  wrangler deploy --assets ./assets]
 				`);
 			});
 
@@ -1391,6 +1365,112 @@ addEventListener('fetch', event => {});`
 
 
 					You should run wrangler deploy --name test-name --compatibility-date 2024-01-01 --assets ./assets next time to deploy this Worker without going through this flow again.
+
+					Proceeding with deployment...
+
+					Total Upload: xx KiB / gzip: xx KiB
+					Worker Startup Time: 100 ms
+					Uploaded test-name (TIMINGS)
+					Deployed test-name triggers (TIMINGS)
+					  https://test-name.test-sub-domain.workers.dev
+					Current Version ID: Galaxy-Class"
+				`);
+			});
+
+			it("includes script path in suggestion when deprecated --script option is used", async ({
+				expect,
+			}) => {
+				writeWorkerSource();
+				mockUploadWorkerRequest({
+					expectedAssets: {
+						jwt: "<<aus-completion-token>>",
+						config: {},
+					},
+					expectedMainModule: "index.js",
+					expectedType: "esm",
+				});
+
+				mockPrompt({
+					text: "What do you want to name your project?",
+					options: { defaultValue: "my-site" },
+					result: "test-name",
+				});
+				mockConfirm({
+					text: "No compatibility date is set. Would you like to use today's date (2024-01-01)?",
+					result: true,
+				});
+				mockConfirm({
+					text: "Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
+					result: false,
+				});
+
+				const bodies: AssetManifest[] = [];
+				await mockAUSRequest(bodies);
+
+				await runWrangler("deploy --script ./index.js --assets ./assets");
+				expect(bodies.length).toBe(1);
+				expect(fs.existsSync("wrangler.jsonc")).toBe(false);
+				expect(std.out).toMatchInlineSnapshot(`
+					"
+					 ⛅️ wrangler x.x.x
+					──────────────────
+
+
+
+					You should run wrangler deploy ./index.js --name test-name --compatibility-date 2024-01-01 --assets ./assets next time to deploy this Worker without going through this flow again.
+
+					Proceeding with deployment...
+
+					Total Upload: xx KiB / gzip: xx KiB
+					Worker Startup Time: 100 ms
+					Uploaded test-name (TIMINGS)
+					Deployed test-name triggers (TIMINGS)
+					  https://test-name.test-sub-domain.workers.dev
+					Current Version ID: Galaxy-Class"
+				`);
+			});
+
+			it("includes --assets in suggestion when positional path is a file and --assets is separate", async ({
+				expect,
+			}) => {
+				writeWorkerSource();
+				mockUploadWorkerRequest({
+					expectedAssets: {
+						jwt: "<<aus-completion-token>>",
+						config: {},
+					},
+					expectedMainModule: "index.js",
+					expectedType: "esm",
+				});
+
+				mockPrompt({
+					text: "What do you want to name your project?",
+					options: { defaultValue: "my-site" },
+					result: "test-name",
+				});
+				mockConfirm({
+					text: "No compatibility date is set. Would you like to use today's date (2024-01-01)?",
+					result: true,
+				});
+				mockConfirm({
+					text: "Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
+					result: false,
+				});
+
+				const bodies: AssetManifest[] = [];
+				await mockAUSRequest(bodies);
+
+				await runWrangler("deploy ./index.js --assets ./assets");
+				expect(bodies.length).toBe(1);
+				expect(fs.existsSync("wrangler.jsonc")).toBe(false);
+				expect(std.out).toMatchInlineSnapshot(`
+					"
+					 ⛅️ wrangler x.x.x
+					──────────────────
+
+
+
+					You should run wrangler deploy ./index.js --name test-name --compatibility-date 2024-01-01 --assets ./assets next time to deploy this Worker without going through this flow again.
 
 					Proceeding with deployment...
 

--- a/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
@@ -1340,6 +1340,19 @@ addEventListener('fetch', event => {});`
 				`);
 			});
 
+			it("should error when --script points to a directory even when positional path is a file", async ({
+				expect,
+			}) => {
+				fs.writeFileSync("index.js", "export default {}");
+
+				await expect(runWrangler("deploy ./index.js --script ./assets")).rejects
+					.toThrowErrorMatchingInlineSnapshot(`
+					[Error: The --script option must point to a Worker entry-point file, not a directory. To deploy a directory of static assets, use the positional path argument or the --assets flag instead:
+					  wrangler deploy ./assets
+					  wrangler deploy --assets ./assets]
+				`);
+			});
+
 			it("does not write out a wrangler config file if the user says no", async ({
 				expect,
 			}) => {

--- a/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
@@ -1326,6 +1326,20 @@ addEventListener('fetch', event => {});`
 				`);
 			});
 
+			it("should error when --script points to a directory even when positional path is also provided", async ({
+				expect,
+			}) => {
+				fs.mkdirSync("other-dir", { recursive: true });
+				fs.writeFileSync("other-dir/page.html", "<h1>Other</h1>");
+
+				await expect(runWrangler("deploy ./assets --script ./other-dir"))
+					.rejects.toThrowErrorMatchingInlineSnapshot(`
+					[Error: The --script option must point to a Worker entry-point file, not a directory. To deploy a directory of static assets, use the positional path argument or the --assets flag instead:
+					  wrangler deploy ./other-dir
+					  wrangler deploy --assets ./other-dir]
+				`);
+			});
+
 			it("does not write out a wrangler config file if the user says no", async ({
 				expect,
 			}) => {

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -56,7 +56,7 @@ describe("wrangler", () => {
 				  wrangler browser                🌐 Manage Browser Run sessions [open beta]
 				  wrangler containers             📦 Manage Containers
 				  wrangler delete [name]          🗑️ Delete a Worker from Cloudflare
-				  wrangler deploy [script]        🆙 Deploy a Worker to Cloudflare
+				  wrangler deploy [path]          🆙 Deploy a Worker to Cloudflare
 				  wrangler deployments            🚢 List and view the current and past deployments for your Worker
 				  wrangler dev [script]           👂 Start a local server for developing your Worker
 				  wrangler dispatch-namespace     🏗️ Manage dispatch namespaces
@@ -137,7 +137,7 @@ describe("wrangler", () => {
 				  wrangler browser                🌐 Manage Browser Run sessions [open beta]
 				  wrangler containers             📦 Manage Containers
 				  wrangler delete [name]          🗑️ Delete a Worker from Cloudflare
-				  wrangler deploy [script]        🆙 Deploy a Worker to Cloudflare
+				  wrangler deploy [path]          🆙 Deploy a Worker to Cloudflare
 				  wrangler deployments            🚢 List and view the current and past deployments for your Worker
 				  wrangler dev [script]           👂 Start a local server for developing your Worker
 				  wrangler dispatch-namespace     🏗️ Manage dispatch namespaces

--- a/packages/wrangler/src/__tests__/versions/versions.help.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.help.test.ts
@@ -19,7 +19,7 @@ describe("versions --help", () => {
 			COMMANDS
 			  wrangler versions view <version-id>         View the details of a specific version of your Worker
 			  wrangler versions list                      List the 10 most recent Versions of your Worker
-			  wrangler versions upload [script]           Uploads your Worker code and config as a new Version
+			  wrangler versions upload [path]             Uploads your Worker code and config as a new Version
 			  wrangler versions deploy [version-specs..]  Safely roll out new Versions of your Worker by splitting traffic between multiple Versions
 			  wrangler versions secret                    Generate a secret that can be referenced in a Worker
 
@@ -52,7 +52,7 @@ describe("versions subhelp", () => {
 			COMMANDS
 			  wrangler versions view <version-id>         View the details of a specific version of your Worker
 			  wrangler versions list                      List the 10 most recent Versions of your Worker
-			  wrangler versions upload [script]           Uploads your Worker code and config as a new Version
+			  wrangler versions upload [path]             Uploads your Worker code and config as a new Version
 			  wrangler versions deploy [version-specs..]  Safely roll out new Versions of your Worker by splitting traffic between multiple Versions
 			  wrangler versions secret                    Generate a secret that can be referenced in a Worker
 

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -1176,6 +1176,21 @@ describe("versions upload", () => {
 			`);
 		});
 
+		test("should error when --script points to a directory even when positional path is a file", async ({
+			expect,
+		}) => {
+			fs.mkdirSync("assets", { recursive: true });
+			fs.writeFileSync("assets/index.html", "<h1>Hello</h1>");
+			fs.writeFileSync("index.js", "export default {}");
+
+			await expect(runWrangler("versions upload ./index.js --script ./assets"))
+				.rejects.toThrowErrorMatchingInlineSnapshot(`
+				[Error: The --script option must point to a Worker entry-point file, not a directory. To deploy a directory of static assets, use the positional path argument or the --assets flag instead:
+				  wrangler versions upload ./assets
+				  wrangler versions upload --assets ./assets]
+			`);
+		});
+
 		test("should error when no name is provided", async ({ expect }) => {
 			writeWorkerSource();
 			await expect(

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -1160,6 +1160,22 @@ describe("versions upload", () => {
 			`);
 		});
 
+		test("should error when --script points to a directory even when positional path is also provided", async ({
+			expect,
+		}) => {
+			fs.mkdirSync("assets", { recursive: true });
+			fs.writeFileSync("assets/index.html", "<h1>Hello</h1>");
+			fs.mkdirSync("other-dir", { recursive: true });
+			fs.writeFileSync("other-dir/page.html", "<h1>Other</h1>");
+
+			await expect(runWrangler("versions upload ./assets --script ./other-dir"))
+				.rejects.toThrowErrorMatchingInlineSnapshot(`
+				[Error: The --script option must point to a Worker entry-point file, not a directory. To deploy a directory of static assets, use the positional path argument or the --assets flag instead:
+				  wrangler versions upload ./other-dir
+				  wrangler versions upload --assets ./other-dir]
+			`);
+		});
+
 		test("should error when no name is provided", async ({ expect }) => {
 			writeWorkerSource();
 			await expect(

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -1146,6 +1146,20 @@ describe("versions upload", () => {
 			).rejects.toThrow(/Workers Sites does not support uploading versions/);
 		});
 
+		test("should error when --script points to a directory", async ({
+			expect,
+		}) => {
+			fs.mkdirSync("assets", { recursive: true });
+			fs.writeFileSync("assets/index.html", "<h1>Hello</h1>");
+
+			await expect(runWrangler("versions upload --script ./assets")).rejects
+				.toThrowErrorMatchingInlineSnapshot(`
+				[Error: The --script option must point to a Worker entry-point file, not a directory. To deploy a directory of static assets, use the positional path argument or the --assets flag instead:
+				  wrangler versions upload ./assets
+				  wrangler versions upload --assets ./assets]
+			`);
+		});
+
 		test("should error when no name is provided", async ({ expect }) => {
 			writeWorkerSource();
 			await expect(
@@ -1752,6 +1766,45 @@ describe("versions upload", () => {
 			fs.writeFileSync("public/index.html", "<h1>Hello</h1>");
 
 			await runWrangler("versions upload --assets public");
+
+			const metadata = await getMetadata(requests[requests.length - 1]);
+			expect(metadata.assets).toBeDefined();
+			expect(metadata.assets?.jwt).toEqual("test-assets-jwt");
+		});
+
+		test("should upload assets when directory is passed as positional path", async ({
+			expect,
+		}) => {
+			mockGetScript();
+			const requests = mockUploadVersion(false, 0);
+
+			// Mock asset upload session
+			msw.use(
+				http.post(
+					`*/accounts/:accountId/workers/scripts/:scriptName/assets-upload-session`,
+					() => {
+						return HttpResponse.json(
+							{
+								success: true,
+								errors: [],
+								messages: [],
+								result: { jwt: "test-assets-jwt", buckets: [[]] },
+							},
+							{ status: 201 }
+						);
+					}
+				)
+			);
+
+			writeWranglerConfig({
+				name: "test-name",
+				main: "./index.js",
+			});
+			writeWorkerSource();
+			fs.mkdirSync("public", { recursive: true });
+			fs.writeFileSync("public/index.html", "<h1>Hello</h1>");
+
+			await runWrangler("versions upload public");
 
 			const metadata = await getMetadata(requests[requests.length - 1]);
 			expect(metadata.assets).toBeDefined();

--- a/packages/wrangler/src/deploy/autoconfig.ts
+++ b/packages/wrangler/src/deploy/autoconfig.ts
@@ -1,4 +1,4 @@
-import { statSync, writeFileSync } from "node:fs";
+import { writeFileSync } from "node:fs";
 import path from "node:path";
 import {
 	configFileName,
@@ -23,6 +23,7 @@ import type { ReadConfigCommandArgs } from "../config";
 type AutoConfigArgs = ReadConfigCommandArgs & {
 	experimentalAutoconfig: boolean | undefined;
 	assets: string | undefined;
+	path: string | undefined;
 	dryRun: boolean | undefined;
 	latest: boolean | undefined;
 	compatibilityDate: string | undefined;
@@ -44,6 +45,7 @@ export async function maybeRunAutoConfig<Args extends AutoConfigArgs>(
 		// If there is a positional parameter, an assets directory specified via --assets, or an
 		// explicit --config path then we don't want to run autoconfig since we assume that the
 		// user knows what they are doing and that they are specifying what needs to be deployed
+		!args.path &&
 		!args.script &&
 		!args.assets &&
 		!args.config;
@@ -128,12 +130,9 @@ export async function maybeRunAutoConfig<Args extends AutoConfigArgs>(
 }
 
 /**
- * Interactively prompts for missing deploy configuration. Handles two phases:
- *
- * 1. If the positional `script` arg is a directory and no config file exists,
- *    asks whether the user intends to deploy static assets.
- * 2. Prompts for missing name and compatibility date, and optionally writes a
- *    new wrangler.jsonc config file.
+ * Interactively prompts for missing deploy configuration:
+ * prompts for missing name and compatibility date, and optionally writes a
+ * new wrangler.jsonc config file.
  *
  * No-op in non-interactive / CI environments.
  */
@@ -141,65 +140,7 @@ export async function promptForMissingConfig<Args extends AutoConfigArgs>(
 	args: Args,
 	config: { configPath?: string; compatibility_date?: string; name?: string }
 ): Promise<Args> {
-	// Phase 1: detect `wrangler deploy <directory>` and offer to treat it as assets
-	let scriptIsDirectory = false;
-	if (!config.configPath && args.script) {
-		try {
-			const stats = statSync(args.script);
-			if (stats.isDirectory()) {
-				scriptIsDirectory = true;
-				args = await promptForMissingAssetFlag(args.script, args);
-			}
-		} catch (error) {
-			// If this is our UserError, re-throw it
-			if (error instanceof UserError) {
-				throw error;
-			}
-			// If stat fails, let the original flow handle the error
-		}
-	}
-
-	// Phase 2: prompt for name / compat-date / config file.
-	// Skip when the user was offered an assets deployment and declined (script is still a directory) —
-	// getEntry will produce the appropriate error about the directory entry point.
-	if (scriptIsDirectory && !args.assets) {
-		return args;
-	}
-
 	return promptForMissingDeployConfig(args, config);
-}
-
-/**
- * Handles the case where a user provides a directory as a positional argument,
- * probably intending to deploy static assets. e.g. `wrangler deploy ./public`.
- * If the user confirms, sets `args.assets` and clears `args.script`.
- */
-export async function promptForMissingAssetFlag<Args extends AutoConfigArgs>(
-	assetDirectory: string,
-	args: Args
-): Promise<Args> {
-	if (isNonInteractiveOrCI()) {
-		return args;
-	}
-
-	// Ask if user intended to deploy assets only
-	logger.log("");
-	if (!args.assets) {
-		const deployAssets = await confirm(
-			"It looks like you are trying to deploy a directory of static assets only. Is this correct?",
-			{ defaultValue: true }
-		);
-		logger.log("");
-		if (deployAssets) {
-			args.assets = assetDirectory;
-			args.script = undefined;
-		} else {
-			// let the usual error handling path kick in
-			return args;
-		}
-	}
-
-	return args;
 }
 
 /**
@@ -293,13 +234,16 @@ export async function promptForMissingDeployConfig<Args extends AutoConfigArgs>(
 				`\nSimply run ${chalk.bold("`wrangler deploy`")} next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.`
 			);
 		} else {
-			const scriptPart = args.script ? `${args.script} ` : "";
+			const pathPart = (args.path ?? args.script) ? `${args.path ?? args.script} ` : "";
 			const flagParts = [
 				args.name ? `--name ${args.name}` : "",
 				effectiveCompatDate
 					? `--compatibility-date ${effectiveCompatDate}`
 					: "",
-				args.assets ? `--assets ${args.assets}` : "",
+				// Only omit --assets when the positional path already covers the assets directory
+				args.assets && args.assets !== args.path
+					? `--assets ${args.assets}`
+					: "",
 				...(args.compatibilityFlags?.length
 					? [`--compatibility-flags ${args.compatibilityFlags.join(" ")}`]
 					: []),
@@ -308,7 +252,7 @@ export async function promptForMissingDeployConfig<Args extends AutoConfigArgs>(
 				.join(" ");
 			logger.log(
 				`\nYou should run ${chalk.bold(
-					`wrangler deploy ${scriptPart}${flagParts}`
+					`wrangler deploy ${pathPart}${flagParts}`
 				)} next time to deploy this Worker without going through this flow again.`
 			);
 		}

--- a/packages/wrangler/src/deploy/autoconfig.ts
+++ b/packages/wrangler/src/deploy/autoconfig.ts
@@ -130,20 +130,6 @@ export async function maybeRunAutoConfig<Args extends AutoConfigArgs>(
 }
 
 /**
- * Interactively prompts for missing deploy configuration:
- * prompts for missing name and compatibility date, and optionally writes a
- * new wrangler.jsonc config file.
- *
- * No-op in non-interactive / CI environments.
- */
-export async function promptForMissingConfig<Args extends AutoConfigArgs>(
-	args: Args,
-	config: { configPath?: string; compatibility_date?: string; name?: string }
-): Promise<Args> {
-	return promptForMissingDeployConfig(args, config);
-}
-
-/**
  * Interactively prompts for missing deployment configuration (name, compatibility date,
  * and optionally config file writing when no config file exists).
  * No-op in non-interactive/CI environments or when all required config is already present.

--- a/packages/wrangler/src/deploy/autoconfig.ts
+++ b/packages/wrangler/src/deploy/autoconfig.ts
@@ -234,7 +234,8 @@ export async function promptForMissingDeployConfig<Args extends AutoConfigArgs>(
 				`\nSimply run ${chalk.bold("`wrangler deploy`")} next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.`
 			);
 		} else {
-			const pathPart = (args.path ?? args.script) ? `${args.path ?? args.script} ` : "";
+			const pathPart =
+				(args.path ?? args.script) ? `${args.path ?? args.script} ` : "";
 			const flagParts = [
 				args.name ? `--name ${args.name}` : "",
 				effectiveCompatDate

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert";
-import { statSync } from "node:fs";
 import path from "node:path";
 import {
 	getTodaysCompatDate,
@@ -37,21 +36,6 @@ export const deployCommand = createCommand({
 	positionalArgs: ["path"],
 	args: {
 		...sharedDeployVersionsArgs,
-		path: {
-			describe:
-				"The path to an entry point for your Worker or a directory of static assets",
-			type: "string",
-		},
-		// Override the shared `script` definition to hide it for `wrangler deploy` —
-		// the `path` positional replaces it. `--script` still works as a named option
-		// for backwards compatibility but only accepts file paths (not directories).
-		script: {
-			describe: "The path to an entry point for your Worker",
-			type: "string",
-			requiresArg: true,
-			hidden: true,
-			deprecated: true,
-		},
 		triggers: {
 			describe: "cron schedules to attach",
 			alias: ["schedule", "schedules"],
@@ -129,46 +113,7 @@ export const deployCommand = createCommand({
 		printMetricsBanner: true,
 	},
 	validateArgs(args) {
-		validateDeployVersionsArgs(args);
-
-		// Resolve the `path` positional into `script` (file) or `assets` (directory).
-		// This must happen before config is read because config resolution uses
-		// `args.script` to locate the wrangler config file relative to the entry point.
-		if (args.path) {
-			try {
-				const stats = statSync(args.path);
-				if (stats.isDirectory()) {
-					if (!args.assets) {
-						args.assets = args.path;
-					}
-				} else {
-					args.script = args.path;
-				}
-			} catch {
-				// If stat fails, assume it's a script path and let downstream handle the error
-				args.script = args.path;
-			}
-		}
-
-		// Validate that --script points to a file, not a directory
-		if (args.script && !args.path) {
-			try {
-				const stats = statSync(args.script);
-				if (stats.isDirectory()) {
-					throw new UserError(
-						`The --script option must point to a Worker entry-point file, not a directory. To deploy a directory of static assets, use the positional path argument or the --assets flag instead:\n  wrangler deploy ${args.script}\n  wrangler deploy --assets ${args.script}`,
-						{
-							telemetryMessage: "deploy script option pointed to directory",
-						}
-					);
-				}
-			} catch (e) {
-				if (e instanceof UserError) {
-					throw e;
-				}
-				// stat failure is fine, downstream will handle missing files
-			}
-		}
+		validateDeployVersionsArgs(args, "deploy");
 	},
 	async handler(args, { config }) {
 		// --- Step 0. Auto-config --- //

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert";
+import { statSync } from "node:fs";
 import path from "node:path";
 import {
 	getTodaysCompatDate,
@@ -33,9 +34,24 @@ export const deployCommand = createCommand({
 		status: "stable",
 		category: "Compute & AI",
 	},
-	positionalArgs: ["script"],
+	positionalArgs: ["path"],
 	args: {
 		...sharedDeployVersionsArgs,
+		path: {
+			describe:
+				"The path to an entry point for your Worker or a directory of static assets",
+			type: "string",
+		},
+		// Override the shared `script` definition to hide it for `wrangler deploy` —
+		// the `path` positional replaces it. `--script` still works as a named option
+		// for backwards compatibility but only accepts file paths (not directories).
+		script: {
+			describe: "The path to an entry point for your Worker",
+			type: "string",
+			requiresArg: true,
+			hidden: true,
+			deprecated: true,
+		},
 		triggers: {
 			describe: "cron schedules to attach",
 			alias: ["schedule", "schedules"],
@@ -114,6 +130,45 @@ export const deployCommand = createCommand({
 	},
 	validateArgs(args) {
 		validateDeployVersionsArgs(args);
+
+		// Resolve the `path` positional into `script` (file) or `assets` (directory).
+		// This must happen before config is read because config resolution uses
+		// `args.script` to locate the wrangler config file relative to the entry point.
+		if (args.path) {
+			try {
+				const stats = statSync(args.path);
+				if (stats.isDirectory()) {
+					if (!args.assets) {
+						args.assets = args.path;
+					}
+				} else {
+					args.script = args.path;
+				}
+			} catch {
+				// If stat fails, assume it's a script path and let downstream handle the error
+				args.script = args.path;
+			}
+		}
+
+		// Validate that --script points to a file, not a directory
+		if (args.script && !args.path) {
+			try {
+				const stats = statSync(args.script);
+				if (stats.isDirectory()) {
+					throw new UserError(
+						`The --script option must point to a Worker entry-point file, not a directory. To deploy a directory of static assets, use the positional path argument or the --assets flag instead:\n  wrangler deploy ${args.script}\n  wrangler deploy --assets ${args.script}`,
+						{
+							telemetryMessage: "deploy script option pointed to directory",
+						}
+					);
+				}
+			} catch (e) {
+				if (e instanceof UserError) {
+					throw e;
+				}
+				// stat failure is fine, downstream will handle missing files
+			}
+		}
 	},
 	async handler(args, { config }) {
 		// --- Step 0. Auto-config --- //

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -22,7 +22,7 @@ import { collectKeyValues } from "../utils/collectKeyValues";
 import { getRules } from "../utils/getRules";
 import { getScriptName } from "../utils/getScriptName";
 import { useServiceEnvironments } from "../utils/useServiceEnvironments";
-import { maybeRunAutoConfig, promptForMissingConfig } from "./autoconfig";
+import { maybeRunAutoConfig, promptForMissingDeployConfig } from "./autoconfig";
 import deploy from "./deploy";
 import { maybeDelegateToOpenNextDeployCommand } from "./open-next";
 
@@ -124,7 +124,7 @@ export const deployCommand = createCommand({
 		config = autoConfigResult.config;
 
 		// Interatively handle missing/incorrect --assets, --script, --name, --compatibility-date
-		args = await promptForMissingConfig(args, config);
+		args = await promptForMissingDeployConfig(args, config);
 
 		// Needs to happen after auto-config logic to capture newly auto-configured open-next apps.
 		// As a precaution we're gating the feature under the autoconfig flag for the time being.

--- a/packages/wrangler/src/deployment-bundle/deploy-args.ts
+++ b/packages/wrangler/src/deployment-bundle/deploy-args.ts
@@ -207,6 +207,10 @@ export function validateDeployVersionsArgs(
 	},
 	commandName: "deploy" | "versions upload"
 ): void {
+	// Capture the original --script value before resolving the positional path,
+	// so we can validate it independently even after args.script is overwritten.
+	const originalScript = args.script;
+
 	// Resolve the `path` positional into `script` (file) or `assets` (directory).
 	// This must happen before config is read because config resolution uses
 	// `args.script` to locate the wrangler config file relative to the entry point.
@@ -227,14 +231,14 @@ export function validateDeployVersionsArgs(
 	}
 
 	// Validate that --script points to a file, not a directory.
-	// Skip when args.script was set from the positional path (they'll be equal)
-	// since the path block above already handled directory detection.
-	if (args.script && args.script !== args.path) {
+	// Use the original --script value (before the positional path may have
+	// overwritten it) so directory validation is never silently bypassed.
+	if (originalScript) {
 		try {
-			const stats = statSync(args.script);
+			const stats = statSync(originalScript);
 			if (stats.isDirectory()) {
 				throw new UserError(
-					`The --script option must point to a Worker entry-point file, not a directory. To deploy a directory of static assets, use the positional path argument or the --assets flag instead:\n  wrangler ${commandName} ${args.script}\n  wrangler ${commandName} --assets ${args.script}`,
+					`The --script option must point to a Worker entry-point file, not a directory. To deploy a directory of static assets, use the positional path argument or the --assets flag instead:\n  wrangler ${commandName} ${originalScript}\n  wrangler ${commandName} --assets ${originalScript}`,
 					{
 						telemetryMessage: `${commandName} script option pointed to directory`,
 					}

--- a/packages/wrangler/src/deployment-bundle/deploy-args.ts
+++ b/packages/wrangler/src/deployment-bundle/deploy-args.ts
@@ -1,12 +1,22 @@
+import { statSync } from "node:fs";
 import { UserError } from "@cloudflare/workers-utils";
 import { logger } from "../logger";
 import type { NamedArgDefinitions } from "../core/types";
 
 export const sharedDeployVersionsArgs = {
+	path: {
+		describe:
+			"The path to an entry point for your Worker or a directory of static assets",
+		type: "string",
+	},
+	// The `path` positional replaces `script`. `--script` still works as a named
+	// option for backwards compatibility but only accepts file paths (not directories).
 	script: {
 		describe: "The path to an entry point for your Worker",
 		type: "string",
 		requiresArg: true,
+		hidden: true,
+		deprecated: true,
 	},
 	name: {
 		describe: "Name of the Worker",
@@ -177,10 +187,65 @@ export const sharedDeployVersionsArgs = {
 	},
 } as const satisfies NamedArgDefinitions;
 
-export function validateDeployVersionsArgs(args: {
-	nodeCompat: boolean | undefined;
-	latest: boolean | undefined;
-}): void {
+/**
+ * Validates and resolves shared arguments for `wrangler deploy` and `wrangler versions upload`.
+ *
+ * Resolves the `path` positional into `script` (file) or `assets` (directory),
+ * validates that `--script` does not point to a directory, and checks deprecated flags.
+ *
+ * @param args - The parsed CLI arguments to validate and mutate.
+ * @param commandName - The CLI command name (e.g. `"deploy"` or `"versions upload"`)
+ *   used in error messages and suggestions.
+ */
+export function validateDeployVersionsArgs(
+	args: {
+		path: string | undefined;
+		script: string | undefined;
+		assets: string | undefined;
+		nodeCompat: boolean | undefined;
+		latest: boolean | undefined;
+	},
+	commandName: "deploy" | "versions upload"
+): void {
+	// Resolve the `path` positional into `script` (file) or `assets` (directory).
+	// This must happen before config is read because config resolution uses
+	// `args.script` to locate the wrangler config file relative to the entry point.
+	if (args.path) {
+		try {
+			const stats = statSync(args.path);
+			if (stats.isDirectory()) {
+				if (!args.assets) {
+					args.assets = args.path;
+				}
+			} else {
+				args.script = args.path;
+			}
+		} catch {
+			// If stat fails, assume it's a script path and let downstream handle the error
+			args.script = args.path;
+		}
+	}
+
+	// Validate that --script points to a file, not a directory
+	if (args.script && !args.path) {
+		try {
+			const stats = statSync(args.script);
+			if (stats.isDirectory()) {
+				throw new UserError(
+					`The --script option must point to a Worker entry-point file, not a directory. To deploy a directory of static assets, use the positional path argument or the --assets flag instead:\n  wrangler ${commandName} ${args.script}\n  wrangler ${commandName} --assets ${args.script}`,
+					{
+						telemetryMessage: `${commandName} script option pointed to directory`,
+					}
+				);
+			}
+		} catch (e) {
+			if (e instanceof UserError) {
+				throw e;
+			}
+			// stat failure is fine, downstream will handle missing files
+		}
+	}
+
 	if (args.nodeCompat) {
 		throw new UserError(
 			"The --node-compat flag is no longer supported as of Wrangler v4. Instead, use the `nodejs_compat` compatibility flag. This includes the functionality from legacy `node_compat` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information.",

--- a/packages/wrangler/src/deployment-bundle/deploy-args.ts
+++ b/packages/wrangler/src/deployment-bundle/deploy-args.ts
@@ -226,8 +226,10 @@ export function validateDeployVersionsArgs(
 		}
 	}
 
-	// Validate that --script points to a file, not a directory
-	if (args.script && !args.path) {
+	// Validate that --script points to a file, not a directory.
+	// Skip when args.script was set from the positional path (they'll be equal)
+	// since the path block above already handled directory detection.
+	if (args.script && args.script !== args.path) {
 		try {
 			const stats = statSync(args.script);
 			if (stats.isDirectory()) {

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -125,7 +125,7 @@ export const versionsUploadCommand = createCommand({
 		owner: "Workers: Authoring and Testing",
 		status: "stable",
 	},
-	positionalArgs: ["script"],
+	positionalArgs: ["path"],
 	args: {
 		...sharedDeployVersionsArgs,
 		"preview-alias": {
@@ -144,7 +144,7 @@ export const versionsUploadCommand = createCommand({
 		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
 	},
 	validateArgs(args) {
-		validateDeployVersionsArgs(args);
+		validateDeployVersionsArgs(args, "versions upload");
 	},
 	handler: async function versionsUploadHandler(args, { config }) {
 		const entry = await getEntry(args, config, "versions upload");


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-2333

The `wrangler deploy` command now accepts a generic `[path]` positional argument that can point to either a Worker entry-point file or a directory of static assets. The type is auto-detected:

- **File**: `wrangler deploy ./src/index.ts` deploys a Worker (same as before)
- **Directory**: `wrangler deploy ./public` deploys a static assets site (no interactive confirmation prompt)

The `--script` named option is now hidden and deprecated for the deploy command. It continues to work for backwards compatibility but only accepts file paths. Passing a directory to `--script` now produces a clear error message suggesting the positional `path` argument or `--assets` flag instead.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/31183
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
