### PR TITLE
fix: Include `currentAgentSkillsInstalled` in command telemetry events

### DIFF
--- a/.changeset/include-agent-skills-in-command-events.md
+++ b/.changeset/include-agent-skills-in-command-events.md
@@ -4,6 +4,5 @@
 
 Include agent skill installation status in all telemetry events
 
-
 The agent skill installation status is now consistently included in all telemetry events, not just a subset of them.
 

--- a/.changeset/include-agent-skills-in-command-events.md
+++ b/.changeset/include-agent-skills-in-command-events.md
@@ -2,6 +2,7 @@
 "wrangler": patch
 ---
 
-fix: Include `currentAgentSkillsInstalled` in command telemetry events
+Include `currentAgentSkillsInstalled` in command telemetry events
+
 
 The `currentAgentSkillsInstalled` property was only included in adhoc telemetry events (e.g. `autoconfig_process_started`) but was missing from command events (`wrangler command started`, `wrangler command completed`, `wrangler command errored`). It is now included in all telemetry events.

--- a/.changeset/include-agent-skills-in-command-events.md
+++ b/.changeset/include-agent-skills-in-command-events.md
@@ -2,7 +2,8 @@
 "wrangler": patch
 ---
 
-Include `currentAgentSkillsInstalled` in command telemetry events
+Include agent skill installation status in all telemetry events
 
 
-The `currentAgentSkillsInstalled` property was only included in adhoc telemetry events (e.g. `autoconfig_process_started`) but was missing from command events (`wrangler command started`, `wrangler command completed`, `wrangler command errored`). It is now included in all telemetry events.
+The agent skill installation status is now consistently included in all telemetry events, not just a subset of them.
+

--- a/.changeset/include-agent-skills-in-command-events.md
+++ b/.changeset/include-agent-skills-in-command-events.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Include `currentAgentSkillsInstalled` in command telemetry events
+
+The `currentAgentSkillsInstalled` property was only included in adhoc telemetry events (e.g. `autoconfig_process_started`) but was missing from command events (`wrangler command started`, `wrangler command completed`, `wrangler command errored`). It is now included in all telemetry events.

--- a/packages/wrangler/src/__tests__/metrics.test.ts
+++ b/packages/wrangler/src/__tests__/metrics.test.ts
@@ -253,6 +253,7 @@ describe("metrics", () => {
 				agent: null,
 				sanitizedCommand: "docs",
 				sanitizedArgs: {},
+				currentAgentSkillsInstalled: null,
 			};
 			beforeEach(() => {
 				// Default: no agent detected

--- a/packages/wrangler/src/metrics/metrics-dispatcher.ts
+++ b/packages/wrangler/src/metrics/metrics-dispatcher.ts
@@ -162,13 +162,21 @@ export function getMetricsDispatcher(options: MetricsConfigOptions) {
 				};
 
 				trackDispatch(
-					dispatch({
-						name,
-						properties: {
-							...commonCommandEventProperties,
-							...properties,
-						},
-					})
+					telemetryCurrentAgentSkillsInstalled()
+						.catch(() => null)
+						.then((currentAgentSkillsInstalled) => {
+							return dispatch({
+								name,
+								properties: {
+									...commonCommandEventProperties,
+									...properties,
+									currentAgentSkillsInstalled,
+								},
+							});
+						})
+						.catch((err) => {
+							logger.debug("Error sending command metrics event", err);
+						})
 				);
 			} catch (err) {
 				logger.debug("Error sending metrics event", err);


### PR DESCRIPTION
Fixes #[insert GH or internal issue link(s)].

_Describe your change..._

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: already documented in telemetry.md

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
