### PR TITLE
In non-interactive mode remove the skills installation message

### DIFF
--- a/.changeset/good-ducks-clean.md
+++ b/.changeset/good-ducks-clean.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+In non-interactive mode remove the skills installation message
+
+When Wrangler run in non interactive mode and it detected agents that it could install skills for, it would print a message such as:
+
+`Cloudflare agent skills are available for: <DETECTED_AGENTS>. Run wrangler in an interactive terminal to install them, or use '--install-skills' to install without prompting.`
+
+This message seems to be confusing and unhelpful so it has now been removed.

--- a/packages/wrangler/src/__tests__/agents-skills-install.test.ts
+++ b/packages/wrangler/src/__tests__/agents-skills-install.test.ts
@@ -322,13 +322,16 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 			});
 		});
 
-		test("logs info and sends skills_install_skipped when TTY is false", async ({
+		test("sends skills_install_skipped without logging anything in the terminal when TTY is false", async ({
 			expect,
 		}) => {
 			setIsTTY(false);
 			const maybeInstallCloudflareSkillsGlobally = await freshImport();
 
 			await maybeInstallCloudflareSkillsGlobally(false);
+
+			// Nothing has been logged
+			expect(std.out).toEqual("");
 
 			// Verify no install call was made
 			expect(mockRosieInstall).not.toHaveBeenCalled();

--- a/packages/wrangler/src/__tests__/agents-skills-install.test.ts
+++ b/packages/wrangler/src/__tests__/agents-skills-install.test.ts
@@ -330,9 +330,6 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 
 			await maybeInstallCloudflareSkillsGlobally(false);
 
-			expect(std.out).toContain(
-				"Cloudflare agent skills are available for: Claude Code"
-			);
 			// Verify no install call was made
 			expect(mockRosieInstall).not.toHaveBeenCalled();
 			expect(sendMetricsEvent).toHaveBeenCalledWith(

--- a/packages/wrangler/src/agents-skills-install.ts
+++ b/packages/wrangler/src/agents-skills-install.ts
@@ -87,11 +87,8 @@ export async function maybeInstallCloudflareSkillsGlobally(
 		return;
 	}
 
-	// In non-interactive terminals (but not CI), log a message
+	// In non-interactive terminals do nothing
 	if (!force && !isInteractive()) {
-		logger.log(
-			`Cloudflare agent skills are available for: ${detectedAgents.map(({ name }) => name).join(", ")}. Run wrangler in an interactive terminal to install them, or use \`--install-skills\` to install without prompting.`
-		);
 		sendResultMetricsEvent({
 			skippedBecause: "Non-interactive terminal",
 		});


### PR DESCRIPTION
Fixes #14144 

When Wrangler run in non interactive mode and it detected agents that it could install skills for, it would print a message such as:

`Cloudflare agent skills are available for: <DETECTED_AGENTS>. Run wrangler in an interactive terminal to install them, or use '--install-skills' to install without prompting.`

This message seems to be confusing and unhelpful so this PR removes it.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: self-explanatory behavior

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
