### PR TITLE
rearrange deploy/versions upload code to group wrangler code and deploy-helpers code

### DIFF
--- a/.changeset/big-snails-shop.md
+++ b/.changeset/big-snails-shop.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Print deploy warnings even in non-interactive contexts when strict mode is off
+
+Currently, wrangler deploy checks whether the incoming deploy configuration has destructive conflicts with the current configuration. Previously, we only performed this check in interactive contexts, or if the `--strict` flag was passed in. Now this warning is always printed, and it remains non-blocking in non-interactive contexts.

--- a/packages/deploy-helpers/src/shared/types.ts
+++ b/packages/deploy-helpers/src/shared/types.ts
@@ -1,8 +1,6 @@
-import type { ContainerNormalizedConfig } from "@cloudflare/containers-shared";
 import type {
 	AssetsOptions,
 	LegacyAssetPaths,
-	CfPlacement,
 	Config,
 	EphemeralDirectory,
 	FetchResultFetcher,
@@ -11,7 +9,6 @@ import type {
 	Route,
 	Entry,
 } from "@cloudflare/workers-utils";
-import type { NodeJSCompatMode } from "miniflare";
 
 /**
  * client needs to handle logger and fetch/auth implementation
@@ -41,20 +38,14 @@ export type DeployHelpersContext = {
  * config.unsafe, config.tail_consumers).
  */
 export type SharedDeployVersionsProps = {
-	config: Config;
 	/** Merged from args.script/config.main/config.site.entry-point/config.assets. */
 	entry: Entry;
-	/** From config.rules. */
-	rules: Config["rules"];
-	/** Merged: --name arg ?? config.name, with CI override applied. */
-	name: string;
-	workerNameOverridden: boolean;
-	/** Merged: --compatibility-date arg ?? config.compatibility_date. Still optional — validated as required in stage 4. */
+	/** Merged: --name arg ?? config.name, with CI override applied. Validated as required separately. */
+	name: string | undefined;
+	/** Merged: --compatibility-date arg ?? config.compatibility_date. Still optional — validated as required later. */
 	compatibilityDate: string | undefined;
 	/** Merged: --compatibility-flags arg ?? config.compatibility_flags. */
 	compatibilityFlags: string[];
-	/** computed based on compat date and args */
-	nodejsCompatMode: NodeJSCompatMode;
 	/** Merged from --assets arg and config.assets. */
 	assetsOptions: AssetsOptions | undefined;
 	/** Merged: --jsx-factory arg || config.jsx_factory. */
@@ -82,7 +73,6 @@ export type SharedDeployVersionsProps = {
 	 * True only when config opts in (legacy_env: false) AND --env is specified.
 	 */
 	useServiceEnvApiPath: boolean;
-	placement: CfPlacement | undefined;
 	/** Output directory for the bundled Worker. From --outdir arg or a temp directory. */
 	destination: string | EphemeralDirectory;
 	/** From --dry-run arg. */
@@ -99,8 +89,8 @@ export type SharedDeployVersionsProps = {
 	message: string | undefined;
 	/** From --secrets-file arg. */
 	secretsFile: string | undefined;
-	/** From collectKeyValues(--var arg). Pre-resolved key-value pairs. */
-	var: Record<string, string>;
+	/** From collectKeyValues(--var arg). CLI-only vars; config vars flow separately via getBindings(config). */
+	cliVars: Record<string, string>;
 	/** From --experimental-auto-create arg. */
 	experimentalAutoCreate: boolean;
 };
@@ -116,7 +106,6 @@ export type DeployProps = SharedDeployVersionsProps & {
 	routes: Route[];
 	/** Merged: --logpush arg ?? config.logpush. */
 	logpush: boolean | undefined;
-	containers: ContainerNormalizedConfig[];
 	/** From --dispatch-namespace arg. Deploy-only (Workers for Platforms). */
 	dispatchNamespace: string | undefined;
 	/** From --strict arg. Deploy-only. */
@@ -125,6 +114,8 @@ export type DeployProps = SharedDeployVersionsProps & {
 	metafile: string | boolean | undefined;
 	/** From --old-asset-ttl arg. Deploy-only. */
 	oldAssetTtl: number | undefined;
+	/** From --containers-rollout arg. Deploy-only. */
+	containersRollout: "immediate" | "gradual" | "none" | undefined;
 };
 
 export type VersionsUploadProps = SharedDeployVersionsProps & {

--- a/packages/deploy-helpers/src/shared/types.ts
+++ b/packages/deploy-helpers/src/shared/types.ts
@@ -1,6 +1,8 @@
 import type {
 	AssetsOptions,
 	LegacyAssetPaths,
+	CfModule,
+	CfModuleType,
 	Config,
 	EphemeralDirectory,
 	FetchResultFetcher,
@@ -9,6 +11,7 @@ import type {
 	Route,
 	Entry,
 } from "@cloudflare/workers-utils";
+import type { NodeJSCompatMode } from "miniflare";
 
 /**
  * client needs to handle logger and fetch/auth implementation
@@ -123,6 +126,32 @@ export type VersionsUploadProps = SharedDeployVersionsProps & {
 	command: "versions upload";
 	/** CLI-only (--preview-alias), or auto-generated from CI branch name. */
 	previewAlias: string | undefined;
+};
+
+export type BuildBundleInfo = {
+	sourceMapPath?: string | undefined;
+	sourceMapMetadata?: { tmpDir: string; entryDirectory: string } | undefined;
+};
+
+export type HandleBuildResult = {
+	modules: CfModule[];
+	dependencies: Record<string, { bytesInOutput: number }>;
+	resolvedEntryPointPath: string;
+	bundleType: CfModuleType;
+	content: string;
+	bundle: BuildBundleInfo;
+};
+
+export type HandleBuild = {
+	build: (
+		props: SharedDeployVersionsProps,
+		config: Config,
+		options: {
+			nodejsCompatMode: NodeJSCompatMode;
+			metafile?: string | boolean;
+		}
+	) => Promise<HandleBuildResult>;
+	cleanup: (props: SharedDeployVersionsProps) => void;
 };
 
 export interface TriggerDeployment {

--- a/packages/deploy-helpers/src/shared/types.ts
+++ b/packages/deploy-helpers/src/shared/types.ts
@@ -96,6 +96,12 @@ export type SharedDeployVersionsProps = {
 	cliVars: Record<string, string>;
 	/** From --experimental-auto-create arg. */
 	experimentalAutoCreate: boolean;
+	/** Resolved from requireAuth() before calling deploy-helpers. undefined only in dry-run. */
+	accountId: string | undefined;
+	/** Resolved from getMetricsUsageHeaders() / config.send_metrics. Controls whether usage metrics headers are sent with upload requests. */
+	sendMetrics: boolean;
+	/** Resolved from getFlag("RESOURCES_PROVISION"). Controls whether bindings are auto-provisioned before upload. */
+	resourcesProvision: boolean;
 };
 
 export type DeployProps = SharedDeployVersionsProps & {

--- a/packages/deploy-helpers/src/shared/types.ts
+++ b/packages/deploy-helpers/src/shared/types.ts
@@ -157,7 +157,6 @@ export type HandleBuild = {
 			metafile?: string | boolean;
 		}
 	) => Promise<HandleBuildResult>;
-	cleanup: (props: SharedDeployVersionsProps) => void;
 };
 
 export interface TriggerDeployment {

--- a/packages/wrangler/src/__tests__/containers/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/containers/deploy.test.ts
@@ -2562,6 +2562,13 @@ describe("wrangler deploy with containers and dispatch namespace", () => {
 	beforeEach(() => {
 		msw.use(...mswSuccessDeploymentScriptMetadata);
 		msw.use(...mswListNewDeploymentsLatestFull);
+		msw.use(
+			http.get(
+				`*/accounts/:accountId/workers/scripts/:scriptName/secrets`,
+				() => HttpResponse.json(createFetchResult([])),
+				{ once: false }
+			)
+		);
 		mockSubDomainRequest();
 		mockServiceScriptData({
 			script: { id: "test-name", migration_tag: "v1" },
@@ -2819,6 +2826,13 @@ function setupDockerMocks(
 function setupCommonMocks() {
 	msw.use(...mswSuccessDeploymentScriptMetadata);
 	msw.use(...mswListNewDeploymentsLatestFull);
+	msw.use(
+		http.get(
+			`*/accounts/:accountId/workers/scripts/:scriptName/secrets`,
+			() => HttpResponse.json(createFetchResult([])),
+			{ once: false }
+		)
+	);
 	mockSubDomainRequest();
 	mockLegacyScriptData({
 		scripts: [{ id: "test-name", migration_tag: "v1" }],

--- a/packages/wrangler/src/__tests__/deploy/config-remote.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/config-remote.test.ts
@@ -381,8 +381,6 @@ describe("deploy", () => {
 				"
 				 ⛅️ wrangler x.x.x
 				──────────────────
-				? Would you like to continue?
-				🤖 Using fallback value in non-interactive context: yes
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -13,7 +13,6 @@ import {
 	formatConfigSnippet,
 	getDockerPath,
 	parseNonHyphenedUuid,
-	getWranglerTmpDir,
 	UserError,
 	formatTime,
 } from "@cloudflare/workers-utils";
@@ -50,6 +49,7 @@ import {
 import { getFlag } from "../experimental-flags";
 import isInteractive, { isNonInteractiveOrCI } from "../is-interactive";
 import { logger } from "../logger";
+import { verifyWorkerMatchesCITag } from "../match-tag";
 import { getMetricsUsageHeaders } from "../metrics";
 import { isNavigatorDefined } from "../navigator-user-agent";
 import { ensureQueuesExistByConfig } from "../queues/client";
@@ -59,11 +59,13 @@ import {
 	getSourceMappedString,
 	maybeRetrieveFileSourceMap,
 } from "../sourcemap";
+import { requireAuth } from "../user";
 import { downloadWorkerConfig } from "../utils/download-worker-config";
 import { helpIfErrorIsSizeOrScriptStartup } from "../utils/friendly-validator-errors";
 import { parseConfigPlacement } from "../utils/placement";
 import { printBindings } from "../utils/print-bindings";
 import { retryOnAPIFailure } from "../utils/retry";
+import { useServiceEnvironments as useServiceEnvironmentsConfig } from "../utils/useServiceEnvironments";
 import { isWorkerNotFoundError } from "../utils/worker-not-found-error";
 import {
 	createDeployment,
@@ -77,60 +79,15 @@ import type { StartDevWorkerInput } from "../api/startDevWorker/types";
 import type { HandlerContext } from "../core/types";
 import type { RetrieveSourceMapFunction } from "../sourcemap";
 import type { ApiVersion, Percentage, VersionId } from "../versions/types";
+import type { DeployProps } from "@cloudflare/deploy-helpers";
 import type {
-	AssetsOptions,
 	CfModule,
 	CfScriptFormat,
 	CfWorkerInit,
 	Config,
-	Entry,
-	LegacyAssetPaths,
 	RawConfig,
 } from "@cloudflare/workers-utils";
 import type { FormData } from "undici";
-
-type Props = {
-	config: Config;
-	accountId: string | undefined;
-	entry: Entry;
-	rules: Config["rules"];
-	name: string;
-	env: string | undefined;
-	compatibilityDate: string | undefined;
-	compatibilityFlags: string[] | undefined;
-	legacyAssetPaths: LegacyAssetPaths | undefined;
-	assetsOptions: AssetsOptions | undefined;
-	vars: Record<string, string> | undefined;
-	defines: Record<string, string> | undefined;
-	alias: Record<string, string> | undefined;
-	triggers: string[] | undefined;
-	routes: string[] | undefined;
-	domains: string[] | undefined;
-	/** Deprecated service environments.*/
-	useServiceEnvironments: boolean | undefined;
-	jsxFactory: string | undefined;
-	jsxFragment: string | undefined;
-	tsconfig: string | undefined;
-	isWorkersSite: boolean;
-	minify: boolean | undefined;
-	outDir: string | undefined;
-	outFile: string | undefined;
-	dryRun: boolean | undefined;
-	noBundle: boolean | undefined;
-	keepVars: boolean | undefined;
-	logpush: boolean | undefined;
-	uploadSourceMaps: boolean | undefined;
-	oldAssetTtl: number | undefined;
-	projectRoot: string | undefined;
-	dispatchNamespace: string | undefined;
-	experimentalAutoCreate: boolean;
-	metafile: string | boolean | undefined;
-	containersRollout: "immediate" | "gradual" | "none" | undefined;
-	strict: boolean | undefined;
-	tag: string | undefined;
-	message: string | undefined;
-	secretsFile: string | undefined;
-};
 
 /**
  * Inject bindings into the Worker to support Workers Sites. These are injected at the last minute so that
@@ -164,7 +121,9 @@ function addWorkersSitesBindings(
 }
 
 export default async function deploy(
-	props: Props,
+	props: DeployProps,
+	config: Config,
+	workerNameOverridden: boolean,
 	ctx: Omit<HandlerContext, "config">
 ): Promise<{
 	sourceMapSize?: number;
@@ -172,23 +131,44 @@ export default async function deploy(
 	workerTag: string | null;
 	targets?: string[];
 }> {
+	if (!props.name) {
+		throw new UserError(
+			'You need to provide a name when publishing a worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`',
+			{ telemetryMessage: "deploy command missing worker name" }
+		);
+	}
+
+	const {
+		entry,
+		name,
+		compatibilityDate,
+		compatibilityFlags,
+		jsxFactory,
+		jsxFragment,
+		keepVars,
+		minify,
+		noBundle,
+		destination,
+		uploadSourceMaps,
+	} = props;
+
+	const accountId = props.dryRun ? undefined : await requireAuth(config);
+
+	if (!props.dryRun) {
+		assert(accountId, "Missing account ID");
+		await verifyWorkerMatchesCITag(config, accountId, name, config.configPath);
+	}
+
 	const deployConfirm = getDeployConfirmFunction(props.strict);
 
 	// TODO: warn if git/hg has uncommitted changes
-	const { config, accountId, name, entry } = props;
 	let workerTag: string | null = null;
 	let versionId: string | null = null;
 	let tags: string[] = []; // arbitrary metadata tags, not to be confused with script tag or annotations
 
 	let workerExists: boolean = true;
 
-	const domainRoutes = (props.domains || []).map((domain) => ({
-		pattern: domain,
-		custom_domain: true,
-	}));
-	const routes =
-		props.routes ?? config.routes ?? (config.route ? [config.route] : []);
-	const allDeploymentRoutes = [...routes, ...domainRoutes];
+	const allDeploymentRoutes = props.routes;
 
 	if (!props.dispatchNamespace && accountId) {
 		try {
@@ -306,11 +286,6 @@ export default async function deploy(
 		}
 	}
 
-	const compatibilityDate =
-		props.compatibilityDate ?? config.compatibility_date;
-	const compatibilityFlags =
-		props.compatibilityFlags ?? config.compatibility_flags;
-
 	if (!compatibilityDate) {
 		const compatibilityDateStr = getTodaysCompatDate();
 
@@ -327,55 +302,42 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 	validateRoutes(allDeploymentRoutes, props.assetsOptions);
 
-	const jsxFactory = props.jsxFactory || config.jsx_factory;
-	const jsxFragment = props.jsxFragment || config.jsx_fragment;
-	const keepVars = props.keepVars || config.keep_vars;
-
-	const minify = props.minify ?? config.minify;
-
 	const nodejsCompatMode = validateNodeCompatMode(
 		compatibilityDate,
 		compatibilityFlags,
-		{
-			noBundle: props.noBundle ?? config.no_bundle,
-		}
+		{ noBundle }
 	);
 
 	// Warn if user tries minify with no-bundle
-	if (props.noBundle && minify) {
+	if (noBundle && minify) {
 		logger.warn(
 			"`--minify` and `--no-bundle` can't be used together. If you want to minify your Worker and disable Wrangler's bundling, please minify as part of your own bundling process."
 		);
 	}
 
-	const scriptName = props.name;
+	const scriptName = name;
 
 	assert(
 		!config.site || config.site.bucket,
 		"A [site] definition requires a `bucket` field with a path to the site's assets directory."
 	);
 
-	if (props.outDir) {
+	if (props.outdir) {
 		// we're using a custom output directory,
 		// so let's first ensure it exists
-		mkdirSync(props.outDir, { recursive: true });
+		mkdirSync(props.outdir, { recursive: true });
 		// add a README
-		const readmePath = path.join(props.outDir, "README.md");
+		const readmePath = path.join(props.outdir, "README.md");
 		writeFileSync(
 			readmePath,
 			`This folder contains the built output assets for the worker "${scriptName}" generated at ${new Date().toISOString()}.`
 		);
 	}
 
-	const destination =
-		props.outDir ?? getWranglerTmpDir(props.projectRoot, "deploy");
 	const envName = props.env ?? "production";
 
 	const start = Date.now();
-	/** Whether to use the deprecated service environments path */
-	const useServiceEnvironments = Boolean(
-		props.useServiceEnvironments && props.env
-	);
+	const useServiceEnvironments = props.useServiceEnvApiPath;
 	const workerName = useServiceEnvironments
 		? `${scriptName} (${envName})`
 		: scriptName;
@@ -385,7 +347,9 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			? `/accounts/${accountId}/workers/services/${scriptName}/environments/${envName}`
 			: `/accounts/${accountId}/workers/scripts/${scriptName}`;
 
-	const { format } = props.entry;
+	const { format } = entry;
+	const projectRoot =
+		config.userConfigPath && path.dirname(config.userConfigPath);
 
 	if (
 		!props.dispatchNamespace &&
@@ -444,32 +408,30 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		props
 	);
 	try {
-		if (props.noBundle) {
+		if (noBundle) {
 			// if we're not building, let's just copy the entry to the destination directory
 			const destinationDir =
 				typeof destination === "string" ? destination : destination.path;
 			mkdirSync(destinationDir, { recursive: true });
 			writeFileSync(
-				path.join(destinationDir, path.basename(props.entry.file)),
-				readFileSync(props.entry.file, "utf-8")
+				path.join(destinationDir, path.basename(entry.file)),
+				readFileSync(entry.file, "utf-8")
 			);
 		}
 
-		const entryDirectory = path.dirname(props.entry.file);
+		const entryDirectory = path.dirname(entry.file);
 		const moduleCollector = createModuleCollector({
 			wrangler1xLegacyModuleReferences: getWrangler1xLegacyModuleReferences(
 				entryDirectory,
-				props.entry.file
+				entry.file
 			),
-			entry: props.entry,
-			// `moduleCollector` doesn't get used when `props.noBundle` is set, so
+			entry,
+			// `moduleCollector` doesn't get used when `noBundle` is set, so
 			// `findAdditionalModules` always defaults to `false`
 			findAdditionalModules: config.find_additional_modules ?? false,
-			rules: props.rules,
+			rules: config.rules ?? [],
 			preserveFileNames: config.preserve_file_names ?? false,
 		});
-		const uploadSourceMaps =
-			props.uploadSourceMaps ?? config.upload_source_maps;
 
 		const {
 			modules,
@@ -477,15 +439,15 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			resolvedEntryPointPath,
 			bundleType,
 			...bundle
-		} = props.noBundle
+		} = noBundle
 			? await noBundleWorker(
-					props.entry,
-					props.rules,
-					props.outDir,
+					entry,
+					config.rules ?? [],
+					props.outdir,
 					config.python_modules.exclude
 				)
 			: await bundleWorker(
-					props.entry,
+					entry,
 					typeof destination === "string" ? destination : destination.path,
 					{
 						metafile: props.metafile,
@@ -496,21 +458,21 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 						workflowBindings: config.workflows ?? [],
 						jsxFactory,
 						jsxFragment,
-						tsconfig: props.tsconfig ?? config.tsconfig,
+						tsconfig: props.tsconfig,
 						minify,
 						keepNames: config.keep_names ?? true,
 						sourcemap: uploadSourceMaps,
 						nodejsCompatMode,
 						compatibilityDate,
 						compatibilityFlags,
-						define: { ...config.define, ...props.defines },
+						define: props.defines,
 						checkFetch: false,
-						alias: { ...config.alias, ...props.alias },
+						alias: props.alias,
 						// We want to know if the build is for development or publishing
 						// This could potentially cause issues as we no longer have identical behaviour between dev and deploy?
 						targetConsumer: "deploy",
 						local: false,
-						projectRoot: props.projectRoot,
+						projectRoot,
 						defineNavigatorUserAgent: isNavigatorDefined(
 							compatibilityDate,
 							compatibilityFlags
@@ -551,7 +513,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			? await getMigrationsToUpload(scriptName, {
 					accountId,
 					config,
-					useServiceEnvironments: props.useServiceEnvironments,
+					useServiceEnvironments: useServiceEnvironmentsConfig(config),
 					env: props.env,
 					dispatchNamespace: props.dispatchNamespace,
 				})
@@ -591,7 +553,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		const bindings = getBindings(config);
 
 		// Vars from the CLI (--var) are hidden so their values aren't logged to the terminal
-		for (const [bindingName, value] of Object.entries(props.vars ?? {})) {
+		for (const [bindingName, value] of Object.entries(props.cliVars)) {
 			bindings[bindingName] = {
 				type: "plain_text",
 				value,
@@ -649,7 +611,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			compatibility_flags: compatibilityFlags,
 			keepVars,
 			keepSecrets: keepVars || !!props.secretsFile,
-			logpush: props.logpush !== undefined ? props.logpush : config.logpush,
+			logpush: props.logpush,
 			placement,
 			tail_consumers: config.tail_consumers,
 			streaming_tail_consumers: config.streaming_tail_consumers,
@@ -772,7 +734,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 					accountId,
 					scriptName,
 					props.experimentalAutoCreate,
-					props.config
+					config
 				);
 			}
 
@@ -823,7 +785,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 					const versionMap = new Map<VersionId, Percentage>();
 					versionMap.set(versionResult.id, 100);
 					await createDeployment(
-						props.config,
+						config,
 						accountId,
 						scriptName,
 						versionMap,
@@ -836,7 +798,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 					try {
 						// Update tail consumers, logpush, and observability settings
 						await patchNonVersionedScriptSettings(
-							props.config,
+							config,
 							accountId,
 							scriptName,
 							{
@@ -892,7 +854,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 					if (!tagsAreEqual(tags, nextTags)) {
 						try {
 							await patchNonVersionedScriptSettings(
-								props.config,
+								config,
 								accountId,
 								scriptName,
 								{
@@ -954,7 +916,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 					err,
 					dependencies,
 					workerBundle,
-					props.projectRoot
+					projectRoot
 				);
 				if (message !== null) {
 					logger.error(message);
@@ -1013,14 +975,14 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 				throw err;
 			}
 		}
-		if (props.outFile) {
+		if (props.outfile) {
 			// we're using a custom output file,
 			// so let's first ensure it's parent directory exists
-			mkdirSync(path.dirname(props.outFile), { recursive: true });
+			mkdirSync(path.dirname(props.outfile), { recursive: true });
 
 			const serializedFormData = await new Response(workerBundle).arrayBuffer();
 
-			writeFileSync(props.outFile, Buffer.from(serializedFormData));
+			writeFileSync(props.outfile, Buffer.from(serializedFormData));
 		}
 	} finally {
 		if (typeof destination !== "string") {
@@ -1061,7 +1023,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			accountId,
 			scriptName,
 			env: props.env,
-			crons: props.triggers || config.triggers?.crons,
+			crons: props.triggers,
 			useServiceEnvironments,
 			firstDeploy: !workerExists,
 			routes: allDeploymentRoutes,

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -929,7 +929,9 @@ function getDeployConfirmFunction(
 			process.exitCode = 1;
 			return false;
 		};
+	} else if (nonInteractive) {
+		// if its not in strict mode, continue without asking
+		return async () => true;
 	}
-
 	return confirm;
 }

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { URLSearchParams } from "node:url";
 import { cancel } from "@cloudflare/cli-shared-helpers";
@@ -23,15 +23,8 @@ import { buildContainer } from "../containers/build";
 import { getNormalizedContainerOptions } from "../containers/config";
 import { deployContainers } from "../containers/deploy";
 import { getBindings, provisionBindings } from "../deployment-bundle/bindings";
-import { bundleWorker } from "../deployment-bundle/bundle";
 import { printBundleSize } from "../deployment-bundle/bundle-reporter";
 import { createWorkerUploadForm } from "../deployment-bundle/create-worker-upload-form";
-import { logBuildOutput } from "../deployment-bundle/esbuild-plugins/log-build-output";
-import {
-	createModuleCollector,
-	getWrangler1xLegacyModuleReferences,
-} from "../deployment-bundle/module-collection";
-import { noBundleWorker } from "../deployment-bundle/no-bundle-worker";
 import { validateNodeCompatMode } from "../deployment-bundle/node-compat";
 import { validateRoutes } from "../deployment-bundle/resolve-config-args";
 import {
@@ -51,7 +44,6 @@ import isInteractive, { isNonInteractiveOrCI } from "../is-interactive";
 import { logger } from "../logger";
 import { verifyWorkerMatchesCITag } from "../match-tag";
 import { getMetricsUsageHeaders } from "../metrics";
-import { isNavigatorDefined } from "../navigator-user-agent";
 import { ensureQueuesExistByConfig } from "../queues/client";
 import { parseBulkInputToObject } from "../secret";
 import { syncWorkersSite } from "../sites";
@@ -79,7 +71,7 @@ import type { StartDevWorkerInput } from "../api/startDevWorker/types";
 import type { HandlerContext } from "../core/types";
 import type { RetrieveSourceMapFunction } from "../sourcemap";
 import type { ApiVersion, Percentage, VersionId } from "../versions/types";
-import type { DeployProps } from "@cloudflare/deploy-helpers";
+import type { DeployProps, HandleBuild } from "@cloudflare/deploy-helpers";
 import type {
 	CfModule,
 	CfScriptFormat,
@@ -123,7 +115,7 @@ function addWorkersSitesBindings(
 export default async function deploy(
 	props: DeployProps,
 	config: Config,
-	workerNameOverridden: boolean,
+	buildWorker: HandleBuild,
 	ctx: Omit<HandlerContext, "config">
 ): Promise<{
 	sourceMapSize?: number;
@@ -143,12 +135,9 @@ export default async function deploy(
 		name,
 		compatibilityDate,
 		compatibilityFlags,
-		jsxFactory,
-		jsxFragment,
 		keepVars,
 		minify,
 		noBundle,
-		destination,
 		uploadSourceMaps,
 	} = props;
 
@@ -322,18 +311,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		"A [site] definition requires a `bucket` field with a path to the site's assets directory."
 	);
 
-	if (props.outdir) {
-		// we're using a custom output directory,
-		// so let's first ensure it exists
-		mkdirSync(props.outdir, { recursive: true });
-		// add a README
-		const readmePath = path.join(props.outdir, "README.md");
-		writeFileSync(
-			readmePath,
-			`This folder contains the built output assets for the worker "${scriptName}" generated at ${new Date().toISOString()}.`
-		);
-	}
-
 	const envName = props.env ?? "production";
 
 	const start = Date.now();
@@ -348,8 +325,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			: `/accounts/${accountId}/workers/scripts/${scriptName}`;
 
 	const { format } = entry;
-	const projectRoot =
-		config.userConfigPath && path.dirname(config.userConfigPath);
+	const { projectRoot } = entry;
 
 	if (
 		!props.dispatchNamespace &&
@@ -407,107 +383,18 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		config,
 		props
 	);
+	const {
+		modules,
+		dependencies,
+		resolvedEntryPointPath,
+		bundleType,
+		content,
+		bundle,
+	} = await buildWorker.build(props, config, {
+		nodejsCompatMode,
+		metafile: props.metafile,
+	});
 	try {
-		if (noBundle) {
-			// if we're not building, let's just copy the entry to the destination directory
-			const destinationDir =
-				typeof destination === "string" ? destination : destination.path;
-			mkdirSync(destinationDir, { recursive: true });
-			writeFileSync(
-				path.join(destinationDir, path.basename(entry.file)),
-				readFileSync(entry.file, "utf-8")
-			);
-		}
-
-		const entryDirectory = path.dirname(entry.file);
-		const moduleCollector = createModuleCollector({
-			wrangler1xLegacyModuleReferences: getWrangler1xLegacyModuleReferences(
-				entryDirectory,
-				entry.file
-			),
-			entry,
-			// `moduleCollector` doesn't get used when `noBundle` is set, so
-			// `findAdditionalModules` always defaults to `false`
-			findAdditionalModules: config.find_additional_modules ?? false,
-			rules: config.rules ?? [],
-			preserveFileNames: config.preserve_file_names ?? false,
-		});
-
-		const {
-			modules,
-			dependencies,
-			resolvedEntryPointPath,
-			bundleType,
-			...bundle
-		} = noBundle
-			? await noBundleWorker(
-					entry,
-					config.rules ?? [],
-					props.outdir,
-					config.python_modules.exclude
-				)
-			: await bundleWorker(
-					entry,
-					typeof destination === "string" ? destination : destination.path,
-					{
-						metafile: props.metafile,
-						bundle: true,
-						additionalModules: [],
-						moduleCollector,
-						doBindings: config.durable_objects.bindings,
-						workflowBindings: config.workflows ?? [],
-						jsxFactory,
-						jsxFragment,
-						tsconfig: props.tsconfig,
-						minify,
-						keepNames: config.keep_names ?? true,
-						sourcemap: uploadSourceMaps,
-						nodejsCompatMode,
-						compatibilityDate,
-						compatibilityFlags,
-						define: props.defines,
-						checkFetch: false,
-						alias: props.alias,
-						// We want to know if the build is for development or publishing
-						// This could potentially cause issues as we no longer have identical behaviour between dev and deploy?
-						targetConsumer: "deploy",
-						local: false,
-						projectRoot,
-						defineNavigatorUserAgent: isNavigatorDefined(
-							compatibilityDate,
-							compatibilityFlags
-						),
-						plugins: [logBuildOutput(nodejsCompatMode)],
-
-						// Pages specific options used by wrangler pages commands
-						entryName: undefined,
-						inject: undefined,
-						isOutfile: undefined,
-						external: undefined,
-
-						// These options are dev-only
-						testScheduled: undefined,
-						watch: undefined,
-					}
-				);
-
-		// Add modules to dependencies for size warning
-		for (const module of modules) {
-			const modulePath =
-				module.filePath === undefined
-					? module.name
-					: path.relative("", module.filePath);
-			const bytesInOutput =
-				typeof module.content === "string"
-					? Buffer.byteLength(module.content)
-					: module.content.byteLength;
-			dependencies[modulePath] = { bytesInOutput };
-		}
-
-		const content = readFileSync(resolvedEntryPointPath, {
-			encoding: "utf-8",
-		});
-
 		// durable object migrations
 		const migrations = !isDryRun
 			? await getMigrationsToUpload(scriptName, {
@@ -985,11 +872,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			writeFileSync(props.outfile, Buffer.from(serializedFormData));
 		}
 	} finally {
-		if (typeof destination !== "string") {
-			// this means we're using a temp dir,
-			// so let's clean up before we proceed
-			destination.remove();
-		}
+		buildWorker.cleanup(props);
 	}
 
 	if (isDryRun) {

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -39,11 +39,9 @@ import {
 	tagsAreEqual,
 	warnOnErrorUpdatingServiceAndEnvironmentTags,
 } from "../environments";
-import { getFlag } from "../experimental-flags";
-import isInteractive, { isNonInteractiveOrCI } from "../is-interactive";
+import { isNonInteractiveOrCI } from "../is-interactive";
 import { logger } from "../logger";
 import { verifyWorkerMatchesCITag } from "../match-tag";
-import { getMetricsUsageHeaders } from "../metrics";
 import { ensureQueuesExistByConfig } from "../queues/client";
 import { parseBulkInputToObject } from "../secret";
 import { syncWorkersSite } from "../sites";
@@ -51,7 +49,6 @@ import {
 	getSourceMappedString,
 	maybeRetrieveFileSourceMap,
 } from "../sourcemap";
-import { requireAuth } from "../user";
 import { downloadWorkerConfig } from "../utils/download-worker-config";
 import { helpIfErrorIsSizeOrScriptStartup } from "../utils/friendly-validator-errors";
 import { parseConfigPlacement } from "../utils/placement";
@@ -139,9 +136,8 @@ export default async function deploy(
 		minify,
 		noBundle,
 		uploadSourceMaps,
+		accountId,
 	} = props;
-
-	const accountId = props.dryRun ? undefined : await requireAuth(config);
 
 	if (!props.dryRun) {
 		assert(accountId, "Missing account ID");
@@ -246,7 +242,7 @@ export default async function deploy(
 		}
 	}
 
-	if (accountId && (isInteractive() || props.strict)) {
+	if (accountId) {
 		const remoteSecretsCheck = await checkRemoteSecretsOverride(
 			config,
 			props.env
@@ -260,11 +256,7 @@ export default async function deploy(
 		}
 	}
 
-	if (
-		accountId &&
-		config.workflows?.length &&
-		(isInteractive() || props.strict)
-	) {
+	if (accountId && config.workflows?.length) {
 		const workflowCheck = await checkWorkflowConflicts(config, accountId, name);
 
 		if (workflowCheck.hasConflicts) {
@@ -615,7 +607,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		} else {
 			assert(accountId, "Missing accountId");
 
-			if (getFlag("RESOURCES_PROVISION")) {
+			if (props.resourcesProvision) {
 				await provisionBindings(
 					bindings ?? {},
 					accountId,
@@ -662,7 +654,9 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 							{
 								method: "POST",
 								body: workerBundle,
-								headers: await getMetricsUsageHeaders(config.send_metrics),
+								headers: props.sendMetrics
+									? { metricsEnabled: "true" }
+									: undefined,
 							},
 							new URLSearchParams({ bindings_inherit: "strict" })
 						)
@@ -725,7 +719,9 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 							{
 								method: "PUT",
 								body: workerBundle,
-								headers: await getMetricsUsageHeaders(config.send_metrics),
+								headers: props.sendMetrics
+									? { metricsEnabled: "true" }
+									: undefined,
 							},
 							new URLSearchParams({
 								// pass excludeScript so the whole body of the

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -370,7 +370,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 	const isDryRun = props.dryRun;
 
-	let sourceMapSize;
 	const normalisedContainerConfig = await getNormalizedContainerOptions(
 		config,
 		props
@@ -386,375 +385,398 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		nodejsCompatMode,
 		metafile: props.metafile,
 	});
-	try {
-		// durable object migrations
-		const migrations = !isDryRun
-			? await getMigrationsToUpload(scriptName, {
-					accountId,
+	// durable object migrations
+	const migrations = !isDryRun
+		? await getMigrationsToUpload(scriptName, {
+				accountId,
+				config,
+				useServiceEnvironments: useServiceEnvironmentsConfig(config),
+				env: props.env,
+				dispatchNamespace: props.dispatchNamespace,
+			})
+		: undefined;
+
+	// Upload assets if assets is being used
+	const assetsJwt =
+		props.assetsOptions && !isDryRun
+			? await syncAssets(
 					config,
-					useServiceEnvironments: useServiceEnvironmentsConfig(config),
-					env: props.env,
-					dispatchNamespace: props.dispatchNamespace,
-				})
+					accountId,
+					props.assetsOptions.directory,
+					scriptName,
+					props.dispatchNamespace
+				)
 			: undefined;
 
-		// Upload assets if assets is being used
-		const assetsJwt =
-			props.assetsOptions && !isDryRun
-				? await syncAssets(
-						config,
-						accountId,
-						props.assetsOptions.directory,
-						scriptName,
-						props.dispatchNamespace
-					)
-				: undefined;
+	// validate asset directory
+	if (props.assetsOptions && isDryRun) {
+		await buildAssetManifest(props.assetsOptions.directory);
+	}
 
-		// validate asset directory
-		if (props.assetsOptions && isDryRun) {
-			await buildAssetManifest(props.assetsOptions.directory);
-		}
+	const workersSitesAssets = await syncWorkersSite(
+		config,
+		accountId,
+		// When we're using the newer service environments, we wouldn't
+		// have added the env name on to the script name. However, we must
+		// include it in the kv namespace name regardless (since there's no
+		// concept of service environments for kv namespaces yet).
+		scriptName + (useServiceEnvironments ? `-${props.env}` : ""),
+		props.legacyAssetPaths,
+		false,
+		isDryRun,
+		props.oldAssetTtl
+	);
 
-		const workersSitesAssets = await syncWorkersSite(
-			config,
-			accountId,
-			// When we're using the newer service environments, we wouldn't
-			// have added the env name on to the script name. However, we must
-			// include it in the kv namespace name regardless (since there's no
-			// concept of service environments for kv namespaces yet).
-			scriptName + (useServiceEnvironments ? `-${props.env}` : ""),
-			props.legacyAssetPaths,
-			false,
-			isDryRun,
-			props.oldAssetTtl
-		);
+	const bindings = getBindings(config);
 
-		const bindings = getBindings(config);
+	// Vars from the CLI (--var) are hidden so their values aren't logged to the terminal
+	for (const [bindingName, value] of Object.entries(props.cliVars)) {
+		bindings[bindingName] = {
+			type: "plain_text",
+			value,
+			hidden: true,
+		};
+	}
 
-		// Vars from the CLI (--var) are hidden so their values aren't logged to the terminal
-		for (const [bindingName, value] of Object.entries(props.cliVars)) {
-			bindings[bindingName] = {
-				type: "plain_text",
-				value,
-				hidden: true,
-			};
-		}
-
-		if (props.secretsFile) {
-			const secretsResult = await parseBulkInputToObject(props.secretsFile);
-			if (secretsResult) {
-				for (const [secretName, secretValue] of Object.entries(
-					secretsResult.content
-				)) {
-					bindings[secretName] = {
-						type: "secret_text",
-						value: secretValue,
-					};
-				}
+	if (props.secretsFile) {
+		const secretsResult = await parseBulkInputToObject(props.secretsFile);
+		if (secretsResult) {
+			for (const [secretName, secretValue] of Object.entries(
+				secretsResult.content
+			)) {
+				bindings[secretName] = {
+					type: "secret_text",
+					value: secretValue,
+				};
 			}
 		}
+	}
 
-		addRequiredSecretsInheritBindings(config, bindings, {
-			type: "deploy",
-			workerExists,
+	addRequiredSecretsInheritBindings(config, bindings, {
+		type: "deploy",
+		workerExists,
+	});
+
+	if (workersSitesAssets.manifest) {
+		modules.push({
+			name: "__STATIC_CONTENT_MANIFEST",
+			filePath: undefined,
+			content: JSON.stringify(workersSitesAssets.manifest),
+			type: "text",
 		});
+	}
 
-		if (workersSitesAssets.manifest) {
-			modules.push({
-				name: "__STATIC_CONTENT_MANIFEST",
-				filePath: undefined,
-				content: JSON.stringify(workersSitesAssets.manifest),
-				type: "text",
+	const placement = parseConfigPlacement(config);
+
+	const entryPointName = path.basename(resolvedEntryPointPath);
+	const main: CfModule = {
+		name: entryPointName,
+		filePath: resolvedEntryPointPath,
+		content: content,
+		type: bundleType,
+	};
+	const worker: CfWorkerInit = {
+		name: scriptName,
+		main,
+		migrations,
+		modules,
+		containers: config.containers,
+		sourceMaps: uploadSourceMaps
+			? loadSourceMaps(main, modules, bundle)
+			: undefined,
+		compatibility_date: compatibilityDate,
+		compatibility_flags: compatibilityFlags,
+		keepVars,
+		keepSecrets: keepVars || !!props.secretsFile,
+		logpush: props.logpush,
+		placement,
+		tail_consumers: config.tail_consumers,
+		streaming_tail_consumers: config.streaming_tail_consumers,
+		limits: config.limits,
+		annotations:
+			props.tag || props.message
+				? {
+						"workers/message": props.message,
+						"workers/tag": props.tag,
+					}
+				: undefined,
+		assets:
+			props.assetsOptions && assetsJwt
+				? {
+						jwt: assetsJwt,
+						routerConfig: props.assetsOptions.routerConfig,
+						assetConfig: props.assetsOptions.assetConfig,
+						_redirects: props.assetsOptions._redirects,
+						_headers: props.assetsOptions._headers,
+						run_worker_first: props.assetsOptions.run_worker_first,
+					}
+				: undefined,
+		observability: config.observability,
+		cache: config.cache,
+	};
+
+	const sourceMapSize = worker.sourceMaps?.reduce(
+		(acc, m) => acc + m.content.length,
+		0
+	);
+
+	await printBundleSize(
+		{ name: path.basename(resolvedEntryPointPath), content: content },
+		modules
+	);
+
+	// We can use the new versions/deployments APIs if we:
+	// * are uploading a worker that already exists
+	// * aren't a dispatch namespace deploy
+	// * aren't a service env deploy
+	// * aren't a service Worker
+	// * we don't have DO migrations
+	// * we aren't an fpw
+	// * not a container worker
+	const canUseNewVersionsDeploymentsApi =
+		workerExists &&
+		props.dispatchNamespace === undefined &&
+		!useServiceEnvironments &&
+		format === "modules" &&
+		migrations === undefined &&
+		!config.first_party_worker &&
+		config.containers === undefined;
+
+	let workerBundle: FormData;
+	const dockerPath = getDockerPath();
+
+	// lets fail earlier in the case where docker isn't installed
+	// and we have containers so that we don't get into a
+	// disjointed state where the worker updates but the container
+	// fails.
+	if (normalisedContainerConfig.length && props.containersRollout !== "none") {
+		// if you have a registry url specified, you don't need docker
+		const containersWithDockerfile = normalisedContainerConfig.filter(
+			(container) => "dockerfile" in container
+		);
+		if (containersWithDockerfile.length > 0) {
+			await verifyDockerInstalled({
+				dockerPath,
+				isDev: false,
+				isDryRun,
+				numberOfContainers: containersWithDockerfile.length,
 			});
 		}
+	}
 
-		const placement = parseConfigPlacement(config);
-
-		const entryPointName = path.basename(resolvedEntryPointPath);
-		const main: CfModule = {
-			name: entryPointName,
-			filePath: resolvedEntryPointPath,
-			content: content,
-			type: bundleType,
-		};
-		const worker: CfWorkerInit = {
-			name: scriptName,
-			main,
-			migrations,
-			modules,
-			containers: config.containers,
-			sourceMaps: uploadSourceMaps
-				? loadSourceMaps(main, modules, bundle)
-				: undefined,
-			compatibility_date: compatibilityDate,
-			compatibility_flags: compatibilityFlags,
-			keepVars,
-			keepSecrets: keepVars || !!props.secretsFile,
-			logpush: props.logpush,
-			placement,
-			tail_consumers: config.tail_consumers,
-			streaming_tail_consumers: config.streaming_tail_consumers,
-			limits: config.limits,
-			annotations:
-				props.tag || props.message
-					? {
-							"workers/message": props.message,
-							"workers/tag": props.tag,
-						}
-					: undefined,
-			assets:
-				props.assetsOptions && assetsJwt
-					? {
-							jwt: assetsJwt,
-							routerConfig: props.assetsOptions.routerConfig,
-							assetConfig: props.assetsOptions.assetConfig,
-							_redirects: props.assetsOptions._redirects,
-							_headers: props.assetsOptions._headers,
-							run_worker_first: props.assetsOptions.run_worker_first,
-						}
-					: undefined,
-			observability: config.observability,
-			cache: config.cache,
-		};
-
-		sourceMapSize = worker.sourceMaps?.reduce(
-			(acc, m) => acc + m.content.length,
-			0
-		);
-
-		await printBundleSize(
-			{ name: path.basename(resolvedEntryPointPath), content: content },
-			modules
-		);
-
-		// We can use the new versions/deployments APIs if we:
-		// * are uploading a worker that already exists
-		// * aren't a dispatch namespace deploy
-		// * aren't a service env deploy
-		// * aren't a service Worker
-		// * we don't have DO migrations
-		// * we aren't an fpw
-		// * not a container worker
-		const canUseNewVersionsDeploymentsApi =
-			workerExists &&
-			props.dispatchNamespace === undefined &&
-			!useServiceEnvironments &&
-			format === "modules" &&
-			migrations === undefined &&
-			!config.first_party_worker &&
-			config.containers === undefined;
-
-		let workerBundle: FormData;
-		const dockerPath = getDockerPath();
-
-		// lets fail earlier in the case where docker isn't installed
-		// and we have containers so that we don't get into a
-		// disjointed state where the worker updates but the container
-		// fails.
-		if (
-			normalisedContainerConfig.length &&
-			props.containersRollout !== "none"
-		) {
-			// if you have a registry url specified, you don't need docker
-			const containersWithDockerfile = normalisedContainerConfig.filter(
-				(container) => "dockerfile" in container
-			);
-			if (containersWithDockerfile.length > 0) {
-				await verifyDockerInstalled({
-					dockerPath,
-					isDev: false,
-					isDryRun,
-					numberOfContainers: containersWithDockerfile.length,
-				});
+	if (isDryRun) {
+		if (normalisedContainerConfig.length) {
+			for (const container of normalisedContainerConfig) {
+				if ("dockerfile" in container && props.containersRollout !== "none") {
+					await buildContainer(
+						container,
+						workerTag ?? "worker-tag",
+						isDryRun,
+						dockerPath
+					);
+				}
 			}
 		}
 
-		if (isDryRun) {
-			if (normalisedContainerConfig.length) {
-				for (const container of normalisedContainerConfig) {
-					if ("dockerfile" in container && props.containersRollout !== "none") {
-						await buildContainer(
-							container,
-							workerTag ?? "worker-tag",
-							isDryRun,
-							dockerPath
-						);
-					}
-				}
+		workerBundle = createWorkerUploadForm(
+			worker,
+			addWorkersSitesBindings(
+				bindings ?? {},
+				workersSitesAssets.namespace,
+				workersSitesAssets.manifest,
+				format
+			),
+			{
+				dryRun: true,
+				unsafe: config.unsafe,
 			}
+		);
 
-			workerBundle = createWorkerUploadForm(
-				worker,
-				addWorkersSitesBindings(
-					bindings ?? {},
-					workersSitesAssets.namespace,
-					workersSitesAssets.manifest,
-					format
-				),
-				{
-					dryRun: true,
-					unsafe: config.unsafe,
-				}
+		printBindings(
+			bindings,
+			config.tail_consumers,
+			config.streaming_tail_consumers,
+			config.containers,
+			{ warnIfNoBindings: true, unsafeMetadata: config.unsafe?.metadata }
+		);
+	} else {
+		assert(accountId, "Missing accountId");
+
+		if (props.resourcesProvision) {
+			await provisionBindings(
+				bindings ?? {},
+				accountId,
+				scriptName,
+				props.experimentalAutoCreate,
+				config
 			);
+		}
 
-			printBindings(
-				bindings,
-				config.tail_consumers,
-				config.streaming_tail_consumers,
-				config.containers,
-				{ warnIfNoBindings: true, unsafeMetadata: config.unsafe?.metadata }
-			);
-		} else {
-			assert(accountId, "Missing accountId");
+		workerBundle = createWorkerUploadForm(
+			worker,
+			addWorkersSitesBindings(
+				bindings ?? {},
+				workersSitesAssets.namespace,
+				workersSitesAssets.manifest,
+				format
+			),
+			{
+				unsafe: config.unsafe,
+			}
+		);
 
-			if (props.resourcesProvision) {
-				await provisionBindings(
-					bindings ?? {},
+		await ensureQueuesExistByConfig(config);
+		let bindingsPrinted = false;
+
+		// Upload the script so it has time to propagate.
+		try {
+			let result: {
+				id: string | null;
+				etag: string | null;
+				pipeline_hash: string | null;
+				mutable_pipeline_id: string | null;
+				deployment_id: string | null;
+				startup_time_ms?: number;
+			};
+
+			// If we're using the new APIs, first upload the version
+			if (canUseNewVersionsDeploymentsApi) {
+				// Upload new version
+				const versionResult = await retryOnAPIFailure(async () =>
+					fetchResult<ApiVersion>(
+						config,
+						`/accounts/${accountId}/workers/scripts/${scriptName}/versions`,
+						{
+							method: "POST",
+							body: workerBundle,
+							headers: props.sendMetrics
+								? { metricsEnabled: "true" }
+								: undefined,
+						},
+						new URLSearchParams({ bindings_inherit: "strict" })
+					)
+				);
+
+				// Deploy new version to 100%
+				const versionMap = new Map<VersionId, Percentage>();
+				versionMap.set(versionResult.id, 100);
+				await createDeployment(
+					config,
 					accountId,
 					scriptName,
-					props.experimentalAutoCreate,
-					config
+					versionMap,
+					props.message
 				);
-			}
 
-			workerBundle = createWorkerUploadForm(
-				worker,
-				addWorkersSitesBindings(
-					bindings ?? {},
-					workersSitesAssets.namespace,
-					workersSitesAssets.manifest,
-					format
-				),
-				{
-					unsafe: config.unsafe,
+				// Update service and environment tags when using environments
+				const nextTags = applyServiceAndEnvironmentTags(config, tags);
+
+				try {
+					// Update tail consumers, logpush, and observability settings
+					await patchNonVersionedScriptSettings(config, accountId, scriptName, {
+						tail_consumers: worker.tail_consumers,
+						logpush: worker.logpush,
+						// If the user hasn't specified observability assume that they want it disabled if they have it on.
+						// This is a no-op in the event that they don't have observability enabled, but will remove observability
+						// if it has been removed from their Wrangler configuration file
+						observability: worker.observability ?? { enabled: false },
+						tags: nextTags,
+					});
+				} catch {
+					warnOnErrorUpdatingServiceAndEnvironmentTags();
 				}
-			);
 
-			await ensureQueuesExistByConfig(config);
-			let bindingsPrinted = false;
-
-			// Upload the script so it has time to propagate.
-			try {
-				let result: {
-					id: string | null;
-					etag: string | null;
-					pipeline_hash: string | null;
-					mutable_pipeline_id: string | null;
-					deployment_id: string | null;
-					startup_time_ms?: number;
+				result = {
+					id: null, // fpw - ignore
+					etag: versionResult.resources.script.etag,
+					pipeline_hash: null, // fpw - ignore
+					mutable_pipeline_id: null, // fpw - ignore
+					deployment_id: versionResult.id, // version id not deployment id but easier to adapt here
+					startup_time_ms: versionResult.startup_time_ms,
 				};
-
-				// If we're using the new APIs, first upload the version
-				if (canUseNewVersionsDeploymentsApi) {
-					// Upload new version
-					const versionResult = await retryOnAPIFailure(async () =>
-						fetchResult<ApiVersion>(
-							config,
-							`/accounts/${accountId}/workers/scripts/${scriptName}/versions`,
-							{
-								method: "POST",
-								body: workerBundle,
-								headers: props.sendMetrics
-									? { metricsEnabled: "true" }
-									: undefined,
-							},
-							new URLSearchParams({ bindings_inherit: "strict" })
-						)
-					);
-
-					// Deploy new version to 100%
-					const versionMap = new Map<VersionId, Percentage>();
-					versionMap.set(versionResult.id, 100);
-					await createDeployment(
+			} else {
+				result = await retryOnAPIFailure(async () =>
+					fetchResult<{
+						id: string | null;
+						etag: string | null;
+						pipeline_hash: string | null;
+						mutable_pipeline_id: string | null;
+						deployment_id: string | null;
+						startup_time_ms: number;
+					}>(
 						config,
-						accountId,
-						scriptName,
-						versionMap,
-						props.message
-					);
+						workerUrl,
+						{
+							method: "PUT",
+							body: workerBundle,
+							headers: props.sendMetrics
+								? { metricsEnabled: "true" }
+								: undefined,
+						},
+						new URLSearchParams({
+							// pass excludeScript so the whole body of the
+							// script doesn't get included in the response
+							excludeScript: "true",
+							bindings_inherit: "strict",
+						})
+					)
+				);
 
-					// Update service and environment tags when using environments
-					const nextTags = applyServiceAndEnvironmentTags(config, tags);
-
+				// Update service and environment tags when using environments
+				const nextTags = applyServiceAndEnvironmentTags(config, tags);
+				if (!tagsAreEqual(tags, nextTags)) {
 					try {
-						// Update tail consumers, logpush, and observability settings
 						await patchNonVersionedScriptSettings(
 							config,
 							accountId,
 							scriptName,
 							{
-								tail_consumers: worker.tail_consumers,
-								logpush: worker.logpush,
-								// If the user hasn't specified observability assume that they want it disabled if they have it on.
-								// This is a no-op in the event that they don't have observability enabled, but will remove observability
-								// if it has been removed from their Wrangler configuration file
-								observability: worker.observability ?? { enabled: false },
 								tags: nextTags,
 							}
 						);
 					} catch {
 						warnOnErrorUpdatingServiceAndEnvironmentTags();
 					}
+				}
+			}
 
-					result = {
-						id: null, // fpw - ignore
-						etag: versionResult.resources.script.etag,
-						pipeline_hash: null, // fpw - ignore
-						mutable_pipeline_id: null, // fpw - ignore
-						deployment_id: versionResult.id, // version id not deployment id but easier to adapt here
-						startup_time_ms: versionResult.startup_time_ms,
-					};
-				} else {
-					result = await retryOnAPIFailure(async () =>
-						fetchResult<{
-							id: string | null;
-							etag: string | null;
-							pipeline_hash: string | null;
-							mutable_pipeline_id: string | null;
-							deployment_id: string | null;
-							startup_time_ms: number;
-						}>(
-							config,
-							workerUrl,
-							{
-								method: "PUT",
-								body: workerBundle,
-								headers: props.sendMetrics
-									? { metricsEnabled: "true" }
-									: undefined,
-							},
-							new URLSearchParams({
-								// pass excludeScript so the whole body of the
-								// script doesn't get included in the response
-								excludeScript: "true",
-								bindings_inherit: "strict",
-							})
-						)
+			if (result.startup_time_ms) {
+				logger.log("Worker Startup Time:", result.startup_time_ms, "ms");
+			}
+			bindingsPrinted = true;
+
+			printBindings(
+				bindings,
+				config.tail_consumers,
+				config.streaming_tail_consumers,
+				config.containers,
+				{ unsafeMetadata: config.unsafe?.metadata }
+			);
+
+			versionId = parseNonHyphenedUuid(result.deployment_id);
+
+			if (config.first_party_worker) {
+				// Print some useful information returned after publishing
+				// Not all fields will be populated for every worker
+				// These fields are likely to be scraped by tools, so do not rename
+				if (result.id) {
+					logger.log("Worker ID: ", result.id);
+				}
+				if (result.etag) {
+					logger.log("Worker ETag: ", result.etag);
+				}
+				if (result.pipeline_hash) {
+					logger.log("Worker PipelineHash: ", result.pipeline_hash);
+				}
+				if (result.mutable_pipeline_id) {
+					logger.log(
+						"Worker Mutable PipelineID (Development ONLY!):",
+						result.mutable_pipeline_id
 					);
-
-					// Update service and environment tags when using environments
-					const nextTags = applyServiceAndEnvironmentTags(config, tags);
-					if (!tagsAreEqual(tags, nextTags)) {
-						try {
-							await patchNonVersionedScriptSettings(
-								config,
-								accountId,
-								scriptName,
-								{
-									tags: nextTags,
-								}
-							);
-						} catch {
-							warnOnErrorUpdatingServiceAndEnvironmentTags();
-						}
-					}
 				}
-
-				if (result.startup_time_ms) {
-					logger.log("Worker Startup Time:", result.startup_time_ms, "ms");
-				}
-				bindingsPrinted = true;
-
+			}
+		} catch (err) {
+			if (!bindingsPrinted) {
 				printBindings(
 					bindings,
 					config.tail_consumers,
@@ -762,113 +784,78 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 					config.containers,
 					{ unsafeMetadata: config.unsafe?.metadata }
 				);
-
-				versionId = parseNonHyphenedUuid(result.deployment_id);
-
-				if (config.first_party_worker) {
-					// Print some useful information returned after publishing
-					// Not all fields will be populated for every worker
-					// These fields are likely to be scraped by tools, so do not rename
-					if (result.id) {
-						logger.log("Worker ID: ", result.id);
-					}
-					if (result.etag) {
-						logger.log("Worker ETag: ", result.etag);
-					}
-					if (result.pipeline_hash) {
-						logger.log("Worker PipelineHash: ", result.pipeline_hash);
-					}
-					if (result.mutable_pipeline_id) {
-						logger.log(
-							"Worker Mutable PipelineID (Development ONLY!):",
-							result.mutable_pipeline_id
-						);
-					}
-				}
-			} catch (err) {
-				if (!bindingsPrinted) {
-					printBindings(
-						bindings,
-						config.tail_consumers,
-						config.streaming_tail_consumers,
-						config.containers,
-						{ unsafeMetadata: config.unsafe?.metadata }
-					);
-				}
-				const message = await helpIfErrorIsSizeOrScriptStartup(
-					err,
-					dependencies,
-					workerBundle,
-					projectRoot
-				);
-				if (message !== null) {
-					logger.error(message);
-				}
-
-				handleMissingSecretsError(err, config, {
-					type: "deploy",
-					workerExists,
-				});
-
-				// Apply source mapping to validation startup errors if possible
-				if (
-					err instanceof APIError &&
-					"code" in err &&
-					err.code === 10021 /* validation error */ &&
-					err.notes.length > 0
-				) {
-					err.preventReport();
-
-					if (
-						err.notes[0].text ===
-						"binding DB of type d1 must have a valid `id` specified [code: 10021]"
-					) {
-						throw new UserError(
-							"You must use a real database in the database_id configuration. You can find your databases using 'wrangler d1 list', or read how to develop locally with D1 here: https://developers.cloudflare.com/d1/configuration/local-development",
-							{ telemetryMessage: "deploy d1 database binding invalid id" }
-						);
-					}
-
-					const maybeNameToFilePath = (moduleName: string) => {
-						// If this is a service worker, always return the entrypoint path.
-						// Service workers can't have additional JavaScript modules.
-						if (bundleType === "commonjs") {
-							return resolvedEntryPointPath;
-						}
-						// Similarly, if the name matches the entrypoint, return its path
-						if (moduleName === entryPointName) {
-							return resolvedEntryPointPath;
-						}
-						// Otherwise, return the file path of the matching module (if any)
-						for (const module of modules) {
-							if (moduleName === module.name) {
-								return module.filePath;
-							}
-						}
-					};
-					const retrieveSourceMap: RetrieveSourceMapFunction = (moduleName) =>
-						maybeRetrieveFileSourceMap(maybeNameToFilePath(moduleName));
-
-					err.notes[0].text = getSourceMappedString(
-						err.notes[0].text,
-						retrieveSourceMap
-					);
-				}
-
-				throw err;
 			}
-		}
-		if (props.outfile) {
-			// we're using a custom output file,
-			// so let's first ensure it's parent directory exists
-			mkdirSync(path.dirname(props.outfile), { recursive: true });
+			const message = await helpIfErrorIsSizeOrScriptStartup(
+				err,
+				dependencies,
+				workerBundle,
+				projectRoot
+			);
+			if (message !== null) {
+				logger.error(message);
+			}
 
-			const serializedFormData = await new Response(workerBundle).arrayBuffer();
+			handleMissingSecretsError(err, config, {
+				type: "deploy",
+				workerExists,
+			});
 
-			writeFileSync(props.outfile, Buffer.from(serializedFormData));
+			// Apply source mapping to validation startup errors if possible
+			if (
+				err instanceof APIError &&
+				"code" in err &&
+				err.code === 10021 /* validation error */ &&
+				err.notes.length > 0
+			) {
+				err.preventReport();
+
+				if (
+					err.notes[0].text ===
+					"binding DB of type d1 must have a valid `id` specified [code: 10021]"
+				) {
+					throw new UserError(
+						"You must use a real database in the database_id configuration. You can find your databases using 'wrangler d1 list', or read how to develop locally with D1 here: https://developers.cloudflare.com/d1/configuration/local-development",
+						{ telemetryMessage: "deploy d1 database binding invalid id" }
+					);
+				}
+
+				const maybeNameToFilePath = (moduleName: string) => {
+					// If this is a service worker, always return the entrypoint path.
+					// Service workers can't have additional JavaScript modules.
+					if (bundleType === "commonjs") {
+						return resolvedEntryPointPath;
+					}
+					// Similarly, if the name matches the entrypoint, return its path
+					if (moduleName === entryPointName) {
+						return resolvedEntryPointPath;
+					}
+					// Otherwise, return the file path of the matching module (if any)
+					for (const module of modules) {
+						if (moduleName === module.name) {
+							return module.filePath;
+						}
+					}
+				};
+				const retrieveSourceMap: RetrieveSourceMapFunction = (moduleName) =>
+					maybeRetrieveFileSourceMap(maybeNameToFilePath(moduleName));
+
+				err.notes[0].text = getSourceMappedString(
+					err.notes[0].text,
+					retrieveSourceMap
+				);
+			}
+
+			throw err;
 		}
-	} finally {
-		buildWorker.cleanup(props);
+	}
+	if (props.outfile) {
+		// we're using a custom output file,
+		// so let's first ensure it's parent directory exists
+		mkdirSync(path.dirname(props.outfile), { recursive: true });
+
+		const serializedFormData = await new Response(workerBundle).arrayBuffer();
+
+		writeFileSync(props.outfile, Buffer.from(serializedFormData));
 	}
 
 	if (isDryRun) {

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -4,7 +4,10 @@ import {
 	validateDeployVersionsArgs,
 } from "../deployment-bundle/deploy-args";
 import { handleBuild } from "../deployment-bundle/maybe-build-worker";
-import { mergeDeployConfigArgs } from "../deployment-bundle/merge-config-args";
+import {
+	cleanupDestination,
+	mergeDeployConfigArgs,
+} from "../deployment-bundle/merge-config-args";
 import * as metrics from "../metrics";
 import { writeOutput } from "../output";
 import { getScriptName } from "../utils/getScriptName";
@@ -127,42 +130,46 @@ export const deployCommand = createCommand({
 		// Merge CLI args with config into a single props object
 		const mergedProps = await mergeDeployConfigArgs(args, config);
 
-		// Derive workerNameOverridden by comparing pre-merge name with post-merge name
-		const preMergeName = getScriptName(args, config);
-		const workerNameOverridden =
-			mergedProps.name !== undefined && mergedProps.name !== preMergeName;
+		try {
+			// Derive workerNameOverridden by comparing pre-merge name with post-merge name
+			const preMergeName = getScriptName(args, config);
+			const workerNameOverridden =
+				mergedProps.name !== undefined && mergedProps.name !== preMergeName;
 
-		const beforeUpload = Date.now();
+			const beforeUpload = Date.now();
 
-		const { sourceMapSize, versionId, workerTag, targets } = await deploy(
-			mergedProps,
-			config,
-			handleBuild,
-			ctx
-		);
+			const { sourceMapSize, versionId, workerTag, targets } = await deploy(
+				mergedProps,
+				config,
+				handleBuild,
+				ctx
+			);
 
-		writeOutput({
-			type: "deploy",
-			version: 1,
-			worker_name: mergedProps.name ?? null,
-			worker_tag: workerTag,
-			version_id: versionId,
-			targets,
-			wrangler_environment: args.env,
-			worker_name_overridden: workerNameOverridden,
-		});
+			writeOutput({
+				type: "deploy",
+				version: 1,
+				worker_name: mergedProps.name ?? null,
+				worker_tag: workerTag,
+				version_id: versionId,
+				targets,
+				wrangler_environment: args.env,
+				worker_name_overridden: workerNameOverridden,
+			});
 
-		metrics.sendMetricsEvent(
-			"deploy worker script",
-			{
-				usesTypeScript: /\.tsx?$/.test(mergedProps.entry.file),
-				durationMs: Date.now() - beforeUpload,
-				sourceMapSize,
-			},
-			{
-				sendMetrics: config.send_metrics,
-			}
-		);
+			metrics.sendMetricsEvent(
+				"deploy worker script",
+				{
+					usesTypeScript: /\.tsx?$/.test(mergedProps.entry.file),
+					durationMs: Date.now() - beforeUpload,
+					sourceMapSize,
+				},
+				{
+					sendMetrics: config.send_metrics,
+				}
+			);
+		} finally {
+			cleanupDestination(mergedProps.destination);
+		}
 	},
 });
 

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -1,27 +1,12 @@
-import assert from "node:assert";
-import path from "node:path";
-import {
-	getTodaysCompatDate,
-	getCIOverrideName,
-	UserError,
-} from "@cloudflare/workers-utils";
-import { getAssetsOptions, validateAssetsArgsAndConfig } from "../assets";
 import { createCommand } from "../core/create-command";
 import {
 	sharedDeployVersionsArgs,
 	validateDeployVersionsArgs,
 } from "../deployment-bundle/deploy-args";
-import { getEntry } from "../deployment-bundle/entry";
-import { logger } from "../logger";
-import { verifyWorkerMatchesCITag } from "../match-tag";
+import { mergeDeployConfigArgs } from "../deployment-bundle/merge-config-args";
 import * as metrics from "../metrics";
 import { writeOutput } from "../output";
-import { getSiteAssetPaths } from "../sites";
-import { requireAuth } from "../user";
-import { collectKeyValues } from "../utils/collectKeyValues";
-import { getRules } from "../utils/getRules";
 import { getScriptName } from "../utils/getScriptName";
-import { useServiceEnvironments } from "../utils/useServiceEnvironments";
 import { maybeRunAutoConfig, promptForMissingDeployConfig } from "./autoconfig";
 import deploy from "./deploy";
 import { maybeDelegateToOpenNextDeployCommand } from "./open-next";
@@ -138,113 +123,27 @@ export const deployCommand = createCommand({
 			return;
 		}
 
-		const entry = await getEntry(args, config, "deploy");
-		validateAssetsArgsAndConfig(args, config);
+		// Merge CLI args with config into a single props object
+		const mergedProps = await mergeDeployConfigArgs(args, config);
 
-		const assetsOptions = getAssetsOptions({
-			args,
-			config,
-		});
-
-		const cliVars = collectKeyValues(args.var);
-		const cliDefines = collectKeyValues(args.define);
-		const cliAlias = collectKeyValues(args.alias);
-
-		const accountId = args.dryRun ? undefined : await requireAuth(config);
-
-		const siteAssetPaths = getSiteAssetPaths(
-			config,
-			args.site,
-			args.siteInclude,
-			args.siteExclude
-		);
+		// Derive workerNameOverridden by comparing pre-merge name with post-merge name
+		const preMergeName = getScriptName(args, config);
+		const workerNameOverridden =
+			mergedProps.name !== undefined && mergedProps.name !== preMergeName;
 
 		const beforeUpload = Date.now();
-		let name = getScriptName(args, config);
-
-		const ciOverrideName = getCIOverrideName();
-		let workerNameOverridden = false;
-		if (ciOverrideName !== undefined && ciOverrideName !== name) {
-			logger.warn(
-				`Failed to match Worker name. Your config file is using the Worker name "${name}", but the CI system expected "${ciOverrideName}". Overriding using the CI provided Worker name. Workers Builds connected builds will attempt to open a pull request to resolve this config name mismatch.`
-			);
-			name = ciOverrideName;
-			workerNameOverridden = true;
-		}
-
-		if (!name) {
-			throw new UserError(
-				'You need to provide a name when publishing a worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`',
-				{ telemetryMessage: "deploy command missing worker name" }
-			);
-		}
-
-		if (!args.dryRun) {
-			assert(accountId, "Missing account ID");
-			await verifyWorkerMatchesCITag(
-				config,
-				accountId,
-				name,
-				config.configPath
-			);
-		}
-
-		// We use the `userConfigPath` to compute the root of a project,
-		// rather than a redirected (potentially generated) `configPath`.
-		const projectRoot =
-			config.userConfigPath && path.dirname(config.userConfigPath);
 
 		const { sourceMapSize, versionId, workerTag, targets } = await deploy(
-			{
-				config,
-				accountId,
-				name,
-				rules: getRules(config),
-				entry,
-				env: args.env,
-				compatibilityDate: args.latest
-					? getTodaysCompatDate()
-					: args.compatibilityDate,
-				compatibilityFlags: args.compatibilityFlags,
-				vars: cliVars,
-				defines: cliDefines,
-				alias: cliAlias,
-				triggers: args.triggers,
-				jsxFactory: args.jsxFactory,
-				jsxFragment: args.jsxFragment,
-				tsconfig: args.tsconfig,
-				routes: args.routes,
-				domains: args.domains,
-				assetsOptions,
-				legacyAssetPaths: siteAssetPaths,
-				useServiceEnvironments: useServiceEnvironments(config),
-				minify: args.minify,
-				isWorkersSite: Boolean(args.site || config.site),
-				outDir: args.outdir,
-				outFile: args.outfile,
-				dryRun: args.dryRun,
-				metafile: args.metafile,
-				noBundle: !(args.bundle ?? !config.no_bundle),
-				keepVars: args.keepVars,
-				logpush: args.logpush,
-				uploadSourceMaps: args.uploadSourceMaps,
-				oldAssetTtl: args.oldAssetTtl,
-				projectRoot,
-				dispatchNamespace: args.dispatchNamespace,
-				experimentalAutoCreate: args.experimentalAutoCreate,
-				containersRollout: args.containersRollout,
-				strict: args.strict,
-				tag: args.tag,
-				message: args.message,
-				secretsFile: args.secretsFile,
-			},
+			mergedProps,
+			config,
+			workerNameOverridden,
 			ctx
 		);
 
 		writeOutput({
 			type: "deploy",
 			version: 1,
-			worker_name: name ?? null,
+			worker_name: mergedProps.name ?? null,
 			worker_tag: workerTag,
 			version_id: versionId,
 			targets,
@@ -255,7 +154,7 @@ export const deployCommand = createCommand({
 		metrics.sendMetricsEvent(
 			"deploy worker script",
 			{
-				usesTypeScript: /\.tsx?$/.test(entry.file),
+				usesTypeScript: /\.tsx?$/.test(mergedProps.entry.file),
 				durationMs: Date.now() - beforeUpload,
 				sourceMapSize,
 			},

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -3,6 +3,7 @@ import {
 	sharedDeployVersionsArgs,
 	validateDeployVersionsArgs,
 } from "../deployment-bundle/deploy-args";
+import { handleBuild } from "../deployment-bundle/maybe-build-worker";
 import { mergeDeployConfigArgs } from "../deployment-bundle/merge-config-args";
 import * as metrics from "../metrics";
 import { writeOutput } from "../output";
@@ -136,7 +137,7 @@ export const deployCommand = createCommand({
 		const { sourceMapSize, versionId, workerTag, targets } = await deploy(
 			mergedProps,
 			config,
-			workerNameOverridden,
+			handleBuild,
 			ctx
 		);
 

--- a/packages/wrangler/src/deployment-bundle/maybe-build-worker.ts
+++ b/packages/wrangler/src/deployment-bundle/maybe-build-worker.ts
@@ -1,0 +1,158 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { isNavigatorDefined } from "../navigator-user-agent";
+import { bundleWorker } from "./bundle";
+import { logBuildOutput } from "./esbuild-plugins/log-build-output";
+import {
+	createModuleCollector,
+	getWrangler1xLegacyModuleReferences,
+} from "./module-collection";
+import { noBundleWorker } from "./no-bundle-worker";
+import type { HandleBuild } from "@cloudflare/deploy-helpers";
+
+export const handleBuild: HandleBuild = {
+	async build(props, config, options) {
+		const {
+			entry,
+			noBundle,
+			destination,
+			uploadSourceMaps,
+			jsxFactory,
+			jsxFragment,
+			minify,
+			compatibilityDate,
+			compatibilityFlags,
+		} = props;
+		const { projectRoot } = entry;
+		const { nodejsCompatMode } = options;
+
+		if (props.outdir) {
+			// we're using a custom output directory,
+			// so let's first ensure it exists
+			mkdirSync(props.outdir, { recursive: true });
+			const readmePath = path.join(props.outdir, "README.md");
+			writeFileSync(
+				readmePath,
+				`This folder contains the built output assets for the worker "${props.name}" generated at ${new Date().toISOString()}.`
+			);
+		}
+
+		if (noBundle) {
+			// if we're not building, let's just copy the entry to the destination directory
+			const destinationDir =
+				typeof destination === "string" ? destination : destination.path;
+			mkdirSync(destinationDir, { recursive: true });
+			writeFileSync(
+				path.join(destinationDir, path.basename(entry.file)),
+				readFileSync(entry.file, "utf-8")
+			);
+		}
+
+		const entryDirectory = path.dirname(entry.file);
+		const moduleCollector = createModuleCollector({
+			wrangler1xLegacyModuleReferences: getWrangler1xLegacyModuleReferences(
+				entryDirectory,
+				entry.file
+			),
+			entry,
+			// `moduleCollector` doesn't get used when `noBundle` is set, so
+			// `findAdditionalModules` always defaults to `false`
+			findAdditionalModules: config.find_additional_modules ?? false,
+			rules: config.rules ?? [],
+			preserveFileNames: config.preserve_file_names ?? false,
+		});
+
+		const {
+			modules,
+			dependencies,
+			resolvedEntryPointPath,
+			bundleType,
+			...bundle
+		} = noBundle
+			? await noBundleWorker(
+					entry,
+					config.rules ?? [],
+					props.outdir,
+					config.python_modules.exclude
+				)
+			: await bundleWorker(
+					entry,
+					typeof destination === "string" ? destination : destination.path,
+					{
+						metafile: options.metafile,
+						bundle: true,
+						additionalModules: [],
+						moduleCollector,
+						doBindings: config.durable_objects.bindings,
+						workflowBindings: config.workflows ?? [],
+						jsxFactory,
+						jsxFragment,
+						tsconfig: props.tsconfig,
+						minify,
+						keepNames: config.keep_names ?? true,
+						sourcemap: uploadSourceMaps,
+						nodejsCompatMode,
+						compatibilityDate,
+						compatibilityFlags,
+						define: props.defines,
+						checkFetch: false,
+						alias: props.alias,
+						// We want to know if the build is for development or publishing
+						// This could potentially cause issues as we no longer have identical behaviour between dev and deploy?
+						targetConsumer: "deploy",
+						local: false,
+						projectRoot,
+						defineNavigatorUserAgent: isNavigatorDefined(
+							compatibilityDate,
+							compatibilityFlags
+						),
+						plugins: [logBuildOutput(nodejsCompatMode)],
+
+						// Pages specific options used by wrangler pages commands
+						entryName: undefined,
+						inject: undefined,
+						isOutfile: undefined,
+						external: undefined,
+
+						// These options are dev-only
+						testScheduled: undefined,
+						watch: undefined,
+					}
+				);
+
+		// Add modules to dependencies for size warning
+		for (const module of modules) {
+			const modulePath =
+				module.filePath === undefined
+					? module.name
+					: path.relative("", module.filePath);
+			const bytesInOutput =
+				typeof module.content === "string"
+					? Buffer.byteLength(module.content)
+					: module.content.byteLength;
+			dependencies[modulePath] = { bytesInOutput };
+		}
+
+		const content = readFileSync(resolvedEntryPointPath, {
+			encoding: "utf-8",
+		});
+
+		return {
+			modules,
+			dependencies,
+			resolvedEntryPointPath,
+			bundleType,
+			content,
+			bundle,
+		};
+	},
+
+	cleanup(props) {
+		const { destination } = props;
+		if (typeof destination !== "string") {
+			// this means we're using a temp dir,
+			// so let's clean up before we proceed
+			destination.remove();
+		}
+	},
+};

--- a/packages/wrangler/src/deployment-bundle/maybe-build-worker.ts
+++ b/packages/wrangler/src/deployment-bundle/maybe-build-worker.ts
@@ -146,13 +146,4 @@ export const handleBuild: HandleBuild = {
 			bundle,
 		};
 	},
-
-	cleanup(props) {
-		const { destination } = props;
-		if (typeof destination !== "string") {
-			// this means we're using a temp dir,
-			// so let's clean up before we proceed
-			destination.remove();
-		}
-	},
 };

--- a/packages/wrangler/src/deployment-bundle/merge-config-args.ts
+++ b/packages/wrangler/src/deployment-bundle/merge-config-args.ts
@@ -6,8 +6,11 @@ import {
 	UserError,
 } from "@cloudflare/workers-utils";
 import { getAssetsOptions, validateAssetsArgsAndConfig } from "../assets";
+import { getFlag } from "../experimental-flags";
 import { logger } from "../logger";
+import { getMetricsUsageHeaders } from "../metrics";
 import { getSiteAssetPaths } from "../sites";
+import { requireAuth } from "../user";
 import { collectKeyValues } from "../utils/collectKeyValues";
 import { getScriptName } from "../utils/getScriptName";
 import { useServiceEnvironmentApi } from "../utils/useServiceEnvironments";
@@ -56,6 +59,12 @@ async function mergeSharedConfigArgs(
 
 	const noBundle = !(args.bundle ?? !config.no_bundle);
 
+	const dryRun = args.dryRun ?? false;
+	const accountId = dryRun ? undefined : await requireAuth(config);
+
+	const metricsHeaders = await getMetricsUsageHeaders(config.send_metrics);
+	const sendMetrics = metricsHeaders !== undefined;
+
 	return {
 		entry,
 		name,
@@ -74,7 +83,7 @@ async function mergeSharedConfigArgs(
 		alias: { ...config.alias, ...collectKeyValues(args.alias) },
 		useServiceEnvApiPath: useServiceEnvironmentApi(args, config),
 		destination: args.outdir ?? getWranglerTmpDir(entry.projectRoot, "deploy"),
-		dryRun: args.dryRun ?? false,
+		dryRun,
 		env: args.env,
 		outdir: args.outdir,
 		outfile: args.outfile,
@@ -83,6 +92,9 @@ async function mergeSharedConfigArgs(
 		secretsFile: args.secretsFile,
 		cliVars: collectKeyValues(args.var),
 		experimentalAutoCreate: args.experimentalAutoCreate,
+		accountId,
+		sendMetrics,
+		resourcesProvision: getFlag("RESOURCES_PROVISION") ?? false,
 	};
 }
 

--- a/packages/wrangler/src/deployment-bundle/merge-config-args.ts
+++ b/packages/wrangler/src/deployment-bundle/merge-config-args.ts
@@ -1,0 +1,155 @@
+import path from "node:path";
+import {
+	getCIGeneratePreviewAlias,
+	getCIOverrideName,
+	getTodaysCompatDate,
+	getWranglerTmpDir,
+	UserError,
+} from "@cloudflare/workers-utils";
+import {
+	getAssetsOptions,
+	validateAssetsArgsAndConfig,
+} from "../assets";
+import { logger } from "../logger";
+import { getSiteAssetPaths } from "../sites";
+import { collectKeyValues } from "../utils/collectKeyValues";
+import { getScriptName } from "../utils/getScriptName";
+import { useServiceEnvironmentApi } from "../utils/useServiceEnvironments";
+import { getEntry } from "./entry";
+import { generatePreviewAlias } from "../versions/upload";
+import type { DeployArgs } from "../deploy/index";
+import type { VersionsUploadArgs } from "../versions/upload";
+import type { HandlerArgs } from "../core/types";
+import type { sharedDeployVersionsArgs } from "./deploy-args";
+import type {
+	DeployProps,
+	SharedDeployVersionsProps,
+	VersionsUploadProps,
+} from "@cloudflare/deploy-helpers";
+import type { Config } from "@cloudflare/workers-utils";
+
+type SharedArgs = HandlerArgs<typeof sharedDeployVersionsArgs>;
+
+async function mergeSharedConfigArgs(
+	command: "deploy" | "versions upload",
+	args: SharedArgs,
+	config: Config
+): Promise<SharedDeployVersionsProps> {
+	const entry = await getEntry(args, config, command);
+
+	validateAssetsArgsAndConfig(args, config);
+
+	const assetsOptions = getAssetsOptions({ args, config });
+
+	let name = getScriptName(args, config);
+
+	const ciOverrideName = getCIOverrideName();
+	if (ciOverrideName !== undefined && ciOverrideName !== name) {
+		logger.warn(
+			`Failed to match Worker name. Your config file is using the Worker name "${name}", but the CI system expected "${ciOverrideName}". Overriding using the CI provided Worker name. Workers Builds connected builds will attempt to open a pull request to resolve this config name mismatch.`
+		);
+		name = ciOverrideName;
+	}
+
+	const compatibilityDate = args.latest
+		? getTodaysCompatDate()
+		: args.compatibilityDate ?? config.compatibility_date;
+
+	const compatibilityFlags =
+		args.compatibilityFlags ?? config.compatibility_flags;
+
+	const noBundle = !(args.bundle ?? !config.no_bundle);
+
+	const projectRoot =
+		command === "deploy"
+			? config.userConfigPath && path.dirname(config.userConfigPath)
+			: entry.projectRoot;
+
+	return {
+		entry,
+		name,
+		compatibilityDate,
+		compatibilityFlags,
+		assetsOptions,
+		jsxFactory: args.jsxFactory || config.jsx_factory,
+		jsxFragment: args.jsxFragment || config.jsx_fragment,
+		tsconfig: args.tsconfig ?? config.tsconfig,
+		minify: args.minify ?? config.minify,
+		noBundle,
+		uploadSourceMaps: args.uploadSourceMaps ?? config.upload_source_maps,
+		keepVars: Boolean(args.keepVars || config.keep_vars),
+		isWorkersSite: Boolean(args.site || config.site),
+		defines: { ...config.define, ...collectKeyValues(args.define) },
+		alias: { ...config.alias, ...collectKeyValues(args.alias) },
+		useServiceEnvApiPath: useServiceEnvironmentApi(args, config),
+		destination: args.outdir ?? getWranglerTmpDir(projectRoot, "deploy"),
+		dryRun: args.dryRun ?? false,
+		env: args.env,
+		outdir: args.outdir,
+		outfile: args.outfile,
+		tag: args.tag,
+		message: args.message,
+		secretsFile: args.secretsFile,
+		cliVars: collectKeyValues(args.var),
+		experimentalAutoCreate: args.experimentalAutoCreate,
+	};
+}
+
+export async function mergeDeployConfigArgs(
+	args: DeployArgs,
+	config: Config
+): Promise<DeployProps> {
+	const shared = await mergeSharedConfigArgs("deploy", args, config);
+
+	const domainRoutes = (args.domains || []).map((domain) => ({
+		pattern: domain,
+		custom_domain: true as const,
+	}));
+	const routes =
+		args.routes ?? config.routes ?? (config.route ? [config.route] : []);
+
+	return {
+		...shared,
+		command: "deploy",
+		legacyAssetPaths: getSiteAssetPaths(
+			config,
+			args.site,
+			args.siteInclude,
+			args.siteExclude
+		),
+		triggers: args.triggers ?? config.triggers?.crons,
+		routes: [...routes, ...domainRoutes],
+		logpush: args.logpush !== undefined ? args.logpush : config.logpush,
+		dispatchNamespace: args.dispatchNamespace,
+		strict: args.strict ?? false,
+		metafile: args.metafile,
+		oldAssetTtl: args.oldAssetTtl,
+		containersRollout: args.containersRollout,
+	};
+}
+
+export async function mergeVersionsUploadConfigArgs(
+	args: VersionsUploadArgs,
+	config: Config
+): Promise<VersionsUploadProps> {
+	if (args.site || config.site) {
+		throw new UserError(
+			"Workers Sites does not support uploading versions through `wrangler versions upload`. You must use `wrangler deploy` instead.",
+			{ telemetryMessage: "versions upload sites unsupported" }
+		);
+	}
+
+	const shared = await mergeSharedConfigArgs("versions upload", args, config);
+
+	const previewAlias =
+		args.previewAlias ??
+		(getCIGeneratePreviewAlias() === "true"
+			? generatePreviewAlias(shared.name ?? "")
+			: undefined);
+
+	return {
+		...shared,
+		command: "versions upload",
+		previewAlias,
+	};
+}

--- a/packages/wrangler/src/deployment-bundle/merge-config-args.ts
+++ b/packages/wrangler/src/deployment-bundle/merge-config-args.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import {
 	getCIGeneratePreviewAlias,
 	getCIOverrideName,
@@ -6,20 +5,17 @@ import {
 	getWranglerTmpDir,
 	UserError,
 } from "@cloudflare/workers-utils";
-import {
-	getAssetsOptions,
-	validateAssetsArgsAndConfig,
-} from "../assets";
+import { getAssetsOptions, validateAssetsArgsAndConfig } from "../assets";
 import { logger } from "../logger";
 import { getSiteAssetPaths } from "../sites";
 import { collectKeyValues } from "../utils/collectKeyValues";
 import { getScriptName } from "../utils/getScriptName";
 import { useServiceEnvironmentApi } from "../utils/useServiceEnvironments";
-import { getEntry } from "./entry";
 import { generatePreviewAlias } from "../versions/upload";
+import { getEntry } from "./entry";
+import type { HandlerArgs } from "../core/types";
 import type { DeployArgs } from "../deploy/index";
 import type { VersionsUploadArgs } from "../versions/upload";
-import type { HandlerArgs } from "../core/types";
 import type { sharedDeployVersionsArgs } from "./deploy-args";
 import type {
 	DeployProps,
@@ -53,17 +49,12 @@ async function mergeSharedConfigArgs(
 
 	const compatibilityDate = args.latest
 		? getTodaysCompatDate()
-		: args.compatibilityDate ?? config.compatibility_date;
+		: (args.compatibilityDate ?? config.compatibility_date);
 
 	const compatibilityFlags =
 		args.compatibilityFlags ?? config.compatibility_flags;
 
 	const noBundle = !(args.bundle ?? !config.no_bundle);
-
-	const projectRoot =
-		command === "deploy"
-			? config.userConfigPath && path.dirname(config.userConfigPath)
-			: entry.projectRoot;
 
 	return {
 		entry,
@@ -82,7 +73,7 @@ async function mergeSharedConfigArgs(
 		defines: { ...config.define, ...collectKeyValues(args.define) },
 		alias: { ...config.alias, ...collectKeyValues(args.alias) },
 		useServiceEnvApiPath: useServiceEnvironmentApi(args, config),
-		destination: args.outdir ?? getWranglerTmpDir(projectRoot, "deploy"),
+		destination: args.outdir ?? getWranglerTmpDir(entry.projectRoot, "deploy"),
 		dryRun: args.dryRun ?? false,
 		env: args.env,
 		outdir: args.outdir,

--- a/packages/wrangler/src/deployment-bundle/merge-config-args.ts
+++ b/packages/wrangler/src/deployment-bundle/merge-config-args.ts
@@ -25,6 +25,7 @@ import type {
 	SharedDeployVersionsProps,
 	VersionsUploadProps,
 } from "@cloudflare/deploy-helpers";
+import type { EphemeralDirectory } from "@cloudflare/workers-utils";
 import type { Config } from "@cloudflare/workers-utils";
 
 type SharedArgs = HandlerArgs<typeof sharedDeployVersionsArgs>;
@@ -155,4 +156,12 @@ export async function mergeVersionsUploadConfigArgs(
 		command: "versions upload",
 		previewAlias,
 	};
+}
+
+export function cleanupDestination(
+	destination: string | EphemeralDirectory
+): void {
+	if (typeof destination !== "string") {
+		destination.remove();
+	}
 }

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -27,7 +27,10 @@ import {
 	validateDeployVersionsArgs,
 } from "../deployment-bundle/deploy-args";
 import { handleBuild } from "../deployment-bundle/maybe-build-worker";
-import { mergeVersionsUploadConfigArgs } from "../deployment-bundle/merge-config-args";
+import {
+	cleanupDestination,
+	mergeVersionsUploadConfigArgs,
+} from "../deployment-bundle/merge-config-args";
 import { validateNodeCompatMode } from "../deployment-bundle/node-compat";
 import {
 	addRequiredSecretsInheritBindings,
@@ -98,35 +101,43 @@ export const versionsUploadCommand = createCommand({
 		// Merge CLI args with config (includes Sites validation and assets validation)
 		const mergedProps = await mergeVersionsUploadConfigArgs(args, config);
 
-		metrics.sendMetricsEvent(
-			"upload worker version",
-			{
-				usesTypeScript: /\.tsx?$/.test(mergedProps.entry.file),
-			},
-			{
-				sendMetrics: config.send_metrics,
-			}
-		);
+		try {
+			metrics.sendMetricsEvent(
+				"upload worker version",
+				{
+					usesTypeScript: /\.tsx?$/.test(mergedProps.entry.file),
+				},
+				{
+					sendMetrics: config.send_metrics,
+				}
+			);
 
-		// Derive workerNameOverridden by comparing pre-merge name with post-merge name
-		const preMergeName = getScriptName(args, config);
-		const workerNameOverridden =
-			mergedProps.name !== undefined && mergedProps.name !== preMergeName;
+			// Derive workerNameOverridden by comparing pre-merge name with post-merge name
+			const preMergeName = getScriptName(args, config);
+			const workerNameOverridden =
+				mergedProps.name !== undefined && mergedProps.name !== preMergeName;
 
-		const { versionId, workerTag, versionPreviewUrl, versionPreviewAliasUrl } =
-			await versionsUpload(mergedProps, config, handleBuild);
+			const {
+				versionId,
+				workerTag,
+				versionPreviewUrl,
+				versionPreviewAliasUrl,
+			} = await versionsUpload(mergedProps, config, handleBuild);
 
-		writeOutput({
-			type: "version-upload",
-			version: 1,
-			worker_name: mergedProps.name ?? null,
-			worker_tag: workerTag,
-			version_id: versionId,
-			preview_url: versionPreviewUrl,
-			preview_alias_url: versionPreviewAliasUrl,
-			wrangler_environment: args.env,
-			worker_name_overridden: workerNameOverridden,
-		});
+			writeOutput({
+				type: "version-upload",
+				version: 1,
+				worker_name: mergedProps.name ?? null,
+				worker_tag: workerTag,
+				version_id: versionId,
+				preview_url: versionPreviewUrl,
+				preview_alias_url: versionPreviewAliasUrl,
+				wrangler_environment: args.env,
+				worker_name_overridden: workerNameOverridden,
+			});
+		} finally {
+			cleanupDestination(mergedProps.destination);
+		}
 	},
 });
 
@@ -222,7 +233,7 @@ export default async function versionsUpload(
 		throw new UserError(
 			`A compatibility_date is required when uploading a Worker Version. Add the following to your ${configFileName(config.configPath)} file:
     \`\`\`
-	${(formatConfigSnippet({ compatibility_date: compatibilityDateStr }, config.configPath), false)}
+	${formatConfigSnippet({ compatibility_date: compatibilityDateStr }, config.configPath, false)}
     \`\`\`
     Or you could pass it in your terminal as \`--compatibility-date ${compatibilityDateStr}\`
 See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`,
@@ -293,132 +304,179 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 	let hasPreview = false;
 
-	try {
-		const {
-			modules,
-			dependencies,
-			resolvedEntryPointPath,
-			bundleType,
-			content,
-			bundle,
-		} = await buildWorker.build(props, config, {
-			nodejsCompatMode,
-		});
-		const bindings = getBindings(config);
+	const {
+		modules,
+		dependencies,
+		resolvedEntryPointPath,
+		bundleType,
+		content,
+		bundle,
+	} = await buildWorker.build(props, config, {
+		nodejsCompatMode,
+	});
+	const bindings = getBindings(config);
 
-		// Vars from the CLI (--var) are hidden so their values aren't logged to the terminal
-		for (const [bindingName, value] of Object.entries(props.cliVars)) {
-			bindings[bindingName] = {
-				type: "plain_text",
-				value,
-				hidden: true,
-			};
-		}
+	// Vars from the CLI (--var) are hidden so their values aren't logged to the terminal
+	for (const [bindingName, value] of Object.entries(props.cliVars)) {
+		bindings[bindingName] = {
+			type: "plain_text",
+			value,
+			hidden: true,
+		};
+	}
 
-		// durable object migrations
-		const migrations = !props.dryRun
-			? await getMigrationsToUpload(scriptName, {
-					accountId,
+	// durable object migrations
+	const migrations = !props.dryRun
+		? await getMigrationsToUpload(scriptName, {
+				accountId,
+				config,
+				useServiceEnvironments: useServiceEnvironmentsConfig(config),
+				env: props.env,
+				dispatchNamespace: undefined,
+			})
+		: undefined;
+
+	// Upload assets if assets is being used
+	const assetsJwt =
+		props.assetsOptions && !props.dryRun
+			? await syncAssets(
 					config,
-					useServiceEnvironments: useServiceEnvironmentsConfig(config),
-					env: props.env,
-					dispatchNamespace: undefined,
-				})
+					accountId,
+					props.assetsOptions.directory,
+					scriptName
+				)
 			: undefined;
 
-		// Upload assets if assets is being used
-		const assetsJwt =
-			props.assetsOptions && !props.dryRun
-				? await syncAssets(
-						config,
-						accountId,
-						props.assetsOptions.directory,
-						scriptName
-					)
-				: undefined;
-
-		if (props.secretsFile) {
-			const secretsResult = await parseBulkInputToObject(props.secretsFile);
-			if (secretsResult) {
-				for (const [secretName, secretValue] of Object.entries(
-					secretsResult.content
-				)) {
-					bindings[secretName] = {
-						type: "secret_text",
-						value: secretValue,
-					};
-				}
+	if (props.secretsFile) {
+		const secretsResult = await parseBulkInputToObject(props.secretsFile);
+		if (secretsResult) {
+			for (const [secretName, secretValue] of Object.entries(
+				secretsResult.content
+			)) {
+				bindings[secretName] = {
+					type: "secret_text",
+					value: secretValue,
+				};
 			}
 		}
+	}
 
-		addRequiredSecretsInheritBindings(config, bindings, { type: "upload" });
+	addRequiredSecretsInheritBindings(config, bindings, { type: "upload" });
 
-		const placement = parseConfigPlacement(config);
+	const placement = parseConfigPlacement(config);
 
-		const entryPointName = path.basename(resolvedEntryPointPath);
-		const main = {
-			name: entryPointName,
-			filePath: resolvedEntryPointPath,
-			content: content,
-			type: bundleType,
-		};
-		const worker: CfWorkerInit = {
-			name: scriptName,
-			main,
-			migrations,
-			modules,
-			containers: config.containers,
-			sourceMaps: uploadSourceMaps
-				? loadSourceMaps(main, modules, bundle)
+	const entryPointName = path.basename(resolvedEntryPointPath);
+	const main = {
+		name: entryPointName,
+		filePath: resolvedEntryPointPath,
+		content: content,
+		type: bundleType,
+	};
+	const worker: CfWorkerInit = {
+		name: scriptName,
+		main,
+		migrations,
+		modules,
+		containers: config.containers,
+		sourceMaps: uploadSourceMaps
+			? loadSourceMaps(main, modules, bundle)
+			: undefined,
+		compatibility_date: compatibilityDate,
+		compatibility_flags: compatibilityFlags,
+		keepVars,
+		// we never delete secret bindings when uploading, even if we are setting secrets from a file
+		// so inherit all unchanged secrets from the previous Worker Version
+		keepSecrets: true,
+		placement,
+		tail_consumers: config.tail_consumers,
+		limits: config.limits,
+		annotations: {
+			"workers/message": props.message,
+			"workers/tag": props.tag,
+			"workers/alias": props.previewAlias,
+		},
+		assets:
+			props.assetsOptions && assetsJwt
+				? {
+						jwt: assetsJwt,
+						routerConfig: props.assetsOptions.routerConfig,
+						assetConfig: props.assetsOptions.assetConfig,
+						_redirects: props.assetsOptions._redirects,
+						_headers: props.assetsOptions._headers,
+						run_worker_first: props.assetsOptions.run_worker_first,
+					}
 				: undefined,
-			compatibility_date: compatibilityDate,
-			compatibility_flags: compatibilityFlags,
-			keepVars,
-			// we never delete secret bindings when uploading, even if we are setting secrets from a file
-			// so inherit all unchanged secrets from the previous Worker Version
-			keepSecrets: true,
-			placement,
-			tail_consumers: config.tail_consumers,
-			limits: config.limits,
-			annotations: {
-				"workers/message": props.message,
-				"workers/tag": props.tag,
-				"workers/alias": props.previewAlias,
-			},
-			assets:
-				props.assetsOptions && assetsJwt
-					? {
-							jwt: assetsJwt,
-							routerConfig: props.assetsOptions.routerConfig,
-							assetConfig: props.assetsOptions.assetConfig,
-							_redirects: props.assetsOptions._redirects,
-							_headers: props.assetsOptions._headers,
-							run_worker_first: props.assetsOptions.run_worker_first,
-						}
-					: undefined,
-			logpush: undefined, // logpush and observability are non-versioned settings
-			observability: undefined,
-			cache: config.cache, // cache is a versioned setting
-		};
+		logpush: undefined, // logpush and observability are non-versioned settings
+		observability: undefined,
+		cache: config.cache, // cache is a versioned setting
+	};
 
-		if (config.containers && config.containers.length > 0) {
-			logger.warn(
-				`Your Worker has Containers configured. Container configuration changes (such as image, max_instances, etc.) will not be gradually rolled out with versions. These changes will only take effect after running \`wrangler deploy\`.`
+	if (config.containers && config.containers.length > 0) {
+		logger.warn(
+			`Your Worker has Containers configured. Container configuration changes (such as image, max_instances, etc.) will not be gradually rolled out with versions. These changes will only take effect after running \`wrangler deploy\`.`
+		);
+	}
+
+	await printBundleSize(
+		{ name: path.basename(resolvedEntryPointPath), content: content },
+		modules
+	);
+
+	let workerBundle: FormData;
+
+	if (props.dryRun) {
+		workerBundle = createWorkerUploadForm(worker, bindings, {
+			dryRun: true,
+			unsafe: config.unsafe,
+		});
+		printBindings(
+			bindings,
+			config.tail_consumers,
+			config.streaming_tail_consumers,
+			undefined,
+			{ unsafeMetadata: config.unsafe?.metadata }
+		);
+	} else {
+		assert(accountId, "Missing accountId");
+		if (props.resourcesProvision) {
+			await provisionBindings(
+				bindings,
+				accountId,
+				scriptName,
+				props.experimentalAutoCreate,
+				config
 			);
 		}
+		workerBundle = createWorkerUploadForm(worker, bindings, {
+			unsafe: config.unsafe,
+		});
 
-		await printBundleSize(
-			{ name: path.basename(resolvedEntryPointPath), content: content },
-			modules
-		);
+		await ensureQueuesExistByConfig(config);
+		let bindingsPrinted = false;
 
-		let workerBundle: FormData;
+		// Upload the version.
+		try {
+			const result = await retryOnAPIFailure(async () =>
+				fetchResult<{
+					id: string;
+					startup_time_ms: number;
+					metadata: {
+						has_preview: boolean;
+					};
+				}>(
+					config,
+					`${workerUrl}/versions`,
+					{
+						method: "POST",
+						body: workerBundle,
+						headers: props.sendMetrics ? { metricsEnabled: "true" } : undefined,
+					},
+					new URLSearchParams({ bindings_inherit: "strict" })
+				)
+			);
 
-		if (props.dryRun) {
-			workerBundle = createWorkerUploadForm(worker, bindings, {
-				dryRun: true,
-				unsafe: config.unsafe,
-			});
+			logger.log("Worker Startup Time:", result.startup_time_ms, "ms");
+			bindingsPrinted = true;
 			printBindings(
 				bindings,
 				config.tail_consumers,
@@ -426,49 +484,10 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 				undefined,
 				{ unsafeMetadata: config.unsafe?.metadata }
 			);
-		} else {
-			assert(accountId, "Missing accountId");
-			if (props.resourcesProvision) {
-				await provisionBindings(
-					bindings,
-					accountId,
-					scriptName,
-					props.experimentalAutoCreate,
-					config
-				);
-			}
-			workerBundle = createWorkerUploadForm(worker, bindings, {
-				unsafe: config.unsafe,
-			});
-
-			await ensureQueuesExistByConfig(config);
-			let bindingsPrinted = false;
-
-			// Upload the version.
-			try {
-				const result = await retryOnAPIFailure(async () =>
-					fetchResult<{
-						id: string;
-						startup_time_ms: number;
-						metadata: {
-							has_preview: boolean;
-						};
-					}>(
-						config,
-						`${workerUrl}/versions`,
-						{
-							method: "POST",
-							body: workerBundle,
-							headers: props.sendMetrics
-								? { metricsEnabled: "true" }
-								: undefined,
-						},
-						new URLSearchParams({ bindings_inherit: "strict" })
-					)
-				);
-
-				logger.log("Worker Startup Time:", result.startup_time_ms, "ms");
-				bindingsPrinted = true;
+			versionId = result.id;
+			hasPreview = result.metadata.has_preview;
+		} catch (err) {
+			if (!bindingsPrinted) {
 				printBindings(
 					bindings,
 					config.tail_consumers,
@@ -476,91 +495,77 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 					undefined,
 					{ unsafeMetadata: config.unsafe?.metadata }
 				);
-				versionId = result.id;
-				hasPreview = result.metadata.has_preview;
-			} catch (err) {
-				if (!bindingsPrinted) {
-					printBindings(
-						bindings,
-						config.tail_consumers,
-						config.streaming_tail_consumers,
-						undefined,
-						{ unsafeMetadata: config.unsafe?.metadata }
-					);
-				}
+			}
 
-				const message = await helpIfErrorIsSizeOrScriptStartup(
-					err,
-					dependencies,
-					workerBundle,
-					projectRoot
+			const message = await helpIfErrorIsSizeOrScriptStartup(
+				err,
+				dependencies,
+				workerBundle,
+				projectRoot
+			);
+			if (message) {
+				logger.error(message);
+			}
+
+			handleMissingSecretsError(err, config, { type: "upload" });
+
+			// Apply source mapping to validation startup errors if possible
+			if (
+				err instanceof ParseError &&
+				"code" in err &&
+				err.code === 10021 /* validation error */ &&
+				err.notes.length > 0
+			) {
+				const maybeNameToFilePath = (moduleName: string) => {
+					// If this is a service worker, always return the entrypoint path.
+					// Service workers can't have additional JavaScript modules.
+					if (bundleType === "commonjs") {
+						return resolvedEntryPointPath;
+					}
+					// Similarly, if the name matches the entrypoint, return its path
+					if (moduleName === entryPointName) {
+						return resolvedEntryPointPath;
+					}
+					// Otherwise, return the file path of the matching module (if any)
+					for (const module of modules) {
+						if (moduleName === module.name) {
+							return module.filePath;
+						}
+					}
+				};
+				const retrieveSourceMap: RetrieveSourceMapFunction = (moduleName) =>
+					maybeRetrieveFileSourceMap(maybeNameToFilePath(moduleName));
+
+				err.notes[0].text = getSourceMappedString(
+					err.notes[0].text,
+					retrieveSourceMap
 				);
-				if (message) {
-					logger.error(message);
-				}
-
-				handleMissingSecretsError(err, config, { type: "upload" });
-
-				// Apply source mapping to validation startup errors if possible
-				if (
-					err instanceof ParseError &&
-					"code" in err &&
-					err.code === 10021 /* validation error */ &&
-					err.notes.length > 0
-				) {
-					const maybeNameToFilePath = (moduleName: string) => {
-						// If this is a service worker, always return the entrypoint path.
-						// Service workers can't have additional JavaScript modules.
-						if (bundleType === "commonjs") {
-							return resolvedEntryPointPath;
-						}
-						// Similarly, if the name matches the entrypoint, return its path
-						if (moduleName === entryPointName) {
-							return resolvedEntryPointPath;
-						}
-						// Otherwise, return the file path of the matching module (if any)
-						for (const module of modules) {
-							if (moduleName === module.name) {
-								return module.filePath;
-							}
-						}
-					};
-					const retrieveSourceMap: RetrieveSourceMapFunction = (moduleName) =>
-						maybeRetrieveFileSourceMap(maybeNameToFilePath(moduleName));
-
-					err.notes[0].text = getSourceMappedString(
-						err.notes[0].text,
-						retrieveSourceMap
-					);
-				}
-
-				throw err;
 			}
 
-			// Update service and environment tags when using environments
+			throw err;
+		}
 
-			const nextTags = applyServiceAndEnvironmentTags(config, tags);
-			if (!tagsAreEqual(tags, nextTags)) {
-				try {
-					await patchNonVersionedScriptSettings(config, accountId, scriptName, {
-						tags: nextTags,
-					});
-				} catch {
-					warnOnErrorUpdatingServiceAndEnvironmentTags();
-				}
+		// Update service and environment tags when using environments
+
+		const nextTags = applyServiceAndEnvironmentTags(config, tags);
+		if (!tagsAreEqual(tags, nextTags)) {
+			try {
+				await patchNonVersionedScriptSettings(config, accountId, scriptName, {
+					tags: nextTags,
+				});
+			} catch {
+				warnOnErrorUpdatingServiceAndEnvironmentTags();
 			}
 		}
-		if (props.outfile) {
-			// we're using a custom output file,
-			// so let's first ensure it's parent directory exists
-			mkdirSync(path.dirname(props.outfile), { recursive: true });
+	}
+	if (props.outfile) {
+		// we're using a custom output file,
+		// so let's first ensure it's parent directory exists
+		mkdirSync(path.dirname(props.outfile), { recursive: true });
 
-			const serializedFormData = await new Response(workerBundle).arrayBuffer();
+		const serializedFormData = await new Response(workerBundle).arrayBuffer();
 
-			writeFileSync(props.outfile, Buffer.from(serializedFormData));
-		}
-	} finally {
-		buildWorker.cleanup(props);
+		writeFileSync(props.outfile, Buffer.from(serializedFormData));
 	}
 
 	if (props.dryRun) {

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -41,10 +41,8 @@ import {
 	tagsAreEqual,
 	warnOnErrorUpdatingServiceAndEnvironmentTags,
 } from "../environments";
-import { getFlag } from "../experimental-flags";
 import { logger } from "../logger";
 import { verifyWorkerMatchesCITag } from "../match-tag";
-import { getMetricsUsageHeaders } from "../metrics";
 import * as metrics from "../metrics";
 import { writeOutput } from "../output";
 import { ensureQueuesExistByConfig } from "../queues/client";
@@ -53,7 +51,6 @@ import {
 	getSourceMappedString,
 	maybeRetrieveFileSourceMap,
 } from "../sourcemap";
-import { requireAuth } from "../user";
 import { helpIfErrorIsSizeOrScriptStartup } from "../utils/friendly-validator-errors";
 import { getScriptName } from "../utils/getScriptName";
 import { parseConfigPlacement } from "../utils/placement";
@@ -160,9 +157,8 @@ export default async function versionsUpload(
 		minify,
 		noBundle,
 		uploadSourceMaps,
+		accountId,
 	} = props;
-
-	const accountId = props.dryRun ? undefined : await requireAuth(config);
 
 	if (!props.dryRun) {
 		assert(accountId, "Missing account ID");
@@ -432,7 +428,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			);
 		} else {
 			assert(accountId, "Missing accountId");
-			if (getFlag("RESOURCES_PROVISION")) {
+			if (props.resourcesProvision) {
 				await provisionBindings(
 					bindings,
 					accountId,
@@ -463,7 +459,9 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 						{
 							method: "POST",
 							body: workerBundle,
-							headers: await getMetricsUsageHeaders(config.send_metrics),
+							headers: props.sendMetrics
+								? { metricsEnabled: "true" }
+								: undefined,
 						},
 						new URLSearchParams({ bindings_inherit: "strict" })
 					)

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -271,6 +271,8 @@ export const versionsUploadCommand = createCommand({
 	},
 });
 
+export type VersionsUploadArgs = (typeof versionsUploadCommand)["args"];
+
 export default async function versionsUpload(props: Props): Promise<{
 	versionId: string | null;
 	workerTag: string | null;

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -9,20 +9,13 @@ import {
 	configFileName,
 	getTodaysCompatDate,
 	formatConfigSnippet,
-	getCIGeneratePreviewAlias,
-	getCIOverrideName,
 	getWorkersCIBranchName,
-	getWranglerTmpDir,
 	ParseError,
 	UserError,
 	formatTime,
 } from "@cloudflare/workers-utils";
 import { Response } from "undici";
-import {
-	getAssetsOptions,
-	syncAssets,
-	validateAssetsArgsAndConfig,
-} from "../assets";
+import { syncAssets } from "../assets";
 import { fetchResult } from "../cfetch";
 import { createCommand } from "../core/create-command";
 import { createDeployHelpersContext } from "../core/deploy-helpers-context";
@@ -34,8 +27,8 @@ import {
 	sharedDeployVersionsArgs,
 	validateDeployVersionsArgs,
 } from "../deployment-bundle/deploy-args";
-import { getEntry } from "../deployment-bundle/entry";
 import { logBuildOutput } from "../deployment-bundle/esbuild-plugins/log-build-output";
+import { mergeVersionsUploadConfigArgs } from "../deployment-bundle/merge-config-args";
 import {
 	createModuleCollector,
 	getWrangler1xLegacyModuleReferences,
@@ -68,58 +61,18 @@ import {
 	maybeRetrieveFileSourceMap,
 } from "../sourcemap";
 import { requireAuth } from "../user";
-import { collectKeyValues } from "../utils/collectKeyValues";
 import { helpIfErrorIsSizeOrScriptStartup } from "../utils/friendly-validator-errors";
-import { getRules } from "../utils/getRules";
 import { getScriptName } from "../utils/getScriptName";
 import { parseConfigPlacement } from "../utils/placement";
 import { printBindings } from "../utils/print-bindings";
 import { retryOnAPIFailure } from "../utils/retry";
-import { useServiceEnvironments } from "../utils/useServiceEnvironments";
+import { useServiceEnvironments as useServiceEnvironmentsConfig } from "../utils/useServiceEnvironments";
 import { isWorkerNotFoundError } from "../utils/worker-not-found-error";
 import { patchNonVersionedScriptSettings } from "./api";
 import type { RetrieveSourceMapFunction } from "../sourcemap";
-import type {
-	AssetsOptions,
-	CfWorkerInit,
-	Config,
-	Entry,
-} from "@cloudflare/workers-utils";
+import type { VersionsUploadProps } from "@cloudflare/deploy-helpers";
+import type { CfWorkerInit, Config } from "@cloudflare/workers-utils";
 import type { FormData } from "undici";
-
-type Props = {
-	config: Config;
-	accountId: string | undefined;
-	entry: Entry;
-	rules: Config["rules"];
-	name: string;
-	useServiceEnvironments: boolean | undefined;
-	env: string | undefined;
-	compatibilityDate: string | undefined;
-	compatibilityFlags: string[] | undefined;
-	assetsOptions: AssetsOptions | undefined;
-	vars: Record<string, string> | undefined;
-	defines: Record<string, string> | undefined;
-	alias: Record<string, string> | undefined;
-	jsxFactory: string | undefined;
-	jsxFragment: string | undefined;
-	tsconfig: string | undefined;
-	isWorkersSite: boolean;
-	minify: boolean | undefined;
-	uploadSourceMaps: boolean | undefined;
-	outDir: string | undefined;
-	outFile: string | undefined;
-	dryRun: boolean | undefined;
-	noBundle: boolean | undefined;
-	keepVars: boolean | undefined;
-	projectRoot: string | undefined;
-	experimentalAutoCreate: boolean;
-
-	tag: string | undefined;
-	message: string | undefined;
-	previewAlias: string | undefined;
-	secretsFile: string | undefined;
-};
 
 export const versionsUploadCommand = createCommand({
 	metadata: {
@@ -149,118 +102,31 @@ export const versionsUploadCommand = createCommand({
 		validateDeployVersionsArgs(args, "versions upload");
 	},
 	handler: async function versionsUploadHandler(args, { config }) {
-		const entry = await getEntry(args, config, "versions upload");
+		// Merge CLI args with config (includes Sites validation and assets validation)
+		const mergedProps = await mergeVersionsUploadConfigArgs(args, config);
+
 		metrics.sendMetricsEvent(
 			"upload worker version",
 			{
-				usesTypeScript: /\.tsx?$/.test(entry.file),
+				usesTypeScript: /\.tsx?$/.test(mergedProps.entry.file),
 			},
 			{
 				sendMetrics: config.send_metrics,
 			}
 		);
 
-		if (args.site || config.site) {
-			throw new UserError(
-				"Workers Sites does not support uploading versions through `wrangler versions upload`. You must use `wrangler deploy` instead.",
-				{ telemetryMessage: "versions upload sites unsupported" }
-			);
-		}
-
-		validateAssetsArgsAndConfig(
-			{
-				site: undefined,
-				assets: args.assets,
-				script: args.script,
-			},
-			config
-		);
-
-		const assetsOptions = getAssetsOptions({
-			args,
-			config,
-		});
-
-		const cliVars = collectKeyValues(args.var);
-		const cliDefines = collectKeyValues(args.define);
-		const cliAlias = collectKeyValues(args.alias);
-
-		const accountId = args.dryRun ? undefined : await requireAuth(config);
-		let name = getScriptName(args, config);
-
-		const ciOverrideName = getCIOverrideName();
-		let workerNameOverridden = false;
-		if (ciOverrideName !== undefined && ciOverrideName !== name) {
-			logger.warn(
-				`Failed to match Worker name. Your config file is using the Worker name "${name}", but the CI system expected "${ciOverrideName}". Overriding using the CI provided Worker name. Workers Builds connected builds will attempt to open a pull request to resolve this config name mismatch.`
-			);
-			name = ciOverrideName;
-			workerNameOverridden = true;
-		}
-
-		if (!name) {
-			throw new UserError(
-				'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`',
-				{ telemetryMessage: "versions upload missing worker name" }
-			);
-		}
-
-		const previewAlias =
-			args.previewAlias ??
-			(getCIGeneratePreviewAlias() === "true"
-				? generatePreviewAlias(name)
-				: undefined);
-
-		if (!args.dryRun) {
-			assert(accountId, "Missing account ID");
-			await verifyWorkerMatchesCITag(
-				config,
-				accountId,
-				name,
-				config.configPath
-			);
-		}
+		// Derive workerNameOverridden by comparing pre-merge name with post-merge name
+		const preMergeName = getScriptName(args, config);
+		const workerNameOverridden =
+			mergedProps.name !== undefined && mergedProps.name !== preMergeName;
 
 		const { versionId, workerTag, versionPreviewUrl, versionPreviewAliasUrl } =
-			await versionsUpload({
-				config,
-				accountId,
-				name,
-				rules: getRules(config),
-				entry,
-				useServiceEnvironments: useServiceEnvironments(config),
-				env: args.env,
-				compatibilityDate: args.latest
-					? getTodaysCompatDate()
-					: args.compatibilityDate,
-				compatibilityFlags: args.compatibilityFlags,
-				vars: cliVars,
-				defines: cliDefines,
-				alias: cliAlias,
-				jsxFactory: args.jsxFactory,
-				jsxFragment: args.jsxFragment,
-				tsconfig: args.tsconfig,
-				assetsOptions,
-				minify: args.minify,
-				uploadSourceMaps: args.uploadSourceMaps,
-				isWorkersSite: Boolean(args.site || config.site),
-				outDir: args.outdir,
-				dryRun: args.dryRun,
-				noBundle: !(args.bundle ?? !config.no_bundle),
-				keepVars: args.keepVars || config.keep_vars,
-				projectRoot: entry.projectRoot,
-				tag: args.tag,
-				message: args.message,
-				previewAlias: previewAlias,
-				experimentalAutoCreate: args.experimentalAutoCreate,
-				outFile: args.outfile,
-				secretsFile: args.secretsFile,
-			});
+			await versionsUpload(mergedProps, config);
 
 		writeOutput({
 			type: "version-upload",
 			version: 1,
-			worker_name: name ?? null,
+			worker_name: mergedProps.name ?? null,
 			worker_tag: workerTag,
 			version_id: versionId,
 			preview_url: versionPreviewUrl,
@@ -273,14 +139,41 @@ export const versionsUploadCommand = createCommand({
 
 export type VersionsUploadArgs = (typeof versionsUploadCommand)["args"];
 
-export default async function versionsUpload(props: Props): Promise<{
+export default async function versionsUpload(
+	props: VersionsUploadProps,
+	config: Config
+): Promise<{
 	versionId: string | null;
 	workerTag: string | null;
 	versionPreviewUrl?: string | undefined;
 	versionPreviewAliasUrl?: string | undefined;
 }> {
-	// TODO: warn if git/hg has uncommitted changes
-	const { config, accountId, name } = props;
+	if (!props.name) {
+		throw new UserError(
+			'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`',
+			{ telemetryMessage: "versions upload missing worker name" }
+		);
+	}
+	const {
+		entry,
+		name,
+		compatibilityDate,
+		compatibilityFlags,
+		jsxFactory,
+		jsxFragment,
+		keepVars,
+		minify,
+		noBundle,
+		destination,
+		uploadSourceMaps,
+	} = props;
+
+	const accountId = props.dryRun ? undefined : await requireAuth(config);
+
+	if (!props.dryRun) {
+		assert(accountId, "Missing account ID");
+		await verifyWorkerMatchesCITag(config, accountId, name, config.configPath);
+	}
 	let versionId: string | null = null;
 	let workerTag: string | null = null;
 	let tags: string[] = []; // arbitrary metadata tags, not to be confused with script tag or annotations
@@ -333,11 +226,6 @@ export default async function versionsUpload(props: Props): Promise<{
 		}
 	}
 
-	const compatibilityDate =
-		props.compatibilityDate || config.compatibility_date;
-	const compatibilityFlags =
-		props.compatibilityFlags ?? config.compatibility_flags;
-
 	if (!compatibilityDate) {
 		const compatibilityDateStr = getTodaysCompatDate();
 
@@ -354,27 +242,20 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		);
 	}
 
-	const jsxFactory = props.jsxFactory || config.jsx_factory;
-	const jsxFragment = props.jsxFragment || config.jsx_fragment;
-
-	const minify = props.minify ?? config.minify;
-
 	const nodejsCompatMode = validateNodeCompatMode(
 		compatibilityDate,
 		compatibilityFlags,
-		{
-			noBundle: props.noBundle ?? config.no_bundle,
-		}
+		{ noBundle }
 	);
 
 	// Warn if user tries minify or node-compat with no-bundle
-	if (props.noBundle && minify) {
+	if (noBundle && minify) {
 		logger.warn(
 			"`--minify` and `--no-bundle` can't be used together. If you want to minify your Worker and disable Wrangler's bundling, please minify as part of your own bundling process."
 		);
 	}
 
-	const scriptName = props.name;
+	const scriptName = name;
 
 	if (config.site && !config.site.bucket) {
 		throw new UserError(
@@ -383,26 +264,24 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		);
 	}
 
-	if (props.outDir) {
+	if (props.outdir) {
 		// we're using a custom output directory,
 		// so let's first ensure it exists
-		mkdirSync(props.outDir, { recursive: true });
+		mkdirSync(props.outdir, { recursive: true });
 		// add a README
-		const readmePath = path.join(props.outDir, "README.md");
+		const readmePath = path.join(props.outdir, "README.md");
 		writeFileSync(
 			readmePath,
 			`This folder contains the built output assets for the worker "${scriptName}" generated at ${new Date().toISOString()}.`
 		);
 	}
 
-	const destination =
-		props.outDir ?? getWranglerTmpDir(props.projectRoot, "deploy");
-
 	const start = Date.now();
 	const workerName = scriptName;
 	const workerUrl = `/accounts/${accountId}/workers/scripts/${scriptName}`;
 
-	const { format } = props.entry;
+	const { format } = entry;
+	const projectRoot = entry.projectRoot;
 
 	if (config.wasm_modules && format === "modules") {
 		throw new UserError(
@@ -437,36 +316,34 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 	let hasPreview = false;
 
 	try {
-		if (props.noBundle) {
+		if (noBundle) {
 			// if we're not building, let's just copy the entry to the destination directory
 			const destinationDir =
 				typeof destination === "string" ? destination : destination.path;
 			mkdirSync(destinationDir, { recursive: true });
 			writeFileSync(
-				path.join(destinationDir, path.basename(props.entry.file)),
-				readFileSync(props.entry.file, "utf-8")
+				path.join(destinationDir, path.basename(entry.file)),
+				readFileSync(entry.file, "utf-8")
 			);
 		}
 
-		const entryDirectory = path.dirname(props.entry.file);
+		const entryDirectory = path.dirname(entry.file);
 		const moduleCollector = createModuleCollector({
 			wrangler1xLegacyModuleReferences: getWrangler1xLegacyModuleReferences(
 				entryDirectory,
-				props.entry.file
+				entry.file
 			),
-			entry: props.entry,
-			// `moduleCollector` doesn't get used when `props.noBundle` is set, so
+			entry,
+			// `moduleCollector` doesn't get used when `noBundle` is set, so
 			// `findAdditionalModules` always defaults to `false`
 			findAdditionalModules: config.find_additional_modules ?? false,
-			rules: props.rules,
+			rules: config.rules ?? [],
 		});
-		const uploadSourceMaps =
-			props.uploadSourceMaps ?? config.upload_source_maps;
 
 		const bindings = getBindings(config);
 
 		// Vars from the CLI (--var) are hidden so their values aren't logged to the terminal
-		for (const [bindingName, value] of Object.entries(props.vars ?? {})) {
+		for (const [bindingName, value] of Object.entries(props.cliVars)) {
 			bindings[bindingName] = {
 				type: "plain_text",
 				value,
@@ -480,15 +357,15 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			resolvedEntryPointPath,
 			bundleType,
 			...bundle
-		} = props.noBundle
+		} = noBundle
 			? await noBundleWorker(
-					props.entry,
-					props.rules,
-					props.outDir,
+					entry,
+					config.rules ?? [],
+					props.outdir,
 					config.python_modules.exclude
 				)
 			: await bundleWorker(
-					props.entry,
+					entry,
 					typeof destination === "string" ? destination : destination.path,
 					{
 						bundle: true,
@@ -498,21 +375,21 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 						workflowBindings: config.workflows,
 						jsxFactory,
 						jsxFragment,
-						tsconfig: props.tsconfig ?? config.tsconfig,
+						tsconfig: props.tsconfig,
 						minify,
 						keepNames: config.keep_names ?? true,
 						sourcemap: uploadSourceMaps,
 						nodejsCompatMode,
 						compatibilityDate,
 						compatibilityFlags,
-						define: { ...config.define, ...props.defines },
-						alias: { ...config.alias, ...props.alias },
+						define: props.defines,
+						alias: props.alias,
 						checkFetch: false,
 						// We want to know if the build is for development or publishing
 						// This could potentially cause issues as we no longer have identical behaviour between dev and deploy?
 						targetConsumer: "deploy",
 						local: false,
-						projectRoot: props.projectRoot,
+						projectRoot,
 						defineNavigatorUserAgent: isNavigatorDefined(
 							compatibilityDate,
 							compatibilityFlags
@@ -554,7 +431,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			? await getMigrationsToUpload(scriptName, {
 					accountId,
 					config,
-					useServiceEnvironments: props.useServiceEnvironments,
+					useServiceEnvironments: useServiceEnvironmentsConfig(config),
 					env: props.env,
 					dispatchNamespace: undefined,
 				})
@@ -607,7 +484,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 				: undefined,
 			compatibility_date: compatibilityDate,
 			compatibility_flags: compatibilityFlags,
-			keepVars: props.keepVars ?? false,
+			keepVars,
 			// we never delete secret bindings when uploading, even if we are setting secrets from a file
 			// so inherit all unchanged secrets from the previous Worker Version
 			keepSecrets: true,
@@ -668,7 +545,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 					accountId,
 					scriptName,
 					props.experimentalAutoCreate,
-					props.config
+					config
 				);
 			}
 			workerBundle = createWorkerUploadForm(worker, bindings, {
@@ -725,7 +602,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 					err,
 					dependencies,
 					workerBundle,
-					props.projectRoot
+					projectRoot
 				);
 				if (message) {
 					logger.error(message);
@@ -782,14 +659,14 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 				}
 			}
 		}
-		if (props.outFile) {
+		if (props.outfile) {
 			// we're using a custom output file,
 			// so let's first ensure it's parent directory exists
-			mkdirSync(path.dirname(props.outFile), { recursive: true });
+			mkdirSync(path.dirname(props.outfile), { recursive: true });
 
 			const serializedFormData = await new Response(workerBundle).arrayBuffer();
 
-			writeFileSync(props.outFile, Buffer.from(serializedFormData));
+			writeFileSync(props.outfile, Buffer.from(serializedFormData));
 		}
 	} finally {
 		if (typeof destination !== "string") {

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import { execSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { blue, gray } from "@cloudflare/cli-shared-helpers/colors";
 import { getWorkersDevSubdomain } from "@cloudflare/deploy-helpers";
@@ -20,20 +20,14 @@ import { fetchResult } from "../cfetch";
 import { createCommand } from "../core/create-command";
 import { createDeployHelpersContext } from "../core/deploy-helpers-context";
 import { getBindings, provisionBindings } from "../deployment-bundle/bindings";
-import { bundleWorker } from "../deployment-bundle/bundle";
 import { printBundleSize } from "../deployment-bundle/bundle-reporter";
 import { createWorkerUploadForm } from "../deployment-bundle/create-worker-upload-form";
 import {
 	sharedDeployVersionsArgs,
 	validateDeployVersionsArgs,
 } from "../deployment-bundle/deploy-args";
-import { logBuildOutput } from "../deployment-bundle/esbuild-plugins/log-build-output";
+import { handleBuild } from "../deployment-bundle/maybe-build-worker";
 import { mergeVersionsUploadConfigArgs } from "../deployment-bundle/merge-config-args";
-import {
-	createModuleCollector,
-	getWrangler1xLegacyModuleReferences,
-} from "../deployment-bundle/module-collection";
-import { noBundleWorker } from "../deployment-bundle/no-bundle-worker";
 import { validateNodeCompatMode } from "../deployment-bundle/node-compat";
 import {
 	addRequiredSecretsInheritBindings,
@@ -52,7 +46,6 @@ import { logger } from "../logger";
 import { verifyWorkerMatchesCITag } from "../match-tag";
 import { getMetricsUsageHeaders } from "../metrics";
 import * as metrics from "../metrics";
-import { isNavigatorDefined } from "../navigator-user-agent";
 import { writeOutput } from "../output";
 import { ensureQueuesExistByConfig } from "../queues/client";
 import { parseBulkInputToObject } from "../secret";
@@ -70,7 +63,10 @@ import { useServiceEnvironments as useServiceEnvironmentsConfig } from "../utils
 import { isWorkerNotFoundError } from "../utils/worker-not-found-error";
 import { patchNonVersionedScriptSettings } from "./api";
 import type { RetrieveSourceMapFunction } from "../sourcemap";
-import type { VersionsUploadProps } from "@cloudflare/deploy-helpers";
+import type {
+	HandleBuild,
+	VersionsUploadProps,
+} from "@cloudflare/deploy-helpers";
 import type { CfWorkerInit, Config } from "@cloudflare/workers-utils";
 import type { FormData } from "undici";
 
@@ -121,7 +117,7 @@ export const versionsUploadCommand = createCommand({
 			mergedProps.name !== undefined && mergedProps.name !== preMergeName;
 
 		const { versionId, workerTag, versionPreviewUrl, versionPreviewAliasUrl } =
-			await versionsUpload(mergedProps, config);
+			await versionsUpload(mergedProps, config, handleBuild);
 
 		writeOutput({
 			type: "version-upload",
@@ -141,7 +137,8 @@ export type VersionsUploadArgs = (typeof versionsUploadCommand)["args"];
 
 export default async function versionsUpload(
 	props: VersionsUploadProps,
-	config: Config
+	config: Config,
+	buildWorker: HandleBuild
 ): Promise<{
 	versionId: string | null;
 	workerTag: string | null;
@@ -159,12 +156,9 @@ export default async function versionsUpload(
 		name,
 		compatibilityDate,
 		compatibilityFlags,
-		jsxFactory,
-		jsxFragment,
 		keepVars,
 		minify,
 		noBundle,
-		destination,
 		uploadSourceMaps,
 	} = props;
 
@@ -264,18 +258,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		);
 	}
 
-	if (props.outdir) {
-		// we're using a custom output directory,
-		// so let's first ensure it exists
-		mkdirSync(props.outdir, { recursive: true });
-		// add a README
-		const readmePath = path.join(props.outdir, "README.md");
-		writeFileSync(
-			readmePath,
-			`This folder contains the built output assets for the worker "${scriptName}" generated at ${new Date().toISOString()}.`
-		);
-	}
-
 	const start = Date.now();
 	const workerName = scriptName;
 	const workerUrl = `/accounts/${accountId}/workers/scripts/${scriptName}`;
@@ -316,30 +298,16 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 	let hasPreview = false;
 
 	try {
-		if (noBundle) {
-			// if we're not building, let's just copy the entry to the destination directory
-			const destinationDir =
-				typeof destination === "string" ? destination : destination.path;
-			mkdirSync(destinationDir, { recursive: true });
-			writeFileSync(
-				path.join(destinationDir, path.basename(entry.file)),
-				readFileSync(entry.file, "utf-8")
-			);
-		}
-
-		const entryDirectory = path.dirname(entry.file);
-		const moduleCollector = createModuleCollector({
-			wrangler1xLegacyModuleReferences: getWrangler1xLegacyModuleReferences(
-				entryDirectory,
-				entry.file
-			),
-			entry,
-			// `moduleCollector` doesn't get used when `noBundle` is set, so
-			// `findAdditionalModules` always defaults to `false`
-			findAdditionalModules: config.find_additional_modules ?? false,
-			rules: config.rules ?? [],
+		const {
+			modules,
+			dependencies,
+			resolvedEntryPointPath,
+			bundleType,
+			content,
+			bundle,
+		} = await buildWorker.build(props, config, {
+			nodejsCompatMode,
 		});
-
 		const bindings = getBindings(config);
 
 		// Vars from the CLI (--var) are hidden so their values aren't logged to the terminal
@@ -350,81 +318,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 				hidden: true,
 			};
 		}
-
-		const {
-			modules,
-			dependencies,
-			resolvedEntryPointPath,
-			bundleType,
-			...bundle
-		} = noBundle
-			? await noBundleWorker(
-					entry,
-					config.rules ?? [],
-					props.outdir,
-					config.python_modules.exclude
-				)
-			: await bundleWorker(
-					entry,
-					typeof destination === "string" ? destination : destination.path,
-					{
-						bundle: true,
-						additionalModules: [],
-						moduleCollector,
-						doBindings: config.durable_objects.bindings,
-						workflowBindings: config.workflows,
-						jsxFactory,
-						jsxFragment,
-						tsconfig: props.tsconfig,
-						minify,
-						keepNames: config.keep_names ?? true,
-						sourcemap: uploadSourceMaps,
-						nodejsCompatMode,
-						compatibilityDate,
-						compatibilityFlags,
-						define: props.defines,
-						alias: props.alias,
-						checkFetch: false,
-						// We want to know if the build is for development or publishing
-						// This could potentially cause issues as we no longer have identical behaviour between dev and deploy?
-						targetConsumer: "deploy",
-						local: false,
-						projectRoot,
-						defineNavigatorUserAgent: isNavigatorDefined(
-							compatibilityDate,
-							compatibilityFlags
-						),
-						plugins: [logBuildOutput(nodejsCompatMode)],
-
-						// Pages specific options used by wrangler pages commands
-						entryName: undefined,
-						inject: undefined,
-						isOutfile: undefined,
-						external: undefined,
-
-						// These options are dev-only
-						testScheduled: undefined,
-						watch: undefined,
-						metafile: undefined,
-					}
-				);
-
-		// Add modules to dependencies for size warning
-		for (const module of modules) {
-			const modulePath =
-				module.filePath === undefined
-					? module.name
-					: path.relative("", module.filePath);
-			const bytesInOutput =
-				typeof module.content === "string"
-					? Buffer.byteLength(module.content)
-					: module.content.byteLength;
-			dependencies[modulePath] = { bytesInOutput };
-		}
-
-		const content = readFileSync(resolvedEntryPointPath, {
-			encoding: "utf-8",
-		});
 
 		// durable object migrations
 		const migrations = !props.dryRun
@@ -669,11 +562,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			writeFileSync(props.outfile, Buffer.from(serializedFormData));
 		}
 	} finally {
-		if (typeof destination !== "string") {
-			// this means we're using a temp dir,
-			// so let's clean up before we proceed
-			destination.remove();
-		}
+		buildWorker.cleanup(props);
 	}
 
 	if (props.dryRun) {


### PR DESCRIPTION
Thought it was best to separate out 'changes' vs just moving code into different packages. This PR isolates the code that will need to be pulled into deploy-helpers - everything now in the `deploy()` and `versionsUpload()` will be moved to deploy-helpers in a subsequent PR. 

This has required moving a few things _out_ of `deploy()` and `versionsUpload()`. 
- merging args and config - cf will have a different set of args. validation has been consolidated into `deploy()` and `versionsUpload()`, because presumably we'll need to same logic in cf too. Also resolving experimental flags, accountId and metrics, because i'm guessing cf will have its only logic for that too.
- worker bundling/not bundling. this logic will be inject it into deploy()/versionsUpload so that it can still happen at the same place. 



---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: refactor
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: refactor

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
