### PR TITLE
Rename web_search binding kind to websearch

### DIFF
--- a/.changeset/rename-web-search-binding-to-websearch.md
+++ b/.changeset/rename-web-search-binding-to-websearch.md
@@ -1,0 +1,18 @@
+---
+"@cloudflare/workers-utils": minor
+"miniflare": minor
+"wrangler": minor
+---
+
+Rename the `web_search` binding kind to `websearch`
+
+Pre-launch rename of the public binding type from `web_search` to `websearch` so the on-the-wire shape matches the product name (Web Search). The wrangler config key, the binding-type string sent to the Cloudflare API, and the miniflare option key all move from `web_search` / `webSearch` to `websearch`.
+
+Update your wrangler config:
+
+```diff
+- "web_search": { "binding": "WEBSEARCH" }
++ "websearch": { "binding": "WEBSEARCH" }
+```
+
+The runtime `WebSearch` type exposed on `env.WEBSEARCH` is unchanged.

--- a/packages/miniflare/src/plugins/index.ts
+++ b/packages/miniflare/src/plugins/index.ts
@@ -41,7 +41,7 @@ import {
 } from "./version-metadata";
 import { VPC_NETWORKS_PLUGIN, VPC_NETWORKS_PLUGIN_NAME } from "./vpc-networks";
 import { VPC_SERVICES_PLUGIN, VPC_SERVICES_PLUGIN_NAME } from "./vpc-services";
-import { WEB_SEARCH_PLUGIN, WEB_SEARCH_PLUGIN_NAME } from "./web-search";
+import { WEBSEARCH_PLUGIN, WEBSEARCH_PLUGIN_NAME } from "./websearch";
 import {
 	WORKER_LOADER_PLUGIN,
 	WORKER_LOADER_PLUGIN_NAME,
@@ -70,7 +70,7 @@ export const PLUGINS = {
 	[AI_PLUGIN_NAME]: AI_PLUGIN,
 	[AGENT_MEMORY_PLUGIN_NAME]: AGENT_MEMORY_PLUGIN,
 	[AI_SEARCH_PLUGIN_NAME]: AI_SEARCH_PLUGIN,
-	[WEB_SEARCH_PLUGIN_NAME]: WEB_SEARCH_PLUGIN,
+	[WEBSEARCH_PLUGIN_NAME]: WEBSEARCH_PLUGIN,
 	[BROWSER_RENDERING_PLUGIN_NAME]: BROWSER_RENDERING_PLUGIN,
 	[DISPATCH_NAMESPACE_PLUGIN_NAME]: DISPATCH_NAMESPACE_PLUGIN,
 	[IMAGES_PLUGIN_NAME]: IMAGES_PLUGIN,
@@ -141,7 +141,7 @@ export type WorkerOptions = z.input<typeof CORE_PLUGIN.options> &
 	z.input<typeof AI_PLUGIN.options> &
 	z.input<typeof AGENT_MEMORY_PLUGIN.options> &
 	z.input<typeof AI_SEARCH_PLUGIN.options> &
-	z.input<typeof WEB_SEARCH_PLUGIN.options> &
+	z.input<typeof WEBSEARCH_PLUGIN.options> &
 	z.input<typeof BROWSER_RENDERING_PLUGIN.options> &
 	z.input<typeof DISPATCH_NAMESPACE_PLUGIN.options> &
 	z.input<typeof IMAGES_PLUGIN.options> &
@@ -234,7 +234,7 @@ export * from "./analytics-engine";
 export * from "./ai";
 export * from "./agent-memory";
 export * from "./ai-search";
-export * from "./web-search";
+export * from "./websearch";
 export * from "./browser-rendering";
 export * from "./dispatch-namespace";
 export * from "./images";

--- a/packages/miniflare/src/plugins/websearch/index.ts
+++ b/packages/miniflare/src/plugins/websearch/index.ts
@@ -6,22 +6,22 @@ import {
 } from "../shared";
 import type { Plugin, RemoteProxyConnectionString } from "../shared";
 
-const WebSearchEntrySchema = z.object({
+const WebsearchEntrySchema = z.object({
 	remoteProxyConnectionString: z
 		.custom<RemoteProxyConnectionString>()
 		.optional(),
 });
 
-export const WebSearchOptionsSchema = z.object({
-	webSearch: z.record(WebSearchEntrySchema).optional(),
+export const WebsearchOptionsSchema = z.object({
+	websearch: z.record(WebsearchEntrySchema).optional(),
 });
 
-export const WEB_SEARCH_PLUGIN_NAME = "web-search";
+export const WEBSEARCH_PLUGIN_NAME = "websearch";
 
-const WEB_SEARCH_SCOPE = "web-search";
+const WEBSEARCH_SCOPE = "websearch";
 
-export const WEB_SEARCH_PLUGIN: Plugin<typeof WebSearchOptionsSchema> = {
-	options: WebSearchOptionsSchema,
+export const WEBSEARCH_PLUGIN: Plugin<typeof WebsearchOptionsSchema> = {
+	options: WebsearchOptionsSchema,
 	async getBindings(options) {
 		const bindings: {
 			name: string;
@@ -29,13 +29,13 @@ export const WEB_SEARCH_PLUGIN: Plugin<typeof WebSearchOptionsSchema> = {
 		}[] = [];
 
 		for (const [bindingName, entry] of Object.entries(
-			options.webSearch ?? {}
+			options.websearch ?? {}
 		)) {
 			bindings.push({
 				name: bindingName,
 				service: {
 					name: getUserBindingServiceName(
-						WEB_SEARCH_SCOPE,
+						WEBSEARCH_SCOPE,
 						bindingName,
 						entry.remoteProxyConnectionString
 					),
@@ -45,10 +45,10 @@ export const WEB_SEARCH_PLUGIN: Plugin<typeof WebSearchOptionsSchema> = {
 
 		return bindings;
 	},
-	getNodeBindings(options: z.infer<typeof WebSearchOptionsSchema>) {
+	getNodeBindings(options: z.infer<typeof WebsearchOptionsSchema>) {
 		const nodeBindings: Record<string, ProxyNodeBinding> = {};
 
-		for (const bindingName of Object.keys(options.webSearch ?? {})) {
+		for (const bindingName of Object.keys(options.websearch ?? {})) {
 			nodeBindings[bindingName] = new ProxyNodeBinding();
 		}
 
@@ -61,11 +61,11 @@ export const WEB_SEARCH_PLUGIN: Plugin<typeof WebSearchOptionsSchema> = {
 		}[] = [];
 
 		for (const [bindingName, entry] of Object.entries(
-			options.webSearch ?? {}
+			options.websearch ?? {}
 		)) {
 			services.push({
 				name: getUserBindingServiceName(
-					WEB_SEARCH_SCOPE,
+					WEBSEARCH_SCOPE,
 					bindingName,
 					entry.remoteProxyConnectionString
 				),

--- a/packages/workers-utils/src/config/binding-local-support.ts
+++ b/packages/workers-utils/src/config/binding-local-support.ts
@@ -69,7 +69,7 @@ const BINDING_LOCAL_SUPPORT: Record<
 	flagship: "DO-NOT-USE-this-resource-will-never-have-a-local-simulator",
 	vpc_service: "DO-NOT-USE-this-resource-will-never-have-a-local-simulator",
 	vpc_network: "DO-NOT-USE-this-resource-will-never-have-a-local-simulator",
-	web_search: "DO-NOT-USE-this-resource-will-never-have-a-local-simulator",
+	websearch: "DO-NOT-USE-this-resource-will-never-have-a-local-simulator",
 	agent_memory: "DO-NOT-USE-this-resource-will-never-have-a-local-simulator",
 };
 

--- a/packages/workers-utils/src/config/config.ts
+++ b/packages/workers-utils/src/config/config.ts
@@ -336,7 +336,7 @@ export const defaultWranglerConfig: Config = {
 	vectorize: [],
 	ai_search_namespaces: [],
 	ai_search: [],
-	web_search: undefined,
+	websearch: undefined,
 	agent_memory: [],
 	hyperdrive: [],
 	workflows: [],

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -1083,7 +1083,7 @@ export interface EnvironmentNonInheritable {
 	 * @default {}
 	 * @nonInheritable
 	 */
-	web_search:
+	websearch:
 		| {
 				/** The binding name used to refer to Web Search in the Worker. */
 				binding: string;

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -82,7 +82,7 @@ export type ConfigBindingFieldName =
 	| "vectorize"
 	| "ai_search_namespaces"
 	| "ai_search"
-	| "web_search"
+	| "websearch"
 	| "agent_memory"
 	| "hyperdrive"
 	| "r2_buckets"
@@ -126,7 +126,7 @@ export const friendlyBindingNames: Record<ConfigBindingFieldName, string> = {
 	vectorize: "Vectorize Index",
 	ai_search_namespaces: "AI Search Namespace",
 	ai_search: "AI Search Instance",
-	web_search: "Web Search",
+	websearch: "Web Search",
 	agent_memory: "Agent Memory",
 	hyperdrive: "Hyperdrive Config",
 	r2_buckets: "R2 Bucket",
@@ -185,7 +185,7 @@ const bindingTypeFriendlyNames: Record<Binding["type"], string> = {
 	vectorize: "Vectorize Index",
 	ai_search_namespace: "AI Search Namespace",
 	ai_search: "AI Search Instance",
-	web_search: "Web Search",
+	websearch: "Web Search",
 	agent_memory: "Agent Memory",
 	hyperdrive: "Hyperdrive Config",
 	service: "Worker",
@@ -1762,13 +1762,13 @@ function normalizeAndValidateEnvironment(
 			validateBindingArray(envName, validateAISearchBinding),
 			[]
 		),
-		web_search: notInheritable(
+		websearch: notInheritable(
 			diagnostics,
 			topLevelEnv,
 			rawConfig,
 			rawEnv,
 			envName,
-			"web_search",
+			"websearch",
 			validateNamedSimpleBinding(envName),
 			undefined
 		),
@@ -3090,7 +3090,7 @@ const validateUnsafeBinding: ValidatorFn = (diagnostics, field, value) => {
 			"ai",
 			"ai_search_namespace",
 			"ai_search",
-			"web_search",
+			"websearch",
 			"agent_memory",
 			"kv_namespace",
 			"durable_object_namespace",

--- a/packages/workers-utils/src/map-worker-metadata-bindings.ts
+++ b/packages/workers-utils/src/map-worker-metadata-bindings.ts
@@ -298,9 +298,9 @@ export function mapWorkerMetadataBindings(
 							},
 						];
 						break;
-					case "web_search":
+					case "websearch":
 						{
-							configObj.web_search = {
+							configObj.websearch = {
 								binding: binding.name,
 							};
 						}

--- a/packages/workers-utils/src/types.ts
+++ b/packages/workers-utils/src/types.ts
@@ -76,7 +76,7 @@ export type WorkerMetadataBinding =
 	| { type: "data_blob"; name: string; part: string }
 	| { type: "ai_search_namespace"; name: string; namespace: string }
 	| { type: "ai_search"; name: string; instance_name: string }
-	| { type: "web_search"; name: string }
+	| { type: "websearch"; name: string }
 	| { type: "agent_memory"; name: string; namespace: string }
 	| { type: "kv_namespace"; name: string; namespace_id: string; raw?: boolean }
 	| { type: "media"; name: string }
@@ -373,7 +373,7 @@ export type Binding =
 	| ({ type: "vectorize" } & BindingOmit<CfVectorize>)
 	| ({ type: "ai_search_namespace" } & BindingOmit<CfAISearchNamespace>)
 	| ({ type: "ai_search" } & BindingOmit<CfAISearch>)
-	| ({ type: "web_search" } & BindingOmit<CfWebSearch>)
+	| ({ type: "websearch" } & BindingOmit<CfWebSearch>)
 	| ({ type: "agent_memory" } & BindingOmit<CfAgentMemory>)
 	| ({ type: "hyperdrive" } & BindingOmit<CfHyperdrive>)
 	| ({ type: "service" } & BindingOmit<CfService>)

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -90,7 +90,7 @@ describe("normalizeAndValidateConfig()", () => {
 			text_blobs: undefined,
 			browser: undefined,
 			ai: undefined,
-			web_search: undefined,
+			websearch: undefined,
 			version_metadata: undefined,
 			triggers: {
 				crons: undefined,
@@ -2021,10 +2021,10 @@ describe("normalizeAndValidateConfig()", () => {
 			});
 		});
 
-		describe("[web_search]", () => {
-			it("should accept a valid web_search binding", ({ expect }) => {
+		describe("[websearch]", () => {
+			it("should accept a valid websearch binding", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
-					{ web_search: { binding: "WEBSEARCH" } } as RawConfig,
+					{ websearch: { binding: "WEBSEARCH" } } as RawConfig,
 					undefined,
 					undefined,
 					{ env: undefined }
@@ -2034,9 +2034,9 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBe(false);
 			});
 
-			it("should error if web_search is an array", ({ expect }) => {
+			it("should error if websearch is an array", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
-					{ web_search: [] } as unknown as RawConfig,
+					{ websearch: [] } as unknown as RawConfig,
 					undefined,
 					undefined,
 					{ env: undefined }
@@ -2045,13 +2045,13 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBe(false);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
-					  - The field "web_search" should be an object but got []."
+					  - The field "websearch" should be an object but got []."
 				`);
 			});
 
-			it("should error if web_search has no binding name", ({ expect }) => {
+			it("should error if websearch has no binding name", ({ expect }) => {
 				const { diagnostics } = normalizeAndValidateConfig(
-					{ web_search: {} } as unknown as RawConfig,
+					{ websearch: {} } as unknown as RawConfig,
 					undefined,
 					undefined,
 					{ env: undefined }

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -554,7 +554,7 @@ const bindingsConfigMock: Omit<
 		},
 	],
 	vpc_networks: [],
-	web_search: undefined,
+	websearch: undefined,
 };
 
 describe("generate types - CLI", () => {

--- a/packages/wrangler/src/api/startDevWorker/utils.ts
+++ b/packages/wrangler/src/api/startDevWorker/utils.ts
@@ -320,9 +320,9 @@ export function convertConfigToBindings(
 				}
 				break;
 			}
-			case "web_search": {
+			case "websearch": {
 				const { binding, ...x } = info;
-				output[binding] = { type: "web_search", ...x };
+				output[binding] = { type: "websearch", ...x };
 				break;
 			}
 			case "agent_memory": {
@@ -744,7 +744,7 @@ export function convertWorkerMetadataBindingsToFlatBindings(
 			case "stream":
 			case "version_metadata":
 			case "media":
-			case "web_search":
+			case "websearch":
 			case "inherit": {
 				// These have the same structure (just type and possibly some flags)
 				const { name: _name, ...rest } = binding;

--- a/packages/wrangler/src/deploy/check-remote-secrets-override.ts
+++ b/packages/wrangler/src/deploy/check-remote-secrets-override.ts
@@ -125,7 +125,7 @@ function extractBindingNames(config: Config): string[] {
 			}
 			case "browser":
 			case "ai":
-			case "web_search": {
+			case "websearch": {
 				const value: Config[typeof key] = untypedValue;
 				return value ? [value.binding] : [];
 			}

--- a/packages/wrangler/src/deploy/config-diffs.ts
+++ b/packages/wrangler/src/deploy/config-diffs.ts
@@ -55,7 +55,7 @@ const reorderableBindings = {
 	images: false,
 	stream: false,
 	media: false,
-	web_search: false,
+	websearch: false,
 	version_metadata: false,
 	unsafe: false,
 	assets: false,
@@ -263,7 +263,7 @@ function removeRemoteConfigFieldFromBindings(normalizedConfig: Config): void {
 		"images",
 		"stream",
 		"media",
-		"web_search",
+		"websearch",
 	] as const;
 	for (const singleBindingField of singleBindingFields) {
 		if (

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -131,7 +131,7 @@ export function createWorkerUploadForm(
 		bindings
 	);
 	const ai_search = extractBindingsOfType("ai_search", bindings);
-	const web_search = extractBindingsOfType("web_search", bindings)[0];
+	const websearch = extractBindingsOfType("websearch", bindings)[0];
 	const agent_memory = extractBindingsOfType("agent_memory", bindings);
 	const hyperdrive = extractBindingsOfType("hyperdrive", bindings);
 	const secrets_store_secrets = extractBindingsOfType(
@@ -369,10 +369,10 @@ export function createWorkerUploadForm(
 		});
 	});
 
-	if (web_search !== undefined) {
+	if (websearch !== undefined) {
 		metadataBindings.push({
-			name: web_search.binding,
-			type: "web_search",
+			name: websearch.binding,
+			type: "websearch",
 		});
 	}
 

--- a/packages/wrangler/src/dev/miniflare/index.ts
+++ b/packages/wrangler/src/dev/miniflare/index.ts
@@ -423,7 +423,7 @@ type WorkerOptionsBindings = Pick<
 	| "ai"
 	| "aiSearchNamespaces"
 	| "aiSearchInstances"
-	| "webSearch"
+	| "websearch"
 	| "agentMemory"
 	| "textBlobBindings"
 	| "dataBlobBindings"
@@ -545,7 +545,7 @@ export function buildMiniflareBindingOptions(
 		bindings
 	);
 	const aiSearchInstanceBindings = extractBindingsOfType("ai_search", bindings);
-	const webSearchBindings = extractBindingsOfType("web_search", bindings);
+	const websearchBindings = extractBindingsOfType("websearch", bindings);
 	const agentMemoryBindings = extractBindingsOfType("agent_memory", bindings);
 	const imagesBindings = extractBindingsOfType("images", bindings);
 	const mediaBindings = extractBindingsOfType("media", bindings);
@@ -655,8 +655,8 @@ export function buildMiniflareBindingOptions(
 		warnOrError("ai_search", inst.remote);
 	}
 
-	for (const ws of webSearchBindings) {
-		warnOrError("web_search", ws.remote);
+	for (const ws of websearchBindings) {
+		warnOrError("websearch", ws.remote);
 	}
 
 	for (const memory of agentMemoryBindings) {
@@ -785,8 +785,8 @@ export function buildMiniflareBindingOptions(
 			])
 		),
 
-		webSearch: Object.fromEntries(
-			webSearchBindings.map((ws) => [
+		websearch: Object.fromEntries(
+			websearchBindings.map((ws) => [
 				ws.binding,
 				{
 					remoteProxyConnectionString,

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -471,8 +471,8 @@ import { vpcServiceGetCommand } from "./vpc/get";
 import { vpcNamespace, vpcServiceNamespace } from "./vpc/index";
 import { vpcServiceListCommand } from "./vpc/list";
 import { vpcServiceUpdateCommand } from "./vpc/update";
-import { webSearchNamespace } from "./websearch/index";
-import { webSearchSearchCommand } from "./websearch/search";
+import { websearchNamespace } from "./websearch/index";
+import { websearchSearchCommand } from "./websearch/search";
 import { workflowsInstanceNamespace, workflowsNamespace } from "./workflows";
 import { workflowsDeleteCommand } from "./workflows/commands/delete";
 import { workflowsDescribeCommand } from "./workflows/commands/describe";
@@ -1565,10 +1565,10 @@ export function createCLIParser(argv: string[]) {
 
 	// websearch
 	registry.define([
-		{ command: "wrangler websearch", definition: webSearchNamespace },
+		{ command: "wrangler websearch", definition: websearchNamespace },
 		{
 			command: "wrangler websearch search",
-			definition: webSearchSearchCommand,
+			definition: websearchSearchCommand,
 		},
 	]);
 	registry.registerNamespace("websearch");

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -2338,17 +2338,17 @@ function collectCoreBindings(
 			addBinding(aiSearch.binding, "AiSearchInstance", "ai_search", envName);
 		}
 
-		if (env.web_search) {
-			if (!env.web_search.binding) {
+		if (env.websearch) {
+			if (!env.websearch.binding) {
 				throwMissingBindingError({
-					binding: env.web_search,
-					bindingType: "web_search",
+					binding: env.websearch,
+					bindingType: "websearch",
 					configPath: args.config,
 					envName,
 					fieldName: "binding",
 				});
 			} else {
-				addBinding(env.web_search.binding, "WebSearch", "web_search", envName);
+				addBinding(env.websearch.binding, "WebSearch", "websearch", envName);
 			}
 		}
 
@@ -3516,19 +3516,19 @@ function collectCoreBindingsPerEnvironment(
 			});
 		}
 
-		if (env.web_search) {
-			if (!env.web_search.binding) {
+		if (env.websearch) {
+			if (!env.websearch.binding) {
 				throwMissingBindingError({
-					binding: env.web_search,
-					bindingType: "web_search",
+					binding: env.websearch,
+					bindingType: "websearch",
 					configPath: args.config,
 					envName,
 					fieldName: "binding",
 				});
 			} else {
 				bindings.push({
-					bindingCategory: "web_search",
-					name: env.web_search.binding,
+					bindingCategory: "websearch",
+					name: env.websearch.binding,
 					type: "WebSearch",
 				});
 			}

--- a/packages/wrangler/src/utils/add-created-resource-config.ts
+++ b/packages/wrangler/src/utils/add-created-resource-config.ts
@@ -20,7 +20,7 @@ type ValidKeys = Exclude<
 	ConfigBindingFieldName,
 	| "ai"
 	| "browser"
-	| "web_search"
+	| "websearch"
 	| "vars"
 	| "wasm_modules"
 	| "text_blobs"

--- a/packages/wrangler/src/utils/print-bindings.ts
+++ b/packages/wrangler/src/utils/print-bindings.ts
@@ -90,7 +90,7 @@ export function printBindings(
 		bindings
 	);
 	const ai_search = extractBindingsOfType("ai_search", bindings);
-	const web_search = extractBindingsOfType("web_search", bindings);
+	const websearch = extractBindingsOfType("websearch", bindings);
 	const agent_memory = extractBindingsOfType("agent_memory", bindings);
 	const hyperdrive = extractBindingsOfType("hyperdrive", bindings);
 	const r2_buckets = extractBindingsOfType("r2_bucket", bindings);
@@ -357,11 +357,11 @@ export function printBindings(
 		);
 	}
 
-	if (web_search.length > 0) {
+	if (websearch.length > 0) {
 		output.push(
-			...web_search.map(({ binding }) => ({
+			...websearch.map(({ binding }) => ({
 				name: binding,
-				type: getBindingTypeFriendlyName("web_search"),
+				type: getBindingTypeFriendlyName("websearch"),
 				value: undefined,
 				mode: getMode({ isSimulatedLocally: false }),
 			}))

--- a/packages/wrangler/src/websearch/index.ts
+++ b/packages/wrangler/src/websearch/index.ts
@@ -1,6 +1,6 @@
 import { createNamespace } from "../core/create-command";
 
-export const webSearchNamespace = createNamespace({
+export const websearchNamespace = createNamespace({
 	metadata: {
 		description: "🔎 Run queries against Cloudflare Web Search",
 		status: "experimental",

--- a/packages/wrangler/src/websearch/search.ts
+++ b/packages/wrangler/src/websearch/search.ts
@@ -2,7 +2,7 @@ import { createCommand } from "../core/create-command";
 import { logger } from "../logger";
 import { search } from "./client";
 
-export const webSearchSearchCommand = createCommand({
+export const websearchSearchCommand = createCommand({
 	metadata: {
 		description: "Run a query against Cloudflare Web Search",
 		status: "experimental",


### PR DESCRIPTION
## What this PR does

Pre-launch rename of the public binding type from `web_search` to `websearch` so the on-the-wire shape matches the product name (Web Search). The wrangler config key, the binding-type string sent to the Cloudflare API (in the multipart-upload metadata), and the miniflare option key all move from `web_search` / `webSearch` to `websearch`.

The runtime `WebSearch` type exposed on `env.WEBSEARCH` is unchanged — this is purely a config-surface rename.

### Update for users

```diff
- "web_search": { "binding": "WEBSEARCH" }
+ "websearch": { "binding": "WEBSEARCH" }
```

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: we will add docs when we release this to the public

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/13955" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->