### PR TITLE
fix(wrangler): version listing limits

### DIFF
--- a/.changeset/late-lemons-report.md
+++ b/.changeset/late-lemons-report.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Limit `wrangler versions list` to the 10 most recent deployable versions
+
+The versions API ignores pagination when filtering to deployable versions, so Wrangler now caps the command output client-side. This keeps the command aligned with its help text and avoids overwhelming terminal output for Workers with many versions.

--- a/packages/wrangler/src/__tests__/versions/versions.list.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.list.test.ts
@@ -2,13 +2,15 @@ import {
 	runInTempDir,
 	writeWranglerConfig,
 } from "@cloudflare/workers-utils/test-helpers";
+import { http, HttpResponse } from "msw";
 import { beforeEach, describe, test } from "vitest";
 import { normalizeOutput } from "../../../e2e/helpers/normalize";
 import { collectCLIOutput } from "../helpers/collect-cli-output";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import { msw, mswListVersions } from "../helpers/msw";
+import { createFetchResult, msw, mswListVersions } from "../helpers/msw";
 import { runWrangler } from "../helpers/run-wrangler";
+import type { ApiVersion } from "../../versions/types";
 
 describe("versions list", () => {
 	mockAccountId();
@@ -18,6 +20,39 @@ describe("versions list", () => {
 	const cnsl = mockConsoleMethods();
 
 	const std = collectCLIOutput();
+
+	function createMockVersion(index: number): ApiVersion {
+		const versionNumber = index + 1;
+		const paddedVersionNumber = versionNumber.toString().padStart(8, "0");
+		const paddedDay = versionNumber.toString().padStart(2, "0");
+		const timestamp = `2021-01-${paddedDay}T00:00:00.000000Z`;
+
+		return {
+			id: `${paddedVersionNumber}-0000-0000-0000-000000000000`,
+			number: versionNumber,
+			metadata: {
+				author_id: "Picard-Gamma-6-0-7-3",
+				author_email: "Jean-Luc-Picard@federation.org",
+				created_on: timestamp,
+				modified_on: timestamp,
+				source: "wrangler",
+			},
+			resources: {
+				bindings: [],
+				script: {
+					etag: "etag",
+					handlers: ["fetch"],
+					last_deployed_from: "wrangler",
+				},
+				script_runtime: {
+					compatibility_date: "2021-01-01",
+					compatibility_flags: [],
+					limits: { cpu_ms: 50 },
+					usage_model: "standard",
+				},
+			},
+		};
+	}
 
 	beforeEach(() => {
 		msw.use(mswListVersions);
@@ -149,6 +184,51 @@ describe("versions list", () => {
 			`);
 
 			expect(cnsl.out).not.toMatch(/⛅️ wrangler/);
+
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
+		test("prints the 10 most recent versions to stdout as valid json", async ({
+			expect,
+		}) => {
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/workers/scripts/:workerName/versions",
+					({ request }) => {
+						const url = new URL(request.url);
+						expect(url.searchParams.get("deployable")).toBe("true");
+						expect(url.searchParams.has("per_page")).toBe(false);
+
+						return HttpResponse.json(
+							createFetchResult({
+								items: Array.from({ length: 12 }, (_, index) =>
+									createMockVersion(index)
+								),
+							})
+						);
+					}
+				)
+			);
+
+			const result = runWrangler("versions list --name test-name --json");
+
+			await expect(result).resolves.toBeUndefined();
+
+			const versions = JSON.parse(std.out) as ApiVersion[];
+			expect(versions.map((version) => version.id)).toMatchInlineSnapshot(`
+				[
+				  "00000003-0000-0000-0000-000000000000",
+				  "00000004-0000-0000-0000-000000000000",
+				  "00000005-0000-0000-0000-000000000000",
+				  "00000006-0000-0000-0000-000000000000",
+				  "00000007-0000-0000-0000-000000000000",
+				  "00000008-0000-0000-0000-000000000000",
+				  "00000009-0000-0000-0000-000000000000",
+				  "00000010-0000-0000-0000-000000000000",
+				  "00000011-0000-0000-0000-000000000000",
+				  "00000012-0000-0000-0000-000000000000",
+				]
+			`);
 
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});

--- a/packages/wrangler/src/versions/list.ts
+++ b/packages/wrangler/src/versions/list.ts
@@ -8,6 +8,7 @@ import { fetchDeployableVersions } from "./api";
 import type { ApiVersion, VersionCache } from "./types";
 
 const BLANK_INPUT = "-"; // To be used where optional user-input is displayed and the value is nullish
+const VERSION_LIST_LIMIT = 10;
 
 export const versionsListCommand = createCommand({
 	metadata: {
@@ -50,11 +51,15 @@ export const versionsListCommand = createCommand({
 		}
 
 		const versionCache: VersionCache = new Map();
+
+		// The versions API ignores pagination when `deployable=true`, so cap the command output client-side.
 		const versions = (
 			await fetchDeployableVersions(config, accountId, workerName, versionCache)
-		).sort((a, b) =>
-			a.metadata.created_on.localeCompare(b.metadata.created_on)
-		);
+		)
+			.sort((a, b) =>
+				a.metadata.created_on.localeCompare(b.metadata.created_on)
+			)
+			.slice(-VERSION_LIST_LIMIT);
 
 		if (args.json) {
 			logRaw(JSON.stringify(versions, null, 2));


### PR DESCRIPTION
Fixes #14160.

This change updates the `wrangler versions list` command to only show 10 version rather than 100, which the API now defaults to.

> [!NOTE]  
> The API does not allow for both `deployable=true` and `per_page=10` parameters together. So we filter the versions list client-sode.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: CLI bug fix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
