### PR TITLE
bump the workers-auth package to its current version

### DIFF
--- a/packages/workers-auth/package.json
+++ b/packages/workers-auth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cloudflare/workers-auth",
-	"version": "0.0.0",
+	"version": "0.1.0",
 	"description": "Internal OAuth 2.0 + PKCE flow for Cloudflare CLIs. Not intended for external use — APIs may change without notice.",
 	"homepage": "https://github.com/cloudflare/workers-sdk/tree/main/packages/workers-auth#readme",
 	"bugs": {


### PR DESCRIPTION
The package has already been published as 0.1.0, so this is just bringing the source code inline with reality.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->