### PR TITLE
Add `skip_wrangler_startup_prompts` configuration option

### DIFF
--- a/.changeset/skip-wrangler-startup-prompts.md
+++ b/.changeset/skip-wrangler-startup-prompts.md
@@ -1,0 +1,16 @@
+---
+"wrangler": minor
+---
+
+Add `skip_wrangler_startup_prompts` configuration option
+
+You can now set `skip_wrangler_startup_prompts: true` in your `wrangler.json` to suppress interactive confirmation prompts that Wrangler shows during its startup sequence. Currently this skips the AI coding agent skills installation prompt.
+
+The `--install-skills` CLI flag still overrides this option and forces skill installation regardless of the config setting.
+
+```jsonc
+// wrangler.json
+{
+	"skip_wrangler_startup_prompts": true,
+}
+```

--- a/packages/workers-utils/src/config/config.ts
+++ b/packages/workers-utils/src/config/config.ts
@@ -181,6 +181,28 @@ export interface ConfigFields<Dev extends RawDevConfig> {
 	 * @nonInheritable
 	 */
 	keep_vars?: boolean;
+
+	/**
+	 * When invoked, Wrangler may present interactive confirmation prompts during
+	 * its startup sequence before the command handler runs.
+	 *
+	 * Setting this option to `true` suppresses those prompts (and the operations
+	 * they guard). Removing the option (or setting it to `false`) restores the
+	 * standard Wrangler behavior.
+	 *
+	 * Prompts currently suppressed by this option:
+	 *
+	 * - **AI coding agent skills installation** — the `confirm()` prompt that asks
+	 *   whether to install Cloudflare skills for detected AI coding agents.
+	 *   The `--install-skills` CLI flag still overrides this option and forces installation.
+	 *
+	 * This option also applies to any future interactive startup prompts that
+	 * Wrangler may introduce.
+	 *
+	 * @default false
+	 * @nonInheritable
+	 */
+	skip_wrangler_startup_prompts?: boolean;
 }
 
 // Pages-specific configuration fields
@@ -365,6 +387,7 @@ export const defaultWranglerConfig: Config = {
 	data_blobs: undefined,
 	keep_vars: undefined,
 	alias: undefined,
+	skip_wrangler_startup_prompts: false,
 
 	/** INHERITABLE ENVIRONMENT FIELDS **/
 	account_id: undefined,

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -314,6 +314,14 @@ export function normalizeAndValidateConfig(
 	validateOptionalProperty(
 		diagnostics,
 		"",
+		"skip_wrangler_startup_prompts",
+		rawConfig.skip_wrangler_startup_prompts,
+		"boolean"
+	);
+
+	validateOptionalProperty(
+		diagnostics,
+		"",
 		"pages_build_output_dir",
 		rawConfig.pages_build_output_dir,
 		"string"
@@ -498,6 +506,7 @@ export function normalizeAndValidateConfig(
 		legacy_env: !useServiceEnvironments,
 		send_metrics: rawConfig.send_metrics,
 		keep_vars: rawConfig.keep_vars,
+		skip_wrangler_startup_prompts: rawConfig.skip_wrangler_startup_prompts,
 		...activeEnv,
 		dev: normalizeAndValidateDev(diagnostics, rawConfig.dev ?? {}, args),
 		site: normalizeAndValidateSite(

--- a/packages/wrangler/src/__tests__/register-yargs-command-skills.test.ts
+++ b/packages/wrangler/src/__tests__/register-yargs-command-skills.test.ts
@@ -63,4 +63,50 @@ describe("register-yargs-command skills integration", () => {
 
 		expect(maybeInstallCloudflareSkillsGlobally).toHaveBeenCalledWith(true);
 	});
+
+	test("does not call maybeInstallCloudflareSkillsGlobally when skip_wrangler_startup_prompts is true", async ({
+		expect,
+	}) => {
+		await seed({
+			"wrangler.jsonc": JSON.stringify({
+				name: "test-worker",
+				skip_wrangler_startup_prompts: true,
+			}),
+		});
+
+		await runWrangler("setup");
+
+		expect(maybeInstallCloudflareSkillsGlobally).not.toHaveBeenCalled();
+	});
+
+	test("still calls maybeInstallCloudflareSkillsGlobally when skip_wrangler_startup_prompts is true but --install-skills is passed", async ({
+		expect,
+	}) => {
+		// Explicit --install-skills overrides the config option.
+		await seed({
+			"wrangler.jsonc": JSON.stringify({
+				name: "test-worker",
+				skip_wrangler_startup_prompts: true,
+			}),
+		});
+
+		await runWrangler("setup --install-skills");
+
+		expect(maybeInstallCloudflareSkillsGlobally).toHaveBeenCalledWith(true);
+	});
+
+	test("calls maybeInstallCloudflareSkillsGlobally when skip_wrangler_startup_prompts is false", async ({
+		expect,
+	}) => {
+		await seed({
+			"wrangler.jsonc": JSON.stringify({
+				name: "test-worker",
+				skip_wrangler_startup_prompts: false,
+			}),
+		});
+
+		await runWrangler("setup");
+
+		expect(maybeInstallCloudflareSkillsGlobally).toHaveBeenCalledWith(false);
+	});
 });

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -138,7 +138,19 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 				await printWranglerBanner();
 			}
 
-			if (!def.behaviour?.skipSkillsPrompt || args.installSkills) {
+			// Perform a lightweight raw config read to check whether the user
+			// opted out of startup prompts.  This runs before the full
+			// `readConfig()` call so we can skip the interactive skills prompt
+			// early.  The `--install-skills` CLI flag always takes precedence.
+			const skipStartupPrompts =
+				experimental_readRawConfig({ config: args.config }).rawConfig
+					.skip_wrangler_startup_prompts === true;
+
+			if (
+				!skipStartupPrompts ||
+				!def.behaviour?.skipSkillsPrompt ||
+				args.installSkills
+			) {
 				await maybeInstallCloudflareSkillsGlobally(args.installSkills);
 			}
 


### PR DESCRIPTION
You can now set `skip_wrangler_startup_prompts: true` in your `wrangler.json` to suppress interactive confirmation prompts that Wrangler shows during its startup sequence. Currently this skips the AI coding agent skills installation prompt.

The `--install-skills` CLI flag still overrides this option and forces skill installation regardless of the config setting.

```jsonc
// wrangler.json
{
	"skip_wrangler_startup_prompts": true,
}
```

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): __TODO__ <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
