### PR TITLE
[wrangler] Write auth config file with mode 0600 and re-chmod on save

### DIFF
--- a/.changeset/wrangler-auth-config-file-mode-0600.md
+++ b/.changeset/wrangler-auth-config-file-mode-0600.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+"@cloudflare/workers-auth": patch
+---
+
+Tighten on-disk permissions of the OAuth credentials file to `0600`
+
+The user auth config file written by `wrangler login` (typically `~/.config/.wrangler/config/default.toml` on Linux/macOS, or `<environment>.toml` for non-production Cloudflare API environments) is now written with mode `0600` and re-`chmod`-ed on every save. This prevents other local users on shared hosts from reading the stored OAuth tokens. Existing files with looser permissions written by older Wrangler versions are tightened the next time Wrangler refreshes the token or the user logs in again. The change is a no-op on Windows, which does not honour POSIX mode bits.

--- a/packages/workers-auth/src/auth-config-file.ts
+++ b/packages/workers-auth/src/auth-config-file.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import {
 	getCloudflareApiEnvironmentFromEnv,
@@ -52,9 +52,17 @@ export function writeAuthConfigFile(config: UserAuthConfig): void {
 	mkdirSync(path.dirname(configPath), {
 		recursive: true,
 	});
+	// Write with mode 0o600 on creation and re-`chmod` on every save so
+	// other local users on shared hosts can't read the OAuth tokens.
+	// `writeFileSync`'s `mode` option only applies when the file is
+	// being created — the explicit `chmodSync` ensures that pre-existing
+	// files (e.g. written by an older Wrangler version with the process
+	// umask) get tightened on the next save too.
 	writeFileSync(configPath, TOML.stringify(config), {
 		encoding: "utf-8",
+		mode: 0o600,
 	});
+	chmodSync(configPath, 0o600);
 }
 
 /**

--- a/packages/workers-auth/tests/auth-config-file.test.ts
+++ b/packages/workers-auth/tests/auth-config-file.test.ts
@@ -1,0 +1,54 @@
+import { chmodSync, statSync } from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
+import { describe, it } from "vitest";
+import {
+	getAuthConfigFilePath,
+	readAuthConfigFile,
+	writeAuthConfigFile,
+} from "../src/auth-config-file";
+import type { UserAuthConfig } from "../src/auth-config-file";
+
+const SAMPLE_CONFIG: UserAuthConfig = {
+	oauth_token: "test-oauth-token",
+	refresh_token: "test-refresh-token",
+	expiration_time: "2099-01-01T00:00:00.000Z",
+	scopes: ["account:read"],
+};
+
+describe("writeAuthConfigFile", () => {
+	runInTempDir();
+
+	it("round-trips a UserAuthConfig through the TOML file", ({ expect }) => {
+		writeAuthConfigFile(SAMPLE_CONFIG);
+		expect(readAuthConfigFile()).toEqual(SAMPLE_CONFIG);
+	});
+
+	// POSIX-only: Windows doesn't honour POSIX mode bits — `chmodSync` only
+	// touches the read-only flag there, so the `& 0o777 === 0o600` assertion
+	// would be meaningless. The hardening still runs unconditionally; we
+	// just skip the assertion that wouldn't hold cross-platform.
+	it.skipIf(process.platform === "win32")(
+		"writes a new auth config file with mode 0o600",
+		({ expect }) => {
+			writeAuthConfigFile(SAMPLE_CONFIG);
+			const mode = statSync(getAuthConfigFilePath()).mode & 0o777;
+			expect(mode).toBe(0o600);
+		}
+	);
+
+	it.skipIf(process.platform === "win32")(
+		"tightens permissions on a pre-existing auth config file with looser mode",
+		({ expect }) => {
+			// Simulate a file left behind by an older Wrangler version that
+			// wrote with the process umask (typically 0o644).
+			writeAuthConfigFile(SAMPLE_CONFIG);
+			chmodSync(getAuthConfigFilePath(), 0o644);
+			expect(statSync(getAuthConfigFilePath()).mode & 0o777).toBe(0o644);
+
+			// Re-saving must restore the tight 0o600 permissions even though
+			// `writeFileSync`'s `mode` option is ignored for existing files.
+			writeAuthConfigFile(SAMPLE_CONFIG);
+			expect(statSync(getAuthConfigFilePath()).mode & 0o777).toBe(0o600);
+		}
+	);
+});


### PR DESCRIPTION
Tighten on-disk permissions of the Wrangler OAuth credentials file to `0600` and re-`chmod` on every save so other local users on shared hosts cannot read the stored tokens.

This is the auth-config-file slice of the broader REVIEW-17452 security hardening — extracted here as a stand-alone defence-in-depth change against the user-credentials file. Other parts of the original review apply only to the WebSocket-callback OAuth flow that is not yet on `main` and will land separately.

### What changes

- `writeAuthConfigFile` in `@cloudflare/workers-auth` now passes `mode: 0o600` to `writeFileSync` so newly-created files are tight from the start, and follows the write with an explicit `chmodSync(path, 0o600)` so files written by older Wrangler versions (or with a looser process umask) get tightened on the next refresh / login.
- The change is a no-op on Windows, which does not honour POSIX mode bits — the tests assert the mode only on non-Windows platforms; the hardening itself runs unconditionally.

### Why both `mode` and `chmodSync`

Node's `writeFileSync({ mode })` option is only honoured when the file is being **created** — if the file already exists, the option is silently ignored. The explicit `chmodSync` covers the upgrade path where an old `default.toml` already exists with `0o644`.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is a defensive permission change on a credentials file that is already an implementation detail of `wrangler login`; there is no user-visible API surface or configuration knob.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->