### PR TITLE
Make Ctrl+C triggered during the skills-install prompt dismiss it permanently

### DIFF
--- a/.changeset/sigint-dismisses-skills-prompt.md
+++ b/.changeset/sigint-dismisses-skills-prompt.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Make Ctrl+C triggered during the skills-install prompt dismiss it permanently
+
+Previously, pressing Ctrl+C (SIGINT) during the "Would you like to install Cloudflare skills?" prompt terminated the process without writing the metadata file, causing the prompt to reappear on every subsequent `wrangler` invocation. A SIGINT handler is now registered around the prompt so that the metadata file is written with `accepted: "SIGINT"` before the process exits, preventing the prompt from being shown again.

--- a/packages/wrangler/src/__tests__/agents-skills-install.test.ts
+++ b/packages/wrangler/src/__tests__/agents-skills-install.test.ts
@@ -6,6 +6,7 @@ import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { detectAgenticEnvironment } from "am-i-vibing";
 import ci from "ci-info";
 import { http, HttpResponse } from "msw";
+import prompts from "prompts";
 import { afterEach, beforeEach, describe, test, vi } from "vitest";
 import { sendMetricsEvent } from "../metrics/send-event";
 import { mockConsoleMethods } from "./helpers/mock-console";
@@ -17,6 +18,7 @@ import type {
 	telemetryCurrentAgentSkillsInstalled as TelemetryFnType,
 } from "../agents-skills-install";
 import type * as SendEventModule from "../metrics/send-event";
+import type { Mock } from "vitest";
 
 // Undo the global no-op mock from vitest.setup.ts so we test the real implementation
 vi.unmock("../agents-skills-install");
@@ -191,6 +193,23 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 					rosie: { id: "claude", globalPath: "/fake/.claude/skills" },
 				},
 			]);
+		});
+
+		test("skips silently when metadata file has accepted: 'SIGINT' (Ctrl+C dismissal)", async ({
+			expect,
+		}) => {
+			writeMetadataFile({
+				version: 1,
+				accepted: "SIGINT",
+				date: "2025-01-01T00:00:00Z",
+			});
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+
+			await maybeInstallCloudflareSkillsGlobally(false);
+
+			expect(mockRosieAgents).not.toHaveBeenCalled();
+			expect(mockRosieInstall).not.toHaveBeenCalled();
+			expect(sendMetricsEvent).not.toHaveBeenCalled();
 		});
 
 		test("force=true ignores existing metadata file", async ({ expect }) => {
@@ -410,6 +429,62 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 				},
 				{}
 			);
+		});
+
+		test("writes SIGINT metadata when user presses Ctrl+C during the prompt", async ({
+			expect,
+		}) => {
+			// Stub process.exit so the abort flow doesn't terminate the test runner.
+			const exitSpy = vi
+				.spyOn(process, "exit")
+				.mockImplementation((() => {}) as never);
+
+			// Simulate Ctrl+C: invoke the onState callback with
+			// { aborted: true }, then resolve with { value: undefined }
+			// just as the real prompts library does on abort.
+			(prompts as unknown as Mock).mockImplementationOnce(
+				({ type, name, message, onState }) => {
+					expect({ type, name }).toStrictEqual({
+						type: "confirm",
+						name: "value",
+					});
+					expect(message).toContain("Claude Code");
+
+					// Trigger the abort handler (simulates Ctrl+C)
+					onState({ aborted: true });
+
+					return Promise.resolve({ value: undefined });
+				}
+			);
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+
+			await maybeInstallCloudflareSkillsGlobally(false);
+
+			// Should have warned the user that Ctrl+C was treated as a decline
+			expect(std.warn).toContain(
+				"Ctrl+C received — skipping Cloudflare skills installation. This prompt will not be shown again."
+			);
+
+			// The onState abort handler should have written metadata
+			// with accepted: "SIGINT"
+			const metadata = readMetadataFile();
+			expect(metadata.accepted).toBe("SIGINT");
+			expect(metadata.version).toBe(1);
+
+			// Should not have attempted installation
+			expect(mockRosieInstall).not.toHaveBeenCalled();
+
+			// Should have sent a skipped metrics event
+			expect(sendMetricsEvent).toHaveBeenCalledWith(
+				"skills_install_skipped",
+				{ reason: "User dismissed (SIGINT)" },
+				{}
+			);
+
+			// Should have called process.exit(1) after flushing metrics
+			expect(exitSpy).toHaveBeenCalledWith(1);
+
+			exitSpy.mockRestore();
 		});
 
 		test("force=true installs skills without prompting", async ({ expect }) => {
@@ -913,6 +988,69 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 			date: new Date().toISOString(),
 			detectedAgents: [],
 			installFailed: false,
+		});
+		mockGitHubSkillsApi(["cloudflare", "wrangler"]);
+		const telemetryCurrentAgentSkillsInstalled = await freshTelemetryImport();
+
+		const result = await telemetryCurrentAgentSkillsInstalled();
+
+		expect(result).toBe("manual");
+	});
+
+	test("resolves to 'manual' when metadata has accepted: 'SIGINT' at primary path", async ({
+		expect,
+	}) => {
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: true,
+			id: "claude-code",
+			name: "Claude Code",
+			type: "agent",
+		});
+		createAgentDir(".claude");
+		const claudeSkills = path.join(os.homedir(), ".claude", "skills");
+		mkdirSync(path.join(claudeSkills, "cloudflare"), { recursive: true });
+		const claudeGlobalSkillsPath = path.join(os.homedir(), ".claude", "skills");
+		writeMetadataFile({
+			version: 1,
+			accepted: "SIGINT",
+			date: new Date().toISOString(),
+			detectedAgents: [
+				{
+					name: "Claude Code",
+					rosie: { id: "claude", globalPath: claudeGlobalSkillsPath },
+				},
+			],
+		});
+		mockGitHubSkillsApi(["cloudflare", "wrangler"]);
+		const telemetryCurrentAgentSkillsInstalled = await freshTelemetryImport();
+
+		const result = await telemetryCurrentAgentSkillsInstalled();
+
+		expect(result).toBe("manual");
+	});
+
+	test("resolves to 'manual' when metadata has accepted: 'SIGINT' at alternativeGlobalPath", async ({
+		expect,
+	}) => {
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: true,
+			id: "opencode",
+			name: "OpenCode",
+			type: "agent",
+		});
+		createAgentDir(".config/opencode");
+		const agentsSkills = path.join(os.homedir(), ".agents", "skills");
+		mkdirSync(path.join(agentsSkills, "cloudflare"), { recursive: true });
+		writeMetadataFile({
+			version: 1,
+			accepted: "SIGINT",
+			date: new Date().toISOString(),
+			detectedAgents: [
+				{
+					name: "Cline, Dexto, Warp",
+					rosie: { id: "warp", globalPath: agentsSkills },
+				},
+			],
 		});
 		mockGitHubSkillsApi(["cloudflare", "wrangler"]);
 		const telemetryCurrentAgentSkillsInstalled = await freshTelemetryImport();

--- a/packages/wrangler/src/agents-skills-install.ts
+++ b/packages/wrangler/src/agents-skills-install.ts
@@ -7,12 +7,13 @@ import {
 } from "@cloudflare/workers-utils";
 import { detectAgenticEnvironment } from "am-i-vibing";
 import ci from "ci-info";
+import prompts from "prompts";
 import { install as rosieInstall, agents as rosieAgents } from "rosie-skills";
 import { fetch } from "undici";
-import { confirm } from "./dialogs";
 import isInteractive from "./is-interactive";
 import { logger } from "./logger";
 import { sendMetricsEvent } from "./metrics";
+import { allMetricsDispatchesCompleted } from "./metrics/metrics-dispatcher";
 
 /**
  * Detects AI coding agents installed on the user's machine and, if
@@ -95,12 +96,48 @@ export async function maybeInstallCloudflareSkillsGlobally(
 		return;
 	}
 
-	const accepted =
-		force ||
-		(await confirm(
-			`Wrangler detected the following AI coding agents: ${detectedAgents.map(({ name }) => name).join(", ")}. Would you like to install Cloudflare skills for them?`,
-			{ defaultValue: true, fallbackValue: false }
-		));
+	let accepted: boolean;
+	let sigintReceived = false;
+	if (force) {
+		accepted = true;
+	} else {
+		// Use prompts directly (instead of the shared `confirm()` helper) so
+		// we can intercept the abort (Ctrl+C) and write SIGINT metadata
+		// before the process exits.  The prompts library's readline interface
+		// swallows SIGINT — it never reaches `process.on("SIGINT")` — so this
+		// `onState` callback is the only reliable place to handle it.
+		const { value } = await prompts({
+			type: "confirm",
+			name: "value",
+			message: `Wrangler detected the following AI coding agents: ${detectedAgents.map(({ name }) => name).join(", ")}. Would you like to install Cloudflare skills for them?`,
+			initial: true,
+			onState: (state) => {
+				if (state.aborted) {
+					sigintReceived = true;
+					logger.warn(
+						"Ctrl+C received — skipping Cloudflare skills installation. This prompt will not be shown again."
+					);
+					// Write metadata synchronously so it survives the exit.
+					writeSkillsInstallMetadataFile({
+						version: 1,
+						accepted: "SIGINT",
+						date: new Date().toISOString(),
+						detectedAgents,
+					});
+				}
+			},
+		});
+		accepted = value;
+	}
+
+	if (sigintReceived) {
+		// Metadata was already written in the onState callback.
+		// Send metrics and wait for the dispatch to complete before exiting.
+		sendResultMetricsEvent({ skippedBecause: "User dismissed (SIGINT)" });
+		await allMetricsDispatchesCompleted();
+		// Note: the return is unnecessary but it guards against tests that stub process.exit
+		return process.exit(1);
+	}
 
 	if (!accepted) {
 		writeSkillsInstallMetadataFile({
@@ -200,8 +237,16 @@ type AgentInfo = {
 interface SkillsInstallMetadata {
 	/** Schema version for forward-compatibility. Currently always `1`. */
 	version: 1;
-	/** Whether the user accepted the prompt to install skills. */
-	accepted: boolean;
+	/**
+	 * Whether the user accepted the prompt to install skills.
+	 *
+	 * - `true` — the user explicitly accepted.
+	 * - `false` — the user explicitly declined.
+	 * - `"SIGINT"` — the user dismissed the prompt via Ctrl+C / SIGINT before
+	 *   answering. Treated as a decline but stored separately so we can
+	 *   distinguish these users in telemetry.
+	 */
+	accepted: boolean | "SIGINT";
 	/** ISO date string of when the user was prompted. */
 	date: string;
 	/** All agents detected on the user's machine. */
@@ -653,7 +698,7 @@ async function computeTelemetryCurrentAgentSkillsInstalled(): Promise<AgentSkill
 		// happens to match this alternative path (e.g. OpenCode reads
 		// ~/.agents/skills, which is Warp's rosie install target).
 		const metadata = readSkillsInstallMetadataFile();
-		if (metadata?.accepted) {
+		if (metadata?.accepted === true) {
 			const altAbsPath = path.resolve(matchedAlternativePath);
 			const wasInstalledForAnotherAgent = metadata.detectedAgents?.some(
 				(agent) => {
@@ -700,7 +745,7 @@ async function computeTelemetryCurrentAgentSkillsInstalled(): Promise<AgentSkill
 			));
 
 	if (
-		metadata.accepted &&
+		metadata.accepted === true &&
 		isInDetectedAgents === true &&
 		!installFailedForAgent
 	) {


### PR DESCRIPTION
Fixes #14036 

Previously, pressing Ctrl+C (SIGINT) during the "Would you like to install Cloudflare skills?" prompt terminated the process without writing the metadata file, causing the prompt to reappear on every subsequent `wrangler` invocation. A SIGINT handler is now registered around the prompt so that the metadata file is written with `accepted: "SIGINT"` before the process exits, preventing the prompt from being shown again.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: self-explanatory behavior

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
