### PR TITLE
Validate containers instance ID at API level

### DIFF
--- a/.changeset/curly-ducks-ssh.md
+++ b/.changeset/curly-ducks-ssh.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Handle API validation errors from `wrangler containers ssh`
+
+Wrangler now lets the Containers API validate SSH instance IDs and preserves raw API error bodies such as `INVALID_INSTANCE_ID` when reporting validation failures.

--- a/packages/containers-shared/src/client/core/request.ts
+++ b/packages/containers-shared/src/client/core/request.ts
@@ -22,6 +22,10 @@ type FetchResult<ResponseType = unknown> = {
 	result_info?: ResultInfo;
 };
 
+type ErrorResponse = {
+	error: string;
+};
+
 const isDefined = <T>(
 	value: T | null | undefined
 ): value is Exclude<T, null | undefined> => {
@@ -46,6 +50,15 @@ const isBlob = (value: any): value is Blob => {
 		typeof value.constructor.name === "string" &&
 		/^(Blob|File)$/.test(value.constructor.name) &&
 		/^(Blob|File)$/.test(value[Symbol.toStringTag])
+	);
+};
+
+const isErrorResponse = (value: unknown): value is ErrorResponse => {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"error" in value &&
+		typeof value.error === "string"
 	);
 };
 
@@ -233,6 +246,8 @@ const parseResponseSchemaV4 = <T>(
 		} else {
 			result = {};
 		}
+	} else if (isErrorResponse(fetchResult)) {
+		result = fetchResult;
 	} else {
 		result = { error: fetchResult.errors?.[0]?.message };
 	}

--- a/packages/containers-shared/tests/request.test.ts
+++ b/packages/containers-shared/tests/request.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, it, vi } from "vitest";
+import { OpenAPI } from "../src/client/core/OpenAPI";
+import { request } from "../src/client/core/request";
+
+describe("request", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		OpenAPI.BASE = "";
+	});
+
+	it("preserves raw error responses parsed from text", async ({ expect }) => {
+		OpenAPI.BASE =
+			"https://api.cloudflare.com/client/v4/accounts/account-id/containers";
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				return new Response(JSON.stringify({ error: "INVALID_INSTANCE_ID" }), {
+					status: 400,
+					headers: { "Content-Type": "text/plain" },
+				});
+			})
+		);
+
+		await expect(
+			request(OpenAPI, {
+				method: "GET",
+				url: "/instances/invalid-id/ssh",
+				errors: { 400: "Bad Request" },
+			})
+		).rejects.toMatchObject({
+			body: { error: "INVALID_INSTANCE_ID" },
+		});
+	});
+});

--- a/packages/wrangler/src/__tests__/containers/ssh.test.ts
+++ b/packages/wrangler/src/__tests__/containers/ssh.test.ts
@@ -87,13 +87,27 @@ describe("containers ssh", () => {
 		`);
 	});
 
-	it("should reject invalid container ID format", async ({ expect }) => {
+	it("should let the API validate invalid container ID format", async ({
+		expect,
+	}) => {
 		setWranglerConfig({});
+		const sshRequest = vi.fn();
+		msw.use(
+			http.get(`*/instances/:instanceId/ssh`, async ({ params }) => {
+				sshRequest(params.instanceId);
+				return HttpResponse.json(
+					{ error: "INVALID_INSTANCE_ID" },
+					{ status: 400 }
+				);
+			})
+		);
+
 		await expect(
 			runWrangler("containers ssh invalid-id")
-		).rejects.toMatchInlineSnapshot(
-			`[Error: Expected an instance ID but got invalid-id]`
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: Error verifying SSH access: INVALID_INSTANCE_ID]`
 		);
+		expect(sshRequest).toHaveBeenCalledWith("invalid-id");
 	});
 
 	it("should handle 500s when getting ssh jwt", async ({ expect }) => {

--- a/packages/wrangler/src/containers/ssh.ts
+++ b/packages/wrangler/src/containers/ssh.ts
@@ -3,7 +3,6 @@ import { createServer } from "node:net";
 import { showCursor } from "@cloudflare/cli-shared-helpers";
 import { bold } from "@cloudflare/cli-shared-helpers/colors";
 import { ApiError, DeploymentsService } from "@cloudflare/containers-shared";
-import { UserError } from "@cloudflare/workers-utils";
 import { WebSocket } from "ws";
 import {
 	fillOpenAPIConfiguration,
@@ -101,12 +100,6 @@ const sshArgDefs = {
 type SshArgs = HandlerArgs<typeof sshArgDefs>;
 
 async function sshCommand(sshArgs: SshArgs, _config: Config) {
-	if (sshArgs.ID.length !== 64) {
-		throw new UserError(`Expected an instance ID but got ${sshArgs.ID}`, {
-			telemetryMessage: "containers ssh invalid instance id",
-		});
-	}
-
 	// Get arguments passed to the SSH command itself. yargs includes
 	// "containers" and "ssh" as the first two elements of the array, which
 	// we don't want, so we don't include those.


### PR DESCRIPTION
We support multiple different kinds of IDs for container SSH. Instead of duplicating that logic in Wrangler, just let the API handle the validation.

---


- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: minor bug fix

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->