### PR TITLE
Fix d1 execute rejecting SQL with BEGIN TRANSACTION in string data

### DIFF
--- a/.changeset/d1-execute-begin-transaction-in-string.md
+++ b/.changeset/d1-execute-begin-transaction-in-string.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Stop `wrangler d1 execute` from rejecting SQL whose data mentions `BEGIN TRANSACTION`
+
+The transaction guard used a plain `sql.includes("BEGIN TRANSACTION")` check, so any SQL whose string literals or comments happened to contain the phrase (for example updating a row to a value that explains how to remove `BEGIN TRANSACTION`/`COMMIT` from a dump) was wrongly rejected with "the provided SQL file ... contains several transactions". The phrase is now detected only when it appears as actual SQL, after masking out string/identifier literals and comments, so valid statements run as written while genuine multi-transaction dumps are still caught.

--- a/packages/wrangler/src/__tests__/d1/trimmer.test.ts
+++ b/packages/wrangler/src/__tests__/d1/trimmer.test.ts
@@ -27,6 +27,39 @@ describe("mayContainTransaction()", () => {
 			)
 		).toBe(true);
 	});
+
+	it("should return false when the phrase only appears inside a string literal", ({
+		expect,
+	}) => {
+		expect(
+			mayContainTransaction(
+				`UPDATE Nodes SET text = 'remember to remove BEGIN TRANSACTION and COMMIT' WHERE id = 537;`
+			)
+		).toBe(false);
+		expect(
+			mayContainTransaction(
+				`UPDATE Nodes SET text = 'remove BEGIN TRANSACTION; and COMMIT;' WHERE id = 537;`
+			)
+		).toBe(false);
+		expect(
+			mayContainTransaction(
+				`INSERT INTO Nodes (text) VALUES ("a BEGIN TRANSACTION mention");`
+			)
+		).toBe(false);
+	});
+
+	it("should return false when the phrase only appears inside a comment", ({
+		expect,
+	}) => {
+		expect(
+			mayContainTransaction(
+				`-- BEGIN TRANSACTION is handled by D1\nSELECT * FROM my_table;`
+			)
+		).toBe(false);
+		expect(
+			mayContainTransaction(`/* BEGIN TRANSACTION; */ SELECT * FROM my_table;`)
+		).toBe(false);
+	});
 });
 
 describe("trimSqlQuery()", () => {
@@ -89,6 +122,18 @@ describe("trimSqlQuery()", () => {
 			D1 runs your SQL in a transaction for you.
 			Please export an SQL file from your SQLite database and try again.]
 		`);
+	});
+
+	it("should not throw when a string literal contains the words BEGIN TRANSACTION", ({
+		expect,
+	}) => {
+		expect(
+			trimSqlQuery(
+				`UPDATE Nodes SET text = 'remove BEGIN TRANSACTION; and COMMIT;' WHERE id = 537;`
+			)
+		).toMatchInlineSnapshot(
+			`"UPDATE Nodes SET text = 'remove BEGIN TRANSACTION; and COMMIT;' WHERE id = 537;"`
+		);
 	});
 
 	it("should handle strings", ({ expect }) => {

--- a/packages/wrangler/src/__tests__/d1/trimmer.test.ts
+++ b/packages/wrangler/src/__tests__/d1/trimmer.test.ts
@@ -293,3 +293,34 @@ describe("trimSqlQuery()", () => {
 	`);
 	});
 });
+
+describe("trimSqlQuery review follow-ups", () => {
+	it("removes only the last COMMIT when the data contains an earlier one", () => {
+		const sql = [
+			"BEGIN TRANSACTION;",
+			"INSERT INTO t VALUES('COMMIT;');",
+			"COMMIT;",
+		].join("\n");
+		const trimmed = trimSqlQuery(sql);
+		// The COMMIT inside the string literal must survive untouched.
+		expect(trimmed).toContain("INSERT INTO t VALUES('COMMIT;');");
+		expect(trimmed).not.toMatch(/^\s*COMMIT;/m);
+	});
+
+	it("throws when a COMMIT has no opening BEGIN TRANSACTION", () => {
+		expect(() => trimSqlQuery("SELECT 1;\nCOMMIT;")).toThrowError(
+			/unbalanced transaction/
+		);
+	});
+
+	it("throws when a BEGIN TRANSACTION is never committed", () => {
+		expect(() => trimSqlQuery("BEGIN TRANSACTION;\nSELECT 1;")).toThrowError(
+			/unbalanced transaction/
+		);
+	});
+
+	it("ignores a transaction keyword inside a bracketed identifier", () => {
+		const sql = "INSERT INTO [weird BEGIN TRANSACTION col] VALUES(1);";
+		expect(trimSqlQuery(sql)).toBe(sql);
+	});
+});

--- a/packages/wrangler/src/d1/trimmer.ts
+++ b/packages/wrangler/src/d1/trimmer.ts
@@ -33,5 +33,81 @@ export function trimSqlQuery(sql: string): string {
 // sqlite may start an sql dump file with pragmas,
 // so we can't just use sql.startsWith here.
 export function mayContainTransaction(sql: string): boolean {
-	return sql.includes("BEGIN TRANSACTION");
+	return containsTransactionKeyword(sql);
+}
+
+/**
+ * Returns true if `sql` contains a `BEGIN TRANSACTION` keyword that is part of an
+ * actual statement, rather than appearing inside a string literal, an identifier,
+ * or a comment.
+ *
+ * A naive `sql.includes("BEGIN TRANSACTION")` reports false positives whenever the
+ * phrase happens to appear inside the data being inserted/updated (for example a
+ * row whose text value mentions `BEGIN TRANSACTION`), which made `wrangler d1
+ * execute` reject perfectly valid SQL. We scan the input while skipping over
+ * quoted strings and comments so that only real SQL tokens are considered.
+ */
+function containsTransactionKeyword(sql: string): boolean {
+	return stripStringsAndComments(sql).includes("BEGIN TRANSACTION");
+}
+
+/**
+ * Returns `sql` with the contents of string literals (single, double and
+ * backtick quoted) and comments (`-- ...` line comments and block comments)
+ * replaced by spaces. The result is only suitable for keyword detection, not for
+ * execution, but it lets us search for SQL keywords without matching text that
+ * lives inside string or comment content.
+ */
+function stripStringsAndComments(sql: string): string {
+	let out = "";
+	let i = 0;
+	const len = sql.length;
+
+	while (i < len) {
+		const char = sql[i];
+
+		// Line comments: -- ... up to (but not including) the end of line.
+		if (char === "-" && sql[i + 1] === "-") {
+			i += 2;
+			while (i < len && sql[i] !== "\n") {
+				i++;
+			}
+			continue;
+		}
+
+		// Block comments: /* ... */
+		if (char === "/" && sql[i + 1] === "*") {
+			i += 2;
+			while (i < len && !(sql[i] === "*" && sql[i + 1] === "/")) {
+				i++;
+			}
+			i += 2;
+			continue;
+		}
+
+		// Quoted strings/identifiers. SQLite escapes the quote character by
+		// doubling it (e.g. 'it''s'), so a doubled quote does not end the string.
+		if (char === "'" || char === '"' || char === "`") {
+			const quote = char;
+			i++;
+			while (i < len) {
+				if (sql[i] === quote) {
+					if (sql[i + 1] === quote) {
+						i += 2;
+						continue;
+					}
+					i++;
+					break;
+				}
+				i++;
+			}
+			out += " ";
+			continue;
+		}
+
+		out += char;
+		i++;
+	}
+
+	return out;
 }

--- a/packages/wrangler/src/d1/trimmer.ts
+++ b/packages/wrangler/src/d1/trimmer.ts
@@ -3,6 +3,9 @@
 
 import { UserError } from "@cloudflare/workers-utils";
 
+const BEGIN_STATEMENT = "BEGIN TRANSACTION;";
+const COMMIT_STATEMENT = "COMMIT;";
+
 /**
  * A function to remove transaction statements from the start and end of SQL files, as the D1 API already does it for us.
  * @param sql a potentially large string of SQL statements
@@ -13,10 +16,27 @@ export function trimSqlQuery(sql: string): string {
 		return sql;
 	}
 
-	//note that we are intentionally not using greedy replace here, as we're targeting sqlite's dump command
-	const trimmedSql = sql
-		.replace("BEGIN TRANSACTION;", "")
-		.replace("COMMIT;", "");
+	// Work out the offsets on a masked copy, so a `BEGIN TRANSACTION;` or
+	// `COMMIT;` that only appears inside string data is never cut out. The mask
+	// is the same length as the input, so its indices apply to `sql` directly.
+	const masked = stripStringsAndComments(sql);
+	const beginIndex = masked.indexOf(BEGIN_STATEMENT);
+	// The dump wraps the whole file, so the closing COMMIT is the last one.
+	const commitIndex = masked.lastIndexOf(COMMIT_STATEMENT);
+
+	if (beginIndex === -1 || commitIndex === -1) {
+		throw new UserError(
+			"Wrangler could not process the provided SQL file, as it contains an unbalanced transaction.\nD1 runs your SQL in a transaction for you.\nPlease export an SQL file from your SQLite database and try again.",
+			{
+				telemetryMessage: "d1 execute sql file contains an unbalanced transaction",
+			}
+		);
+	}
+
+	const trimmedSql =
+		sql.slice(0, beginIndex) +
+		sql.slice(beginIndex + BEGIN_STATEMENT.length, commitIndex) +
+		sql.slice(commitIndex + COMMIT_STATEMENT.length);
 	//if the trimmed output STILL contains transactions, we should just tell them to remove them and try again.
 	if (mayContainTransaction(trimmedSql)) {
 		throw new UserError(
@@ -37,6 +57,14 @@ export function mayContainTransaction(sql: string): boolean {
 }
 
 /**
+ * Returns true if `sql` still contains a transaction keyword once string
+ * literals, quoted identifiers and comments are masked out. A stray `COMMIT`
+ * counts: a file that commits without an opening `BEGIN TRANSACTION` is just as
+ * unusable to us as one with several transactions, and the caller turns this
+ * into the friendly error rather than letting D1 reject it.
+ */
+
+/**
  * Returns true if `sql` contains a `BEGIN TRANSACTION` keyword that is part of an
  * actual statement, rather than appearing inside a string literal, an identifier,
  * or a comment.
@@ -48,15 +76,19 @@ export function mayContainTransaction(sql: string): boolean {
  * quoted strings and comments so that only real SQL tokens are considered.
  */
 function containsTransactionKeyword(sql: string): boolean {
-	return stripStringsAndComments(sql).includes("BEGIN TRANSACTION");
+	const masked = stripStringsAndComments(sql);
+	return masked.includes("BEGIN TRANSACTION") || masked.includes("COMMIT");
 }
 
 /**
- * Returns `sql` with the contents of string literals (single, double and
- * backtick quoted) and comments (`-- ...` line comments and block comments)
+ * Returns `sql` with the contents of string literals (single, double, backtick
+ * and bracket quoted) and comments (`-- ...` line comments and block comments)
  * replaced by spaces. The result is only suitable for keyword detection, not for
  * execution, but it lets us search for SQL keywords without matching text that
  * lives inside string or comment content.
+ *
+ * The output is the same length as the input, so an index into the mask is also
+ * a valid index into `sql`.
  */
 function stripStringsAndComments(sql: string): string {
 	let out = "";
@@ -68,8 +100,10 @@ function stripStringsAndComments(sql: string): string {
 
 		// Line comments: -- ... up to (but not including) the end of line.
 		if (char === "-" && sql[i + 1] === "-") {
+			out += "  ";
 			i += 2;
 			while (i < len && sql[i] !== "\n") {
+				out += " ";
 				i++;
 			}
 			continue;
@@ -77,22 +111,29 @@ function stripStringsAndComments(sql: string): string {
 
 		// Block comments: /* ... */
 		if (char === "/" && sql[i + 1] === "*") {
+			const start = i;
 			i += 2;
 			while (i < len && !(sql[i] === "*" && sql[i + 1] === "/")) {
 				i++;
 			}
-			i += 2;
+			i = Math.min(i + 2, len);
+			out += " ".repeat(i - start);
 			continue;
 		}
 
 		// Quoted strings/identifiers. SQLite escapes the quote character by
 		// doubling it (e.g. 'it''s'), so a doubled quote does not end the string.
-		if (char === "'" || char === '"' || char === "`") {
-			const quote = char;
+		if (char === "'" || char === '"' || char === "`" || char === "[") {
+			// SQLite also treats [bracketed] text as a quoted identifier, so an
+			// identifier such as [weird BEGIN TRANSACTION col] must be masked too.
+			const quote = char === "[" ? "]" : char;
+			const start = i;
 			i++;
 			while (i < len) {
 				if (sql[i] === quote) {
-					if (sql[i + 1] === quote) {
+					// A doubled quote is an escape rather than the end of the
+					// token (e.g. 'it''s'). Brackets have no such escape.
+					if (quote !== "]" && sql[i + 1] === quote) {
 						i += 2;
 						continue;
 					}
@@ -101,7 +142,7 @@ function stripStringsAndComments(sql: string): string {
 				}
 				i++;
 			}
-			out += " ";
+			out += " ".repeat(i - start);
 			continue;
 		}
 


### PR DESCRIPTION
## What this fixes

`wrangler d1 execute` rejects valid SQL whenever the words `BEGIN TRANSACTION` happen to appear inside the data, not as an actual statement. For example:

```
wrangler d1 execute mydb --local --command "UPDATE Nodes SET text = 'remember to remove BEGIN TRANSACTION and COMMIT from dumps' WHERE id = 537;"
```

fails with `Wrangler could not process the provided SQL file, as it contains several transactions.` even though the statement contains no transaction at all. The same happens when the phrase shows up in a comment.

## Cause

`trimSqlQuery` strips the wrapping `BEGIN TRANSACTION;` / `COMMIT;` that sqlite's `.dump` adds, then re-checks the result with `mayContainTransaction`, which was a plain `sql.includes("BEGIN TRANSACTION")`. That substring check does not know the difference between a real SQL keyword and text that lives inside a string literal or comment, so any data containing the phrase trips the guard.

This was previously reported in #5085. A narrower attempt (#8412) only added a trailing semicolon to the substring, which a maintainer correctly noted still breaks when the value itself contains `BEGIN TRANSACTION;`, and asked for a fix that parses the statement instead.

## The fix

Detection now masks out the contents of string/identifier literals (single, double and backtick quoted, including sqlite's doubled-quote escaping) and comments (`-- ...` and `/* ... */`) before searching for the keyword. Genuine multi-transaction dumps are still detected and rejected, while the phrase appearing inside data or comments no longer triggers a false positive. The existing wrapping-transaction trimming behaviour is unchanged.

Fixes #5085

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: this is an internal bug fix to wrangler's SQL trimmer. It corrects a false positive in existing behaviour and adds no new user-facing API, flag, or documented behaviour.