### PR TITLE
chore: improved browser ci test retry handling

### DIFF
--- a/fixtures/browser-run/test/index.spec.ts
+++ b/fixtures/browser-run/test/index.spec.ts
@@ -4,6 +4,14 @@ import { resolve } from "path";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { runWranglerDev } from "../../shared/src/run-wrangler-long-lived";
 
+const BROWSER_RENDERING_RETRY = {
+	retry: {
+		condition: /Chrome readiness probe .* timed out|Test timed out/i,
+		count: 3,
+		delay: 1_000,
+	},
+};
+
 describe.sequential("Local Browser", () => {
 	let ip: string,
 		port: number,
@@ -47,33 +55,43 @@ describe.sequential("Local Browser", () => {
 				).resolves.toEqual("Please add an ?url=https://example.com/ parameter");
 			});
 
-			it("Run a browser, and check h1 text content", async ({ expect }) => {
-				await expect(
-					fetchText(
-						`http://${ip}:${port}/?lib=${lib}&url=https://example.com&action=select`
-					)
-				).resolves.toEqual("Example Domain");
-			});
+			it(
+				"Run a browser, and check h1 text content",
+				BROWSER_RENDERING_RETRY,
+				async ({ expect }) => {
+					await expect(
+						fetchText(
+							`http://${ip}:${port}/?lib=${lib}&url=https://example.com&action=select`
+						)
+					).resolves.toEqual("Example Domain");
+				}
+			);
 
-			it("Run a browser, and check p text content", async ({ expect }) => {
-				await expect(
-					fetchText(
-						`http://${ip}:${port}/?lib=${lib}&url=https://example.com&action=alter`
-					)
-				).resolves.toEqual(
-					`New paragraph text set by ${lib === "playwright" ? "Playwright" : "Puppeteer"}!`
-				);
-			});
+			it(
+				"Run a browser, and check p text content",
+				BROWSER_RENDERING_RETRY,
+				async ({ expect }) => {
+					await expect(
+						fetchText(
+							`http://${ip}:${port}/?lib=${lib}&url=https://example.com&action=alter`
+						)
+					).resolves.toEqual(
+						`New paragraph text set by ${lib === "playwright" ? "Playwright" : "Puppeteer"}!`
+					);
+				}
+			);
 
-			it("Disconnect a browser, and check its session connection status", async ({
-				expect,
-			}) => {
-				await expect(
-					fetchText(
-						`http://${ip}:${port}/?lib=${lib}&url=https://example.com&action=disconnect`
-					)
-				).resolves.toEqual(`Browser disconnected`);
-			});
+			it(
+				"Disconnect a browser, and check its session connection status",
+				BROWSER_RENDERING_RETRY,
+				async ({ expect }) => {
+					await expect(
+						fetchText(
+							`http://${ip}:${port}/?lib=${lib}&url=https://example.com&action=disconnect`
+						)
+					).resolves.toEqual(`Browser disconnected`);
+				}
+			);
 		});
 	}
 });

--- a/fixtures/browser-run/test/index.spec.ts
+++ b/fixtures/browser-run/test/index.spec.ts
@@ -1,7 +1,7 @@
 // test/index.spec.ts
 import { rm } from "node:fs/promises";
 import { resolve } from "path";
-import { afterAll, beforeAll, describe, it } from "vitest";
+import { afterAll, beforeAll, describe, it, TestOptions } from "vitest";
 import { runWranglerDev } from "../../shared/src/run-wrangler-long-lived";
 
 const BROWSER_RENDERING_RETRY = {
@@ -10,7 +10,7 @@ const BROWSER_RENDERING_RETRY = {
 		count: 3,
 		delay: 1_000,
 	},
-};
+} satisfies TestOptions;
 
 describe.sequential("Local Browser", () => {
 	let ip: string,

--- a/packages/miniflare/test/plugins/browser/index.spec.ts
+++ b/packages/miniflare/test/plugins/browser/index.spec.ts
@@ -55,6 +55,14 @@ async function waitForClosedConnection(ws: WebSocket): Promise<void> {
 	});
 }
 
+const BROWSER_RENDERING_RETRY = {
+	retry: {
+		condition: /Chrome readiness probe .* timed out|Test timed out/i,
+		count: 3,
+		delay: 1_000,
+	},
+};
+
 const BROWSER_WORKER_SCRIPT = () => `
 export default {
 	async fetch(request, env) {
@@ -77,25 +85,29 @@ describe.sequential("browser rendering", { timeout: 20_000 }, () => {
 		vi.restoreAllMocks();
 	});
 
-	test("it creates a browser session", { retry: 3 }, async ({ expect }) => {
-		const opts: MiniflareOptions = {
-			name: "worker",
-			compatibilityDate: "2024-11-20",
-			modules: true,
-			script: BROWSER_WORKER_SCRIPT(),
-			browserRendering: { binding: "MYBROWSER" },
-		};
-		const mf = new Miniflare(opts);
-		useDispose(mf);
+	test(
+		"it creates a browser session",
+		BROWSER_RENDERING_RETRY,
+		async ({ expect }) => {
+			const opts: MiniflareOptions = {
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: BROWSER_WORKER_SCRIPT(),
+				browserRendering: { binding: "MYBROWSER" },
+			};
+			const mf = new Miniflare(opts);
+			useDispose(mf);
 
-		const res = await mf.dispatchFetch("https://localhost/session");
-		const text = await res.text();
-		expect(text.includes("sessionId")).toBe(true);
-	});
+			const res = await mf.dispatchFetch("https://localhost/session");
+			const text = await res.text();
+			expect(text.includes("sessionId")).toBe(true);
+		}
+	);
 
 	test(
 		"two workers with different browser bindings can coexist",
-		{ retry: 3 },
+		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
 			const workerScript = (bindingName: string) => `
 			export default {
@@ -154,20 +166,24 @@ export default {
 };
 `;
 
-	test("it closes a browser session", { retry: 3 }, async ({ expect }) => {
-		const opts: MiniflareOptions = {
-			name: "worker",
-			compatibilityDate: "2024-11-20",
-			modules: true,
-			script: BROWSER_WORKER_CLOSE_SCRIPT,
-			browserRendering: { binding: "MYBROWSER" },
-		};
-		const mf = new Miniflare(opts);
-		useDispose(mf);
+	test(
+		"it closes a browser session",
+		BROWSER_RENDERING_RETRY,
+		async ({ expect }) => {
+			const opts: MiniflareOptions = {
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: BROWSER_WORKER_CLOSE_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			};
+			const mf = new Miniflare(opts);
+			useDispose(mf);
 
-		const res = await mf.dispatchFetch("https://localhost/close");
-		expect(await res.text()).toBe("Browser closed");
-	});
+			const res = await mf.dispatchFetch("https://localhost/close");
+			expect(await res.text()).toBe("Browser closed");
+		}
+	);
 
 	const BROWSER_WORKER_REUSE_SCRIPT = `
 ${sendMessage.toString()}
@@ -197,20 +213,24 @@ export default {
 };
 `;
 
-	test("it reuses a browser session", { retry: 3 }, async ({ expect }) => {
-		const opts: MiniflareOptions = {
-			name: "worker",
-			compatibilityDate: "2024-11-20",
-			modules: true,
-			script: BROWSER_WORKER_REUSE_SCRIPT,
-			browserRendering: { binding: "MYBROWSER" },
-		};
-		const mf = new Miniflare(opts);
-		useDispose(mf);
+	test(
+		"it reuses a browser session",
+		BROWSER_RENDERING_RETRY,
+		async ({ expect }) => {
+			const opts: MiniflareOptions = {
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: BROWSER_WORKER_REUSE_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			};
+			const mf = new Miniflare(opts);
+			useDispose(mf);
 
-		const res = await mf.dispatchFetch("https://localhost");
-		expect(await res.text()).toBe("Browser session reused");
-	});
+			const res = await mf.dispatchFetch("https://localhost");
+			expect(await res.text()).toBe("Browser session reused");
+		}
+	);
 
 	const BROWSER_WORKER_RECONNECT_SCRIPT = `
 ${sendMessage.toString()}
@@ -286,7 +306,7 @@ export default {
 
 	test(
 		"it reconnects and sends CDP commands after disconnect",
-		{ retry: 3 },
+		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
 			const opts: MiniflareOptions = {
 				name: "worker",
@@ -330,6 +350,7 @@ export default {
 
 	test.skipIf(process.platform === "win32")(
 		"fails if browser session already in use",
+		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
 			const opts: MiniflareOptions = {
 				name: "worker",
@@ -377,7 +398,7 @@ export default {
 
 	test(
 		"gets sessions while acquiring and closing session",
-		{ retry: 3 },
+		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
 			const opts: MiniflareOptions = {
 				name: "worker",
@@ -429,7 +450,7 @@ export default {
 
 	test(
 		"gets sessions while connecting and disconnecting session",
-		{ retry: 3 },
+		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
 			const opts: MiniflareOptions = {
 				name: "worker",
@@ -509,7 +530,7 @@ export default {
 
 	test(
 		"devtools session list and detail endpoints",
-		{ retry: 3 },
+		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
 			const mf = new Miniflare({
 				name: "worker",
@@ -556,7 +577,7 @@ export default {
 
 	test(
 		"devtools json/version, json/list, json endpoints",
-		{ retry: 3 },
+		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
 			const mf = new Miniflare({
 				name: "worker",
@@ -616,7 +637,7 @@ export default {
 
 	test(
 		"DELETE /v1/devtools/browser/:session_id closes browser",
-		{ retry: 3 },
+		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
 			const mf = new Miniflare({
 				name: "worker",
@@ -674,7 +695,7 @@ export default {
 
 	test(
 		"POST /v1/devtools/browser acquires session, GET /v1/devtools/browser/:id connects and returns cf-browser-session-id",
-		{ retry: 3 },
+		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
 			const mf = new Miniflare({
 				name: "worker",
@@ -706,7 +727,7 @@ export default {
 
 	test(
 		"GET /v1/devtools/browser acquires and connects",
-		{ retry: 3 },
+		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
 			const mf = new Miniflare({
 				name: "worker",
@@ -755,22 +776,26 @@ export default {
 };
 `;
 
-	test("devtools json/protocol endpoint", { retry: 3 }, async ({ expect }) => {
-		const mf = new Miniflare({
-			name: "worker",
-			compatibilityDate: "2024-11-20",
-			modules: true,
-			script: DEVTOOLS_JSON_PROTOCOL_SCRIPT,
-			browserRendering: { binding: "MYBROWSER" },
-		});
-		useDispose(mf);
+	test(
+		"devtools json/protocol endpoint",
+		BROWSER_RENDERING_RETRY,
+		async ({ expect }) => {
+			const mf = new Miniflare({
+				name: "worker",
+				compatibilityDate: "2024-11-20",
+				modules: true,
+				script: DEVTOOLS_JSON_PROTOCOL_SCRIPT,
+				browserRendering: { binding: "MYBROWSER" },
+			});
+			useDispose(mf);
 
-		const { hasDomains } = (await mf
-			.dispatchFetch("https://localhost")
-			.then((r) => r.json())) as any;
+			const { hasDomains } = (await mf
+				.dispatchFetch("https://localhost")
+				.then((r) => r.json())) as any;
 
-		expect(hasDomains).toBe(true);
-	});
+			expect(hasDomains).toBe(true);
+		}
+	);
 
 	const DEVTOOLS_JSON_NEW_ACTIVATE_CLOSE_SCRIPT = `
 export default {
@@ -797,7 +822,7 @@ export default {
 
 	test(
 		"devtools json/new, json/activate, json/close endpoints",
-		{ retry: 3 },
+		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
 			const mf = new Miniflare({
 				name: "worker",
@@ -843,7 +868,7 @@ export default {
 
 	test(
 		"devtools page/:target_id WebSocket endpoint",
-		{ retry: 3 },
+		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
 			const mf = new Miniflare({
 				name: "worker",
@@ -864,7 +889,7 @@ export default {
 
 	test(
 		"DELETE without prior WebSocket connection",
-		{ retry: 3 },
+		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
 			const mf = new Miniflare({
 				name: "worker",
@@ -948,7 +973,7 @@ export default {
 
 	test(
 		"DELETE closes all WebSocket connections (browser + page)",
-		{ retry: 3 },
+		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
 			const mf = new Miniflare({
 				name: "worker",
@@ -973,7 +998,7 @@ export default {
 
 	test(
 		"multiple concurrent raw WebSocket connections to same session",
-		{ retry: 3 },
+		BROWSER_RENDERING_RETRY,
 		async ({ expect }) => {
 			const mf = new Miniflare({
 				name: "worker",

--- a/packages/miniflare/test/plugins/browser/index.spec.ts
+++ b/packages/miniflare/test/plugins/browser/index.spec.ts
@@ -1,5 +1,12 @@
 import { Miniflare } from "miniflare";
-import { afterEach, beforeEach, describe, test, TestOptions, vi } from "vitest";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	test,
+	type TestOptions,
+	vi,
+} from "vitest";
 import { useDispose } from "../../test-shared";
 import type { MiniflareOptions } from "miniflare";
 

--- a/packages/miniflare/test/plugins/browser/index.spec.ts
+++ b/packages/miniflare/test/plugins/browser/index.spec.ts
@@ -1,5 +1,5 @@
 import { Miniflare } from "miniflare";
-import { afterEach, beforeEach, describe, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, test, TestOptions, vi } from "vitest";
 import { useDispose } from "../../test-shared";
 import type { MiniflareOptions } from "miniflare";
 
@@ -61,7 +61,7 @@ const BROWSER_RENDERING_RETRY = {
 		count: 3,
 		delay: 1_000,
 	},
-};
+} satisfies TestOptions;
 
 const BROWSER_WORKER_SCRIPT = () => `
 export default {


### PR DESCRIPTION
Improves the Browser Run CI tests timeout retry logic. This is an attempt to improve the flakey CI that keeps failing on "Version Packages" PR's.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Internal CI test improvements

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
