### PR TITLE
[create-cloudflare] Fix ERR_PNPM_IGNORED_BUILDS on pnpm 11 + close C3 e2e test gap

### DIFF
--- a/.changeset/c3-exit-code-on-error.md
+++ b/.changeset/c3-exit-code-on-error.md
@@ -3,5 +3,3 @@
 ---
 
 Fix `create cloudflare` exiting with code `0` even after an unhandled error
-
-The top-level error handler in `create cloudflare` was logging unhandled errors to stderr but the `.finally()` block always called `process.exit()` without an explicit code, which Node treats as `0` when `process.exitCode` is unset. The CLI now sets `process.exitCode = 1` in the catch path before the finally runs, so callers (CI, shell scripts) can reliably detect a failed scaffold. `CancelError` (user-initiated cancellation such as Ctrl-C or declining a prompt) still exits with `0`.

--- a/.changeset/c3-exit-code-on-error.md
+++ b/.changeset/c3-exit-code-on-error.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+Fix `create cloudflare` exiting with code `0` even after an unhandled error
+
+The top-level error handler in `create cloudflare` was logging unhandled errors to stderr but the `.finally()` block always called `process.exit()` without an explicit code, which Node treats as `0` when `process.exitCode` is unset. The CLI now sets `process.exitCode = 1` in the catch path before the finally runs, so callers (CI, shell scripts) can reliably detect a failed scaffold. `CancelError` (user-initiated cancellation such as Ctrl-C or declining a prompt) still exits with `0`.

--- a/.changeset/swift-fox-flies.md
+++ b/.changeset/swift-fox-flies.md
@@ -1,0 +1,11 @@
+---
+"create-cloudflare": patch
+---
+
+Fix `create cloudflare` aborting with `ERR_PNPM_IGNORED_BUILDS` on pnpm 11
+
+pnpm 11 flipped `strictDepBuilds` to `true` by default, which makes the install fail when dependencies have unapproved build scripts. `wrangler` depends on `workerd` and `esbuild`, and (via miniflare) on `sharp` — all three need their postinstall scripts to produce platform binaries. Without pre-approval, `pnpm create cloudflare` aborted on pnpm 11 with a red `ERR_PNPM_IGNORED_BUILDS` error before the scaffold was usable.
+
+The scaffold step now writes (or minimally merges into) a `pnpm-workspace.yaml` in the generated project that approves exactly those three packages. C3 deliberately does _not_ approve build scripts for packages introduced by framework generators (such as `@parcel/watcher`, `@swc/core`, `lmdb`, etc.) — those are the generator's or the user's responsibility, and the user can approve them via `pnpm approve-builds` in the generated project.
+
+If an install still fails with `ERR_PNPM_IGNORED_BUILDS` (because a framework generator pulled in unapproved build scripts), C3 now prints actionable guidance pointing at `pnpm approve-builds` alongside the raw pnpm output.

--- a/.changeset/swift-fox-flies.md
+++ b/.changeset/swift-fox-flies.md
@@ -4,12 +4,6 @@
 
 Fix `create cloudflare` aborting with `ERR_PNPM_IGNORED_BUILDS` on pnpm 11
 
-pnpm 11 flipped `strictDepBuilds` to `true` by default, which makes the install fail when dependencies have unapproved build scripts. `wrangler` depends on `workerd` and `esbuild`, and (via miniflare) on `sharp` — all three need their postinstall scripts to produce platform binaries. Without pre-approval, `pnpm create cloudflare` aborted on pnpm 11 with a red `ERR_PNPM_IGNORED_BUILDS` error before the scaffold was usable.
+pnpm 11 flipped `strictDepBuilds` to `true` by default, which makes the install fail when dependencies have unapproved build scripts. `wrangler` depends on `workerd` and `esbuild`, and (via miniflare) on `sharp` — all three need their postinstall scripts to produce platform binaries.
 
-The scaffold step now writes (or minimally merges into) a `pnpm-workspace.yaml` in the generated project that approves exactly those three packages. C3 deliberately does _not_ pre-approve build scripts for packages introduced by framework generators (such as `@parcel/watcher`, `@swc/core`, `lmdb`, etc.) — those are the generator's or the user's responsibility.
-
-When pnpm still aborts the install with `ERR_PNPM_IGNORED_BUILDS` (because a framework generator pulled in unapproved build scripts), C3 now:
-
-- parses the flagged package list out of the pnpm output instead of dumping the entire transcript,
-- prompts to run `pnpm approve-builds <pkg>…` and retry the install once (default: yes),
-- after a declined prompt, an unsuccessful retry, or a closed stdin (e.g. `pnpm create cloudflare < /dev/null`), prints a concise summary with the exact `pnpm approve-builds` command to run in the generated project.
+C3 now writes or merges in a `pnpm-workspace.yaml` in the generated project that approves exactly those three packages. If other packages trigger this error, C3 also now interactively offers to retry with `pnpm approve-builds <pkg>…`

--- a/.changeset/swift-fox-flies.md
+++ b/.changeset/swift-fox-flies.md
@@ -6,6 +6,10 @@ Fix `create cloudflare` aborting with `ERR_PNPM_IGNORED_BUILDS` on pnpm 11
 
 pnpm 11 flipped `strictDepBuilds` to `true` by default, which makes the install fail when dependencies have unapproved build scripts. `wrangler` depends on `workerd` and `esbuild`, and (via miniflare) on `sharp` — all three need their postinstall scripts to produce platform binaries. Without pre-approval, `pnpm create cloudflare` aborted on pnpm 11 with a red `ERR_PNPM_IGNORED_BUILDS` error before the scaffold was usable.
 
-The scaffold step now writes (or minimally merges into) a `pnpm-workspace.yaml` in the generated project that approves exactly those three packages. C3 deliberately does _not_ approve build scripts for packages introduced by framework generators (such as `@parcel/watcher`, `@swc/core`, `lmdb`, etc.) — those are the generator's or the user's responsibility, and the user can approve them via `pnpm approve-builds` in the generated project.
+The scaffold step now writes (or minimally merges into) a `pnpm-workspace.yaml` in the generated project that approves exactly those three packages. C3 deliberately does _not_ pre-approve build scripts for packages introduced by framework generators (such as `@parcel/watcher`, `@swc/core`, `lmdb`, etc.) — those are the generator's or the user's responsibility.
 
-If an install still fails with `ERR_PNPM_IGNORED_BUILDS` (because a framework generator pulled in unapproved build scripts), C3 now prints actionable guidance pointing at `pnpm approve-builds` alongside the raw pnpm output.
+When pnpm still aborts the install with `ERR_PNPM_IGNORED_BUILDS` (because a framework generator pulled in unapproved build scripts), C3 now:
+
+- parses the flagged package list out of the pnpm output instead of dumping the entire transcript,
+- in an interactive shell, asks before running `pnpm approve-builds <pkg>…` and retrying the install once, and
+- in a non-interactive shell (or after a declined prompt or unsuccessful retry), prints a concise summary with the exact `pnpm approve-builds` command to run in the generated project.

--- a/.changeset/swift-fox-flies.md
+++ b/.changeset/swift-fox-flies.md
@@ -11,5 +11,5 @@ The scaffold step now writes (or minimally merges into) a `pnpm-workspace.yaml` 
 When pnpm still aborts the install with `ERR_PNPM_IGNORED_BUILDS` (because a framework generator pulled in unapproved build scripts), C3 now:
 
 - parses the flagged package list out of the pnpm output instead of dumping the entire transcript,
-- in an interactive shell, asks before running `pnpm approve-builds <pkg>…` and retrying the install once, and
-- in a non-interactive shell (or after a declined prompt or unsuccessful retry), prints a concise summary with the exact `pnpm approve-builds` command to run in the generated project.
+- prompts to run `pnpm approve-builds <pkg>…` and retry the install once (default: yes),
+- after a declined prompt, an unsuccessful retry, or a closed stdin (e.g. `pnpm create cloudflare < /dev/null`), prints a concise summary with the exact `pnpm approve-builds` command to run in the generated project.

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -7,9 +7,25 @@ permissions:
   contents: read
   pull-requests: read
 
+# pnpm 11-specific settings, applied at workflow level so every step
+# (including the matrix-version verify) bypasses two pnpm 11 defaults that
+# would otherwise block the e2e flow. Both are recognised by pnpm 11+ and
+# silently ignored by pnpm 10.
+#
+# - pmOnFail=ignore: pnpm 11's default `download` would silently re-exec as
+#   the monorepo's pinned pnpm 10.33.0, defeating the matrix override.
+# - verifyDepsBeforeRun=false: pnpm 11's default `install` would re-run
+#   `pnpm install` at the monorepo root before invoking the script, which
+#   then trips on engines.pnpm.
+env:
+  pnpm_config_pm_on_fail: ignore
+  pnpm_config_verify_deps_before_run: "false"
+
 jobs:
   e2e:
-    # Runs the non-frameworks C3 E2E tests on all supported operating systems and package managers.
+    # Runs the non-frameworks C3 E2E tests on all supported operating systems
+    # and package managers. The pnpm jobs deliberately run pnpm 11.5.1 so the
+    # e2e suite actually exercises pnpm 11's stricter build-script policy.
     timeout-minutes: 45
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os.name }}-${{ matrix.pm.name }}-${{ matrix.pm.version }}${{ matrix.experimental && '-experimental' || '' }}-${{ matrix.filter }}
@@ -22,23 +38,23 @@ jobs:
         filter: ["cli", "workers"]
         os: [{ name: ubuntu-latest, description: Linux }]
         pm:
-          - { name: pnpm, version: "10.33.0" }
+          - { name: pnpm, version: "11.5.1" }
           - { name: npm, version: "0.0.0" }
           # The yarn tests keep failing on Linux with out of space errors, with no clear reason why. Disabling for now.
           # - { name: yarn, version: "1.0.0" }
         include:
           - os: { name: windows-latest, description: Windows }
-            pm: { name: pnpm, version: "10.33.0" }
+            pm: { name: pnpm, version: "11.5.1" }
             filter: "cli"
           - os: { name: windows-latest, description: Windows }
-            pm: { name: pnpm, version: "10.33.0" }
+            pm: { name: pnpm, version: "11.5.1" }
             filter: "workers"
           - os: { name: ubuntu-latest, description: Linux }
-            pm: { name: pnpm, version: "10.33.0" }
+            pm: { name: pnpm, version: "11.5.1" }
             experimental: true
             filter: "cli"
           - os: { name: ubuntu-latest, description: Linux }
-            pm: { name: pnpm, version: "10.33.0" }
+            pm: { name: pnpm, version: "11.5.1" }
             experimental: true
             filter: "workers"
     runs-on: ${{ matrix.os.name }}
@@ -82,6 +98,50 @@ jobs:
           git config --global user.email wrangler@cloudflare.com
           git config --global user.name 'Wrangler Tester'
 
+      # The `Install Dependencies` step above installs the monorepo's pinned
+      # pnpm 10.33.0 (read from the root `packageManager` field). For the pnpm
+      # matrix entry below we need the scaffolded-project installs that C3
+      # spawns to actually run the matrix version on PATH, so the e2e suite
+      # exercises pnpm 11's behaviour. Without this, `E2E_TEST_PM_VERSION`
+      # only relabels C3's `npm_config_user_agent` and the underlying pnpm
+      # stays at 10.33.0 (so pnpm 11 regressions go undetected).
+      #
+      # `pnpm/action-setup` refuses to install when both `version` input and
+      # the root `package.json#packageManager` are set, so we point it at a
+      # stub `package.json` via `package_json_file`. We also loosen
+      # `engines.pnpm` because pnpm 11 otherwise bails with
+      # ERR_PNPM_UNSUPPORTED_ENGINE on every command at the monorepo root.
+      - name: Prepare workspace for matrix pnpm install
+        if: matrix.pm.name == 'pnpm' && steps.changes.outputs.everything_but_markdown == 'true'
+        shell: bash
+        run: |
+          mkdir -p .ci-pnpm-setup-stub
+          printf '{"name":"ci-stub","private":true}\n' > .ci-pnpm-setup-stub/package.json
+          node -e "
+            const fs = require('node:fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json','utf8'));
+            if (pkg.engines && pkg.engines.pnpm) pkg.engines.pnpm = '*';
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, '\t') + '\n');
+          "
+      - name: Install matrix pnpm version for scaffolded installs
+        if: matrix.pm.name == 'pnpm' && steps.changes.outputs.everything_but_markdown == 'true'
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+        with:
+          version: ${{ matrix.pm.version }}
+          package_json_file: .ci-pnpm-setup-stub/package.json
+          # Install to a distinct directory so the action's `addPath` prepends
+          # this entry ahead of the earlier `~/setup-pnpm` (which holds the
+          # monorepo's pinned pnpm 10.x).
+          dest: ~/matrix-pnpm
+      - name: Verify pnpm on PATH matches matrix version
+        if: matrix.pm.name == 'pnpm' && steps.changes.outputs.everything_but_markdown == 'true'
+        shell: bash
+        run: |
+          got="$(pnpm --version)"
+          want="${{ matrix.pm.version }}"
+          echo "pnpm on PATH: $got (expected $want)"
+          [ "$got" = "$want" ] || { echo "ERROR: PATH pnpm is $got, not $want — scaffolded installs would silently run the wrong version."; exit 1; }
+
       - id: run-e2e
         if: steps.changes.outputs.everything_but_markdown == 'true'
         shell: bash
@@ -113,6 +173,16 @@ jobs:
 
   frameworks-e2e:
     # Runs the C3 frameworks E2E tests only in the merge queue, on the release branch, if create-cloudflare has changed, or when explicitly requested via label.
+    #
+    # The pnpm job here intentionally stays on pnpm 10.33.0 (monorepo's
+    # pinned version). Several framework generators (Next.js, Nuxt, Analog,
+    # Qwik, Hono) pull in additional build-script dependencies
+    # (`@parcel/watcher`, `unrs-resolver`, `lmdb`, ...) that are outside C3's
+    # pre-approval scope — those approvals are the framework generator's or
+    # the user's responsibility, not C3's. Until upstream generators approve
+    # their own builds, pnpm 11 in CI would fail those frameworks
+    # non-interactively. pnpm 10 only warns, so the scaffold exercise stays
+    # meaningful.
     timeout-minutes: 45
     concurrency:
       group: ${{ github.workflow }}-frameworks${{ matrix.experimental && '-experimental' || '' }}-${{ github.ref }}-${{ matrix.os.name }}-${{ matrix.pm.name }}-${{ matrix.pm.version }}

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -122,7 +122,9 @@ jobs:
       fail-fast: false
       matrix:
         experimental: [false]
-        os: [{ name: ubuntu-latest, description: Linux }]
+        os:
+          - { name: ubuntu-latest, description: Linux }
+          - { name: macos-latest, description: macOS }
         pm:
           - { name: pnpm, version: "10.33.0" }
           - { name: npm, version: "0.0.0" }

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -24,13 +24,17 @@ env:
 jobs:
   e2e:
     # Runs the non-frameworks C3 E2E tests on all supported operating systems
-    # and package managers. The pnpm jobs deliberately run pnpm 11.5.1 so the
-    # e2e suite actually exercises pnpm 11's stricter build-script policy.
+    # and package managers. The Linux matrix exercises both pnpm 10.33.0 and
+    # pnpm 11.5.1 so any pnpm-version-specific regression in C3's CLI or
+    # workers scaffolding path is caught. Windows and the experimental matrix
+    # entries only run pnpm 11.5.1 — pnpm 11 is the current default and we
+    # rely on the Linux pnpm 10 entry to catch regressions on the older
+    # version.
     timeout-minutes: 45
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os.name }}-${{ matrix.pm.name }}-${{ matrix.pm.version }}${{ matrix.experimental && '-experimental' || '' }}-${{ matrix.filter }}
       cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
-    name: ${{ format('C3 E2E ({0}, {1}{2}) - {3}', matrix.pm.name, matrix.os.description, matrix.experimental && ', experimental' || '', matrix.filter) }}
+    name: ${{ format('C3 E2E ({0}@{1}, {2}{3}) - {4}', matrix.pm.name, matrix.pm.version, matrix.os.description, matrix.experimental && ', experimental' || '', matrix.filter) }}
     strategy:
       fail-fast: false
       matrix:
@@ -38,6 +42,7 @@ jobs:
         filter: ["cli", "workers"]
         os: [{ name: ubuntu-latest, description: Linux }]
         pm:
+          - { name: pnpm, version: "10.33.0" }
           - { name: pnpm, version: "11.5.1" }
           - { name: npm, version: "0.0.0" }
           # The yarn tests keep failing on Linux with out of space errors, with no clear reason why. Disabling for now.
@@ -159,7 +164,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ !cancelled() && steps.changes.outputs.everything_but_markdown == 'true' }}
         with:
-          name: ${{ format('e2e-logs-{0}-{1}-{2}-{3}', matrix.pm.name, matrix.os.description, matrix.experimental && 'experimental' || 'normal', matrix.filter) }}
+          name: ${{ format('e2e-logs-{0}-{1}-{2}-{3}-{4}', matrix.pm.name, matrix.pm.version, matrix.os.description, matrix.experimental && 'experimental' || 'normal', matrix.filter) }}
           path: packages/create-cloudflare/.e2e-logs${{matrix.experimental == 'true' && '-experimental' || ''}}/${{ matrix.pm.name }}/${{ matrix.filter }}
           include-hidden-files: true
 
@@ -167,7 +172,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ !cancelled() && steps.changes.outputs.everything_but_markdown == 'true' }}
         with:
-          name: ${{ format('turbo-runs-{0}-{1}-{2}-{3}', matrix.pm.name, matrix.os.description, matrix.experimental && 'experimental' || 'normal', matrix.filter) }}
+          name: ${{ format('turbo-runs-{0}-{1}-{2}-{3}-{4}', matrix.pm.name, matrix.pm.version, matrix.os.description, matrix.experimental && 'experimental' || 'normal', matrix.filter) }}
           path: .turbo/runs
           include-hidden-files: true
 

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -194,7 +194,6 @@ jobs:
         experimental: [false]
         os:
           - { name: ubuntu-latest, description: Linux }
-          - { name: macos-latest, description: macOS }
         pm:
           - { name: pnpm, version: "10.33.0" }
           - { name: npm, version: "0.0.0" }

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -24,17 +24,24 @@ env:
 jobs:
   e2e:
     # Runs the non-frameworks C3 E2E tests on all supported operating systems
-    # and package managers. The Linux matrix exercises both pnpm 10.33.0 and
-    # pnpm 11.5.1 so any pnpm-version-specific regression in C3's CLI or
-    # workers scaffolding path is caught. Windows and the experimental matrix
-    # entries only run pnpm 11.5.1 — pnpm 11 is the current default and we
-    # rely on the Linux pnpm 10 entry to catch regressions on the older
-    # version.
+    # and package managers. The Linux base matrix exercises both pnpm 10.33.0
+    # (the monorepo's pinned default) and pnpm 11.5.1, so any
+    # pnpm-version-specific regression in C3's CLI or workers scaffolding
+    # path is caught. Windows and experimental matrix entries stay on the
+    # default pnpm — the Linux pnpm 11 entry covers that version's behaviour
+    # and the historical check names (e.g. `C3 E2E (pnpm, Windows) - cli`)
+    # are preserved for required-status-check stability.
     timeout-minutes: 45
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os.name }}-${{ matrix.pm.name }}-${{ matrix.pm.version }}${{ matrix.experimental && '-experimental' || '' }}-${{ matrix.filter }}
       cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
-    name: ${{ format('C3 E2E ({0}@{1}, {2}{3}) - {4}', matrix.pm.name, matrix.pm.version, matrix.os.description, matrix.experimental && ', experimental' || '', matrix.filter) }}
+    # `matrix.pm.label` is the display/identifier shown in the job name and
+    # artifact names. The default-version entry of each package manager uses
+    # the plain name (e.g. `pnpm`, `npm`) so the resulting check name matches
+    # what's historically been used as a required status check; non-default
+    # entries (e.g. pnpm 11) suffix the version so the two runs can be
+    # distinguished. Keep these in sync when adding new pm entries.
+    name: ${{ format('C3 E2E ({0}, {1}{2}) - {3}', matrix.pm.label, matrix.os.description, matrix.experimental && ', experimental' || '', matrix.filter) }}
     strategy:
       fail-fast: false
       matrix:
@@ -42,24 +49,28 @@ jobs:
         filter: ["cli", "workers"]
         os: [{ name: ubuntu-latest, description: Linux }]
         pm:
-          - { name: pnpm, version: "10.33.0" }
-          - { name: pnpm, version: "11.5.1" }
-          - { name: npm, version: "0.0.0" }
+          - { name: pnpm, version: "10.33.0", label: "pnpm" }
+          - { name: pnpm, version: "11.5.1", label: "pnpm@11.5.1" }
+          - { name: npm, version: "0.0.0", label: "npm" }
           # The yarn tests keep failing on Linux with out of space errors, with no clear reason why. Disabling for now.
-          # - { name: yarn, version: "1.0.0" }
+          # - { name: yarn, version: "1.0.0", label: "yarn" }
         include:
+          # Windows and experimental matrix entries stick to the default pnpm
+          # version so the resulting check names match what's historically
+          # been used as required checks. pnpm 11 coverage is exercised by
+          # the Linux base entries above.
           - os: { name: windows-latest, description: Windows }
-            pm: { name: pnpm, version: "11.5.1" }
+            pm: { name: pnpm, version: "10.33.0", label: "pnpm" }
             filter: "cli"
           - os: { name: windows-latest, description: Windows }
-            pm: { name: pnpm, version: "11.5.1" }
+            pm: { name: pnpm, version: "10.33.0", label: "pnpm" }
             filter: "workers"
           - os: { name: ubuntu-latest, description: Linux }
-            pm: { name: pnpm, version: "11.5.1" }
+            pm: { name: pnpm, version: "10.33.0", label: "pnpm" }
             experimental: true
             filter: "cli"
           - os: { name: ubuntu-latest, description: Linux }
-            pm: { name: pnpm, version: "11.5.1" }
+            pm: { name: pnpm, version: "10.33.0", label: "pnpm" }
             experimental: true
             filter: "workers"
     runs-on: ${{ matrix.os.name }}
@@ -164,7 +175,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ !cancelled() && steps.changes.outputs.everything_but_markdown == 'true' }}
         with:
-          name: ${{ format('e2e-logs-{0}-{1}-{2}-{3}-{4}', matrix.pm.name, matrix.pm.version, matrix.os.description, matrix.experimental && 'experimental' || 'normal', matrix.filter) }}
+          name: ${{ format('e2e-logs-{0}-{1}-{2}-{3}', matrix.pm.label, matrix.os.description, matrix.experimental && 'experimental' || 'normal', matrix.filter) }}
           path: packages/create-cloudflare/.e2e-logs${{matrix.experimental == 'true' && '-experimental' || ''}}/${{ matrix.pm.name }}/${{ matrix.filter }}
           include-hidden-files: true
 
@@ -172,7 +183,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ !cancelled() && steps.changes.outputs.everything_but_markdown == 'true' }}
         with:
-          name: ${{ format('turbo-runs-{0}-{1}-{2}-{3}-{4}', matrix.pm.name, matrix.pm.version, matrix.os.description, matrix.experimental && 'experimental' || 'normal', matrix.filter) }}
+          name: ${{ format('turbo-runs-{0}-{1}-{2}-{3}', matrix.pm.label, matrix.os.description, matrix.experimental && 'experimental' || 'normal', matrix.filter) }}
           path: .turbo/runs
           include-hidden-files: true
 
@@ -198,7 +209,8 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-frameworks${{ matrix.experimental && '-experimental' || '' }}-${{ github.ref }}-${{ matrix.os.name }}-${{ matrix.pm.name }}-${{ matrix.pm.version }}
       cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
-    name: ${{ format('C3 E2E ({0}@{1}, {2}{3}) - frameworks', matrix.pm.name, matrix.pm.version, matrix.os.description, matrix.experimental && ', experimental' || '') }}
+    # See the note on `matrix.pm.label` in the `e2e` job above.
+    name: ${{ format('C3 E2E ({0}, {1}{2}) - frameworks', matrix.pm.label, matrix.os.description, matrix.experimental && ', experimental' || '') }}
     strategy:
       fail-fast: false
       matrix:
@@ -206,15 +218,16 @@ jobs:
         os:
           - { name: ubuntu-latest, description: Linux }
         pm:
-          - { name: pnpm, version: "10.33.0" }
-          - { name: pnpm, version: "11.5.1" }
-          - { name: npm, version: "0.0.0" }
+          - { name: pnpm, version: "10.33.0", label: "pnpm" }
+          - { name: pnpm, version: "11.5.1", label: "pnpm@11.5.1" }
+          - { name: npm, version: "0.0.0", label: "npm" }
         include:
+          # Experimental stays on the default pnpm version so the check name
+          # matches what's historically been used as a required check.
+          # pnpm 11 coverage is exercised by the (non-experimental) Linux
+          # base entry above.
           - os: { name: ubuntu-latest, description: Linux }
-            pm: { name: pnpm, version: "10.33.0" }
-            experimental: true
-          - os: { name: ubuntu-latest, description: Linux }
-            pm: { name: pnpm, version: "11.5.1" }
+            pm: { name: pnpm, version: "10.33.0", label: "pnpm" }
             experimental: true
     runs-on: ${{ matrix.os.name }}
     steps:
@@ -332,7 +345,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ !cancelled() && steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true' }}
         with:
-          name: ${{ format('e2e-logs-{0}-{1}-{2}-{3}-frameworks', matrix.pm.name, matrix.pm.version, matrix.os.description, matrix.experimental && 'experimental' || 'normal') }}
+          name: ${{ format('e2e-logs-{0}-{1}-{2}-frameworks', matrix.pm.label, matrix.os.description, matrix.experimental && 'experimental' || 'normal') }}
           path: packages/create-cloudflare/.e2e-logs${{matrix.experimental == 'true' && '-experimental' || ''}}/${{ matrix.pm.name }}/frameworks
           include-hidden-files: true
 
@@ -340,6 +353,6 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ !cancelled() && steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true' }}
         with:
-          name: ${{ format('turbo-runs-{0}-{1}-{2}-{3}-frameworks', matrix.pm.name, matrix.pm.version, matrix.os.description, matrix.experimental && 'experimental' || 'normal') }}
+          name: ${{ format('turbo-runs-{0}-{1}-{2}-frameworks', matrix.pm.label, matrix.os.description, matrix.experimental && 'experimental' || 'normal') }}
           path: .turbo/runs
           include-hidden-files: true

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -7,9 +7,7 @@ permissions:
   contents: read
   pull-requests: read
 
-# pnpm 11-specific settings, applied at workflow level so every step
-# (including the matrix-version verify) bypasses two pnpm 11 defaults that
-# would otherwise block the e2e flow. Both are recognised by pnpm 11+ and
+# pnpm 11-specific settings - recognised by pnpm 11+ and
 # silently ignored by pnpm 10.
 #
 # - pmOnFail=ignore: pnpm 11's default `download` would silently re-exec as
@@ -24,23 +22,14 @@ env:
 jobs:
   e2e:
     # Runs the non-frameworks C3 E2E tests on all supported operating systems
-    # and package managers. The Linux base matrix exercises both pnpm 10.33.0
-    # (the monorepo's pinned default) and pnpm 11.5.1, so any
-    # pnpm-version-specific regression in C3's CLI or workers scaffolding
-    # path is caught. Windows and experimental matrix entries stay on the
-    # default pnpm — the Linux pnpm 11 entry covers that version's behaviour
-    # and the historical check names (e.g. `C3 E2E (pnpm, Windows) - cli`)
-    # are preserved for required-status-check stability.
+    # and package managers.
     timeout-minutes: 45
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os.name }}-${{ matrix.pm.name }}-${{ matrix.pm.version }}${{ matrix.experimental && '-experimental' || '' }}-${{ matrix.filter }}
       cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
-    # `matrix.pm.label` is the display/identifier shown in the job name and
-    # artifact names. The default-version entry of each package manager uses
-    # the plain name (e.g. `pnpm`, `npm`) so the resulting check name matches
-    # what's historically been used as a required status check; non-default
-    # entries (e.g. pnpm 11) suffix the version so the two runs can be
-    # distinguished. Keep these in sync when adding new pm entries.
+    # `matrix.pm.label` is the display name in job/artifact names. Default
+    # pm entries use the plain name (e.g. `pnpm`) to keep historical required-
+    # check names stable; non-default entries (e.g. pnpm 11) suffix the version.
     name: ${{ format('C3 E2E ({0}, {1}{2}) - {3}', matrix.pm.label, matrix.os.description, matrix.experimental && ', experimental' || '', matrix.filter) }}
     strategy:
       fail-fast: false
@@ -55,10 +44,9 @@ jobs:
           # The yarn tests keep failing on Linux with out of space errors, with no clear reason why. Disabling for now.
           # - { name: yarn, version: "1.0.0", label: "yarn" }
         include:
-          # Windows and experimental matrix entries stick to the default pnpm
-          # version so the resulting check names match what's historically
-          # been used as required checks. pnpm 11 coverage is exercised by
-          # the Linux base entries above.
+          # Windows and experimental entries stay on the default pnpm to
+          # preserve historical required-check names. pnpm 11 coverage comes
+          # from the Linux base entries above.
           - os: { name: windows-latest, description: Windows }
             pm: { name: pnpm, version: "10.33.0", label: "pnpm" }
             filter: "cli"
@@ -114,19 +102,15 @@ jobs:
           git config --global user.email wrangler@cloudflare.com
           git config --global user.name 'Wrangler Tester'
 
-      # The `Install Dependencies` step above installs the monorepo's pinned
-      # pnpm 10.33.0 (read from the root `packageManager` field). For the pnpm
-      # matrix entry below we need the scaffolded-project installs that C3
-      # spawns to actually run the matrix version on PATH, so the e2e suite
-      # exercises pnpm 11's behaviour. Without this, `E2E_TEST_PM_VERSION`
-      # only relabels C3's `npm_config_user_agent` and the underlying pnpm
-      # stays at 10.33.0 (so pnpm 11 regressions go undetected).
+      # Put the matrix pnpm version on PATH so scaffolded-project installs
+      # run it (not the monorepo's pinned pnpm 10.33.0). Without this, the
+      # matrix only relabels C3's `npm_config_user_agent` and pnpm 11
+      # regressions go undetected.
       #
-      # `pnpm/action-setup` refuses to install when both `version` input and
-      # the root `package.json#packageManager` are set, so we point it at a
-      # stub `package.json` via `package_json_file`. We also loosen
-      # `engines.pnpm` because pnpm 11 otherwise bails with
-      # ERR_PNPM_UNSUPPORTED_ENGINE on every command at the monorepo root.
+      # `pnpm/action-setup` refuses when both `version` input and the root
+      # `package.json#packageManager` are set, so we point it at a stub
+      # `package.json`. We also loosen `engines.pnpm` to avoid pnpm 11
+      # bailing with ERR_PNPM_UNSUPPORTED_ENGINE at the monorepo root.
       - name: Prepare workspace for matrix pnpm install
         if: matrix.pm.name == 'pnpm' && steps.changes.outputs.everything_but_markdown == 'true'
         shell: bash
@@ -145,9 +129,8 @@ jobs:
         with:
           version: ${{ matrix.pm.version }}
           package_json_file: .ci-pnpm-setup-stub/package.json
-          # Install to a distinct directory so the action's `addPath` prepends
-          # this entry ahead of the earlier `~/setup-pnpm` (which holds the
-          # monorepo's pinned pnpm 10.x).
+          # Distinct dest so `addPath` prepends ahead of the monorepo's
+          # pinned pnpm 10.x from the earlier `~/setup-pnpm`.
           dest: ~/matrix-pnpm
       - name: Verify pnpm on PATH matches matrix version
         if: matrix.pm.name == 'pnpm' && steps.changes.outputs.everything_but_markdown == 'true'
@@ -190,26 +173,13 @@ jobs:
   frameworks-e2e:
     # Runs the C3 frameworks E2E tests only in the merge queue, on the release branch, if create-cloudflare has changed, or when explicitly requested via label.
     #
-    # The matrix exercises pnpm 10.33.0 *and* pnpm 11.5.1 (plus npm), so any
-    # pnpm 11 regression in C3's install path is caught by CI.
-    #
-    # C3 has a recovery path for `ERR_PNPM_IGNORED_BUILDS` when *C3 itself*
-    # runs `pnpm install` — the e2e harness's background responder accepts
-    # the `pnpm approve-builds <pkgs>` prompt non-interactively (see
-    # `e2e/helpers/run-c3.ts`). That covers framework templates that pass
-    # `--no-install` to their generator (e.g. `react-router`, `nuxt`,
-    # `astro`, plus `svelte` and `next` via flags / template download).
-    #
-    # Frameworks that delegate install to their own generator (e.g. `hono`
-    # passes `--install` to `create-hono`) don't route through C3's recovery,
-    # so on pnpm 11 they fail before recovery can engage. Such tests opt out
-    # of pnpm 11 via `unsupportedPmRanges` in the test config rather than
-    # being silently skipped here.
+    # Frameworks that delegate install to their own generator (e.g. `hono`)
+    # don't route through C3's `ERR_PNPM_IGNORED_BUILDS` recovery path; those
+    # tests opt out of pnpm 11 via `unsupportedPmRanges` in the test config.
     timeout-minutes: 45
     concurrency:
       group: ${{ github.workflow }}-frameworks${{ matrix.experimental && '-experimental' || '' }}-${{ github.ref }}-${{ matrix.os.name }}-${{ matrix.pm.name }}-${{ matrix.pm.version }}
       cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
-    # See the note on `matrix.pm.label` in the `e2e` job above.
     name: ${{ format('C3 E2E ({0}, {1}{2}) - frameworks', matrix.pm.label, matrix.os.description, matrix.experimental && ', experimental' || '') }}
     strategy:
       fail-fast: false
@@ -222,10 +192,8 @@ jobs:
           - { name: pnpm, version: "11.5.1", label: "pnpm@11.5.1" }
           - { name: npm, version: "0.0.0", label: "npm" }
         include:
-          # Experimental stays on the default pnpm version so the check name
-          # matches what's historically been used as a required check.
-          # pnpm 11 coverage is exercised by the (non-experimental) Linux
-          # base entry above.
+          # Experimental stays on the default pnpm to preserve historical
+          # required-check names; pnpm 11 coverage comes from the base entry.
           - os: { name: ubuntu-latest, description: Linux }
             pm: { name: pnpm, version: "10.33.0", label: "pnpm" }
             experimental: true
@@ -296,10 +264,7 @@ jobs:
           git config --global user.email wrangler@cloudflare.com
           git config --global user.name 'Wrangler Tester'
 
-      # See the comment on the equivalent step in the `e2e` job above for why
-      # this dance is necessary. Without it, scaffolded-project installs would
-      # silently keep using the monorepo's pinned pnpm 10.x even when the
-      # matrix says pnpm 11.
+      # See the equivalent step in the `e2e` job above for context.
       - name: Prepare workspace for matrix pnpm install
         if: matrix.pm.name == 'pnpm' && steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true'
         shell: bash

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -174,8 +174,8 @@ jobs:
   frameworks-e2e:
     # Runs the C3 frameworks E2E tests only in the merge queue, on the release branch, if create-cloudflare has changed, or when explicitly requested via label.
     #
-    # The pnpm job here intentionally stays on pnpm 10.33.0 (monorepo's
-    # pinned version).
+    # The matrix exercises pnpm 10.33.0 *and* pnpm 11.5.1 (plus npm), so any
+    # pnpm 11 regression in C3's install path is caught by CI.
     #
     # C3 has a recovery path for `ERR_PNPM_IGNORED_BUILDS` when *C3 itself*
     # runs `pnpm install` — the e2e harness's background responder accepts
@@ -184,17 +184,16 @@ jobs:
     # `--no-install` to their generator (e.g. `react-router`, `nuxt`,
     # `astro`, plus `svelte` and `next` via flags / template download).
     #
-    # But several frameworks delegate install to their own generator
-    # (e.g. `hono` passes `--install` to `create-hono`, and many generators
-    # default to installing). Those internal installs aren't routed through
-    # C3, so on pnpm 11 they would fail with `ERR_PNPM_IGNORED_BUILDS`
-    # before the recovery path can engage. Until those generators approve
-    # their own build scripts upstream, frameworks-e2e stays on pnpm 10.
+    # Frameworks that delegate install to their own generator (e.g. `hono`
+    # passes `--install` to `create-hono`) don't route through C3's recovery,
+    # so on pnpm 11 they fail before recovery can engage. Such tests opt out
+    # of pnpm 11 via `unsupportedPmRanges` in the test config rather than
+    # being silently skipped here.
     timeout-minutes: 45
     concurrency:
       group: ${{ github.workflow }}-frameworks${{ matrix.experimental && '-experimental' || '' }}-${{ github.ref }}-${{ matrix.os.name }}-${{ matrix.pm.name }}-${{ matrix.pm.version }}
       cancel-in-progress: ${{ github.head_ref != 'changeset-release/main' }}
-    name: ${{ format('C3 E2E ({0}, {1}{2}) - frameworks', matrix.pm.name, matrix.os.description, matrix.experimental && ', experimental' || '') }}
+    name: ${{ format('C3 E2E ({0}@{1}, {2}{3}) - frameworks', matrix.pm.name, matrix.pm.version, matrix.os.description, matrix.experimental && ', experimental' || '') }}
     strategy:
       fail-fast: false
       matrix:
@@ -203,10 +202,14 @@ jobs:
           - { name: ubuntu-latest, description: Linux }
         pm:
           - { name: pnpm, version: "10.33.0" }
+          - { name: pnpm, version: "11.5.1" }
           - { name: npm, version: "0.0.0" }
         include:
           - os: { name: ubuntu-latest, description: Linux }
             pm: { name: pnpm, version: "10.33.0" }
+            experimental: true
+          - os: { name: ubuntu-latest, description: Linux }
+            pm: { name: pnpm, version: "11.5.1" }
             experimental: true
     runs-on: ${{ matrix.os.name }}
     steps:
@@ -275,6 +278,38 @@ jobs:
           git config --global user.email wrangler@cloudflare.com
           git config --global user.name 'Wrangler Tester'
 
+      # See the comment on the equivalent step in the `e2e` job above for why
+      # this dance is necessary. Without it, scaffolded-project installs would
+      # silently keep using the monorepo's pinned pnpm 10.x even when the
+      # matrix says pnpm 11.
+      - name: Prepare workspace for matrix pnpm install
+        if: matrix.pm.name == 'pnpm' && steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true'
+        shell: bash
+        run: |
+          mkdir -p .ci-pnpm-setup-stub
+          printf '{"name":"ci-stub","private":true}\n' > .ci-pnpm-setup-stub/package.json
+          node -e "
+            const fs = require('node:fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json','utf8'));
+            if (pkg.engines && pkg.engines.pnpm) pkg.engines.pnpm = '*';
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, '\t') + '\n');
+          "
+      - name: Install matrix pnpm version for scaffolded installs
+        if: matrix.pm.name == 'pnpm' && steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true'
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+        with:
+          version: ${{ matrix.pm.version }}
+          package_json_file: .ci-pnpm-setup-stub/package.json
+          dest: ~/matrix-pnpm
+      - name: Verify pnpm on PATH matches matrix version
+        if: matrix.pm.name == 'pnpm' && steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true'
+        shell: bash
+        run: |
+          got="$(pnpm --version)"
+          want="${{ matrix.pm.version }}"
+          echo "pnpm on PATH: $got (expected $want)"
+          [ "$got" = "$want" ] || { echo "ERROR: PATH pnpm is $got, not $want — scaffolded installs would silently run the wrong version."; exit 1; }
+
       - id: run-e2e
         if: steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true'
         shell: bash
@@ -292,7 +327,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ !cancelled() && steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true' }}
         with:
-          name: ${{ format('e2e-logs-{0}-{1}-{2}-frameworks', matrix.pm.name, matrix.os.description, matrix.experimental && 'experimental' || 'normal') }}
+          name: ${{ format('e2e-logs-{0}-{1}-{2}-{3}-frameworks', matrix.pm.name, matrix.pm.version, matrix.os.description, matrix.experimental && 'experimental' || 'normal') }}
           path: packages/create-cloudflare/.e2e-logs${{matrix.experimental == 'true' && '-experimental' || ''}}/${{ matrix.pm.name }}/frameworks
           include-hidden-files: true
 
@@ -300,6 +335,6 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ !cancelled() && steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true' }}
         with:
-          name: ${{ format('turbo-runs-{0}-{1}-{2}-frameworks', matrix.pm.name, matrix.os.description, matrix.experimental && 'experimental' || 'normal') }}
+          name: ${{ format('turbo-runs-{0}-{1}-{2}-{3}-frameworks', matrix.pm.name, matrix.pm.version, matrix.os.description, matrix.experimental && 'experimental' || 'normal') }}
           path: .turbo/runs
           include-hidden-files: true

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -175,14 +175,21 @@ jobs:
     # Runs the C3 frameworks E2E tests only in the merge queue, on the release branch, if create-cloudflare has changed, or when explicitly requested via label.
     #
     # The pnpm job here intentionally stays on pnpm 10.33.0 (monorepo's
-    # pinned version). Several framework generators (Next.js, Nuxt, Analog,
-    # Qwik, Hono) pull in additional build-script dependencies
-    # (`@parcel/watcher`, `unrs-resolver`, `lmdb`, ...) that are outside C3's
-    # pre-approval scope — those approvals are the framework generator's or
-    # the user's responsibility, not C3's. Until upstream generators approve
-    # their own builds, pnpm 11 in CI would fail those frameworks
-    # non-interactively. pnpm 10 only warns, so the scaffold exercise stays
-    # meaningful.
+    # pinned version).
+    #
+    # C3 has a recovery path for `ERR_PNPM_IGNORED_BUILDS` when *C3 itself*
+    # runs `pnpm install` — the e2e harness's background responder accepts
+    # the `pnpm approve-builds <pkgs>` prompt non-interactively (see
+    # `e2e/helpers/run-c3.ts`). That covers framework templates that pass
+    # `--no-install` to their generator (e.g. `react-router`, `nuxt`,
+    # `astro`, plus `svelte` and `next` via flags / template download).
+    #
+    # But several frameworks delegate install to their own generator
+    # (e.g. `hono` passes `--install` to `create-hono`, and many generators
+    # default to installing). Those internal installs aren't routed through
+    # C3, so on pnpm 11 they would fail with `ERR_PNPM_IGNORED_BUILDS`
+    # before the recovery path can engage. Until those generators approve
+    # their own build scripts upstream, frameworks-e2e stays on pnpm 10.
     timeout-minutes: 45
     concurrency:
       group: ${{ github.workflow }}-frameworks${{ matrix.experimental && '-experimental' || '' }}-${{ github.ref }}-${{ matrix.os.name }}-${{ matrix.pm.name }}-${{ matrix.pm.version }}

--- a/packages/create-cloudflare/e2e/helpers/framework-helpers.ts
+++ b/packages/create-cloudflare/e2e/helpers/framework-helpers.ts
@@ -39,35 +39,10 @@ export type FrameworkTestConfig = RunnerConfig & {
 	unsupportedPms?: string[];
 	unsupportedOSs?: string[];
 	/**
-	 * Per–package-manager semver ranges that should be skipped. Use this when a
-	 * framework template fails on a specific package-manager version. Two
-	 * recurring cases on pnpm >=11 (which makes `strictDepBuilds` the default
-	 * and turns ignored build scripts into a fatal `ERR_PNPM_IGNORED_BUILDS`):
-	 *
-	 * 1. The framework runs its own install inside the generator (e.g. Hono's
-	 *    `create-hono --install`, Docusaurus's internal install). The failure
-	 *    fires before C3's `npmInstall` recovery path can engage.
-	 *
-	 * 2. The framework template's deps trip `ERR_PNPM_IGNORED_BUILDS` *and*
-	 *    the test config defines an ordered `promptHandlers` entry. C3's
-	 *    recovery prompt would fire after the last ordered handler is
-	 *    consumed, but `runC3` closes the harness stdin at that point (it
-	 *    must, or framework generators spawned with `stdio: "inherit"` keep
-	 *    the harness alive past their work — see `e2e/helpers/run-c3.ts`).
-	 *    With stdin closed the background responder can no longer write to
-	 *    it, so the recovery prompt can't be answered in CI. The real-TTY
-	 *    end-user path is unaffected; only the e2e harness can't handle this
-	 *    combination today.
-	 *
-	 * Case 2 is currently latent for `qwik`/`react`/`vike` etc. — those
-	 * templates don't pull in unapproved build scripts beyond C3's
-	 * pre-approved set (`workerd`/`esbuild`/`sharp`), so the recovery prompt
-	 * never fires. If a future template change introduces such a dep, add a
-	 * matching `unsupportedPmRanges` entry rather than rely on this
-	 * happenstance.
-	 *
-	 * Keys are package-manager names ("pnpm", "npm", "yarn", "bun") and
-	 * values are semver ranges understood by `semver.satisfies`.
+	 * Per–package-manager semver ranges to skip. Keys are pm names ("pnpm",
+	 * "npm", "yarn", "bun"); values are semver ranges. Used on pnpm >=11 for
+	 * frameworks that either run their own install (e.g. Hono) or whose
+	 * recovery prompt fires after the e2e harness has closed stdin.
 	 */
 	unsupportedPmRanges?: Partial<Record<string, string>>;
 	flags?: string[];
@@ -462,9 +437,7 @@ function isUnsupportedPmVersion(testConfig: FrameworkTestConfig): boolean {
 	if (!range || !testPackageManagerVersion) {
 		return false;
 	}
-	// Coerce to a clean semver in case the env value carries extra suffixes
-	// (e.g. "11.5.1-canary"). `semver.coerce` returns null for unparseable
-	// inputs — in that case we fall back to running the test.
+	// Coerce to handle suffixes like "11.5.1-canary"; unparseable → run test.
 	const coerced = semver.coerce(testPackageManagerVersion);
 	if (!coerced) {
 		return false;

--- a/packages/create-cloudflare/e2e/helpers/framework-helpers.ts
+++ b/packages/create-cloudflare/e2e/helpers/framework-helpers.ts
@@ -14,6 +14,7 @@ import {
 import { detectPackageManager } from "helpers/packageManagers";
 import { retry } from "helpers/retry";
 import * as jsonc from "jsonc-parser";
+import semver from "semver";
 import { fetch } from "undici";
 import { version } from "../../package.json";
 import { getFrameworkMap } from "../../src/templates";
@@ -23,6 +24,7 @@ import {
 	isExperimental,
 	runDeployTests,
 	testPackageManager,
+	testPackageManagerVersion,
 } from "./constants";
 import { runC3 } from "./run-c3";
 import { kill, spawnWithLogging } from "./spawn";
@@ -36,6 +38,16 @@ export type FrameworkTestConfig = RunnerConfig & {
 	nodeCompat: boolean;
 	unsupportedPms?: string[];
 	unsupportedOSs?: string[];
+	/**
+	 * Per–package-manager semver ranges that should be skipped. Use this when a
+	 * framework template fails on a specific package-manager version (e.g.
+	 * Hono's `create-hono --install` step pulls in unapproved build scripts and
+	 * fails on pnpm >=11, which enforces `ERR_PNPM_IGNORED_BUILDS`).
+	 *
+	 * Keys are package-manager names ("pnpm", "npm", "yarn", "bun") and values
+	 * are semver ranges understood by `semver.satisfies`.
+	 */
+	unsupportedPmRanges?: Partial<Record<string, string>>;
 	flags?: string[];
 	extraEnv?: Record<string, string | undefined>;
 };
@@ -417,8 +429,25 @@ export function shouldRunTest(testConfig: FrameworkTestConfig) {
 		// Skip if the package manager is unsupported
 		!testConfig.unsupportedPms?.includes(testPackageManager) &&
 		// Skip if the OS is unsupported
-		!testConfig.unsupportedOSs?.includes(process.platform)
+		!testConfig.unsupportedOSs?.includes(process.platform) &&
+		// Skip if the package-manager version falls inside an unsupported range
+		!isUnsupportedPmVersion(testConfig)
 	);
+}
+
+function isUnsupportedPmVersion(testConfig: FrameworkTestConfig): boolean {
+	const range = testConfig.unsupportedPmRanges?.[testPackageManager];
+	if (!range || !testPackageManagerVersion) {
+		return false;
+	}
+	// Coerce to a clean semver in case the env value carries extra suffixes
+	// (e.g. "11.5.1-canary"). `semver.coerce` returns null for unparseable
+	// inputs — in that case we fall back to running the test.
+	const coerced = semver.coerce(testPackageManagerVersion);
+	if (!coerced) {
+		return false;
+	}
+	return semver.satisfies(coerced, range);
 }
 
 /**

--- a/packages/create-cloudflare/e2e/helpers/framework-helpers.ts
+++ b/packages/create-cloudflare/e2e/helpers/framework-helpers.ts
@@ -40,12 +40,34 @@ export type FrameworkTestConfig = RunnerConfig & {
 	unsupportedOSs?: string[];
 	/**
 	 * Per–package-manager semver ranges that should be skipped. Use this when a
-	 * framework template fails on a specific package-manager version (e.g.
-	 * Hono's `create-hono --install` step pulls in unapproved build scripts and
-	 * fails on pnpm >=11, which enforces `ERR_PNPM_IGNORED_BUILDS`).
+	 * framework template fails on a specific package-manager version. Two
+	 * recurring cases on pnpm >=11 (which makes `strictDepBuilds` the default
+	 * and turns ignored build scripts into a fatal `ERR_PNPM_IGNORED_BUILDS`):
 	 *
-	 * Keys are package-manager names ("pnpm", "npm", "yarn", "bun") and values
-	 * are semver ranges understood by `semver.satisfies`.
+	 * 1. The framework runs its own install inside the generator (e.g. Hono's
+	 *    `create-hono --install`, Docusaurus's internal install). The failure
+	 *    fires before C3's `npmInstall` recovery path can engage.
+	 *
+	 * 2. The framework template's deps trip `ERR_PNPM_IGNORED_BUILDS` *and*
+	 *    the test config defines an ordered `promptHandlers` entry. C3's
+	 *    recovery prompt would fire after the last ordered handler is
+	 *    consumed, but `runC3` closes the harness stdin at that point (it
+	 *    must, or framework generators spawned with `stdio: "inherit"` keep
+	 *    the harness alive past their work — see `e2e/helpers/run-c3.ts`).
+	 *    With stdin closed the background responder can no longer write to
+	 *    it, so the recovery prompt can't be answered in CI. The real-TTY
+	 *    end-user path is unaffected; only the e2e harness can't handle this
+	 *    combination today.
+	 *
+	 * Case 2 is currently latent for `qwik`/`react`/`vike` etc. — those
+	 * templates don't pull in unapproved build scripts beyond C3's
+	 * pre-approved set (`workerd`/`esbuild`/`sharp`), so the recovery prompt
+	 * never fires. If a future template change introduces such a dep, add a
+	 * matching `unsupportedPmRanges` entry rather than rely on this
+	 * happenstance.
+	 *
+	 * Keys are package-manager names ("pnpm", "npm", "yarn", "bun") and
+	 * values are semver ranges understood by `semver.satisfies`.
 	 */
 	unsupportedPmRanges?: Partial<Record<string, string>>;
 	flags?: string[];

--- a/packages/create-cloudflare/e2e/helpers/run-c3.ts
+++ b/packages/create-cloudflare/e2e/helpers/run-c3.ts
@@ -22,6 +22,17 @@ export type PromptHandler = {
 		  };
 };
 
+/**
+ * A `BackgroundResponder` fires whenever its matcher appears in C3's stdout,
+ * regardless of ordering in `promptHandlers`. It is meant for "opportunistic"
+ * prompts that only show up under specific conditions (e.g. the pnpm 11
+ * approve-builds confirmation). Each responder fires at most once per run.
+ */
+type BackgroundResponder = {
+	matcher: RegExp;
+	keys: string[];
+};
+
 export type RunnerConfig = {
 	promptHandlers?: PromptHandler[];
 	argv?: string[];
@@ -86,8 +97,39 @@ export const runC3 = async (
 		logStream
 	);
 
+	// Background responders fire independently of `promptHandlers` and don't
+	// participate in the ordered queue. They handle recovery-style prompts
+	// that may or may not appear, depending on the framework's dependency
+	// graph (e.g. pnpm 11's `pnpm approve-builds` confirmation, which only
+	// shows up when a framework pulls in unapproved build scripts).
+	const backgroundResponders: BackgroundResponder[] = [
+		{
+			matcher: /Run `pnpm approve-builds [^`]+` and retry the install\?/,
+			// Accept the default ("yes") to run approve-builds + retry.
+			keys: [keys.enter],
+		},
+	];
+	const handledBackground = new WeakSet<BackgroundResponder>();
+
 	const onData = (data: string) => {
+		handleBackgroundPrompts(data);
 		handlePrompt(data);
+	};
+
+	const handleBackgroundPrompts = (data: string) => {
+		const text = stripAnsi(data.toString());
+		for (const responder of backgroundResponders) {
+			if (handledBackground.has(responder)) {
+				continue;
+			}
+			if (!responder.matcher.test(text)) {
+				continue;
+			}
+			handledBackground.add(responder);
+			for (const keystroke of responder.keys) {
+				proc.stdin.write(keystroke);
+			}
+		}
 	};
 
 	// Clone the prompt handlers so we can consume them destructively

--- a/packages/create-cloudflare/e2e/helpers/run-c3.ts
+++ b/packages/create-cloudflare/e2e/helpers/run-c3.ts
@@ -99,9 +99,19 @@ export const runC3 = async (
 
 	// Background responders fire independently of `promptHandlers` and don't
 	// participate in the ordered queue. They handle recovery-style prompts
-	// that may or may not appear, depending on the framework's dependency
-	// graph (e.g. pnpm 11's `pnpm approve-builds` confirmation, which only
-	// shows up when a framework pulls in unapproved build scripts).
+	// that may or may not appear, depending on the dependency graph (e.g.
+	// pnpm 11's `pnpm approve-builds` confirmation, which only shows up when
+	// installs trip `ERR_PNPM_IGNORED_BUILDS`).
+	//
+	// Note: a responder can only write to stdin while stdin is still open.
+	// `handlePrompt` closes stdin once the last *ordered* prompt handler is
+	// consumed (otherwise framework generators spawned with `stdio: "inherit"`
+	// keep stdin alive and hang on exit). So a background responder is only
+	// reliably answered for runs whose `promptHandlers` queue is empty
+	// (typically: simple worker templates, where no framework generator runs).
+	// Framework templates whose recovery prompt fires *after* the last
+	// ordered handler should opt out of the impacted package-manager version
+	// via `unsupportedPmRanges` in the test config.
 	const backgroundResponders: BackgroundResponder[] = [
 		{
 			matcher: /Run `pnpm approve-builds [^`]+` and retry the install\?/,
@@ -129,29 +139,7 @@ export const runC3 = async (
 			for (const keystroke of responder.keys) {
 				proc.stdin.write(keystroke);
 			}
-			// If this was the last interaction we expected (no ordered prompts
-			// left, all background responders fired), close stdin so C3 exits
-			// cleanly. Otherwise we'd leave the child process holding an open
-			// stdin pipe waiting for input that will never come.
-			maybeEndStdin();
 		}
-	};
-
-	// Close stdin once we've exhausted every prompt handler *and* every
-	// background responder has fired. Leaving stdin open until then is what
-	// allows opportunistic recovery prompts (e.g. `pnpm approve-builds` under
-	// pnpm 11) to be answered after the last ordered prompt.
-	const maybeEndStdin = () => {
-		if (promptHandlers[0] !== undefined) {
-			return;
-		}
-		const allBackgroundDone = backgroundResponders.every((responder) =>
-			handledBackground.has(responder)
-		);
-		if (!allBackgroundDone) {
-			return;
-		}
-		proc.stdin.end();
 	};
 
 	// Clone the prompt handlers so we can consume them destructively
@@ -262,10 +250,11 @@ export const runC3 = async (
 		// Consume the handler once we've used it
 		promptHandlers.shift();
 
-		// If we've consumed the last prompt handler, defer closing stdin to
-		// `maybeEndStdin` — it keeps stdin open while any background responder
-		// (e.g. the pnpm 11 `approve-builds` recovery prompt) is still pending.
-		maybeEndStdin();
+		// If we've consumed the last prompt handler, close the input stream
+		// Otherwise, the process wont exit properly
+		if (promptHandlers[0] === undefined) {
+			proc.stdin.end();
+		}
 	};
 
 	return waitForExit(proc, onData);

--- a/packages/create-cloudflare/e2e/helpers/run-c3.ts
+++ b/packages/create-cloudflare/e2e/helpers/run-c3.ts
@@ -23,10 +23,9 @@ export type PromptHandler = {
 };
 
 /**
- * A `BackgroundResponder` fires whenever its matcher appears in C3's stdout,
- * regardless of ordering in `promptHandlers`. It is meant for "opportunistic"
- * prompts that only show up under specific conditions (e.g. the pnpm 11
- * approve-builds confirmation). Each responder fires at most once per run.
+ * Responder for "opportunistic" prompts that only show up under specific
+ * conditions (e.g. the pnpm 11 approve-builds confirmation). Fires at most
+ * once per run, independent of the ordered `promptHandlers` queue.
  */
 type BackgroundResponder = {
 	matcher: RegExp;
@@ -97,25 +96,13 @@ export const runC3 = async (
 		logStream
 	);
 
-	// Background responders fire independently of `promptHandlers` and don't
-	// participate in the ordered queue. They handle recovery-style prompts
-	// that may or may not appear, depending on the dependency graph (e.g.
-	// pnpm 11's `pnpm approve-builds` confirmation, which only shows up when
-	// installs trip `ERR_PNPM_IGNORED_BUILDS`).
-	//
-	// Note: a responder can only write to stdin while stdin is still open.
-	// `handlePrompt` closes stdin once the last *ordered* prompt handler is
-	// consumed (otherwise framework generators spawned with `stdio: "inherit"`
-	// keep stdin alive and hang on exit). So a background responder is only
-	// reliably answered for runs whose `promptHandlers` queue is empty
-	// (typically: simple worker templates, where no framework generator runs).
-	// Framework templates whose recovery prompt fires *after* the last
-	// ordered handler should opt out of the impacted package-manager version
-	// via `unsupportedPmRanges` in the test config.
+	// Responders for prompts that may or may not appear. Note that a responder
+	// can only write to stdin while it's still open — `handlePrompt` closes
+	// stdin once the last ordered handler is consumed. Framework tests whose
+	// recovery prompt fires after that should opt out via `unsupportedPmRanges`.
 	const backgroundResponders: BackgroundResponder[] = [
 		{
 			matcher: /Run `pnpm approve-builds [^`]+` and retry the install\?/,
-			// Accept the default ("yes") to run approve-builds + retry.
 			keys: [keys.enter],
 		},
 	];

--- a/packages/create-cloudflare/e2e/helpers/run-c3.ts
+++ b/packages/create-cloudflare/e2e/helpers/run-c3.ts
@@ -129,7 +129,29 @@ export const runC3 = async (
 			for (const keystroke of responder.keys) {
 				proc.stdin.write(keystroke);
 			}
+			// If this was the last interaction we expected (no ordered prompts
+			// left, all background responders fired), close stdin so C3 exits
+			// cleanly. Otherwise we'd leave the child process holding an open
+			// stdin pipe waiting for input that will never come.
+			maybeEndStdin();
 		}
+	};
+
+	// Close stdin once we've exhausted every prompt handler *and* every
+	// background responder has fired. Leaving stdin open until then is what
+	// allows opportunistic recovery prompts (e.g. `pnpm approve-builds` under
+	// pnpm 11) to be answered after the last ordered prompt.
+	const maybeEndStdin = () => {
+		if (promptHandlers[0] !== undefined) {
+			return;
+		}
+		const allBackgroundDone = backgroundResponders.every((responder) =>
+			handledBackground.has(responder)
+		);
+		if (!allBackgroundDone) {
+			return;
+		}
+		proc.stdin.end();
 	};
 
 	// Clone the prompt handlers so we can consume them destructively
@@ -240,11 +262,10 @@ export const runC3 = async (
 		// Consume the handler once we've used it
 		promptHandlers.shift();
 
-		// If we've consumed the last prompt handler, close the input stream
-		// Otherwise, the process wont exit properly
-		if (promptHandlers[0] === undefined) {
-			proc.stdin.end();
-		}
+		// If we've consumed the last prompt handler, defer closing stdin to
+		// `maybeEndStdin` — it keeps stdin open while any background responder
+		// (e.g. the pnpm 11 `approve-builds` recovery prompt) is still pending.
+		maybeEndStdin();
 	};
 
 	return waitForExit(proc, onData);

--- a/packages/create-cloudflare/e2e/helpers/run-c3.ts
+++ b/packages/create-cloudflare/e2e/helpers/run-c3.ts
@@ -124,7 +124,9 @@ export const runC3 = async (
 			}
 			handledBackground.add(responder);
 			for (const keystroke of responder.keys) {
-				proc.stdin.write(keystroke);
+				if (proc.stdin.writable) {
+					proc.stdin.write(keystroke);
+				}
 			}
 		}
 	};

--- a/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
+++ b/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
@@ -322,21 +322,23 @@ describe("Create Cloudflare CLI", () => {
 		test.skipIf(isWindows)(
 			"Error when --lang=python is used with a category that has no Python templates",
 			async ({ expect, logStream, project }) => {
-				const { errors } = await runC3(
-					[
-						project.path,
-						"--lang=python",
-						"--category=demo",
-						"--no-deploy",
-						"--git=false",
-					],
-					[],
-					logStream
-				);
-
-				expect(errors).toContain(
-					`No templates available for language "python" in the "demo" category`
-				);
+				await expect(
+					runC3(
+						[
+							project.path,
+							"--lang=python",
+							"--category=demo",
+							"--no-deploy",
+							"--git=false",
+						],
+						[],
+						logStream
+					)
+				).rejects.toMatchObject({
+					errors: expect.stringContaining(
+						`No templates available for language "python" in the "demo" category`
+					),
+				});
 			}
 		);
 
@@ -745,14 +747,17 @@ describe("Create Cloudflare CLI", () => {
 				expect,
 				logStream,
 			}) => {
-				const { errors } = await runC3(
-					["--platform=pages", `--framework=${framework}`, "my-app"],
-					[],
-					logStream
-				);
-				expect(errors).toMatch(
-					/Error: The .*? framework doesn't support the "pages" platform/
-				);
+				await expect(
+					runC3(
+						["--platform=pages", `--framework=${framework}`, "my-app"],
+						[],
+						logStream
+					)
+				).rejects.toMatchObject({
+					errors: expect.stringMatching(
+						/Error: The .*? framework doesn't support the "pages" platform/
+					),
+				});
 			})
 		);
 
@@ -760,63 +765,72 @@ describe("Create Cloudflare CLI", () => {
 			expect,
 			logStream,
 		}) => {
-			const { errors } = await runC3(
-				[
-					"my-app",
-					"--framework=react",
-					"--platform=workers",
-					"--variant=invalid-variant",
-					"--no-deploy",
-					"--git=false",
-				],
-				[],
-				logStream
-			);
-			expect(errors).toContain(
-				'Unknown variant "invalid-variant". Valid variants are: react-ts, react'
-			);
+			await expect(
+				runC3(
+					[
+						"my-app",
+						"--framework=react",
+						"--platform=workers",
+						"--variant=invalid-variant",
+						"--no-deploy",
+						"--git=false",
+					],
+					[],
+					logStream
+				)
+			).rejects.toMatchObject({
+				errors: expect.stringContaining(
+					'Unknown variant "invalid-variant". Valid variants are: react-ts, react'
+				),
+			});
 		});
 
 		test("error when using deprecated SWC --variant for React Workers framework", async ({
 			expect,
 			logStream,
 		}) => {
-			const { errors } = await runC3(
-				[
-					"my-app",
-					"--framework=react",
-					"--platform=workers",
-					"--variant=react-swc-ts",
-					"--no-deploy",
-					"--git=false",
-				],
-				[],
-				logStream
-			);
-			expect(errors).toContain(
-				'The React variant "react-swc-ts" is no longer available. Use "react-ts" instead.'
-			);
+			await expect(
+				runC3(
+					[
+						"my-app",
+						"--framework=react",
+						"--platform=workers",
+						"--variant=react-swc-ts",
+						"--no-deploy",
+						"--git=false",
+					],
+					[],
+					logStream
+				)
+			).rejects.toMatchObject({
+				errors: expect.stringContaining(
+					'The React variant "react-swc-ts" is no longer available. Use "react-ts" instead.'
+				),
+			});
 		});
 
 		test("error when using invalid --variant for React Pages framework", async ({
 			expect,
 			logStream,
 		}) => {
-			const { errors } = await runC3(
-				[
-					"my-app",
-					"--framework=react",
-					"--platform=pages",
-					"--variant=invalid-variant",
-					"--no-deploy",
-					"--git=false",
-				],
-				[],
-				logStream
-			);
-			expect(errors).toContain(
-				'Unknown variant "invalid-variant". Valid variants are: react-ts, react-swc-ts, react, react-swc'
-			);
+			await expect(
+				runC3(
+					[
+						"my-app",
+						"--framework=react",
+						"--platform=pages",
+						"--variant=invalid-variant",
+						"--no-deploy",
+						"--git=false",
+					],
+					[],
+					logStream
+				)
+			).rejects.toMatchObject({
+				errors: expect.stringContaining(
+					'Unknown variant "invalid-variant". Valid variants are: react-ts, react-swc-ts, react, react-swc'
+				),
+			});
 		});
 
 		test("accepts --variant for React Pages framework without prompting", async ({
@@ -921,14 +935,17 @@ describe("Create Cloudflare CLI", () => {
 				logStream,
 				project,
 			}) => {
-				const { errors } = await runC3(
-					[project.path, "--platform=pages", `--category=${category}`],
-					[],
-					logStream
-				);
-				expect(errors).toContain(
-					`The "${category}" category is not available for the "pages" platform`
-				);
+				await expect(
+					runC3(
+						[project.path, "--platform=pages", `--category=${category}`],
+						[],
+						logStream
+					)
+				).rejects.toMatchObject({
+					errors: expect.stringContaining(
+						`The "${category}" category is not available for the "pages" platform`
+					),
+				});
 			})
 		);
 	});

--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -385,6 +385,17 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			timeout: LONG_TIMEOUT,
 			unsupportedPms: ["yarn"], // Currently nitro requires youch which expects Node 20+, and yarn will fail hard since we run on Node 18
 			unsupportedOSs: ["win32"],
+			// On pnpm >=11 Nuxt's deps (notably `@parcel/watcher`) trip
+			// `ERR_PNPM_IGNORED_BUILDS` when C3 runs its own `pnpm install`
+			// after the `--no-install` generator finishes. C3's interactive
+			// recovery prompt works for real TTY users, but the e2e harness
+			// has already closed stdin by the time the prompt fires (it
+			// closes after the last ordered `promptHandler` is consumed), so
+			// the background responder can't write to it. Skip in CI until
+			// either the harness can keep stdin open without hanging
+			// inherit-stdio framework generators, or Nuxt's template
+			// pre-approves its build scripts.
+			unsupportedPmRanges: { pnpm: ">=11.0.0" },
 			verifyDeploy: {
 				route: "/",
 				expectedText: "Welcome to Nuxt!",
@@ -410,6 +421,8 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			timeout: LONG_TIMEOUT,
 			unsupportedPms: ["yarn"], // Currently nitro requires youch which expects Node 20+, and yarn will fail hard since we run on Node 18
 			unsupportedOSs: ["win32"],
+			// See note on nuxt:pages above.
+			unsupportedPmRanges: { pnpm: ">=11.0.0" },
 			verifyDeploy: {
 				route: "/",
 				expectedText: "Welcome to Nuxt!",
@@ -830,6 +843,10 @@ function getExperimentalFrameworkTestConfig(
 			testCommitMessage: true,
 			timeout: LONG_TIMEOUT,
 			unsupportedOSs: ["win32"],
+			// See note on nuxt:pages in the non-experimental list: the e2e
+			// harness can't answer C3's approve-builds recovery prompt for
+			// Nuxt under pnpm 11.
+			unsupportedPmRanges: { pnpm: ">=11.0.0" },
 			verifyDeploy: {
 				route: "/",
 				expectedText: "Welcome to Nuxt!",

--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -90,14 +90,9 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			name: "docusaurus:pages",
 			argv: ["--platform", "pages"],
 			unsupportedPms: ["bun"],
-			// `create-docusaurus` installs its dependencies internally as part
-			// of `runFrameworkGenerator` (no `--no-install` switch is exposed),
-			// so the install runs before C3 reaches its own `npmInstall`
-			// recovery path. On pnpm >=11 the docusaurus template pulls in
-			// `@swc/core` and `core-js` whose postinstall scripts are
-			// unapproved, tripping `ERR_PNPM_IGNORED_BUILDS`. Until docusaurus
-			// approves those upstream (or gains a `--no-install` flag we can
-			// pass), this combination cannot succeed in CI.
+			// `create-docusaurus` installs internally (no `--no-install`),
+			// tripping `ERR_PNPM_IGNORED_BUILDS` on pnpm 11 before C3's
+			// recovery path can engage.
 			unsupportedPmRanges: { pnpm: ">=11.0.0" },
 			testCommitMessage: true,
 			unsupportedOSs: ["win32"],
@@ -257,16 +252,8 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			argv: ["--platform", "pages"],
 			testCommitMessage: true,
 			unsupportedOSs: ["win32"],
-			// `create-hono` is invoked with `--install`
-			// (`templates/hono/pages/c3.ts`), so the dependency install runs
-			// inside the framework generator, *before* C3 reaches its own
-			// `npmInstall`. On pnpm >=11 the default `strictDepBuilds=true`
-			// turns unapproved postinstall scripts (workerd, esbuild, sharp via
-			// wrangler) into a fatal `ERR_PNPM_IGNORED_BUILDS`. C3's
-			// approve-builds recovery path can't engage that early, so the
-			// generator fails before we ever return. Until `create-hono`
-			// supports `--no-install` (or approves its own build scripts), we
-			// skip this test on pnpm 11+.
+			// `create-hono --install` runs the install inside the generator,
+			// before C3's recovery path can engage. Fails on pnpm 11.
 			unsupportedPmRanges: { pnpm: ">=11.0.0" },
 			verifyDeploy: {
 				route: "/",
@@ -385,16 +372,9 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			timeout: LONG_TIMEOUT,
 			unsupportedPms: ["yarn"], // Currently nitro requires youch which expects Node 20+, and yarn will fail hard since we run on Node 18
 			unsupportedOSs: ["win32"],
-			// On pnpm >=11 Nuxt's deps (notably `@parcel/watcher`) trip
-			// `ERR_PNPM_IGNORED_BUILDS` when C3 runs its own `pnpm install`
-			// after the `--no-install` generator finishes. C3's interactive
-			// recovery prompt works for real TTY users, but the e2e harness
-			// has already closed stdin by the time the prompt fires (it
-			// closes after the last ordered `promptHandler` is consumed), so
-			// the background responder can't write to it. Skip in CI until
-			// either the harness can keep stdin open without hanging
-			// inherit-stdio framework generators, or Nuxt's template
-			// pre-approves its build scripts.
+			// Nuxt's deps trip `ERR_PNPM_IGNORED_BUILDS` on pnpm 11; the e2e
+			// harness has closed stdin by the time C3's recovery prompt fires
+			// (real-TTY users are unaffected).
 			unsupportedPmRanges: { pnpm: ">=11.0.0" },
 			verifyDeploy: {
 				route: "/",
@@ -743,9 +723,7 @@ function getExperimentalFrameworkTestConfig(
 			name: "docusaurus:workers",
 			argv: ["--platform", "workers"],
 			unsupportedPms: ["bun"],
-			// See note on docusaurus:pages in the non-experimental list:
-			// `create-docusaurus` installs internally, so pnpm 11 trips
-			// `ERR_PNPM_IGNORED_BUILDS` before C3's recovery can engage.
+			// See note on docusaurus:pages above.
 			unsupportedPmRanges: { pnpm: ">=11.0.0" },
 			testCommitMessage: true,
 			unsupportedOSs: ["win32"],
@@ -843,9 +821,7 @@ function getExperimentalFrameworkTestConfig(
 			testCommitMessage: true,
 			timeout: LONG_TIMEOUT,
 			unsupportedOSs: ["win32"],
-			// See note on nuxt:pages in the non-experimental list: the e2e
-			// harness can't answer C3's approve-builds recovery prompt for
-			// Nuxt under pnpm 11.
+			// See note on nuxt:pages above.
 			unsupportedPmRanges: { pnpm: ">=11.0.0" },
 			verifyDeploy: {
 				route: "/",

--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -246,6 +246,17 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			argv: ["--platform", "pages"],
 			testCommitMessage: true,
 			unsupportedOSs: ["win32"],
+			// `create-hono` is invoked with `--install`
+			// (`templates/hono/pages/c3.ts`), so the dependency install runs
+			// inside the framework generator, *before* C3 reaches its own
+			// `npmInstall`. On pnpm >=11 the default `strictDepBuilds=true`
+			// turns unapproved postinstall scripts (workerd, esbuild, sharp via
+			// wrangler) into a fatal `ERR_PNPM_IGNORED_BUILDS`. C3's
+			// approve-builds recovery path can't engage that early, so the
+			// generator fails before we ever return. Until `create-hono`
+			// supports `--no-install` (or approves its own build scripts), we
+			// skip this test on pnpm 11+.
+			unsupportedPmRanges: { pnpm: ">=11.0.0" },
 			verifyDeploy: {
 				route: "/",
 				expectedText: "Hello!",
@@ -268,6 +279,8 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			argv: ["--platform", "workers"],
 			testCommitMessage: true,
 			unsupportedOSs: ["win32"],
+			// See note on hono:pages above.
+			unsupportedPmRanges: { pnpm: ">=11.0.0" },
 			verifyDeploy: {
 				route: "/message",
 				expectedText: "Hello Hono!",

--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -90,6 +90,15 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			name: "docusaurus:pages",
 			argv: ["--platform", "pages"],
 			unsupportedPms: ["bun"],
+			// `create-docusaurus` installs its dependencies internally as part
+			// of `runFrameworkGenerator` (no `--no-install` switch is exposed),
+			// so the install runs before C3 reaches its own `npmInstall`
+			// recovery path. On pnpm >=11 the docusaurus template pulls in
+			// `@swc/core` and `core-js` whose postinstall scripts are
+			// unapproved, tripping `ERR_PNPM_IGNORED_BUILDS`. Until docusaurus
+			// approves those upstream (or gains a `--no-install` flag we can
+			// pass), this combination cannot succeed in CI.
+			unsupportedPmRanges: { pnpm: ">=11.0.0" },
 			testCommitMessage: true,
 			unsupportedOSs: ["win32"],
 			timeout: LONG_TIMEOUT,
@@ -119,6 +128,8 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			name: "docusaurus:workers",
 			argv: ["--platform", "workers"],
 			unsupportedPms: ["bun"],
+			// See note on docusaurus:pages above.
+			unsupportedPmRanges: { pnpm: ">=11.0.0" },
 			testCommitMessage: true,
 			unsupportedOSs: ["win32"],
 			timeout: LONG_TIMEOUT,
@@ -719,6 +730,10 @@ function getExperimentalFrameworkTestConfig(
 			name: "docusaurus:workers",
 			argv: ["--platform", "workers"],
 			unsupportedPms: ["bun"],
+			// See note on docusaurus:pages in the non-experimental list:
+			// `create-docusaurus` installs internally, so pnpm 11 trips
+			// `ERR_PNPM_IGNORED_BUILDS` before C3's recovery can engage.
+			unsupportedPmRanges: { pnpm: ">=11.0.0" },
 			testCommitMessage: true,
 			unsupportedOSs: ["win32"],
 			timeout: LONG_TIMEOUT,

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -259,8 +259,13 @@ const offerAgentsMd = async (ctx: C3Context) => {
 main(process.argv)
 	.catch((e) => {
 		if (e instanceof CancelError) {
+			// User-initiated cancellation (Ctrl-C, declined prompt) — not a
+			// failure from the script's perspective; leave the exit code at 0.
 			cancel(e.message);
-		} else if (isIgnoredBuildsError(e)) {
+			return;
+		}
+
+		if (isIgnoredBuildsError(e)) {
 			// pnpm refused to run dependency build scripts for packages C3
 			// does not pre-approve (e.g. framework-introduced native deps).
 			// `npmInstall` already attempted the interactive recovery path
@@ -272,12 +277,19 @@ main(process.argv)
 		} else {
 			error(e);
 		}
+
+		// Any error reaching here is a real failure: mark `process.exitCode`
+		// so CI / shell callers can detect it. The `process.exit()` call in
+		// the finally below picks this up automatically (per Node's docs,
+		// `exit()` without an explicit code uses `process.exitCode`).
+		process.exitCode = 1;
 	})
 	.finally(async () => {
 		await reporter.waitForAllEventsSettled();
 
-		// ensure we explicitly exit the process, otherwise any ongoing async
-		// calls or leftover tasks in the stack queue will keep running until
-		// completed
+		// Force-exit so any ongoing async calls or leftover tasks in the
+		// stack queue don't keep the event loop alive. The exit code falls
+		// through from `process.exitCode` set in the catch above (0 on
+		// success / user cancellation, 1 on error).
 		process.exit();
 	});

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -24,7 +24,7 @@ import {
 import { installWrangler, npmInstall } from "helpers/packages";
 import {
 	getPnpmIgnoredBuildsGuidance,
-	isPnpmIgnoredBuildsError,
+	isIgnoredBuildsError,
 	writePnpmBuildApprovals,
 } from "helpers/pnpmBuildApprovals";
 import { version } from "../package.json";
@@ -157,10 +157,11 @@ const create = async (ctx: C3Context) => {
 	updatePackageName(ctx);
 
 	// Pre-approve the build scripts C3 itself depends on (`workerd`, `esbuild`,
-	// `sharp` — via wrangler/miniflare). Required before any `pnpm install` on
-	// pnpm 11+, where unapproved build scripts are a fatal
-	// `ERR_PNPM_IGNORED_BUILDS`. Framework-introduced build approvals are not
-	// our concern and are left to the framework generator or the user.
+	// `sharp` — via wrangler/miniflare). Required before any `pnpm install`
+	// on pnpm 11+, where unapproved build scripts are a fatal
+	// `ERR_PNPM_IGNORED_BUILDS`. Framework-introduced build scripts (e.g.
+	// `@parcel/watcher`, `lmdb`) are intentionally _not_ pre-approved here —
+	// `npmInstall` handles those interactively via `pnpm approve-builds`.
 	writePnpmBuildApprovals(ctx.project.path);
 
 	chdir(ctx.project.path);
@@ -259,12 +260,15 @@ main(process.argv)
 	.catch((e) => {
 		if (e instanceof CancelError) {
 			cancel(e.message);
-		} else if (isPnpmIgnoredBuildsError(e)) {
-			// A framework-introduced build script was not approved.
-			// `writePnpmBuildApprovals` only covers C3's own dependencies; the
-			// framework generator (or the user) is responsible for the rest.
-			// Surface the pnpm output alongside actionable guidance.
-			error(`${e.message}\n\n${getPnpmIgnoredBuildsGuidance()}`);
+		} else if (isIgnoredBuildsError(e)) {
+			// pnpm refused to run dependency build scripts for packages C3
+			// does not pre-approve (e.g. framework-introduced native deps).
+			// `npmInstall` already attempted the interactive recovery path
+			// (`pnpm approve-builds <pkg>` + retry); reaching here means we
+			// either couldn't recover or the user declined. Print a concise
+			// summary with the parsed package list — not the full pnpm
+			// transcript — alongside actionable guidance.
+			error(`${e.message}\n\n${getPnpmIgnoredBuildsGuidance(e.packages)}`);
 		} else {
 			error(e);
 		}

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -22,6 +22,11 @@ import {
 	rectifyPmMismatch,
 } from "helpers/packageManagers";
 import { installWrangler, npmInstall } from "helpers/packages";
+import {
+	getPnpmIgnoredBuildsGuidance,
+	isPnpmIgnoredBuildsError,
+	writePnpmBuildApprovals,
+} from "helpers/pnpmBuildApprovals";
 import { version } from "../package.json";
 import { maybeOpenBrowser, offerToDeploy, runDeploy } from "./deploy";
 import { printSummary, printWelcomeMessage } from "./dialog";
@@ -151,6 +156,13 @@ const create = async (ctx: C3Context) => {
 	}
 	updatePackageName(ctx);
 
+	// Pre-approve the build scripts C3 itself depends on (`workerd`, `esbuild`,
+	// `sharp` — via wrangler/miniflare). Required before any `pnpm install` on
+	// pnpm 11+, where unapproved build scripts are a fatal
+	// `ERR_PNPM_IGNORED_BUILDS`. Framework-introduced build approvals are not
+	// our concern and are left to the framework generator or the user.
+	writePnpmBuildApprovals(ctx.project.path);
+
 	chdir(ctx.project.path);
 	await npmInstall(ctx);
 	await rectifyPmMismatch(ctx);
@@ -247,6 +259,12 @@ main(process.argv)
 	.catch((e) => {
 		if (e instanceof CancelError) {
 			cancel(e.message);
+		} else if (isPnpmIgnoredBuildsError(e)) {
+			// A framework-introduced build script was not approved.
+			// `writePnpmBuildApprovals` only covers C3's own dependencies; the
+			// framework generator (or the user) is responsible for the rest.
+			// Surface the pnpm output alongside actionable guidance.
+			error(`${e.message}\n\n${getPnpmIgnoredBuildsGuidance()}`);
 		} else {
 			error(e);
 		}

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -156,12 +156,6 @@ const create = async (ctx: C3Context) => {
 	}
 	updatePackageName(ctx);
 
-	// Pre-approve the build scripts C3 itself depends on (`workerd`, `esbuild`,
-	// `sharp` — via wrangler/miniflare). Required before any `pnpm install`
-	// on pnpm 11+, where unapproved build scripts are a fatal
-	// `ERR_PNPM_IGNORED_BUILDS`. Framework-introduced build scripts (e.g.
-	// `@parcel/watcher`, `lmdb`) are intentionally _not_ pre-approved here —
-	// `npmInstall` handles those interactively via `pnpm approve-builds`.
 	writePnpmBuildApprovals(ctx.project.path);
 
 	chdir(ctx.project.path);
@@ -258,38 +252,24 @@ const offerAgentsMd = async (ctx: C3Context) => {
 
 main(process.argv)
 	.catch((e) => {
+		// User-initiated cancellation isn't a failure; leave exit code at 0.
 		if (e instanceof CancelError) {
-			// User-initiated cancellation (Ctrl-C, declined prompt) — not a
-			// failure from the script's perspective; leave the exit code at 0.
 			cancel(e.message);
 			return;
 		}
 
 		if (isIgnoredBuildsError(e)) {
-			// pnpm refused to run dependency build scripts for packages C3
-			// does not pre-approve (e.g. framework-introduced native deps).
-			// `npmInstall` already attempted the interactive recovery path
-			// (`pnpm approve-builds <pkg>` + retry); reaching here means we
-			// either couldn't recover or the user declined. Print a concise
-			// summary with the parsed package list — not the full pnpm
-			// transcript — alongside actionable guidance.
 			error(`${e.message}\n\n${getPnpmIgnoredBuildsGuidance(e.packages)}`);
 		} else {
 			error(e);
 		}
 
-		// Any error reaching here is a real failure: mark `process.exitCode`
-		// so CI / shell callers can detect it. The `process.exit()` call in
-		// the finally below picks this up automatically (per Node's docs,
-		// `exit()` without an explicit code uses `process.exitCode`).
+		// `process.exit()` in the finally below picks this up.
 		process.exitCode = 1;
 	})
 	.finally(async () => {
 		await reporter.waitForAllEventsSettled();
 
-		// Force-exit so any ongoing async calls or leftover tasks in the
-		// stack queue don't keep the event loop alive. The exit code falls
-		// through from `process.exitCode` set in the catch above (0 on
-		// success / user cancellation, 1 on error).
+		// Force-exit so leftover async work doesn't keep the event loop alive.
 		process.exit();
 	});

--- a/packages/create-cloudflare/src/helpers/__tests__/packages.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/packages.test.ts
@@ -1,0 +1,219 @@
+import { existsSync } from "node:fs";
+import { runCommand } from "@cloudflare/cli-shared-helpers/command";
+import {
+	inputPrompt,
+	isInteractive,
+} from "@cloudflare/cli-shared-helpers/interactive";
+import { npmInstall } from "helpers/packages";
+import { isIgnoredBuildsError } from "helpers/pnpmBuildApprovals";
+import { beforeEach, describe, test, vi } from "vitest";
+import { mockPackageManager, mockSpinner } from "./mocks";
+import type { IgnoredBuildsError } from "helpers/pnpmBuildApprovals";
+import type { C3Context } from "types";
+
+vi.mock("node:fs");
+vi.mock("@cloudflare/cli-shared-helpers/command");
+vi.mock("@cloudflare/cli-shared-helpers/interactive");
+vi.mock("which-pm-runs");
+
+const ctx = (): C3Context =>
+	({
+		project: { name: "x", path: "/tmp/x" },
+	}) as unknown as C3Context;
+
+const pnpmIgnoredBuildsError = (packagesLine: string): Error =>
+	new Error(
+		`Packages: +1\n+\n[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: ${packagesLine}\n\nRun "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.\n`
+	);
+
+describe("npmInstall", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+		mockSpinner();
+		// project directory does not yet have node_modules
+		vi.mocked(existsSync).mockReturnValue(false);
+		// default to a non-interactive shell unless the test opts in
+		vi.mocked(isInteractive).mockReturnValue(false);
+	});
+
+	test("falls through to plain `npm install` for non-pnpm", async ({
+		expect,
+	}) => {
+		mockPackageManager("npm");
+		vi.mocked(runCommand).mockResolvedValueOnce("");
+
+		await npmInstall(ctx());
+
+		expect(runCommand).toHaveBeenCalledTimes(1);
+		const [cmd] = vi.mocked(runCommand).mock.calls[0];
+		expect(cmd).toEqual(["npm", "install"]);
+	});
+
+	test("skips entirely when node_modules already exists", async ({
+		expect,
+	}) => {
+		mockPackageManager("pnpm", "11.5.1");
+		vi.mocked(existsSync).mockReturnValue(true);
+
+		await npmInstall(ctx());
+
+		expect(runCommand).not.toHaveBeenCalled();
+	});
+
+	describe("pnpm", () => {
+		beforeEach(() => {
+			mockPackageManager("pnpm", "11.5.1");
+		});
+
+		test("runs a single `pnpm install` when nothing is flagged", async ({
+			expect,
+		}) => {
+			vi.mocked(runCommand).mockResolvedValueOnce("");
+
+			await npmInstall(ctx());
+
+			expect(runCommand).toHaveBeenCalledTimes(1);
+			const [cmd, opts] = vi.mocked(runCommand).mock.calls[0];
+			expect(cmd).toEqual(["pnpm", "install"]);
+			// We manage the spinner outside runCommand to suppress the noisy
+			// full-transcript dump on failure.
+			expect(opts).toMatchObject({ silent: true, useSpinner: false });
+		});
+
+		test("rethrows non-ignored-builds install failures verbatim", async ({
+			expect,
+		}) => {
+			const networkErr = new Error("ENOTFOUND registry.npmjs.org");
+			vi.mocked(runCommand).mockRejectedValueOnce(networkErr);
+
+			await expect(npmInstall(ctx())).rejects.toBe(networkErr);
+			expect(runCommand).toHaveBeenCalledTimes(1);
+			expect(inputPrompt).not.toHaveBeenCalled();
+		});
+
+		test("non-interactive: throws IgnoredBuildsError with parsed packages and never prompts", async ({
+			expect,
+		}) => {
+			vi.mocked(runCommand).mockRejectedValueOnce(
+				pnpmIgnoredBuildsError("@parcel/watcher@2.5.6, lmdb@2.8.1")
+			);
+
+			let caught: unknown;
+			await npmInstall(ctx()).catch((e) => {
+				caught = e;
+			});
+
+			expect(isIgnoredBuildsError(caught)).toBe(true);
+			expect((caught as IgnoredBuildsError).packages).toEqual([
+				"@parcel/watcher",
+				"lmdb",
+			]);
+			expect(inputPrompt).not.toHaveBeenCalled();
+			expect(runCommand).toHaveBeenCalledTimes(1);
+		});
+
+		test("interactive + approved: runs `pnpm approve-builds <pkgs>` and retries install once", async ({
+			expect,
+		}) => {
+			vi.mocked(isInteractive).mockReturnValue(true);
+			vi.mocked(inputPrompt).mockResolvedValueOnce(true);
+			// 1) install fails with ignored builds, 2) approve-builds OK, 3) retry install OK
+			vi.mocked(runCommand)
+				.mockRejectedValueOnce(pnpmIgnoredBuildsError("@parcel/watcher@2.5.6"))
+				.mockResolvedValueOnce("") // approve-builds
+				.mockResolvedValueOnce(""); // retry install
+
+			await npmInstall(ctx());
+
+			expect(runCommand).toHaveBeenCalledTimes(3);
+			expect(vi.mocked(runCommand).mock.calls[0][0]).toEqual([
+				"pnpm",
+				"install",
+			]);
+			// approve-builds is invoked with the parsed package list, NOT --all.
+			expect(vi.mocked(runCommand).mock.calls[1][0]).toEqual([
+				"pnpm",
+				"approve-builds",
+				"@parcel/watcher",
+			]);
+			expect(vi.mocked(runCommand).mock.calls[2][0]).toEqual([
+				"pnpm",
+				"install",
+			]);
+		});
+
+		test("interactive + declined: throws IgnoredBuildsError without running approve-builds", async ({
+			expect,
+		}) => {
+			vi.mocked(isInteractive).mockReturnValue(true);
+			vi.mocked(inputPrompt).mockResolvedValueOnce(false);
+			vi.mocked(runCommand).mockRejectedValueOnce(
+				pnpmIgnoredBuildsError("@parcel/watcher@2.5.6")
+			);
+
+			let caught: unknown;
+			await npmInstall(ctx()).catch((e) => {
+				caught = e;
+			});
+
+			expect(isIgnoredBuildsError(caught)).toBe(true);
+			expect((caught as IgnoredBuildsError).packages).toEqual([
+				"@parcel/watcher",
+			]);
+			expect(runCommand).toHaveBeenCalledTimes(1); // no approve-builds, no retry
+		});
+
+		test("retry still fails with ignored builds: throws IgnoredBuildsError carrying the second list", async ({
+			expect,
+		}) => {
+			vi.mocked(isInteractive).mockReturnValue(true);
+			vi.mocked(inputPrompt).mockResolvedValueOnce(true);
+			vi.mocked(runCommand)
+				.mockRejectedValueOnce(pnpmIgnoredBuildsError("@parcel/watcher@2.5.6"))
+				.mockResolvedValueOnce("") // approve-builds
+				.mockRejectedValueOnce(pnpmIgnoredBuildsError("lmdb@2.8.1")); // retry: new package flagged
+
+			let caught: unknown;
+			await npmInstall(ctx()).catch((e) => {
+				caught = e;
+			});
+
+			expect(isIgnoredBuildsError(caught)).toBe(true);
+			expect((caught as IgnoredBuildsError).packages).toEqual(["lmdb"]);
+		});
+
+		test("retry fails for an unrelated reason: rethrows verbatim", async ({
+			expect,
+		}) => {
+			vi.mocked(isInteractive).mockReturnValue(true);
+			vi.mocked(inputPrompt).mockResolvedValueOnce(true);
+			const retryErr = new Error("disk full");
+			vi.mocked(runCommand)
+				.mockRejectedValueOnce(pnpmIgnoredBuildsError("@parcel/watcher@2.5.6"))
+				.mockResolvedValueOnce("") // approve-builds
+				.mockRejectedValueOnce(retryErr);
+
+			await expect(npmInstall(ctx())).rejects.toBe(retryErr);
+		});
+
+		test("unparseable ignored-builds error: throws IgnoredBuildsError with empty list", async ({
+			expect,
+		}) => {
+			vi.mocked(isInteractive).mockReturnValue(true);
+			// pnpm error without a recognisable `Ignored build scripts:` line
+			vi.mocked(runCommand).mockRejectedValueOnce(
+				new Error("[ERR_PNPM_IGNORED_BUILDS] something unexpected")
+			);
+
+			let caught: unknown;
+			await npmInstall(ctx()).catch((e) => {
+				caught = e;
+			});
+
+			expect(isIgnoredBuildsError(caught)).toBe(true);
+			expect((caught as IgnoredBuildsError).packages).toEqual([]);
+			// We never prompt if we can't tell the user which packages need approval.
+			expect(inputPrompt).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/create-cloudflare/src/helpers/__tests__/packages.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/packages.test.ts
@@ -1,9 +1,7 @@
 import { existsSync } from "node:fs";
 import { runCommand } from "@cloudflare/cli-shared-helpers/command";
-import {
-	inputPrompt,
-	isInteractive,
-} from "@cloudflare/cli-shared-helpers/interactive";
+import { CancelError } from "@cloudflare/cli-shared-helpers/error";
+import { inputPrompt } from "@cloudflare/cli-shared-helpers/interactive";
 import { npmInstall } from "helpers/packages";
 import { isIgnoredBuildsError } from "helpers/pnpmBuildApprovals";
 import { beforeEach, describe, test, vi } from "vitest";
@@ -32,8 +30,6 @@ describe("npmInstall", () => {
 		mockSpinner();
 		// project directory does not yet have node_modules
 		vi.mocked(existsSync).mockReturnValue(false);
-		// default to a non-interactive shell unless the test opts in
-		vi.mocked(isInteractive).mockReturnValue(false);
 	});
 
 	test("falls through to plain `npm install` for non-pnpm", async ({
@@ -91,31 +87,9 @@ describe("npmInstall", () => {
 			expect(inputPrompt).not.toHaveBeenCalled();
 		});
 
-		test("non-interactive: throws IgnoredBuildsError with parsed packages and never prompts", async ({
+		test("prompt approved: runs `pnpm approve-builds <pkgs>` and retries install once", async ({
 			expect,
 		}) => {
-			vi.mocked(runCommand).mockRejectedValueOnce(
-				pnpmIgnoredBuildsError("@parcel/watcher@2.5.6, lmdb@2.8.1")
-			);
-
-			let caught: unknown;
-			await npmInstall(ctx()).catch((e) => {
-				caught = e;
-			});
-
-			expect(isIgnoredBuildsError(caught)).toBe(true);
-			expect((caught as IgnoredBuildsError).packages).toEqual([
-				"@parcel/watcher",
-				"lmdb",
-			]);
-			expect(inputPrompt).not.toHaveBeenCalled();
-			expect(runCommand).toHaveBeenCalledTimes(1);
-		});
-
-		test("interactive + approved: runs `pnpm approve-builds <pkgs>` and retries install once", async ({
-			expect,
-		}) => {
-			vi.mocked(isInteractive).mockReturnValue(true);
 			vi.mocked(inputPrompt).mockResolvedValueOnce(true);
 			// 1) install fails with ignored builds, 2) approve-builds OK, 3) retry install OK
 			vi.mocked(runCommand)
@@ -125,6 +99,7 @@ describe("npmInstall", () => {
 
 			await npmInstall(ctx());
 
+			expect(inputPrompt).toHaveBeenCalledTimes(1);
 			expect(runCommand).toHaveBeenCalledTimes(3);
 			expect(vi.mocked(runCommand).mock.calls[0][0]).toEqual([
 				"pnpm",
@@ -142,10 +117,9 @@ describe("npmInstall", () => {
 			]);
 		});
 
-		test("interactive + declined: throws IgnoredBuildsError without running approve-builds", async ({
+		test("prompt declined: throws IgnoredBuildsError without running approve-builds", async ({
 			expect,
 		}) => {
-			vi.mocked(isInteractive).mockReturnValue(true);
 			vi.mocked(inputPrompt).mockResolvedValueOnce(false);
 			vi.mocked(runCommand).mockRejectedValueOnce(
 				pnpmIgnoredBuildsError("@parcel/watcher@2.5.6")
@@ -163,10 +137,48 @@ describe("npmInstall", () => {
 			expect(runCommand).toHaveBeenCalledTimes(1); // no approve-builds, no retry
 		});
 
+		test("prompt cancelled (no TTY / Ctrl-C): throws IgnoredBuildsError carrying the parsed list", async ({
+			expect,
+		}) => {
+			// inputPrompt with `throwOnError: true` throws CancelError when the
+			// prompt is cancelled — e.g. stdin is at EOF in a non-TTY CI shell,
+			// or the user hits Ctrl-C. We must surface a concise
+			// IgnoredBuildsError instead of letting the CancelError propagate.
+			vi.mocked(inputPrompt).mockRejectedValueOnce(
+				new CancelError("Operation cancelled")
+			);
+			vi.mocked(runCommand).mockRejectedValueOnce(
+				pnpmIgnoredBuildsError("@parcel/watcher@2.5.6, lmdb@2.8.1")
+			);
+
+			let caught: unknown;
+			await npmInstall(ctx()).catch((e) => {
+				caught = e;
+			});
+
+			expect(isIgnoredBuildsError(caught)).toBe(true);
+			expect((caught as IgnoredBuildsError).packages).toEqual([
+				"@parcel/watcher",
+				"lmdb",
+			]);
+			expect(runCommand).toHaveBeenCalledTimes(1); // no approve-builds, no retry
+		});
+
+		test("prompt errors for an unrelated reason: rethrows verbatim", async ({
+			expect,
+		}) => {
+			const promptErr = new Error("rendering broke");
+			vi.mocked(inputPrompt).mockRejectedValueOnce(promptErr);
+			vi.mocked(runCommand).mockRejectedValueOnce(
+				pnpmIgnoredBuildsError("@parcel/watcher@2.5.6")
+			);
+
+			await expect(npmInstall(ctx())).rejects.toBe(promptErr);
+		});
+
 		test("retry still fails with ignored builds: throws IgnoredBuildsError carrying the second list", async ({
 			expect,
 		}) => {
-			vi.mocked(isInteractive).mockReturnValue(true);
 			vi.mocked(inputPrompt).mockResolvedValueOnce(true);
 			vi.mocked(runCommand)
 				.mockRejectedValueOnce(pnpmIgnoredBuildsError("@parcel/watcher@2.5.6"))
@@ -185,7 +197,6 @@ describe("npmInstall", () => {
 		test("retry fails for an unrelated reason: rethrows verbatim", async ({
 			expect,
 		}) => {
-			vi.mocked(isInteractive).mockReturnValue(true);
 			vi.mocked(inputPrompt).mockResolvedValueOnce(true);
 			const retryErr = new Error("disk full");
 			vi.mocked(runCommand)
@@ -199,7 +210,6 @@ describe("npmInstall", () => {
 		test("unparseable ignored-builds error: throws IgnoredBuildsError with empty list", async ({
 			expect,
 		}) => {
-			vi.mocked(isInteractive).mockReturnValue(true);
 			// pnpm error without a recognisable `Ignored build scripts:` line
 			vi.mocked(runCommand).mockRejectedValueOnce(
 				new Error("[ERR_PNPM_IGNORED_BUILDS] something unexpected")

--- a/packages/create-cloudflare/src/helpers/__tests__/packages.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/packages.test.ts
@@ -71,8 +71,7 @@ describe("npmInstall", () => {
 			expect(runCommand).toHaveBeenCalledTimes(1);
 			const [cmd, opts] = vi.mocked(runCommand).mock.calls[0];
 			expect(cmd).toEqual(["pnpm", "install"]);
-			// We manage the spinner outside runCommand to suppress the noisy
-			// full-transcript dump on failure.
+			// Spinner managed outside runCommand to suppress noisy failure output.
 			expect(opts).toMatchObject({ silent: true, useSpinner: false });
 		});
 
@@ -140,10 +139,6 @@ describe("npmInstall", () => {
 		test("prompt cancelled (no TTY / Ctrl-C): throws IgnoredBuildsError carrying the parsed list", async ({
 			expect,
 		}) => {
-			// inputPrompt with `throwOnError: true` throws CancelError when the
-			// prompt is cancelled — e.g. stdin is at EOF in a non-TTY CI shell,
-			// or the user hits Ctrl-C. We must surface a concise
-			// IgnoredBuildsError instead of letting the CancelError propagate.
 			vi.mocked(inputPrompt).mockRejectedValueOnce(
 				new CancelError("Operation cancelled")
 			);

--- a/packages/create-cloudflare/src/helpers/__tests__/pnpmBuildApprovals.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/pnpmBuildApprovals.test.ts
@@ -37,8 +37,6 @@ describe("writePnpmBuildApprovals", () => {
 		expect(vi.mocked(writeFile)).toHaveBeenCalledTimes(1);
 		const [calledPath, calledContent] = vi.mocked(writeFile).mock.calls[0];
 		expect(calledPath).toBe(yamlPath);
-		// Approves exactly the three packages C3 itself requires, with real
-		// YAML boolean values (not a placeholder string).
 		expect(calledContent).toMatch(/^allowBuilds:$/m);
 		expect(calledContent).toMatch(/^ {2}esbuild: true$/m);
 		expect(calledContent).toMatch(/^ {2}workerd: true$/m);
@@ -48,8 +46,6 @@ describe("writePnpmBuildApprovals", () => {
 	test("writes the yaml for pnpm 10 as well (no version gate)", ({
 		expect,
 	}) => {
-		// pnpm 10 only warns by default, but writing the file is still correct
-		// and silences the warning. The helper is intentionally version-agnostic.
 		mockPackageManager("pnpm", "10.33.0");
 
 		writePnpmBuildApprovals(projectPath);
@@ -84,8 +80,7 @@ describe("writePnpmBuildApprovals", () => {
 	});
 
 	test("is a no-op when no package manager can be detected", ({ expect }) => {
-		// whichPmRuns returns undefined when c3 is invoked outside any PM.
-		// `detectPackageManager` then falls back to npm.
+		// Falls back to npm when c3 is invoked outside any PM.
 		vi.mocked(whichPMRuns).mockReturnValue(
 			undefined as unknown as ReturnType<typeof whichPMRuns>
 		);
@@ -102,8 +97,6 @@ describe("writePnpmBuildApprovals", () => {
 		vi.mocked(existsSync).mockImplementation(
 			(path) => path.toString() === yamlPath
 		);
-		// Existing file written by a framework generator's `pnpm install` on
-		// pnpm 11 — placeholders for everything pnpm flagged.
 		vi.mocked(readFile).mockReturnValue(
 			[
 				"allowBuilds:",
@@ -118,12 +111,11 @@ describe("writePnpmBuildApprovals", () => {
 
 		expect(vi.mocked(writeFile)).toHaveBeenCalledTimes(1);
 		const written = vi.mocked(writeFile).mock.calls[0][1] as string;
-		// Our own keys: placeholders converted to `true`.
+		// Our keys: placeholders → `true`; missing keys are added.
 		expect(written).toMatch(/^ {2}esbuild: true$/m);
 		expect(written).toMatch(/^ {2}sharp: true$/m);
-		// Our key that wasn't listed: added.
 		expect(written).toMatch(/^ {2}workerd: true$/m);
-		// Framework key: NOT touched — still the placeholder pnpm wrote.
+		// Framework key: untouched.
 		expect(written).toMatch(
 			/^ {2}'@parcel\/watcher': set this to true or false$/m
 		);
@@ -134,8 +126,6 @@ describe("writePnpmBuildApprovals", () => {
 		vi.mocked(existsSync).mockImplementation(
 			(path) => path.toString() === yamlPath
 		);
-		// The user (or a future C3 run) explicitly opted out of esbuild's
-		// postinstall. We respect that and only add the missing entries.
 		vi.mocked(readFile).mockReturnValue(
 			[
 				"allowBuilds:",
@@ -148,7 +138,6 @@ describe("writePnpmBuildApprovals", () => {
 
 		writePnpmBuildApprovals(projectPath);
 
-		// Every one of our keys is already present with an explicit decision.
 		expect(vi.mocked(writeFile)).not.toHaveBeenCalled();
 	});
 
@@ -185,10 +174,8 @@ describe("writePnpmBuildApprovals", () => {
 
 		expect(vi.mocked(writeFile)).toHaveBeenCalledTimes(1);
 		const written = vi.mocked(writeFile).mock.calls[0][1] as string;
-		// Original content is preserved.
 		expect(written).toMatch(/^packages:$/m);
 		expect(written).toMatch(/^ {2}- 'packages\/\*'$/m);
-		// New allowBuilds block at the end.
 		expect(written).toMatch(/^allowBuilds:$/m);
 		expect(written).toMatch(/^ {2}esbuild: true$/m);
 		expect(written).toMatch(/^ {2}workerd: true$/m);
@@ -225,7 +212,6 @@ describe("mergeAllowBuilds", () => {
 	});
 
 	test("never touches a value on a key that isn't ours", ({ expect }) => {
-		// `@parcel/watcher` is framework-introduced; we don't decide for it.
 		const input = [
 			"allowBuilds:",
 			"  esbuild: true",
@@ -268,14 +254,11 @@ describe("getPnpmIgnoredBuildsGuidance", () => {
 	test("points the user at pnpm approve-builds", ({ expect }) => {
 		const guidance = getPnpmIgnoredBuildsGuidance();
 		expect(guidance).toContain("pnpm approve-builds");
-		// Mentions that C3 deliberately doesn't approve framework builds.
 		expect(guidance).toMatch(/framework|own/i);
 	});
 
 	test("inlines the package list when one is known", ({ expect }) => {
 		const guidance = getPnpmIgnoredBuildsGuidance(["@parcel/watcher", "lmdb"]);
-		// The exact remediation command is surfaced verbatim so the user can
-		// copy-paste it into the generated project.
 		expect(guidance).toContain("pnpm approve-builds @parcel/watcher lmdb");
 	});
 
@@ -359,9 +342,7 @@ describe("IgnoredBuildsError", () => {
 		expect,
 	}) => {
 		expect(isIgnoredBuildsError(new IgnoredBuildsError(["x"]))).toBe(true);
-		// The raw runCommand error still trips `isPnpmIgnoredBuildsError`, but
-		// must NOT trip `isIgnoredBuildsError` (or the top-level handler would
-		// dump the raw transcript again).
+		// Raw pnpm errors trip `isPnpmIgnoredBuildsError` but not `isIgnoredBuildsError`.
 		const raw = new Error("[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: x");
 		expect(isIgnoredBuildsError(raw)).toBe(false);
 		expect(isPnpmIgnoredBuildsError(raw)).toBe(true);

--- a/packages/create-cloudflare/src/helpers/__tests__/pnpmBuildApprovals.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/pnpmBuildApprovals.test.ts
@@ -1,0 +1,271 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { readFile, writeFile } from "helpers/files";
+import {
+	getPnpmIgnoredBuildsGuidance,
+	isPnpmIgnoredBuildsError,
+	mergeAllowBuilds,
+	writePnpmBuildApprovals,
+} from "helpers/pnpmBuildApprovals";
+import { beforeEach, describe, test, vi } from "vitest";
+import whichPMRuns from "which-pm-runs";
+import { mockPackageManager } from "./mocks";
+
+vi.mock("fs");
+vi.mock("helpers/files");
+vi.mock("which-pm-runs");
+
+const projectPath = join("/path/to/my-project");
+const yamlPath = join(projectPath, "pnpm-workspace.yaml");
+
+describe("writePnpmBuildApprovals", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+		vi.mocked(existsSync).mockReturnValue(false);
+	});
+
+	test("writes a fresh yaml when pnpm is in use and no file exists", ({
+		expect,
+	}) => {
+		mockPackageManager("pnpm", "11.5.1");
+
+		writePnpmBuildApprovals(projectPath);
+
+		expect(vi.mocked(writeFile)).toHaveBeenCalledTimes(1);
+		const [calledPath, calledContent] = vi.mocked(writeFile).mock.calls[0];
+		expect(calledPath).toBe(yamlPath);
+		// Approves exactly the three packages C3 itself requires, with real
+		// YAML boolean values (not a placeholder string).
+		expect(calledContent).toMatch(/^allowBuilds:$/m);
+		expect(calledContent).toMatch(/^ {2}esbuild: true$/m);
+		expect(calledContent).toMatch(/^ {2}workerd: true$/m);
+		expect(calledContent).toMatch(/^ {2}sharp: true$/m);
+	});
+
+	test("writes the yaml for pnpm 10 as well (no version gate)", ({
+		expect,
+	}) => {
+		// pnpm 10 only warns by default, but writing the file is still correct
+		// and silences the warning. The helper is intentionally version-agnostic.
+		mockPackageManager("pnpm", "10.33.0");
+
+		writePnpmBuildApprovals(projectPath);
+
+		expect(vi.mocked(writeFile)).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(writeFile).mock.calls[0][0]).toBe(yamlPath);
+	});
+
+	test("is a no-op for npm", ({ expect }) => {
+		mockPackageManager("npm");
+
+		writePnpmBuildApprovals(projectPath);
+
+		expect(vi.mocked(writeFile)).not.toHaveBeenCalled();
+		expect(vi.mocked(readFile)).not.toHaveBeenCalled();
+	});
+
+	test("is a no-op for yarn", ({ expect }) => {
+		mockPackageManager("yarn", "3.5.1");
+
+		writePnpmBuildApprovals(projectPath);
+
+		expect(vi.mocked(writeFile)).not.toHaveBeenCalled();
+	});
+
+	test("is a no-op for bun", ({ expect }) => {
+		mockPackageManager("bun", "1.1.0");
+
+		writePnpmBuildApprovals(projectPath);
+
+		expect(vi.mocked(writeFile)).not.toHaveBeenCalled();
+	});
+
+	test("is a no-op when no package manager can be detected", ({ expect }) => {
+		// whichPmRuns returns undefined when c3 is invoked outside any PM.
+		// `detectPackageManager` then falls back to npm.
+		vi.mocked(whichPMRuns).mockReturnValue(
+			undefined as unknown as ReturnType<typeof whichPMRuns>
+		);
+
+		writePnpmBuildApprovals(projectPath);
+
+		expect(vi.mocked(writeFile)).not.toHaveBeenCalled();
+	});
+
+	test("converts our placeholders to true while leaving framework keys untouched", ({
+		expect,
+	}) => {
+		mockPackageManager("pnpm", "11.5.1");
+		vi.mocked(existsSync).mockImplementation(
+			(path) => path.toString() === yamlPath
+		);
+		// Existing file written by a framework generator's `pnpm install` on
+		// pnpm 11 — placeholders for everything pnpm flagged.
+		vi.mocked(readFile).mockReturnValue(
+			[
+				"allowBuilds:",
+				"  esbuild: set this to true or false",
+				"  '@parcel/watcher': set this to true or false",
+				"  sharp: set this to true or false",
+				"",
+			].join("\n")
+		);
+
+		writePnpmBuildApprovals(projectPath);
+
+		expect(vi.mocked(writeFile)).toHaveBeenCalledTimes(1);
+		const written = vi.mocked(writeFile).mock.calls[0][1] as string;
+		// Our own keys: placeholders converted to `true`.
+		expect(written).toMatch(/^ {2}esbuild: true$/m);
+		expect(written).toMatch(/^ {2}sharp: true$/m);
+		// Our key that wasn't listed: added.
+		expect(written).toMatch(/^ {2}workerd: true$/m);
+		// Framework key: NOT touched — still the placeholder pnpm wrote.
+		expect(written).toMatch(
+			/^ {2}'@parcel\/watcher': set this to true or false$/m
+		);
+	});
+
+	test("respects an explicit `false` for one of our keys", ({ expect }) => {
+		mockPackageManager("pnpm", "11.5.1");
+		vi.mocked(existsSync).mockImplementation(
+			(path) => path.toString() === yamlPath
+		);
+		// The user (or a future C3 run) explicitly opted out of esbuild's
+		// postinstall. We respect that and only add the missing entries.
+		vi.mocked(readFile).mockReturnValue(
+			[
+				"allowBuilds:",
+				"  esbuild: false",
+				"  workerd: true",
+				"  sharp: true",
+				"",
+			].join("\n")
+		);
+
+		writePnpmBuildApprovals(projectPath);
+
+		// Every one of our keys is already present with an explicit decision.
+		expect(vi.mocked(writeFile)).not.toHaveBeenCalled();
+	});
+
+	test("is a no-op when all our keys are already approved", ({ expect }) => {
+		mockPackageManager("pnpm", "11.5.1");
+		vi.mocked(existsSync).mockImplementation(
+			(path) => path.toString() === yamlPath
+		);
+		vi.mocked(readFile).mockReturnValue(
+			[
+				"allowBuilds:",
+				"  esbuild: true",
+				"  workerd: true",
+				"  sharp: true",
+				"",
+			].join("\n")
+		);
+
+		writePnpmBuildApprovals(projectPath);
+
+		expect(vi.mocked(writeFile)).not.toHaveBeenCalled();
+	});
+
+	test("appends an allowBuilds block when the file has none", ({ expect }) => {
+		mockPackageManager("pnpm", "11.5.1");
+		vi.mocked(existsSync).mockImplementation(
+			(path) => path.toString() === yamlPath
+		);
+		vi.mocked(readFile).mockReturnValue(
+			["packages:", "  - 'packages/*'", ""].join("\n")
+		);
+
+		writePnpmBuildApprovals(projectPath);
+
+		expect(vi.mocked(writeFile)).toHaveBeenCalledTimes(1);
+		const written = vi.mocked(writeFile).mock.calls[0][1] as string;
+		// Original content is preserved.
+		expect(written).toMatch(/^packages:$/m);
+		expect(written).toMatch(/^ {2}- 'packages\/\*'$/m);
+		// New allowBuilds block at the end.
+		expect(written).toMatch(/^allowBuilds:$/m);
+		expect(written).toMatch(/^ {2}esbuild: true$/m);
+		expect(written).toMatch(/^ {2}workerd: true$/m);
+		expect(written).toMatch(/^ {2}sharp: true$/m);
+	});
+});
+
+describe("mergeAllowBuilds", () => {
+	test("preserves CRLF line endings on Windows-style input", ({ expect }) => {
+		const input = [
+			"allowBuilds:",
+			"  esbuild: set this to true or false",
+			"  workerd: set this to true or false",
+			"  sharp: set this to true or false",
+			"",
+		].join("\r\n");
+
+		const output = mergeAllowBuilds(input);
+
+		expect(output).toContain("\r\n");
+		expect(output).toMatch(/^ {2}esbuild: true$/m);
+	});
+
+	test("never flips an explicit boolean on one of our keys", ({ expect }) => {
+		const input = [
+			"allowBuilds:",
+			"  esbuild: false",
+			"  workerd: true",
+			"  sharp: true",
+			"",
+		].join("\n");
+
+		expect(mergeAllowBuilds(input)).toBe(input);
+	});
+
+	test("never touches a value on a key that isn't ours", ({ expect }) => {
+		// `@parcel/watcher` is framework-introduced; we don't decide for it.
+		const input = [
+			"allowBuilds:",
+			"  esbuild: true",
+			"  workerd: true",
+			"  sharp: true",
+			"  '@parcel/watcher': set this to true or false",
+			"  '@swc/core': false",
+			"",
+		].join("\n");
+
+		expect(mergeAllowBuilds(input)).toBe(input);
+	});
+});
+
+describe("isPnpmIgnoredBuildsError", () => {
+	test("matches pnpm's error code substring", ({ expect }) => {
+		const err = new Error(
+			"[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild, sharp, workerd"
+		);
+		expect(isPnpmIgnoredBuildsError(err)).toBe(true);
+	});
+
+	test("returns false for unrelated errors", ({ expect }) => {
+		expect(isPnpmIgnoredBuildsError(new Error("network timed out"))).toBe(
+			false
+		);
+	});
+
+	test("returns false for non-Error values", ({ expect }) => {
+		expect(isPnpmIgnoredBuildsError("ERR_PNPM_IGNORED_BUILDS")).toBe(false);
+		expect(isPnpmIgnoredBuildsError(undefined)).toBe(false);
+		expect(isPnpmIgnoredBuildsError(null)).toBe(false);
+		expect(
+			isPnpmIgnoredBuildsError({ message: "ERR_PNPM_IGNORED_BUILDS" })
+		).toBe(false);
+	});
+});
+
+describe("getPnpmIgnoredBuildsGuidance", () => {
+	test("points the user at pnpm approve-builds", ({ expect }) => {
+		const guidance = getPnpmIgnoredBuildsGuidance();
+		expect(guidance).toContain("pnpm approve-builds");
+		// Mentions that C3 deliberately doesn't approve framework builds.
+		expect(guidance).toMatch(/framework|own/i);
+	});
+});

--- a/packages/create-cloudflare/src/helpers/__tests__/pnpmBuildApprovals.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/pnpmBuildApprovals.test.ts
@@ -2,7 +2,10 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { readFile, writeFile } from "helpers/files";
 import {
+	extractIgnoredBuildPackages,
 	getPnpmIgnoredBuildsGuidance,
+	IgnoredBuildsError,
+	isIgnoredBuildsError,
 	isPnpmIgnoredBuildsError,
 	mergeAllowBuilds,
 	writePnpmBuildApprovals,
@@ -267,5 +270,106 @@ describe("getPnpmIgnoredBuildsGuidance", () => {
 		expect(guidance).toContain("pnpm approve-builds");
 		// Mentions that C3 deliberately doesn't approve framework builds.
 		expect(guidance).toMatch(/framework|own/i);
+	});
+
+	test("inlines the package list when one is known", ({ expect }) => {
+		const guidance = getPnpmIgnoredBuildsGuidance(["@parcel/watcher", "lmdb"]);
+		// The exact remediation command is surfaced verbatim so the user can
+		// copy-paste it into the generated project.
+		expect(guidance).toContain("pnpm approve-builds @parcel/watcher lmdb");
+	});
+
+	test("falls back to the bare command when no packages are known", ({
+		expect,
+	}) => {
+		const guidance = getPnpmIgnoredBuildsGuidance([]);
+		expect(guidance).toMatch(/^ {2}pnpm approve-builds$/m);
+	});
+});
+
+describe("extractIgnoredBuildPackages", () => {
+	test("parses a single flagged package with version suffix", ({ expect }) => {
+		const err = new Error(
+			[
+				"Packages: +442",
+				"Progress: resolved 527, reused 205, downloaded 239, added 442, done",
+				"",
+				"[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @parcel/watcher@2.5.6",
+				"",
+				'Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.',
+			].join("\n")
+		);
+		expect(extractIgnoredBuildPackages(err)).toEqual(["@parcel/watcher"]);
+	});
+
+	test("parses multiple comma-separated packages and dedupes", ({ expect }) => {
+		const err = new Error(
+			"[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @parcel/watcher@2.5.6, lmdb@2.8.1, esbuild@0.27.7, lmdb@2.8.1"
+		);
+		expect(extractIgnoredBuildPackages(err)).toEqual([
+			"@parcel/watcher",
+			"lmdb",
+			"esbuild",
+		]);
+	});
+
+	test("handles unscoped and scoped packages without version suffixes", ({
+		expect,
+	}) => {
+		const err = new Error(
+			"[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild, @swc/core"
+		);
+		expect(extractIgnoredBuildPackages(err)).toEqual(["esbuild", "@swc/core"]);
+	});
+
+	test("accepts a raw string in addition to an Error", ({ expect }) => {
+		expect(
+			extractIgnoredBuildPackages(
+				"[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: sharp@0.34.5"
+			)
+		).toEqual(["sharp"]);
+	});
+
+	test("returns an empty array when no list can be parsed", ({ expect }) => {
+		expect(extractIgnoredBuildPackages(new Error("network timeout"))).toEqual(
+			[]
+		);
+		expect(extractIgnoredBuildPackages(undefined)).toEqual([]);
+		expect(extractIgnoredBuildPackages(null)).toEqual([]);
+		expect(extractIgnoredBuildPackages({ message: "anything" })).toEqual([]);
+	});
+});
+
+describe("IgnoredBuildsError", () => {
+	test("renders the parsed package list in the message", ({ expect }) => {
+		const err = new IgnoredBuildsError(["@parcel/watcher", "lmdb"]);
+		expect(err.message).toContain("@parcel/watcher");
+		expect(err.message).toContain("lmdb");
+		expect(err.packages).toEqual(["@parcel/watcher", "lmdb"]);
+	});
+
+	test("falls back to a placeholder when no packages are known", ({
+		expect,
+	}) => {
+		const err = new IgnoredBuildsError([]);
+		expect(err.message).toMatch(/unknown/);
+	});
+
+	test("`isIgnoredBuildsError` discriminates on instance, not message text", ({
+		expect,
+	}) => {
+		expect(isIgnoredBuildsError(new IgnoredBuildsError(["x"]))).toBe(true);
+		// The raw runCommand error still trips `isPnpmIgnoredBuildsError`, but
+		// must NOT trip `isIgnoredBuildsError` (or the top-level handler would
+		// dump the raw transcript again).
+		const raw = new Error("[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: x");
+		expect(isIgnoredBuildsError(raw)).toBe(false);
+		expect(isPnpmIgnoredBuildsError(raw)).toBe(true);
+	});
+
+	test("preserves the underlying pnpm error as `cause`", ({ expect }) => {
+		const original = new Error("raw pnpm output");
+		const wrapped = new IgnoredBuildsError(["sharp"], original);
+		expect(wrapped.cause).toBe(original);
 	});
 });

--- a/packages/create-cloudflare/src/helpers/packages.ts
+++ b/packages/create-cloudflare/src/helpers/packages.ts
@@ -175,6 +175,15 @@ const promptOrEOF = async (packages: string[]): Promise<boolean> => {
 		process.stdin.resume();
 	});
 
+	// Attach a silent error handler to the prompt so a late rejection from
+	// clack (e.g. because stdin closed *after* the EOF race already won)
+	// can't surface as an unhandled rejection. `Promise.race` below also
+	// attaches handlers to both inputs, so in practice this is already
+	// covered today, but this extra `.catch` makes the safety property
+	// explicit and future-proofs against any change in Node's
+	// unhandled-rejection policy.
+	prompt.catch(() => {});
+
 	try {
 		return await Promise.race([prompt, eof]);
 	} finally {

--- a/packages/create-cloudflare/src/helpers/packages.ts
+++ b/packages/create-cloudflare/src/helpers/packages.ts
@@ -3,9 +3,9 @@ import nodePath from "node:path";
 import { updateStatus } from "@cloudflare/cli-shared-helpers";
 import { brandColor, dim, red } from "@cloudflare/cli-shared-helpers/colors";
 import { runCommand } from "@cloudflare/cli-shared-helpers/command";
+import { CancelError } from "@cloudflare/cli-shared-helpers/error";
 import {
 	inputPrompt,
-	isInteractive,
 	spinner,
 } from "@cloudflare/cli-shared-helpers/interactive";
 import * as cliPackages from "@cloudflare/cli-shared-helpers/packages";
@@ -107,10 +107,14 @@ const runPnpmInstallQuiet = async (
  *      scripts, rethrow.
  *   3. If pnpm refused to run dependency build scripts, parse the flagged
  *      package list.
- *      - If we couldn't parse the list, or we're not running interactively
- *        (CI), throw an `IgnoredBuildsError` carrying whatever we did parse;
- *        the top-level handler renders a concise message + guidance.
+ *      - If we couldn't parse the list, throw an `IgnoredBuildsError` with
+ *        an empty list; the top-level handler renders a concise message +
+ *        guidance.
  *      - Otherwise, prompt the user to approve those packages and retry.
+ *      - If the prompt is cancelled (no TTY / closed stdin / Ctrl-C) or the
+ *        user declines, throw an `IgnoredBuildsError` carrying the parsed
+ *        list. The top-level handler renders concise guidance instead of
+ *        the raw pnpm transcript.
  *   4. If they confirm, run `pnpm approve-builds <pkgs>` (deterministic and
  *      non-interactive when packages are passed explicitly) and re-run the
  *      install once. A second failure becomes an `IgnoredBuildsError`.
@@ -126,6 +130,57 @@ const pnpmInstallWithBuildApprovalRetry = async (
 			throw err;
 		}
 		await recoverFromIgnoredBuilds(npm, err);
+	}
+};
+
+/**
+ * Sentinel error used to distinguish "stdin closed before the prompt was
+ * answered" from a normal `CancelError` (which clack throws when the user
+ * cancels an interactive prompt). Both map to `IgnoredBuildsError` for the
+ * user, but keeping the sentinel internal keeps the intent clear.
+ */
+const STDIN_EOF_MARKER = "__c3_stdin_eof__";
+const isStdinEOFError = (err: unknown): boolean =>
+	err instanceof Error && err.message === STDIN_EOF_MARKER;
+
+/**
+ * Race the approve-builds confirm prompt against stdin's `end` event. In a
+ * TTY the event never fires. In the e2e harness, the harness writes to stdin
+ * before EOF and the prompt resolves first. In a fully non-interactive
+ * shell (e.g. `pnpm create cloudflare < /dev/null`) stdin EOFs immediately,
+ * the event loop would otherwise drain and the process would silently exit
+ * with code 0; here we reject with a sentinel that the caller converts to
+ * `IgnoredBuildsError`.
+ */
+const promptOrEOF = async (packages: string[]): Promise<boolean> => {
+	const prompt = inputPrompt<boolean>({
+		type: "confirm",
+		question: `Run \`pnpm approve-builds ${packages.join(" ")}\` and retry the install?`,
+		label: "approve-builds",
+		defaultValue: true,
+		throwOnError: true,
+	});
+
+	if (process.stdin.isTTY) {
+		// A real terminal won't EOF on its own; no need for the race.
+		return prompt;
+	}
+
+	let onEnd: (() => void) | undefined;
+	const eof = new Promise<boolean>((_, reject) => {
+		onEnd = () => reject(new Error(STDIN_EOF_MARKER));
+		process.stdin.once("end", onEnd);
+		// `resume()` keeps the event loop alive long enough for the `end`
+		// event to fire even when nothing else is reading stdin.
+		process.stdin.resume();
+	});
+
+	try {
+		return await Promise.race([prompt, eof]);
+	} finally {
+		if (onEnd) {
+			process.stdin.removeListener("end", onEnd);
+		}
 	}
 };
 
@@ -145,18 +200,25 @@ const recoverFromIgnoredBuilds = async (
 		`${red("pnpm refused to run build scripts for:")} ${packages.join(", ")}`
 	);
 
-	if (!isInteractive()) {
-		// CI / non-TTY: don't auto-approve framework-introduced build scripts.
-		throw new IgnoredBuildsError(packages, originalErr);
+	// Drive recovery through the same prompt the e2e harness already knows how
+	// to answer. In a real interactive shell the user types y/n. In the e2e
+	// harness, a background responder writes Enter when it sees this question
+	// (see `runC3` in e2e/helpers/run-c3.ts).
+	//
+	// In a fully non-interactive shell (no TTY, stdin already at EOF) clack
+	// has no input to read; without intervention the event loop drains and
+	// the process exits silently with code 0. To turn that into a clean,
+	// actionable error we race the prompt against stdin's `end` event and
+	// convert the EOF to an `IgnoredBuildsError` carrying the parsed list.
+	let approve: boolean;
+	try {
+		approve = await promptOrEOF(packages);
+	} catch (promptErr) {
+		if (promptErr instanceof CancelError || isStdinEOFError(promptErr)) {
+			throw new IgnoredBuildsError(packages, originalErr);
+		}
+		throw promptErr;
 	}
-
-	const approve = await inputPrompt<boolean>({
-		type: "confirm",
-		question: `Run \`pnpm approve-builds ${packages.join(" ")}\` and retry the install?`,
-		label: "approve-builds",
-		defaultValue: true,
-		throwOnError: true,
-	});
 
 	if (!approve) {
 		throw new IgnoredBuildsError(packages, originalErr);

--- a/packages/create-cloudflare/src/helpers/packages.ts
+++ b/packages/create-cloudflare/src/helpers/packages.ts
@@ -1,10 +1,21 @@
 import { existsSync } from "node:fs";
 import nodePath from "node:path";
-import { brandColor, dim } from "@cloudflare/cli-shared-helpers/colors";
+import { updateStatus } from "@cloudflare/cli-shared-helpers";
+import { brandColor, dim, red } from "@cloudflare/cli-shared-helpers/colors";
 import { runCommand } from "@cloudflare/cli-shared-helpers/command";
+import {
+	inputPrompt,
+	isInteractive,
+	spinner,
+} from "@cloudflare/cli-shared-helpers/interactive";
 import * as cliPackages from "@cloudflare/cli-shared-helpers/packages";
 import { fetch } from "undici";
 import { detectPackageManager } from "./packageManagers";
+import {
+	extractIgnoredBuildPackages,
+	IgnoredBuildsError,
+	isPnpmIgnoredBuildsError,
+} from "./pnpmBuildApprovals";
 import type { C3Context } from "types";
 
 type InstallConfig = {
@@ -38,6 +49,11 @@ export async function installWrangler() {
 
 /**
  * Install dependencies in the project directory via `npm install` or its equivalent.
+ *
+ * For pnpm, we handle `ERR_PNPM_IGNORED_BUILDS` specially: instead of dumping
+ * the full pnpm transcript to the user, we parse the flagged packages and (in
+ * an interactive shell) offer to run `pnpm approve-builds <pkg>...` and retry
+ * the install once. See `pnpmInstallWithBuildApprovalRetry`.
  */
 export const npmInstall = async (ctx: C3Context) => {
 	// Skip this step if packages have already been installed
@@ -48,11 +64,125 @@ export const npmInstall = async (ctx: C3Context) => {
 
 	const { npm } = detectPackageManager();
 
+	if (npm === "pnpm") {
+		await pnpmInstallWithBuildApprovalRetry(npm);
+		return;
+	}
+
 	await runCommand([npm, "install"], {
 		silent: true,
 		startText: "Installing dependencies",
 		doneText: `${brandColor("installed")} ${dim(`via \`${npm} install\``)}`,
 	});
+};
+
+/**
+ * Run `pnpm install` quietly under our own spinner. We use `useSpinner: false`
+ * to disable `runCommand`'s built-in spinner so that, on failure, we don't
+ * dump the entire captured pnpm transcript into the spinner's stop line.
+ * The caller is responsible for interpreting any thrown error.
+ */
+const runPnpmInstallQuiet = async (
+	npm: string,
+	startText: string
+): Promise<void> => {
+	const s = spinner();
+	s.start(startText);
+	try {
+		await runCommand([npm, "install"], { silent: true, useSpinner: false });
+		s.stop(`${brandColor("installed")} ${dim(`via \`${npm} install\``)}`);
+	} catch (err) {
+		// Show a one-line failure; the caller decides whether to print more.
+		s.stop(red("install failed"));
+		throw err;
+	}
+};
+
+/**
+ * Drives a pnpm install with a single-shot recovery path for
+ * `ERR_PNPM_IGNORED_BUILDS`:
+ *
+ *   1. Try `pnpm install`.
+ *   2. If the install fails for any reason _other than_ ignored build
+ *      scripts, rethrow.
+ *   3. If pnpm refused to run dependency build scripts, parse the flagged
+ *      package list.
+ *      - If we couldn't parse the list, or we're not running interactively
+ *        (CI), throw an `IgnoredBuildsError` carrying whatever we did parse;
+ *        the top-level handler renders a concise message + guidance.
+ *      - Otherwise, prompt the user to approve those packages and retry.
+ *   4. If they confirm, run `pnpm approve-builds <pkgs>` (deterministic and
+ *      non-interactive when packages are passed explicitly) and re-run the
+ *      install once. A second failure becomes an `IgnoredBuildsError`.
+ */
+const pnpmInstallWithBuildApprovalRetry = async (
+	npm: string
+): Promise<void> => {
+	try {
+		await runPnpmInstallQuiet(npm, "Installing dependencies");
+		return;
+	} catch (err) {
+		if (!isPnpmIgnoredBuildsError(err)) {
+			throw err;
+		}
+		await recoverFromIgnoredBuilds(npm, err);
+	}
+};
+
+const recoverFromIgnoredBuilds = async (
+	npm: string,
+	originalErr: Error
+): Promise<void> => {
+	const packages = extractIgnoredBuildPackages(originalErr);
+
+	if (packages.length === 0) {
+		// pnpm flagged ignored builds but we couldn't parse the list — bail
+		// out with a clean error rather than guess.
+		throw new IgnoredBuildsError([], originalErr);
+	}
+
+	updateStatus(
+		`${red("pnpm refused to run build scripts for:")} ${packages.join(", ")}`
+	);
+
+	if (!isInteractive()) {
+		// CI / non-TTY: don't auto-approve framework-introduced build scripts.
+		throw new IgnoredBuildsError(packages, originalErr);
+	}
+
+	const approve = await inputPrompt<boolean>({
+		type: "confirm",
+		question: `Run \`pnpm approve-builds ${packages.join(" ")}\` and retry the install?`,
+		label: "approve-builds",
+		defaultValue: true,
+		throwOnError: true,
+	});
+
+	if (!approve) {
+		throw new IgnoredBuildsError(packages, originalErr);
+	}
+
+	// `pnpm approve-builds <pkg>...` is non-interactive when packages are
+	// listed explicitly; it writes them to `pnpm-workspace.yaml#allowBuilds`
+	// (matching the format `writePnpmBuildApprovals` already uses) and runs
+	// their build scripts in place.
+	await runCommand([npm, "approve-builds", ...packages], {
+		silent: true,
+		startText: "Approving dependency build scripts",
+		doneText: `${brandColor("approved")} ${dim(packages.join(", "))}`,
+	});
+
+	try {
+		await runPnpmInstallQuiet(npm, "Re-running install");
+	} catch (retryErr) {
+		if (isPnpmIgnoredBuildsError(retryErr)) {
+			throw new IgnoredBuildsError(
+				extractIgnoredBuildPackages(retryErr),
+				retryErr
+			);
+		}
+		throw retryErr;
+	}
 };
 
 type NpmInfoResponse = {

--- a/packages/create-cloudflare/src/helpers/packages.ts
+++ b/packages/create-cloudflare/src/helpers/packages.ts
@@ -49,11 +49,6 @@ export async function installWrangler() {
 
 /**
  * Install dependencies in the project directory via `npm install` or its equivalent.
- *
- * For pnpm, we handle `ERR_PNPM_IGNORED_BUILDS` specially: instead of dumping
- * the full pnpm transcript to the user, we parse the flagged packages and (in
- * an interactive shell) offer to run `pnpm approve-builds <pkg>...` and retry
- * the install once. See `pnpmInstallWithBuildApprovalRetry`.
  */
 export const npmInstall = async (ctx: C3Context) => {
 	// Skip this step if packages have already been installed
@@ -77,10 +72,8 @@ export const npmInstall = async (ctx: C3Context) => {
 };
 
 /**
- * Run `pnpm install` quietly under our own spinner. We use `useSpinner: false`
- * to disable `runCommand`'s built-in spinner so that, on failure, we don't
- * dump the entire captured pnpm transcript into the spinner's stop line.
- * The caller is responsible for interpreting any thrown error.
+ * Run `pnpm install` under our own spinner so that on failure we don't dump
+ * the captured pnpm transcript into the spinner's stop line.
  */
 const runPnpmInstallQuiet = async (
 	npm: string,
@@ -92,33 +85,11 @@ const runPnpmInstallQuiet = async (
 		await runCommand([npm, "install"], { silent: true, useSpinner: false });
 		s.stop(`${brandColor("installed")} ${dim(`via \`${npm} install\``)}`);
 	} catch (err) {
-		// Show a one-line failure; the caller decides whether to print more.
 		s.stop(red("install failed"));
 		throw err;
 	}
 };
 
-/**
- * Drives a pnpm install with a single-shot recovery path for
- * `ERR_PNPM_IGNORED_BUILDS`:
- *
- *   1. Try `pnpm install`.
- *   2. If the install fails for any reason _other than_ ignored build
- *      scripts, rethrow.
- *   3. If pnpm refused to run dependency build scripts, parse the flagged
- *      package list.
- *      - If we couldn't parse the list, throw an `IgnoredBuildsError` with
- *        an empty list; the top-level handler renders a concise message +
- *        guidance.
- *      - Otherwise, prompt the user to approve those packages and retry.
- *      - If the prompt is cancelled (no TTY / closed stdin / Ctrl-C) or the
- *        user declines, throw an `IgnoredBuildsError` carrying the parsed
- *        list. The top-level handler renders concise guidance instead of
- *        the raw pnpm transcript.
- *   4. If they confirm, run `pnpm approve-builds <pkgs>` (deterministic and
- *      non-interactive when packages are passed explicitly) and re-run the
- *      install once. A second failure becomes an `IgnoredBuildsError`.
- */
 const pnpmInstallWithBuildApprovalRetry = async (
 	npm: string
 ): Promise<void> => {
@@ -133,24 +104,18 @@ const pnpmInstallWithBuildApprovalRetry = async (
 	}
 };
 
-/**
- * Sentinel error used to distinguish "stdin closed before the prompt was
- * answered" from a normal `CancelError` (which clack throws when the user
- * cancels an interactive prompt). Both map to `IgnoredBuildsError` for the
- * user, but keeping the sentinel internal keeps the intent clear.
- */
+// Sentinel for "stdin closed before the prompt was answered", to
+// distinguish from a normal `CancelError`. Both map to `IgnoredBuildsError`.
 const STDIN_EOF_MARKER = "__c3_stdin_eof__";
 const isStdinEOFError = (err: unknown): boolean =>
 	err instanceof Error && err.message === STDIN_EOF_MARKER;
 
 /**
  * Race the approve-builds confirm prompt against stdin's `end` event. In a
- * TTY the event never fires. In the e2e harness, the harness writes to stdin
- * before EOF and the prompt resolves first. In a fully non-interactive
- * shell (e.g. `pnpm create cloudflare < /dev/null`) stdin EOFs immediately,
- * the event loop would otherwise drain and the process would silently exit
- * with code 0; here we reject with a sentinel that the caller converts to
- * `IgnoredBuildsError`.
+ * TTY the event never fires; in the e2e harness the prompt resolves first;
+ * in a fully non-interactive shell (no TTY, stdin at EOF) we reject with a
+ * sentinel so the caller can convert it to `IgnoredBuildsError` instead of
+ * letting the process exit silently with code 0.
  */
 const promptOrEOF = async (packages: string[]): Promise<boolean> => {
 	const prompt = inputPrompt<boolean>({
@@ -161,8 +126,8 @@ const promptOrEOF = async (packages: string[]): Promise<boolean> => {
 		throwOnError: true,
 	});
 
+	// A real terminal won't EOF on its own; no need for the race.
 	if (process.stdin.isTTY) {
-		// A real terminal won't EOF on its own; no need for the race.
 		return prompt;
 	}
 
@@ -170,18 +135,12 @@ const promptOrEOF = async (packages: string[]): Promise<boolean> => {
 	const eof = new Promise<boolean>((_, reject) => {
 		onEnd = () => reject(new Error(STDIN_EOF_MARKER));
 		process.stdin.once("end", onEnd);
-		// `resume()` keeps the event loop alive long enough for the `end`
-		// event to fire even when nothing else is reading stdin.
+		// Keep the event loop alive so the `end` event can fire.
 		process.stdin.resume();
 	});
 
-	// Attach a silent error handler to the prompt so a late rejection from
-	// clack (e.g. because stdin closed *after* the EOF race already won)
-	// can't surface as an unhandled rejection. `Promise.race` below also
-	// attaches handlers to both inputs, so in practice this is already
-	// covered today, but this extra `.catch` makes the safety property
-	// explicit and future-proofs against any change in Node's
-	// unhandled-rejection policy.
+	// Swallow late prompt rejections (e.g. after EOF wins the race) so they
+	// don't surface as unhandled rejections.
 	prompt.catch(() => {});
 
 	try {
@@ -200,8 +159,8 @@ const recoverFromIgnoredBuilds = async (
 	const packages = extractIgnoredBuildPackages(originalErr);
 
 	if (packages.length === 0) {
-		// pnpm flagged ignored builds but we couldn't parse the list — bail
-		// out with a clean error rather than guess.
+		// Flagged ignored builds but couldn't parse the list — bail out
+		// rather than guess.
 		throw new IgnoredBuildsError([], originalErr);
 	}
 
@@ -209,16 +168,6 @@ const recoverFromIgnoredBuilds = async (
 		`${red("pnpm refused to run build scripts for:")} ${packages.join(", ")}`
 	);
 
-	// Drive recovery through the same prompt the e2e harness already knows how
-	// to answer. In a real interactive shell the user types y/n. In the e2e
-	// harness, a background responder writes Enter when it sees this question
-	// (see `runC3` in e2e/helpers/run-c3.ts).
-	//
-	// In a fully non-interactive shell (no TTY, stdin already at EOF) clack
-	// has no input to read; without intervention the event loop drains and
-	// the process exits silently with code 0. To turn that into a clean,
-	// actionable error we race the prompt against stdin's `end` event and
-	// convert the EOF to an `IgnoredBuildsError` carrying the parsed list.
 	let approve: boolean;
 	try {
 		approve = await promptOrEOF(packages);
@@ -233,10 +182,7 @@ const recoverFromIgnoredBuilds = async (
 		throw new IgnoredBuildsError(packages, originalErr);
 	}
 
-	// `pnpm approve-builds <pkg>...` is non-interactive when packages are
-	// listed explicitly; it writes them to `pnpm-workspace.yaml#allowBuilds`
-	// (matching the format `writePnpmBuildApprovals` already uses) and runs
-	// their build scripts in place.
+	// Non-interactive when packages are listed explicitly.
 	await runCommand([npm, "approve-builds", ...packages], {
 		silent: true,
 		startText: "Approving dependency build scripts",

--- a/packages/create-cloudflare/src/helpers/pnpmBuildApprovals.ts
+++ b/packages/create-cloudflare/src/helpers/pnpmBuildApprovals.ts
@@ -3,45 +3,17 @@ import { join } from "node:path";
 import { readFile, writeFile } from "./files";
 import { detectPackageManager } from "./packageManagers";
 
-/**
- * Build-script packages that C3 itself requires through the dependencies it
- * installs (wrangler → `esbuild`, `workerd`; wrangler → miniflare → `sharp`).
- * These are the only packages C3 pre-approves; build scripts introduced by a
- * framework generator (`@parcel/watcher`, `@swc/core`, `lmdb`, …) are the
- * generator's or the user's responsibility, not ours.
- *
- * Listing a package here that isn't actually in the dependency graph is a
- * no-op: pnpm only consults `allowBuilds` entries for packages it resolves.
- */
+// Build-script packages C3 pre-approves: wrangler depends on `esbuild` and
+// `workerd`, and (via miniflare) on `sharp`. Framework-introduced build
+// scripts are out of scope.
 const APPROVED_BUILDS = ["esbuild", "workerd", "sharp"] as const;
 const APPROVED_BUILDS_SET = new Set<string>(APPROVED_BUILDS);
 
 /**
- * pnpm 10.x defaults `strictDepBuilds` to `false`, so dependency build scripts
- * that haven't been explicitly approved produce a warning and the install
- * still succeeds. pnpm 11.x flipped that default to `true`, so the same
- * situation fails the install with `ERR_PNPM_IGNORED_BUILDS`.
- *
- * Wrangler depends on `workerd` and `esbuild`, and (via miniflare) on `sharp`.
- * Without pre-approval, every C3 scaffold that installs Wrangler will fail on
- * pnpm 11. This helper writes — or minimally merges into — a
- * `pnpm-workspace.yaml` in the generated project that approves exactly those
- * three packages.
- *
- * Behaviour:
- *
- * 1. **No existing `pnpm-workspace.yaml`** — write a fresh file approving
- *    `esbuild`, `workerd`, `sharp`.
- * 2. **Existing file, no `allowBuilds` block** — append our `allowBuilds`
- *    block at the end, leaving the rest of the file untouched.
- * 3. **Existing file with `allowBuilds`** — for *our* three keys only:
- *    convert a placeholder value (anything other than `true`/`false`) to
- *    `true`; add the entry if it's missing; respect an explicit
- *    `true`/`false` if the user (or a generator) already decided.
- *    **Never** touch any other entry — framework-introduced build approvals
- *    are out of scope for C3.
- *
- * No-op for non-pnpm package managers.
+ * Write or merge `allowBuilds` entries for `APPROVED_BUILDS` into the
+ * generated project's `pnpm-workspace.yaml`. Without these, pnpm 11+ aborts
+ * the install with `ERR_PNPM_IGNORED_BUILDS`. No-op for non-pnpm package
+ * managers. Preserves any pre-existing entries the user/generator added.
  */
 export const writePnpmBuildApprovals = (projectPath: string) => {
 	const { npm } = detectPackageManager();
@@ -70,9 +42,7 @@ const FRESH_HEADER = [
 	"# aborts the install with ERR_PNPM_IGNORED_BUILDS.",
 ];
 
-// Scoped package names start with `@`, which YAML 1.1 parsers may interpret
-// as a node anchor reference. Quote those to be safe; everything else is a
-// plain identifier and doesn't need quoting.
+// Quote scoped names (`@…`) so YAML 1.1 doesn't treat `@` as a node anchor.
 const formatEntry = (pkg: string) =>
 	pkg.startsWith("@") ? `  '${pkg}': true` : `  ${pkg}: true`;
 
@@ -84,15 +54,10 @@ const freshWorkspaceYaml = () =>
 		"",
 	].join("\n");
 
-// Matches a YAML entry inside `allowBuilds:` indented 2 spaces, capturing the
-// key (optionally single- or double-quoted, allowing `@scope/name`) and the
-// raw value.
+// Captures a 2-space-indented YAML entry: key (optionally quoted) and value.
 const ALLOW_BUILDS_ENTRY = /^( {2})(['"]?)([^'":]+)\2:\s*(.*)$/;
 
-/**
- * Merge approvals for our own build-script packages into an existing
- * `pnpm-workspace.yaml` body. Exported for unit testing.
- */
+/** Exported for unit testing. */
 export const mergeAllowBuilds = (original: string): string => {
 	const eol = detectEol(original);
 	const lines = original.split(/\r?\n/);
@@ -100,7 +65,7 @@ export const mergeAllowBuilds = (original: string): string => {
 	const headerIdx = lines.findIndex((line) => /^allowBuilds:\s*$/.test(line));
 
 	if (headerIdx === -1) {
-		// No allowBuilds block: append a fresh one for our three keys.
+		// No allowBuilds block: append a fresh one.
 		const needsLeadingBlank =
 			lines.length > 0 && lines[lines.length - 1] !== "";
 		const block = [
@@ -113,8 +78,8 @@ export const mergeAllowBuilds = (original: string): string => {
 		return original.replace(/(\r?\n)?$/, eol + block);
 	}
 
-	// Walk the existing allowBuilds block. For *our* keys only, convert
-	// non-boolean placeholders to `true`. Never touch other keys.
+	// For our keys only, convert non-boolean placeholders to `true`. Other
+	// keys are left untouched.
 	const seenOurKeys = new Set<string>();
 	let blockEnd = lines.length;
 	for (let i = headerIdx + 1; i < lines.length; i++) {
@@ -137,10 +102,10 @@ export const mergeAllowBuilds = (original: string): string => {
 		seenOurKeys.add(key);
 		const trimmed = value.trim();
 		if (trimmed !== "true" && trimmed !== "false") {
-			// Placeholder (or any other unrecognised value) — approve.
+			// Placeholder or unrecognised value — approve. Explicit
+			// `true`/`false` is respected.
 			lines[i] = `${indent}${quote}${key}${quote}: true`;
 		}
-		// If the user explicitly wrote `true` or `false`, respect it.
 	}
 
 	const missing = APPROVED_BUILDS.filter((pkg) => !seenOurKeys.has(pkg)).map(
@@ -156,13 +121,6 @@ export const mergeAllowBuilds = (original: string): string => {
 const detectEol = (text: string): string =>
 	text.includes("\r\n") ? "\r\n" : "\n";
 
-/**
- * Heuristic: did this error originate from pnpm refusing to run dependency
- * build scripts? `runCommand` rejects with an Error whose `message` is the
- * combined raw stdout/stderr of the failed install, so we substring-match
- * the pnpm error code printed verbatim by both pnpm 10 (with
- * `strictDepBuilds: true`) and pnpm 11 (default).
- */
 export const isPnpmIgnoredBuildsError = (error: unknown): error is Error => {
 	if (!(error instanceof Error)) {
 		return false;
@@ -170,21 +128,12 @@ export const isPnpmIgnoredBuildsError = (error: unknown): error is Error => {
 	return error.message.includes("ERR_PNPM_IGNORED_BUILDS");
 };
 
-// Captures the comma-separated list pnpm emits after `Ignored build scripts:`.
-// pnpm appends `@version` to each package; we strip that below.
 const IGNORED_BUILDS_LINE = /Ignored build scripts:\s*([^\n\r]+)/;
 
 /**
- * Extract the list of packages pnpm refused to run build scripts for, parsed
- * out of the raw pnpm error output captured by `runCommand`.
- *
- * pnpm prints a single line of the form:
- *
- *     [ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @parcel/watcher@2.5.6, lmdb@2.8.1
- *
- * We return the package names without their `@version` suffix so we can pass
- * them to `pnpm approve-builds <pkg>...`. Returns an empty array when the
- * input doesn't contain a recognisable list.
+ * Parse the package list pnpm prints after `Ignored build scripts:`, returning
+ * names without their `@version` suffix (so they can be passed to
+ * `pnpm approve-builds`). Returns `[]` if the input has no recognisable list.
  */
 export const extractIgnoredBuildPackages = (error: unknown): string[] => {
 	const text =
@@ -214,8 +163,7 @@ export const extractIgnoredBuildPackages = (error: unknown): string[] => {
 	return result;
 };
 
-// Strip a `@version` suffix from a package spec, preserving the leading `@`
-// on scoped names. `@scope/name@1.2.3` → `@scope/name`; `name@1.2.3` → `name`.
+// `@scope/name@1.2.3` → `@scope/name`; `name@1.2.3` → `name`.
 const stripPackageVersion = (spec: string): string => {
 	if (spec.startsWith("@")) {
 		const slashIdx = spec.indexOf("/");
@@ -230,11 +178,9 @@ const stripPackageVersion = (spec: string): string => {
 };
 
 /**
- * Thrown when the install fails because pnpm refused to run dependency build
- * scripts and we either couldn't recover automatically or the user declined
- * to approve them. Carries the parsed package list so callers (notably the
- * top-level error handler in `cli.ts`) can produce a concise message instead
- * of dumping the full pnpm transcript.
+ * Thrown when pnpm refused to run dependency build scripts and recovery
+ * failed (or the user declined). Carries the parsed package list so the
+ * top-level error handler can render a concise message.
  */
 export class IgnoredBuildsError extends Error {
 	readonly packages: readonly string[];
@@ -254,14 +200,6 @@ export const isIgnoredBuildsError = (
 	error: unknown
 ): error is IgnoredBuildsError => error instanceof IgnoredBuildsError;
 
-/**
- * Actionable guidance to append when an install fails with
- * `ERR_PNPM_IGNORED_BUILDS`. C3 only pre-approves the build scripts it owns
- * (`esbuild`, `workerd`, `sharp`); when a framework generator pulls in
- * additional native build-script dependencies, that's outside our scope —
- * we point the user at the standard pnpm approval flow. When we know which
- * packages pnpm flagged, we surface the exact command to run.
- */
 export const getPnpmIgnoredBuildsGuidance = (
 	packages: readonly string[] = []
 ) => {

--- a/packages/create-cloudflare/src/helpers/pnpmBuildApprovals.ts
+++ b/packages/create-cloudflare/src/helpers/pnpmBuildApprovals.ts
@@ -1,0 +1,193 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { readFile, writeFile } from "./files";
+import { detectPackageManager } from "./packageManagers";
+
+/**
+ * Build-script packages that C3 itself requires through the dependencies it
+ * installs (wrangler → `esbuild`, `workerd`; wrangler → miniflare → `sharp`).
+ * These are the only packages C3 pre-approves; build scripts introduced by a
+ * framework generator (`@parcel/watcher`, `@swc/core`, `lmdb`, …) are the
+ * generator's or the user's responsibility, not ours.
+ *
+ * Listing a package here that isn't actually in the dependency graph is a
+ * no-op: pnpm only consults `allowBuilds` entries for packages it resolves.
+ */
+const APPROVED_BUILDS = ["esbuild", "workerd", "sharp"] as const;
+const APPROVED_BUILDS_SET = new Set<string>(APPROVED_BUILDS);
+
+/**
+ * pnpm 10.x defaults `strictDepBuilds` to `false`, so dependency build scripts
+ * that haven't been explicitly approved produce a warning and the install
+ * still succeeds. pnpm 11.x flipped that default to `true`, so the same
+ * situation fails the install with `ERR_PNPM_IGNORED_BUILDS`.
+ *
+ * Wrangler depends on `workerd` and `esbuild`, and (via miniflare) on `sharp`.
+ * Without pre-approval, every C3 scaffold that installs Wrangler will fail on
+ * pnpm 11. This helper writes — or minimally merges into — a
+ * `pnpm-workspace.yaml` in the generated project that approves exactly those
+ * three packages.
+ *
+ * Behaviour:
+ *
+ * 1. **No existing `pnpm-workspace.yaml`** — write a fresh file approving
+ *    `esbuild`, `workerd`, `sharp`.
+ * 2. **Existing file, no `allowBuilds` block** — append our `allowBuilds`
+ *    block at the end, leaving the rest of the file untouched.
+ * 3. **Existing file with `allowBuilds`** — for *our* three keys only:
+ *    convert a placeholder value (anything other than `true`/`false`) to
+ *    `true`; add the entry if it's missing; respect an explicit
+ *    `true`/`false` if the user (or a generator) already decided.
+ *    **Never** touch any other entry — framework-introduced build approvals
+ *    are out of scope for C3.
+ *
+ * No-op for non-pnpm package managers.
+ */
+export const writePnpmBuildApprovals = (projectPath: string) => {
+	const { npm } = detectPackageManager();
+	if (npm !== "pnpm") {
+		return;
+	}
+
+	const yamlPath = join(projectPath, "pnpm-workspace.yaml");
+
+	if (!existsSync(yamlPath)) {
+		writeFile(yamlPath, freshWorkspaceYaml());
+		return;
+	}
+
+	const original = readFile(yamlPath);
+	const updated = mergeAllowBuilds(original);
+	if (updated !== original) {
+		writeFile(yamlPath, updated);
+	}
+};
+
+const FRESH_HEADER = [
+	"# Pre-approve build scripts for the packages C3 itself installs that need",
+	"# them: `workerd` downloads the platform binary, `esbuild` and `sharp`",
+	"# (via miniflare) download/build native bindings. Without these, pnpm 11+",
+	"# aborts the install with ERR_PNPM_IGNORED_BUILDS.",
+];
+
+// Scoped package names start with `@`, which YAML 1.1 parsers may interpret
+// as a node anchor reference. Quote those to be safe; everything else is a
+// plain identifier and doesn't need quoting.
+const formatEntry = (pkg: string) =>
+	pkg.startsWith("@") ? `  '${pkg}': true` : `  ${pkg}: true`;
+
+const freshWorkspaceYaml = () =>
+	[
+		...FRESH_HEADER,
+		"allowBuilds:",
+		...APPROVED_BUILDS.map(formatEntry),
+		"",
+	].join("\n");
+
+// Matches a YAML entry inside `allowBuilds:` indented 2 spaces, capturing the
+// key (optionally single- or double-quoted, allowing `@scope/name`) and the
+// raw value.
+const ALLOW_BUILDS_ENTRY = /^( {2})(['"]?)([^'":]+)\2:\s*(.*)$/;
+
+/**
+ * Merge approvals for our own build-script packages into an existing
+ * `pnpm-workspace.yaml` body. Exported for unit testing.
+ */
+export const mergeAllowBuilds = (original: string): string => {
+	const eol = detectEol(original);
+	const lines = original.split(/\r?\n/);
+
+	const headerIdx = lines.findIndex((line) => /^allowBuilds:\s*$/.test(line));
+
+	if (headerIdx === -1) {
+		// No allowBuilds block: append a fresh one for our three keys.
+		const needsLeadingBlank =
+			lines.length > 0 && lines[lines.length - 1] !== "";
+		const block = [
+			...(needsLeadingBlank ? [""] : []),
+			...FRESH_HEADER,
+			"allowBuilds:",
+			...APPROVED_BUILDS.map(formatEntry),
+			"",
+		].join(eol);
+		return original.replace(/(\r?\n)?$/, eol + block);
+	}
+
+	// Walk the existing allowBuilds block. For *our* keys only, convert
+	// non-boolean placeholders to `true`. Never touch other keys.
+	const seenOurKeys = new Set<string>();
+	let blockEnd = lines.length;
+	for (let i = headerIdx + 1; i < lines.length; i++) {
+		const line = lines[i];
+		if (line.trim() === "") {
+			continue;
+		}
+		if (!line.startsWith("  ")) {
+			blockEnd = i;
+			break;
+		}
+		const match = line.match(ALLOW_BUILDS_ENTRY);
+		if (!match) {
+			continue;
+		}
+		const [, indent, quote, key, value] = match;
+		if (!APPROVED_BUILDS_SET.has(key)) {
+			continue;
+		}
+		seenOurKeys.add(key);
+		const trimmed = value.trim();
+		if (trimmed !== "true" && trimmed !== "false") {
+			// Placeholder (or any other unrecognised value) — approve.
+			lines[i] = `${indent}${quote}${key}${quote}: true`;
+		}
+		// If the user explicitly wrote `true` or `false`, respect it.
+	}
+
+	const missing = APPROVED_BUILDS.filter((pkg) => !seenOurKeys.has(pkg)).map(
+		formatEntry
+	);
+	if (missing.length > 0) {
+		lines.splice(blockEnd, 0, ...missing);
+	}
+
+	return lines.join(eol);
+};
+
+const detectEol = (text: string): string =>
+	text.includes("\r\n") ? "\r\n" : "\n";
+
+/**
+ * Heuristic: did this error originate from pnpm refusing to run dependency
+ * build scripts? `runCommand` rejects with an Error whose `message` is the
+ * combined raw stdout/stderr of the failed install, so we substring-match
+ * the pnpm error code printed verbatim by both pnpm 10 (with
+ * `strictDepBuilds: true`) and pnpm 11 (default).
+ */
+export const isPnpmIgnoredBuildsError = (error: unknown): error is Error => {
+	if (!(error instanceof Error)) {
+		return false;
+	}
+	return error.message.includes("ERR_PNPM_IGNORED_BUILDS");
+};
+
+/**
+ * Actionable guidance to append when an install fails with
+ * `ERR_PNPM_IGNORED_BUILDS`. C3 only pre-approves the build scripts it owns
+ * (`esbuild`, `workerd`, `sharp`); when a framework generator pulls in
+ * additional native build-script dependencies, that's outside our scope —
+ * we point the user at the standard pnpm approval flow.
+ */
+export const getPnpmIgnoredBuildsGuidance = () =>
+	[
+		"pnpm refused to run dependency build scripts (ERR_PNPM_IGNORED_BUILDS).",
+		"",
+		"create-cloudflare only pre-approves build scripts for the packages it",
+		"installs itself. The packages listed in the pnpm output above were",
+		"introduced by a framework generator and need to be approved separately.",
+		"",
+		"Inside the generated project, run:",
+		"",
+		"  pnpm approve-builds",
+		"",
+		"to review and approve them interactively, then re-run the install.",
+	].join("\n");

--- a/packages/create-cloudflare/src/helpers/pnpmBuildApprovals.ts
+++ b/packages/create-cloudflare/src/helpers/pnpmBuildApprovals.ts
@@ -170,24 +170,114 @@ export const isPnpmIgnoredBuildsError = (error: unknown): error is Error => {
 	return error.message.includes("ERR_PNPM_IGNORED_BUILDS");
 };
 
+// Captures the comma-separated list pnpm emits after `Ignored build scripts:`.
+// pnpm appends `@version` to each package; we strip that below.
+const IGNORED_BUILDS_LINE = /Ignored build scripts:\s*([^\n\r]+)/;
+
+/**
+ * Extract the list of packages pnpm refused to run build scripts for, parsed
+ * out of the raw pnpm error output captured by `runCommand`.
+ *
+ * pnpm prints a single line of the form:
+ *
+ *     [ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @parcel/watcher@2.5.6, lmdb@2.8.1
+ *
+ * We return the package names without their `@version` suffix so we can pass
+ * them to `pnpm approve-builds <pkg>...`. Returns an empty array when the
+ * input doesn't contain a recognisable list.
+ */
+export const extractIgnoredBuildPackages = (error: unknown): string[] => {
+	const text =
+		error instanceof Error
+			? error.message
+			: typeof error === "string"
+				? error
+				: "";
+	const match = text.match(IGNORED_BUILDS_LINE);
+	if (!match) {
+		return [];
+	}
+
+	const seen = new Set<string>();
+	const result: string[] = [];
+	for (const raw of match[1].split(",")) {
+		const trimmed = raw.trim();
+		if (!trimmed) {
+			continue;
+		}
+		const name = stripPackageVersion(trimmed);
+		if (name && !seen.has(name)) {
+			seen.add(name);
+			result.push(name);
+		}
+	}
+	return result;
+};
+
+// Strip a `@version` suffix from a package spec, preserving the leading `@`
+// on scoped names. `@scope/name@1.2.3` → `@scope/name`; `name@1.2.3` → `name`.
+const stripPackageVersion = (spec: string): string => {
+	if (spec.startsWith("@")) {
+		const slashIdx = spec.indexOf("/");
+		if (slashIdx === -1) {
+			return spec;
+		}
+		const versionAt = spec.indexOf("@", slashIdx);
+		return versionAt === -1 ? spec : spec.slice(0, versionAt);
+	}
+	const atIdx = spec.indexOf("@");
+	return atIdx === -1 ? spec : spec.slice(0, atIdx);
+};
+
+/**
+ * Thrown when the install fails because pnpm refused to run dependency build
+ * scripts and we either couldn't recover automatically or the user declined
+ * to approve them. Carries the parsed package list so callers (notably the
+ * top-level error handler in `cli.ts`) can produce a concise message instead
+ * of dumping the full pnpm transcript.
+ */
+export class IgnoredBuildsError extends Error {
+	readonly packages: readonly string[];
+
+	constructor(packages: readonly string[], cause?: unknown) {
+		const list = packages.length > 0 ? packages.join(", ") : "(unknown)";
+		super(`pnpm blocked unapproved dependency build scripts: ${list}`);
+		this.name = "IgnoredBuildsError";
+		this.packages = packages;
+		if (cause !== undefined) {
+			this.cause = cause;
+		}
+	}
+}
+
+export const isIgnoredBuildsError = (
+	error: unknown
+): error is IgnoredBuildsError => error instanceof IgnoredBuildsError;
+
 /**
  * Actionable guidance to append when an install fails with
  * `ERR_PNPM_IGNORED_BUILDS`. C3 only pre-approves the build scripts it owns
  * (`esbuild`, `workerd`, `sharp`); when a framework generator pulls in
  * additional native build-script dependencies, that's outside our scope —
- * we point the user at the standard pnpm approval flow.
+ * we point the user at the standard pnpm approval flow. When we know which
+ * packages pnpm flagged, we surface the exact command to run.
  */
-export const getPnpmIgnoredBuildsGuidance = () =>
-	[
-		"pnpm refused to run dependency build scripts (ERR_PNPM_IGNORED_BUILDS).",
-		"",
+export const getPnpmIgnoredBuildsGuidance = (
+	packages: readonly string[] = []
+) => {
+	const approveCommand =
+		packages.length > 0
+			? `  pnpm approve-builds ${packages.join(" ")}`
+			: "  pnpm approve-builds";
+	return [
 		"create-cloudflare only pre-approves build scripts for the packages it",
-		"installs itself. The packages listed in the pnpm output above were",
-		"introduced by a framework generator and need to be approved separately.",
+		"installs itself. The packages flagged above were introduced by the",
+		"framework generator and need to be approved separately.",
 		"",
 		"Inside the generated project, run:",
 		"",
-		"  pnpm approve-builds",
+		approveCommand,
 		"",
-		"to review and approve them interactively, then re-run the install.",
+		"then re-run the install.",
 	].join("\n");
+};


### PR DESCRIPTION
Fixes #13928. Supersedes #13967 (thanks @matingathani for filing first and identifying the shape of the fix).

This PR contains three connected changes that together fix the `pnpm create cloudflare` regression on pnpm 11, and close the e2e test gap that let it ship undetected.

### 1. Root cause

pnpm 11 flipped `strictDepBuilds` to `true` by default. That turns the previous warning about unapproved dependency build scripts into a fatal `ERR_PNPM_IGNORED_BUILDS`. `wrangler` depends on `workerd` and `esbuild`, and (via miniflare) on `sharp` — all three need their postinstall scripts to produce platform binaries. So every C3 scaffold that installs Wrangler aborted on pnpm 11 with a red error box before the project was usable.

### 2. C3 fix — `create-cloudflare`

**Pre-approve C3's own build scripts.** C3 now writes (or minimally merges into) a `pnpm-workspace.yaml` in the generated project that approves exactly the three packages C3 itself requires (`workerd`, `esbuild`, `sharp`). The merge logic only ever touches *our* three keys — any other entry pnpm or a framework generator wrote is left untouched.

This deliberately does **not** pre-approve build scripts for packages introduced by framework generators (`@parcel/watcher`, `@swc/core`, `lmdb`, etc.) — those approvals are the generator's or the user's responsibility, not C3's.

**Handle framework-introduced ignored builds gracefully.** When pnpm still aborts the install because a framework brought in unapproved build scripts, C3 used to dump the entire pnpm transcript twice (once via the spinner stop, once via the top-level error handler) before printing a hint. The result was a giant red wall of noise on every framework that needs a native build step.

That now becomes a focused recovery path that uses **one** prompt mechanism for all three runtime shapes:

- Parse the flagged package list out of pnpm's output (`extractIgnoredBuildPackages` — handles scoped/unscoped names, strips `@version` suffixes, dedupes) instead of showing the raw transcript.
- Run `pnpm install` under C3's own spinner so failures stop with a short `install failed` line, not the full captured stdout.
- Prompt:

  > `Run \`pnpm approve-builds @parcel/watcher\` and retry the install?`

  - **TTY (real user)**: the prompt is rendered normally; the user types y/n.
  - **Piped stdin (e2e harness, scripted CI)**: C3's e2e harness now has a `backgroundResponders` channel that fires independently of the ordered `promptHandlers` queue. A default responder accepts this prompt, so every framework test inherits the behaviour without bespoke config.
  - **Closed stdin (`pnpm create cloudflare < /dev/null`)**: previously the event loop drained and the process exited `0` silently. C3 now races the prompt against a stdin-`end` event and converts the EOF into an `IgnoredBuildsError` with the parsed list — same concise output as the explicit-decline path.
- On confirm, run `pnpm approve-builds <pkgs>` (deterministic and non-interactive when packages are listed explicitly — writes to `pnpm-workspace.yaml#allowBuilds`, the same key `writePnpmBuildApprovals` uses) and retry the install once.
- On a declined prompt, an EOF, a `CancelError` (Ctrl-C), or a retry that still fails, throw a typed `IgnoredBuildsError` carrying the parsed package list. The top-level handler in `cli.ts` renders a concise summary plus the exact `pnpm approve-builds <pkgs>` command to run — no more transcript dumps.

Verified end-to-end against a real pnpm 11.5.1 environment running C3's actual `npmInstall` path against a project depending on `@parcel/watcher`:

| stdin shape | observed behaviour |
|---|---|
| `</dev/null` (closed) | `RESULT: caught IgnoredBuildsError; packages = ["@parcel/watcher"]` |
| piped `\r` (Enter) | `yes approve-builds` → `installed via \`pnpm install\`` |
| piped `n\r` | `no approve-builds` → `IgnoredBuildsError` |

This closes the fast-follow #14201 in the same PR.

### 3. Test-gap fix — `c3-e2e.yml`

The matrix labelled C3's e2e pnpm jobs as `pnpm 10.33.0` but **`E2E_TEST_PM_VERSION` only relabels C3's `npm_config_user_agent`** — the underlying pnpm binary stays at whatever the monorepo's pinned `packageManager` says (also 10.33.0). So the e2e suite silently exercised pnpm 10 only, and the pnpm-11 regression went undetected.

Both `e2e` (cli + workers) and `frameworks-e2e` now genuinely exercise pnpm 11.5.1 via a second `pnpm/action-setup` overlay (kept distinct from the monorepo install via a stub `package.json` + dedicated `dest`), with `pnpm_config_pm_on_fail` and `pnpm_config_verify_deps_before_run` set so pnpm 11 doesn't silently re-exec as the pinned pnpm 10 or trigger an implicit install at the monorepo root. A verify step fails fast if `pnpm --version` on PATH doesn't match the matrix.

The `frameworks-e2e` matrix now runs three combinations on Linux:

- `pnpm@10.33.0`
- `pnpm@11.5.1`
- `npm`

For frameworks whose generators do their own install (so C3's recovery path can't engage), we now express that as a per-test version constraint instead of pinning the whole job to pnpm 10:

- `FrameworkTestConfig.unsupportedPmRanges` accepts a per–package-manager semver range. `shouldRunTest` evaluates it with `semver.satisfies(coerce(version), range)`.
- `hono:pages` and `hono:workers` are now marked `unsupportedPmRanges: { pnpm: ">=11.0.0" }`. Hono's C3 template calls `create-hono --install`, so the install runs inside the generator before C3 reaches its own `npmInstall`. On pnpm 11 that internal install trips `ERR_PNPM_IGNORED_BUILDS` (Wrangler's workerd/esbuild/sharp postinstalls) and there's no upstream `--no-install` toggle yet, so until that lands, Hono honestly is unsupported on pnpm 11. Other frameworks remain in scope on pnpm 11.

Artifact and job-display names for `frameworks-e2e` now include `matrix.pm.version` to keep the pnpm 10 and pnpm 11 runs from colliding.

### Relationship to #13967

@matingathani's #13967 takes the same core approach (pre-approve build scripts via `pnpm-workspace.yaml`). This PR diverges on two design choices:

- **Strict scope** — only `workerd`/`esbuild`/`sharp` (C3's own dependencies) are auto-approved; framework-introduced build scripts go through the new prompt-and-retry flow instead. (#13967 took a version-branched approach across pnpm 9/10/11; `allowBuilds` was only added in pnpm v10.26, so the v10.0–v10.25 branch would not have worked anyway.)
- **Closes the CI gap** — without the workflow change here, a future pnpm-version regression could slip through the same way.

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: this is a bug fix with no user-facing API change.
