### PR TITLE
Show actionable error message when authentication fails during remote dev

### DIFF
--- a/.changeset/fix-remote-dev-auth-error-ux.md
+++ b/.changeset/fix-remote-dev-auth-error-ux.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Show actionable error message when authentication fails during remote dev
+
+When `wrangler dev` with remote bindings encountered an authentication error (expired token, revoked OAuth, or invalid API token), the user saw a generic "A request to the Cloudflare API failed" message with no indication that authentication was the problem.
+
+Now, authentication failures during remote dev display a clear error message with actionable steps.

--- a/packages/wrangler/src/__tests__/api/startDevWorker/RemoteRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/RemoteRuntimeController.test.ts
@@ -1,3 +1,4 @@
+import { APIError } from "@cloudflare/workers-utils";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { RemoteRuntimeController } from "../../../api/startDevWorker/RemoteRuntimeController";
 // Import the mocked functions so we can set their behavior
@@ -8,6 +9,8 @@ import {
 import {
 	createRemoteWorkerInit,
 	getWorkerAccountAndContext,
+	handlePreviewSessionCreationError,
+	handlePreviewSessionUploadError,
 } from "../../../dev/remote";
 import { getAccessHeaders } from "../../../user/access";
 import { FakeBus } from "../../helpers/fake-bus";
@@ -415,6 +418,113 @@ describe("RemoteRuntimeController", () => {
 						"cf-workers-preview-token": "test-preview-token",
 					},
 				},
+			});
+		});
+	});
+
+	describe("authentication error handling", () => {
+		/**
+		 * Creates an APIError that simulates a Cloudflare API authentication failure.
+		 *
+		 * @param code - the Cloudflare API error code (e.g. 9106, 10000)
+		 * @param noteText - the note text from the API response
+		 * @returns an APIError with the specified code
+		 */
+		function makeAuthError(code: number, noteText: string): APIError {
+			const error = new APIError({
+				text: "A request to the Cloudflare API (/accounts/test/workers/subdomain/edge-preview) failed.",
+				notes: [{ text: noteText }],
+				status: 400,
+				telemetryMessage: false,
+			});
+			error.code = code;
+			return error;
+		}
+
+		it("should call handlePreviewSessionCreationError when createPreviewSession throws a code 10000 auth error", async ({
+			expect,
+		}) => {
+			const authError = makeAuthError(
+				10000,
+				"Authentication error [code: 10000]"
+			);
+			vi.mocked(createPreviewSession).mockRejectedValue(authError);
+
+			const { controller, bus } = setup();
+			const config = makeConfig();
+			const bundle = makeBundle();
+
+			controller.onBundleStart({ type: "bundleStart", config });
+			controller.onBundleComplete({ type: "bundleComplete", config, bundle });
+
+			const errorEvent = await bus.waitFor("error");
+
+			expect(handlePreviewSessionCreationError).toHaveBeenCalledWith(
+				authError,
+				"test-account-id"
+			);
+			expect(errorEvent).toMatchObject({
+				type: "error",
+				reason: "Error reloading remote server",
+				source: "RemoteRuntimeController",
+			});
+		});
+
+		it("should call handlePreviewSessionCreationError when createPreviewSession throws a code 9106 auth error", async ({
+			expect,
+		}) => {
+			const authError = makeAuthError(
+				9106,
+				"Authentication failed (status: 400) [code: 9106]"
+			);
+			vi.mocked(createPreviewSession).mockRejectedValue(authError);
+
+			const { controller, bus } = setup();
+			const config = makeConfig();
+			const bundle = makeBundle();
+
+			controller.onBundleStart({ type: "bundleStart", config });
+			controller.onBundleComplete({ type: "bundleComplete", config, bundle });
+
+			const errorEvent = await bus.waitFor("error");
+
+			expect(handlePreviewSessionCreationError).toHaveBeenCalledWith(
+				authError,
+				"test-account-id"
+			);
+			expect(errorEvent).toMatchObject({
+				type: "error",
+				reason: "Error reloading remote server",
+				source: "RemoteRuntimeController",
+			});
+		});
+
+		it("should call handlePreviewSessionUploadError when createWorkerPreview throws a code 10000 auth error", async ({
+			expect,
+		}) => {
+			const authError = makeAuthError(
+				10000,
+				"Authentication error [code: 10000]"
+			);
+			vi.mocked(createWorkerPreview).mockRejectedValue(authError);
+
+			const { controller, bus } = setup();
+			const config = makeConfig();
+			const bundle = makeBundle();
+
+			controller.onBundleStart({ type: "bundleStart", config });
+			controller.onBundleComplete({ type: "bundleComplete", config, bundle });
+
+			const errorEvent = await bus.waitFor("error");
+
+			expect(handlePreviewSessionUploadError).toHaveBeenCalledWith(
+				authError,
+				"test-account-id"
+			);
+			expect(errorEvent).toMatchObject({
+				type: "error",
+				reason: "Failed to obtain a preview token",
+				source: "RemoteRuntimeController",
 			});
 		});
 	});

--- a/packages/wrangler/src/__tests__/core/handle-errors.test.ts
+++ b/packages/wrangler/src/__tests__/core/handle-errors.test.ts
@@ -1,5 +1,10 @@
+import { APIError, ParseError } from "@cloudflare/workers-utils";
 import { beforeEach, describe, it, vi } from "vitest";
-import { getErrorType, handleError } from "../../core/handle-errors";
+import {
+	getErrorType,
+	handleError,
+	isAuthenticationError,
+} from "../../core/handle-errors";
 import { mockConsoleMethods } from "../helpers/mock-console";
 
 describe("getErrorType", () => {
@@ -256,6 +261,50 @@ describe("getErrorType", () => {
 		});
 	});
 
+	describe("Authentication errors", () => {
+		it("should return 'AuthenticationError' for code 10000 (expired/revoked token)", ({
+			expect,
+		}) => {
+			const error = new APIError({
+				text: "A request to the Cloudflare API failed.",
+				notes: [{ text: "Authentication error [code: 10000]" }],
+				status: 400,
+				telemetryMessage: false,
+			});
+			error.code = 10000;
+
+			expect(getErrorType(error)).toBe("AuthenticationError");
+		});
+
+		it("should return 'AuthenticationError' for code 9106 (invalid token)", ({
+			expect,
+		}) => {
+			const error = new APIError({
+				text: "A request to the Cloudflare API failed.",
+				notes: [{ text: "Authentication failed (status: 400) [code: 9106]" }],
+				status: 400,
+				telemetryMessage: false,
+			});
+			error.code = 9106;
+
+			expect(getErrorType(error)).toBe("AuthenticationError");
+		});
+
+		it("should NOT return 'AuthenticationError' for other API errors", ({
+			expect,
+		}) => {
+			const error = new APIError({
+				text: "A request to the Cloudflare API failed.",
+				notes: [{ text: "Some other error [code: 10063]" }],
+				status: 400,
+				telemetryMessage: false,
+			});
+			error.code = 10063;
+
+			expect(getErrorType(error)).not.toBe("AuthenticationError");
+		});
+	});
+
 	describe("Fallback behavior", () => {
 		it("should return constructor name for unknown Error types", ({
 			expect,
@@ -270,6 +319,78 @@ describe("getErrorType", () => {
 			expect(getErrorType(null)).toBe(undefined);
 			expect(getErrorType(undefined)).toBe(undefined);
 		});
+	});
+});
+
+describe("isAuthenticationError", () => {
+	it("should return true for APIError with code 10000", ({ expect }) => {
+		const error = new APIError({
+			text: "A request to the Cloudflare API failed.",
+			notes: [{ text: "Authentication error [code: 10000]" }],
+			status: 400,
+			telemetryMessage: false,
+		});
+		error.code = 10000;
+
+		expect(isAuthenticationError(error)).toBe(true);
+	});
+
+	it("should return true for APIError with code 9106", ({ expect }) => {
+		const error = new APIError({
+			text: "A request to the Cloudflare API failed.",
+			notes: [{ text: "Authentication failed (status: 400) [code: 9106]" }],
+			status: 400,
+			telemetryMessage: false,
+		});
+		error.code = 9106;
+
+		expect(isAuthenticationError(error)).toBe(true);
+	});
+
+	it("should return true for ParseError with code 10000", ({ expect }) => {
+		const error = new ParseError({
+			text: "Auth error",
+			telemetryMessage: false,
+		});
+		(error as unknown as { code: number }).code = 10000;
+
+		expect(isAuthenticationError(error)).toBe(true);
+	});
+
+	it("should return false for APIError with a non-auth code", ({ expect }) => {
+		const error = new APIError({
+			text: "A request to the Cloudflare API failed.",
+			notes: [{ text: "Some other error [code: 10063]" }],
+			status: 404,
+			telemetryMessage: false,
+		});
+		error.code = 10063;
+
+		expect(isAuthenticationError(error)).toBe(false);
+	});
+
+	it("should return false for APIError with no code", ({ expect }) => {
+		const error = new APIError({
+			text: "A request to the Cloudflare API failed.",
+			notes: [],
+			status: 500,
+			telemetryMessage: false,
+		});
+
+		expect(isAuthenticationError(error)).toBe(false);
+	});
+
+	it("should return false for a plain Error", ({ expect }) => {
+		const error = new Error("something went wrong");
+
+		expect(isAuthenticationError(error)).toBe(false);
+	});
+
+	it("should return false for non-Error values", ({ expect }) => {
+		expect(isAuthenticationError("string")).toBe(false);
+		expect(isAuthenticationError(null)).toBe(false);
+		expect(isAuthenticationError(undefined)).toBe(false);
+		expect(isAuthenticationError(10000)).toBe(false);
 	});
 });
 

--- a/packages/wrangler/src/__tests__/dev/remote.test.ts
+++ b/packages/wrangler/src/__tests__/dev/remote.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, vi } from "vitest";
+import { RemoteSessionAuthenticationError } from "../../dev/remote";
+
+describe("RemoteSessionAuthenticationError", () => {
+	it("preserves the original error as its cause", ({ expect }) => {
+		const cause = new Error("original API error");
+		const error = new RemoteSessionAuthenticationError(cause);
+		expect(error.cause).toBe(cause);
+	});
+
+	it("sets a static telemetryMessage", ({ expect }) => {
+		const error = new RemoteSessionAuthenticationError(new Error("api error"));
+		expect(error.telemetryMessage).toBe("remote dev authentication error");
+	});
+
+	describe("when authenticating via CLOUDFLARE_API_TOKEN", () => {
+		it("mentions the API token environment variable in the message", ({
+			expect,
+		}) => {
+			vi.stubEnv("CLOUDFLARE_API_TOKEN", "test-token");
+
+			const error = new RemoteSessionAuthenticationError(
+				new Error("api error")
+			);
+
+			expect(error.message).toMatchInlineSnapshot(`
+				"Failed to establish remote session due to an authentication issue.
+				It looks like you are authenticating via a custom API token (\`CLOUDFLARE_API_TOKEN\`) set in an environment variable.
+				The token may be invalid or lack the required permissions for this operation.
+
+				To fix this, verify that your token is valid and has the correct permissions.
+				You can also run \`wrangler whoami\` to check your current authentication status."
+			`);
+		});
+	});
+
+	describe("when authenticating via CLOUDFLARE_API_KEY + CLOUDFLARE_EMAIL", () => {
+		it("mentions the Global API Key environment variable in the message", ({
+			expect,
+		}) => {
+			vi.stubEnv("CLOUDFLARE_API_KEY", "test-key");
+			vi.stubEnv("CLOUDFLARE_EMAIL", "test@example.com");
+
+			const error = new RemoteSessionAuthenticationError(
+				new Error("api error")
+			);
+
+			expect(error.message).toMatchInlineSnapshot(`
+				"Failed to establish remote session due to an authentication issue.
+				It looks like you are authenticating via a Global API Key (\`CLOUDFLARE_API_KEY\`) set in an environment variable.
+				The token may be invalid or lack the required permissions for this operation.
+
+				To fix this, verify that your token is valid and has the correct permissions.
+				You can also run \`wrangler whoami\` to check your current authentication status."
+			`);
+		});
+	});
+
+	describe("when authenticating via OAuth (no env credentials)", () => {
+		it("suggests re-authenticating with wrangler login", ({ expect }) => {
+			// Stub all auth env vars to empty strings so getAuthFromEnv()
+			// returns undefined (empty strings are falsy).
+			vi.stubEnv("CLOUDFLARE_API_TOKEN", "");
+			vi.stubEnv("CLOUDFLARE_API_KEY", "");
+			vi.stubEnv("CLOUDFLARE_EMAIL", "");
+
+			const error = new RemoteSessionAuthenticationError(
+				new Error("api error")
+			);
+
+			expect(error.message).toMatchInlineSnapshot(`
+				"Failed to establish remote session due to an authentication issue.
+				Your credentials may have expired or been revoked.
+
+				To fix this, try to:
+				  - Run \`wrangler whoami\` to check your current authentication status.
+				  - Run \`wrangler logout\` and then \`wrangler login\` to re-authenticate."
+			`);
+		});
+	});
+});

--- a/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
+++ b/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
@@ -67,7 +67,7 @@ function findRemoteSessionAuthError(
 	}
 
 	if (isErrorEvent(error) || (error instanceof Error && error.cause)) {
-		return findRemoteSessionAuthError((error as { cause?: unknown }).cause);
+		return findRemoteSessionAuthError(error.cause);
 	}
 
 	return undefined;

--- a/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
+++ b/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import chalk from "chalk";
 import { DeferredPromise } from "miniflare";
 import remoteBindingsWorkerPath from "worker:remoteBindings/ProxyServerWorker";
+import { RemoteSessionAuthenticationError } from "../../dev/remote";
 import { logger } from "../../logger";
 import { getBasePath } from "../../paths";
 import { startWorker } from "../startDevWorker";
@@ -45,6 +46,28 @@ function getErrorMessage(error: unknown): string | undefined {
 			const maybeCause = (error as { cause?: unknown }).cause;
 			return getErrorMessage(maybeCause) ?? maybeMessage;
 		}
+	}
+
+	return undefined;
+}
+
+/**
+ * Walks the cause chain of an error (including {@link ErrorEvent} wrappers)
+ * looking for a {@link RemoteSessionAuthenticationError}.
+ *
+ * @param error - the error or ErrorEvent to inspect
+ * @returns the first {@link RemoteSessionAuthenticationError} found, or
+ *   `undefined` if none exists in the chain
+ */
+function findRemoteSessionAuthError(
+	error: unknown
+): RemoteSessionAuthenticationError | undefined {
+	if (error instanceof RemoteSessionAuthenticationError) {
+		return error;
+	}
+
+	if (isErrorEvent(error) || (error instanceof Error && error.cause)) {
+		return findRemoteSessionAuthError((error as { cause?: unknown }).cause);
 	}
 
 	return undefined;
@@ -118,6 +141,11 @@ export async function startRemoteProxySession(
 	]);
 
 	if (maybeError && maybeError.error) {
+		const authError = findRemoteSessionAuthError(maybeError.error);
+		if (authError) {
+			throw authError;
+		}
+
 		const details = formatRemoteProxySessionError(maybeError.error);
 		throw new Error(
 			details

--- a/packages/wrangler/src/core/handle-errors.ts
+++ b/packages/wrangler/src/core/handle-errors.ts
@@ -259,10 +259,26 @@ function isContainersAuthenticationError(e: unknown): e is UserError {
 }
 
 /**
- * @returns whether `e` is a standard Cloudflare API authentication error
+ * Cloudflare API error codes that indicate an authentication problem.
+ *
+ * - 9106: "Authentication failed" — token not recognized (invalid or malformed).
+ * - 10000: "Authentication error" — token is structurally valid but rejected
+ *          (expired, revoked server-side, or wrong scope).
+ */
+const AUTHENTICATION_ERROR_CODES = [9106, 10000];
+
+/**
+ * Checks whether `e` is a standard Cloudflare API authentication error.
+ *
+ * @param e - the error to inspect
+ * @returns whether the error is an APIError with an auth error code
  */
 export function isAuthenticationError(e: unknown): e is ParseError {
-	return e instanceof ParseError && (e as { code?: number }).code === 10000;
+	if (!(e instanceof ParseError)) {
+		return false;
+	}
+	const code = (e as { code?: number }).code;
+	return code !== undefined && AUTHENTICATION_ERROR_CODES.includes(code);
 }
 
 /**

--- a/packages/wrangler/src/dev/remote.ts
+++ b/packages/wrangler/src/dev/remote.ts
@@ -2,13 +2,14 @@ import assert from "node:assert";
 import path from "node:path";
 import { APIError, UserError } from "@cloudflare/workers-utils";
 import { syncAssets } from "../assets";
+import { isAuthenticationError } from "../core/handle-errors";
 import { printBundleSize } from "../deployment-bundle/bundle-reporter";
 import { getBundleType } from "../deployment-bundle/bundle-type";
 import { withSourceURLs } from "../deployment-bundle/source-url";
 import { getInferredHost } from "../dev";
 import { logger } from "../logger";
 import { syncWorkersSite } from "../sites";
-import { requireApiToken } from "../user";
+import { getAuthFromEnv, requireApiToken } from "../user";
 import { isAbortError } from "../utils/isAbortError";
 import { getZoneIdForPreview } from "../zones";
 import type { StartDevWorkerInput } from "../api";
@@ -25,6 +26,54 @@ import type {
 	LegacyAssetPaths,
 	Route,
 } from "@cloudflare/workers-utils";
+
+/**
+ * Error thrown when a remote dev session fails due to an authentication
+ * problem.  The error message is a user-friendly description with actionable
+ * guidance, tailored to the caller's authentication method (environment
+ * variable token vs. OAuth).  The original API error is preserved as the
+ * error's {@link Error.cause | cause}.
+ *
+ * Consumers that catch this error can display {@link Error.message | message}
+ * directly — no additional logging helper is needed.
+ */
+export class RemoteSessionAuthenticationError extends UserError {
+	/**
+	 * @param cause - The original error that triggered the authentication
+	 *   failure (e.g. an {@link APIError} with code 9106 or 10000).
+	 */
+	constructor(cause: unknown) {
+		const envAuth = getAuthFromEnv();
+
+		let errorMessage =
+			"Failed to establish remote session due to an authentication issue.\n";
+		if (envAuth !== undefined) {
+			// The user is authenticating via an environment variable
+			const method =
+				"apiToken" in envAuth
+					? "a custom API token (`CLOUDFLARE_API_TOKEN`)"
+					: "a Global API Key (`CLOUDFLARE_API_KEY`)";
+
+			errorMessage +=
+				`It looks like you are authenticating via ${method} set in an environment variable.\n` +
+				"The token may be invalid or lack the required permissions for this operation.\n\n" +
+				"To fix this, verify that your token is valid and has the correct permissions.\n" +
+				"You can also run `wrangler whoami` to check your current authentication status.";
+		} else {
+			// The user is authenticating via OAuth (wrangler login)
+			errorMessage +=
+				"Your credentials may have expired or been revoked.\n\n" +
+				"To fix this, try to:\n" +
+				"  - Run `wrangler whoami` to check your current authentication status.\n" +
+				"  - Run `wrangler logout` and then `wrangler login` to re-authenticate.";
+		}
+
+		super(errorMessage, {
+			cause,
+			telemetryMessage: "remote dev authentication error",
+		});
+	}
+}
 
 export function handlePreviewSessionUploadError(
 	err: unknown,
@@ -58,8 +107,11 @@ export function handlePreviewSessionCreationError(
 	assert(err && typeof err === "object");
 	// instead of logging the raw API error to the user,
 	// give them friendly instructions
+	if (isAuthenticationError(err)) {
+		throw new RemoteSessionAuthenticationError(err);
+	}
 	// for error 10063 (workers.dev subdomain required)
-	if ("code" in err && err.code === 10063) {
+	else if ("code" in err && err.code === 10063) {
 		logger.error(
 			`You need to register a workers.dev subdomain before running the dev command in remote mode. You can either enable local mode by pressing l, or register a workers.dev subdomain here: https://dash.cloudflare.com/${accountId}/workers/onboarding`
 		);
@@ -253,6 +305,12 @@ export async function getWorkerAccountAndContext(props: {
 function handleUserFriendlyError(error: unknown, accountId?: string) {
 	if (error instanceof APIError) {
 		switch (error.code) {
+			// code 9106 and 10000 are authentication errors
+			case 9106:
+			case 10000: {
+				throw new RemoteSessionAuthenticationError(error);
+			}
+
 			// code 10021 is a validation error
 			case 10021: {
 				// if it is the following message, give a more user friendly


### PR DESCRIPTION
Fixes #14136 

When `wrangler dev` with remote bindings encountered an authentication error (expired token, revoked OAuth, or invalid API token), the user saw a generic "A request to the Cloudflare API failed" message with no indication that authentication was the problem.

Now, authentication failures during remote dev display a clear error message with actionable steps.

---

Before:
<img width="1541" height="430" alt="Screenshot of error message before changes" src="https://github.com/user-attachments/assets/8d87c61d-8213-4f34-8834-8c3408030969" />

After:
<img width="763" height="454" alt="Screenshot of error message after changes" src="https://github.com/user-attachments/assets/cfaf824a-e230-4d7d-92ed-b6cd58dbcdc5" />


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: improved error message

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
