### PR TITLE
[wrangler] Validate secret bulk JSON stdin values

### DIFF
--- a/.changeset/tall-secrets-sneeze.md
+++ b/.changeset/tall-secrets-sneeze.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Validate JSON stdin values for `wrangler secret bulk`
+
+JSON input piped through stdin now validates that secret values are strings or null before sending them to the API, matching the existing behavior for file input.

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -1268,6 +1268,22 @@ describe("wrangler secret", () => {
 			);
 		});
 
+		it("should fail if JSON stdin contains a record with non-string values", async ({
+			expect,
+		}) => {
+			mockReadlineInput(
+				JSON.stringify({
+					"invalid-secret": 999,
+				})
+			);
+
+			await expect(
+				runWrangler("secret bulk --name script-name")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: The value for "invalid-secret" in "piped input" is not null or a "string" instead it is of type "number"]`
+			);
+		});
+
 		it("should count success and network failure on secret bulk", async ({
 			expect,
 		}) => {

--- a/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
@@ -251,6 +251,22 @@ describe("versions secret bulk", () => {
 		`);
 	});
 
+	test("should error on json stdin with non-string values", async ({
+		expect,
+	}) => {
+		mockReadlineInput(
+			JSON.stringify({
+				SECRET_1: 1,
+			})
+		);
+
+		await expect(
+			runWrangler(`versions secret bulk --name script-name`)
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: The value for "SECRET_1" in "piped input" is not null or a "string" instead it is of type "number"]`
+		);
+	});
+
 	test("unsafe metadata is provided", async ({ expect }) => {
 		writeWranglerConfig({
 			name: "script-name",

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -652,14 +652,6 @@ export async function parseBulkInputToObject(
 				});
 			}
 		}
-		validateFileSecrets(content, input);
-		if (!includeNull) {
-			content = Object.fromEntries(
-				Object.entries(content).filter(
-					(entry): entry is [string, string] => entry[1] != null
-				)
-			);
-		}
 	} else {
 		secretSource = "stdin";
 		try {
@@ -683,6 +675,14 @@ export async function parseBulkInputToObject(
 		} catch {
 			return;
 		}
+	}
+	validateFileSecrets(content, input ?? "piped input");
+	if (!includeNull) {
+		content = Object.fromEntries(
+			Object.entries(content).filter(
+				(entry): entry is [string, string] => entry[1] != null
+			)
+		);
 	}
 	return { content, secretSource, secretFormat };
 }


### PR DESCRIPTION

Follow-up to #14124.

Validate JSON secret values read from stdin before sending them to the API. This makes stdin JSON input match file JSON input: secret values must be strings or null, rather than being implicitly accepted and failing later as an API validation error.

For example, this now fails locally in Wrangler instead of sending an invalid secret binding request:

```json
{
  "hello": 5
}
```

This covers both `wrangler secret bulk` and `wrangler versions secret bulk`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This keeps stdin validation consistent with existing file input behavior and does not add or change user-facing options.

Tested with:

- `corepack pnpm prettify`
- `corepack pnpm -w test:ci -F wrangler -- secret.test.ts`
- `corepack pnpm -w test:ci -F wrangler -- versions/secrets/bulk.test.ts`
- `git diff --check`

*A picture of a cute animal (not mandatory, but encouraged)*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->