### PR TITLE
[wrangler] Fix circular dependency build warning between api/index.ts and binding-utils.ts

### DIFF
--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -18,7 +18,7 @@ import { startDev } from "./dev/start-dev";
 import { experimentalNewConfigArg } from "./experimental-config/cli-flag";
 import { logger } from "./logger";
 import { detectAgent } from "./utils/detect-agent";
-import type { StartDevWorkerInput, Trigger } from "./api";
+import type { StartDevWorkerInput, Trigger } from "./api/startDevWorker/types";
 import type { EnablePagesAssetsServiceBindingOptions } from "./miniflare-cli/types";
 import type {
 	Binding,


### PR DESCRIPTION
Rollup emits a circular chunk dependency warning during wrangler's DTS build:

```
Export "convertConfigBindingsToStartWorkerBindings" of module
"src/api/startDevWorker/binding-utils.ts" was reexported through module
"src/api/index.ts" while both modules are dependencies of each other and
will end up in different chunks by current Rollup settings. This scenario
is not well supported at the moment as it will produce a circular
dependency between chunks and will likely lead to broken execution order.
```

The cycle is:

1. `api/index.ts` re-exports `convertConfigBindingsToStartWorkerBindings` from `startDevWorker/binding-utils.ts`
2. `binding-utils.ts` type-imports `AdditionalDevProps` from `../../dev`
3. `dev.ts` type-imports `StartDevWorkerInput` and `Trigger` from `./api`, closing the loop back to step 1

This points `dev.ts` at `./api/startDevWorker/types` directly, cutting edge 3. Type imports are real edges in the DTS module graph, which is why changing an `import type` specifier is enough to silence the warning.

Verified by building both ways: the warning reappears if this one line is reverted, and disappears with it applied.

Notes for reviewers:

- Only an `import type` specifier changes, so there is no effect on runtime module evaluation order or on the emitted JS.
- This does not remove the `api/index.ts` ⇄ `binding-utils.ts` cycle entirely — `binding-utils.ts` still type-imports `StartDevWorkerOptions` from `"."`. It breaks the specific edge Rollup was tripping over. Fully de-barrelling `api/index.ts` would be a much more invasive change and would conflict badly with in-flight refactors.
- There is a separate, pre-existing circular dependency warning in `@cloudflare/workers-utils` (`src/config/config.ts` ⇄ `src/config/index.ts`) that is untouched here.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: build-warning-only fix. Only an `import type` specifier changes, so there is no runtime behaviour change and no emitted-JS change. Verified `pnpm build -F wrangler` (warning gone), `pnpm test:ci -F wrangler` (248 files / 4800 tests pass), `check:type`, `type:tests`, oxlint `--type-aware` and oxfmt.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: internal build fix with no user-facing surface.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
