### PR TITLE
[miniflare] Authenticate remote bindings with Cloudflare Access service tokens

### DIFF
--- a/.changeset/remote-bindings-access-service-token.md
+++ b/.changeset/remote-bindings-access-service-token.md
@@ -1,14 +1,15 @@
 ---
 "miniflare": patch
+"wrangler": patch
 ---
 
-Authenticate remote binding requests with Cloudflare Access service tokens
+Authenticate remote binding traffic with Cloudflare Access
 
 When `wrangler dev` (or the Vite plugin) uses remote bindings against a Worker whose `workers.dev` domain is protected by Cloudflare Access, requests from the local proxy client to the remote proxy server were rejected with a 401/403 — breaking AI, Vectorize, Images, Artifacts, and other remote bindings.
 
-If `CLOUDFLARE_ACCESS_CLIENT_ID` and `CLOUDFLARE_ACCESS_CLIENT_SECRET` are set (the same Service Token env vars already used by `getAccessHeaders()` for the realish-preview HTTP path), they are now attached to remote-binding traffic:
+Wrangler now resolves the Access headers for the proxy server's host via the canonical `getAccessHeaders()` helper (the same one the realish-preview hop already uses) and carries them on the remote proxy connection string, so Miniflare attaches them to the binding traffic:
 
-- **HTTP path (`makeFetch`)** — wrapped-fetcher bindings such as AI, Vectorize, and Images now send `CF-Access-Client-Id` / `CF-Access-Client-Secret` headers to the proxy server.
-- **WebSocket/capnweb path (`makeRemoteProxyStub`)** — RPC bindings such as Artifacts now establish the capnweb WebSocket via a `fetch()` upgrade (`Upgrade: websocket`) so the Access headers are included in the handshake, since `new WebSocket(url)` cannot set request headers in the Workers runtime.
+- **HTTP path (`makeFetch`)** — wrapped-fetcher bindings such as AI, Vectorize, and Images send the headers to the proxy server.
+- **WebSocket/capnweb path (`makeRemoteProxyStub`)** — RPC bindings such as Artifacts establish the capnweb WebSocket through a custom transport that performs a `fetch()` upgrade (`Upgrade: websocket`), so the headers are included in the handshake — `new WebSocket(url)` cannot set request headers in the Workers runtime.
 
-Without service token credentials, behaviour is unchanged.
+Because the headers come from `getAccessHeaders()`, both Access service tokens (`CLOUDFLARE_ACCESS_CLIENT_ID` / `CLOUDFLARE_ACCESS_CLIENT_SECRET`) and interactive `cloudflared access login` cookie auth are supported, and the credentials travel per-session so multiworker dev stays correct when different workers target different Access-protected hosts. When the host is not behind Access, behaviour is unchanged.

--- a/.changeset/remote-bindings-access-service-token.md
+++ b/.changeset/remote-bindings-access-service-token.md
@@ -1,0 +1,14 @@
+---
+"miniflare": patch
+---
+
+Authenticate remote binding requests with Cloudflare Access service tokens
+
+When `wrangler dev` (or the Vite plugin) uses remote bindings against a Worker whose `workers.dev` domain is protected by Cloudflare Access, requests from the local proxy client to the remote proxy server were rejected with a 401/403 — breaking AI, Vectorize, Images, Artifacts, and other remote bindings.
+
+If `CLOUDFLARE_ACCESS_CLIENT_ID` and `CLOUDFLARE_ACCESS_CLIENT_SECRET` are set (the same Service Token env vars already used by `getAccessHeaders()` for the realish-preview HTTP path), they are now attached to remote-binding traffic:
+
+- **HTTP path (`makeFetch`)** — wrapped-fetcher bindings such as AI, Vectorize, and Images now send `CF-Access-Client-Id` / `CF-Access-Client-Secret` headers to the proxy server.
+- **WebSocket/capnweb path (`makeRemoteProxyStub`)** — RPC bindings such as Artifacts now establish the capnweb WebSocket via a `fetch()` upgrade (`Upgrade: websocket`) so the Access headers are included in the handshake, since `new WebSocket(url)` cannot set request headers in the Workers runtime.
+
+Without service token credentials, behaviour is unchanged.

--- a/packages/miniflare/src/plugins/shared/constants.ts
+++ b/packages/miniflare/src/plugins/shared/constants.ts
@@ -84,16 +84,19 @@ export function remoteProxyClientWorker(
 	script?: () => string
 ) {
 	const cfTraceId = process.env.CF_TRACE_ID;
-	// Forward Cloudflare Access Service Token credentials to the proxy client
-	// worker so both the HTTP (`makeFetch`) and WebSocket/capnweb
-	// (`makeRemoteProxyStub`) paths can attach CF-Access-Client-Id /
-	// CF-Access-Client-Secret headers. Read from the environment (consistent
-	// with `getAccessHeaders()` used for the realish-preview HTTP path) rather
-	// than worker vars, since these are tooling credentials, not worker runtime
-	// configuration. Without them, remote bindings fail with a 401/403 when the
-	// workers.dev domain is protected by Access.
-	const accessClientId = process.env.CLOUDFLARE_ACCESS_CLIENT_ID;
-	const accessClientSecret = process.env.CLOUDFLARE_ACCESS_CLIENT_SECRET;
+	// Forward any auth headers needed to reach the remote-bindings proxy server
+	// (e.g. a Cloudflare Access service token or a `cloudflared` cookie) to the
+	// proxy client worker, so both the HTTP (`makeFetch`) and WebSocket/capnweb
+	// (`makeRemoteProxyStub`) paths can attach them. These are computed
+	// wrangler-side via `@cloudflare/workers-auth`'s `getAccessHeaders()` and
+	// carried on the connection string, rather than read from `process.env`
+	// here — so non-wrangler embedders (Vite plugin, vitest-pool-workers,
+	// getPlatformProxy, programmatic users) work too, and so multiworker dev
+	// stays correct when different workers target different Access-protected
+	// hosts. Forwarded as a single opaque JSON binding so the worker side stays
+	// agnostic to the auth scheme. Without them, remote bindings fail with a
+	// 401/403 when the workers.dev domain is protected by Access.
+	const remoteProxyHeaders = remoteProxyConnectionString?.remoteProxyHeaders;
 	return {
 		compatibilityDate: "2025-01-01",
 		modules: [
@@ -123,19 +126,11 @@ export function remoteProxyClientWorker(
 						},
 					]
 				: []),
-			...(accessClientId
+			...(remoteProxyHeaders && Object.keys(remoteProxyHeaders).length > 0
 				? [
 						{
-							name: "accessClientId",
-							text: accessClientId,
-						},
-					]
-				: []),
-			...(accessClientSecret
-				? [
-						{
-							name: "accessClientSecret",
-							text: accessClientSecret,
+							name: "remoteProxyHeaders",
+							text: JSON.stringify(remoteProxyHeaders),
 						},
 					]
 				: []),

--- a/packages/miniflare/src/plugins/shared/constants.ts
+++ b/packages/miniflare/src/plugins/shared/constants.ts
@@ -84,6 +84,16 @@ export function remoteProxyClientWorker(
 	script?: () => string
 ) {
 	const cfTraceId = process.env.CF_TRACE_ID;
+	// Forward Cloudflare Access Service Token credentials to the proxy client
+	// worker so both the HTTP (`makeFetch`) and WebSocket/capnweb
+	// (`makeRemoteProxyStub`) paths can attach CF-Access-Client-Id /
+	// CF-Access-Client-Secret headers. Read from the environment (consistent
+	// with `getAccessHeaders()` used for the realish-preview HTTP path) rather
+	// than worker vars, since these are tooling credentials, not worker runtime
+	// configuration. Without them, remote bindings fail with a 401/403 when the
+	// workers.dev domain is protected by Access.
+	const accessClientId = process.env.CLOUDFLARE_ACCESS_CLIENT_ID;
+	const accessClientSecret = process.env.CLOUDFLARE_ACCESS_CLIENT_SECRET;
 	return {
 		compatibilityDate: "2025-01-01",
 		modules: [
@@ -110,6 +120,22 @@ export function remoteProxyClientWorker(
 						{
 							name: "cfTraceId",
 							text: cfTraceId,
+						},
+					]
+				: []),
+			...(accessClientId
+				? [
+						{
+							name: "accessClientId",
+							text: accessClientId,
+						},
+					]
+				: []),
+			...(accessClientSecret
+				? [
+						{
+							name: "accessClientSecret",
+							text: accessClientSecret,
 						},
 					]
 				: []),

--- a/packages/miniflare/src/plugins/shared/index.ts
+++ b/packages/miniflare/src/plugins/shared/index.ts
@@ -179,6 +179,21 @@ export function namespaceKeys(
 
 export type RemoteProxyConnectionString = URL & {
 	__brand: "RemoteProxyConnectionString";
+	/**
+	 * Optional auth headers (e.g. a Cloudflare Access service token or a
+	 * `cloudflared` cookie) required to reach the remote-bindings proxy server.
+	 *
+	 * Computed wrangler-side via `getAccessHeaders()` and carried here so the
+	 * credentials travel *with* the connection string into Miniflare. This keeps
+	 * them correct per-worker in multiworker dev — where a single Miniflare
+	 * instance hosts several workers whose proxy sessions may target different
+	 * `workers.dev` hosts behind different Access applications — without leaking
+	 * wrangler-flavoured `process.env` reads into Miniflare.
+	 *
+	 * The bag is opaque: the worker side forwards it as a single JSON binding and
+	 * spreads it onto outgoing requests, so it is agnostic to the auth scheme.
+	 */
+	remoteProxyHeaders?: Record<string, string>;
 };
 
 export function namespaceEntries(

--- a/packages/miniflare/src/workers/dispatch-namespace/dispatch-namespace-proxy.worker.ts
+++ b/packages/miniflare/src/workers/dispatch-namespace/dispatch-namespace-proxy.worker.ts
@@ -28,8 +28,9 @@ export default class DispatchNamespaceProxy extends WorkerEntrypoint<RemoteBindi
 			},
 			this.env.cfTraceId,
 			this.env[SharedBindings.MAYBE_SERVICE_LOOPBACK],
-			this.env.accessClientId,
-			this.env.accessClientSecret
+			this.env.remoteProxyHeaders
+				? (JSON.parse(this.env.remoteProxyHeaders) as Record<string, string>)
+				: undefined
 		);
 	}
 }

--- a/packages/miniflare/src/workers/dispatch-namespace/dispatch-namespace-proxy.worker.ts
+++ b/packages/miniflare/src/workers/dispatch-namespace/dispatch-namespace-proxy.worker.ts
@@ -27,7 +27,9 @@ export default class DispatchNamespaceProxy extends WorkerEntrypoint<RemoteBindi
 				}),
 			},
 			this.env.cfTraceId,
-			this.env[SharedBindings.MAYBE_SERVICE_LOOPBACK]
+			this.env[SharedBindings.MAYBE_SERVICE_LOOPBACK],
+			this.env.accessClientId,
+			this.env.accessClientSecret
 		);
 	}
 }

--- a/packages/miniflare/src/workers/shared/remote-bindings-utils.ts
+++ b/packages/miniflare/src/workers/shared/remote-bindings-utils.ts
@@ -1,5 +1,6 @@
-import { newWebSocketRpcSession } from "capnweb";
+import { newWebSocketRpcSession, RpcSession } from "capnweb";
 import type { SharedBindings } from "./constants";
+import type { RpcTransport } from "capnweb";
 
 /**
  * Common environment type for remote binding workers.
@@ -8,13 +9,15 @@ export type RemoteBindingEnv = {
 	remoteProxyConnectionString?: string;
 	binding: string;
 	cfTraceId?: string;
-	// Cloudflare Access Service Token credentials. When set, these are attached
-	// as CF-Access-Client-Id / CF-Access-Client-Secret headers to requests to
-	// the remote-bindings proxy server so that both HTTP (`makeFetch`) and
-	// WebSocket/capnweb (`makeRemoteProxyStub`) remote bindings pass through
-	// Access policies protecting the workers.dev domain.
-	accessClientId?: string;
-	accessClientSecret?: string;
+	// Opaque, JSON-encoded bag of extra headers attached to every request to the
+	// remote-bindings proxy server (e.g. a Cloudflare Access service token —
+	// `CF-Access-Client-Id` / `CF-Access-Client-Secret` — or a `cloudflared`
+	// `Cookie: CF_Authorization=…`). Computed wrangler-side via
+	// `getAccessHeaders()` and forwarded as a single binding so both the HTTP
+	// (`makeFetch`) and WebSocket/capnweb (`makeRemoteProxyStub`) paths can pass
+	// through Access policies protecting the workers.dev domain. The worker side
+	// stays agnostic to the auth scheme.
+	remoteProxyHeaders?: string;
 	// Optional loopback service used to surface diagnostics back to the
 	// Miniflare host (e.g. a Cloudflare Access block detected on the response
 	// from the remote-bindings proxy server).
@@ -126,8 +129,7 @@ export function makeFetch(
 	extraHeaders?: Headers,
 	cfTraceId?: string,
 	loopback?: Fetcher,
-	accessClientId?: string,
-	accessClientSecret?: string
+	remoteProxyHeaders?: Record<string, string>
 ) {
 	return async (
 		input: RequestInfo | URL,
@@ -156,15 +158,17 @@ export function makeFetch(
 			// Also forward through to the binding call via the MF-Header proxy mechanism
 			proxiedHeaders.set("MF-Header-cf-trace-id", cfTraceId);
 		}
-		// Attach Cloudflare Access Service Token credentials so the request to
-		// the remote-bindings proxy server (hosted on the workers.dev domain)
-		// passes through any Access policy protecting it. Wrapped-fetcher
-		// bindings such as AI, Vectorize, and Images route their
-		// `fetcher.fetch()` calls through here, so without these headers they
-		// fail with a 403/401 when the workers.dev domain is behind Access.
-		if (accessClientId && accessClientSecret) {
-			proxiedHeaders.set("CF-Access-Client-Id", accessClientId);
-			proxiedHeaders.set("CF-Access-Client-Secret", accessClientSecret);
+		// Attach any auth headers needed to reach the remote-bindings proxy
+		// server (hosted on the workers.dev domain) so the request passes through
+		// an Access policy protecting it. Wrapped-fetcher bindings such as AI,
+		// Vectorize, and Images route their `fetcher.fetch()` calls through here,
+		// so without these headers they fail with a 403/401 when the workers.dev
+		// domain is behind Access. The bag is opaque (service-token pair or a
+		// cookie), so we just spread it.
+		if (remoteProxyHeaders) {
+			for (const [name, value] of Object.entries(remoteProxyHeaders)) {
+				proxiedHeaders.set(name, value);
+			}
 		}
 		const req = new Request(request, {
 			headers: proxiedHeaders,
@@ -216,15 +220,170 @@ async function connectWebSocketWithHeaders(
 }
 
 /**
+ * A capnweb {@link RpcTransport} that establishes its WebSocket lazily via an
+ * async `connect()` callback (a `fetch()`-based Upgrade, so custom headers ride
+ * the handshake).
+ *
+ * capnweb's `newWebSocketRpcSession()` only accepts an already-open `WebSocket`
+ * or a URL string (which it opens with `new WebSocket(url)` — no header support
+ * in the Workers runtime). By implementing the transport ourselves we let
+ * capnweb build the session and stub *synchronously* while the authenticated
+ * upgrade completes in the background: sends are buffered until the socket
+ * opens, and connection failures propagate to RPC callers through `receive()`,
+ * per capnweb's documented transport contract. This keeps the proxy that wraps
+ * the stub trivial (it only has to intercept `.fetch`), with no thenable guard
+ * or lazy-stub bookkeeping.
+ *
+ * Mirrors capnweb's own (non-exported) `WebSocketTransport`, generalised to a
+ * promised socket.
+ */
+class FetchWebSocketTransport implements RpcTransport {
+	#socket?: WebSocket;
+	#sendQueue: string[] = [];
+	#receiveQueue: string[] = [];
+	#receiveResolver?: (message: string) => void;
+	#receiveRejecter?: (err: unknown) => void;
+	#error?: unknown;
+	#ready: Promise<void>;
+
+	constructor(connect: () => Promise<WebSocket>) {
+		this.#ready = connect().then(
+			(webSocket) => this.#onOpen(webSocket),
+			(err) => this.#receivedError(err)
+		);
+		// If neither `send()` nor `receive()` ever awaits `#ready` (e.g. only the
+		// HTTP `.fetch()` path of the binding is used), a failed upgrade would
+		// otherwise surface as an unhandled rejection. capnweb pumps `receive()`
+		// immediately for an active session, so in practice the error is consumed
+		// there; this guard just covers the never-used-as-RPC case.
+		this.#ready.catch(() => {});
+	}
+
+	#onOpen(webSocket: WebSocket): void {
+		// The session may have been aborted before the socket finished
+		// connecting; don't wire up a socket nobody is listening to.
+		if (this.#error !== undefined) {
+			try {
+				webSocket.close();
+			} catch {
+				// best-effort
+			}
+			return;
+		}
+		this.#socket = webSocket;
+		webSocket.addEventListener("message", (event: MessageEvent) => {
+			if (this.#error !== undefined) {
+				return;
+			}
+			if (typeof event.data === "string") {
+				if (this.#receiveResolver) {
+					this.#receiveResolver(event.data);
+					this.#receiveResolver = undefined;
+					this.#receiveRejecter = undefined;
+				} else {
+					this.#receiveQueue.push(event.data);
+				}
+			} else {
+				this.#receivedError(
+					new TypeError("Received non-string message from WebSocket.")
+				);
+			}
+		});
+		webSocket.addEventListener("close", (event: CloseEvent) => {
+			this.#receivedError(
+				new Error(`Peer closed WebSocket: ${event.code} ${event.reason}`)
+			);
+		});
+		webSocket.addEventListener("error", () => {
+			this.#receivedError(new Error("WebSocket connection failed."));
+		});
+		try {
+			for (const message of this.#sendQueue) {
+				webSocket.send(message);
+			}
+		} catch (err) {
+			this.#receivedError(err);
+		}
+		this.#sendQueue = [];
+	}
+
+	async send(message: string): Promise<void> {
+		if (this.#error !== undefined) {
+			throw this.#error;
+		}
+		if (this.#socket) {
+			this.#socket.send(message);
+		} else {
+			// Buffer until the upgrade completes; `#onOpen` flushes in order.
+			this.#sendQueue.push(message);
+		}
+	}
+
+	async receive(): Promise<string> {
+		if (this.#receiveQueue.length > 0) {
+			return this.#receiveQueue.shift() as string;
+		}
+		if (this.#error !== undefined) {
+			throw this.#error;
+		}
+		// Surface a slow or failed upgrade through `receive()`, which is where
+		// capnweb expects transport errors to propagate (it rejects all
+		// outstanding and future RPC calls).
+		if (!this.#socket) {
+			await this.#ready;
+			if (this.#receiveQueue.length > 0) {
+				return this.#receiveQueue.shift() as string;
+			}
+			if (this.#error !== undefined) {
+				throw this.#error;
+			}
+		}
+		return new Promise<string>((resolve, reject) => {
+			this.#receiveResolver = resolve;
+			this.#receiveRejecter = reject;
+		});
+	}
+
+	abort(reason: unknown): void {
+		if (this.#socket) {
+			const message = reason instanceof Error ? reason.message : `${reason}`;
+			try {
+				this.#socket.close(3000, message);
+			} catch {
+				// best-effort
+			}
+		}
+		if (this.#error === undefined) {
+			this.#error = reason;
+		}
+	}
+
+	#receivedError(reason: unknown): void {
+		if (this.#error === undefined) {
+			this.#error = reason;
+			if (this.#receiveRejecter) {
+				this.#receiveRejecter(reason);
+				this.#receiveResolver = undefined;
+				this.#receiveRejecter = undefined;
+			}
+		}
+	}
+}
+
+/**
  * Create a remote proxy stub that proxies to a remote binding via capnweb.
  *
- * Intercepts `.fetch()` to use plain HTTP; forwards other accesses to capnweb.
+ * Intercepts `.fetch()` to use plain HTTP; forwards every other access to the
+ * capnweb stub.
  *
- * When Access service token credentials are provided, the capnweb WebSocket is
- * established via `fetch()` with the CF-Access-Client-Id / CF-Access-Client-Secret
- * headers so RPC-based bindings (e.g. Artifacts) pass through Access policies
- * protecting the workers.dev domain. The `.fetch()` path threads the same
- * credentials through to `makeFetch`.
+ * When auth headers are provided (e.g. a Cloudflare Access service token), the
+ * capnweb WebSocket is established through {@link FetchWebSocketTransport} via a
+ * `fetch()` Upgrade so the headers ride the handshake — letting RPC bindings
+ * (e.g. Artifacts) pass through Access policies protecting the workers.dev
+ * domain. capnweb builds the stub synchronously either way, so the wrapping
+ * proxy only needs to special-case `.fetch`; everything else (including the
+ * `then === undefined` non-thenable behaviour) comes from the real stub. The
+ * `.fetch()` path threads the same headers through to `makeFetch`.
  */
 export function makeRemoteProxyStub(
 	remoteProxyConnectionString: string,
@@ -232,8 +391,7 @@ export function makeRemoteProxyStub(
 	metadata?: ProxyMetadata,
 	cfTraceId?: string,
 	loopback?: Fetcher,
-	accessClientId?: string,
-	accessClientSecret?: string
+	remoteProxyHeaders?: Record<string, string>
 ): Fetcher {
 	const wsUrl = new URL(remoteProxyConnectionString);
 	wsUrl.protocol = wsUrl.protocol === "https:" ? "wss:" : "ws:";
@@ -251,35 +409,22 @@ export function makeRemoteProxyStub(
 		connect: never;
 	};
 
-	// Without Access credentials, hand capnweb the ws(s):// URL directly — it
-	// upgrades via `new WebSocket(url)` (no header support needed). With Access
-	// credentials, establish the WebSocket ourselves via a fetch() upgrade
-	// against the http(s):// URL so the Access headers ride along, then hand the
-	// connected socket to capnweb. RPC methods are async, so awaiting the
-	// connected socket is transparent to callers (e.g. `await env.X.method()`).
-	let resolvedStub: ProxiedService | undefined;
-	let stubPromise: Promise<ProxiedService> | undefined;
-
-	if (accessClientId && accessClientSecret) {
+	// Without auth headers, hand capnweb the ws(s):// URL directly — it upgrades
+	// via `new WebSocket(url)`. With headers — which `new WebSocket(url)` cannot
+	// send in the Workers runtime — drive the upgrade ourselves through a custom
+	// transport that does a `fetch()` Upgrade so the headers ride the handshake.
+	// Either way capnweb returns a real stub synchronously.
+	let stub: ProxiedService;
+	if (remoteProxyHeaders && Object.keys(remoteProxyHeaders).length > 0) {
 		// fetch() needs the http(s):// scheme; reuse the same query params.
 		const httpUrl = new URL(wsUrl.href);
 		httpUrl.protocol = httpUrl.protocol === "wss:" ? "https:" : "http:";
-		stubPromise = connectWebSocketWithHeaders(httpUrl.href, {
-			"CF-Access-Client-Id": accessClientId,
-			"CF-Access-Client-Secret": accessClientSecret,
-		}).then((ws) => {
-			resolvedStub = newWebSocketRpcSession(ws) as unknown as ProxiedService;
-			return resolvedStub;
-		});
-		// If the caller only ever uses the `.fetch()` (HTTP) path, `stubPromise`
-		// is never awaited — swallow the rejection here to avoid an orphaned
-		// unhandled rejection. The error still surfaces when an RPC property is
-		// accessed, because the async wrapper below awaits `stubPromise` directly.
-		stubPromise.catch(() => {});
+		const transport = new FetchWebSocketTransport(() =>
+			connectWebSocketWithHeaders(httpUrl.href, remoteProxyHeaders)
+		);
+		stub = new RpcSession(transport).getRemoteMain() as unknown as ProxiedService;
 	} else {
-		resolvedStub = newWebSocketRpcSession(
-			wsUrl.href
-		) as unknown as ProxiedService;
+		stub = newWebSocketRpcSession(wsUrl.href) as unknown as ProxiedService;
 	}
 
 	const headers = metadata
@@ -290,8 +435,8 @@ export function makeRemoteProxyStub(
 			)
 		: undefined;
 
-	return new Proxy<ProxiedService>({} as ProxiedService, {
-		get(_, p) {
+	return new Proxy<ProxiedService>(stub, {
+		get(target, p) {
 			if (p === "fetch") {
 				return makeFetch(
 					remoteProxyConnectionString,
@@ -299,36 +444,10 @@ export function makeRemoteProxyStub(
 					headers,
 					cfTraceId,
 					loopback,
-					accessClientId,
-					accessClientSecret
+					remoteProxyHeaders
 				);
 			}
-			if (resolvedStub) {
-				return Reflect.get(resolvedStub, p);
-			}
-			if (stubPromise) {
-				// While the WebSocket is still connecting, this branch handles
-				// every property access. Return `undefined` for `then` so the
-				// proxy is not mistaken for a thenable — otherwise `await`-ing
-				// the stub (or any implicit thenable check) would invoke the
-				// wrapper for `then` and dispatch a bogus remote `then` RPC.
-				if (p === "then") {
-					return undefined;
-				}
-				// The capnweb stub is itself a Proxy whose properties are RPC
-				// methods — they must be invoked as `stub[p](...args)` (calling
-				// `.apply()`/`.call()` would be interpreted as a remote method
-				// named "apply"/"call"). Return an async wrapper that awaits the
-				// authenticated WebSocket upgrade, then dispatches the RPC call.
-				return async (...args: unknown[]) => {
-					const stub = (await stubPromise) as Record<
-						string | symbol,
-						(...a: unknown[]) => unknown
-					>;
-					return stub[p](...args);
-				};
-			}
-			throwRemoteRequired(bindingName);
+			return Reflect.get(target, p);
 		},
 	});
 }

--- a/packages/miniflare/src/workers/shared/remote-bindings-utils.ts
+++ b/packages/miniflare/src/workers/shared/remote-bindings-utils.ts
@@ -8,6 +8,13 @@ export type RemoteBindingEnv = {
 	remoteProxyConnectionString?: string;
 	binding: string;
 	cfTraceId?: string;
+	// Cloudflare Access Service Token credentials. When set, these are attached
+	// as CF-Access-Client-Id / CF-Access-Client-Secret headers to requests to
+	// the remote-bindings proxy server so that both HTTP (`makeFetch`) and
+	// WebSocket/capnweb (`makeRemoteProxyStub`) remote bindings pass through
+	// Access policies protecting the workers.dev domain.
+	accessClientId?: string;
+	accessClientSecret?: string;
 	// Optional loopback service used to surface diagnostics back to the
 	// Miniflare host (e.g. a Cloudflare Access block detected on the response
 	// from the remote-bindings proxy server).
@@ -118,7 +125,9 @@ export function makeFetch(
 	bindingName: string,
 	extraHeaders?: Headers,
 	cfTraceId?: string,
-	loopback?: Fetcher
+	loopback?: Fetcher,
+	accessClientId?: string,
+	accessClientSecret?: string
 ) {
 	return async (
 		input: RequestInfo | URL,
@@ -147,6 +156,16 @@ export function makeFetch(
 			// Also forward through to the binding call via the MF-Header proxy mechanism
 			proxiedHeaders.set("MF-Header-cf-trace-id", cfTraceId);
 		}
+		// Attach Cloudflare Access Service Token credentials so the request to
+		// the remote-bindings proxy server (hosted on the workers.dev domain)
+		// passes through any Access policy protecting it. Wrapped-fetcher
+		// bindings such as AI, Vectorize, and Images route their
+		// `fetcher.fetch()` calls through here, so without these headers they
+		// fail with a 403/401 when the workers.dev domain is behind Access.
+		if (accessClientId && accessClientSecret) {
+			proxiedHeaders.set("CF-Access-Client-Id", accessClientId);
+			proxiedHeaders.set("CF-Access-Client-Secret", accessClientSecret);
+		}
 		const req = new Request(request, {
 			headers: proxiedHeaders,
 		});
@@ -166,24 +185,63 @@ export function makeFetch(
 }
 
 /**
+ * Open a WebSocket to the remote-bindings proxy server via `fetch()` with an
+ * `Upgrade: websocket` header so that custom headers (e.g. Cloudflare Access
+ * service token credentials) are included in the handshake.
+ *
+ * In the Workers runtime, `new WebSocket(url)` (which capnweb uses when given a
+ * URL string) cannot set request headers, so when the proxy server is behind
+ * Cloudflare Access the upgrade is rejected with a 401. Using `fetch()` against
+ * the http(s) URL lets us attach the Access headers; the returned
+ * `response.webSocket` is then handed to capnweb.
+ */
+async function connectWebSocketWithHeaders(
+	httpUrl: string,
+	headers: Record<string, string>
+): Promise<WebSocket> {
+	const resp = await fetch(httpUrl, {
+		headers: { Upgrade: "websocket", ...headers },
+	});
+	const ws = resp.webSocket;
+	if (!ws) {
+		throw new Error(
+			`Remote bindings WebSocket upgrade failed (HTTP ${resp.status}). ` +
+				`If your workers.dev domain is protected by Cloudflare Access, ensure ` +
+				`CLOUDFLARE_ACCESS_CLIENT_ID and CLOUDFLARE_ACCESS_CLIENT_SECRET are set ` +
+				`to valid Service Token credentials.`
+		);
+	}
+	ws.accept();
+	return ws;
+}
+
+/**
  * Create a remote proxy stub that proxies to a remote binding via capnweb.
  *
  * Intercepts `.fetch()` to use plain HTTP; forwards other accesses to capnweb.
+ *
+ * When Access service token credentials are provided, the capnweb WebSocket is
+ * established via `fetch()` with the CF-Access-Client-Id / CF-Access-Client-Secret
+ * headers so RPC-based bindings (e.g. Artifacts) pass through Access policies
+ * protecting the workers.dev domain. The `.fetch()` path threads the same
+ * credentials through to `makeFetch`.
  */
 export function makeRemoteProxyStub(
 	remoteProxyConnectionString: string,
 	bindingName: string,
 	metadata?: ProxyMetadata,
 	cfTraceId?: string,
-	loopback?: Fetcher
+	loopback?: Fetcher,
+	accessClientId?: string,
+	accessClientSecret?: string
 ): Fetcher {
-	const url = new URL(remoteProxyConnectionString);
-	url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
-	url.searchParams.set("MF-Binding", bindingName);
+	const wsUrl = new URL(remoteProxyConnectionString);
+	wsUrl.protocol = wsUrl.protocol === "https:" ? "wss:" : "ws:";
+	wsUrl.searchParams.set("MF-Binding", bindingName);
 	if (metadata) {
 		for (const [key, value] of Object.entries(metadata)) {
 			if (value !== undefined) {
-				url.searchParams.set(key, value);
+				wsUrl.searchParams.set(key, value);
 			}
 		}
 	}
@@ -192,7 +250,32 @@ export function makeRemoteProxyStub(
 		fetch: typeof fetch;
 		connect: never;
 	};
-	const stub = newWebSocketRpcSession(url.href) as unknown as ProxiedService;
+
+	// Without Access credentials, hand capnweb the ws(s):// URL directly — it
+	// upgrades via `new WebSocket(url)` (no header support needed). With Access
+	// credentials, establish the WebSocket ourselves via a fetch() upgrade
+	// against the http(s):// URL so the Access headers ride along, then hand the
+	// connected socket to capnweb. RPC methods are async, so awaiting the
+	// connected socket is transparent to callers (e.g. `await env.X.method()`).
+	let resolvedStub: ProxiedService | undefined;
+	let stubPromise: Promise<ProxiedService> | undefined;
+
+	if (accessClientId && accessClientSecret) {
+		// fetch() needs the http(s):// scheme; reuse the same query params.
+		const httpUrl = new URL(wsUrl.href);
+		httpUrl.protocol = httpUrl.protocol === "wss:" ? "https:" : "http:";
+		stubPromise = connectWebSocketWithHeaders(httpUrl.href, {
+			"CF-Access-Client-Id": accessClientId,
+			"CF-Access-Client-Secret": accessClientSecret,
+		}).then((ws) => {
+			resolvedStub = newWebSocketRpcSession(ws) as unknown as ProxiedService;
+			return resolvedStub;
+		});
+	} else {
+		resolvedStub = newWebSocketRpcSession(
+			wsUrl.href
+		) as unknown as ProxiedService;
+	}
 
 	const headers = metadata
 		? new Headers(
@@ -202,7 +285,7 @@ export function makeRemoteProxyStub(
 			)
 		: undefined;
 
-	return new Proxy<ProxiedService>(stub, {
+	return new Proxy<ProxiedService>({} as ProxiedService, {
 		get(_, p) {
 			if (p === "fetch") {
 				return makeFetch(
@@ -210,10 +293,29 @@ export function makeRemoteProxyStub(
 					bindingName,
 					headers,
 					cfTraceId,
-					loopback
+					loopback,
+					accessClientId,
+					accessClientSecret
 				);
 			}
-			return Reflect.get(stub, p);
+			if (resolvedStub) {
+				return Reflect.get(resolvedStub, p);
+			}
+			if (stubPromise) {
+				// The capnweb stub is itself a Proxy whose properties are RPC
+				// methods — they must be invoked as `stub[p](...args)` (calling
+				// `.apply()`/`.call()` would be interpreted as a remote method
+				// named "apply"/"call"). Return an async wrapper that awaits the
+				// authenticated WebSocket upgrade, then dispatches the RPC call.
+				return async (...args: unknown[]) => {
+					const stub = (await stubPromise) as Record<
+						string | symbol,
+						(...a: unknown[]) => unknown
+					>;
+					return stub[p](...args);
+				};
+			}
+			throwRemoteRequired(bindingName);
 		},
 	});
 }

--- a/packages/miniflare/src/workers/shared/remote-bindings-utils.ts
+++ b/packages/miniflare/src/workers/shared/remote-bindings-utils.ts
@@ -271,6 +271,11 @@ export function makeRemoteProxyStub(
 			resolvedStub = newWebSocketRpcSession(ws) as unknown as ProxiedService;
 			return resolvedStub;
 		});
+		// If the caller only ever uses the `.fetch()` (HTTP) path, `stubPromise`
+		// is never awaited — swallow the rejection here to avoid an orphaned
+		// unhandled rejection. The error still surfaces when an RPC property is
+		// accessed, because the async wrapper below awaits `stubPromise` directly.
+		stubPromise.catch(() => {});
 	} else {
 		resolvedStub = newWebSocketRpcSession(
 			wsUrl.href
@@ -302,6 +307,14 @@ export function makeRemoteProxyStub(
 				return Reflect.get(resolvedStub, p);
 			}
 			if (stubPromise) {
+				// While the WebSocket is still connecting, this branch handles
+				// every property access. Return `undefined` for `then` so the
+				// proxy is not mistaken for a thenable — otherwise `await`-ing
+				// the stub (or any implicit thenable check) would invoke the
+				// wrapper for `then` and dispatch a bogus remote `then` RPC.
+				if (p === "then") {
+					return undefined;
+				}
 				// The capnweb stub is itself a Proxy whose properties are RPC
 				// methods — they must be invoked as `stub[p](...args)` (calling
 				// `.apply()`/`.call()` would be interpreted as a remote method

--- a/packages/miniflare/src/workers/shared/remote-proxy-client.worker.ts
+++ b/packages/miniflare/src/workers/shared/remote-proxy-client.worker.ts
@@ -15,7 +15,9 @@ export default class Client extends WorkerEntrypoint<RemoteBindingEnv> {
 			this.env.binding,
 			undefined,
 			this.env.cfTraceId,
-			this.env[SharedBindings.MAYBE_SERVICE_LOOPBACK]
+			this.env[SharedBindings.MAYBE_SERVICE_LOOPBACK],
+			this.env.accessClientId,
+			this.env.accessClientSecret
 		)(request);
 	}
 
@@ -28,7 +30,9 @@ export default class Client extends WorkerEntrypoint<RemoteBindingEnv> {
 					env.binding,
 					undefined,
 					env.cfTraceId,
-					env[SharedBindings.MAYBE_SERVICE_LOOPBACK]
+					env[SharedBindings.MAYBE_SERVICE_LOOPBACK],
+					env.accessClientId,
+					env.accessClientSecret
 				)
 			: undefined;
 

--- a/packages/miniflare/src/workers/shared/remote-proxy-client.worker.ts
+++ b/packages/miniflare/src/workers/shared/remote-proxy-client.worker.ts
@@ -7,6 +7,15 @@ import {
 } from "./remote-bindings-utils";
 import type { RemoteBindingEnv } from "./remote-bindings-utils";
 
+/** Parse the opaque JSON header bag forwarded by `remoteProxyClientWorker`. */
+function parseRemoteProxyHeaders(
+	env: RemoteBindingEnv
+): Record<string, string> | undefined {
+	return env.remoteProxyHeaders
+		? (JSON.parse(env.remoteProxyHeaders) as Record<string, string>)
+		: undefined;
+}
+
 /** Generic remote proxy client for bindings. */
 export default class Client extends WorkerEntrypoint<RemoteBindingEnv> {
 	fetch(request: Request): Promise<Response> {
@@ -16,8 +25,7 @@ export default class Client extends WorkerEntrypoint<RemoteBindingEnv> {
 			undefined,
 			this.env.cfTraceId,
 			this.env[SharedBindings.MAYBE_SERVICE_LOOPBACK],
-			this.env.accessClientId,
-			this.env.accessClientSecret
+			parseRemoteProxyHeaders(this.env)
 		)(request);
 	}
 
@@ -31,8 +39,7 @@ export default class Client extends WorkerEntrypoint<RemoteBindingEnv> {
 					undefined,
 					env.cfTraceId,
 					env[SharedBindings.MAYBE_SERVICE_LOOPBACK],
-					env.accessClientId,
-					env.accessClientSecret
+					parseRemoteProxyHeaders(env)
 				)
 			: undefined;
 

--- a/packages/miniflare/test/plugins/shared/remote-bindings-access-headers.spec.ts
+++ b/packages/miniflare/test/plugins/shared/remote-bindings-access-headers.spec.ts
@@ -1,0 +1,202 @@
+import { Miniflare } from "miniflare";
+import { describe, test } from "vitest";
+import { TestLog, useDispose, useServer } from "../../test-shared";
+import type { RemoteProxyConnectionString } from "miniflare";
+
+// Build a `remoteProxyConnectionString` (a branded URL) that carries an opaque
+// auth header bag, mirroring what wrangler's `startRemoteProxySession()` does
+// after resolving `getAccessHeaders()`. Miniflare forwards the bag to the proxy
+// client worker, which spreads it onto outgoing requests to the proxy server.
+function connStrWithHeaders(
+	url: URL,
+	headers?: Record<string, string>
+): RemoteProxyConnectionString {
+	const connStr = new URL(url.href) as RemoteProxyConnectionString;
+	if (headers) {
+		connStr.remoteProxyHeaders = headers;
+	}
+	return connStr;
+}
+
+// User worker that drives the HTTP (`makeFetch`) path of a remote binding.
+const HTTP_SCRIPT = /* javascript */ `
+	export default {
+		async fetch(request, env) {
+			const res = await env.SERVICE.fetch("http://example.com/");
+			return new Response(await res.text(), { status: res.status });
+		},
+	};
+`;
+
+// User worker that drives the WebSocket/capnweb (RPC) path of a remote binding.
+// The fake proxy server doesn't speak capnweb, so the RPC never resolves — we
+// only care that the authenticated handshake reached the server. Swallow the
+// resulting error so the request completes.
+const RPC_SCRIPT = /* javascript */ `
+	export default {
+		async fetch(request, env) {
+			try {
+				await env.SERVICE.ping();
+			} catch {}
+			return new Response("done");
+		},
+	};
+`;
+
+describe("remote-bindings proxy client: auth header forwarding", () => {
+	describe("HTTP (makeFetch) path", () => {
+		test("forwards Access service-token headers to the proxy server", async ({
+			expect,
+		}) => {
+			let received: Record<string, string | string[] | undefined> = {};
+			const { http: proxyUrl } = await useServer((req, res) => {
+				received = req.headers;
+				res.statusCode = 200;
+				res.end("ok");
+			});
+
+			const mf = new Miniflare({
+				modules: true,
+				compatibilityDate: "2025-01-01",
+				log: new TestLog(),
+				script: HTTP_SCRIPT,
+				serviceBindings: {
+					SERVICE: {
+						name: "some-remote-service",
+						remoteProxyConnectionString: connStrWithHeaders(proxyUrl, {
+							"CF-Access-Client-Id": "test-client-id.access",
+							"CF-Access-Client-Secret": "test-client-secret",
+						}),
+					},
+				},
+			});
+			useDispose(mf);
+
+			const response = await mf.dispatchFetch("http://localhost/");
+			await response.text();
+
+			expect(received["cf-access-client-id"]).toBe("test-client-id.access");
+			expect(received["cf-access-client-secret"]).toBe("test-client-secret");
+		});
+
+		test("forwards a cloudflared cookie to the proxy server", async ({
+			expect,
+		}) => {
+			let received: Record<string, string | string[] | undefined> = {};
+			const { http: proxyUrl } = await useServer((req, res) => {
+				received = req.headers;
+				res.statusCode = 200;
+				res.end("ok");
+			});
+
+			const mf = new Miniflare({
+				modules: true,
+				compatibilityDate: "2025-01-01",
+				log: new TestLog(),
+				script: HTTP_SCRIPT,
+				serviceBindings: {
+					SERVICE: {
+						name: "some-remote-service",
+						remoteProxyConnectionString: connStrWithHeaders(proxyUrl, {
+							Cookie: "CF_Authorization=test-cookie-token",
+						}),
+					},
+				},
+			});
+			useDispose(mf);
+
+			const response = await mf.dispatchFetch("http://localhost/");
+			await response.text();
+
+			expect(received["cookie"]).toBe("CF_Authorization=test-cookie-token");
+		});
+
+		test("sends no Access headers when none are configured", async ({
+			expect,
+		}) => {
+			let received: Record<string, string | string[] | undefined> = {};
+			const { http: proxyUrl } = await useServer((req, res) => {
+				received = req.headers;
+				res.statusCode = 200;
+				res.end("ok");
+			});
+
+			const mf = new Miniflare({
+				modules: true,
+				compatibilityDate: "2025-01-01",
+				log: new TestLog(),
+				script: HTTP_SCRIPT,
+				serviceBindings: {
+					SERVICE: {
+						name: "some-remote-service",
+						remoteProxyConnectionString: connStrWithHeaders(proxyUrl),
+					},
+				},
+			});
+			useDispose(mf);
+
+			const response = await mf.dispatchFetch("http://localhost/");
+			await response.text();
+
+			expect(received["cf-access-client-id"]).toBeUndefined();
+			expect(received["cf-access-client-secret"]).toBeUndefined();
+			expect(received["cookie"]).toBeUndefined();
+		});
+	});
+
+	describe("WebSocket (capnweb) path", () => {
+		test("includes Access headers in the capnweb upgrade handshake", async ({
+			expect,
+		}) => {
+			let upgradeHeaders:
+				| Record<string, string | string[] | undefined>
+				| undefined;
+			const { http: proxyUrl } = await useServer(
+				(_req, res) => {
+					// Non-WebSocket requests (e.g. an HTTP probe) just succeed.
+					res.statusCode = 200;
+					res.end("ok");
+				},
+				(socket, req) => {
+					// Capture the handshake headers, then close so the (non-capnweb)
+					// RPC attempt fails fast instead of hanging the test.
+					upgradeHeaders = req.headers;
+					socket.close();
+				}
+			);
+
+			const mf = new Miniflare({
+				modules: true,
+				compatibilityDate: "2025-01-01",
+				log: new TestLog(),
+				script: RPC_SCRIPT,
+				serviceBindings: {
+					SERVICE: {
+						name: "some-remote-service",
+						remoteProxyConnectionString: connStrWithHeaders(proxyUrl, {
+							"CF-Access-Client-Id": "ws-client-id.access",
+							"CF-Access-Client-Secret": "ws-client-secret",
+						}),
+					},
+				},
+			});
+			useDispose(mf);
+
+			const response = await mf.dispatchFetch("http://localhost/");
+			await response.text();
+
+			// Give the background upgrade a moment to land if it hasn't already.
+			for (let i = 0; i < 20 && upgradeHeaders === undefined; i++) {
+				await new Promise((resolve) => setTimeout(resolve, 50));
+			}
+
+			expect(upgradeHeaders).toBeDefined();
+			expect(upgradeHeaders?.["cf-access-client-id"]).toBe(
+				"ws-client-id.access"
+			);
+			expect(upgradeHeaders?.["cf-access-client-secret"]).toBe(
+				"ws-client-secret"
+			);
+		});
+	});
+});

--- a/packages/wrangler/src/__tests__/api/remoteBindings/start-remote-proxy-session.test.ts
+++ b/packages/wrangler/src/__tests__/api/remoteBindings/start-remote-proxy-session.test.ts
@@ -7,8 +7,11 @@ import { getAccessHeaders } from "../../../user/access";
 // resolving `getAccessHeaders()` for the proxy host and carrying the result on
 // the connection string + session.
 let proxyUrl = new URL("https://proxy-a.example.workers.dev/");
+// Captures the most recently created fake worker so tests can assert on its
+// `dispose` (e.g. the cleanup-on-throw path).
+let lastFakeWorker: ReturnType<typeof makeFakeWorker> | undefined;
 function makeFakeWorker() {
-	return {
+	const worker = {
 		ready: Promise.resolve(),
 		url: Promise.resolve(proxyUrl),
 		dispose: vi.fn(async () => {}),
@@ -21,6 +24,8 @@ function makeFakeWorker() {
 			},
 		},
 	};
+	lastFakeWorker = worker;
+	return worker;
 }
 
 vi.mock("../../../api/startDevWorker", async (importOriginal) => {
@@ -39,6 +44,7 @@ vi.mock("../../../user/access", () => ({
 describe("startRemoteProxySession - Access auth", () => {
 	beforeEach(() => {
 		proxyUrl = new URL("https://proxy-a.example.workers.dev/");
+		lastFakeWorker = undefined;
 		vi.mocked(getAccessHeaders).mockReset();
 	});
 
@@ -133,5 +139,22 @@ describe("startRemoteProxySession - Access auth", () => {
 				"CF-Access-Client-Id"
 			]
 		).toBe("token-b.access");
+	});
+
+	it("disposes the proxy worker if getAccessHeaders throws (no leak)", async ({
+		expect,
+	}) => {
+		// e.g. a non-interactive UserError when the host is behind Access with no
+		// service token, or a cloudflared failure.
+		const accessError = new Error("Access auth failed");
+		vi.mocked(getAccessHeaders).mockRejectedValue(accessError);
+
+		await expect(startRemoteProxySession({})).rejects.toThrow(
+			"Access auth failed"
+		);
+
+		// The already-started worker must be cleaned up before the error
+		// propagates, since the caller never receives a session to dispose.
+		expect(lastFakeWorker?.dispose).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/wrangler/src/__tests__/api/remoteBindings/start-remote-proxy-session.test.ts
+++ b/packages/wrangler/src/__tests__/api/remoteBindings/start-remote-proxy-session.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
+import { startRemoteProxySession } from "../../../api/remoteBindings/start-remote-proxy-session";
+import { getAccessHeaders } from "../../../user/access";
+
+// `startRemoteProxySession` spins up a real proxy-server worker via
+// `startWorker`. Stub it out so the test focuses on the Access-header wiring:
+// resolving `getAccessHeaders()` for the proxy host and carrying the result on
+// the connection string + session.
+let proxyUrl = new URL("https://proxy-a.example.workers.dev/");
+function makeFakeWorker() {
+	return {
+		ready: Promise.resolve(),
+		url: Promise.resolve(proxyUrl),
+		dispose: vi.fn(async () => {}),
+		patchConfig: vi.fn(async () => {}),
+		raw: {
+			addListener: vi.fn(),
+			proxy: {
+				localServerReady: { promise: Promise.resolve() },
+				runtimeMessageMutex: { drained: vi.fn(async () => {}) },
+			},
+		},
+	};
+}
+
+vi.mock("../../../api/startDevWorker", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../../../api/startDevWorker")>();
+	return {
+		...actual,
+		startWorker: vi.fn(async () => makeFakeWorker()),
+	};
+});
+
+vi.mock("../../../user/access", () => ({
+	getAccessHeaders: vi.fn(),
+}));
+
+describe("startRemoteProxySession - Access auth", () => {
+	beforeEach(() => {
+		proxyUrl = new URL("https://proxy-a.example.workers.dev/");
+		vi.mocked(getAccessHeaders).mockReset();
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("resolves Access headers for the proxy host and carries them on the connection string", async ({
+		expect,
+	}) => {
+		const headers = {
+			"CF-Access-Client-Id": "client-id.access",
+			"CF-Access-Client-Secret": "client-secret",
+		};
+		vi.mocked(getAccessHeaders).mockResolvedValue(headers);
+
+		const session = await startRemoteProxySession({});
+
+		// Looked up against the proxy server's host (not some other domain).
+		expect(getAccessHeaders).toHaveBeenCalledWith(
+			"proxy-a.example.workers.dev"
+		);
+		// Exposed on the session for observability/testing...
+		expect(session.remoteProxyHeaders).toEqual(headers);
+		// ...and carried on the connection string so Miniflare forwards them.
+		expect(session.remoteProxyConnectionString.remoteProxyHeaders).toEqual(
+			headers
+		);
+	});
+
+	it("supports cloudflared cookie auth (Cookie header)", async ({ expect }) => {
+		const headers = { Cookie: "CF_Authorization=token-value" };
+		vi.mocked(getAccessHeaders).mockResolvedValue(headers);
+
+		const session = await startRemoteProxySession({});
+
+		expect(session.remoteProxyHeaders).toEqual(headers);
+		expect(session.remoteProxyConnectionString.remoteProxyHeaders).toEqual(
+			headers
+		);
+	});
+
+	it("attaches nothing when the host is not behind Access", async ({
+		expect,
+	}) => {
+		vi.mocked(getAccessHeaders).mockResolvedValue({});
+
+		const session = await startRemoteProxySession({});
+
+		expect(session.remoteProxyHeaders).toBeUndefined();
+		expect(
+			session.remoteProxyConnectionString.remoteProxyHeaders
+		).toBeUndefined();
+	});
+
+	it("resolves headers per proxy host (multiworker: each session carries its own token)", async ({
+		expect,
+	}) => {
+		// First worker / host.
+		proxyUrl = new URL("https://worker-a.example.workers.dev/");
+		vi.mocked(getAccessHeaders).mockResolvedValue({
+			"CF-Access-Client-Id": "token-a.access",
+			"CF-Access-Client-Secret": "secret-a",
+		});
+		const sessionA = await startRemoteProxySession({});
+
+		// Second worker / host, different token.
+		proxyUrl = new URL("https://worker-b.example.workers.dev/");
+		vi.mocked(getAccessHeaders).mockResolvedValue({
+			"CF-Access-Client-Id": "token-b.access",
+			"CF-Access-Client-Secret": "secret-b",
+		});
+		const sessionB = await startRemoteProxySession({});
+
+		expect(getAccessHeaders).toHaveBeenNthCalledWith(
+			1,
+			"worker-a.example.workers.dev"
+		);
+		expect(getAccessHeaders).toHaveBeenNthCalledWith(
+			2,
+			"worker-b.example.workers.dev"
+		);
+		// Each connection string carries its own host's token — sending worker-a's
+		// token to worker-b's proxy would be the multiworker failure mode.
+		expect(
+			sessionA.remoteProxyConnectionString.remoteProxyHeaders?.[
+				"CF-Access-Client-Id"
+			]
+		).toBe("token-a.access");
+		expect(
+			sessionB.remoteProxyConnectionString.remoteProxyHeaders?.[
+				"CF-Access-Client-Id"
+			]
+		).toBe("token-b.access");
+	});
+});

--- a/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
+++ b/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
@@ -53,6 +53,10 @@ const remoteProxyConnectionString = new URL(
 let proxyWorkerBindings: Record<string, Binding> | undefined;
 let sessionOptions: StartRemoteProxySessionOptions | undefined;
 let startRemoteProxySessionCallCount = 0;
+// When set, the mocked session resolves these Access headers and carries them
+// on the connection string (mirroring what the real `startRemoteProxySession`
+// does after `getAccessHeaders()`), so we can assert they reach Miniflare.
+let mockRemoteProxyHeaders: Record<string, string> | undefined;
 vi.mock("../../api/remoteBindings/start-remote-proxy-session", async () => {
 	const actual = await vi.importActual<
 		typeof import("../../api/remoteBindings/start-remote-proxy-session")
@@ -66,11 +70,17 @@ vi.mock("../../api/remoteBindings/start-remote-proxy-session", async () => {
 			proxyWorkerBindings = remoteBindings;
 			sessionOptions = options;
 			startRemoteProxySessionCallCount++;
+			if (mockRemoteProxyHeaders) {
+				remoteProxyConnectionString.remoteProxyHeaders = mockRemoteProxyHeaders;
+			} else {
+				delete remoteProxyConnectionString.remoteProxyHeaders;
+			}
 			return {
 				ready: Promise.resolve(),
 				async dispose() {},
 				async updateBindings() {},
 				remoteProxyConnectionString,
+				remoteProxyHeaders: mockRemoteProxyHeaders,
 			};
 		},
 	};
@@ -120,6 +130,8 @@ describe("dev with remote bindings", { sequential: true, retry: 2 }, () => {
 		proxyWorkerBindings = undefined;
 		startRemoteProxySessionCallCount = 0;
 		workerOptions = [];
+		mockRemoteProxyHeaders = undefined;
+		delete remoteProxyConnectionString.remoteProxyHeaders;
 	});
 
 	// These test cases cover all the different types of remote bindings we support
@@ -544,6 +556,56 @@ describe("dev with remote bindings", { sequential: true, retry: 2 }, () => {
 			await wranglerStopped;
 		}
 	);
+
+	it("forwards the remote proxy session's Access headers into the Miniflare options", async ({
+		expect,
+	}) => {
+		// Mirror what the real session does after `getAccessHeaders()`: resolve a
+		// service-token bag and carry it on the connection string.
+		mockRemoteProxyHeaders = {
+			"CF-Access-Client-Id": "test-client-id.access",
+			"CF-Access-Client-Secret": "test-client-secret",
+		};
+		await seed({
+			"wrangler.jsonc": JSON.stringify(
+				{
+					name: "worker",
+					main: "index.js",
+					compatibility_date: "2025-01-01",
+					services: [
+						{
+							binding: "SERVICE",
+							service: "remote-service-binding-worker",
+							remote: true,
+						},
+					],
+				},
+				null,
+				2
+			),
+			"index.js": `export default { fetch() { return new Response("hello") } }`,
+		});
+		const wranglerStopped = runWrangler("dev --port=0 --inspector-port=0");
+		await vi.waitFor(() => expect(std.out).toMatch(/Ready/), {
+			timeout: 5_000,
+		});
+
+		// The connection string carrying the headers must reach the Miniflare
+		// worker options (it is passed by reference onto each remote binding).
+		expect(workerOptions).toEqual([
+			expect.objectContaining({
+				serviceBindings: expect.objectContaining({
+					SERVICE: expect.objectContaining({ remoteProxyConnectionString }),
+				}),
+			}),
+		]);
+		expect(remoteProxyConnectionString.remoteProxyHeaders).toEqual(
+			mockRemoteProxyHeaders
+		);
+
+		await stopWrangler();
+		await wranglerStopped;
+	});
 
 	it("should attempt to setup remote $name bindings when updating config during a running `wrangler dev` session", async () => {
 		const { config, expectedProxyWorkerBindings, expectedWorkerOptions } =

--- a/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
+++ b/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
@@ -119,6 +119,9 @@ export async function startRemoteProxySession(
 
 	if (maybeError && maybeError.error) {
 		const details = formatRemoteProxySessionError(maybeError.error);
+		// The worker started but then errored; dispose it so we don't leak the
+		// proxy process when we bail out.
+		await worker.dispose().catch(() => {});
 		throw new Error(
 			details
 				? `Failed to start the remote proxy session. ${details}`
@@ -145,10 +148,21 @@ export async function startRemoteProxySession(
 	// `@cloudflare/workers-utils` chain into this module's eval, which perturbs
 	// module init order for importers that only need the proxy session (e.g.
 	// tests that mock this function), so keep it off the module load path.
-	const { getAccessHeaders } = await import("../../user/access");
-	const remoteProxyHeaders = await getAccessHeaders(
-		remoteProxyConnectionString.hostname
-	);
+	//
+	// `getAccessHeaders()` can throw (a non-interactive `UserError` when the host
+	// is behind Access with no service token, or a `cloudflared` failure), so
+	// dispose the already-started worker before propagating to avoid leaking the
+	// proxy process for callers that catch and continue (e.g. getPlatformProxy).
+	let remoteProxyHeaders: Record<string, string>;
+	try {
+		const { getAccessHeaders } = await import("../../user/access");
+		remoteProxyHeaders = await getAccessHeaders(
+			remoteProxyConnectionString.hostname
+		);
+	} catch (error) {
+		await worker.dispose().catch(() => {});
+		throw error;
+	}
 	const hasRemoteProxyHeaders = Object.keys(remoteProxyHeaders).length > 0;
 	if (hasRemoteProxyHeaders) {
 		remoteProxyConnectionString.remoteProxyHeaders = remoteProxyHeaders;

--- a/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
+++ b/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
@@ -132,6 +132,28 @@ export async function startRemoteProxySession(
 	const remoteProxyConnectionString =
 		(await worker.url) as RemoteProxyConnectionString;
 
+	// Authenticate the binding-proxy hop the same way the realish-preview hop is
+	// authenticated: resolve Access headers for the proxy server's host via the
+	// canonical `getAccessHeaders()` helper (service token, the
+	// "only one var set" warning, the non-interactive UserError, and interactive
+	// `cloudflared` cookie auth all come for free) and carry them on the
+	// connection string so Miniflare attaches them to every request it makes to
+	// the proxy server. Both hops terminate on the same workers.dev host behind
+	// the same Access application, so the lookup is typically already cached.
+	//
+	// Imported lazily: a static import pulls the `@cloudflare/workers-auth` /
+	// `@cloudflare/workers-utils` chain into this module's eval, which perturbs
+	// module init order for importers that only need the proxy session (e.g.
+	// tests that mock this function), so keep it off the module load path.
+	const { getAccessHeaders } = await import("../../user/access");
+	const remoteProxyHeaders = await getAccessHeaders(
+		remoteProxyConnectionString.hostname
+	);
+	const hasRemoteProxyHeaders = Object.keys(remoteProxyHeaders).length > 0;
+	if (hasRemoteProxyHeaders) {
+		remoteProxyConnectionString.remoteProxyHeaders = remoteProxyHeaders;
+	}
+
 	const updateBindings = async (
 		newBindings: StartDevWorkerInput["bindings"]
 	) => {
@@ -176,6 +198,7 @@ export async function startRemoteProxySession(
 	return {
 		ready: worker.ready,
 		remoteProxyConnectionString,
+		remoteProxyHeaders: hasRemoteProxyHeaders ? remoteProxyHeaders : undefined,
 		updateBindings,
 		dispose: worker.dispose,
 	};
@@ -184,6 +207,14 @@ export async function startRemoteProxySession(
 export type RemoteProxySession = Pick<Worker, "ready" | "dispose"> & {
 	updateBindings: (bindings: StartDevWorkerInput["bindings"]) => Promise<void>;
 	remoteProxyConnectionString: RemoteProxyConnectionString;
+	/**
+	 * Auth headers resolved for the proxy server's host (e.g. a Cloudflare Access
+	 * service token or a `cloudflared` cookie), or `undefined` when the host is
+	 * not behind Access. Exposed for observability/testing; the same bag is also
+	 * carried on `remoteProxyConnectionString` so Miniflare forwards it on the
+	 * binding traffic.
+	 */
+	remoteProxyHeaders?: Record<string, string>;
 };
 
 /**


### PR DESCRIPTION
## What

When `wrangler dev` (or the Vite plugin) uses **remote bindings** against a Worker whose `*.workers.dev` domain is protected by **Cloudflare Access**, requests from the local remote-bindings proxy client to the remote proxy server are rejected with a `401`/`403`. This breaks every remote binding behind Access — **Workers AI, AI Gateway, Vectorize, Images, Artifacts**, etc.

This builds on #14008 / #14011 (which fixed Access service-token auth for the realish-preview HTTP path and added a block warning) by also authenticating the **binding proxy traffic** itself. There are two distinct code paths and both needed fixing:

| Path | Used by | Fix |
|------|---------|-----|
| **HTTP `makeFetch`** | wrapped-fetcher bindings: AI, Vectorize, Images | Attach `CF-Access-Client-Id` / `CF-Access-Client-Secret` headers to the request to the proxy server |
| **capnweb WebSocket `makeRemoteProxyStub`** | RPC bindings: Artifacts, service bindings | Establish the WebSocket via a `fetch()` upgrade (`Upgrade: websocket`) so the Access headers ride the handshake — `new WebSocket(url)` cannot set request headers in the Workers runtime |

Credentials are read from `CLOUDFLARE_ACCESS_CLIENT_ID` / `CLOUDFLARE_ACCESS_CLIENT_SECRET` — the **same Service Token env vars** that `getAccessHeaders()` already uses for the realish-preview HTTP path (`packages/wrangler/src/user/access.ts`), so this is consistent with existing wrangler conventions. They're forwarded to the proxy client worker as text bindings (`accessClientId` / `accessClientSecret`).

When the env vars are unset, behaviour is unchanged.

## Why the WebSocket change

`capnweb`'s `newWebSocketRpcSession` accepts either a URL string (which it upgrades with `new WebSocket(url)` — no header support) **or** a pre-connected `WebSocket`. When Access credentials are present we do the upgrade ourselves via `fetch(httpUrl, { headers: { Upgrade: "websocket", ...accessHeaders } })` and hand the resulting `response.webSocket` to capnweb. RPC methods are async over the network, so awaiting the authenticated upgrade is transparent to callers (e.g. `await env.ARTIFACTS.<method>()`).

## Testing

Verified end-to-end against a real internal app (D1/Vectorize/AI/Artifacts, all `remote: true`) on a `workers.dev` account protected by an Access policy:

- ✅ **Workers AI + AI Gateway** (course generation) — was failing with `InferenceUpstreamError: invalid_token`, now succeeds
- ✅ **Vectorize** query + AI embeddings (vector search) — returns ranked results
- ✅ **Artifacts** git read/write over capnweb RPC — commits succeed and content reads back
- ✅ Confirmed by elimination: patch + creds → works; creds only → `invalid_token`; patch only → `invalid_token`
- ✅ `pnpm --filter miniflare build` passes with 0 type errors

---

- Tests
  - [x] Tests included/updated — **not added** (see note below)
- Public documentation
  - [x] Documentation not necessary because: the existing Service Token docs (added in cloudflare/cloudflare-docs#31021) already cover `CLOUDFLARE_ACCESS_CLIENT_ID` / `CLOUDFLARE_ACCESS_CLIENT_SECRET`; this extends the same mechanism to all remote bindings.

> Note: I'm happy to add automated coverage if a maintainer can point me at the right harness — the existing remote-bindings paths are largely exercised in staging/manual since they require a real Access-protected `workers.dev` origin. Verified manually as above.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->