### PR TITLE
Prevent concurrent wrangler dev instances from fighting over the skills-install prompt

### DIFF
--- a/.changeset/fix-concurrent-skills-prompt.md
+++ b/.changeset/fix-concurrent-skills-prompt.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Prevent concurrent `wrangler dev` instances from fighting over the skills-install prompt
+
+When two `wrangler dev` processes start in parallel, both could reach the interactive "Install Cloudflare skills?" prompt simultaneously. The second process's TTY output would overwrite the first's interactive prompt, making it invisible and unresponsive to the user.
+
+A collision-detection mechanism now prevents this using the metadata JSONC file itself as a lock. Before showing the prompt, each process atomically creates the metadata file with a pending marker containing its PID and waits a 500 ms grace period. If a second process starts during that window, it overwrites the marker with its own PID and skips. The first process detects the PID change after the grace period and also skips. This ensures the prompt is only shown when a single `wrangler dev` instance is running. Stale pending markers (older than 60 seconds, e.g. from a crashed process) are automatically cleaned up.

--- a/packages/wrangler/src/__tests__/agents-skills-install.test.ts
+++ b/packages/wrangler/src/__tests__/agents-skills-install.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, utimesSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { getGlobalWranglerConfigPath } from "@cloudflare/workers-utils";
@@ -94,6 +94,28 @@ function readMetadataFile(): Record<string, unknown> {
 		"agents-skills-install.jsonc"
 	);
 	return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+/** Returns the absolute path to the metadata/pending marker file. */
+function getMetadataFilePath(): string {
+	return path.join(
+		getGlobalWranglerConfigPath(),
+		"agents-skills-install.jsonc"
+	);
+}
+
+/**
+ * Writes a pending collision-detection marker to the metadata file,
+ * simulating another wrangler instance that has already started the
+ * concurrent-instance detection flow.
+ *
+ * @param pid - The PID to write into the marker. Defaults to a fake PID
+ *   that won't match the current process.
+ */
+function writePendingMarker(pid = 999999): void {
+	const filePath = getMetadataFilePath();
+	mkdirSync(path.dirname(filePath), { recursive: true });
+	writeFileSync(filePath, JSON.stringify({ pending: true, pid }));
 }
 
 /**
@@ -715,6 +737,159 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 			const metadata = readMetadataFile();
 			expect(metadata.accepted).toBe(true);
 			expect(metadata.installFailed).toBe(false);
+		});
+	});
+
+	describe("concurrent instance detection", () => {
+		test("skips when another instance has a pending marker in the metadata file", async ({
+			expect,
+		}) => {
+			// Simulate another wrangler instance that already wrote a pending
+			// marker. Our process will find EEXIST, overwrite with its own PID
+			// to signal contention, and bail.
+			writePendingMarker();
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+
+			await maybeInstallCloudflareSkillsGlobally(false);
+
+			// Neither prompt nor install should have been attempted.
+			expect(mockRosieInstall).not.toHaveBeenCalled();
+			expect(sendMetricsEvent).toHaveBeenCalledWith(
+				"skills_install_skipped",
+				{ reason: "Concurrent wrangler instances detected" },
+				{}
+			);
+
+			// The metadata file should now contain the current process's PID
+			// (overwritten to signal contention to the first process).
+			const marker = readMetadataFile();
+			expect(marker.pending).toBe(true);
+			expect(marker.pid).toBe(process.pid);
+		});
+
+		test("prompts normally when no concurrent instance appears during grace period", async ({
+			expect,
+		}) => {
+			mockConfirm({
+				text: expect.stringContaining("Claude Code") as unknown as string,
+				result: true,
+			});
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+
+			await maybeInstallCloudflareSkillsGlobally(false);
+
+			// The prompt should have fired and install should have succeeded.
+			expect(mockRosieInstall).toHaveBeenCalled();
+			expect(std.out).toContain(
+				"Successfully installed Cloudflare skills for: Claude Code."
+			);
+
+			// The metadata file should now contain real metadata (the pending
+			// marker was overwritten by writeSkillsInstallMetadataFile).
+			const metadata = readMetadataFile();
+			expect(metadata.pending).toBeUndefined();
+			expect(metadata.accepted).toBe(true);
+		});
+
+		test("removes stale pending marker and proceeds with prompt", async ({
+			expect,
+		}) => {
+			// Create a pending marker and backdate it to simulate a crashed process.
+			writePendingMarker();
+			const staleTime = Date.now() - 120_000; // 2 minutes ago
+			const staleDate = new Date(staleTime);
+			utimesSync(getMetadataFilePath(), staleDate, staleDate);
+
+			mockConfirm({
+				text: expect.stringContaining("Claude Code") as unknown as string,
+				result: true,
+			});
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+
+			await maybeInstallCloudflareSkillsGlobally(false);
+
+			// The stale marker should have been removed and the prompt shown.
+			expect(mockRosieInstall).toHaveBeenCalled();
+			expect(std.out).toContain(
+				"Successfully installed Cloudflare skills for: Claude Code."
+			);
+		});
+
+		test("force=true skips contention detection entirely", async ({
+			expect,
+		}) => {
+			// Pending marker from "another process"
+			writePendingMarker();
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+
+			await maybeInstallCloudflareSkillsGlobally(true);
+
+			// force=true should bypass contention detection and install anyway.
+			expect(mockRosieInstall).toHaveBeenCalled();
+			expect(std.out).toContain(
+				"Successfully installed Cloudflare skills for: Claude Code."
+			);
+		});
+
+		test("skips prompt when real metadata appears during grace period", async ({
+			expect,
+		}) => {
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+
+			// Schedule overwriting the pending marker with real metadata
+			// 200ms into the 500ms grace period, simulating another
+			// (non-concurrent) wrangler instance that completed the prompt.
+			setTimeout(() => {
+				writeMetadataFile({
+					version: 1,
+					accepted: true,
+					date: new Date().toISOString(),
+					detectedAgents: [
+						{
+							name: "Claude Code",
+							rosie: {
+								id: "claude",
+								globalPath: "/fake/.claude/skills",
+							},
+						},
+					],
+					installFailed: false,
+				});
+			}, 200);
+
+			await maybeInstallCloudflareSkillsGlobally(false);
+
+			// The metadata re-check after the grace period should have caught
+			// the newly-written real metadata and returned without prompting.
+			expect(mockRosieInstall).not.toHaveBeenCalled();
+			// No metrics event is sent in this case (same as the initial
+			// metadata-exists check at the top of the function).
+			expect(sendMetricsEvent).not.toHaveBeenCalled();
+		});
+
+		test("ignores pending marker when reading metadata file at startup", async ({
+			expect,
+		}) => {
+			// A stale pending marker from a crashed process should not prevent
+			// the skills install prompt from appearing. The readSkillsInstallMetadataFile
+			// function should treat pending markers as non-existent.
+			writePendingMarker();
+			// Backdate so the stale detection in waitForConcurrentInstances
+			// cleans it up and lets the prompt proceed.
+			const staleDate = new Date(Date.now() - 120_000);
+			utimesSync(getMetadataFilePath(), staleDate, staleDate);
+
+			mockConfirm({
+				text: expect.stringContaining("Claude Code") as unknown as string,
+				result: true,
+			});
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+
+			await maybeInstallCloudflareSkillsGlobally(false);
+
+			// The prompt should have appeared — the pending marker was not
+			// treated as existing metadata.
+			expect(mockRosieInstall).toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/agents-skills-install.test.ts
+++ b/packages/wrangler/src/__tests__/agents-skills-install.test.ts
@@ -815,6 +815,30 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 			);
 		});
 
+		test("keeps old pending marker when owning process is still alive", async ({
+			expect,
+		}) => {
+			// Write a pending marker with the current process's own PID (which is
+			// guaranteed to be alive) and backdate it past the stale threshold.
+			// The liveness check should prevent the marker from being treated as
+			// stale, causing the second instance to skip the prompt.
+			writePendingMarker(process.pid);
+			const staleDate = new Date(Date.now() - 120_000);
+			utimesSync(getMetadataFilePath(), staleDate, staleDate);
+
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+
+			await maybeInstallCloudflareSkillsGlobally(false);
+
+			// The prompt should NOT have appeared — the owning process is alive.
+			expect(mockRosieInstall).not.toHaveBeenCalled();
+			expect(sendMetricsEvent).toHaveBeenCalledWith(
+				"skills_install_skipped",
+				{ reason: "Concurrent wrangler instances detected" },
+				{}
+			);
+		});
+
 		test("force=true skips contention detection entirely", async ({
 			expect,
 		}) => {

--- a/packages/wrangler/src/agents-skills-install.ts
+++ b/packages/wrangler/src/agents-skills-install.ts
@@ -141,14 +141,34 @@ export async function maybeInstallCloudflareSkillsGlobally(
 		// before the process exits.  The prompts library's readline interface
 		// swallows SIGINT — it never reaches `process.on("SIGINT")` — so this
 		// `onState` callback is the only reliable place to handle it.
+		//
+		// We pass a thin stdout proxy so we can mute the prompts library's
+		// abort rendering (the "✖ … yes" line it writes after onState
+		// returns).  Using a proxy keeps process.stdout untouched.
+		let muted = false;
+		const stdoutProxy = new Proxy(process.stdout, {
+			get(target, prop, receiver) {
+				if (prop === "write") {
+					return (...args: Parameters<typeof target.write>) =>
+						muted ? true : target.write(...args);
+				}
+				return Reflect.get(target, prop, receiver);
+			},
+		});
 		const { value } = await prompts({
 			type: "confirm",
 			name: "value",
 			message: `Wrangler detected the following AI coding agents: ${detectedAgents.map(({ name }) => name).join(", ")}. Would you like to install Cloudflare skills for them?`,
 			initial: true,
+			stdout: stdoutProxy,
 			onState: (state) => {
 				if (state.aborted) {
 					sigintReceived = true;
+					// Mute the stdout proxy so the prompts library's abort()
+					// → render() cycle doesn't print a duplicate "✖" line
+					// after the warning.  render() runs synchronously right
+					// after this callback returns.
+					muted = true;
 					logger.warn(
 						"Ctrl+C received — skipping Cloudflare skills installation. This prompt will not be shown again."
 					);

--- a/packages/wrangler/src/agents-skills-install.ts
+++ b/packages/wrangler/src/agents-skills-install.ts
@@ -367,6 +367,33 @@ interface PendingSkillsInstallMarker {
 }
 
 /**
+ * Checks whether a process with the given PID is still running.
+ *
+ * Uses `process.kill(pid, 0)` which sends signal 0 (no actual signal) to
+ * probe for existence. Returns `false` if the PID is not a valid number or
+ * the process has exited.
+ *
+ * Note: PID reuse across separate OS process lifetimes can cause a false
+ * positive (reporting alive when the original process is gone and a new
+ * unrelated process reused the PID). This is an acceptable edge case given
+ * the short window involved.
+ *
+ * @param pid - The process ID to check.
+ * @returns `true` if the process is alive, `false` otherwise.
+ */
+function isProcessAlive(pid: number | undefined): boolean {
+	if (typeof pid !== "number") {
+		return false;
+	}
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Detects whether multiple wrangler processes are starting concurrently by
  * using the metadata JSONC file itself as both the lock and the contention
  * signal. No separate lockfile or marker file is needed.
@@ -388,7 +415,11 @@ interface PendingSkillsInstallMarker {
  *    real metadata by {@link writeSkillsInstallMetadataFile}.
  *
  * Stale pending files (older than {@link SKILLS_INSTALL_PENDING_STALE_MS})
- * from crashed processes are detected and cleaned up automatically.
+ * from crashed processes are detected and cleaned up automatically, but only
+ * when the owning PID is no longer alive (checked via {@link isProcessAlive}).
+ * This prevents a second instance from stealing the prompt while the first
+ * instance's user is still answering it (even if they take longer than the
+ * stale threshold).
  *
  * @returns `true` if no concurrent instance was detected (safe to prompt),
  *   `false` if contention was detected (skip the prompt).
@@ -408,8 +439,11 @@ async function waitForConcurrentInstances(): Promise<boolean> {
 			// eslint-disable-next-line no-bitwise -- atomic create-or-fail
 			constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY
 		);
-		writeFileSync(fd, JSON.stringify(myMarker));
-		closeSync(fd);
+		try {
+			writeFileSync(fd, JSON.stringify(myMarker));
+		} finally {
+			closeSync(fd);
+		}
 	} catch (err) {
 		if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
 			// Unexpected filesystem error — fail open so the prompt still
@@ -438,11 +472,23 @@ async function waitForConcurrentInstances(): Promise<boolean> {
 			return true;
 		}
 
-		// The file is a pending marker from another process. Check if it's stale.
+		// The file is a pending marker from another process. Check whether the
+		// owning process is still alive and whether the marker is stale.
+		// Note: a process killed via SIGKILL during the prompt leaves a
+		// non-stale marker that suppresses the next prompt for up to
+		// SKILLS_INSTALL_PENDING_STALE_MS. This is acceptable because
+		// isProcessAlive() will detect the dead process and the age check
+		// provides a secondary safeguard for PID-reuse edge cases.
 		try {
 			const fileStat = statSync(metadataPath);
-			if (Date.now() - fileStat.mtimeMs >= SKILLS_INSTALL_PENDING_STALE_MS) {
-				// Stale pending marker — the creating process likely crashed.
+			const owningPid = (existingContent as { pid?: number }).pid;
+			const ownerAlive = isProcessAlive(owningPid);
+
+			if (
+				!ownerAlive &&
+				Date.now() - fileStat.mtimeMs >= SKILLS_INSTALL_PENDING_STALE_MS
+			) {
+				// Stale pending marker — the creating process is gone.
 				// Delete and treat as a fresh single instance.
 				unlinkSync(metadataPath);
 				return true;

--- a/packages/wrangler/src/agents-skills-install.ts
+++ b/packages/wrangler/src/agents-skills-install.ts
@@ -1,6 +1,17 @@
-import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import {
+	closeSync,
+	constants,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	readdirSync,
+	statSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { setTimeout } from "node:timers/promises";
 import {
 	getGlobalWranglerConfigPath,
 	parseJSONC,
@@ -94,6 +105,30 @@ export async function maybeInstallCloudflareSkillsGlobally(
 			skippedBecause: "Non-interactive terminal",
 		});
 		return;
+	}
+
+	// When not forced, check for concurrent wrangler instances. If multiple
+	// instances are starting at the same time, all of them skip the prompt to
+	// avoid TTY contention (the second process's output would overwrite the
+	// first's interactive prompt, making it invisible to the user).
+	// When force=true the user explicitly requested installation via
+	// --install-skills, and confirm() is bypassed, so no TTY contention.
+	if (!force) {
+		const safeToPrompt = await waitForConcurrentInstances();
+		if (!safeToPrompt) {
+			sendResultMetricsEvent({
+				skippedBecause: "Concurrent wrangler instances detected",
+			});
+			return;
+		}
+
+		// Another single-instance wrangler run may have completed the prompt
+		// during the grace period. Re-check the metadata file so we don't
+		// prompt a second time.
+		const freshConfig = readSkillsInstallMetadataFile();
+		if (freshConfig !== undefined) {
+			return;
+		}
 	}
 
 	let accepted: boolean;
@@ -263,6 +298,22 @@ interface SkillsInstallMetadata {
 /** Jsonc metadata file created when Cloudflare agent skills are installed */
 const SKILLS_INSTALL_METADATA_FILENAME = "agents-skills-install.jsonc";
 
+/**
+ * Maximum age (in milliseconds) of a pending metadata file before it is
+ * considered stale and eligible for removal. A process that crashed after
+ * writing the pending marker but before completing the prompt leaves a stale
+ * file; 60 seconds is well above the expected prompt+install duration.
+ */
+const SKILLS_INSTALL_PENDING_STALE_MS = 60_000;
+
+/**
+ * Grace period (in milliseconds) the first process waits after writing the
+ * pending metadata file before checking whether a concurrent instance
+ * overwrote it. This gives a second wrangler process time to start up and
+ * signal its presence by writing its own PID into the file.
+ */
+const SKILLS_INSTALL_GRACE_MS = 500;
+
 /** GitHub Contents API URL for listing skill directories in the cloudflare/skills repo. */
 const SKILLS_REPO_CONTENTS_URL =
 	"https://api.github.com/repos/cloudflare/skills/contents/skills";
@@ -281,6 +332,156 @@ function getSkillsInstallMetadataFilePath(): string {
 		getGlobalWranglerConfigPath(),
 		SKILLS_INSTALL_METADATA_FILENAME
 	);
+}
+
+/**
+ * Shape of the temporary "pending" marker written to the metadata file during
+ * concurrent-instance collision detection. Distinguished from real metadata
+ * by the presence of the `pending` field.
+ */
+interface PendingSkillsInstallMarker {
+	/** Always `true` — signals this is a pending marker, not real metadata. */
+	pending: true;
+	/** PID of the wrangler process that wrote this marker. */
+	pid: number;
+}
+
+/**
+ * Detects whether multiple wrangler processes are starting concurrently by
+ * using the metadata JSONC file itself as both the lock and the contention
+ * signal. No separate lockfile or marker file is needed.
+ *
+ * **How it works:**
+ *
+ * 1. The first process atomically creates the metadata JSONC file
+ *    (`O_CREAT | O_EXCL`) and writes `{"pending": true, "pid": <PID>}`.
+ * 2. Any subsequent process that finds the file already exists reads it.
+ *    If it contains a `pending` marker (not real metadata), the second process
+ *    overwrites the file with its own PID (signalling contention) and returns
+ *    `false`.
+ * 3. The first process waits a {@link SKILLS_INSTALL_GRACE_MS | grace period}
+ *    (500 ms), then re-reads the file and checks whether the PID still matches.
+ *    - Same PID → no contention, return `true` (safe to prompt).
+ *    - Different PID → contention detected, delete the file, return `false`.
+ * 4. On contention the file is deleted so the next single-instance run can
+ *    prompt. On success the file is left in place and later overwritten with
+ *    real metadata by {@link writeSkillsInstallMetadataFile}.
+ *
+ * Stale pending files (older than {@link SKILLS_INSTALL_PENDING_STALE_MS})
+ * from crashed processes are detected and cleaned up automatically.
+ *
+ * @returns `true` if no concurrent instance was detected (safe to prompt),
+ *   `false` if contention was detected (skip the prompt).
+ */
+async function waitForConcurrentInstances(): Promise<boolean> {
+	const metadataPath = getSkillsInstallMetadataFilePath();
+	const myPid = process.pid;
+	mkdirSync(path.dirname(metadataPath), { recursive: true });
+
+	const myMarker: PendingSkillsInstallMarker = { pending: true, pid: myPid };
+
+	try {
+		// Atomically create the file — fails with EEXIST if another process
+		// (or a previous completed run) already created it.
+		const fd = openSync(
+			metadataPath,
+			// eslint-disable-next-line no-bitwise -- atomic create-or-fail
+			constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY
+		);
+		writeFileSync(fd, JSON.stringify(myMarker));
+		closeSync(fd);
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+			// Unexpected filesystem error — fail open so the prompt still
+			// appears rather than being silently suppressed forever.
+			return true;
+		}
+
+		// The file already exists. Read it to determine what's inside.
+		let existingContent: Record<string, unknown>;
+		try {
+			existingContent = JSON.parse(readFileSync(metadataPath, "utf8"));
+		} catch {
+			// File is corrupt or unreadable — delete and fail open.
+			try {
+				unlinkSync(metadataPath);
+			} catch {
+				// Best-effort cleanup.
+			}
+			return true;
+		}
+
+		// If the file contains real metadata (not a pending marker), another
+		// run already completed. The caller's initial metadata check should
+		// have caught this, but handle it defensively.
+		if (!existingContent.pending) {
+			return true;
+		}
+
+		// The file is a pending marker from another process. Check if it's stale.
+		try {
+			const fileStat = statSync(metadataPath);
+			if (Date.now() - fileStat.mtimeMs >= SKILLS_INSTALL_PENDING_STALE_MS) {
+				// Stale pending marker — the creating process likely crashed.
+				// Delete and treat as a fresh single instance.
+				unlinkSync(metadataPath);
+				return true;
+			}
+		} catch {
+			// Cannot stat — fail open.
+			return true;
+		}
+
+		// Fresh pending marker from another process — overwrite with our PID
+		// to signal contention, then bail.
+		try {
+			writeFileSync(metadataPath, JSON.stringify(myMarker));
+		} catch {
+			// Best-effort — if the overwrite fails, the first process will
+			// see its own PID and proceed with the prompt (acceptable).
+		}
+		return false;
+	}
+
+	// We created the file. Wait the grace period for a second instance to
+	// overwrite it with a different PID.
+	await setTimeout(SKILLS_INSTALL_GRACE_MS);
+
+	// Re-read the file and check whether our PID is still there.
+	try {
+		const content = JSON.parse(readFileSync(metadataPath, "utf8")) as {
+			pending?: boolean;
+			pid?: number;
+		};
+
+		if (!content.pending) {
+			// The file no longer contains a pending marker — another process
+			// completed the prompt and wrote real metadata during the grace
+			// period. Return true (safe to proceed); the caller will re-read
+			// the metadata file and see the completed state.
+			return true;
+		}
+
+		if (content.pid === myPid) {
+			// No contention — our PID is still there. Leave the file in place;
+			// it will be overwritten with real metadata after the prompt.
+			return true;
+		}
+
+		// A different process overwrote our pending marker with its own PID —
+		// contention detected. Delete the file so the next single-instance
+		// run can prompt.
+		try {
+			unlinkSync(metadataPath);
+		} catch {
+			// Best-effort cleanup.
+		}
+		return false;
+	} catch {
+		// File was deleted or is unreadable — another process cleaned up.
+		// Fail open so the prompt still appears.
+		return true;
+	}
 }
 
 /**
@@ -349,12 +550,21 @@ function migrateMetadataToV1(
  * If the file uses the legacy schema (no `version` field), it is automatically
  * migrated to the current version-1 format and overwritten on disk.
  *
- * @returns The parsed metadata file, or `undefined` if the file doesn't exist or can't be parsed.
+ * Temporary "pending" markers written by the concurrent-instance detection
+ * logic (identified by a `pending` field) are treated as non-existent.
+ *
+ * @returns The parsed metadata file, or `undefined` if the file doesn't exist,
+ *   can't be parsed, or contains a pending collision-detection marker.
  */
 function readSkillsInstallMetadataFile(): SkillsInstallMetadata | undefined {
 	try {
 		const content = readFileSync(getSkillsInstallMetadataFilePath(), "utf8");
 		const parsed = parseJSONC(content) as Record<string, unknown>;
+
+		// Ignore temporary pending markers written by waitForConcurrentInstances().
+		if ((parsed as { pending?: unknown }).pending) {
+			return undefined;
+		}
 
 		// TODO(dario): Remove this migration branch after 2026-06-05 — by then
 		// most active users' metadata files will have been converted to version 1.


### PR DESCRIPTION
Fixes the concurrency bug described in https://github.com/cloudflare/workers-sdk/issues/14116#issuecomment-4589582329

When two `wrangler dev` processes start in parallel, both could reach the interactive "Install Cloudflare skills?" prompt simultaneously. The second process's TTY output would overwrite the first's interactive prompt, making it invisible and unresponsive to the user.

A collision-detection mechanism now prevents this using the metadata JSONC file itself as a lock. Before showing the prompt, each process atomically creates the metadata file with a pending marker containing its PID and waits a 500 ms grace period. If a second process starts during that window, it overwrites the marker with its own PID and skips. The first process detects the PID change after the grace period and also skips. This ensures the prompt is only shown when a single `wrangler dev` instance is running. Stale pending markers (older than 60 seconds, e.g. from a crashed process) are automatically cleaned up.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: self explanatory

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
