### PR TITLE
[wrangler] Add `--version-tag` support to `versions deploy`

### DIFF
--- a/.changeset/versions-deploy-by-tag.md
+++ b/.changeset/versions-deploy-by-tag.md
@@ -1,0 +1,11 @@
+---
+"wrangler": minor
+---
+
+Add `--tag` support to `wrangler versions deploy` to deploy a version by its tag
+
+You can now roll out or roll back a version by the tag it was uploaded with (e.g. a commit SHA passed to `--tag` at upload time) instead of first looking up its Version ID:
+
+`wrangler versions deploy --tag <sha>@100%`
+
+The tag is resolved to a Version ID against the worker's deployable versions, and the `<tag>@<percentage>` shorthand works just like the existing `<version-id>@<percentage>` notation, including splitting traffic across multiple `--tag` values. If a tag matches no deployable version, or matches more than one, the command errors and asks you to deploy by Version ID directly. Note that tags can only be resolved against recent (deployable) versions — older versions that have aged out of that window must still be deployed by Version ID.

--- a/.changeset/versions-deploy-by-tag.md
+++ b/.changeset/versions-deploy-by-tag.md
@@ -2,10 +2,10 @@
 "wrangler": minor
 ---
 
-Add `--tag` support to `wrangler versions deploy` to deploy a version by its tag
+Add `--version-tag` support to `wrangler versions deploy` to deploy a version by its tag
 
 You can now roll out or roll back a version by the tag it was uploaded with (e.g. a commit SHA passed to `--tag` at upload time) instead of first looking up its Version ID:
 
-`wrangler versions deploy --tag <sha>@100%`
+`wrangler versions deploy --version-tag <sha>@100%`
 
-The tag is resolved to a Version ID against the worker's deployable versions, and the `<tag>@<percentage>` shorthand works just like the existing `<version-id>@<percentage>` notation, including splitting traffic across multiple `--tag` values. If a tag matches no deployable version, or matches more than one, the command errors and asks you to deploy by Version ID directly. Note that tags can only be resolved against recent (deployable) versions — older versions that have aged out of that window must still be deployed by Version ID.
+The tag is resolved to a Version ID against the worker's deployable versions, and the `<version-tag>@<percentage>` shorthand works just like the existing `<version-id>@<percentage>` notation, including splitting traffic across multiple `--version-tag` values. If a tag matches no deployable version, or matches more than one, the command errors and asks you to deploy by Version ID directly. Note that tags can only be resolved against recent (deployable) versions — older versions that have aged out of that window must still be deployed by Version ID.

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -78,7 +78,7 @@ const mswGetVersion30000000 = http.get(
 
 // MSW handler for the deployable-versions endpoint (GET /versions?deployable=true)
 // returning versions that carry `workers/tag` annotations, used to test
-// `versions deploy --tag <tag>`.
+// `versions deploy --version-tag <version-tag>`.
 const mswListVersionsWithTags = http.get(
 	"*/accounts/:accountId/workers/scripts/:workerName/versions",
 	() =>
@@ -1301,7 +1301,7 @@ describe("versions deploy", () => {
 				const captured = captureDeployment();
 
 				await expect(
-					runWrangler("versions deploy --tag def5678@100% --yes")
+					runWrangler("versions deploy --version-tag def5678@100% --yes")
 				).resolves.toBeUndefined();
 
 				expect(captured.versions).toEqual([
@@ -1325,7 +1325,7 @@ describe("versions deploy", () => {
 
 				await expect(
 					runWrangler(
-						"versions deploy --tag abc1234@40% --tag def5678@60% --yes"
+						"versions deploy --version-tag abc1234@40% --version-tag def5678@60% --yes"
 					)
 				).resolves.toBeUndefined();
 
@@ -1348,7 +1348,7 @@ describe("versions deploy", () => {
 
 				await expect(
 					runWrangler(
-						"versions deploy 10000000-0000-0000-0000-000000000000@30% --tag def5678@70% --yes"
+						"versions deploy 10000000-0000-0000-0000-000000000000@30% --version-tag def5678@70% --yes"
 					)
 				).resolves.toBeUndefined();
 
@@ -1370,8 +1370,9 @@ describe("versions deploy", () => {
 				writeWranglerConfig();
 				msw.use(mswListVersionsWithTags);
 
-				await expect(runWrangler("versions deploy --tag nope@100% --yes"))
-					.rejects.toMatchInlineSnapshot(`
+				await expect(
+					runWrangler("versions deploy --version-tag nope@100% --yes")
+				).rejects.toMatchInlineSnapshot(`
 					[Error: No deployable version found with tag "nope".
 					Tags can only be resolved against recent (deployable) versions. Run \`wrangler versions list\` to see available versions, or deploy by Version ID directly.]
 				`);
@@ -1383,8 +1384,9 @@ describe("versions deploy", () => {
 				writeWranglerConfig();
 				msw.use(mswListVersionsWithDuplicateTags);
 
-				await expect(runWrangler("versions deploy --tag dupe@100% --yes"))
-					.rejects.toMatchInlineSnapshot(`
+				await expect(
+					runWrangler("versions deploy --version-tag dupe@100% --yes")
+				).rejects.toMatchInlineSnapshot(`
 					[Error: Tag "dupe" matches multiple versions:
 					  - 20000000-0000-0000-0000-000000000000
 					  - 10000000-0000-0000-0000-000000000000
@@ -1474,20 +1476,20 @@ describe("units", () => {
 		});
 
 		test("tag without percentage", ({ expect }) => {
-			const result = parseTagSpecs({ tag: ["abc1234"] });
+			const result = parseTagSpecs({ versionTag: ["abc1234"] });
 
 			expect(Object.fromEntries(result)).toMatchObject({ abc1234: null });
 		});
 
 		test("tag with percentage shorthand", ({ expect }) => {
-			const result = parseTagSpecs({ tag: ["abc1234@100%"] });
+			const result = parseTagSpecs({ versionTag: ["abc1234@100%"] });
 
 			expect(Object.fromEntries(result)).toMatchObject({ abc1234: 100 });
 		});
 
 		test("multiple tags with percentages", ({ expect }) => {
 			const result = parseTagSpecs({
-				tag: ["abc1234@40%", "def5678@60%"],
+				versionTag: ["abc1234@40%", "def5678@60%"],
 			});
 
 			expect(Object.fromEntries(result)).toMatchObject({
@@ -1497,20 +1499,24 @@ describe("units", () => {
 		});
 
 		test("throws on empty tag", ({ expect }) => {
-			expect(() => parseTagSpecs({ tag: ["@100%"] })).toThrowError(
-				`Could not parse a tag from --tag arg "@100%".`
+			expect(() => parseTagSpecs({ versionTag: ["@100%"] })).toThrowError(
+				`Could not parse a tag from --version-tag arg "@100%".`
 			);
 		});
 
 		test("throws on out-of-range percentage", ({ expect }) => {
-			expect(() => parseTagSpecs({ tag: ["abc1234@101%"] })).toThrowError(
-				`Percentage value (101%) parsed from --tag arg "abc1234@101%" must be between 0 and 100.`
+			expect(() =>
+				parseTagSpecs({ versionTag: ["abc1234@101%"] })
+			).toThrowError(
+				`Percentage value (101%) parsed from --version-tag arg "abc1234@101%" must be between 0 and 100.`
 			);
 		});
 
 		test("throws on unparseable percentage", ({ expect }) => {
-			expect(() => parseTagSpecs({ tag: ["abc1234@oops"] })).toThrowError(
-				`Could not parse percentage value from --tag arg "abc1234@oops"`
+			expect(() =>
+				parseTagSpecs({ versionTag: ["abc1234@oops"] })
+			).toThrowError(
+				`Could not parse percentage value from --version-tag arg "abc1234@oops"`
 			);
 		});
 	});

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -1498,10 +1498,28 @@ describe("units", () => {
 			});
 		});
 
-		test("tag containing @ splits on the last @", ({ expect }) => {
+		test("tag containing @ with a percentage splits on the last @", ({
+			expect,
+		}) => {
 			const result = parseTagSpecs({ versionTag: ["v1.0@beta@100%"] });
 
 			expect(Object.fromEntries(result)).toMatchObject({ "v1.0@beta": 100 });
+		});
+
+		test("tag containing @ without a percentage is kept whole", ({
+			expect,
+		}) => {
+			const result = parseTagSpecs({ versionTag: ["v1.0@beta"] });
+
+			expect(Object.fromEntries(result)).toMatchObject({ "v1.0@beta": null });
+		});
+
+		test("trailing @ keeps a percentage-like tag whole with no percentage", ({
+			expect,
+		}) => {
+			const result = parseTagSpecs({ versionTag: ["build@2@"] });
+
+			expect(Object.fromEntries(result)).toMatchObject({ "build@2": null });
 		});
 
 		test("throws on empty tag", ({ expect }) => {
@@ -1518,12 +1536,12 @@ describe("units", () => {
 			);
 		});
 
-		test("throws on unparseable percentage", ({ expect }) => {
-			expect(() =>
-				parseTagSpecs({ versionTag: ["abc1234@oops"] })
-			).toThrowError(
-				`Could not parse percentage value from --version-tag arg "abc1234@oops"`
-			);
+		test("treats a non-numeric @ suffix as part of the tag", ({ expect }) => {
+			const result = parseTagSpecs({ versionTag: ["abc1234@oops"] });
+
+			expect(Object.fromEntries(result)).toMatchObject({
+				"abc1234@oops": null,
+			});
 		});
 	});
 

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, it, test, vi } from "vitest";
 import { normalizeOutput } from "../../../e2e/helpers/normalize";
 import {
 	assignAndDistributePercentages,
+	parseTagSpecs,
 	parseVersionSpecs,
 	summariseVersionTraffic,
 	validateTrafficSubtotal,
@@ -71,6 +72,93 @@ const mswGetVersion30000000 = http.get(
 						limits: { cpu_ms: 50 },
 					},
 				},
+			})
+		)
+);
+
+// MSW handler for the deployable-versions endpoint (GET /versions?deployable=true)
+// returning versions that carry `workers/tag` annotations, used to test
+// `versions deploy --tag <tag>`.
+const mswListVersionsWithTags = http.get(
+	"*/accounts/:accountId/workers/scripts/:workerName/versions",
+	() =>
+		HttpResponse.json(
+			createFetchResult({
+				items: [
+					{
+						id: "10000000-0000-0000-0000-000000000000",
+						number: "1",
+						annotations: {
+							"workers/triggered_by": "upload",
+							"workers/tag": "abc1234",
+						},
+						metadata: {
+							author_id: "Picard-Gamma-6-0-7-3",
+							author_email: "Jean-Luc-Picard@federation.org",
+							source: "wrangler",
+							created_on: "2021-01-01T00:00:00.000000Z",
+							modified_on: "2021-01-01T00:00:00.000000Z",
+						},
+					},
+					{
+						id: "20000000-0000-0000-0000-000000000000",
+						number: "2",
+						annotations: {
+							"workers/triggered_by": "upload",
+							"workers/tag": "def5678",
+						},
+						metadata: {
+							author_id: "Picard-Gamma-6-0-7-3",
+							author_email: "Jean-Luc-Picard@federation.org",
+							source: "wrangler",
+							created_on: "2021-01-02T00:00:00.000000Z",
+							modified_on: "2021-01-02T00:00:00.000000Z",
+						},
+					},
+				],
+			})
+		)
+);
+
+// MSW handler where two deployable versions share the same `workers/tag`,
+// used to test the ambiguity error.
+const mswListVersionsWithDuplicateTags = http.get(
+	"*/accounts/:accountId/workers/scripts/:workerName/versions",
+	() =>
+		HttpResponse.json(
+			createFetchResult({
+				items: [
+					{
+						id: "10000000-0000-0000-0000-000000000000",
+						number: "1",
+						annotations: {
+							"workers/triggered_by": "upload",
+							"workers/tag": "dupe",
+						},
+						metadata: {
+							author_id: "Picard-Gamma-6-0-7-3",
+							author_email: "Jean-Luc-Picard@federation.org",
+							source: "wrangler",
+							created_on: "2021-01-01T00:00:00.000000Z",
+							modified_on: "2021-01-01T00:00:00.000000Z",
+						},
+					},
+					{
+						id: "20000000-0000-0000-0000-000000000000",
+						number: "2",
+						annotations: {
+							"workers/triggered_by": "upload",
+							"workers/tag": "dupe",
+						},
+						metadata: {
+							author_id: "Picard-Gamma-6-0-7-3",
+							author_email: "Jean-Luc-Picard@federation.org",
+							source: "wrangler",
+							created_on: "2021-01-02T00:00:00.000000Z",
+							modified_on: "2021-01-02T00:00:00.000000Z",
+						},
+					},
+				],
 			})
 		)
 );
@@ -1180,6 +1268,130 @@ describe("versions deploy", () => {
 				expect(consoleStd.warn).toMatchInlineSnapshot(`""`);
 			});
 		});
+
+		describe("deploy by tag", () => {
+			type DeployedVersion = { version_id: string; percentage: number };
+
+			// Captures the versions sent to the create-deployment endpoint so we can
+			// assert that the tag was resolved to the correct Version ID.
+			function captureDeployment() {
+				const captured: { versions?: DeployedVersion[] } = {};
+				msw.use(
+					http.post(
+						"*/accounts/:accountId/workers/scripts/:workerName/deployments",
+						async ({ request }) => {
+							const body = (await request.json()) as {
+								versions: DeployedVersion[];
+							};
+							captured.versions = body.versions;
+							return HttpResponse.json(
+								createFetchResult({ id: "mock-new-deployment-id" })
+							);
+						}
+					)
+				);
+				return captured;
+			}
+
+			test("resolves a single tag to its Version ID and deploys it", async ({
+				expect,
+			}) => {
+				writeWranglerConfig();
+				msw.use(mswListVersionsWithTags);
+				const captured = captureDeployment();
+
+				await expect(
+					runWrangler("versions deploy --tag def5678@100% --yes")
+				).resolves.toBeUndefined();
+
+				expect(captured.versions).toEqual([
+					{
+						version_id: "20000000-0000-0000-0000-000000000000",
+						percentage: 100,
+					},
+				]);
+
+				const output = normalizeOutput(cliStd.out);
+				expect(output).toContain("Resolving tags to versions");
+				expect(output).toContain("SUCCESS  Deployed test-name version");
+			});
+
+			test("splits traffic between multiple tags using shorthand percentages", async ({
+				expect,
+			}) => {
+				writeWranglerConfig();
+				msw.use(mswListVersionsWithTags);
+				const captured = captureDeployment();
+
+				await expect(
+					runWrangler(
+						"versions deploy --tag abc1234@40% --tag def5678@60% --yes"
+					)
+				).resolves.toBeUndefined();
+
+				expect(captured.versions).toEqual([
+					{
+						version_id: "10000000-0000-0000-0000-000000000000",
+						percentage: 40,
+					},
+					{
+						version_id: "20000000-0000-0000-0000-000000000000",
+						percentage: 60,
+					},
+				]);
+			});
+
+			test("can be combined with a Version ID", async ({ expect }) => {
+				writeWranglerConfig();
+				msw.use(mswListVersionsWithTags);
+				const captured = captureDeployment();
+
+				await expect(
+					runWrangler(
+						"versions deploy 10000000-0000-0000-0000-000000000000@30% --tag def5678@70% --yes"
+					)
+				).resolves.toBeUndefined();
+
+				expect(captured.versions).toEqual([
+					{
+						version_id: "10000000-0000-0000-0000-000000000000",
+						percentage: 30,
+					},
+					{
+						version_id: "20000000-0000-0000-0000-000000000000",
+						percentage: 70,
+					},
+				]);
+			});
+
+			test("errors when no deployable version matches the tag", async ({
+				expect,
+			}) => {
+				writeWranglerConfig();
+				msw.use(mswListVersionsWithTags);
+
+				await expect(runWrangler("versions deploy --tag nope@100% --yes"))
+					.rejects.toMatchInlineSnapshot(`
+					[Error: No deployable version found with tag "nope".
+					Tags can only be resolved against recent (deployable) versions. Run \`wrangler versions list\` to see available versions, or deploy by Version ID directly.]
+				`);
+			});
+
+			test("errors when a tag matches multiple versions", async ({
+				expect,
+			}) => {
+				writeWranglerConfig();
+				msw.use(mswListVersionsWithDuplicateTags);
+
+				await expect(runWrangler("versions deploy --tag dupe@100% --yes"))
+					.rejects.toMatchInlineSnapshot(`
+					[Error: Tag "dupe" matches multiple versions:
+					  - 20000000-0000-0000-0000-000000000000
+					  - 10000000-0000-0000-0000-000000000000
+					Deploy by Version ID directly to disambiguate.]
+				`);
+			});
+		});
 	});
 });
 
@@ -1251,6 +1463,55 @@ describe("units", () => {
 				"10000000-0000-0000-0000-000000000000": 10,
 				"20000000-0000-0000-0000-000000000000": null,
 			});
+		});
+	});
+
+	describe("parseTagSpecs", () => {
+		test("no args", ({ expect }) => {
+			const result = parseTagSpecs({});
+
+			expect(result).toMatchObject(new Map());
+		});
+
+		test("tag without percentage", ({ expect }) => {
+			const result = parseTagSpecs({ tag: ["abc1234"] });
+
+			expect(Object.fromEntries(result)).toMatchObject({ abc1234: null });
+		});
+
+		test("tag with percentage shorthand", ({ expect }) => {
+			const result = parseTagSpecs({ tag: ["abc1234@100%"] });
+
+			expect(Object.fromEntries(result)).toMatchObject({ abc1234: 100 });
+		});
+
+		test("multiple tags with percentages", ({ expect }) => {
+			const result = parseTagSpecs({
+				tag: ["abc1234@40%", "def5678@60%"],
+			});
+
+			expect(Object.fromEntries(result)).toMatchObject({
+				abc1234: 40,
+				def5678: 60,
+			});
+		});
+
+		test("throws on empty tag", ({ expect }) => {
+			expect(() => parseTagSpecs({ tag: ["@100%"] })).toThrowError(
+				`Could not parse a tag from --tag arg "@100%".`
+			);
+		});
+
+		test("throws on out-of-range percentage", ({ expect }) => {
+			expect(() => parseTagSpecs({ tag: ["abc1234@101%"] })).toThrowError(
+				`Percentage value (101%) parsed from --tag arg "abc1234@101%" must be between 0 and 100.`
+			);
+		});
+
+		test("throws on unparseable percentage", ({ expect }) => {
+			expect(() => parseTagSpecs({ tag: ["abc1234@oops"] })).toThrowError(
+				`Could not parse percentage value from --tag arg "abc1234@oops"`
+			);
 		});
 	});
 

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -1498,6 +1498,12 @@ describe("units", () => {
 			});
 		});
 
+		test("tag containing @ splits on the last @", ({ expect }) => {
+			const result = parseTagSpecs({ versionTag: ["v1.0@beta@100%"] });
+
+			expect(Object.fromEntries(result)).toMatchObject({ "v1.0@beta": 100 });
+		});
+
 		test("throws on empty tag", ({ expect }) => {
 			expect(() => parseTagSpecs({ versionTag: ["@100%"] })).toThrowError(
 				`Could not parse a tag from --version-tag arg "@100%".`

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -760,6 +760,44 @@ type ParseTagSpecsArgs = {
 	versionTag?: string[];
 };
 
+// A percentage suffix in a `<version-tag>@<percentage>` spec, e.g. "100", "100%"
+// or "50.5%". An out-of-range value like "101%" still matches (and is reported
+// later by parseOptionalPercentage); a non-numeric suffix does not.
+const PERCENTAGE_SUFFIX_REGEX = /^-?\d+(\.\d+)?%?$/;
+
+/**
+ * Splits a `<version-tag>@<percentage>` spec into its tag and percentage parts.
+ *
+ * Tags can contain `@` (the upload `--tag` flag accepts arbitrary strings), so
+ * we split on the *last* `@` and only treat the suffix as a percentage when it
+ * actually looks like one. That way `v1.0@beta@100%` parses as tag `v1.0@beta`
+ * at 100%, while `v1.0@beta` (no percentage) is kept whole as the tag rather
+ * than misreading `beta` as a percentage.
+ */
+function splitTagSpec(spec: string): {
+	tag: string;
+	percentageString: string | undefined;
+} {
+	const atIndex = spec.lastIndexOf("@");
+	if (atIndex === -1) {
+		return { tag: spec, percentageString: undefined };
+	}
+
+	const suffix = spec.substring(atIndex + 1);
+
+	// A trailing `@` (empty suffix) is an explicit "no percentage" separator,
+	// letting you keep a tag that ends in something percentage-like whole.
+	if (suffix === "") {
+		return { tag: spec.substring(0, atIndex), percentageString: undefined };
+	}
+
+	if (PERCENTAGE_SUFFIX_REGEX.test(suffix)) {
+		return { tag: spec.substring(0, atIndex), percentageString: suffix };
+	}
+
+	return { tag: spec, percentageString: undefined };
+}
+
 /**
  * Parses the `--version-tag` args into a map of tag to optional percentage,
  * supporting the `<version-tag>@<percentage>` shorthand. Tags are resolved to
@@ -771,12 +809,7 @@ export function parseTagSpecs(
 	const tagTraffic = new Map<string, OptionalPercentage>();
 
 	for (const spec of args.versionTag ?? []) {
-		// Split on the last `@` so that tags which themselves contain `@` (the
-		// upload `--tag` flag accepts arbitrary strings) are not truncated.
-		const atIndex = spec.lastIndexOf("@");
-		const tag = atIndex === -1 ? spec : spec.substring(0, atIndex);
-		const percentageString =
-			atIndex === -1 ? undefined : spec.substring(atIndex + 1);
+		const { tag, percentageString } = splitTagSpec(spec);
 
 		if (!tag) {
 			throw new UserError(

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -76,9 +76,9 @@ export const versionsDeployCommand = createCommand({
 			type: "string",
 			array: true,
 		},
-		tag: {
+		"version-tag": {
 			describe:
-				"Worker Version tag(s) to deploy, resolved to a Version ID against the deployable versions. Supports the shorthand notation [<tag>@<percentage>..].",
+				"Worker Version tag(s) to deploy, resolved to a Version ID against the deployable versions. Supports the shorthand notation [<version-tag>@<percentage>..].",
 			type: "string",
 			array: true,
 			requiresArg: true,
@@ -136,8 +136,8 @@ export const versionsDeployCommand = createCommand({
 
 		await printLatestDeployment(config, accountId, workerName, versionCache);
 
-		// Resolve any --tag args to their Version IDs against the deployable
-		// versions, then merge them into the version traffic to deploy.
+		// Resolve any --version-tag args to their Version IDs against the
+		// deployable versions, then merge them into the version traffic to deploy.
 		if (tagTraffic.size > 0) {
 			const resolvedTagTraffic = await resolveTagsToVersions(
 				config,
@@ -757,32 +757,33 @@ export function parseVersionSpecs(
 }
 
 type ParseTagSpecsArgs = {
-	tag?: string[];
+	versionTag?: string[];
 };
 
 /**
- * Parses the `--tag` args into a map of tag to optional percentage, supporting
- * the `<tag>@<percentage>` shorthand. Tags are resolved to Version IDs later by
- * {@link resolveTagsToVersions}.
+ * Parses the `--version-tag` args into a map of tag to optional percentage,
+ * supporting the `<version-tag>@<percentage>` shorthand. Tags are resolved to
+ * Version IDs later by {@link resolveTagsToVersions}.
  */
 export function parseTagSpecs(
 	args: ParseTagSpecsArgs
 ): Map<string, OptionalPercentage> {
 	const tagTraffic = new Map<string, OptionalPercentage>();
 
-	for (const spec of args.tag ?? []) {
+	for (const spec of args.versionTag ?? []) {
 		const [tag, percentageString] = spec.split("@");
 
 		if (!tag) {
-			throw new UserError(`Could not parse a tag from --tag arg "${spec}".`, {
-				telemetryMessage: "versions deploy tag parse failed",
-			});
+			throw new UserError(
+				`Could not parse a tag from --version-tag arg "${spec}".`,
+				{ telemetryMessage: "versions deploy tag parse failed" }
+			);
 		}
 
 		const percentage = parseOptionalPercentage(
 			percentageString,
 			spec,
-			"--tag arg"
+			"--version-tag arg"
 		);
 
 		tagTraffic.set(tag, percentage);
@@ -792,7 +793,7 @@ export function parseTagSpecs(
 }
 
 /**
- * Resolves tags (e.g. commit SHAs supplied via `--tag`) to Version IDs by
+ * Resolves tags (e.g. commit SHAs supplied via `--version-tag`) to Version IDs by
  * matching against the `workers/tag` annotation on the worker's deployable
  * versions.
  *

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -771,7 +771,12 @@ export function parseTagSpecs(
 	const tagTraffic = new Map<string, OptionalPercentage>();
 
 	for (const spec of args.versionTag ?? []) {
-		const [tag, percentageString] = spec.split("@");
+		// Split on the last `@` so that tags which themselves contain `@` (the
+		// upload `--tag` flag accepts arbitrary strings) are not truncated.
+		const atIndex = spec.lastIndexOf("@");
+		const tag = atIndex === -1 ? spec : spec.substring(0, atIndex);
+		const percentageString =
+			atIndex === -1 ? undefined : spec.substring(atIndex + 1);
 
 		if (!tag) {
 			throw new UserError(

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -659,8 +659,6 @@ async function maybePatchSettings(
 // ***********
 //    UNITS
 // ***********
-type Tag = string;
-
 /**
  * Parses an optional `@<percentage>` suffix from a shorthand spec (e.g.
  * `<version-id>@<percentage>` or `<tag>@<percentage>`), validating that the
@@ -758,9 +756,10 @@ export function parseVersionSpecs(
 	return optionalVersionTraffic;
 }
 
-export type ParseTagSpecsArgs = {
+type ParseTagSpecsArgs = {
 	tag?: string[];
 };
+
 /**
  * Parses the `--tag` args into a map of tag to optional percentage, supporting
  * the `<tag>@<percentage>` shorthand. Tags are resolved to Version IDs later by
@@ -768,13 +767,13 @@ export type ParseTagSpecsArgs = {
  */
 export function parseTagSpecs(
 	args: ParseTagSpecsArgs
-): Map<Tag, OptionalPercentage> {
-	const tagTraffic = new Map<Tag, OptionalPercentage>();
+): Map<string, OptionalPercentage> {
+	const tagTraffic = new Map<string, OptionalPercentage>();
 
 	for (const spec of args.tag ?? []) {
 		const [tag, percentageString] = spec.split("@");
 
-		if (tag === "") {
+		if (!tag) {
 			throw new UserError(`Could not parse a tag from --tag arg "${spec}".`, {
 				telemetryMessage: "versions deploy tag parse failed",
 			});
@@ -809,7 +808,7 @@ async function resolveTagsToVersions(
 	complianceConfig: ComplianceConfig,
 	accountId: string,
 	workerName: string,
-	tagTraffic: Map<Tag, OptionalPercentage>,
+	tagTraffic: Map<string, OptionalPercentage>,
 	versionCache: VersionCache
 ): Promise<Map<VersionId, OptionalPercentage>> {
 	const versions = await spinnerWhile({
@@ -826,7 +825,7 @@ async function resolveTagsToVersions(
 
 	// A tag may be present on more than one version (e.g. a re-deploy of the same
 	// commit, or a secret change inheriting the tag), so collect all matches.
-	const versionsByTag = new Map<Tag, ApiVersion[]>();
+	const versionsByTag = new Map<string, ApiVersion[]>();
 	for (const version of versions) {
 		const tag = version.annotations?.["workers/tag"];
 		if (tag === undefined) {

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -76,6 +76,13 @@ export const versionsDeployCommand = createCommand({
 			type: "string",
 			array: true,
 		},
+		tag: {
+			describe:
+				"Worker Version tag(s) to deploy, resolved to a Version ID against the deployable versions. Supports the shorthand notation [<tag>@<percentage>..].",
+			type: "string",
+			array: true,
+			requiresArg: true,
+		},
 		message: {
 			describe: "Description of this deployment (optional)",
 			type: "string",
@@ -117,7 +124,9 @@ export const versionsDeployCommand = createCommand({
 
 		const versionCache: VersionCache = new Map();
 		const optionalVersionTraffic = parseVersionSpecs(args);
-		const acceptPromptDefaults = args.yes || optionalVersionTraffic.size > 0;
+		const tagTraffic = parseTagSpecs(args);
+		const acceptPromptDefaults =
+			args.yes || optionalVersionTraffic.size + tagTraffic.size > 0;
 
 		cli.startSection(
 			"Deploy Worker Versions",
@@ -126,6 +135,21 @@ export const versionsDeployCommand = createCommand({
 		);
 
 		await printLatestDeployment(config, accountId, workerName, versionCache);
+
+		// Resolve any --tag args to their Version IDs against the deployable
+		// versions, then merge them into the version traffic to deploy.
+		if (tagTraffic.size > 0) {
+			const resolvedTagTraffic = await resolveTagsToVersions(
+				config,
+				accountId,
+				workerName,
+				tagTraffic,
+				versionCache
+			);
+			for (const [versionId, percentage] of resolvedTagTraffic) {
+				optionalVersionTraffic.set(versionId, percentage);
+			}
+		}
 
 		// prompt to confirm or change the versionIds from the args
 		const confirmedVersionsToDeploy = await promptVersionsToDeploy(
@@ -635,6 +659,48 @@ async function maybePatchSettings(
 // ***********
 //    UNITS
 // ***********
+type Tag = string;
+
+/**
+ * Parses an optional `@<percentage>` suffix from a shorthand spec (e.g.
+ * `<version-id>@<percentage>` or `<tag>@<percentage>`), validating that the
+ * percentage (if present) is a number between 0 and 100.
+ *
+ * @param percentageString The raw percentage portion (after the `@`), if any.
+ * @param spec The full spec string, used for error messages.
+ * @param specLabel A label describing the arg the spec came from, used for error messages.
+ * @returns The parsed percentage, or `null` if none was specified.
+ */
+function parseOptionalPercentage(
+	percentageString: string | undefined,
+	spec: string,
+	specLabel: string
+): OptionalPercentage {
+	if (percentageString === undefined || percentageString === "") {
+		return null;
+	}
+
+	const percentage = parseFloat(percentageString);
+
+	if (isNaN(percentage)) {
+		throw new UserError(
+			`Could not parse percentage value from ${specLabel} "${spec}"`,
+			{ telemetryMessage: "versions deploy percentage parse failed" }
+		);
+	}
+
+	if (percentage < 0 || percentage > 100) {
+		throw new UserError(
+			`Percentage value (${percentage}%) parsed from ${specLabel} "${spec}" must be between 0 and 100.`,
+			{
+				telemetryMessage: "versions deploy positional percentage out of range",
+			}
+		);
+	}
+
+	return percentage;
+}
+
 export type ParseVersionSpecsArgs = {
 	percentage?: number[];
 	versionId?: string[];
@@ -649,29 +715,11 @@ export function parseVersionSpecs(
 	for (const spec of args.versionSpecs ?? []) {
 		const [versionId, percentageString] = spec.split("@");
 
-		const percentage =
-			percentageString === undefined || percentageString === ""
-				? null
-				: parseFloat(percentageString);
-
-		if (percentage !== null) {
-			if (isNaN(percentage)) {
-				throw new UserError(
-					`Could not parse percentage value from version-spec positional arg "${spec}"`,
-					{ telemetryMessage: "versions deploy percentage parse failed" }
-				);
-			}
-
-			if (percentage < 0 || percentage > 100) {
-				throw new UserError(
-					`Percentage value (${percentage}%) parsed from version-spec positional arg "${spec}" must be between 0 and 100.`,
-					{
-						telemetryMessage:
-							"versions deploy positional percentage out of range",
-					}
-				);
-			}
-		}
+		const percentage = parseOptionalPercentage(
+			percentageString,
+			spec,
+			"version-spec positional arg"
+		);
 
 		versionIds.push(versionId);
 		percentages.push(percentage);
@@ -708,6 +756,116 @@ export function parseVersionSpecs(
 	);
 
 	return optionalVersionTraffic;
+}
+
+export type ParseTagSpecsArgs = {
+	tag?: string[];
+};
+/**
+ * Parses the `--tag` args into a map of tag to optional percentage, supporting
+ * the `<tag>@<percentage>` shorthand. Tags are resolved to Version IDs later by
+ * {@link resolveTagsToVersions}.
+ */
+export function parseTagSpecs(
+	args: ParseTagSpecsArgs
+): Map<Tag, OptionalPercentage> {
+	const tagTraffic = new Map<Tag, OptionalPercentage>();
+
+	for (const spec of args.tag ?? []) {
+		const [tag, percentageString] = spec.split("@");
+
+		if (tag === "") {
+			throw new UserError(`Could not parse a tag from --tag arg "${spec}".`, {
+				telemetryMessage: "versions deploy tag parse failed",
+			});
+		}
+
+		const percentage = parseOptionalPercentage(
+			percentageString,
+			spec,
+			"--tag arg"
+		);
+
+		tagTraffic.set(tag, percentage);
+	}
+
+	return tagTraffic;
+}
+
+/**
+ * Resolves tags (e.g. commit SHAs supplied via `--tag`) to Version IDs by
+ * matching against the `workers/tag` annotation on the worker's deployable
+ * versions.
+ *
+ * Tags are not guaranteed to be unique, so this errors if a tag matches more
+ * than one version, prompting the user to disambiguate with a Version ID. It
+ * also errors if a tag matches no deployable version (e.g. the version has aged
+ * out of the deployable window).
+ *
+ * The fetched versions populate `versionCache`, so a subsequent
+ * `promptVersionsToDeploy` call can reuse them without re-fetching.
+ */
+async function resolveTagsToVersions(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	workerName: string,
+	tagTraffic: Map<Tag, OptionalPercentage>,
+	versionCache: VersionCache
+): Promise<Map<VersionId, OptionalPercentage>> {
+	const versions = await spinnerWhile({
+		startMessage: "Resolving tags to versions",
+		promise() {
+			return fetchDeployableVersions(
+				complianceConfig,
+				accountId,
+				workerName,
+				versionCache
+			);
+		},
+	});
+
+	// A tag may be present on more than one version (e.g. a re-deploy of the same
+	// commit, or a secret change inheriting the tag), so collect all matches.
+	const versionsByTag = new Map<Tag, ApiVersion[]>();
+	for (const version of versions) {
+		const tag = version.annotations?.["workers/tag"];
+		if (tag === undefined) {
+			continue;
+		}
+
+		const matches = versionsByTag.get(tag) ?? [];
+		matches.push(version);
+		versionsByTag.set(tag, matches);
+	}
+
+	const resolvedVersionTraffic = new Map<VersionId, OptionalPercentage>();
+	for (const [tag, percentage] of tagTraffic) {
+		const matches = versionsByTag.get(tag) ?? [];
+
+		if (matches.length === 0) {
+			throw new UserError(
+				`No deployable version found with tag "${tag}".\nTags can only be resolved against recent (deployable) versions. Run \`wrangler versions list\` to see available versions, or deploy by Version ID directly.`,
+				{ telemetryMessage: "versions deploy tag not found" }
+			);
+		}
+
+		if (matches.length > 1) {
+			const ids = matches
+				.sort((a, b) =>
+					b.metadata.created_on.localeCompare(a.metadata.created_on)
+				)
+				.map((version) => `  - ${version.id}`)
+				.join("\n");
+			throw new UserError(
+				`Tag "${tag}" matches multiple versions:\n${ids}\nDeploy by Version ID directly to disambiguate.`,
+				{ telemetryMessage: "versions deploy tag ambiguous" }
+			);
+		}
+
+		resolvedVersionTraffic.set(matches[0].id, percentage);
+	}
+
+	return resolvedVersionTraffic;
 }
 
 export function assignAndDistributePercentages(


### PR DESCRIPTION
Production deploys are commonly tagged with the commit SHA via `wrangler versions deploy --tag <sha>` (or at upload time). When rolling back, developers think in commit SHAs, but `wrangler versions deploy` only accepts CF Version IDs — so a rollback requires first running `wrangler versions list` to map a commit SHA to a Version ID.

This adds a `--version-tag` flag to `wrangler versions deploy` so you can deploy a version by its tag directly:

```sh
wrangler versions deploy --version-tag <sha>@100%
```

The tag is resolved to a Version ID by matching the `workers/tag` annotation against the worker's deployable versions. The `<version-tag>@<percentage>` shorthand mirrors the existing `<version-id>@<percentage>` notation, and multiple `--version-tag` values can be used to split traffic (and `--version-tag` can be combined with explicit Version IDs).

Behaviour notes:

- If a tag matches **no** deployable version, the command errors and points to `wrangler versions list`.
- If a tag matches **more than one** version, the command errors and lists the matching Version IDs so you can disambiguate by deploying with a Version ID directly.
- Tags can only be resolved against recent (deployable) versions — versions that have aged out of the deployable window must still be deployed by Version ID.

The deployable-versions fetch populates the existing version cache, so the subsequent prompt/deploy flow reuses it without extra API round-trips.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this PR is an initial draft for review; a Cloudflare docs update for the new `--version-tag` flag will follow before it ships.
