### PR TITLE
Improve authentication error messages with specific failure reasons

### DIFF
--- a/.changeset/improve-login-error-messages.md
+++ b/.changeset/improve-login-error-messages.md
@@ -1,0 +1,10 @@
+---
+"@cloudflare/workers-auth": patch
+"wrangler": patch
+---
+
+Improve authentication error messages with specific failure reasons
+
+When authentication fails (e.g. during `wrangler dev --remote` or when using remote bindings), the error message now explains exactly what went wrong -- whether no credentials were found, the token expired, or the environment is non-interactive -- and lists actionable steps to fix it, including a `wrangler whoami` tip.
+
+Previously, auth failures could produce multiple confusing errors (e.g. "Failed to fetch auth token: 400 Bad Request" followed by "Failed to start the remote proxy session"). Now a single, clear error is shown.

--- a/packages/workers-auth/src/flow.ts
+++ b/packages/workers-auth/src/flow.ts
@@ -33,6 +33,31 @@ import type { OAuthFlowContext } from "./context";
 import type { ComplianceConfig } from "@cloudflare/workers-utils";
 
 /**
+ * Reason why {@link OAuthFlowAPI.loginOrRefreshIfRequired} could not
+ * authenticate the user.
+ */
+export type LoginOrRefreshFailureReason =
+	/** no stored credentials and the environment is non-interactive (CI, piped stdin, etc.) so a browser login cannot be started. */
+	| "no-credentials-non-interactive"
+	/** stored credentials and the interactive login attempt was unsuccessful (user cancelled, etc.). */
+	| "no-credentials-login-failed"
+	/** the stored token has expired, refresh failed, and the environment is non-interactive so a browser login cannot be started. */
+	| "token-expired-non-interactive"
+	/** the stored token has expired, refresh failed, and the interactive login attempt was unsuccessful. */
+	| "token-expired-login-failed";
+
+/**
+ * Discriminated union returned by {@link OAuthFlowAPI.loginOrRefreshIfRequired}.
+ *
+ * When `loggedIn` is `true` the caller can proceed. When `false`, `reason`
+ * describes why authentication failed so the caller can surface a
+ * targeted error message.
+ */
+export type LoginOrRefreshResult =
+	| { loggedIn: true }
+	| { loggedIn: false; reason: LoginOrRefreshFailureReason };
+
+/**
  * Options for an interactive OAuth login.
  */
 export interface LoginProps {
@@ -86,11 +111,12 @@ export interface OAuthFlowAPI {
 	 * Scopes are required in case an interactive login is triggered — the
 	 * consumer's scope catalog lives outside this package.
 	 *
-	 * @returns `true` when the user is logged in (or env credentials are
-	 * present), `false` when interactive login was needed but skipped (e.g.
-	 * non-interactive environment).
+	 * @returns `{ loggedIn: true }` when the user is authenticated (or env
+	 * credentials are present). When authentication fails, returns
+	 * `{ loggedIn: false, reason }` describing why — see
+	 * {@link LoginOrRefreshFailureReason}.
 	 */
-	loginOrRefreshIfRequired(props: LoginProps): Promise<boolean>;
+	loginOrRefreshIfRequired(props: LoginProps): Promise<LoginOrRefreshResult>;
 
 	/**
 	 * Read the OAuth access token from local state, refreshing it first if
@@ -240,32 +266,51 @@ export function createOAuthFlow(ctx: OAuthFlowContext): OAuthFlowAPI {
 		}
 	}
 
-	async function loginOrRefreshIfRequired(props: LoginProps): Promise<boolean> {
+	async function loginOrRefreshIfRequired(
+		props: LoginProps
+	): Promise<LoginOrRefreshResult> {
 		// If env credentials are present, the consumer's credential resolver
 		// will use those rather than the stored OAuth token, so we don't need
 		// to refresh or log in.
 		if (ctx.hasEnvCredentials()) {
-			return true;
+			return { loggedIn: true };
 		}
 		// TODO: ask permission before opening browser
 		const stored = readStoredAuthState({ warningLogger: ctx.logger });
 		if (!stored.accessToken && !stored.deprecatedApiToken) {
 			// Not logged in.
 			// If we are not interactive, we cannot ask the user to login
-			return !ctx.isNonInteractiveOrCI() && (await login(props));
+			if (ctx.isNonInteractiveOrCI()) {
+				return {
+					loggedIn: false,
+					reason: "no-credentials-non-interactive",
+				};
+			}
+			if (await login(props)) {
+				return { loggedIn: true };
+			}
+			return { loggedIn: false, reason: "no-credentials-login-failed" };
 		} else if (isRefreshNeeded()) {
 			// We're logged in, but the refresh token seems to have expired,
 			// so let's try to refresh it
 			const didRefresh = await refreshToken();
 			if (didRefresh) {
 				// The token was refreshed, so we're done here
-				return true;
-			} else {
-				// If the refresh token isn't valid, then we ask the user to login again
-				return !ctx.isNonInteractiveOrCI() && (await login(props));
+				return { loggedIn: true };
 			}
+			// If the refresh token isn't valid, then we ask the user to login again
+			if (ctx.isNonInteractiveOrCI()) {
+				return {
+					loggedIn: false,
+					reason: "token-expired-non-interactive",
+				};
+			}
+			if (await login(props)) {
+				return { loggedIn: true };
+			}
+			return { loggedIn: false, reason: "token-expired-login-failed" };
 		} else {
-			return true;
+			return { loggedIn: true };
 		}
 	}
 

--- a/packages/workers-auth/src/index.ts
+++ b/packages/workers-auth/src/index.ts
@@ -56,7 +56,12 @@ export {
 } from "./errors";
 
 export { createOAuthFlow, OAUTH_CALLBACK_URL } from "./flow";
-export type { LoginProps, OAuthFlowAPI } from "./flow";
+export type {
+	LoginOrRefreshFailureReason,
+	LoginOrRefreshResult,
+	LoginProps,
+	OAuthFlowAPI,
+} from "./flow";
 
 export { generateAuthUrl } from "./generate-auth-url";
 

--- a/packages/workers-auth/src/token-exchange.ts
+++ b/packages/workers-auth/src/token-exchange.ts
@@ -325,7 +325,10 @@ export async function fetchAuthToken(
 			headers,
 		});
 		if (!response.ok) {
-			logger.error(
+			// Log at debug level — callers handle non-OK responses and surface
+			// structured errors, so an error-level log here would be redundant
+			// noise that confuses users with multiple error messages.
+			logger.debug(
 				"Failed to fetch auth token:",
 				response.status,
 				response.statusText
@@ -333,7 +336,8 @@ export async function fetchAuthToken(
 		}
 		return response;
 	} catch (e) {
-		logger.error("Failed to fetch auth token:", e);
+		// Log at debug level — the error is re-thrown for the caller to handle.
+		logger.debug("Failed to fetch auth token:", e);
 		throw e;
 	}
 }

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -224,7 +224,15 @@ describe.sequential("wrangler dev", () => {
 			await expect(
 				runWrangler("dev --remote index.js")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: You must be logged in to use wrangler dev in remote mode. Try logging in, or run wrangler dev --local.]`
+				`
+				[Error: Could not start remote dev session. No credentials found, and the environment is non-interactive so browser login cannot be started.
+				Either:
+				 - Set a CLOUDFLARE_API_TOKEN environment variable
+				 - Run \`wrangler login\` in an interactive terminal first
+				 - Or use \`wrangler dev --local\` to develop locally (remote resources like KV, D1, etc. will use local simulators instead).
+
+				You can run \`wrangler whoami\` to check your current authentication status.]
+			`
 			);
 		});
 	});

--- a/packages/wrangler/src/__tests__/dev/remote-bindings-errors.test.ts
+++ b/packages/wrangler/src/__tests__/dev/remote-bindings-errors.test.ts
@@ -43,12 +43,10 @@ describe("errors during dev with remote bindings", () => {
 
 		assert(thrownError);
 
-		expect(thrownError.message).toContain(
-			"Failed to start the remote proxy session"
-		);
-
-		// The issue here is that with the test setup there is more than one account available (but we're
-		// in non-interactive mode). Here we make sure that this information is presented in the thrown error
+		// UserErrors (like auth/account selection failures) are re-thrown
+		// directly without being wrapped in a generic "Failed to start the
+		// remote proxy session" envelope, so the user sees a single,
+		// actionable error message.
 		expect(thrownError.message).toContain(
 			"More than one account available but unable to select one in non-interactive mode."
 		);

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -422,7 +422,10 @@ describe("User", () => {
 		vi.mocked(ci).isCI = true;
 		await expect(
 			loginOrRefreshIfRequired(COMPLIANCE_REGION_CONFIG_UNKNOWN)
-		).resolves.toEqual(false);
+		).resolves.toEqual({
+			loggedIn: false,
+			reason: "no-credentials-non-interactive",
+		});
 	});
 
 	it("should revert to non-interactive mode if isTTY throws an error", async ({
@@ -436,7 +439,10 @@ describe("User", () => {
 		});
 		await expect(
 			loginOrRefreshIfRequired(COMPLIANCE_REGION_CONFIG_UNKNOWN)
-		).resolves.toEqual(false);
+		).resolves.toEqual({
+			loggedIn: false,
+			reason: "no-credentials-non-interactive",
+		});
 	});
 
 	describe("CLOUDFLARE_API_TOKEN priority over stored OAuth state", () => {
@@ -488,7 +494,7 @@ describe("User", () => {
 
 			await expect(
 				loginOrRefreshIfRequired(COMPLIANCE_REGION_CONFIG_UNKNOWN)
-			).resolves.toEqual(true);
+			).resolves.toEqual({ loggedIn: true });
 			expect(oauthRefreshCalled).toBe(false);
 		});
 

--- a/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
+++ b/packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts
@@ -1,5 +1,6 @@
 import events from "node:events";
 import path from "node:path";
+import { UserError } from "@cloudflare/workers-utils";
 import chalk from "chalk";
 import { DeferredPromise } from "miniflare";
 import remoteBindingsWorkerPath from "worker:remoteBindings/ProxyServerWorker";
@@ -116,6 +117,13 @@ export async function startRemoteProxySession(
 		},
 		bindings: rawBindings,
 	}).catch((startWorkerError) => {
+		// If the error is already a UserError (e.g. an auth failure from
+		// ConfigController), re-throw it directly so the top-level error
+		// handler can display the original, actionable message without
+		// wrapping it in a generic "Failed to start" envelope.
+		if (startWorkerError instanceof UserError) {
+			throw startWorkerError;
+		}
 		let errorMessage = startWorkerError;
 		if (startWorkerError instanceof Error) {
 			if (startWorkerError.cause instanceof Error) {

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -46,6 +46,7 @@ import type {
 	StartDevWorkerOptions,
 	Trigger,
 } from "./types";
+import type { LoginOrRefreshFailureReason } from "@cloudflare/workers-auth";
 import type { CfUnsafe, Config } from "@cloudflare/workers-utils";
 import type { WorkerRegistry } from "miniflare";
 
@@ -77,12 +78,15 @@ async function resolveDevConfig(
 ): Promise<StartDevWorkerOptions["dev"]> {
 	const auth = async () => {
 		if (input.dev?.remote) {
-			const isLoggedIn = await loginOrRefreshIfRequired(config);
-			if (!isLoggedIn) {
-				throw new UserError(
-					"You must be logged in to use wrangler dev in remote mode. Try logging in, or run wrangler dev --local.",
-					{ telemetryMessage: "api dev remote login required" }
+			const result = await loginOrRefreshIfRequired(config);
+			if (!result.loggedIn) {
+				const errorMessage = getLoginOrRefreshFailureErrorMessage(
+					input.dev.remote,
+					result.reason
 				);
+				throw new UserError(errorMessage, {
+					telemetryMessage: "api dev remote login required",
+				});
 			}
 		}
 
@@ -169,6 +173,55 @@ async function resolveDevConfig(
 		generateTypes: input.dev?.generateTypes ?? config.dev.generate_types,
 		tunnel: input.dev?.tunnel,
 	} satisfies StartDevWorkerOptions["dev"];
+}
+
+/**
+ * Maps a {@link LoginOrRefreshFailureReason} to a user-facing error message
+ * with actionable remediation steps (e.g. re-running `wrangler login`,
+ * setting `CLOUDFLARE_API_TOKEN`, or falling back to local dev).
+ *
+ * @param remoteMode - The remote dev mode that was requested. When
+ *   `"minimal"` (remote-bindings mode), the suggestion to fall back to
+ *   `--local` dev is omitted because local dev is not a useful alternative.
+ * @param failureReason - The specific {@link LoginOrRefreshFailureReason}
+ *   that describes why login or token refresh could not succeed.
+ * @returns A formatted error message string prefixed with a generic failure
+ *   summary, followed by reason-specific guidance and a `wrangler whoami` tip.
+ */
+function getLoginOrRefreshFailureErrorMessage(
+	remoteMode: boolean | "minimal",
+	failureReason: LoginOrRefreshFailureReason
+) {
+	const errorMessagePrefix = "Could not start remote dev session.";
+	const localFallback =
+		remoteMode === "minimal"
+			? "" // Remote bindings mode — local dev is not a useful fallback
+			: "\n - Or use `wrangler dev --local` to develop locally (remote resources like KV, D1, etc. will use local simulators instead).";
+	const whoamiTip =
+		"\n\nYou can run `wrangler whoami` to check your current authentication status.";
+	const errorMessageBodies = {
+		"no-credentials-non-interactive":
+			" No credentials found, and the environment is non-interactive so browser login cannot be started.\n" +
+			"Either:\n" +
+			" - Set a CLOUDFLARE_API_TOKEN environment variable\n" +
+			` - Run \`wrangler login\` in an interactive terminal first${localFallback}${whoamiTip}`,
+		"no-credentials-login-failed":
+			" No credentials found and the login attempt was unsuccessful.\n" +
+			"Either:\n" +
+			` - Run \`wrangler login\` to try again${localFallback}${whoamiTip}`,
+		"token-expired-non-interactive":
+			" Your auth token has expired and could not be refreshed, and the environment is non-interactive so browser login cannot be started.\n" +
+			"Either:\n" +
+			" - Run `wrangler login` in an interactive terminal\n" +
+			` - Set a CLOUDFLARE_API_TOKEN environment variable${localFallback}${whoamiTip}`,
+		"token-expired-login-failed":
+			" Your auth token has expired and could not be refreshed, and the login attempt was unsuccessful.\n" +
+			"Either:\n" +
+			` - Run \`wrangler login\` to try again${localFallback}${whoamiTip}`,
+	};
+	const errorMessageBody = errorMessageBodies[failureReason];
+	const errorMessage = errorMessagePrefix + errorMessageBody;
+	return errorMessage;
 }
 
 async function resolveBindings(

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -156,12 +156,29 @@ export async function resolveCredentials(
 	return apiToken ?? requireApiToken();
 }
 
+/**
+ * Ensures the user is logged in before making an API request.
+ *
+ * @param complianceConfig - Compliance region configuration
+ * @throws {UserError} If the user could not be authenticated, with a message
+ *   describing the specific reason for failure.
+ */
 export async function requireLoggedIn(
 	complianceConfig: ComplianceConfig
 ): Promise<void> {
-	const loggedIn = await loginOrRefreshIfRequired(complianceConfig);
-	if (!loggedIn) {
-		throw new UserError("Not logged in.", {
+	const result = await loginOrRefreshIfRequired(complianceConfig);
+	if (!result.loggedIn) {
+		const errorMessageBodies: Record<string, string> = {
+			"no-credentials-non-interactive": `Could not authenticate because no credentials were found and the environment is non-interactive. Set a CLOUDFLARE_API_TOKEN environment variable or run \`wrangler login\` in an interactive terminal first.`,
+			"no-credentials-login-failed": `No credentials were found and the login attempt was unsuccessful. Run \`wrangler login\` to try again.`,
+			"token-expired-non-interactive": `Your auth token has expired and could not be refreshed, and the environment is non-interactive. Run \`wrangler login\` in an interactive terminal or set a CLOUDFLARE_API_TOKEN.`,
+			"token-expired-login-failed": `Your auth token has expired and could not be refreshed, and the login attempt was unsuccessful. Run \`wrangler login\` to try again.`,
+		};
+		const errorMessageBody = errorMessageBodies[result.reason];
+		const whoamiTip =
+			"\nRun `wrangler whoami` to check your current authentication status.";
+		const errorMessage = `Not logged in. ${errorMessageBody}${whoamiTip}`;
+		throw new UserError(errorMessage, {
 			telemetryMessage: "cfetch auth login required",
 		});
 	}

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -157,6 +157,29 @@ export async function resolveCredentials(
 }
 
 /**
+ * Maps authentication failure reasons to user-facing error message bodies.
+ *
+ * Each key corresponds to a specific failure scenario returned by
+ * {@link loginOrRefreshIfRequired}, and the value is the descriptive message
+ * included in the {@link UserError} thrown by {@link requireLoggedIn}.
+ */
+const requireLoggedInErrorMessageBodies = {
+	"no-credentials-non-interactive": `Could not authenticate because no credentials were found and the environment is non-interactive. Set a CLOUDFLARE_API_TOKEN environment variable or run \`wrangler login\` in an interactive terminal first.`,
+	"no-credentials-login-failed": `No credentials were found and the login attempt was unsuccessful. Run \`wrangler login\` to try again.`,
+	"token-expired-non-interactive": `Your auth token has expired and could not be refreshed, and the environment is non-interactive. Run \`wrangler login\` in an interactive terminal or set a CLOUDFLARE_API_TOKEN.`,
+	"token-expired-login-failed": `Your auth token has expired and could not be refreshed, and the login attempt was unsuccessful. Run \`wrangler login\` to try again.`,
+} as const;
+
+/**
+ * Tip appended to authentication error messages, prompting the user to run
+ * `wrangler whoami` to inspect their current login state.
+ *
+ * Used by {@link requireLoggedIn} when constructing the {@link UserError} message.
+ */
+const requireLoggedInErrorWhoAmITip =
+	"\nRun `wrangler whoami` to check your current authentication status." as const;
+
+/**
  * Ensures the user is logged in before making an API request.
  *
  * @param complianceConfig - Compliance region configuration
@@ -168,16 +191,8 @@ export async function requireLoggedIn(
 ): Promise<void> {
 	const result = await loginOrRefreshIfRequired(complianceConfig);
 	if (!result.loggedIn) {
-		const errorMessageBodies: Record<string, string> = {
-			"no-credentials-non-interactive": `Could not authenticate because no credentials were found and the environment is non-interactive. Set a CLOUDFLARE_API_TOKEN environment variable or run \`wrangler login\` in an interactive terminal first.`,
-			"no-credentials-login-failed": `No credentials were found and the login attempt was unsuccessful. Run \`wrangler login\` to try again.`,
-			"token-expired-non-interactive": `Your auth token has expired and could not be refreshed, and the environment is non-interactive. Run \`wrangler login\` in an interactive terminal or set a CLOUDFLARE_API_TOKEN.`,
-			"token-expired-login-failed": `Your auth token has expired and could not be refreshed, and the login attempt was unsuccessful. Run \`wrangler login\` to try again.`,
-		};
-		const errorMessageBody = errorMessageBodies[result.reason];
-		const whoamiTip =
-			"\nRun `wrangler whoami` to check your current authentication status.";
-		const errorMessage = `Not logged in. ${errorMessageBody}${whoamiTip}`;
+		const errorMessageBody = requireLoggedInErrorMessageBodies[result.reason];
+		const errorMessage = `Not logged in. ${errorMessageBody}${requireLoggedInErrorWhoAmITip}`;
 		throw new UserError(errorMessage, {
 			telemetryMessage: "cfetch auth login required",
 		});

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -31,7 +31,10 @@ import { fetchAllAccounts } from "./fetch-accounts";
 import { generateAuthUrl } from "./generate-auth-url";
 import { generateRandomState } from "./generate-random-state";
 import type { Account } from "./shared";
-import type { LoginProps } from "@cloudflare/workers-auth";
+import type {
+	LoginOrRefreshResult,
+	LoginProps,
+} from "@cloudflare/workers-auth";
 import type {
 	ApiCredentials,
 	ComplianceConfig,
@@ -243,10 +246,19 @@ export async function logout(): Promise<void> {
 	return oauthFlow.logout();
 }
 
+/**
+ * Attempt to ensure the user is authenticated, refreshing or prompting for
+ * login as needed.
+ *
+ * @param complianceConfig - Compliance region configuration
+ * @param props - Optional overrides for scopes, browser behaviour, etc.
+ * @returns A {@link LoginOrRefreshResult} indicating success or the specific
+ *   reason authentication could not be established.
+ */
 export async function loginOrRefreshIfRequired(
 	complianceConfig: ComplianceConfig,
 	props?: WranglerLoginProps
-): Promise<boolean> {
+): Promise<LoginOrRefreshResult> {
 	return oauthFlow.loginOrRefreshIfRequired(
 		withDefaultScopes(complianceConfig, props)
 	);
@@ -384,9 +396,12 @@ export async function requireAuth(
 		account_id?: string;
 	}
 ): Promise<string> {
-	const loggedIn = await loginOrRefreshIfRequired(config);
-	if (!loggedIn) {
-		if (isNonInteractiveOrCI()) {
+	const result = await loginOrRefreshIfRequired(config);
+	if (!result.loggedIn) {
+		if (
+			result.reason === "no-credentials-non-interactive" ||
+			result.reason === "token-expired-non-interactive"
+		) {
 			throw new UserError(
 				"In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/fundamentals/api/get-started/create-token/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN.",
 				{ telemetryMessage: "user auth missing api token non interactive" }


### PR DESCRIPTION
Followup for https://github.com/cloudflare/workers-sdk/pull/14195 this PR improves some other unhelpful error messages that remote bindings currently produces.

___


Example error before:
<img width="978" height="347" alt="screenshot of an unhelpful error message before the changes" src="https://github.com/user-attachments/assets/cf5916dd-a559-48df-a31b-39bbc70dd3ab" />

Example error after:
<img width="1167" height="404" alt="screenshot of a helpful error message after the changes" src="https://github.com/user-attachments/assets/1558d60d-c9aa-458b-b787-e68cca7c9d9b" />

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: error messages improvment

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
