### PR TITLE
Fix skills-install prompt getting stuck with concurrent wrangler instances

### DIFF
--- a/.changeset/cuddly-walls-arrive.md
+++ b/.changeset/cuddly-walls-arrive.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Fix skills-install prompt reappearing when not answered and getting stuck with concurrent wrangler instances
+
+Previously, if the skills-install prompt was never answered — whether due to Ctrl+C, a crash, `kill`, or any other interruption — no metadata file was written, causing the prompt to reappear on every subsequent `wrangler` invocation. The metadata file is now written with `accepted: "unanswered"` before agent detection and before the prompt is shown, so any scenario where the user does not answer leaves the file on disk and prevents the prompt from reappearing. When the user answers, the file is overwritten with the real response.
+
+Additionally, running two `wrangler` instances concurrently could cause both to show the prompt simultaneously, corrupting the terminal. A PID-based coordination protocol now detects concurrent instances: the second instance writes its own PID and skips the prompt, while the first instance detects the PID change and silently aborts.

--- a/.changeset/sigint-dismisses-skills-prompt.md
+++ b/.changeset/sigint-dismisses-skills-prompt.md
@@ -1,7 +1,0 @@
----
-"wrangler": patch
----
-
-Make Ctrl+C triggered during the skills-install prompt dismiss it permanently
-
-Previously, pressing Ctrl+C (SIGINT) during the "Would you like to install Cloudflare skills?" prompt terminated the process without writing the metadata file, causing the prompt to reappear on every subsequent `wrangler` invocation. A SIGINT handler is now registered around the prompt so that the metadata file is written with `accepted: "SIGINT"` before the process exits, preventing the prompt from being shown again.

--- a/packages/wrangler/src/__tests__/agents-skills-install.test.ts
+++ b/packages/wrangler/src/__tests__/agents-skills-install.test.ts
@@ -195,13 +195,14 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 			]);
 		});
 
-		test("skips silently when metadata file has accepted: 'SIGINT' (Ctrl+C dismissal)", async ({
+		test("skips and overwrites when metadata file has accepted: 'unanswered'", async ({
 			expect,
 		}) => {
 			writeMetadataFile({
 				version: 1,
-				accepted: "SIGINT",
+				accepted: "unanswered",
 				date: "2025-01-01T00:00:00Z",
+				pid: 99999,
 			});
 			const maybeInstallCloudflareSkillsGlobally = await freshImport();
 
@@ -210,6 +211,13 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 			expect(mockRosieAgents).not.toHaveBeenCalled();
 			expect(mockRosieInstall).not.toHaveBeenCalled();
 			expect(sendMetricsEvent).not.toHaveBeenCalled();
+
+			// The file should have been overwritten with this process's
+			// PID so the first instance can detect that a concurrent
+			// process started and skip its own prompt.
+			const metadata = readMetadataFile();
+			expect(metadata.accepted).toBe("unanswered");
+			expect(metadata.pid).toBe(process.pid);
 		});
 
 		test("force=true ignores existing metadata file", async ({ expect }) => {
@@ -431,60 +439,147 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 			);
 		});
 
-		test("writes SIGINT metadata when user presses Ctrl+C during the prompt", async ({
+		test("writes 'unanswered' metadata before showing the prompt so concurrent instances and interruptions are handled", async ({
 			expect,
 		}) => {
-			// Stub process.exit so the abort flow doesn't terminate the test runner.
-			const exitSpy = vi
-				.spyOn(process, "exit")
-				.mockImplementation((() => {}) as never);
+			// Intercept the prompts call to verify the metadata file was
+			// written with accepted: "unanswered" BEFORE the prompt is shown.
+			(prompts as unknown as Mock).mockImplementationOnce(({ type, name }) => {
+				expect({ type, name }).toStrictEqual({
+					type: "confirm",
+					name: "value",
+				});
 
-			// Simulate Ctrl+C: invoke the onState callback with
-			// { aborted: true }, then resolve with { value: undefined }
-			// just as the real prompts library does on abort.
+				// At this point (before the user answers) the metadata file
+				// should already exist with accepted: "unanswered" and this
+				// process's PID.
+				const metadata = readMetadataFile();
+				expect(metadata.accepted).toBe("unanswered");
+				expect(metadata.version).toBe(1);
+				expect(metadata.pid).toBe(process.pid);
+
+				// Simulate the user accepting
+				return Promise.resolve({ value: true });
+			});
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+
+			await maybeInstallCloudflareSkillsGlobally(false);
+
+			// After the user accepts, the metadata should be overwritten
+			// with accepted: true.
+			const metadata = readMetadataFile();
+			expect(metadata.accepted).toBe(true);
+			expect(mockRosieInstall).toHaveBeenCalled();
+		});
+
+		test("a concurrent wrangler instance overwrites the 'unanswered' metadata with its own PID and skips", async ({
+			expect,
+		}) => {
+			// Simulate a first instance having written the "unanswered"
+			// metadata (i.e. it is currently doing agent detection or
+			// showing its prompt).
+			const firstInstancePid = 99999;
+			writeMetadataFile({
+				version: 1,
+				accepted: "unanswered",
+				date: new Date().toISOString(),
+				pid: firstInstancePid,
+				detectedAgents: [
+					{
+						name: "Claude Code",
+						rosie: { id: "claude", globalPath: "/fake/.claude/skills" },
+					},
+				],
+			});
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+
+			// The second instance should see the metadata file, overwrite
+			// it with its own PID (signalling to the first instance), and
+			// return immediately without prompting.
+			await maybeInstallCloudflareSkillsGlobally(false);
+
+			expect(mockRosieAgents).not.toHaveBeenCalled();
+			expect(mockRosieInstall).not.toHaveBeenCalled();
+			expect(sendMetricsEvent).not.toHaveBeenCalled();
+
+			// The metadata file should now have this process's PID instead
+			// of the first instance's PID.
+			const metadata = readMetadataFile();
+			expect(metadata.accepted).toBe("unanswered");
+			expect(metadata.pid).toBe(process.pid);
+			expect(metadata.pid).not.toBe(firstInstancePid);
+		});
+
+		test("first instance detects a concurrent instance (before prompt) via PID change and skips the prompt", async ({
+			expect,
+		}) => {
+			// Simulate a concurrent wrangler instance overwriting the
+			// metadata file while the first instance is doing slow work
+			// (agent detection). We do this by intercepting the
+			// rosieAgents() call and overwriting the metadata file from
+			// inside it — this runs between the initial write and the
+			// re-read that happens before the prompt.
+			const secondInstancePid = 88888;
+			mockRosieAgents.mockImplementationOnce(async () => {
+				// Overwrite the metadata file with a different PID,
+				// simulating a second wrangler instance starting up.
+				writeMetadataFile({
+					version: 1,
+					accepted: "unanswered",
+					date: new Date().toISOString(),
+					pid: secondInstancePid,
+				});
+				return DEFAULT_AGENTS;
+			});
+			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+
+			await maybeInstallCloudflareSkillsGlobally(false);
+
+			// The first instance should detect the PID mismatch and
+			// return without showing the prompt or installing.
+			expect(prompts).not.toHaveBeenCalled();
+			expect(mockRosieInstall).not.toHaveBeenCalled();
+		});
+
+		test("first instance aborts active prompt when a concurrent instance overwrites the PID", async ({
+			expect,
+		}) => {
+			const secondInstancePid = 88888;
 			(prompts as unknown as Mock).mockImplementationOnce(
-				({ type, name, message, onState }) => {
-					expect({ type, name }).toStrictEqual({
-						type: "confirm",
-						name: "value",
+				({ onState }: { onState: (state: { aborted: boolean }) => void }) => {
+					// Overwrite the metadata file with a different PID,
+					// simulating a second wrangler instance starting up
+					// while the prompt is active.
+					writeMetadataFile({
+						version: 1,
+						accepted: "unanswered",
+						date: new Date().toISOString(),
+						pid: secondInstancePid,
 					});
-					expect(message).toContain("Claude Code");
 
-					// Trigger the abort handler (simulates Ctrl+C)
-					onState({ aborted: true });
-
-					return Promise.resolve({ value: undefined });
+					// Listen for the synthetic Ctrl+C keypress that the
+					// poll interval will emit when it detects the PID change.
+					return new Promise<{ value: undefined }>((resolve) => {
+						const keypressHandler = (
+							_ch: string,
+							key: { name: string; ctrl: boolean }
+						) => {
+							if (key?.ctrl && key?.name === "c") {
+								process.stdin.removeListener("keypress", keypressHandler);
+								onState({ aborted: true });
+								resolve({ value: undefined });
+							}
+						};
+						process.stdin.on("keypress", keypressHandler);
+					});
 				}
 			);
 			const maybeInstallCloudflareSkillsGlobally = await freshImport();
 
 			await maybeInstallCloudflareSkillsGlobally(false);
 
-			// Should have warned the user that Ctrl+C was treated as a decline
-			expect(std.warn).toContain(
-				"Ctrl+C received — skipping Cloudflare skills installation. This prompt will not be shown again."
-			);
-
-			// The onState abort handler should have written metadata
-			// with accepted: "SIGINT"
-			const metadata = readMetadataFile();
-			expect(metadata.accepted).toBe("SIGINT");
-			expect(metadata.version).toBe(1);
-
-			// Should not have attempted installation
+			// Should have aborted without installing or exiting.
 			expect(mockRosieInstall).not.toHaveBeenCalled();
-
-			// Should have sent a skipped metrics event
-			expect(sendMetricsEvent).toHaveBeenCalledWith(
-				"skills_install_skipped",
-				{ reason: "User dismissed (SIGINT)" },
-				{}
-			);
-
-			// Should have called process.exit(1) after flushing metrics
-			expect(exitSpy).toHaveBeenCalledWith(1);
-
-			exitSpy.mockRestore();
 		});
 
 		test("force=true installs skills without prompting", async ({ expect }) => {
@@ -997,7 +1092,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 		expect(result).toBe("manual");
 	});
 
-	test("resolves to 'manual' when metadata has accepted: 'SIGINT' at primary path", async ({
+	test("resolves to 'manual' when metadata has accepted: 'unanswered' at primary path", async ({
 		expect,
 	}) => {
 		vi.mocked(detectAgenticEnvironment).mockReturnValue({
@@ -1012,7 +1107,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 		const claudeGlobalSkillsPath = path.join(os.homedir(), ".claude", "skills");
 		writeMetadataFile({
 			version: 1,
-			accepted: "SIGINT",
+			accepted: "unanswered",
 			date: new Date().toISOString(),
 			detectedAgents: [
 				{
@@ -1029,7 +1124,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 		expect(result).toBe("manual");
 	});
 
-	test("resolves to 'manual' when metadata has accepted: 'SIGINT' at alternativeGlobalPath", async ({
+	test("resolves to 'manual' when metadata has accepted: 'unanswered' at alternativeGlobalPath", async ({
 		expect,
 	}) => {
 		vi.mocked(detectAgenticEnvironment).mockReturnValue({
@@ -1043,7 +1138,7 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 		mkdirSync(path.join(agentsSkills, "cloudflare"), { recursive: true });
 		writeMetadataFile({
 			version: 1,
-			accepted: "SIGINT",
+			accepted: "unanswered",
 			date: new Date().toISOString(),
 			detectedAgents: [
 				{

--- a/packages/wrangler/src/agents-skills-install.ts
+++ b/packages/wrangler/src/agents-skills-install.ts
@@ -13,7 +13,6 @@ import { fetch } from "undici";
 import isInteractive from "./is-interactive";
 import { logger } from "./logger";
 import { sendMetricsEvent } from "./metrics";
-import { allMetricsDispatchesCompleted } from "./metrics/metrics-dispatcher";
 
 /**
  * Detects AI coding agents installed on the user's machine and, if
@@ -57,10 +56,22 @@ export async function maybeInstallCloudflareSkillsGlobally(
 		}
 	};
 
-	// If the user has already been prompted, don't ask again
+	// If the user has already been prompted, don't ask again.
 	const existingConfig = readSkillsInstallMetadataFile();
 	if (existingConfig !== undefined && !force) {
-		// Note: no metrics event is sent in this case
+		if (existingConfig.accepted === "unanswered") {
+			// Another wrangler instance is currently showing the prompt (or
+			// was interrupted before it could answer). Overwrite the file
+			// with this process's PID so the first instance can detect that
+			// a concurrent process started and skip its own prompt, avoiding
+			// a stuck/corrupted TTY.
+			writeSkillsInstallMetadataFile({
+				version: 1,
+				accepted: "unanswered",
+				date: new Date().toISOString(),
+				pid: process.pid,
+			});
+		}
 		return;
 	}
 
@@ -68,6 +79,24 @@ export async function maybeInstallCloudflareSkillsGlobally(
 		// In CI environments, skip silently
 		sendResultMetricsEvent({ skippedBecause: "Running in CI" });
 		return;
+	}
+
+	// Write "unanswered" metadata as early as possible, before any slow
+	// operations (agent detection loads WASM). This ensures concurrent
+	// wrangler instances see the file and skip the prompt, and also
+	// handles interruptions (Ctrl+C, crash, kill -9) — the file is
+	// already on disk so the prompt won't reappear. The metadata is
+	// overwritten with the real answer once the user responds.
+	//
+	// We record our PID so we can detect whether a concurrent instance
+	// overwrote the file while we were doing slow work (agent detection).
+	if (!force) {
+		writeSkillsInstallMetadataFile({
+			version: 1,
+			accepted: "unanswered",
+			date: new Date().toISOString(),
+			pid: process.pid,
+		});
 	}
 
 	let detectedAgents: AgentInfo[];
@@ -97,46 +126,86 @@ export async function maybeInstallCloudflareSkillsGlobally(
 	}
 
 	let accepted: boolean;
-	let sigintReceived = false;
 	if (force) {
 		accepted = true;
 	} else {
-		// Use prompts directly (instead of the shared `confirm()` helper) so
-		// we can intercept the abort (Ctrl+C) and write SIGINT metadata
-		// before the process exits.  The prompts library's readline interface
-		// swallows SIGINT — it never reaches `process.on("SIGINT")` — so this
-		// `onState` callback is the only reliable place to handle it.
+		// Re-read the metadata file before showing the prompt. If a concurrent
+		// wrangler instance started while we were doing slow work (e.g. WASM
+		// agent detection), it will have overwritten the file with its own PID.
+		// Detecting this avoids showing a prompt that would be immediately
+		// corrupted by the other process's terminal output.
+		const currentMetadata = readSkillsInstallMetadataFile();
+		if (currentMetadata?.pid !== process.pid) {
+			return;
+		}
+
+		// Watch for concurrent instances while the prompt is active. If
+		// another wrangler process overwrites the metadata file with its
+		// own PID, we abort the prompt by emitting a synthetic Ctrl+C
+		// keypress on stdin. The `concurrentInstanceDetected` flag
+		// prevents the `onState` abort handler from calling
+		// `process.exit(1)` — we want to return silently instead.
+		let concurrentInstanceDetected = false;
+		const pollInterval = setInterval(() => {
+			const meta = readSkillsInstallMetadataFile();
+			if (meta?.pid !== process.pid) {
+				concurrentInstanceDetected = true;
+				clearInterval(pollInterval);
+				process.stdin.emit("keypress", "\x03", {
+					name: "c",
+					ctrl: true,
+				});
+			}
+		}, 300);
+
+		// Thin stdout proxy that can be muted to suppress the prompts
+		// library's abort rendering (the "✖ … yes" line it writes after
+		// the onState callback returns). Using a proxy keeps
+		// process.stdout untouched.
+		let muted = false;
+		const stdoutProxy = new Proxy(process.stdout, {
+			get(target, prop, receiver) {
+				if (prop === "write") {
+					return (...args: Parameters<typeof target.write>) =>
+						muted ? true : target.write(...args);
+				}
+				return Reflect.get(target, prop, receiver);
+			},
+		});
+
 		const { value } = await prompts({
 			type: "confirm",
 			name: "value",
 			message: `Wrangler detected the following AI coding agents: ${detectedAgents.map(({ name }) => name).join(", ")}. Would you like to install Cloudflare skills for them?`,
 			initial: true,
+			stdout: stdoutProxy,
 			onState: (state) => {
 				if (state.aborted) {
-					sigintReceived = true;
-					logger.warn(
-						"Ctrl+C received — skipping Cloudflare skills installation. This prompt will not be shown again."
-					);
-					// Write metadata synchronously so it survives the exit.
-					writeSkillsInstallMetadataFile({
-						version: 1,
-						accepted: "SIGINT",
-						date: new Date().toISOString(),
-						detectedAgents,
-					});
+					// Mute the stdout proxy so the prompts library's
+					// abort() → render() cycle doesn't print a "✖" line
+					// after this callback returns.
+					muted = true;
+					if (!concurrentInstanceDetected) {
+						process.nextTick(() => {
+							process.exit(1);
+						});
+					}
 				}
 			},
 		});
-		accepted = value;
-	}
+		clearInterval(pollInterval);
 
-	if (sigintReceived) {
-		// Metadata was already written in the onState callback.
-		// Send metrics and wait for the dispatch to complete before exiting.
-		sendResultMetricsEvent({ skippedBecause: "User dismissed (SIGINT)" });
-		await allMetricsDispatchesCompleted();
-		// Note: the return is unnecessary but it guards against tests that stub process.exit
-		return process.exit(1);
+		if (concurrentInstanceDetected) {
+			// Erase the prompt line that was already printed to stdout.
+			// The prompts library renders on a single line, so one
+			// cursor-up + erase-line sequence is enough to clean it up.
+			// This avoids leaving orphaned prompt text on the terminal
+			// when the abort was triggered by a concurrent instance.
+			process.stdout.write("\x1B[1A\x1B[2K");
+			return;
+		}
+
+		accepted = value;
 	}
 
 	if (!accepted) {
@@ -242,13 +311,24 @@ interface SkillsInstallMetadata {
 	 *
 	 * - `true` — the user explicitly accepted.
 	 * - `false` — the user explicitly declined.
-	 * - `"SIGINT"` — the user dismissed the prompt via Ctrl+C / SIGINT before
-	 *   answering. Treated as a decline but stored separately so we can
-	 *   distinguish these users in telemetry.
+	 * - `"unanswered"` — the prompt was written to disk before being shown but
+	 *   was never explicitly answered. This happens when the user presses
+	 *   Ctrl+C, the process crashes, or another concurrent wrangler instance
+	 *   starts up and skips the prompt because the file already exists.
 	 */
-	accepted: boolean | "SIGINT";
+	accepted: boolean | "unanswered";
 	/** ISO date string of when the user was prompted. */
 	date: string;
+	/**
+	 * PID of the wrangler process that wrote the metadata file when
+	 * `accepted` is `"unanswered"`. Used for concurrent-instance detection:
+	 * before showing the prompt, the process re-reads the file and compares
+	 * PIDs — if another process overwrote it with a different PID, the
+	 * prompt is skipped to avoid a stuck/corrupted TTY.
+	 *
+	 * Only present when `accepted` is `"unanswered"`.
+	 */
+	pid?: number;
 	/** All agents detected on the user's machine. */
 	detectedAgents?: AgentInfo[];
 	/**


### PR DESCRIPTION
This fixes the concurrency bug described in https://github.com/cloudflare/workers-sdk/issues/14116#issuecomment-4589582329 while trying to simplify the pre-existing flow where we specifically listen for Ctrl+C events.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: self-explanatory behaviour

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->