### PR TITLE
feat(wrangler): capture runtime logs and print debug timelines with `createTestHarness()`

### DIFF
--- a/.changeset/gentle-cougars-build.md
+++ b/.changeset/gentle-cougars-build.md
@@ -8,7 +8,7 @@ It runs Workers in a local preview environment using production build output and
 
 Use it from any Node.js test runner to send requests to individual Workers, trigger scheduled events, reset the server between tests, and mock outbound requests with libraries that intercept `globalThis.fetch()`, such as MSW.
 
-This also captures Workers runtime logs for assertions and can print a diagnostic timeline when tests fail:
+You can also capture structured logs from your Workers with `getLogs()`, or dump out a diagnostic timeline with `debug()` when tests fail:
 
 ```ts
 import { createTestHarness } from "wrangler";

--- a/.changeset/gentle-cougars-build.md
+++ b/.changeset/gentle-cougars-build.md
@@ -6,7 +6,9 @@ Introduce `createTestHarness()` for integration testing Workers
 
 It runs Workers in a local preview environment using production build output and works with both Wrangler projects and Workers built by the Cloudflare Vite plugin.
 
-Use it from any Node.js test runner to send requests to individual Workers, trigger scheduled events, reset the server between tests, and mock outbound requests with libraries that intercept `globalThis.fetch()`, such as MSW:
+Use it from any Node.js test runner to send requests to individual Workers, trigger scheduled events, reset the server between tests, and mock outbound requests with libraries that intercept `globalThis.fetch()`, such as MSW.
+
+This also captures Workers runtime logs for assertions and can print a diagnostic timeline when tests fail:
 
 ```ts
 import { createTestHarness } from "wrangler";
@@ -24,6 +26,12 @@ await server.fetch("http://example.com");
 const apiWorker = server.getWorker("api-worker");
 await apiWorker.fetch("http://example.com/users/123");
 await apiWorker.scheduled({ cron: "0 0 * * *" });
+
+server.getLogs();
+
+if (testFailed) {
+	server.debug();
+}
 
 await server.reset();
 await server.close();

--- a/packages/wrangler/e2e/createTestHarness.test.ts
+++ b/packages/wrangler/e2e/createTestHarness.test.ts
@@ -1,9 +1,17 @@
 import path from "node:path";
 import { setTimeout } from "node:timers/promises";
+import { mockConsoleMethods } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import dedent from "ts-dedent";
-import { beforeEach, describe, it, onTestFinished } from "vitest";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	it,
+	onTestFinished,
+	vi,
+} from "vitest";
 import {
 	importWrangler,
 	WranglerE2ETestHelper,
@@ -11,14 +19,26 @@ import {
 
 const { createTestHarness } = await importWrangler();
 
-describe("createTestHarness", { sequential: true }, () => {
+describe("createTestHarness", () => {
+	const logs = mockConsoleMethods();
+
 	let helper: WranglerE2ETestHelper;
+
+	function normalizeDebugOutput(output: string) {
+		return String(output)
+			.replace(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/gm, "<timestamp>")
+			.replace(/http:\/\/127\.0\.0\.1:\d+/g, "http://127.0.0.1:<port>");
+	}
 
 	beforeEach(() => {
 		helper = new WranglerE2ETestHelper();
 	});
 
-	it("starts with default server options", async ({ expect }) => {
+	afterEach(() => {
+		vi.resetAllMocks();
+	});
+
+	it("starts with default server options", async ({ expect, onTestFailed }) => {
 		await helper.seed({
 			"wrangler.jsonc": dedent`
 				{
@@ -45,6 +65,7 @@ describe("createTestHarness", { sequential: true }, () => {
 			],
 		});
 		onTestFinished(server.close);
+		onTestFailed(server.debug);
 
 		const { url } = await server.listen();
 
@@ -952,6 +973,19 @@ describe("createTestHarness", { sequential: true }, () => {
 
 		const afterScheduled = await server.fetch("/");
 		await expect(afterScheduled.text()).resolves.toBe("* * * * *");
+
+		server.debug();
+		expect(normalizeDebugOutput(logs.getAndClearOut())).toMatchInlineSnapshot(`
+			"--------------- debug logs ---------------
+			<timestamp> [server] startup - started
+			<timestamp> [server] startup - completed
+			<timestamp> [server] fetch - GET / - started
+			<timestamp> [server] fetch - GET / - 200
+			<timestamp> [server] [scheduled-worker] scheduled - GET /cdn-cgi/handler/scheduled?format=json&cron=*+*+*+*+*&time=1700000100000 - started
+			<timestamp> [server] [scheduled-worker] scheduled - GET /cdn-cgi/handler/scheduled?format=json&cron=*+*+*+*+*&time=1700000100000 - 200
+			<timestamp> [server] fetch - GET / - started
+			<timestamp> [server] fetch - GET / - 200"
+		`);
 	});
 
 	it("does not reload on source changes by default", async ({ expect }) => {
@@ -1013,5 +1047,145 @@ describe("createTestHarness", { sequential: true }, () => {
 
 		const response3 = await server.fetch("/");
 		await expect(response3.text()).resolves.toBe("Hello World");
+	});
+
+	it("captures runtime logs and prints debug timelines", async ({ expect }) => {
+		await helper.seed({
+			"wrangler.primary.jsonc": dedent`
+				{
+					"name": "primary-worker",
+					"main": "src/primary.ts",
+					"compatibility_date": "2026-05-20"
+				}
+			`,
+			"wrangler.auxiliary.jsonc": dedent`
+				{
+					"name": "auxiliary-worker",
+					"main": "src/auxiliary.ts",
+					"compatibility_date": "2026-05-20"
+				}
+			`,
+			"src/primary.ts": dedent`
+				export default {
+					fetch() {
+						console.info("primary log");
+						return new Response("primary ok");
+					}
+				};
+			`,
+			"src/auxiliary.ts": dedent`
+				export default {
+					fetch() {
+						console.warn("auxiliary warning");
+						throw new Error("auxiliary failed");
+					}
+				};
+			`,
+		});
+
+		const server = createTestHarness({
+			root: helper.tmpPath,
+			workers: [
+				{ configPath: "./wrangler.primary.jsonc" },
+				{ configPath: "./wrangler.auxiliary.jsonc" },
+			],
+		});
+		onTestFinished(server.close);
+
+		server.debug();
+
+		expect(logs.getAndClearOut()).toMatchInlineSnapshot(
+			`"-------------- No debug log --------------"`
+		);
+
+		await server.listen();
+		expect(server.getLogs()).toEqual([]);
+
+		server.clearLogs();
+
+		const primaryResponse = await server.getWorker("primary-worker").fetch("/");
+
+		await expect(primaryResponse.text()).resolves.toBe("primary ok");
+		await expect(
+			server
+				.getWorker("auxiliary-worker")
+				.fetch("https://example.com/greet", { method: "post" })
+		).rejects.toThrow("auxiliary failed");
+		expect(server.getLogs()).toEqual([
+			{ timestamp: expect.any(Number), level: "info", message: "primary log" },
+			{
+				timestamp: expect.any(Number),
+				level: "warn",
+				message: "auxiliary warning",
+			},
+		]);
+
+		server.debug();
+		expect(normalizeDebugOutput(logs.getAndClearOut())).toMatchInlineSnapshot(`
+			"--------------- debug logs ---------------
+			<timestamp> [server] startup - started
+			<timestamp> [server] startup - completed
+			<timestamp> [server] [primary-worker] fetch - GET / - started
+			<timestamp> [runtime] info: primary log
+			<timestamp> [server] [primary-worker] fetch - GET / - 200
+			<timestamp> [server] [auxiliary-worker] fetch - POST https://example.com/greet - started
+			<timestamp> [runtime] warn: auxiliary warning
+			<timestamp> [server] [auxiliary-worker] fetch - POST https://example.com/greet - failed"
+		`);
+
+		server.clearLogs();
+		expect(server.getLogs()).toEqual([]);
+
+		server.debug();
+		expect(normalizeDebugOutput(logs.getAndClearOut())).toMatchInlineSnapshot(`
+			"--------------- debug logs ---------------
+			<timestamp> [server] startup - started
+			<timestamp> [server] startup - completed
+			<timestamp> [server] [primary-worker] fetch - GET / - started
+			<timestamp> [runtime] info: primary log
+			<timestamp> [server] [primary-worker] fetch - GET / - 200
+			<timestamp> [server] [auxiliary-worker] fetch - POST https://example.com/greet - started
+			<timestamp> [runtime] warn: auxiliary warning
+			<timestamp> [server] [auxiliary-worker] fetch - POST https://example.com/greet - failed"
+		`);
+
+		await server.reset();
+		expect(server.getLogs()).toEqual([]);
+
+		server.debug();
+		expect(normalizeDebugOutput(logs.getAndClearOut())).toMatchInlineSnapshot(`
+			"--------------- debug logs ---------------
+			<timestamp> [server] startup - started
+			<timestamp> [server] startup - completed"
+		`);
+
+		await server.update((options) => ({
+			...options,
+			workers: [...options.workers],
+		}));
+		expect(server.getLogs()).toEqual([]);
+
+		server.debug();
+		expect(normalizeDebugOutput(logs.getAndClearOut())).toMatchInlineSnapshot(`
+			"--------------- debug logs ---------------
+			<timestamp> [server] startup - started
+			<timestamp> [server] startup - completed
+			<timestamp> [server] update - started
+			<timestamp> [server] update - completed"
+		`);
+
+		// Make sure debug logs are still visible after server is closed
+		await server.close();
+
+		server.debug();
+		expect(normalizeDebugOutput(logs.getAndClearOut())).toMatchInlineSnapshot(`
+			"--------------- debug logs ---------------
+			<timestamp> [server] startup - started
+			<timestamp> [server] startup - completed
+			<timestamp> [server] update - started
+			<timestamp> [server] update - completed
+			<timestamp> [server] teardown - started
+			<timestamp> [server] teardown - completed"
+		`);
 	});
 });

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -159,6 +159,7 @@ async function resolveDevConfig(
 		liveReload: input.dev?.liveReload || false,
 		testScheduled: input.dev?.testScheduled,
 		outboundService: input.dev?.outboundService,
+		structuredLogsHandler: input.dev?.structuredLogsHandler,
 		// absolute resolved path
 		persist: localPersistencePath,
 		registry: input.dev?.registry,

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -220,6 +220,7 @@ export async function convertToConfigBundle(
 					secure: event.config.dev.server.secure,
 				})
 			: undefined,
+		structuredLogsHandler: event.config.dev.structuredLogsHandler,
 	};
 }
 

--- a/packages/wrangler/src/api/startDevWorker/types.ts
+++ b/packages/wrangler/src/api/startDevWorker/types.ts
@@ -20,7 +20,12 @@ import type {
 	ServiceFetch,
 	Trigger,
 } from "@cloudflare/workers-utils";
-import type { DispatchFetch, Miniflare, NodeJSCompatMode } from "miniflare";
+import type {
+	DispatchFetch,
+	Miniflare,
+	NodeJSCompatMode,
+	WorkerdStructuredLog,
+} from "miniflare";
 import type * as undici from "undici";
 
 type MiniflareWorker = Awaited<ReturnType<Miniflare["getWorker"]>>;
@@ -166,6 +171,8 @@ export interface StartDevWorkerInput {
 		origin?: { hostname?: string; secure?: boolean }; // hostname: --host (remote)/--local-upstream (local), port: doesn't make sense in remote/=== server.port in local, secure: --upstream-protocol
 		/** A hook for outbound fetch calls from within the worker. */
 		outboundService?: ServiceFetch;
+		/** Handles structured runtime logs. */
+		structuredLogsHandler?: (log: WorkerdStructuredLog) => void;
 		/** An undici MockAgent to declaratively mock fetch calls to particular resources. */
 		mockFetch?: undici.MockAgent;
 

--- a/packages/wrangler/src/api/test-harness.ts
+++ b/packages/wrangler/src/api/test-harness.ts
@@ -7,7 +7,6 @@ import {
 } from "@cloudflare/workers-utils";
 import { Headers, Request } from "miniflare";
 import { validateNodeCompatMode } from "../deployment-bundle/node-compat";
-import { logger } from "../logger";
 import { requireApiToken, requireAuth } from "../user";
 import { DevEnv } from "./startDevWorker/DevEnv";
 import { MultiworkerRuntimeController } from "./startDevWorker/MultiworkerRuntimeController";
@@ -21,7 +20,13 @@ import type {
 	FetcherScheduledResult,
 } from "@cloudflare/workers-types/experimental";
 import type { Config, RawConfig } from "@cloudflare/workers-utils";
-import type { DispatchFetch, Json, Miniflare, RequestInfo } from "miniflare";
+import type {
+	DispatchFetch,
+	Json,
+	Miniflare,
+	RequestInfo,
+	WorkerdStructuredLog,
+} from "miniflare";
 
 export type TestHarnessOptions = {
 	/**
@@ -112,6 +117,23 @@ export type TestHarness = {
 	 */
 	getWorker(name?: string): WorkerHandle;
 	/**
+	 * Returns captured Workers runtime logs since the current server session
+	 * started or `clearLogs()` was last called.
+	 */
+	getLogs(): WorkerdStructuredLog[];
+	/**
+	 * Clears captured Workers runtime logs.
+	 */
+	clearLogs(): void;
+	/**
+	 * Prints a diagnostic timeline for this test server.
+	 *
+	 * Use this to trace the sequence of server events and Workers runtime logs
+	 * leading up to a test failure. Call `server.debug()` from your test runner's
+	 * failure or cleanup hook when the current test has failed.
+	 */
+	debug(): void;
+	/**
 	 * Updates the server configuration and reloads the running Workers.
 	 *
 	 * If the server has not started yet, this configures the options that will be
@@ -167,6 +189,14 @@ type ServerSession = {
 	devEnvs: DevEnv[];
 };
 
+type DebugLog = {
+	source: "server" | "runtime";
+	worker?: string;
+	level?: string;
+	message: string;
+	timestamp: number;
+};
+
 /**
  * Creates a local test server for running Workers.
  *
@@ -188,6 +218,34 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 	let currentOptions = options;
 	let serverSession: ServerSession | undefined;
 	let startPromise: Promise<ServerSession> | undefined;
+	let workerdLogs: WorkerdStructuredLog[] = [];
+	let debugLogs: DebugLog[] = [];
+
+	function debugLog(message: string, worker?: string) {
+		debugLogs.push({
+			source: "server",
+			worker,
+			message,
+			timestamp: Date.now(),
+		});
+	}
+
+	function captureStructuredLog(log: WorkerdStructuredLog) {
+		workerdLogs.push(log);
+		debugLogs.push({
+			source: "runtime",
+			level: log.level,
+			message: log.message,
+			timestamp: log.timestamp,
+		});
+	}
+
+	function formatLocalTimestamp(timestamp: number) {
+		const date = new Date(timestamp);
+		const pad = (value: number) => String(value).padStart(2, "0");
+
+		return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+	}
 
 	function resolvePath(basePath: string, maybePath: string | URL): string {
 		if (maybePath instanceof URL) {
@@ -208,7 +266,7 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 			normalizeAndValidateConfig(config, configPath, configPath, {});
 
 		if (diagnostics.hasWarnings()) {
-			logger.warn(diagnostics.renderWarnings());
+			debugLog(diagnostics.renderWarnings(), normalizedConfig.name);
 		}
 
 		if (diagnostics.hasErrors()) {
@@ -251,11 +309,12 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 				dev: {
 					auth: serverAuthHook,
 					server: { hostname: "127.0.0.1", port: 0 },
-					logLevel: "error",
+					logLevel: "none",
 					watch: false,
 					persist: false,
 					inspector: false,
 					registry: undefined,
+					structuredLogsHandler: (log) => captureStructuredLog(log),
 					outboundService: (request) => {
 						/**
 						 * Miniflare passes its own undici-based Request here. Pass the URL as
@@ -304,12 +363,14 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 			primaryDevEnv,
 			devEnvs: [primaryDevEnv, ...auxiliaryDevEnvs],
 		};
-
 		try {
+			debugLog("startup - started");
 			await updateConfig(session, inputs);
 			await waitForProxyReady(session);
+			debugLog("startup - completed");
 			return session;
 		} catch (error) {
+			debugLog("startup - failed");
 			await teardownSession(session);
 			throw error;
 		}
@@ -325,11 +386,9 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 		}
 	}
 
-	async function resolveSession(workerName?: string) {
+	async function resolveSession() {
 		if (startPromise) {
-			const session = await startPromise;
-			assertWorkerExists(session, workerName);
-			return session;
+			return await startPromise;
 		}
 
 		assert(
@@ -337,17 +396,20 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 			"Server has not been started. Start it with server.listen() before calling this method."
 		);
 
-		assertWorkerExists(serverSession, workerName);
-
 		return serverSession;
 	}
 
-	function assertWorkerExists(
+	function resolveWorkerName(
 		session: ServerSession,
 		workerName: string | undefined
 	) {
 		if (workerName === undefined) {
-			return;
+			const primaryWorkerName = session.primaryDevEnv.config.latestConfig?.name;
+			assert(
+				primaryWorkerName,
+				"Primary Worker name is not available. Add a Worker `name` or call server.getWorker(name)."
+			);
+			return primaryWorkerName;
 		}
 
 		const workerExists = session.devEnvs.some((devEnv) => {
@@ -359,6 +421,8 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 				`Worker ${JSON.stringify(workerName)} does not exist in this server.`
 			);
 		}
+
+		return workerName;
 	}
 
 	async function serverAuthHook(
@@ -372,7 +436,12 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 
 	async function teardownSession(session: ServerSession) {
 		try {
+			debugLog("teardown - started");
 			await Promise.all(session.devEnvs.map((devEnv) => devEnv.teardown()));
+			debugLog("teardown - completed");
+		} catch (error) {
+			debugLog("teardown - failed");
+			throw error;
 		} finally {
 			if (session === serverSession) {
 				serverSession = undefined;
@@ -388,6 +457,8 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 				);
 			}
 
+			workerdLogs = [];
+			debugLogs = [];
 			initialOptions = currentOptions;
 			startPromise = createSession(initialOptions)
 				.then((session) => {
@@ -496,13 +567,28 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 		return miniflare;
 	}
 
+	function getInputUrl(input: RequestInfo) {
+		if (typeof input === "string") {
+			return input;
+		}
+
+		if (input instanceof URL) {
+			return input.href;
+		}
+
+		return input.url;
+	}
+
 	async function dispatchFetch(
 		miniflare: Miniflare,
 		input: RequestInfo,
 		init?: RequestInit,
-		worker?: string
+		worker?: string,
+		event = "fetch"
 	) {
-		if (typeof input === "string") {
+		let resolvedInput = input;
+
+		if (typeof input === "string" && !URL.canParse(input)) {
 			const session = await resolveSession();
 			const { url } = await waitForProxyReady(session);
 			const baseUrl = new URL(url);
@@ -516,19 +602,26 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 				baseUrl.hostname = "localhost";
 			}
 
-			input = new URL(input, baseUrl);
+			resolvedInput = new URL(input, baseUrl);
 		}
 
-		if (worker === undefined) {
-			return miniflare.dispatchFetch(input, init);
-		}
-
-		const request = new Request(input, init);
+		const request = new Request(resolvedInput, init);
 		const headers = new Headers(request.headers);
+		const context = `${event} - ${request.method} ${getInputUrl(input)}`;
 
-		headers.set("MF-Route-Override", worker);
+		if (worker) {
+			headers.set("MF-Route-Override", worker);
+		}
 
-		return miniflare.dispatchFetch(request, { headers });
+		try {
+			debugLog(`${context} - started`, worker);
+			const response = await miniflare.dispatchFetch(request, { headers });
+			debugLog(`${context} - ${response.status}`, worker);
+			return response;
+		} catch (error) {
+			debugLog(`${context} - failed`, worker);
+			throw error;
+		}
 	}
 
 	return {
@@ -553,35 +646,72 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 		getWorker(name?: string) {
 			return {
 				async fetch(input, init) {
-					const session = await resolveSession(name);
+					const session = await resolveSession();
 					const miniflare = await getRuntimeMiniflare(session);
+					const workerName = resolveWorkerName(session, name);
 
-					return dispatchFetch(miniflare, input, init, name);
+					return dispatchFetch(miniflare, input, init, workerName);
 				},
 				async scheduled(scheduledOptions) {
-					const session = await resolveSession(name);
+					const session = await resolveSession();
 					const miniflare = await getRuntimeMiniflare(session);
-					const url = new URL(
-						"http://localhost/cdn-cgi/handler/scheduled?format=json"
-					);
+					const workerName = resolveWorkerName(session, name);
+					const searchParams = new URLSearchParams({
+						format: "json",
+					});
 
 					if (scheduledOptions?.cron !== undefined) {
-						url.searchParams.set("cron", scheduledOptions.cron);
+						searchParams.set("cron", scheduledOptions.cron);
 					}
 
 					if (scheduledOptions?.scheduledTime !== undefined) {
-						url.searchParams.set(
+						searchParams.set(
 							"time",
 							String(scheduledOptions.scheduledTime.getTime())
 						);
 					}
 
-					const response = await dispatchFetch(miniflare, url, undefined, name);
+					const response = await dispatchFetch(
+						miniflare,
+						`/cdn-cgi/handler/scheduled?${searchParams.toString()}`,
+						undefined,
+						workerName,
+						"scheduled"
+					);
 					const result = await response.json();
 
 					return result as FetcherScheduledResult;
 				},
 			};
+		},
+		getLogs() {
+			return structuredClone(workerdLogs);
+		},
+		clearLogs() {
+			workerdLogs = [];
+		},
+		debug() {
+			let message = "-------------- No debug log --------------";
+
+			if (debugLogs.length > 0) {
+				const lines = debugLogs.map((log) => {
+					const tags = [log.source, log.worker]
+						.filter((tag) => tag !== undefined)
+						.map((tag) => `[${tag}]`)
+						.join(" ");
+
+					const level = log.level === undefined ? "" : `${log.level}: `;
+
+					return `${formatLocalTimestamp(log.timestamp)} ${tags} ${level}${log.message}`;
+				});
+
+				message = ["--------------- debug logs ---------------", ...lines].join(
+					"\n"
+				);
+			}
+
+			// oxlint-disable-next-line no-console -- Use console.log() directly as the logger is disabled
+			console.log(message);
 		},
 		async update(updateInput) {
 			let nextOptions: TestHarnessOptions;
@@ -602,20 +732,23 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 			}
 
 			if (serverSession) {
-				const nextInputs = resolveWorkerInputs(nextOptions);
-
-				if (nextInputs.length !== serverSession.devEnvs.length) {
-					throw new Error(
-						`Updating the number of workers running in the server is not supported.`
-					);
-				}
-
 				try {
+					debugLog("update - started");
+					const nextInputs = resolveWorkerInputs(nextOptions);
+
+					if (nextInputs.length !== serverSession.devEnvs.length) {
+						throw new Error(
+							`Updating the number of workers running in the server is not supported.`
+						);
+					}
+
 					await Promise.all([
 						waitForReloadComplete(serverSession),
 						updateConfig(serverSession, nextInputs),
 					]);
+					debugLog("update - completed");
 				} catch (error) {
+					debugLog("update - failed");
 					await teardownSession(serverSession);
 					throw error;
 				}

--- a/packages/wrangler/src/api/test-harness.ts
+++ b/packages/wrangler/src/api/test-harness.ts
@@ -732,16 +732,16 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 			}
 
 			if (serverSession) {
+				debugLog("update - started");
+				const nextInputs = resolveWorkerInputs(nextOptions);
+
+				if (nextInputs.length !== serverSession.devEnvs.length) {
+					throw new Error(
+						`Updating the number of workers running in the server is not supported.`
+					);
+				}
+
 				try {
-					debugLog("update - started");
-					const nextInputs = resolveWorkerInputs(nextOptions);
-
-					if (nextInputs.length !== serverSession.devEnvs.length) {
-						throw new Error(
-							`Updating the number of workers running in the server is not supported.`
-						);
-					}
-
 					await Promise.all([
 						waitForReloadComplete(serverSession),
 						updateConfig(serverSession, nextInputs),

--- a/packages/wrangler/src/dev/miniflare/index.ts
+++ b/packages/wrangler/src/dev/miniflare/index.ts
@@ -108,6 +108,7 @@ export interface ConfigBundle {
 	// The stable, externally-reachable URL of the proxy server in front of
 	// this Miniflare instance (e.g. Wrangler's ProxyWorker URL).
 	publicUrl: string | undefined;
+	structuredLogsHandler: ((log: WorkerdStructuredLog) => void) | undefined;
 }
 
 export class WranglerLog extends Log {
@@ -1130,7 +1131,7 @@ export async function buildMiniflareOptions(
 		logRequests: false,
 		log,
 		verbose: logger.loggerLevel === "debug",
-		handleStructuredLogs,
+		handleStructuredLogs: config.structuredLogsHandler ?? handleStructuredLogs,
 		defaultPersistRoot,
 		workers: [
 			{


### PR DESCRIPTION
Fixes n/a.

This extends the test harness with 3 new methods:
- `server.debug()` prints a diagnostic timeline for this test server
- `server.getLogs()` returns captured Workers runtime logs since the current server session started or `clearLogs()` was last called.
- `server.clearLogs()` clears captured Workers runtime logs. 

```ts
import { afterAll, afterEach, beforeAll, expect, test } from "vitest";
import { createTestHarness } from "wrangler";

const server = createTestHarness({
    workers: [{ configPath: "./dist/worker/wrangler.json" }],
});

beforeAll(async () => {
    await server.listen();
});

afterAll(async () => {
    await server.close();
});

afterEach(async (context) => {
    // Automatically print a debug timeline for any test that failed.
    if (context.task.result?.state === "fail") {
        server.debug();
    }

    await server.reset();
});

test("worker logs", async () => {
    const response = await server.fetch("/api/users");
    expect(response.status).toBe(200);

    expect(server.getLogs()).toEqual([
        {
            timestamp: expect.any(Number),
            level: "info",
            message: "Fetched users",
        },
    ]);
});
```

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: I will work on a docs PR separately.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
