### PR TITLE
feat(wrangler): improve createTestHarness() configuration setup

### DIFF
--- a/packages/wrangler/e2e/createTestHarness.test.ts
+++ b/packages/wrangler/e2e/createTestHarness.test.ts
@@ -66,6 +66,59 @@ describe("createTestHarness", { sequential: true }, () => {
 		);
 	});
 
+	it("can be configured after creation", async ({ expect }) => {
+		await helper.seed({
+			"wrangler.jsonc": dedent`
+				{
+					"name": "delayed-config-worker",
+					"main": "src/index.ts",
+					"compatibility_date": "2026-05-20",
+					"vars": { "GREETING": "initial" }
+				}
+			`,
+			"src/index.ts": dedent`
+				export default {
+					fetch(_request, env) {
+						return new Response(env.GREETING);
+					}
+				};
+			`,
+		});
+
+		const server = createTestHarness();
+		onTestFinished(server.close);
+
+		await expect(server.listen()).rejects.toThrow(
+			"Test harness options have not been configured."
+		);
+
+		await server.update({
+			root: helper.tmpPath,
+			workers: [{ configPath: "./wrangler.jsonc" }],
+		});
+		await server.listen();
+
+		const initialResponse = await server.fetch("/");
+		await expect(initialResponse.text()).resolves.toBe("initial");
+
+		await server.update((options) => ({
+			...options,
+			workers: options.workers.map((worker) =>
+				"configPath" in worker
+					? { ...worker, vars: { GREETING: "updated" } }
+					: worker
+			),
+		}));
+
+		const updatedResponse = await server.fetch("/");
+		await expect(updatedResponse.text()).resolves.toBe("updated");
+
+		await server.reset();
+
+		const resetResponse = await server.fetch("/");
+		await expect(resetResponse.text()).resolves.toBe("initial");
+	});
+
 	it("support fetching different workers from the same session", async ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/api/test-harness.ts
+++ b/packages/wrangler/src/api/test-harness.ts
@@ -68,6 +68,9 @@ export type TestHarness = {
 	 * Starts the server and returns its current URL.
 	 * Calling this more than once returns the same running server session until
 	 * the server is closed or reset.
+	 *
+	 * If no options were passed to `createTestHarness()`, call `update(options)`
+	 * before starting the server.
 	 */
 	listen(): Promise<{
 		url: URL;
@@ -110,6 +113,9 @@ export type TestHarness = {
 	getWorker(name?: string): WorkerHandle;
 	/**
 	 * Updates the server configuration and reloads the running Workers.
+	 *
+	 * If the server has not started yet, this configures the options that will be
+	 * used by `listen()`.
 	 */
 	update(
 		options:
@@ -117,9 +123,8 @@ export type TestHarness = {
 			| ((currentOptions: TestHarnessOptions) => TestHarnessOptions)
 	): Promise<void>;
 	/**
-	 * Restores the server to its initial `createTestHarness()` options and restarts the
-	 * active server session. Storage is recreated, and the server URL may change
-	 * after reset.
+	 * Restores the server to the options used when the current session first
+	 * started. Storage is recreated, and the server URL may change after reset.
 	 */
 	reset(): Promise<void>;
 	/**
@@ -178,8 +183,8 @@ type ServerSession = {
  * await server.close();
  * ```
  */
-export function createTestHarness(options: TestHarnessOptions): TestHarness {
-	const initialOptions = options;
+export function createTestHarness(options?: TestHarnessOptions): TestHarness {
+	let initialOptions = options;
 	let currentOptions = options;
 	let serverSession: ServerSession | undefined;
 	let startPromise: Promise<ServerSession> | undefined;
@@ -377,7 +382,14 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
 
 	async function startServerSession() {
 		if (!startPromise) {
-			startPromise = createSession(currentOptions)
+			if (currentOptions === undefined) {
+				throw new Error(
+					"Test harness options have not been configured. Pass options to createTestHarness() or call server.update(options) before server.listen()."
+				);
+			}
+
+			initialOptions = currentOptions;
+			startPromise = createSession(initialOptions)
 				.then((session) => {
 					serverSession = session;
 					return session;
@@ -572,10 +584,17 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
 			};
 		},
 		async update(updateInput) {
-			const nextOptions =
-				typeof updateInput === "function"
-					? updateInput(currentOptions)
-					: updateInput;
+			let nextOptions: TestHarnessOptions;
+
+			if (typeof updateInput === "function") {
+				assert(
+					currentOptions,
+					"Cannot update test harness options with a function before options have been configured. Pass options to createTestHarness() or call server.update(options) first."
+				);
+				nextOptions = updateInput(currentOptions);
+			} else {
+				nextOptions = updateInput;
+			}
 
 			// If listen() is still starting, wait until serverSession is available so the update is applied to the running Workers.
 			if (startPromise) {
@@ -606,6 +625,11 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
 		},
 		async reset() {
 			const session = await resolveSession();
+
+			assert(
+				initialOptions,
+				"Server has not been started. Start it with server.listen() before calling this method."
+			);
 
 			await teardownSession(session);
 			currentOptions = initialOptions;


### PR DESCRIPTION
Fixes n/a.

`createTestHarness()` originally required server options to be provided upfront. In some tests, those options depend on setup work that only runs later in a lifecycle hook. For example, a test might start a local database or HTTP server in `beforeAll()`, then pass its assigned port to the Worker through a var override.

This change allows the harness to be created first, then configured with `server.update()` before `server.listen()`. The options used for the first successful `listen()` become the reset baseline.

```ts
const server = createTestHarness();

beforeAll(async () => {
    const api = await startTestApiServer();

    await server.update({
        workers: [
            {
                configPath: "./dist/worker/wrangler.json",
                vars: { API_URL: api.url },
            },
        ],
    });

    await server.listen(); // Establishes the reset baseline.
});

afterEach(async () => {
    await server.reset(); // Resets to the beforeAll options.
});
```

No changset added as it's just a minor improvement to the `createTestHarness()` API that isn't released yet.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Will do it after shipping this API.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->