### PR TITLE
Improve D1 error messages for missing or conflicting options

### DIFF
--- a/.changeset/improve-d1-errors.md
+++ b/.changeset/improve-d1-errors.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Improve D1 error messages for missing or conflicting options
+
+Error messages for `d1 execute`, `d1 export`, `d1 time-travel restore`, and `d1 insights` now clearly state which option is missing or conflicting, explain why the combination is invalid, and suggest how to fix the issue.
+
+Additionally, duration validation errors in `d1 insights` are now thrown as `UserError` instead of plain `Error`, ensuring they are displayed cleanly to users rather than as unexpected crashes.

--- a/packages/wrangler/src/__tests__/d1/execute.test.ts
+++ b/packages/wrangler/src/__tests__/d1/execute.test.ts
@@ -46,7 +46,7 @@ describe("execute", () => {
 		});
 
 		await expect(runWrangler("d1 execute db")).rejects.toThrowError(
-			`Error: must provide --command or --file`
+			`Missing required option --command or --file. Provide a SQL command inline with --command="<SQL>", or a path to a SQL file with --file=<path>.`
 		);
 	});
 
@@ -81,7 +81,7 @@ describe("execute", () => {
 		await expect(
 			runWrangler(`d1 execute db --command "select;" --local --remote`)
 		).rejects.toThrowError(
-			"Error: can't use --local and --remote at the same time"
+			`Error: can't use --local and --remote at the same time`
 		);
 	});
 
@@ -95,7 +95,9 @@ describe("execute", () => {
 
 		await expect(
 			runWrangler(`d1 execute db --command "select;" --local --preview`)
-		).rejects.toThrowError(`Error: can't use --preview without --remote`);
+		).rejects.toThrowError(
+			`Cannot use --preview without --remote. The --preview flag targets a preview D1 database, which requires the --remote flag. Remove --preview or add --remote.`
+		);
 	});
 
 	it("should reject the use of --preview with --local with --json", async ({
@@ -114,7 +116,7 @@ describe("execute", () => {
 			JSON.stringify(
 				{
 					error: {
-						text: "Error: can't use --preview without --remote",
+						text: "Cannot use --preview without --remote. The --preview flag targets a preview D1 database, which requires the --remote flag. Remove --preview or add --remote.",
 					},
 				},
 				null,

--- a/packages/wrangler/src/__tests__/d1/insights.test.ts
+++ b/packages/wrangler/src/__tests__/d1/insights.test.ts
@@ -26,14 +26,14 @@ describe("getDurationDates()", () => {
 		expect,
 	}) => {
 		expect(() => getDurationDates("32d")).toThrowError(
-			"Duration cannot be greater than 31 days"
+			`Invalid --time-period value "32d": 32 days exceeds the maximum of 31 days. Provide a value of 31d or less.`
 		);
 	});
 	it("should throw an error if duration is greater than 31 days (in minutes)", ({
 		expect,
 	}) => {
 		expect(() => getDurationDates("44641m")).toThrowError(
-			"Duration cannot be greater than 44640 minutes (31 days)"
+			`Invalid --time-period value "44641m": 44641 minutes exceeds the maximum of 44640 minutes (31 days). Provide a value of 44640m or less.`
 		);
 	});
 
@@ -41,12 +41,14 @@ describe("getDurationDates()", () => {
 		expect,
 	}) => {
 		expect(() => getDurationDates("745h")).toThrowError(
-			"Duration cannot be greater than 744 hours (31 days)"
+			`Invalid --time-period value "745h": 745 hours exceeds the maximum of 744 hours (31 days). Provide a value of 744h or less.`
 		);
 	});
 
 	it("should throw an error if duration unit is invalid", ({ expect }) => {
-		expect(() => getDurationDates("1y")).toThrowError("Invalid duration unit");
+		expect(() => getDurationDates("1y")).toThrowError(
+			`Invalid --time-period unit "y" in "1y". Supported units: d (days), h (hours), m (minutes). Example: --time-period=7d.`
+		);
 	});
 
 	it("should return the correct start and end dates", ({ expect }) => {

--- a/packages/wrangler/src/__tests__/d1/migrate.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrate.test.ts
@@ -291,7 +291,9 @@ describe("migrate", () => {
 
 			await expect(
 				runWrangler("d1 migrations apply --local db --preview")
-			).rejects.toThrowError(`Error: can't use --preview without --remote`);
+			).rejects.toThrowError(
+				`Cannot use --preview without --remote. The --preview flag targets a preview D1 database, which requires the --remote flag. Remove --preview or add --remote.`
+			);
 		});
 
 		it("multiple accounts: should throw when trying to apply migrations without an account_id in config", async ({

--- a/packages/wrangler/src/__tests__/d1/timeTravel.test.ts
+++ b/packages/wrangler/src/__tests__/d1/timeTravel.test.ts
@@ -35,7 +35,7 @@ describe("time-travel", () => {
 					"d1 time-travel restore db --timestamp=1234 --bookmark=5678"
 				)
 			).rejects.toThrowError(
-				`Provide either a timestamp, or a bookmark - not both.`
+				`Cannot use --timestamp and --bookmark together. Provide only one: --timestamp to restore to a point in time, or --bookmark to restore to a specific bookmark.`
 			);
 		});
 	});

--- a/packages/wrangler/src/d1/execute.ts
+++ b/packages/wrangler/src/d1/execute.ts
@@ -238,9 +238,12 @@ export async function executeSql({
 				? ({ command } as ExecuteInput)
 				: null;
 		if (!input) {
-			throw new UserError(`Error: must provide --command or --file.`, {
-				telemetryMessage: "d1 execute missing command or file",
-			});
+			throw new UserError(
+				`Missing required option --command or --file. Provide a SQL command inline with --command="<SQL>", or a path to a SQL file with --file=<path>.`,
+				{
+					telemetryMessage: "d1 execute missing command or file",
+				}
+			);
 		}
 		if (local && remote) {
 			throw new UserError(
@@ -251,14 +254,20 @@ export async function executeSql({
 			);
 		}
 		if (preview && !remote) {
-			throw new UserError(`Error: can't use --preview without --remote`, {
-				telemetryMessage: "d1 execute preview requires remote",
-			});
+			throw new UserError(
+				`Cannot use --preview without --remote. The --preview flag targets a preview D1 database, which requires the --remote flag. Remove --preview or add --remote.`,
+				{
+					telemetryMessage: "d1 execute preview requires remote",
+				}
+			);
 		}
 		if (persistTo && !local) {
-			throw new UserError(`Error: can't use --persist-to without --local`, {
-				telemetryMessage: "d1 execute persist-to requires local",
-			});
+			throw new UserError(
+				`Cannot use --persist-to without --local. The --persist-to flag specifies a local persistence directory, which requires the --local flag. Remove --persist-to or add --local.`,
+				{
+					telemetryMessage: "d1 execute persist-to requires local",
+				}
+			);
 		}
 		if (input.file) {
 			await checkForSQLiteBinary(input.file);

--- a/packages/wrangler/src/d1/export.ts
+++ b/packages/wrangler/src/d1/export.ts
@@ -92,9 +92,12 @@ export const d1ExportCommand = createCommand({
 			args;
 
 		if (!schema && !data) {
-			throw new UserError(`You cannot specify both --no-schema and --no-data`, {
-				telemetryMessage: "d1 export conflicting no-schema and no-data flags",
-			});
+			throw new UserError(
+				`Cannot use --no-schema and --no-data together. At least one of schema or data must be included in the export. Remove one of the flags.`,
+				{
+					telemetryMessage: "d1 export conflicting no-schema and no-data flags",
+				}
+			);
 		}
 
 		const stats = statSync(output, { throwIfNoEntry: false });

--- a/packages/wrangler/src/d1/insights.ts
+++ b/packages/wrangler/src/d1/insights.ts
@@ -1,3 +1,4 @@
+import { UserError } from "@cloudflare/workers-utils";
 import { fetchGraphqlResult } from "../cfetch";
 import { createCommand } from "../core/create-command";
 import { logger } from "../logger";
@@ -25,7 +26,10 @@ export function getDurationDates(durationString: string) {
 	switch (durationUnit) {
 		case "d":
 			if (durationValue > 31) {
-				throw new Error("Duration cannot be greater than 31 days");
+				throw new UserError(
+					`Invalid --time-period value "${durationString}": ${durationValue} days exceeds the maximum of 31 days. Provide a value of 31d or less.`,
+					{ telemetryMessage: "d1 insights duration exceeds maximum" }
+				);
 			}
 			startDate = new Date(
 				endDate.getTime() - durationValue * 24 * 60 * 60 * 1000
@@ -33,22 +37,27 @@ export function getDurationDates(durationString: string) {
 			break;
 		case "m":
 			if (durationValue > 31 * 24 * 60) {
-				throw new Error(
-					`Duration cannot be greater than ${31 * 24 * 60} minutes (31 days)`
+				throw new UserError(
+					`Invalid --time-period value "${durationString}": ${durationValue} minutes exceeds the maximum of ${31 * 24 * 60} minutes (31 days). Provide a value of ${31 * 24 * 60}m or less.`,
+					{ telemetryMessage: "d1 insights duration exceeds maximum" }
 				);
 			}
 			startDate = new Date(endDate.getTime() - durationValue * 60 * 1000);
 			break;
 		case "h":
 			if (durationValue > 31 * 24) {
-				throw new Error(
-					`Duration cannot be greater than ${31 * 24} hours (31 days)`
+				throw new UserError(
+					`Invalid --time-period value "${durationString}": ${durationValue} hours exceeds the maximum of ${31 * 24} hours (31 days). Provide a value of ${31 * 24}h or less.`,
+					{ telemetryMessage: "d1 insights duration exceeds maximum" }
 				);
 			}
 			startDate = new Date(endDate.getTime() - durationValue * 60 * 60 * 1000);
 			break;
 		default:
-			throw new Error("Invalid duration unit");
+			throw new UserError(
+				`Invalid --time-period unit "${durationUnit}" in "${durationString}". Supported units: d (days), h (hours), m (minutes). Example: --time-period=7d.`,
+				{ telemetryMessage: "d1 insights invalid duration unit" }
+			);
 	}
 
 	return [startDate.toISOString(), endDate.toISOString()];

--- a/packages/wrangler/src/d1/timeTravel/restore.ts
+++ b/packages/wrangler/src/d1/timeTravel/restore.ts
@@ -49,17 +49,20 @@ export const d1TimeTravelRestoreCommand = createCommand({
 	validateArgs(args) {
 		if (args.timestamp && args.bookmark) {
 			throw new UserError(
-				"Provide either a timestamp, or a bookmark - not both.",
+				"Cannot use --timestamp and --bookmark together. Provide only one: --timestamp to restore to a point in time, or --bookmark to restore to a specific bookmark.",
 				{
 					telemetryMessage:
 						"d1 time travel restore conflicting timestamp and bookmark",
 				}
 			);
 		} else if (!args.timestamp && !args.bookmark) {
-			throw new UserError("Provide either a timestamp or a bookmark", {
-				telemetryMessage:
-					"d1 time travel restore missing timestamp or bookmark",
-			});
+			throw new UserError(
+				"Missing required option --timestamp or --bookmark. Provide --timestamp to restore to a point in time (e.g. --timestamp=2023-07-13T08:46:42.228Z), or --bookmark to restore to a specific bookmark.",
+				{
+					telemetryMessage:
+						"d1 time travel restore missing timestamp or bookmark",
+				}
+			);
 		}
 	},
 	async handler({ database, json, timestamp, bookmark }, { config }) {


### PR DESCRIPTION
Error messages for `d1 execute`, `d1 export`, `d1 time-travel restore`, and `d1 insights` now clearly state which option is missing or conflicting, explain why the combination is invalid, and suggest how to fix the issue.

Additionally, duration validation errors in `d1 insights` are now thrown as `UserError` instead of plain `Error`, ensuring they are displayed cleanly to users rather than as unexpected crashes.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: improved user errors

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
