### PR TITLE
fix: dependabot workerd PR skip description validation label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,7 +42,7 @@ updates:
     labels:
       - "miniflare"
       - "dependencies"
-      - "skip-pr-description-validation"
+      - "ci:skip-pr-description-validation"
     allow:
       - dependency-name: "workerd"
       - dependency-name: "@cloudflare/workers-types"


### PR DESCRIPTION
Fixes a bug with dependabot CI workflow file where the recent GitHub repository label changes broke it since it had the incorrect label.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: CI workflow fix
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Internal CI workflow fix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
