### PR TITLE
[investigate] Baseline tests for #14198 (remote-bindings Access auth)

### DIFF
--- a/investigation/remote-access-repro/README.md
+++ b/investigation/remote-access-repro/README.md
@@ -1,0 +1,110 @@
+# Remote-bindings + Cloudflare Access repro (investigation for #14198)
+
+A minimal, two-path reproduction for the remote-bindings-behind-Access question
+raised in [#14198](https://github.com/cloudflare/workers-sdk/pull/14198) and
+investigated in [#14234](https://github.com/cloudflare/workers-sdk/pull/14234).
+
+It deliberately exercises **both** remote-binding proxy code paths in one
+`wrangler dev` worker and reports each independently:
+
+| Report key     | Binding call            | Proxy path                                |
+| -------------- | ----------------------- | ----------------------------------------- |
+| `ai`           | `env.AI.run(...)`       | HTTP `makeFetch` (wrapped fetcher)        |
+| `serviceFetch` | `env.TARGET.fetch(...)` | HTTP `makeFetch` (service `.fetch`)       |
+| `rpc`          | `env.TARGET.add(1, 2)`  | WebSocket `makeRemoteProxyStub` (capnweb) |
+
+> This is a **manual, account-dependent** tool. It is not a workspace member and
+> is not run in CI. The Access enforcement it tests happens at the real
+> Cloudflare edge and cannot be faked locally.
+
+## Layout
+
+```
+target/   # WorkerEntrypoint `Api.add` + default fetch — DEPLOY this to your account
+dev/      # the worker you run with `wrangler dev` (remote AI + remote service binding)
+```
+
+## Prerequisites (account side — you do these)
+
+1. **Auth**: `wrangler login` (or `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID`).
+2. **Workers AI** enabled on the account. (If unavailable, swap the `ai` binding
+   in `dev/wrangler.jsonc` + the `ai` call in `dev/src/index.js` for Vectorize or
+   Images — any wrapped-fetcher binding exercises the same HTTP path.)
+3. **Deploy the target worker** (needed for the remote service binding):
+   ```bash
+   cd target && node <repo>/packages/wrangler/bin/wrangler.js deploy
+   ```
+4. **Protect your account's `workers.dev` subdomain with Cloudflare Access**,
+   with a **Service Auth** policy. (Dashboard → Zero Trust → Access.)
+5. **Create a Service Token** and note its Client ID / Secret.
+
+## Run protocol
+
+The repro runs against the **locally built** wrangler so it reflects whatever
+branch is checked out (this lets us compare `main` vs PR #14198 cleanly).
+
+```bash
+# (A) Build the branch under test (rebuilds wrangler + bundled miniflare + templates)
+cd <repo>
+git checkout main          # later: git checkout <pr-14198-ref>
+pnpm build
+
+# (B) Run the dev worker with debug logging
+cd investigation/remote-access-repro/dev
+export CLOUDFLARE_ACCESS_CLIENT_ID="<client-id>.access"      # set for scenarios B & D, unset for A & C
+export CLOUDFLARE_ACCESS_CLIENT_SECRET="<client-secret>"
+WRANGLER_LOG=debug node <repo>/packages/wrangler/bin/wrangler.js dev
+
+# (C) In another shell, trigger all three paths
+curl -s localhost:8787 | jq
+```
+
+### Scenario matrix
+
+| #     | Branch    | Creds set? | Notes                                |
+| ----- | --------- | ---------- | ------------------------------------ |
+| A     | `main`    | no         | baseline — expect Access to block    |
+| **B** | `main`    | **yes**    | **decisive** — does it already work? |
+| C     | PR #14198 | no         | PR says fails                        |
+| D     | PR #14198 | yes        | PR says works                        |
+
+## What to capture each run
+
+- The full JSON report from `curl` (per-path `ok`/`error`).
+- These `WRANGLER_LOG=debug` lines from the terminal:
+  - `Using Access Service Token headers for domain: <host>`
+    (`packages/workers-auth/src/access.ts:111`) — proves the proxy session put
+    service-token headers into `proxyData` for the `*.workers.dev` preview host.
+  - Any `Cloudflare Access blocked a remote bindings request` warning
+    (HTTP path only — added in #14011).
+  - The temporary `[mf-access-debug] forward ...` lines (see below).
+
+## Temporary ProxyWorker instrumentation (the smoking gun)
+
+A throwaway debug log has been added to
+`packages/wrangler/templates/startDevWorker/ProxyWorker.ts` (search for
+`mf-access-debug`). For **every** request the local ProxyWorker forwards to the
+`*.workers.dev` edge — HTTP **and** WebSocket upgrades — it logs the target URL,
+whether it's an `Upgrade`, and whether the merged headers carry the Access
+credentials + preview token:
+
+```
+[mf-access-debug] forward {"to":"https://...workers.dev/...","upgrade":"websocket","binding":"TARGET","hasAccessClientId":true,"hasCookie":false,"hasPreviewToken":true}
+```
+
+This directly answers the central question: **do the Access headers reach the
+edge on the WS-upgrade hop?** It requires a `pnpm build` to take effect, and
+**must be reverted before merge** (it is debug-only `console.log` in a template).
+
+## Interpreting scenario B (the decisive run)
+
+| JSON result                             | Conclusion                                                                    |
+| --------------------------------------- | ----------------------------------------------------------------------------- |
+| `ai.ok && serviceFetch.ok && rpc.ok`    | Existing path authenticates **all** paths → #14198's auth is redundant        |
+| `ai.ok`, `rpc` fails w/ Access/WS error | WS path **not** authenticated by existing path → #14198's WS change justified |
+| `ai` fails w/ `invalid_token`           | AI-upstream issue, **not** Cloudflare Access → #14198 misattributes           |
+| `ai` fails w/ Access `403` HTML         | HTTP path unauthenticated → broader bug to hunt                               |
+
+Cross-check against the `[mf-access-debug]` lines: if `hasAccessClientId` (or
+`hasCookie`) is `true` on the WS-`upgrade` forward line, the edge hop is being
+authenticated regardless of what the binding ultimately returns.

--- a/investigation/remote-access-repro/dev/src/index.js
+++ b/investigation/remote-access-repro/dev/src/index.js
@@ -1,0 +1,41 @@
+// Dev worker for the remote-bindings Access repro. Run with `wrangler dev`.
+//
+// A single GET to this worker exercises BOTH remote-binding proxy code paths
+// independently and reports the outcome of each, so one request tells us which
+// path works/fails and why:
+//
+//   - `ai`           → HTTP `makeFetch` path  (wrapped-fetcher binding; the
+//                       AI `invalid_token` case reported in PR #14198)
+//   - `serviceFetch` → HTTP `makeFetch` path  (service binding `.fetch`)
+//   - `rpc`          → WebSocket `makeRemoteProxyStub` path (capnweb RPC; the
+//                       Artifacts/service-RPC case reported in PR #14198)
+//
+// See ../README.md for the run protocol and how to read the results.
+
+async function settle(path, fn) {
+	try {
+		return { path, ok: true, result: await fn() };
+	} catch (e) {
+		return { path, ok: false, error: e && e.message ? e.message : String(e) };
+	}
+}
+
+export default {
+	async fetch(_request, env) {
+		const report = {
+			ai: await settle("http/makeFetch (AI)", () =>
+				env.AI.run("@cf/meta/llama-3.1-8b-instruct-fast", {
+					messages: [{ role: "user", content: "Reply with the word: ok" }],
+				})
+			),
+			serviceFetch: await settle("http/makeFetch (service.fetch)", async () => {
+				const res = await env.TARGET.fetch("http://example.com");
+				return await res.text();
+			}),
+			rpc: await settle("ws/makeRemoteProxyStub (service RPC)", () =>
+				env.TARGET.add(1, 2)
+			),
+		};
+		return Response.json(report);
+	},
+};

--- a/investigation/remote-access-repro/dev/wrangler.jsonc
+++ b/investigation/remote-access-repro/dev/wrangler.jsonc
@@ -1,0 +1,17 @@
+{
+	"name": "repro-remote-dev",
+	"main": "src/index.js",
+	"compatibility_date": "2025-04-28",
+	"ai": {
+		"binding": "AI",
+		"remote": true,
+	},
+	"services": [
+		{
+			"binding": "TARGET",
+			"service": "repro-remote-target",
+			"entrypoint": "Api",
+			"remote": true,
+		},
+	],
+}

--- a/investigation/remote-access-repro/target/src/index.js
+++ b/investigation/remote-access-repro/target/src/index.js
@@ -1,0 +1,22 @@
+import { WorkerEntrypoint } from "cloudflare:workers";
+
+// Deployed target worker for the remote-bindings Access repro.
+//
+// Exposes:
+//   - a default `fetch` (exercised via the HTTP `makeFetch` proxy path)
+//   - an `Api` WorkerEntrypoint with an `add` RPC method (exercised via the
+//     capnweb / WebSocket `makeRemoteProxyStub` proxy path)
+//
+// Deploy with:  wrangler deploy   (see ../README.md)
+
+export class Api extends WorkerEntrypoint {
+	add(a, b) {
+		return a + b;
+	}
+}
+
+export default {
+	fetch() {
+		return new Response("target default fetch ok");
+	},
+};

--- a/investigation/remote-access-repro/target/wrangler.jsonc
+++ b/investigation/remote-access-repro/target/wrangler.jsonc
@@ -1,0 +1,5 @@
+{
+	"name": "repro-remote-target",
+	"main": "src/index.js",
+	"compatibility_date": "2025-04-28",
+}

--- a/packages/miniflare/test/plugins/shared/proxy-websocket-header-forwarding.spec.ts
+++ b/packages/miniflare/test/plugins/shared/proxy-websocket-header-forwarding.spec.ts
@@ -1,0 +1,135 @@
+import { Miniflare } from "miniflare";
+import { describe, test } from "vitest";
+import { useDispose, useServer } from "../../test-shared";
+import type { IncomingHttpHeaders } from "node:http";
+
+// Baseline-characterisation test for PR #14198
+// (krys-cf:fix/remote-bindings-access-service-token).
+//
+// This test isolates the one workerd capability that BOTH the existing code path
+// and PR #14198 implicitly rely on: that a fetch with `Upgrade: websocket` carries
+// arbitrary request headers all the way to the upstream WebSocket server during
+// the upgrade handshake.
+//
+// In remote-bindings dev today the request flow is:
+//
+//   User worker (Miniflare A)
+//     └─ remote-proxy-client.worker  ─ws/http─▶  http://127.0.0.1:<port>  (ProxyWorker B, LOCAL)
+//          ProxyWorker.processQueue   [packages/wrangler/templates/startDevWorker/ProxyWorker.ts]
+//            headers = new Headers(request.headers);              // line ~121
+//            for (...) headers.set(key, value);                   // line ~146-155 (proxyData merge)
+//            fetch(userWorkerUrl, new Request(request, { headers })); // line ~158
+//                                          ─▶  https://<token.host>.workers.dev   (edge, MAYBE Access-protected)
+//
+// `proxyData.headers` is computed by RemoteRuntimeController and contains the
+// result of `getAccessHeaders(token.host)`. So *if* workerd preserves both
+// (a) the proxyData-merged headers AND (b) the incoming-request headers on the
+// outbound WS upgrade, the ProxyWorker→edge hop already authenticates with
+// Access service-token headers — without any miniflare-side credential plumbing.
+//
+// This test reproduces ProxyWorker.processQueue's forward line in isolation
+// against a fake edge that records the upgrade handshake headers. Two distinct
+// sentinel headers — one set by the worker (simulating proxyData.headers) and
+// one passed in on the incoming request (simulating client-originated headers)
+// — let us distinguish:
+//
+//   ┌───────────────────────────────────────┬─────────────────────────────────┐
+//   │ Edge receives                         │ Verdict                         │
+//   ├───────────────────────────────────────┼─────────────────────────────────┤
+//   │ both sentinels                        │ Existing path already auths WS  │
+//   │                                       │ → PR's WS fetch-upgrade auth is │
+//   │                                       │   REDUNDANT for reaching the    │
+//   │                                       │   edge.                         │
+//   ├───────────────────────────────────────┼─────────────────────────────────┤
+//   │ only incoming sentinel                │ proxyData headers dropped on WS │
+//   │                                       │ → PR's mechanism is JUSTIFIED.  │
+//   ├───────────────────────────────────────┼─────────────────────────────────┤
+//   │ only proxyData sentinel               │ Existing path works; PR's       │
+//   │                                       │ client-side header wouldn't     │
+//   │                                       │ propagate.                      │
+//   ├───────────────────────────────────────┼─────────────────────────────────┤
+//   │ neither                               │ WS header forwarding broken →   │
+//   │                                       │ PR couldn't work either; the AI │
+//   │                                       │ `invalid_token` is a separate   │
+//   │                                       │ failure (look elsewhere).       │
+//   └───────────────────────────────────────┴─────────────────────────────────┘
+
+// Mirrors the exact forward line in ProxyWorker.processQueue
+// (packages/wrangler/templates/startDevWorker/ProxyWorker.ts:121, 146-155, 158).
+// `new Headers(request.headers)` preserves the incoming request's headers;
+// `headers.set(...)` adds the proxyData-merged sentinel; `fetch(EDGE_URL, new
+// Request(request, { headers }))` forwards the (now header-merged) request,
+// including any `Upgrade: websocket`.
+const FORWARDING_WORKER = /* javascript */ `
+	export default {
+		async fetch(request, env) {
+			const headers = new Headers(request.headers);
+			headers.set("x-proxydata-sentinel", "from-proxydata");
+			return fetch(env.EDGE_URL, new Request(request, { headers }));
+		}
+	};
+`;
+
+describe("ProxyWorker WS-upgrade header forwarding (baseline)", () => {
+	test("workerd forwards both proxyData-merged and incoming-request headers on a WS upgrade", async ({
+		expect,
+	}) => {
+		let upgradeHeaders: IncomingHttpHeaders | undefined;
+
+		// Fake "edge" server. The HTTP listener serves any non-WS request with a
+		// 426 so the test doesn't accidentally pass on a non-upgrade request.
+		// The WS listener captures the upgrade headers (which is all we need)
+		// then immediately closes the socket.
+		const { http: edge } = await useServer(
+			(_req, res) => {
+				res.statusCode = 426;
+				res.end();
+			},
+			(socket, req) => {
+				upgradeHeaders = { ...req.headers };
+				socket.close();
+			}
+		);
+
+		const mf = new Miniflare({
+			modules: true,
+			compatibilityDate: "2025-01-01",
+			script: FORWARDING_WORKER,
+			bindings: { EDGE_URL: edge.toString() },
+		});
+		useDispose(mf);
+
+		// Send a WS-upgrade request *into* the forwarding worker, with our
+		// "incoming-request" sentinel. The worker will set the
+		// "proxydata-merged" sentinel and re-issue the request against the
+		// fake edge URL it has via `env.EDGE_URL`. workerd's outbound fetch
+		// handles the WS upgrade.
+		const res = await mf.dispatchFetch("http://localhost/", {
+			headers: {
+				Upgrade: "websocket",
+				"x-incoming-sentinel": "from-client",
+			},
+		});
+		// Release whatever the worker handed back so the response stream
+		// (and any associated WebSocket) is cleaned up promptly.
+		if (res.webSocket) {
+			res.webSocket.accept();
+			res.webSocket.close();
+		} else {
+			await res.body?.cancel();
+		}
+
+		// Give the fake WS server a tick to record the upgrade headers in case
+		// the close races the connection event (the existing access-warning
+		// spec uses the same pattern at remote-bindings-access-warning.spec.ts).
+		for (let i = 0; i < 50 && upgradeHeaders === undefined; i++) {
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+
+		expect(upgradeHeaders).toBeDefined();
+		// (a) Does the proxyData-merged header reach the edge on a WS upgrade?
+		expect(upgradeHeaders?.["x-proxydata-sentinel"]).toBe("from-proxydata");
+		// (b) Does the incoming-request header reach the edge on a WS upgrade?
+		expect(upgradeHeaders?.["x-incoming-sentinel"]).toBe("from-client");
+	});
+});

--- a/packages/miniflare/test/plugins/shared/remote-bindings-access-warning.spec.ts
+++ b/packages/miniflare/test/plugins/shared/remote-bindings-access-warning.spec.ts
@@ -1,7 +1,7 @@
 import { LogLevel, Miniflare } from "miniflare";
 import { describe, test } from "vitest";
 import { TestLog, useDispose, useServer } from "../../test-shared";
-import type { RemoteProxyConnectionString } from "miniflare";
+import type { RemoteProxyConnectionString, WorkerOptions } from "miniflare";
 
 const CF_ACCESS_BLOCK_HTML = `<!DOCTYPE html>
 <html>
@@ -207,5 +207,90 @@ describe("remote-bindings proxy client: Cloudflare Access warning", () => {
 			.logsAtLevel(LogLevel.WARN)
 			.filter((message) => message.includes(ACCESS_WARNING_FRAGMENT));
 		expect(accessWarnings).toHaveLength(0);
+	});
+});
+
+// Baseline-characterisation tests for PR #14198
+// (krys-cf:fix/remote-bindings-access-service-token).
+//
+// PR #14011 added the Access-block warning + readable-body substitution above,
+// but wired it only into the HTTP `makeFetch` path. The capnweb/WebSocket path
+// in `makeRemoteProxyStub` was not updated. These tests characterise that gap:
+// when the remote-bindings proxy returns a Cloudflare Access block on a
+// WebSocket upgrade (which is what would happen if the proxy hop genuinely
+// required client-side Access auth), the RPC binding fails opaquely with no
+// actionable warning to the user — in contrast to the HTTP path above which
+// produces a single, actionable warning + readable error body.
+//
+// Script that exercises a non-`.fetch` RPC method on a service binding so the
+// proxy stub takes the capnweb / WebSocket path inside `makeRemoteProxyStub`
+// (rather than the HTTP path that the existing tests in this file exercise).
+const RPC_SCRIPT = /* javascript */ `
+	export default {
+		async fetch(request, env) {
+			try {
+				const result = await env.SERVICE.someRpcMethod();
+				return new Response("ok:" + JSON.stringify(result));
+			} catch (e) {
+				return new Response("err:" + (e && e.message ? e.message : String(e)), {
+					status: 500,
+				});
+			}
+		},
+	};
+`;
+
+describe("remote-bindings proxy client: Cloudflare Access block on WS/RPC path", () => {
+	test("RPC call fails AND no Access warning fires when the proxy returns an Access block on the WS upgrade", async ({
+		expect,
+	}) => {
+		// Local server that returns a Cloudflare Access block for every
+		// request — including WS upgrades, because no `webSocketListener` is
+		// passed to `useServer`, so the upgrade falls through to the HTTP
+		// listener and gets the 403.
+		const { http: proxyUrl } = await useServer((req, res) => {
+			res.statusCode = 403;
+			res.setHeader("Content-Type", "text/html");
+			res.end(CF_ACCESS_BLOCK_HTML);
+		});
+
+		const log = new TestLog();
+		const mf = new Miniflare({
+			modules: true,
+			compatibilityDate: "2025-01-01",
+			log,
+			script: RPC_SCRIPT,
+			serviceBindings: {
+				SERVICE: {
+					name: "some-remote-service",
+					remoteProxyConnectionString:
+						proxyUrl as unknown as RemoteProxyConnectionString,
+				},
+			} satisfies WorkerOptions["serviceBindings"],
+		});
+		useDispose(mf);
+
+		const response = await mf.dispatchFetch("http://localhost/");
+		const body = await response.text();
+
+		// The RPC call must have failed (capnweb couldn't open its
+		// WebSocket — the upgrade got a 403 instead of a 101) ...
+		expect(response.status).toBe(500);
+		expect(body.startsWith("err:")).toBe(true);
+
+		// ... but the user got no actionable guidance. The capnweb path in
+		// makeRemoteProxyStub has no equivalent of makeFetch's
+		// `maybeReportCloudflareAccessBlock`, so no warning is logged AND
+		// the error body the worker sees is whatever opaque error capnweb /
+		// the WebSocket constructor surfaced — not the readable
+		// "Cloudflare Access blocked..." guidance that the HTTP path above
+		// produces.
+		await new Promise((resolve) => setTimeout(resolve, 200));
+		const accessWarnings = log
+			.logsAtLevel(LogLevel.WARN)
+			.filter((message) => message.includes(ACCESS_WARNING_FRAGMENT));
+		expect(accessWarnings).toHaveLength(0);
+		expect(body).not.toContain("Cloudflare Access blocked");
+		expect(body).not.toContain("CLOUDFLARE_ACCESS_CLIENT_ID");
 	});
 });

--- a/packages/wrangler/src/__tests__/api/startDevWorker/RemoteRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/RemoteRuntimeController.test.ts
@@ -528,4 +528,95 @@ describe("RemoteRuntimeController", () => {
 			});
 		});
 	});
+
+	// Baseline-characterisation tests for PR #14198 (krys-cf:fix/remote-bindings-access-service-token)
+	//
+	// These assert what the *existing* RemoteRuntimeController already does on `main` with regard
+	// to Cloudflare Access service-token headers. They are intentionally PR-independent — their
+	// purpose is to settle whether the PR's miniflare-side credential plumbing is necessary, by
+	// proving (or disproving) that the proxy session already places Access headers into the
+	// `proxyData` that the local ProxyWorker merges into every request it forwards to the edge.
+	//
+	// Companion baseline tests live in
+	//   packages/miniflare/test/plugins/shared/proxy-websocket-header-forwarding.spec.ts
+	//   packages/miniflare/test/plugins/shared/remote-bindings-access-warning.spec.ts
+	describe("Cloudflare Access headers in proxyData (baseline)", () => {
+		it("places service-token headers into proxyData on every reload, in remote: 'minimal' mode", async ({
+			expect,
+		}) => {
+			vi.mocked(getAccessHeaders).mockResolvedValue({
+				"CF-Access-Client-Id": "id.access",
+				"CF-Access-Client-Secret": "secret",
+			});
+
+			const { controller, bus } = setup();
+			// `remote: "minimal"` matches what `startRemoteProxySession` uses
+			// (packages/wrangler/src/api/remoteBindings/start-remote-proxy-session.ts:109).
+			const config = makeConfig({
+				dev: {
+					remote: "minimal",
+					persist: false,
+					auth: {
+						accountId: "test-account-id",
+						apiToken: { apiToken: "test-token" },
+					},
+				},
+			} as Partial<StartDevWorkerOptions>);
+			const bundle = makeBundle();
+
+			controller.onBundleStart({ type: "bundleStart", config });
+			controller.onBundleComplete({ type: "bundleComplete", config, bundle });
+			const reload = await bus.waitFor("reloadComplete");
+
+			// `getAccessHeaders` is called against the preview token's host
+			// (RemoteRuntimeController.ts:325) — the *.workers.dev preview host
+			// that's behind Cloudflare Access — NOT the loopback URL the
+			// remote-bindings proxy client connects to.
+			expect(getAccessHeaders).toHaveBeenCalledWith("test.workers.dev");
+
+			// The headers are spread into proxyData.headers verbatim, alongside
+			// the preview token. The local ProxyWorker's `processQueue` then
+			// merges these into every forwarded request (HTTP and WebSocket
+			// upgrades alike — see ProxyWorker.ts:146-158).
+			expect(reload).toMatchObject({
+				type: "reloadComplete",
+				proxyData: {
+					headers: {
+						"CF-Access-Client-Id": "id.access",
+						"CF-Access-Client-Secret": "secret",
+						"cf-workers-preview-token": "test-preview-token",
+					},
+				},
+			});
+		});
+
+		it("places cookie-based Access auth (cloudflared) into proxyData", async ({
+			expect,
+		}) => {
+			// `getAccessHeaders` can return either the service-token pair or a
+			// `Cookie: CF_Authorization=...` (from `cloudflared access login`).
+			// Either way it goes through the same proxyData channel — so the
+			// existing path covers both auth modes uniformly.
+			vi.mocked(getAccessHeaders).mockResolvedValue({
+				Cookie: "CF_Authorization=jwt-from-cloudflared-login",
+			});
+
+			const { controller, bus } = setup();
+			const config = makeConfig();
+			const bundle = makeBundle();
+
+			controller.onBundleStart({ type: "bundleStart", config });
+			controller.onBundleComplete({ type: "bundleComplete", config, bundle });
+			const reload = await bus.waitFor("reloadComplete");
+
+			expect(reload).toMatchObject({
+				type: "reloadComplete",
+				proxyData: {
+					headers: {
+						Cookie: "CF_Authorization=jwt-from-cloudflared-login",
+					},
+				},
+			});
+		});
+	});
 });

--- a/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
@@ -154,6 +154,25 @@ export class ProxyWorker implements DurableObject {
 				}
 			}
 
+			// TEMP DEBUG (#14198 investigation) — REMOVE BEFORE MERGE.
+			// Logs, for every request forwarded to the *.workers.dev edge (HTTP
+			// and WebSocket upgrades alike), whether the merged headers carry the
+			// Cloudflare Access credentials + preview token. This answers: do the
+			// Access headers reach the edge on the WS-upgrade hop? Grep for
+			// `mf-access-debug` in `WRANGLER_LOG=debug` output.
+			// eslint-disable-next-line no-console -- temporary investigation logging
+			console.log(
+				"[mf-access-debug] forward",
+				JSON.stringify({
+					to: userWorkerUrl.href,
+					upgrade: headers.get("upgrade") ?? null,
+					binding: headers.get("MF-Binding") ?? null,
+					hasAccessClientId: headers.has("CF-Access-Client-Id"),
+					hasCookie: headers.has("cookie"),
+					hasPreviewToken: headers.has("cf-workers-preview-token"),
+				})
+			);
+
 			// explicitly NOT await-ing this promise, we are in a loop and want to process the whole queue quickly + synchronously
 			void fetch(userWorkerUrl, new Request(request, { headers }))
 				.then(async (res) => {


### PR DESCRIPTION
**Discussion / investigation PR — companion to #14198.** Not intended to merge as-is. The goal is to share three baseline-characterisation tests that run on `main` (without #14198 applied), and use their empirical results to discuss whether #14198's miniflare-side credential plumbing is necessary, and what the genuine outstanding gap is.

cc @krys-cf @petebacondarwin

## TL;DR

- All three tests **pass on `main`** without #14198 applied.
- The decisive result (Test 2) shows that the ProxyWorker→edge hop **already carries arbitrary headers, including the proxyData-merged ones, on a WebSocket upgrade**. Combined with Test 1's confirmation that `RemoteRuntimeController` always injects `getAccessHeaders(token.host)` into `proxyData.headers`, this means **the edge hop already authenticates remote-binding traffic — HTTP and WS alike — with the existing service-token env vars**.
- Test 3 demonstrates a real, separate gap: when the proxy returns a Cloudflare Access block on a WebSocket upgrade, the RPC call fails opaquely with **no warning** — in contrast to #14011's HTTP-path warning. This gap is unrelated to authentication and worth addressing on its own.

If these results hold up under closer scrutiny / a debug repro from @krys-cf, then #14198's two mechanisms (HTTP creds in `makeFetch` and the `fetch()`-based WS upgrade in `makeRemoteProxyStub`) appear to be redundant for the auth they target, and the AI `InferenceUpstreamError: invalid_token` reported in #14198 may be a separate AI-upstream concern rather than a Cloudflare Access failure.

## Why this matters / topology recap

`remoteProxyConnectionString` is **not** the workers.dev URL — it resolves to the **local** ProxyController Miniflare (`http://127.0.0.1:<port>`, `start-remote-proxy-session.ts:160-161` → `DevEnv.ts:215-217` → `ProxyController.ts:188` with no host override, defaulting to `127.0.0.1`). The Access-protected host is `token.host` (`*.workers.dev`), one hop further in.

```
User worker (Miniflare A)
  └─ remote-proxy-client.worker   ─ws/http─▶   http://127.0.0.1:<port>     ← LOCAL loopback
       Local ProxyWorker (Miniflare B)         [ProxyWorker.ts]
         processQueue:
           headers = new Headers(request.headers);
           for (...) headers.set(key, value);       ← merges proxyData.headers
           fetch(userWorkerUrl, new Request(request, { headers }));
                                          ─▶  https://<token.host>.workers.dev   ← Access-protected
            ProxyServerWorker (edge)
              ├─ newWorkersRpcResponse  (capnweb / WS-RPC)
              └─ fetcher.fetch          (raw HTTP bindings)
```

The only Access-gated hop is **B→edge**. `RemoteRuntimeController.ts:325` already calls `getAccessHeaders(token.host)` and spreads it into `proxyData.headers` (`:333-337`). `ProxyWorker.processQueue` unconditionally merges those into every forwarded request (`ProxyWorker.ts:146-158`), including WS upgrades.

The remaining question — and the entire reason I wrote Test 2 — is whether workerd actually carries those merged headers on a WS upgrade, or whether something subtle (e.g. `new Response(res.body, res)` at `ProxyWorker.ts:160` dropping the `webSocket`) causes the WS path to silently lose them. The workerd C++ source (`Response::constructor` in `src/workerd/api/http.c++`) preserves both `webSocket` and `statusCode` when constructed from another Response, but a runtime check is more decisive than reading C++.

## The three tests + their empirical results

### Test 1 — `RemoteRuntimeController` puts Access headers in `proxyData`

**File:** `packages/wrangler/src/__tests__/api/startDevWorker/RemoteRuntimeController.test.ts` (+91 lines)
**Run:** `pnpm test:ci -F wrangler -- RemoteRuntimeController`
**Result:** ✅ passes on `main`. The controller calls `getAccessHeaders(token.host)` on every reload (including `remote: "minimal"`) and spreads the result into `proxyData.headers` alongside the preview token. Verified for both auth modes (service-token pair *and* `Cookie: CF_Authorization=...` from `cloudflared`).

### Test 2 — workerd forwards headers on a WS upgrade (the linchpin)

**File:** `packages/miniflare/test/plugins/shared/proxy-websocket-header-forwarding.spec.ts` (new)
**Run:** `pnpm --filter miniflare exec vitest run test/plugins/shared/proxy-websocket-header-forwarding.spec.ts`
**Result:** ✅ passes on `main` — **"both sentinels"** outcome.

The test replicates `ProxyWorker.processQueue`'s exact forward line:
```js
const headers = new Headers(request.headers);
headers.set("x-proxydata-sentinel", "from-proxydata");
return fetch(env.EDGE_URL, new Request(request, { headers }));
```
…sends an `Upgrade: websocket` request with `x-incoming-sentinel: from-client`, and a fake WS server (via `useServer(_, wsListener)`) captures the upgrade `req.headers`. Both sentinels arrive at the edge:

| Edge receives | Verdict |
|---|---|
| **both** ← actual result | Existing path already auths WS → #14198's WS fetch-upgrade is **redundant** for reaching the edge. |
| only incoming | proxyData headers dropped on WS → #14198's mechanism would be justified. |
| only proxyData | Client-side header wouldn't propagate. |
| neither | WS forwarding broken → AI `invalid_token` is a separate issue. |

### Test 3 — WS/RPC path has no Access-block detection

**File:** `packages/miniflare/test/plugins/shared/remote-bindings-access-warning.spec.ts` (+87 lines)
**Run:** `pnpm --filter miniflare exec vitest run test/plugins/shared/remote-bindings-access-warning.spec.ts`
**Result:** ✅ passes on `main` — confirms the gap.

A fake proxy server returns a 403 Cloudflare Access block (the same HTML body the existing HTTP-path tests use) for every request, including WS upgrades. A worker script invokes a non-`.fetch` RPC method on the service binding (so the proxy stub takes the capnweb / WebSocket path, not `makeFetch`). The RPC call fails (`response.status === 500`, body `err:…`) **and** no Access warning is logged — in contrast to the HTTP path which produces a single, actionable warning + readable error body courtesy of #14011's `maybeReportCloudflareAccessBlock`. The capnweb path in `makeRemoteProxyStub` has no equivalent.

## What this implies for #14198

If the empirical results above hold up under @krys-cf's repro:

1. **Authentication isn't actually missing on either remote-binding path** (HTTP or WS) — `proxyData.headers` already carries `CF-Access-Client-Id`/`Secret` (or `Cookie`) to the edge. The PR's HTTP-side credential injection in `makeFetch` and its WS-side `fetch()`-based upgrade in `makeRemoteProxyStub` would, in this reading, be attaching Access headers on the localhost loopback hop where Access is not enforced.
2. **The AI `InferenceUpstreamError: invalid_token`** reported in #14198 may not be a Cloudflare Access failure — it's an AI-upstream / Inference Gateway error code. Worth confirming separately.
3. **The real gap** is detection/UX on the WS/RPC path: Access blocks there are opaque. The cleanest follow-up — independent of the auth question — is to wire `maybeReportCloudflareAccessBlock` (or equivalent) into the capnweb path so RPC bindings surface the same single, actionable warning the HTTP path already does.

If, on the other hand, @krys-cf can reproduce the failure with the PR reverted, env creds set, and `WRANGLER_LOG=debug` confirming `Using Access Service Token headers for domain: <token.host>` is logged for the proxy session — then there's a real bug somewhere that my static + isolated tests have missed, and we should hunt for it before plumbing more credentials.

## Specific things I'd love a debug capture of

If @krys-cf has time, the most useful data point would be: with the PR fully reverted, env creds set, against the failing repro, `WRANGLER_LOG=debug` output capturing:

1. Whether `getAccessHeaders` logs `Using Access Service Token headers for domain: <token.host>` for the proxy session (`access.ts:111`). If yes, `proxyData` should carry them, and the question is what happens after the merge.
2. The exact failing response — a 403 Cloudflare Access HTML body, or the AI `InferenceUpstreamError: invalid_token` text? These are different failure modes.
3. Which binding actually fails first — a wrapped-fetcher binding (AI/Vectorize/Images, HTTP path) or a JSRPC binding (Artifacts/service, WS path)?

That single capture would distinguish "real bug in B→edge for some bindings" from "AI-upstream auth issue conflated with Access" from "Access is the culprit for some other reason I haven't traced".

---

Fixes #N/A — discussion PR; not intended to merge as-is.

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: this PR is investigation-only and adds tests that characterise existing behaviour — no shipped behaviour changes.
