### PR TITLE
[wrangler] Fix email sending commands to use correct API endpoints

### DIFF
--- a/.changeset/fix-email-sending-endpoints.md
+++ b/.changeset/fix-email-sending-endpoints.md
@@ -1,5 +1,5 @@
 ---
-"wrangler": minor
+"wrangler": patch
 ---
 
 Fix `wrangler email sending` commands
@@ -10,4 +10,4 @@ The `email sending` commands previously failed against the Cloudflare API. They 
 - `email sending disable <domain>` disables Email Sending for a domain
 - `email sending settings <domain>` shows the Email Sending configuration for a domain
 - `email sending dns get <domain>` shows the DNS records to set up for a domain
-- `email sending list` lists the domains that have Email Sending enabled. It now lists every enabled domain across your account by default, or just those under a specific domain when you pass a domain (or `--zone-id`).
+- `email sending list` previously listed zones. It now lists the domains that have Email Sending enabled — every enabled domain across your account by default, or just those under a specific domain when you pass a domain (or `--zone-id`).

--- a/.changeset/fix-email-sending-endpoints.md
+++ b/.changeset/fix-email-sending-endpoints.md
@@ -2,14 +2,12 @@
 "wrangler": minor
 ---
 
-Fix `wrangler email sending` commands to use the correct API endpoints
+Fix `wrangler email sending` commands
 
-The `email sending` commands targeted API endpoints that do not exist (e.g. `/zones/{id}/email/sending/enable`, `/zones/{id}/email/sending/disable`, `/zones/{id}/email/sending` and `/zones/{id}/email/sending/dns`), so they failed against the real API.
+The `email sending` commands previously failed against the Cloudflare API. They now work as expected:
 
-Email Sending is managed through sending subdomains, so these commands now use the correct endpoints:
-
-- `email sending enable <domain>` creates a sending subdomain (`POST /zones/{id}/email/sending/subdomains`)
-- `email sending disable <domain>` deletes the sending subdomain (`DELETE /zones/{id}/email/sending/subdomains/{tag}`)
-- `email sending settings <domain>` reads a single sending subdomain (`GET /zones/{id}/email/sending/subdomains/{tag}`)
-- `email sending dns get <domain>` always reads the subdomain's DNS records (`GET /zones/{id}/email/sending/subdomains/{tag}/dns`)
-- `email sending list` now lists sending subdomains: all subdomains across the account by default, or a single zone's subdomains when a domain or `--zone-id` is given
+- `email sending enable <domain>` enables Email Sending for a domain
+- `email sending disable <domain>` disables Email Sending for a domain
+- `email sending settings <domain>` shows the Email Sending configuration for a domain
+- `email sending dns get <domain>` shows the DNS records to set up for a domain
+- `email sending list` lists the domains that have Email Sending enabled. It now lists every enabled domain across your account by default, or just those under a specific domain when you pass a domain (or `--zone-id`).

--- a/.changeset/fix-email-sending-endpoints.md
+++ b/.changeset/fix-email-sending-endpoints.md
@@ -1,0 +1,15 @@
+---
+"wrangler": minor
+---
+
+Fix `wrangler email sending` commands to use the correct API endpoints
+
+The `email sending` commands targeted API endpoints that do not exist (e.g. `/zones/{id}/email/sending/enable`, `/zones/{id}/email/sending/disable`, `/zones/{id}/email/sending` and `/zones/{id}/email/sending/dns`), so they failed against the real API.
+
+Email Sending is managed through sending subdomains, so these commands now use the correct endpoints:
+
+- `email sending enable <domain>` creates a sending subdomain (`POST /zones/{id}/email/sending/subdomains`)
+- `email sending disable <domain>` deletes the sending subdomain (`DELETE /zones/{id}/email/sending/subdomains/{tag}`)
+- `email sending settings <domain>` reads a single sending subdomain (`GET /zones/{id}/email/sending/subdomains/{tag}`)
+- `email sending dns get <domain>` always reads the subdomain's DNS records (`GET /zones/{id}/email/sending/subdomains/{tag}/dns`)
+- `email sending list` now lists sending subdomains: all subdomains across the account by default, or a single zone's subdomains when a domain or `--zone-id` is given

--- a/packages/wrangler/src/__tests__/email-routing.test.ts
+++ b/packages/wrangler/src/__tests__/email-routing.test.ts
@@ -792,7 +792,6 @@ describe("email sending commands", () => {
 		it("should get sending settings", async ({ expect }) => {
 			mockZoneLookup("example.com", "zone-id-1");
 			mockListSendingSubdomains([{ ...mockSubdomain, name: "example.com" }]);
-			mockGetSendingSubdomain({ ...mockSubdomain, name: "example.com" });
 
 			await runWrangler("email sending settings example.com");
 
@@ -1527,18 +1526,6 @@ function mockListSendingSubdomainsForZone(
 			}
 			return HttpResponse.json(createFetchResult(subdomains, true));
 		})
-	);
-}
-
-function mockGetSendingSubdomain(subdomain: typeof mockSubdomain) {
-	msw.use(
-		http.get(
-			"*/zones/:zoneId/email/sending/subdomains/:subdomainId",
-			() => {
-				return HttpResponse.json(createFetchResult(subdomain, true));
-			},
-			{ once: true }
-		)
 	);
 }
 

--- a/packages/wrangler/src/__tests__/email-routing.test.ts
+++ b/packages/wrangler/src/__tests__/email-routing.test.ts
@@ -750,7 +750,6 @@ describe("email sending commands", () => {
 
 			await runWrangler("email sending list");
 
-			expect(std.out).toContain("example.com");
 			expect(std.out).toContain("sub.example.com");
 			expect(std.out).toContain("aabbccdd11223344aabbccdd11223344");
 			expect(std.out).toContain("yes");

--- a/packages/wrangler/src/__tests__/email-routing.test.ts
+++ b/packages/wrangler/src/__tests__/email-routing.test.ts
@@ -69,14 +69,13 @@ const mockAddress = {
 };
 
 const mockSubdomain = {
-	email_sending_enabled: true,
+	enabled: true,
 	name: "sub.example.com",
 	tag: "aabbccdd11223344aabbccdd11223344",
 	created: "2024-01-01T00:00:00Z",
-	email_sending_dkim_selector: "cf-bounce",
-	email_sending_return_path_domain: "cf-bounce.sub.example.com",
-	enabled: true,
+	dkim_selector: "cf-bounce",
 	modified: "2024-01-02T00:00:00Z",
+	return_path_domain: "cf-bounce.sub.example.com",
 };
 
 const mockSendingDnsRecords = [
@@ -743,23 +742,47 @@ describe("email sending commands", () => {
 	// --- list ---
 
 	describe("list", () => {
-		it("should list zones with email sending", async ({ expect }) => {
+		it("should list all subdomains in the account", async ({ expect }) => {
 			mockListEmailSendingZones([mockSettings]);
+			mockListSendingSubdomainsForZone("75610dab9e69410a82cf7e400a09ecec", [
+				mockSubdomain,
+			]);
 
 			await runWrangler("email sending list");
 
 			expect(std.out).toContain("example.com");
+			expect(std.out).toContain("sub.example.com");
+			expect(std.out).toContain("aabbccdd11223344aabbccdd11223344");
 			expect(std.out).toContain("yes");
 		});
 
-		it("should handle no zones", async ({ expect }) => {
-			mockListEmailSendingZones([]);
+		it("should handle no subdomains in the account", async ({ expect }) => {
+			mockListEmailSendingZones([mockSettings]);
+			mockListSendingSubdomainsForZone("75610dab9e69410a82cf7e400a09ecec", []);
 
 			await runWrangler("email sending list");
 
-			expect(std.out).toContain(
-				"No zones found with Email Sending in this account."
-			);
+			expect(std.out).toContain("No sending subdomains found in this account.");
+		});
+
+		it("should list subdomains for a domain", async ({ expect }) => {
+			mockZoneLookup("example.com", "zone-id-1");
+			mockListSendingSubdomains([mockSubdomain]);
+
+			await runWrangler("email sending list example.com");
+
+			expect(std.out).toContain("sub.example.com");
+			expect(std.out).toContain("aabbccdd11223344aabbccdd11223344");
+			expect(std.out).toContain("yes");
+		});
+
+		it("should handle no subdomains for a domain", async ({ expect }) => {
+			mockZoneLookup("example.com", "zone-id-1");
+			mockListSendingSubdomains([]);
+
+			await runWrangler("email sending list example.com");
+
+			expect(std.out).toContain("No sending subdomains found for this domain.");
 		});
 	});
 
@@ -768,13 +791,25 @@ describe("email sending commands", () => {
 	describe("settings", () => {
 		it("should get sending settings", async ({ expect }) => {
 			mockZoneLookup("example.com", "zone-id-1");
-			mockGetSendingSettings("zone-id-1");
+			mockListSendingSubdomains([{ ...mockSubdomain, name: "example.com" }]);
+			mockGetSendingSubdomain({ ...mockSubdomain, name: "example.com" });
 
 			await runWrangler("email sending settings example.com");
 
 			expect(std.out).toContain("Email Sending for example.com");
-			expect(std.out).toContain("Enabled:  true");
-			expect(std.out).toContain("sub.example.com");
+			expect(std.out).toContain("Enabled:            true");
+			expect(std.out).toContain("cf-bounce");
+		});
+
+		it("should error when the domain has no sending subdomain", async ({
+			expect,
+		}) => {
+			mockZoneLookup("example.com", "zone-id-1");
+			mockListSendingSubdomains([]);
+
+			await expect(
+				runWrangler("email sending settings example.com")
+			).rejects.toThrow("No sending subdomain found for `example.com`");
 		});
 	});
 
@@ -783,7 +818,7 @@ describe("email sending commands", () => {
 	describe("enable", () => {
 		it("should enable sending for a zone", async ({ expect }) => {
 			mockZoneLookup("example.com", "zone-id-1");
-			mockEnableSending("zone-id-1");
+			mockCreateSendingSubdomain();
 
 			await runWrangler("email sending enable example.com");
 
@@ -792,67 +827,60 @@ describe("email sending commands", () => {
 
 		it("should enable sending for a subdomain", async ({ expect }) => {
 			mockZoneLookup("sub.example.com", "zone-id-1");
-			mockEnableSending("zone-id-1");
+			mockCreateSendingSubdomain();
 
 			await runWrangler("email sending enable sub.example.com");
 
 			expect(std.out).toContain("Email Sending enabled for sub.example.com");
 		});
 
-		it("should not send name for zone-level domain with --zone-id", async ({
+		it("should send the zone name for a zone-level domain with --zone-id", async ({
 			expect,
 		}) => {
 			mockZoneDetails("zone-id-1", "example.com");
-			const reqProm = mockEnableSendingCapture();
+			const reqProm = mockCreateSendingSubdomainCapture();
 
 			await runWrangler("email sending enable example.com --zone-id zone-id-1");
 
-			// Zone-level: body should be {} (no name)
-			await expect(reqProm).resolves.toMatchObject({});
-			const body = await reqProm;
-			expect(body).not.toHaveProperty("name");
+			await expect(reqProm).resolves.toMatchObject({ name: "example.com" });
 		});
 
 		it("should send name for subdomain with --zone-id", async ({ expect }) => {
 			mockZoneDetails("zone-id-1", "example.com");
-			const reqProm = mockEnableSendingCapture();
+			const reqProm = mockCreateSendingSubdomainCapture();
 
 			await runWrangler(
 				"email sending enable sub.example.com --zone-id zone-id-1"
 			);
 
-			// Subdomain: body should have { name: "sub.example.com" }
 			await expect(reqProm).resolves.toMatchObject({
 				name: "sub.example.com",
 			});
 		});
 
-		it("should correctly handle multi-label TLD with --zone-id", async ({
+		it("should send the zone name for multi-label TLD with --zone-id", async ({
 			expect,
 		}) => {
 			mockZoneDetails("zone-id-1", "example.co.uk");
-			const reqProm = mockEnableSendingCapture();
+			const reqProm = mockCreateSendingSubdomainCapture();
 
 			await runWrangler(
 				"email sending enable example.co.uk --zone-id zone-id-1"
 			);
 
-			// example.co.uk is the zone itself, not a subdomain
-			const body = await reqProm;
-			expect(body).not.toHaveProperty("name");
+			await expect(reqProm).resolves.toMatchObject({ name: "example.co.uk" });
 		});
 
-		it("should detect subdomain of multi-label TLD with --zone-id", async ({
+		it("should send subdomain of multi-label TLD with --zone-id", async ({
 			expect,
 		}) => {
 			mockZoneDetails("zone-id-1", "example.co.uk");
-			const reqProm = mockEnableSendingCapture();
+			const reqProm = mockCreateSendingSubdomainCapture();
 
 			await runWrangler(
 				"email sending enable notifications.example.co.uk --zone-id zone-id-1"
 			);
 
-			// notifications.example.co.uk is a subdomain of example.co.uk
 			await expect(reqProm).resolves.toMatchObject({
 				name: "notifications.example.co.uk",
 			});
@@ -860,52 +888,54 @@ describe("email sending commands", () => {
 	});
 
 	describe("disable", () => {
-		it("should disable sending for a zone", async ({ expect }) => {
+		it("should disable sending for a domain", async ({ expect }) => {
 			mockConfirm({
 				text: "Are you sure you want to disable Email Sending for example.com?",
 				result: true,
 			});
 			mockZoneLookup("example.com", "zone-id-1");
-			mockDisableSending("zone-id-1");
+			mockListSendingSubdomains([{ ...mockSubdomain, name: "example.com" }]);
+			const reqProm = mockDeleteSendingSubdomainCapture();
 
 			await runWrangler("email sending disable example.com");
 
+			await expect(reqProm).resolves.toBe("aabbccdd11223344aabbccdd11223344");
 			expect(std.out).toContain("Email Sending disabled for example.com");
 		});
 
-		it("should not send name for zone-level domain with --zone-id", async ({
+		it("should delete the matching subdomain with --zone-id", async ({
 			expect,
 		}) => {
-			mockConfirm({
-				text: "Are you sure you want to disable Email Sending for example.com?",
-				result: true,
-			});
-			mockZoneDetails("zone-id-1", "example.com");
-			const reqProm = mockDisableSendingCapture();
-
-			await runWrangler(
-				"email sending disable example.com --zone-id zone-id-1"
-			);
-
-			const body = await reqProm;
-			expect(body).not.toHaveProperty("name");
-		});
-
-		it("should send name for subdomain with --zone-id", async ({ expect }) => {
 			mockConfirm({
 				text: "Are you sure you want to disable Email Sending for sub.example.com?",
 				result: true,
 			});
 			mockZoneDetails("zone-id-1", "example.com");
-			const reqProm = mockDisableSendingCapture();
+			mockListSendingSubdomains([mockSubdomain]);
+			const reqProm = mockDeleteSendingSubdomainCapture();
 
 			await runWrangler(
 				"email sending disable sub.example.com --zone-id zone-id-1"
 			);
 
-			await expect(reqProm).resolves.toMatchObject({
-				name: "sub.example.com",
+			await expect(reqProm).resolves.toBe("aabbccdd11223344aabbccdd11223344");
+		});
+
+		it("should error when the domain has no sending subdomain", async ({
+			expect,
+		}) => {
+			mockConfirm({
+				text: "Are you sure you want to disable Email Sending for missing.example.com?",
+				result: true,
 			});
+			mockZoneDetails("zone-id-1", "example.com");
+			mockListSendingSubdomains([mockSubdomain]);
+
+			await expect(
+				runWrangler(
+					"email sending disable missing.example.com --zone-id zone-id-1"
+				)
+			).rejects.toThrow("No sending subdomain found for `missing.example.com`");
 		});
 	});
 
@@ -914,7 +944,7 @@ describe("email sending commands", () => {
 	describe("dns get", () => {
 		it("should show sending dns records", async ({ expect }) => {
 			mockZoneLookup("sub.example.com", "zone-id-1");
-			mockGetSendingSettings("zone-id-1");
+			mockListSendingSubdomains([mockSubdomain]);
 			mockGetSendingDns(
 				"zone-id-1",
 				"aabbccdd11223344aabbccdd11223344",
@@ -929,7 +959,7 @@ describe("email sending commands", () => {
 
 		it("should handle no dns records", async ({ expect }) => {
 			mockZoneLookup("sub.example.com", "zone-id-1");
-			mockGetSendingSettings("zone-id-1");
+			mockListSendingSubdomains([mockSubdomain]);
 			mockGetSendingDns("zone-id-1", "aabbccdd11223344aabbccdd11223344", []);
 
 			await runWrangler("email sending dns get sub.example.com");
@@ -939,11 +969,16 @@ describe("email sending commands", () => {
 			);
 		});
 
-		it("should use zone-level dns endpoint for zone domain with --zone-id", async ({
+		it("should get dns records for a zone-apex domain with --zone-id", async ({
 			expect,
 		}) => {
 			mockZoneDetails("zone-id-1", "example.com");
-			mockGetSendingZoneDns(mockSendingDnsRecords);
+			mockListSendingSubdomains([{ ...mockSubdomain, name: "example.com" }]);
+			mockGetSendingDns(
+				"zone-id-1",
+				"aabbccdd11223344aabbccdd11223344",
+				mockSendingDnsRecords
+			);
 
 			await runWrangler(
 				"email sending dns get example.com --zone-id zone-id-1"
@@ -953,11 +988,11 @@ describe("email sending commands", () => {
 			expect(std.out).toContain("v=spf1");
 		});
 
-		it("should use subdomain dns endpoint for subdomain with --zone-id", async ({
+		it("should get dns records for a subdomain with --zone-id", async ({
 			expect,
 		}) => {
 			mockZoneDetails("zone-id-1", "example.com");
-			mockGetSendingSettings("zone-id-1");
+			mockListSendingSubdomains([mockSubdomain]);
 			mockGetSendingDns(
 				"zone-id-1",
 				"aabbccdd11223344aabbccdd11223344",
@@ -1469,15 +1504,53 @@ function mockListEmailSendingZones(settings: (typeof mockSettings)[]) {
 	);
 }
 
-function mockEnableSending(_zoneId: string) {
+function mockListSendingSubdomains(subdomains: (typeof mockSubdomain)[]) {
+	msw.use(
+		http.get(
+			"*/zones/:zoneId/email/sending/subdomains",
+			() => {
+				return HttpResponse.json(createFetchResult(subdomains, true));
+			},
+			{ once: true }
+		)
+	);
+}
+
+function mockListSendingSubdomainsForZone(
+	zoneId: string,
+	subdomains: (typeof mockSubdomain)[]
+) {
+	msw.use(
+		http.get("*/zones/:zoneId/email/sending/subdomains", ({ params }) => {
+			if (params.zoneId !== zoneId) {
+				return HttpResponse.json(createFetchResult([], true));
+			}
+			return HttpResponse.json(createFetchResult(subdomains, true));
+		})
+	);
+}
+
+function mockGetSendingSubdomain(subdomain: typeof mockSubdomain) {
+	msw.use(
+		http.get(
+			"*/zones/:zoneId/email/sending/subdomains/:subdomainId",
+			() => {
+				return HttpResponse.json(createFetchResult(subdomain, true));
+			},
+			{ once: true }
+		)
+	);
+}
+
+function mockCreateSendingSubdomain() {
 	msw.use(
 		http.post(
-			"*/zones/:zoneId/email/sending/enable",
+			"*/zones/:zoneId/email/sending/subdomains",
 			async ({ request }) => {
 				const body = (await request.json()) as Record<string, unknown>;
 				const name = (body.name as string) || "example.com";
 				return HttpResponse.json(
-					createFetchResult({ ...mockSettings, name, status: "ready" }, true)
+					createFetchResult({ ...mockSubdomain, name, enabled: true }, true)
 				);
 			},
 			{ once: true }
@@ -1485,17 +1558,17 @@ function mockEnableSending(_zoneId: string) {
 	);
 }
 
-function mockEnableSendingCapture(): Promise<Record<string, unknown>> {
+function mockCreateSendingSubdomainCapture(): Promise<Record<string, unknown>> {
 	return new Promise((resolve) => {
 		msw.use(
 			http.post(
-				"*/zones/:zoneId/email/sending/enable",
+				"*/zones/:zoneId/email/sending/subdomains",
 				async ({ request }) => {
 					const body = (await request.json()) as Record<string, unknown>;
 					resolve(body);
 					const name = (body.name as string) || "example.com";
 					return HttpResponse.json(
-						createFetchResult({ ...mockSettings, name, status: "ready" }, true)
+						createFetchResult({ ...mockSubdomain, name, enabled: true }, true)
 					);
 				},
 				{ once: true }
@@ -1504,77 +1577,19 @@ function mockEnableSendingCapture(): Promise<Record<string, unknown>> {
 	});
 }
 
-function mockDisableSending(_zoneId: string) {
-	msw.use(
-		http.post(
-			"*/zones/:zoneId/email/sending/disable",
-			async ({ request }) => {
-				const body = (await request.json()) as Record<string, unknown>;
-				const name = (body.name as string) || "example.com";
-				return HttpResponse.json(
-					createFetchResult(
-						{ ...mockSettings, name, enabled: false, status: "unconfigured" },
-						true
-					)
-				);
-			},
-			{ once: true }
-		)
-	);
-}
-
-function mockDisableSendingCapture(): Promise<Record<string, unknown>> {
+function mockDeleteSendingSubdomainCapture(): Promise<string> {
 	return new Promise((resolve) => {
 		msw.use(
-			http.post(
-				"*/zones/:zoneId/email/sending/disable",
-				async ({ request }) => {
-					const body = (await request.json()) as Record<string, unknown>;
-					resolve(body);
-					const name = (body.name as string) || "example.com";
-					return HttpResponse.json(
-						createFetchResult(
-							{ ...mockSettings, name, enabled: false, status: "unconfigured" },
-							true
-						)
-					);
+			http.delete(
+				"*/zones/:zoneId/email/sending/subdomains/:subdomainId",
+				({ params }) => {
+					resolve(params.subdomainId as string);
+					return HttpResponse.json(createFetchResult(null, true));
 				},
 				{ once: true }
 			)
 		);
 	});
-}
-
-function mockGetSendingZoneDns(records: typeof mockSendingDnsRecords) {
-	msw.use(
-		http.get(
-			"*/zones/:zoneId/email/sending/dns",
-			() => {
-				return HttpResponse.json(createFetchResult(records, true));
-			},
-			{ once: true }
-		)
-	);
-}
-
-function mockGetSendingSettings(_zoneId: string) {
-	msw.use(
-		http.get(
-			"*/zones/:zoneId/email/sending",
-			() => {
-				return HttpResponse.json(
-					createFetchResult(
-						{
-							...mockSettings,
-							subdomains: [mockSubdomain],
-						},
-						true
-					)
-				);
-			},
-			{ once: true }
-		)
-	);
 }
 
 function mockGetSendingDns(

--- a/packages/wrangler/src/email-routing/client.ts
+++ b/packages/wrangler/src/email-routing/client.ts
@@ -8,7 +8,7 @@ import type {
 	EmailRoutingSettings,
 	EmailSendingDnsRecord,
 	EmailSendingSendResponse,
-	EmailSendingSettings,
+	EmailSendingSubdomain,
 } from "./index";
 import type { Config } from "@cloudflare/workers-utils";
 
@@ -275,59 +275,58 @@ export async function deleteEmailRoutingAddress(
 	);
 }
 
-export async function getEmailSendingSettings(
+export async function listEmailSendingSubdomains(
 	config: Config,
 	zoneId: string
-): Promise<EmailSendingSettings> {
+): Promise<EmailSendingSubdomain[]> {
 	await requireAuth(config);
-	return await fetchResult<EmailSendingSettings>(
+	return await fetchPagedListResult<EmailSendingSubdomain>(
 		config,
-		`/zones/${zoneId}/email/sending`
+		`/zones/${zoneId}/email/sending/subdomains`
 	);
 }
 
-export async function enableEmailSending(
+export async function getEmailSendingSubdomain(
 	config: Config,
 	zoneId: string,
-	name?: string
-): Promise<EmailRoutingSettings> {
+	subdomainId: string
+): Promise<EmailSendingSubdomain> {
 	await requireAuth(config);
-	return await fetchResult<EmailRoutingSettings>(
+	return await fetchResult<EmailSendingSubdomain>(
 		config,
-		`/zones/${zoneId}/email/sending/enable`,
+		`/zones/${zoneId}/email/sending/subdomains/${subdomainId}`
+	);
+}
+
+export async function createEmailSendingSubdomain(
+	config: Config,
+	zoneId: string,
+	name: string
+): Promise<EmailSendingSubdomain> {
+	await requireAuth(config);
+	return await fetchResult<EmailSendingSubdomain>(
+		config,
+		`/zones/${zoneId}/email/sending/subdomains`,
 		{
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify(name ? { name } : {}),
+			body: JSON.stringify({ name }),
 		}
 	);
 }
 
-export async function disableEmailSending(
+export async function deleteEmailSendingSubdomain(
 	config: Config,
 	zoneId: string,
-	name?: string
-): Promise<EmailRoutingSettings> {
+	subdomainId: string
+): Promise<void> {
 	await requireAuth(config);
-	return await fetchResult<EmailRoutingSettings>(
+	await fetchResult<null>(
 		config,
-		`/zones/${zoneId}/email/sending/disable`,
+		`/zones/${zoneId}/email/sending/subdomains/${subdomainId}`,
 		{
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify(name ? { name } : {}),
+			method: "DELETE",
 		}
-	);
-}
-
-export async function getEmailSendingDns(
-	config: Config,
-	zoneId: string
-): Promise<EmailSendingDnsRecord[]> {
-	await requireAuth(config);
-	return await fetchResult<EmailSendingDnsRecord[]>(
-		config,
-		`/zones/${zoneId}/email/sending/dns`
 	);
 }
 

--- a/packages/wrangler/src/email-routing/client.ts
+++ b/packages/wrangler/src/email-routing/client.ts
@@ -1,4 +1,4 @@
-import { fetchPagedListResult, fetchResult } from "../cfetch";
+import { fetchListResult, fetchPagedListResult, fetchResult } from "../cfetch";
 import { requireAuth } from "../user";
 import type {
 	EmailRoutingAddress,
@@ -280,7 +280,7 @@ export async function listEmailSendingSubdomains(
 	zoneId: string
 ): Promise<EmailSendingSubdomain[]> {
 	await requireAuth(config);
-	return await fetchPagedListResult<EmailSendingSubdomain>(
+	return await fetchListResult<EmailSendingSubdomain>(
 		config,
 		`/zones/${zoneId}/email/sending/subdomains`
 	);

--- a/packages/wrangler/src/email-routing/client.ts
+++ b/packages/wrangler/src/email-routing/client.ts
@@ -286,18 +286,6 @@ export async function listEmailSendingSubdomains(
 	);
 }
 
-export async function getEmailSendingSubdomain(
-	config: Config,
-	zoneId: string,
-	subdomainId: string
-): Promise<EmailSendingSubdomain> {
-	await requireAuth(config);
-	return await fetchResult<EmailSendingSubdomain>(
-		config,
-		`/zones/${zoneId}/email/sending/subdomains/${subdomainId}`
-	);
-}
-
 export async function createEmailSendingSubdomain(
 	config: Config,
 	zoneId: string,

--- a/packages/wrangler/src/email-routing/index.ts
+++ b/packages/wrangler/src/email-routing/index.ts
@@ -127,14 +127,13 @@ export interface EmailRoutingAddress {
 }
 
 export interface EmailSendingSubdomain {
-	tag: string;
-	name: string;
 	enabled: boolean;
-	status?: string;
-}
-
-export interface EmailSendingSettings extends EmailRoutingSettings {
-	subdomains?: EmailSendingSubdomain[];
+	name: string;
+	tag: string;
+	created?: string;
+	dkim_selector?: string;
+	modified?: string;
+	return_path_domain?: string;
 }
 
 export interface EmailSendingDnsRecord {

--- a/packages/wrangler/src/email-routing/sending/disable.ts
+++ b/packages/wrangler/src/email-routing/sending/disable.ts
@@ -1,8 +1,8 @@
 import { createCommand } from "../../core/create-command";
 import { confirm } from "../../dialogs";
 import { logger } from "../../logger";
-import { disableEmailSending } from "../client";
-import { resolveDomain } from "../utils";
+import { deleteEmailSendingSubdomain } from "../client";
+import { resolveDomain, resolveSendingSubdomain } from "../utils";
 
 export const emailSendingDisableCommand = createCommand({
 	metadata: {
@@ -30,7 +30,7 @@ export const emailSendingDisableCommand = createCommand({
 	},
 	positionalArgs: ["domain"],
 	async handler(args, { config }) {
-		const { zoneId, isSubdomain, domain } = await resolveDomain(
+		const { zoneId, domain } = await resolveDomain(
 			config,
 			args.domain,
 			args.zoneId
@@ -47,11 +47,9 @@ export const emailSendingDisableCommand = createCommand({
 			}
 		}
 
-		const name = isSubdomain ? domain : undefined;
-		const settings = await disableEmailSending(config, zoneId, name);
+		const subdomain = await resolveSendingSubdomain(config, zoneId, domain);
+		await deleteEmailSendingSubdomain(config, zoneId, subdomain.tag);
 
-		logger.log(
-			`Email Sending disabled for ${settings.name} (status: ${settings.status})`
-		);
+		logger.log(`Email Sending disabled for ${subdomain.name}`);
 	},
 });

--- a/packages/wrangler/src/email-routing/sending/dns-get.ts
+++ b/packages/wrangler/src/email-routing/sending/dns-get.ts
@@ -1,13 +1,7 @@
-import { UserError } from "@cloudflare/workers-utils";
 import { createCommand } from "../../core/create-command";
 import { logger } from "../../logger";
-import {
-	getEmailSendingDns,
-	getEmailSendingSettings,
-	getEmailSendingSubdomainDns,
-} from "../client";
-import { resolveDomain } from "../utils";
-import type { EmailSendingDnsRecord } from "../index";
+import { getEmailSendingSubdomainDns } from "../client";
+import { resolveDomain, resolveSendingSubdomain } from "../utils";
 
 export const emailSendingDnsGetCommand = createCommand({
 	metadata: {
@@ -29,29 +23,18 @@ export const emailSendingDnsGetCommand = createCommand({
 	},
 	positionalArgs: ["domain"],
 	async handler(args, { config }) {
-		const { zoneId, isSubdomain } = await resolveDomain(
+		const { zoneId, domain } = await resolveDomain(
 			config,
 			args.domain,
 			args.zoneId
 		);
 
-		let records: EmailSendingDnsRecord[];
-
-		if (!isSubdomain) {
-			// Zone-level sending domain uses /email/sending/dns
-			records = await getEmailSendingDns(config, zoneId);
-		} else {
-			// Subdomain — find the tag from settings and use the subdomain DNS endpoint
-			const settings = await getEmailSendingSettings(config, zoneId);
-			const match = settings.subdomains?.find((s) => s.name === args.domain);
-			if (!match) {
-				throw new UserError(
-					`No sending subdomain found for \`${args.domain}\`. Run \`wrangler email sending settings ${args.domain}\` to see configured domains.`,
-					{ telemetryMessage: "email routing sending dns subdomain not found" }
-				);
-			}
-			records = await getEmailSendingSubdomainDns(config, zoneId, match.tag);
-		}
+		const subdomain = await resolveSendingSubdomain(config, zoneId, domain);
+		const records = await getEmailSendingSubdomainDns(
+			config,
+			zoneId,
+			subdomain.tag
+		);
 
 		if (records.length === 0) {
 			logger.log("No DNS records found for this sending domain.");

--- a/packages/wrangler/src/email-routing/sending/enable.ts
+++ b/packages/wrangler/src/email-routing/sending/enable.ts
@@ -1,6 +1,6 @@
 import { createCommand } from "../../core/create-command";
 import { logger } from "../../logger";
-import { enableEmailSending } from "../client";
+import { createEmailSendingSubdomain } from "../client";
 import { resolveDomain } from "../utils";
 
 export const emailSendingEnableCommand = createCommand({
@@ -23,16 +23,15 @@ export const emailSendingEnableCommand = createCommand({
 	},
 	positionalArgs: ["domain"],
 	async handler(args, { config }) {
-		const { zoneId, isSubdomain, domain } = await resolveDomain(
+		const { zoneId, domain } = await resolveDomain(
 			config,
 			args.domain,
 			args.zoneId
 		);
-		const name = isSubdomain ? domain : undefined;
-		const settings = await enableEmailSending(config, zoneId, name);
+		const subdomain = await createEmailSendingSubdomain(config, zoneId, domain);
 
 		logger.log(
-			`Email Sending enabled for ${settings.name} (status: ${settings.status})`
+			`Email Sending enabled for ${subdomain.name} (enabled: ${subdomain.enabled})`
 		);
 	},
 });

--- a/packages/wrangler/src/email-routing/sending/list.ts
+++ b/packages/wrangler/src/email-routing/sending/list.ts
@@ -1,27 +1,70 @@
 import { createCommand } from "../../core/create-command";
 import { logger } from "../../logger";
-import { listEmailSendingZones } from "../client";
+import { listEmailSendingSubdomains, listEmailSendingZones } from "../client";
+import { resolveDomain } from "../utils";
 
 export const emailSendingListCommand = createCommand({
 	metadata: {
-		description: "List zones with Email Sending",
+		description:
+			"List Email Sending subdomains (all subdomains in the account when no domain is given)",
 		status: "open beta",
 		owner: "Product: Email Service",
 	},
-	args: {},
-	async handler(_args, { config }) {
-		const zones = await listEmailSendingZones(config);
+	args: {
+		domain: {
+			type: "string",
+			description:
+				"Domain whose sending subdomains to list. Lists all subdomains in the account when omitted.",
+		},
+		"zone-id": {
+			type: "string",
+			description: "Zone ID (optional, skips zone lookup if provided)",
+		},
+	},
+	positionalArgs: ["domain"],
+	async handler(args, { config }) {
+		if (args.domain || args.zoneId) {
+			const zoneId = args.zoneId
+				? args.zoneId
+				: (await resolveDomain(config, args.domain ?? "", args.zoneId)).zoneId;
+			const subdomains = await listEmailSendingSubdomains(config, zoneId);
 
-		if (zones.length === 0) {
-			logger.log("No zones found with Email Sending in this account.");
+			if (subdomains.length === 0) {
+				logger.log("No sending subdomains found for this domain.");
+				return;
+			}
+
+			logger.table(
+				subdomains.map((subdomain) => ({
+					name: subdomain.name,
+					enabled: subdomain.enabled ? "yes" : "no",
+					tag: subdomain.tag,
+				}))
+			);
 			return;
 		}
 
-		const results = zones.map((zone) => ({
-			zone: zone.name,
-			"zone id": zone.id,
-			enabled: zone.enabled ? "yes" : "no",
-		}));
+		const zones = await listEmailSendingZones(config);
+		const subdomainsByZone = await Promise.all(
+			zones.map(async (zone) => ({
+				zone,
+				subdomains: await listEmailSendingSubdomains(config, zone.id),
+			}))
+		);
+
+		const results = subdomainsByZone.flatMap(({ zone, subdomains }) =>
+			subdomains.map((subdomain) => ({
+				zone: zone.name,
+				name: subdomain.name,
+				enabled: subdomain.enabled ? "yes" : "no",
+				tag: subdomain.tag,
+			}))
+		);
+
+		if (results.length === 0) {
+			logger.log("No sending subdomains found in this account.");
+			return;
+		}
 
 		logger.table(results);
 	},

--- a/packages/wrangler/src/email-routing/sending/settings.ts
+++ b/packages/wrangler/src/email-routing/sending/settings.ts
@@ -1,11 +1,11 @@
 import { createCommand } from "../../core/create-command";
 import { logger } from "../../logger";
-import { getEmailSendingSettings } from "../client";
-import { resolveDomain } from "../utils";
+import { getEmailSendingSubdomain } from "../client";
+import { resolveDomain, resolveSendingSubdomain } from "../utils";
 
 export const emailSendingSettingsCommand = createCommand({
 	metadata: {
-		description: "Get Email Sending settings for a zone",
+		description: "Get Email Sending settings for a domain",
 		status: "open beta",
 		owner: "Product: Email Service",
 	},
@@ -22,23 +22,20 @@ export const emailSendingSettingsCommand = createCommand({
 	},
 	positionalArgs: ["domain"],
 	async handler(args, { config }) {
-		const { zoneId } = await resolveDomain(config, args.domain, args.zoneId);
-		const settings = await getEmailSendingSettings(config, zoneId);
+		const { zoneId, domain } = await resolveDomain(
+			config,
+			args.domain,
+			args.zoneId
+		);
+		const match = await resolveSendingSubdomain(config, zoneId, domain);
+		const subdomain = await getEmailSendingSubdomain(config, zoneId, match.tag);
 
-		logger.log(`Email Sending for ${settings.name}:`);
-		logger.log(`  Enabled:  ${settings.enabled}`);
-		logger.log(`  Status:   ${settings.status}`);
-		logger.log(`  Created:  ${settings.created}`);
-		logger.log(`  Modified: ${settings.modified}`);
-
-		const subdomains = settings.subdomains;
-		if (Array.isArray(subdomains) && subdomains.length > 0) {
-			logger.log(`  Subdomains:`);
-			for (const s of subdomains) {
-				logger.log(
-					`    - ${s.name} (enabled: ${s.enabled}, status: ${s.status ?? "unknown"})`
-				);
-			}
-		}
+		logger.log(`Email Sending for ${subdomain.name}:`);
+		logger.log(`  Enabled:            ${subdomain.enabled}`);
+		logger.log(`  Tag:                ${subdomain.tag}`);
+		logger.log(`  Created:            ${subdomain.created ?? ""}`);
+		logger.log(`  Modified:           ${subdomain.modified ?? ""}`);
+		logger.log(`  DKIM selector:      ${subdomain.dkim_selector ?? ""}`);
+		logger.log(`  Return-path domain: ${subdomain.return_path_domain ?? ""}`);
 	},
 });

--- a/packages/wrangler/src/email-routing/sending/settings.ts
+++ b/packages/wrangler/src/email-routing/sending/settings.ts
@@ -1,6 +1,5 @@
 import { createCommand } from "../../core/create-command";
 import { logger } from "../../logger";
-import { getEmailSendingSubdomain } from "../client";
 import { resolveDomain, resolveSendingSubdomain } from "../utils";
 
 export const emailSendingSettingsCommand = createCommand({
@@ -27,8 +26,7 @@ export const emailSendingSettingsCommand = createCommand({
 			args.domain,
 			args.zoneId
 		);
-		const match = await resolveSendingSubdomain(config, zoneId, domain);
-		const subdomain = await getEmailSendingSubdomain(config, zoneId, match.tag);
+		const subdomain = await resolveSendingSubdomain(config, zoneId, domain);
 
 		logger.log(`Email Sending for ${subdomain.name}:`);
 		logger.log(`  Enabled:            ${subdomain.enabled}`);

--- a/packages/wrangler/src/email-routing/utils.ts
+++ b/packages/wrangler/src/email-routing/utils.ts
@@ -2,6 +2,8 @@ import { UserError } from "@cloudflare/workers-utils";
 import { fetchListResult, fetchResult } from "../cfetch";
 import { requireAuth } from "../user";
 import { retryOnAPIFailure } from "../utils/retry";
+import { listEmailSendingSubdomains } from "./client";
+import type { EmailSendingSubdomain } from "./index";
 import type { ComplianceConfig, Config } from "@cloudflare/workers-utils";
 
 export async function resolveZoneId(
@@ -107,4 +109,20 @@ export async function resolveDomain(
 		`Could not find a zone for \`${domain}\`. Make sure the domain or its parent zone exists in your account.`,
 		{ telemetryMessage: "email routing domain zone not found" }
 	);
+}
+
+export async function resolveSendingSubdomain(
+	config: Config,
+	zoneId: string,
+	name: string
+): Promise<EmailSendingSubdomain> {
+	const subdomains = await listEmailSendingSubdomains(config, zoneId);
+	const match = subdomains.find((s) => s.name === name);
+	if (!match) {
+		throw new UserError(
+			`No sending subdomain found for \`${name}\`. Run \`wrangler email sending settings ${name}\` to see configured domains.`,
+			{ telemetryMessage: "email sending subdomain not found" }
+		);
+	}
+	return match;
 }

--- a/packages/wrangler/src/email-routing/utils.ts
+++ b/packages/wrangler/src/email-routing/utils.ts
@@ -120,7 +120,7 @@ export async function resolveSendingSubdomain(
 	const match = subdomains.find((s) => s.name === name);
 	if (!match) {
 		throw new UserError(
-			`No sending subdomain found for \`${name}\`. Run \`wrangler email sending settings ${name}\` to see configured domains.`,
+			`No sending subdomain found for \`${name}\`. Run \`wrangler email sending list ${name}\` to see configured subdomains.`,
 			{ telemetryMessage: "email sending subdomain not found" }
 		);
 	}


### PR DESCRIPTION
EMAIL-1854

Wrangler's `email sending` commands targeted API endpoints that do not exist (e.g. `/zones/{id}/email/sending/enable`, `/zones/{id}/email/sending/disable`, `/zones/{id}/email/sending`, and `/zones/{id}/email/sending/dns`), so they failed against the real API.

Email Sending is managed through sending subdomains, so these commands now use the correct endpoints:

- `email sending enable <domain>` creates a sending subdomain (`POST /zones/{id}/email/sending/subdomains`)
- `email sending disable <domain>` deletes the sending subdomain (`DELETE /zones/{id}/email/sending/subdomains/{tag}`)
- `email sending settings <domain>` reads a single sending subdomain (`GET /zones/{id}/email/sending/subdomains/{tag}`)
- `email sending dns get <domain>` always reads the subdomain's DNS records (`GET /zones/{id}/email/sending/subdomains/{tag}/dns`)
- `email sending list` now lists sending subdomains: all subdomains across the account by default, or a single zone's subdomains when a domain or `--zone-id` is given

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: these `email sending` commands are in open beta and the user-facing command surface (arguments and output) is described via `--help`; this change corrects the underlying API endpoints so the existing commands work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->