### PR TITLE
Improve error messages for CLI flags, type generation, auth scopes, dev server tunnels, and compatibility flags

### DIFF
--- a/.changeset/improve-error-messages-cli-types-auth-dev-compat.md
+++ b/.changeset/improve-error-messages-cli-types-auth-dev-compat.md
@@ -1,0 +1,13 @@
+---
+"wrangler": patch
+---
+
+Improve error messages for CLI flags, type generation, auth scopes, dev server tunnels, and compatibility flags
+
+Error messages across several areas now name the exact flags or values involved and suggest how to fix the problem:
+
+- KV commands (`kv key put`, `kv key get`, `kv key delete`): error messages now include `--` prefixes and clear "Missing required option" / "Conflicting options" phrasing instead of the vague "Exactly one of the arguments ... is required".
+- `wrangler types --include-env=false --include-runtime=false`: the error now names both flags and explains what each does.
+- `wrangler login --scopes`: invalid scopes are individually identified instead of dumping the entire array.
+- `wrangler dev --tunnel --remote`: the error now explains why tunnels require local mode and suggests two concrete fixes.
+- Conflicting compatibility flags (`nodejs_compat_populate_process_env` / `nodejs_compat_do_not_populate_process_env`, `global_navigator` / `no_global_navigator`): errors now name the specific conflicting flags.

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -3069,7 +3069,7 @@ describe.sequential("wrangler dev", () => {
 			await expect(
 				runWrangler("dev --tunnel --remote")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: --tunnel is only supported in local mode.]`
+				`[Error: --tunnel cannot be used with --remote. Tunnels expose your local dev server to the internet, which is only applicable in local mode. Remove --remote to use --tunnel, or remove --tunnel to use --remote.]`
 			);
 		});
 	});

--- a/packages/wrangler/src/__tests__/kv/key.test.ts
+++ b/packages/wrangler/src/__tests__/kv/key.test.ts
@@ -441,7 +441,7 @@ describe("kv", () => {
 				await expect(
 					runWrangler("kv key put --remote foo bar")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: Exactly one of the arguments binding and namespace-id is required]`
+					`[Error: Missing required option: exactly one of --binding and --namespace-id must be provided]`
 				);
 
 				expect(std.out).toMatchInlineSnapshot(`
@@ -479,7 +479,7 @@ describe("kv", () => {
 					      --persist-to    Directory for local persistence  [string]"
 				`);
 				expect(std.err).toMatchInlineSnapshot(`
-			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mExactly one of the arguments binding and namespace-id is required[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mMissing required option: exactly one of --binding and --namespace-id must be provided[0m
 
 			          "
 		        `);
@@ -493,7 +493,7 @@ describe("kv", () => {
 						"kv key put --remote foo bar --binding x --namespace-id y"
 					)
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: Arguments binding and namespace-id are mutually exclusive]`
+					`[Error: Conflicting options: --binding and --namespace-id cannot be used together. Please provide only one.]`
 				);
 
 				expect(std.out).toMatchInlineSnapshot(`
@@ -531,7 +531,7 @@ describe("kv", () => {
 					      --persist-to    Directory for local persistence  [string]"
 				`);
 				expect(std.err).toMatchInlineSnapshot(`
-			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mArguments binding and namespace-id are mutually exclusive[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mConflicting options: --binding and --namespace-id cannot be used together. Please provide only one.[0m
 
 			          "
 		        `);
@@ -543,7 +543,7 @@ describe("kv", () => {
 				await expect(
 					runWrangler("kv key put --remote key --namespace-id 12345")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: Exactly one of the arguments value and path is required]`
+					`[Error: Missing required option: exactly one of <value> and --path must be provided]`
 				);
 
 				expect(std.out).toMatchInlineSnapshot(`
@@ -581,7 +581,7 @@ describe("kv", () => {
 					      --persist-to    Directory for local persistence  [string]"
 				`);
 				expect(std.err).toMatchInlineSnapshot(`
-			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mExactly one of the arguments value and path is required[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mMissing required option: exactly one of <value> and --path must be provided[0m
 
 			          "
 		        `);
@@ -642,7 +642,7 @@ describe("kv", () => {
 						"kv key put --remote key value --path xyz --namespace-id 12345"
 					)
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: Arguments value and path are mutually exclusive]`
+					`[Error: Conflicting options: <value> and --path cannot be used together. Please provide only one.]`
 				);
 
 				expect(std.out).toMatchInlineSnapshot(`
@@ -680,7 +680,7 @@ describe("kv", () => {
 					      --persist-to    Directory for local persistence  [string]"
 				`);
 				expect(std.err).toMatchInlineSnapshot(`
-			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mArguments value and path are mutually exclusive[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mConflicting options: <value> and --path cannot be used together. Please provide only one.[0m
 
 			          "
 		        `);
@@ -1133,7 +1133,7 @@ describe("kv", () => {
 				await expect(
 					runWrangler("kv key get --remote foo")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: Exactly one of the arguments binding and namespace-id is required]`
+					`[Error: Missing required option: exactly one of --binding and --namespace-id must be provided]`
 				);
 				expect(std.out).toMatchInlineSnapshot(`
 					"
@@ -1163,7 +1163,7 @@ describe("kv", () => {
 					      --persist-to    Directory for local persistence  [string]"
 				`);
 				expect(std.err).toMatchInlineSnapshot(`
-			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mExactly one of the arguments binding and namespace-id is required[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mMissing required option: exactly one of --binding and --namespace-id must be provided[0m
 
 			          "
 		        `);
@@ -1175,7 +1175,7 @@ describe("kv", () => {
 				await expect(
 					runWrangler("kv key get --remote foo --binding x --namespace-id y")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: Arguments binding and namespace-id are mutually exclusive]`
+					`[Error: Conflicting options: --binding and --namespace-id cannot be used together. Please provide only one.]`
 				);
 
 				expect(std.out).toMatchInlineSnapshot(`
@@ -1206,7 +1206,7 @@ describe("kv", () => {
 					      --persist-to    Directory for local persistence  [string]"
 				`);
 				expect(std.err).toMatchInlineSnapshot(`
-			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mArguments binding and namespace-id are mutually exclusive[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mConflicting options: --binding and --namespace-id cannot be used together. Please provide only one.[0m
 
 			          "
 		        `);

--- a/packages/wrangler/src/__tests__/navigator-user-agent.test.ts
+++ b/packages/wrangler/src/__tests__/navigator-user-agent.test.ts
@@ -73,7 +73,7 @@ describe("isNavigatorDefined", () => {
 			assert(false, "Unreachable");
 		} catch (e) {
 			expect(e).toMatchInlineSnapshot(
-				`[Error: Can't both enable and disable a flag]`
+				`[Error: Conflicting compatibility flags: "global_navigator" and "no_global_navigator" cannot both be set. Remove one of these flags from your configuration.]`
 			);
 		}
 	});

--- a/packages/wrangler/src/__tests__/process-env-populated.test.ts
+++ b/packages/wrangler/src/__tests__/process-env-populated.test.ts
@@ -77,7 +77,7 @@ describe("isProcessEnvPopulated", () => {
 			assert(false, "Unreachable");
 		} catch (e) {
 			expect(e).toMatchInlineSnapshot(
-				`[Error: Can't both enable and disable a flag]`
+				`[Error: Conflicting compatibility flags: "nodejs_compat_populate_process_env" and "nodejs_compat_do_not_populate_process_env" cannot both be set. Remove one of these flags from your configuration.]`
 			);
 		}
 	});

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -3897,7 +3897,7 @@ describe("generate types - API", () => {
 				includeRuntime: false,
 			})
 		).rejects.toThrow(
-			"You cannot run this command without including either Env or Runtime types"
+			"At least one of --include-env or --include-runtime must be enabled."
 		);
 
 		await expect(

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -3413,6 +3413,24 @@ describe("generate types - CLI", () => {
 					);
 				}
 			});
+
+			it("should error if both --include-env and --include-runtime are false", async ({
+				expect,
+			}) => {
+				fs.writeFileSync(
+					"./wrangler.jsonc",
+					JSON.stringify({
+						vars: bindingsConfigMock.vars,
+					}),
+					"utf-8"
+				);
+
+				await expect(
+					runWrangler("types --include-env=false --include-runtime=false")
+				).rejects.toThrowError(
+					"At least one of --include-env or --include-runtime must be enabled."
+				);
+			});
 		});
 
 		it("should allow multiple customizations to be applied together", async ({
@@ -3897,7 +3915,7 @@ describe("generate types - API", () => {
 				includeRuntime: false,
 			})
 		).rejects.toThrow(
-			"At least one of --include-env or --include-runtime must be enabled."
+			"At least one of includeEnv or includeRuntime must be enabled."
 		);
 
 		await expect(

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -384,6 +384,26 @@ describe("User", () => {
 				);
 			});
 		});
+
+		it("should error if --scopes contains an invalid scope", async ({
+			expect,
+		}) => {
+			await expect(
+				runWrangler("login --scopes account:read bogus_scope")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Invalid authentication scope: "bogus_scope". Run "wrangler login --scopes-list" to see all valid scopes.]`
+			);
+		});
+
+		it("should error if --scopes contains multiple invalid scopes", async ({
+			expect,
+		}) => {
+			await expect(
+				runWrangler("login --scopes bad_one bad_two")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Invalid authentication scopes: "bad_one", "bad_two". Run "wrangler login --scopes-list" to see all valid scopes.]`
+			);
+		});
 	});
 
 	it("should handle errors for failed token refresh in a non-interactive environment", async ({

--- a/packages/wrangler/src/core/helpers.ts
+++ b/packages/wrangler/src/core/helpers.ts
@@ -8,26 +8,63 @@ import type {
 } from "./types";
 
 /**
+ * Formats an argument name for display in error messages.
+ * Positional arguments are shown as `<name>`, flags as `--name`.
+ *
+ * @param name - The argument name
+ * @param positionalArgs - Optional set of argument names that are positional (not flags)
+ * @returns The formatted argument name
+ */
+function formatArgName(
+	name: string,
+	positionalArgs?: ReadonlySet<string>
+): string {
+	return positionalArgs?.has(name) ? `<${name}>` : `--${name}`;
+}
+
+/**
+ * Joins a list of items with commas and "and" before the last item.
+ *
+ * @param items - The items to join
+ * @returns The joined string (e.g. "a, b and c")
+ */
+function joinWithAnd(items: string[]): string {
+	return items.length > 1
+		? `${items.slice(0, -1).join(", ")} and ${items[items.length - 1]}`
+		: items[0];
+}
+
+/**
  * A helper to demand one of a set of options
  * via https://github.com/yargs/yargs/issues/1093#issuecomment-491299261
+ *
+ * @param options - The option names to demand exactly one of
+ * @returns A validation function that checks the argv object. The returned function
+ *   accepts an optional `positionalArgs` set to distinguish positional arguments
+ *   from flags in error messages (positional args are shown as `<name>` instead of `--name`).
  */
 export function demandOneOfOption(...options: string[]) {
-	return function (argv: { [key: string]: unknown }) {
+	return function (
+		argv: { [key: string]: unknown },
+		positionalArgs?: ReadonlySet<string>
+	) {
 		const count = options.filter((option) => argv[option]).length;
-		const lastOption = options.pop();
+		const flagList = joinWithAnd(
+			options.map((o) => formatArgName(o, positionalArgs))
+		);
 
 		if (count === 0) {
 			throw new CommandLineArgsError(
-				`Exactly one of the arguments ${options.join(
-					", "
-				)} and ${lastOption} is required`,
+				`Missing required option: exactly one of ${flagList} must be provided`,
 				{ telemetryMessage: "core arguments missing exclusive option" }
 			);
 		} else if (count > 1) {
+			const provided = options
+				.filter((option) => argv[option])
+				.map((o) => formatArgName(o, positionalArgs));
+			const providedList = joinWithAnd(provided);
 			throw new CommandLineArgsError(
-				`Arguments ${options.join(
-					", "
-				)} and ${lastOption} are mutually exclusive`,
+				`Conflicting options: ${providedList} cannot be used together. Please provide only one.`,
 				{ telemetryMessage: "core arguments mutually exclusive options" }
 			);
 		}

--- a/packages/wrangler/src/core/helpers.ts
+++ b/packages/wrangler/src/core/helpers.ts
@@ -22,17 +22,8 @@ function formatArgName(
 	return positionalArgs?.has(name) ? `<${name}>` : `--${name}`;
 }
 
-/**
- * Joins a list of items with commas and "and" before the last item.
- *
- * @param items - The items to join
- * @returns The joined string (e.g. "a, b and c")
- */
-function joinWithAnd(items: string[]): string {
-	return items.length > 1
-		? `${items.slice(0, -1).join(", ")} and ${items[items.length - 1]}`
-		: items[0];
-}
+/** Formats a list of items as a human-readable conjunction (e.g. "a, b, and c"). */
+const listFormatter = new Intl.ListFormat("en-US");
 
 /**
  * A helper to demand one of a set of options
@@ -49,7 +40,7 @@ export function demandOneOfOption(...options: string[]) {
 		positionalArgs?: ReadonlySet<string>
 	) {
 		const count = options.filter((option) => argv[option]).length;
-		const flagList = joinWithAnd(
+		const flagList = listFormatter.format(
 			options.map((o) => formatArgName(o, positionalArgs))
 		);
 
@@ -62,7 +53,7 @@ export function demandOneOfOption(...options: string[]) {
 			const provided = options
 				.filter((option) => argv[option])
 				.map((o) => formatArgName(o, positionalArgs));
-			const providedList = joinWithAnd(provided);
+			const providedList = listFormatter.format(provided);
 			throw new CommandLineArgsError(
 				`Conflicting options: ${providedList} cannot be used together. Please provide only one.`,
 				{ telemetryMessage: "core arguments mutually exclusive options" }

--- a/packages/wrangler/src/core/helpers.ts
+++ b/packages/wrangler/src/core/helpers.ts
@@ -30,15 +30,19 @@ const listFormatter = new Intl.ListFormat("en-US");
  * via https://github.com/yargs/yargs/issues/1093#issuecomment-491299261
  *
  * @param options - The option names to demand exactly one of
- * @returns A validation function that checks the argv object. The returned function
- *   accepts an optional `positionalArgs` set to distinguish positional arguments
+ * @param def - Optional command definition used to distinguish positional arguments
  *   from flags in error messages (positional args are shown as `<name>` instead of `--name`).
+ * @returns A validation function that checks the argv object
  */
-export function demandOneOfOption(...options: string[]) {
-	return function (
-		argv: { [key: string]: unknown },
-		positionalArgs?: ReadonlySet<string>
-	) {
+export function demandOneOfOption(
+	options: string[],
+	def?: { positionalArgs?: ReadonlyArray<string> }
+) {
+	const positionalArgs = def?.positionalArgs
+		? new Set(def.positionalArgs)
+		: undefined;
+
+	return function (argv: { [key: string]: unknown }) {
 		const count = options.filter((option) => argv[option]).length;
 		const flagList = listFormatter.format(
 			options.map((o) => formatArgName(o, positionalArgs))

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -168,7 +168,7 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 				}
 			}
 
-			await def.validateArgs?.(args);
+			await def.validateArgs?.(args, def);
 
 			const shouldPrintResourceLocation =
 				typeof def.behaviour?.printResourceLocation === "function"

--- a/packages/wrangler/src/core/types.ts
+++ b/packages/wrangler/src/core/types.ts
@@ -251,8 +251,14 @@ export type CommandDefinition<
 	 * A hook to implement custom validation of the args before the handler is called.
 	 * Throw `CommandLineArgsError` with actionable error message if args are invalid.
 	 * The return value is ignored.
+	 *
+	 * @param args - The parsed CLI arguments
+	 * @param def - The command definition, useful for passing to helpers like `demandOneOfOption`
 	 */
-	validateArgs?: (args: HandlerArgs<NamedArgDefs>) => void | Promise<void>;
+	validateArgs?: (
+		args: HandlerArgs<NamedArgDefs>,
+		def: CommandDefinition<NamedArgDefs>
+	) => void | Promise<void>;
 
 	/**
 	 * The implementation of the command which is given camelCase'd args

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -284,9 +284,12 @@ export const dev = createCommand({
 			);
 		}
 		if (args.tunnel && args.remote) {
-			throw new UserError("--tunnel is only supported in local mode.", {
-				telemetryMessage: "dev command tunnel remote conflict",
-			});
+			throw new UserError(
+				"--tunnel cannot be used with --remote. Tunnels expose your local dev server to the internet, which is only applicable in local mode. Remove --remote to use --tunnel, or remove --tunnel to use --remote.",
+				{
+					telemetryMessage: "dev command tunnel remote conflict",
+				}
+			);
 		}
 
 		if (isWebContainer()) {

--- a/packages/wrangler/src/kv/index.ts
+++ b/packages/wrangler/src/kv/index.ts
@@ -491,9 +491,9 @@ export const kvKeyPutCommand = createCommand({
 		},
 		...putCommonArgs,
 	},
-	validateArgs(args) {
-		demandOneOfOption("binding", "namespace-id")(args);
-		demandOneOfOption("value", "path")(args, new Set(["value"]));
+	validateArgs(args, def) {
+		demandOneOfOption(["binding", "namespace-id"])(args);
+		demandOneOfOption(["value", "path"], def)(args);
 	},
 
 	async handler({ key, ttl, expiration, metadata, ...args }) {
@@ -606,7 +606,7 @@ export const kvKeyListCommand = createCommand({
 		},
 	},
 	validateArgs(args) {
-		demandOneOfOption("binding", "namespace-id")(args);
+		demandOneOfOption(["binding", "namespace-id"])(args);
 	},
 
 	async handler({ prefix, ...args }) {
@@ -706,7 +706,7 @@ export const kvKeyGetCommand = createCommand({
 		...getCommonArgs,
 	},
 	validateArgs(args) {
-		demandOneOfOption("binding", "namespace-id")(args);
+		demandOneOfOption(["binding", "namespace-id"])(args);
 	},
 	async handler({ key, ...args }) {
 		const localMode = isLocal(args);

--- a/packages/wrangler/src/kv/index.ts
+++ b/packages/wrangler/src/kv/index.ts
@@ -493,7 +493,7 @@ export const kvKeyPutCommand = createCommand({
 	},
 	validateArgs(args) {
 		demandOneOfOption("binding", "namespace-id")(args);
-		demandOneOfOption("value", "path")(args);
+		demandOneOfOption("value", "path")(args, new Set(["value"]));
 	},
 
 	async handler({ key, ttl, expiration, metadata, ...args }) {

--- a/packages/wrangler/src/navigator-user-agent.ts
+++ b/packages/wrangler/src/navigator-user-agent.ts
@@ -8,9 +8,12 @@ export function isNavigatorDefined(
 		compatibility_flags.includes("global_navigator") &&
 		compatibility_flags.includes("no_global_navigator")
 	) {
-		throw new UserError("Can't both enable and disable a flag", {
-			telemetryMessage: "navigator user agent compatibility flags conflict",
-		});
+		throw new UserError(
+			'Conflicting compatibility flags: "global_navigator" and "no_global_navigator" cannot both be set. Remove one of these flags from your configuration.',
+			{
+				telemetryMessage: "navigator user agent compatibility flags conflict",
+			}
+		);
 	}
 
 	if (compatibility_flags.includes("global_navigator")) {

--- a/packages/wrangler/src/process-env.ts
+++ b/packages/wrangler/src/process-env.ts
@@ -8,9 +8,12 @@ export function isProcessEnvPopulated(
 		compatibility_flags.includes("nodejs_compat_populate_process_env") &&
 		compatibility_flags.includes("nodejs_compat_do_not_populate_process_env")
 	) {
-		throw new UserError("Can't both enable and disable a flag", {
-			telemetryMessage: "process env compatibility flags conflict",
-		});
+		throw new UserError(
+			'Conflicting compatibility flags: "nodejs_compat_populate_process_env" and "nodejs_compat_do_not_populate_process_env" cannot both be set. Remove one of these flags from your configuration.',
+			{
+				telemetryMessage: "process env compatibility flags conflict",
+			}
+		);
 	}
 
 	if (

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -195,7 +195,7 @@ export const typesCommand = createCommand({
 
 		if (!args.includeEnv && !args.includeRuntime) {
 			throw new CommandLineArgsError(
-				`You cannot run this command without including either Env or Runtime types`,
+				"At least one of --include-env or --include-runtime must be enabled. Use --include-env to generate environment/binding types, or --include-runtime to generate Workers runtime types.",
 				{
 					telemetryMessage: "type generation args missing type selection",
 				}
@@ -698,7 +698,7 @@ function validateGenerateTypesOptions({
 
 	if (!includeEnv && !includeRuntime) {
 		throw new UserError(
-			`You cannot run this command without including either Env or Runtime types`,
+			"At least one of --include-env or --include-runtime must be enabled. Use --include-env to generate environment/binding types, or --include-runtime to generate Workers runtime types.",
 			{ telemetryMessage: "type generation args missing type selection" }
 		);
 	}

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -207,6 +207,7 @@ export const typesCommand = createCommand({
 			logSecondaryEntries: true,
 			validateOptions: false,
 			validateOutputPath: false,
+			source: "cli",
 		});
 
 		resolvedOptions.envHeaderCommand = buildGenerateTypesHeaderCommand(
@@ -297,6 +298,7 @@ export async function generateTypesFromWranglerOptions(
 		logSecondaryEntries: false,
 		validateOptions: true,
 		validateOutputPath: false,
+		source: "api",
 	});
 	resolvedOptions.envHeaderCommand = buildGenerateTypesHeaderCommand(
 		options,
@@ -409,10 +411,12 @@ async function resolveGenerateTypesOptions(
 		logSecondaryEntries,
 		validateOptions,
 		validateOutputPath,
+		source,
 	}: {
 		logSecondaryEntries: boolean;
 		validateOptions: boolean;
 		validateOutputPath: boolean;
+		source: "cli" | "api";
 	}
 ): Promise<ResolvedGenerateTypesOptions> {
 	const envInterface = options.envInterface ?? "Env";
@@ -428,6 +432,7 @@ async function resolveGenerateTypesOptions(
 			includeRuntime,
 			path,
 			validateOutputPath,
+			source,
 		});
 	}
 
@@ -655,12 +660,15 @@ function assertConfigFileDetected(
 }
 
 /**
- * Validates programmatic type-generation options.
+ * Validates type-generation options.
  *
  * Applies the same constraints as CLI argument validation for env interface
  * naming, output file extension, and include-env/include-runtime combinations.
  *
  * @param options - Normalized options to validate.
+ * @param options.source - Whether the caller is `"cli"` or `"api"`, so error
+ *   messages can reference CLI flags (`--include-env`) or JS option names
+ *   (`includeEnv`) accordingly.
  *
  * @throws {UserError} When any option is invalid.
  */
@@ -670,12 +678,14 @@ function validateGenerateTypesOptions({
 	includeRuntime,
 	path,
 	validateOutputPath,
+	source,
 }: {
 	envInterface: string;
 	includeEnv: boolean;
 	includeRuntime: boolean;
 	path: string;
 	validateOutputPath: boolean;
+	source: "cli" | "api";
 }): void {
 	const validInterfaceRegex = /^[a-zA-Z][a-zA-Z0-9_]*$/;
 	if (!validInterfaceRegex.test(envInterface)) {
@@ -697,8 +707,13 @@ function validateGenerateTypesOptions({
 	}
 
 	if (!includeEnv && !includeRuntime) {
+		const [envOpt, runtimeOpt] =
+			source === "cli"
+				? ["--include-env", "--include-runtime"]
+				: ["includeEnv", "includeRuntime"];
+
 		throw new UserError(
-			"At least one of --include-env or --include-runtime must be enabled. Use --include-env to generate environment/binding types, or --include-runtime to generate Workers runtime types.",
+			`At least one of ${envOpt} or ${runtimeOpt} must be enabled. Use ${envOpt} to generate environment/binding types, or ${runtimeOpt} to generate Workers runtime types.`,
 			{ telemetryMessage: "type generation args missing type selection" }
 		);
 	}

--- a/packages/wrangler/src/user/commands.ts
+++ b/packages/wrangler/src/user/commands.ts
@@ -4,6 +4,7 @@ import { createCommand, createNamespace } from "../core/create-command";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
 import {
+	DefaultScopeKeys,
 	getAuthFromEnv,
 	getOAuthTokenFromLocalState,
 	listScopes,
@@ -72,8 +73,10 @@ export const loginCommand = createCommand({
 				return;
 			}
 			if (!validateScopeKeys(args.scopes)) {
+				const validSet = new Set<string>(DefaultScopeKeys);
+				const invalidScopes = args.scopes.filter((s) => !validSet.has(s));
 				throw new CommandLineArgsError(
-					`One of ${args.scopes} is not a valid authentication scope. Run "wrangler login --scopes-list" to see the valid scopes.`,
+					`Invalid authentication scope${invalidScopes.length > 1 ? "s" : ""}: ${invalidScopes.map((s) => `"${s}"`).join(", ")}. Run "wrangler login --scopes-list" to see all valid scopes.`,
 					{ telemetryMessage: "user login invalid scope" }
 				);
 			}


### PR DESCRIPTION
Error messages across several areas now name the exact flags or values involved and suggest how to fix the problem:

- `demandOneOfOption` (used by KV commands): messages now include `--` prefixes and clear "Missing required option" / "Conflicting options" phrasing instead of the vague "Exactly one of the arguments ... is required".
- `wrangler types --include-env=false --include-runtime=false`: the error now names both flags and explains what each does.
- `wrangler login --scopes`: invalid scopes are individually identified instead of dumping the entire array.
- `wrangler dev --tunnel --remote`: the error now explains why tunnels require local mode and suggests two concrete fixes.
- Conflicting compatibility flags (`nodejs_compat_populate_process_env` / `nodejs_compat_do_not_populate_process_env`, `global_navigator` / `no_global_navigator`): errors now name the specific conflicting flags.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: improved error messages

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
