### PR TITLE
Gate Network.enable on an attached DevTools client

### DIFF
--- a/.changeset/gate-network-enable-when-headless.md
+++ b/.changeset/gate-network-enable-when-headless.md
@@ -2,6 +2,8 @@
 "wrangler": patch
 ---
 
-Only enable the workerd Network inspector domain when a DevTools client is attached
+Stop the headless inspector Network flood that wedges long-running `wrangler dev`
 
-`InspectorProxyWorker` sent `Network.enable` to the runtime on every connect even with no DevTools client attached. Run headless (e.g. a long-lived `wrangler dev` with containers), the runtime then streams a `Network.dataReceived` message per response body chunk into a buffer that is never drained without a client, flooding the inspector until the dev server stops accepting connections. Gate `Network.enable` on an attached DevTools client, mirroring the existing `Debugger.enable` gate. Fixes #14191.
+`InspectorProxyWorker` enabled the runtime Network domain whether or not a DevTools client was attached, so headless `wrangler dev` (e.g. a long-lived session using the containers feature) received a `Network.dataReceived` message per response body chunk into `runtimeMessageBuffer`, which `tryDrainRuntimeMessageBuffer` never drains while no DevTools client is connected. Over a long session under load this grows unbounded and the dev server eventually stops accepting connections.
+
+Two changes close it: gate the `Network.enable` sent on runtime connect on an attached DevTools client (mirroring the existing `Debugger.enable` gate), and send `Network.disable` when DevTools disconnects (mirroring the existing `Debugger.disable`) so the attach-then-detach case doesn't reintroduce the flood. Interactive debugging is unaffected: DevTools sends its own `Network.enable` on attach. Fixes #14191.

--- a/.changeset/gate-network-enable-when-headless.md
+++ b/.changeset/gate-network-enable-when-headless.md
@@ -2,8 +2,6 @@
 "wrangler": patch
 ---
 
-Stop the headless inspector Network flood that wedges long-running `wrangler dev`
+Fix a memory leak that could make long-running headless `wrangler dev` sessions unresponsive
 
-`InspectorProxyWorker` enabled the runtime Network domain whether or not a DevTools client was attached, so headless `wrangler dev` (e.g. a long-lived session using the containers feature) received a `Network.dataReceived` message per response body chunk into `runtimeMessageBuffer`, which `tryDrainRuntimeMessageBuffer` never drains while no DevTools client is connected. Over a long session under load this grows unbounded and the dev server eventually stops accepting connections.
-
-Two changes close it: gate the `Network.enable` sent on runtime connect on an attached DevTools client (mirroring the existing `Debugger.enable` gate), and send `Network.disable` when DevTools disconnects (mirroring the existing `Debugger.disable`) so the attach-then-detach case doesn't reintroduce the flood. Interactive debugging is unaffected: DevTools sends its own `Network.enable` on attach. Fixes #14191.
+Long-running `wrangler dev` sessions with no DevTools attached (for example using the containers feature under sustained traffic) could gradually consume unbounded memory and eventually stop accepting connections. The inspector proxy now only enables network tracking while a DevTools client is connected, so the buildup no longer happens. Interactive debugging is unaffected. Fixes #14191.

--- a/.changeset/gate-network-enable-when-headless.md
+++ b/.changeset/gate-network-enable-when-headless.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Only enable the workerd Network inspector domain when a DevTools client is attached
+
+`InspectorProxyWorker` sent `Network.enable` to the runtime on every connect even with no DevTools client attached. Run headless (e.g. a long-lived `wrangler dev` with containers), the runtime then streams a `Network.dataReceived` message per response body chunk into a buffer that is never drained without a client, flooding the inspector until the dev server stops accepting connections. Gate `Network.enable` on an attached DevTools client, mirroring the existing `Debugger.enable` gate. Fixes #14191.

--- a/packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts
@@ -414,10 +414,16 @@ export class InspectorProxyWorker implements DurableObject {
 				runtime
 			);
 		}
-		this.sendRuntimeMessage(
-			{ method: "Network.enable", id: this.nextCounter() },
-			runtime
-		);
+		// Only enable the Network domain when DevTools is attached. Otherwise the
+		// runtime streams a Network.dataReceived per response body chunk into a
+		// buffer that is never drained without a client (headless `wrangler dev`),
+		// flooding the inspector until the dev server stops accepting connections.
+		if (this.websockets.devtools !== undefined) {
+			this.sendRuntimeMessage(
+				{ method: "Network.enable", id: this.nextCounter() },
+				runtime
+			);
+		}
 
 		clearInterval(this.runtimeKeepAliveInterval);
 		this.runtimeKeepAliveInterval = setInterval(() => {

--- a/packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts
@@ -569,11 +569,19 @@ export class InspectorProxyWorker implements DurableObject {
 				if (this.websockets.devtools === devtools) {
 					this.websockets.devtools = undefined;
 
-					// Notify the runtime to disable the debugger when DevTools disconnects.
+					// Notify the runtime to disable the Debugger and Network domains when
+					// DevTools disconnects. Without disabling Network the runtime keeps
+					// streaming Network.dataReceived into runtimeMessageBuffer, which is no
+					// longer drained once devtools is undefined, reintroducing the same
+					// headless flood this proxy otherwise avoids.
 					if (this.websockets.runtime) {
 						this.sendRuntimeMessage({
 							id: this.nextCounter(),
 							method: "Debugger.disable",
+						});
+						this.sendRuntimeMessage({
+							id: this.nextCounter(),
+							method: "Network.disable",
 						});
 					}
 				}


### PR DESCRIPTION
## What this does

`InspectorProxyWorker.handleRuntimeWebSocketOpen` sends `Network.enable` to the runtime on every connect, unconditionally, even when no DevTools client is attached. Note that `Debugger.enable` just above it *is* gated on `this.websockets.devtools !== undefined`.

Run headless (for example a long-lived `wrangler dev` using the containers feature), the runtime then streams a `Network.dataReceived` message per response body chunk into `runtimeMessageBuffer`, which `tryDrainRuntimeMessageBuffer` never drains while `websockets.devtools === undefined`. Over a long session under load this floods the inspector (unbounded buffer growth plus per-message processing and debug-file logging) until the dev server stops accepting connections and wedges.

This gates the `Network.enable` send on an attached DevTools client, mirroring the existing `Debugger.enable` gate right above it. When DevTools later attaches it sends its own `Network.enable`, so interactive debugging is unaffected.

Fixes #14191.

## How this is tested

Verified on a long-running `wrangler dev` (containers feature, hundreds of sandbox lifecycles): with the gate the wrangler debug log records zero `Network.dataReceived` entries and the dev server stays responsive for hours under load; without it the same workload floods the log and the inspector and HTTP server eventually wedge.

<!-- devin-review-badge-begin -->

---

- Tests
  - [ ] Tests included/updated
  - [x] Automated tests not possible - manual testing has been completed as follows: verified on long-running `wrangler dev` session
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->