### PR TITLE
[wrangler] Add `--json` flag to `containers info`

### DIFF
--- a/.changeset/wrangler-containers-info-json.md
+++ b/.changeset/wrangler-containers-info-json.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add `--json` flag to `wrangler containers info`.
+
+`wrangler containers list` and `wrangler containers instances` already document `--json` as a boolean flag, but `wrangler containers info` only emitted JSON through the implicit `isNonInteractiveOrCI()` path (e.g. `CI=true`). Scripts that piped `wrangler containers info <ID> | jq` from a shell that wasn't detected as non-interactive received a human-readable banner instead, which `jq` couldn't parse. The flag now exposes the existing JSON path explicitly and matches the sibling commands' surface; behavior for callers that relied on the implicit non-TTY path is unchanged.

--- a/.changeset/wrangler-containers-info-json.md
+++ b/.changeset/wrangler-containers-info-json.md
@@ -4,4 +4,4 @@
 
 Add a `--json` flag to `wrangler containers info`.
 
-`wrangler containers list` and `wrangler containers instances` already document `--json` as a boolean flag, but `wrangler containers info` only emitted JSON through the implicit `isNonInteractiveOrCI()` path (e.g. `CI=true`). Scripts that piped `wrangler containers info <ID> | jq` from a shell that wasn't detected as non-interactive received a human-readable banner instead, which `jq` couldn't parse. The flag now exposes the existing JSON path explicitly and matches the sibling commands' surface; behavior for callers that relied on the implicit non-TTY path is unchanged.
+Previously, `wrangler containers info` only emitted JSON when wrangler detected a non-interactive shell, so piping its output to a tool like `jq` from an interactive terminal returned the human-readable banner and failed to parse. The new `--json` flag makes JSON output explicit, matching the flag already available on `wrangler containers list` and `wrangler containers instances`.

--- a/.changeset/wrangler-containers-info-json.md
+++ b/.changeset/wrangler-containers-info-json.md
@@ -2,6 +2,6 @@
 "wrangler": minor
 ---
 
-Add `--json` flag to `wrangler containers info`.
+Add a `--json` flag to `wrangler containers info`.
 
 `wrangler containers list` and `wrangler containers instances` already document `--json` as a boolean flag, but `wrangler containers info` only emitted JSON through the implicit `isNonInteractiveOrCI()` path (e.g. `CI=true`). Scripts that piped `wrangler containers info <ID> | jq` from a shell that wasn't detected as non-interactive received a human-readable banner instead, which `jq` couldn't parse. The flag now exposes the existing JSON path explicitly and matches the sibling commands' surface; behavior for callers that relied on the implicit non-TTY path is unchanged.

--- a/packages/wrangler/src/__tests__/containers/info.test.ts
+++ b/packages/wrangler/src/__tests__/containers/info.test.ts
@@ -40,7 +40,10 @@ describe("containers info", () => {
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
 			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
-			  -v, --version         Show version number  [boolean]"
+			  -v, --version         Show version number  [boolean]
+
+			OPTIONS
+			      --json  Return output as JSON  [boolean] [default: false]"
 		`);
 	});
 
@@ -76,6 +79,63 @@ describe("containers info", () => {
 		);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 		await runWrangler("containers info asdf");
+		expect(std.out).toMatchInlineSnapshot(`
+			"{
+			    "id": "asdf",
+			    "created_at": "2025-02-14T18:03:13.268999936Z",
+			    "account_id": "test-account",
+			    "name": "app-test",
+			    "version": 1,
+			    "configuration": {
+			        "image": "registry.test.cfdata.org/test-app:v1",
+			        "network": {
+			            "mode": "private"
+			        }
+			    },
+			    "scheduling_policy": "regional",
+			    "instances": 2,
+			    "jobs": false,
+			    "constraints": {
+			        "region": "WNAM"
+			    },
+			    "durable_objects": {
+			        "namespace_id": "test-id"
+			    },
+			    "health": {
+			        "instances": {
+			            "healthy": 2,
+			            "failed": 0,
+			            "scheduling": 0,
+			            "starting": 0
+			        }
+			    }
+			}"
+		`);
+	});
+
+	it("should show a single container when --json is passed in interactive mode", async ({
+		expect,
+	}) => {
+		// Regression for #14035: `containers info` previously only emitted JSON
+		// when `isNonInteractiveOrCI()` was true, which made the JSON path
+		// unreachable from an interactive shell. Setting TTY=true here would
+		// otherwise drop into the TUI path and never call `logger.json`.
+		setIsTTY(true);
+		setWranglerConfig({});
+		msw.use(
+			http.get(
+				"*/applications/asdf",
+				async ({ request }) => {
+					expect(await request.text()).toEqual("");
+					return HttpResponse.json(
+						`{"success": true, "result": ${MOCK_APPLICATION_SINGLE}}`
+					);
+				},
+				{ once: true }
+			)
+		);
+		await runWrangler("containers info asdf --json");
+		expect(std.err).toMatchInlineSnapshot(`""`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"{
 			    "id": "asdf",

--- a/packages/wrangler/src/containers/containers.ts
+++ b/packages/wrangler/src/containers/containers.ts
@@ -85,10 +85,16 @@ export async function deleteCommand(
 }
 
 export function infoYargs(args: CommonYargsArgv) {
-	return args.positional("ID", {
-		describe: "id of the containers to view",
-		type: "string",
-	});
+	return args
+		.positional("ID", {
+			describe: "id of the containers to view",
+			type: "string",
+		})
+		.option("json", {
+			describe: "Return output as JSON",
+			type: "boolean",
+			default: false,
+		});
 }
 
 export async function infoCommand(
@@ -100,7 +106,7 @@ export async function infoCommand(
 			"You must provide an ID. Use 'wrangler containers list` to view your containers."
 		);
 	}
-	if (isNonInteractiveOrCI()) {
+	if (infoArgs.json || isNonInteractiveOrCI()) {
 		const application = await ApplicationsService.getApplication(infoArgs.ID);
 		logger.json(application);
 		return;
@@ -135,13 +141,18 @@ export const containersInfoCommand = createCommand({
 		owner: "Product: Cloudchamber",
 	},
 	behaviour: {
-		printBanner: () => !isNonInteractiveOrCI(),
+		printBanner: (args) => !args.json && !isNonInteractiveOrCI(),
 	},
 	args: {
 		ID: {
 			describe: "ID of the container to view",
 			type: "string",
 			demandOption: true,
+		},
+		json: {
+			describe: "Return output as JSON",
+			type: "boolean",
+			default: false,
 		},
 	},
 	positionalArgs: ["ID"],


### PR DESCRIPTION
Fixes #14035.

`wrangler containers list` and `wrangler containers instances` already document `--json` as an explicit boolean flag, but `wrangler containers info` only routed to the JSON path through the implicit `isNonInteractiveOrCI()` check (`CI=true` or non-TTY). That makes the JSON output unreachable from `wrangler containers info --help` discovery, and pipelines like

```sh
wrangler containers info <APPLICATION_ID> | jq '.configuration.authorized_keys // []'
```

silently die with `jq: parse error: Invalid numeric literal at line 1, column 11` when the calling shell happens to be detected as interactive — wrangler emits the human-readable banner on stdout, jq parses the first banner line, chokes at the first non-numeric character.

This PR adds an explicit `--json` boolean flag to `infoYargs` and the `containersInfoCommand` `createCommand` surface, mirrors the `containersListCommand` pattern, and gates `logger.json(application)` on `infoArgs.json || isNonInteractiveOrCI()` so the implicit non-TTY path keeps working unchanged. The banner is suppressed when `--json` is passed (matches `containersListCommand`'s `printBanner` gate).

A regression test in `containers/info.test.ts` sets TTY=true and runs `containers info asdf --json` — without the flag this path would drop into the TUI handler and never call `logger.json`.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: `--json` exists already on the sibling commands and was already documented in their `--help` surface; the docs site's containers reference covers `containers list --json` / `containers instances --json` with the same shape, so this change brings `containers info` into the existing documented pattern rather than introducing a new affordance.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->