### PR TITLE
move build earlier in deploy path

### DIFF
--- a/.changeset/move-build-before-deploy.md
+++ b/.changeset/move-build-before-deploy.md
@@ -1,0 +1,6 @@
+---
+"wrangler": patch
+"@cloudflare/deploy-helpers": patch
+---
+
+Move worker build step earlier in deploy/upload step, before upload specific config validation

--- a/packages/deploy-helpers/src/deploy/deploy.ts
+++ b/packages/deploy-helpers/src/deploy/deploy.ts
@@ -39,7 +39,6 @@ import {
 } from "./helpers/environments";
 import { helpIfErrorIsSizeOrScriptStartup } from "./helpers/friendly-validator-errors";
 import { verifyWorkerMatchesCITag } from "./helpers/match-tag";
-import { validateNodeCompatMode } from "./helpers/node-compat";
 import { parseBulkInputToObject } from "./helpers/parse-bulk-input";
 import { parseConfigPlacement } from "./helpers/placement";
 import { printBindings } from "./helpers/print-bindings";
@@ -60,7 +59,7 @@ import {
 } from "./helpers/versions-api";
 import { isWorkerNotFoundError } from "./helpers/worker-not-found-error";
 import { addWorkersSitesBindings } from "./helpers/workers-sites-bindings";
-import type { DeployProps, HandleBuild } from "../shared/types";
+import type { DeployProps, WorkerBuildResult } from "../shared/types";
 import type { RetrieveSourceMapFunction } from "./helpers/sourcemap";
 import type {
 	ApiVersion,
@@ -144,7 +143,7 @@ export type DeployCallbacks = {
 export default async function deploy(
 	props: DeployProps,
 	config: Config,
-	buildWorker: HandleBuild,
+	buildResult: WorkerBuildResult,
 	callbacks: DeployCallbacks
 ): Promise<{
 	sourceMapSize?: number;
@@ -165,8 +164,6 @@ export default async function deploy(
 		compatibilityDate,
 		compatibilityFlags,
 		keepVars,
-		minify,
-		noBundle,
 		uploadSourceMaps,
 		accountId,
 	} = props;
@@ -318,19 +315,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 	validateRoutes(allDeploymentRoutes, props.assetsOptions);
 
-	const nodejsCompatMode = validateNodeCompatMode(
-		compatibilityDate,
-		compatibilityFlags,
-		{ noBundle }
-	);
-
-	// Warn if user tries minify with no-bundle
-	if (noBundle && minify) {
-		logger.warn(
-			"`--minify` and `--no-bundle` can't be used together. If you want to minify your Worker and disable Wrangler's bundling, please minify as part of your own bundling process."
-		);
-	}
-
 	const scriptName = name;
 
 	assert(
@@ -415,10 +399,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		bundleType,
 		content,
 		bundle,
-	} = await buildWorker.build(props, config, {
-		nodejsCompatMode,
-		metafile: props.metafile,
-	});
+	} = buildResult;
 	// durable object migrations
 	const migrations = !isDryRun
 		? await getMigrationsToUpload(scriptName, {

--- a/packages/deploy-helpers/src/deploy/versions-upload.ts
+++ b/packages/deploy-helpers/src/deploy/versions-upload.ts
@@ -27,7 +27,6 @@ import {
 } from "./helpers/environments";
 import { helpIfErrorIsSizeOrScriptStartup } from "./helpers/friendly-validator-errors";
 import { verifyWorkerMatchesCITag } from "./helpers/match-tag";
-import { validateNodeCompatMode } from "./helpers/node-compat";
 import { parseBulkInputToObject } from "./helpers/parse-bulk-input";
 import { parseConfigPlacement } from "./helpers/placement";
 import { printBindings } from "./helpers/print-bindings";
@@ -43,7 +42,7 @@ import {
 import { useServiceEnvironments as useServiceEnvironmentsConfig } from "./helpers/use-service-environments";
 import { patchNonVersionedScriptSettings } from "./helpers/versions-api";
 import { isWorkerNotFoundError } from "./helpers/worker-not-found-error";
-import type { HandleBuild, VersionsUploadProps } from "../shared/types";
+import type { VersionsUploadProps, WorkerBuildResult } from "../shared/types";
 import type { DeployCallbacks } from "./deploy";
 import type { RetrieveSourceMapFunction } from "./helpers/sourcemap";
 import type { CfWorkerInit, Config } from "@cloudflare/workers-utils";
@@ -57,7 +56,7 @@ export type VersionsUploadCallbacks = Pick<
 export default async function versionsUpload(
 	props: VersionsUploadProps,
 	config: Config,
-	buildWorker: HandleBuild,
+	buildResult: WorkerBuildResult,
 	callbacks: VersionsUploadCallbacks
 ): Promise<{
 	versionId: string | null;
@@ -77,8 +76,6 @@ export default async function versionsUpload(
 		compatibilityDate,
 		compatibilityFlags,
 		keepVars,
-		minify,
-		noBundle,
 		uploadSourceMaps,
 		accountId,
 	} = props;
@@ -155,19 +152,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		);
 	}
 
-	const nodejsCompatMode = validateNodeCompatMode(
-		compatibilityDate,
-		compatibilityFlags,
-		{ noBundle }
-	);
-
-	// Warn if user tries minify or node-compat with no-bundle
-	if (noBundle && minify) {
-		logger.warn(
-			"`--minify` and `--no-bundle` can't be used together. If you want to minify your Worker and disable Wrangler's bundling, please minify as part of your own bundling process."
-		);
-	}
-
 	const scriptName = name;
 
 	if (config.site && !config.site.bucket) {
@@ -223,9 +207,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		bundleType,
 		content,
 		bundle,
-	} = await buildWorker.build(props, config, {
-		nodejsCompatMode,
-	});
+	} = buildResult;
 	const bindings = getBindings(config);
 
 	// Vars from the CLI (--var) are hidden so their values aren't logged to the terminal

--- a/packages/deploy-helpers/src/shared/types.ts
+++ b/packages/deploy-helpers/src/shared/types.ts
@@ -13,7 +13,6 @@ import type {
 	Route,
 	Entry,
 } from "@cloudflare/workers-utils";
-import type { NodeJSCompatMode } from "miniflare";
 
 /**
  * client needs to handle logger and fetch/auth implementation
@@ -143,24 +142,13 @@ export type BuildBundleInfo = {
 	sourceMapMetadata?: { tmpDir: string; entryDirectory: string } | undefined;
 };
 
-export type HandleBuildResult = {
+export type WorkerBuildResult = {
 	modules: CfModule[];
 	dependencies: Record<string, { bytesInOutput: number }>;
 	resolvedEntryPointPath: string;
 	bundleType: CfModuleType;
 	content: string;
 	bundle: BuildBundleInfo;
-};
-
-export type HandleBuild = {
-	build: (
-		props: SharedDeployVersionsProps,
-		config: Config,
-		options: {
-			nodejsCompatMode: NodeJSCompatMode;
-			metafile?: string | boolean;
-		}
-	) => Promise<HandleBuildResult>;
 };
 
 export interface TriggerDeployment {

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -9,7 +9,7 @@ import {
 	sharedDeployVersionsArgs,
 	validateDeployVersionsArgs,
 } from "../deployment-bundle/deploy-args";
-import { handleBuild } from "../deployment-bundle/maybe-build-worker";
+import { buildWorker } from "../deployment-bundle/maybe-build-worker";
 import {
 	cleanupDestination,
 	mergeDeployConfigArgs,
@@ -144,10 +144,14 @@ export const deployCommand = createCommand({
 
 			const beforeUpload = Date.now();
 
+			const buildResult = await buildWorker(mergedProps, config, {
+				metafile: mergedProps.metafile,
+			});
+
 			const { sourceMapSize, versionId, workerTag, targets } = await deploy(
 				mergedProps,
 				config,
-				handleBuild,
+				buildResult,
 				{
 					syncWorkersSite,
 					provisionBindings,

--- a/packages/wrangler/src/deployment-bundle/maybe-build-worker.ts
+++ b/packages/wrangler/src/deployment-bundle/maybe-build-worker.ts
@@ -1,5 +1,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { validateNodeCompatMode } from "@cloudflare/deploy-helpers";
+import { logger } from "../logger";
 import { isNavigatorDefined } from "../navigator-user-agent";
 import { bundleWorker } from "./bundle";
 import { logBuildOutput } from "./esbuild-plugins/log-build-output";
@@ -8,142 +10,157 @@ import {
 	getWrangler1xLegacyModuleReferences,
 } from "./module-collection";
 import { noBundleWorker } from "./no-bundle-worker";
-import type { HandleBuild } from "@cloudflare/deploy-helpers";
+import type { WorkerBuildResult } from "@cloudflare/deploy-helpers";
+import type { SharedDeployVersionsProps } from "@cloudflare/deploy-helpers";
+import type { Config } from "@cloudflare/workers-utils";
 
-export const handleBuild: HandleBuild = {
-	async build(props, config, options) {
-		const {
-			entry,
-			noBundle,
-			destination,
-			uploadSourceMaps,
-			jsxFactory,
-			jsxFragment,
-			minify,
-			compatibilityDate,
-			compatibilityFlags,
-		} = props;
-		const { projectRoot } = entry;
-		const { nodejsCompatMode } = options;
+export async function buildWorker(
+	props: SharedDeployVersionsProps,
+	config: Config,
+	options: {
+		metafile?: string | boolean;
+	}
+): Promise<WorkerBuildResult> {
+	const nodejsCompatMode = validateNodeCompatMode(
+		props.compatibilityDate,
+		props.compatibilityFlags,
+		{ noBundle: props.noBundle }
+	);
 
-		if (props.outdir) {
-			// we're using a custom output directory,
-			// so let's first ensure it exists
-			mkdirSync(props.outdir, { recursive: true });
-			const readmePath = path.join(props.outdir, "README.md");
-			writeFileSync(
-				readmePath,
-				`This folder contains the built output assets for the worker "${props.name}" generated at ${new Date().toISOString()}.`
-			);
-		}
+	if (props.noBundle && props.minify) {
+		logger.warn(
+			"`--minify` and `--no-bundle` can't be used together. If you want to minify your Worker and disable Wrangler's bundling, please minify as part of your own bundling process."
+		);
+	}
+	const {
+		entry,
+		noBundle,
+		destination,
+		uploadSourceMaps,
+		jsxFactory,
+		jsxFragment,
+		minify,
+		compatibilityDate,
+		compatibilityFlags,
+	} = props;
 
-		if (noBundle) {
-			// if we're not building, let's just copy the entry to the destination directory
-			const destinationDir =
-				typeof destination === "string" ? destination : destination.path;
-			mkdirSync(destinationDir, { recursive: true });
-			writeFileSync(
-				path.join(destinationDir, path.basename(entry.file)),
-				readFileSync(entry.file, "utf-8")
-			);
-		}
+	if (props.outdir) {
+		// we're using a custom output directory,
+		// so let's first ensure it exists
+		mkdirSync(props.outdir, { recursive: true });
+		const readmePath = path.join(props.outdir, "README.md");
+		writeFileSync(
+			readmePath,
+			`This folder contains the built output assets for the worker "${props.name}" generated at ${new Date().toISOString()}.`
+		);
+	}
 
-		const entryDirectory = path.dirname(entry.file);
-		const moduleCollector = createModuleCollector({
-			wrangler1xLegacyModuleReferences: getWrangler1xLegacyModuleReferences(
-				entryDirectory,
-				entry.file
-			),
-			entry,
-			// `moduleCollector` doesn't get used when `noBundle` is set, so
-			// `findAdditionalModules` always defaults to `false`
-			findAdditionalModules: config.find_additional_modules ?? false,
-			rules: config.rules ?? [],
-			preserveFileNames: config.preserve_file_names ?? false,
-		});
+	if (noBundle) {
+		// if we're not building, let's just copy the entry to the destination directory
+		const destinationDir =
+			typeof destination === "string" ? destination : destination.path;
+		mkdirSync(destinationDir, { recursive: true });
+		writeFileSync(
+			path.join(destinationDir, path.basename(entry.file)),
+			readFileSync(entry.file, "utf-8")
+		);
+	}
 
-		const {
-			modules,
-			dependencies,
-			resolvedEntryPointPath,
-			bundleType,
-			...bundle
-		} = noBundle
-			? await noBundleWorker(
-					entry,
-					config.rules ?? [],
-					props.outdir,
-					config.python_modules.exclude
-				)
-			: await bundleWorker(
-					entry,
-					typeof destination === "string" ? destination : destination.path,
-					{
-						metafile: options.metafile,
-						bundle: true,
-						additionalModules: [],
-						moduleCollector,
-						doBindings: config.durable_objects.bindings,
-						workflowBindings: config.workflows ?? [],
-						jsxFactory,
-						jsxFragment,
-						tsconfig: props.tsconfig,
-						minify,
-						keepNames: config.keep_names ?? true,
-						sourcemap: uploadSourceMaps,
-						nodejsCompatMode,
+	const entryDirectory = path.dirname(entry.file);
+	const moduleCollector = createModuleCollector({
+		wrangler1xLegacyModuleReferences: getWrangler1xLegacyModuleReferences(
+			entryDirectory,
+			entry.file
+		),
+		entry,
+		// `moduleCollector` doesn't get used when `noBundle` is set, so
+		// `findAdditionalModules` always defaults to `false`
+		findAdditionalModules: config.find_additional_modules ?? false,
+		rules: config.rules ?? [],
+		preserveFileNames: config.preserve_file_names ?? false,
+	});
+
+	const {
+		modules,
+		dependencies,
+		resolvedEntryPointPath,
+		bundleType,
+		...bundle
+	} = noBundle
+		? await noBundleWorker(
+				entry,
+				config.rules ?? [],
+				props.outdir,
+				config.python_modules.exclude
+			)
+		: await bundleWorker(
+				entry,
+				typeof destination === "string" ? destination : destination.path,
+				{
+					metafile: options.metafile,
+					bundle: true,
+					additionalModules: [],
+					moduleCollector,
+					doBindings: config.durable_objects.bindings,
+					workflowBindings: config.workflows ?? [],
+					jsxFactory,
+					jsxFragment,
+					tsconfig: props.tsconfig,
+					minify,
+					keepNames: config.keep_names ?? true,
+					sourcemap: uploadSourceMaps,
+					nodejsCompatMode,
+					compatibilityDate,
+					compatibilityFlags,
+					define: props.defines,
+					checkFetch: false,
+					alias: props.alias,
+					// We want to know if the build is for development or publishing
+					// This could potentially cause issues as we no longer have identical behaviour between dev and deploy?
+					targetConsumer: "deploy",
+					local: false,
+					projectRoot: entry.projectRoot,
+					defineNavigatorUserAgent: isNavigatorDefined(
 						compatibilityDate,
-						compatibilityFlags,
-						define: props.defines,
-						checkFetch: false,
-						alias: props.alias,
-						// We want to know if the build is for development or publishing
-						// This could potentially cause issues as we no longer have identical behaviour between dev and deploy?
-						targetConsumer: "deploy",
-						local: false,
-						projectRoot,
-						defineNavigatorUserAgent: isNavigatorDefined(
-							compatibilityDate,
-							compatibilityFlags
-						),
-						plugins: [logBuildOutput(nodejsCompatMode)],
+						compatibilityFlags
+					),
+					plugins: [logBuildOutput(nodejsCompatMode)],
 
-						// Pages specific options used by wrangler pages commands
-						entryName: undefined,
-						inject: undefined,
-						isOutfile: undefined,
-						external: undefined,
+					// Pages specific options used by wrangler pages commands
+					entryName: undefined,
+					inject: undefined,
+					isOutfile: undefined,
+					external: undefined,
 
-						// These options are dev-only
-						testScheduled: undefined,
-						watch: undefined,
-					}
-				);
+					// These options are dev-only
+					testScheduled: undefined,
+					watch: undefined,
+				}
+			);
 
-		// Add modules to dependencies for size warning
-		for (const module of modules) {
-			const modulePath =
-				module.filePath === undefined
-					? module.name
-					: path.relative("", module.filePath);
-			const bytesInOutput =
-				typeof module.content === "string"
-					? Buffer.byteLength(module.content)
-					: module.content.byteLength;
-			dependencies[modulePath] = { bytesInOutput };
-		}
+	// Add modules to dependencies for size warning
+	for (const module of modules) {
+		const modulePath =
+			module.filePath === undefined
+				? module.name
+				: path.relative("", module.filePath);
+		const bytesInOutput =
+			typeof module.content === "string"
+				? Buffer.byteLength(module.content)
+				: module.content.byteLength;
+		dependencies[modulePath] = { bytesInOutput };
+	}
 
-		const content = readFileSync(resolvedEntryPointPath, {
-			encoding: "utf-8",
-		});
+	const content = readFileSync(resolvedEntryPointPath, {
+		encoding: "utf-8",
+	});
 
-		return {
-			modules,
-			dependencies,
-			resolvedEntryPointPath,
-			bundleType,
-			content,
-			bundle,
-		};
-	},
-};
+	return {
+		modules,
+		dependencies,
+		resolvedEntryPointPath,
+		bundleType,
+		content,
+		bundle,
+	};
+}

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -1,4 +1,4 @@
-import { versionsUpload as versionsUploadBase } from "@cloudflare/deploy-helpers";
+import { versionsUpload } from "@cloudflare/deploy-helpers";
 import { analyseBundle } from "../check/commands";
 import { createCommand } from "../core/create-command";
 import { provisionBindings } from "../deployment-bundle/bindings";
@@ -6,7 +6,7 @@ import {
 	sharedDeployVersionsArgs,
 	validateDeployVersionsArgs,
 } from "../deployment-bundle/deploy-args";
-import { handleBuild } from "../deployment-bundle/maybe-build-worker";
+import { buildWorker } from "../deployment-bundle/maybe-build-worker";
 import {
 	cleanupDestination,
 	mergeVersionsUploadConfigArgs,
@@ -14,11 +14,6 @@ import {
 import * as metrics from "../metrics";
 import { writeOutput } from "../output";
 import { getScriptName } from "../utils/getScriptName";
-import type {
-	HandleBuild,
-	VersionsUploadProps,
-} from "@cloudflare/deploy-helpers";
-import type { Config } from "@cloudflare/workers-utils";
 
 export const versionsUploadCommand = createCommand({
 	metadata: {
@@ -67,12 +62,17 @@ export const versionsUploadCommand = createCommand({
 			const workerNameOverridden =
 				mergedProps.name !== undefined && mergedProps.name !== preMergeName;
 
+			const buildResult = await buildWorker(mergedProps, config, {});
+
 			const {
 				versionId,
 				workerTag,
 				versionPreviewUrl,
 				versionPreviewAliasUrl,
-			} = await versionsUpload(mergedProps, config, handleBuild);
+			} = await versionsUpload(mergedProps, config, buildResult, {
+				provisionBindings: provisionBindings,
+				analyseBundle: analyseBundle,
+			});
 
 			writeOutput({
 				type: "version-upload",
@@ -92,19 +92,3 @@ export const versionsUploadCommand = createCommand({
 });
 
 export type VersionsUploadArgs = (typeof versionsUploadCommand)["args"];
-
-export default async function versionsUpload(
-	props: VersionsUploadProps,
-	config: Config,
-	buildWorker: HandleBuild
-): Promise<{
-	versionId: string | null;
-	workerTag: string | null;
-	versionPreviewUrl?: string | undefined;
-	versionPreviewAliasUrl?: string | undefined;
-}> {
-	return versionsUploadBase(props, config, buildWorker, {
-		provisionBindings,
-		analyseBundle,
-	});
-}


### PR DESCRIPTION
Move build before upload specific config validation - this helps us support the build output api, where the build _produces_ the config to use for deploy.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: should continue to pass existing tests/simple refactor
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: refactor

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->