### PR TITLE
Add missing R2 ownership in .codeowners

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -63,6 +63,15 @@
 & packages/miniflare/test/plugins/kv/** @cloudflare/workers-kv
 
 # ----------------------------------------------------------
+# R2 ownership (AND: requires wrangler + r2)
+# ----------------------------------------------------------
+& packages/wrangler/src/r2/** @cloudflare/r2
+& packages/wrangler/src/__tests__/r2/** @cloudflare/r2
+& packages/miniflare/src/plugins/r2/** @cloudflare/r2
+& packages/miniflare/src/workers/r2/** @cloudflare/r2
+& packages/miniflare/test/plugins/r2/** @cloudflare/r2
+
+# ----------------------------------------------------------
 # Workflows ownership (AND: requires wrangler + workflows)
 # ----------------------------------------------------------
 # */** excludes root-level files (CHANGELOG.md, package.json)


### PR DESCRIPTION
In https://github.com/cloudflare/workers-sdk/pull/14233 I noticed that the R2 team is not set as codeowner for the r2 files, I'm addressing that in this PR

> [!Note]
> There are other teams missing such as hyperdrive and secret store, etc... but there are quite a few and I don't think that there are also all those teams in github, so here I am just adding the r2 one which is clear cut. (Possibly in the future, if necessary / beneficial we can look into adding the others too)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: just a codeowners change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: just a codeowners change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->