### PR TITLE
Suggest Cloudflare skills installation after commands instead of before

### DIFF
--- a/.changeset/suggest-skills-after-commands.md
+++ b/.changeset/suggest-skills-after-commands.md
@@ -1,0 +1,9 @@
+---
+"wrangler": minor
+---
+
+Suggest Cloudflare skills installation after commands instead of before
+
+The automatic prompt to install Cloudflare skills for detected AI coding agents no longer runs before every Wrangler command. Instead, Wrangler now suggests installing skills, when appropriate, after some commands complete successfully. Commands that output JSON suppress the suggestion to keep their output clean. The `--install-skills` flag remains available on all commands to explicitly run the skills installation flow before the command executes, without prompting.
+
+As before, Wrangler asks the skills installation question at most once. The skills install metadata file is now written before the confirmation prompt is shown, so even if the user interrupts the process (e.g. CTRL+C, closing the terminal) during the prompt, the question is recorded as unanswered and will not reappear on subsequent runs.

--- a/packages/wrangler/src/__tests__/agent-memory.test.ts
+++ b/packages/wrangler/src/__tests__/agent-memory.test.ts
@@ -44,7 +44,7 @@ describe("agent-memory help", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});
@@ -73,7 +73,7 @@ describe("agent-memory help", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});

--- a/packages/wrangler/src/__tests__/agents-skills-install.test.ts
+++ b/packages/wrangler/src/__tests__/agents-skills-install.test.ts
@@ -6,6 +6,7 @@ import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { detectAgenticEnvironment } from "am-i-vibing";
 import ci from "ci-info";
 import { http, HttpResponse } from "msw";
+import prompts from "prompts";
 import { afterEach, beforeEach, describe, test, vi } from "vitest";
 import { sendMetricsEvent } from "../metrics/send-event";
 import { mockConsoleMethods } from "./helpers/mock-console";
@@ -13,7 +14,7 @@ import { clearDialogs, mockConfirm } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { msw } from "./helpers/msw";
 import type {
-	maybeInstallCloudflareSkillsGlobally as InstallFnType,
+	runSkillsInstallFlow as RunFlowFnType,
 	telemetryCurrentAgentSkillsInstalled as TelemetryFnType,
 } from "../agents-skills-install";
 import type * as SendEventModule from "../metrics/send-event";
@@ -98,11 +99,13 @@ function readMetadataFile(): Record<string, unknown> {
  * Re-imports the agents-skills-install module with a fresh module graph.
  * This is necessary because tests need a clean module state after mocks
  * are reconfigured per test.
+ *
+ * @returns The `runSkillsInstallFlow` function from a fresh module import.
  */
-async function freshImport(): Promise<typeof InstallFnType> {
+async function freshImport(): Promise<typeof RunFlowFnType> {
 	vi.resetModules();
 	const mod = await import("../agents-skills-install");
-	return mod.maybeInstallCloudflareSkillsGlobally;
+	return mod.runSkillsInstallFlow;
 }
 
 /**
@@ -129,10 +132,14 @@ function createAgentDir(dirName: string): void {
 	mkdirSync(path.join(os.homedir(), dirName), { recursive: true });
 }
 
-describe("maybeInstallCloudflareSkillsGlobally", () => {
+describe("runSkillsInstallFlow with force-install prompt", () => {
 	runInTempDir();
 	const std = mockConsoleMethods();
 	const { setIsTTY } = useMockIsTTY();
+
+	/** The prompt message used by the --install-skills global flag. */
+	const installPromptMessage = (agents: string[]) =>
+		`Wrangler detected the following AI coding agents: ${agents.join(", ")}. Would you like to install Cloudflare skills for them?`;
 
 	beforeEach(() => {
 		setIsTTY(true);
@@ -149,9 +156,38 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 			expect,
 		}) => {
 			writeMetadataFile({ accepted: true, date: "2025-01-01T00:00:00Z" });
-			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+			const runSkillsInstallFlow = await freshImport();
 
-			await maybeInstallCloudflareSkillsGlobally(false);
+			await runSkillsInstallFlow({
+				force: false,
+				promptMessage: installPromptMessage,
+			});
+
+			expect(mockRosieAgents).not.toHaveBeenCalled();
+			expect(mockRosieInstall).not.toHaveBeenCalled();
+			expect(sendMetricsEvent).not.toHaveBeenCalled();
+		});
+
+		test("skips silently when metadata file has accepted='unanswered' (user interrupted prompt)", async ({
+			expect,
+		}) => {
+			writeMetadataFile({
+				version: 1,
+				accepted: "unanswered",
+				date: "2025-01-01T00:00:00Z",
+				detectedAgents: [
+					{
+						name: "Claude Code",
+						rosie: { id: "claude", globalPath: "/fake/.claude/skills" },
+					},
+				],
+			});
+			const runSkillsInstallFlow = await freshImport();
+
+			await runSkillsInstallFlow({
+				force: false,
+				promptMessage: installPromptMessage,
+			});
 
 			expect(mockRosieAgents).not.toHaveBeenCalled();
 			expect(mockRosieInstall).not.toHaveBeenCalled();
@@ -175,9 +211,12 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 				],
 				installFailed: false,
 			});
-			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+			const runSkillsInstallFlow = await freshImport();
 
-			await maybeInstallCloudflareSkillsGlobally(false);
+			await runSkillsInstallFlow({
+				force: false,
+				promptMessage: installPromptMessage,
+			});
 
 			expect(mockRosieAgents).not.toHaveBeenCalled();
 			expect(mockRosieInstall).not.toHaveBeenCalled();
@@ -195,14 +234,15 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 
 		test("force=true ignores existing metadata file", async ({ expect }) => {
 			writeMetadataFile({ accepted: true, date: "2025-01-01T00:00:00Z" });
-			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+			const runSkillsInstallFlow = await freshImport();
 
-			await maybeInstallCloudflareSkillsGlobally(true);
+			await runSkillsInstallFlow({ force: true });
 
 			expect(mockRosieInstall).toHaveBeenCalledWith("cloudflare/skills", {
 				global: true,
 				agent: ["claude"],
 				lockfile: false,
+				onLog: expect.any(Function),
 			});
 			expect(std.out).toContain(
 				"Successfully installed Cloudflare skills for: Claude Code."
@@ -220,9 +260,12 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 					installPath: null,
 				},
 			]);
-			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+			const runSkillsInstallFlow = await freshImport();
 
-			await maybeInstallCloudflareSkillsGlobally(false);
+			await runSkillsInstallFlow({
+				force: false,
+				promptMessage: installPromptMessage,
+			});
 
 			expect(mockRosieInstall).not.toHaveBeenCalled();
 			expect(sendMetricsEvent).toHaveBeenCalledWith(
@@ -236,9 +279,12 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 			expect,
 		}) => {
 			mockRosieAgents.mockResolvedValueOnce([]);
-			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+			const runSkillsInstallFlow = await freshImport();
 
-			await maybeInstallCloudflareSkillsGlobally(false);
+			await runSkillsInstallFlow({
+				force: false,
+				promptMessage: installPromptMessage,
+			});
 
 			expect(mockRosieInstall).not.toHaveBeenCalled();
 			expect(sendMetricsEvent).toHaveBeenCalledWith(
@@ -252,10 +298,10 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 			expect,
 		}) => {
 			mockRosieInstall.mockRejectedValueOnce(new Error("network failure"));
-			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+			const runSkillsInstallFlow = await freshImport();
 
 			// force=true so we don't need to mock the confirm dialog
-			await maybeInstallCloudflareSkillsGlobally(true);
+			await runSkillsInstallFlow({ force: true });
 
 			expect(std.warn).toContain(
 				"Failed to install Cloudflare skills: network failure"
@@ -274,9 +320,12 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 			expect,
 		}) => {
 			mockRosieAgents.mockRejectedValueOnce(new Error("WASM load failed"));
-			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+			const runSkillsInstallFlow = await freshImport();
 
-			await maybeInstallCloudflareSkillsGlobally(false);
+			await runSkillsInstallFlow({
+				force: false,
+				promptMessage: installPromptMessage,
+			});
 
 			expect(mockRosieInstall).not.toHaveBeenCalled();
 			expect(sendMetricsEvent).toHaveBeenCalledWith(
@@ -293,9 +342,12 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 			expect,
 		}) => {
 			vi.mocked(ci).isCI = true;
-			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+			const runSkillsInstallFlow = await freshImport();
 
-			await maybeInstallCloudflareSkillsGlobally(false);
+			await runSkillsInstallFlow({
+				force: false,
+				promptMessage: installPromptMessage,
+			});
 
 			// Verify neither agent detection nor install was attempted
 			expect(mockRosieAgents).not.toHaveBeenCalled();
@@ -311,14 +363,15 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 			expect,
 		}) => {
 			vi.mocked(ci).isCI = true;
-			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+			const runSkillsInstallFlow = await freshImport();
 
-			await maybeInstallCloudflareSkillsGlobally(true);
+			await runSkillsInstallFlow({ force: true });
 
 			expect(mockRosieInstall).toHaveBeenCalledWith("cloudflare/skills", {
 				global: true,
 				agent: ["claude"],
 				lockfile: false,
+				onLog: expect.any(Function),
 			});
 		});
 
@@ -326,9 +379,12 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 			expect,
 		}) => {
 			setIsTTY(false);
-			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+			const runSkillsInstallFlow = await freshImport();
 
-			await maybeInstallCloudflareSkillsGlobally(false);
+			await runSkillsInstallFlow({
+				force: false,
+				promptMessage: installPromptMessage,
+			});
 
 			// Nothing has been logged
 			expect(std.out).toEqual("");
@@ -351,9 +407,12 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 				text: expect.stringContaining("Claude Code") as unknown as string,
 				result: false,
 			});
-			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+			const runSkillsInstallFlow = await freshImport();
 
-			await maybeInstallCloudflareSkillsGlobally(false);
+			await runSkillsInstallFlow({
+				force: false,
+				promptMessage: installPromptMessage,
+			});
 
 			// must not log a success message when the user declined
 			expect(std.out).not.toContain(
@@ -381,14 +440,18 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 				text: expect.stringContaining("Claude Code") as unknown as string,
 				result: true,
 			});
-			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+			const runSkillsInstallFlow = await freshImport();
 
-			await maybeInstallCloudflareSkillsGlobally(false);
+			await runSkillsInstallFlow({
+				force: false,
+				promptMessage: installPromptMessage,
+			});
 
 			expect(mockRosieInstall).toHaveBeenCalledWith("cloudflare/skills", {
 				global: true,
 				agent: ["claude"],
 				lockfile: false,
+				onLog: expect.any(Function),
 			});
 
 			expect(std.out).toContain(
@@ -412,20 +475,124 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 			);
 		});
 
+		test("writes metadata with accepted='unanswered' before showing the confirm prompt", async ({
+			expect,
+		}) => {
+			// Intercept the prompts call to inspect the metadata file state at
+			// the moment the confirmation prompt is displayed to the user.
+			vi.mocked(prompts).mockImplementationOnce(() => {
+				const metadata = readMetadataFile();
+				expect(metadata.accepted).toBe("unanswered");
+				expect(metadata.detectedAgents).toEqual([
+					{
+						name: "Claude Code",
+						rosie: { id: "claude", globalPath: "/fake/.claude/skills" },
+					},
+				]);
+				return Promise.resolve({ value: true });
+			});
+			const runSkillsInstallFlow = await freshImport();
+
+			await runSkillsInstallFlow({
+				force: false,
+				promptMessage: installPromptMessage,
+			});
+
+			// After the flow completes, the final metadata should reflect the
+			// user's actual answer, overwriting the "unanswered" marker.
+			const finalMetadata = readMetadataFile();
+			expect(finalMetadata.accepted).toBe(true);
+		});
+
 		test("force=true installs skills without prompting", async ({ expect }) => {
 			// No mockConfirm — if a prompt fires, the test will fail with "Unexpected call to prompts"
-			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+			const runSkillsInstallFlow = await freshImport();
 
-			await maybeInstallCloudflareSkillsGlobally(true);
+			await runSkillsInstallFlow({ force: true });
 
 			expect(mockRosieInstall).toHaveBeenCalledWith("cloudflare/skills", {
 				global: true,
 				agent: ["claude"],
 				lockfile: false,
+				onLog: expect.any(Function),
 			});
 
 			expect(std.out).toContain(
 				"Successfully installed Cloudflare skills for: Claude Code."
+			);
+		});
+
+		test("force=true does not write 'unanswered' metadata before installing", async ({
+			expect,
+		}) => {
+			const runSkillsInstallFlow = await freshImport();
+
+			await runSkillsInstallFlow({ force: true });
+
+			// The final metadata should be accepted=true, never "unanswered"
+			const metadata = readMetadataFile();
+			expect(metadata.accepted).toBe(true);
+		});
+	});
+
+	describe("telemetry command property", () => {
+		test("includes command in skills_install_completed when provided", async ({
+			expect,
+		}) => {
+			const runSkillsInstallFlow = await freshImport();
+
+			await runSkillsInstallFlow({ force: true, command: "deploy" });
+
+			expect(sendMetricsEvent).toHaveBeenCalledWith(
+				"skills_install_completed",
+				{
+					agents: [
+						{
+							name: "Claude Code",
+							rosie: {
+								id: "claude",
+								globalPath: "/fake/.claude/skills",
+							},
+						},
+					],
+					command: "deploy",
+				},
+				{}
+			);
+		});
+
+		test("includes command in skills_install_skipped when provided", async ({
+			expect,
+		}) => {
+			mockRosieAgents.mockResolvedValueOnce([]);
+			const runSkillsInstallFlow = await freshImport();
+
+			await runSkillsInstallFlow({
+				force: false,
+				command: "dev",
+				promptMessage: installPromptMessage,
+			});
+
+			expect(sendMetricsEvent).toHaveBeenCalledWith(
+				"skills_install_skipped",
+				{ reason: "No supported agents detected", command: "dev" },
+				{}
+			);
+		});
+
+		test("omits command from metrics when not provided", async ({ expect }) => {
+			mockRosieAgents.mockResolvedValueOnce([]);
+			const runSkillsInstallFlow = await freshImport();
+
+			await runSkillsInstallFlow({
+				force: false,
+				promptMessage: installPromptMessage,
+			});
+
+			expect(sendMetricsEvent).toHaveBeenCalledWith(
+				"skills_install_skipped",
+				{ reason: "No supported agents detected" },
+				{}
 			);
 		});
 	});
@@ -452,14 +619,18 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 				text: expect.stringContaining("Claude Code") as unknown as string,
 				result: true,
 			});
-			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+			const runSkillsInstallFlow = await freshImport();
 
-			await maybeInstallCloudflareSkillsGlobally(false);
+			await runSkillsInstallFlow({
+				force: false,
+				promptMessage: installPromptMessage,
+			});
 
 			expect(mockRosieInstall).toHaveBeenCalledWith("cloudflare/skills", {
 				global: true,
 				agent: ["claude", "cursor"],
 				lockfile: false,
+				onLog: expect.any(Function),
 			});
 
 			expect(std.out).toContain(
@@ -475,9 +646,9 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 			mockRosieInstall.mockRejectedValueOnce(
 				new Error("tarball download failed")
 			);
-			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+			const runSkillsInstallFlow = await freshImport();
 
-			await maybeInstallCloudflareSkillsGlobally(true);
+			await runSkillsInstallFlow({ force: true });
 
 			expect(std.warn).toContain(
 				"Failed to install Cloudflare skills: tarball download failed"
@@ -519,9 +690,9 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 				failedAgents: ["cursor"],
 				installedInstruction: null,
 			});
-			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+			const runSkillsInstallFlow = await freshImport();
 
-			await maybeInstallCloudflareSkillsGlobally(true);
+			await runSkillsInstallFlow({ force: true });
 
 			// Success message should only mention succeeded agents
 			expect(std.out).toContain(
@@ -547,9 +718,12 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 				text: expect.stringContaining("Claude Code") as unknown as string,
 				result: true,
 			});
-			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+			const runSkillsInstallFlow = await freshImport();
 
-			await maybeInstallCloudflareSkillsGlobally(false);
+			await runSkillsInstallFlow({
+				force: false,
+				promptMessage: installPromptMessage,
+			});
 
 			const metadata = readMetadataFile();
 			expect(metadata.accepted).toBe(true);
@@ -570,9 +744,12 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 				text: expect.stringContaining("Claude Code") as unknown as string,
 				result: false,
 			});
-			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+			const runSkillsInstallFlow = await freshImport();
 
-			await maybeInstallCloudflareSkillsGlobally(false);
+			await runSkillsInstallFlow({
+				force: false,
+				promptMessage: installPromptMessage,
+			});
 
 			const metadata = readMetadataFile();
 			expect(metadata.accepted).toBe(false);
@@ -585,9 +762,12 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 				text: expect.stringContaining("Claude Code") as unknown as string,
 				result: false,
 			});
-			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+			const runSkillsInstallFlow = await freshImport();
 
-			await maybeInstallCloudflareSkillsGlobally(false);
+			await runSkillsInstallFlow({
+				force: false,
+				promptMessage: installPromptMessage,
+			});
 
 			const metadata = readMetadataFile();
 			expect(metadata.installFailed).toBeUndefined();
@@ -597,9 +777,9 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 			expect,
 		}) => {
 			mockRosieInstall.mockRejectedValueOnce(new Error("download failed"));
-			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+			const runSkillsInstallFlow = await freshImport();
 
-			await maybeInstallCloudflareSkillsGlobally(true);
+			await runSkillsInstallFlow({ force: true });
 
 			const metadata = readMetadataFile();
 			expect(metadata.installFailed).toBe(true);
@@ -621,9 +801,9 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 				failedAgents: ["cursor"],
 				installedInstruction: null,
 			});
-			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+			const runSkillsInstallFlow = await freshImport();
 
-			await maybeInstallCloudflareSkillsGlobally(true);
+			await runSkillsInstallFlow({ force: true });
 
 			const metadata = readMetadataFile();
 			expect(metadata.accepted).toBe(true);
@@ -633,13 +813,185 @@ describe("maybeInstallCloudflareSkillsGlobally", () => {
 		test("sets installFailed to false when all agents succeed", async ({
 			expect,
 		}) => {
-			const maybeInstallCloudflareSkillsGlobally = await freshImport();
+			const runSkillsInstallFlow = await freshImport();
 
-			await maybeInstallCloudflareSkillsGlobally(true);
+			await runSkillsInstallFlow({ force: true });
 
 			const metadata = readMetadataFile();
 			expect(metadata.accepted).toBe(true);
 			expect(metadata.installFailed).toBe(false);
+		});
+	});
+});
+
+describe("runSkillsInstallFlow with custom prompt message", () => {
+	runInTempDir();
+	const std = mockConsoleMethods();
+	const { setIsTTY } = useMockIsTTY();
+
+	/** The prompt message used by register-yargs-command.ts for suggestSkillsAfterHandler. */
+	const suggestPromptMessage = (agents: string[]) =>
+		`Before you go, Wrangler detected potential configurations for the following AI coding agents on your system likely without Cloudflare skills: ${agents.join(", ")}. Would you like Wrangler to automatically install the Cloudflare skills for you?`;
+
+	beforeEach(() => {
+		setIsTTY(true);
+		mockRosieAgents.mockResolvedValue(DEFAULT_AGENTS);
+		mockRosieInstall.mockResolvedValue(DEFAULT_INSTALL_RESULT);
+	});
+
+	afterEach(() => {
+		clearDialogs();
+	});
+
+	describe("skip conditions", () => {
+		test("skips silently when metadata file exists", async ({ expect }) => {
+			writeMetadataFile({ accepted: true, date: "2025-01-01T00:00:00Z" });
+			const flow = await freshImport();
+
+			await flow({ force: false, promptMessage: suggestPromptMessage });
+
+			expect(mockRosieAgents).not.toHaveBeenCalled();
+			expect(mockRosieInstall).not.toHaveBeenCalled();
+			expect(sendMetricsEvent).not.toHaveBeenCalled();
+		});
+
+		test("skips silently when metadata file records a decline", async ({
+			expect,
+		}) => {
+			writeMetadataFile({ accepted: false, date: "2025-01-01T00:00:00Z" });
+			const flow = await freshImport();
+
+			await flow({ force: false, promptMessage: suggestPromptMessage });
+
+			expect(mockRosieAgents).not.toHaveBeenCalled();
+			expect(mockRosieInstall).not.toHaveBeenCalled();
+			expect(sendMetricsEvent).not.toHaveBeenCalled();
+		});
+
+		test("skips silently when metadata file has accepted='unanswered'", async ({
+			expect,
+		}) => {
+			writeMetadataFile({
+				version: 1,
+				accepted: "unanswered",
+				date: "2025-01-01T00:00:00Z",
+			});
+			const flow = await freshImport();
+
+			await flow({ force: false, promptMessage: suggestPromptMessage });
+
+			expect(mockRosieAgents).not.toHaveBeenCalled();
+			expect(mockRosieInstall).not.toHaveBeenCalled();
+			expect(sendMetricsEvent).not.toHaveBeenCalled();
+		});
+
+		test("skips in CI", async ({ expect }) => {
+			vi.mocked(ci).isCI = true;
+			const flow = await freshImport();
+
+			await flow({ force: false, promptMessage: suggestPromptMessage });
+
+			expect(mockRosieInstall).not.toHaveBeenCalled();
+			expect(sendMetricsEvent).toHaveBeenCalledWith(
+				"skills_install_skipped",
+				{ reason: "Running in CI" },
+				{}
+			);
+		});
+
+		test("skips in non-interactive terminal", async ({ expect }) => {
+			setIsTTY(false);
+			const flow = await freshImport();
+
+			await flow({ force: false, promptMessage: suggestPromptMessage });
+
+			expect(std.out).toEqual("");
+			expect(mockRosieInstall).not.toHaveBeenCalled();
+			expect(sendMetricsEvent).toHaveBeenCalledWith(
+				"skills_install_skipped",
+				{ reason: "Non-interactive terminal" },
+				{}
+			);
+		});
+
+		test("skips when no agents are detected", async ({ expect }) => {
+			mockRosieAgents.mockResolvedValueOnce([]);
+			const flow = await freshImport();
+
+			await flow({ force: false, promptMessage: suggestPromptMessage });
+
+			expect(mockRosieInstall).not.toHaveBeenCalled();
+			expect(sendMetricsEvent).toHaveBeenCalledWith(
+				"skills_install_skipped",
+				{ reason: "No supported agents detected" },
+				{}
+			);
+		});
+	});
+
+	describe("prompt message", () => {
+		test("uses the caller-provided prompt message", async ({ expect }) => {
+			mockConfirm({
+				text: "Before you go, Wrangler detected potential configurations for the following AI coding agents on your system likely without Cloudflare skills: Claude Code. Would you like Wrangler to automatically install the Cloudflare skills for you?",
+				result: false,
+			});
+			const flow = await freshImport();
+
+			await flow({ force: false, promptMessage: suggestPromptMessage });
+
+			expect(sendMetricsEvent).toHaveBeenCalledWith(
+				"skills_install_skipped",
+				{ reason: "User declined" },
+				{}
+			);
+		});
+	});
+
+	describe("user prompt interaction", () => {
+		test("installs skills when user accepts", async ({ expect }) => {
+			mockConfirm({
+				text: expect.stringContaining(
+					"without Cloudflare skills"
+				) as unknown as string,
+				result: true,
+			});
+			const flow = await freshImport();
+
+			await flow({ force: false, promptMessage: suggestPromptMessage });
+
+			expect(mockRosieInstall).toHaveBeenCalledWith("cloudflare/skills", {
+				global: true,
+				agent: ["claude"],
+				lockfile: false,
+				onLog: expect.any(Function),
+			});
+
+			expect(std.out).toContain(
+				"Successfully installed Cloudflare skills for: Claude Code."
+			);
+
+			const metadata = readMetadataFile();
+			expect(metadata.accepted).toBe(true);
+			expect(metadata.installFailed).toBe(false);
+		});
+
+		test("writes metadata with accepted=false when user declines", async ({
+			expect,
+		}) => {
+			mockConfirm({
+				text: expect.stringContaining(
+					"without Cloudflare skills"
+				) as unknown as string,
+				result: false,
+			});
+			const flow = await freshImport();
+
+			await flow({ force: false, promptMessage: suggestPromptMessage });
+
+			expect(mockRosieInstall).not.toHaveBeenCalled();
+
+			const metadata = readMetadataFile();
+			expect(metadata.accepted).toBe(false);
 		});
 	});
 });
@@ -919,6 +1271,40 @@ describe("telemetryCurrentAgentSkillsInstalled", () => {
 
 		const result = await telemetryCurrentAgentSkillsInstalled();
 
+		expect(result).toBe("manual");
+	});
+
+	test("resolves to 'manual' when metadata has accepted='unanswered' (user interrupted prompt)", async ({
+		expect,
+	}) => {
+		vi.mocked(detectAgenticEnvironment).mockReturnValue({
+			isAgentic: true,
+			id: "claude-code",
+			name: "Claude Code",
+			type: "agent",
+		});
+		createAgentDir(".claude");
+		const claudeSkills = path.join(os.homedir(), ".claude", "skills");
+		mkdirSync(path.join(claudeSkills, "cloudflare"), { recursive: true });
+		const claudeGlobalSkillsPath = path.join(os.homedir(), ".claude", "skills");
+		writeMetadataFile({
+			version: 1,
+			accepted: "unanswered",
+			date: new Date().toISOString(),
+			detectedAgents: [
+				{
+					name: "Claude Code",
+					rosie: { id: "claude", globalPath: claudeGlobalSkillsPath },
+				},
+			],
+		});
+		mockGitHubSkillsApi(["cloudflare", "wrangler"]);
+		const telemetryCurrentAgentSkillsInstalled = await freshTelemetryImport();
+
+		const result = await telemetryCurrentAgentSkillsInstalled();
+
+		// "unanswered" must not be treated as "accepted" — skills were never
+		// installed by Wrangler, so the correct status is "manual".
 		expect(result).toBe("manual");
 	});
 

--- a/packages/wrangler/src/__tests__/agents-skills-install.test.ts
+++ b/packages/wrangler/src/__tests__/agents-skills-install.test.ts
@@ -8,15 +8,16 @@ import ci from "ci-info";
 import { http, HttpResponse } from "msw";
 import prompts from "prompts";
 import { afterEach, beforeEach, describe, test, vi } from "vitest";
+import {
+	skillInstallPromptMessageAfterWranglerCommandHandler,
+	type runSkillsInstallFlow as RunFlowFnType,
+	type telemetryCurrentAgentSkillsInstalled as TelemetryFnType,
+} from "../agents-skills-install";
 import { sendMetricsEvent } from "../metrics/send-event";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs, mockConfirm } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import { msw } from "./helpers/msw";
-import type {
-	runSkillsInstallFlow as RunFlowFnType,
-	telemetryCurrentAgentSkillsInstalled as TelemetryFnType,
-} from "../agents-skills-install";
 import type * as SendEventModule from "../metrics/send-event";
 
 // Undo the global no-op mock from vitest.setup.ts so we test the real implementation
@@ -829,10 +830,6 @@ describe("runSkillsInstallFlow with custom prompt message", () => {
 	const std = mockConsoleMethods();
 	const { setIsTTY } = useMockIsTTY();
 
-	/** The prompt message used by register-yargs-command.ts for suggestSkillsAfterHandler. */
-	const suggestPromptMessage = (agents: string[]) =>
-		`Before you go, Wrangler detected potential configurations for the following AI coding agents on your system likely without Cloudflare skills: ${agents.join(", ")}. Would you like Wrangler to automatically install the Cloudflare skills for you?`;
-
 	beforeEach(() => {
 		setIsTTY(true);
 		mockRosieAgents.mockResolvedValue(DEFAULT_AGENTS);
@@ -848,7 +845,10 @@ describe("runSkillsInstallFlow with custom prompt message", () => {
 			writeMetadataFile({ accepted: true, date: "2025-01-01T00:00:00Z" });
 			const flow = await freshImport();
 
-			await flow({ force: false, promptMessage: suggestPromptMessage });
+			await flow({
+				force: false,
+				promptMessage: skillInstallPromptMessageAfterWranglerCommandHandler,
+			});
 
 			expect(mockRosieAgents).not.toHaveBeenCalled();
 			expect(mockRosieInstall).not.toHaveBeenCalled();
@@ -861,7 +861,10 @@ describe("runSkillsInstallFlow with custom prompt message", () => {
 			writeMetadataFile({ accepted: false, date: "2025-01-01T00:00:00Z" });
 			const flow = await freshImport();
 
-			await flow({ force: false, promptMessage: suggestPromptMessage });
+			await flow({
+				force: false,
+				promptMessage: skillInstallPromptMessageAfterWranglerCommandHandler,
+			});
 
 			expect(mockRosieAgents).not.toHaveBeenCalled();
 			expect(mockRosieInstall).not.toHaveBeenCalled();
@@ -878,7 +881,10 @@ describe("runSkillsInstallFlow with custom prompt message", () => {
 			});
 			const flow = await freshImport();
 
-			await flow({ force: false, promptMessage: suggestPromptMessage });
+			await flow({
+				force: false,
+				promptMessage: skillInstallPromptMessageAfterWranglerCommandHandler,
+			});
 
 			expect(mockRosieAgents).not.toHaveBeenCalled();
 			expect(mockRosieInstall).not.toHaveBeenCalled();
@@ -889,7 +895,10 @@ describe("runSkillsInstallFlow with custom prompt message", () => {
 			vi.mocked(ci).isCI = true;
 			const flow = await freshImport();
 
-			await flow({ force: false, promptMessage: suggestPromptMessage });
+			await flow({
+				force: false,
+				promptMessage: skillInstallPromptMessageAfterWranglerCommandHandler,
+			});
 
 			expect(mockRosieInstall).not.toHaveBeenCalled();
 			expect(sendMetricsEvent).toHaveBeenCalledWith(
@@ -903,7 +912,10 @@ describe("runSkillsInstallFlow with custom prompt message", () => {
 			setIsTTY(false);
 			const flow = await freshImport();
 
-			await flow({ force: false, promptMessage: suggestPromptMessage });
+			await flow({
+				force: false,
+				promptMessage: skillInstallPromptMessageAfterWranglerCommandHandler,
+			});
 
 			expect(std.out).toEqual("");
 			expect(mockRosieInstall).not.toHaveBeenCalled();
@@ -918,7 +930,10 @@ describe("runSkillsInstallFlow with custom prompt message", () => {
 			mockRosieAgents.mockResolvedValueOnce([]);
 			const flow = await freshImport();
 
-			await flow({ force: false, promptMessage: suggestPromptMessage });
+			await flow({
+				force: false,
+				promptMessage: skillInstallPromptMessageAfterWranglerCommandHandler,
+			});
 
 			expect(mockRosieInstall).not.toHaveBeenCalled();
 			expect(sendMetricsEvent).toHaveBeenCalledWith(
@@ -932,12 +947,15 @@ describe("runSkillsInstallFlow with custom prompt message", () => {
 	describe("prompt message", () => {
 		test("uses the caller-provided prompt message", async ({ expect }) => {
 			mockConfirm({
-				text: "Before you go, Wrangler detected potential configurations for the following AI coding agents on your system likely without Cloudflare skills: Claude Code. Would you like Wrangler to automatically install the Cloudflare skills for you?",
+				text: "Before you go, Wrangler detected AI coding agents that may not be best configured to work with Cloudflare: Claude Code. Would you like Wrangler to automatically install Cloudflare skills for the best experience?",
 				result: false,
 			});
 			const flow = await freshImport();
 
-			await flow({ force: false, promptMessage: suggestPromptMessage });
+			await flow({
+				force: false,
+				promptMessage: skillInstallPromptMessageAfterWranglerCommandHandler,
+			});
 
 			expect(sendMetricsEvent).toHaveBeenCalledWith(
 				"skills_install_skipped",
@@ -951,13 +969,16 @@ describe("runSkillsInstallFlow with custom prompt message", () => {
 		test("installs skills when user accepts", async ({ expect }) => {
 			mockConfirm({
 				text: expect.stringContaining(
-					"without Cloudflare skills"
+					"Would you like Wrangler to automatically install Cloudflare skills"
 				) as unknown as string,
 				result: true,
 			});
 			const flow = await freshImport();
 
-			await flow({ force: false, promptMessage: suggestPromptMessage });
+			await flow({
+				force: false,
+				promptMessage: skillInstallPromptMessageAfterWranglerCommandHandler,
+			});
 
 			expect(mockRosieInstall).toHaveBeenCalledWith("cloudflare/skills", {
 				global: true,
@@ -980,13 +1001,16 @@ describe("runSkillsInstallFlow with custom prompt message", () => {
 		}) => {
 			mockConfirm({
 				text: expect.stringContaining(
-					"without Cloudflare skills"
+					"Would you like Wrangler to automatically install Cloudflare skills"
 				) as unknown as string,
 				result: false,
 			});
 			const flow = await freshImport();
 
-			await flow({ force: false, promptMessage: suggestPromptMessage });
+			await flow({
+				force: false,
+				promptMessage: skillInstallPromptMessageAfterWranglerCommandHandler,
+			});
 
 			expect(mockRosieInstall).not.toHaveBeenCalled();
 

--- a/packages/wrangler/src/__tests__/ai.test.ts
+++ b/packages/wrangler/src/__tests__/ai.test.ts
@@ -32,7 +32,7 @@ describe("ai help", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});
@@ -65,7 +65,7 @@ describe("ai help", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});
@@ -89,7 +89,7 @@ describe("ai help", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});
@@ -112,7 +112,7 @@ describe("ai help", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});

--- a/packages/wrangler/src/__tests__/cert.test.ts
+++ b/packages/wrangler/src/__tests__/cert.test.ts
@@ -506,7 +506,7 @@ describe("wrangler", () => {
 						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 						  -h, --help            Show help  [boolean]
-						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 						  -v, --version         Show version number  [boolean]"
 					`);
 				});

--- a/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
@@ -86,7 +86,7 @@ describe("cloudchamber create", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]
 
 			OPTIONS

--- a/packages/wrangler/src/__tests__/cloudchamber/curl.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/curl.test.ts
@@ -43,7 +43,7 @@ describe("cloudchamber curl", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]
 
 			OPTIONS

--- a/packages/wrangler/src/__tests__/cloudchamber/delete.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/delete.test.ts
@@ -39,7 +39,7 @@ describe("cloudchamber delete", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});

--- a/packages/wrangler/src/__tests__/cloudchamber/images.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/images.test.ts
@@ -41,7 +41,7 @@ describe("cloudchamber image", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});
@@ -194,7 +194,7 @@ describe("cloudchamber image list", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
@@ -453,7 +453,7 @@ describe("cloudchamber image delete", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});

--- a/packages/wrangler/src/__tests__/cloudchamber/list.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/list.test.ts
@@ -39,7 +39,7 @@ describe("cloudchamber list", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]
 
 			OPTIONS

--- a/packages/wrangler/src/__tests__/cloudchamber/modify.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/modify.test.ts
@@ -54,7 +54,7 @@ describe("cloudchamber modify", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]
 
 			OPTIONS

--- a/packages/wrangler/src/__tests__/containers/delete.test.ts
+++ b/packages/wrangler/src/__tests__/containers/delete.test.ts
@@ -40,7 +40,7 @@ describe("containers delete", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});

--- a/packages/wrangler/src/__tests__/containers/images.test.ts
+++ b/packages/wrangler/src/__tests__/containers/images.test.ts
@@ -47,7 +47,7 @@ describe("containers images list", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
@@ -220,7 +220,7 @@ describe("containers images delete", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]
 
 			OPTIONS

--- a/packages/wrangler/src/__tests__/containers/info.test.ts
+++ b/packages/wrangler/src/__tests__/containers/info.test.ts
@@ -39,7 +39,7 @@ describe("containers info", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});

--- a/packages/wrangler/src/__tests__/containers/instances.test.ts
+++ b/packages/wrangler/src/__tests__/containers/instances.test.ts
@@ -111,7 +111,7 @@ describe("containers instances", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]
 
 			OPTIONS

--- a/packages/wrangler/src/__tests__/containers/list.test.ts
+++ b/packages/wrangler/src/__tests__/containers/list.test.ts
@@ -53,7 +53,7 @@ describe("containers list", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]
 
 			OPTIONS

--- a/packages/wrangler/src/__tests__/containers/push.test.ts
+++ b/packages/wrangler/src/__tests__/containers/push.test.ts
@@ -50,7 +50,7 @@ describe("containers push", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]
 
 			OPTIONS

--- a/packages/wrangler/src/__tests__/containers/registries.test.ts
+++ b/packages/wrangler/src/__tests__/containers/registries.test.ts
@@ -40,7 +40,7 @@ describe("containers registries --help", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});

--- a/packages/wrangler/src/__tests__/containers/ssh.test.ts
+++ b/packages/wrangler/src/__tests__/containers/ssh.test.ts
@@ -79,7 +79,7 @@ describe("containers ssh", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]
 
 			OPTIONS

--- a/packages/wrangler/src/__tests__/d1/d1.test.ts
+++ b/packages/wrangler/src/__tests__/d1/d1.test.ts
@@ -34,7 +34,7 @@ describe("d1", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});
@@ -74,7 +74,7 @@ describe("d1", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});
@@ -101,7 +101,7 @@ describe("d1", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});
@@ -126,7 +126,7 @@ describe("d1", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});

--- a/packages/wrangler/src/__tests__/deploy/secrets.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/secrets.test.ts
@@ -133,21 +133,21 @@ describe("deploy secrets", () => {
 			await runWrangler(`deploy --secrets-file ${secretsFile}`);
 
 			expect(std.out).toMatchInlineSnapshot(`
-			"
-			 ⛅️ wrangler x.x.x
-			──────────────────
-			Total Upload: xx KiB / gzip: xx KiB
-			Worker Startup Time: 100 ms
-			Your Worker has access to the following bindings:
-			Binding                       Resource
-			env.SECRET1 ("(hidden)")      Environment Variable
-			env.SECRET2 ("(hidden)")      Environment Variable
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				Total Upload: xx KiB / gzip: xx KiB
+				Worker Startup Time: 100 ms
+				Your Worker has access to the following bindings:
+				Binding                       Resource
+				env.SECRET1 ("(hidden)")      Environment Variable
+				env.SECRET2 ("(hidden)")      Environment Variable
 
-			Uploaded test-name (TIMINGS)
-			Deployed test-name triggers (TIMINGS)
-			  https://test-name.test-sub-domain.workers.dev
-			Current Version ID: Galaxy-Class"
-		`);
+				Uploaded test-name (TIMINGS)
+				Deployed test-name triggers (TIMINGS)
+				  https://test-name.test-sub-domain.workers.dev
+				Current Version ID: Galaxy-Class"
+			`);
 		});
 
 		it("should upload secrets from a .env file alongside the worker", async ({
@@ -193,22 +193,22 @@ SECRET3=value3`
 			await runWrangler(`deploy --secrets-file ${secretsFile}`);
 
 			expect(std.out).toMatchInlineSnapshot(`
-			"
-			 ⛅️ wrangler x.x.x
-			──────────────────
-			Total Upload: xx KiB / gzip: xx KiB
-			Worker Startup Time: 100 ms
-			Your Worker has access to the following bindings:
-			Binding                       Resource
-			env.SECRET1 ("(hidden)")      Environment Variable
-			env.SECRET2 ("(hidden)")      Environment Variable
-			env.SECRET3 ("(hidden)")      Environment Variable
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				Total Upload: xx KiB / gzip: xx KiB
+				Worker Startup Time: 100 ms
+				Your Worker has access to the following bindings:
+				Binding                       Resource
+				env.SECRET1 ("(hidden)")      Environment Variable
+				env.SECRET2 ("(hidden)")      Environment Variable
+				env.SECRET3 ("(hidden)")      Environment Variable
 
-			Uploaded test-name (TIMINGS)
-			Deployed test-name triggers (TIMINGS)
-			  https://test-name.test-sub-domain.workers.dev
-			Current Version ID: Galaxy-Class"
-		`);
+				Uploaded test-name (TIMINGS)
+				Deployed test-name triggers (TIMINGS)
+				  https://test-name.test-sub-domain.workers.dev
+				Current Version ID: Galaxy-Class"
+			`);
 		});
 
 		it("should set keepSecrets to inherit non-provided secrets when providing secrets file", async ({
@@ -243,20 +243,20 @@ SECRET3=value3`
 			await runWrangler(`deploy --secrets-file ${secretsFile}`);
 
 			expect(std.out).toMatchInlineSnapshot(`
-			"
-			 ⛅️ wrangler x.x.x
-			──────────────────
-			Total Upload: xx KiB / gzip: xx KiB
-			Worker Startup Time: 100 ms
-			Your Worker has access to the following bindings:
-			Binding                         Resource
-			env.MY_SECRET ("(hidden)")      Environment Variable
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				Total Upload: xx KiB / gzip: xx KiB
+				Worker Startup Time: 100 ms
+				Your Worker has access to the following bindings:
+				Binding                         Resource
+				env.MY_SECRET ("(hidden)")      Environment Variable
 
-			Uploaded test-name (TIMINGS)
-			Deployed test-name triggers (TIMINGS)
-			  https://test-name.test-sub-domain.workers.dev
-			Current Version ID: Galaxy-Class"
-		`);
+				Uploaded test-name (TIMINGS)
+				Deployed test-name triggers (TIMINGS)
+				  https://test-name.test-sub-domain.workers.dev
+				Current Version ID: Galaxy-Class"
+			`);
 		});
 
 		it("should fail when secrets file does not exist", async ({ expect }) => {

--- a/packages/wrangler/src/__tests__/deployments.test.ts
+++ b/packages/wrangler/src/__tests__/deployments.test.ts
@@ -70,7 +70,7 @@ describe("deployments", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});

--- a/packages/wrangler/src/__tests__/docs.test.ts
+++ b/packages/wrangler/src/__tests__/docs.test.ts
@@ -51,7 +51,7 @@ describe("wrangler docs", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]
 
 			OPTIONS

--- a/packages/wrangler/src/__tests__/experimental-commands-api.test.ts
+++ b/packages/wrangler/src/__tests__/experimental-commands-api.test.ts
@@ -48,7 +48,7 @@ describe("experimental_getWranglerCommands", () => {
 			  },
 			  "install-skills": {
 			    "default": false,
-			    "describe": "Install Cloudflare agents skills, if not already present, without asking the user for confirmation",
+			    "describe": "Install Cloudflare skills for detected AI coding agents before running the command",
 			    "type": "boolean",
 			  },
 			  "v": {

--- a/packages/wrangler/src/__tests__/hyperdrive.test.ts
+++ b/packages/wrangler/src/__tests__/hyperdrive.test.ts
@@ -46,7 +46,7 @@ describe("hyperdrive help", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});
@@ -82,7 +82,7 @@ describe("hyperdrive help", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -96,7 +96,7 @@ describe("wrangler", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]
 
 				Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose"
@@ -177,7 +177,7 @@ describe("wrangler", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]
 
 				Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose"
@@ -275,7 +275,7 @@ describe("wrangler", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});
@@ -302,7 +302,7 @@ describe("wrangler", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});
@@ -329,7 +329,7 @@ describe("wrangler", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});
@@ -355,7 +355,7 @@ describe("wrangler", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});
@@ -381,7 +381,7 @@ describe("wrangler", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});

--- a/packages/wrangler/src/__tests__/kv/help.test.ts
+++ b/packages/wrangler/src/__tests__/kv/help.test.ts
@@ -43,7 +43,7 @@ describe("kv", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});
@@ -67,7 +67,7 @@ describe("kv", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});
@@ -100,7 +100,7 @@ describe("kv", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});

--- a/packages/wrangler/src/__tests__/kv/key.test.ts
+++ b/packages/wrangler/src/__tests__/kv/key.test.ts
@@ -413,7 +413,7 @@ describe("kv", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
@@ -463,7 +463,7 @@ describe("kv", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
@@ -515,7 +515,7 @@ describe("kv", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
@@ -565,7 +565,7 @@ describe("kv", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
@@ -612,7 +612,7 @@ describe("kv", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
@@ -664,7 +664,7 @@ describe("kv", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
@@ -1108,7 +1108,7 @@ describe("kv", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
@@ -1150,7 +1150,7 @@ describe("kv", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
@@ -1193,7 +1193,7 @@ describe("kv", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS

--- a/packages/wrangler/src/__tests__/kv/namespace.test.ts
+++ b/packages/wrangler/src/__tests__/kv/namespace.test.ts
@@ -72,7 +72,7 @@ describe("kv", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
@@ -111,7 +111,7 @@ describe("kv", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
@@ -656,7 +656,7 @@ describe("kv", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS

--- a/packages/wrangler/src/__tests__/mtls-certificates.test.ts
+++ b/packages/wrangler/src/__tests__/mtls-certificates.test.ts
@@ -420,7 +420,7 @@ describe("wrangler", () => {
 						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 						  -h, --help            Show help  [boolean]
-						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 						  -v, --version         Show version number  [boolean]"
 					`);
 				});

--- a/packages/wrangler/src/__tests__/pages/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deploy.test.ts
@@ -87,7 +87,7 @@ describe("pages deploy", () => {
 			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]
 
 			OPTIONS

--- a/packages/wrangler/src/__tests__/pages/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages.test.ts
@@ -38,7 +38,7 @@ describe("pages", () => {
 			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});
@@ -62,7 +62,7 @@ describe("pages", () => {
 			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
@@ -112,7 +112,7 @@ describe("pages", () => {
 			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});
@@ -140,7 +140,7 @@ describe("pages", () => {
 			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});
@@ -163,7 +163,7 @@ describe("pages", () => {
 			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
@@ -199,7 +199,7 @@ describe("pages", () => {
 			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});
@@ -222,7 +222,7 @@ describe("pages", () => {
 			      --cwd             Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});

--- a/packages/wrangler/src/__tests__/provision.test.ts
+++ b/packages/wrangler/src/__tests__/provision.test.ts
@@ -447,45 +447,45 @@ describe("resource provisioning", () => {
 			await runWrangler("deploy --x-auto-create=false");
 
 			expect(std.out).toMatchInlineSnapshot(`
-			"
-			 ⛅️ wrangler x.x.x
-			──────────────────
-			Total Upload: xx KiB / gzip: xx KiB
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				Total Upload: xx KiB / gzip: xx KiB
 
-			Experimental: The following bindings need to be provisioned:
-			Binding        Resource
-			env.KV         KV Namespace
-			env.D1         D1 Database
-			env.R2         R2 Bucket
+				Experimental: The following bindings need to be provisioned:
+				Binding        Resource
+				env.KV         KV Namespace
+				env.D1         D1 Database
+				env.R2         R2 Bucket
 
 
-			Provisioning KV (KV Namespace)...
-			🌀 Creating new KV Namespace "new-kv"...
-			✨ KV provisioned 🎉
+				Provisioning KV (KV Namespace)...
+				🌀 Creating new KV Namespace "new-kv"...
+				✨ KV provisioned 🎉
 
-			Provisioning D1 (D1 Database)...
-			🌀 Creating new D1 Database "new-d1"...
-			✨ D1 provisioned 🎉
+				Provisioning D1 (D1 Database)...
+				🌀 Creating new D1 Database "new-d1"...
+				✨ D1 provisioned 🎉
 
-			Provisioning R2 (R2 Bucket)...
-			🌀 Creating new R2 Bucket "new-r2"...
-			✨ R2 provisioned 🎉
+				Provisioning R2 (R2 Bucket)...
+				🌀 Creating new R2 Bucket "new-r2"...
+				✨ R2 provisioned 🎉
 
-			Your Worker was deployed with provisioned resources. We've written the IDs of these resources to your config file, which you can choose to save or discard. Either way future deploys will continue to work.
-			🎉 All resources provisioned, continuing with deployment...
+				Your Worker was deployed with provisioned resources. We've written the IDs of these resources to your config file, which you can choose to save or discard. Either way future deploys will continue to work.
+				🎉 All resources provisioned, continuing with deployment...
 
-			Worker Startup Time: 100 ms
-			Your Worker has access to the following bindings:
-			Binding                 Resource
-			env.KV (new-kv-id)      KV Namespace
-			env.D1 (new-d1-id)      D1 Database
-			env.R2 (new-r2)         R2 Bucket
+				Worker Startup Time: 100 ms
+				Your Worker has access to the following bindings:
+				Binding                 Resource
+				env.KV (new-kv-id)      KV Namespace
+				env.D1 (new-d1-id)      D1 Database
+				env.R2 (new-r2)         R2 Bucket
 
-			Uploaded test-name (TIMINGS)
-			Deployed test-name triggers (TIMINGS)
-			  https://test-name.test-sub-domain.workers.dev
-			Current Version ID: Galaxy-Class"
-		`);
+				Uploaded test-name (TIMINGS)
+				Deployed test-name triggers (TIMINGS)
+				  https://test-name.test-sub-domain.workers.dev
+				Current Version ID: Galaxy-Class"
+			`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 

--- a/packages/wrangler/src/__tests__/queues/queues-subscription.test.ts
+++ b/packages/wrangler/src/__tests__/queues/queues-subscription.test.ts
@@ -79,7 +79,7 @@ describe("queues subscription", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]
 
 				OPTIONS
@@ -258,7 +258,7 @@ describe("queues subscription", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]
 
 				OPTIONS
@@ -435,7 +435,7 @@ describe("queues subscription", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]
 
 				OPTIONS
@@ -556,7 +556,7 @@ describe("queues subscription", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]
 
 				OPTIONS

--- a/packages/wrangler/src/__tests__/queues/queues.test.ts
+++ b/packages/wrangler/src/__tests__/queues/queues.test.ts
@@ -51,7 +51,7 @@ describe("wrangler", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});
@@ -100,7 +100,7 @@ describe("wrangler", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
@@ -250,7 +250,7 @@ describe("wrangler", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
@@ -492,7 +492,7 @@ describe("wrangler", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
@@ -661,7 +661,7 @@ describe("wrangler", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]"
 				`);
 			});
@@ -736,7 +736,7 @@ describe("wrangler", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]"
 				`);
 			});
@@ -787,7 +787,7 @@ describe("wrangler", () => {
 						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 						  -h, --help            Show help  [boolean]
-						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 						  -v, --version         Show version number  [boolean]
 
 						OPTIONS
@@ -839,12 +839,12 @@ describe("wrangler", () => {
 					expect(postRequest.count).toEqual(1);
 
 					expect(std.out).toMatchInlineSnapshot(`
-					"
-					 ⛅️ wrangler x.x.x
-					──────────────────
-					Adding consumer to queue testQueue.
-					Added consumer to queue testQueue."
-				`);
+						"
+						 ⛅️ wrangler x.x.x
+						──────────────────
+						Adding consumer to queue testQueue.
+						Added consumer to queue testQueue."
+					`);
 				});
 
 				it("should add a consumer using custom values", async ({ expect }) => {
@@ -1152,7 +1152,7 @@ describe("wrangler", () => {
 						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 						  -h, --help            Show help  [boolean]
-						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 						  -v, --version         Show version number  [boolean]"
 					`);
 				});
@@ -1215,12 +1215,12 @@ describe("wrangler", () => {
 						expect(queueNameResolveRequest.count).toEqual(1);
 						expect(deleteRequest.count).toEqual(1);
 						expect(std.out).toMatchInlineSnapshot(`
-						"
-						 ⛅️ wrangler x.x.x
-						──────────────────
-						Removing consumer from queue testQueue.
-						Removed consumer from queue testQueue."
-					`);
+							"
+							 ⛅️ wrangler x.x.x
+							──────────────────
+							Removing consumer from queue testQueue.
+							Removed consumer from queue testQueue."
+						`);
 					});
 
 					it("should show error when deleting a non-existing consumer", async ({
@@ -1299,12 +1299,12 @@ describe("wrangler", () => {
 						expect(queueNameResolveRequest.count).toEqual(1);
 						expect(deleteRequest.count).toEqual(1);
 						expect(std.out).toMatchInlineSnapshot(`
-						"
-						 ⛅️ wrangler x.x.x
-						──────────────────
-						Removing consumer from queue testQueue.
-						Removed consumer from queue testQueue."
-					`);
+							"
+							 ⛅️ wrangler x.x.x
+							──────────────────
+							Removing consumer from queue testQueue.
+							Removed consumer from queue testQueue."
+						`);
 					});
 
 					it("should show error when deleting a non-matching environment", async ({
@@ -1584,7 +1584,7 @@ describe("wrangler", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]"
 				`);
 			});
@@ -1634,7 +1634,7 @@ describe("wrangler", () => {
 						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 						  -h, --help            Show help  [boolean]
-						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 						  -v, --version         Show version number  [boolean]
 
 						OPTIONS
@@ -1681,12 +1681,12 @@ describe("wrangler", () => {
 					expect(queueNameResolveRequest.count).toEqual(1);
 					expect(postRequest.count).toEqual(1);
 					expect(std.out).toMatchInlineSnapshot(`
-					"
-					 ⛅️ wrangler x.x.x
-					──────────────────
-					Adding consumer to queue testQueue.
-					Added consumer to queue testQueue."
-				`);
+						"
+						 ⛅️ wrangler x.x.x
+						──────────────────
+						Adding consumer to queue testQueue.
+						Added consumer to queue testQueue."
+					`);
 				});
 
 				it("should add a consumer using custom values", async ({ expect }) => {
@@ -1785,7 +1785,7 @@ describe("wrangler", () => {
 						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 						  -h, --help            Show help  [boolean]
-						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 						  -v, --version         Show version number  [boolean]"
 					`);
 				});
@@ -1875,7 +1875,7 @@ describe("wrangler", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
@@ -1971,7 +1971,7 @@ describe("wrangler", () => {
 					├─┼─┼─┼─┼─┼─┤
 					│ 1002 │ my-dlq │ 5 │ 2 │ 10000 │ 15 │
 					└─┴─┴─┴─┴─┴─┘"
-			`);
+				`);
 			});
 
 			it("should show empty message when queue has no consumers", async ({
@@ -2106,7 +2106,7 @@ describe("wrangler", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
@@ -2271,7 +2271,7 @@ describe("wrangler", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
@@ -2302,7 +2302,7 @@ describe("wrangler", () => {
 					├─┼─┼─┼─┼─┼─┤
 					│ 1002 │ my-dlq │ 5 │ 2 │ 10000 │ 15 │
 					└─┴─┴─┴─┴─┴─┘"
-			`);
+				`);
 			});
 
 			it("should show empty message when queue has no http consumers", async ({
@@ -2456,7 +2456,7 @@ describe("wrangler", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]"
 				`);
 			});
@@ -2636,7 +2636,7 @@ describe("wrangler", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});
@@ -2753,7 +2753,7 @@ describe("wrangler", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});
@@ -2862,7 +2862,7 @@ describe("wrangler", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]
 
 				OPTIONS

--- a/packages/wrangler/src/__tests__/r2/bucket.test.ts
+++ b/packages/wrangler/src/__tests__/r2/bucket.test.ts
@@ -127,7 +127,7 @@ describe("r2", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});
@@ -171,7 +171,7 @@ describe("r2", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});
@@ -351,7 +351,7 @@ describe("r2", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
@@ -390,7 +390,7 @@ describe("r2", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
@@ -526,7 +526,7 @@ describe("r2", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]"
 				`);
 				expect(std.err).toMatchInlineSnapshot(`
@@ -558,7 +558,7 @@ describe("r2", () => {
 						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 						  -h, --help            Show help  [boolean]
-						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 						  -v, --version         Show version number  [boolean]
 
 						OPTIONS
@@ -624,7 +624,7 @@ describe("r2", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
@@ -690,7 +690,7 @@ describe("r2", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]
 
 					OPTIONS
@@ -763,7 +763,7 @@ describe("r2", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]"
 				`);
 			});
@@ -867,7 +867,7 @@ describe("r2", () => {
 						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 						  -h, --help            Show help  [boolean]
-						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 						  -v, --version         Show version number  [boolean]
 
 						OPTIONS
@@ -1057,7 +1057,7 @@ describe("r2", () => {
 						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 						  -h, --help            Show help  [boolean]
-						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 						  -v, --version         Show version number  [boolean]
 
 						OPTIONS
@@ -1116,7 +1116,7 @@ describe("r2", () => {
 						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 						  -h, --help            Show help  [boolean]
-						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 						  -v, --version         Show version number  [boolean]
 
 						OPTIONS
@@ -1192,7 +1192,7 @@ describe("r2", () => {
 					  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 					      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 					  -h, --help            Show help  [boolean]
-					      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+					      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 					  -v, --version         Show version number  [boolean]"
 				`);
 			});
@@ -1255,7 +1255,7 @@ describe("r2", () => {
 						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 						  -h, --help            Show help  [boolean]
-						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 						  -v, --version         Show version number  [boolean]"
 					`);
 					expect(std.err).toMatchInlineSnapshot(`
@@ -1289,7 +1289,7 @@ describe("r2", () => {
 						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 						  -h, --help            Show help  [boolean]
-						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 						  -v, --version         Show version number  [boolean]"
 					`);
 					expect(std.err).toMatchInlineSnapshot(`
@@ -1388,7 +1388,7 @@ describe("r2", () => {
 						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 						  -h, --help            Show help  [boolean]
-						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 						  -v, --version         Show version number  [boolean]"
 					`);
 					expect(std.err).toMatchInlineSnapshot(`
@@ -1499,7 +1499,7 @@ describe("r2", () => {
 						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 						  -h, --help            Show help  [boolean]
-						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 						  -v, --version         Show version number  [boolean]"
 					`);
 				});
@@ -1578,7 +1578,7 @@ describe("r2", () => {
 							  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 							      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 							  -h, --help            Show help  [boolean]
-							      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+							      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 							  -v, --version         Show version number  [boolean]
 
 							OPTIONS
@@ -1715,7 +1715,7 @@ describe("r2", () => {
 							  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 							      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 							  -h, --help            Show help  [boolean]
-							      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+							      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 							  -v, --version         Show version number  [boolean]"
 						`);
 						expect(std.err).toMatchInlineSnapshot(`
@@ -1862,7 +1862,7 @@ describe("r2", () => {
 						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 						  -h, --help            Show help  [boolean]
-						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 						  -v, --version         Show version number  [boolean]"
 					`);
 				});
@@ -1993,7 +1993,7 @@ describe("r2", () => {
 							  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 							      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 							  -h, --help            Show help  [boolean]
-							      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+							      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 							  -v, --version         Show version number  [boolean]
 
 							OPTIONS
@@ -2113,7 +2113,7 @@ describe("r2", () => {
 							  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 							      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 							  -h, --help            Show help  [boolean]
-							      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+							      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 							  -v, --version         Show version number  [boolean]
 
 							OPTIONS
@@ -2417,7 +2417,7 @@ describe("r2", () => {
 						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 						  -h, --help            Show help  [boolean]
-						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 						  -v, --version         Show version number  [boolean]
 
 						OPTIONS
@@ -2792,7 +2792,7 @@ describe("r2", () => {
 						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 						  -h, --help            Show help  [boolean]
-						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 						  -v, --version         Show version number  [boolean]
 
 						OPTIONS
@@ -2959,7 +2959,7 @@ describe("r2", () => {
 						  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 						      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 						  -h, --help            Show help  [boolean]
-						      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+						      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 						  -v, --version         Show version number  [boolean]
 
 						OPTIONS

--- a/packages/wrangler/src/__tests__/r2/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/r2/bulk.test.ts
@@ -34,7 +34,7 @@ describe("r2", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});

--- a/packages/wrangler/src/__tests__/r2/help.test.ts
+++ b/packages/wrangler/src/__tests__/r2/help.test.ts
@@ -31,7 +31,7 @@ describe("r2", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});
@@ -65,7 +65,7 @@ describe("r2", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});

--- a/packages/wrangler/src/__tests__/r2/local-uploads.test.ts
+++ b/packages/wrangler/src/__tests__/r2/local-uploads.test.ts
@@ -38,7 +38,7 @@ describe("r2 bucket local-uploads", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});

--- a/packages/wrangler/src/__tests__/r2/object.test.ts
+++ b/packages/wrangler/src/__tests__/r2/object.test.ts
@@ -41,7 +41,7 @@ describe("r2", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});

--- a/packages/wrangler/src/__tests__/register-yargs-command-skills.test.ts
+++ b/packages/wrangler/src/__tests__/register-yargs-command-skills.test.ts
@@ -1,6 +1,6 @@
 import { runInTempDir, seed } from "@cloudflare/workers-utils/test-helpers";
 import { beforeEach, describe, test, vi } from "vitest";
-import { maybeInstallCloudflareSkillsGlobally } from "../agents-skills-install";
+import { runSkillsInstallFlow } from "../agents-skills-install";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { runWrangler } from "./helpers/run-wrangler";
 
@@ -22,45 +22,104 @@ describe("register-yargs-command skills integration", () => {
 	mockConsoleMethods();
 
 	beforeEach(async () => {
-		// Seed a wrangler config so `wrangler setup` skips autoconfig and
-		// returns quickly — we only care about the skills install call.
 		await seed({
 			"wrangler.jsonc": JSON.stringify({ name: "test-worker" }),
 		});
 	});
 
-	test("calls maybeInstallCloudflareSkillsGlobally with false by default", async ({
+	test("does not call runSkillsInstallFlow for commands without suggestSkillsAfterHandler", async ({
+		expect,
+	}) => {
+		// `wrangler complete` intentionally does not suggest skills because
+		// its stdout is captured by shell eval.
+		await runWrangler("complete zsh");
+
+		expect(runSkillsInstallFlow).not.toHaveBeenCalled();
+	});
+
+	test("calls runSkillsInstallFlow with force: true and command when --install-skills is passed", async ({
+		expect,
+	}) => {
+		// Use `complete` to isolate the --install-skills call from
+		// suggestSkillsAfterHandler (which complete does not have).
+		await runWrangler("complete zsh --install-skills");
+
+		expect(runSkillsInstallFlow).toHaveBeenCalledWith({
+			force: true,
+			command: "complete",
+		});
+	});
+
+	test("calls runSkillsInstallFlow after commands with suggestSkillsAfterHandler: true", async ({
 		expect,
 	}) => {
 		await runWrangler("setup");
 
-		expect(maybeInstallCloudflareSkillsGlobally).toHaveBeenCalledWith(false);
+		expect(runSkillsInstallFlow).toHaveBeenCalledWith({
+			force: false,
+			command: "setup",
+			promptMessage: expect.any(Function),
+		});
 	});
 
-	test("calls maybeInstallCloudflareSkillsGlobally with true when --install-skills is passed", async ({
+	test("calls runSkillsInstallFlow after `wrangler whoami` (non-JSON)", async ({
 		expect,
 	}) => {
-		await runWrangler("setup --install-skills");
+		// whoami in non-JSON mode completes successfully even without auth
+		// (it just prints "You are not authenticated") — the suggest-skills
+		// hook should still fire afterwards.
+		await runWrangler("whoami");
 
-		expect(maybeInstallCloudflareSkillsGlobally).toHaveBeenCalledWith(true);
+		expect(runSkillsInstallFlow).toHaveBeenCalledWith({
+			force: false,
+			command: "whoami",
+			promptMessage: expect.any(Function),
+		});
 	});
 
-	test("does not call maybeInstallCloudflareSkillsGlobally for `wrangler complete`", async ({
+	test("command in skills install event contains only the command name, not positional args or flags", async ({
 		expect,
 	}) => {
-		// `wrangler complete zsh` output is captured by `eval "$(wrangler complete zsh)"`.
-		// The interactive skills prompt must not appear in that output.
-		await runWrangler("complete zsh");
-
-		expect(maybeInstallCloudflareSkillsGlobally).not.toHaveBeenCalled();
-	});
-
-	test("still calls maybeInstallCloudflareSkillsGlobally when --install-skills is explicit on `wrangler complete`", async ({
-		expect,
-	}) => {
-		// Explicit --install-skills should be honored even for `complete`.
+		// `wrangler complete zsh --install-skills` has:
+		//   - positional arg: "zsh"
+		//   - flag: "--install-skills"
+		// The `command` passed to runSkillsInstallFlow should be just the
+		// static command name from the definition ("complete"), with no
+		// positional arg values or flags leaked into it.
 		await runWrangler("complete zsh --install-skills");
 
-		expect(maybeInstallCloudflareSkillsGlobally).toHaveBeenCalledWith(true);
+		const call = vi.mocked(runSkillsInstallFlow).mock.calls[0][0];
+		expect(call.command).toBe("complete");
+		expect(call.command).not.toContain("zsh");
+		expect(call.command).not.toContain("install-skills");
+	});
+
+	test("does not call runSkillsInstallFlow after `wrangler whoami --json`", async ({
+		expect,
+	}) => {
+		// whoami --json without auth throws (non-zero exit), so we catch it.
+		// The suggestSkillsAfterHandler function returns false for --json,
+		// but the handler also throws, so the hook wouldn't run either way.
+		await expect(runWrangler("whoami --json")).rejects.toThrow();
+
+		expect(runSkillsInstallFlow).not.toHaveBeenCalled();
+	});
+
+	test("does not fail the command when runSkillsInstallFlow throws", async ({
+		expect,
+	}) => {
+		// If the post-handler skills suggestion fails (e.g. EACCES writing
+		// the metadata file, or an I/O error from the confirm prompt), the
+		// command itself should still succeed — the error is swallowed and
+		// logged at debug level.
+		vi.mocked(runSkillsInstallFlow).mockRejectedValueOnce(
+			new Error("EACCES: permission denied")
+		);
+
+		// `setup` has suggestSkillsAfterHandler: true, so it triggers the flow.
+		// This should resolve successfully despite the skills flow throwing.
+		await runWrangler("setup");
+
+		expect(runSkillsInstallFlow).toHaveBeenCalled();
 	});
 });

--- a/packages/wrangler/src/__tests__/secrets-store.test.ts
+++ b/packages/wrangler/src/__tests__/secrets-store.test.ts
@@ -42,7 +42,7 @@ describe("secrets-store help", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});
@@ -73,7 +73,7 @@ describe("secrets-store help", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});

--- a/packages/wrangler/src/__tests__/setup.test.ts
+++ b/packages/wrangler/src/__tests__/setup.test.ts
@@ -42,7 +42,7 @@ describe("wrangler setup", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]
 
 			OPTIONS

--- a/packages/wrangler/src/__tests__/tunnel/tunnel.test.ts
+++ b/packages/wrangler/src/__tests__/tunnel/tunnel.test.ts
@@ -85,7 +85,7 @@ describe("tunnel help", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});

--- a/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
+++ b/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
@@ -46,7 +46,7 @@ describe("vectorize help", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});
@@ -91,7 +91,7 @@ describe("vectorize help", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});
@@ -123,7 +123,7 @@ describe("vectorize help", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
@@ -159,7 +159,7 @@ describe("vectorize help", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]
 
 			OPTIONS
@@ -1090,7 +1090,7 @@ describe("vectorize commands", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]
 
 			OPTIONS

--- a/packages/wrangler/src/__tests__/versions/versions.help.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.help.test.ts
@@ -29,7 +29,7 @@ describe("versions --help", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});
@@ -62,7 +62,7 @@ describe("versions subhelp", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});

--- a/packages/wrangler/src/__tests__/vitest.setup.ts
+++ b/packages/wrangler/src/__tests__/vitest.setup.ts
@@ -250,10 +250,7 @@ vi.mock("../metrics/metrics-config", async (importOriginal) => {
 vi.mock("../agents-skills-install", async (importOriginal) => {
 	const realModule =
 		await importOriginal<typeof import("../agents-skills-install")>();
-	vi.spyOn(
-		realModule,
-		"maybeInstallCloudflareSkillsGlobally"
-	).mockResolvedValue(undefined);
+	vi.spyOn(realModule, "runSkillsInstallFlow").mockResolvedValue(undefined);
 	vi.spyOn(realModule, "telemetryCurrentAgentSkillsInstalled").mockReturnValue(
 		Promise.resolve(null)
 	);

--- a/packages/wrangler/src/__tests__/vpc.test.ts
+++ b/packages/wrangler/src/__tests__/vpc.test.ts
@@ -45,7 +45,7 @@ describe("vpc help", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});
@@ -75,7 +75,7 @@ describe("vpc help", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]"
 		`);
 	});

--- a/packages/wrangler/src/__tests__/worker-namespace.test.ts
+++ b/packages/wrangler/src/__tests__/worker-namespace.test.ts
@@ -54,7 +54,7 @@ describe("dispatch-namespace", () => {
 			  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 			      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 			  -h, --help            Show help  [boolean]
-			      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+			      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 			  -v, --version         Show version number  [boolean]",
 			  "warn": "",
 			}
@@ -109,7 +109,7 @@ describe("dispatch-namespace", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});
@@ -162,7 +162,7 @@ describe("dispatch-namespace", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});
@@ -224,7 +224,7 @@ describe("dispatch-namespace", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});
@@ -337,7 +337,7 @@ describe("dispatch-namespace", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});

--- a/packages/wrangler/src/__tests__/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/workflows.test.ts
@@ -165,7 +165,7 @@ describe("wrangler workflows", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`
 			);
@@ -201,7 +201,7 @@ describe("wrangler workflows", () => {
 				  -e, --env             Environment to use for operations, and for selecting .env and .dev.vars files  [string]
 				      --env-file        Path to an .env file to load - can be specified multiple times - values from earlier files are overridden by values in later files  [array]
 				  -h, --help            Show help  [boolean]
-				      --install-skills  Install Cloudflare agents skills, if not already present, without asking the user for confirmation  [boolean] [default: false]
+				      --install-skills  Install Cloudflare skills for detected AI coding agents before running the command  [boolean] [default: false]
 				  -v, --version         Show version number  [boolean]"
 			`);
 		});

--- a/packages/wrangler/src/agents-skills-install.ts
+++ b/packages/wrangler/src/agents-skills-install.ts
@@ -15,20 +15,53 @@ import { logger } from "./logger";
 import { sendMetricsEvent } from "./metrics";
 
 /**
- * Detects AI coding agents installed on the user's machine and, if
- * appropriate, offers to install Cloudflare skill files into their global
- * skills directories.
+ * Options for {@link runSkillsInstallFlow}.
  *
- * Skills are installed via the rosie-skills JS API, which handles
- * downloading from the `cloudflare/skills` GitHub repository, agent
- * detection, and file placement.
- *
- * @param force - When `true` the interactive prompt is skipped and skills are
- *   installed unconditionally (used by `--install-skills`).
+ * When `force` is `true`, the interactive prompt is skipped entirely so no
+ * `promptMessage` is needed. When `force` is `false`, a `promptMessage`
+ * function must be provided to generate the confirmation prompt shown to the user.
  */
-export async function maybeInstallCloudflareSkillsGlobally(
-	force: boolean
+type SkillsInstallFlowOptions =
+	| {
+			/** Skip the interactive prompt and install unconditionally. Metadata and CI checks are also bypassed. */
+			force: true;
+			/**
+			 * The wrangler command that triggered the skills install flow
+			 * (e.g. `"deploy"`, `"dev"`). Included in telemetry events so
+			 * we can correlate skills installs with the commands that prompted them.
+			 */
+			command?: string;
+	  }
+	| {
+			/** Show the interactive prompt before installing. */
+			force: false;
+			/**
+			 * The wrangler command that triggered the skills install flow
+			 * (e.g. `"deploy"`, `"dev"`). Included in telemetry events so
+			 * we can correlate skills installs with the commands that prompted them.
+			 */
+			command?: string;
+			/**
+			 * Returns the confirmation prompt message shown to the user.
+			 *
+			 * @param agentNames - Display names of the detected agents.
+			 * @returns The prompt string passed to {@link confirm}.
+			 */
+			promptMessage: (agentNames: string[]) => string;
+	  };
+
+/**
+ * Shared implementation for skills installation flows. Handles guard checks
+ * (metadata, CI, agent detection, interactivity), prompts the user with a
+ * caller-provided message, and performs the installation via rosie.
+ *
+ * @param options - Controls whether to force-install and what prompt to show.
+ */
+export async function runSkillsInstallFlow(
+	options: SkillsInstallFlowOptions
 ): Promise<void> {
+	const { force, command } = options;
+
 	const sendResultMetricsEvent = (
 		result:
 			| { skippedBecause: string; errorMessage?: string }
@@ -42,6 +75,7 @@ export async function maybeInstallCloudflareSkillsGlobally(
 				{
 					reason: result.skippedBecause,
 					...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
+					...(command ? { command } : {}),
 				},
 				{}
 			);
@@ -50,6 +84,7 @@ export async function maybeInstallCloudflareSkillsGlobally(
 				"skills_install_completed",
 				{
 					agents: result.targetedAgents,
+					...(command ? { command } : {}),
 				},
 				{}
 			);
@@ -95,12 +130,28 @@ export async function maybeInstallCloudflareSkillsGlobally(
 		return;
 	}
 
-	const accepted =
-		force ||
-		(await confirm(
-			`Wrangler detected the following AI coding agents: ${detectedAgents.map(({ name }) => name).join(", ")}. Would you like to install Cloudflare skills for them?`,
-			{ defaultValue: true, fallbackValue: false }
-		));
+	let accepted: boolean;
+	if (force) {
+		accepted = true;
+	} else {
+		// Persist an "unanswered" marker *before* showing the prompt so that if
+		// the user interrupts the process (CTRL+C, terminal closed, etc.) the
+		// metadata file already exists and the prompt won't reappear next time.
+		writeSkillsInstallMetadataFile({
+			version: 1,
+			accepted: "unanswered",
+			date: new Date().toISOString(),
+			detectedAgents,
+		});
+
+		logger.log();
+
+		const agentDisplayNames = detectedAgents.map(({ name }) => name);
+		accepted = await confirm(options.promptMessage(agentDisplayNames), {
+			defaultValue: true,
+			fallbackValue: false,
+		});
+	}
 
 	if (!accepted) {
 		writeSkillsInstallMetadataFile({
@@ -119,6 +170,10 @@ export async function maybeInstallCloudflareSkillsGlobally(
 			global: true,
 			agent: agentNames,
 			lockfile: false,
+			// rosie shows a bunch of extra logs regarding the installation
+			// we do not want to show them as standard output so we just log
+			// them at the debug level
+			onLog: ({ message }) => logger.debug(message),
 		});
 
 		const failedSet = new Set(failedAgents);
@@ -128,11 +183,12 @@ export async function maybeInstallCloudflareSkillsGlobally(
 
 		if (succeededAgents.length > 0) {
 			logger.log(
-				`Successfully installed Cloudflare skills for: ${succeededAgents.map(({ name }) => name).join(", ")}.`
+				`\n🚀 Successfully installed Cloudflare skills for: ${succeededAgents.map(({ name }) => name).join(", ")}.\n`
 			);
 		}
 
 		if (failedAgents.length > 0) {
+			logger.log();
 			logger.warn(
 				`Skills installation failed for agents: ${failedAgents.join(", ")}.`
 			);
@@ -200,8 +256,17 @@ type AgentInfo = {
 interface SkillsInstallMetadata {
 	/** Schema version for forward-compatibility. Currently always `1`. */
 	version: 1;
-	/** Whether the user accepted the prompt to install skills. */
-	accepted: boolean;
+	/**
+	 * Whether the user accepted the prompt to install skills.
+	 *
+	 * - `true`  — the user accepted and installation was attempted.
+	 * - `false` — the user explicitly declined.
+	 * - `"unanswered"` — the metadata file was written before the prompt was
+	 *   shown but the user never answered (e.g. CTRL+C, terminal closed).
+	 *   Treated the same as a decline for the purpose of suppressing future
+	 *   prompts.
+	 */
+	accepted: boolean | "unanswered";
 	/** ISO date string of when the user was prompted. */
 	date: string;
 	/** All agents detected on the user's machine. */
@@ -653,7 +718,7 @@ async function computeTelemetryCurrentAgentSkillsInstalled(): Promise<AgentSkill
 		// happens to match this alternative path (e.g. OpenCode reads
 		// ~/.agents/skills, which is Warp's rosie install target).
 		const metadata = readSkillsInstallMetadataFile();
-		if (metadata?.accepted) {
+		if (metadata?.accepted === true) {
 			const altAbsPath = path.resolve(matchedAlternativePath);
 			const wasInstalledForAnotherAgent = metadata.detectedAgents?.some(
 				(agent) => {
@@ -700,7 +765,7 @@ async function computeTelemetryCurrentAgentSkillsInstalled(): Promise<AgentSkill
 			));
 
 	if (
-		metadata.accepted &&
+		metadata.accepted === true &&
 		isInDetectedAgents === true &&
 		!installFailedForAgent
 	) {

--- a/packages/wrangler/src/agents-skills-install.ts
+++ b/packages/wrangler/src/agents-skills-install.ts
@@ -227,6 +227,24 @@ export async function runSkillsInstallFlow(
 	}
 }
 
+/**
+ * Builds the confirmation prompt shown to the user after a wrangler command
+ * completes, asking whether to install Cloudflare skills for detected AI
+ * coding agents.
+ *
+ * Used as the {@link SkillsInstallFlowOptions.promptMessage} callback when
+ * skills installation is suggested via `suggestSkillsAfterHandler`.
+ *
+ * @param agentNames - Display names of the detected AI coding agents
+ *   (e.g. `["Claude Code", "Cursor"]`).
+ * @returns The formatted confirmation prompt string passed to {@link confirm}.
+ */
+export function skillInstallPromptMessageAfterWranglerCommandHandler(
+	agentNames: string[]
+): string {
+	return `Before you go, Wrangler detected AI coding agents that may not be best configured to work with Cloudflare: ${agentNames.join(", ")}. Would you like Wrangler to automatically install Cloudflare skills for the best experience?`;
+}
+
 /** The GitHub repo spec for Cloudflare skills, used with rosie.install(). */
 const SKILLS_REPO = "cloudflare/skills";
 

--- a/packages/wrangler/src/build/index.ts
+++ b/packages/wrangler/src/build/index.ts
@@ -11,6 +11,7 @@ export const buildCommand = createCommand({
 	behaviour: {
 		printBanner: false,
 		provideConfig: false,
+		suggestSkillsAfterHandler: true,
 	},
 	async handler(buildArgs) {
 		const { wrangler } = createCLIParser([

--- a/packages/wrangler/src/check/commands.ts
+++ b/packages/wrangler/src/check/commands.ts
@@ -141,6 +141,9 @@ export const checkStartupCommand = createCommand({
 		owner: "Workers: Authoring and Testing",
 		status: "alpha",
 	},
+	behaviour: {
+		suggestSkillsAfterHandler: true,
+	},
 	handler: checkStartupHandler,
 });
 

--- a/packages/wrangler/src/complete.ts
+++ b/packages/wrangler/src/complete.ts
@@ -132,7 +132,6 @@ export const completionsCommand = createCommand({
 	behaviour: {
 		printBanner: false,
 		provideConfig: false,
-		skipSkillsPrompt: true,
 	},
 	positionalArgs: ["shell"],
 	args: {

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -8,7 +8,7 @@ import {
 	UserError,
 } from "@cloudflare/workers-utils";
 import chalk from "chalk";
-import { maybeInstallCloudflareSkillsGlobally } from "../agents-skills-install";
+import { runSkillsInstallFlow } from "../agents-skills-install";
 import {
 	fetchKVGetValue,
 	fetchResult,
@@ -146,8 +146,8 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 				await printWranglerBanner();
 			}
 
-			if (!def.behaviour?.skipSkillsPrompt || args.installSkills) {
-				await maybeInstallCloudflareSkillsGlobally(args.installSkills);
+			if (args.installSkills) {
+				await runSkillsInstallFlow({ force: true, command: sanitizedCommand });
 			}
 
 			if (!getWranglerHideBanner()) {
@@ -304,6 +304,28 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 						},
 						def.behaviour
 					);
+
+					const shouldSuggestSkills =
+						def.behaviour?.suggestSkillsAfterHandler ?? false;
+					const suggestSkillsEnabled =
+						shouldSuggestSkills === true ||
+						(typeof shouldSuggestSkills === "function" &&
+							shouldSuggestSkills(args) === true);
+
+					if (suggestSkillsEnabled) {
+						try {
+							await runSkillsInstallFlow({
+								force: false,
+								command: sanitizedCommand,
+								promptMessage: (agents) =>
+									`Before you go, Wrangler detected potential configurations for the following AI coding agents on your system likely without Cloudflare skills: ${agents.join(", ")}. Would you like Wrangler to automatically install the Cloudflare skills for you?`,
+							});
+						} catch (skillsErr) {
+							logger.debug(
+								`Skills suggestion failed: ${skillsErr instanceof Error ? skillsErr.message : skillsErr}`
+							);
+						}
+					}
 
 					return result;
 				} catch (err) {

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -8,7 +8,10 @@ import {
 	UserError,
 } from "@cloudflare/workers-utils";
 import chalk from "chalk";
-import { runSkillsInstallFlow } from "../agents-skills-install";
+import {
+	runSkillsInstallFlow,
+	skillInstallPromptMessageAfterWranglerCommandHandler,
+} from "../agents-skills-install";
 import {
 	fetchKVGetValue,
 	fetchResult,
@@ -317,8 +320,8 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 							await runSkillsInstallFlow({
 								force: false,
 								command: sanitizedCommand,
-								promptMessage: (agents) =>
-									`Before you go, Wrangler detected AI coding agents that may not be best configured to work with Cloudflare: ${agents.join(", ")}. Would you like Wrangler to automatically install Cloudflare skills for the best experience?`,
+								promptMessage:
+									skillInstallPromptMessageAfterWranglerCommandHandler,
 							});
 						} catch (skillsErr) {
 							logger.debug(

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -318,7 +318,7 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 								force: false,
 								command: sanitizedCommand,
 								promptMessage: (agents) =>
-									`Before you go, Wrangler detected potential configurations for the following AI coding agents on your system likely without Cloudflare skills: ${agents.join(", ")}. Would you like Wrangler to automatically install the Cloudflare skills for you?`,
+									`Before you go, Wrangler detected AI coding agents that may not be best configured to work with Cloudflare: ${agents.join(", ")}. Would you like Wrangler to automatically install Cloudflare skills for the best experience?`,
 							});
 						} catch (skillsErr) {
 							logger.debug(

--- a/packages/wrangler/src/core/types.ts
+++ b/packages/wrangler/src/core/types.ts
@@ -225,12 +225,19 @@ export type CommandDefinition<
 		sendMetrics?: boolean;
 
 		/**
-		 * Skip the AI coding agent skills installation prompt for this command.
-		 * Set to `true` for commands whose stdout is captured by the shell (e.g. `complete`),
-		 * where interactive prompts would corrupt the output.
+		 * After the command handler completes successfully, suggest installing
+		 * Cloudflare skills for detected AI coding agents that don't have them.
+		 *
+		 * When set to `true`, the suggestion always runs after the handler.
+		 * When set to a function, it receives the parsed args and should return
+		 * `true` to enable the suggestion — use this to skip the prompt in modes
+		 * where interactive output is inappropriate (e.g. `--json`).
+		 *
 		 * @default false
 		 */
-		skipSkillsPrompt?: boolean;
+		suggestSkillsAfterHandler?:
+			| boolean
+			| ((args: HandlerArgs<NamedArgDefs>) => boolean);
 	};
 
 	/**

--- a/packages/wrangler/src/delete.ts
+++ b/packages/wrangler/src/delete.ts
@@ -65,6 +65,9 @@ export const deleteCommand = createCommand({
 		status: "stable",
 		category: "Compute & AI",
 	},
+	behaviour: {
+		suggestSkillsAfterHandler: true,
+	},
 	args: {
 		script: {
 			describe: "The path to an entry point for your worker",

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -106,6 +106,7 @@ export const deployCommand = createCommand({
 		}),
 		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
 		printMetricsBanner: true,
+		suggestSkillsAfterHandler: true,
 	},
 	validateArgs(args) {
 		validateDeployVersionsArgs(args, "deploy");

--- a/packages/wrangler/src/docs/index.ts
+++ b/packages/wrangler/src/docs/index.ts
@@ -25,6 +25,7 @@ export const docs = createCommand({
 	},
 	behaviour: {
 		printMetricsBanner: true,
+		suggestSkillsAfterHandler: true,
 	},
 	positionalArgs: ["search"],
 	async handler(args, { config }) {

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -549,7 +549,7 @@ export function createCLIParser(argv: string[]) {
 		},
 		"install-skills": {
 			describe:
-				"Install Cloudflare agents skills, if not already present, without asking the user for confirmation",
+				"Install Cloudflare skills for detected AI coding agents before running the command",
 			type: "boolean",
 			default: false,
 		},

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -56,6 +56,7 @@ export const init = createCommand({
 	},
 	behaviour: {
 		provideConfig: false,
+		suggestSkillsAfterHandler: true,
 	},
 	positionalArgs: ["name"],
 	async handler(args) {

--- a/packages/wrangler/src/metrics/commands.ts
+++ b/packages/wrangler/src/metrics/commands.ts
@@ -29,6 +29,7 @@ export const telemetryDisableCommand = createCommand({
 	},
 	behaviour: {
 		sendMetrics: false,
+		suggestSkillsAfterHandler: true,
 	},
 	async handler() {
 		updateMetricsPermission(false);
@@ -45,6 +46,9 @@ export const telemetryEnableCommand = createCommand({
 		owner: "Workers: Authoring and Testing",
 		status: "stable",
 	},
+	behaviour: {
+		suggestSkillsAfterHandler: true,
+	},
 	async handler() {
 		updateMetricsPermission(true);
 		logTelemetryStatus(true);
@@ -59,6 +63,9 @@ export const telemetryStatusCommand = createCommand({
 		description: "Check whether Wrangler telemetry collection is enabled",
 		owner: "Workers: Authoring and Testing",
 		status: "stable",
+	},
+	behaviour: {
+		suggestSkillsAfterHandler: true,
 	},
 	async handler(_, { config }) {
 		const savedConfig = readMetricsConfig();

--- a/packages/wrangler/src/preview/index.ts
+++ b/packages/wrangler/src/preview/index.ts
@@ -61,6 +61,7 @@ export const previewCommand = createCommand({
 	behaviour: {
 		useConfigRedirectIfAvailable: true,
 		printBanner: (args) => args.json !== true,
+		suggestSkillsAfterHandler: (args) => args.json !== true,
 	},
 	handler: handlePreviewCommand,
 });
@@ -92,6 +93,9 @@ export const previewDeleteCommand = createCommand({
 			requiresArg: true,
 		},
 	},
+	behaviour: {
+		suggestSkillsAfterHandler: true,
+	},
 	handler: handlePreviewDeleteCommand,
 });
 
@@ -116,6 +120,9 @@ export const previewSettingsUpdateCommand = createCommand({
 			default: false,
 			alias: "y",
 		},
+	},
+	behaviour: {
+		suggestSkillsAfterHandler: true,
 	},
 	handler: handlePreviewSettingsUpdateCommand,
 });
@@ -142,6 +149,7 @@ export const previewSettingsCommand = createCommand({
 	},
 	behaviour: {
 		printBanner: (args) => args.json !== true,
+		suggestSkillsAfterHandler: (args) => args.json !== true,
 	},
 	handler: handlePreviewSettingsCommand,
 });
@@ -176,6 +184,9 @@ export const previewSecretPutCommand = createCommand({
 			requiresArg: true,
 		},
 	},
+	behaviour: {
+		suggestSkillsAfterHandler: true,
+	},
 	handler: handlePreviewSecretPutCommand,
 });
 
@@ -206,6 +217,9 @@ export const previewSecretDeleteCommand = createCommand({
 			requiresArg: true,
 		},
 	},
+	behaviour: {
+		suggestSkillsAfterHandler: true,
+	},
 	handler: handlePreviewSecretDeleteCommand,
 });
 
@@ -231,6 +245,7 @@ export const previewSecretListCommand = createCommand({
 	},
 	behaviour: {
 		printBanner: (args) => args.json !== true,
+		suggestSkillsAfterHandler: (args) => args.json !== true,
 	},
 	handler: handlePreviewSecretListCommand,
 });
@@ -254,6 +269,9 @@ export const previewSecretBulkCommand = createCommand({
 			type: "string",
 			requiresArg: true,
 		},
+	},
+	behaviour: {
+		suggestSkillsAfterHandler: true,
 	},
 	handler: handlePreviewSecretBulkCommand,
 });

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -100,6 +100,7 @@ export const secretPutCommand = createCommand({
 	positionalArgs: ["key"],
 	behaviour: {
 		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
+		suggestSkillsAfterHandler: true,
 	},
 	args: {
 		key: {
@@ -230,6 +231,7 @@ export const secretDeleteCommand = createCommand({
 	positionalArgs: ["key"],
 	behaviour: {
 		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
+		suggestSkillsAfterHandler: true,
 	},
 	args: {
 		key: {
@@ -329,6 +331,7 @@ export const secretListCommand = createCommand({
 	},
 	behaviour: {
 		printBanner: (args) => args.format === "pretty",
+		suggestSkillsAfterHandler: (args) => args.format === "pretty",
 	},
 	async handler(args, { config }) {
 		if (config.pages_build_output_dir) {
@@ -431,6 +434,7 @@ export const secretBulkCommand = createCommand({
 	positionalArgs: ["file"],
 	behaviour: {
 		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
+		suggestSkillsAfterHandler: true,
 	},
 	args: {
 		file: {

--- a/packages/wrangler/src/setup.ts
+++ b/packages/wrangler/src/setup.ts
@@ -17,6 +17,9 @@ export const setupCommand = createCommand({
 		status: "stable",
 		category: "Compute & AI",
 	},
+	behaviour: {
+		suggestSkillsAfterHandler: true,
+	},
 	args: {
 		yes: {
 			describe: 'Answer "yes" to any prompts for configuring your project',

--- a/packages/wrangler/src/triggers/index.ts
+++ b/packages/wrangler/src/triggers/index.ts
@@ -60,6 +60,7 @@ export const triggersDeployCommand = createCommand({
 	},
 	behaviour: {
 		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
+		suggestSkillsAfterHandler: true,
 	},
 	async handler(args, { config }) {
 		metrics.sendMetricsEvent("deploy worker triggers", {

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -114,6 +114,7 @@ export const typesCommand = createCommand({
 	},
 	behaviour: {
 		provideConfig: false,
+		suggestSkillsAfterHandler: true,
 	},
 	positionalArgs: ["path"],
 	args: {

--- a/packages/wrangler/src/user/commands.ts
+++ b/packages/wrangler/src/user/commands.ts
@@ -30,6 +30,7 @@ export const loginCommand = createCommand({
 	},
 	behaviour: {
 		printConfigWarnings: false,
+		suggestSkillsAfterHandler: true,
 	},
 	args: {
 		"scopes-list": {
@@ -110,6 +111,7 @@ export const logoutCommand = createCommand({
 	behaviour: {
 		printConfigWarnings: false,
 		provideConfig: false,
+		suggestSkillsAfterHandler: true,
 	},
 	async handler() {
 		await logout();
@@ -137,6 +139,7 @@ export const whoamiCommand = createCommand({
 	behaviour: {
 		printBanner: (args) => !args.json,
 		printConfigWarnings: false,
+		suggestSkillsAfterHandler: (args) => !args.json,
 	},
 	args: {
 		account: {
@@ -177,6 +180,7 @@ export const authTokenCommand = createCommand({
 	behaviour: {
 		printBanner: (args) => !args.json,
 		printConfigWarnings: false,
+		suggestSkillsAfterHandler: (args) => !args.json,
 	},
 	args: {
 		json: {

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -42,6 +42,7 @@ export const versionsDeployCommand = createCommand({
 	behaviour: {
 		useConfigRedirectIfAvailable: true,
 		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
+		suggestSkillsAfterHandler: true,
 	},
 
 	args: {

--- a/packages/wrangler/src/versions/deployments/list.ts
+++ b/packages/wrangler/src/versions/deployments/list.ts
@@ -32,6 +32,7 @@ export const deploymentsListCommand = createCommand({
 	},
 	behaviour: {
 		printBanner: (args) => !args.json,
+		suggestSkillsAfterHandler: (args) => !args.json,
 	},
 	handler: async function versionsDeploymentsListHandler(args, { config }) {
 		metrics.sendMetricsEvent(

--- a/packages/wrangler/src/versions/deployments/status.ts
+++ b/packages/wrangler/src/versions/deployments/status.ts
@@ -32,6 +32,7 @@ export const deploymentsStatusCommand = createCommand({
 	},
 	behaviour: {
 		printBanner: (args) => !args.json,
+		suggestSkillsAfterHandler: (args) => !args.json,
 	},
 	handler: async function versionsDeploymentsStatusHandler(args, { config }) {
 		metrics.sendMetricsEvent("view latest versioned deployment", {

--- a/packages/wrangler/src/versions/deployments/view.ts
+++ b/packages/wrangler/src/versions/deployments/view.ts
@@ -8,6 +8,9 @@ export const deploymentsViewCommand = createCommand({
 		status: "stable",
 		hidden: true,
 	},
+	behaviour: {
+		suggestSkillsAfterHandler: true,
+	},
 	args: {
 		name: {
 			describe: "Name of the Worker",

--- a/packages/wrangler/src/versions/list.ts
+++ b/packages/wrangler/src/versions/list.ts
@@ -18,6 +18,7 @@ export const versionsListCommand = createCommand({
 	},
 	behaviour: {
 		printBanner: (args) => !args.json,
+		suggestSkillsAfterHandler: (args) => !args.json,
 	},
 	args: {
 		name: {

--- a/packages/wrangler/src/versions/rollback/index.ts
+++ b/packages/wrangler/src/versions/rollback/index.ts
@@ -43,6 +43,9 @@ export const versionsRollbackCommand = createCommand({
 		status: "stable",
 		category: "Compute & AI",
 	},
+	behaviour: {
+		suggestSkillsAfterHandler: true,
+	},
 	handler: async function handleRollback(args, { config }) {
 		const accountId = await requireAuth(config);
 		const workerName = args.name ?? config.name;

--- a/packages/wrangler/src/versions/secrets/bulk.ts
+++ b/packages/wrangler/src/versions/secrets/bulk.ts
@@ -18,6 +18,7 @@ export const versionsSecretBulkCommand = createCommand({
 	behaviour: {
 		printConfigWarnings: false,
 		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
+		suggestSkillsAfterHandler: true,
 	},
 	args: {
 		file: {

--- a/packages/wrangler/src/versions/secrets/delete.ts
+++ b/packages/wrangler/src/versions/secrets/delete.ts
@@ -18,6 +18,7 @@ export const versionsSecretDeleteCommand = createCommand({
 	behaviour: {
 		printConfigWarnings: false,
 		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
+		suggestSkillsAfterHandler: true,
 	},
 	args: {
 		key: {

--- a/packages/wrangler/src/versions/secrets/list.ts
+++ b/packages/wrangler/src/versions/secrets/list.ts
@@ -16,6 +16,7 @@ export const versionsSecretsListCommand = createCommand({
 	},
 	behaviour: {
 		printConfigWarnings: false,
+		suggestSkillsAfterHandler: true,
 	},
 	args: {
 		name: {

--- a/packages/wrangler/src/versions/secrets/put.ts
+++ b/packages/wrangler/src/versions/secrets/put.ts
@@ -19,6 +19,7 @@ export const versionsSecretPutCommand = createCommand({
 	behaviour: {
 		printConfigWarnings: false,
 		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
+		suggestSkillsAfterHandler: true,
 	},
 	args: {
 		key: {

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -43,6 +43,7 @@ export const versionsUploadCommand = createCommand({
 			AUTOCREATE_RESOURCES: args.experimentalAutoCreate,
 		}),
 		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
+		suggestSkillsAfterHandler: true,
 	},
 	validateArgs(args) {
 		validateDeployVersionsArgs(args, "versions upload");

--- a/packages/wrangler/src/versions/view.ts
+++ b/packages/wrangler/src/versions/view.ts
@@ -19,6 +19,7 @@ export const versionsViewCommand = createCommand({
 	},
 	behaviour: {
 		printBanner: (args) => !args.json,
+		suggestSkillsAfterHandler: (args) => !args.json,
 	},
 	args: {
 		"version-id": {


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/14116

Before wrangler on every command would trigger the skills installation flow when it checks for agents configurations and after an interactive prompt potentially installs them for the user (at most once).

This had many various edge cases and downsides, like:
 - disturbing/surprising users with this interactive prompt unrelated to their current task
 - interrupting the user's flow
 - not working well for parallel wrangler executions (where they could each hid the prompt of the other, effectively blocking them)
 
Now instead the question is presented after the successful execution of non-long lived commands (such as `wrangler login`), this doesn't insert the prompt upfront for every command so it should address all the problematic edge case scenarios we've seen.
 
Additionally this PR adds extra logic to save the skills metadata file **before** asking the prompt (and potentially overriding it after), this should ensure that user should not see this prompt more than once.

---

### Example of new flow:
```
$ npx https://pkg.pr.new/wrangler@14264 whoami 

 ⛅️ wrangler 4.100.0 (dario/install-skills-scoped)
──────────────────────────────────────────────────
Getting User settings...
👋 You are logged in with an OAuth Token, associated with the email dario@cloudflare.com.
┌──────────────┬──────────────────────────────────┐
│ Account Name │ Account ID                       │
├──────────────┼──────────────────────────────────┤
│ ...          │ ...                              │
└──────────────┴──────────────────────────────────┘
🔓 Token Permissions:
Scope (Access)
- ...

? Before you go, Wrangler detected potential configurations for the following AI coding agents on your system likely without Cloudflare skills: Claude Code, OpenCode, GitHub Copilot. Would you like Wrangler to automatically install the Cloudflare skills for you? › (Y/n)
```

---

To try the flow just run one of the Wrangler commands that trigger this using the prerelease, like for example:
```
$ npx https://pkg.pr.new/wrangler@14264 whoami 
```
(To trigger this make sure not to have a `agents-skills-install.jsonc` file in your global `.wrangler` directory)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: self explanatory feature / behavior

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->