### PR TITLE
[wrangler] Data platform CLI improvements

### DIFF
--- a/.changeset/data-platform-pipeline-stream-normalization.md
+++ b/.changeset/data-platform-pipeline-stream-normalization.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+"@cloudflare/workers-utils": patch
+---
+
+Normalize deprecated `pipeline` field to `stream` in pipeline bindings config
+
+When `wrangler.json` uses the deprecated `pipeline` field in a pipelines binding, the value is now copied to `stream` and `pipeline` is removed during config validation. This eliminates the need for fallback logic across the codebase and ensures all downstream consumers see a consistent config shape.

--- a/.changeset/data-platform-pipelines-fixes.md
+++ b/.changeset/data-platform-pipelines-fixes.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix `pipelines sinks list --json` outputting invalid JSON
+
+The `--json` flag on `wrangler pipelines sinks list` was using `logger.log()` instead of `logger.json()`, producing Node.js `util.inspect` output (unquoted keys, `[Object]` placeholders) rather than valid JSON. The output can now be reliably piped to `jq` or consumed by scripts.

--- a/.changeset/data-platform-pipelines-streams-binding.md
+++ b/.changeset/data-platform-pipelines-streams-binding.md
@@ -1,0 +1,9 @@
+---
+"wrangler": minor
+---
+
+Add auto-config binding prompt to `pipelines streams create` and `pipelines setup`
+
+After creating a stream, wrangler now shows the correct `wrangler.json` binding snippet and offers to add it to your config file automatically — matching the behavior of `kv namespace create`, `d1 create`, and other resource-creation commands. The `--binding`, `--update-config`, and `--use-remote` flags are also supported for non-interactive use.
+
+The binding snippet now uses the `stream` field instead of the deprecated `pipeline` field.

--- a/.changeset/data-platform-r2-sql-improvements.md
+++ b/.changeset/data-platform-r2-sql-improvements.md
@@ -1,0 +1,18 @@
+---
+"wrangler": minor
+---
+
+Add `--json`, `--csv`, and `--sql-file` flags to `wrangler r2 sql query`
+
+The R2 SQL query command now supports multiple output formats and file-based query input:
+
+- `--json`: Output results as a JSON array, suitable for piping to `jq` or other tools
+- `--csv`: Output results as RFC 4180-compliant CSV with header row
+- `--sql-file`: Read the SQL query from a `.sql` file instead of passing it as an argument
+
+The metrics line now includes the R2 request count alongside bytes scanned and files scanned. `EXPLAIN FORMAT JSON` queries are automatically pretty-printed.
+
+```
+wrangler r2 sql query <warehouse> "SELECT * FROM ns.table" --json
+wrangler r2 sql query <warehouse> --sql-file query.sql --csv
+```

--- a/packages/deploy-helpers/src/deploy/helpers/create-worker-upload-form.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/create-worker-upload-form.ts
@@ -517,22 +517,15 @@ export function createWorkerUploadForm(
 		});
 	});
 
-	pipelines.forEach(({ binding, stream: pipelineStream, pipeline }) => {
-		if (pipelineStream) {
-			metadataBindings.push({
-				name: binding,
-				type: "pipelines",
-				stream: pipelineStream,
-			});
-		} else if (pipeline) {
-			metadataBindings.push({
-				name: binding,
-				type: "pipelines",
-				pipeline,
-			});
-		} else {
-			throw new Error("Pipeline binding must specify a stream or pipeline");
+	pipelines.forEach(({ binding, stream: pipelineStream }) => {
+		if (!pipelineStream) {
+			throw new Error("Pipeline binding must specify a stream");
 		}
+		metadataBindings.push({
+			name: binding,
+			type: "pipelines",
+			stream: pipelineStream,
+		});
 	});
 
 	worker_loaders.forEach(({ binding }) => {

--- a/packages/deploy-helpers/src/deploy/helpers/print-bindings.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/print-bindings.ts
@@ -659,16 +659,14 @@ export function printBindings(
 
 	if (pipelines.length > 0) {
 		output.push(
-			...pipelines.map(
-				({ binding, stream: pipelineStream, pipeline, remote }) => ({
-					name: binding,
-					type: getBindingTypeFriendlyName("pipeline"),
-					value: pipelineStream || pipeline,
-					mode: getMode({
-						isSimulatedLocally: context.remoteBindingsDisabled || !remote,
-					}),
-				})
-			)
+			...pipelines.map(({ binding, stream: pipelineStream, remote }) => ({
+				name: binding,
+				type: getBindingTypeFriendlyName("pipeline"),
+				value: pipelineStream,
+				mode: getMode({
+					isSimulatedLocally: context.remoteBindingsDisabled || !remote,
+				}),
+			}))
 		);
 	}
 

--- a/packages/miniflare/src/plugins/pipelines/index.ts
+++ b/packages/miniflare/src/plugins/pipelines/index.ts
@@ -104,24 +104,24 @@ function bindingEntries(
 			Object.entries(namespaces) as [
 				string,
 				(
-			| string
-				| {
+					| string
+					| {
 							stream?: string;
 							/** @deprecated Use `stream` instead. */
 							pipeline?: string;
 							remoteProxyConnectionString?: RemoteProxyConnectionString;
 					  }
-			),
-		][]
-	).map(([name, opts]) => [
-		name,
-		typeof opts === "string"
-			? { id: opts }
-			: {
-					id: opts.stream ?? opts.pipeline ?? "",
-					remoteProxyConnectionString: opts.remoteProxyConnectionString,
-				},
-	]);
+				),
+			][]
+		).map(([name, opts]) => [
+			name,
+			typeof opts === "string"
+				? { id: opts }
+				: {
+						id: opts.stream ?? opts.pipeline ?? "",
+						remoteProxyConnectionString: opts.remoteProxyConnectionString,
+					},
+		]);
 	} else {
 		return [];
 	}

--- a/packages/miniflare/src/plugins/pipelines/index.ts
+++ b/packages/miniflare/src/plugins/pipelines/index.ts
@@ -107,7 +107,6 @@ function bindingEntries(
 					| string
 					| {
 							stream?: string;
-							pipeline?: string;
 							remoteProxyConnectionString?: RemoteProxyConnectionString;
 					  }
 				),
@@ -117,7 +116,7 @@ function bindingEntries(
 			typeof opts === "string"
 				? { id: opts }
 				: {
-						id: opts.stream ?? opts.pipeline ?? "",
+						id: opts.stream ?? "",
 						remoteProxyConnectionString: opts.remoteProxyConnectionString,
 					},
 		]);

--- a/packages/miniflare/src/plugins/pipelines/index.ts
+++ b/packages/miniflare/src/plugins/pipelines/index.ts
@@ -104,22 +104,24 @@ function bindingEntries(
 			Object.entries(namespaces) as [
 				string,
 				(
-					| string
-					| {
+			| string
+				| {
 							stream?: string;
+							/** @deprecated Use `stream` instead. */
+							pipeline?: string;
 							remoteProxyConnectionString?: RemoteProxyConnectionString;
 					  }
-				),
-			][]
-		).map(([name, opts]) => [
-			name,
-			typeof opts === "string"
-				? { id: opts }
-				: {
-						id: opts.stream ?? "",
-						remoteProxyConnectionString: opts.remoteProxyConnectionString,
-					},
-		]);
+			),
+		][]
+	).map(([name, opts]) => [
+		name,
+		typeof opts === "string"
+			? { id: opts }
+			: {
+					id: opts.stream ?? opts.pipeline ?? "",
+					remoteProxyConnectionString: opts.remoteProxyConnectionString,
+				},
+	]);
 	} else {
 		return [];
 	}

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -4960,6 +4960,8 @@ const validatePipelineBinding: ValidatorFn = (diagnostics, field, value) => {
 		diagnostics.warnings.push(
 			`The "pipeline" field in "${field}" bindings is deprecated. Use "stream" instead.`
 		);
+		v.stream = v.pipeline;
+		delete v.pipeline;
 	} else {
 		diagnostics.errors.push(
 			`"${field}" bindings must have a string "stream" field but got ${JSON.stringify(

--- a/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
+++ b/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
@@ -439,7 +439,6 @@ describe("dev with remote bindings", { sequential: true, retry: 2 }, () => {
 			},
 			expectedProxyWorkerBindings: {
 				PIPELINE: {
-					pipeline: "preserve-e2e-pipelines",
 					stream: "preserve-e2e-pipelines",
 					remote: true,
 					type: "pipeline",

--- a/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
+++ b/packages/wrangler/src/__tests__/dev/remote-bindings.test.ts
@@ -440,6 +440,7 @@ describe("dev with remote bindings", { sequential: true, retry: 2 }, () => {
 			expectedProxyWorkerBindings: {
 				PIPELINE: {
 					pipeline: "preserve-e2e-pipelines",
+					stream: "preserve-e2e-pipelines",
 					remote: true,
 					type: "pipeline",
 				},
@@ -448,7 +449,7 @@ describe("dev with remote bindings", { sequential: true, retry: 2 }, () => {
 				expect.objectContaining({
 					pipelines: {
 						PIPELINE: {
-							pipeline: "preserve-e2e-pipelines",
+							stream: "preserve-e2e-pipelines",
 							remoteProxyConnectionString,
 						},
 					},

--- a/packages/wrangler/src/__tests__/pipelines-setup.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines-setup.test.ts
@@ -1402,7 +1402,7 @@ describe("wrangler pipelines setup", () => {
 				{
 				  "pipelines": [
 				    {
-				      "pipeline": "stream_123",
+				      "stream": "stream_123",
 				      "binding": "TEST_PIPELINE_STREAM"
 				    }
 				  ]

--- a/packages/wrangler/src/__tests__/pipelines.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines.test.ts
@@ -366,54 +366,11 @@ describe("wrangler pipelines", () => {
 				name: "my_pipeline",
 				sql,
 			});
-			const getPipelineRequest = mockGetPipelineRequest("pipeline_123", {
-				id: "pipeline_123",
-				name: "my_pipeline",
-				sql,
-				status: "active",
-				created_at: "2024-01-01T00:00:00Z",
-				modified_at: "2024-01-01T00:00:00Z",
-				tables: [
-					{
-						id: "stream_456",
-						name: "test_stream",
-						type: "stream",
-						version: 1,
-						latest: 1,
-						href: "/accounts/some-account-id/pipelines/v1/streams/stream_456",
-					},
-					{
-						id: "sink_789",
-						name: "test_sink",
-						type: "sink",
-						version: 1,
-						latest: 1,
-						href: "/accounts/some-account-id/pipelines/v1/sinks/sink_789",
-					},
-				],
-			});
-			const getStreamRequest = mockGetStreamRequest("stream_456", {
-				id: "stream_456",
-				name: "test_stream",
-				version: 1,
-				endpoint: "https://pipelines.cloudflare.com/stream_456",
-				format: { type: "json", unstructured: true },
-				schema: null,
-				http: {
-					enabled: true,
-					authentication: false,
-				},
-				worker_binding: { enabled: true },
-				created_at: "2024-01-01T00:00:00Z",
-				modified_at: "2024-01-01T00:00:00Z",
-			});
 
 			await runWrangler(`pipelines create my_pipeline --sql "${sql}"`);
 
 			expect(validateRequest.count).toBe(1);
 			expect(createRequest.count).toBe(1);
-			expect(getPipelineRequest.count).toBe(1);
-			expect(getStreamRequest.count).toBe(1);
 
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.out).toContain("🌀 Validating SQL...");
@@ -424,8 +381,9 @@ describe("wrangler pipelines", () => {
 			expect(std.out).toContain(
 				"✨ Successfully created pipeline 'my_pipeline' with id 'pipeline_123'."
 			);
-			expect(std.out).toContain("Then send events:");
-			expect(std.out).toContain("Or via HTTP:");
+			expect(std.out).toContain(
+				"Run 'wrangler pipelines get pipeline_123' to view full details."
+			);
 		});
 
 		it("should create pipeline from SQL file", async ({ expect }) => {
@@ -438,54 +396,11 @@ describe("wrangler pipelines", () => {
 				name: "my_pipeline",
 				sql,
 			});
-			const getPipelineRequest = mockGetPipelineRequest("pipeline_123", {
-				id: "pipeline_123",
-				name: "my_pipeline",
-				sql,
-				status: "active",
-				created_at: "2024-01-01T00:00:00Z",
-				modified_at: "2024-01-01T00:00:00Z",
-				tables: [
-					{
-						id: "stream_456",
-						name: "test_stream",
-						type: "stream",
-						version: 1,
-						latest: 1,
-						href: "/accounts/some-account-id/pipelines/v1/streams/stream_456",
-					},
-					{
-						id: "sink_789",
-						name: "test_sink",
-						type: "sink",
-						version: 1,
-						latest: 1,
-						href: "/accounts/some-account-id/pipelines/v1/sinks/sink_789",
-					},
-				],
-			});
-			const getStreamRequest = mockGetStreamRequest("stream_456", {
-				id: "stream_456",
-				name: "test_stream",
-				version: 1,
-				endpoint: "https://pipelines.cloudflare.com/stream_456",
-				format: { type: "json", unstructured: true },
-				schema: null,
-				http: {
-					enabled: true,
-					authentication: false,
-				},
-				worker_binding: { enabled: true },
-				created_at: "2024-01-01T00:00:00Z",
-				modified_at: "2024-01-01T00:00:00Z",
-			});
 
 			await runWrangler(`pipelines create my_pipeline --sql-file ${sqlFile}`);
 
 			expect(validateRequest.count).toBe(1);
 			expect(createRequest.count).toBe(1);
-			expect(getPipelineRequest.count).toBe(1);
-			expect(getStreamRequest.count).toBe(1);
 
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.out).toContain("🌀 Validating SQL...");
@@ -1571,7 +1486,31 @@ describe("wrangler pipelines", () => {
 				  Endpoint:        https://pipelines.cloudflare.com/my_stream
 				  CORS Origins:    None
 
-				Input Schema: Unstructured JSON (single 'value' column)"
+				Input Schema: Unstructured JSON (single 'value' column)
+				To access your new Pipeline in your Worker, add the following snippet to your configuration file:
+				{
+				  "pipelines": [
+				    {
+				      "stream": "stream_123",
+				      "binding": "MY_STREAM"
+				    }
+				  ]
+				}
+
+				Then send events:
+
+				  await env.MY_STREAM.send([{"user_id":"sample_user_id","event_name":"sample_event_name","timestamp":1781200927146}]);
+
+				Or via HTTP:
+
+				  curl -X POST https://pipelines.cloudflare.com/my_stream /
+				     -H "Authorization: Bearer YOUR_API_TOKEN" /
+				     -H "Content-Type: application/json" /
+				     -d '[{"user_id":"sample_user_id","event_name":"sample_event_name","timestamp":1781200927146}]'
+
+				  (Replace YOUR_API_TOKEN with your Cloudflare API token)
+				Docs: https://developers.cloudflare.com/pipelines/
+				"
 			`);
 		});
 
@@ -1625,7 +1564,31 @@ describe("wrangler pipelines", () => {
 				│ id │ string │ │ Yes │
 				├─┼─┼─┼─┤
 				│ timestamp │ timestamp │ millisecond │ Yes │
-				└─┴─┴─┴─┘"
+				└─┴─┴─┴─┘
+				To access your new Pipeline in your Worker, add the following snippet to your configuration file:
+				{
+				  "pipelines": [
+				    {
+				      "stream": "stream_123",
+				      "binding": "MY_STREAM"
+				    }
+				  ]
+				}
+
+				Then send events:
+
+				  await env.MY_STREAM.send([{"id":"sample_id","timestamp":1781200927155}]);
+
+				Or via HTTP:
+
+				  curl -X POST https://pipelines.cloudflare.com/my_stream /
+				     -H "Authorization: Bearer YOUR_API_TOKEN" /
+				     -H "Content-Type: application/json" /
+				     -d '[{"id":"sample_id","timestamp":1781200927155}]'
+
+				  (Replace YOUR_API_TOKEN with your Cloudflare API token)
+				Docs: https://developers.cloudflare.com/pipelines/
+				"
 			`);
 		});
 	});
@@ -2384,16 +2347,20 @@ describe("wrangler pipelines", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.out).toMatchInlineSnapshot(`
 				"[
-				  {
-				    id: 'sink_1',
-				    name: 'sink_one',
-				    type: 'r2',
-				    format: { type: 'json' },
-				    schema: null,
-				    config: { bucket: 'bucket1' },
-				    created_at: '2024-01-01T00:00:00Z',
-				    modified_at: '2024-01-01T00:00:00Z'
-				  }
+				    {
+				        "id": "sink_1",
+				        "name": "sink_one",
+				        "type": "r2",
+				        "format": {
+				            "type": "json"
+				        },
+				        "schema": null,
+				        "config": {
+				            "bucket": "bucket1"
+				        },
+				        "created_at": "2024-01-01T00:00:00Z",
+				        "modified_at": "2024-01-01T00:00:00Z"
+				    }
 				]"
 			`);
 		});

--- a/packages/wrangler/src/__tests__/pipelines.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines.test.ts
@@ -1,7 +1,7 @@
 import { writeFileSync } from "node:fs";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
-import { describe, it } from "vitest";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { mockConfirm } from "./helpers/mock-dialogs";
@@ -1372,6 +1372,12 @@ describe("wrangler pipelines", () => {
 
 	describe("pipelines streams create", () => {
 		const { setIsTTY } = useMockIsTTY();
+		beforeEach(() => {
+			vi.useFakeTimers({ now: new Date("2026-01-01T00:00:00Z") });
+		});
+		afterEach(() => {
+			vi.useRealTimers();
+		});
 		function mockCreateStreamRequest(
 			expect: ExpectStatic,
 			expectedRequest: {
@@ -1499,14 +1505,14 @@ describe("wrangler pipelines", () => {
 
 				Then send events:
 
-				  await env.MY_STREAM.send([{"user_id":"sample_user_id","event_name":"sample_event_name","timestamp":1781495934630}]);
+				  await env.MY_STREAM.send([{"user_id":"sample_user_id","event_name":"sample_event_name","timestamp":1767225600000}]);
 
 				Or via HTTP:
 
 				  curl -X POST https://pipelines.cloudflare.com/my_stream /
 				     -H "Authorization: Bearer YOUR_API_TOKEN" /
 				     -H "Content-Type: application/json" /
-				     -d '[{"user_id":"sample_user_id","event_name":"sample_event_name","timestamp":1781495934630}]'
+				     -d '[{"user_id":"sample_user_id","event_name":"sample_event_name","timestamp":1767225600000}]'
 
 				  (Replace YOUR_API_TOKEN with your Cloudflare API token)
 				Docs: https://developers.cloudflare.com/pipelines/
@@ -1577,14 +1583,14 @@ describe("wrangler pipelines", () => {
 
 				Then send events:
 
-				  await env.MY_STREAM.send([{"id":"sample_id","timestamp":1781495934639}]);
+				  await env.MY_STREAM.send([{"id":"sample_id","timestamp":1767225600000}]);
 
 				Or via HTTP:
 
 				  curl -X POST https://pipelines.cloudflare.com/my_stream /
 				     -H "Authorization: Bearer YOUR_API_TOKEN" /
 				     -H "Content-Type: application/json" /
-				     -d '[{"id":"sample_id","timestamp":1781495934639}]'
+				     -d '[{"id":"sample_id","timestamp":1767225600000}]'
 
 				  (Replace YOUR_API_TOKEN with your Cloudflare API token)
 				Docs: https://developers.cloudflare.com/pipelines/

--- a/packages/wrangler/src/__tests__/pipelines.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines.test.ts
@@ -1499,14 +1499,14 @@ describe("wrangler pipelines", () => {
 
 				Then send events:
 
-				  await env.MY_STREAM.send([{"user_id":"sample_user_id","event_name":"sample_event_name","timestamp":1781200927146}]);
+				  await env.MY_STREAM.send([{"user_id":"sample_user_id","event_name":"sample_event_name","timestamp":1781495934630}]);
 
 				Or via HTTP:
 
 				  curl -X POST https://pipelines.cloudflare.com/my_stream /
 				     -H "Authorization: Bearer YOUR_API_TOKEN" /
 				     -H "Content-Type: application/json" /
-				     -d '[{"user_id":"sample_user_id","event_name":"sample_event_name","timestamp":1781200927146}]'
+				     -d '[{"user_id":"sample_user_id","event_name":"sample_event_name","timestamp":1781495934630}]'
 
 				  (Replace YOUR_API_TOKEN with your Cloudflare API token)
 				Docs: https://developers.cloudflare.com/pipelines/
@@ -1577,14 +1577,14 @@ describe("wrangler pipelines", () => {
 
 				Then send events:
 
-				  await env.MY_STREAM.send([{"id":"sample_id","timestamp":1781200927155}]);
+				  await env.MY_STREAM.send([{"id":"sample_id","timestamp":1781495934639}]);
 
 				Or via HTTP:
 
 				  curl -X POST https://pipelines.cloudflare.com/my_stream /
 				     -H "Authorization: Bearer YOUR_API_TOKEN" /
 				     -H "Content-Type: application/json" /
-				     -d '[{"id":"sample_id","timestamp":1781200927155}]'
+				     -d '[{"id":"sample_id","timestamp":1781495934639}]'
 
 				  (Replace YOUR_API_TOKEN with your Cloudflare API token)
 				Docs: https://developers.cloudflare.com/pipelines/

--- a/packages/wrangler/src/__tests__/r2/sql.test.ts
+++ b/packages/wrangler/src/__tests__/r2/sql.test.ts
@@ -1,3 +1,4 @@
+import { writeFileSync } from "node:fs";
 import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, it, vi } from "vitest";
@@ -19,7 +20,6 @@ describe("r2 sql", () => {
 			await endEventLoop();
 			expect(std.out).toContain("wrangler r2 sql");
 			expect(std.out).toContain("Send queries and manage R2 SQL");
-			expect(std.out).toContain("wrangler r2 sql query <warehouse> <query>");
 		});
 
 		it("should show help for query command", async ({ expect }) => {
@@ -30,6 +30,10 @@ describe("r2 sql", () => {
 			expect(std.out).toContain("R2 Data Catalog warehouse name");
 			expect(std.out).toContain("query");
 			expect(std.out).toContain("The SQL query to execute");
+			expect(std.out).toContain("--sql-file");
+			expect(std.out).toContain("A .sql file to execute");
+			expect(std.out).toContain("--json");
+			expect(std.out).toContain("--csv");
 		});
 	});
 
@@ -37,18 +41,83 @@ describe("r2 sql", () => {
 		const mockWarehouse = "account123_mybucket";
 		const mockQuery = "SELECT * FROM data";
 		const mockToken = "test-token-123";
+		const API_URL =
+			"https://api.sql.cloudflarestorage.com/api/v1/accounts/:accountId/r2-sql/query/:bucketName";
+
+		function mockSqlResponse(response: object, status = 200) {
+			msw.use(
+				http.post(
+					API_URL,
+					async () => {
+						return HttpResponse.json(response, { status });
+					},
+					{ once: true }
+				)
+			);
+		}
+
+		const successResponse = {
+			success: true,
+			errors: [],
+			messages: [],
+			result: {
+				schema: [
+					{ name: "id", type: "Int64" },
+					{ name: "name", type: "Utf8" },
+					{ name: "age", type: "Int64" },
+				],
+				rows: [
+					{ id: 1, name: "Alice", age: 30 },
+					{ id: 2, name: "Bob", age: 25 },
+					{ id: 3, name: "Charlie", age: 35 },
+				],
+				metrics: {
+					r2_requests_count: 5,
+					files_scanned: 2,
+					bytes_scanned: 1024 * 1024,
+				},
+			},
+		};
 
 		beforeEach(() => {
 			vi.stubEnv("WRANGLER_R2_SQL_AUTH_TOKEN", mockToken);
 		});
 
-		it("should require warehouse and query arguments", async ({ expect }) => {
+		it("should require warehouse argument", async ({ expect }) => {
 			await expect(runWrangler("r2 sql query")).rejects.toThrow(
-				"Not enough non-option arguments: got 0, need at least 2"
+				"Not enough non-option arguments"
 			);
+		});
 
-			await expect(runWrangler("r2 sql query testWarehouse")).rejects.toThrow(
-				"Not enough non-option arguments: got 1, need at least 2"
+		it("should require either query argument or --sql-file", async ({
+			expect,
+		}) => {
+			await expect(
+				runWrangler(`r2 sql query ${mockWarehouse}`)
+			).rejects.toThrow(
+				"Must provide a SQL query as an argument or via --sql-file."
+			);
+		});
+
+		it("should reject both query argument and --sql-file", async ({
+			expect,
+		}) => {
+			writeFileSync("test.sql", mockQuery);
+			await expect(
+				runWrangler(
+					`r2 sql query ${mockWarehouse} "${mockQuery}" --sql-file test.sql`
+				)
+			).rejects.toThrow(
+				"Cannot provide both a query argument and --sql-file flag."
+			);
+		});
+
+		it("should reject both --json and --csv", async ({ expect }) => {
+			mockSqlResponse(successResponse);
+			await expect(
+				runWrangler(`r2 sql query ${mockWarehouse} "${mockQuery}" --json --csv`)
+			).rejects.toThrow(
+				"Cannot use both --json and --csv flags at the same time."
 			);
 		});
 
@@ -76,32 +145,9 @@ describe("r2 sql", () => {
 		it("should execute a successful query and display results", async ({
 			expect,
 		}) => {
-			const mockResponse = {
-				success: true,
-				errors: [],
-				messages: [],
-				result: {
-					schema: [
-						{ name: "id", type: "Int64" },
-						{ name: "name", type: "Utf8" },
-						{ name: "age", type: "Int64" },
-					],
-					rows: [
-						{ id: 1, name: "Alice", age: 30 },
-						{ id: 2, name: "Bob", age: 25 },
-						{ id: 3, name: "Charlie", age: 35 },
-					],
-					metrics: {
-						r2_requests_count: 5,
-						files_scanned: 2,
-						bytes_scanned: 1024 * 1024,
-					},
-				},
-			};
-
 			msw.use(
 				http.post(
-					"https://api.sql.cloudflarestorage.com/api/v1/accounts/:accountId/r2-sql/query/:bucketName",
+					API_URL,
 					async ({ request, params }) => {
 						const { accountId, bucketName } = params;
 						expect(accountId).toEqual("account123");
@@ -117,7 +163,7 @@ describe("r2 sql", () => {
 						const authHeader = request.headers.get("Authorization");
 						expect(authHeader).toEqual(`Bearer ${mockToken}`);
 
-						return HttpResponse.json(mockResponse);
+						return HttpResponse.json(successResponse);
 					},
 					{ once: true }
 				)
@@ -132,8 +178,8 @@ describe("r2 sql", () => {
 			expect(std.out).toContain("Alice");
 			expect(std.out).toContain("Bob");
 			expect(std.out).toContain("Charlie");
-			expect(std.out).toContain("across 2 files from R2");
-			// Not checking MB/s speed as it depends on timing.
+			expect(std.out).toContain("across 2 files");
+			expect(std.out).toContain("5 R2 requests");
 		});
 
 		it("should handle queries with no results", async ({ expect }) => {
@@ -152,15 +198,7 @@ describe("r2 sql", () => {
 				},
 			};
 
-			msw.use(
-				http.post(
-					"https://api.sql.cloudflarestorage.com/api/v1/accounts/:accountId/r2-sql/query/:bucketName",
-					async () => {
-						return HttpResponse.json(mockResponse);
-					},
-					{ once: true }
-				)
-			);
+			mockSqlResponse(mockResponse);
 
 			await runWrangler(`r2 sql query ${mockWarehouse} "${mockQuery}"`);
 			expect(std.out).toContain("Query executed successfully with no results");
@@ -177,15 +215,7 @@ describe("r2 sql", () => {
 				result: null,
 			};
 
-			msw.use(
-				http.post(
-					"https://api.sql.cloudflarestorage.com/api/v1/accounts/:accountId/r2-sql/query/:bucketName",
-					async () => {
-						return HttpResponse.json(mockResponse, { status: 500 });
-					},
-					{ once: true }
-				)
-			);
+			mockSqlResponse(mockResponse, 500);
 
 			await runWrangler(`r2 sql query ${mockWarehouse} "${mockQuery}"`);
 			expect(std.err).toContain(
@@ -198,7 +228,7 @@ describe("r2 sql", () => {
 		it("should handle API connection errors", async ({ expect }) => {
 			msw.use(
 				http.post(
-					"https://api.sql.cloudflarestorage.com/api/v1/accounts/:accountId/r2-sql/query/:bucketName",
+					API_URL,
 					async () => {
 						return HttpResponse.error();
 					},
@@ -214,7 +244,7 @@ describe("r2 sql", () => {
 		it("should handle invalid JSON responses", async ({ expect }) => {
 			msw.use(
 				http.post(
-					"https://api.sql.cloudflarestorage.com/api/v1/accounts/:accountId/r2-sql/query/:bucketName",
+					API_URL,
 					async () => {
 						return HttpResponse.text("Invalid JSON", { status: 200 });
 					},
@@ -282,15 +312,7 @@ describe("r2 sql", () => {
 				},
 			};
 
-			msw.use(
-				http.post(
-					"https://api.sql.cloudflarestorage.com/api/v1/accounts/:accountId/r2-sql/query/:bucketName",
-					async () => {
-						return HttpResponse.json(mockResponse);
-					},
-					{ once: true }
-				)
-			);
+			mockSqlResponse(mockResponse);
 
 			await runWrangler(`r2 sql query ${mockWarehouse} "${mockQuery}"`);
 
@@ -329,20 +351,206 @@ describe("r2 sql", () => {
 				},
 			};
 
-			msw.use(
-				http.post(
-					"https://api.sql.cloudflarestorage.com/api/v1/accounts/:accountId/r2-sql/query/:bucketName",
-					async () => {
-						return HttpResponse.json(mockResponse);
-					},
-					{ once: true }
-				)
-			);
+			mockSqlResponse(mockResponse);
 
 			await runWrangler(`r2 sql query ${mockWarehouse} "${mockQuery}"`);
 			// The output should handle null values gracefully (displayed as empty strings).
 			expect(std.out).toContain("Alice");
 			expect(std.out).toContain("bob@example.com");
+		});
+
+		describe("--json output", () => {
+			it("should output results as JSON", async ({ expect }) => {
+				mockSqlResponse(successResponse);
+
+				await runWrangler(
+					`r2 sql query ${mockWarehouse} "${mockQuery}" --json`
+				);
+
+				const parsed = JSON.parse(std.out);
+				expect(parsed).toEqual(successResponse.result.rows);
+			});
+
+			it("should output empty array for no results", async ({ expect }) => {
+				mockSqlResponse({
+					success: true,
+					errors: [],
+					messages: [],
+					result: { schema: [], rows: [], metrics: {} },
+				});
+
+				await runWrangler(
+					`r2 sql query ${mockWarehouse} "${mockQuery}" --json`
+				);
+
+				const parsed = JSON.parse(std.out);
+				expect(parsed).toEqual([]);
+			});
+
+			it("should output error as JSON on failure", async ({ expect }) => {
+				const errorResponse = {
+					success: false,
+					errors: [{ code: 1001, message: "Bad query" }],
+					messages: [],
+					result: null,
+				};
+				mockSqlResponse(errorResponse, 400);
+
+				await runWrangler(
+					`r2 sql query ${mockWarehouse} "${mockQuery}" --json`
+				);
+
+				const parsed = JSON.parse(std.out);
+				expect(parsed.success).toBe(false);
+				expect(parsed.errors[0].code).toBe(1001);
+			});
+		});
+
+		describe("--csv output", () => {
+			it("should output results as CSV", async ({ expect }) => {
+				mockSqlResponse(successResponse);
+
+				await runWrangler(`r2 sql query ${mockWarehouse} "${mockQuery}" --csv`);
+
+				const lines = std.out.trim().split("\n");
+				expect(lines[0]).toBe("id,name,age");
+				expect(lines[1]).toBe("1,Alice,30");
+				expect(lines[2]).toBe("2,Bob,25");
+				expect(lines[3]).toBe("3,Charlie,35");
+			});
+
+			it("should escape CSV fields with commas and quotes", async ({
+				expect,
+			}) => {
+				mockSqlResponse({
+					success: true,
+					errors: [],
+					messages: [],
+					result: {
+						schema: [
+							{ name: "name", type: "Utf8" },
+							{ name: "description", type: "Utf8" },
+						],
+						rows: [
+							{
+								name: 'O"Brien',
+								description: "has, commas",
+							},
+						],
+						metrics: {
+							r2_requests_count: 1,
+							files_scanned: 1,
+							bytes_scanned: 100,
+						},
+					},
+				});
+
+				await runWrangler(`r2 sql query ${mockWarehouse} "${mockQuery}" --csv`);
+
+				const lines = std.out.trim().split("\n");
+				expect(lines[0]).toBe("name,description");
+				expect(lines[1]).toBe('"O""Brien","has, commas"');
+			});
+		});
+
+		describe("--sql-file flag", () => {
+			it("should read query from a .sql file", async ({ expect }) => {
+				const fileQuery = "SELECT id, name FROM users LIMIT 5";
+				writeFileSync("query.sql", fileQuery);
+
+				msw.use(
+					http.post(
+						API_URL,
+						async ({ request }) => {
+							const body = (await request.json()) as { query: string };
+							expect(body.query).toEqual(fileQuery);
+							return HttpResponse.json(successResponse);
+						},
+						{ once: true }
+					)
+				);
+
+				await runWrangler(`r2 sql query ${mockWarehouse} --sql-file query.sql`);
+
+				expect(std.out).toContain("Alice");
+			});
+		});
+
+		describe("EXPLAIN formatting", () => {
+			it("should render plain EXPLAIN in table format", async ({ expect }) => {
+				const explainResponse = {
+					success: true,
+					errors: [],
+					messages: [],
+					result: {
+						schema: [{ name: "plan", type: "Utf8" }],
+						rows: [
+							{ plan: "IcebergScan: table=data" },
+							{ plan: "  Projection: id, name" },
+						],
+						metrics: {
+							r2_requests_count: 1,
+							files_scanned: 0,
+							bytes_scanned: 0,
+						},
+					},
+				};
+
+				mockSqlResponse(explainResponse);
+
+				await runWrangler(
+					`r2 sql query ${mockWarehouse} "EXPLAIN SELECT id, name FROM data"`
+				);
+
+				expect(std.out).toContain("IcebergScan: table=data");
+				expect(std.out).toContain("Projection: id, name");
+				// Plain EXPLAIN uses the standard table view
+				expect(std.out).toContain("┌");
+			});
+
+			it("should pretty-print EXPLAIN FORMAT JSON output", async ({
+				expect,
+			}) => {
+				const jsonPlan = {
+					type: "IcebergScan",
+					table: "data",
+					filters: ["id > 10"],
+				};
+				const explainJsonResponse = {
+					success: true,
+					errors: [],
+					messages: [],
+					result: {
+						schema: [{ name: "plan", type: "Utf8" }],
+						rows: [{ plan: jsonPlan }],
+						metrics: {
+							r2_requests_count: 1,
+							files_scanned: 0,
+							bytes_scanned: 0,
+						},
+					},
+				};
+
+				mockSqlResponse(explainJsonResponse);
+
+				await runWrangler(
+					`r2 sql query ${mockWarehouse} "EXPLAIN FORMAT JSON SELECT * FROM data"`
+				);
+
+				// Should be pretty-printed JSON
+				expect(std.out).toContain('"type": "IcebergScan"');
+				expect(std.out).toContain('"table": "data"');
+			});
+		});
+
+		describe("metrics display", () => {
+			it("should display r2_requests_count in metrics", async ({ expect }) => {
+				mockSqlResponse(successResponse);
+
+				await runWrangler(`r2 sql query ${mockWarehouse} "${mockQuery}"`);
+
+				expect(std.out).toContain("5 R2 requests");
+			});
 		});
 	});
 });

--- a/packages/wrangler/src/dev/miniflare/index.ts
+++ b/packages/wrangler/src/dev/miniflare/index.ts
@@ -291,38 +291,23 @@ function pipelineEntry(
 	remoteProxyConnectionString?: RemoteProxyConnectionString
 ): [
 	string,
-	(
-		| {
-				stream: string;
-				remoteProxyConnectionString?: RemoteProxyConnectionString;
-		  }
-		| {
-				pipeline: string;
-				remoteProxyConnectionString?: RemoteProxyConnectionString;
-		  }
-	),
+	{
+		stream: string;
+		remoteProxyConnectionString?: RemoteProxyConnectionString;
+	},
 ] {
-	if (stream) {
-		return [
-			binding,
-			{
-				stream,
-				...(remoteProxyConnectionString &&
-					remote && { remoteProxyConnectionString }),
-			},
-		];
-	} else if (pipeline) {
-		return [
-			binding,
-			{
-				pipeline,
-				...(remoteProxyConnectionString &&
-					remote && { remoteProxyConnectionString }),
-			},
-		];
-	} else {
-		throw new Error("Pipeline must have either a stream");
+	const streamId = stream ?? pipeline;
+	if (!streamId) {
+		throw new Error("Pipeline must have a stream");
 	}
+	return [
+		binding,
+		{
+			stream: streamId,
+			...(remoteProxyConnectionString &&
+				remote && { remoteProxyConnectionString }),
+		},
+	];
 }
 function hyperdriveEntry(hyperdrive: CfHyperdrive): [string, string] {
 	return [hyperdrive.binding, hyperdrive.localConnectionString ?? ""];

--- a/packages/wrangler/src/pipelines/cli/create.ts
+++ b/packages/wrangler/src/pipelines/cli/create.ts
@@ -3,8 +3,7 @@ import { APIError, UserError } from "@cloudflare/workers-utils";
 import { createCommand } from "../../core/create-command";
 import { logger } from "../../logger";
 import { requireAuth } from "../../user";
-import { createPipeline, getPipeline, getStream, validateSql } from "../client";
-import { displayUsageExamples } from "./streams/utils";
+import { createPipeline, validateSql } from "../client";
 import type { CreatePipelineRequest } from "../types";
 
 export const pipelinesCreateCommand = createCommand({
@@ -123,26 +122,8 @@ export const pipelinesCreateCommand = createCommand({
 			`✨ Successfully created pipeline '${pipeline.name}' with id '${pipeline.id}'.`
 		);
 
-		try {
-			const fullPipeline = await getPipeline(config, pipeline.id);
-
-			const streamTable = fullPipeline.tables?.find(
-				(table) => table.type === "stream"
-			);
-
-			if (streamTable) {
-				const stream = await getStream(config, streamTable.id);
-				await displayUsageExamples(stream, config, args);
-			} else {
-				logger.log(
-					`\nRun 'wrangler pipelines get ${pipeline.id}' to view full details.`
-				);
-			}
-		} catch {
-			logger.warn("Could not fetch pipeline details for usage examples.");
-			logger.log(
-				`\nRun 'wrangler pipelines get ${pipeline.id}' to view full details.`
-			);
-		}
+		logger.log(
+			`\nRun 'wrangler pipelines get ${pipeline.id}' to view full details.`
+		);
 	},
 });

--- a/packages/wrangler/src/pipelines/cli/sinks/list.ts
+++ b/packages/wrangler/src/pipelines/cli/sinks/list.ts
@@ -43,7 +43,7 @@ export const pipelinesSinksListCommand = createCommand({
 		});
 
 		if (args.json) {
-			logger.log(sinks);
+			logger.json(sinks);
 			return;
 		}
 

--- a/packages/wrangler/src/pipelines/cli/streams/create.ts
+++ b/packages/wrangler/src/pipelines/cli/streams/create.ts
@@ -4,9 +4,10 @@ import { createCommand } from "../../../core/create-command";
 import { confirm } from "../../../dialogs";
 import { logger } from "../../../logger";
 import { requireAuth } from "../../../user";
+import { sharedResourceCreationArgs } from "../../../utils/add-created-resource-config";
 import { createStream } from "../../client";
 import { validateEntityName } from "../../validate";
-import { displayStreamConfiguration } from "./utils";
+import { displayStreamConfiguration, displayUsageExamples } from "./utils";
 import type { CreateStreamRequest, SchemaField } from "../../types";
 
 export const pipelinesStreamsCreateCommand = createCommand({
@@ -41,6 +42,7 @@ export const pipelinesStreamsCreateCommand = createCommand({
 			type: "string",
 			array: true,
 		},
+		...sharedResourceCreationArgs,
 	},
 	validateArgs: (args) => {
 		validateEntityName("stream", args.stream);
@@ -130,6 +132,13 @@ export const pipelinesStreamsCreateCommand = createCommand({
 
 		displayStreamConfiguration(stream, "Creation Summary", {
 			includeTimestamps: false,
+		});
+
+		await displayUsageExamples(stream, config, {
+			env: args.env,
+			binding: args.binding,
+			useRemote: args.useRemote,
+			updateConfig: args.updateConfig,
 		});
 	},
 });

--- a/packages/wrangler/src/pipelines/cli/streams/utils.ts
+++ b/packages/wrangler/src/pipelines/cli/streams/utils.ts
@@ -209,25 +209,35 @@ function generateExampleData(stream: Stream): string {
 export async function displayUsageExamples(
 	stream: Stream,
 	config: Config,
-	args: { env?: string }
+	args: {
+		env?: string;
+		binding?: string;
+		useRemote?: boolean;
+		updateConfig?: boolean;
+	}
 ) {
-	const bindingName = generateStreamBindingName(stream.name);
+	const bindingName = args.binding ?? generateStreamBindingName(stream.name);
 	const exampleData = generateExampleData(stream);
 	const compactData = JSON.stringify(JSON.parse(exampleData));
 
 	await createdResourceConfig(
 		"pipelines",
 		(customBindingName) => ({
-			pipeline: stream.id,
+			stream: stream.id,
 			binding: customBindingName ?? bindingName,
 		}),
 		config.configPath,
 		args.env,
-		{ updateConfig: false }
+		{
+			binding: args.binding,
+			useRemote: args.useRemote,
+			updateConfig: args.updateConfig,
+		}
 	);
 
+	const displayBindingName = args.binding ?? bindingName;
 	logger.log("\nThen send events:\n");
-	logger.log(`  await env.${bindingName}.send([${compactData}]);\n`);
+	logger.log(`  await env.${displayBindingName}.send([${compactData}]);\n`);
 
 	if (stream.http.enabled) {
 		logger.log("Or via HTTP:\n");

--- a/packages/wrangler/src/preview/shared.ts
+++ b/packages/wrangler/src/preview/shared.ts
@@ -113,7 +113,7 @@ export function getBindingValue(binding: Binding): string {
 		case "mtls_certificate":
 			return String(binding.certificate_id ?? "");
 		case "pipelines":
-			return String(binding.stream ?? binding.pipeline ?? "");
+			return String(binding.stream ?? "");
 		case "secrets_store_secret":
 			return binding.secret_name
 				? `${binding.store_id}/${binding.secret_name}`

--- a/packages/wrangler/src/r2/sql.ts
+++ b/packages/wrangler/src/r2/sql.ts
@@ -2,6 +2,7 @@ import { spinner } from "@cloudflare/cli-shared-helpers/interactive";
 import {
 	APIError,
 	parseJSON,
+	readFileSync,
 	UserError,
 	truncate,
 } from "@cloudflare/workers-utils";
@@ -19,24 +20,63 @@ interface SqlQueryResponse {
 		request_id?: string;
 		schema: { name: string; type: string }[];
 		rows: Record<string, unknown>[];
-		metrics: {
-			r2_requests_count: number;
-			files_scanned: number;
-			bytes_scanned: number;
-		};
+		metrics: SqlMetrics;
 	};
 	success: boolean;
 	errors: { code: number; message: string }[];
 	messages: string[];
 }
 
-function formatSqlResults(data: SqlQueryResponse, duration: number): void {
+interface SqlMetrics {
+	r2_requests_count: number;
+	files_scanned: number;
+	bytes_scanned: number;
+}
+
+function isExplainJsonQuery(query: string): boolean {
+	return /^\s*explain\s+format\s+json\b/i.test(query);
+}
+
+function formatExplainJsonResults(data: SqlQueryResponse): void {
+	if (!data?.result?.rows || data.result.rows.length === 0) {
+		logger.log("EXPLAIN returned no results");
+		return;
+	}
+
+	const { rows } = data.result;
+
+	if (rows.length === 1) {
+		const firstRow = rows[0];
+		const values = Object.values(firstRow);
+		if (
+			values.length === 1 &&
+			values[0] !== null &&
+			typeof values[0] === "object"
+		) {
+			logger.log(JSON.stringify(values[0], null, 2));
+			return;
+		}
+		if (values.length === 1 && typeof values[0] === "string") {
+			try {
+				const parsed = JSON.parse(values[0]);
+				logger.log(JSON.stringify(parsed, null, 2));
+				return;
+			} catch {
+				// Not valid JSON, fall through to table display
+			}
+		}
+	}
+
+	formatTableResults(data);
+}
+
+function formatTableResults(data: SqlQueryResponse): void {
 	if (!data?.result?.rows || data.result.rows.length === 0) {
 		logger.log("Query executed successfully with no results");
 		return;
 	}
 
-	const { schema, rows, metrics } = data.result;
+	const { schema, rows } = data.result;
 	const column_order = schema.map((field) => field.name);
 	logger.table(
 		rows.map((row) =>
@@ -58,9 +98,48 @@ function formatSqlResults(data: SqlQueryResponse, duration: number): void {
 		),
 		{ wordWrap: true, head: column_order }
 	);
+}
 
+function formatCsvResults(data: SqlQueryResponse): void {
+	if (!data?.result?.rows || data.result.rows.length === 0) {
+		logger.log("Query executed successfully with no results");
+		return;
+	}
+
+	const { schema, rows } = data.result;
+	const columns = schema.map((field) => field.name);
+
+	logger.log(columns.map(escapeCsvField).join(","));
+	for (const row of rows) {
+		const values = columns.map((col) => {
+			const value = row[col];
+			if (value === null || value === undefined) {
+				return "";
+			}
+			if (typeof value === "object") {
+				return escapeCsvField(JSON.stringify(value));
+			}
+			return escapeCsvField(String(value));
+		});
+		logger.log(values.join(","));
+	}
+}
+
+function escapeCsvField(field: string): string {
+	if (
+		field.includes(",") ||
+		field.includes('"') ||
+		field.includes("\n") ||
+		field.includes("\r")
+	) {
+		return `"${field.replace(/"/g, '""')}"`;
+	}
+	return field;
+}
+
+function formatMetrics(metrics: SqlMetrics, duration: number): void {
 	logger.log(
-		`Read ${prettyBytes(metrics.bytes_scanned)} across ${metrics.files_scanned} files from R2`
+		`Read ${prettyBytes(metrics.bytes_scanned)} across ${metrics.files_scanned} files (${metrics.r2_requests_count} R2 requests)`
 	);
 	if (duration > 0) {
 		const bytesPerSecond = (metrics.bytes_scanned / duration) * 1000;
@@ -92,10 +171,59 @@ export const r2SqlQueryCommand = createCommand({
 		query: {
 			describe: "The SQL query to execute",
 			type: "string",
-			demandOption: true,
+		},
+		"sql-file": {
+			describe: "A .sql file to execute",
+			type: "string",
+		},
+		json: {
+			describe: "Output results as JSON",
+			type: "boolean",
+			default: false,
+		},
+		csv: {
+			describe: "Output results as CSV",
+			type: "boolean",
+			default: false,
 		},
 	},
-	async handler({ warehouse, query }) {
+	behaviour: {
+		printBanner: (args) => !args.json && !args.csv,
+	},
+	async handler({ warehouse, query, sqlFile, json, csv }) {
+		if (sqlFile && query) {
+			throw new UserError(
+				"Cannot provide both a query argument and --sql-file flag.",
+				{ telemetryMessage: "r2 sql query conflicting query and file" }
+			);
+		}
+
+		let resolvedQuery: string;
+		if (sqlFile) {
+			try {
+				resolvedQuery = readFileSync(sqlFile);
+			} catch (error) {
+				throw new UserError(
+					`Failed to read SQL file '${sqlFile}': ${error instanceof Error ? error.message : String(error)}`,
+					{ telemetryMessage: "r2 sql query sql file read failed" }
+				);
+			}
+		} else if (query) {
+			resolvedQuery = query;
+		} else {
+			throw new UserError(
+				"Must provide a SQL query as an argument or via --sql-file.",
+				{ telemetryMessage: "r2 sql query missing query" }
+			);
+		}
+
+		if (json && csv) {
+			throw new UserError(
+				"Cannot use both --json and --csv flags at the same time.",
+				{ telemetryMessage: "r2 sql query conflicting output formats" }
+			);
+		}
+
 		let token = getWranglerR2SqlAuthToken();
 		if (!token) {
 			token = getCloudflareAPITokenFromEnv();
@@ -127,12 +255,14 @@ export const r2SqlQueryCommand = createCommand({
 		];
 
 		const s = spinner();
-		s.start("Query in progress");
+		if (!json && !csv) {
+			s.start("Query in progress");
+		}
 		const apiUrl = `https://api.sql.cloudflarestorage.com/api/v1/accounts/${accountId}/r2-sql/query/${bucketName}`;
-		let responseStatus = null;
-		let statusText = null;
-		let text = null;
-		let duration = null;
+		let responseStatus = 0;
+		let statusText = "";
+		let text = "";
+		let duration = 0;
 		try {
 			const start = Date.now();
 			const response = await fetch(apiUrl, {
@@ -143,7 +273,7 @@ export const r2SqlQueryCommand = createCommand({
 				},
 				body: JSON.stringify({
 					warehouse,
-					query,
+					query: resolvedQuery,
 				}),
 			});
 			responseStatus = response.status;
@@ -164,7 +294,7 @@ export const r2SqlQueryCommand = createCommand({
 			);
 		}
 
-		let parsed = null;
+		let parsed: SqlQueryResponse;
 		try {
 			parsed = parseJSON(text) as SqlQueryResponse;
 		} catch {
@@ -183,15 +313,34 @@ export const r2SqlQueryCommand = createCommand({
 			});
 		}
 
-		s.stop();
+		if (!json && !csv) {
+			s.stop();
+		}
+
 		if (parsed.success) {
-			formatSqlResults(parsed, duration);
-		} else {
-			let errors = "";
-			for (const { code, message } of parsed.errors) {
-				errors += `\n* ${code}: ${message}`;
+			if (json) {
+				logger.json(parsed.result?.rows ?? []);
+			} else if (csv) {
+				formatCsvResults(parsed);
+			} else if (isExplainJsonQuery(resolvedQuery)) {
+				formatExplainJsonResults(parsed);
+			} else {
+				formatTableResults(parsed);
 			}
-			logger.error(`Query failed because of the following errors:${errors}`);
+
+			if (parsed.result?.metrics && !json && !csv) {
+				formatMetrics(parsed.result.metrics, duration);
+			}
+		} else {
+			if (json) {
+				logger.json(parsed);
+			} else {
+				let errors = "";
+				for (const { code, message } of parsed.errors) {
+					errors += `\n* ${code}: ${message}`;
+				}
+				logger.error(`Query failed because of the following errors:${errors}`);
+			}
 		}
 	},
 });

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -4093,7 +4093,8 @@ function collectPipelinesPerEnvironment(
 				});
 			}
 
-			const streamId = pipeline.stream;
+			// Raw config may still have the deprecated `pipeline` field
+			const streamId = pipeline.stream ?? pipeline.pipeline;
 			if (streamId) {
 				pipelines.push({
 					binding: pipeline.binding,

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -4093,15 +4093,11 @@ function collectPipelinesPerEnvironment(
 				});
 			}
 
-			if (pipeline.stream) {
+			const streamId = pipeline.stream;
+			if (streamId) {
 				pipelines.push({
 					binding: pipeline.binding,
-					stream: pipeline.stream,
-				});
-			} else if (pipeline.pipeline) {
-				pipelines.push({
-					binding: pipeline.binding,
-					pipeline: pipeline.pipeline,
+					stream: streamId,
 				});
 			} else {
 				throwMissingBindingError({

--- a/packages/wrangler/src/type-generation/pipeline-schema.ts
+++ b/packages/wrangler/src/type-generation/pipeline-schema.ts
@@ -234,7 +234,7 @@ export async function fetchPipelineTypes(
 	// Fetch all streams in parallel for better performance
 	const streams = await Promise.all(
 		pipelines.map((p) => {
-			const streamID = p.stream;
+			const streamID = p.stream ?? p.pipeline;
 			if (!streamID) {
 				throw new Error(
 					`Pipeline binding ${p.binding} is missing the stream ID`

--- a/packages/wrangler/src/type-generation/pipeline-schema.ts
+++ b/packages/wrangler/src/type-generation/pipeline-schema.ts
@@ -234,7 +234,7 @@ export async function fetchPipelineTypes(
 	// Fetch all streams in parallel for better performance
 	const streams = await Promise.all(
 		pipelines.map((p) => {
-			const streamID = p.stream || p.pipeline;
+			const streamID = p.stream;
 			if (!streamID) {
 				throw new Error(
 					`Pipeline binding ${p.binding} is missing the stream ID`


### PR DESCRIPTION
## Changes

### R2 SQL (`wrangler r2 sql query`)

- **New:** `--json` flag — output results as a JSON array for scripting/piping to `jq`
- **New:** `--csv` flag — output results as RFC 4180-compliant CSV
- **New:** `--sql-file` flag — read query from a `.sql` file (matches `pipelines create --sql-file`)
- **New:** `EXPLAIN FORMAT JSON` queries are automatically pretty-printed
- **Improved:** Metrics line now shows R2 request count: `Read 1.05 MB across 2 files (5 R2 requests)`

```bash
# JSON output
wrangler r2 sql query "$WAREHOUSE" "SELECT * FROM ns.table LIMIT 5" --json | jq .

# CSV export
wrangler r2 sql query "$WAREHOUSE" "SELECT * FROM ns.table" --csv > data.csv

# Query from file
wrangler r2 sql query "$WAREHOUSE" --sql-file query.sql
```

### Pipelines

- **Fixed:** `pipelines sinks list --json` now outputs valid JSON (was outputting Node.js `util.inspect` format with unquoted keys and `[Object]` placeholders)
- **New:** `pipelines streams create` now shows the binding snippet and prompts to auto-add it to `wrangler.json` — matching `kv namespace create`, `d1 create`, etc. Supports `--binding`, `--update-config`, and `--use-remote` flags.
- **New:** `pipelines setup` now prompts to auto-add the binding to config at the end of the wizard
- **Fixed:** Binding snippet now uses `"stream"` field instead of the deprecated `"pipeline"` field
- **Removed:** `pipelines create` no longer shows binding/usage examples (the pipeline itself has no binding — only the stream does)

### Config normalization

- The deprecated `"pipeline"` field in `wrangler.json` pipeline bindings is now normalized to `"stream"` during config validation, with the old field removed. Downstream consumers no longer need fallback logic.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: CLI help text and `--help` output updated inline; no new concepts requiring docs changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->