### PR TITLE
fix: Support dev.plugin on typed services bindings

### DIFF
--- a/.changeset/typed-service-binding-dev-plugin.md
+++ b/.changeset/typed-service-binding-dev-plugin.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+"@cloudflare/workers-utils": patch
+"@cloudflare/deploy-helpers": patch
+---
+
+Support `dev.plugin` on typed services bindings
+
+Wrangler only honored `dev.plugin` on `unsafe.bindings` entries, so users authoring a service binding via `services[]` could not wire it to a local Miniflare plugin during `wrangler dev` — they had to fall back to `unsafe.bindings` and accept a "directly supported by wrangler" warning. Typed services bindings now accept the same `dev: { plugin, options? }` shape, route the binding through Miniflare's external-plugin pathway in `wrangler dev`, and strip the field at deploy time. Validation rejects malformed `dev` shapes.

--- a/packages/deploy-helpers/src/deploy/helpers/print-bindings.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/print-bindings.ts
@@ -513,7 +513,7 @@ export function printBindings(
 
 	if (services.length > 0) {
 		output.push(
-			...services.map(({ binding, service, entrypoint, remote }) => {
+			...services.map(({ binding, service, entrypoint, remote, dev }) => {
 				let value = service;
 				let mode = undefined;
 
@@ -521,7 +521,9 @@ export function printBindings(
 					value += `#${entrypoint}`;
 				}
 
-				if (remote) {
+				if (dev !== undefined && context.local) {
+					mode = getMode({ isSimulatedLocally: true });
+				} else if (remote) {
 					mode = getMode({ isSimulatedLocally: false });
 				} else if (context.local && context.registry !== null) {
 					const isSelfBinding = service === context.name;

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -4589,6 +4589,70 @@ const validateServiceBinding: ValidatorFn = (diagnostics, field, value) => {
 		);
 		isValid = false;
 	}
+	if (hasProperty(value, "dev") && value.dev !== undefined) {
+		if (
+			typeof value.dev !== "object" ||
+			value.dev === null ||
+			Array.isArray(value.dev)
+		) {
+			diagnostics.errors.push(
+				`"${field}" bindings should have an object "dev" field but got ${JSON.stringify(
+					value.dev
+				)}.`
+			);
+			isValid = false;
+		} else {
+			if (
+				!hasProperty(value.dev, "plugin") ||
+				typeof value.dev.plugin !== "object" ||
+				value.dev.plugin === null ||
+				Array.isArray(value.dev.plugin)
+			) {
+				diagnostics.errors.push(
+					`"${field}.dev" should have an object "plugin" field but got ${JSON.stringify(
+						(value.dev as { plugin?: unknown }).plugin
+					)}.`
+				);
+				isValid = false;
+			} else {
+				if (!isRequiredProperty(value.dev.plugin, "package", "string")) {
+					diagnostics.errors.push(
+						`"${field}.dev.plugin" should have a string "package" field but got ${JSON.stringify(
+							(value.dev.plugin as { package?: unknown }).package
+						)}.`
+					);
+					isValid = false;
+				}
+				if (!isRequiredProperty(value.dev.plugin, "name", "string")) {
+					diagnostics.errors.push(
+						`"${field}.dev.plugin" should have a string "name" field but got ${JSON.stringify(
+							(value.dev.plugin as { name?: unknown }).name
+						)}.`
+					);
+					isValid = false;
+				}
+			}
+			if (
+				hasProperty(value.dev, "options") &&
+				value.dev.options !== undefined &&
+				(typeof value.dev.options !== "object" ||
+					value.dev.options === null ||
+					Array.isArray(value.dev.options))
+			) {
+				diagnostics.errors.push(
+					`"${field}.dev.options" should be an object but got ${JSON.stringify(
+						value.dev.options
+					)}.`
+				);
+				isValid = false;
+			}
+		}
+		if ((value as { remote?: unknown }).remote === true) {
+			diagnostics.warnings.push(
+				`"${field}" binding has both "dev" and "remote" set; "remote" is ignored when "dev" is present and the binding is routed through the local Miniflare plugin.`
+			);
+		}
+	}
 	if (!isRemoteValid(value, field, diagnostics)) {
 		isValid = false;
 	}

--- a/packages/workers-utils/src/worker.ts
+++ b/packages/workers-utils/src/worker.ts
@@ -297,6 +297,26 @@ export interface CfHyperdrive {
 	localConnectionString?: string;
 }
 
+export interface CfDevPluginCfg {
+	plugin: {
+		/**
+		 * Package is the bare specifier of the package that exposes plugins to integrate into Miniflare via a named `plugins` export.
+		 * @example "@cloudflare/my-external-miniflare-plugin"
+		 */
+		package: string;
+		/**
+		 * Plugin is the name of the plugin exposed by the package.
+		 * @example "my-unsafe-plugin"
+		 */
+		name: string;
+	};
+
+	/**
+	 * dev-only options to pass to the plugin.
+	 */
+	options?: Record<string, unknown>;
+}
+
 export interface CfService {
 	binding: string;
 	service: string;
@@ -305,6 +325,7 @@ export interface CfService {
 	props?: Record<string, unknown>;
 	remote?: boolean;
 	cross_account_grant?: string;
+	dev?: CfDevPluginCfg;
 }
 
 export interface CfVpcService {
@@ -366,25 +387,7 @@ export interface CfUnsafeBinding {
 	name: string;
 	type: string;
 
-	dev?: {
-		plugin: {
-			/**
-			 * Package is the bare specifier of the package that exposes plugins to integrate into Miniflare via a named `plugins` export.
-			 * @example "@cloudflare/my-external-miniflare-plugin"
-			 */
-			package: string;
-			/**
-			 * Plugin is the name of the plugin exposed by the package.
-			 * @example "my-unsafe-plugin"
-			 */
-			name: string;
-		};
-
-		/**
-		 * dev-only options to pass to the plugin.
-		 */
-		options?: Record<string, unknown>;
-	};
+	dev?: CfDevPluginCfg;
 }
 
 type CfUnsafeMetadata = Record<string, unknown>;

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -4253,6 +4253,120 @@ describe("normalizeAndValidateConfig()", () => {
 					  - "services[8]" bindings should have a string "entrypoint" field but got {"binding":"SERVICE_BINDING_1","service":"SERVICE_BINDING_SERVICE_1","entrypoint":123}."
 				`);
 			});
+
+			it("should accept a valid `dev` local-plugin configuration", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						services: [
+							{
+								binding: "ENTITLEMENTS",
+								service: "edge-entitlements",
+								dev: {
+									plugin: {
+										package: "@cloudflare/workers-toolbox-plugins",
+										name: "entitlements",
+									},
+									options: { entitlements: [], mapping: {} },
+								},
+							},
+							{
+								binding: "ENTITLEMENTS_NO_OPTS",
+								service: "edge-entitlements",
+								dev: {
+									plugin: {
+										package: "@cloudflare/workers-toolbox-plugins",
+										name: "entitlements",
+									},
+								},
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(diagnostics.hasWarnings()).toBe(false);
+			});
+
+			it("should error on a malformed service binding `dev` field", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						services: [
+							{
+								binding: "BAD_DEV_NOT_OBJECT",
+								service: "svc",
+								dev: "nope",
+							},
+							{
+								binding: "BAD_DEV_MISSING_PLUGIN",
+								service: "svc",
+								dev: {},
+							},
+							{
+								binding: "BAD_DEV_PLUGIN_WRONG_SHAPE",
+								service: "svc",
+								dev: { plugin: { package: 1, name: 2 } },
+							},
+							{
+								binding: "BAD_DEV_OPTIONS_NOT_OBJECT",
+								service: "svc",
+								dev: {
+									plugin: { package: "p", name: "n" },
+									options: "should-be-object",
+								},
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "services[0]" bindings should have an object "dev" field but got "nope".
+					  - "services[1].dev" should have an object "plugin" field but got undefined.
+					  - "services[2].dev.plugin" should have a string "package" field but got 1.
+					  - "services[2].dev.plugin" should have a string "name" field but got 2.
+					  - "services[3].dev.options" should be an object but got "should-be-object"."
+				`);
+			});
+
+			it("should warn when both `dev` and `remote: true` are set", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						services: [
+							{
+								binding: "SERVICE",
+								service: "svc",
+								remote: true,
+								dev: {
+									plugin: { package: "p", name: "n" },
+								},
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(diagnostics.hasWarnings()).toBe(true);
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "services[0]" binding has both "dev" and "remote" set; "remote" is ignored when "dev" is present and the binding is routed through the local Miniflare plugin."
+				`);
+			});
 		});
 
 		describe("[analytics_engine_datasets]", () => {

--- a/packages/wrangler/src/__tests__/deploy/bindings.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/bindings.test.ts
@@ -1971,6 +1971,55 @@ describe("deploy", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
+
+			it("should strip the local-dev `dev` field from a typed service binding at deploy time", async ({
+				expect,
+			}) => {
+				writeWranglerConfig({
+					services: [
+						{
+							binding: "ENTITLEMENTS",
+							service: "edge-entitlements",
+							entrypoint: "EntitlementsRPCService",
+							// @ts-expect-error - cross_account_grant and dev are not in the public config types
+							cross_account_grant: "entitlements-grant",
+							dev: {
+								plugin: {
+									package: "@cloudflare/workers-toolbox-plugins",
+									name: "entitlements",
+								},
+								options: {
+									entitlements: [
+										{
+											key: "containers.enabled",
+											targets: ["account"],
+											type: "bool",
+										},
+									],
+									mapping: { "*": { "containers.enabled": true } },
+								},
+							},
+						},
+					],
+				});
+				writeWorkerSource();
+				mockSubDomainRequest();
+				mockUploadWorkerRequest({
+					expectedBindings: [
+						{
+							type: "service",
+							name: "ENTITLEMENTS",
+							service: "edge-entitlements",
+							entrypoint: "EntitlementsRPCService",
+							cross_account_grant: "entitlements-grant",
+						},
+					],
+				});
+
+				await runWrangler("deploy index.js");
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(std.warn).toMatchInlineSnapshot(`""`);
+			});
 		});
 
 		describe("[analytics_engine_datasets]", () => {

--- a/packages/wrangler/src/__tests__/unstable-get-miniflare-worker-options.test.ts
+++ b/packages/wrangler/src/__tests__/unstable-get-miniflare-worker-options.test.ts
@@ -135,4 +135,100 @@ describe("unstable_getMiniflareWorkerOptions", () => {
 			expect(workerOptions.zone).toBeUndefined();
 		});
 	});
+
+	describe("typed services bindings with `dev.plugin`", () => {
+		it("routes a typed service binding with `dev.plugin` to miniflare's unsafe-binding plugin pathway", ({
+			expect,
+		}) => {
+			writeWranglerConfig(
+				{
+					name: "test-worker",
+					main: "./index.js",
+					compatibility_date: "2024-10-04",
+					services: [
+						{
+							binding: "ENTITLEMENTS",
+							service: "edge-entitlements",
+							entrypoint: "EntitlementsRPCService",
+							// @ts-expect-error - cross_account_grant is internal-only and not in the public config types
+							cross_account_grant: "entitlements-grant",
+							dev: {
+								plugin: {
+									package: "@cloudflare/workers-toolbox-plugins",
+									name: "entitlements",
+								},
+								options: {
+									entitlements: [
+										{
+											key: "containers.enabled",
+											targets: ["account"],
+											type: "bool",
+										},
+									],
+									mapping: { "*": { "containers.enabled": true } },
+								},
+							},
+						},
+					],
+				},
+				"./wrangler.json"
+			);
+			const { workerOptions } =
+				unstable_getMiniflareWorkerOptions("./wrangler.json");
+
+			expect(workerOptions.serviceBindings?.ENTITLEMENTS).toBeUndefined();
+			expect(workerOptions.unsafeBindings).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						name: "ENTITLEMENTS",
+						type: "service",
+						plugin: {
+							package: "@cloudflare/workers-toolbox-plugins",
+							name: "entitlements",
+						},
+						options: expect.objectContaining({
+							service: "edge-entitlements",
+							entrypoint: "EntitlementsRPCService",
+							cross_account_grant: "entitlements-grant",
+							entitlements: [
+								{
+									key: "containers.enabled",
+									targets: ["account"],
+									type: "bool",
+								},
+							],
+							mapping: { "*": { "containers.enabled": true } },
+						}),
+					}),
+				])
+			);
+		});
+
+		it("leaves a typed service binding without `dev` on the regular service-binding pathway", ({
+			expect,
+		}) => {
+			writeWranglerConfig(
+				{
+					name: "test-worker",
+					main: "./index.js",
+					compatibility_date: "2024-10-04",
+					services: [
+						{
+							binding: "MY_SERVICE",
+							service: "real-service",
+						},
+					],
+				},
+				"./wrangler.json"
+			);
+			const { workerOptions } =
+				unstable_getMiniflareWorkerOptions("./wrangler.json");
+			expect(workerOptions.serviceBindings?.MY_SERVICE).toBeDefined();
+			expect(
+				(workerOptions.unsafeBindings ?? []).find(
+					(b) => "name" in b && b.name === "MY_SERVICE"
+				)
+			).toBeUndefined();
+		});
+	});
 });

--- a/packages/wrangler/src/dev/miniflare/index.ts
+++ b/packages/wrangler/src/dev/miniflare/index.ts
@@ -611,7 +611,33 @@ export function buildMiniflareBindingOptions(
 	const serviceBindings: NonNullable<WorkerOptions["serviceBindings"]> =
 		Object.fromEntries(fetchers.map((f) => [f.binding, f.fetcher]));
 
+	const unsafeBindings: WorkerOptionsBindings["unsafeBindings"] = [];
+
 	for (const service of services) {
+		// A `dev` plugin overrides the regular service binding and routes the binding through Miniflare's external-plugin pathway instead.
+		if (service.dev !== undefined) {
+			const {
+				binding: _binding,
+				dev: { plugin, options: devOptions },
+				remote: _remote,
+				props: _props,
+				...options
+			} = service;
+
+			logger.debug(
+				`Binding ${service.binding} is a local binding to plugin ${plugin.name} provided by package ${plugin.package}`
+			);
+
+			unsafeBindings.push({
+				name: service.binding,
+				type: "service",
+				plugin,
+				options: { ...options, ...devOptions },
+			});
+
+			continue;
+		}
+
 		if (remoteProxyConnectionString && service.remote) {
 			serviceBindings[service.binding] = {
 				name: service.service,
@@ -679,7 +705,6 @@ export function buildMiniflareBindingOptions(
 		warnOrError("flagship", flagship.remote);
 	}
 
-	const unsafeBindings: WorkerOptionsBindings["unsafeBindings"] = [];
 	const unsafeBindingsWithLocalDev = Object.entries(bindings ?? {}).filter(
 		(b) => isUnsafeServiceBindingWithDevCfg(b[1])
 	);


### PR DESCRIPTION
Wrangler previously only honored `dev.plugin` on `unsafe.bindings` entries, so users authoring a service binding via `services[]` could not wire it to a local Miniflare plugin during `wrangler dev` — they had to fall back to `unsafe.bindings` and accept a warning such as:

```
The binding type "service" is directly supported by wrangler.
Consider migrating this unsafe binding to a format for 'service' bindings that is supported by wrangler for optimal support.
```

The typed `services[]` form now accepts the same `dev: { plugin, options? }` shape, routes the binding through Miniflare's external-plugin pathway in `wrangler dev`, and strips the field at deploy time. Validation rejects malformed dev shapes.

Needed as a prerequisite to fixing https://jira.cfdata.org/browse/CC-7944

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: `services` bindings are [already documented](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/). This is just a fix for the equivalent of [`CfUnsafeBinding.dev.plugin`](https://github.com/cloudflare/workers-sdk/blob/a36a1defa98a6947b0b2bad676c24e7d7690d2fa/packages/workers-utils/src/worker.ts#L370) to work without requiring an unsafe binding.

*A picture of a cute animal (not mandatory, but encouraged)*
<img width="2576" height="1449" alt="image" src="https://github.com/user-attachments/assets/2ad469cd-5e74-4f4a-ad16-9f550b8c2717" />


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->