### PR TITLE
D1 subcommands resolve auto-provisioned bindings via API

### DIFF
--- a/.changeset/fix-d1-auto-provisioned-binding-subcommands.md
+++ b/.changeset/fix-d1-auto-provisioned-binding-subcommands.md
@@ -1,0 +1,13 @@
+---
+"wrangler": patch
+---
+
+Resolve auto-provisioned D1 bindings via the API in remote subcommands
+
+Remote D1 subcommands (`d1 execute --remote`, `d1 export --remote`, `d1 info`, `d1 insights`, `d1 delete`, `d1 migrations apply --remote`, `d1 migrations list --remote`, `d1 time-travel`) previously failed with:
+
+> Found a database with name or binding DB but it is missing a database_id, which is needed for operations on remote resources.
+
+when the `[[d1_databases]]` config entry only had `binding` and `database_name` (the shape `wrangler deploy` writes for automatically-provisioned bindings). They now resolve the real database UUID via `GET /accounts/:accountId/d1/database/:name?fields=uuid` and proceed as if `database_id` had been set in config.
+
+Non-404 API failures (auth, rate-limit, server errors) now propagate verbatim instead of being masked as "database not found".

--- a/.changeset/fix-d1-auto-provisioned-binding-subcommands.md
+++ b/.changeset/fix-d1-auto-provisioned-binding-subcommands.md
@@ -10,4 +10,6 @@ Remote D1 subcommands (`d1 execute --remote`, `d1 export --remote`, `d1 info`, `
 
 when the `[[d1_databases]]` config entry only had `binding` and `database_name` (the shape `wrangler deploy` writes for automatically-provisioned bindings). They now resolve the real database UUID via `GET /accounts/:accountId/d1/database/:name?fields=uuid` and proceed as if `database_id` had been set in config.
 
+If the config entry only has a `binding` (no `database_name`, no `database_id`), the lookup uses the same name `wrangler deploy` would create via auto provisioning (`<worker name>-<binding-lowercased-with-dashes>`).
+
 Non-404 API failures (auth, rate-limit, server errors) now propagate verbatim instead of being masked as "database not found".

--- a/packages/wrangler/src/__tests__/d1/delete.test.ts
+++ b/packages/wrangler/src/__tests__/d1/delete.test.ts
@@ -24,7 +24,7 @@ describe("delete", () => {
 		msw.use(
 			...getMswSuccessMembershipHandlers([{ id: "1701", name: "enterprise" }])
 		);
-		mockDatabaseList("test-db", "db-uuid-123");
+		mockDatabaseGet("test-db", "db-uuid-123");
 	});
 
 	it("should not delete database when confirmation is rejected", async ({
@@ -93,25 +93,24 @@ describe("delete", () => {
 	});
 });
 
-function mockDatabaseList(name: string, uuid: string) {
+function mockDatabaseGet(name: string, uuid: string) {
 	msw.use(
-		http.get("*/accounts/:accountId/d1/database", async () => {
-			return HttpResponse.json(
-				{
-					result: [
-						{
-							uuid,
-							name,
-							primary_location_hint: "WNAM",
-							created_in_region: "WNAM",
-						},
-					],
-					success: true,
-					errors: [],
-					messages: [],
-				},
-				{ status: 200 }
-			);
+		http.get("*/accounts/:accountId/d1/database/:name", async ({ params }) => {
+			if (params.name !== name) {
+				return HttpResponse.json(
+					{
+						success: false,
+						errors: [{ code: 7404, message: "Not Found" }],
+					},
+					{ status: 404 }
+				);
+			}
+			return HttpResponse.json({
+				result: { uuid },
+				success: true,
+				errors: [],
+				messages: [],
+			});
 		})
 	);
 }

--- a/packages/wrangler/src/__tests__/d1/export.test.ts
+++ b/packages/wrangler/src/__tests__/d1/export.test.ts
@@ -264,7 +264,9 @@ describe("export", () => {
 		expect(std.out).toContain("Exporting SQL to test-remote.sql...");
 	});
 
-	it("should not export remotely without database_id", async ({ expect }) => {
+	it("should fail when database_id absent from config and not found in API", async ({
+		expect,
+	}) => {
 		setIsTTY(false);
 		writeWranglerConfig({
 			d1_databases: [{ binding: "D1", database_name: "D1" }],
@@ -272,13 +274,19 @@ describe("export", () => {
 		msw.use(
 			...getMswSuccessMembershipHandlers([
 				{ id: "some-account-id", name: "test-account" },
-			])
+			]),
+			http.get("*/accounts/:accountId/d1/database/:name", () => {
+				return HttpResponse.json(
+					{ success: false, errors: [{ code: 7404, message: "Not Found" }] },
+					{ status: 404 }
+				);
+			})
 		);
 
 		await expect(
 			runWrangler("d1 export D1 --output test-remote.sql --remote")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
-			`[Error: Found a database with name or binding D1 but it is missing a database_id, which is needed for operations on remote resources. Please create the remote D1 database by deploying your project or running 'wrangler d1 create D1'.]`
+			`[Error: Couldn't find a D1 DB named 'D1' (bound as 'D1') in the API. Run 'wrangler d1 create D1' to create it.]`
 		);
 	});
 

--- a/packages/wrangler/src/__tests__/d1/info.test.ts
+++ b/packages/wrangler/src/__tests__/d1/info.test.ts
@@ -33,41 +33,6 @@ describe("info", () => {
 			],
 		});
 	});
-	it("should display version as valid json when alpha", async ({ expect }) => {
-		msw.use(
-			http.get("*/accounts/:accountId/d1/database/*", async () => {
-				return HttpResponse.json(
-					{
-						result: {
-							uuid: "d5b1d127-xxxx-xxxx-xxxx-cbc69f0a9e06",
-							name: "northwind",
-							created_at: "2023-05-23T08:33:54.590Z",
-							version: "alpha",
-							num_tables: 13,
-							file_size: 33067008,
-							running_in_region: "WEUR",
-						},
-						success: true,
-						errors: [],
-						messages: [],
-					},
-					{ status: 200 }
-				);
-			})
-		);
-		await runWrangler("d1 info northwind --json");
-		expect(JSON.parse(std.out)).toMatchInlineSnapshot(`
-			{
-			  "created_at": "2023-05-23T08:33:54.590Z",
-			  "database_size": 33067008,
-			  "name": "northwind",
-			  "num_tables": 13,
-			  "running_in_region": "WEUR",
-			  "uuid": "d5b1d127-xxxx-xxxx-xxxx-cbc69f0a9e06",
-			  "version": "alpha",
-			}
-		`);
-	});
 
 	it("should not display version as valid json when not alpha", async ({
 		expect,

--- a/packages/wrangler/src/__tests__/d1/insights.test.ts
+++ b/packages/wrangler/src/__tests__/d1/insights.test.ts
@@ -83,34 +83,16 @@ describe("insights", () => {
 		setIsTTY(false);
 		msw.use(
 			...getMswSuccessMembershipHandlers([{ id: "1701", name: "enterprise" }]),
-			http.get("*/accounts/:accountId/d1/database", async () => {
+			http.get("*/accounts/:accountId/d1/database/:name", async () => {
 				return HttpResponse.json(
-					{
-						result: [
-							{
-								created_at: "2022-11-15T18:25:44.442097Z",
-								name: "my-database",
-								uuid: "d5b1d127-xxxx-xxxx-xxxx-cbc69f0a9e06",
-								version: "production",
-							},
-						],
-						success: true,
-						result_info: {
-							count: 1,
-							page: 1,
-							per_page: 10,
-							total_count: 1,
-						},
-						errors: [],
-						messages: [],
-					},
-					{ status: 200 }
+					{ success: false, errors: [{ code: 7404, message: "Not Found" }] },
+					{ status: 404 }
 				);
 			})
 		);
 
 		await expect(() => runWrangler("d1 insights not-a-db")).rejects.toThrow(
-			"Couldn't find DB with name 'not-a-db'"
+			"Couldn't find a D1 DB with name or binding 'not-a-db' in your config or the API."
 		);
 	});
 
@@ -127,46 +109,16 @@ describe("insights", () => {
 		});
 		msw.use(
 			...getMswSuccessMembershipHandlers([{ id: "1701", name: "enterprise" }]),
-			http.get("*/accounts/:accountId/d1/database", async () => {
-				return HttpResponse.json(
-					{
-						result: [
-							{
-								created_at: "2022-11-15T18:25:44.442097Z",
-								name: "my-database",
-								uuid: "d5b1d127-xxxx-xxxx-xxxx-cbc69f0a9e06",
-								version: "production",
-							},
-						],
-						success: true,
-						errors: [],
-						messages: [],
+			http.get("*/accounts/:accountId/d1/database/:name", async () => {
+				return HttpResponse.json({
+					result: {
+						uuid: "d5b1d127-xxxx-xxxx-xxxx-cbc69f0a9e06",
+						name: "northwind",
 					},
-					{ status: 200 }
-				);
-			})
-		);
-		msw.use(
-			http.get("*/accounts/:accountId/d1/database/*", async () => {
-				return HttpResponse.json(
-					{
-						result: [
-							{
-								uuid: "d5b1d127-xxxx-xxxx-xxxx-cbc69f0a9e06",
-								name: "northwind",
-								created_at: "2023-05-23T08:33:54.590Z",
-								version: "beta",
-								num_tables: 13,
-								file_size: 33067008,
-								running_in_region: "WEUR",
-							},
-						],
-						success: true,
-						errors: [],
-						messages: [],
-					},
-					{ status: 200 }
-				);
+					success: true,
+					errors: [],
+					messages: [],
+				});
 			})
 		);
 		msw.use(

--- a/packages/wrangler/src/__tests__/d1/utils.test.ts
+++ b/packages/wrangler/src/__tests__/d1/utils.test.ts
@@ -293,8 +293,14 @@ describe("getDatabaseByNameOrBinding", () => {
 		} as unknown as Config;
 		await expect(
 			getDatabaseByNameOrBinding(config, "123", "DB")
-		).rejects.toThrow(
-			"Found a database with binding 'DB' but it has no 'database_name' or 'database_id'. This is needed for operations on remote resources unless the workers project has been auto-provisioned with a top-level 'name' set. Please create the remote D1 database by deploying your project or running 'wrangler d1 create DB' adding 'database_name' / 'database_id' to your config"
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`
+			[Error: Found a database binding named 'DB' but it has no 'database_name' or 'database_id', and the worker has no 'name'.
+
+			In order to connect to an existing database, please specify either 'database_name' or 'database_id' in the binding.
+
+			Alternatively specify a 'name' for the worker and then run 'wrangler deploy'. This will auto-provision a database named '<worker-name>-db'.]
+		`
 		);
 	});
 

--- a/packages/wrangler/src/__tests__/d1/utils.test.ts
+++ b/packages/wrangler/src/__tests__/d1/utils.test.ts
@@ -134,7 +134,7 @@ describe("getDatabaseByNameOrBinding", () => {
 		} as unknown as Config;
 		await expect(
 			getDatabaseByNameOrBinding(config, "123", "db")
-		).rejects.toThrowError(
+		).rejects.toThrow(
 			"Couldn't find a D1 DB with name or binding 'db' in your config or the API. Run 'wrangler d1 create db' to create it."
 		);
 	});

--- a/packages/wrangler/src/__tests__/d1/utils.test.ts
+++ b/packages/wrangler/src/__tests__/d1/utils.test.ts
@@ -1,8 +1,7 @@
 import { type Config } from "@cloudflare/workers-utils";
 import { http, HttpResponse } from "msw";
-import { beforeEach, describe, it } from "vitest";
+import { describe, it } from "vitest";
 import {
-	clearGetDatabaseByNameOrBindingCache,
 	getDatabaseByNameOrBinding,
 	getDatabaseInfoFromConfig,
 } from "../../d1/utils";
@@ -119,10 +118,6 @@ describe("getDatabaseInfoFromConfig", () => {
 describe("getDatabaseByNameOrBinding", () => {
 	mockAccountId({ accountId: null });
 	mockApiToken();
-	// Tests here share (accountId, name) tuples — clear the module-level
-	// lookup cache between cases so the API mocks each test installs are
-	// actually consulted.
-	beforeEach(clearGetDatabaseByNameOrBindingCache);
 
 	it("should handle no database", async ({ expect }) => {
 		msw.use(

--- a/packages/wrangler/src/__tests__/d1/utils.test.ts
+++ b/packages/wrangler/src/__tests__/d1/utils.test.ts
@@ -122,23 +122,10 @@ describe("getDatabaseByNameOrBinding", () => {
 	it("should handle no database", async ({ expect }) => {
 		msw.use(
 			...getMswSuccessMembershipHandlers([{ id: "IG-88", name: "enterprise" }]),
-			http.get("*/accounts/:accountId/d1/database", async () => {
+			http.get("*/accounts/:accountId/d1/database/:name", async () => {
 				return HttpResponse.json(
-					{
-						result: [
-							{
-								file_size: 7421952,
-								name: "benchmark3-v1",
-								num_tables: 2,
-								uuid: "7b0c1d24-ec57-4179-8663-9b82dafe9277",
-								version: "alpha",
-							},
-						],
-						success: true,
-						errors: [],
-						messages: [],
-					},
-					{ status: 200 }
+					{ success: false, errors: [{ code: 7404, message: "Not Found" }] },
+					{ status: 404 }
 				);
 			})
 		);
@@ -147,29 +134,22 @@ describe("getDatabaseByNameOrBinding", () => {
 		} as unknown as Config;
 		await expect(
 			getDatabaseByNameOrBinding(config, "123", "db")
-		).rejects.toThrowError("Couldn't find DB with name 'db'");
+		).rejects.toThrowError(
+			"Couldn't find a D1 DB with name or binding 'db' in your config or the API. Run 'wrangler d1 create db' to create it."
+		);
 	});
 
-	it("should handle a matching database", async ({ expect }) => {
-		const mockDb = {
-			file_size: 7421952,
-			name: "db",
-			num_tables: 2,
-			uuid: "7b0c1d24-ec57-4179-8663-9b82dafe9277",
-			version: "alpha",
-		};
+	it("should resolve a database by name via the D1 API", async ({ expect }) => {
+		const uuid = "7b0c1d24-ec57-4179-8663-9b82dafe9277";
 		msw.use(
 			...getMswSuccessMembershipHandlers([{ id: "IG-88", name: "enterprise" }]),
-			http.get("*/accounts/:accountId/d1/database", async () => {
-				return HttpResponse.json(
-					{
-						result: [mockDb],
-						success: true,
-						errors: [],
-						messages: [],
-					},
-					{ status: 200 }
-				);
+			http.get("*/accounts/:accountId/d1/database/:name", async () => {
+				return HttpResponse.json({
+					result: { uuid, name: "db" },
+					success: true,
+					errors: [],
+					messages: [],
+				});
 			})
 		);
 		const config = {
@@ -177,6 +157,82 @@ describe("getDatabaseByNameOrBinding", () => {
 		} as unknown as Config;
 		await expect(
 			getDatabaseByNameOrBinding(config, "123", "db")
-		).resolves.toStrictEqual(mockDb);
+		).resolves.toStrictEqual({
+			uuid,
+			name: "db",
+			binding: "db",
+			migrationsTableName: "d1_migrations",
+		});
+	});
+
+	it("should resolve an auto-provisioned binding (no database_id) via the D1 API", async ({
+		expect,
+	}) => {
+		const uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+		msw.use(
+			...getMswSuccessMembershipHandlers([{ id: "IG-88", name: "enterprise" }]),
+			http.get(
+				"*/accounts/:accountId/d1/database/:name",
+				async ({ params }) => {
+					// Should be looked up by `database_name`, not by the binding.
+					expect(params.name).toBe("my-database");
+					return HttpResponse.json({
+						result: { uuid, name: "my-database" },
+						success: true,
+						errors: [],
+						messages: [],
+					});
+				}
+			)
+		);
+		const config = {
+			d1_databases: [
+				{
+					binding: "DB",
+					database_name: "my-database",
+					migrations_dir: "./migrations",
+				},
+			],
+		} as unknown as Config;
+		await expect(
+			getDatabaseByNameOrBinding(config, "123", "DB")
+		).resolves.toStrictEqual({
+			uuid,
+			name: "my-database",
+			binding: "DB",
+			migrationsTableName: "d1_migrations",
+			migrationsDirRaw: "./migrations",
+			migrationsPattern: undefined,
+			previewDatabaseUuid: undefined,
+			internal_env: undefined,
+		});
+	});
+
+	it("propagates non-404 API errors instead of masking them as not-found", async ({
+		expect,
+	}) => {
+		msw.use(
+			...getMswSuccessMembershipHandlers([{ id: "IG-88", name: "enterprise" }]),
+			http.get("*/accounts/:accountId/d1/database/:name", async () => {
+				return HttpResponse.json(
+					{
+						success: false,
+						errors: [{ code: 10000, message: "Authentication error" }],
+					},
+					{ status: 401 }
+				);
+			})
+		);
+		const config = {
+			d1_databases: [],
+		} as unknown as Config;
+		// Surface the underlying API failure verbatim instead of replacing
+		// it with the "Couldn't find a D1 DB" UserError (which would only
+		// be correct for a 404).
+		await expect(
+			getDatabaseByNameOrBinding(config, "123", "db")
+		).rejects.toThrow(
+			"A request to the Cloudflare API (/accounts/123/d1/database/db) failed."
+		);
 	});
 });

--- a/packages/wrangler/src/__tests__/d1/utils.test.ts
+++ b/packages/wrangler/src/__tests__/d1/utils.test.ts
@@ -1,7 +1,8 @@
 import { type Config } from "@cloudflare/workers-utils";
 import { http, HttpResponse } from "msw";
-import { describe, it } from "vitest";
+import { beforeEach, describe, it } from "vitest";
 import {
+	clearGetDatabaseByNameOrBindingCache,
 	getDatabaseByNameOrBinding,
 	getDatabaseInfoFromConfig,
 } from "../../d1/utils";
@@ -118,6 +119,10 @@ describe("getDatabaseInfoFromConfig", () => {
 describe("getDatabaseByNameOrBinding", () => {
 	mockAccountId({ accountId: null });
 	mockApiToken();
+	// Tests here share (accountId, name) tuples — clear the module-level
+	// lookup cache between cases so the API mocks each test installs are
+	// actually consulted.
+	beforeEach(clearGetDatabaseByNameOrBindingCache);
 
 	it("should handle no database", async ({ expect }) => {
 		msw.use(

--- a/packages/wrangler/src/__tests__/d1/utils.test.ts
+++ b/packages/wrangler/src/__tests__/d1/utils.test.ts
@@ -208,6 +208,96 @@ describe("getDatabaseByNameOrBinding", () => {
 		});
 	});
 
+	it("resolves a binding-only config via the auto-provisioned name (worker name + binding)", async ({
+		expect,
+	}) => {
+		const uuid = "c0ffee00-c0ffee00-c0ffee00-c0ffee000000";
+		msw.use(
+			...getMswSuccessMembershipHandlers([{ id: "IG-88", name: "enterprise" }]),
+			http.get(
+				"*/accounts/:accountId/d1/database/:name",
+				async ({ params }) => {
+					// Mirrors runProvisioningFlow's defaultName:
+					// `${scriptName}-${binding.toLowerCase().replaceAll("_", "-")}`
+					expect(params.name).toBe("my-worker-d1-binding-name");
+					return HttpResponse.json({
+						result: {
+							uuid,
+							name: params.name,
+						},
+						success: true,
+						errors: [],
+						messages: [],
+					});
+				}
+			)
+		);
+		const config = {
+			name: "my-worker",
+			d1_databases: [
+				{
+					binding: "D1_BINDING_NAME",
+				},
+			],
+		} as unknown as Config;
+		await expect(
+			getDatabaseByNameOrBinding(config, "123", "D1_BINDING_NAME")
+		).resolves.toStrictEqual({
+			binding: "D1_BINDING_NAME",
+			name: "my-worker-d1-binding-name",
+			uuid,
+			migrationsTableName: "d1_migrations",
+			migrationsDirRaw: undefined,
+			migrationsPattern: undefined,
+			previewDatabaseUuid: undefined,
+			internal_env: undefined,
+		});
+	});
+
+	it("does not silently bind to an unrelated DB with the same name as the binding", async ({
+		expect,
+	}) => {
+		// Foot-gun guard: even though a DB literally named "DB" exists on the
+		// account, the auto-provisioned name is `<worker>-db`, so we must look
+		// for that and 404 — not bind to the unrelated "DB" database.
+		msw.use(
+			...getMswSuccessMembershipHandlers([{ id: "IG-88", name: "enterprise" }]),
+			http.get(
+				"*/accounts/:accountId/d1/database/:name",
+				async ({ params }) => {
+					expect(params.name).toBe("my-worker-db");
+					return HttpResponse.json(
+						{ success: false, errors: [{ code: 7404, message: "Not Found" }] },
+						{ status: 404 }
+					);
+				}
+			)
+		);
+		const config = {
+			name: "my-worker",
+			d1_databases: [{ binding: "DB" }],
+		} as unknown as Config;
+		await expect(
+			getDatabaseByNameOrBinding(config, "123", "DB")
+		).rejects.toThrow(
+			"Couldn't find an auto-provisioned D1 DB named 'my-worker-db' for binding 'DB'. Run 'wrangler deploy' to provision it, or add 'database_name' / 'database_id' to your config."
+		);
+	});
+
+	it("refuses to guess when binding has no database_name/id and worker has no name", async ({
+		expect,
+	}) => {
+		// No HTTP handler — we want to confirm we never call out.
+		const config = {
+			d1_databases: [{ binding: "DB" }],
+		} as unknown as Config;
+		await expect(
+			getDatabaseByNameOrBinding(config, "123", "DB")
+		).rejects.toThrow(
+			"Found a database with binding 'DB' but it has no 'database_name' or 'database_id'. This is needed for operations on remote resources unless the workers project has been auto-provisioned with a top-level 'name' set. Please create the remote D1 database by deploying your project or running 'wrangler d1 create DB' adding 'database_name' / 'database_id' to your config"
+		);
+	});
+
 	it("propagates non-404 API errors instead of masking them as not-found", async ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/d1/execute.ts
+++ b/packages/wrangler/src/d1/execute.ts
@@ -306,9 +306,7 @@ async function executeLocally({
 	input: ExecuteInput;
 	persistTo: string | undefined;
 }) {
-	const localDB = getDatabaseInfoFromConfig(config, name, {
-		requireDatabaseId: false,
-	});
+	const localDB = getDatabaseInfoFromConfig(config, name);
 	if (!localDB) {
 		throw new UserError(
 			`Couldn't find a D1 DB with the name or binding '${name}' in your ${configFileName(config.configPath)} file.`,
@@ -316,7 +314,8 @@ async function executeLocally({
 		);
 	}
 
-	const id = localDB.previewDatabaseUuid ?? localDB.uuid;
+	// TODO(#11870): Really we should prefer localDB.name here, but that would break users with existing local databases.
+	const id = localDB.previewDatabaseUuid ?? localDB.uuid ?? localDB.binding;
 	const persistencePath = getLocalPersistencePath(persistTo, config);
 	const d1Persist = path.join(persistencePath, "v3", "d1");
 

--- a/packages/wrangler/src/d1/export.ts
+++ b/packages/wrangler/src/d1/export.ts
@@ -138,9 +138,7 @@ async function exportLocal(
 	noSchema: boolean,
 	noData: boolean
 ) {
-	const localDB = getDatabaseInfoFromConfig(config, name, {
-		requireDatabaseId: false,
-	});
+	const localDB = getDatabaseInfoFromConfig(config, name);
 	if (!localDB) {
 		throw new UserError(
 			`Couldn't find a D1 DB with the name or binding '${name}' in your ${configFileName(config.configPath)} file.`,
@@ -148,7 +146,8 @@ async function exportLocal(
 		);
 	}
 
-	const id = localDB.previewDatabaseUuid ?? localDB.uuid;
+	// TODO(#11870): Really we should prefer localDB.name here, but that would break users with existing local databases.
+	const id = localDB.previewDatabaseUuid ?? localDB.uuid ?? localDB.binding;
 
 	// TODO: should we allow customising persistence path?
 	// Should it be --persist-to for consistency (even though this isn't persisting anything)?

--- a/packages/wrangler/src/d1/info.ts
+++ b/packages/wrangler/src/d1/info.ts
@@ -49,19 +49,21 @@ export const d1InfoCommand = createCommand({
 			output["database_size"] = output["file_size"];
 			delete output["file_size"];
 		}
-		if (output["version"] !== "alpha") {
-			delete output["version"];
-		}
-		if (result.version !== "alpha") {
-			const today = new Date();
-			const yesterday = new Date(new Date(today).setDate(today.getDate() - 1));
 
-			const graphqlResult = await fetchGraphqlResult<D1MetricsGraphQLResponse>(
-				config,
-				{
-					method: "POST",
-					body: JSON.stringify({
-						query: `query getD1MetricsOverviewQuery($accountTag: string, $filter: ZoneWorkersRequestsFilter_InputObject) {
+		// Snip off the "uuid" property from the response. We use it as the header.
+		delete output["uuid"];
+		// All alpha databses have been deleted, so version is useless noise.
+		delete output["version"];
+
+		const today = new Date();
+		const yesterday = new Date(new Date(today).setDate(today.getDate() - 1));
+
+		const graphqlResult = await fetchGraphqlResult<D1MetricsGraphQLResponse>(
+			config,
+			{
+				method: "POST",
+				body: JSON.stringify({
+					query: `query getD1MetricsOverviewQuery($accountTag: string, $filter: ZoneWorkersRequestsFilter_InputObject) {
 								viewer {
 									accounts(filter: {accountTag: $accountTag}) {
 										d1AnalyticsAdaptiveGroups(limit: 10000, filter: $filter) {
@@ -78,46 +80,45 @@ export const d1InfoCommand = createCommand({
 								}
 							}
 						}`,
-						operationName: "getD1MetricsOverviewQuery",
-						variables: {
-							accountTag: accountId,
-							filter: {
-								AND: [
-									{
-										datetimeHour_geq: yesterday.toISOString(),
-										datetimeHour_leq: today.toISOString(),
-										databaseId: db.uuid,
-									},
-								],
-							},
+					operationName: "getD1MetricsOverviewQuery",
+					variables: {
+						accountTag: accountId,
+						filter: {
+							AND: [
+								{
+									datetimeHour_geq: yesterday.toISOString(),
+									datetimeHour_leq: today.toISOString(),
+									databaseId: db.uuid,
+								},
+							],
 						},
-					}),
-					headers: {
-						"Content-Type": "application/json",
 					},
+				}),
+				headers: {
+					"Content-Type": "application/json",
+				},
+			}
+		);
+
+		const metrics = {
+			readQueries: 0,
+			writeQueries: 0,
+			rowsRead: 0,
+			rowsWritten: 0,
+		};
+		if (graphqlResult) {
+			graphqlResult.data?.viewer?.accounts[0]?.d1AnalyticsAdaptiveGroups?.forEach(
+				(row) => {
+					metrics.readQueries += row?.sum?.readQueries ?? 0;
+					metrics.writeQueries += row?.sum?.writeQueries ?? 0;
+					metrics.rowsRead += row?.sum?.rowsRead ?? 0;
+					metrics.rowsWritten += row?.sum?.rowsWritten ?? 0;
 				}
 			);
-
-			const metrics = {
-				readQueries: 0,
-				writeQueries: 0,
-				rowsRead: 0,
-				rowsWritten: 0,
-			};
-			if (graphqlResult) {
-				graphqlResult.data?.viewer?.accounts[0]?.d1AnalyticsAdaptiveGroups?.forEach(
-					(row) => {
-						metrics.readQueries += row?.sum?.readQueries ?? 0;
-						metrics.writeQueries += row?.sum?.writeQueries ?? 0;
-						metrics.rowsRead += row?.sum?.rowsRead ?? 0;
-						metrics.rowsWritten += row?.sum?.rowsWritten ?? 0;
-					}
-				);
-				output.read_queries_24h = metrics.readQueries;
-				output.write_queries_24h = metrics.writeQueries;
-				output.rows_read_24h = metrics.rowsRead;
-				output.rows_written_24h = metrics.rowsWritten;
-			}
+			output.read_queries_24h = metrics.readQueries;
+			output.write_queries_24h = metrics.writeQueries;
+			output.rows_read_24h = metrics.rowsRead;
+			output.rows_written_24h = metrics.rowsWritten;
 		}
 
 		if (json) {
@@ -129,12 +130,7 @@ export const d1InfoCommand = createCommand({
 				delete output["read_replication"];
 			}
 
-			// Snip off the "uuid" property from the response and use those as the header
-			const entries = Object.entries(output).filter(
-				// also remove any version that isn't "alpha"
-				([k, v]) => k !== "uuid" && !(k === "version" && v !== "alpha")
-			);
-			const data = entries.map(([k, v]) => {
+			const data = Object.entries(output).map(([k, v]) => {
 				let value;
 				if (k === "database_size") {
 					value = prettyBytes(Number(v));

--- a/packages/wrangler/src/d1/info.ts
+++ b/packages/wrangler/src/d1/info.ts
@@ -7,7 +7,7 @@ import {
 	getDatabaseByNameOrBinding,
 	getDatabaseInfoFromIdOrName,
 } from "./utils";
-import type { D1MetricsGraphQLResponse, Database } from "./types";
+import type { D1MetricsGraphQLResponse } from "./types";
 
 export const d1InfoCommand = createCommand({
 	metadata: {
@@ -36,11 +36,7 @@ export const d1InfoCommand = createCommand({
 	positionalArgs: ["name"],
 	async handler({ name, json }, { config }) {
 		const accountId = await requireAuth(config);
-		const db: Database = await getDatabaseByNameOrBinding(
-			config,
-			accountId,
-			name
-		);
+		const db = await getDatabaseByNameOrBinding(config, accountId, name);
 
 		const result = await getDatabaseInfoFromIdOrName(
 			config,

--- a/packages/wrangler/src/d1/info.ts
+++ b/packages/wrangler/src/d1/info.ts
@@ -50,8 +50,6 @@ export const d1InfoCommand = createCommand({
 			delete output["file_size"];
 		}
 
-		// Snip off the "uuid" property from the response. We use it as the header.
-		delete output["uuid"];
 		// All alpha databses have been deleted, so version is useless noise.
 		delete output["version"];
 
@@ -124,6 +122,9 @@ export const d1InfoCommand = createCommand({
 		if (json) {
 			logger.log(JSON.stringify(output, null, 2));
 		} else {
+			// Snip off the "uuid" property from the response. We use it as the header instead.
+			delete output["uuid"];
+
 			// Selectively bring the nested read_replication info at the top level.
 			if (result.read_replication) {
 				output["read_replication.mode"] = result.read_replication.mode;

--- a/packages/wrangler/src/d1/insights.ts
+++ b/packages/wrangler/src/d1/insights.ts
@@ -3,11 +3,8 @@ import { fetchGraphqlResult } from "../cfetch";
 import { createCommand } from "../core/create-command";
 import { logger } from "../logger";
 import { requireAuth } from "../user";
-import {
-	getDatabaseByNameOrBinding,
-	getDatabaseInfoFromIdOrName,
-} from "./utils";
-import type { D1QueriesGraphQLResponse, Database } from "./types";
+import { getDatabaseByNameOrBinding } from "./utils";
+import type { D1QueriesGraphQLResponse } from "./types";
 
 const cliOptionToGraphQLOption = {
 	time: "queryDurationMs",
@@ -127,32 +124,21 @@ export const d1InsightsCommand = createCommand({
 		{ config }
 	) {
 		const accountId = await requireAuth(config);
-		const db: Database = await getDatabaseByNameOrBinding(
-			config,
-			accountId,
-			name
-		);
-
-		const result = await getDatabaseInfoFromIdOrName(
-			config,
-			accountId,
-			db.uuid
-		);
+		const db = await getDatabaseByNameOrBinding(config, accountId, name);
 
 		const output: Record<string, string | number>[] = [];
 
-		if (result.version !== "alpha") {
-			const [startDate, endDate] = getDurationDates(timePeriod);
-			const parsedSortBy = cliOptionToGraphQLOption[sortBy];
-			const orderByClause =
-				parsedSortBy === "count"
-					? `${parsedSortBy}_${sortDirection}`
-					: `${sortType}_${parsedSortBy}_${sortDirection}`;
-			const graphqlQueriesResult =
-				await fetchGraphqlResult<D1QueriesGraphQLResponse>(config, {
-					method: "POST",
-					body: JSON.stringify({
-						query: `query getD1QueriesOverviewQuery($accountTag: string, $filter: ZoneWorkersRequestsFilter_InputObject) {
+		const [startDate, endDate] = getDurationDates(timePeriod);
+		const parsedSortBy = cliOptionToGraphQLOption[sortBy];
+		const orderByClause =
+			parsedSortBy === "count"
+				? `${parsedSortBy}_${sortDirection}`
+				: `${sortType}_${parsedSortBy}_${sortDirection}`;
+		const graphqlQueriesResult =
+			await fetchGraphqlResult<D1QueriesGraphQLResponse>(config, {
+				method: "POST",
+				body: JSON.stringify({
+					query: `query getD1QueriesOverviewQuery($accountTag: string, $filter: ZoneWorkersRequestsFilter_InputObject) {
 								viewer {
 									accounts(filter: {accountTag: $accountTag}) {
 										d1QueriesAdaptiveGroups(limit: ${limit}, filter: $filter, orderBy: [${orderByClause}]) {
@@ -176,47 +162,46 @@ export const d1InsightsCommand = createCommand({
 									}
 								}
 							}`,
-						operationName: "getD1QueriesOverviewQuery",
-						variables: {
-							accountTag: accountId,
-							filter: {
-								AND: [
-									{
-										datetimeHour_geq: startDate,
-										datetimeHour_leq: endDate,
-										databaseId: db.uuid,
-									},
-								],
-							},
+					operationName: "getD1QueriesOverviewQuery",
+					variables: {
+						accountTag: accountId,
+						filter: {
+							AND: [
+								{
+									datetimeHour_geq: startDate,
+									datetimeHour_leq: endDate,
+									databaseId: db.uuid,
+								},
+							],
 						},
-					}),
-					headers: {
-						"Content-Type": "application/json",
 					},
-				});
+				}),
+				headers: {
+					"Content-Type": "application/json",
+				},
+			});
 
-			graphqlQueriesResult?.data?.viewer?.accounts[0]?.d1QueriesAdaptiveGroups?.forEach(
-				(row) => {
-					if (!row.dimensions.query) {
-						return;
-					}
-					output.push({
-						query: row.dimensions.query,
-						avgRowsRead: row?.avg?.rowsRead ?? 0,
-						totalRowsRead: row?.sum?.rowsRead ?? 0,
-						avgRowsWritten: row?.avg?.rowsWritten ?? 0,
-						totalRowsWritten: row?.sum?.rowsWritten ?? 0,
-						avgDurationMs: row?.avg?.queryDurationMs ?? 0,
-						totalDurationMs: row?.sum?.queryDurationMs ?? 0,
-						numberOfTimesRun: row?.count ?? 0,
-						queryEfficiency:
-							row?.avg?.rowsReturned && row?.avg?.rowsRead
-								? row?.avg?.rowsReturned / row?.avg?.rowsRead
-								: 0,
-					});
+		graphqlQueriesResult?.data?.viewer?.accounts[0]?.d1QueriesAdaptiveGroups?.forEach(
+			(row) => {
+				if (!row.dimensions.query) {
+					return;
 				}
-			);
-		}
+				output.push({
+					query: row.dimensions.query,
+					avgRowsRead: row?.avg?.rowsRead ?? 0,
+					totalRowsRead: row?.sum?.rowsRead ?? 0,
+					avgRowsWritten: row?.avg?.rowsWritten ?? 0,
+					totalRowsWritten: row?.sum?.rowsWritten ?? 0,
+					avgDurationMs: row?.avg?.queryDurationMs ?? 0,
+					totalDurationMs: row?.sum?.queryDurationMs ?? 0,
+					numberOfTimesRun: row?.count ?? 0,
+					queryEfficiency:
+						row?.avg?.rowsReturned && row?.avg?.rowsRead
+							? row?.avg?.rowsReturned / row?.avg?.rowsRead
+							: 0,
+				});
+			}
+		);
 
 		if (json) {
 			logger.log(JSON.stringify(output, null, 2));

--- a/packages/wrangler/src/d1/list.ts
+++ b/packages/wrangler/src/d1/list.ts
@@ -2,7 +2,7 @@ import { fetchResult } from "../cfetch";
 import { createCommand } from "../core/create-command";
 import { logger } from "../logger";
 import { requireAuth } from "../user";
-import type { Database } from "./types";
+import type { ConcreteDatabase, Database } from "./types";
 import type { ComplianceConfig } from "@cloudflare/workers-utils";
 
 export const d1ListCommand = createCommand({
@@ -46,20 +46,19 @@ export const listDatabases = async (
 	accountId: string,
 	limitCalls: boolean = false,
 	pageSize: number = 10
-): Promise<Array<Omit<Database, "name"> & { name: string }>> => {
+): Promise<Array<ConcreteDatabase>> => {
 	let page = 1;
 	const results = [];
 	while (results.length % pageSize === 0) {
-		const json: Array<Omit<Database, "name"> & { name: string }> =
-			await fetchResult(
-				complianceConfig,
-				`/accounts/${accountId}/d1/database`,
-				{},
-				new URLSearchParams({
-					per_page: pageSize.toString(),
-					page: page.toString(),
-				})
-			);
+		const json: Array<ConcreteDatabase> = await fetchResult(
+			complianceConfig,
+			`/accounts/${accountId}/d1/database`,
+			{},
+			new URLSearchParams({
+				per_page: pageSize.toString(),
+				page: page.toString(),
+			})
+		);
 		page++;
 		results.push(...json);
 		if (limitCalls && page > 3) {

--- a/packages/wrangler/src/d1/migrations/apply.ts
+++ b/packages/wrangler/src/d1/migrations/apply.ts
@@ -5,7 +5,6 @@ import { createCommand } from "../../core/create-command";
 import { confirm } from "../../dialogs";
 import { isNonInteractiveOrCI } from "../../is-interactive";
 import { logger } from "../../logger";
-import { isLocal } from "../../utils/is-local";
 import { executeSql } from "../execute";
 import { getDatabaseInfoFromConfig } from "../utils";
 import {
@@ -76,9 +75,7 @@ export const d1MigrationsApplyCommand = createCommand({
 			);
 		}
 
-		const databaseInfo = getDatabaseInfoFromConfig(config, database, {
-			requireDatabaseId: !isLocal({ local, remote }),
-		});
+		const databaseInfo = getDatabaseInfoFromConfig(config, database);
 
 		if (!databaseInfo && remote) {
 			throw new UserError(

--- a/packages/wrangler/src/d1/migrations/create.ts
+++ b/packages/wrangler/src/d1/migrations/create.ts
@@ -52,9 +52,7 @@ export const d1MigrationsCreateCommand = createCommand({
 			);
 		}
 
-		const databaseInfo = getDatabaseInfoFromConfig(config, database, {
-			requireDatabaseId: false,
-		});
+		const databaseInfo = getDatabaseInfoFromConfig(config, database);
 		if (!databaseInfo) {
 			throw new UserError(
 				`Couldn't find a D1 DB with the name or binding '${database}' in your ${configFileName(config.configPath)} file.`,

--- a/packages/wrangler/src/d1/migrations/list.ts
+++ b/packages/wrangler/src/d1/migrations/list.ts
@@ -2,7 +2,6 @@ import { configFileName, UserError } from "@cloudflare/workers-utils";
 import { createCommand } from "../../core/create-command";
 import { logger } from "../../logger";
 import { requireAuth } from "../../user";
-import { isLocal } from "../../utils/is-local";
 import { getDatabaseInfoFromConfig } from "../utils";
 import {
 	getMigrationsPath,
@@ -62,9 +61,7 @@ export const d1MigrationsListCommand = createCommand({
 			);
 		}
 
-		const databaseInfo = getDatabaseInfoFromConfig(config, database, {
-			requireDatabaseId: !isLocal({ local, remote }), // Only require database_id for remote operations
-		});
+		const databaseInfo = getDatabaseInfoFromConfig(config, database);
 		if (!databaseInfo && remote) {
 			throw new UserError(
 				`Couldn't find a D1 DB with the name or binding '${database}' in your ${configFileName(config.configPath)} file.`,

--- a/packages/wrangler/src/d1/types.ts
+++ b/packages/wrangler/src/d1/types.ts
@@ -1,5 +1,6 @@
+/** Database info, possibly translated from wrangler configs with bits missing */
 export type Database = {
-	uuid: string;
+	uuid?: string;
 	previewDatabaseUuid?: string;
 	name?: string;
 	binding: string;
@@ -17,6 +18,27 @@ export type Database = {
 	 */
 	migrationsPattern?: string;
 };
+
+/** Most --remote commands need a database with a uuid. This may be fetched from the API */
+export type DatabaseWithUuid = Omit<Database, "uuid"> & {
+	uuid: string;
+};
+
+export function hasUuid(db: Database | null): db is DatabaseWithUuid {
+	return !!db?.uuid;
+}
+
+/** If we made a request to get database info then we will have both name and uuid */
+export type ConcreteDatabase = Omit<Database, "name" | "uuid"> & {
+	name: string;
+	uuid: string;
+};
+
+export function isConcreteDatabase(
+	db: Database | null
+): db is ConcreteDatabase {
+	return !!(db?.name && db?.uuid);
+}
 
 export type DatabaseCreationResult = {
 	uuid: string;

--- a/packages/wrangler/src/d1/utils.ts
+++ b/packages/wrangler/src/d1/utils.ts
@@ -1,5 +1,6 @@
 import { APIError, UserError } from "@cloudflare/workers-utils";
 import { fetchResult } from "../cfetch";
+import { autoProvisionedResourceName } from "../deployment-bundle/auto-provisioned-name";
 import { DEFAULT_MIGRATION_TABLE } from "./constants";
 import {
 	type DatabaseWithUuid,
@@ -47,7 +48,39 @@ export const getDatabaseByNameOrBinding = async (
 	// Either not in config at all, or the binding exists but `database_id` is
 	// absent (auto-provisioned binding — see Workers automatic resource
 	// provisioning). Look up the real UUID via the D1 API.
-	const lookupName = dbFromConfig?.name ?? nameOrBinding;
+	//
+	let lookupName: string;
+	if (dbFromConfig?.name) {
+		// Config has `database_name` — use it directly.
+		lookupName = dbFromConfig.name;
+	} else if (dbFromConfig) {
+		// Binding is in config but has no `database_name`. Use the name
+		// `wrangler deploy` would create (`<worker name>-<binding>`),
+		// if the worker has a `name`.
+		if (config.name) {
+			lookupName = autoProvisionedResourceName(
+				config.name,
+				dbFromConfig.binding
+			);
+		} else {
+			// No worker name, no database_name, no database_id — there's no
+			// way to pick out which D1 database the binding refers to. Refuse
+			// rather than silently falling back to nameOrBinding, which could
+			// bind to an unrelated DB on the account that happens to share
+			// the binding name.
+			throw new UserError(
+				`Found a database with binding '${nameOrBinding}' but it has no 'database_name' or 'database_id'. This is needed for operations on remote resources unless the workers project has been auto-provisioned with a top-level 'name' set. Please create the remote D1 database by deploying your project or running 'wrangler d1 create ${nameOrBinding}' adding 'database_name' / 'database_id' to your config`,
+				{
+					telemetryMessage: "d1 database lookup missing name and id",
+				}
+			);
+		}
+	} else {
+		// Not in config at all — treat `nameOrBinding` as a literal name
+		// (e.g. `wrangler d1 execute <db-name>` with no matching config entry).
+		lookupName = nameOrBinding;
+	}
+
 	let uuid: string;
 	let name: string;
 	try {
@@ -62,10 +95,26 @@ export const getDatabaseByNameOrBinding = async (
 		// else (401, 403, 429, 5xx, network) should propagate so the user
 		// sees the real failure instead of a misleading "DB not found".
 		if (err instanceof APIError && err.status === 404) {
+			if (dbFromConfig?.name) {
+				throw new UserError(
+					`Couldn't find a D1 DB named '${lookupName}' (bound as '${nameOrBinding}') in the API. Run 'wrangler d1 create ${lookupName}' to create it.`,
+					{ telemetryMessage: "d1 database lookup database not found" }
+				);
+			}
+			if (dbFromConfig) {
+				// Binding-only config — `lookupName` is the auto-provisioned
+				// guess. The DB doesn't exist yet, so point the user at
+				// `wrangler deploy` rather than `wrangler d1 create`.
+				throw new UserError(
+					`Couldn't find an auto-provisioned D1 DB named '${lookupName}' for binding '${nameOrBinding}'. Run 'wrangler deploy' to provision it, or add 'database_name' / 'database_id' to your config.`,
+					{
+						telemetryMessage:
+							"d1 database lookup auto-provisioned database not found",
+					}
+				);
+			}
 			throw new UserError(
-				dbFromConfig
-					? `Couldn't find a D1 DB named '${lookupName}' (bound as '${nameOrBinding}') in the API. Run 'wrangler d1 create ${lookupName}' to create it.`
-					: `Couldn't find a D1 DB with name or binding '${nameOrBinding}' in your config or the API. Run 'wrangler d1 create ${nameOrBinding}' to create it.`,
+				`Couldn't find a D1 DB with name or binding '${nameOrBinding}' in your config or the API. Run 'wrangler d1 create ${nameOrBinding}' to create it.`,
 				{ telemetryMessage: "d1 database lookup database not found" }
 			);
 		}

--- a/packages/wrangler/src/d1/utils.ts
+++ b/packages/wrangler/src/d1/utils.ts
@@ -34,25 +34,6 @@ export function getDatabaseInfoFromConfig(
 	return null;
 }
 
-/**
- * In-memory cache of `GET /accounts/:accountId/d1/database/:name?fields=…`
- *
- * This matters for `d1 migrations apply` against an auto-provisioned binding,
- * where `executeSql` is called N+2 times (init, list-applied, then once per
- * migration) and each call would otherwise re-hit the API for the same name.
- *
- * Keyed by the resouce path (`/accounts/.../d1/database/...`)
- */
-const getDatabaseByNameOrBindingCache = new Map<
-	string,
-	{ uuid: string; name: string }
->();
-
-/** @internal — for use in test setup only. */
-export function clearGetDatabaseByNameOrBindingCache() {
-	getDatabaseByNameOrBindingCache.clear();
-}
-
 /** May do an api lookup to fill in uuid. Not suitable for --local mode. */
 export const getDatabaseByNameOrBinding = async (
 	config: Config,
@@ -67,34 +48,29 @@ export const getDatabaseByNameOrBinding = async (
 	// absent (auto-provisioned binding — see Workers automatic resource
 	// provisioning). Look up the real UUID via the D1 API.
 	const lookupName = dbFromConfig?.name ?? nameOrBinding;
-	const lookupUrl = `/accounts/${accountId}/d1/database/${encodeURIComponent(lookupName)}`;
-	let resolved = getDatabaseByNameOrBindingCache.get(lookupUrl);
-	if (!resolved) {
-		try {
-			resolved = await fetchResult<{ uuid: string; name: string }>(
-				config,
-				lookupUrl,
-				{},
-				new URLSearchParams({ fields: "uuid,name" })
+	let uuid: string;
+	let name: string;
+	try {
+		({ uuid, name } = await fetchResult<{ uuid: string; name: string }>(
+			config,
+			`/accounts/${accountId}/d1/database/${encodeURIComponent(lookupName)}`,
+			{},
+			new URLSearchParams({ fields: "uuid,name" })
+		));
+	} catch (err) {
+		// Only convert 404 into the friendly "not found" UserError. Anything
+		// else (401, 403, 429, 5xx, network) should propagate so the user
+		// sees the real failure instead of a misleading "DB not found".
+		if (err instanceof APIError && err.status === 404) {
+			throw new UserError(
+				dbFromConfig
+					? `Couldn't find a D1 DB named '${lookupName}' (bound as '${nameOrBinding}') in the API. Run 'wrangler d1 create ${lookupName}' to create it.`
+					: `Couldn't find a D1 DB with name or binding '${nameOrBinding}' in your config or the API. Run 'wrangler d1 create ${nameOrBinding}' to create it.`,
+				{ telemetryMessage: "d1 database lookup database not found" }
 			);
-		} catch (err) {
-			// Only convert 404 into the friendly "not found" UserError.
-			// Anything else (401, 403, 429, 5xx, network) should propagate so
-			// the user sees the real failure instead of a misleading "DB not
-			// found".
-			if (err instanceof APIError && err.status === 404) {
-				throw new UserError(
-					dbFromConfig
-						? `Couldn't find a D1 DB named '${lookupName}' (bound as '${nameOrBinding}') in the API. Run 'wrangler d1 create ${lookupName}' to create it.`
-						: `Couldn't find a D1 DB with name or binding '${nameOrBinding}' in your config or the API. Run 'wrangler d1 create ${nameOrBinding}' to create it.`,
-					{ telemetryMessage: "d1 database lookup database not found" }
-				);
-			}
-			throw err;
 		}
-		getDatabaseByNameOrBindingCache.set(lookupUrl, resolved);
+		throw err;
 	}
-	const { uuid, name } = resolved;
 
 	if (dbFromConfig) {
 		// Binding in config but no database_id — merge real uuid from API

--- a/packages/wrangler/src/d1/utils.ts
+++ b/packages/wrangler/src/d1/utils.ts
@@ -9,6 +9,7 @@ import {
 	type DatabaseInfo,
 } from "./types";
 import type { ComplianceConfig, Config } from "@cloudflare/workers-utils";
+import { dedent } from "ts-dedent";
 
 export function getDatabaseInfoFromConfig(
 	config: Config,
@@ -69,7 +70,12 @@ export const getDatabaseByNameOrBinding = async (
 			// bind to an unrelated DB on the account that happens to share
 			// the binding name.
 			throw new UserError(
-				`Found a database with binding '${nameOrBinding}' but it has no 'database_name' or 'database_id'. This is needed for operations on remote resources unless the workers project has been auto-provisioned with a top-level 'name' set. Please create the remote D1 database by deploying your project or running 'wrangler d1 create ${nameOrBinding}' adding 'database_name' / 'database_id' to your config`,
+				dedent`Found a database binding named '${nameOrBinding}' but it has no 'database_name' or 'database_id', and the worker has no 'name'.
+
+				In order to connect to an existing database, please specify either 'database_name' or 'database_id' in the binding.
+
+				Alternatively specify a 'name' for the worker and then run 'wrangler deploy'. This will auto-provision a database named '${autoProvisionedResourceName('<worker-name>', nameOrBinding)}'.
+				`,
 				{
 					telemetryMessage: "d1 database lookup missing name and id",
 				}

--- a/packages/wrangler/src/d1/utils.ts
+++ b/packages/wrangler/src/d1/utils.ts
@@ -1,4 +1,5 @@
 import { APIError, UserError } from "@cloudflare/workers-utils";
+import { dedent } from "ts-dedent";
 import { fetchResult } from "../cfetch";
 import { autoProvisionedResourceName } from "../deployment-bundle/auto-provisioned-name";
 import { DEFAULT_MIGRATION_TABLE } from "./constants";
@@ -9,7 +10,6 @@ import {
 	type DatabaseInfo,
 } from "./types";
 import type { ComplianceConfig, Config } from "@cloudflare/workers-utils";
-import { dedent } from "ts-dedent";
 
 export function getDatabaseInfoFromConfig(
 	config: Config,
@@ -74,7 +74,7 @@ export const getDatabaseByNameOrBinding = async (
 
 				In order to connect to an existing database, please specify either 'database_name' or 'database_id' in the binding.
 
-				Alternatively specify a 'name' for the worker and then run 'wrangler deploy'. This will auto-provision a database named '${autoProvisionedResourceName('<worker-name>', nameOrBinding)}'.
+				Alternatively specify a 'name' for the worker and then run 'wrangler deploy'. This will auto-provision a database named '${autoProvisionedResourceName("<worker-name>", nameOrBinding)}'.
 				`,
 				{
 					telemetryMessage: "d1 database lookup missing name and id",

--- a/packages/wrangler/src/d1/utils.ts
+++ b/packages/wrangler/src/d1/utils.ts
@@ -34,6 +34,25 @@ export function getDatabaseInfoFromConfig(
 	return null;
 }
 
+/**
+ * In-memory cache of `GET /accounts/:accountId/d1/database/:name?fields=…`
+ *
+ * This matters for `d1 migrations apply` against an auto-provisioned binding,
+ * where `executeSql` is called N+2 times (init, list-applied, then once per
+ * migration) and each call would otherwise re-hit the API for the same name.
+ *
+ * Keyed by the resouce path (`/accounts/.../d1/database/...`)
+ */
+const getDatabaseByNameOrBindingCache = new Map<
+	string,
+	{ uuid: string; name: string }
+>();
+
+/** @internal — for use in test setup only. */
+export function clearGetDatabaseByNameOrBindingCache() {
+	getDatabaseByNameOrBindingCache.clear();
+}
+
 /** May do an api lookup to fill in uuid. Not suitable for --local mode. */
 export const getDatabaseByNameOrBinding = async (
 	config: Config,
@@ -48,29 +67,34 @@ export const getDatabaseByNameOrBinding = async (
 	// absent (auto-provisioned binding — see Workers automatic resource
 	// provisioning). Look up the real UUID via the D1 API.
 	const lookupName = dbFromConfig?.name ?? nameOrBinding;
-	let uuid: string;
-	let name: string;
-	try {
-		({ uuid, name } = await fetchResult<{ uuid: string; name: string }>(
-			config,
-			`/accounts/${accountId}/d1/database/${encodeURIComponent(lookupName)}`,
-			{},
-			new URLSearchParams({ fields: "uuid,name" })
-		));
-	} catch (err) {
-		// Only convert 404 into the friendly "not found" UserError. Anything
-		// else (401, 403, 429, 5xx, network) should propagate so the user
-		// sees the real failure instead of a misleading "DB not found".
-		if (err instanceof APIError && err.status === 404) {
-			throw new UserError(
-				dbFromConfig
-					? `Couldn't find a D1 DB named '${lookupName}' (bound as '${nameOrBinding}') in the API. Run 'wrangler d1 create ${lookupName}' to create it.`
-					: `Couldn't find a D1 DB with name or binding '${nameOrBinding}' in your config or the API. Run 'wrangler d1 create ${nameOrBinding}' to create it.`,
-				{ telemetryMessage: "d1 database lookup database not found" }
+	const lookupUrl = `/accounts/${accountId}/d1/database/${encodeURIComponent(lookupName)}`;
+	let resolved = getDatabaseByNameOrBindingCache.get(lookupUrl);
+	if (!resolved) {
+		try {
+			resolved = await fetchResult<{ uuid: string; name: string }>(
+				config,
+				lookupUrl,
+				{},
+				new URLSearchParams({ fields: "uuid,name" })
 			);
+		} catch (err) {
+			// Only convert 404 into the friendly "not found" UserError.
+			// Anything else (401, 403, 429, 5xx, network) should propagate so
+			// the user sees the real failure instead of a misleading "DB not
+			// found".
+			if (err instanceof APIError && err.status === 404) {
+				throw new UserError(
+					dbFromConfig
+						? `Couldn't find a D1 DB named '${lookupName}' (bound as '${nameOrBinding}') in the API. Run 'wrangler d1 create ${lookupName}' to create it.`
+						: `Couldn't find a D1 DB with name or binding '${nameOrBinding}' in your config or the API. Run 'wrangler d1 create ${nameOrBinding}' to create it.`,
+					{ telemetryMessage: "d1 database lookup database not found" }
+				);
+			}
+			throw err;
 		}
-		throw err;
+		getDatabaseByNameOrBindingCache.set(lookupUrl, resolved);
 	}
+	const { uuid, name } = resolved;
 
 	if (dbFromConfig) {
 		// Binding in config but no database_id — merge real uuid from API

--- a/packages/wrangler/src/d1/utils.ts
+++ b/packages/wrangler/src/d1/utils.ts
@@ -1,40 +1,25 @@
-import { UserError } from "@cloudflare/workers-utils";
+import { APIError, UserError } from "@cloudflare/workers-utils";
 import { fetchResult } from "../cfetch";
 import { DEFAULT_MIGRATION_TABLE } from "./constants";
-import { listDatabases } from "./list";
-import type { Database, DatabaseInfo } from "./types";
+import {
+	type DatabaseWithUuid,
+	hasUuid,
+	type Database,
+	type DatabaseInfo,
+} from "./types";
 import type { ComplianceConfig, Config } from "@cloudflare/workers-utils";
 
 export function getDatabaseInfoFromConfig(
 	config: Config,
-	name: string,
-	options?: {
-		/**
-		 * Local databases might not have a database id, so we don't require it for local-only operations
-		 * @default true
-		 */
-		requireDatabaseId?: boolean;
-	}
+	nameOrBinding: string
 ): Database | null {
-	const requireDatabaseId = options?.requireDatabaseId ?? true;
-
 	for (const d1Database of config.d1_databases) {
-		if (name === d1Database.database_name || name === d1Database.binding) {
-			if (requireDatabaseId && !d1Database.database_id) {
-				throw new UserError(
-					`Found a database with name or binding ${name} but it is missing a database_id, which is needed for operations on remote resources. Please create the remote D1 database by deploying your project or running 'wrangler d1 create ${name}'.`,
-					{ telemetryMessage: "d1 database config missing database id" }
-				);
-			}
-			// If requireDatabaseId is true (default), skip entries without database_id
-			// This is needed for remote operations that require a real database UUID
-
-			// For local operations, fall back to using the binding as the ID
-			// This matches the behavior in wrangler dev (see d1DatabaseEntry in dev/miniflare/index.ts)
-			const uuid = d1Database.database_id ?? d1Database.binding;
-
+		if (
+			nameOrBinding === d1Database.database_name ||
+			nameOrBinding === d1Database.binding
+		) {
 			return {
-				uuid,
+				uuid: d1Database.database_id,
 				previewDatabaseUuid: d1Database.preview_database_id,
 				binding: d1Database.binding,
 				name: d1Database.database_name,
@@ -49,24 +34,60 @@ export function getDatabaseInfoFromConfig(
 	return null;
 }
 
+/** May do an api lookup to fill in uuid. Not suitable for --local mode. */
 export const getDatabaseByNameOrBinding = async (
 	config: Config,
 	accountId: string,
-	name: string
-): Promise<Database> => {
-	const dbFromConfig = getDatabaseInfoFromConfig(config, name);
-	if (dbFromConfig) {
+	nameOrBinding: string
+): Promise<DatabaseWithUuid> => {
+	const dbFromConfig = getDatabaseInfoFromConfig(config, nameOrBinding);
+	if (hasUuid(dbFromConfig)) {
 		return dbFromConfig;
 	}
-
-	const allDBs = await listDatabases(config, accountId);
-	const matchingDB = allDBs.find((db) => db.name === name);
-	if (!matchingDB) {
-		throw new UserError(`Couldn't find DB with name '${name}'`, {
-			telemetryMessage: "d1 database lookup database not found",
-		});
+	// Either not in config at all, or the binding exists but `database_id` is
+	// absent (auto-provisioned binding — see Workers automatic resource
+	// provisioning). Look up the real UUID via the D1 API.
+	const lookupName = dbFromConfig?.name ?? nameOrBinding;
+	let uuid: string;
+	let name: string;
+	try {
+		({ uuid, name } = await fetchResult<{ uuid: string; name: string }>(
+			config,
+			`/accounts/${accountId}/d1/database/${encodeURIComponent(lookupName)}`,
+			{},
+			new URLSearchParams({ fields: "uuid,name" })
+		));
+	} catch (err) {
+		// Only convert 404 into the friendly "not found" UserError. Anything
+		// else (401, 403, 429, 5xx, network) should propagate so the user
+		// sees the real failure instead of a misleading "DB not found".
+		if (err instanceof APIError && err.status === 404) {
+			throw new UserError(
+				dbFromConfig
+					? `Couldn't find a D1 DB named '${lookupName}' (bound as '${nameOrBinding}') in the API. Run 'wrangler d1 create ${lookupName}' to create it.`
+					: `Couldn't find a D1 DB with name or binding '${nameOrBinding}' in your config or the API. Run 'wrangler d1 create ${nameOrBinding}' to create it.`,
+				{ telemetryMessage: "d1 database lookup database not found" }
+			);
+		}
+		throw err;
 	}
-	return matchingDB;
+
+	if (dbFromConfig) {
+		// Binding in config but no database_id — merge real uuid from API
+		// with migration settings from config.
+		return {
+			...dbFromConfig,
+			name,
+			uuid,
+		};
+	}
+
+	return {
+		uuid,
+		name,
+		binding: nameOrBinding,
+		migrationsTableName: DEFAULT_MIGRATION_TABLE,
+	};
 };
 
 export const getDatabaseInfoFromIdOrName = async (

--- a/packages/wrangler/src/deployment-bundle/auto-provisioned-name.ts
+++ b/packages/wrangler/src/deployment-bundle/auto-provisioned-name.ts
@@ -1,0 +1,9 @@
+/**
+ * The resource name that auto-provisioning will create for a given binding.
+ */
+export function autoProvisionedResourceName(
+	scriptName: string,
+	bindingName: string
+): string {
+	return `${scriptName}-${bindingName.toLowerCase().replaceAll("_", "-")}`;
+}

--- a/packages/wrangler/src/deployment-bundle/bindings.ts
+++ b/packages/wrangler/src/deployment-bundle/bindings.ts
@@ -28,6 +28,7 @@ import {
 } from "../r2/helpers/bucket";
 import { printBindings } from "../utils/print-bindings";
 import { useServiceEnvironments } from "../utils/useServiceEnvironments";
+import { autoProvisionedResourceName } from "./auto-provisioned-name";
 import type { Binding, StartDevWorkerInput } from "../api/startDevWorker/types";
 import type {
 	CfAgentMemory,
@@ -893,7 +894,7 @@ async function runProvisioningFlow(
 		});
 	}
 
-	const defaultName = `${scriptName}-${item.binding.toLowerCase().replaceAll("_", "-")}`;
+	const defaultName = autoProvisionedResourceName(scriptName, item.binding);
 	logger.log("Provisioning", item.binding, `(${friendlyBindingName})...`);
 
 	if (item.handler.name) {


### PR DESCRIPTION
This supersedes https://github.com/cloudflare/workers-sdk/pull/14025 because 

1) I've taken it over and pushed a bunch of refactors in there, so it doesn't feel right that I could be the D1 approver for it.
2) I don't like the tone of the bot that's driving it (https://github.com/cloudflare/workers-sdk/pull/14025#issuecomment-4687857442) and I don't want it interfering as I drive the changeset over the line.

Original description:

> When a D1 binding is configured without `database_id` — for example, after automatic resource provisioning via `wrangler deploy` — D1 subcommands like `d1 migrations apply --remote`, `d1 migrations list --remote`, and `d1 execute --remote` failed immediately with:
>
>    ✘ [ERROR] Found a database with name or binding DB but it is missing a database_id,
>    which is needed for operations on remote resources. Please create the remote D1
>    database by deploying your project or running 'wrangler d1 create DB'.
>
> This happened even when the database had already been provisioned and was visible via `wrangler d1 list`.


Changes:

* getDatabaseByNameOrBinding() now calls out to D1's control plane to find out the uuid if none is provided in the config
  * Note that it may call out to ask about the same name multiple times when applying migrations. Threading a cache context through go-style was too much work, and the ai reviewer is allergic to global caches, so I decided not to fight it.
* I cleaned up some types and function signatures:
  * Database.uuid is now optional. We don't lie to the caller by setting it to .binding on localhost
  * I made DatabaseWithUuid and ConcreteDatabase types for the cases where .uuid and .name are known to be supplied (naming is hard: suggestions welcome)
  * getDatabaseInfoFromConfig() no longer has a requireDatabaseId option - we never require databaseid



Fixes #13632.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: it's more of a bug fix for auto-provisioned template projects. Changelog will hopefuly be enough.

<details><summary>*A picture of a cute animal (not mandatory, but encouraged)*</summary>

![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExMmk5bWx1cWp0cm4wczloYzZscHd5OTN5em85MnBibnp3eDl3bWN3MiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ls9LEC3EOzGve/giphy.gif)

</details>

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->