### PR TITLE
Graduate autoconfig from experimental to stable

### DIFF
--- a/.changeset/graduate-autoconfig-stable.md
+++ b/.changeset/graduate-autoconfig-stable.md
@@ -1,0 +1,9 @@
+---
+"wrangler": minor
+---
+
+Graduate autoconfig from experimental to stable
+
+The `--experimental-autoconfig` and `--x-autoconfig` deploy CLI flags have been replaced with `--autoconfig`.
+
+Note that the `--autoconfig` flag defaults to `true` and that it can be used to disable Wrangler's auto-configuration logic by setting it to `false` via `--autoconfig=false` or `--no-autoconfig`

--- a/packages/wrangler/src/__tests__/autoconfig/run.test.ts
+++ b/packages/wrangler/src/__tests__/autoconfig/run.test.ts
@@ -92,21 +92,38 @@ describe("autoconfig (deploy)", () => {
 		clearOutputFilePath();
 	});
 
-	it("should not check for autoconfig when `deploy` is run with `--x-autoconfig=false`", async ({
+	it("should not run autoconfig when `deploy` is run with `--no-autoconfig`", async ({
 		expect,
 	}) => {
 		writeWorkerSource();
 		writeWranglerConfig({ main: "index.js" });
 		const getDetailsSpy = vi.spyOn(details, "getDetailsForAutoConfig");
-		await runDeploy(expect, `--x-autoconfig=false`);
+		const runSpy = vi.spyOn(run, "runAutoConfig");
+
+		await runDeploy(expect, `--no-autoconfig`);
 
 		expect(getDetailsSpy).not.toHaveBeenCalled();
+		expect(runSpy).not.toHaveBeenCalled();
+	});
+
+	it("should not run autoconfig when `deploy` is run with `--autoconfig=false`", async ({
+		expect,
+	}) => {
+		writeWorkerSource();
+		writeWranglerConfig({ main: "index.js" });
+		const getDetailsSpy = vi.spyOn(details, "getDetailsForAutoConfig");
+		const runSpy = vi.spyOn(run, "runAutoConfig");
+
+		await runDeploy(expect, `--autoconfig=false`);
+
+		expect(getDetailsSpy).not.toHaveBeenCalled();
+		expect(runSpy).not.toHaveBeenCalled();
 	});
 
 	it("should check for autoconfig with flag", async ({ expect }) => {
 		const getDetailsSpy = vi.spyOn(details, "getDetailsForAutoConfig");
 
-		await runDeploy(expect, "--x-autoconfig");
+		await runDeploy(expect, "--autoconfig");
 
 		expect(getDetailsSpy).toHaveBeenCalled();
 	});
@@ -128,7 +145,7 @@ describe("autoconfig (deploy)", () => {
 			);
 		const runSpy = vi.spyOn(run, "runAutoConfig");
 
-		await runDeploy(expect, "--x-autoconfig");
+		await runDeploy(expect, "--autoconfig");
 
 		expect(getDetailsSpy).toHaveBeenCalled();
 		expect(runSpy).toHaveBeenCalled();
@@ -149,7 +166,7 @@ describe("autoconfig (deploy)", () => {
 			);
 		const runSpy = vi.spyOn(run, "runAutoConfig");
 
-		await runDeploy(expect, "--x-autoconfig");
+		await runDeploy(expect, "--autoconfig");
 
 		expect(getDetailsSpy).toHaveBeenCalled();
 		expect(runSpy).not.toHaveBeenCalled();
@@ -182,7 +199,7 @@ describe("autoconfig (deploy)", () => {
 		});
 
 		// Should not throw - just return early
-		await runWrangler("deploy --x-autoconfig");
+		await runWrangler("deploy --autoconfig");
 
 		// Should show warning about Pages project
 		expect(std.warn).toContain(

--- a/packages/wrangler/src/__tests__/deploy/core.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/core.test.ts
@@ -535,7 +535,7 @@ describe("deploy", () => {
 		`);
 	});
 
-	it("should error helpfully if pages_build_output_dir is set in wrangler.toml when --x-autoconfig=false", async ({
+	it("should error helpfully if pages_build_output_dir is set in wrangler.toml when --no-autoconfig", async ({
 		expect,
 	}) => {
 		writeWranglerConfig({
@@ -543,7 +543,7 @@ describe("deploy", () => {
 			name: "test-name",
 		});
 		await expect(
-			runWrangler("deploy --x-autoconfig=false")
+			runWrangler("deploy --no-autoconfig")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
 			`
 			[Error: It looks like you've run a Workers-specific command in a Pages project.
@@ -552,7 +552,7 @@ describe("deploy", () => {
 		);
 	});
 
-	it("should error helpfully if pages_build_output_dir is set in wrangler.toml and --x-autoconfig is provided", async ({
+	it("should error helpfully if pages_build_output_dir is set in wrangler.toml", async ({
 		expect,
 	}) => {
 		mockConfirm({
@@ -564,13 +564,13 @@ describe("deploy", () => {
 			pages_build_output_dir: "public",
 			name: "test-name",
 		});
-		await expect(runWrangler("deploy --x-autoconfig")).rejects.toThrowError();
+		await expect(runWrangler("deploy")).rejects.toThrowError();
 		expect(std.warn).toContain(
 			"It seems that you have run `wrangler deploy` on a Pages project, `wrangler pages deploy` should be used instead."
 		);
 	});
 
-	it("should attempt to run the autoconfig flow when pages_build_output_dir and (--x-autoconfig is used)", async ({
+	it("should attempt to run the autoconfig flow when pages_build_output_dir", async ({
 		expect,
 	}) => {
 		writeWranglerConfig({
@@ -603,7 +603,7 @@ describe("deploy", () => {
 			result: false,
 		});
 
-		await runWrangler("deploy --x-autoconfig");
+		await runWrangler("deploy");
 
 		expect(getDetailsForAutoConfigSpy).toHaveBeenCalled();
 
@@ -612,7 +612,7 @@ describe("deploy", () => {
 		);
 	});
 
-	it("in non-interactive mode, attempts to deploy a Pages project when --x-autoconfig is used", async ({
+	it("in non-interactive mode, attempts to deploy a Pages project using autoconfig", async ({
 		expect,
 	}) => {
 		setIsTTY(false);
@@ -642,7 +642,7 @@ describe("deploy", () => {
 
 		// The command will fail later due to missing entry-point, but we can still verify
 		// that the deployment of the (Pages) project was attempted
-		await expect(runWrangler("deploy --x-autoconfig")).rejects.toThrow();
+		await expect(runWrangler("deploy")).rejects.toThrow();
 
 		expect(getDetailsForAutoConfigSpy).toHaveBeenCalled();
 
@@ -1433,7 +1433,7 @@ describe("deploy", () => {
 			};
 		});
 
-		await runWrangler("deploy --x-autoconfig --dry-run", {
+		await runWrangler("deploy --dry-run", {
 			...process.env,
 			WRANGLER_OUTPUT_FILE_PATH: outputFile,
 		});

--- a/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
@@ -340,7 +340,7 @@ export default{
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should not trigger autoconfig on `wrangler deploy <script>` when called with `--x-autoconfig`", async ({
+		it("should not trigger autoconfig on `wrangler deploy <script>`", async ({
 			expect,
 		}) => {
 			vi.mock(import("../../autoconfig/details"), { spy: true });
@@ -358,7 +358,7 @@ export default{
 			mockUploadWorkerRequest({ expectedEntry: "var foo = 100;" });
 			mockSubDomainRequest();
 
-			await runWrangler("deploy ./src/index.js --x-autoconfig");
+			await runWrangler("deploy ./src/index.js");
 
 			expect(getDetailsForAutoConfigSpy).not.toHaveBeenCalled();
 			expect(runAutoConfigSpy).not.toHaveBeenCalled();
@@ -885,8 +885,19 @@ addEventListener('fetch', event => {});`
 				vi.useRealTimers();
 			});
 
-			// TODO: remove this test once autoconfig goes GA and its experimental opt-in flag is removed
-			it("should handle `wrangler deploy <directory>`", async ({ expect }) => {
+			it("should handle interactive `wrangler deploy <directory>` flows without triggering autoconfig", async ({
+				expect,
+			}) => {
+				vi.mock(import("../../autoconfig/details"), { spy: true });
+				vi.mock(import("../../autoconfig/run"), { spy: true });
+
+				const getDetailsForAutoConfigSpy = (
+					await import("../../autoconfig/details")
+				).getDetailsForAutoConfig;
+
+				const runAutoConfigSpy = (await import("../../autoconfig/run"))
+					.runAutoConfig;
+
 				mockPrompt({
 					text: "What do you want to name your project?",
 					options: { defaultValue: "my-site" },
@@ -951,161 +962,11 @@ addEventListener('fetch', event => {});`
 					  https://test-name.test-sub-domain.workers.dev
 					Current Version ID: Galaxy-Class"
 				`);
-			});
-
-			it("should handle interactive `wrangler deploy <directory>` flows without triggering autoconfig when called with `--x-autoconfig`", async ({
-				expect,
-			}) => {
-				vi.mock(import("../../autoconfig/details"), { spy: true });
-				vi.mock(import("../../autoconfig/run"), { spy: true });
-
-				const getDetailsForAutoConfigSpy = (
-					await import("../../autoconfig/details")
-				).getDetailsForAutoConfig;
-
-				const runAutoConfigSpy = (await import("../../autoconfig/run"))
-					.runAutoConfig;
-
-				mockPrompt({
-					text: "What do you want to name your project?",
-					options: { defaultValue: "my-site" },
-					result: "test-name",
-				});
-				mockConfirm({
-					text: "No compatibility date is set. Would you like to use today's date (2024-01-01)?",
-					result: true,
-				});
-				mockConfirm({
-					text: "Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
-					result: true,
-				});
-
-				const bodies: AssetManifest[] = [];
-				await mockAUSRequest(bodies);
-
-				await runWrangler("deploy ./assets --x-autoconfig");
-				expect(bodies.length).toBe(1);
-				expect(bodies[0]).toEqual({
-					manifest: {
-						"/index.html": {
-							hash: "8308ce789f3d08668ce87176838d59d0",
-							size: 17,
-						},
-					},
-				});
-				expect(fs.readFileSync("wrangler.jsonc", "utf-8"))
-					.toMatchInlineSnapshot(`
-						"{
-						  "name": "test-name",
-						  "compatibility_date": "2024-01-01",
-						  "assets": {
-						    "directory": "./assets"
-						  }
-						}"
-					`);
-				expect(std.out).toMatchInlineSnapshot(`
-					"
-					 ⛅️ wrangler x.x.x
-					──────────────────
-
-
-					Wrote
-					{
-					  "name": "test-name",
-					  "compatibility_date": "2024-01-01",
-					  "assets": {
-					    "directory": "./assets"
-					  }
-					}
-					 to <cwd>/wrangler.jsonc.
-
-					Simply run \`wrangler deploy\` next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.
-
-					Proceeding with deployment...
-
-					Total Upload: xx KiB / gzip: xx KiB
-					Worker Startup Time: 100 ms
-					Uploaded test-name (TIMINGS)
-					Deployed test-name triggers (TIMINGS)
-					  https://test-name.test-sub-domain.workers.dev
-					Current Version ID: Galaxy-Class"
-				`);
 				expect(getDetailsForAutoConfigSpy).not.toHaveBeenCalled();
 				expect(runAutoConfigSpy).not.toHaveBeenCalled();
 			});
 
-			// TODO: remove this test once autoconfig goes GA and its experimental opt-in flag is removed
-			it("should handle `wrangler deploy --assets` without name or compat date", async ({
-				expect,
-			}) => {
-				// if the user has used --assets flag and args.script is not set, we just need to prompt for the name and add compat date
-				mockPrompt({
-					text: "What do you want to name your project?",
-					options: { defaultValue: "my-site" },
-					result: "test-name",
-				});
-				mockConfirm({
-					text: "No compatibility date is set. Would you like to use today's date (2024-01-01)?",
-					result: true,
-				});
-				mockConfirm({
-					text: "Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
-					result: true,
-				});
-
-				const bodies: AssetManifest[] = [];
-				await mockAUSRequest(bodies);
-
-				await runWrangler("deploy --assets ./assets");
-				expect(bodies.length).toBe(1);
-				expect(bodies[0]).toEqual({
-					manifest: {
-						"/index.html": {
-							hash: "8308ce789f3d08668ce87176838d59d0",
-							size: 17,
-						},
-					},
-				});
-				expect(fs.readFileSync("wrangler.jsonc", "utf-8"))
-					.toMatchInlineSnapshot(`
-						"{
-						  "name": "test-name",
-						  "compatibility_date": "2024-01-01",
-						  "assets": {
-						    "directory": "./assets"
-						  }
-						}"
-					`);
-				expect(std.out).toMatchInlineSnapshot(`
-					"
-					 ⛅️ wrangler x.x.x
-					──────────────────
-
-
-					Wrote
-					{
-					  "name": "test-name",
-					  "compatibility_date": "2024-01-01",
-					  "assets": {
-					    "directory": "./assets"
-					  }
-					}
-					 to <cwd>/wrangler.jsonc.
-
-					Simply run \`wrangler deploy\` next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.
-
-					Proceeding with deployment...
-
-					Total Upload: xx KiB / gzip: xx KiB
-					Worker Startup Time: 100 ms
-					Uploaded test-name (TIMINGS)
-					Deployed test-name triggers (TIMINGS)
-					  https://test-name.test-sub-domain.workers.dev
-					Current Version ID: Galaxy-Class"
-				`);
-			});
-
-			it("should handle `wrangler deploy --assets` without name or compat date without triggering autoconfig when called with `--x-autoconfig`", async ({
+			it("should handle `wrangler deploy --assets` without name or compat date without triggering autoconfig", async ({
 				expect,
 			}) => {
 				vi.mock(import("../../autoconfig/details"), { spy: true });
@@ -1136,88 +997,7 @@ addEventListener('fetch', event => {});`
 				const bodies: AssetManifest[] = [];
 				await mockAUSRequest(bodies);
 
-				await runWrangler("deploy --assets ./assets --x-autoconfig");
-				expect(bodies.length).toBe(1);
-				expect(bodies[0]).toEqual({
-					manifest: {
-						"/index.html": {
-							hash: "8308ce789f3d08668ce87176838d59d0",
-							size: 17,
-						},
-					},
-				});
-				expect(fs.readFileSync("wrangler.jsonc", "utf-8"))
-					.toMatchInlineSnapshot(`
-						"{
-						  "name": "test-name",
-						  "compatibility_date": "2024-01-01",
-						  "assets": {
-						    "directory": "./assets"
-						  }
-						}"
-					`);
-				expect(std.out).toMatchInlineSnapshot(`
-					"
-					 ⛅️ wrangler x.x.x
-					──────────────────
-
-
-					Wrote
-					{
-					  "name": "test-name",
-					  "compatibility_date": "2024-01-01",
-					  "assets": {
-					    "directory": "./assets"
-					  }
-					}
-					 to <cwd>/wrangler.jsonc.
-
-					Simply run \`wrangler deploy\` next time. Wrangler will automatically use the configuration saved to wrangler.jsonc.
-
-					Proceeding with deployment...
-
-					Total Upload: xx KiB / gzip: xx KiB
-					Worker Startup Time: 100 ms
-					Uploaded test-name (TIMINGS)
-					Deployed test-name triggers (TIMINGS)
-					  https://test-name.test-sub-domain.workers.dev
-					Current Version ID: Galaxy-Class"
-				`);
-				expect(getDetailsForAutoConfigSpy).not.toHaveBeenCalled();
-				expect(runAutoConfigSpy).not.toHaveBeenCalled();
-			});
-
-			it("should not trigger autoconfig on `wrangler deploy <directory>` when called with `--x-autoconfig`", async ({
-				expect,
-			}) => {
-				vi.mock(import("../../autoconfig/details"), { spy: true });
-				vi.mock(import("../../autoconfig/run"), { spy: true });
-
-				const getDetailsForAutoConfigSpy = (
-					await import("../../autoconfig/details")
-				).getDetailsForAutoConfig;
-
-				const runAutoConfigSpy = (await import("../../autoconfig/run"))
-					.runAutoConfig;
-
-				mockPrompt({
-					text: "What do you want to name your project?",
-					options: { defaultValue: "my-site" },
-					result: "test-name",
-				});
-				mockConfirm({
-					text: "No compatibility date is set. Would you like to use today's date (2024-01-01)?",
-					result: true,
-				});
-				mockConfirm({
-					text: "Do you want Wrangler to write a wrangler.jsonc config file to store this configuration?\nThis will allow you to simply run `wrangler deploy` on future deployments.",
-					result: true,
-				});
-
-				const bodies: AssetManifest[] = [];
-				await mockAUSRequest(bodies);
-
-				await runWrangler("deploy ./assets --x-autoconfig");
+				await runWrangler("deploy --assets ./assets");
 				expect(bodies.length).toBe(1);
 				expect(bodies[0]).toEqual({
 					manifest: {

--- a/packages/wrangler/src/__tests__/deploy/open-next.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/open-next.test.ts
@@ -172,7 +172,6 @@ describe("deploy", () => {
 				"npx",
 				"wrangler",
 				"deploy",
-				"--x-autoconfig",
 			]);
 			const runCommandSpy = (
 				await import("@cloudflare/cli-shared-helpers/command")
@@ -180,17 +179,12 @@ describe("deploy", () => {
 
 			await mockOpenNextLikeProject();
 
-			await runWrangler("deploy --x-autoconfig");
+			await runWrangler("deploy");
 
 			expect(runCommandSpy).toHaveBeenCalledOnce();
 			const call = (runCommandSpy as unknown as MockInstance).mock.calls[0];
 			const [command, options] = call;
-			expect(command).toEqual([
-				"npx",
-				"opennextjs-cloudflare",
-				"deploy",
-				"--x-autoconfig",
-			]);
+			expect(command).toEqual(["npx", "opennextjs-cloudflare", "deploy"]);
 			expect(options).toMatchObject({
 				env: {
 					// Note: we want to ensure that OPEN_NEXT_DEPLOY has been set, this is not strictly necessary but it helps us
@@ -221,7 +215,6 @@ describe("deploy", () => {
 				"wrangler",
 				"deploy",
 				"--keep-vars",
-				"--x-autoconfig",
 			]);
 			const runCommandSpy = (
 				await import("@cloudflare/cli-shared-helpers/command")
@@ -229,7 +222,7 @@ describe("deploy", () => {
 
 			await mockOpenNextLikeProject();
 
-			await runWrangler("deploy --x-autoconfig");
+			await runWrangler("deploy");
 
 			expect(runCommandSpy).toHaveBeenCalledOnce();
 			const call = (runCommandSpy as unknown as MockInstance).mock.calls[0];
@@ -241,7 +234,6 @@ describe("deploy", () => {
 				// `opennextjs-cloudflare deploy` accepts all the same arguments `wrangler deploy` does (since it then forwards them
 				// to wrangler), so we do want to make sure that arguments are indeed forwarded to `opennextjs-cloudflare deploy`
 				"--keep-vars",
-				"--x-autoconfig",
 			]);
 			expect(options).toMatchObject({
 				env: {
@@ -276,7 +268,7 @@ describe("deploy", () => {
 
 			await mockOpenNextLikeProject();
 
-			await runWrangler("deploy --x-autoconfig");
+			await runWrangler("deploy");
 
 			expect(runCommandSpy).not.toHaveBeenCalledOnce();
 
@@ -299,7 +291,7 @@ describe("deploy", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should not delegate to open-next deploy when --x-autoconfig=false is provided", async ({
+		it("should not delegate to open-next deploy when --no-autoconfig is provided", async ({
 			expect,
 		}) => {
 			const runCommandSpy = (
@@ -308,7 +300,7 @@ describe("deploy", () => {
 
 			await mockOpenNextLikeProject();
 
-			await runWrangler("deploy --x-autoconfig=false");
+			await runWrangler("deploy --no-autoconfig");
 
 			expect(runCommandSpy).not.toHaveBeenCalledOnce();
 
@@ -343,7 +335,7 @@ describe("deploy", () => {
 			// Let's delete the next.config.js file
 			fs.rmSync("./next.config.js");
 
-			await runWrangler("deploy --x-autoconfig");
+			await runWrangler("deploy");
 
 			expect(runCommandSpy).not.toHaveBeenCalledOnce();
 
@@ -378,7 +370,7 @@ describe("deploy", () => {
 			// Let's delete the open-next.config.ts file
 			fs.rmSync("./open-next.config.ts");
 
-			await runWrangler("deploy --x-autoconfig");
+			await runWrangler("deploy --autoconfig");
 
 			expect(runCommandSpy).not.toHaveBeenCalledOnce();
 

--- a/packages/wrangler/src/deploy/autoconfig.ts
+++ b/packages/wrangler/src/deploy/autoconfig.ts
@@ -55,11 +55,11 @@ type DeployConfigFlags = {
  * The full set of CLI args consumed by the interactive deploy autoconfig flow.
  * Combines the base config/script/name args from {@link ReadConfigCommandArgs},
  * all deployment-affecting flags from {@link DeployConfigFlags}, and the
- * autoconfig-specific control flags (experimentalAutoconfig, assets, dryRun, latest).
+ * autoconfig-specific control flags (autoconfig, assets, dryRun, latest).
  */
 type AutoConfigArgs = ReadConfigCommandArgs &
 	DeployConfigFlags & {
-		experimentalAutoconfig: boolean | undefined;
+		autoconfig: boolean | undefined;
 		path: string | undefined;
 		assets: string | undefined;
 		dryRun: boolean | undefined;
@@ -77,7 +77,7 @@ export async function maybeRunAutoConfig<Args extends AutoConfigArgs>(
 	config: Config
 ): Promise<{ config: Config; aborted: boolean }> {
 	const shouldRunAutoConfig =
-		args.experimentalAutoconfig &&
+		args.autoconfig &&
 		// If there is a positional parameter, an assets directory specified via --assets, or an
 		// explicit --config path then we don't want to run autoconfig since we assume that the
 		// user knows what they are doing and that they are specifying what needs to be deployed

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -91,10 +91,9 @@ export const deployCommand = createCommand({
 			type: "boolean",
 			default: false,
 		},
-		"experimental-autoconfig": {
-			alias: ["x-autoconfig"],
+		autoconfig: {
 			describe:
-				"Experimental: Enables framework detection and automatic configuration when deploying",
+				"Enables framework detection and automatic configuration when deploying",
 			type: "boolean",
 			default: true,
 		},
@@ -127,7 +126,7 @@ export const deployCommand = createCommand({
 		// As a precaution we're gating the feature under the autoconfig flag for the time being.
 		// If the user explicitly provided a --config path, they are targeting a specific Worker config and we should not delegate
 		if (
-			args.experimentalAutoconfig &&
+			args.autoconfig &&
 			!args.config &&
 			!args.dryRun &&
 			(await maybeDelegateToOpenNextDeployCommand(process.cwd()))

--- a/packages/wrangler/src/metrics/sanitization.ts
+++ b/packages/wrangler/src/metrics/sanitization.ts
@@ -83,7 +83,7 @@ export const COMMAND_ARG_ALLOW_LIST: AllowList = {
 		updateConfig: ALLOW,
 		nodeCompat: ALLOW,
 		enableContainers: ALLOW,
-		xAutoconfig: ALLOW,
+		autoconfig: ALLOW,
 		ignoreDefaults: ALLOW,
 	},
 	tail: { status: ALLOW },


### PR DESCRIPTION
Autoconfig has been turned on by default for a long time now and it was supposed to be stabilized much sooner, in any case I am graduating it in this PR since I don't think that the feature needs to still be experimental.

Note: The programmatic API is still experimental though, I think this will be useful as it will allow us to extract those function in their own package without neither being a breaking change for wrangler or forcing wrangler to re-export them.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: the docs already treat autoconfig as stable

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
