### PR TITLE
fix asset routing broken by custom routes

### DIFF
--- a/.changeset/fix-dev-spa-route-fallback.md
+++ b/.changeset/fix-dev-spa-route-fallback.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+"miniflare": patch
+---
+
+Fix asset routing when custom domain routes are configured
+
+Previously, local dev was routing custom-domain matches directly to the user Worker instead of the Workers + Assets router, meaning asset handling behaviour like `single-page-application` and `404-page` were not being applied on the root path.

--- a/fixtures/workers-with-assets-spa/wrangler.jsonc
+++ b/fixtures/workers-with-assets-spa/wrangler.jsonc
@@ -9,4 +9,6 @@
 		"not_found_handling": "single-page-application",
 		"run_worker_first": false,
 	},
+	// should not affect routing
+	"routes": [{ "pattern": "spa-repro.example.com", "custom_domain": true }],
 }

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -1052,10 +1052,22 @@ export function getGlobalServices({
 			name: CoreBindings.SERVICE_USER_FALLBACK,
 			service: { name: fallbackWorkerName },
 		},
-		...workerNames.map((name) => ({
-			name: CoreBindings.SERVICE_USER_ROUTE_PREFIX + name,
-			service: { name: getUserServiceName(name) },
-		})),
+		...workerNames.map((name) => {
+			const assetWorker = name.startsWith(`${RPC_PROXY_SERVICE_NAME}:`)
+				? undefined
+				: allWorkerOpts?.find(
+						(worker) =>
+							(worker.core.name ?? "") === name && worker.assets?.assets
+						);
+			return {
+				name: CoreBindings.SERVICE_USER_ROUTE_PREFIX + name,
+				service: {
+					name: assetWorker?.assets.assets
+						? `${RPC_PROXY_SERVICE_NAME}:${assetWorker.assets.assets.workerName}`
+						: getUserServiceName(name),
+				},
+			};
+		}),
 		{
 			name: CoreBindings.DURABLE_OBJECT_NAMESPACE_PROXY,
 			durableObjectNamespace: { className: "ProxyServer" },

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -1058,7 +1058,7 @@ export function getGlobalServices({
 				: allWorkerOpts?.find(
 						(worker) =>
 							(worker.core.name ?? "") === name && worker.assets?.assets
-						);
+					);
 			return {
 				name: CoreBindings.SERVICE_USER_ROUTE_PREFIX + name,
 				service: {


### PR DESCRIPTION
Fixes #14255 

This error was introduced in #14169 - that started passing in `routes` from wrangler config to miniflare under `core.routes` (i don't think this was wired up properly before). This meant that miniflare route handling kicked in, and that points to the user worker, bypassing the asset routing workers. This mean we stopped rewriting to /index.html for SPAs, serving 404 pages, etc.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
