### PR TITLE
fix(wrangler): preserve asset fallback with routes

### DIFF
--- a/.changeset/fix-dev-assets-route-dispatch.md
+++ b/.changeset/fix-dev-assets-route-dispatch.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+"@cloudflare/workers-utils": patch
+---
+
+Fix `wrangler dev` asset fallback with custom routes
+
+`wrangler dev` now applies Workers Assets fallback behavior consistently when routes are configured, including SPA fallback and `404-page` handling.

--- a/fixtures/workers-with-assets-spa/wrangler.jsonc
+++ b/fixtures/workers-with-assets-spa/wrangler.jsonc
@@ -9,4 +9,5 @@
 		"not_found_handling": "single-page-application",
 		"run_worker_first": false,
 	},
+	"routes": ["example.com"],
 }

--- a/packages/workers-utils/src/types.ts
+++ b/packages/workers-utils/src/types.ts
@@ -562,6 +562,8 @@ export interface StartDevWorkerInput {
 		multiworkerPrimary?: boolean;
 		/** Whether to infer the local request origin from configured routes. */
 		inferOriginFromRoutes?: boolean;
+		/** Whether local requests should be matched against configured routes. */
+		routeRequestsByRoutes?: boolean;
 
 		containerBuildId?: string;
 		/** Whether to build and connect to containers during local dev. Requires Docker daemon to be running. Defaults to true. */

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -174,6 +174,7 @@ async function resolveDevConfig(
 		registry: input.dev?.registry,
 		multiworkerPrimary: input.dev?.multiworkerPrimary,
 		inferOriginFromRoutes: input.dev?.inferOriginFromRoutes ?? true,
+		routeRequestsByRoutes: input.dev?.routeRequestsByRoutes ?? false,
 		enableContainers:
 			input.dev?.enableContainers ?? config.dev.enable_containers,
 		dockerPath: input.dev?.dockerPath ?? getDockerPath(),

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -194,7 +194,7 @@ export async function convertToConfigBundle(
 		localPersistencePath: event.config.dev.persist,
 		liveReload: event.config.dev?.liveReload ?? false,
 		crons,
-		routes,
+		routes: event.config.dev.routeRequestsByRoutes ? routes : undefined,
 		queueConsumers,
 		outboundService: event.config.dev.outboundService,
 		localProtocol: event.config.dev?.server?.secure ? "https" : "http",

--- a/packages/wrangler/src/api/test-harness.ts
+++ b/packages/wrangler/src/api/test-harness.ts
@@ -326,6 +326,7 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 					},
 					multiworkerPrimary: isMultiworker ? isPrimaryWorker : undefined,
 					inferOriginFromRoutes: false,
+					routeRequestsByRoutes: true,
 				},
 				build: {
 					nodejsCompatMode: (config) => {


### PR DESCRIPTION
Fixes #14255

I enabled automatic server route matching in #14169, but this causes an issue with assets handling as matching requests are routes to the user working directly. This disables the route matching behavior for `wrangler dev`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->