### PR TITLE
[wrangler] Reuse existing KV namespace in provisioning flow (closes #14284)

### DIFF
--- a/.changeset/fix-kv-provision-idempotent.md
+++ b/.changeset/fix-kv-provision-idempotent.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: reuse existing KV namespace instead of erroring with `10014` on re-deploy
+
+When `wrangler deploy` is run with auto-provisioning (the default; used by Workers Builds and `--x-auto-create=true`), and a `kv_namespaces` binding has no `id`, the provisioning flow always called `kv.namespaces.create()` with the default `<worker>-<binding>` title. On subsequent deploys the title already existed from the first deploy, so the Cloudflare API returned `a namespace with this account ID and title already exists [code: 10014]` and the deploy failed.
+
+The flow now scans the loaded list of existing KV namespaces first and connects to the one whose title matches the resolved name (default `<worker>-<binding>` for the auto-create path, or the user-supplied name when set in config), only falling back to `create()` when no match is found. Same change applied to the `item.handler.name` branch so user-provided names with a pre-existing namespace are reused rather than erroring.

--- a/.changeset/fix-kv-provision-idempotent.md
+++ b/.changeset/fix-kv-provision-idempotent.md
@@ -2,8 +2,8 @@
 "wrangler": patch
 ---
 
-fix: reuse existing KV namespace instead of erroring with `10014` on re-deploy
+Reuse existing KV namespace instead of erroring with `10014` on re-deploy
 
 When `wrangler deploy` is run with auto-provisioning (the default; used by Workers Builds and `--x-auto-create=true`), and a `kv_namespaces` binding has no `id`, the provisioning flow always called `kv.namespaces.create()` with the default `<worker>-<binding>` title. On subsequent deploys the title already existed from the first deploy, so the Cloudflare API returned `a namespace with this account ID and title already exists [code: 10014]` and the deploy failed.
 
-The flow now scans the loaded list of existing KV namespaces first and connects to the one whose title matches the resolved name (default `<worker>-<binding>` for the auto-create path, or the user-supplied name when set in config), only falling back to `create()` when no match is found. Same change applied to the `item.handler.name` branch so user-provided names with a pre-existing namespace are reused rather than erroring.
+The flow now scans the loaded list of existing resources first and connects to the one whose title matches the resolved name (default `<worker>-<binding>` for the auto-create path, or the user-supplied name when set in config), only falling back to `create()` when no match is found. Same change applied to the `item.handler.name` branch so user-provided names with a pre-existing namespace are reused rather than erroring. R2 buckets are deliberately excluded from this lookup since the loaded list does not carry jurisdiction, so a same-name bucket in a different jurisdiction would be misidentified — for R2 the flow keeps its existing behavior of calling `provision()` directly.

--- a/packages/wrangler/src/__tests__/provision.test.ts
+++ b/packages/wrangler/src/__tests__/provision.test.ts
@@ -1317,6 +1317,45 @@ describe("resource provisioning", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
+
+		it("should connect to existing KV namespace under autoCreate when default title already exists (#14284)", async ({
+			expect,
+		}) => {
+			// Workers Builds re-deploy scenario: the first deploy created the
+			// `<worker>-<binding>` KV namespace via autoCreate, and the second
+			// deploy was hitting `error: a namespace with this account ID and
+			// title already exists [code: 10014]`. With the fix, the provisioning
+			// flow first scans the loaded list and connects to the existing
+			// namespace by id rather than re-issuing `create`.
+			writeWranglerConfig({
+				main: "index.js",
+				kv_namespaces: [{ binding: "SESSION" }],
+			});
+			mockGetSettings();
+			mockListKVNamespacesRequest(expect, {
+				title: "test-name-session",
+				id: "existing-session-kv-id",
+			});
+			mockUploadWorkerRequest({
+				expectedBindings: [
+					{
+						name: "SESSION",
+						type: "kv_namespace",
+						namespace_id: "existing-session-kv-id",
+					},
+				],
+			});
+
+			await runWrangler("deploy");
+
+			expect(std.out).toContain(
+				'🔗 Connecting to existing KV Namespace "test-name-session"...'
+			);
+			expect(std.out).not.toContain(
+				'🌀 Creating new KV Namespace "test-name-session"...'
+			);
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
 	});
 
 	describe("provisions agent_memory bindings", () => {

--- a/packages/wrangler/src/deployment-bundle/bindings.ts
+++ b/packages/wrangler/src/deployment-bundle/bindings.ts
@@ -896,9 +896,17 @@ async function runProvisioningFlow(
 	const defaultName = `${scriptName}-${item.binding.toLowerCase().replaceAll("_", "-")}`;
 	logger.log("Provisioning", item.binding, `(${friendlyBindingName})...`);
 
+	// `preExisting` carries only `{title, value}`; for R2 the loaded title is
+	// the bucket name without jurisdiction, so a name-match could route to a
+	// bucket in the wrong jurisdiction. KV / D1 / AI Search / Agent Memory
+	// names are unique within an account, so the lookup is safe there.
+	const canReuseByTitle = item.resourceType !== "r2_bucket";
+
 	if (item.handler.name) {
 		logger.log("Resource name found in config:", item.handler.name);
-		const existing = preExisting.find((r) => r.title === item.handler.name);
+		const existing = canReuseByTitle
+			? preExisting.find((r) => r.title === item.handler.name)
+			: undefined;
 		if (existing) {
 			logger.log(
 				`🔗 Connecting to existing ${friendlyBindingName} "${item.handler.name}"...`
@@ -911,7 +919,9 @@ async function runProvisioningFlow(
 			await item.handler.provision(item.handler.name);
 		}
 	} else if (autoCreate) {
-		const existing = preExisting.find((r) => r.title === defaultName);
+		const existing = canReuseByTitle
+			? preExisting.find((r) => r.title === defaultName)
+			: undefined;
 		if (existing) {
 			logger.log(
 				`🔗 Connecting to existing ${friendlyBindingName} "${defaultName}"...`

--- a/packages/wrangler/src/deployment-bundle/bindings.ts
+++ b/packages/wrangler/src/deployment-bundle/bindings.ts
@@ -898,13 +898,29 @@ async function runProvisioningFlow(
 
 	if (item.handler.name) {
 		logger.log("Resource name found in config:", item.handler.name);
-		logger.log(
-			`🌀 Creating new ${friendlyBindingName} "${item.handler.name}"...`
-		);
-		await item.handler.provision(item.handler.name);
+		const existing = preExisting.find((r) => r.title === item.handler.name);
+		if (existing) {
+			logger.log(
+				`🔗 Connecting to existing ${friendlyBindingName} "${item.handler.name}"...`
+			);
+			item.handler.connect(existing.value);
+		} else {
+			logger.log(
+				`🌀 Creating new ${friendlyBindingName} "${item.handler.name}"...`
+			);
+			await item.handler.provision(item.handler.name);
+		}
 	} else if (autoCreate) {
-		logger.log(`🌀 Creating new ${friendlyBindingName} "${defaultName}"...`);
-		await item.handler.provision(defaultName);
+		const existing = preExisting.find((r) => r.title === defaultName);
+		if (existing) {
+			logger.log(
+				`🔗 Connecting to existing ${friendlyBindingName} "${defaultName}"...`
+			);
+			item.handler.connect(existing.value);
+		} else {
+			logger.log(`🌀 Creating new ${friendlyBindingName} "${defaultName}"...`);
+			await item.handler.provision(defaultName);
+		}
 	} else {
 		let action: string = NEW_OPTION_VALUE;
 


### PR DESCRIPTION
<!-- 
Please update PR title (your description here)
Add associated issue link if you have one (e.g. closes #1234)
-->
Closes #14284.

<!-- Describe your change here -->

## What this changes

`runProvisioningFlow` in `packages/wrangler/src/deployment-bundle/bindings.ts` always called `item.handler.provision(name)` for both the `item.handler.name` branch and the `autoCreate` branch — even when the loaded `preExisting` list (from `HANDLERS[type].load`) already contained a resource with that title. For KV that mapped to `kv.namespaces.create`, which returns `a namespace with this account ID and title already exists [code: 10014]`, so Workers Builds users were getting their deploys broken on every push after the first one (the reporter's `<worker>-session` namespace is the exact shape this hits).

The fix scans `preExisting` for a title match first, and if found, calls `item.handler.connect(existing.value)` instead of going through `create`. Falls through to the create path only when no match exists. Applied to both the `item.handler.name` branch and the `autoCreate` branch so it covers both user-named and auto-created shapes.

Same idea as R2's existing `isConnectedToExistingResource()` short-circuit, just applied at the provisioning-flow layer so KV (which doesn't override `isConnectedToExistingResource`) is covered too without duplicating the resolver-level logic.

## Test plan

Added `should connect to existing KV namespace under autoCreate when default title already exists (#14284)` to `provision.test.ts`. Mocks the KV list to return a `test-name-session` namespace, runs `wrangler deploy` against a config with `kv_namespaces: [{ binding: "SESSION" }]` (so the default name resolves to `test-name-session`), and asserts:

- `🔗 Connecting to existing KV Namespace "test-name-session"...` appears in stdout
- `🌀 Creating new KV Namespace "test-name-session"...` does NOT appear in stdout
- The uploaded worker bindings use `namespace_id: "existing-session-kv-id"`

Could not run unit tests locally because the monorepo's `node_modules` isn't populated on this machine and `pnpm i` for the whole tree is large; CI will validate. The change is small (one helper call added in two parallel branches, otherwise the structure is unchanged) and follows the exact pattern of the surrounding existing-bucket short-circuit at line 1121 for R2.

<!-- 
Please update with associated PR/issue link from the cloudflare/cloudflare-docs repository.
If a documentation update is not necessary, please add a note explaining why.
-->
## Author has addressed the following

- Tests
  - [x] Tests included
- E2E tests
  - [x] E2E tests already cover the auto-create provisioning path; the new unit test exercises the specific regression
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changeset))
  - [x] Changeset included
- Public documentation
  - [ ] Documentation not necessary because: the fix restores the documented auto-provisioning behavior (idempotent re-deploy) rather than introducing new behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
