### PR TITLE
feat(wrangler): add test harness resource accessors

### DIFF
--- a/.changeset/fuzzy-buckets-compare.md
+++ b/.changeset/fuzzy-buckets-compare.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+Improve errors for missing resource bindings
+
+When methods like `getKVNamespace()` or `getR2Bucket()` are called with a binding name that is not configured for that resource type, Miniflare now reports the expected binding type in the error message.

--- a/.changeset/small-dragons-smile.md
+++ b/.changeset/small-dragons-smile.md
@@ -1,0 +1,13 @@
+---
+"wrangler": minor
+---
+
+Add per-Worker resource accessors to `createTestHarness()`
+
+`createTestHarness()` now provides methods for accessing configured KV namespaces, R2 buckets, D1 databases, and Durable Object namespaces. Use `server.getWorker(name)` to access resources scoped to that specific Worker:
+
+```ts
+const worker = server.getWorker("api-worker");
+const bucket = await worker.getR2Bucket("BUCKET");
+const db = await worker.getD1Database("DB");
+```

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -2998,8 +2998,7 @@ export class Miniflare {
 	async #getProxy<T>(
 		pluginName: string,
 		bindingName: string,
-		workerName?: string,
-		expectedBindingType?: string
+		workerName?: string
 	): Promise<T> {
 		const proxyClient = await this._getProxyClient();
 		const resolvedWorkerName =
@@ -3012,11 +3011,14 @@ export class Miniflare {
 		const proxy = proxyClient.env[proxyBindingName];
 		if (proxy === undefined) {
 			// If the user specified an invalid binding/worker name, throw
-			const friendlyWorkerName = workerName
-				? `${JSON.stringify(workerName)} worker`
+			const friendlyWorkerName = resolvedWorkerName
+				? `${JSON.stringify(resolvedWorkerName)} worker`
 				: "the worker";
-			const bindingType = expectedBindingType
-				? `${expectedBindingType} binding`
+			const bindingTypeDescription = Object.fromEntries(
+				this.#mergedPluginEntries
+			)[pluginName]?.bindingTypeDescription;
+			const bindingType = bindingTypeDescription
+				? `${bindingTypeDescription} binding`
 				: "binding";
 			throw new TypeError(
 				`No ${bindingType} named ${JSON.stringify(bindingName)} found in ${friendlyWorkerName}.`
@@ -3070,34 +3072,19 @@ export class Miniflare {
 		return result.deleted;
 	}
 	getD1Database(bindingName: string, workerName?: string): Promise<D1Database> {
-		return this.#getProxy(
-			D1_PLUGIN_NAME,
-			bindingName,
-			workerName,
-			"D1 database"
-		);
+		return this.#getProxy(D1_PLUGIN_NAME, bindingName, workerName);
 	}
 	getDurableObjectNamespace(
 		bindingName: string,
 		workerName?: string
 	): Promise<ReplaceWorkersTypes<DurableObjectNamespace>> {
-		return this.#getProxy(
-			DURABLE_OBJECTS_PLUGIN_NAME,
-			bindingName,
-			workerName,
-			"Durable Object namespace"
-		);
+		return this.#getProxy(DURABLE_OBJECTS_PLUGIN_NAME, bindingName, workerName);
 	}
 	getKVNamespace(
 		bindingName: string,
 		workerName?: string
 	): Promise<ReplaceWorkersTypes<KVNamespace>> {
-		return this.#getProxy(
-			KV_PLUGIN_NAME,
-			bindingName,
-			workerName,
-			"KV namespace"
-		);
+		return this.#getProxy(KV_PLUGIN_NAME, bindingName, workerName);
 	}
 	getSecretsStoreSecretAPI(
 		bindingName: string,
@@ -3122,18 +3109,13 @@ export class Miniflare {
 		bindingName: string,
 		workerName?: string
 	): Promise<Queue<Body>> {
-		return this.#getProxy(
-			QUEUES_PLUGIN_NAME,
-			bindingName,
-			workerName,
-			"Queue producer"
-		);
+		return this.#getProxy(QUEUES_PLUGIN_NAME, bindingName, workerName);
 	}
 	getR2Bucket(
 		bindingName: string,
 		workerName?: string
 	): Promise<ReplaceWorkersTypes<R2Bucket>> {
-		return this.#getProxy(R2_PLUGIN_NAME, bindingName, workerName, "R2 bucket");
+		return this.#getProxy(R2_PLUGIN_NAME, bindingName, workerName);
 	}
 	getImagesBinding(
 		bindingName: string,

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -2998,22 +2998,28 @@ export class Miniflare {
 	async #getProxy<T>(
 		pluginName: string,
 		bindingName: string,
-		workerName?: string
+		workerName?: string,
+		expectedBindingType?: string
 	): Promise<T> {
 		const proxyClient = await this._getProxyClient();
+		const resolvedWorkerName =
+			workerName ?? this.#workerOpts[0].core.name ?? "";
 		const proxyBindingName = getProxyBindingName(
 			pluginName,
-			// Default to entrypoint worker if none specified
-			workerName ?? this.#workerOpts[0].core.name ?? "",
+			resolvedWorkerName,
 			bindingName
 		);
 		const proxy = proxyClient.env[proxyBindingName];
 		if (proxy === undefined) {
 			// If the user specified an invalid binding/worker name, throw
-			const friendlyWorkerName =
-				workerName === undefined ? "entrypoint" : JSON.stringify(workerName);
+			const friendlyWorkerName = workerName
+				? `${JSON.stringify(workerName)} worker`
+				: "the worker";
+			const bindingType = expectedBindingType
+				? `${expectedBindingType} binding`
+				: "binding";
 			throw new TypeError(
-				`${JSON.stringify(bindingName)} unbound in ${friendlyWorkerName} worker`
+				`No ${bindingType} named ${JSON.stringify(bindingName)} found in ${friendlyWorkerName}.`
 			);
 		}
 		return proxy as T;
@@ -3064,19 +3070,34 @@ export class Miniflare {
 		return result.deleted;
 	}
 	getD1Database(bindingName: string, workerName?: string): Promise<D1Database> {
-		return this.#getProxy(D1_PLUGIN_NAME, bindingName, workerName);
+		return this.#getProxy(
+			D1_PLUGIN_NAME,
+			bindingName,
+			workerName,
+			"D1 database"
+		);
 	}
 	getDurableObjectNamespace(
 		bindingName: string,
 		workerName?: string
 	): Promise<ReplaceWorkersTypes<DurableObjectNamespace>> {
-		return this.#getProxy(DURABLE_OBJECTS_PLUGIN_NAME, bindingName, workerName);
+		return this.#getProxy(
+			DURABLE_OBJECTS_PLUGIN_NAME,
+			bindingName,
+			workerName,
+			"Durable Object namespace"
+		);
 	}
 	getKVNamespace(
 		bindingName: string,
 		workerName?: string
 	): Promise<ReplaceWorkersTypes<KVNamespace>> {
-		return this.#getProxy(KV_PLUGIN_NAME, bindingName, workerName);
+		return this.#getProxy(
+			KV_PLUGIN_NAME,
+			bindingName,
+			workerName,
+			"KV namespace"
+		);
 	}
 	getSecretsStoreSecretAPI(
 		bindingName: string,
@@ -3101,13 +3122,18 @@ export class Miniflare {
 		bindingName: string,
 		workerName?: string
 	): Promise<Queue<Body>> {
-		return this.#getProxy(QUEUES_PLUGIN_NAME, bindingName, workerName);
+		return this.#getProxy(
+			QUEUES_PLUGIN_NAME,
+			bindingName,
+			workerName,
+			"Queue producer"
+		);
 	}
 	getR2Bucket(
 		bindingName: string,
 		workerName?: string
 	): Promise<ReplaceWorkersTypes<R2Bucket>> {
-		return this.#getProxy(R2_PLUGIN_NAME, bindingName, workerName);
+		return this.#getProxy(R2_PLUGIN_NAME, bindingName, workerName, "R2 bucket");
 	}
 	getImagesBinding(
 		bindingName: string,

--- a/packages/miniflare/src/plugins/agent-memory/index.ts
+++ b/packages/miniflare/src/plugins/agent-memory/index.ts
@@ -23,6 +23,7 @@ const AGENT_MEMORY_SCOPE = "agent-memory";
 
 export const AGENT_MEMORY_PLUGIN: Plugin<typeof AgentMemoryOptionsSchema> = {
 	options: AgentMemoryOptionsSchema,
+	bindingTypeDescription: "Agent Memory",
 	async getBindings(options) {
 		if (!options.agentMemory) {
 			return [];

--- a/packages/miniflare/src/plugins/ai-search/index.ts
+++ b/packages/miniflare/src/plugins/ai-search/index.ts
@@ -28,6 +28,7 @@ const AI_SEARCH_INST_SCOPE = "ai-search-inst";
 
 export const AI_SEARCH_PLUGIN: Plugin<typeof AISearchOptionsSchema> = {
 	options: AISearchOptionsSchema,
+	bindingTypeDescription: "AI Search",
 	async getBindings(options) {
 		const bindings: {
 			name: string;

--- a/packages/miniflare/src/plugins/ai/index.ts
+++ b/packages/miniflare/src/plugins/ai/index.ts
@@ -21,6 +21,7 @@ export const AI_PLUGIN_NAME = "ai";
 
 export const AI_PLUGIN: Plugin<typeof AIOptionsSchema> = {
 	options: AIOptionsSchema,
+	bindingTypeDescription: "AI",
 	async getBindings(options) {
 		if (!options.ai) {
 			return [];

--- a/packages/miniflare/src/plugins/analytics-engine/index.ts
+++ b/packages/miniflare/src/plugins/analytics-engine/index.ts
@@ -26,6 +26,7 @@ export const ANALYTICS_ENGINE_PLUGIN: Plugin<
 > = {
 	options: AnalyticsEngineSchemaOptionsSchema,
 	sharedOptions: AnalyticsEngineSchemaSharedOptionsSchema,
+	bindingTypeDescription: "Analytics Engine dataset",
 	async getBindings(options) {
 		if (!options.analyticsEngineDatasets) {
 			return [];

--- a/packages/miniflare/src/plugins/artifacts/index.ts
+++ b/packages/miniflare/src/plugins/artifacts/index.ts
@@ -21,6 +21,7 @@ export const ARTIFACTS_PLUGIN_NAME = "artifacts";
 
 export const ARTIFACTS_PLUGIN: Plugin<typeof ArtifactsOptionsSchema> = {
 	options: ArtifactsOptionsSchema,
+	bindingTypeDescription: "Artifacts",
 	async getBindings(options) {
 		if (!options.artifacts) {
 			return [];

--- a/packages/miniflare/src/plugins/assets/index.ts
+++ b/packages/miniflare/src/plugins/assets/index.ts
@@ -60,6 +60,7 @@ const tempDirCache = new Map<string, string>();
 
 export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 	options: AssetsOptionsSchema,
+	bindingTypeDescription: "Assets",
 	async getBindings(options: z.infer<typeof AssetsOptionsSchema>) {
 		if (!options.assets?.binding) {
 			return [];

--- a/packages/miniflare/src/plugins/browser-rendering/index.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/index.ts
@@ -43,6 +43,7 @@ export const BROWSER_RENDERING_PLUGIN: Plugin<
 	typeof BrowserRenderingOptionsSchema
 > = {
 	options: BrowserRenderingOptionsSchema,
+	bindingTypeDescription: "Browser Rendering",
 	async getBindings(options) {
 		if (!options.browserRendering) {
 			return [];

--- a/packages/miniflare/src/plugins/d1/index.ts
+++ b/packages/miniflare/src/plugins/d1/index.ts
@@ -60,6 +60,7 @@ export const D1_PLUGIN: Plugin<
 > = {
 	options: D1OptionsSchema,
 	sharedOptions: D1SharedOptionsSchema,
+	bindingTypeDescription: "D1 database",
 	getBindings(options) {
 		const databases = namespaceEntries(options.d1Databases);
 		return databases.map<Worker_Binding>(

--- a/packages/miniflare/src/plugins/dispatch-namespace/index.ts
+++ b/packages/miniflare/src/plugins/dispatch-namespace/index.ts
@@ -40,6 +40,7 @@ export const DISPATCH_NAMESPACE_PLUGIN: Plugin<
 	typeof DispatchNamespaceOptionsSchema
 > = {
 	options: DispatchNamespaceOptionsSchema,
+	bindingTypeDescription: "Dispatch namespace",
 	async getBindings(options) {
 		if (!options.dispatchNamespaces) {
 			return [];

--- a/packages/miniflare/src/plugins/do/index.ts
+++ b/packages/miniflare/src/plugins/do/index.ts
@@ -101,6 +101,7 @@ export const DURABLE_OBJECTS_PLUGIN: Plugin<
 > = {
 	options: DurableObjectsOptionsSchema,
 	sharedOptions: DurableObjectsSharedOptionsSchema,
+	bindingTypeDescription: "Durable Object namespace",
 	getBindings(options) {
 		return Object.entries(options.durableObjects ?? {}).map<Worker_Binding>(
 			([name, klass]) => {

--- a/packages/miniflare/src/plugins/email/index.ts
+++ b/packages/miniflare/src/plugins/email/index.ts
@@ -55,6 +55,7 @@ function buildJsonBindings(bindings: Record<string, any>): Worker_Binding[] {
 
 export const EMAIL_PLUGIN: Plugin<typeof EmailOptionsSchema> = {
 	options: EmailOptionsSchema,
+	bindingTypeDescription: "Email",
 	getBindings(options): Worker_Binding[] {
 		if (!options.email?.send_email) {
 			return [];

--- a/packages/miniflare/src/plugins/flagship/index.ts
+++ b/packages/miniflare/src/plugins/flagship/index.ts
@@ -22,6 +22,7 @@ export const FLAGSHIP_PLUGIN_NAME = "flagship";
 
 export const FLAGSHIP_PLUGIN: Plugin<typeof FlagshipOptionsSchema> = {
 	options: FlagshipOptionsSchema,
+	bindingTypeDescription: "Flagship",
 	async getBindings(options) {
 		if (!options.flagship) {
 			return [];

--- a/packages/miniflare/src/plugins/hello-world/index.ts
+++ b/packages/miniflare/src/plugins/hello-world/index.ts
@@ -35,6 +35,7 @@ export const HELLO_WORLD_PLUGIN: Plugin<
 > = {
 	options: HelloWorldOptionsSchema,
 	sharedOptions: HelloWorldSharedOptionsSchema,
+	bindingTypeDescription: "Hello World",
 	async getBindings(options) {
 		if (!options.helloWorld) {
 			return [];

--- a/packages/miniflare/src/plugins/hyperdrive/index.ts
+++ b/packages/miniflare/src/plugins/hyperdrive/index.ts
@@ -77,6 +77,7 @@ export const HyperdriveInputOptionsSchema = z.object({
 
 export const HYPERDRIVE_PLUGIN: Plugin<typeof HyperdriveInputOptionsSchema> = {
 	options: HyperdriveInputOptionsSchema,
+	bindingTypeDescription: "Hyperdrive",
 	getBindings(options) {
 		return Object.entries(options.hyperdrives ?? {}).map<Worker_Binding>(
 			([name, url]) => {

--- a/packages/miniflare/src/plugins/images/index.ts
+++ b/packages/miniflare/src/plugins/images/index.ts
@@ -41,6 +41,7 @@ export const IMAGES_PLUGIN: Plugin<
 > = {
 	options: ImagesOptionsSchema,
 	sharedOptions: ImagesSharedOptionsSchema,
+	bindingTypeDescription: "Images",
 	async getBindings(options) {
 		if (!options.images) {
 			return [];

--- a/packages/miniflare/src/plugins/kv/index.ts
+++ b/packages/miniflare/src/plugins/kv/index.ts
@@ -77,6 +77,7 @@ export const KV_PLUGIN: Plugin<
 > = {
 	options: KVOptionsSchema,
 	sharedOptions: KVSharedOptionsSchema,
+	bindingTypeDescription: "KV namespace",
 	async getBindings(options) {
 		const namespaces = namespaceEntries(options.kvNamespaces);
 		const bindings = namespaces.map<Worker_Binding>(([name, namespace]) => ({

--- a/packages/miniflare/src/plugins/media/index.ts
+++ b/packages/miniflare/src/plugins/media/index.ts
@@ -21,6 +21,7 @@ export const MediaOptionsSchema = z.object({
 
 export const MEDIA_PLUGIN: Plugin<typeof MediaOptionsSchema> = {
 	options: MediaOptionsSchema,
+	bindingTypeDescription: "Media",
 	async getBindings(options) {
 		if (!options.media) {
 			return [];

--- a/packages/miniflare/src/plugins/mtls/index.ts
+++ b/packages/miniflare/src/plugins/mtls/index.ts
@@ -21,6 +21,7 @@ export const MTLS_PLUGIN_NAME = "mtls";
 
 export const MTLS_PLUGIN: Plugin<typeof MtlsOptionsSchema> = {
 	options: MtlsOptionsSchema,
+	bindingTypeDescription: "mTLS certificate",
 	async getBindings(options) {
 		if (!options.mtlsCertificates) {
 			return [];

--- a/packages/miniflare/src/plugins/pipelines/index.ts
+++ b/packages/miniflare/src/plugins/pipelines/index.ts
@@ -39,6 +39,7 @@ const SERVICE_PIPELINE_PREFIX = `${PIPELINES_PLUGIN_NAME}:pipeline`;
 
 export const PIPELINE_PLUGIN: Plugin<typeof PipelineOptionsSchema> = {
 	options: PipelineOptionsSchema,
+	bindingTypeDescription: "Pipeline",
 	getBindings(options) {
 		const pipelines = bindingEntries(options.pipelines);
 		return pipelines.map<Service>(([name, { id }]) => ({

--- a/packages/miniflare/src/plugins/queues/index.ts
+++ b/packages/miniflare/src/plugins/queues/index.ts
@@ -52,6 +52,7 @@ const QUEUE_BROKER_OBJECT: Worker_Binding_DurableObjectNamespaceDesignator = {
 
 export const QUEUES_PLUGIN: Plugin<typeof QueuesOptionsSchema> = {
 	options: QueuesOptionsSchema,
+	bindingTypeDescription: "Queue producer",
 	getBindings(options) {
 		const queues = bindingEntries(options.queueProducers);
 		return queues.map<Worker_Binding>(([name, id]) => ({

--- a/packages/miniflare/src/plugins/r2/index.ts
+++ b/packages/miniflare/src/plugins/r2/index.ts
@@ -92,6 +92,7 @@ export const R2_PLUGIN: Plugin<
 > = {
 	options: R2OptionsSchema,
 	sharedOptions: R2SharedOptionsSchema,
+	bindingTypeDescription: "R2 bucket",
 	getBindings(options) {
 		const buckets = namespaceEntries(options.r2Buckets);
 		return buckets.map<Worker_Binding>(([name, bucket]) => ({

--- a/packages/miniflare/src/plugins/ratelimit/index.ts
+++ b/packages/miniflare/src/plugins/ratelimit/index.ts
@@ -34,6 +34,7 @@ function buildJsonBindings(bindings: Record<string, any>): Worker_Binding[] {
 
 export const RATELIMIT_PLUGIN: Plugin<typeof RatelimitOptionsSchema> = {
 	options: RatelimitOptionsSchema,
+	bindingTypeDescription: "Rate Limit",
 	getBindings(options: z.infer<typeof RatelimitOptionsSchema>) {
 		if (!options.ratelimits) {
 			return [];

--- a/packages/miniflare/src/plugins/secret-store/index.ts
+++ b/packages/miniflare/src/plugins/secret-store/index.ts
@@ -39,6 +39,7 @@ export const SECRET_STORE_PLUGIN: Plugin<
 > = {
 	options: SecretsStoreSecretsOptionsSchema,
 	sharedOptions: SecretsStoreSecretsSharedOptionsSchema,
+	bindingTypeDescription: "Secrets Store secret",
 	async getBindings(options) {
 		if (!options.secretsStoreSecrets) {
 			return [];

--- a/packages/miniflare/src/plugins/shared/index.ts
+++ b/packages/miniflare/src/plugins/shared/index.ts
@@ -103,6 +103,7 @@ export interface PluginBase<
 	SharedOptions extends z.ZodType | undefined,
 > {
 	options: Options;
+	bindingTypeDescription?: string;
 	getBindings(
 		options: z.infer<Options>,
 		workerIndex: number

--- a/packages/miniflare/src/plugins/stream/index.ts
+++ b/packages/miniflare/src/plugins/stream/index.ts
@@ -43,6 +43,7 @@ export const STREAM_PLUGIN: Plugin<
 > = {
 	options: StreamOptionsSchema,
 	sharedOptions: StreamSharedOptionsSchema,
+	bindingTypeDescription: "Stream",
 	async getBindings(options) {
 		if (!options.stream) {
 			return [];

--- a/packages/miniflare/src/plugins/vectorize/index.ts
+++ b/packages/miniflare/src/plugins/vectorize/index.ts
@@ -21,6 +21,7 @@ export const VECTORIZE_PLUGIN_NAME = "vectorize";
 
 export const VECTORIZE_PLUGIN: Plugin<typeof VectorizeOptionsSchema> = {
 	options: VectorizeOptionsSchema,
+	bindingTypeDescription: "Vectorize index",
 	async getBindings(options) {
 		if (!options.vectorize) {
 			return [];

--- a/packages/miniflare/src/plugins/vpc-networks/index.ts
+++ b/packages/miniflare/src/plugins/vpc-networks/index.ts
@@ -29,6 +29,7 @@ export const VPC_NETWORKS_PLUGIN_NAME = "vpc-networks";
 
 export const VPC_NETWORKS_PLUGIN: Plugin<typeof VpcNetworksOptionsSchema> = {
 	options: VpcNetworksOptionsSchema,
+	bindingTypeDescription: "VPC network",
 	async getBindings(options) {
 		if (!options.vpcNetworks) {
 			return [];

--- a/packages/miniflare/src/plugins/vpc-services/index.ts
+++ b/packages/miniflare/src/plugins/vpc-services/index.ts
@@ -21,6 +21,7 @@ export const VPC_SERVICES_PLUGIN_NAME = "vpc-services";
 
 export const VPC_SERVICES_PLUGIN: Plugin<typeof VpcServicesOptionsSchema> = {
 	options: VpcServicesOptionsSchema,
+	bindingTypeDescription: "VPC service",
 	async getBindings(options) {
 		if (!options.vpcServices) {
 			return [];

--- a/packages/miniflare/src/plugins/websearch/index.ts
+++ b/packages/miniflare/src/plugins/websearch/index.ts
@@ -22,6 +22,7 @@ const WEBSEARCH_SCOPE = "websearch";
 
 export const WEBSEARCH_PLUGIN: Plugin<typeof WebsearchOptionsSchema> = {
 	options: WebsearchOptionsSchema,
+	bindingTypeDescription: "Web Search",
 	async getBindings(options) {
 		const bindings: {
 			name: string;

--- a/packages/miniflare/src/plugins/workflows/index.ts
+++ b/packages/miniflare/src/plugins/workflows/index.ts
@@ -49,6 +49,7 @@ export const WORKFLOWS_PLUGIN: Plugin<
 > = {
 	options: WorkflowsOptionsSchema,
 	sharedOptions: WorkflowsSharedOptionsSchema,
+	bindingTypeDescription: "Workflow",
 	async getBindings(options: z.infer<typeof WorkflowsOptionsSchema>) {
 		return Object.entries(options.workflows ?? {}).map(
 			([bindingName, workflow]) => ({

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -2666,36 +2666,43 @@ test("Miniflare: getBindings() and friends return bindings for different workers
 	// Check `getD1Database()`
 	let binding: unknown = await mf.getD1Database("DB");
 	expect(binding).toBeDefined();
+	await expect(() => mf.getD1Database("DO")).rejects.toThrow(
+		new TypeError(`No D1 database binding named "DO" found in the worker.`)
+	);
 	await expect(() => mf.getD1Database("DB", "c")).rejects.toThrow(
-		new TypeError(`"DB" unbound in "c" worker`)
+		new TypeError(`No D1 database binding named "DB" found in "c" worker.`)
 	);
 
 	// Check `getDurableObjectNamespace()`
 	binding = await mf.getDurableObjectNamespace("DO");
 	expect(binding).toBeDefined();
 	await expect(() => mf.getDurableObjectNamespace("DO", "c")).rejects.toThrow(
-		new TypeError(`"DO" unbound in "c" worker`)
+		new TypeError(
+			`No Durable Object namespace binding named "DO" found in "c" worker.`
+		)
 	);
 
 	// Check `getKVNamespace()`
 	binding = await mf.getKVNamespace("KV", "");
 	expect(binding).toBeDefined();
 	await expect(() => mf.getKVNamespace("KV", "c")).rejects.toThrow(
-		new TypeError(`"KV" unbound in "c" worker`)
+		new TypeError(`No KV namespace binding named "KV" found in "c" worker.`)
 	);
 
 	// Check `getQueueProducer()`
 	binding = await mf.getQueueProducer("QUEUE", "");
 	expect(binding).toBeDefined();
 	await expect(() => mf.getQueueProducer("QUEUE", "c")).rejects.toThrow(
-		new TypeError(`"QUEUE" unbound in "c" worker`)
+		new TypeError(
+			`No Queue producer binding named "QUEUE" found in "c" worker.`
+		)
 	);
 
 	// Check `getR2Bucket()`
 	binding = await mf.getR2Bucket("BUCKET", "b");
 	expect(binding).toBeDefined();
 	await expect(() => mf.getR2Bucket("BUCKET", "c")).rejects.toThrow(
-		new TypeError(`"BUCKET" unbound in "c" worker`)
+		new TypeError(`No R2 bucket binding named "BUCKET" found in "c" worker.`)
 	);
 });
 

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -2667,7 +2667,7 @@ test("Miniflare: getBindings() and friends return bindings for different workers
 	let binding: unknown = await mf.getD1Database("DB");
 	expect(binding).toBeDefined();
 	await expect(() => mf.getD1Database("DO")).rejects.toThrow(
-		new TypeError(`No D1 database binding named "DO" found in the worker.`)
+		new TypeError(`No D1 database binding named "DO" found in "a" worker.`)
 	);
 	await expect(() => mf.getD1Database("DB", "c")).rejects.toThrow(
 		new TypeError(`No D1 database binding named "DB" found in "c" worker.`)

--- a/packages/wrangler/e2e/createTestHarness.test.ts
+++ b/packages/wrangler/e2e/createTestHarness.test.ts
@@ -208,6 +208,159 @@ describe("createTestHarness", () => {
 		);
 	});
 
+	it("exposes resource accessors scoped to each worker", async ({ expect }) => {
+		await helper.seed({
+			"wrangler.api.jsonc": dedent`
+				{
+					"name": "api-worker",
+					"main": "src/api.ts",
+					"compatibility_date": "2026-05-20",
+					"kv_namespaces": [
+						{ "binding": "STORE", "id": "api-store" }
+					],
+					"r2_buckets": [
+						{ "binding": "BUCKET", "bucket_name": "api-bucket" }
+					]
+				}
+			`,
+			"wrangler.admin.jsonc": dedent`
+				{
+					"name": "admin-worker",
+					"main": "src/admin.ts",
+					"compatibility_date": "2026-05-20",
+					"d1_databases": [
+						{
+							"binding": "DATABASE",
+							"database_name": "admin-database",
+							"database_id": "00000000-0000-0000-0000-000000000002"
+						}
+					],
+					"durable_objects": {
+						"bindings": [
+							{ "name": "OBJECT", "class_name": "Counter" }
+						]
+					},
+					"migrations": [
+						{ "tag": "v1", "new_sqlite_classes": ["Counter"] }
+					]
+				}
+			`,
+			"src/api.ts": dedent`
+				export default {
+					async fetch(request, env) {
+						const url = new URL(request.url);
+						if (url.pathname === "/write-storage") {
+							await env.STORE.put("key", "api");
+							await env.BUCKET.put("key", "api");
+							return new Response("written");
+						}
+
+						return new Response("ok");
+					}
+				};
+			`,
+			"src/admin.ts": dedent`
+			import { DurableObject } from "cloudflare:workers";
+
+			export class Counter extends DurableObject {
+				async fetch() {
+					const value = (await this.ctx.storage.get("value")) ?? 0;
+					const next = value + 1;
+					await this.ctx.storage.put("value", next);
+					return new Response(String(next));
+				}
+			}
+
+			export default {
+				async fetch(request, env) {
+					const url = new URL(request.url);
+					if (url.pathname === "/write-storage") {
+						await env.DATABASE.exec("CREATE TABLE entries (value TEXT);");
+						await env.DATABASE.prepare("INSERT INTO entries (value) VALUES (?);")
+							.bind("admin")
+							.run();
+
+						const id = env.OBJECT.idFromName("shared");
+						const stub = env.OBJECT.get(id);
+						return stub.fetch("http://example.com/");
+					}
+
+					return new Response("ok");
+				}
+			};
+			`,
+		});
+
+		const server = createTestHarness({
+			root: helper.tmpPath,
+			workers: [
+				{ configPath: "./wrangler.api.jsonc" },
+				{ configPath: "./wrangler.admin.jsonc" },
+			],
+		});
+		onTestFinished(server.close);
+
+		await server.listen();
+
+		const api = server.getWorker("api-worker");
+		const admin = server.getWorker("admin-worker");
+		const apiWriteResponse = await api.fetch("/write-storage");
+		expect(await apiWriteResponse.text()).toBe("written");
+		const adminWriteResponse = await admin.fetch("/write-storage");
+		expect(await adminWriteResponse.text()).toBe("1");
+
+		// KV Namespace
+		const STORE = await api.getKVNamespace("STORE");
+		await expect(STORE.get("key")).resolves.toBe("api");
+		await expect(admin.getKVNamespace("STORE")).rejects.toThrow(
+			`No KV namespace binding named "STORE" found in "admin-worker" worker.`
+		);
+		await expect(api.getKVNamespace("BUCKET")).rejects.toThrow(
+			`No KV namespace binding named "BUCKET" found in "api-worker" worker.`
+		);
+
+		// R2 Bucket
+		const BUCKET = await api.getR2Bucket("BUCKET");
+		const object = await BUCKET.get("key");
+
+		if (object === null) {
+			expect.fail("Expected R2 object to exist");
+		} else {
+			await expect(object.text()).resolves.toBe("api");
+		}
+
+		await expect(admin.getR2Bucket("BUCKET")).rejects.toThrow(
+			`No R2 bucket binding named "BUCKET" found in "admin-worker" worker.`
+		);
+		await expect(api.getR2Bucket("STORE")).rejects.toThrow(
+			`No R2 bucket binding named "STORE" found in "api-worker" worker.`
+		);
+
+		// D1 Database
+		const DATABASE = await admin.getD1Database("DATABASE");
+		await expect(
+			DATABASE.prepare("SELECT value FROM entries").first("value")
+		).resolves.toBe("admin");
+		await expect(api.getD1Database("DATABASE")).rejects.toThrow(
+			`No D1 database binding named "DATABASE" found in "api-worker" worker.`
+		);
+		await expect(admin.getD1Database("OBJECT")).rejects.toThrow(
+			`No D1 database binding named "OBJECT" found in "admin-worker" worker.`
+		);
+
+		// Durable Object Namespace
+		const adminDO = await admin.getDurableObjectNamespace("OBJECT");
+		const adminStub = adminDO.getByName("shared");
+		const adminResponse = await adminStub.fetch("http://example.com/");
+		await expect(adminResponse.text()).resolves.toBe("2");
+		await expect(api.getDurableObjectNamespace("OBJECT")).rejects.toThrow(
+			`No Durable Object namespace binding named "OBJECT" found in "api-worker" worker.`
+		);
+		await expect(admin.getDurableObjectNamespace("DATABASE")).rejects.toThrow(
+			`No Durable Object namespace binding named "DATABASE" found in "admin-worker" worker.`
+		);
+	});
+
 	it("supports service bindings between workers", async ({ expect }) => {
 		await helper.seed({
 			"wrangler.primary.jsonc": dedent`

--- a/packages/wrangler/src/api/test-harness.ts
+++ b/packages/wrangler/src/api/test-harness.ts
@@ -66,6 +66,49 @@ export type WorkerHandle = {
 	 * ```
 	 */
 	scheduled(options: FetcherScheduledOptions): Promise<FetcherScheduledResult>;
+	/**
+	 * Returns a KV namespace binding configured on this Worker.
+	 *
+	 * @example
+	 * ```ts
+	 * const store = await worker.getKVNamespace("STORE");
+	 * const value = await store.get("key");
+	 * ```
+	 */
+	getKVNamespace(bindingName: string): ReturnType<Miniflare["getKVNamespace"]>;
+	/**
+	 * Returns an R2 bucket binding configured on this Worker.
+	 *
+	 * @example
+	 * ```ts
+	 * const bucket = await worker.getR2Bucket("BUCKET");
+	 * const object = await bucket.get("key");
+	 * ```
+	 */
+	getR2Bucket(bindingName: string): ReturnType<Miniflare["getR2Bucket"]>;
+	/**
+	 * Returns a D1 database binding configured on this Worker.
+	 *
+	 * @example
+	 * ```ts
+	 * const db = await worker.getD1Database("DB");
+	 * const value = await db.prepare("SELECT value FROM entries").first("value");
+	 * ```
+	 */
+	getD1Database(bindingName: string): ReturnType<Miniflare["getD1Database"]>;
+	/**
+	 * Returns a Durable Object namespace binding configured on this Worker.
+	 *
+	 * @example
+	 * ```ts
+	 * const namespace = await worker.getDurableObjectNamespace("OBJECT");
+	 * const stub = namespace.getByName("counter");
+	 * const response = await stub.fetch("http://example.com/");
+	 * ```
+	 */
+	getDurableObjectNamespace(
+		bindingName: string
+	): ReturnType<Miniflare["getDurableObjectNamespace"]>;
 };
 
 export type TestHarness = {
@@ -366,8 +409,11 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 		};
 		try {
 			debugLog("startup - started");
-			await updateConfig(session, inputs);
-			await waitForProxyReady(session);
+			await Promise.all([
+				waitForProxyReady(session),
+				waitForReloadComplete(session),
+				updateConfig(session, inputs),
+			]);
 			debugLog("startup - completed");
 			return session;
 		} catch (error) {
@@ -562,7 +608,6 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 	}
 
 	async function getRuntimeMiniflare(session: ServerSession) {
-		await session.primaryDevEnv.proxy.runtimeMessageMutex.drained();
 		const miniflare = session.primaryDevEnv.runtimes[0].mf;
 		assert(miniflare, "Worker runtime is not available.");
 		return miniflare;
@@ -591,7 +636,7 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 
 		if (typeof input === "string" && !URL.canParse(input)) {
 			const session = await resolveSession();
-			const { url } = await waitForProxyReady(session);
+			const { url } = await session.primaryDevEnv.proxy.ready.promise;
 			const baseUrl = new URL(url);
 
 			if (
@@ -628,7 +673,7 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 	return {
 		async listen() {
 			const session = serverSession ?? (await startServerSession());
-			const ready = await waitForProxyReady(session);
+			const ready = await session.primaryDevEnv.proxy.ready.promise;
 
 			return {
 				url: ready.url,
@@ -682,6 +727,34 @@ export function createTestHarness(options?: TestHarnessOptions): TestHarness {
 					const result = await response.json();
 
 					return result as FetcherScheduledResult;
+				},
+				async getKVNamespace(bindingName) {
+					const session = await resolveSession();
+					const miniflare = await getRuntimeMiniflare(session);
+					const workerName = resolveWorkerName(session, name);
+
+					return miniflare.getKVNamespace(bindingName, workerName);
+				},
+				async getR2Bucket(bindingName) {
+					const session = await resolveSession();
+					const miniflare = await getRuntimeMiniflare(session);
+					const workerName = resolveWorkerName(session, name);
+
+					return miniflare.getR2Bucket(bindingName, workerName);
+				},
+				async getD1Database(bindingName) {
+					const session = await resolveSession();
+					const miniflare = await getRuntimeMiniflare(session);
+					const workerName = resolveWorkerName(session, name);
+
+					return miniflare.getD1Database(bindingName, workerName);
+				},
+				async getDurableObjectNamespace(bindingName) {
+					const session = await resolveSession();
+					const miniflare = await getRuntimeMiniflare(session);
+					const workerName = resolveWorkerName(session, name);
+
+					return miniflare.getDurableObjectNamespace(bindingName, workerName);
 				},
 			};
 		},


### PR DESCRIPTION
Fixes n/a.

This adds per-Worker resource accessors to `createTestHarness()`, so tests can inspect the same local resources that a Worker used while handling a request.

For example:

```ts
const server = createTestHarness({
  workers: [{ configPath: "./wrangler.jsonc" }],
});

await server.listen();

const worker = server.getWorker("api-worker");

// Exercise the Worker code that writes to storage.
await worker.fetch("/create-user", {
  method: "POST",
  body: JSON.stringify({ email: "user@example.com" }),
});

// Assert the resulting storage state directly.
const db = await worker.getD1Database("DB");
const latestUser = await db
  .prepare("SELECT id, email FROM users ORDER BY created_at DESC LIMIT 1")
  .first<{ id: string; email: string }>();

expect(latestUser.email).toBe("user@example.com");

const bucket = await worker.getR2Bucket("BUCKET");
const avatar = await bucket.get(`avatars/${latestUser.id}.png`);

expect(avatar).not.toBeNull();
```


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: I will add it seperately.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->