### PR TITLE
[wrangler] Send `login user` metric when `--scopes` is provided

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -28,6 +28,7 @@ pnpm changeset
 
 - Major versions for `wrangler` are currently **forbidden**. This rule will be removed when we are preparing for the next major release of `wrangler`.
 - Major versions for other packages require strong justification
+- If the change collects more analytics, it should be a minor even though there is no user-visible change.
 
 ## Changeset Message Format
 

--- a/.changeset/wrangler-login-scopes-metrics.md
+++ b/.changeset/wrangler-login-scopes-metrics.md
@@ -1,5 +1,5 @@
 ---
-"wrangler": patch
+"wrangler": minor
 ---
 
 Send the `login user` telemetry event when `wrangler login --scopes ...` succeeds

--- a/.changeset/wrangler-login-scopes-metrics.md
+++ b/.changeset/wrangler-login-scopes-metrics.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Send the `login user` telemetry event when `wrangler login --scopes ...` succeeds
+
+`wrangler login` was already reporting the `login user` event when called without `--scopes`, but the scoped login path returned early before the event could be sent. Both paths now report the event, so successful scoped logins are counted alongside unscoped ones.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,7 @@ start with a capital letter and describe the change directly (e.g., "Remove unus
 - Config examples must use `wrangler.json` (JSONC), not `wrangler.toml`
 - Separate changesets for distinct changes; do not lump unrelated changes
 - Focus on user-facing impact; reference the public-facing package, not internal implementation packages
+- If the change collects more analytics, it should be a minor even though there is no user-visible change
 
 ## Anti-Patterns
 

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -13,6 +13,7 @@ import ci from "ci-info";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, it, vi } from "vitest";
 import { saveToConfigCache } from "../config-cache";
+import * as metricsModule from "../metrics";
 import {
 	fetchAllAccounts,
 	getAccountFromCache,
@@ -447,6 +448,39 @@ describe("User", () => {
 			).rejects.toThrowErrorMatchingInlineSnapshot(
 				`[Error: Invalid authentication scopes: "bad_one", "bad_two". Run "wrangler login --scopes-list" to see all valid scopes.]`
 			);
+		});
+
+		it("should send the `login user` metric when `--scopes` is provided", async ({
+			expect,
+		}) => {
+			// Regression: the scoped login path used to early-return before
+			// `sendMetricsEvent("login user", ...)` could run, so successful
+			// logins via `wrangler login --scopes ...` were never counted.
+			const sendMetricsEventSpy = vi.spyOn(metricsModule, "sendMetricsEvent");
+			try {
+				mockOAuthServerCallback("success");
+				msw.use(
+					http.post(
+						"*/oauth2/token",
+						async () =>
+							HttpResponse.json({
+								access_token: "test-access-token",
+								expires_in: 100000,
+								refresh_token: "test-refresh-token",
+								scope: "account:read",
+							}),
+						{ once: true }
+					)
+				);
+
+				await runWrangler("login --scopes account:read");
+
+				expect(sendMetricsEventSpy).toHaveBeenCalledWith("login user", {
+					sendMetrics: undefined,
+				});
+			} finally {
+				sendMetricsEventSpy.mockRestore();
+			}
 		});
 	});
 

--- a/packages/wrangler/src/user/commands.ts
+++ b/packages/wrangler/src/user/commands.ts
@@ -67,6 +67,10 @@ export const loginCommand = createCommand({
 			listScopes();
 			return;
 		}
+		// Validate `--scopes` up front so we can share a single `login(...)`
+		// call (and a single `sendMetricsEvent("login user", ...)` site) between
+		// the scoped and unscoped paths.
+		let scopes: typeof DefaultScopeKeys | undefined;
 		if (args.scopes) {
 			if (args.scopes.length === 0) {
 				// don't allow no scopes to be passed, that would be weird
@@ -81,15 +85,10 @@ export const loginCommand = createCommand({
 					{ telemetryMessage: "user login invalid scope" }
 				);
 			}
-			await login(config, {
-				scopes: args.scopes,
-				browser: args.browser,
-				callbackHost: args.callbackHost,
-				callbackPort: args.callbackPort,
-			});
-			return;
+			scopes = args.scopes;
 		}
 		await login(config, {
+			scopes,
 			browser: args.browser,
 			callbackHost: args.callbackHost,
 			callbackPort: args.callbackPort,


### PR DESCRIPTION
Wrangler's `login` command was already reporting the `login user` telemetry event when run without `--scopes`, but the scoped login path returned early before the event could be sent. Both paths now share a single `login(...)` call site and a single `sendMetricsEvent(...)` call, so successful scoped logins are counted alongside unscoped ones.

This was spotted by an automated review on #14064 as a pre-existing gap, and split out into its own PR.

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: internal telemetry-only change with no user-facing behaviour change.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->