### PR TITLE
remove deprecated `toThrowError` assertions

### DIFF
--- a/packages/vite-plugin-cloudflare/src/__tests__/get-validated-wrangler-config-path.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/get-validated-wrangler-config-path.spec.ts
@@ -60,7 +60,7 @@ describe("invalid cases", () => {
 					join(fixturesPath, "simple-wrangler"),
 					forAuxiliaryWorker
 				);
-			}).toThrowError(
+			}).toThrow(
 				forAuxiliaryWorker
 					? /The provided configPath \(.*?simple-wrangler\) requested for one of your auxiliary workers doesn't point to a file with the correct file extension. It should point to a jsonc, json or toml file \(no extension found instead\)/
 					: /The provided configPath \(.*?simple-wrangler\) doesn't point to a file with the correct file extension. It should point to a jsonc, json or toml file \(no extension found instead\)/
@@ -76,7 +76,7 @@ describe("invalid cases", () => {
 					join(fixturesPath, "simple-wrangler.txt"),
 					forAuxiliaryWorker
 				);
-			}).toThrowError(
+			}).toThrow(
 				forAuxiliaryWorker
 					? /The provided configPath \(.*?simple-wrangler\.txt\) requested for one of your auxiliary workers doesn't point to a file with the correct file extension. It should point to a jsonc, json or toml file \("txt" found instead\)/
 					: /The provided configPath \(.*?simple-wrangler\.txt\) doesn't point to a file with the correct file extension. It should point to a jsonc, json or toml file \("txt" found instead\)/
@@ -92,7 +92,7 @@ describe("invalid cases", () => {
 					join(fixturesPath, "empty-dir.jsonc"),
 					forAuxiliaryWorker
 				);
-			}).toThrowError(
+			}).toThrow(
 				forAuxiliaryWorker
 					? /The provided configPath \(.*?empty-dir.jsonc\) requested for one of your auxiliary workers points to a directory\. It should point to a file\./
 					: /The provided configPath \(.*?empty-dir.jsonc\) points to a directory\. It should point to a file\./
@@ -108,7 +108,7 @@ describe("invalid cases", () => {
 					join(fixturesPath, "empty-dir/wrangler.jsonc"),
 					forAuxiliaryWorker
 				);
-			}).toThrowError(
+			}).toThrow(
 				forAuxiliaryWorker
 					? /The provided configPath \(.*?wrangler.jsonc\) requested for one of your auxiliary workers doesn't point to an existing file/
 					: /The provided configPath \(.*?wrangler.jsonc\) doesn't point to an existing file/

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -478,7 +478,7 @@ describe("User", () => {
 		});
 
 		// Handles the requireAuth error throw from failed login that is unhandled due to directly calling it here
-		await expect(requireAuth({} as Config)).rejects.toThrowError();
+		await expect(requireAuth({} as Config)).rejects.toThrow();
 		expect(std.err).toContain("");
 	});
 
@@ -792,7 +792,7 @@ describe("User", () => {
 		});
 
 		it("should error when not logged in", async ({ expect }) => {
-			await expect(runWrangler("auth token")).rejects.toThrowError(
+			await expect(runWrangler("auth token")).rejects.toThrow(
 				"Not logged in. Please run `wrangler login` to authenticate."
 			);
 		});
@@ -813,7 +813,7 @@ describe("User", () => {
 			vi.stubEnv("CLOUDFLARE_API_KEY", "test-api-key");
 			vi.stubEnv("CLOUDFLARE_EMAIL", "test@example.com");
 
-			await expect(runWrangler("auth token")).rejects.toThrowError(
+			await expect(runWrangler("auth token")).rejects.toThrow(
 				"Cannot output a single token when using CLOUDFLARE_API_KEY and CLOUDFLARE_EMAIL"
 			);
 		});
@@ -882,7 +882,7 @@ describe("User", () => {
 
 			mockExchangeRefreshTokenForAccessToken({ respondWith: "refreshError" });
 
-			await expect(runWrangler("auth token")).rejects.toThrowError(
+			await expect(runWrangler("auth token")).rejects.toThrow(
 				"Not logged in. Please run `wrangler login` to authenticate."
 			);
 		});
@@ -1195,7 +1195,7 @@ describe("User", () => {
 		it("should throw when no accounts are found", async ({ expect }) => {
 			msw.use(...getMswSuccessMembershipHandlers([]));
 
-			await expect(fetchAllAccounts({})).rejects.toThrowError(
+			await expect(fetchAllAccounts({})).rejects.toThrow(
 				/Failed to automatically retrieve account IDs for the logged in user/
 			);
 		});
@@ -1227,7 +1227,7 @@ describe("User", () => {
 				)
 			);
 
-			await expect(fetchAllAccounts({})).rejects.toThrowError(
+			await expect(fetchAllAccounts({})).rejects.toThrow(
 				/Failed to automatically retrieve account IDs for the logged in user/
 			);
 		});
@@ -1295,7 +1295,7 @@ describe("User", () => {
 				)
 			);
 
-			await expect(fetchAllAccounts({})).rejects.toThrowError(
+			await expect(fetchAllAccounts({})).rejects.toThrow(
 				/incorrect permissions on your API token/
 			);
 		});
@@ -1355,7 +1355,7 @@ describe("User", () => {
 				)
 			);
 
-			await expect(fetchAllAccounts({})).rejects.toThrowError(
+			await expect(fetchAllAccounts({})).rejects.toThrow(
 				/incorrect permissions on your API token/
 			);
 		});
@@ -1385,7 +1385,7 @@ describe("User", () => {
 				)
 			);
 
-			await expect(fetchAllAccounts({})).rejects.toThrowError(
+			await expect(fetchAllAccounts({})).rejects.toThrow(
 				/CLOUDFLARE_API_TOKEN/
 			);
 		});
@@ -1407,7 +1407,7 @@ describe("User", () => {
 				)
 			);
 
-			await expect(fetchAllAccounts({})).rejects.toThrowError(
+			await expect(fetchAllAccounts({})).rejects.toThrow(
 				/A request to the Cloudflare API \(\/memberships\) failed/
 			);
 		});


### PR DESCRIPTION
`toThrowError` is deprecated (see: [vitest source](https://github.com/vitest-dev/vitest/blob/d40fa598817fcf6bc97ce1c35dfa188f04527fb6/packages/expect/src/types.ts#L535)) and `toThrow` should be used instead. I'm just updating a few places here where `toThrowError` is used/


<img width="1140" height="437" alt="Screenshot of deprecation tooltip" src="https://github.com/user-attachments/assets/0b0e1bc2-f04c-42c1-9bb1-dd5e432fb726" />


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: minor tests change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->