### PR TITLE
skip provisioning in asset only projects

### DIFF
--- a/.changeset/quiet-assets-provision.md
+++ b/.changeset/quiet-assets-provision.md
@@ -5,4 +5,4 @@
 
 Skip resource provisioning for asset-only deployments
 
-Previously, asset-only deployments would provision resources even when there was no user Worker script. On a subsequent deploy, we would re-attempt provisioning as the previous asset-only upload would/could not be bound to the previously provisioned resource. Provisioning woul then error as the resource had already been created, blocking the deploy.
+Previously, asset-only deployments would provision resources even when there was no user Worker script. On a subsequent deploy, we would re-attempt provisioning as the previous asset-only upload would/could not be bound to the previously provisioned resource. Provisioning would then error as the resource had already been created, blocking the deploy.

--- a/.changeset/quiet-assets-provision.md
+++ b/.changeset/quiet-assets-provision.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/deploy-helpers": patch
+"wrangler": patch
+---
+
+Skip resource provisioning for asset-only deployments
+
+Previously, asset-only deployments would provision resources even when there was no user Worker script. On a subsequent deploy, we would re-attempt provisioning as the previous asset-only upload would/could not be bound to the previously provisioned resource. Provisioning woul then error as the resource had already been created, blocking the deploy.

--- a/packages/deploy-helpers/src/deploy/deploy.ts
+++ b/packages/deploy-helpers/src/deploy/deploy.ts
@@ -623,7 +623,9 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 	} else {
 		assert(accountId, "Missing accountId");
 
-		if (props.resourcesProvision && callbacks.provisionBindings) {
+		if (props.assetsOptions?.routerConfig.has_user_worker === false) {
+			logger.debug("skipping provisioning on assets-only project");
+		} else if (props.resourcesProvision && callbacks.provisionBindings) {
 			await callbacks.provisionBindings(
 				bindings ?? {},
 				accountId,

--- a/packages/deploy-helpers/src/deploy/versions-upload.ts
+++ b/packages/deploy-helpers/src/deploy/versions-upload.ts
@@ -332,7 +332,9 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		);
 	} else {
 		assert(accountId, "Missing accountId");
-		if (props.resourcesProvision && callbacks.provisionBindings) {
+		if (props.assetsOptions?.routerConfig.has_user_worker === false) {
+			logger.debug("skipping provisioning on assets-only project");
+		} else if (props.resourcesProvision && callbacks.provisionBindings) {
 			await callbacks.provisionBindings(
 				bindings,
 				accountId,

--- a/packages/wrangler/src/__tests__/deploy/assets.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/assets.test.ts
@@ -1263,6 +1263,51 @@ describe("deploy", () => {
 			await runWrangler("deploy");
 		});
 
+		it("should not provision bindings for an asset-only project", async ({
+			expect,
+		}) => {
+			const assets = [
+				{ filePath: "file-1.txt", content: "Content of file-1" },
+				{ filePath: "boop/file-2.txt", content: "Content of file-2" },
+			];
+			const listNamespaces = vi.fn(() =>
+				HttpResponse.json(createFetchResult([]))
+			);
+
+			writeAssets(assets);
+			writeWorkerSource({ format: "js" });
+			writeWranglerConfig({
+				compatibility_date: "2024-09-27",
+				compatibility_flags: ["nodejs_compat"],
+				assets: {
+					directory: "assets",
+					html_handling: "none",
+				},
+				kv_namespaces: [{ binding: "KV" }],
+			});
+			await mockAUSRequest();
+			mockSubDomainRequest();
+			msw.use(
+				http.get("*/accounts/:accountId/storage/kv/namespaces", listNamespaces)
+			);
+			mockUploadWorkerRequest({
+				expectedAssets: {
+					jwt: "<<aus-completion-token>>",
+					config: { html_handling: "none" },
+				},
+				expectedCompatibilityDate: "2024-09-27",
+				expectedCompatibilityFlags: ["nodejs_compat"],
+				expectedMainModule: undefined,
+			});
+
+			await runWrangler("deploy", { WRANGLER_LOG: "debug" });
+
+			expect(listNamespaces).not.toHaveBeenCalled();
+			expect(std.debug).toContain(
+				"skipping provisioning on assets-only project"
+			);
+		});
+
 		it("should be able to upload to a WfP script", async () => {
 			const assets = [
 				{ filePath: "file-1.txt", content: "Content of file-1" },


### PR DESCRIPTION
Fixes #14262 

Previously, asset-only deployments would provision resources even when there was no user Worker script. On a subsequent deploy, we would re-attempt provisioning as the previous asset-only upload would/could not be bound to the previously provisioned resource, so we thought this was a 'new' binding. Provisioning would then error as the resource had already been created, blocking the deploy.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->