### PR TITLE
[wrangler]  Improve asset upload performance with single-file uploads

### DIFF
--- a/.changeset/petite-lands-cover.md
+++ b/.changeset/petite-lands-cover.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/deploy-helpers": patch
+"wrangler": patch
+---
+
+Improve asset upload performance with single-file uploads
+
+Asset uploads now use a more efficient per-file upload path when the platform enables it. This is rolled out server-side and requires no configuration changes. Existing upload behavior is unchanged when the new path is not enabled.

--- a/packages/deploy-helpers/src/deploy/deploy.ts
+++ b/packages/deploy-helpers/src/deploy/deploy.ts
@@ -62,6 +62,7 @@ import {
 } from "./helpers/versions-api";
 import { addWorkersSitesBindings } from "./helpers/workers-sites-bindings";
 import type { DeployProps, WorkerBuildResult } from "../shared/types";
+import type { AssetUploadStats } from "./helpers/assets";
 import type { RetrieveSourceMapFunction } from "./helpers/sourcemap";
 import type {
 	ApiVersion,
@@ -141,6 +142,7 @@ export default async function deploy(
 	sourceMapSize?: number;
 	versionId: string | null;
 	workerTag: string | null;
+	assetUploadStats?: AssetUploadStats;
 	targets?: string[];
 }> {
 	const { entry, compatibilityDate, compatibilityFlags, keepVars, accountId } =
@@ -223,7 +225,7 @@ export default async function deploy(
 	});
 
 	// Upload assets if assets is being used
-	const assetsJwt =
+	const assetsUploadResult =
 		assetsOptions && !isDryRun
 			? await syncAssets(
 					config,
@@ -233,6 +235,8 @@ export default async function deploy(
 					props.dispatchNamespace
 				)
 			: undefined;
+	const assetsJwt = assetsUploadResult?.jwt;
+	const assetUploadStats = assetsUploadResult?.assetUploadStats;
 
 	// validate asset directory
 	if (assetsOptions && isDryRun) {
@@ -751,7 +755,7 @@ export default async function deploy(
 	// Early exit for WfP since it doesn't need the below code
 	if (props.dispatchNamespace !== undefined) {
 		deployWfpUserWorker(props.dispatchNamespace, versionId);
-		return { versionId, workerTag };
+		return { versionId, workerTag, assetUploadStats };
 	}
 	assert(accountId);
 	// deploy triggers
@@ -772,6 +776,7 @@ export default async function deploy(
 		sourceMapSize,
 		versionId,
 		workerTag,
+		assetUploadStats,
 		targets: targets ?? [],
 	};
 }

--- a/packages/deploy-helpers/src/deploy/helpers/assets.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/assets.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert";
+import { createReadStream } from "node:fs";
 import { readdir, readFile, stat } from "node:fs/promises";
 import * as path from "node:path";
 import { parseStaticRouting } from "@cloudflare/workers-shared/utils/configuration/parseStaticRouting";
@@ -27,7 +28,7 @@ import prettyBytes from "pretty-bytes";
 import { FormData } from "undici";
 import { fetchResult, logger } from "../../shared/context";
 import { hashFile } from "./hash";
-import { isJwtExpired } from "./jwt";
+import { decodeJwtPayload, isJwtExpired } from "./jwt";
 import type { SharedDeployVersionsProps } from "../../shared/types";
 import type { AssetConfig, RouterConfig } from "@cloudflare/workers-shared";
 import type {
@@ -48,8 +49,21 @@ type UploadResponse = {
 	jwt?: string;
 };
 
+export type AssetUploadStats = {
+	assetUploadDurationMs: number;
+	assetUploadIsBulk: boolean;
+	assetUploadFileCount: number;
+	assetUploadTotalBytes: number;
+};
+
+export type AssetsUploadResult = {
+	jwt: string;
+	assetUploadStats: AssetUploadStats;
+};
+
 // constants same as Pages for now
 const BULK_UPLOAD_CONCURRENCY = 3;
+const EDGE_KV_UPLOAD_CONCURRENCY = 50;
 const MAX_UPLOAD_ATTEMPTS = 5;
 const MAX_UPLOAD_GATEWAY_ERRORS = 5;
 
@@ -61,7 +75,7 @@ export const syncAssets = async (
 	assetDirectory: string,
 	scriptName: string,
 	dispatchNamespace?: string
-): Promise<string> => {
+): Promise<AssetsUploadResult> => {
 	assert(accountId, "Missing accountId");
 
 	// 1. generate asset manifest
@@ -92,8 +106,13 @@ export const syncAssets = async (
 		);
 	}
 
+	const filesToUpload = initializeAssetsResponse.buckets.flat();
+	const useSingleAssetUpload = isSingleAssetUploadMode(
+		initializeAssetsResponse.jwt
+	);
+
 	// if nothing to upload, return
-	if (initializeAssetsResponse.buckets.flat().length === 0) {
+	if (filesToUpload.length === 0) {
 		if (!initializeAssetsResponse.jwt) {
 			throw new FatalError(
 				"Could not find assets information to attach to deployment. Please try again.",
@@ -103,11 +122,19 @@ export const syncAssets = async (
 		logger.info(
 			`No updated asset files to upload. Proceeding with deployment...`
 		);
-		return initializeAssetsResponse.jwt;
+		return {
+			jwt: initializeAssetsResponse.jwt,
+			assetUploadStats: {
+				assetUploadDurationMs: 0,
+				assetUploadIsBulk: !useSingleAssetUpload,
+				assetUploadFileCount: 0,
+				assetUploadTotalBytes: 0,
+			},
+		};
 	}
 
 	// 3. fill buckets and upload assets
-	const numberFilesToUpload = initializeAssetsResponse.buckets.flat().length;
+	const numberFilesToUpload = filesToUpload.length;
 	logger.info(
 		`🌀 Found ${numberFilesToUpload} new or modified static asset${
 			numberFilesToUpload > 1 ? "s" : ""
@@ -140,54 +167,90 @@ export const syncAssets = async (
 		});
 	});
 
-	const queue = new PQueue({ concurrency: BULK_UPLOAD_CONCURRENCY });
+	const uploadBuckets = useSingleAssetUpload
+		? assetBuckets.flat().map((entry) => [entry])
+		: assetBuckets;
+
+	const concurrency = useSingleAssetUpload
+		? getEdgeKvUploadConcurrency(initializeAssetsResponse.jwt)
+		: BULK_UPLOAD_CONCURRENCY;
+	if (useSingleAssetUpload) {
+		logger.debug(`Edge KV asset upload concurrency: ${concurrency}`);
+	}
+	const queue = new PQueue({ concurrency });
 	const queuePromises: Array<Promise<void>> = [];
-	let attempts = 0;
 	const start = Date.now();
 	let completionJwt = "";
 	let uploadedAssetsCount = 0;
+	let uploadedBytes = 0;
 
-	for (const [bucketIndex, bucket] of assetBuckets.entries()) {
-		attempts = 0;
+	for (const [bucketIndex, bucket] of uploadBuckets.entries()) {
+		let attempts = 0;
 		let gatewayErrors = 0;
 		const doUpload = async (): Promise<UploadResponse> => {
-			// Populate the payload only when actually uploading (this is limited to 3 concurrent uploads at 50 MiB per bucket meaning we'd only load in a max of ~150 MiB)
-			// This is so we don't run out of memory trying to upload the files.
-			const payload = new FormData();
 			const uploadedFiles: string[] = [];
 			for (const manifestEntry of bucket) {
-				const absFilePath = path.join(assetDirectory, manifestEntry[0]);
 				uploadedFiles.push(manifestEntry[0]);
-				payload.append(
-					manifestEntry[1].hash,
-					new File(
-						[(await readFile(absFilePath)).toString("base64")],
-						manifestEntry[1].hash,
-						{
-							// Most formdata body encoders (incl. undici's) will override with "application/octet-stream" if you use a falsy value here
-							// Additionally, it appears that undici doesn't support non-standard main types (e.g. "null")
-							// So, to make it easier for any other clients, we'll just parse "application/null" on the API
-							// to mean actually null (signal to not send a Content-Type header with the response)
-							type: getContentType(absFilePath) ?? "application/null",
-						}
-					),
-					manifestEntry[1].hash
-				);
 			}
 
 			try {
-				const res = await fetchResult<UploadResponse>(
-					complianceConfig,
-					`/accounts/${accountId}/workers/assets/upload?base64=true`,
-					{
-						method: "POST",
-						headers: {
-							Authorization: `Bearer ${initializeAssetsResponse.jwt}`,
-						},
-						body: payload,
+				let res: UploadResponse;
+				if (useSingleAssetUpload) {
+					const manifestEntry = bucket[0];
+					const absFilePath = path.join(assetDirectory, manifestEntry[0]);
+					const contentType = getContentType(absFilePath);
+					res = await fetchResult<UploadResponse>(
+						complianceConfig,
+						`/accounts/${accountId}/workers/assets/upload/${manifestEntry[1].hash}`,
+						{
+							method: "POST",
+							headers: {
+								Authorization: `Bearer ${initializeAssetsResponse.jwt}`,
+								"Content-Type": contentType ?? "application/null",
+							},
+							body: createReadStream(absFilePath),
+							duplex: "half",
+						}
+					);
+				} else {
+					// Populate the payload only when actually uploading (this is limited to 3 concurrent uploads at 50 MiB per bucket meaning we'd only load in a max of ~150 MiB)
+					// This is so we don't run out of memory trying to upload the files.
+					const payload = new FormData();
+					for (const manifestEntry of bucket) {
+						const absFilePath = path.join(assetDirectory, manifestEntry[0]);
+						payload.append(
+							manifestEntry[1].hash,
+							new File(
+								[(await readFile(absFilePath)).toString("base64")],
+								manifestEntry[1].hash,
+								{
+									// Most formdata body encoders (incl. undici's) will override with "application/octet-stream" if you use a falsy value here
+									// Additionally, it appears that undici doesn't support non-standard main types (e.g. "null")
+									// So, to make it easier for any other clients, we'll just parse "application/null" on the API
+									// to mean actually null (signal to not send a Content-Type header with the response)
+									type: getContentType(absFilePath) ?? "application/null",
+								}
+							),
+							manifestEntry[1].hash
+						);
 					}
-				);
+					res = await fetchResult<UploadResponse>(
+						complianceConfig,
+						`/accounts/${accountId}/workers/assets/upload?base64=true`,
+						{
+							method: "POST",
+							headers: {
+								Authorization: `Bearer ${initializeAssetsResponse.jwt}`,
+							},
+							body: payload,
+						}
+					);
+				}
 				uploadedAssetsCount += bucket.length;
+				uploadedBytes += bucket.reduce(
+					(total, manifestEntry) => total + manifestEntry[1].size,
+					0
+				);
 				logAssetsUploadStatus(
 					numberFilesToUpload,
 					uploadedAssetsCount,
@@ -225,7 +288,7 @@ export const syncAssets = async (
 					throw new FatalError(
 						`Upload took too long.\n` +
 							`Asset upload took too long on bucket ${bucketIndex + 1}/${
-								initializeAssetsResponse.buckets.length
+								uploadBuckets.length
 							}. Please try again.\n` +
 							`Assets already uploaded have been saved, so the next attempt will automatically resume from this point.`,
 						{ telemetryMessage: "Asset upload took too long" }
@@ -271,8 +334,33 @@ export const syncAssets = async (
 		} ${skippedMessage}${formatTime(uploadMs)}\n`
 	);
 
-	return completionJwt;
+	return {
+		jwt: completionJwt,
+		assetUploadStats: {
+			assetUploadDurationMs: uploadMs,
+			assetUploadIsBulk: !useSingleAssetUpload,
+			assetUploadFileCount: uploadedAssetsCount,
+			assetUploadTotalBytes: uploadedBytes,
+		},
+	};
 };
+
+function isSingleAssetUploadMode(jwt: string): boolean {
+	try {
+		return decodeJwtPayload(jwt).wrangler_single_asset_uploads === true;
+	} catch {
+		return false;
+	}
+}
+
+export function getEdgeKvUploadConcurrency(jwt: string): number {
+	try {
+		const value = Number(decodeJwtPayload(jwt).edge_kv_upload_concurrency);
+		return value > 0 ? Math.floor(value) : EDGE_KV_UPLOAD_CONCURRENCY;
+	} catch {
+		return EDGE_KV_UPLOAD_CONCURRENCY;
+	}
+}
 
 export const buildAssetManifest = async (dir: string) => {
 	const files = await readdir(dir, { recursive: true });

--- a/packages/deploy-helpers/src/deploy/helpers/jwt.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/jwt.ts
@@ -1,3 +1,7 @@
+export const decodeJwtPayload = (token: string) => {
+	return JSON.parse(Buffer.from(token.split(".")[1], "base64").toString());
+};
+
 export const isJwtExpired = (token: string): boolean | undefined => {
 	// During testing we don't use valid JWTs, so don't try and parse them.
 	if (
@@ -9,9 +13,7 @@ export const isJwtExpired = (token: string): boolean | undefined => {
 		return false;
 	}
 	try {
-		const decodedJwt = JSON.parse(
-			Buffer.from(token.split(".")[1], "base64").toString()
-		);
+		const decodedJwt = decodeJwtPayload(token);
 
 		const dateNow = new Date().getTime() / 1000;
 

--- a/packages/deploy-helpers/src/deploy/versions-upload.ts
+++ b/packages/deploy-helpers/src/deploy/versions-upload.ts
@@ -45,6 +45,7 @@ import {
 import { patchNonVersionedScriptSettings } from "./helpers/versions-api";
 import type { VersionsUploadProps, WorkerBuildResult } from "../shared/types";
 import type { DeployCallbacks } from "./deploy";
+import type { AssetUploadStats } from "./helpers/assets";
 import type { RetrieveSourceMapFunction } from "./helpers/sourcemap";
 import type { CfWorkerInit, Config } from "@cloudflare/workers-utils";
 import type { FormData } from "undici";
@@ -59,6 +60,7 @@ export default async function versionsUpload(
 ): Promise<{
 	versionId: string | null;
 	workerTag: string | null;
+	assetUploadStats?: AssetUploadStats;
 	versionPreviewUrl?: string | undefined;
 	versionPreviewAliasUrl?: string | undefined;
 }> {
@@ -126,10 +128,11 @@ export default async function versionsUpload(
 	});
 
 	// Upload assets if assets is being used
-	const assetsJwt =
+	const assetsUploadResult =
 		assetsOptions && !props.dryRun
 			? await syncAssets(config, accountId, assetsOptions.directory, scriptName)
 			: undefined;
+	const assetsJwt = assetsUploadResult?.jwt;
 
 	if (props.secretsFile) {
 		const secretsResult = await parseBulkInputToObject(props.secretsFile);
@@ -422,5 +425,11 @@ Changes to triggers (routes, custom domains, cron schedules, etc) must be applie
 `)
 	);
 
-	return { versionId, workerTag, versionPreviewUrl, versionPreviewAliasUrl };
+	return {
+		versionId,
+		workerTag,
+		assetUploadStats: assetsUploadResult?.assetUploadStats,
+		versionPreviewUrl,
+		versionPreviewAliasUrl,
+	};
 }

--- a/packages/wrangler/src/__tests__/deploy/assets.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/assets.test.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import { getInstalledPackageVersion } from "@cloudflare/autoconfig";
+import { getEdgeKvUploadConcurrency } from "@cloudflare/deploy-helpers";
 import {
 	runInTempDir,
 	writeWranglerConfig,
@@ -7,6 +8,7 @@ import {
 import { http, HttpResponse } from "msw";
 import dedent from "ts-dedent";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
+import * as metrics from "../../metrics";
 import { clearOutputFilePath } from "../../output";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -57,6 +59,10 @@ vi.mock("@cloudflare/autoconfig", async (importOriginal) => ({
 	getInstalledPackageVersion: vi.fn(),
 }));
 vi.mock("@cloudflare/cli-shared-helpers/command");
+
+function createJwt(payload: Record<string, unknown>) {
+	return `header.${Buffer.from(JSON.stringify(payload)).toString("base64")}.signature`;
+}
 
 describe("deploy", () => {
 	mockAccountId();
@@ -1054,6 +1060,198 @@ describe("deploy", () => {
 			});
 		});
 
+		describe.each([
+			{ name: "wrangler_single_asset_uploads is missing", jwt: createJwt({}) },
+			{
+				name: "wrangler_single_asset_uploads is false",
+				jwt: createJwt({ wrangler_single_asset_uploads: false }),
+			},
+			{ name: "the upload token cannot be decoded", jwt: "<<aus-token>>" },
+		])("when $name", (fallbackCase) => {
+			it("should use legacy base64 bucket upload", async ({ expect }) => {
+				const assets = [
+					{ filePath: "file-1.txt", content: "Content of file-1" },
+				];
+				writeAssets(assets);
+				writeWranglerConfig({ assets: { directory: "assets" } });
+
+				const mockBuckets = [["0de3dd5df907418e9730fd2bd747bd5e"]];
+				await mockAUSRequest([], mockBuckets, fallbackCase.jwt);
+				const uploadBodies: FormData[] = [];
+				const uploadContentTypeHeaders: (string | null)[] = [];
+				const uploadAuthHeaders: (string | null)[] = [];
+				const uploadUrls: string[] = [];
+				await mockAssetUploadRequest(
+					mockBuckets.length,
+					uploadBodies,
+					uploadContentTypeHeaders,
+					uploadAuthHeaders,
+					uploadUrls
+				);
+				mockSubDomainRequest();
+				mockUploadWorkerRequest({
+					expectedAssets: { jwt: "<<aus-completion-token>>", config: {} },
+					expectedType: "none",
+				});
+
+				await runWrangler("deploy");
+
+				expect(uploadUrls).toHaveLength(1);
+				expect(new URL(uploadUrls[0]).pathname).toContain(
+					"/workers/assets/upload"
+				);
+				expect(new URL(uploadUrls[0]).search).toBe("?base64=true");
+			});
+		});
+
+		it("should upload each asset individually with raw bytes when wrangler_single_asset_uploads is true", async ({
+			expect,
+		}) => {
+			const sendMetricsEventSpy = vi
+				.spyOn(metrics, "sendMetricsEvent")
+				.mockImplementation(() => {});
+			const assets = [
+				{ filePath: "file-1.txt", content: "Content of file-1" },
+				{ filePath: "foobar.greg", content: "something-binary" },
+			];
+			writeAssets(assets);
+			writeWranglerConfig({ assets: { directory: "assets" } });
+
+			const file1Hash = "0de3dd5df907418e9730fd2bd747bd5e";
+			const unknownHash = "80e40c1f2422528cb2fba3f9389ce315";
+			const mockBuckets = [[file1Hash, unknownHash]];
+			const edgeKvJwt = createJwt({ wrangler_single_asset_uploads: true });
+			await mockAUSRequest([], mockBuckets, edgeKvJwt);
+
+			const uploadedRequests: {
+				url: string;
+				contentType: string | null;
+				authorization: string | null;
+				body: ArrayBuffer;
+			}[] = [];
+			msw.use(
+				http.post(
+					"*/accounts/some-account-id/workers/assets/upload/:hash",
+					async ({ request }) => {
+						uploadedRequests.push({
+							url: request.url,
+							contentType: request.headers.get("Content-Type"),
+							authorization: request.headers.get("Authorization"),
+							body: await request.arrayBuffer(),
+						});
+						return HttpResponse.json(
+							{
+								success: true,
+								errors: [],
+								messages: [],
+								result:
+									uploadedRequests.length === 2
+										? { jwt: "<<aus-completion-token>>" }
+										: {},
+							},
+							{ status: uploadedRequests.length === 2 ? 201 : 202 }
+						);
+					}
+				)
+			);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedAssets: { jwt: "<<aus-completion-token>>", config: {} },
+				expectedType: "none",
+			});
+
+			await runWrangler("deploy");
+
+			expect(uploadedRequests).toHaveLength(2);
+
+			// Verify per-hash URLs with no query string
+			const paths = uploadedRequests.map((r) => new URL(r.url).pathname).sort();
+			expect(paths).toEqual([
+				expect.stringContaining(`/workers/assets/upload/${file1Hash}`),
+				expect.stringContaining(`/workers/assets/upload/${unknownHash}`),
+			]);
+			for (const req of uploadedRequests) {
+				expect(new URL(req.url).search).toBe("");
+			}
+
+			// Verify authorization
+			for (const req of uploadedRequests) {
+				expect(req.authorization).toBe(`Bearer ${edgeKvJwt}`);
+			}
+
+			// Verify raw bytes (not base64) for file-1.txt
+			const file1Req = uploadedRequests.find((r) => r.url.includes(file1Hash));
+			if (!file1Req) {
+				throw new Error("missing upload request for file1Hash");
+			}
+			expect(Buffer.from(file1Req.body).toString("utf-8")).toBe(
+				"Content of file-1"
+			);
+			expect(file1Req.contentType).toMatch(/text\/plain/);
+
+			// Verify unknown content type gets application/null sentinel
+			const unknownReq = uploadedRequests.find((r) =>
+				r.url.includes(unknownHash)
+			);
+			if (!unknownReq) {
+				throw new Error("missing upload request for unknownHash");
+			}
+			expect(Buffer.from(unknownReq.body).toString("utf-8")).toBe(
+				"something-binary"
+			);
+			expect(unknownReq.contentType).toBe("application/null");
+
+			expect(sendMetricsEventSpy).toHaveBeenCalledWith(
+				"deploy worker script",
+				expect.objectContaining({
+					assetUploadDurationMs: expect.any(Number),
+					assetUploadIsBulk: false,
+					assetUploadFileCount: 2,
+					assetUploadTotalBytes: 33,
+				}),
+				expect.any(Object)
+			);
+			sendMetricsEventSpy.mockRestore();
+		});
+
+		it("should send bulk asset upload stats with deploy metrics", async ({
+			expect,
+		}) => {
+			const sendMetricsEventSpy = vi
+				.spyOn(metrics, "sendMetricsEvent")
+				.mockImplementation(() => {});
+			const assets = [{ filePath: "file-1.txt", content: "Content of file-1" }];
+			writeAssets(assets);
+			writeWranglerConfig({ assets: { directory: "assets" } });
+
+			const mockBuckets = [["0de3dd5df907418e9730fd2bd747bd5e"]];
+			await mockAUSRequest(
+				[],
+				mockBuckets,
+				createJwt({ wrangler_single_asset_uploads: false })
+			);
+			await mockAssetUploadRequest(mockBuckets.length, [], [], []);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedAssets: { jwt: "<<aus-completion-token>>", config: {} },
+				expectedType: "none",
+			});
+
+			await runWrangler("deploy");
+
+			expect(sendMetricsEventSpy).toHaveBeenCalledWith(
+				"deploy worker script",
+				expect.objectContaining({
+					assetUploadDurationMs: expect.any(Number),
+					assetUploadIsBulk: true,
+					assetUploadFileCount: 1,
+					assetUploadTotalBytes: 17,
+				}),
+				expect.any(Object)
+			);
+			sendMetricsEventSpy.mockRestore();
+		});
+
 		it("should be able to upload a user worker with ASSETS binding and config", async () => {
 			const assets = [
 				{ filePath: "file-1.txt", content: "Content of file-1" },
@@ -1375,26 +1573,37 @@ describe("deploy", () => {
 			);
 		});
 
-		it("should retry asset uploads on failure and log a retry message including the attempt count", async ({
-			expect,
-		}) => {
-			vi.stubEnv("WRANGLER_LOG", "debug");
+		for (const retryCase of [
+			{
+				name: "legacy upload",
+				jwt: "<<aus-token>>",
+				urlPattern: "*/accounts/some-account-id/workers/assets/upload",
+			},
+			{
+				name: "edge KV upload",
+				jwt: createJwt({ wrangler_single_asset_uploads: true }),
+				urlPattern: "*/accounts/some-account-id/workers/assets/upload/:hash",
+			},
+		]) {
+			it(`should retry asset uploads on failure for ${retryCase.name}`, async ({
+				expect,
+			}) => {
+				vi.stubEnv("WRANGLER_LOG", "debug");
 
-			const assets = [{ filePath: "file-1.txt", content: "Content of file-1" }];
-			writeAssets(assets);
-			writeWranglerConfig({
-				assets: { directory: "assets" },
-			});
+				const assets = [
+					{ filePath: "file-1.txt", content: "Content of file-1" },
+				];
+				writeAssets(assets);
+				writeWranglerConfig({
+					assets: { directory: "assets" },
+				});
 
-			const mockBuckets = [["0de3dd5df907418e9730fd2bd747bd5e"]];
-			await mockAUSRequest([], mockBuckets, "<<aus-token>>");
+				const mockBuckets = [["0de3dd5df907418e9730fd2bd747bd5e"]];
+				await mockAUSRequest([], mockBuckets, retryCase.jwt);
 
-			// Fail the first upload attempt, succeed on the second.
-			const uploadAttempts: Request[] = [];
-			msw.use(
-				http.post(
-					"*/accounts/some-account-id/workers/assets/upload",
-					async ({ request }) => {
+				const uploadAttempts: Request[] = [];
+				msw.use(
+					http.post(retryCase.urlPattern, async ({ request }) => {
 						uploadAttempts.push(request);
 						if (uploadAttempts.length === 1) {
 							return HttpResponse.json(
@@ -1416,34 +1625,43 @@ describe("deploy", () => {
 							},
 							{ status: 201 }
 						);
-					}
-				)
-			);
+					})
+				);
 
-			mockSubDomainRequest();
-			mockUploadWorkerRequest({
-				expectedAssets: {
-					jwt: "<<aus-completion-token>>",
-					config: {},
-				},
-				expectedType: "none",
+				mockSubDomainRequest();
+				mockUploadWorkerRequest({
+					expectedAssets: {
+						jwt: "<<aus-completion-token>>",
+						config: {},
+					},
+					expectedType: "none",
+				});
+
+				await runWrangler("deploy");
+
+				expect(uploadAttempts.length).toBe(2);
+				expect(std.info).toContain(
+					"Asset upload failed. Retrying... 1 of 5 attempts."
+				);
+				expect(std.info).not.toContain("upload-boom-from-test");
+				expect(std.debug).toContain("upload-boom-from-test");
 			});
+		}
+	});
+});
 
-			await runWrangler("deploy");
+describe("getEdgeKvUploadConcurrency", () => {
+	it("returns value from JWT claim", ({ expect }) => {
+		const jwt = createJwt({ edge_kv_upload_concurrency: 42 });
+		expect(getEdgeKvUploadConcurrency(jwt)).toBe(42);
+	});
 
-			// The upload endpoint was hit twice: once failing, once succeeding.
-			expect(uploadAttempts.length).toBe(2);
+	it("returns default when claim is missing", ({ expect }) => {
+		const jwt = createJwt({});
+		expect(getEdgeKvUploadConcurrency(jwt)).toBe(50);
+	});
 
-			// The new info message includes the attempt count.
-			expect(std.info).toContain(
-				"Asset upload failed. Retrying... 1 of 5 attempts."
-			);
-
-			// The error details no longer leak into the user-facing info log.
-			expect(std.info).not.toContain("upload-boom-from-test");
-
-			// The error is now logged at debug level instead.
-			expect(std.debug).toContain("upload-boom-from-test");
-		});
+	it("returns default when JWT is undecodable", ({ expect }) => {
+		expect(getEdgeKvUploadConcurrency("garbage")).toBe(50);
 	});
 });

--- a/packages/wrangler/src/__tests__/deploy/helpers.ts
+++ b/packages/wrangler/src/__tests__/deploy/helpers.ts
@@ -717,12 +717,14 @@ export const mockAssetUploadRequest = async (
 	numberOfBuckets: number,
 	bodies: FormData[],
 	uploadContentTypeHeaders: (string | null)[],
-	uploadAuthHeaders: (string | null)[]
+	uploadAuthHeaders: (string | null)[],
+	uploadUrls?: string[]
 ) => {
 	msw.use(
 		http.post(
 			"*/accounts/some-account-id/workers/assets/upload",
 			async ({ request }) => {
+				uploadUrls?.push(request.url);
 				uploadContentTypeHeaders.push(request.headers.get("Content-Type"));
 				uploadAuthHeaders.push(request.headers.get("Authorization"));
 				const formData = await request.formData();

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -16,6 +16,7 @@ import { http, HttpResponse } from "msw";
  * TODO: remove this `expect` import
  */
 import { beforeEach, describe, expect, it, test, vi } from "vitest";
+import * as metrics from "../../metrics";
 import { dedent } from "../../utils/dedent";
 import { makeApiRequestAsserter } from "../helpers/assert-request";
 import { captureRequestsFrom } from "../helpers/capture-requests-from";
@@ -2103,9 +2104,12 @@ describe("versions upload", () => {
 			setIsTTY(false);
 		});
 
-		test("should upload assets and include jwt in metadata", async ({
+		test("should upload assets and include stats in upload metrics", async ({
 			expect,
 		}) => {
+			const sendMetricsEventSpy = vi
+				.spyOn(metrics, "sendMetricsEvent")
+				.mockImplementation(() => {});
 			mockGetScript();
 			const requests = mockUploadVersion(false, 0);
 
@@ -2113,13 +2117,34 @@ describe("versions upload", () => {
 			msw.use(
 				http.post(
 					`*/accounts/:accountId/workers/scripts/:scriptName/assets-upload-session`,
-					() => {
+					async ({ request }) => {
+						const { manifest } = (await request.json()) as {
+							manifest: Record<string, { hash: string; size: number }>;
+						};
 						return HttpResponse.json(
 							{
 								success: true,
 								errors: [],
 								messages: [],
-								result: { jwt: "test-assets-jwt", buckets: [[]] },
+								result: {
+									jwt: "test-assets-jwt",
+									buckets: [Object.values(manifest).map(({ hash }) => hash)],
+								},
+							},
+							{ status: 201 }
+						);
+					}
+				),
+				http.post(
+					`*/accounts/:accountId/workers/assets/upload`,
+					async ({ request }) => {
+						expect(new URL(request.url).search).toBe("?base64=true");
+						return HttpResponse.json(
+							{
+								success: true,
+								errors: [],
+								messages: [],
+								result: { jwt: "test-assets-completion-jwt" },
 							},
 							{ status: 201 }
 						);
@@ -2140,7 +2165,18 @@ describe("versions upload", () => {
 
 			const metadata = await getMetadata(requests[requests.length - 1]);
 			expect(metadata.assets).toBeDefined();
-			expect(metadata.assets?.jwt).toEqual("test-assets-jwt");
+			expect(metadata.assets?.jwt).toEqual("test-assets-completion-jwt");
+			expect(sendMetricsEventSpy).toHaveBeenCalledWith(
+				"upload worker version",
+				expect.objectContaining({
+					assetUploadDurationMs: expect.any(Number),
+					assetUploadIsBulk: true,
+					assetUploadFileCount: 1,
+					assetUploadTotalBytes: 14,
+				}),
+				expect.any(Object)
+			);
+			sendMetricsEventSpy.mockRestore();
 		});
 
 		test("should upload assets via --assets CLI flag", async ({ expect }) => {

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -142,18 +142,14 @@ export const deployCommand = createCommand({
 
 			const buildResult = await buildWorker(buildProps, config);
 
-			const { sourceMapSize, versionId, workerTag, targets } = await deploy(
-				props,
-				config,
-				buildResult,
-				{
+			const { sourceMapSize, versionId, workerTag, assetUploadStats, targets } =
+				await deploy(props, config, buildResult, {
 					syncWorkersSite,
 					getNormalizedContainerOptions,
 					buildContainer,
 					deployContainers,
 					analyseBundle,
-				}
-			);
+				});
 
 			writeOutput({
 				type: "deploy",
@@ -172,6 +168,7 @@ export const deployCommand = createCommand({
 					usesTypeScript: /\.tsx?$/.test(props.entry.file),
 					durationMs: Date.now() - beforeUpload,
 					sourceMapSize,
+					...assetUploadStats,
 				},
 				{
 					sendMetrics: config.send_metrics,

--- a/packages/wrangler/src/dev/remote.ts
+++ b/packages/wrangler/src/dev/remote.ts
@@ -197,7 +197,7 @@ export async function createRemoteWorkerInit(props: {
 		});
 	}
 
-	const assetsJwt = props.assets
+	const assetsUploadResult = props.assets
 		? await syncAssets(
 				props.complianceConfig,
 				props.accountId,
@@ -205,6 +205,7 @@ export async function createRemoteWorkerInit(props: {
 				props.name
 			)
 		: undefined;
+	const assetsJwt = assetsUploadResult?.jwt;
 
 	const bindings = { ...props.bindings };
 

--- a/packages/wrangler/src/pages/upload.ts
+++ b/packages/wrangler/src/pages/upload.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { spinner } from "@cloudflare/cli-shared-helpers/interactive";
-import { isJwtExpired } from "@cloudflare/deploy-helpers";
+import { decodeJwtPayload, isJwtExpired } from "@cloudflare/deploy-helpers";
 import {
 	APIError,
 	COMPLIANCE_REGION_CONFIG_PUBLIC,
@@ -28,7 +28,7 @@ import { validate } from "./validate";
 import type { UploadPayloadFile } from "./types";
 import type { FileContainer } from "./validate";
 
-export { isJwtExpired } from "@cloudflare/deploy-helpers";
+export { decodeJwtPayload, isJwtExpired } from "@cloudflare/deploy-helpers";
 
 export const pagesProjectUploadCommand = createCommand({
 	metadata: {
@@ -408,9 +408,7 @@ export const maxFileCountAllowedFromClaims = (token: string): number => {
 		// Not validating the JWT here, which ordinarily would be a big red flag.
 		// However, if the JWT is invalid, no uploads (calls to /pages/assets/upload)
 		// will succeed.
-		const decodedJwt = JSON.parse(
-			Buffer.from(token.split(".")[1], "base64").toString()
-		);
+		const decodedJwt = decodeJwtPayload(token);
 
 		const maxFileCountAllowed = decodedJwt["max_file_count_allowed"];
 		if (typeof maxFileCountAllowed == "number") {

--- a/packages/wrangler/src/preview/preview.ts
+++ b/packages/wrangler/src/preview/preview.ts
@@ -321,14 +321,14 @@ async function assemblePreviewDeploymentSettings(
 	request.modules = deploymentModules.modules;
 
 	if (assetsOptions) {
-		const assetsJwt = await syncAssets(
+		const assetsUploadResult = await syncAssets(
 			config,
 			accountId,
 			assetsOptions.directory,
 			workerName
 		);
 		request.assets = {
-			jwt: assetsJwt,
+			jwt: assetsUploadResult.jwt,
 			config: {
 				html_handling: assetsOptions.assetConfig.html_handling,
 				not_found_handling: assetsOptions.assetConfig.not_found_handling,

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -1,4 +1,7 @@
-import { versionsUpload } from "@cloudflare/deploy-helpers";
+import {
+	versionsUpload,
+	type AssetUploadStats,
+} from "@cloudflare/deploy-helpers";
 import { analyseBundle } from "../check/commands";
 import { createCommand } from "../core/create-command";
 import {
@@ -51,18 +54,9 @@ export const versionsUploadCommand = createCommand({
 			args,
 			config
 		);
+		let assetUploadStats: AssetUploadStats | undefined;
 
 		try {
-			metrics.sendMetricsEvent(
-				"upload worker version",
-				{
-					usesTypeScript: /\.tsx?$/.test(props.entry.file),
-				},
-				{
-					sendMetrics: config.send_metrics,
-				}
-			);
-
 			// Derive workerNameOverridden by comparing pre-merge name with post-merge name
 			const preMergeName = getScriptName(args, config);
 			const workerNameOverridden =
@@ -73,11 +67,13 @@ export const versionsUploadCommand = createCommand({
 			const {
 				versionId,
 				workerTag,
+				assetUploadStats: uploadStats,
 				versionPreviewUrl,
 				versionPreviewAliasUrl,
 			} = await versionsUpload(props, config, buildResult, {
 				analyseBundle: analyseBundle,
 			});
+			assetUploadStats = uploadStats;
 
 			writeOutput({
 				type: "version-upload",
@@ -91,6 +87,16 @@ export const versionsUploadCommand = createCommand({
 				worker_name_overridden: workerNameOverridden,
 			});
 		} finally {
+			metrics.sendMetricsEvent(
+				"upload worker version",
+				{
+					usesTypeScript: /\.tsx?$/.test(props.entry.file),
+					...assetUploadStats,
+				},
+				{
+					sendMetrics: config.send_metrics,
+				}
+			);
 			cleanupDestination(buildProps.destination);
 		}
 	},


### PR DESCRIPTION
Fixes #WC-4107

Begin onboarding wrangler to use the improved API endpoint for uploading Workers Assets.
This is being staged as a gradual rollout:

- By default, users will continue to use the existing wrangler codepath and API endpoint.
- Users that are opted-in to the new feature (controlled on the server side) will use the new endpoint.

This allows us to gradually roll out and validate the new feature without a hard cutover during a new wrangler release, or the need for emergency wrangler patch releases if something goes wrong.
---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not a new feature just an implementation detail change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
