### PR TITLE
(workflows): update rollback context types

### DIFF
--- a/.changeset/bright-trees-explain.md
+++ b/.changeset/bright-trees-explain.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/workflows-shared": patch
+---
+
+Add step context to Workflows rollback handlers
+
+Rollback handlers now receive the original step context under `ctx`, making `ctx.step.name`, `ctx.step.count`, `ctx.attempt`, and the resolved step `config` available during rollback. The legacy `stepName` field remains available and is equivalent to `${ctx.step.name}-${ctx.step.count}`.
+
+`rollbackConfig` is now limited to retry and timeout settings, matching the behavior supported by rollback handlers.

--- a/packages/workflows-shared/src/context.ts
+++ b/packages/workflows-shared/src/context.ts
@@ -143,7 +143,7 @@ export class Context extends RpcTarget {
 	#registerRollback(options: {
 		cacheKey: string;
 		rollbackFn: RollbackFn | undefined;
-		stepName: string;
+		target: string;
 		stepContext: WorkflowStepContext;
 		output?: unknown;
 		rollbackConfig?: WorkflowStepConfig;
@@ -151,7 +151,7 @@ export class Context extends RpcTarget {
 		const {
 			cacheKey,
 			rollbackFn,
-			stepName,
+			target,
 			stepContext,
 			output,
 			rollbackConfig,
@@ -160,7 +160,7 @@ export class Context extends RpcTarget {
 			registerRollbackFn(this.#engine.rollbackRegistry, {
 				cacheKey,
 				fn: rollbackFn,
-				stepName,
+				target,
 				stepContext,
 				...("output" in options && { output }),
 				...(rollbackConfig !== undefined && { config: rollbackConfig }),
@@ -268,17 +268,17 @@ export class Context extends RpcTarget {
 
 		let cacheKey: string;
 		let count: number;
-		let stepNameWithCounter: string;
+		let target: string;
 		const rollbackStep = this.#rollbackStep;
 		if (rollbackStep !== undefined) {
 			cacheKey = `${ROLLBACK_CACHE_KEY_PREFIX}${rollbackStep.cacheKey}`;
 			count = 1;
-			stepNameWithCounter = name;
+			target = name;
 		} else {
 			const hash = await computeHash(name);
 			count = this.#getCount("run-" + name);
 			cacheKey = `${hash}-${count}`;
-			stepNameWithCounter = `${name}-${count}`;
+			target = `${name}-${count}`;
 		}
 
 		const valueKey = `${cacheKey}-value`;
@@ -310,7 +310,7 @@ export class Context extends RpcTarget {
 			);
 			if (maybeOutputError !== undefined) {
 				throw new WorkflowInternalError(
-					`Stored output for ${stepNameWithCounter} is corrupt or incomplete.`
+					`Stored output for ${target} is corrupt or incomplete.`
 				);
 			}
 
@@ -322,7 +322,7 @@ export class Context extends RpcTarget {
 			this.#registerRollback({
 				cacheKey,
 				rollbackFn,
-				stepName: stepNameWithCounter,
+				target,
 				stepContext: {
 					step: { name, count },
 					attempt: cachedState?.attemptedCount ?? 1,
@@ -349,7 +349,7 @@ export class Context extends RpcTarget {
 			this.#registerRollback({
 				cacheKey,
 				rollbackFn,
-				stepName: stepNameWithCounter,
+				target,
 				stepContext: {
 					step: { name, count },
 					attempt: cachedState?.attemptedCount ?? 1,
@@ -412,18 +412,13 @@ export class Context extends RpcTarget {
 				// @ts-expect-error priorityQueue is initiated in init
 				this.#engine.priorityQueue.remove(timeoutEntryPQ);
 			}
-			this.#engine.writeLog(
-				events.attemptFailure,
-				cacheKey,
-				stepNameWithCounter,
-				{
-					attempt: stepState.attemptedCount,
-					error: {
-						name: "WorkflowInternalError",
-						message: `Attempt failed due to internal workflows error`,
-					},
-				}
-			);
+			this.#engine.writeLog(events.attemptFailure, cacheKey, target, {
+				attempt: stepState.attemptedCount,
+				error: {
+					name: "WorkflowInternalError",
+					message: `Attempt failed due to internal workflows error`,
+				},
+			});
 
 			await this.#state.storage.put(stepStateKey, stepState);
 		}
@@ -450,7 +445,7 @@ export class Context extends RpcTarget {
 			await this.#engine.timeoutHandler.acquire(this.#engine);
 
 			if (stepState.attemptedCount == 0) {
-				this.#engine.writeLog(events.start, cacheKey, stepNameWithCounter, {
+				this.#engine.writeLog(events.start, cacheKey, target, {
 					config,
 				});
 			} else {
@@ -528,14 +523,9 @@ export class Context extends RpcTarget {
 					throw error;
 				};
 
-				this.#engine.writeLog(
-					events.attemptStart,
-					cacheKey,
-					stepNameWithCounter,
-					{
-						attempt: stepState.attemptedCount + 1,
-					}
-				);
+				this.#engine.writeLog(events.attemptStart, cacheKey, target, {
+					attempt: stepState.attemptedCount + 1,
+				});
 				stepState.attemptedCount++;
 				await this.#state.storage.put(stepStateKey, stepState);
 				const priorityQueueHash = `${cacheKey}-${stepState.attemptedCount}`;
@@ -671,21 +661,11 @@ export class Context extends RpcTarget {
 						e instanceof OversizedStreamChunkError ||
 						e instanceof UnsupportedStreamChunkError
 					) {
-						this.#engine.writeLog(
-							events.attemptFailure,
-							cacheKey,
-							stepNameWithCounter,
-							{
-								attempt: stepState.attemptedCount,
-								error: new WorkflowFatalError(e.message),
-							}
-						);
-						this.#engine.writeLog(
-							events.failure,
-							cacheKey,
-							stepNameWithCounter,
-							{}
-						);
+						this.#engine.writeLog(events.attemptFailure, cacheKey, target, {
+							attempt: stepState.attemptedCount,
+							error: new WorkflowFatalError(e.message),
+						});
+						this.#engine.writeLog(events.failure, cacheKey, target, {});
 						this.#engine.writeLog(InstanceEvent.WORKFLOW_FAILURE, null, null, {
 							error: new WorkflowFatalError(
 								`The execution of the Workflow instance was terminated, as the step "${name}" returned an invalid ReadableStream output. ${e.message}`
@@ -703,21 +683,11 @@ export class Context extends RpcTarget {
 					}
 
 					if (e instanceof StreamOutputStorageLimitError) {
-						this.#engine.writeLog(
-							events.attemptFailure,
-							cacheKey,
-							stepNameWithCounter,
-							{
-								attempt: stepState.attemptedCount,
-								error: new WorkflowFatalError(e.message),
-							}
-						);
-						this.#engine.writeLog(
-							events.failure,
-							cacheKey,
-							stepNameWithCounter,
-							{}
-						);
+						this.#engine.writeLog(events.attemptFailure, cacheKey, target, {
+							attempt: stepState.attemptedCount,
+							error: new WorkflowFatalError(e.message),
+						});
+						this.#engine.writeLog(events.failure, cacheKey, target, {});
 						this.#engine.writeLog(InstanceEvent.WORKFLOW_FAILURE, null, null, {
 							error: new WorkflowFatalError(
 								"The instance has exceeded the 1GiB storage limit"
@@ -736,23 +706,13 @@ export class Context extends RpcTarget {
 
 					// something that cannot be written to storage
 					if (e instanceof Error && e.name === "DataCloneError") {
-						this.#engine.writeLog(
-							events.attemptFailure,
-							cacheKey,
-							stepNameWithCounter,
-							{
-								attempt: stepState.attemptedCount,
-								error: new WorkflowFatalError(
-									`Value returned from step "${name}" is not serialisable`
-								),
-							}
-						);
-						this.#engine.writeLog(
-							events.failure,
-							cacheKey,
-							stepNameWithCounter,
-							{}
-						);
+						this.#engine.writeLog(events.attemptFailure, cacheKey, target, {
+							attempt: stepState.attemptedCount,
+							error: new WorkflowFatalError(
+								`Value returned from step "${name}" is not serialisable`
+							),
+						});
+						this.#engine.writeLog(events.failure, cacheKey, target, {});
 						this.#engine.writeLog(InstanceEvent.WORKFLOW_FAILURE, null, null, {
 							error: new WorkflowFatalError(
 								`The execution of the Workflow instance was terminated, as the step "${name}" returned a value which is not serialisable`
@@ -771,12 +731,12 @@ export class Context extends RpcTarget {
 						e.message.includes("string or blob too big: SQLITE_TOOBIG")
 					) {
 						throw new WorkflowInternalError(
-							`Step ${stepNameWithCounter} output is too large. Maximum allowed size is 1MiB.`
+							`Step ${target} output is too large. Maximum allowed size is 1MiB.`
 						);
 					} else {
 						// TODO (WOR-77): Send this to Sentry
 						throw new WorkflowInternalError(
-							`Storage failure for ${stepNameWithCounter} due to internal error.`
+							`Storage failure for ${target} due to internal error.`
 						);
 					}
 					return;
@@ -789,14 +749,9 @@ export class Context extends RpcTarget {
 					type: "timeout",
 				});
 
-				this.#engine.writeLog(
-					events.attemptSuccess,
-					cacheKey,
-					stepNameWithCounter,
-					{
-						attempt: stepState.attemptedCount,
-					}
-				);
+				this.#engine.writeLog(events.attemptSuccess, cacheKey, target, {
+					attempt: stepState.attemptedCount,
+				});
 			} catch (e) {
 				const error = e as Error;
 				// if we reach here, means that the closure ran but errored out and we can remove the timeout from the PQ
@@ -830,25 +785,15 @@ export class Context extends RpcTarget {
 								`Step threw a NonRetryableError with message "${e.message}"`
 							);
 
-					this.#engine.writeLog(
-						events.attemptFailure,
-						cacheKey,
-						stepNameWithCounter,
-						{
-							attempt: stepState.attemptedCount,
-							error: attemptError,
-						}
-					);
-					this.#engine.writeLog(
-						events.failure,
-						cacheKey,
-						stepNameWithCounter,
-						{}
-					);
+					this.#engine.writeLog(events.attemptFailure, cacheKey, target, {
+						attempt: stepState.attemptedCount,
+						error: attemptError,
+					});
+					this.#engine.writeLog(events.failure, cacheKey, target, {});
 					this.#registerRollback({
 						cacheKey,
 						rollbackFn,
-						stepName: stepNameWithCounter,
+						target,
 						stepContext: forwardStepContext(),
 						rollbackConfig,
 					});
@@ -856,20 +801,15 @@ export class Context extends RpcTarget {
 					throw error;
 				}
 
-				this.#engine.writeLog(
-					events.attemptFailure,
-					cacheKey,
-					stepNameWithCounter,
-					{
-						attempt: stepState.attemptedCount,
-						error: {
-							name: error.name,
-							message: error.message,
-							// TODO (WOR-79): Stacks are all incorrect over RPC and need work
-							// stack: error.stack,
-						},
-					}
-				);
+				this.#engine.writeLog(events.attemptFailure, cacheKey, target, {
+					attempt: stepState.attemptedCount,
+					error: {
+						name: error.name,
+						message: error.message,
+						// TODO (WOR-79): Stacks are all incorrect over RPC and need work
+						// stack: error.stack,
+					},
+				});
 
 				await this.#state.storage.put(stepStateKey, stepState);
 
@@ -942,16 +882,11 @@ export class Context extends RpcTarget {
 					} catch {
 						// Best-effort cleanup
 					}
-					this.#engine.writeLog(
-						events.failure,
-						cacheKey,
-						stepNameWithCounter,
-						{}
-					);
+					this.#engine.writeLog(events.failure, cacheKey, target, {});
 					this.#registerRollback({
 						cacheKey,
 						rollbackFn,
-						stepName: stepNameWithCounter,
+						target,
 						stepContext: forwardStepContext(),
 						rollbackConfig,
 					});
@@ -961,7 +896,7 @@ export class Context extends RpcTarget {
 				}
 			}
 
-			this.#engine.writeLog(events.success, cacheKey, stepNameWithCounter, {
+			this.#engine.writeLog(events.success, cacheKey, target, {
 				// TODO (WOR-86): Add limits, figure out serialization
 				result: lastStreamMeta ? undefined : result,
 				...(lastStreamMeta && {
@@ -971,7 +906,7 @@ export class Context extends RpcTarget {
 			this.#registerRollback({
 				cacheKey,
 				rollbackFn,
-				stepName: stepNameWithCounter,
+				target,
 				stepContext: forwardStepContext(),
 				output: result,
 				rollbackConfig,

--- a/packages/workflows-shared/src/context.ts
+++ b/packages/workflows-shared/src/context.ts
@@ -144,15 +144,24 @@ export class Context extends RpcTarget {
 		cacheKey: string;
 		rollbackFn: RollbackFn | undefined;
 		stepName: string;
+		stepContext: WorkflowStepContext;
 		output?: unknown;
 		rollbackConfig?: WorkflowStepConfig;
 	}): void {
-		const { cacheKey, rollbackFn, stepName, output, rollbackConfig } = options;
+		const {
+			cacheKey,
+			rollbackFn,
+			stepName,
+			stepContext,
+			output,
+			rollbackConfig,
+		} = options;
 		if (rollbackFn && this.#rollbackStep === undefined) {
 			registerRollbackFn(this.#engine.rollbackRegistry, {
 				cacheKey,
 				fn: rollbackFn,
 				stepName,
+				stepContext,
 				...("output" in options && { output }),
 				...(rollbackConfig !== undefined && { config: rollbackConfig }),
 			});
@@ -284,6 +293,7 @@ export class Context extends RpcTarget {
 			streamMetaKey,
 			configKey,
 			errorKey,
+			stepStateKey,
 		]);
 
 		// Check cache -- streams first, then plain values
@@ -292,6 +302,7 @@ export class Context extends RpcTarget {
 			| undefined
 			| null;
 		if (maybeStreamMeta?.state === StreamOutputState.Complete) {
+			const cachedState = maybeMap.get(stepStateKey) as StepState | undefined;
 			const maybeOutputError = getInvalidStoredStreamOutputError(
 				this.#state.storage,
 				cacheKey,
@@ -312,6 +323,13 @@ export class Context extends RpcTarget {
 				cacheKey,
 				rollbackFn,
 				stepName: stepNameWithCounter,
+				stepContext: {
+					step: { name, count },
+					attempt: cachedState?.attemptedCount ?? 1,
+					config:
+						(maybeMap.get(configKey) as ResolvedStepConfig | undefined) ??
+						config,
+				},
 				output: result,
 				rollbackConfig,
 			});
@@ -326,11 +344,19 @@ export class Context extends RpcTarget {
 		const maybeResult = maybeMap.get(valueKey);
 
 		if (maybeResult) {
+			const cachedState = maybeMap.get(stepStateKey) as StepState | undefined;
 			const result = (maybeResult as { value: T }).value;
 			this.#registerRollback({
 				cacheKey,
 				rollbackFn,
 				stepName: stepNameWithCounter,
+				stepContext: {
+					step: { name, count },
+					attempt: cachedState?.attemptedCount ?? 1,
+					config:
+						(maybeMap.get(configKey) as ResolvedStepConfig | undefined) ??
+						config,
+				},
 				output: result,
 				rollbackConfig,
 			});
@@ -410,6 +436,11 @@ export class Context extends RpcTarget {
 			)) as StepState) ?? {
 				attemptedCount: 0,
 			};
+			const forwardStepContext = (): WorkflowStepContext => ({
+				step: { name, count },
+				attempt: stepState.attemptedCount,
+				config: structuredClone(config),
+			});
 
 			// NOTE(caio): this might be a stream returning step - if so cleanup stale data from previous lifetimes
 			await cleanupPendingStreamOutput(this.#state.storage, cacheKey).catch(
@@ -818,6 +849,7 @@ export class Context extends RpcTarget {
 						cacheKey,
 						rollbackFn,
 						stepName: stepNameWithCounter,
+						stepContext: forwardStepContext(),
 						rollbackConfig,
 					});
 
@@ -920,6 +952,7 @@ export class Context extends RpcTarget {
 						cacheKey,
 						rollbackFn,
 						stepName: stepNameWithCounter,
+						stepContext: forwardStepContext(),
 						rollbackConfig,
 					});
 
@@ -939,6 +972,7 @@ export class Context extends RpcTarget {
 				cacheKey,
 				rollbackFn,
 				stepName: stepNameWithCounter,
+				stepContext: forwardStepContext(),
 				output: result,
 				rollbackConfig,
 			});

--- a/packages/workflows-shared/src/context.ts
+++ b/packages/workflows-shared/src/context.ts
@@ -428,7 +428,7 @@ export class Context extends RpcTarget {
 			const forwardStepContext = (): WorkflowStepContext => ({
 				step: { name, count },
 				attempt: stepState.attemptedCount,
-				config: structuredClone(config),
+				config,
 			});
 
 			// NOTE(caio): this might be a stream returning step - if so cleanup stale data from previous lifetimes

--- a/packages/workflows-shared/src/context.ts
+++ b/packages/workflows-shared/src/context.ts
@@ -143,7 +143,6 @@ export class Context extends RpcTarget {
 	#registerRollback(options: {
 		cacheKey: string;
 		rollbackFn: RollbackFn | undefined;
-		stepName: string;
 		stepContext: WorkflowStepContext;
 		output?: unknown;
 		rollbackConfig?: WorkflowStepConfig;
@@ -151,7 +150,6 @@ export class Context extends RpcTarget {
 		const {
 			cacheKey,
 			rollbackFn,
-			stepName,
 			stepContext,
 			output,
 			rollbackConfig,
@@ -160,7 +158,6 @@ export class Context extends RpcTarget {
 			registerRollbackFn(this.#engine.rollbackRegistry, {
 				cacheKey,
 				fn: rollbackFn,
-				stepName,
 				stepContext,
 				...("output" in options && { output }),
 				...(rollbackConfig !== undefined && { config: rollbackConfig }),
@@ -322,7 +319,6 @@ export class Context extends RpcTarget {
 			this.#registerRollback({
 				cacheKey,
 				rollbackFn,
-				stepName: stepNameWithCounter,
 				stepContext: {
 					step: { name, count },
 					attempt: cachedState?.attemptedCount ?? 1,
@@ -349,7 +345,6 @@ export class Context extends RpcTarget {
 			this.#registerRollback({
 				cacheKey,
 				rollbackFn,
-				stepName: stepNameWithCounter,
 				stepContext: {
 					step: { name, count },
 					attempt: cachedState?.attemptedCount ?? 1,
@@ -848,7 +843,6 @@ export class Context extends RpcTarget {
 					this.#registerRollback({
 						cacheKey,
 						rollbackFn,
-						stepName: stepNameWithCounter,
 						stepContext: forwardStepContext(),
 						rollbackConfig,
 					});
@@ -951,7 +945,6 @@ export class Context extends RpcTarget {
 					this.#registerRollback({
 						cacheKey,
 						rollbackFn,
-						stepName: stepNameWithCounter,
 						stepContext: forwardStepContext(),
 						rollbackConfig,
 					});
@@ -971,7 +964,6 @@ export class Context extends RpcTarget {
 			this.#registerRollback({
 				cacheKey,
 				rollbackFn,
-				stepName: stepNameWithCounter,
 				stepContext: forwardStepContext(),
 				output: result,
 				rollbackConfig,

--- a/packages/workflows-shared/src/context.ts
+++ b/packages/workflows-shared/src/context.ts
@@ -147,13 +147,8 @@ export class Context extends RpcTarget {
 		output?: unknown;
 		rollbackConfig?: WorkflowStepConfig;
 	}): void {
-		const {
-			cacheKey,
-			rollbackFn,
-			stepContext,
-			output,
-			rollbackConfig,
-		} = options;
+		const { cacheKey, rollbackFn, stepContext, output, rollbackConfig } =
+			options;
 		if (rollbackFn && this.#rollbackStep === undefined) {
 			registerRollbackFn(this.#engine.rollbackRegistry, {
 				cacheKey,
@@ -298,6 +293,9 @@ export class Context extends RpcTarget {
 			| StreamOutputMeta
 			| undefined
 			| null;
+		const cachedConfig = maybeMap.get(configKey) as
+			| ResolvedStepConfig
+			| undefined;
 		if (maybeStreamMeta?.state === StreamOutputState.Complete) {
 			const cachedState = maybeMap.get(stepStateKey) as StepState | undefined;
 			const maybeOutputError = getInvalidStoredStreamOutputError(
@@ -322,9 +320,7 @@ export class Context extends RpcTarget {
 				stepContext: {
 					step: { name, count },
 					attempt: cachedState?.attemptedCount ?? 1,
-					config:
-						(maybeMap.get(configKey) as ResolvedStepConfig | undefined) ??
-						config,
+					config: cachedConfig ?? config,
 				},
 				output: result,
 				rollbackConfig,
@@ -348,9 +344,7 @@ export class Context extends RpcTarget {
 				stepContext: {
 					step: { name, count },
 					attempt: cachedState?.attemptedCount ?? 1,
-					config:
-						(maybeMap.get(configKey) as ResolvedStepConfig | undefined) ??
-						config,
+					config: cachedConfig ?? config,
 				},
 				output: result,
 				rollbackConfig,
@@ -368,10 +362,10 @@ export class Context extends RpcTarget {
 		}
 
 		// Persist initial config because user can pass in dynamic config
-		if (!maybeMap.has(configKey)) {
+		if (cachedConfig === undefined) {
 			await this.#state.storage.put(configKey, config);
 		} else {
-			config = maybeMap.get(configKey) as ResolvedStepConfig;
+			config = cachedConfig;
 		}
 
 		const attemptLogs = this.#engine

--- a/packages/workflows-shared/src/context.ts
+++ b/packages/workflows-shared/src/context.ts
@@ -143,7 +143,7 @@ export class Context extends RpcTarget {
 	#registerRollback(options: {
 		cacheKey: string;
 		rollbackFn: RollbackFn | undefined;
-		target: string;
+		stepName: string;
 		stepContext: WorkflowStepContext;
 		output?: unknown;
 		rollbackConfig?: WorkflowStepConfig;
@@ -151,7 +151,7 @@ export class Context extends RpcTarget {
 		const {
 			cacheKey,
 			rollbackFn,
-			target,
+			stepName,
 			stepContext,
 			output,
 			rollbackConfig,
@@ -160,7 +160,7 @@ export class Context extends RpcTarget {
 			registerRollbackFn(this.#engine.rollbackRegistry, {
 				cacheKey,
 				fn: rollbackFn,
-				target,
+				stepName,
 				stepContext,
 				...("output" in options && { output }),
 				...(rollbackConfig !== undefined && { config: rollbackConfig }),
@@ -268,17 +268,17 @@ export class Context extends RpcTarget {
 
 		let cacheKey: string;
 		let count: number;
-		let target: string;
+		let stepNameWithCounter: string;
 		const rollbackStep = this.#rollbackStep;
 		if (rollbackStep !== undefined) {
 			cacheKey = `${ROLLBACK_CACHE_KEY_PREFIX}${rollbackStep.cacheKey}`;
 			count = 1;
-			target = name;
+			stepNameWithCounter = name;
 		} else {
 			const hash = await computeHash(name);
 			count = this.#getCount("run-" + name);
 			cacheKey = `${hash}-${count}`;
-			target = `${name}-${count}`;
+			stepNameWithCounter = `${name}-${count}`;
 		}
 
 		const valueKey = `${cacheKey}-value`;
@@ -310,7 +310,7 @@ export class Context extends RpcTarget {
 			);
 			if (maybeOutputError !== undefined) {
 				throw new WorkflowInternalError(
-					`Stored output for ${target} is corrupt or incomplete.`
+					`Stored output for ${stepNameWithCounter} is corrupt or incomplete.`
 				);
 			}
 
@@ -322,7 +322,7 @@ export class Context extends RpcTarget {
 			this.#registerRollback({
 				cacheKey,
 				rollbackFn,
-				target,
+				stepName: stepNameWithCounter,
 				stepContext: {
 					step: { name, count },
 					attempt: cachedState?.attemptedCount ?? 1,
@@ -349,7 +349,7 @@ export class Context extends RpcTarget {
 			this.#registerRollback({
 				cacheKey,
 				rollbackFn,
-				target,
+				stepName: stepNameWithCounter,
 				stepContext: {
 					step: { name, count },
 					attempt: cachedState?.attemptedCount ?? 1,
@@ -412,13 +412,18 @@ export class Context extends RpcTarget {
 				// @ts-expect-error priorityQueue is initiated in init
 				this.#engine.priorityQueue.remove(timeoutEntryPQ);
 			}
-			this.#engine.writeLog(events.attemptFailure, cacheKey, target, {
-				attempt: stepState.attemptedCount,
-				error: {
-					name: "WorkflowInternalError",
-					message: `Attempt failed due to internal workflows error`,
-				},
-			});
+			this.#engine.writeLog(
+				events.attemptFailure,
+				cacheKey,
+				stepNameWithCounter,
+				{
+					attempt: stepState.attemptedCount,
+					error: {
+						name: "WorkflowInternalError",
+						message: `Attempt failed due to internal workflows error`,
+					},
+				}
+			);
 
 			await this.#state.storage.put(stepStateKey, stepState);
 		}
@@ -445,7 +450,7 @@ export class Context extends RpcTarget {
 			await this.#engine.timeoutHandler.acquire(this.#engine);
 
 			if (stepState.attemptedCount == 0) {
-				this.#engine.writeLog(events.start, cacheKey, target, {
+				this.#engine.writeLog(events.start, cacheKey, stepNameWithCounter, {
 					config,
 				});
 			} else {
@@ -523,9 +528,14 @@ export class Context extends RpcTarget {
 					throw error;
 				};
 
-				this.#engine.writeLog(events.attemptStart, cacheKey, target, {
-					attempt: stepState.attemptedCount + 1,
-				});
+				this.#engine.writeLog(
+					events.attemptStart,
+					cacheKey,
+					stepNameWithCounter,
+					{
+						attempt: stepState.attemptedCount + 1,
+					}
+				);
 				stepState.attemptedCount++;
 				await this.#state.storage.put(stepStateKey, stepState);
 				const priorityQueueHash = `${cacheKey}-${stepState.attemptedCount}`;
@@ -661,11 +671,21 @@ export class Context extends RpcTarget {
 						e instanceof OversizedStreamChunkError ||
 						e instanceof UnsupportedStreamChunkError
 					) {
-						this.#engine.writeLog(events.attemptFailure, cacheKey, target, {
-							attempt: stepState.attemptedCount,
-							error: new WorkflowFatalError(e.message),
-						});
-						this.#engine.writeLog(events.failure, cacheKey, target, {});
+						this.#engine.writeLog(
+							events.attemptFailure,
+							cacheKey,
+							stepNameWithCounter,
+							{
+								attempt: stepState.attemptedCount,
+								error: new WorkflowFatalError(e.message),
+							}
+						);
+						this.#engine.writeLog(
+							events.failure,
+							cacheKey,
+							stepNameWithCounter,
+							{}
+						);
 						this.#engine.writeLog(InstanceEvent.WORKFLOW_FAILURE, null, null, {
 							error: new WorkflowFatalError(
 								`The execution of the Workflow instance was terminated, as the step "${name}" returned an invalid ReadableStream output. ${e.message}`
@@ -683,11 +703,21 @@ export class Context extends RpcTarget {
 					}
 
 					if (e instanceof StreamOutputStorageLimitError) {
-						this.#engine.writeLog(events.attemptFailure, cacheKey, target, {
-							attempt: stepState.attemptedCount,
-							error: new WorkflowFatalError(e.message),
-						});
-						this.#engine.writeLog(events.failure, cacheKey, target, {});
+						this.#engine.writeLog(
+							events.attemptFailure,
+							cacheKey,
+							stepNameWithCounter,
+							{
+								attempt: stepState.attemptedCount,
+								error: new WorkflowFatalError(e.message),
+							}
+						);
+						this.#engine.writeLog(
+							events.failure,
+							cacheKey,
+							stepNameWithCounter,
+							{}
+						);
 						this.#engine.writeLog(InstanceEvent.WORKFLOW_FAILURE, null, null, {
 							error: new WorkflowFatalError(
 								"The instance has exceeded the 1GiB storage limit"
@@ -706,13 +736,23 @@ export class Context extends RpcTarget {
 
 					// something that cannot be written to storage
 					if (e instanceof Error && e.name === "DataCloneError") {
-						this.#engine.writeLog(events.attemptFailure, cacheKey, target, {
-							attempt: stepState.attemptedCount,
-							error: new WorkflowFatalError(
-								`Value returned from step "${name}" is not serialisable`
-							),
-						});
-						this.#engine.writeLog(events.failure, cacheKey, target, {});
+						this.#engine.writeLog(
+							events.attemptFailure,
+							cacheKey,
+							stepNameWithCounter,
+							{
+								attempt: stepState.attemptedCount,
+								error: new WorkflowFatalError(
+									`Value returned from step "${name}" is not serialisable`
+								),
+							}
+						);
+						this.#engine.writeLog(
+							events.failure,
+							cacheKey,
+							stepNameWithCounter,
+							{}
+						);
 						this.#engine.writeLog(InstanceEvent.WORKFLOW_FAILURE, null, null, {
 							error: new WorkflowFatalError(
 								`The execution of the Workflow instance was terminated, as the step "${name}" returned a value which is not serialisable`
@@ -731,12 +771,12 @@ export class Context extends RpcTarget {
 						e.message.includes("string or blob too big: SQLITE_TOOBIG")
 					) {
 						throw new WorkflowInternalError(
-							`Step ${target} output is too large. Maximum allowed size is 1MiB.`
+							`Step ${stepNameWithCounter} output is too large. Maximum allowed size is 1MiB.`
 						);
 					} else {
 						// TODO (WOR-77): Send this to Sentry
 						throw new WorkflowInternalError(
-							`Storage failure for ${target} due to internal error.`
+							`Storage failure for ${stepNameWithCounter} due to internal error.`
 						);
 					}
 					return;
@@ -749,9 +789,14 @@ export class Context extends RpcTarget {
 					type: "timeout",
 				});
 
-				this.#engine.writeLog(events.attemptSuccess, cacheKey, target, {
-					attempt: stepState.attemptedCount,
-				});
+				this.#engine.writeLog(
+					events.attemptSuccess,
+					cacheKey,
+					stepNameWithCounter,
+					{
+						attempt: stepState.attemptedCount,
+					}
+				);
 			} catch (e) {
 				const error = e as Error;
 				// if we reach here, means that the closure ran but errored out and we can remove the timeout from the PQ
@@ -785,15 +830,25 @@ export class Context extends RpcTarget {
 								`Step threw a NonRetryableError with message "${e.message}"`
 							);
 
-					this.#engine.writeLog(events.attemptFailure, cacheKey, target, {
-						attempt: stepState.attemptedCount,
-						error: attemptError,
-					});
-					this.#engine.writeLog(events.failure, cacheKey, target, {});
+					this.#engine.writeLog(
+						events.attemptFailure,
+						cacheKey,
+						stepNameWithCounter,
+						{
+							attempt: stepState.attemptedCount,
+							error: attemptError,
+						}
+					);
+					this.#engine.writeLog(
+						events.failure,
+						cacheKey,
+						stepNameWithCounter,
+						{}
+					);
 					this.#registerRollback({
 						cacheKey,
 						rollbackFn,
-						target,
+						stepName: stepNameWithCounter,
 						stepContext: forwardStepContext(),
 						rollbackConfig,
 					});
@@ -801,15 +856,20 @@ export class Context extends RpcTarget {
 					throw error;
 				}
 
-				this.#engine.writeLog(events.attemptFailure, cacheKey, target, {
-					attempt: stepState.attemptedCount,
-					error: {
-						name: error.name,
-						message: error.message,
-						// TODO (WOR-79): Stacks are all incorrect over RPC and need work
-						// stack: error.stack,
-					},
-				});
+				this.#engine.writeLog(
+					events.attemptFailure,
+					cacheKey,
+					stepNameWithCounter,
+					{
+						attempt: stepState.attemptedCount,
+						error: {
+							name: error.name,
+							message: error.message,
+							// TODO (WOR-79): Stacks are all incorrect over RPC and need work
+							// stack: error.stack,
+						},
+					}
+				);
 
 				await this.#state.storage.put(stepStateKey, stepState);
 
@@ -882,11 +942,16 @@ export class Context extends RpcTarget {
 					} catch {
 						// Best-effort cleanup
 					}
-					this.#engine.writeLog(events.failure, cacheKey, target, {});
+					this.#engine.writeLog(
+						events.failure,
+						cacheKey,
+						stepNameWithCounter,
+						{}
+					);
 					this.#registerRollback({
 						cacheKey,
 						rollbackFn,
-						target,
+						stepName: stepNameWithCounter,
 						stepContext: forwardStepContext(),
 						rollbackConfig,
 					});
@@ -896,7 +961,7 @@ export class Context extends RpcTarget {
 				}
 			}
 
-			this.#engine.writeLog(events.success, cacheKey, target, {
+			this.#engine.writeLog(events.success, cacheKey, stepNameWithCounter, {
 				// TODO (WOR-86): Add limits, figure out serialization
 				result: lastStreamMeta ? undefined : result,
 				...(lastStreamMeta && {
@@ -906,7 +971,7 @@ export class Context extends RpcTarget {
 			this.#registerRollback({
 				cacheKey,
 				rollbackFn,
-				target,
+				stepName: stepNameWithCounter,
 				stepContext: forwardStepContext(),
 				output: result,
 				rollbackConfig,

--- a/packages/workflows-shared/src/engine.ts
+++ b/packages/workflows-shared/src/engine.ts
@@ -585,8 +585,11 @@ export class Engine extends DurableObject<Env> {
 		string,
 		{ resolve: (v: unknown) => void; reject: (e: unknown) => void }
 	> = new Map();
-	async waitForStepResult(name: string, stepCount?: number): Promise<unknown> {
-		const hash = await computeHash(name);
+	async waitForStepResult(
+		stepName: string,
+		stepCount?: number
+	): Promise<unknown> {
+		const hash = await computeHash(stepName);
 		const count = stepCount ?? 1;
 		const cacheKey = `${hash}-${count}`;
 

--- a/packages/workflows-shared/src/engine.ts
+++ b/packages/workflows-shared/src/engine.ts
@@ -585,11 +585,8 @@ export class Engine extends DurableObject<Env> {
 		string,
 		{ resolve: (v: unknown) => void; reject: (e: unknown) => void }
 	> = new Map();
-	async waitForStepResult(
-		stepName: string,
-		stepCount?: number
-	): Promise<unknown> {
-		const hash = await computeHash(stepName);
+	async waitForStepResult(name: string, stepCount?: number): Promise<unknown> {
+		const hash = await computeHash(name);
 		const count = stepCount ?? 1;
 		const cacheKey = `${hash}-${count}`;
 

--- a/packages/workflows-shared/src/lib/rollback.ts
+++ b/packages/workflows-shared/src/lib/rollback.ts
@@ -16,7 +16,7 @@ export type RollbackContext = {
 	ctx: WorkflowStepContext;
 	error: Error;
 	output: unknown;
-	/** @deprecated Use `ctx.step.name` and `ctx.step.count` instead. */
+	/** @deprecated Use `${ctx.step.name}-${ctx.step.count}` instead. */
 	stepName: string;
 };
 

--- a/packages/workflows-shared/src/lib/rollback.ts
+++ b/packages/workflows-shared/src/lib/rollback.ts
@@ -32,7 +32,7 @@ export type WorkflowStepRollbackOptions = {
 
 export type RollbackRegistryEntry = {
 	fn: RollbackFn;
-	target: string;
+	stepName: string;
 	stepContext: WorkflowStepContext;
 	output?: unknown;
 	config?: WorkflowStepConfig;
@@ -43,7 +43,7 @@ export type RollbackRegistration = RollbackRegistryEntry & {
 };
 
 export function parseRollbackOptions(
-	target: string,
+	stepName: string,
 	options: unknown
 ): WorkflowStepRollbackOptions | undefined {
 	if (options === undefined) {
@@ -56,7 +56,7 @@ export function parseRollbackOptions(
 		Array.isArray(options)
 	) {
 		const error = new WorkflowFatalError(
-			`Rollback options for "${target}" must be an object`
+			`Rollback options for "${stepName}" must be an object`
 		) as Error & UserErrorField;
 		error.isUserError = true;
 		throw error;
@@ -65,7 +65,7 @@ export function parseRollbackOptions(
 	const rollbackOptions = options as Partial<WorkflowStepRollbackOptions>;
 	if (typeof rollbackOptions.rollback !== "function") {
 		const error = new WorkflowFatalError(
-			`Rollback for "${target}" must be a function`
+			`Rollback for "${stepName}" must be a function`
 		) as Error & UserErrorField;
 		error.isUserError = true;
 		throw error;
@@ -76,7 +76,7 @@ export function parseRollbackOptions(
 		!isValidStepConfig(rollbackOptions.rollbackConfig)
 	) {
 		const error = new WorkflowFatalError(
-			`Rollback config for "${target}" is in a invalid format. See https://developers.cloudflare.com/workflows/build/sleeping-and-retrying/`
+			`Rollback config for "${stepName}" is in a invalid format. See https://developers.cloudflare.com/workflows/build/sleeping-and-retrying/`
 		) as Error & UserErrorField;
 		error.isUserError = true;
 		throw error;
@@ -101,14 +101,14 @@ export function registerRollbackFn(
 	registry: Map<string, RollbackRegistryEntry>,
 	registration: RollbackRegistration
 ): void {
-	const { cacheKey, fn, target, stepContext, output, config } = registration;
+	const { cacheKey, fn, stepName, stepContext, output, config } = registration;
 	const existing = registry.get(cacheKey);
 	if (existing) {
 		disposeRollbackStub(existing.fn);
 	}
 	registry.set(cacheKey, {
 		fn: dupRollbackStub(fn),
-		target,
+		stepName,
 		stepContext,
 		...("output" in registration && { output }),
 		...(config !== undefined && { config }),
@@ -177,7 +177,7 @@ export async function executeRollbacks(
 	for (const [i, [cacheKey, entry]] of entries.entries()) {
 		const ctx = engine.createRollbackContext({ cacheKey });
 		try {
-			await ctx.do(entry.target, entry.config ?? {}, async () => {
+			await ctx.do(entry.stepName, entry.config ?? {}, async () => {
 				await entry.fn({
 					ctx: structuredClone(entry.stepContext),
 					error: triggerError,

--- a/packages/workflows-shared/src/lib/rollback.ts
+++ b/packages/workflows-shared/src/lib/rollback.ts
@@ -32,7 +32,6 @@ export type WorkflowStepRollbackOptions = {
 
 export type RollbackRegistryEntry = {
 	fn: RollbackFn;
-	stepName: string;
 	stepContext: WorkflowStepContext;
 	output?: unknown;
 	config?: WorkflowStepConfig;
@@ -101,14 +100,13 @@ export function registerRollbackFn(
 	registry: Map<string, RollbackRegistryEntry>,
 	registration: RollbackRegistration
 ): void {
-	const { cacheKey, fn, stepName, stepContext, output, config } = registration;
+	const { cacheKey, fn, stepContext, output, config } = registration;
 	const existing = registry.get(cacheKey);
 	if (existing) {
 		disposeRollbackStub(existing.fn);
 	}
 	registry.set(cacheKey, {
 		fn: dupRollbackStub(fn),
-		stepName,
 		stepContext,
 		...("output" in registration && { output }),
 		...(config !== undefined && { config }),
@@ -176,8 +174,9 @@ export async function executeRollbacks(
 
 	for (const [i, [cacheKey, entry]] of entries.entries()) {
 		const ctx = engine.createRollbackContext({ cacheKey });
+		const rollbackName = `${entry.stepContext.step.name}-${entry.stepContext.step.count}`;
 		try {
-			await ctx.do(entry.stepName, entry.config ?? {}, async () => {
+			await ctx.do(rollbackName, entry.config ?? {}, async () => {
 				await entry.fn({
 					ctx: structuredClone(entry.stepContext),
 					error: triggerError,

--- a/packages/workflows-shared/src/lib/rollback.ts
+++ b/packages/workflows-shared/src/lib/rollback.ts
@@ -16,6 +16,8 @@ export type RollbackContext = {
 	ctx: WorkflowStepContext;
 	error: Error;
 	output: unknown;
+	/** @deprecated Use `ctx.step.name` and `ctx.step.count` instead. */
+	stepName: string;
 };
 
 // dup() to outlive the originating step.do call; Symbol.dispose locally
@@ -25,9 +27,14 @@ export type RollbackFn = ((ctx: RollbackContext) => Promise<void>) & {
 	[Symbol.dispose]?: () => void;
 };
 
+export type WorkflowStepRollbackConfig = Pick<
+	WorkflowStepConfig,
+	"retries" | "timeout"
+>;
+
 export type WorkflowStepRollbackOptions = {
 	rollback: RollbackFn;
-	rollbackConfig?: WorkflowStepConfig;
+	rollbackConfig?: WorkflowStepRollbackConfig;
 };
 
 export type RollbackRegistryEntry = {
@@ -181,6 +188,7 @@ export async function executeRollbacks(
 					ctx: structuredClone(entry.stepContext),
 					error: triggerError,
 					output: entry.output,
+					stepName: rollbackName,
 				});
 			});
 			completed++;

--- a/packages/workflows-shared/src/lib/rollback.ts
+++ b/packages/workflows-shared/src/lib/rollback.ts
@@ -1,6 +1,7 @@
 import { InstanceEvent } from "../instance";
 import { WorkflowFatalError } from "./errors";
 import { isValidStepConfig } from "./validators";
+import type { WorkflowStepContext } from "../context";
 import type { Engine } from "../engine";
 import type { WorkflowStepConfig } from "cloudflare:workers";
 
@@ -12,9 +13,9 @@ type UserErrorField = {
 export const ROLLBACK_CACHE_KEY_PREFIX = "rollback:";
 
 export type RollbackContext = {
+	ctx: WorkflowStepContext;
 	error: Error;
 	output: unknown;
-	stepName: string;
 };
 
 // dup() to outlive the originating step.do call; Symbol.dispose locally
@@ -32,6 +33,7 @@ export type WorkflowStepRollbackOptions = {
 export type RollbackRegistryEntry = {
 	fn: RollbackFn;
 	stepName: string;
+	stepContext: WorkflowStepContext;
 	output?: unknown;
 	config?: WorkflowStepConfig;
 };
@@ -99,7 +101,7 @@ export function registerRollbackFn(
 	registry: Map<string, RollbackRegistryEntry>,
 	registration: RollbackRegistration
 ): void {
-	const { cacheKey, fn, stepName, output, config } = registration;
+	const { cacheKey, fn, stepName, stepContext, output, config } = registration;
 	const existing = registry.get(cacheKey);
 	if (existing) {
 		disposeRollbackStub(existing.fn);
@@ -107,6 +109,7 @@ export function registerRollbackFn(
 	registry.set(cacheKey, {
 		fn: dupRollbackStub(fn),
 		stepName,
+		stepContext,
 		...("output" in registration && { output }),
 		...(config !== undefined && { config }),
 	});
@@ -176,9 +179,9 @@ export async function executeRollbacks(
 		try {
 			await ctx.do(entry.stepName, entry.config ?? {}, async () => {
 				await entry.fn({
+					ctx: structuredClone(entry.stepContext),
 					error: triggerError,
 					output: entry.output,
-					stepName: entry.stepName,
 				});
 			});
 			completed++;

--- a/packages/workflows-shared/src/lib/rollback.ts
+++ b/packages/workflows-shared/src/lib/rollback.ts
@@ -32,7 +32,7 @@ export type WorkflowStepRollbackOptions = {
 
 export type RollbackRegistryEntry = {
 	fn: RollbackFn;
-	stepName: string;
+	target: string;
 	stepContext: WorkflowStepContext;
 	output?: unknown;
 	config?: WorkflowStepConfig;
@@ -43,7 +43,7 @@ export type RollbackRegistration = RollbackRegistryEntry & {
 };
 
 export function parseRollbackOptions(
-	stepName: string,
+	target: string,
 	options: unknown
 ): WorkflowStepRollbackOptions | undefined {
 	if (options === undefined) {
@@ -56,7 +56,7 @@ export function parseRollbackOptions(
 		Array.isArray(options)
 	) {
 		const error = new WorkflowFatalError(
-			`Rollback options for "${stepName}" must be an object`
+			`Rollback options for "${target}" must be an object`
 		) as Error & UserErrorField;
 		error.isUserError = true;
 		throw error;
@@ -65,7 +65,7 @@ export function parseRollbackOptions(
 	const rollbackOptions = options as Partial<WorkflowStepRollbackOptions>;
 	if (typeof rollbackOptions.rollback !== "function") {
 		const error = new WorkflowFatalError(
-			`Rollback for "${stepName}" must be a function`
+			`Rollback for "${target}" must be a function`
 		) as Error & UserErrorField;
 		error.isUserError = true;
 		throw error;
@@ -76,7 +76,7 @@ export function parseRollbackOptions(
 		!isValidStepConfig(rollbackOptions.rollbackConfig)
 	) {
 		const error = new WorkflowFatalError(
-			`Rollback config for "${stepName}" is in a invalid format. See https://developers.cloudflare.com/workflows/build/sleeping-and-retrying/`
+			`Rollback config for "${target}" is in a invalid format. See https://developers.cloudflare.com/workflows/build/sleeping-and-retrying/`
 		) as Error & UserErrorField;
 		error.isUserError = true;
 		throw error;
@@ -101,14 +101,14 @@ export function registerRollbackFn(
 	registry: Map<string, RollbackRegistryEntry>,
 	registration: RollbackRegistration
 ): void {
-	const { cacheKey, fn, stepName, stepContext, output, config } = registration;
+	const { cacheKey, fn, target, stepContext, output, config } = registration;
 	const existing = registry.get(cacheKey);
 	if (existing) {
 		disposeRollbackStub(existing.fn);
 	}
 	registry.set(cacheKey, {
 		fn: dupRollbackStub(fn),
-		stepName,
+		target,
 		stepContext,
 		...("output" in registration && { output }),
 		...(config !== undefined && { config }),
@@ -177,7 +177,7 @@ export async function executeRollbacks(
 	for (const [i, [cacheKey, entry]] of entries.entries()) {
 		const ctx = engine.createRollbackContext({ cacheKey });
 		try {
-			await ctx.do(entry.stepName, entry.config ?? {}, async () => {
+			await ctx.do(entry.target, entry.config ?? {}, async () => {
 				await entry.fn({
 					ctx: structuredClone(entry.stepContext),
 					error: triggerError,

--- a/packages/workflows-shared/tests/engine.test.ts
+++ b/packages/workflows-shared/tests/engine.test.ts
@@ -1559,7 +1559,8 @@ describe("Rollback", () => {
 						ctx.error.message !== "boom" ||
 						ctx.output !== "out" ||
 						ctx.ctx.step.name !== "ctx-step" ||
-						ctx.ctx.step.count !== 1
+						ctx.ctx.step.count !== 1 ||
+						ctx.stepName !== "ctx-step-1"
 					) {
 						throw new Error("unexpected rollback context");
 					}
@@ -1591,7 +1592,8 @@ describe("Rollback", () => {
 							ctx.error.message !== "step-boom" ||
 							ctx.output !== undefined ||
 							ctx.ctx.step.name !== "failed-step" ||
-							ctx.ctx.step.count !== 1
+							ctx.ctx.step.count !== 1 ||
+							ctx.stepName !== "failed-step-1"
 						) {
 							throw new Error("unexpected failed-step rollback context");
 						}

--- a/packages/workflows-shared/tests/engine.test.ts
+++ b/packages/workflows-shared/tests/engine.test.ts
@@ -1558,7 +1558,8 @@ describe("Rollback", () => {
 						ctx.error.name !== "Error" ||
 						ctx.error.message !== "boom" ||
 						ctx.output !== "out" ||
-						ctx.stepName !== "ctx-step-1"
+						ctx.ctx.step.name !== "ctx-step" ||
+						ctx.ctx.step.count !== 1
 					) {
 						throw new Error("unexpected rollback context");
 					}
@@ -1589,7 +1590,8 @@ describe("Rollback", () => {
 						if (
 							ctx.error.message !== "step-boom" ||
 							ctx.output !== undefined ||
-							ctx.stepName !== "failed-step-1"
+							ctx.ctx.step.name !== "failed-step" ||
+							ctx.ctx.step.count !== 1
 						) {
 							throw new Error("unexpected failed-step rollback context");
 						}


### PR DESCRIPTION
Updates Workflows rollback types and local runtime behavior:

- Adds deprecated legacy `stepName` to rollback context while keeping `ctx.step.name` and `ctx.step.count` as the preferred fields.
- Narrows `rollbackConfig` to only `retries` and `timeout`.
- Requires `rollback` when rollback options are provided.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/31479
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*
very cute cat from [twitter](https://x.com/Symedia_/status/2065438101846008203)
<img width="3000" height="4000" alt="image" src="https://github.com/user-attachments/assets/0a50dae2-0b35-4b3a-8cb1-cfd89284d582" />


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
