### PR TITLE
Pin babel in workers-with-assets-spa fixture

### DIFF
--- a/fixtures/workers-with-assets-spa/public/index.html
+++ b/fixtures/workers-with-assets-spa/public/index.html
@@ -218,6 +218,6 @@
 			src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js"
 		></script>
 
-		<script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+		<script src="https://unpkg.com/@babel/standalone@7.26.4/babel.min.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
Pin `babel` in workers-with-assets-spa fixture due to breaking changes in babel 8.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: covered by existing tests
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
