### PR TITLE
[wrangler] Mention temporary preview accounts in whoami when unauthenticated

### DIFF
--- a/.changeset/whoami-temporary-account-hint.md
+++ b/.changeset/whoami-temporary-account-hint.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Mention temporary preview accounts in `wrangler whoami` output when unauthenticated
+
+When you run `wrangler whoami` without being logged in, Wrangler now also tells you that you can deploy without logging in by running a command like `wrangler deploy --temporary` to use a temporary preview account.

--- a/packages/wrangler/src/__tests__/whoami.test.ts
+++ b/packages/wrangler/src/__tests__/whoami.test.ts
@@ -471,6 +471,18 @@ describe("whoami", () => {
 		expect(output).toEqual({ loggedIn: false });
 	});
 
+	it("should suggest a temporary preview account when not authenticated", async ({
+		expect,
+	}) => {
+		await runWrangler("whoami");
+		expect(std.out).toContain(
+			"You are not authenticated. Please run `wrangler login`."
+		);
+		expect(std.out).toContain(
+			"To deploy without logging in, run a command like `wrangler deploy --temporary` to use a temporary preview account."
+		);
+	});
+
 	it("should output JSON with API token auth type", async ({ expect }) => {
 		vi.stubEnv("CLOUDFLARE_API_TOKEN", "123456789");
 		msw.use(

--- a/packages/wrangler/src/user/whoami.ts
+++ b/packages/wrangler/src/user/whoami.ts
@@ -67,6 +67,9 @@ export async function whoami(
 	const user = await getUserInfo(complianceConfig);
 	if (!user) {
 		logger.log("You are not authenticated. Please run `wrangler login`.");
+		logger.log(
+			"To deploy without logging in, run a command like `wrangler deploy --temporary` to use a temporary preview account."
+		);
 		return;
 	}
 	printUserEmail(user);


### PR DESCRIPTION
When `wrangler whoami` is run without credentials, it previously printed only:

> You are not authenticated. Please run `wrangler login`.

This didn't surface the temporary-preview-account feature (the hidden `--temporary` flag). Since models and users frequently run `wrangler whoami` to check auth status, this PR adds a second line nudging them toward deploying without logging in:

> To deploy without logging in, run a command like `wrangler deploy --temporary` to use a temporary preview account.

The wording matches the existing nudge already shown on non-interactive auth errors in `register-yargs-command.ts`. The original first line is left intact so existing references/tests don't break. A test asserting both lines has been added (there was previously no coverage of the non-JSON unauthenticated output).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this only adds an informational hint to existing CLI output for the already-documented `--temporary` flag; no public API or behavior changes.

*A picture of a cute animal (not mandatory, but encouraged)*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->