### PR TITLE
[wrangler] Fix first-deploy guidance for required secrets

### DIFF
--- a/.changeset/fix-required-secrets-first-deploy-guidance.md
+++ b/.changeset/fix-required-secrets-first-deploy-guidance.md
@@ -4,8 +4,9 @@
 
 Fix misleading error guidance when deploying a new Worker with `secrets.required`
 
-When a Worker declares `secrets.required` and has never been deployed before, the previous error message suggested running `wrangler secret put <NAME>`, which fails with `code: 10007` because the Worker doesn't exist yet. The `.dev.vars` / environment variable path was also suggested but does not work for `wrangler deploy`.
+When a Worker declares `secrets.required` and has never been deployed before, the previous error message suggested running `wrangler secret put <NAME>`, which doesn't work because the Worker doesn't exist yet.
 
 The one path that does work — `wrangler deploy --secrets-file <path>` — was not mentioned anywhere in the error output.
 
-The pre-deploy error now explains that `wrangler secret put` cannot be used for a new Worker, and directs users to the `--secrets-file` flag instead. The post-deploy API error (code 10057) for existing Workers now also mentions `--secrets-file` alongside `wrangler secret put`.
+The pre-deploy error now explains that `wrangler secret put` cannot be used for a new Worker, and directs users to the `--secrets-file` flag instead. The post-deploy error for existing Workers now also mentions `--secrets-file` alongside `wrangler secret put`.
+

--- a/.changeset/fix-required-secrets-first-deploy-guidance.md
+++ b/.changeset/fix-required-secrets-first-deploy-guidance.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+Fix misleading error guidance when deploying a new Worker with `secrets.required`
+
+When a Worker declares `secrets.required` and has never been deployed before, the previous error message suggested running `wrangler secret put <NAME>`, which fails with `code: 10007` because the Worker doesn't exist yet. The `.dev.vars` / environment variable path was also suggested but does not work for `wrangler deploy`.
+
+The one path that does work — `wrangler deploy --secrets-file <path>` — was not mentioned anywhere in the error output.
+
+The pre-deploy error now explains that `wrangler secret put` cannot be used for a new Worker, and directs users to the `--secrets-file` flag instead. The post-deploy API error (code 10057) for existing Workers now also mentions `--secrets-file` alongside `wrangler secret put`.

--- a/.changeset/fix-required-secrets-first-deploy-guidance.md
+++ b/.changeset/fix-required-secrets-first-deploy-guidance.md
@@ -9,4 +9,3 @@ When a Worker declares `secrets.required` and has never been deployed before, th
 The one path that does work — `wrangler deploy --secrets-file <path>` — was not mentioned anywhere in the error output.
 
 The pre-deploy error now explains that `wrangler secret put` cannot be used for a new Worker, and directs users to the `--secrets-file` flag instead. The post-deploy error for existing Workers now also mentions `--secrets-file` alongside `wrangler secret put`.
-

--- a/packages/deploy-helpers/src/deploy/helpers/secrets-validation.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/secrets-validation.ts
@@ -71,14 +71,8 @@ export function handleMissingSecretsError(
 
 	if (missingSecretNames.length > 0) {
 		err.preventReport();
-		const secretPutCommand =
-			options.type === "deploy"
-				? "wrangler secret put"
-				: "wrangler versions secret put";
-		const secretsFileCommand =
-			options.type === "deploy"
-				? "wrangler deploy --secrets-file <path-to-file>"
-				: "wrangler versions upload --secrets-file <path-to-file>";
+		const secretPutCommand = `wrangler ${options.type === "deploy" ? "" : "versions "}secret put`;
+		const secretsFileCommand = `wrangler ${options.type === "deploy" ? "deploy" : "versions upload"} --secrets-file <path-to-file>`;
 		const action = options.type === "deploy" ? "deploying" : "uploading";
 		throw new UserError(
 			`The following required secrets have not been set: ${missingSecretNames.join(", ")}\n` +

--- a/packages/deploy-helpers/src/deploy/helpers/secrets-validation.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/secrets-validation.ts
@@ -34,9 +34,12 @@ export function addRequiredSecretsInheritBindings(
 	if (options.type === "deploy" && !options.workerExists) {
 		throw new UserError(
 			`The following required secrets have not been set: ${inheritedSecrets.join(", ")}\n` +
-				`Use \`wrangler secret put <NAME>\` to set secrets before deploying.\n` +
+				`This Worker does not exist yet, so secrets cannot be set in advance with \`wrangler secret put\`.\n` +
+				`To deploy a new Worker with secrets, supply them via a secrets file:\n` +
+				`  wrangler deploy --secrets-file <path-to-file>\n` +
+				`where the file contains lines in the format \`SECRET_NAME=value\` (or JSON).\n` +
 				`See https://developers.cloudflare.com/workers/configuration/secrets/#secrets-on-deployed-workers for more information.`,
-			{ telemetryMessage: "required secrets missing before deploy" }
+			{ telemetryMessage: "required secrets missing before first deploy" }
 		);
 	}
 
@@ -68,9 +71,19 @@ export function handleMissingSecretsError(
 
 	if (missingSecretNames.length > 0) {
 		err.preventReport();
+		const secretPutCommand =
+			options.type === "deploy"
+				? "wrangler secret put"
+				: "wrangler versions secret put";
+		const secretsFileCommand =
+			options.type === "deploy"
+				? "wrangler deploy --secrets-file <path-to-file>"
+				: "wrangler versions upload --secrets-file <path-to-file>";
+		const action = options.type === "deploy" ? "deploying" : "uploading";
 		throw new UserError(
 			`The following required secrets have not been set: ${missingSecretNames.join(", ")}\n` +
-				`Use \`wrangler ${options.type === "deploy" ? "secret put" : "versions secret put"} <NAME>\` to set secrets before ${options.type === "deploy" ? "deploying" : "uploading"}.\n` +
+				`Use \`${secretPutCommand} <NAME>\` to set secrets before ${action},\n` +
+				`or supply them when ${action} with \`${secretsFileCommand}\`.\n` +
 				`See https://developers.cloudflare.com/workers/configuration/secrets/#secrets-on-deployed-workers for more information.`,
 			{ telemetryMessage: "required secrets missing during upload or deploy" }
 		);

--- a/packages/wrangler/src/__tests__/deploy/secrets.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/secrets.test.ts
@@ -338,7 +338,8 @@ SECRET3=value3`
 				runWrangler("deploy index.js")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
 				`[Error: The following required secrets have not been set: API_KEY, DB_PASSWORD
-Use \`wrangler secret put <NAME>\` to set secrets before deploying.
+Use \`wrangler secret put <NAME>\` to set secrets before deploying,
+or supply them when deploying with \`wrangler deploy --secrets-file <path-to-file>\`.
 See https://developers.cloudflare.com/workers/configuration/secrets/#secrets-on-deployed-workers for more information.]`
 			);
 		});
@@ -358,7 +359,10 @@ See https://developers.cloudflare.com/workers/configuration/secrets/#secrets-on-
 				runWrangler("deploy index.js")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
 				`[Error: The following required secrets have not been set: API_KEY, DB_PASSWORD
-Use \`wrangler secret put <NAME>\` to set secrets before deploying.
+This Worker does not exist yet, so secrets cannot be set in advance with \`wrangler secret put\`.
+To deploy a new Worker with secrets, supply them via a secrets file:
+  wrangler deploy --secrets-file <path-to-file>
+where the file contains lines in the format \`SECRET_NAME=value\` (or JSON).
 See https://developers.cloudflare.com/workers/configuration/secrets/#secrets-on-deployed-workers for more information.]`
 			);
 		});
@@ -432,7 +436,10 @@ See https://developers.cloudflare.com/workers/configuration/secrets/#secrets-on-
 				runWrangler(`deploy --secrets-file ${secretsFile}`)
 			).rejects.toThrowErrorMatchingInlineSnapshot(
 				`[Error: The following required secrets have not been set: SECRET2, SECRET3
-Use \`wrangler secret put <NAME>\` to set secrets before deploying.
+This Worker does not exist yet, so secrets cannot be set in advance with \`wrangler secret put\`.
+To deploy a new Worker with secrets, supply them via a secrets file:
+  wrangler deploy --secrets-file <path-to-file>
+where the file contains lines in the format \`SECRET_NAME=value\` (or JSON).
 See https://developers.cloudflare.com/workers/configuration/secrets/#secrets-on-deployed-workers for more information.]`
 			);
 		});

--- a/packages/wrangler/src/__tests__/versions/secrets.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets.test.ts
@@ -331,7 +331,8 @@ SECRET3=value3`
 				runWrangler(`versions upload --name ${workerName}`)
 			).rejects.toThrowErrorMatchingInlineSnapshot(
 				`[Error: The following required secrets have not been set: API_KEY, DB_PASSWORD
-Use \`wrangler versions secret put <NAME>\` to set secrets before uploading.
+Use \`wrangler versions secret put <NAME>\` to set secrets before uploading,
+or supply them when uploading with \`wrangler versions upload --secrets-file <path-to-file>\`.
 See https://developers.cloudflare.com/workers/configuration/secrets/#secrets-on-deployed-workers for more information.]`
 			);
 		});


### PR DESCRIPTION
Fixes #14258.

On a **first deploy** of a new Worker that declares `secrets: { required: [...] }`, every remedy Wrangler suggested was impossible:

- `wrangler secret put <NAME>` → fails, the Worker doesn't exist yet (API `10007`)
- `.dev.vars` / `.env` → `wrangler deploy` doesn't read these
- The one working path — `wrangler deploy --secrets-file <file>` — was mentioned nowhere.

This PR fixes the guidance so it points at the path that actually works:

- **Pre-deploy error** (`addRequiredSecretsInheritBindings`, first-deploy branch): now explains that `wrangler secret put` can't be used for a Worker that doesn't exist yet, and directs users to `wrangler deploy --secrets-file <path-to-file>` (with the expected `SECRET_NAME=value`/JSON file format).
- **Post-deploy API error** (`handleMissingSecretsError`, code `10057`): now also surfaces the `--secrets-file` option alongside `secret put`, branching the recommended command per code path (`wrangler deploy --secrets-file` vs `wrangler versions upload --secrets-file`).

This is the low-risk messaging fix. The issue also proposes a deeper behavioral change (routing env/`.dev.vars`-supplied required secrets through the "new secret binding" path that `--secrets-file` uses, instead of the inherit path that yields `10057` on first deploy). I assessed that as a separate, more invasive feature: there is currently **no** code path that reads `process.env`/`.dev.vars` into secret bindings at deploy time, so this would be net-new behavior rather than a re-route. Left as a follow-up.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this only updates Wrangler's CLI error message copy; no public documentation describes these specific error strings.

*A picture of a cute animal (not mandatory, but encouraged)*

🦦

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->