### PR TITLE
Add build command to cf-vite

### DIFF
--- a/.changeset/cf-vite-build-verb.md
+++ b/.changeset/cf-vite-build-verb.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": minor
+---
+
+Add a `build` command to the experimental, internal `cf-vite` delegate binary
+
+`cf-vite build` runs Vite's full multi-environment app build (via the Builder API) and enables the experimental Build Output API by default, emitting a self-contained `.cloudflare/output/v0/` directory. It forces `experimental.newConfig` and `experimental.newConfig.cfBuildOutput` on, so a `cloudflare.config.ts` is required at the project root.

--- a/packages/vite-plugin-cloudflare/AGENTS.md
+++ b/packages/vite-plugin-cloudflare/AGENTS.md
@@ -29,21 +29,39 @@ API and not meant for direct end-user invocation. It is the sibling of
 `wrangler`'s `cf-wrangler` binary, and the two MUST keep a shared spawn
 contract so the parent can drive either impl interchangeably.
 
-- **Verb dispatch.** `cf-vite <verb> [flags]`. `dev` is the only verb
-  today; future verbs (`build`, `deploy`) follow the same shape.
+- **Verb dispatch.** `cf-vite <verb> [flags]`. `dev` and `build` are the
+  verbs today; future verbs (`deploy`) follow the same shape.
   Unknown/missing verbs exit `2` (this doubles as the parent's
   version-detection signal — no JSON handshake).
-- **Shared flag vocabulary.** Only `--mode`, `--port`, `--host`,
-  `--local` are accepted, mirroring `cf-wrangler` exactly. Parsed with
-  `node:util.parseArgs` strict mode → unknown flags exit `2`. Do NOT add
-  flags here unless `cf-wrangler` grows them too. (There is no `--config`
-  flag: the wrangler config is discovered by `cloudflare()` itself.)
-- **Flag wiring.** `cf-vite` boots Vite via `createServer()` against the
-  user's own `vite.config.ts` (which must include `cloudflare()`).
-  Plugin-owned flags are bridged via env vars the plugin already reads
-  (`--local` → `CLOUDFLARE_VITE_FORCE_LOCAL`); Vite-owned flags go
-  through inline config (`--port`/`--host` → `server.*`, `--mode` →
-  `mode`).
+- **Shared flag vocabulary (`dev`).** For `dev`, only `--mode`, `--port`,
+  `--host`, `--local` are accepted, mirroring `cf-wrangler` exactly.
+  Parsed with `node:util.parseArgs` strict mode → unknown flags exit `2`.
+  Do NOT add flags here unless `cf-wrangler` grows them too. (There is no
+  `--config` flag: the wrangler config is discovered by `cloudflare()`
+  itself.)
+- **`build`** `cf-vite build` runs Vite's full multi-environment
+  app build via `createBuilder().buildApp()` (NOT the legacy
+  single-environment `build()` helper, which would skip the plugin's
+  worker/build-output orchestration — mirrors Vite's own `vite build`
+  CLI). It accepts **only `--mode`** (`--port`/`--host`/`--local` don't
+  apply to a build and exit `2`). It forces the experimental Build Output
+  API on by default by setting `CLOUDFLARE_VITE_FORCE_BUILD_OUTPUT`
+  (enabling `experimental.newConfig` +
+  `experimental.newConfig.cfBuildOutput`, overriding plugin config),
+  which requires a `cloudflare.config.ts` at the project root. The env
+  var name and read logic live in `build-output-env.ts`
+  (`FORCE_BUILD_OUTPUT_ENV_VAR` / `isForcedBuildOutput()`), shared by the
+  two read sites that MUST agree: `index.ts` (selects the build-output
+  plugin at construction) and `resolvePluginConfig`. Both read directly
+  from `process.env` (NOT Vite's `loadEnv`), since `index.ts` runs before
+  Vite resolves a root/mode and this is an internal bridge, not a
+  `.env`-file knob.
+- **`dev`** `cf-vite dev` boots Vite via `createServer()`
+  against the user's own `vite.config.ts` (which must include
+  `cloudflare()`). Plugin-owned flags are bridged via env vars the plugin
+  already reads (`--local` → `CLOUDFLARE_VITE_FORCE_LOCAL`); Vite-owned
+  flags go through inline config (`--port`/`--host` → `server.*`,
+  `--mode` → `mode`).
 - **`--local`** forces remote bindings off. There is no plugin env knob
   for `remoteBindings` other than `CLOUDFLARE_VITE_FORCE_LOCAL`, which
   `resolvePluginConfig` in `plugin-config.ts` honours by overriding the

--- a/packages/vite-plugin-cloudflare/src/__tests__/experimental-new-config.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/experimental-new-config.spec.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { removeDirSync } from "@cloudflare/workers-utils";
-import { afterEach, beforeEach, describe, test } from "vitest";
+import { afterEach, beforeEach, describe, test, vi } from "vitest";
 import { resolvePluginConfig } from "../plugin-config";
 import type { PluginConfig, WorkersResolvedConfig } from "../plugin-config";
 
@@ -28,6 +28,7 @@ describe("resolvePluginConfig - experimental.newConfig", () => {
 	});
 
 	afterEach(() => {
+		vi.unstubAllEnvs();
 		removeDirSync(tempDir);
 	});
 
@@ -398,5 +399,68 @@ describe("resolvePluginConfig - experimental.newConfig", () => {
 		const secondMtime = fs.statSync(dtsPath).mtimeMs;
 
 		expect(secondMtime).toBe(firstMtime);
+	});
+
+	test("CLOUDFLARE_VITE_FORCE_BUILD_OUTPUT=true forces newConfig + cfBuildOutput on", async ({
+		expect,
+	}) => {
+		vi.stubEnv("CLOUDFLARE_VITE_FORCE_BUILD_OUTPUT", "true");
+		seedWorkerSource();
+		writeWorkerConfig(
+			[
+				"import { defineWorker } from '@cloudflare/config';",
+				"export default defineWorker({",
+				"  name: 'experimental-config-worker',",
+				"  entrypoint: './src/index.ts',",
+				"  compatibilityDate: '2024-12-30',",
+				"});",
+			].join("\n")
+		);
+
+		// No `experimental.newConfig` in the plugin config — the env var
+		// (set by `cf-vite build`) forces it on.
+		const result = (await resolvePluginConfig(
+			{},
+			{ root: tempDir },
+			viteEnv
+		)) as WorkersResolvedConfig;
+
+		expect(result.type).toBe("workers");
+		expect(result.experimental.newConfig).toEqual({
+			types: { generate: true },
+			cfBuildOutput: true,
+		});
+	});
+
+	test("CLOUDFLARE_VITE_FORCE_BUILD_OUTPUT=true overrides cfBuildOutput: false in config", async ({
+		expect,
+	}) => {
+		vi.stubEnv("CLOUDFLARE_VITE_FORCE_BUILD_OUTPUT", "true");
+		seedWorkerSource();
+		writeWorkerConfig(
+			[
+				"import { defineWorker } from '@cloudflare/config';",
+				"export default defineWorker({",
+				"  name: 'experimental-config-worker',",
+				"  entrypoint: './src/index.ts',",
+				"  compatibilityDate: '2024-12-30',",
+				"});",
+			].join("\n")
+		);
+
+		const pluginConfig: PluginConfig = {
+			experimental: { newConfig: { cfBuildOutput: false } },
+		};
+
+		const result = (await resolvePluginConfig(
+			pluginConfig,
+			{ root: tempDir },
+			viteEnv
+		)) as WorkersResolvedConfig;
+
+		expect(result.experimental.newConfig).toEqual({
+			types: { generate: true },
+			cfBuildOutput: true,
+		});
 	});
 });

--- a/packages/vite-plugin-cloudflare/src/build-output-env.ts
+++ b/packages/vite-plugin-cloudflare/src/build-output-env.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared definition of the internal env var that the `cf-vite build`
+ * delegate uses to force the experimental Build Output API on by default.
+ */
+export const FORCE_BUILD_OUTPUT_ENV_VAR = "CLOUDFLARE_VITE_FORCE_BUILD_OUTPUT";
+
+/** Whether `cf-vite build` has forced the Build Output API on. */
+export function isForcedBuildOutput(): boolean {
+	return process.env[FORCE_BUILD_OUTPUT_ENV_VAR] === "true";
+}

--- a/packages/vite-plugin-cloudflare/src/cf-vite.ts
+++ b/packages/vite-plugin-cloudflare/src/cf-vite.ts
@@ -4,9 +4,10 @@
  * EXPERIMENTAL / internal: spawned by Cloudflare's "cf-dev" parent
  * process, not invoked directly by end users. Contract may change.
  *
- * Usage: `<pkgRoot>/bin/cf-vite <verb> [flags...]`. `dev` is the only
- * verb today; future verbs follow the same shape. Unknown/missing verbs
- * exit 2 (also the parent's version-detection signal).
+ * Usage: `<pkgRoot>/bin/cf-vite <verb> [flags...]`. `dev` and `build`
+ * are the verbs today; future verbs follow the same shape.
+ * Unknown/missing verbs exit 2 (also the parent's version-detection
+ * signal).
  *
  * Spawn contract for `dev`: parent uses `stdio: "inherit"` and forwards
  * SIGINT/SIGTERM. Accepted flags mirror the sibling `cf-wrangler`
@@ -17,12 +18,22 @@
  * Vite via `createServer()` against the user's own config (expected to
  * include `cloudflare()`); flags are bridged to it as documented inline.
  *
+ * `build` runs Vite's full multi-environment app build via
+ * `createBuilder().buildApp()` (NOT the legacy single-environment
+ * `build()` helper, which would skip the plugin's worker builds). It
+ * accepts only `--mode` (the other shared flags don't apply to a build)
+ * and forces the experimental Build Output API on by default by setting
+ * `CLOUDFLARE_VITE_FORCE_BUILD_OUTPUT`, which the plugin reads during
+ * config resolution to enable `experimental.newConfig` +
+ * `experimental.newConfig.cfBuildOutput`.
+ *
  * Exit codes: 0 graceful, 2 unknown verb / parse error, 130 SIGINT,
  * 143 SIGTERM.
  */
 
 import { parseArgs as nodeParseArgs } from "node:util";
-import { createServer } from "vite";
+import { createBuilder, createServer } from "vite";
+import { FORCE_BUILD_OUTPUT_ENV_VAR } from "./build-output-env";
 import type { InlineConfig, ServerOptions } from "vite";
 
 interface DevArgs {
@@ -40,7 +51,7 @@ class ArgParseError extends Error {
 }
 
 /** Strict argv parser; mirrors `cf-wrangler`'s flags (unknown → throw). */
-function parseArgs(argv: string[]): DevArgs {
+function parseDevArgs(argv: string[]): DevArgs {
 	let parsed;
 	try {
 		parsed = nodeParseArgs({
@@ -84,23 +95,58 @@ function parseArgs(argv: string[]): DevArgs {
 	return out;
 }
 
+interface BuildArgs {
+	mode?: string;
+}
+
+function parseBuildArgs(argv: string[]): BuildArgs {
+	let parsed;
+	try {
+		parsed = nodeParseArgs({
+			args: argv,
+			options: {
+				mode: { type: "string" },
+			},
+			strict: true,
+			allowPositionals: false,
+		});
+	} catch (err) {
+		throw new ArgParseError(err instanceof Error ? err.message : String(err));
+	}
+
+	const out: BuildArgs = {};
+	if (parsed.values.mode !== undefined) {
+		out.mode = parsed.values.mode;
+	}
+
+	return out;
+}
+
 async function main(): Promise<number> {
 	// argv: [0] node [1] cf-vite.mjs [2] verb [3+] forwarded flags.
 	const verb = process.argv[2];
 	const userArgv = process.argv.slice(3);
 
-	if (verb !== "dev") {
-		// Format mirrors `cf-wrangler`.
-		process.stderr.write(
-			`Error: unknown subcommand "${verb ?? ""}".\n` +
-				`Usage: cf-vite dev [args]\n`
-		);
-		return 2;
+	if (verb === "dev") {
+		return runDev(userArgv);
 	}
 
+	if (verb === "build") {
+		return runBuild(userArgv);
+	}
+
+	// Format mirrors `cf-wrangler`.
+	process.stderr.write(
+		`Error: unknown subcommand "${verb ?? ""}".\n` +
+			`Usage: cf-vite <dev|build> [args]\n`
+	);
+	return 2;
+}
+
+async function runDev(userArgv: string[]): Promise<number> {
 	let args: DevArgs;
 	try {
-		args = parseArgs(userArgv);
+		args = parseDevArgs(userArgv);
 	} catch (err) {
 		if (err instanceof ArgParseError) {
 			process.stderr.write(`Error: ${err.message}\n`);
@@ -167,6 +213,33 @@ async function main(): Promise<number> {
 	// Keep the event loop alive until a signal handler exits; Vite's own
 	// handles (HTTP listener, watchers, workerd) hold the process open.
 	return new Promise<number>(() => {});
+}
+
+async function runBuild(userArgv: string[]): Promise<number> {
+	let args: BuildArgs;
+	try {
+		args = parseBuildArgs(userArgv);
+	} catch (err) {
+		if (err instanceof ArgParseError) {
+			process.stderr.write(`Error: ${err.message}\n`);
+			return 2;
+		}
+		throw err;
+	}
+
+	// Force the experimental Build Output API on by default. The plugin
+	// reads this env var to enable `experimental.newConfig` and `experimental.newConfig.cfBuildOutput`.
+	// Must be set before the builder loads the user's `vite.config.ts`.
+	process.env[FORCE_BUILD_OUTPUT_ENV_VAR] = "true";
+
+	const inlineConfig: InlineConfig = {};
+	if (args.mode !== undefined) {
+		inlineConfig.mode = args.mode;
+	}
+	const builder = await createBuilder(inlineConfig);
+	await builder.buildApp();
+
+	return 0;
 }
 
 // Let unhandled rejections propagate — Node prints the stack and exits

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -1,5 +1,6 @@
 import { assertWranglerVersion } from "./assert-wrangler-version";
 import { DEFAULT_COMPAT_DATE } from "./build-constants";
+import { isForcedBuildOutput } from "./build-output-env";
 import { PluginContext } from "./context";
 import { resolvePluginConfig } from "./plugin-config";
 import { additionalModulesPlugin } from "./plugins/additional-modules";
@@ -70,7 +71,8 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 
 	const newConfig = pluginConfig.experimental?.newConfig;
 	const cfBuildOutput =
-		typeof newConfig === "object" && newConfig?.cfBuildOutput === true;
+		isForcedBuildOutput() ||
+		(typeof newConfig === "object" && newConfig?.cfBuildOutput === true);
 	const outputPlugin = cfBuildOutput
 		? buildOutputPlugin(ctx)
 		: outputConfigPlugin(ctx);

--- a/packages/vite-plugin-cloudflare/src/plugin-config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugin-config.ts
@@ -12,6 +12,7 @@ import { defu } from "defu";
 import * as vite from "vite";
 import * as wrangler from "wrangler";
 import { DEFAULT_COMPAT_DATE } from "./build-constants";
+import { isForcedBuildOutput } from "./build-output-env";
 import { readBuildOutputWorkers } from "./build-output-preview";
 import { getWorkerConfigs } from "./deploy-config";
 import { hasNodeJsCompat, NodeJsCompat } from "./nodejs-compat";
@@ -135,6 +136,20 @@ interface Experimental {
 function normalizeNewConfig(
 	option: boolean | ExperimentalNewConfig | undefined
 ): ResolvedExperimentalNewConfig | undefined {
+	// The `cf-vite build` delegate sets `CLOUDFLARE_VITE_FORCE_BUILD_OUTPUT`
+	// to enable the Build Output API by default. This forces
+	// `experimental.newConfig` on (the Build Output API requires
+	// `cloudflare.config.ts`) and `cfBuildOutput` to `true`, overriding the
+	// values in the plugin config.
+	if (isForcedBuildOutput()) {
+		return {
+			types: {
+				generate:
+					typeof option === "object" ? (option.types?.generate ?? true) : true,
+			},
+			cfBuildOutput: true,
+		};
+	}
 	if (option === undefined || option === false) {
 		return undefined;
 	}


### PR DESCRIPTION
Add a `build` command to the experimental, internal `cf-vite` delegate binary

`cf-vite build` runs Vite's full multi-environment app build (via the Builder API) and enables the experimental Build Output API by default, emitting a self-contained `.cloudflare/output/v0/` directory. It forces `experimental.newConfig` and `experimental.newConfig.cfBuildOutput` on, so a `cloudflare.config.ts` is required at the project root.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: experimental feature

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
