### PR TITLE
Use digest-pinned images for Dockerfile container deploys

### DIFF
--- a/.changeset/dockerfile-container-digest.md
+++ b/.changeset/dockerfile-container-digest.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Use digest-pinned image references for Dockerfile container deploys
+
+Dockerfile-backed container deploys now use the pushed image digest when deploying the container application. This lets snapshot-enabled container apps pass Cloudchamber validation while keeping local, non-pushed builds and registry image URI deploys unchanged.

--- a/packages/containers-shared/src/client/models/ModifyUserDeploymentConfiguration.ts
+++ b/packages/containers-shared/src/client/models/ModifyUserDeploymentConfiguration.ts
@@ -76,4 +76,5 @@ export type ModifyUserDeploymentConfiguration = {
 	checks?: Array<DeploymentCheckRequestBody>;
 	provisioner?: ProvisionerConfiguration;
 	observability?: Observability;
+	experimental_flags?: Array<string>;
 };

--- a/packages/containers-shared/src/client/models/UserDeploymentConfiguration.ts
+++ b/packages/containers-shared/src/client/models/UserDeploymentConfiguration.ts
@@ -76,4 +76,5 @@ export type UserDeploymentConfiguration = {
 	checks?: Array<DeploymentCheckRequestBody>;
 	provisioner?: ProvisionerConfiguration;
 	observability?: Observability;
+	experimental_flags?: Array<string>;
 };

--- a/packages/wrangler/e2e/deployments.test.ts
+++ b/packages/wrangler/e2e/deployments.test.ts
@@ -899,6 +899,7 @@ describe.skipIf(skipContainersTest)("containers", () => {
 						class_name = "MyDurableObject"
 						image = "./Dockerfile"
 						max_instances = 1
+						unsafe = { configuration = { experimental_flags = ["experimental_enable_snapshots"] } }
 
 						[[migrations]]
 						tag = "v1"
@@ -975,7 +976,7 @@ describe.skipIf(skipContainersTest)("containers", () => {
 	}, 30_000);
 
 	it(
-		"won't rebuild unchanged containers",
+		"can deploy a snapshot-enabled Dockerfile container and skip unchanged rebuilds",
 		{ timeout: 60 * 2 * 1000 },
 		async ({ expect }) => {
 			const outputOne = await helper.run(`wrangler deploy`);
@@ -987,6 +988,26 @@ describe.skipIf(skipContainersTest)("containers", () => {
 			);
 			applicationId = matchApplicationId?.groups?.applicationId;
 			assert(matchApplicationId?.groups);
+			assert(applicationId);
+			assert(CLOUDFLARE_ACCOUNT_ID);
+
+			const containerInfo = await helper.run(
+				`wrangler containers info ${applicationId}`
+			);
+			const application = JSON.parse(containerInfo.stdout) as {
+				configuration?: {
+					experimental_flags?: unknown;
+					image?: unknown;
+				};
+			};
+			expect(application.configuration?.experimental_flags).toContain(
+				"experimental_enable_snapshots"
+			);
+			const image = application.configuration?.image;
+			assert(typeof image === "string");
+			const expectedImagePrefix = `registry.cloudflare.com/${CLOUDFLARE_ACCOUNT_ID}/e2e-test-${workerName}@sha256:`;
+			expect(image.startsWith(expectedImagePrefix)).toBe(true);
+			expect(image).toMatch(/@sha256:[a-f0-9]{64}$/);
 
 			const outputTwo = await helper.run(`wrangler deploy`);
 			expect(outputTwo.stdout).toContain(`No changes to be made`);

--- a/packages/wrangler/src/__tests__/cloudchamber/build.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/build.test.ts
@@ -40,7 +40,11 @@ describe("buildAndMaybePush", () => {
 			// return empty array of repo digests (i.e. image does not exist remotely)
 			.mockResolvedValueOnce("[]")
 			// return image size and number of layers
-			.mockResolvedValueOnce("53387881 2");
+			.mockResolvedValueOnce("53387881 2")
+			// return digest after pushing the namespaced image
+			.mockResolvedValueOnce(
+				'["registry.cloudflare.com/some-account-id/test-app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]'
+			);
 		// we can set this to anything since there is nothing to match from docker image inspect
 		vi.mocked(runDockerCmdWithOutput).mockReturnValueOnce(
 			'{"Descriptor":{"digest":"wont-match-sha"}}'
@@ -77,7 +81,7 @@ describe("buildAndMaybePush", () => {
 			dockerfile,
 		});
 
-		// 3 calls: docker tag + docker push
+		// 2 calls: docker tag + docker push
 		expect(runDockerCmd).toHaveBeenCalledTimes(2);
 		expect(runDockerCmd).toHaveBeenNthCalledWith(1, "docker", [
 			"tag",
@@ -89,7 +93,7 @@ describe("buildAndMaybePush", () => {
 			`${getCloudflareContainerRegistry()}/some-account-id/test-app:tag`,
 		]);
 
-		expect(dockerImageInspect).toHaveBeenCalledTimes(2);
+		expect(dockerImageInspect).toHaveBeenCalledTimes(3);
 		expect(dockerImageInspect).toHaveBeenNthCalledWith(1, "docker", {
 			imageTag: `test-app:tag`,
 			formatString: "{{ json .RepoDigests }}",
@@ -97,6 +101,10 @@ describe("buildAndMaybePush", () => {
 		expect(dockerImageInspect).toHaveBeenNthCalledWith(2, "docker", {
 			imageTag: `test-app:tag`,
 			formatString: "{{ .Size }} {{ len .RootFS.Layers }}",
+		});
+		expect(dockerImageInspect).toHaveBeenNthCalledWith(3, "docker", {
+			imageTag: `${getCloudflareContainerRegistry()}/some-account-id/test-app:tag`,
+			formatString: "{{ json .RepoDigests }}",
 		});
 		expect(dockerLoginImageRegistry).toHaveBeenCalledOnce();
 	});
@@ -124,7 +132,7 @@ describe("buildAndMaybePush", () => {
 			dockerfile,
 		});
 
-		// 3 calls: docker tag + docker push
+		// 2 calls: docker tag + docker push
 		expect(runDockerCmd).toHaveBeenCalledTimes(2);
 		expect(runDockerCmd).toHaveBeenNthCalledWith(1, "docker", [
 			"tag",
@@ -135,7 +143,7 @@ describe("buildAndMaybePush", () => {
 			"push",
 			`${getCloudflareContainerRegistry()}/some-account-id/test-app:tag`,
 		]);
-		expect(dockerImageInspect).toHaveBeenCalledTimes(2);
+		expect(dockerImageInspect).toHaveBeenCalledTimes(3);
 		expect(dockerImageInspect).toHaveBeenNthCalledWith(1, "docker", {
 			imageTag: `${getCloudflareContainerRegistry()}/test-app:tag`,
 			formatString: "{{ json .RepoDigests }}",
@@ -143,6 +151,10 @@ describe("buildAndMaybePush", () => {
 		expect(dockerImageInspect).toHaveBeenNthCalledWith(2, "docker", {
 			imageTag: `${getCloudflareContainerRegistry()}/test-app:tag`,
 			formatString: "{{ .Size }} {{ len .RootFS.Layers }}",
+		});
+		expect(dockerImageInspect).toHaveBeenNthCalledWith(3, "docker", {
+			imageTag: `${getCloudflareContainerRegistry()}/some-account-id/test-app:tag`,
+			formatString: "{{ json .RepoDigests }}",
 		});
 		expect(dockerLoginImageRegistry).toHaveBeenCalledOnce();
 	});
@@ -170,7 +182,7 @@ describe("buildAndMaybePush", () => {
 			dockerfile,
 		});
 
-		// 3 calls: docker tag + docker push
+		// 2 calls: docker tag + docker push
 		expect(runDockerCmd).toHaveBeenCalledTimes(2);
 		expect(runDockerCmd).toHaveBeenNthCalledWith(1, "docker", [
 			"tag",
@@ -181,7 +193,7 @@ describe("buildAndMaybePush", () => {
 			"push",
 			`${getCloudflareContainerRegistry()}/some-account-id/test-app:tag`,
 		]);
-		expect(dockerImageInspect).toHaveBeenCalledTimes(2);
+		expect(dockerImageInspect).toHaveBeenCalledTimes(3);
 		expect(dockerImageInspect).toHaveBeenNthCalledWith(1, "docker", {
 			imageTag: `registry.cloudflare.com/some-account-id/test-app:tag`,
 			formatString: "{{ json .RepoDigests }}",
@@ -189,6 +201,10 @@ describe("buildAndMaybePush", () => {
 		expect(dockerImageInspect).toHaveBeenNthCalledWith(2, "docker", {
 			imageTag: `registry.cloudflare.com/some-account-id/test-app:tag`,
 			formatString: "{{ .Size }} {{ len .RootFS.Layers }}",
+		});
+		expect(dockerImageInspect).toHaveBeenNthCalledWith(3, "docker", {
+			imageTag: `${getCloudflareContainerRegistry()}/some-account-id/test-app:tag`,
+			formatString: "{{ json .RepoDigests }}",
 		});
 		expect(dockerLoginImageRegistry).toHaveBeenCalledOnce();
 	});
@@ -213,7 +229,7 @@ describe("buildAndMaybePush", () => {
 			],
 			dockerfile,
 		});
-		expect(dockerImageInspect).toHaveBeenCalledTimes(2);
+		expect(dockerImageInspect).toHaveBeenCalledTimes(3);
 		expect(dockerImageInspect).toHaveBeenNthCalledWith(
 			1,
 			"/custom/docker/path",
@@ -228,6 +244,14 @@ describe("buildAndMaybePush", () => {
 			{
 				imageTag: `test-app:tag`,
 				formatString: "{{ .Size }} {{ len .RootFS.Layers }}",
+			}
+		);
+		expect(dockerImageInspect).toHaveBeenNthCalledWith(
+			3,
+			"/custom/docker/path",
+			{
+				imageTag: `${getCloudflareContainerRegistry()}/some-account-id/test-app:tag`,
+				formatString: "{{ json .RepoDigests }}",
 			}
 		);
 		expect(runDockerCmd).toHaveBeenCalledWith("/custom/docker/path", [
@@ -261,7 +285,7 @@ describe("buildAndMaybePush", () => {
 			dockerfile,
 		});
 
-		// 3 calls: docker tag + docker push
+		// 2 calls: docker tag + docker push
 		expect(runDockerCmd).toHaveBeenCalledTimes(2);
 		expect(runDockerCmd).toHaveBeenNthCalledWith(1, "docker", [
 			"tag",
@@ -272,7 +296,7 @@ describe("buildAndMaybePush", () => {
 			"push",
 			`${getCloudflareContainerRegistry()}/some-account-id/test-app:tag`,
 		]);
-		expect(dockerImageInspect).toHaveBeenCalledTimes(2);
+		expect(dockerImageInspect).toHaveBeenCalledTimes(3);
 		expect(dockerImageInspect).toHaveBeenNthCalledWith(1, "docker", {
 			imageTag: `test-app:tag`,
 			formatString: "{{ json .RepoDigests }}",
@@ -280,6 +304,10 @@ describe("buildAndMaybePush", () => {
 		expect(dockerImageInspect).toHaveBeenNthCalledWith(2, "docker", {
 			imageTag: `test-app:tag`,
 			formatString: "{{ .Size }} {{ len .RootFS.Layers }}",
+		});
+		expect(dockerImageInspect).toHaveBeenNthCalledWith(3, "docker", {
+			imageTag: `${getCloudflareContainerRegistry()}/some-account-id/test-app:tag`,
+			formatString: "{{ json .RepoDigests }}",
 		});
 		expect(dockerLoginImageRegistry).toHaveBeenCalledOnce();
 	});
@@ -294,12 +322,12 @@ describe("buildAndMaybePush", () => {
 		vi.mocked(dockerImageInspect).mockReset();
 		vi.mocked(dockerImageInspect)
 			.mockResolvedValueOnce(
-				'["registry.cloudflare.com/test-app@sha256:three"]'
+				'["registry.cloudflare.com/test-app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]'
 			)
 			.mockResolvedValueOnce("53387881 2");
 		vi.mocked(runDockerCmdWithOutput).mockReset();
 		vi.mocked(runDockerCmdWithOutput).mockImplementationOnce(() => {
-			return '{"Descriptor":{"digest":"three}}';
+			return '{"Descriptor":{"digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}';
 		});
 
 		await runWrangler(
@@ -325,7 +353,7 @@ describe("buildAndMaybePush", () => {
 			"manifest",
 			"inspect",
 			"-v",
-			`${getCloudflareContainerRegistry()}/some-account-id/test-app@sha256:three`,
+			`${getCloudflareContainerRegistry()}/some-account-id/test-app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`,
 		]);
 		expect(dockerImageInspect).toHaveBeenCalledTimes(2);
 		expect(dockerImageInspect).toHaveBeenNthCalledWith(1, "docker", {
@@ -336,7 +364,52 @@ describe("buildAndMaybePush", () => {
 			imageTag: `test-app:tag`,
 			formatString: "{{ .Size }} {{ len .RootFS.Layers }}",
 		});
+		expect(runDockerCmd).toHaveBeenCalledOnce();
+		expect(runDockerCmd).toHaveBeenCalledWith("docker", [
+			"image",
+			"rm",
+			"test-app:tag",
+		]);
 		expect(dockerLoginImageRegistry).toHaveBeenCalledOnce();
+	});
+
+	it("should inspect the pushed image digest if the local digest is not remote", async ({
+		expect,
+	}) => {
+		vi.mocked(dockerImageInspect).mockReset();
+		vi.mocked(dockerImageInspect)
+			.mockResolvedValueOnce(
+				'["registry.cloudflare.com/test-app@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"]'
+			)
+			.mockResolvedValueOnce("53387881 2")
+			.mockResolvedValueOnce(
+				'["registry.cloudflare.com/some-account-id/test-app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]'
+			);
+		vi.mocked(runDockerCmdWithOutput).mockReset();
+		vi.mocked(runDockerCmdWithOutput).mockImplementationOnce(() => {
+			return '{"Descriptor":{"digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"}}';
+		});
+
+		await runWrangler(
+			"containers build ./container-context -t test-app:tag -p"
+		);
+
+		expect(runDockerCmdWithOutput).toHaveBeenCalledOnce();
+		expect(runDockerCmd).toHaveBeenCalledTimes(2);
+		expect(runDockerCmd).toHaveBeenNthCalledWith(1, "docker", [
+			"tag",
+			`test-app:tag`,
+			`${getCloudflareContainerRegistry()}/some-account-id/test-app:tag`,
+		]);
+		expect(runDockerCmd).toHaveBeenNthCalledWith(2, "docker", [
+			"push",
+			`${getCloudflareContainerRegistry()}/some-account-id/test-app:tag`,
+		]);
+		expect(dockerImageInspect).toHaveBeenCalledTimes(3);
+		expect(dockerImageInspect).toHaveBeenNthCalledWith(3, "docker", {
+			imageTag: `${getCloudflareContainerRegistry()}/some-account-id/test-app:tag`,
+			formatString: "{{ json .RepoDigests }}",
+		});
 	});
 
 	it("should match digests for images with registry ports", async ({
@@ -348,11 +421,13 @@ describe("buildAndMaybePush", () => {
 		});
 		vi.mocked(dockerImageInspect).mockReset();
 		vi.mocked(dockerImageInspect)
-			.mockResolvedValueOnce('["localhost:5000/test-app@sha256:three"]')
+			.mockResolvedValueOnce(
+				'["localhost:5000/test-app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]'
+			)
 			.mockResolvedValueOnce("53387881 2");
 		vi.mocked(runDockerCmdWithOutput).mockReset();
 		vi.mocked(runDockerCmdWithOutput).mockImplementationOnce(() => {
-			return '{"Descriptor":{"digest":"sha256:three"}}';
+			return '{"Descriptor":{"digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}';
 		});
 
 		await runWrangler(
@@ -364,7 +439,7 @@ describe("buildAndMaybePush", () => {
 			"manifest",
 			"inspect",
 			"-v",
-			"localhost:5000/test-app@sha256:three",
+			"localhost:5000/test-app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		]);
 		expect(runDockerCmd).toHaveBeenCalledTimes(1);
 		expect(runDockerCmd).toHaveBeenCalledWith("docker", [
@@ -393,8 +468,37 @@ describe("buildAndMaybePush", () => {
 			],
 			dockerfile,
 		});
-		expect(dockerImageInspect).not.toHaveBeenCalledOnce();
+		expect(dockerImageInspect).not.toHaveBeenCalled();
 		expect(dockerLoginImageRegistry).not.toHaveBeenCalled();
+	});
+
+	it("should fall back to manifest inspect if pushed image digests are unavailable", async ({
+		expect,
+	}) => {
+		vi.mocked(dockerImageInspect).mockReset();
+		vi.mocked(dockerImageInspect)
+			.mockResolvedValueOnce("[]")
+			.mockResolvedValueOnce("53387881 2")
+			.mockResolvedValueOnce("[]");
+		vi.mocked(runDockerCmdWithOutput).mockReset();
+		vi.mocked(runDockerCmdWithOutput).mockImplementationOnce(() => {
+			return '{"Descriptor":{"digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}';
+		});
+
+		await runWrangler(
+			"containers build ./container-context -t test-app:tag -p"
+		);
+
+		expect(dockerImageInspect).toHaveBeenCalledTimes(3);
+		expect(runDockerCmdWithOutput).toHaveBeenCalledOnce();
+		expect(runDockerCmdWithOutput).toHaveBeenCalledWith("docker", [
+			"manifest",
+			"inspect",
+			"-v",
+			`${getCloudflareContainerRegistry()}/some-account-id/test-app:tag`,
+		]);
+		expect(runDockerCmd).toHaveBeenCalledTimes(2);
+		expect(dockerLoginImageRegistry).toHaveBeenCalledOnce();
 	});
 
 	it("should add --network=host flag if WRANGLER_CI_OVERRIDE_NETWORK_MODE_HOST is set", async ({

--- a/packages/wrangler/src/__tests__/containers/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/containers/deploy.test.ts
@@ -130,7 +130,7 @@ describe("wrangler deploy with containers", () => {
 			configuration: {
 				image:
 					getCloudflareContainerRegistry() +
-					"/some-account-id/my-container:Galaxy",
+					"/some-account-id/my-container@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			},
 			durable_objects: {
 				// uses namespace_id when the DO is a binding
@@ -177,7 +177,7 @@ describe("wrangler deploy with containers", () => {
 			│   rollout_active_grace_period = 0
 			│
 			│   [containers.configuration]
-			│   image = "registry.cloudflare.com/some-account-id/my-container:Galaxy"
+			│   image = "registry.cloudflare.com/some-account-id/my-container@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 			│   instance_type = "lite"
 			│
 			│   [containers.constraints]
@@ -193,6 +193,64 @@ describe("wrangler deploy with containers", () => {
 
 			"
 		`);
+	});
+	it("should be able to deploy a snapshot-enabled container from a dockerfile", async ({
+		expect,
+	}) => {
+		mockGetVersion("Galaxy-Class");
+		setupDockerMocks(expect, "my-container", "Galaxy");
+		writeWranglerConfig({
+			...DEFAULT_DURABLE_OBJECTS,
+			containers: [
+				{
+					...DEFAULT_CONTAINER_FROM_DOCKERFILE,
+					unsafe: {
+						configuration: {
+							experimental_flags: ["experimental_enable_snapshots"],
+						},
+					},
+				},
+			],
+		});
+		mockGetApplications([]);
+		fs.writeFileSync("./Dockerfile", "FROM scratch");
+		mockGenerateImageRegistryCredentials(expect);
+
+		mockCreateApplication(expect, {
+			name: "my-container",
+			configuration: {
+				experimental_flags: ["experimental_enable_snapshots"],
+				image:
+					getCloudflareContainerRegistry() +
+					"/some-account-id/my-container@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			},
+		});
+
+		await runWrangler("deploy index.js");
+	});
+	it("should retry when the uploaded Worker version is not immediately available", async ({
+		expect,
+	}) => {
+		mockGetVersionNotFoundOnce("Galaxy-Class");
+		setupDockerMocks(expect, "my-container", "Galaxy");
+		writeWranglerConfig({
+			...DEFAULT_DURABLE_OBJECTS,
+			containers: [DEFAULT_CONTAINER_FROM_DOCKERFILE],
+		});
+		mockGetApplications([]);
+		fs.writeFileSync("./Dockerfile", "FROM scratch");
+		mockGenerateImageRegistryCredentials(expect);
+
+		mockCreateApplication(expect, {
+			name: "my-container",
+			configuration: {
+				image:
+					getCloudflareContainerRegistry() +
+					"/some-account-id/my-container@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			},
+		});
+
+		await runWrangler("deploy index.js");
 	});
 	it("should be able to deploy a new container from an image uri", async ({
 		expect,
@@ -519,7 +577,7 @@ describe("wrangler deploy with containers", () => {
 			configuration: {
 				image:
 					getCloudflareContainerRegistry() +
-					"/some-account-id/my-container:Galaxy",
+					"/some-account-id/my-container@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			},
 		});
 
@@ -594,7 +652,7 @@ describe("wrangler deploy with containers", () => {
 			configuration: {
 				image:
 					getCloudflareContainerRegistry() +
-					"/some-account-id/my-container:Galaxy",
+					"/some-account-id/my-container@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			},
 		});
 
@@ -672,7 +730,8 @@ describe("wrangler deploy with containers", () => {
 		mockGenerateImageRegistryCredentials(expect);
 		mockModifyApplication(expect, {
 			configuration: {
-				image: "registry.cloudflare.com/some-account-id/my-container:Galaxy",
+				image:
+					"registry.cloudflare.com/some-account-id/my-container@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			},
 			max_instances: 10,
 			rollout_active_grace_period: 600,
@@ -702,7 +761,7 @@ describe("wrangler deploy with containers", () => {
 			│   scheduling_policy = "default"
 			│   [containers.configuration]
 			│ - image = "registry.cloudflare.com/some-account-id/my-container:old"
-			│ + image = "registry.cloudflare.com/some-account-id/my-container:Galaxy"
+			│ + image = "registry.cloudflare.com/some-account-id/my-container@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 			│   instance_type = "lite"
 			│   [containers.constraints]
 			│
@@ -818,7 +877,8 @@ describe("wrangler deploy with containers", () => {
 		mockGenerateImageRegistryCredentials(expect);
 		mockModifyApplication(expect, {
 			configuration: {
-				image: "registry.cloudflare.com/some-account-id/my-container:Galaxy",
+				image:
+					"registry.cloudflare.com/some-account-id/my-container@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			},
 			max_instances: 10,
 		});
@@ -851,7 +911,7 @@ describe("wrangler deploy with containers", () => {
 			│   scheduling_policy = "default"
 			│   [containers.configuration]
 			│ - image = "registry.cloudflare.com/some-account-id/my-container:old"
-			│ + image = "registry.cloudflare.com/some-account-id/my-container:Galaxy"
+			│ + image = "registry.cloudflare.com/some-account-id/my-container@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 			│   instance_type = "lite"
 			│   [containers.constraints]
 			│
@@ -913,7 +973,8 @@ describe("wrangler deploy with containers", () => {
 				scheduling_policy: SchedulingPolicy.DEFAULT,
 				rollout_active_grace_period: 0,
 				configuration: {
-					image: "registry.cloudflare.com/some-account-id/my-container:Galaxy",
+					image:
+						"registry.cloudflare.com/some-account-id/my-container@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					disk: {
 						size: "2GB",
 						size_mb: 2000,
@@ -1767,12 +1828,7 @@ describe("wrangler deploy with containers", () => {
 				)
 			)
 			.mockImplementationOnce(
-				mockDockerImageInspectDigestsWithRepoDigest(
-					expect,
-					containerName,
-					tag,
-					"sha256:three"
-				)
+				mockDockerImageInspectDigestsWithRepoDigest(expect, containerName, tag)
 			)
 			.mockImplementationOnce(
 				mockDockerImageInspectSize(expect, containerName, tag)
@@ -1798,12 +1854,112 @@ describe("wrangler deploy with containers", () => {
 				if (args && args[0] === "manifest" && args[1] === "inspect") {
 					// Verify the format: registry.cloudflare.com/account-id/image@hash
 					expect(args[3]).toBe(
-						`${getCloudflareContainerRegistry()}/some-account-id/${containerName}@sha256:three`
+						`${getCloudflareContainerRegistry()}/some-account-id/${containerName}@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
 					);
 					// Return a manifest that matches the sha, indicating the image exists remotely
 					return JSON.stringify({
 						Descriptor: {
-							digest: "sha256:three",
+							digest:
+								"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+						},
+					});
+				}
+				return "";
+			}
+		);
+
+		writeWranglerConfig({
+			...DEFAULT_DURABLE_OBJECTS,
+			containers: [DEFAULT_CONTAINER_FROM_DOCKERFILE],
+		});
+		mockGetApplications([
+			{
+				id: "abc",
+				name: "my-container",
+				instances: 0,
+				max_instances: 10,
+				created_at: new Date().toString(),
+				version: 1,
+				account_id: "1",
+				scheduling_policy: SchedulingPolicy.DEFAULT,
+				rollout_active_grace_period: 0,
+				configuration: {
+					image: `${getCloudflareContainerRegistry()}/some-account-id/my-container@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`,
+					disk: {
+						size: "2GB",
+						size_mb: 2000,
+					},
+					vcpu: 0.0625,
+					memory: "256MB",
+					memory_mib: 256,
+				},
+				constraints: {
+					tiers: [1, 2],
+				},
+				durable_objects: {
+					namespace_id: "1",
+				},
+			},
+		]);
+		fs.writeFileSync("./Dockerfile", "FROM scratch");
+		mockGenerateImageRegistryCredentials(expect);
+
+		await runWrangler("deploy index.js");
+
+		expect(std.out).toContain("Image already exists remotely, skipping push");
+		expect(cliStd.stdout).toMatchInlineSnapshot(`
+			"╭ Deploy a container application deploy changes to your application
+			│
+			│ Container application changes
+			│
+			├ no changes my-container
+			│
+			╰ No changes to be made
+
+			"
+		`);
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		expect(std.warn).toMatchInlineSnapshot(`""`);
+	});
+
+	it("should use digest when an existing tagged image already exists remotely", async ({
+		expect,
+	}) => {
+		mockGetVersion("Galaxy-Class");
+		const containerName = "my-container";
+		const tag = "Galaxy";
+		vi.mocked(spawn).mockReset();
+		vi.mocked(spawn)
+			.mockImplementationOnce(mockDockerInfo(expect))
+			.mockImplementationOnce(
+				mockDockerBuild(
+					expect,
+					containerName,
+					tag,
+					"FROM scratch",
+					process.cwd()
+				)
+			)
+			.mockImplementationOnce(
+				mockDockerImageInspectDigestsWithRepoDigest(expect, containerName, tag)
+			)
+			.mockImplementationOnce(
+				mockDockerImageInspectSize(expect, containerName, tag)
+			)
+			.mockImplementationOnce(mockDockerLogin(expect, "mockpassword"))
+			.mockImplementationOnce(
+				mockDockerImageDelete(expect, containerName, tag)
+			);
+		vi.mocked(execFileSync).mockImplementation(
+			(_file: string, args?: readonly string[]) => {
+				if (args && args[0] === "manifest" && args[1] === "inspect") {
+					expect(args[3]).toBe(
+						`${getCloudflareContainerRegistry()}/some-account-id/${containerName}@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
+					);
+					return JSON.stringify({
+						Descriptor: {
+							digest:
+								"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 						},
 					});
 				}
@@ -1846,6 +2002,16 @@ describe("wrangler deploy with containers", () => {
 		]);
 		fs.writeFileSync("./Dockerfile", "FROM scratch");
 		mockGenerateImageRegistryCredentials(expect);
+		mockModifyApplication(expect, {
+			configuration: {
+				image: `${getCloudflareContainerRegistry()}/some-account-id/my-container@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`,
+			},
+		});
+		mockCreateApplicationRollout(expect, {
+			description: "Progressive update",
+			strategy: "rolling",
+			kind: "full_auto",
+		});
 
 		await runWrangler("deploy index.js");
 
@@ -1855,9 +2021,19 @@ describe("wrangler deploy with containers", () => {
 			│
 			│ Container application changes
 			│
-			├ no changes my-container
+			├ EDIT my-container
 			│
-			╰ No changes to be made
+			│   scheduling_policy = "default"
+			│   [containers.configuration]
+			│ - image = "registry.cloudflare.com/some-account-id/my-container:Galaxy"
+			│ + image = "registry.cloudflare.com/some-account-id/my-container@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			│   instance_type = "lite"
+			│   [containers.constraints]
+			│
+			│
+			│  SUCCESS  Modified application my-container (Application ID: abc)
+			│
+			╰ Applied changes
 
 			"
 		`);
@@ -2771,7 +2947,8 @@ function createDockerMockChain(
 		mockDockerImageInspectDigests(expect, containerName, tag),
 		mockDockerImageInspectSize(expect, containerName, tag),
 		mockDockerLogin(expect, "mockpassword"),
-		// Skip manifest inspect mock - it's not being called due to empty repoDigests
+		// Default manifest inspect output is invalid JSON, so Dockerfile deploy tests exercise
+		// the push path before using the post-push RepoDigests lookup.
 		mockDockerTag(
 			expect,
 			containerName,
@@ -2779,6 +2956,11 @@ function createDockerMockChain(
 			tag
 		),
 		mockDockerPush(expect, "some-account-id/" + containerName, tag),
+		mockDockerImageInspectDigestsForImage(
+			expect,
+			`${getCloudflareContainerRegistry()}/some-account-id/${containerName}:${tag}`,
+			`${getCloudflareContainerRegistry()}/some-account-id/${containerName}@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
+		),
 	];
 
 	return mocks;
@@ -2897,6 +3079,45 @@ function mockGetVersion(versionId: string, bindings = [defaultDOBinding]) {
 					})
 				);
 			}
+		)
+	);
+}
+
+function mockGetVersionNotFoundOnce(
+	versionId: string,
+	bindings = [defaultDOBinding]
+) {
+	let requestCount = 0;
+	msw.use(
+		http.get(
+			`*/accounts/:accountId/workers/scripts/:scriptName/versions/${versionId}`,
+			async () => {
+				requestCount++;
+				if (requestCount === 1) {
+					return HttpResponse.json(
+						createFetchResult(null, false, [
+							{
+								code: 100146,
+								message:
+									"The requested Worker version could not be found, please check the ID being passed and try again.",
+							},
+						]),
+						{ status: 404 }
+					);
+				}
+
+				return HttpResponse.json(
+					createFetchResult({
+						id: versionId,
+						metadata: {},
+						number: 2,
+						resources: {
+							bindings,
+						},
+					})
+				);
+			},
+			{ once: false }
 		)
 	);
 }
@@ -3086,12 +3307,24 @@ function mockDockerImageInspectDigests(
 	containerName: string,
 	tag: string
 ) {
+	return mockDockerImageInspectDigestsForImage(
+		expect,
+		`${containerName}:${tag}`,
+		`${getCloudflareContainerRegistry()}/${containerName}@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
+	);
+}
+
+function mockDockerImageInspectDigestsForImage(
+	expect: ExpectStatic,
+	imageTag: string,
+	repoDigest: string
+) {
 	return (cmd: string, args: readonly string[]) => {
 		expect(cmd).toBe("/usr/bin/docker");
 		expect(args).toEqual([
 			"image",
 			"inspect",
-			`${containerName}:${tag}`,
+			imageTag,
 			"--format",
 			"{{ json .RepoDigests }}",
 		]);
@@ -3111,10 +3344,7 @@ function mockDockerImageInspectDigests(
 		};
 
 		setImmediate(() => {
-			stdout.emit(
-				"data",
-				`["${getCloudflareContainerRegistry()}/${containerName}@sha256:three"] config-sha`
-			);
+			stdout.emit("data", `["${repoDigest}"]`);
 		});
 
 		return child as unknown as ChildProcess;
@@ -3124,8 +3354,7 @@ function mockDockerImageInspectDigests(
 function mockDockerImageInspectDigestsWithRepoDigest(
 	expect: ExpectStatic,
 	containerName: string,
-	tag: string,
-	imageId: string
+	tag: string
 ) {
 	return (cmd: string, args: readonly string[]) => {
 		expect(cmd).toBe("/usr/bin/docker");
@@ -3155,7 +3384,7 @@ function mockDockerImageInspectDigestsWithRepoDigest(
 			// Include account-id in the digest to match the managed registry format
 			stdout.emit(
 				"data",
-				`["${getCloudflareContainerRegistry()}/some-account-id/${containerName}@sha256:three"] ${imageId}`
+				`["${getCloudflareContainerRegistry()}/some-account-id/${containerName}@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]`
 			);
 		});
 

--- a/packages/wrangler/src/cloudchamber/build.ts
+++ b/packages/wrangler/src/cloudchamber/build.ts
@@ -82,15 +82,88 @@ export function pushYargs(yargs: CommonYargsArgv) {
 
 /**
  *
- * `{ remoteDigest: string }` implies the image already exists remotely. we will
- * try and replace this with the image tag from the last deployment if possible.
- * If a deployment failed between push and deploy, we can't know for certain
- * what the tag of the last push was, so we will use the digest instead.
+ * `{ remoteDigest: string }` implies the image was pushed to, or already exists in,
+ * the managed registry. Deployments should use this digest-pinned reference.
  *
- * `{ newTag: string }` implies the image was built and pushed and the deployment
- * should be associated with a new tag.
+ * `{ newTag: string }` implies the image was built locally without pushing.
  */
 export type ImageRef = { remoteDigest: string } | { newTag: string };
+
+// Based on the Docker reference grammar used by containers/image. These only
+// strip suffixes from refs that have already been normalized by resolveImageName().
+const DIGEST_SUFFIX_REGEXP =
+	/@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*:[a-fA-F0-9]{32,}$/;
+const DIGEST_VALUE_REGEXP =
+	/^[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*:[a-fA-F0-9]{32,}$/;
+const TAG_SUFFIX_REGEXP = /:[\w][\w.-]{0,127}$/;
+
+function getRepositoryOnly(
+	externalAccountId: string,
+	imageTag: string
+): string {
+	return resolveImageName(externalAccountId, imageTag)
+		.replace(DIGEST_SUFFIX_REGEXP, "")
+		.replace(TAG_SUFFIX_REGEXP, "");
+}
+
+function imageRefWithDigest(
+	externalAccountId: string,
+	imageTag: string,
+	digest: string
+): string {
+	if (!DIGEST_VALUE_REGEXP.test(digest)) {
+		throw new Error(
+			`Expected image digest to match algorithm:hex format, got ${digest}`
+		);
+	}
+	return `${getRepositoryOnly(externalAccountId, imageTag)}@${digest}`;
+}
+
+function findManifestDigest(manifestOutput: string): string {
+	const parsedManifest = JSON.parse(manifestOutput);
+	const digest = parsedManifest?.Descriptor?.digest;
+	if (typeof digest !== "string" || digest.length === 0) {
+		throw new Error(
+			`Expected docker manifest inspect output to include Descriptor.digest, got ${manifestOutput}`
+		);
+	}
+	return digest;
+}
+
+function findRemoteDigest(
+	repoDigestsJson: string,
+	externalAccountId: string,
+	imageTag: string
+): string {
+	const parsedDigests = JSON.parse(repoDigestsJson);
+	if (!Array.isArray(parsedDigests)) {
+		throw new Error(
+			`Expected RepoDigests from docker inspect to be an array but got ${JSON.stringify(parsedDigests)}`
+		);
+	}
+
+	const repositoryOnly = getRepositoryOnly(externalAccountId, imageTag);
+	logger.debug("respositoryOnly:", repositoryOnly);
+
+	// make sure the repository + name provided in wrangler config
+	// matches the repository + name from the digests
+	const digest = parsedDigests.find((d): d is string => {
+		if (typeof d !== "string" || !d.includes("@")) {
+			return false;
+		}
+		const resolved = resolveImageName(externalAccountId, d);
+		logger.debug(`Comparing ${resolved.split("@")[0]} to ${repositoryOnly}`);
+		return typeof d === "string" && resolved.split("@")[0] === repositoryOnly;
+	});
+	if (!digest) {
+		throw new Error(
+			`Could not find a digest for the image ${repositoryOnly}. Found digests: ${parsedDigests.join(", ")}`
+		);
+	}
+
+	const [, hash] = digest.split("@");
+	return imageRefWithDigest(externalAccountId, imageTag, hash);
+}
 
 export async function buildAndMaybePush(
 	args: BuildArgs,
@@ -150,52 +223,14 @@ export async function buildAndMaybePush(
 				getCloudflareContainerRegistry()
 			);
 			try {
-				const [digests] = imageInfo.split(" ");
-
-				// We don't try to parse until this point
-				// because we don't want to fail on parse errors if we
-				// won't be pushing the image anyways.
-				const parsedDigests = JSON.parse(digests);
-				if (!Array.isArray(parsedDigests)) {
-					// If it's not the format we expect, fall back to pushing
-					// since it's annoying but safe.
-					throw new Error(
-						`Expected RepoDigests from docker inspect to be an array but got ${JSON.stringify(parsedDigests)}`
-					);
-				}
-
-				const imageUrl = new URL(
-					`http://${resolveImageName(account.external_account_id, imageTag)}`
-				);
-				const repositoryOnly = `${imageUrl.host}${imageUrl.pathname.split(":")[0]}`;
-				logger.debug("respositoryOnly:", repositoryOnly);
-
-				// make sure the repository + name provided in wrangler config
-				// matches the repository + name from the digests
-				const digest = parsedDigests.find((d): d is string => {
-					const resolved = resolveImageName(account.external_account_id, d);
-					logger.debug(
-						`Comparing ${resolved.split("@")[0]} to ${repositoryOnly}`
-					);
-					return (
-						typeof d === "string" && resolved.split("@")[0] === repositoryOnly
-					);
-				});
-				if (!digest) {
-					throw new Error(
-						`Could not find a digest for the image ${repositoryOnly}. Found digests: ${parsedDigests.join(", ")}`
-					);
-				}
-				// Resolve the image name to include the user's
-				// account ID before checking if it exists in
-				// the managed registry.
-				const [image, hash] = digest.split("@");
-				const resolvedImage = resolveImageName(
+				// We don't try to parse until this point because we don't want to fail on
+				// parse errors if we won't be pushing the image anyways.
+				const remoteDigest = findRemoteDigest(
+					imageInfo,
 					account.external_account_id,
-					image
+					imageTag
 				);
-
-				const remoteDigest = `${resolvedImage}@${hash}`;
+				const [, hash] = remoteDigest.split("@");
 
 				// NOTE: this is an experimental docker command so the API may change
 				// and break this flow. Hopefully not!
@@ -242,6 +277,38 @@ export async function buildAndMaybePush(
 			);
 			await runDockerCmd(pathToDocker, ["tag", imageTag, namespacedImageTag]);
 			await runDockerCmd(pathToDocker, ["push", namespacedImageTag]);
+
+			let remoteDigest: string;
+			try {
+				const pushedImageInfo = await dockerImageInspect(pathToDocker, {
+					imageTag: namespacedImageTag,
+					formatString: "{{ json .RepoDigests }}",
+				});
+				remoteDigest = findRemoteDigest(
+					pushedImageInfo,
+					account.external_account_id,
+					namespacedImageTag
+				);
+			} catch (error) {
+				if (error instanceof Error) {
+					logger.debug(
+						`Inspecting pushed image ${namespacedImageTag} failed with error: ${error.message}`
+					);
+				}
+				const remoteManifest = runDockerCmdWithOutput(pathToDocker, [
+					"manifest",
+					"inspect",
+					"-v",
+					namespacedImageTag,
+				]);
+				remoteDigest = imageRefWithDigest(
+					account.external_account_id,
+					namespacedImageTag,
+					findManifestDigest(remoteManifest)
+				);
+			}
+
+			return { remoteDigest };
 		}
 
 		return { newTag: imageTag };

--- a/packages/wrangler/src/containers/deploy.ts
+++ b/packages/wrangler/src/containers/deploy.ts
@@ -3,6 +3,7 @@
  * However this code is only used for containers interactions, not cloudchamber ones!
  */
 import assert from "node:assert";
+import { setTimeout } from "node:timers/promises";
 import {
 	endSection,
 	log,
@@ -26,6 +27,7 @@ import {
 	RolloutsService,
 } from "@cloudflare/containers-shared";
 import {
+	APIError,
 	FatalError,
 	formatConfigSnippet,
 	getDockerPath,
@@ -101,7 +103,7 @@ export async function deployContainers(
 
 		// Only bound DOs are returned in version info. For unbound DOs, we need to list all DO namespaces.
 		if (boundDOs.has(container.class_name)) {
-			maybeVersionInfo ??= await fetchVersion(
+			maybeVersionInfo ??= await fetchUploadedVersion(
 				config,
 				accountId,
 				scriptName,
@@ -162,6 +164,29 @@ export async function deployContainers(
 			);
 		}
 	}
+}
+
+async function fetchUploadedVersion(
+	config: Config,
+	accountId: string,
+	scriptName: string,
+	versionId: string
+): Promise<ApiVersion> {
+	for (let attempt = 0; attempt < 5; attempt++) {
+		try {
+			return await fetchVersion(config, accountId, scriptName, versionId);
+		} catch (error) {
+			if (
+				!(error instanceof APIError) ||
+				error.code !== 100146 ||
+				attempt === 4
+			) {
+				throw error;
+			}
+			await setTimeout(500);
+		}
+	}
+	throw new Error("Unable to fetch uploaded Worker version");
 }
 
 type DurableObjectNamespace = {
@@ -381,12 +406,9 @@ export async function apply(
 		(app) => app.name === containerConfig.name
 	);
 
-	// if there is a remote digest, it indicates that the image already exists in the managed registry
-	// so we should try and use the tag from the previous deployment if possible.
-	// however deployments that fail after push may result in no previous app but the image still existing
 	const imageRef =
 		"remoteDigest" in args.imageRef
-			? (prevApp?.configuration.image ?? args.imageRef.remoteDigest)
+			? args.imageRef.remoteDigest
 			: args.imageRef.newTag;
 	log(dim("Container application changes\n"));
 


### PR DESCRIPTION
Snapshot-enabled container applications are rejected by Cloudchamber unless configuration.image is a registry reference pinned by digest. Wrangler still lets users configure Dockerfile-backed containers with image = "./Dockerfile", but after building and pushing the image it deployed the mutable tag, which fails validation when experimental_enable_snapshots is enabled.

Return a digest-pinned image reference from pushed Dockerfile builds and use it in container application deploys. Preserve the local tag path for non-pushed builds, keep registry image URI deploys unchanged, and fall back to docker manifest inspect when Docker does not expose RepoDigests after push.

This lets Dockerfile-based Wrangler configs continue to work for snapshot-enabled container apps while giving Cloudchamber the immutable image reference it requires.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [X] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: fixing a bug

*A picture of a cute animal (not mandatory, but encouraged)*
<img width="1024" height="768" alt="image" src="https://github.com/user-attachments/assets/015962fe-cb9a-49f9-8fc7-eb53814833b2" />
<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
