### PR TITLE
Bump ws to 8.21.0 to address GHSA-96hv-2xvq-fx4p

### DIFF
--- a/.changeset/bump-ws-8-21-0.md
+++ b/.changeset/bump-ws-8-21-0.md
@@ -1,0 +1,9 @@
+---
+"miniflare": patch
+"wrangler": patch
+"@cloudflare/vite-plugin": patch
+---
+
+Bump `ws` from 8.20.1 to 8.21.0 to address GHSA-96hv-2xvq-fx4p
+
+[GHSA-96hv-2xvq-fx4p](https://github.com/advisories/GHSA-96hv-2xvq-fx4p) / [CVE-2026-48779](https://www.cve.org/CVERecord?id=CVE-2026-48779) (high severity) reports a remote memory-exhaustion DoS in `ws@<8.21.0`: a peer sending a high volume of tiny fragments and data chunks over modest network traffic can crash a `ws` server or client via OOM. The fix shipped in [ws@8.21.0](https://github.com/websockets/ws/releases/tag/8.21.0) (commit `2b2abd45`, released 2026-05-22), which also introduces the `maxBufferedChunks` and `maxFragments` options. This change bumps the workspace catalog entry so that `miniflare`, `wrangler`, and `@cloudflare/vite-plugin` all pick up the patched release.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ catalogs:
       specifier: 4.1.0
       version: 4.1.0
     ws:
-      specifier: 8.20.1
-      version: 8.20.1
+      specifier: 8.21.0
+      version: 8.21.0
 
 overrides:
   '@types/react-dom@18>@types/react': ^18
@@ -2165,7 +2165,7 @@ importers:
         version: 1.20260617.1
       ws:
         specifier: catalog:default
-        version: 8.20.1
+        version: 8.21.0
       youch:
         specifier: 4.1.0-beta.10
         version: 4.1.0-beta.10(patch_hash=3e73fc48581841f22ea1d2cf5a3560bde280fdba04940253073fb121a70a9269)
@@ -2512,7 +2512,7 @@ importers:
         version: link:../wrangler
       ws:
         specifier: catalog:default
-        version: 8.20.1
+        version: 8.21.0
     devDependencies:
       '@cloudflare/config':
         specifier: workspace:*
@@ -4467,7 +4467,7 @@ importers:
         version: 0.4.0(vitest@4.1.0)
       ws:
         specifier: catalog:default
-        version: 8.20.1
+        version: 8.21.0
       xxhash-wasm:
         specifier: ^1.0.1
         version: 1.0.1
@@ -15399,8 +15399,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -27149,7 +27149,7 @@ snapshots:
 
   ws@8.18.0: {}
 
-  ws@8.20.1: {}
+  ws@8.21.0: {}
 
   wsl-utils@0.3.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -115,7 +115,7 @@ catalog:
   undici-types: "7.24.8"
   vitest: "4.1.0"
   vite: "8.0.13"
-  "ws": "8.20.1"
+  "ws": "8.21.0"
   esbuild: "0.28.1"
   playwright-chromium: "1.60.0"
   "@cloudflare/workers-types": "^4.20260617.1"


### PR DESCRIPTION
Bumps the `ws` catalog entry from 8.20.1 to 8.21.0 to fix [GHSA-96hv-2xvq-fx4p](https://github.com/advisories/GHSA-96hv-2xvq-fx4p) / [CVE-2026-48779](https://www.cve.org/CVERecord?id=CVE-2026-48779). A high-severity DoS where a flood of tiny frames can OOM-crash a `ws` server or client. Fixed upstream in [ws@8.21.0](https://github.com/websockets/ws/releases/tag/8.21.0).

The catalog bump updates the three packages that use `ws` via `catalog:default`: `miniflare`, `wrangler`, and `@cloudflare/vite-plugin`. Mirrors #13978, which did the same for an earlier advisory.

Changed: `pnpm-workspace.yaml`, `pnpm-lock.yaml` (`ws` entries), and a patch changeset.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: patch bump of `ws` (8.20.1 → 8.21.0); upstream notes it as a security fix with no behavior change, and miniflare's existing tests cover the WebSocket code path.
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: dependency bump only, nothing user-facing.

*A picture of a cute animal (not mandatory, but encouraged)*
🦒

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->