### PR TITLE
[ci] Update GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -20,7 +20,7 @@ runs:
   using: "composite"
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
     - name: Install Node.js ${{ inputs.node-version }} (with pnpm cache)
       if: inputs.disable-cache != 'true'

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -20,11 +20,11 @@ runs:
   using: "composite"
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+      uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
 
     - name: Install Node.js ${{ inputs.node-version }} (with pnpm cache)
       if: inputs.disable-cache != 'true'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: "pnpm"
@@ -32,7 +32,7 @@ runs:
 
     - name: Install Node.js ${{ inputs.node-version }} (without pnpm cache)
       if: inputs.disable-cache == 'true'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -69,7 +69,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           filters: |
@@ -119,7 +119,7 @@ jobs:
           "
       - name: Install matrix pnpm version for scaffolded installs
         if: matrix.pm.name == 'pnpm' && steps.changes.outputs.everything_but_markdown == 'true'
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
         with:
           version: ${{ matrix.pm.version }}
           package_json_file: .ci-pnpm-setup-stub/package.json
@@ -149,7 +149,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }} # Needed for begit to clone the repo in the e2e tests for solid-start
 
       - name: Upload Logs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() && steps.changes.outputs.everything_but_markdown == 'true' }}
         with:
           name: ${{ format('e2e-logs-{0}-{1}-{2}-{3}', matrix.pm.label, matrix.os.description, matrix.experimental && 'experimental' || 'normal', matrix.filter) }}
@@ -157,7 +157,7 @@ jobs:
           include-hidden-files: true
 
       - name: Upload Turbo Summary
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() && steps.changes.outputs.everything_but_markdown == 'true' }}
         with:
           name: ${{ format('turbo-runs-{0}-{1}-{2}-{3}', matrix.pm.label, matrix.os.description, matrix.experimental && 'experimental' || 'normal', matrix.filter) }}
@@ -199,7 +199,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           filters: |
@@ -267,7 +267,7 @@ jobs:
           "
       - name: Install matrix pnpm version for scaffolded installs
         if: matrix.pm.name == 'pnpm' && steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true'
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
         with:
           version: ${{ matrix.pm.version }}
           package_json_file: .ci-pnpm-setup-stub/package.json
@@ -295,7 +295,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Upload Logs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() && steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true' }}
         with:
           name: ${{ format('e2e-logs-{0}-{1}-{2}-frameworks', matrix.pm.label, matrix.os.description, matrix.experimental && 'experimental' || 'normal') }}
@@ -303,7 +303,7 @@ jobs:
           include-hidden-files: true
 
       - name: Upload Turbo Summary
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() && steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true' }}
         with:
           name: ${{ format('turbo-runs-{0}-{1}-{2}-frameworks', matrix.pm.label, matrix.os.description, matrix.experimental && 'experimental' || 'normal') }}

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -119,7 +119,7 @@ jobs:
           "
       - name: Install matrix pnpm version for scaffolded installs
         if: matrix.pm.name == 'pnpm' && steps.changes.outputs.everything_but_markdown == 'true'
-        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: ${{ matrix.pm.version }}
           package_json_file: .ci-pnpm-setup-stub/package.json
@@ -267,7 +267,7 @@ jobs:
           "
       - name: Install matrix pnpm version for scaffolded installs
         if: matrix.pm.name == 'pnpm' && steps.check-frameworks.outputs.run_frameworks == 'true' && steps.changes.outputs.everything_but_markdown == 'true'
-        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: ${{ matrix.pm.version }}
           package_json_file: .ci-pnpm-setup-stub/package.json

--- a/.github/workflows/changeset-review.yml
+++ b/.github/workflows/changeset-review.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Get changed changeset files
         id: changed-changesets
-        uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |
             .changeset/*.md
@@ -81,7 +81,7 @@ jobs:
 
       - name: Post review comment
         if: steps.opencode-review.outcome == 'success'
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3.0.3
         with:
           header: changeset-review
           path: changeset-review.md

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -72,7 +72,7 @@ jobs:
       # builds native modules (tree-sitter) that are not compatible with
       # Node 24's C++20 requirement for V8 headers.
       - name: Switch to Node 22 for non-npm package deployments
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
 

--- a/.github/workflows/deploy-previews.yml
+++ b/.github/workflows/deploy-previews.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: "Comment on PR with Devtools Link"
         if: contains(github.event.*.labels.*.name, 'preview:chrome-devtools-patches')
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff # v3.0.3
         with:
           header: chrome-devtools-preview
           message: |

--- a/.github/workflows/e2e-local-explorer-ui.yml
+++ b/.github/workflows/e2e-local-explorer-ui.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           filters: |
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload turbo logs
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: turbo-runs
           path: .turbo/runs

--- a/.github/workflows/e2e-vite.yml
+++ b/.github/workflows/e2e-vite.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           filters: |
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload turbo logs
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: turbo-runs-${{ matrix.os }}
           path: .turbo/runs

--- a/.github/workflows/e2e-wrangler.yml
+++ b/.github/workflows/e2e-wrangler.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           filters: |
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload turbo logs
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: turbo-runs-${{ matrix.os }}-shard-${{ matrix.shard }}
           path: .turbo/runs

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -13,28 +13,28 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/add-to-project@a9f041ddd462ed185893ea1024cec954f50dbe42 # v0.3.0
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/cloudflare/projects/1
           github-token: ${{ secrets.GH_ACCESS_TOKEN }}
           labeled: bug, enhancement
           label-operator: OR
-      - uses: actions/add-to-project@a9f041ddd462ed185893ea1024cec954f50dbe42 # v0.3.0
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/cloudflare/projects/2
           github-token: ${{ secrets.GH_ACCESS_TOKEN }}
           labeled: product:pages
-      - uses: actions/add-to-project@a9f041ddd462ed185893ea1024cec954f50dbe42 # v0.3.0
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/cloudflare/projects/6
           github-token: ${{ secrets.GH_ACCESS_TOKEN }}
           labeled: product:d1
-      - uses: actions/add-to-project@a9f041ddd462ed185893ea1024cec954f50dbe42 # v0.3.0
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/cloudflare/projects/12
           github-token: ${{ secrets.GH_ACCESS_TOKEN }}
           labeled: product:c3
-      - uses: actions/add-to-project@a9f041ddd462ed185893ea1024cec954f50dbe42 # v0.3.0
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/cloudflare/projects/8
           github-token: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/test-and-check-other-node.yml
+++ b/.github/workflows/test-and-check-other-node.yml
@@ -35,7 +35,7 @@ jobs:
           persist-credentials: false
 
       - name: Filter changed paths
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           filters: |
@@ -75,7 +75,7 @@ jobs:
       # the download to finish within their timeout window.
       - name: Restore Chrome browser cache (Browser Run)
         if: steps.should_run.outputs.result == 'true'
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: chrome-${{ runner.os }}-${{ hashFiles('packages/miniflare/src/plugins/browser-rendering/browser-version.ts') }}
           path: |

--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -52,7 +52,7 @@ jobs:
           NODE_OPTIONS: "--max_old_space_size=8192"
 
       - name: Filter changed paths
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           filters: |
@@ -70,7 +70,7 @@ jobs:
 
       # Check for old Node.js version warnings and errors
       - name: Use Node.js v20
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
 
@@ -111,7 +111,7 @@ jobs:
           persist-credentials: false
 
       - name: Filter changed paths
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           filters: |
@@ -141,7 +141,7 @@ jobs:
       # `fixtures`.
       - name: Restore Chrome browser cache (Browser Run)
         if: steps.changes.outputs.everything_but_markdown == 'true' && (matrix.suite == 'packages-and-tools' || (matrix.suite == 'fixtures' && matrix.os != 'ubuntu-latest'))
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           # The Chrome version lives in
           # `packages/miniflare/src/plugins/browser-rendering/browser-version.ts`.
@@ -192,7 +192,7 @@ jobs:
 
       - name: Upload turbo logs
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: turbo-runs-${{ matrix.os }}-${{ matrix.suite }}
           path: .turbo/runs

--- a/.github/workflows/validate-pr-description.yml
+++ b/.github/workflows/validate-pr-description.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           filters: |

--- a/.github/workflows/vite-plugin-playgrounds.yml
+++ b/.github/workflows/vite-plugin-playgrounds.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Filter changed paths
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           filters: |
@@ -94,7 +94,7 @@ jobs:
           CI_OS: ${{ matrix.os }}
       - name: Upload turbo logs
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: turbo-runs-${{ matrix.os }}-${{ matrix.vite }}
           path: .turbo/runs


### PR DESCRIPTION
Resolves the GitHub Actions Node.js 20 deprecation warning surfaced during the Wrangler E2E run:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/setup-node@v4`, `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02`, `dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36`, `pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061`. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

### Action upgrades

All actions are SHA-pinned with a `# vX.Y.Z` comment, per the workflow security policy in `.github/workflows/README.md`.

| Action | Old | New |
| --- | --- | --- |
| `actions/setup-node` | v4 (Node 20) | **v6.4.0** (Node 24) |
| `actions/upload-artifact` | v4 (Node 20) | **v7.0.1** (Node 24) |
| `dorny/paths-filter` | v3 (Node 20) | **v4.0.1** (Node 24) |
| `pnpm/action-setup` | v4 (Node 20) | **v6.0.9** (Node 24) |

While auditing the repo for similar issues, the following additional Node 20 (or older) actions were also updated:

| Action | Old | New |
| --- | --- | --- |
| `actions/cache` | v4 (Node 20) | **v5.0.5** (Node 24) |
| `tj-actions/changed-files` | v45 (Node 20) | **v47.0.6** (Node 24) |
| `marocchino/sticky-pull-request-comment` | v2 (Node 20) | **v3.0.3** (Node 24) |
| `actions/add-to-project` | v0.3.0 (Node 16) | **v1.0.2** (Node 20 — latest available) |

### Intentional Node-version pins preserved

Two workflow steps deliberately install older Node versions for a specific purpose; only the action runtime was upgraded, not the `node-version` input:

- `.github/workflows/test-and-check.yml` — keeps `node-version: 20` for the test that asserts Wrangler's old-Node warning message.
- `.github/workflows/changesets.yml` — keeps `node-version: 22` per the existing comment about tree-sitter / Node 24 C++20 incompatibility for the quick-edit deploy.

### Security policy fix

Two `actions/setup-node@v4` references in `.github/actions/install-dependencies/action.yml` were tag-pinned (not SHA-pinned). They are now SHA-pinned per `.github/workflows/README.md`.

### Follow-up

`Ana06/get-changed-files@v2.3.0` in `.github/workflows/validate-pr-description.yml` still targets Node 20. v2.3.0 is the latest release of that action — there is no Node 24 version available, so it has been left as-is for now and should eventually be replaced.

### Validation

- ✅ `pnpm prettify` produced no changes
- ✅ `pnpm check` — 187/187 tasks pass (lint, types, format)
- ✅ `zizmor .github/workflows/*.yml` — "No findings to report. Good job! (6 ignored, 176 suppressed)"

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: This change only bumps the pinned versions of GitHub Actions in CI workflows. There is no application code change; the workflows themselves will be exercised by CI as soon as this PR runs.
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Internal CI-only change with no user-facing or API impact.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->