### PR TITLE
Fix React Router template overriding newly released v8 dependencies

### DIFF
--- a/.changeset/wise-planets-stare.md
+++ b/.changeset/wise-planets-stare.md
@@ -2,4 +2,4 @@
 "create-cloudflare": patch
 ---
 
-Fix React Router template overriding newly released v8 dependencies
+Upgrade `create-react-router` to `8.0.0` and prevent React Router template overriding v8 dependencies

--- a/.changeset/wise-planets-stare.md
+++ b/.changeset/wise-planets-stare.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Fix React Router template overriding newly released v8 dependencies

--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -943,6 +943,7 @@ function getExperimentalFrameworkTestConfig(
 		},
 		{
 			name: "react-router",
+			quarantine: true,
 			unsupportedOSs: ["win32"],
 			testCommitMessage: true,
 			timeout: LONG_TIMEOUT,

--- a/packages/create-cloudflare/src/frameworks/package.json
+++ b/packages/create-cloudflare/src/frameworks/package.json
@@ -9,7 +9,7 @@
 		"create-hono": "0.19.4",
 		"create-next-app": "16.2.9",
 		"create-qwik": "1.20.0",
-		"create-react-router": "7.17.0",
+		"create-react-router": "8.0.0",
 		"create-rwsdk": "3.1.3",
 		"create-solid": "0.7.0",
 		"create-vike": "0.0.651",

--- a/packages/create-cloudflare/templates/react-router/c3.ts
+++ b/packages/create-cloudflare/templates/react-router/c3.ts
@@ -67,12 +67,6 @@ const config: TemplateConfig = {
 	generate,
 	configure,
 	transformPackageJson: async () => ({
-		dependencies: {
-			"react-router": "^7.10.0",
-		},
-		devDependencies: {
-			"@react-router/dev": "^7.10.0",
-		},
 		scripts: {
 			deploy: `${npm} run build && wrangler deploy`,
 			preview: `${npm} run build && vite preview`,


### PR DESCRIPTION
Upgrade `create-react-router` to `8.0.0` and prevent React Router template overriding v8 dependencies

The previous dependency overrides were introduced in https://github.com/cloudflare/workers-sdk/pull/11507 to ensure compatibility with a change in the configuration. This was unnecessary, however, as the template always uses the latest versions.

Note that I have also quarantined the experimental React Router C3 tests as auto-config requires additional changes.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: covered by existing tests
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
