### PR TITLE
Force the experimental new config on by default in the cf-vite dev delegate

### DIFF
--- a/.changeset/cf-vite-dev-force-build-output.md
+++ b/.changeset/cf-vite-dev-force-build-output.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Force the experimental Build Output API on by default in the `cf-vite dev` delegate
+
+`cf-vite dev` now sets `CLOUDFLARE_VITE_FORCE_BUILD_OUTPUT` before booting Vite, matching the behaviour of `cf-vite build`. This enables `experimental.newConfig` and `experimental.newConfig.cfBuildOutput` during development, so both commands of the experimental, internal delegate binary behave consistently.

--- a/.changeset/cf-vite-dev-force-build-output.md
+++ b/.changeset/cf-vite-dev-force-build-output.md
@@ -2,6 +2,4 @@
 "@cloudflare/vite-plugin": patch
 ---
 
-Force the experimental Build Output API on by default in the `cf-vite dev` delegate
-
-`cf-vite dev` now sets `CLOUDFLARE_VITE_FORCE_BUILD_OUTPUT` before booting Vite, matching the behaviour of `cf-vite build`. This enables `experimental.newConfig` and `experimental.newConfig.cfBuildOutput` during development, so both commands of the experimental, internal delegate binary behave consistently.
+Force the experimental new config on by default in the `cf-vite dev` delegate

--- a/packages/vite-plugin-cloudflare/AGENTS.md
+++ b/packages/vite-plugin-cloudflare/AGENTS.md
@@ -44,10 +44,11 @@ contract so the parent can drive either impl interchangeably.
   single-environment `build()` helper, which would skip the plugin's
   worker/build-output orchestration — mirrors Vite's own `vite build`
   CLI). It accepts **only `--mode`** (`--port`/`--host`/`--local` don't
-  apply to a build and exit `2`). It forces the experimental Build Output
-  API on by default by setting `CLOUDFLARE_VITE_FORCE_BUILD_OUTPUT`
-  (enabling `experimental.newConfig` +
-  `experimental.newConfig.cfBuildOutput`, overriding plugin config),
+  apply to a build and exit `2`).
+- **Build Output API forced for every verb.** `main()` sets
+  `CLOUDFLARE_VITE_FORCE_BUILD_OUTPUT` unconditionally (before Vite
+  loads the user's config), enabling `experimental.newConfig` +
+  `experimental.newConfig.cfBuildOutput` (overriding plugin config),
   which requires a `cloudflare.config.ts` at the project root. The env
   var name and read logic live in `build-output-env.ts`
   (`FORCE_BUILD_OUTPUT_ENV_VAR` / `isForcedBuildOutput()`), shared by the

--- a/packages/vite-plugin-cloudflare/src/cf-vite.ts
+++ b/packages/vite-plugin-cloudflare/src/cf-vite.ts
@@ -9,6 +9,11 @@
  * Unknown/missing verbs exit 2 (also the parent's version-detection
  * signal).
  *
+ * Every verb forces the experimental Build Output API on by default by
+ * setting `CLOUDFLARE_VITE_FORCE_BUILD_OUTPUT` in `main()` before Vite
+ * loads the user's config; the plugin reads it during config resolution
+ * to enable `experimental.newConfig` + `experimental.newConfig.cfBuildOutput`.
+ *
  * Spawn contract for `dev`: parent uses `stdio: "inherit"` and forwards
  * SIGINT/SIGTERM. Accepted flags mirror the sibling `cf-wrangler`
  * delegate (`--mode`, `--port`, `--host`, `--local`) so the parent can
@@ -21,11 +26,7 @@
  * `build` runs Vite's full multi-environment app build via
  * `createBuilder().buildApp()` (NOT the legacy single-environment
  * `build()` helper, which would skip the plugin's worker builds). It
- * accepts only `--mode` (the other shared flags don't apply to a build)
- * and forces the experimental Build Output API on by default by setting
- * `CLOUDFLARE_VITE_FORCE_BUILD_OUTPUT`, which the plugin reads during
- * config resolution to enable `experimental.newConfig` +
- * `experimental.newConfig.cfBuildOutput`.
+ * accepts only `--mode` (the other shared flags don't apply to a build).
  *
  * Exit codes: 0 graceful, 2 unknown verb / parse error, 130 SIGINT,
  * 143 SIGTERM.
@@ -127,6 +128,12 @@ async function main(): Promise<number> {
 	const verb = process.argv[2];
 	const userArgv = process.argv.slice(3);
 
+	// Force the experimental Build Output API on by default for every
+	// delegate verb. The plugin reads this during config resolution to
+	// enable `experimental.newConfig` + `.cfBuildOutput`. Set before Vite
+	// loads the user's `vite.config.ts`.
+	process.env[FORCE_BUILD_OUTPUT_ENV_VAR] = "true";
+
 	if (verb === "dev") {
 		return runDev(userArgv);
 	}
@@ -226,11 +233,6 @@ async function runBuild(userArgv: string[]): Promise<number> {
 		}
 		throw err;
 	}
-
-	// Force the experimental Build Output API on by default. The plugin
-	// reads this env var to enable `experimental.newConfig` and `experimental.newConfig.cfBuildOutput`.
-	// Must be set before the builder loads the user's `vite.config.ts`.
-	process.env[FORCE_BUILD_OUTPUT_ENV_VAR] = "true";
 
 	const inlineConfig: InlineConfig = {};
 	if (args.mode !== undefined) {


### PR DESCRIPTION
Force the experimental new config on by default in the `cf-vite dev` delegate

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: tested manually
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: experimental feature

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->