### PR TITLE
Verify Docker is installed and running before `wrangler containers build`

### DIFF
--- a/.changeset/verify-docker-before-build.md
+++ b/.changeset/verify-docker-before-build.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Verify Docker is installed and running before `wrangler containers build`
+
+Previously, running `wrangler containers build` without Docker installed or with the Docker daemon stopped would fail with an unhelpful spawn error. Now the command checks that Docker is reachable upfront and shows a clear, actionable error message with installation and troubleshooting steps.

--- a/packages/containers-shared/src/build.ts
+++ b/packages/containers-shared/src/build.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { UserError } from "@cloudflare/workers-utils";
+import { verifyDockerInstalled } from "./utils";
 import type {
 	BuildArgs,
 	ContainerDevOptions,
@@ -40,13 +41,37 @@ export async function constructBuildCommand(
 	return { buildCmd, dockerfile };
 }
 
-export function dockerBuild(
+/**
+ * Spawns a Docker build process and returns a handle to abort or await the build.
+ *
+ * By default this function first verifies that the Docker daemon is reachable.
+ * Callers that have already performed this check (e.g. the dev and deploy flows)
+ * should pass `verifyDockerIsRunning: false` to avoid a redundant check.
+ *
+ * @param dockerPath - Path to the Docker CLI executable.
+ * @param options - Build options including the command arguments and Dockerfile content.
+ * @param options.buildCmd - The Docker build command arguments.
+ * @param options.dockerfile - The Dockerfile content to pipe into stdin.
+ * @param options.verifyDockerIsRunning - When `true` (the default), verifies Docker is installed
+ *   and the daemon is running before spawning the build. Set to `false` to skip the check.
+ *
+ * @returns An object with an `abort` function and a `ready` promise.
+ */
+export async function dockerBuild(
 	dockerPath: string,
 	options: {
 		buildCmd: string[];
 		dockerfile: string;
+		verifyDockerIsRunning?: boolean;
 	}
-): { abort: () => void; ready: Promise<void> } {
+): Promise<{ abort: () => void; ready: Promise<void> }> {
+	if (options.verifyDockerIsRunning !== false) {
+		await verifyDockerInstalled({
+			dockerPath,
+			imageNoun: "the image",
+		});
+	}
+
 	let errorHandled = false;
 	let resolve: () => void;
 	let reject: (err: unknown) => void;
@@ -109,9 +134,21 @@ export function dockerBuild(
 	};
 }
 
+/**
+ * Builds a container image from the given container dev options.
+ *
+ * @param dockerPath - Path to the Docker CLI executable.
+ * @param options - Container configuration including the Dockerfile path, build context, and image tag.
+ * @param verifyDockerIsRunning - When `true` (the default), verifies Docker is installed
+ *   and the daemon is running before building. Set to `false` when the caller has already
+ *   performed this check.
+ *
+ * @returns An object with an `abort` function and a `ready` promise.
+ */
 export async function buildImage(
 	dockerPath: string,
-	options: Exclude<ContainerDevOptions, ImageURIConfig>
+	options: Exclude<ContainerDevOptions, ImageURIConfig>,
+	verifyDockerIsRunning?: boolean
 ) {
 	const { buildCmd, dockerfile } = await constructBuildCommand({
 		tag: options.image_tag,
@@ -121,5 +158,9 @@ export async function buildImage(
 		platform: "linux/amd64",
 	});
 
-	return dockerBuild(dockerPath, { buildCmd, dockerfile });
+	return dockerBuild(dockerPath, {
+		buildCmd,
+		dockerfile,
+		verifyDockerIsRunning,
+	});
 }

--- a/packages/containers-shared/src/images.ts
+++ b/packages/containers-shared/src/images.ts
@@ -127,11 +127,16 @@ export async function prepareContainerImagesForDev(args: {
 	}
 	await verifyDockerInstalled({
 		dockerPath,
-		numberOfContainers: containerOptions.length,
+		operation: "running dev",
+		imageNoun:
+			containerOptions.length !== 1
+				? "the configured images"
+				: "the configured image",
+		hint: "To suppress this error if you do not intend on triggering any container instances, set dev.enable_containers to false in your Wrangler config or pass --enable-containers=false.",
 	});
 	for (const options of containerOptions) {
 		if ("dockerfile" in options) {
-			const build = await buildImage(dockerPath, options);
+			const build = await buildImage(dockerPath, options, false);
 			onContainerImagePreparationStart({
 				containerOptions: options,
 				abort: () => {

--- a/packages/containers-shared/src/utils.ts
+++ b/packages/containers-shared/src/utils.ts
@@ -104,21 +104,26 @@ export const isDockerRunning = async (dockerPath: string) => {
 };
 
 /** Options for verifying that Docker is installed and the daemon is running. */
-type VerifyDockerInstalledOptions = {
+export type VerifyDockerInstalledOptions = {
 	/** Path to the Docker CLI executable. */
 	dockerPath: string;
-	/** The number of container images that need to be built. Used to pluralize the error message. */
-	numberOfContainers: number;
 	/**
-	 * Flag indicating whether the check is being run as part of `wrangler dev`.
-	 * @default true
+	 * Human-readable description of the operation that requires Docker,
+	 * e.g. `"running dev"`, `"deploying"`.
+	 * When provided, the error headline reads "... before ${operation} ...".
+	 * When omitted, the "before ..." clause is left out entirely.
 	 */
-	isDev?: boolean;
+	operation?: string;
 	/**
-	 * Flag indicating whether the check is being run as part of a dry-run execution.
-	 * @default false
+	 * Noun describing what needs to be built, used in the error headline.
+	 * For example `"the configured image"` or `"the configured images"`.
 	 */
-	isDryRun?: boolean;
+	imageNoun: string;
+	/**
+	 * Optional context-specific hint appended at the end of the error message.
+	 * When omitted, no hint paragraph is included.
+	 */
+	hint?: string;
 };
 
 /**
@@ -127,20 +132,25 @@ type VerifyDockerInstalledOptions = {
  * @throws {UserError} If the Docker CLI cannot be reached.
  *
  * @param options - Docker verification options.
+ * @param options.dockerPath - Path to the Docker CLI executable.
+ * @param options.operation - Optional human-readable operation description for the error message
+ *   headline. When provided, produces "before ${operation}". When omitted, the clause is skipped.
+ * @param options.imageNoun - Noun describing what needs to be built (e.g. "the configured image").
+ * @param options.hint - Optional context-specific hint appended to the error message.
  */
 export const verifyDockerInstalled = async ({
 	dockerPath,
-	numberOfContainers,
-	isDev = true,
-	isDryRun = false,
+	operation,
+	imageNoun,
+	hint,
 }: VerifyDockerInstalledOptions) => {
 	const dockerIsRunning = await isDockerRunning(dockerPath);
 	if (!dockerIsRunning) {
 		throw new UserError(
 			getFailedToRunDockerErrorMessage({
-				numberOfContainers,
-				isDev,
-				isDryRun,
+				operation,
+				imageNoun,
+				hint,
 			}),
 			{
 				telemetryMessage: false,
@@ -152,20 +162,20 @@ export const verifyDockerInstalled = async ({
 /**
  * Builds the user-facing error message shown when Docker cannot be reached.
  *
- * @param options - Docker verification options.
+ * @param options - Options controlling the error message content.
+ * @param options.operation - Optional human-readable operation description for the headline.
+ * @param options.imageNoun - Noun describing what needs to be built.
+ * @param options.hint - Optional context-specific hint paragraph.
  *
  * @returns The formatted error message string.
  */
 function getFailedToRunDockerErrorMessage({
-	numberOfContainers,
-	isDev,
-	isDryRun,
+	operation,
+	imageNoun,
+	hint,
 }: Omit<VerifyDockerInstalledOptions, "dockerPath">): string {
-	const operation = isDev
-		? "running dev"
-		: `deploying${isDryRun ? " (even in dry-run mode)" : ""}`;
-
-	const headline = `The Docker CLI is needed to build the configured ${numberOfContainers !== 1 ? "images" : "image"} before ${operation} but could not be launched.`;
+	const beforeOperation = operation ? ` before ${operation}` : "";
+	const headline = `The Docker CLI is needed to build ${imageNoun}${beforeOperation} but could not be launched.`;
 
 	let daemonHint: string;
 	if (process.platform === "darwin") {
@@ -185,11 +195,12 @@ function getFailedToRunDockerErrorMessage({
 	const alternatives =
 		"Note: Other container tooling that is compatible with the Docker CLI and engine may work, but is not yet guaranteed to do so.";
 
-	const hint = isDev
-		? "To suppress this error if you do not intend on triggering any container instances, set dev.enable_containers to false in your Wrangler config or pass --enable-containers=false."
-		: "If you cannot run Docker locally, you can still deploy your Worker by passing --containers-rollout=none. This will not deploy or update your Container.";
+	let message = `${headline}\n${steps}\n\n${alternatives}`;
+	if (hint) {
+		message += `\n\n${hint}`;
+	}
 
-	return `${headline}\n${steps}\n\n${alternatives}\n\n${hint}`;
+	return message;
 }
 
 /**

--- a/packages/containers-shared/tests/build.test.ts
+++ b/packages/containers-shared/tests/build.test.ts
@@ -1,0 +1,87 @@
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { beforeEach, describe, it, vi } from "vitest";
+import { dockerBuild } from "../src/build";
+
+vi.mock("node:child_process");
+vi.mock("node:fs");
+
+/**
+ * Creates a fake child process that emits a `close` event with the given exit code.
+ *
+ * @param exitCode - The exit code the fake process should emit.
+ * @returns A minimal child-process-like object accepted by `spawn` callers.
+ */
+function createFakeChildProcess(exitCode: number): ReturnType<typeof spawn> {
+	const emitter = new EventEmitter();
+	// Simulate async close so listeners are registered before the event fires.
+	process.nextTick(() => emitter.emit("close", exitCode));
+	return Object.assign(emitter, {
+		pid: 1234,
+		stdin: null,
+		unref: vi.fn(),
+	}) as unknown as ReturnType<typeof spawn>;
+}
+
+describe("dockerBuild", () => {
+	beforeEach(() => {
+		vi.mocked(spawn).mockReset();
+	});
+
+	it("throws a clear error without 'before building' when Docker is not running", async ({
+		expect,
+	}) => {
+		// The first spawn call is for `docker info` (the verification check).
+		// Return a fake process that exits with code 1 to simulate Docker not running.
+		vi.mocked(spawn).mockReturnValue(createFakeChildProcess(1));
+
+		try {
+			await dockerBuild("docker", {
+				buildCmd: ["build", "-t", "test"],
+				dockerfile: "FROM node:18",
+			});
+			expect.unreachable("Expected dockerBuild to throw");
+		} catch (error) {
+			const message = (error as Error).message;
+			expect(message).toContain(
+				"The Docker CLI is needed to build the image but could not be launched."
+			);
+			expect(message).not.toContain("before building");
+		}
+	});
+
+	it("skips Docker verification when verifyDockerIsRunning is false", async ({
+		expect,
+	}) => {
+		const fakeProcess = new EventEmitter();
+		const fakeStdin = { write: vi.fn(), end: vi.fn() };
+		Object.assign(fakeProcess, {
+			pid: 1234,
+			stdin: fakeStdin,
+			unref: vi.fn(),
+		});
+		vi.mocked(spawn).mockReturnValue(
+			fakeProcess as unknown as ReturnType<typeof spawn>
+		);
+
+		const resultPromise = dockerBuild("docker", {
+			buildCmd: ["build", "-t", "test"],
+			dockerfile: "FROM node:18",
+			verifyDockerIsRunning: false,
+		});
+
+		// The promise should resolve without calling docker info first.
+		// spawn should only be called once (for the actual build, not for docker info).
+		expect(spawn).toHaveBeenCalledTimes(1);
+		expect(spawn).toHaveBeenCalledWith(
+			"docker",
+			["build", "-t", "test"],
+			expect.any(Object)
+		);
+
+		// Simulate successful build
+		process.nextTick(() => fakeProcess.emit("exit", 0));
+		const result = await resultPromise;
+		await result.ready;
+	});
+});

--- a/packages/containers-shared/tests/utils.test.ts
+++ b/packages/containers-shared/tests/utils.test.ts
@@ -1,6 +1,11 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
 import { beforeEach, describe, it, vi } from "vitest";
-import { checkExposedPorts, cleanupDuplicateImageTags } from "./../src/utils";
+import {
+	checkExposedPorts,
+	cleanupDuplicateImageTags,
+	verifyDockerInstalled,
+} from "./../src/utils";
 import type { ContainerDevOptions } from "../src/types";
 
 let docketImageInspectResult = "0";
@@ -88,6 +93,130 @@ describe("cleanupDuplicateImageTags", () => {
 			"docker",
 			["rmi", "cloudflare-dev/egresstestcontainer:build-122"],
 			{ encoding: "utf8" }
+		);
+	});
+});
+
+/**
+ * Creates a fake child process that emits a `close` event with the given exit code.
+ *
+ * @param exitCode - The exit code the fake process should emit.
+ * @returns A minimal child-process-like object accepted by `runDockerCmd`.
+ */
+function createFakeChildProcess(exitCode: number): ReturnType<typeof spawn> {
+	const emitter = new EventEmitter();
+	// Simulate async close so listeners are registered before the event fires.
+	process.nextTick(() => emitter.emit("close", exitCode));
+	return Object.assign(emitter, {
+		pid: 1234,
+		stdin: null,
+		unref: vi.fn(),
+	}) as unknown as ReturnType<typeof spawn>;
+}
+
+describe("verifyDockerInstalled", () => {
+	beforeEach(() => {
+		vi.mocked(spawn).mockReset();
+	});
+
+	it("does not throw when Docker is running", async ({ expect }) => {
+		vi.mocked(spawn).mockReturnValue(createFakeChildProcess(0));
+
+		await expect(
+			verifyDockerInstalled({
+				dockerPath: "docker",
+				imageNoun: "the image",
+			})
+		).resolves.toBeUndefined();
+	});
+
+	it("throws a UserError with the correct headline when Docker is not running", async ({
+		expect,
+	}) => {
+		vi.mocked(spawn).mockReturnValue(createFakeChildProcess(1));
+
+		await expect(
+			verifyDockerInstalled({
+				dockerPath: "docker",
+				operation: "running dev",
+				imageNoun: "the configured image",
+			})
+		).rejects.toThrowError(
+			/The Docker CLI is needed to build the configured image before running dev but could not be launched/
+		);
+	});
+
+	it("omits the 'before ...' clause when no operation is provided", async ({
+		expect,
+	}) => {
+		vi.mocked(spawn).mockReturnValue(createFakeChildProcess(1));
+
+		await expect(
+			verifyDockerInstalled({
+				dockerPath: "docker",
+				imageNoun: "the image",
+			})
+		).rejects.toThrowError(
+			/The Docker CLI is needed to build the image but could not be launched/
+		);
+	});
+
+	it("includes the hint in the error message when provided", async ({
+		expect,
+	}) => {
+		vi.mocked(spawn).mockReturnValue(createFakeChildProcess(1));
+
+		await expect(
+			verifyDockerInstalled({
+				dockerPath: "docker",
+				operation: "running dev",
+				imageNoun: "the configured images",
+				hint: "Set enable_containers to false.",
+			})
+		).rejects.toThrowError(/Set enable_containers to false\./);
+	});
+
+	it("omits the hint paragraph when no hint is provided", async ({
+		expect,
+	}) => {
+		vi.mocked(spawn).mockReturnValue(createFakeChildProcess(1));
+
+		try {
+			await verifyDockerInstalled({
+				dockerPath: "docker",
+				operation: "deploying",
+				imageNoun: "the configured image",
+			});
+			// Should not reach here
+			expect.unreachable("Expected verifyDockerInstalled to throw");
+		} catch (error) {
+			const message = (error as Error).message;
+			expect(message).toContain(
+				"The Docker CLI is needed to build the configured image before deploying but could not be launched."
+			);
+			expect(message).toContain("To fix this, try the following:");
+			expect(message).toContain(
+				"Note: Other container tooling that is compatible with the Docker CLI and engine may work"
+			);
+			// The message should end after the alternatives section -- no trailing hint.
+			expect(message).not.toContain("To suppress this error");
+			expect(message).not.toContain("--containers-rollout=none");
+		}
+	});
+
+	it("uses the correct operation and image noun in the error headline", async ({
+		expect,
+	}) => {
+		vi.mocked(spawn).mockReturnValue(createFakeChildProcess(1));
+
+		await expect(
+			verifyDockerInstalled({
+				dockerPath: "docker",
+				operation: "deploying (even in dry-run mode)",
+				imageNoun: "the configured images",
+			})
+		).rejects.toThrowError(
+			/The Docker CLI is needed to build the configured images before deploying \(even in dry-run mode\) but could not be launched/
 		);
 	});
 });

--- a/packages/deploy-helpers/src/deploy/deploy.ts
+++ b/packages/deploy-helpers/src/deploy/deploy.ts
@@ -114,7 +114,8 @@ export type DeployCallbacks = {
 				containerConfig: Exclude<ContainerNormalizedConfig, ImageURIConfig>,
 				imageTag: string,
 				dryRun: boolean,
-				pathToDocker: string
+				pathToDocker: string,
+				verifyDockerIsRunning: boolean
 		  ) => Promise<unknown>)
 		| undefined;
 	deployContainers:
@@ -502,9 +503,12 @@ export default async function deploy(
 		if (containersWithDockerfile.length > 0) {
 			await verifyDockerInstalled({
 				dockerPath,
-				isDev: false,
-				isDryRun,
-				numberOfContainers: containersWithDockerfile.length,
+				operation: `deploying${isDryRun ? " (even in dry-run mode)" : ""}`,
+				imageNoun:
+					containersWithDockerfile.length !== 1
+						? "the configured images"
+						: "the configured image",
+				hint: "If you cannot run Docker locally, you can still deploy your Worker by passing --containers-rollout=none. This will not deploy or update your Container.",
 			});
 		}
 	}
@@ -521,7 +525,8 @@ export default async function deploy(
 						container,
 						workerTag ?? "worker-tag",
 						isDryRun,
-						dockerPath
+						dockerPath,
+						false
 					);
 				}
 			}

--- a/packages/wrangler/src/__tests__/cloudchamber/build.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/build.test.ts
@@ -21,7 +21,10 @@ vi.mock("@cloudflare/containers-shared", async (importOriginal) => {
 		dockerLoginImageRegistry: vi.fn(),
 		runDockerCmd: vi.fn(),
 		runDockerCmdWithOutput: vi.fn(),
-		dockerBuild: vi.fn(() => ({ abort: () => {}, ready: Promise.resolve() })),
+		dockerBuild: vi.fn(async () => ({
+			abort: () => {},
+			ready: Promise.resolve(),
+		})),
 		dockerImageInspect: vi.fn(),
 	});
 });
@@ -559,7 +562,7 @@ describe("buildAndMaybePush", () => {
 
 	it("should throw UserError when docker build fails", async ({ expect }) => {
 		const errorMessage = "Docker build failed";
-		vi.mocked(dockerBuild).mockReturnValue({
+		vi.mocked(dockerBuild).mockResolvedValue({
 			abort: () => {},
 			ready: Promise.reject(new Error(errorMessage)),
 		});

--- a/packages/wrangler/src/cloudchamber/build.ts
+++ b/packages/wrangler/src/cloudchamber/build.ts
@@ -165,11 +165,24 @@ function findRemoteDigest(
 	return imageRefWithDigest(externalAccountId, imageTag, hash);
 }
 
+/**
+ * Builds a Docker image and optionally pushes it to the Cloudflare managed registry.
+ *
+ * @param args - Build arguments including tag, Dockerfile path, build context, and platform.
+ * @param pathToDocker - Path to the Docker CLI executable.
+ * @param push - Whether to push the built image to the remote registry.
+ * @param containerConfig - Optional container configuration for limit validation.
+ * @param verifyDockerIsRunning - When `true` (the default), verifies Docker is installed and the
+ *   daemon is running before building. Set to `false` when the caller has already performed this check.
+ *
+ * @returns An {@link ImageRef} describing the built/pushed image.
+ */
 export async function buildAndMaybePush(
 	args: BuildArgs,
 	pathToDocker: string,
 	push: boolean,
-	containerConfig?: Exclude<ContainerNormalizedConfig, ImageURIConfig>
+	containerConfig?: Exclude<ContainerNormalizedConfig, ImageURIConfig>,
+	verifyDockerIsRunning?: boolean
 ): Promise<ImageRef> {
 	try {
 		const imageTag = args.tag;
@@ -185,10 +198,12 @@ export async function buildAndMaybePush(
 			logger
 		);
 
-		await dockerBuild(pathToDocker, {
+		const build = await dockerBuild(pathToDocker, {
 			buildCmd,
 			dockerfile,
-		}).ready;
+			verifyDockerIsRunning,
+		});
+		await build.ready;
 
 		if (push) {
 			/**

--- a/packages/wrangler/src/containers/build.ts
+++ b/packages/wrangler/src/containers/build.ts
@@ -95,7 +95,8 @@ export async function buildContainer(
 	/** just the tag component. will be prefixed with the container name */
 	imageTag: string,
 	dryRun: boolean,
-	pathToDocker: string
+	pathToDocker: string,
+	verifyDockerIsRunning?: boolean
 ): Promise<ImageRef> {
 	const imageFullName = containerConfig.name + ":" + imageTag.split("-")[0];
 	logger.log("Building image", imageFullName);
@@ -109,6 +110,7 @@ export async function buildContainer(
 		},
 		pathToDocker,
 		!dryRun,
-		containerConfig
+		containerConfig,
+		verifyDockerIsRunning
 	);
 }

--- a/packages/wrangler/src/containers/deploy.ts
+++ b/packages/wrangler/src/containers/deploy.ts
@@ -95,7 +95,8 @@ export async function deployContainers(
 				container,
 				versionId,
 				false, // dry runs will have already exited by this point
-				pathToDocker
+				pathToDocker,
+				false
 			);
 		} else {
 			imageRef = { newTag: container.image_uri };


### PR DESCRIPTION
Right now running `wrangler containers build` without the docker daemon running results in a non super helpful error message:
```
ERROR: Cannot connect to the Docker daemon at unix:///Users/dario/.docker/run/docker.sock. Is the docker daemon running?

✘ [ERROR] Docker build exited with code: 1
```

I'm updating it here to present the same helpful and actionable error message we get for dev and deploy instead:
```
✘ [ERROR] The Docker CLI is needed to build the image but could not be launched.

  To fix this, try the following:
    - If Docker is not installed, download it from https://docs.docker.com/get-started/get-docker/
    - If Docker is installed but the daemon is not running,
      open the Docker Desktop app or run `open -a Docker`.
    - If you use an alternative Docker-compatible CLI (e.g. Podman),
      set the WRANGLER_DOCKER_BIN environment variable to its path and DOCKER_HOST to its socket.
  
  Note: Other container tooling that is compatible with the Docker CLI and engine may work, but is
  not yet guaranteed to do so.
```

___

| Before | After |
|--------|--------|
| <img width="1008" height="211" alt="Screenshot of the error message before the changes" src="https://github.com/user-attachments/assets/3b5d24ee-48af-4a29-87cd-d8f10af5271b" />  | <img width="857" height="371" alt="Screenshot of the error message after the changes" src="https://github.com/user-attachments/assets/dc3d94ac-bf9e-4a83-8e83-a82ba188a0e4" /> | 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: better error message

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
