### PR TITLE
move auto provisioning to deploy-helpers

### DIFF
--- a/.changeset/deploy-helpers-provision-bindings.md
+++ b/.changeset/deploy-helpers-provision-bindings.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/deploy-helpers": patch
+---
+
+Move resource provisioning into deploy helpers
+
+Worker deploy and versions upload now share the deploy helpers implementation for provisioning bindings, reducing Wrangler-specific callback wiring while preserving existing behavior.

--- a/packages/deploy-helpers/src/deploy/deploy.ts
+++ b/packages/deploy-helpers/src/deploy/deploy.ts
@@ -626,7 +626,10 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 				accountId,
 				scriptName,
 				props.experimentalAutoCreate,
-				config
+				config,
+				{
+					skipConfigWriteback: props.skipProvisioningConfigWriteback,
+				}
 			);
 		}
 

--- a/packages/deploy-helpers/src/deploy/deploy.ts
+++ b/packages/deploy-helpers/src/deploy/deploy.ts
@@ -46,6 +46,7 @@ import { verifyWorkerMatchesCITag } from "./helpers/match-tag";
 import { parseBulkInputToObject } from "./helpers/parse-bulk-input";
 import { parseConfigPlacement } from "./helpers/placement";
 import { printBindings } from "./helpers/print-bindings";
+import { provisionBindings } from "./helpers/provision-bindings";
 import {
 	addRequiredSecretsInheritBindings,
 	handleMissingSecretsError,
@@ -74,7 +75,6 @@ import type {
 	ImageURIConfig,
 } from "@cloudflare/containers-shared";
 import type {
-	Binding,
 	CfModule,
 	CfWorkerInit,
 	ComplianceConfig,
@@ -103,16 +103,6 @@ export type DeployCallbacks = {
 				manifest: { [filePath: string]: string } | undefined;
 				namespace: string | undefined;
 		  }>)
-		| undefined;
-	provisionBindings:
-		| ((
-				bindings: Record<string, Binding>,
-				accountId: string,
-				scriptName: string,
-				autoCreate: boolean,
-				config: Config,
-				requireRemote?: boolean
-		  ) => Promise<void>)
 		| undefined;
 	getNormalizedContainerOptions:
 		| ((
@@ -630,8 +620,8 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 		if (assetsOptions?.routerConfig.has_user_worker === false) {
 			logger.debug("skipping provisioning on assets-only project");
-		} else if (props.resourcesProvision && callbacks.provisionBindings) {
-			await callbacks.provisionBindings(
+		} else if (props.resourcesProvision) {
+			await provisionBindings(
 				bindings ?? {},
 				accountId,
 				scriptName,

--- a/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
@@ -86,6 +86,8 @@ abstract class ProvisionResourceHandler<
 		public accountId: string
 	) {}
 
+	// Does this resource already exist in the currently deployed version of the Worker?
+	// If it does, that means we can inherit from it.
 	abstract canInherit(
 		settings: Settings | undefined
 	): boolean | Promise<boolean>;
@@ -108,22 +110,34 @@ abstract class ProvisionResourceHandler<
 		this.connect(id);
 	}
 
+	// This binding is fully specified and can't/shouldn't be provisioned.
+	// This is usually when it has an id (e.g. D1 `database_id`).
 	isFullySpecified(): boolean {
 		return false;
 	}
 
+	// Does this binding need to be provisioned?
+	// Some bindings are not fully specified, but don't need provisioning
+	// (e.g. R2 binding, with a bucket_name that already exists).
 	async isConnectedToExistingResource(): Promise<boolean | string> {
 		return false;
 	}
 
+	// Should this resource be provisioned?
 	async shouldProvision(settings: Settings | undefined) {
+		// If the resource is fully specified, don't provision.
 		if (!this.isFullySpecified()) {
+			// If we can inherit, do that and don't provision.
 			if (await this.canInherit(settings)) {
 				this.inherit();
 			} else {
+				// If the resource is connected to a remote resource that _exists_
+				// (see comments on the individual functions for why this is different to isFullySpecified()).
 				const connected = await this.isConnectedToExistingResource();
 				if (connected) {
 					if (typeof connected === "string") {
+						// Basically a special case for D1: the resource is specified by name in config
+						// and exists, but needs to be specified by ID for the first deploy to work.
 						this.connect(connected);
 					}
 					return false;
@@ -169,10 +183,20 @@ class R2Handler extends ProvisionResourceHandler<
 		);
 	}
 
+	/**
+	 * Inheriting an R2 binding replaces the id property (bucket_name for R2) with the inheritance symbol.
+	 * This works when deploying (and is appropriate for all other binding types), but it means that the
+	 * bucket_name for an R2 bucket is not displayed when deploying. As such, only use the inheritance symbol
+	 * if the R2 binding has no `bucket_name`.
+	 */
 	override inherit(): void {
 		this.binding.bucket_name ??= INHERIT_SYMBOL;
 	}
 
+	/**
+	 * R2 bindings can be inherited if the binding name and jurisdiction match.
+	 * Additionally, if the user has specified a bucket_name in config, make sure that matches.
+	 */
 	canInherit(settings: Settings | undefined): boolean {
 		return !!settings?.bindings.find(
 			(existing) =>
@@ -187,6 +211,7 @@ class R2Handler extends ProvisionResourceHandler<
 	async isConnectedToExistingResource(): Promise<boolean> {
 		assert(typeof this.binding.bucket_name !== "symbol");
 
+		// If the user hasn't specified a bucket_name in config, we always provision.
 		if (!this.binding.bucket_name) {
 			return false;
 		}
@@ -197,12 +222,15 @@ class R2Handler extends ProvisionResourceHandler<
 				this.binding.bucket_name,
 				this.binding.jurisdiction
 			);
+			// This bucket_name exists! We don't need to provision it.
 			return true;
 		} catch (e) {
 			if (!(e instanceof APIError && e.code === 10006)) {
+				// This is an error that is not "bucket not found", so we do want to throw.
 				throw e;
 			}
 
+			// This bucket_name doesn't exist, so let's provision.
 			return false;
 		}
 	}
@@ -397,11 +425,15 @@ class D1Handler extends ProvisionResourceHandler<
 			(existing) =>
 				existing.type === this.type && existing.name === this.bindingName
 		) as Extract<WorkerMetadataBinding, { type: "d1" }> | undefined;
+		// A D1 binding with the same binding name exists is already present on the worker...
 		if (maybeInherited) {
+			// ...and the user hasn't specified a name in their config, so we don't need to check if the database_name matches.
 			if (!this.binding.database_name) {
 				return true;
 			}
 
+			// ...and the user HAS specified a name in their config, so we need to check if the database_name they provided
+			// matches the database_name of the existing binding (which isn't present in settings, so we'll need to make an API call to check).
 			const dbFromId = await getDatabaseInfoFromIdOrName(
 				this.complianceConfig,
 				this.accountId,
@@ -416,6 +448,7 @@ class D1Handler extends ProvisionResourceHandler<
 	async isConnectedToExistingResource(): Promise<boolean | string> {
 		assert(typeof this.binding.database_name !== "symbol");
 
+		// If the user hasn't specified a database_name in config, we always provision.
 		if (!this.binding.database_name) {
 			return false;
 		}
@@ -426,12 +459,15 @@ class D1Handler extends ProvisionResourceHandler<
 				this.binding.database_name
 			);
 
+			// This database_name exists! We don't need to provision it.
 			return db.uuid;
 		} catch (e) {
 			if (!(e instanceof APIError && e.code === 7404)) {
+				// This is an error that is not "database not found", so we do want to throw.
 				throw e;
 			}
 
+			// This database_name doesn't exist, so let's provision.
 			return false;
 		}
 	}
@@ -530,6 +566,8 @@ const HANDLERS = {
 		keyDescription: "namespace name",
 		configField: "ai_search_namespaces" as const,
 		load: async (_complianceConfig: ComplianceConfig, _accountId: string) => {
+			// AI Search namespaces don't have a general list API in this context.
+			// The provisioning system will create them if they don't exist.
 			return [];
 		},
 		toConfig: (
@@ -550,6 +588,15 @@ const HANDLERS = {
 		keyDescription: "namespace name",
 		configField: "agent_memory" as const,
 		load: async (_complianceConfig: ComplianceConfig, _accountId: string) => {
+			// `load` only populates the interactive picker in `runProvisioningFlow`
+			// (the "Would you like to connect an existing X or create a new one?"
+			// prompt). For agent_memory, `namespace` is required in config — so
+			// `handler.name` is always set at provision time and `runProvisioningFlow`
+			// goes straight to the "Resource name found in config" branch without
+			// ever consulting this list. Whether or not the namespace already exists
+			// is decided by `isConnectedToExistingResource()` (which hits the GET
+			// /namespaces/:name endpoint), not by this list. Returning [] is
+			// therefore safe and avoids an unnecessary list call at deploy time.
 			return [];
 		},
 		toConfig: (
@@ -760,6 +807,9 @@ export async function provisionBindings(
 		const isUsingRedirectedConfig =
 			config.userConfigPath && config.userConfigPath !== config.configPath;
 
+		// If we're using a redirected config, then the redirected config potentially has injected
+		// bindings that weren't originally in the user config. These can be provisioned, but we
+		// should not write the IDs back to the user config file (because the bindings weren't there in the first place).
 		if (isUsingRedirectedConfig) {
 			const { rawConfig: unredirectedConfig } =
 				await experimental_readRawConfig(
@@ -781,6 +831,7 @@ export async function provisionBindings(
 				continue;
 			}
 
+			// See above for why we skip writing back some bindings to the config file.
 			if (isUsingRedirectedConfig && !existingBindingNames.has(bindingName)) {
 				continue;
 			}
@@ -794,12 +845,17 @@ export async function provisionBindings(
 			(patch[resourceType] as unknown as Array<Record<string, string>>).push(
 				Object.fromEntries(
 					Object.entries(bindingToWrite).filter(
+						// Make sure all the values are JSON serialisable.
+						// Otherwise we end up with "undefined" in the config.
 						([_, value]) => typeof value === "string"
 					)
 				)
 			);
 		}
 
+		// If the user is performing an interactive deploy, write the provisioned IDs back to the config file.
+		// This is not necessary, as future deploys can use inherited resources, but it can help with
+		// portability of the config file, and adds robustness to bindings being renamed.
 		if (!isNonInteractiveOrCI()) {
 			try {
 				await experimental_patchConfig(configPath, patch, false);
@@ -807,6 +863,7 @@ export async function provisionBindings(
 					"Your Worker was deployed with provisioned resources. We've written the IDs of these resources to your config file, which you can choose to save or discard. Either way future deploys will continue to work."
 				);
 			} catch (e) {
+				// no-op — if the user is using TOML config we can't update it.
 				if (!(e instanceof PatchConfigError)) {
 					throw e;
 				}
@@ -833,7 +890,9 @@ function printDivider() {
 }
 
 type NormalisedResourceInfo = {
+	/** The name of the resource */
 	title: string;
+	/** The id of the resource */
 	value: string;
 };
 
@@ -847,6 +906,7 @@ async function runProvisioningFlow(
 	const NEW_OPTION_VALUE = "__WRANGLER_INTERNAL_NEW";
 	const SEARCH_OPTION_VALUE = "__WRANGLER_INTERNAL_SEARCH";
 	const MAX_OPTIONS = 4;
+	// NB preExisting does not actually contain all resources on the account - we max out at ~30 d1 databases, ~100 kv, and ~20 r2.
 	const options = preExisting.slice(0, MAX_OPTIONS - 1);
 	if (options.length < preExisting.length) {
 		options.push({
@@ -893,6 +953,7 @@ async function runProvisioningFlow(
 			logger.log(`🌀 Creating new ${friendlyBindingName} "${name}"...`);
 			await item.handler.provision(name);
 		} else if (action === SEARCH_OPTION_VALUE) {
+			// Search through pre-existing resources that weren't listed.
 			let foundResource: NormalisedResourceInfo | undefined;
 			while (foundResource === undefined) {
 				const input = await prompt(
@@ -918,6 +979,9 @@ async function runProvisioningFlow(
 	printDivider();
 }
 
+/**
+ * The resource name that auto-provisioning will create for a given binding.
+ */
 function autoProvisionedResourceName(
 	scriptName: string,
 	bindingName: string
@@ -925,6 +989,11 @@ function autoProvisionedResourceName(
 	return `${scriptName}-${bindingName.toLowerCase().replaceAll("_", "-")}`;
 }
 
+/**
+ * Create a new KV namespace under the given `accountId` with the given `title`.
+ *
+ * @returns the generated id of the created namespace.
+ */
 async function createKVNamespace(
 	complianceConfig: ComplianceConfig,
 	accountId: string,
@@ -947,6 +1016,9 @@ async function createKVNamespace(
 	return response.id;
 }
 
+/**
+ * Fetch a list of all KV namespaces under the given `accountId`.
+ */
 async function listKVNamespaces(
 	complianceConfig: ComplianceConfig,
 	accountId: string,
@@ -1062,6 +1134,9 @@ async function getDatabaseInfoFromIdOrName(
 	);
 }
 
+/**
+ * Fetch a list of all R2 buckets under the given `accountId`.
+ */
 async function listR2Buckets(
 	complianceConfig: ComplianceConfig,
 	accountId: string,
@@ -1097,6 +1172,12 @@ async function getR2Bucket(
 	);
 }
 
+/**
+ * Create an R2 bucket with the given `bucketName` within the account given by `accountId`.
+ *
+ * A 400 is returned if the account already owns a bucket with this name.
+ * A bucket must be explicitly deleted to be replaced.
+ */
 async function createR2Bucket(
 	complianceConfig: ComplianceConfig,
 	accountId: string,
@@ -1124,6 +1205,10 @@ async function createR2Bucket(
 	);
 }
 
+/**
+ * Get an AI Search namespace for the given account.
+ * Returns `null` if the namespace does not exist (404); other errors propagate.
+ */
 async function getAISearchNamespace(
 	complianceConfig: ComplianceConfig,
 	accountId: string,
@@ -1143,6 +1228,10 @@ async function getAISearchNamespace(
 	}
 }
 
+/**
+ * Create an AI Search namespace for the given account.
+ * Used by the provisioning system when a namespace doesn't exist at deploy time.
+ */
 async function createAISearchNamespace(
 	complianceConfig: ComplianceConfig,
 	accountId: string,
@@ -1159,6 +1248,14 @@ async function createAISearchNamespace(
 	);
 }
 
+/**
+ * Get an Agent Memory namespace for the given account.
+ * Returns `null` if the namespace does not exist (404); other errors propagate.
+ *
+ * Used by the provisioning system at deploy time to decide whether a
+ * configured namespace needs to be created. The caller (not this function)
+ * is responsible for provisioning when `null` is returned.
+ */
 async function getAgentMemoryNamespace(
 	complianceConfig: ComplianceConfig,
 	accountId: string,
@@ -1177,6 +1274,10 @@ async function getAgentMemoryNamespace(
 	}
 }
 
+/**
+ * Create an Agent Memory namespace for the given account.
+ * Used by the provisioning system when a namespace doesn't exist at deploy time.
+ */
 async function createAgentMemoryNamespace(
 	complianceConfig: ComplianceConfig,
 	accountId: string,

--- a/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
@@ -8,29 +8,16 @@ import {
 	UserError,
 } from "@cloudflare/workers-utils";
 import {
-	createAgentMemoryNamespace,
-	getAgentMemoryNamespace,
-} from "../agent-memory/provisioning";
-import { createAISearchNamespace, getAISearchNamespace } from "../ai-search";
-import { fetchResult } from "../cfetch";
-import { createD1Database } from "../d1/create";
-import { listDatabases } from "../d1/list";
-import { getDatabaseInfoFromIdOrName } from "../d1/utils";
-import { prompt, select } from "../dialogs";
-import { isNonInteractiveOrCI } from "../is-interactive";
-import { createKVNamespace, listKVNamespaces } from "../kv/helpers";
-import { logger } from "../logger";
-import * as metrics from "../metrics";
-import {
-	createR2Bucket,
-	getR2Bucket,
-	listR2Buckets,
-} from "../r2/helpers/bucket";
-import { printBindings } from "../utils/print-bindings";
-import { useServiceEnvironments } from "../utils/useServiceEnvironments";
-import { autoProvisionedResourceName } from "./auto-provisioned-name";
-import type { Binding, StartDevWorkerInput } from "../api/startDevWorker/types";
+	fetchResult,
+	isNonInteractiveOrCI,
+	logger,
+	prompt,
+	select,
+} from "../../shared/context";
+import { printBindings } from "./print-bindings";
+import { useServiceEnvironments } from "./use-service-environments";
 import type {
+	Binding,
 	CfAgentMemory,
 	CfAISearchNamespace,
 	CfD1Database,
@@ -42,10 +29,48 @@ import type {
 	WorkerMetadataBinding,
 } from "@cloudflare/workers-utils";
 
-export { getBindings } from "@cloudflare/deploy-helpers";
-
 export type Settings = {
 	bindings: Array<WorkerMetadataBinding>;
+};
+
+type DatabaseCreationResult = {
+	uuid: string;
+	name: string;
+};
+
+type ConcreteDatabase = {
+	uuid: string;
+	name: string;
+};
+
+type DatabaseInfo = {
+	uuid: string;
+	name: string;
+};
+
+type R2BucketInfo = {
+	name: string;
+	creation_date: string;
+	location?: string;
+	storage_class?: string;
+};
+
+type AISearchNamespace = {
+	name: string;
+};
+
+type AgentMemoryNamespace = {
+	id: string;
+	name: string;
+	account_id: string;
+	created_at: string;
+	updated_at: string;
+};
+
+type KVNamespaceInfo = {
+	id: string;
+	title: string;
+	supports_url_encoding?: boolean;
 };
 
 abstract class ProvisionResourceHandler<
@@ -61,8 +86,6 @@ abstract class ProvisionResourceHandler<
 		public accountId: string
 	) {}
 
-	// Does this resource already exist in the currently deployed version of the Worker?
-	// If it does, that means we can inherit from it.
 	abstract canInherit(
 		settings: Settings | undefined
 	): boolean | Promise<boolean>;
@@ -85,34 +108,22 @@ abstract class ProvisionResourceHandler<
 		this.connect(id);
 	}
 
-	// This binding is fully specified and can't/shouldn't be provisioned
-	// This is usually when it has an id (e.g. D1 `database_id`)
 	isFullySpecified(): boolean {
 		return false;
 	}
 
-	// Does this binding need to be provisioned?
-	// Some bindings are not fully specified, but don't need provisioning
-	// (e.g. R2 binding, with a bucket_name that already exists)
 	async isConnectedToExistingResource(): Promise<boolean | string> {
 		return false;
 	}
 
-	// Should this resource be provisioned?
 	async shouldProvision(settings: Settings | undefined) {
-		// If the resource is fully specified, don't provision
 		if (!this.isFullySpecified()) {
-			// If we can inherit, do that and don't provision
 			if (await this.canInherit(settings)) {
 				this.inherit();
 			} else {
-				// If the resource is connected to a remote resource that _exists_
-				// (see comments on the individual functions for why this is different to isFullySpecified())
 				const connected = await this.isConnectedToExistingResource();
 				if (connected) {
 					if (typeof connected === "string") {
-						// Basically a special case for D1: the resource is specified by name in config
-						// and exists, but needs to be specified by ID for the first deploy to work
 						this.connect(connected);
 					}
 					return false;
@@ -158,20 +169,10 @@ class R2Handler extends ProvisionResourceHandler<
 		);
 	}
 
-	/**
-	 * Inheriting an R2 binding replaces the id property (bucket_name for R2) with the inheritance symbol.
-	 * This works when deploying (and is appropriate for all other binding types), but it means that the
-	 * bucket_name for an R2 bucket is not displayed when deploying. As such, only use the inheritance symbol
-	 * if the R2 binding has no `bucket_name`.
-	 */
 	override inherit(): void {
 		this.binding.bucket_name ??= INHERIT_SYMBOL;
 	}
 
-	/**
-	 * R2 bindings can be inherited if the binding name and jurisdiction match.
-	 * Additionally, if the user has specified a bucket_name in config, make sure that matches
-	 */
 	canInherit(settings: Settings | undefined): boolean {
 		return !!settings?.bindings.find(
 			(existing) =>
@@ -186,7 +187,6 @@ class R2Handler extends ProvisionResourceHandler<
 	async isConnectedToExistingResource(): Promise<boolean> {
 		assert(typeof this.binding.bucket_name !== "symbol");
 
-		// If the user hasn't specified a bucket_name in config, we always provision
 		if (!this.binding.bucket_name) {
 			return false;
 		}
@@ -197,15 +197,12 @@ class R2Handler extends ProvisionResourceHandler<
 				this.binding.bucket_name,
 				this.binding.jurisdiction
 			);
-			// This bucket_name exists! We don't need to provision it
 			return true;
 		} catch (e) {
 			if (!(e instanceof APIError && e.code === 10006)) {
-				// this is an error that is not "bucket not found", so we do want to throw
 				throw e;
 			}
 
-			// This bucket_name doesn't exist—let's provision
 			return false;
 		}
 	}
@@ -400,15 +397,11 @@ class D1Handler extends ProvisionResourceHandler<
 			(existing) =>
 				existing.type === this.type && existing.name === this.bindingName
 		) as Extract<WorkerMetadataBinding, { type: "d1" }> | undefined;
-		// A D1 binding with the same binding name exists is already present on the worker...
 		if (maybeInherited) {
-			// ...and the user hasn't specified a name in their config, so we don't need to check if the database_name matches
 			if (!this.binding.database_name) {
 				return true;
 			}
 
-			// ...and the user HAS specified a name in their config, so we need to check if the database_name they provided
-			// matches the database_name of the existing binding (which isn't present in settings, so we'll need to make an API call to check)
 			const dbFromId = await getDatabaseInfoFromIdOrName(
 				this.complianceConfig,
 				this.accountId,
@@ -423,7 +416,6 @@ class D1Handler extends ProvisionResourceHandler<
 	async isConnectedToExistingResource(): Promise<boolean | string> {
 		assert(typeof this.binding.database_name !== "symbol");
 
-		// If the user hasn't specified a database_name in config, we always provision
 		if (!this.binding.database_name) {
 			return false;
 		}
@@ -434,15 +426,12 @@ class D1Handler extends ProvisionResourceHandler<
 				this.binding.database_name
 			);
 
-			// This database_name exists! We don't need to provision it
 			return db.uuid;
 		} catch (e) {
 			if (!(e instanceof APIError && e.code === 7404)) {
-				// this is an error that is not "database not found", so we do want to throw
 				throw e;
 			}
 
-			// This database_name doesn't exist—let's provision
 			return false;
 		}
 	}
@@ -541,8 +530,6 @@ const HANDLERS = {
 		keyDescription: "namespace name",
 		configField: "ai_search_namespaces" as const,
 		load: async (_complianceConfig: ComplianceConfig, _accountId: string) => {
-			// AI Search namespaces don't have a general list API in this context.
-			// The provisioning system will create them if they don't exist.
 			return [];
 		},
 		toConfig: (
@@ -563,15 +550,6 @@ const HANDLERS = {
 		keyDescription: "namespace name",
 		configField: "agent_memory" as const,
 		load: async (_complianceConfig: ComplianceConfig, _accountId: string) => {
-			// `load` only populates the interactive picker in `runProvisioningFlow`
-			// (the "Would you like to connect an existing X or create a new one?"
-			// prompt). For agent_memory, `namespace` is required in config — so
-			// `handler.name` is always set at provision time and `runProvisioningFlow`
-			// goes straight to the "Resource name found in config" branch without
-			// ever consulting this list. Whether or not the namespace already exists
-			// is decided by `isConnectedToExistingResource()` (which hits the GET
-			// /namespaces/:name endpoint), not by this list. Returning [] is
-			// therefore safe and avoids an unnecessary list call at deploy time.
 			return [];
 		},
 		toConfig: (
@@ -671,7 +649,7 @@ async function collectPendingResources(
 	complianceConfig: ComplianceConfig,
 	accountId: string,
 	scriptName: string,
-	bindings: StartDevWorkerInput["bindings"],
+	bindings: Record<string, Binding>,
 	requireRemote: boolean
 ): Promise<PendingResource[]> {
 	let settings: Settings | undefined;
@@ -693,13 +671,18 @@ async function collectPendingResources(
 			continue;
 		}
 
-		const h = createHandler(bindingName, binding, complianceConfig, accountId);
+		const handler = createHandler(
+			bindingName,
+			binding,
+			complianceConfig,
+			accountId
+		);
 
-		if (await h.shouldProvision(settings)) {
+		if (await handler.shouldProvision(settings)) {
 			pendingResources.push({
 				binding: bindingName,
 				resourceType: binding.type,
-				handler: h,
+				handler,
 			});
 		}
 	}
@@ -710,7 +693,7 @@ async function collectPendingResources(
 }
 
 export async function provisionBindings(
-	bindings: StartDevWorkerInput["bindings"],
+	bindings: Record<string, Binding>,
 	accountId: string,
 	scriptName: string,
 	autoCreate: boolean,
@@ -742,7 +725,10 @@ export async function provisionBindings(
 
 		printBindings(
 			Object.fromEntries(
-				pendingResources.map((r) => [r.binding, { type: r.resourceType }])
+				pendingResources.map((resource) => [
+					resource.binding,
+					{ type: resource.resourceType },
+				])
 			) as Record<string, Binding>,
 			config.tail_consumers,
 			config.streaming_tail_consumers,
@@ -774,9 +760,6 @@ export async function provisionBindings(
 		const isUsingRedirectedConfig =
 			config.userConfigPath && config.userConfigPath !== config.configPath;
 
-		// If we're using a redirected config, then the redirected config potentially has injected
-		// bindings that weren't originally in the user config. These can be provisioned, but we
-		// should not write the IDs back to the user config file (because the bindings weren't there in the first place)
 		if (isUsingRedirectedConfig) {
 			const { rawConfig: unredirectedConfig } =
 				await experimental_readRawConfig(
@@ -798,7 +781,6 @@ export async function provisionBindings(
 				continue;
 			}
 
-			// See above for why we skip writing back some bindings to the config file
 			if (isUsingRedirectedConfig && !existingBindingNames.has(bindingName)) {
 				continue;
 			}
@@ -812,17 +794,12 @@ export async function provisionBindings(
 			(patch[resourceType] as unknown as Array<Record<string, string>>).push(
 				Object.fromEntries(
 					Object.entries(bindingToWrite).filter(
-						// Make sure all the values are JSON serialisable.
-						// Otherwise we end up with "undefined" in the config
 						([_, value]) => typeof value === "string"
 					)
 				)
 			);
 		}
 
-		// If the user is performing an interactive deploy, write the provisioned IDs back to the config file.
-		// This is not necessary, as future deploys can use inherited resources, but it can help with
-		// portability of the config file, and adds robustness to bindings being renamed.
 		if (!isNonInteractiveOrCI()) {
 			try {
 				await experimental_patchConfig(configPath, patch, false);
@@ -830,26 +807,13 @@ export async function provisionBindings(
 					"Your Worker was deployed with provisioned resources. We've written the IDs of these resources to your config file, which you can choose to save or discard. Either way future deploys will continue to work."
 				);
 			} catch (e) {
-				// no-op — if the user is using TOML config we can't update it.
 				if (!(e instanceof PatchConfigError)) {
 					throw e;
 				}
 			}
 		}
 
-		const resourceCount = pendingResources.reduce(
-			(acc, resource) => {
-				acc[resource.resourceType] ??= 0;
-				acc[resource.resourceType]++;
-				return acc;
-			},
-			{} as Record<string, number>
-		);
 		logger.log(`🎉 All resources provisioned, continuing with deployment...\n`);
-
-		metrics.sendMetricsEvent("provision resources", resourceCount, {
-			sendMetrics: config.send_metrics,
-		});
 	}
 }
 
@@ -869,9 +833,7 @@ function printDivider() {
 }
 
 type NormalisedResourceInfo = {
-	/** The name of the resource */
 	title: string;
-	/** The id of the resource */
 	value: string;
 };
 
@@ -885,7 +847,6 @@ async function runProvisioningFlow(
 	const NEW_OPTION_VALUE = "__WRANGLER_INTERNAL_NEW";
 	const SEARCH_OPTION_VALUE = "__WRANGLER_INTERNAL_SEARCH";
 	const MAX_OPTIONS = 4;
-	// NB preExisting does not actually contain all resources on the account - we max out at ~30 d1 databases, ~100 kv, and ~20 r2.
 	const options = preExisting.slice(0, MAX_OPTIONS - 1);
 	if (options.length < preExisting.length) {
 		options.push({
@@ -932,14 +893,13 @@ async function runProvisioningFlow(
 			logger.log(`🌀 Creating new ${friendlyBindingName} "${name}"...`);
 			await item.handler.provision(name);
 		} else if (action === SEARCH_OPTION_VALUE) {
-			// search through pre-existing resources that weren't listed
 			let foundResource: NormalisedResourceInfo | undefined;
 			while (foundResource === undefined) {
 				const input = await prompt(
 					`Enter the ${HANDLERS[item.resourceType].keyDescription} for an existing ${friendlyBindingName}`
 				);
 				foundResource = preExisting.find(
-					(r) => r.title === input || r.value === input
+					(resource) => resource.title === input || resource.value === input
 				);
 				if (foundResource) {
 					item.handler.connect(foundResource.value);
@@ -956,4 +916,279 @@ async function runProvisioningFlow(
 
 	logger.log(`✨ ${item.binding} provisioned 🎉`);
 	printDivider();
+}
+
+function autoProvisionedResourceName(
+	scriptName: string,
+	bindingName: string
+): string {
+	return `${scriptName}-${bindingName.toLowerCase().replaceAll("_", "-")}`;
+}
+
+async function createKVNamespace(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	title: string
+): Promise<string> {
+	const response = await fetchResult<{ id: string }>(
+		complianceConfig,
+		`/accounts/${accountId}/storage/kv/namespaces`,
+		{
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				title,
+			}),
+		}
+	);
+
+	return response.id;
+}
+
+async function listKVNamespaces(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	limitCalls = false
+): Promise<KVNamespaceInfo[]> {
+	const pageSize = 100;
+	let page = 1;
+	const results: KVNamespaceInfo[] = [];
+	while (results.length % pageSize === 0) {
+		const json = await fetchResult<KVNamespaceInfo[]>(
+			complianceConfig,
+			`/accounts/${accountId}/storage/kv/namespaces`,
+			{},
+			new URLSearchParams({
+				per_page: pageSize.toString(),
+				order: "title",
+				direction: "asc",
+				page: page.toString(),
+			})
+		);
+		page++;
+		results.push(...json);
+		if (limitCalls) {
+			break;
+		}
+		if (json.length < pageSize) {
+			break;
+		}
+	}
+	return results;
+}
+
+async function createD1Database(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	name: string
+) {
+	try {
+		return await fetchResult<DatabaseCreationResult>(
+			complianceConfig,
+			`/accounts/${accountId}/d1/database`,
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ name }),
+			}
+		);
+	} catch (e) {
+		const errorCode = (e as { code: number }).code;
+
+		if (errorCode === 7502) {
+			throw new UserError("A database with that name already exists", {
+				telemetryMessage: "d1 create database already exists",
+			});
+		}
+
+		if (errorCode === 7406) {
+			throw new UserError(
+				"You have reached the maximum number of D1 databases for your account. Please consider deleting unused databases, or visit the D1 documentation to learn more: https://developers.cloudflare.com/d1/",
+				{ telemetryMessage: "d1 create database limit reached" }
+			);
+		}
+
+		throw e;
+	}
+}
+
+async function listDatabases(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	limitCalls = false,
+	pageSize = 10
+): Promise<Array<ConcreteDatabase>> {
+	let page = 1;
+	const results = [];
+	while (results.length % pageSize === 0) {
+		const json: Array<ConcreteDatabase> = await fetchResult(
+			complianceConfig,
+			`/accounts/${accountId}/d1/database`,
+			{},
+			new URLSearchParams({
+				per_page: pageSize.toString(),
+				page: page.toString(),
+			})
+		);
+		page++;
+		results.push(...json);
+		if (limitCalls && page > 3) {
+			break;
+		}
+		if (json.length < pageSize) {
+			break;
+		}
+	}
+	return results;
+}
+
+async function getDatabaseInfoFromIdOrName(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	databaseIdOrName: string
+): Promise<DatabaseInfo> {
+	return await fetchResult<DatabaseInfo>(
+		complianceConfig,
+		`/accounts/${accountId}/d1/database/${databaseIdOrName}`,
+		{
+			headers: {
+				"Content-Type": "application/json",
+			},
+		}
+	);
+}
+
+async function listR2Buckets(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	jurisdiction?: string
+): Promise<R2BucketInfo[]> {
+	const headers: Record<string, string> = {};
+	if (jurisdiction !== undefined) {
+		headers["cf-r2-jurisdiction"] = jurisdiction;
+	}
+	const results = await fetchResult<{
+		buckets: R2BucketInfo[];
+	}>(complianceConfig, `/accounts/${accountId}/r2/buckets`, { headers });
+	return results.buckets;
+}
+
+async function getR2Bucket(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	bucketName: string,
+	jurisdiction?: string
+): Promise<R2BucketInfo> {
+	const headers: Record<string, string> = {};
+	if (jurisdiction !== undefined) {
+		headers["cf-r2-jurisdiction"] = jurisdiction;
+	}
+	return await fetchResult<R2BucketInfo>(
+		complianceConfig,
+		`/accounts/${accountId}/r2/buckets/${bucketName}`,
+		{
+			method: "GET",
+			headers,
+		}
+	);
+}
+
+async function createR2Bucket(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	bucketName: string,
+	location?: string,
+	jurisdiction?: string,
+	storageClass?: string
+): Promise<void> {
+	const headers: Record<string, string> = {};
+	if (jurisdiction !== undefined) {
+		headers["cf-r2-jurisdiction"] = jurisdiction;
+	}
+	return await fetchResult<void>(
+		complianceConfig,
+		`/accounts/${accountId}/r2/buckets`,
+		{
+			method: "POST",
+			body: JSON.stringify({
+				name: bucketName,
+				...(storageClass !== undefined && { storageClass }),
+				...(location !== undefined && { locationHint: location }),
+			}),
+			headers,
+		}
+	);
+}
+
+async function getAISearchNamespace(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	namespaceName: string
+): Promise<AISearchNamespace | null> {
+	try {
+		return await fetchResult<AISearchNamespace>(
+			complianceConfig,
+			`/accounts/${accountId}/ai-search/namespaces/${namespaceName}`,
+			{ method: "GET" }
+		);
+	} catch (e) {
+		if (e instanceof APIError && e.status === 404) {
+			return null;
+		}
+		throw e;
+	}
+}
+
+async function createAISearchNamespace(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	namespaceName: string
+): Promise<void> {
+	await fetchResult<void>(
+		complianceConfig,
+		`/accounts/${accountId}/ai-search/namespaces`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ name: namespaceName }),
+		}
+	);
+}
+
+async function getAgentMemoryNamespace(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	namespaceName: string
+): Promise<AgentMemoryNamespace | null> {
+	try {
+		return await fetchResult<AgentMemoryNamespace>(
+			complianceConfig,
+			`/accounts/${accountId}/agent-memory/namespaces/${namespaceName}`
+		);
+	} catch (e) {
+		if (e instanceof APIError && e.status === 404) {
+			return null;
+		}
+		throw e;
+	}
+}
+
+async function createAgentMemoryNamespace(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	namespaceName: string
+): Promise<void> {
+	await fetchResult<AgentMemoryNamespace>(
+		complianceConfig,
+		`/accounts/${accountId}/agent-memory/namespaces`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ name: namespaceName }),
+		}
+	);
 }

--- a/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
@@ -26,6 +26,7 @@ import type {
 	ComplianceConfig,
 	Config,
 	RawConfig,
+	StartDevWorkerInput,
 	WorkerMetadataBinding,
 } from "@cloudflare/workers-utils";
 
@@ -696,7 +697,7 @@ async function collectPendingResources(
 	complianceConfig: ComplianceConfig,
 	accountId: string,
 	scriptName: string,
-	bindings: Record<string, Binding>,
+	bindings: StartDevWorkerInput["bindings"],
 	requireRemote: boolean
 ): Promise<PendingResource[]> {
 	let settings: Settings | undefined;
@@ -740,7 +741,7 @@ async function collectPendingResources(
 }
 
 export async function provisionBindings(
-	bindings: Record<string, Binding>,
+	bindings: StartDevWorkerInput["bindings"],
 	accountId: string,
 	scriptName: string,
 	autoCreate: boolean,

--- a/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts
@@ -697,8 +697,7 @@ async function collectPendingResources(
 	complianceConfig: ComplianceConfig,
 	accountId: string,
 	scriptName: string,
-	bindings: StartDevWorkerInput["bindings"],
-	requireRemote: boolean
+	bindings: StartDevWorkerInput["bindings"]
 ): Promise<PendingResource[]> {
 	let settings: Settings | undefined;
 
@@ -712,10 +711,6 @@ async function collectPendingResources(
 
 	for (const [bindingName, binding] of Object.entries(bindings ?? {})) {
 		if (!isProvisionableBinding(binding)) {
-			continue;
-		}
-
-		if (requireRemote && !("remote" in binding && binding.remote)) {
 			continue;
 		}
 
@@ -746,15 +741,16 @@ export async function provisionBindings(
 	scriptName: string,
 	autoCreate: boolean,
 	config: Config,
-	requireRemote = false
+	options: {
+		skipConfigWriteback?: boolean;
+	}
 ): Promise<void> {
 	const configPath = config.userConfigPath ?? config.configPath;
 	const pendingResources = await collectPendingResources(
 		config,
 		accountId,
 		scriptName,
-		bindings,
-		requireRemote
+		bindings
 	);
 
 	if (pendingResources.length > 0) {
@@ -857,7 +853,11 @@ export async function provisionBindings(
 		// If the user is performing an interactive deploy, write the provisioned IDs back to the config file.
 		// This is not necessary, as future deploys can use inherited resources, but it can help with
 		// portability of the config file, and adds robustness to bindings being renamed.
-		if (!isNonInteractiveOrCI()) {
+		if (options.skipConfigWriteback) {
+			logger.log(
+				"Your Worker was deployed with provisioned resources. You may add the resource IDs to your config file if you wish, but future deploys will continue to work even without IDs."
+			);
+		} else if (!isNonInteractiveOrCI()) {
 			try {
 				await experimental_patchConfig(configPath, patch, false);
 				logger.log(

--- a/packages/deploy-helpers/src/deploy/versions-upload.ts
+++ b/packages/deploy-helpers/src/deploy/versions-upload.ts
@@ -30,6 +30,7 @@ import { verifyWorkerMatchesCITag } from "./helpers/match-tag";
 import { parseBulkInputToObject } from "./helpers/parse-bulk-input";
 import { parseConfigPlacement } from "./helpers/placement";
 import { printBindings } from "./helpers/print-bindings";
+import { provisionBindings } from "./helpers/provision-bindings";
 import {
 	addRequiredSecretsInheritBindings,
 	handleMissingSecretsError,
@@ -47,10 +48,7 @@ import type { RetrieveSourceMapFunction } from "./helpers/sourcemap";
 import type { CfWorkerInit, Config } from "@cloudflare/workers-utils";
 import type { FormData } from "undici";
 
-export type VersionsUploadCallbacks = Pick<
-	DeployCallbacks,
-	"provisionBindings" | "analyseBundle"
->;
+export type VersionsUploadCallbacks = Pick<DeployCallbacks, "analyseBundle">;
 
 export default async function versionsUpload(
 	props: VersionsUploadProps,
@@ -330,8 +328,8 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		assert(accountId, "Missing accountId");
 		if (assetsOptions?.routerConfig.has_user_worker === false) {
 			logger.debug("skipping provisioning on assets-only project");
-		} else if (props.resourcesProvision && callbacks.provisionBindings) {
-			await callbacks.provisionBindings(
+		} else if (props.resourcesProvision) {
+			await provisionBindings(
 				bindings,
 				accountId,
 				scriptName,

--- a/packages/deploy-helpers/src/deploy/versions-upload.ts
+++ b/packages/deploy-helpers/src/deploy/versions-upload.ts
@@ -334,7 +334,10 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 				accountId,
 				scriptName,
 				props.experimentalAutoCreate,
-				config
+				config,
+				{
+					skipConfigWriteback: props.skipProvisioningConfigWriteback,
+				}
 			);
 		}
 		workerBundle = createWorkerUploadForm(worker, bindings, {

--- a/packages/deploy-helpers/src/index.ts
+++ b/packages/deploy-helpers/src/index.ts
@@ -43,3 +43,4 @@ export * from "./deploy/helpers/print-bindings";
 export * from "./deploy/helpers/assets";
 export * from "./deploy/helpers/hash";
 export * from "./deploy/helpers/jwt";
+export * from "./deploy/helpers/provision-bindings";

--- a/packages/deploy-helpers/src/shared/context.ts
+++ b/packages/deploy-helpers/src/shared/context.ts
@@ -26,6 +26,7 @@ export let fetchPagedListResult: FetchPagedListResultFetcher;
 export let fetchKVGetValue: FetchKVGetValueFetcher;
 export let confirm: DeployHelpersContext["confirm"];
 export let prompt: DeployHelpersContext["prompt"];
+export let select: DeployHelpersContext["select"];
 export let isNonInteractiveOrCI: () => boolean;
 
 /**
@@ -40,5 +41,6 @@ export function initDeployHelpersContext(ctx: DeployHelpersContext): void {
 	fetchKVGetValue = ctx.fetchKVGetValue;
 	confirm = ctx.confirm;
 	prompt = ctx.prompt;
+	select = ctx.select;
 	isNonInteractiveOrCI = ctx.isNonInteractiveOrCI;
 }

--- a/packages/deploy-helpers/src/shared/types.ts
+++ b/packages/deploy-helpers/src/shared/types.ts
@@ -106,6 +106,8 @@ export type SharedDeployVersionsProps = {
 	sendMetrics: boolean;
 	/** Resolved from getFlag("RESOURCES_PROVISION"). Controls whether bindings are auto-provisioned before upload. */
 	resourcesProvision: boolean;
+	/** Controls whether provisioned resource IDs are written back to the config file. */
+	skipProvisioningConfigWriteback: boolean;
 	/** temporary hack - cf is not yet a recognised deploy source, so any deploys from cf comes back normalised to 'api'*/
 	skipLastDeployedFromApiCheck: boolean;
 };

--- a/packages/deploy-helpers/src/shared/types.ts
+++ b/packages/deploy-helpers/src/shared/types.ts
@@ -32,6 +32,18 @@ export type DeployHelpersContext = {
 		text: string,
 		options?: { defaultValue?: string }
 	) => Promise<string>;
+	select: <Values extends string>(
+		text: string,
+		options: {
+			choices: {
+				title: string;
+				description?: string;
+				value: Values;
+			}[];
+			defaultOption?: number;
+			fallbackOption?: number;
+		}
+	) => Promise<Values>;
 	isNonInteractiveOrCI: () => boolean;
 };
 

--- a/packages/deploy-helpers/tests/index.test.ts
+++ b/packages/deploy-helpers/tests/index.test.ts
@@ -17,6 +17,7 @@ describe("context singleton", () => {
 			fetchKVGetValue: (() => {}) as never,
 			confirm: (() => {}) as never,
 			prompt: (() => {}) as never,
+			select: (() => {}) as never,
 			isNonInteractiveOrCI: () => false,
 		});
 

--- a/packages/wrangler/src/__tests__/helpers/mock-worker-settings.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-worker-settings.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from "msw";
 import { assert } from "vitest";
 import { msw } from "./msw";
-import type { Settings } from "../../deployment-bundle/bindings";
+import type { Settings } from "@cloudflare/deploy-helpers";
 
 export function mockGetSettings(
 	options: {

--- a/packages/wrangler/src/__tests__/vitest.setup.ts
+++ b/packages/wrangler/src/__tests__/vitest.setup.ts
@@ -9,7 +9,7 @@ import {
 	fetchListResult,
 	fetchPagedListResult,
 } from "../cfetch";
-import { confirm, prompt } from "../dialogs";
+import { confirm, prompt, select } from "../dialogs";
 import { isNonInteractiveOrCI } from "../is-interactive";
 import { logger } from "../logger";
 import { msw } from "./helpers/msw";
@@ -25,6 +25,7 @@ initDeployHelpersContext({
 	fetchKVGetValue,
 	confirm,
 	prompt,
+	select,
 	isNonInteractiveOrCI,
 });
 

--- a/packages/wrangler/src/agent-memory/provisioning.ts
+++ b/packages/wrangler/src/agent-memory/provisioning.ts
@@ -9,6 +9,9 @@ import type { AgentMemoryNamespace } from "./client";
  * Used by the provisioning system at deploy time to decide whether a
  * configured namespace needs to be created. The caller (not this function)
  * is responsible for provisioning when `null` is returned.
+ *
+ * Keep in sync with the local provisioning copy in
+ * packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts.
  */
 export async function getAgentMemoryNamespace(
 	complianceConfig: ComplianceConfig,
@@ -32,6 +35,9 @@ export async function getAgentMemoryNamespace(
 /**
  * Create an Agent Memory namespace for the given account.
  * Used by the provisioning system when a namespace doesn't exist at deploy time.
+ *
+ * Keep in sync with the local provisioning copy in
+ * packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts.
  */
 export async function createAgentMemoryNamespace(
 	complianceConfig: ComplianceConfig,

--- a/packages/wrangler/src/ai-search.ts
+++ b/packages/wrangler/src/ai-search.ts
@@ -8,6 +8,9 @@ export interface AISearchNamespace {
 /**
  * Get an AI Search namespace for the given account.
  * Throws an APIError (status 404) if the namespace does not exist.
+ *
+ * Keep in sync with the local provisioning copy in
+ * packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts.
  */
 export async function getAISearchNamespace(
 	complianceConfig: ComplianceConfig,
@@ -33,6 +36,9 @@ export async function getAISearchNamespace(
  * Create an AI Search namespace for the given account.
  * Used by the provisioning system (R2 bucket pattern) when a namespace
  * doesn't exist at deploy time.
+ *
+ * Keep in sync with the local provisioning copy in
+ * packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts.
  */
 export async function createAISearchNamespace(
 	complianceConfig: ComplianceConfig,

--- a/packages/wrangler/src/api/deploy-helpers-context.ts
+++ b/packages/wrangler/src/api/deploy-helpers-context.ts
@@ -5,7 +5,7 @@ import {
 	fetchPagedListResult,
 	fetchResult,
 } from "../cfetch";
-import { confirm, prompt } from "../dialogs";
+import { confirm, prompt, select } from "../dialogs";
 import { isNonInteractiveOrCI } from "../is-interactive";
 import { logger } from "../logger";
 
@@ -18,6 +18,7 @@ export function initApiDeployHelpersContext(): void {
 		fetchKVGetValue,
 		confirm,
 		prompt,
+		select,
 		isNonInteractiveOrCI,
 	});
 }

--- a/packages/wrangler/src/api/pages/create-worker-bundle-contents.ts
+++ b/packages/wrangler/src/api/pages/create-worker-bundle-contents.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
+import { getBindings } from "@cloudflare/deploy-helpers";
 import { Response } from "undici";
-import { getBindings } from "../../deployment-bundle/bindings";
 import { createWorkerUploadForm } from "../../deployment-bundle/create-worker-upload-form";
 import { loadSourceMaps } from "../../deployment-bundle/source-maps";
 import { parseConfigPlacement } from "../../utils/placement";

--- a/packages/wrangler/src/api/startDevWorker/DevEnv.ts
+++ b/packages/wrangler/src/api/startDevWorker/DevEnv.ts
@@ -13,7 +13,7 @@ import {
 	isBuildFailure,
 	isBuildFailureFromCause,
 } from "../../deployment-bundle/build-failures";
-import { confirm, prompt } from "../../dialogs";
+import { confirm, prompt, select } from "../../dialogs";
 import { isNonInteractiveOrCI } from "../../is-interactive";
 import { logBuildFailure, logger, runWithLogLevel } from "../../logger";
 import { BundlerController } from "./BundlerController";
@@ -47,6 +47,7 @@ export class DevEnv extends EventEmitter implements ControllerBus {
 			fetchKVGetValue,
 			confirm,
 			prompt,
+			select,
 			isNonInteractiveOrCI,
 		});
 

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -20,7 +20,7 @@ import {
 } from "../cfetch";
 import { createCloudflareClient } from "../cfetch/internal";
 import { readConfig, readNewConfig } from "../config";
-import { confirm, prompt } from "../dialogs";
+import { confirm, prompt, select } from "../dialogs";
 import { run } from "../experimental-flags";
 import { isNonInteractiveOrCI } from "../is-interactive";
 import { logger } from "../logger";
@@ -303,6 +303,7 @@ function createHandler(def: InternalCommandDefinition, argv: string[]) {
 						fetchKVGetValue,
 						confirm,
 						prompt,
+						select,
 						isNonInteractiveOrCI,
 					});
 

--- a/packages/wrangler/src/d1/create.ts
+++ b/packages/wrangler/src/d1/create.ts
@@ -20,6 +20,8 @@ import {
 import type { DatabaseCreationResult } from "./types";
 import type { ComplianceConfig } from "@cloudflare/workers-utils";
 
+// Keep in sync with the local provisioning copy in
+// packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts.
 export async function createD1Database(
 	complianceConfig: ComplianceConfig,
 	accountId: string,

--- a/packages/wrangler/src/d1/list.ts
+++ b/packages/wrangler/src/d1/list.ts
@@ -41,6 +41,8 @@ export const d1ListCommand = createCommand({
 	},
 });
 
+// Keep in sync with the local provisioning copy in
+// packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts.
 export const listDatabases = async (
 	complianceConfig: ComplianceConfig,
 	accountId: string,

--- a/packages/wrangler/src/d1/utils.ts
+++ b/packages/wrangler/src/d1/utils.ts
@@ -145,6 +145,8 @@ export const getDatabaseByNameOrBinding = async (
 	};
 };
 
+// Keep in sync with the local provisioning copy in
+// packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts.
 export const getDatabaseInfoFromIdOrName = async (
 	complianceConfig: ComplianceConfig,
 	accountId: string,

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -4,7 +4,6 @@ import { buildContainer } from "../containers/build";
 import { getNormalizedContainerOptions } from "../containers/config";
 import { deployContainers } from "../containers/deploy";
 import { createCommand } from "../core/create-command";
-import { provisionBindings } from "../deployment-bundle/bindings";
 import {
 	sharedDeployVersionsArgs,
 	validateDeployVersionsArgs,
@@ -155,7 +154,6 @@ export const deployCommand = createCommand({
 				buildResult,
 				{
 					syncWorkersSite,
-					provisionBindings,
 					getNormalizedContainerOptions,
 					buildContainer,
 					deployContainers,

--- a/packages/wrangler/src/deployment-bundle/merge-config-args.ts
+++ b/packages/wrangler/src/deployment-bundle/merge-config-args.ts
@@ -95,6 +95,7 @@ async function mergeSharedConfigArgs(
 		accountId,
 		sendMetrics,
 		resourcesProvision: getFlag("RESOURCES_PROVISION") ?? false,
+		skipProvisioningConfigWriteback: false,
 		skipLastDeployedFromApiCheck: false,
 	};
 

--- a/packages/wrangler/src/kv/helpers.ts
+++ b/packages/wrangler/src/kv/helpers.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import { Blob } from "node:buffer";
 import { URLSearchParams } from "node:url";
+import { getSettings } from "@cloudflare/deploy-helpers";
 import { type KVNamespace } from "@cloudflare/workers-types/experimental";
 import {
 	isOptionalProperty,
@@ -10,7 +11,6 @@ import {
 import { Miniflare } from "miniflare";
 import { FormData } from "undici";
 import { fetchKVGetValue, fetchListResult, fetchResult } from "../cfetch";
-import { getSettings } from "../deployment-bundle/bindings";
 import { getLocalPersistencePath } from "../dev/get-local-persistence-path";
 import { getDefaultPersistRoot } from "../dev/miniflare";
 import { getFlag } from "../experimental-flags";

--- a/packages/wrangler/src/kv/helpers.ts
+++ b/packages/wrangler/src/kv/helpers.ts
@@ -38,6 +38,9 @@ type KvArgs = {
 /**
  * Create a new namespace under the given `accountId` with the given `title`.
  *
+ * Keep in sync with the local provisioning copy in
+ * packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts.
+ *
  * @returns the generated id of the created namespace.
  */
 export async function createKVNamespace(
@@ -73,6 +76,9 @@ export interface KVNamespaceInfo {
 
 /**
  * Fetch a list of all the namespaces under the given `accountId`.
+ *
+ * Keep in sync with the local provisioning copy in
+ * packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts.
  */
 export async function listKVNamespaces(
 	complianceConfig: ComplianceConfig,

--- a/packages/wrangler/src/preview/preview.ts
+++ b/packages/wrangler/src/preview/preview.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { getBindings } from "@cloudflare/deploy-helpers";
 import {
 	configFileName,
 	getBindingTypeFriendlyName,
@@ -8,7 +9,6 @@ import {
 } from "@cloudflare/workers-utils";
 import chalk from "chalk";
 import { getAssetsOptions, syncAssets } from "../assets";
-import { getBindings } from "../deployment-bundle/bindings";
 import { bundleWorker } from "../deployment-bundle/bundle";
 import { moduleTypeMimeType } from "../deployment-bundle/create-worker-upload-form";
 import { getEntry } from "../deployment-bundle/entry";

--- a/packages/wrangler/src/r2/helpers/bucket.ts
+++ b/packages/wrangler/src/r2/helpers/bucket.ts
@@ -36,6 +36,9 @@ export interface R2BucketMetricsGraphQLResponse {
 
 /**
  * Fetch a list of all the buckets under the given `accountId`.
+ *
+ * Keep in sync with the local provisioning copy in
+ * packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts.
  */
 export async function listR2Buckets(
 	complianceConfig: ComplianceConfig,
@@ -66,6 +69,8 @@ export function tableFromR2BucketsListResponse(buckets: R2BucketInfo[]): {
 	return rows;
 }
 
+// Keep in sync with the local provisioning copy in
+// packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts.
 export async function getR2Bucket(
 	complianceConfig: ComplianceConfig,
 	accountId: string,
@@ -168,6 +173,9 @@ export async function getR2BucketMetrics(
  *
  * A 400 is returned if the account already owns a bucket with this name.
  * A bucket must be explicitly deleted to be replaced.
+ *
+ * Keep in sync with the local provisioning copy in
+ * packages/deploy-helpers/src/deploy/helpers/provision-bindings.ts.
  */
 export async function createR2Bucket(
 	complianceConfig: ComplianceConfig,

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -1,7 +1,6 @@
 import { versionsUpload } from "@cloudflare/deploy-helpers";
 import { analyseBundle } from "../check/commands";
 import { createCommand } from "../core/create-command";
-import { provisionBindings } from "../deployment-bundle/bindings";
 import {
 	sharedDeployVersionsArgs,
 	validateDeployVersionsArgs,
@@ -77,7 +76,6 @@ export const versionsUploadCommand = createCommand({
 				versionPreviewUrl,
 				versionPreviewAliasUrl,
 			} = await versionsUpload(props, config, buildResult, {
-				provisionBindings: provisionBindings,
 				analyseBundle: analyseBundle,
 			});
 


### PR DESCRIPTION
This turned out to be extremely straightforward 😅 

- Added 'select' to deployHelpersContext so cf can provide a clack version
- Removed a metrics event for provisioning, to keep things simple



---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: should pass existing
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: refactor

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->