### PR TITLE
[local-explorer-ui] Add Observability (Traces) tab

### DIFF
--- a/packages/local-explorer-ui/src/components/Sidebar.tsx
+++ b/packages/local-explorer-ui/src/components/Sidebar.tsx
@@ -5,7 +5,12 @@ import {
 	Sidebar,
 	useSidebar,
 } from "@cloudflare/kumo";
-import { MonitorIcon, MoonIcon, SunIcon } from "@phosphor-icons/react";
+import {
+	MonitorIcon,
+	MoonIcon,
+	PulseIcon,
+	SunIcon,
+} from "@phosphor-icons/react";
 import { useRouter } from "@tanstack/react-router";
 import { useCallback, useState } from "react";
 import D1Icon from "../assets/icons/d1.svg?react";
@@ -237,6 +242,21 @@ export function AppSidebar({
 						onWorkerChange={onWorkerChange}
 					/>
 				)}
+
+				<Sidebar.MenuItem>
+					<Sidebar.MenuButton
+						icon={<PulseIcon width={20} height={20} />}
+						onClick={() =>
+							router.navigate({ to: "/observability", search: workerSearch })
+						}
+						className={cn(
+							"cursor-pointer",
+							currentPath === "/observability" && "bg-kumo-tint"
+						)}
+					>
+						Observability
+					</Sidebar.MenuButton>
+				</Sidebar.MenuItem>
 
 				{sidebar.open ? (
 					<Sidebar.MenuItem className="space-y-1">

--- a/packages/local-explorer-ui/src/components/observability/TraceWaterfall.tsx
+++ b/packages/local-explorer-ui/src/components/observability/TraceWaterfall.tsx
@@ -1,0 +1,292 @@
+import { cn } from "@cloudflare/kumo";
+import { useMemo, useState } from "react";
+import {
+	buildSpanTree,
+	parseAttributes,
+	spanKind,
+	type SpanRow,
+} from "../../lib/traces";
+import type { LayoutSpan } from "../../lib/traces";
+
+interface TraceWaterfallProps {
+	spans: SpanRow[];
+	rootSpanId: string;
+	traceDurationMs: number;
+}
+
+const NAME_WIDTH = 300;
+const ROW_H = 32; // px, matches Stratus h-8
+
+// Kind → small dot color (kind is shown via the dot, like Stratus's per-kind icon).
+const KIND_DOT: Record<string, string> = {
+	http: "bg-purple-500",
+	kv: "bg-blue-500",
+	d1: "bg-cyan-500",
+	fetch: "bg-emerald-500",
+	r2: "bg-violet-500",
+	do: "bg-orange-500",
+	span: "bg-gray-400",
+};
+
+const KIND_LABEL: Record<string, string> = {
+	http: "HTTP",
+	kv: "KV",
+	d1: "D1",
+	fetch: "FETCH",
+	r2: "R2",
+	do: "DO",
+	span: "",
+};
+
+// Bar color encodes state (Stratus model): root = orange, error = red, else accent.
+function barColor(span: LayoutSpan): string {
+	if (span.error || (span.outcome && span.outcome !== "ok")) {
+		return "bg-red-500";
+	}
+	if (span.depth === 0) {
+		return "bg-orange-500";
+	}
+	return "bg-indigo-500";
+}
+
+function niceTicks(max: number): { ticks: number[]; step: number } {
+	const target = 6;
+	const raw = Math.max(max / target, 1);
+	const pow = Math.pow(10, Math.floor(Math.log10(raw)));
+	const step = [1, 2, 5, 10].map((c) => c * pow).find((c) => c >= raw) ?? pow * 10;
+	const ticks: number[] = [];
+	for (let t = 0; t <= max; t += step) {
+		ticks.push(t);
+	}
+	return { ticks, step };
+}
+
+export function TraceWaterfall({
+	spans,
+	rootSpanId,
+	traceDurationMs,
+}: TraceWaterfallProps): JSX.Element {
+	const ordered = useMemo(
+		() => buildSpanTree(spans, rootSpanId),
+		[spans, rootSpanId]
+	);
+	const [selectedId, setSelectedId] = useState<string | null>(null);
+	const [hoveredId, setHoveredId] = useState<string | null>(null);
+
+	const total = Math.max(
+		1,
+		traceDurationMs ||
+			ordered.reduce((m, s) => Math.max(m, (s.end_ms ?? s.start_ms) || 0), 0)
+	);
+	const scale = total * 1.05; // 5% right padding
+	const { ticks } = useMemo(() => niceTicks(scale), [scale]);
+
+	const selected = ordered.find((s) => s.span_id === selectedId) ?? null;
+
+	const rowBg = (id: string) =>
+		selectedId === id
+			? "bg-blue-100 dark:bg-blue-900/30"
+			: hoveredId === id
+				? "bg-kumo-tint"
+				: "";
+
+	return (
+		<div className="bg-kumo-elevated overflow-hidden rounded-lg border">
+			<div className="flex">
+				{/* ---- name column ---- */}
+				<div
+					className="border-r shrink-0"
+					style={{ width: NAME_WIDTH }}
+				>
+					<div className="text-text-secondary flex h-9 items-center border-b px-3 text-xs font-medium">
+						Span
+					</div>
+					{ordered.map((span) => {
+						const k = spanKind(span);
+						const isErr =
+							!!span.error || (!!span.outcome && span.outcome !== "ok");
+						return (
+							<button
+								type="button"
+								key={span.span_id}
+								onClick={() =>
+									setSelectedId(selectedId === span.span_id ? null : span.span_id)
+								}
+								onMouseEnter={() => setHoveredId(span.span_id)}
+								onMouseLeave={() => setHoveredId(null)}
+								className={cn(
+									"flex w-full items-center gap-2 overflow-hidden px-3 text-left transition-colors",
+									rowBg(span.span_id)
+								)}
+								style={{ height: ROW_H, paddingLeft: 12 + span.depth * 16 }}
+							>
+								<span
+									className={cn(
+										"size-2 shrink-0 rounded-full",
+										KIND_DOT[k] ?? KIND_DOT.span
+									)}
+								/>
+								<span
+									className={cn(
+										"truncate font-mono text-xs",
+										isErr ? "text-red-500" : "text-text"
+									)}
+								>
+									{span.name ?? "span"}
+								</span>
+								{KIND_LABEL[k] ? (
+									<span className="text-text-secondary ml-auto shrink-0 text-[9px] tracking-wide">
+										{KIND_LABEL[k]}
+									</span>
+								) : null}
+							</button>
+						);
+					})}
+				</div>
+
+				{/* ---- timeline column ---- */}
+				<div className="relative flex-1">
+					{/* vertical gridlines */}
+					<div className="pointer-events-none absolute inset-0">
+						{ticks.map((t, i) => (
+							<div
+								key={i}
+								className="border-kumo-fill absolute top-0 bottom-0 border-l"
+								style={{ left: `${(t / scale) * 100}%` }}
+							/>
+						))}
+					</div>
+
+					{/* axis */}
+					<div className="text-text-secondary relative h-9 border-b text-[10px]">
+						{ticks.map((t, i) => (
+							<span
+								key={i}
+								className="absolute top-1/2 -translate-y-1/2 pl-1"
+								style={{ left: `${(t / scale) * 100}%` }}
+							>
+								{t}ms
+							</span>
+						))}
+					</div>
+
+					{/* bars */}
+					{ordered.map((span) => {
+						const leftPct = (span.start_ms / scale) * 100;
+						const widthPct = (span.duration_ms / scale) * 100;
+						const wide = widthPct > 8;
+						return (
+							<button
+								type="button"
+								key={span.span_id}
+								onClick={() =>
+									setSelectedId(selectedId === span.span_id ? null : span.span_id)
+								}
+								onMouseEnter={() => setHoveredId(span.span_id)}
+								onMouseLeave={() => setHoveredId(null)}
+								className={cn(
+									"relative block w-full transition-colors",
+									rowBg(span.span_id)
+								)}
+								style={{ height: ROW_H }}
+							>
+								<div
+									className={cn(
+										"absolute top-1/2 flex h-3.5 -translate-y-1/2 items-center rounded-sm",
+										barColor(span)
+									)}
+									style={{
+										left: `${leftPct}%`,
+										width: `${widthPct}%`,
+										minWidth: 3,
+									}}
+								>
+									{wide ? (
+										<span className="truncate px-1.5 text-[10px] font-medium text-white">
+											{Math.round(span.duration_ms)}ms
+										</span>
+									) : null}
+								</div>
+								{!wide ? (
+									<span
+										className="text-text-secondary absolute top-1/2 -translate-y-1/2 pl-1 text-[10px]"
+										style={{ left: `${leftPct + widthPct}%` }}
+									>
+										{Math.round(span.duration_ms)}ms
+									</span>
+								) : null}
+							</button>
+						);
+					})}
+				</div>
+			</div>
+
+			{selected ? <SpanDetail span={selected} /> : null}
+		</div>
+	);
+}
+
+function SpanDetail({ span }: { span: LayoutSpan }): JSX.Element {
+	const attrs = parseAttributes(span);
+	const entries = Object.entries(attrs);
+	const isErr = !!span.error || (!!span.outcome && span.outcome !== "ok");
+	return (
+		<div className="bg-kumo-base border-t p-4">
+			<div className="mb-3 flex items-center gap-2">
+				<span
+					className={cn(
+						"size-2 rounded-full",
+						KIND_DOT[spanKind(span)] ?? KIND_DOT.span
+					)}
+				/>
+				<span className="text-text font-mono text-sm font-semibold">
+					{span.name}
+				</span>
+				<span
+					className={cn(
+						"rounded px-1.5 py-0.5 text-[10px] font-medium",
+						isErr
+							? "bg-red-500/15 text-red-500"
+							: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400"
+					)}
+				>
+					{span.outcome ?? "?"}
+				</span>
+				<span className="text-text-secondary text-xs">
+					{Math.round(span.duration_ms)}ms
+				</span>
+			</div>
+			{span.error ? (
+				<div className="mb-3 rounded bg-red-500/10 px-2 py-1.5 text-xs text-red-500">
+					{span.error}
+				</div>
+			) : null}
+			{entries.length ? (
+				<div className="overflow-hidden rounded border">
+					<table className="w-full text-xs">
+						<tbody>
+							{entries.map(([k, v], i) => (
+								<tr
+									key={k}
+									className={cn(
+										"align-top",
+										i % 2 ? "bg-kumo-elevated" : ""
+									)}
+								>
+									<td className="text-text-secondary w-1/3 px-3 py-1.5 font-mono whitespace-nowrap">
+										{k}
+									</td>
+									<td className="text-text px-3 py-1.5 font-mono break-all">
+										{typeof v === "object" ? JSON.stringify(v) : String(v)}
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
+			) : (
+				<div className="text-text-secondary text-xs italic">No attributes</div>
+			)}
+		</div>
+	);
+}

--- a/packages/local-explorer-ui/src/lib/traces.ts
+++ b/packages/local-explorer-ui/src/lib/traces.ts
@@ -1,0 +1,202 @@
+import { d1RawDatabaseQuery } from "../api";
+import type { LocalExplorerWorkerBindings } from "../api";
+
+/**
+ * Data layer for the Observability (Traces) tab.
+ *
+ * Traces are persisted by the local trace collector into a regular local D1
+ * database (tables `traces` + `spans`). The local explorer can already read any
+ * local D1 via the D1 raw-query endpoint, so this tab is just a purpose-built
+ * view over that same SQLite store — no separate data pipeline.
+ */
+
+export interface TraceRow {
+	trace_id: string;
+	root_span_id: string;
+	name: string | null;
+	duration_ms: number | null;
+	outcome: string | null;
+	status_code: number | null;
+	error: string | null;
+	span_count: number | null;
+	created_at: string | null;
+}
+
+export interface SpanRow {
+	trace_id: string;
+	span_id: string;
+	parent_id: string | null;
+	name: string | null;
+	kind: string | null;
+	/** offset from trace start, in ms */
+	start_ms: number;
+	end_ms: number | null;
+	duration_ms: number;
+	outcome: string | null;
+	error: string | null;
+	/** JSON string of span attributes */
+	attributes: string | null;
+}
+
+/** A span with computed tree layout (depth + flattened DFS order). */
+export interface LayoutSpan extends SpanRow {
+	depth: number;
+	hasChildren: boolean;
+}
+
+/** Run a SQL statement against a local D1 and return row objects. */
+async function runSql(
+	databaseId: string,
+	sql: string
+): Promise<Record<string, unknown>[]> {
+	const response = await d1RawDatabaseQuery({
+		body: { sql },
+		path: { database_id: databaseId },
+	});
+	const result = response.data?.result?.[0];
+	if (!result?.results) {
+		return [];
+	}
+	const columns = result.results.columns ?? [];
+	const rows = (result.results.rows ?? []) as unknown[][];
+	return rows.map((row) => {
+		const obj: Record<string, unknown> = {};
+		columns.forEach((col, i) => {
+			obj[col] = row[i];
+		});
+		return obj;
+	});
+}
+
+/**
+ * Find the D1 database that holds the trace store among a worker's bindings.
+ * Matches by binding/database name containing "trace".
+ */
+export function findTraceDatabaseId(
+	bindings: LocalExplorerWorkerBindings | undefined
+): string | undefined {
+	const candidates = bindings?.d1 ?? [];
+	const match = candidates.find((db) =>
+		/trace/i.test(db.bindingName ?? "")
+	);
+	return match?.id;
+}
+
+/** Whether the trace store has been initialised (tables exist + have rows). */
+export async function hasTraceTables(databaseId: string): Promise<boolean> {
+	const rows = await runSql(
+		databaseId,
+		"SELECT name FROM sqlite_master WHERE type='table' AND name IN ('traces','spans')"
+	);
+	return rows.length >= 2;
+}
+
+/** Fetch recent traces (most recent first). */
+export async function listTraces(
+	databaseId: string,
+	limit = 100
+): Promise<TraceRow[]> {
+	const rows = await runSql(
+		databaseId,
+		`SELECT trace_id, root_span_id, name, duration_ms, outcome, status_code, error, span_count, created_at
+		 FROM traces ORDER BY created_at DESC, ROWID DESC LIMIT ${Number(limit)}`
+	);
+	return rows as unknown as TraceRow[];
+}
+
+/** Fetch all spans for a single trace. */
+export async function getTraceSpans(
+	databaseId: string,
+	traceId: string
+): Promise<SpanRow[]> {
+	const safe = traceId.replace(/'/g, "''");
+	const rows = await runSql(
+		databaseId,
+		`SELECT trace_id, span_id, parent_id, name, kind, start_ms, end_ms, duration_ms, outcome, error, attributes
+		 FROM spans WHERE trace_id='${safe}' ORDER BY start_ms ASC`
+	);
+	return rows as unknown as SpanRow[];
+}
+
+/**
+ * Flatten spans into a depth-ordered list (DFS), mirroring the dashboard's
+ * trace waterfall layout. Children are grouped by parent_id and sorted by
+ * start offset; orphans are attached to the root.
+ */
+export function buildSpanTree(
+	spans: SpanRow[],
+	rootSpanId: string
+): LayoutSpan[] {
+	const byId = new Map(spans.map((s) => [s.span_id, s]));
+	const childrenOf = new Map<string, SpanRow[]>();
+
+	for (const s of spans) {
+		if (s.span_id === rootSpanId) {
+			continue;
+		}
+		let parent = s.parent_id ?? rootSpanId;
+		if (!byId.has(parent)) {
+			parent = rootSpanId;
+		}
+		const arr = childrenOf.get(parent) ?? [];
+		arr.push(s);
+		childrenOf.set(parent, arr);
+	}
+
+	for (const arr of childrenOf.values()) {
+		arr.sort((a, b) => a.start_ms - b.start_ms);
+	}
+
+	const out: LayoutSpan[] = [];
+	const visit = (spanId: string, depth: number) => {
+		const span = byId.get(spanId);
+		if (!span) {
+			return;
+		}
+		const children = childrenOf.get(spanId) ?? [];
+		out.push({ ...span, depth, hasChildren: children.length > 0 });
+		for (const child of children) {
+			visit(child.span_id, depth + 1);
+		}
+	};
+
+	const root = byId.get(rootSpanId) ?? spans[0];
+	if (root) {
+		visit(root.span_id, 0);
+	}
+	return out;
+}
+
+/** Color/icon kind for a span. */
+export function spanKind(span: SpanRow): string {
+	if (span.kind) {
+		return span.kind;
+	}
+	const n = (span.name ?? "").toLowerCase();
+	if (n.includes("kv")) {
+		return "kv";
+	}
+	if (n.includes("d1")) {
+		return "d1";
+	}
+	if (n.includes("fetch")) {
+		return "fetch";
+	}
+	if (n.includes("r2")) {
+		return "r2";
+	}
+	return "span";
+}
+
+/** Parse the JSON attributes column into an object (or empty). */
+export function parseAttributes(span: SpanRow): Record<string, unknown> {
+	if (!span.attributes) {
+		return {};
+	}
+	try {
+		const parsed = JSON.parse(span.attributes);
+		return parsed && typeof parsed === "object" ? parsed : {};
+	} catch {
+		return {};
+	}
+}

--- a/packages/local-explorer-ui/src/routeTree.gen.ts
+++ b/packages/local-explorer-ui/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as ObservabilityRouteImport } from './routes/observability'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as WorkflowsWorkflowNameRouteImport } from './routes/workflows/$workflowName'
 import { Route as R2BucketNameRouteImport } from './routes/r2/$bucketName'
@@ -22,6 +23,11 @@ import { Route as WorkflowsWorkflowNameInstanceIdRouteImport } from './routes/wo
 import { Route as DoClassNameObjectIdRouteImport } from './routes/do/$className/$objectId'
 import { Route as R2BucketNameObjectSplatRouteImport } from './routes/r2/$bucketName/object.$'
 
+const ObservabilityRoute = ObservabilityRouteImport.update({
+  id: '/observability',
+  path: '/observability',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -87,6 +93,7 @@ const R2BucketNameObjectSplatRoute = R2BucketNameObjectSplatRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/observability': typeof ObservabilityRoute
   '/d1/$databaseId': typeof D1DatabaseIdRoute
   '/do/$className': typeof DoClassNameRouteWithChildren
   '/kv/$namespaceId': typeof KvNamespaceIdRoute
@@ -101,6 +108,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/observability': typeof ObservabilityRoute
   '/d1/$databaseId': typeof D1DatabaseIdRoute
   '/kv/$namespaceId': typeof KvNamespaceIdRoute
   '/do/$className/$objectId': typeof DoClassNameObjectIdRoute
@@ -113,6 +121,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/observability': typeof ObservabilityRoute
   '/d1/$databaseId': typeof D1DatabaseIdRoute
   '/do/$className': typeof DoClassNameRouteWithChildren
   '/kv/$namespaceId': typeof KvNamespaceIdRoute
@@ -129,6 +138,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/observability'
     | '/d1/$databaseId'
     | '/do/$className'
     | '/kv/$namespaceId'
@@ -143,6 +153,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/observability'
     | '/d1/$databaseId'
     | '/kv/$namespaceId'
     | '/do/$className/$objectId'
@@ -154,6 +165,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/observability'
     | '/d1/$databaseId'
     | '/do/$className'
     | '/kv/$namespaceId'
@@ -169,6 +181,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  ObservabilityRoute: typeof ObservabilityRoute
   D1DatabaseIdRoute: typeof D1DatabaseIdRoute
   DoClassNameRoute: typeof DoClassNameRouteWithChildren
   KvNamespaceIdRoute: typeof KvNamespaceIdRoute
@@ -178,6 +191,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/observability': {
+      id: '/observability'
+      path: '/observability'
+      fullPath: '/observability'
+      preLoaderRoute: typeof ObservabilityRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -310,6 +330,7 @@ const WorkflowsWorkflowNameRouteWithChildren =
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  ObservabilityRoute: ObservabilityRoute,
   D1DatabaseIdRoute: D1DatabaseIdRoute,
   DoClassNameRoute: DoClassNameRouteWithChildren,
   KvNamespaceIdRoute: KvNamespaceIdRoute,

--- a/packages/local-explorer-ui/src/routes/observability.tsx
+++ b/packages/local-explorer-ui/src/routes/observability.tsx
@@ -1,0 +1,272 @@
+import { cn } from "@cloudflare/kumo";
+import {
+	ArrowsCounterClockwiseIcon,
+	PulseIcon,
+} from "@phosphor-icons/react";
+import { createFileRoute, getRouteApi } from "@tanstack/react-router";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { TraceWaterfall } from "../components/observability/TraceWaterfall";
+import {
+	findTraceDatabaseId,
+	getTraceSpans,
+	listTraces,
+	type SpanRow,
+	type TraceRow,
+} from "../lib/traces";
+
+export const Route = createFileRoute("/observability")({
+	component: ObservabilityView,
+	validateSearch: (search): { worker?: string } => ({
+		worker: typeof search.worker === "string" ? search.worker : undefined,
+	}),
+});
+
+const rootRoute = getRouteApi("__root__");
+
+function ObservabilityView(): JSX.Element {
+	const rootData = rootRoute.useLoaderData();
+
+	const databaseId = useMemo(() => {
+		for (const worker of rootData.workers) {
+			const id = findTraceDatabaseId(worker.bindings);
+			if (id) {
+				return id;
+			}
+		}
+		return undefined;
+	}, [rootData.workers]);
+
+	const [traces, setTraces] = useState<TraceRow[]>([]);
+	const [selected, setSelected] = useState<TraceRow | null>(null);
+	const [spans, setSpans] = useState<SpanRow[]>([]);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const refresh = useCallback(async () => {
+		if (!databaseId) {
+			return;
+		}
+		setLoading(true);
+		setError(null);
+		try {
+			setTraces(await listTraces(databaseId));
+		} catch (e) {
+			setError(e instanceof Error ? e.message : "Failed to load traces");
+		} finally {
+			setLoading(false);
+		}
+	}, [databaseId]);
+
+	useEffect(() => {
+		void refresh();
+	}, [refresh]);
+
+	const selectTrace = useCallback(
+		async (trace: TraceRow) => {
+			setSelected(trace);
+			setSpans([]);
+			if (!databaseId) {
+				return;
+			}
+			try {
+				setSpans(await getTraceSpans(databaseId, trace.trace_id));
+			} catch (e) {
+				setError(e instanceof Error ? e.message : "Failed to load spans");
+			}
+		},
+		[databaseId]
+	);
+
+	const maxDuration = useMemo(
+		() => Math.max(1, ...traces.map((t) => t.duration_ms ?? 0)),
+		[traces]
+	);
+
+	if (!databaseId) {
+		return (
+			<EmptyState
+				title="No trace store found"
+				body="Run a Worker with the local trace collector attached (a D1 binding whose name contains “trace”). Once requests are traced, they'll appear here."
+			/>
+		);
+	}
+
+	return (
+		<div className="flex h-full flex-col">
+			<header className="flex min-h-14 items-center gap-2.5 border-b px-4">
+				<PulseIcon size={18} className="text-text-secondary" />
+				<div className="flex flex-col">
+					<h2 className="text-text text-sm leading-tight font-semibold">
+						Traces
+					</h2>
+					<span className="text-text-secondary text-[11px] leading-tight">
+						{traces.length} trace{traces.length === 1 ? "" : "s"}
+					</span>
+				</div>
+				<div className="flex-1" />
+				<button
+					type="button"
+					onClick={() => void refresh()}
+					className="text-text-secondary hover:bg-kumo-tint hover:text-text flex items-center gap-1.5 rounded px-2 py-1 text-xs"
+				>
+					<ArrowsCounterClockwiseIcon
+						size={13}
+						className={loading ? "animate-spin" : undefined}
+					/>
+					Refresh
+				</button>
+			</header>
+
+			<div className="flex-1 overflow-y-auto p-4">
+				{error ? (
+					<div className="mb-3 rounded bg-red-500/10 px-3 py-2 text-xs text-red-500">
+						{error}
+					</div>
+				) : null}
+
+				{traces.length === 0 && !loading ? (
+					<EmptyState
+						title="No traces yet"
+						body="Send some requests to your Worker (with observability traces enabled) and they'll show up here."
+						inline
+					/>
+				) : (
+					<div className="bg-kumo-elevated overflow-hidden rounded-lg border">
+						<table className="w-full text-sm">
+							<thead>
+								<tr className="text-text-secondary border-b text-left text-[11px] uppercase tracking-wide">
+									<th className="px-3 py-2 font-medium">Operation</th>
+									<th className="w-56 px-3 py-2 font-medium">Duration</th>
+									<th className="w-24 px-3 py-2 font-medium">Status</th>
+									<th className="w-20 px-3 py-2 font-medium">Spans</th>
+									<th className="w-44 px-3 py-2 font-medium">Time</th>
+								</tr>
+							</thead>
+							<tbody>
+								{traces.map((t) => {
+									const isSel = selected?.trace_id === t.trace_id;
+									const dur = t.duration_ms ?? 0;
+									return (
+										<tr
+											key={t.trace_id}
+											onClick={() => void selectTrace(t)}
+											className={cn(
+												"hover:bg-kumo-tint cursor-pointer border-b last:border-0",
+												isSel && "bg-blue-100 dark:bg-blue-900/30"
+											)}
+										>
+											<td className="text-text px-3 py-2 font-mono text-xs">
+												{t.name ?? t.trace_id.slice(0, 16)}
+											</td>
+											<td className="px-3 py-2">
+												<div className="flex items-center gap-2">
+													<span className="text-text w-14 shrink-0 text-right text-xs tabular-nums">
+														{Math.round(dur)}ms
+													</span>
+													<div className="bg-kumo-fill h-1.5 flex-1 overflow-hidden rounded-full">
+														<div
+															className="bg-indigo-500 h-full rounded-full"
+															style={{
+																width: `${Math.max((dur / maxDuration) * 100, 2)}%`,
+															}}
+														/>
+													</div>
+												</div>
+											</td>
+											<td className="px-3 py-2">
+												<StatusBadge
+													statusCode={t.status_code}
+													outcome={t.outcome}
+												/>
+											</td>
+											<td className="text-text-secondary px-3 py-2 text-xs tabular-nums">
+												{t.span_count ?? "-"}
+											</td>
+											<td className="text-text-secondary px-3 py-2 text-xs">
+												{t.created_at ?? ""}
+											</td>
+										</tr>
+									);
+								})}
+							</tbody>
+						</table>
+					</div>
+				)}
+
+				{selected && spans.length > 0 ? (
+					<div className="mt-6">
+						<div className="mb-2 flex items-baseline gap-2">
+							<span className="text-text font-mono text-sm font-semibold">
+								{selected.name ?? selected.trace_id}
+							</span>
+							<span className="text-text-secondary font-mono text-[11px]">
+								{selected.trace_id.slice(0, 16)}
+							</span>
+							<span className="text-text-secondary text-[11px]">
+								· {Math.round(selected.duration_ms ?? 0)}ms ·{" "}
+								{selected.span_count ?? spans.length} spans
+							</span>
+						</div>
+						<TraceWaterfall
+							spans={spans}
+							rootSpanId={selected.root_span_id}
+							traceDurationMs={selected.duration_ms ?? 0}
+						/>
+					</div>
+				) : null}
+			</div>
+		</div>
+	);
+}
+
+function StatusBadge({
+	statusCode,
+	outcome,
+}: {
+	statusCode: number | null;
+	outcome: string | null;
+}): JSX.Element {
+	const code = statusCode ?? 0;
+	const label = statusCode ? String(statusCode) : (outcome ?? "?");
+	let cls = "bg-gray-500/15 text-text-secondary";
+	if (code >= 500) {
+		cls = "bg-red-500/15 text-red-500";
+	} else if (code >= 400) {
+		cls = "bg-amber-500/15 text-amber-600 dark:text-amber-400";
+	} else if (code >= 200) {
+		cls = "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400";
+	}
+	return (
+		<span
+			className={cn(
+				"inline-block rounded px-1.5 py-0.5 text-[11px] font-medium tabular-nums",
+				cls
+			)}
+		>
+			{label}
+		</span>
+	);
+}
+
+function EmptyState({
+	title,
+	body,
+	inline,
+}: {
+	title: string;
+	body: string;
+	inline?: boolean;
+}): JSX.Element {
+	return (
+		<div
+			className={cn(
+				"flex flex-col items-center justify-center text-center",
+				inline ? "py-16" : "h-full"
+			)}
+		>
+			<PulseIcon size={28} className="text-text-secondary mb-2" />
+			<h3 className="text-text text-sm font-semibold">{title}</h3>
+			<p className="text-text-secondary mt-1 max-w-md text-xs">{body}</p>
+		</div>
+	);
+}


### PR DESCRIPTION
Adds a top-level Observability tab to the local dev explorer that renders a trace waterfall, modeled on the Workers Observability dashboard's Traces page.

- src/lib/traces.ts: read the local trace store (D1 traces/spans tables) via the existing D1 raw-query endpoint; discover the trace DB from worker bindings; build the span tree from parent_id.
- src/components/observability/TraceWaterfall.tsx: two-column waterfall (span-name tree + timeline) with gridlines, nice time axis, state-colored bars, kind dots, hover/selection, and a span attributes detail panel.
- src/routes/observability.tsx: trace list (duration gauge + status badges) with click-to-expand waterfall.
- Sidebar: top-level Observability entry.

Reuses the explorer's existing D1 read path - no backend/openapi changes.

Fixes #[insert GH or internal issue link(s)].

_Describe your change..._

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->