### PR TITLE
[wrangler] Update temporary account Terms URL

### DIFF
--- a/.changeset/temporary-preview-account-terms-url.md
+++ b/.changeset/temporary-preview-account-terms-url.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+"@cloudflare/workers-auth": patch
+---
+
+Use `https://www.cloudflare.com/terms` for temporary preview account Terms of Service links
+
+Wrangler's temporary account flow now prints and submits the general Cloudflare Terms of Service URL without the legacy website-specific path.

--- a/packages/workers-auth/src/temporary.ts
+++ b/packages/workers-auth/src/temporary.ts
@@ -14,7 +14,7 @@ import type { OAuthFlowLogger } from "./context";
 import type { PowSolution } from "./pow";
 
 export const TEMPORARY_TERMS_URLS = {
-	termsOfService: "https://www.cloudflare.com/terms/",
+	termsOfService: "https://www.cloudflare.com/terms",
 	privacyPolicy: "https://www.cloudflare.com/privacypolicy/",
 } as const;
 

--- a/packages/wrangler/src/__tests__/deploy/core.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/core.test.ts
@@ -100,7 +100,7 @@ describe("deploy", () => {
 	} = mockOAuthFlow();
 	const temporaryPreviewAccountUrl =
 		"https://api.cloudflare.com/client/v4/provisioning/previews";
-	const temporaryTermsUrl = "https://www.cloudflare.com/terms/";
+	const temporaryTermsUrl = "https://www.cloudflare.com/terms";
 	const legacyTemporaryTermsUrl = "https://www.cloudflare.com/website-terms/";
 
 	// Mocks the proof-of-work challenge minting expects. Small k/g so the

--- a/packages/wrangler/src/__tests__/deploy/core.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/core.test.ts
@@ -100,6 +100,8 @@ describe("deploy", () => {
 	} = mockOAuthFlow();
 	const temporaryPreviewAccountUrl =
 		"https://api.cloudflare.com/client/v4/provisioning/previews";
+	const temporaryTermsUrl = "https://www.cloudflare.com/terms/";
+	const legacyTemporaryTermsUrl = "https://www.cloudflare.com/website-terms/";
 
 	// Mocks the proof-of-work challenge minting expects. Small k/g so the
 	// solve is instant.
@@ -1080,7 +1082,7 @@ describe("deploy", () => {
 
 				expect(previewContentType).toBe("application/json");
 				expect(previewRequestBody).toEqual({
-					termsOfService: "https://www.cloudflare.com/terms/",
+					termsOfService: temporaryTermsUrl,
 					privacyPolicy: "https://www.cloudflare.com/privacypolicy/",
 					acceptTermsOfService: "yes",
 					challengeToken: "challenge-token",
@@ -1096,6 +1098,8 @@ describe("deploy", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.out).not.toContain("Attempting to login via OAuth...");
 				expect(std.out).toContain(TEMPORARY_TERMS_NOTICE);
+				expect(std.out).toContain(temporaryTermsUrl);
+				expect(std.out).not.toContain(legacyTemporaryTermsUrl);
 				expect(std.out).toContain("Temporary account ready:");
 				expect(std.out).toContain("Account: Preview Account Alpha (created)");
 				expect(std.out).toContain("Claim within:");

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -39,6 +39,8 @@ describe("versions upload", () => {
 	const assertApiRequest = makeApiRequestAsserter(std);
 	const temporaryPreviewAccountUrl =
 		"https://api.cloudflare.com/client/v4/provisioning/previews";
+	const temporaryTermsUrl = "https://www.cloudflare.com/terms/";
+	const legacyTemporaryTermsUrl = "https://www.cloudflare.com/website-terms/";
 
 	function mockGetScript(result?: unknown) {
 		msw.use(
@@ -200,6 +202,8 @@ describe("versions upload", () => {
 
 			expect(previewAccountRequests).toBe(1);
 			expect(std.out).toContain(TEMPORARY_TERMS_NOTICE);
+			expect(std.out).toContain(temporaryTermsUrl);
+			expect(std.out).not.toContain(legacyTemporaryTermsUrl);
 			expect(std.out).toContain("Temporary account ready:");
 			expect(std.out).toContain("Account: Preview Account Alpha (created)");
 			expect(std.out).toContain("Uploaded test-name");

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -39,7 +39,7 @@ describe("versions upload", () => {
 	const assertApiRequest = makeApiRequestAsserter(std);
 	const temporaryPreviewAccountUrl =
 		"https://api.cloudflare.com/client/v4/provisioning/previews";
-	const temporaryTermsUrl = "https://www.cloudflare.com/terms/";
+	const temporaryTermsUrl = "https://www.cloudflare.com/terms";
 	const legacyTemporaryTermsUrl = "https://www.cloudflare.com/website-terms/";
 
 	function mockGetScript(result?: unknown) {


### PR DESCRIPTION
Updates the temporary preview account Terms of Service URL to `https://www.cloudflare.com/terms`.

The link is used in Wrangler's temporary account prompt/notice and submitted with temporary account provisioning requests. The existing deploy and versions upload tests now assert the exact URL and guard against the old website-specific path.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this updates a CLI link to an existing Cloudflare Terms page.

*A picture of a cute animal (not mandatory, but encouraged)*