### PR TITLE
[wrangler] fix: don't require private credential when reusing an existing Secrets Store secret

### DIFF
--- a/.changeset/free-islands-sink.md
+++ b/.changeset/free-islands-sink.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Don't require the private credential when reusing an existing Secrets Store secret in `containers registries configure`
+
+`wrangler containers registries configure` now checks whether the target Secrets Store secret already exists before resolving the private credential. When the secret already exists it is reused by reference, so the private credential no longer needs to be supplied (via stdin in non-interactive mode, or via a prompt interactively). This applies to all external registries.
+
+The new-secret path is unchanged: the credential is still required and stored. The only visible interactive change is that the secret prompt now appears last and only when a new secret is being created.

--- a/packages/wrangler/src/__tests__/containers/registries.test.ts
+++ b/packages/wrangler/src/__tests__/containers/registries.test.ts
@@ -237,14 +237,14 @@ describe("containers registries configure", () => {
 			const awsEcrDomain = "123456789012.dkr.ecr.us-west-2.amazonaws.com";
 			const storeId = "test-store-id-123";
 			mockPrompt({
-				text: "Enter AWS Secret Access Key:",
-				options: { isSecret: true },
-				result: "test-secret-access-key",
-			});
-			mockPrompt({
 				text: "Secret name:",
 				options: { isSecret: false, defaultValue: "AWS_Secret_Access_Key" },
 				result: "AWS_Secret_Access_Key",
+			});
+			mockPrompt({
+				text: "Enter AWS Secret Access Key:",
+				options: { isSecret: true },
+				result: "test-secret-access-key",
 			});
 
 			mockListSecretStores([
@@ -285,11 +285,6 @@ describe("containers registries configure", () => {
 			const awsEcrDomain = "123456789012.dkr.ecr.us-west-2.amazonaws.com";
 			const newStoreId = "new-store-id-456";
 
-			mockPrompt({
-				text: "Enter AWS Secret Access Key:",
-				options: { isSecret: true },
-				result: "test-secret-access-key",
-			});
 			mockConfirm({
 				text: "No existing Secret Stores found. Create a Secret Store to store your registry credentials?",
 				result: true,
@@ -298,6 +293,11 @@ describe("containers registries configure", () => {
 				text: "Secret name:",
 				options: { isSecret: false, defaultValue: "AWS_Secret_Access_Key" },
 				result: "AWS_Secret_Access_Key",
+			});
+			mockPrompt({
+				text: "Enter AWS Secret Access Key:",
+				options: { isSecret: true },
+				result: "test-secret-access-key",
 			});
 
 			mockListSecretStores([]);
@@ -335,14 +335,14 @@ describe("containers registries configure", () => {
 			const providedStoreId = "provided-store-id-789";
 
 			mockPrompt({
-				text: "Enter AWS Secret Access Key:",
-				options: { isSecret: true },
-				result: "test-secret-access-key",
-			});
-			mockPrompt({
 				text: "Secret name:",
 				options: { isSecret: false, defaultValue: "AWS_Secret_Access_Key" },
 				result: "AWS_Secret_Access_Key",
+			});
+			mockPrompt({
+				text: "Enter AWS Secret Access Key:",
+				options: { isSecret: true },
+				result: "test-secret-access-key",
 			});
 
 			mockListSecrets(providedStoreId, []);
@@ -371,12 +371,12 @@ describe("containers registries configure", () => {
 				│
 				│ Configuring AWS ECR registry: 123456789012.dkr.ecr.us-west-2.amazonaws.com
 				│
-				│ Getting AWS Secret Access Key...
-				│
 				│
 				│ Setting up integration with Secrets Store...
 				│
 				│
+				│
+				│ Getting AWS Secret Access Key...
 				│
 				│ Container-scoped secret "AWS_Secret_Access_Key" created in Secrets Store.
 				│
@@ -384,6 +384,51 @@ describe("containers registries configure", () => {
 
 				"
 			`);
+		});
+
+		it("should reuse an existing secret interactively without prompting for the credential", async ({
+			expect,
+		}) => {
+			setIsTTY(true);
+			const awsEcrDomain = "123456789012.dkr.ecr.us-west-2.amazonaws.com";
+			const providedStoreId = "provided-store-id-reuse";
+			const secretName = "existing_secret";
+
+			mockConfirm({
+				text: "Do you want to reuse the existing secret? If not, then you'll be prompted to pick a new name.",
+				result: true,
+			});
+
+			mockListSecrets(providedStoreId, [
+				{
+					id: "existing-secret-id",
+					store_id: providedStoreId,
+					name: secretName,
+					comment: "",
+					scopes: ["containers"],
+					created: "2024-01-01T00:00:00Z",
+					modified: "2024-01-01T00:00:00Z",
+					status: "active",
+				},
+			]);
+			mockPutRegistry(expect, {
+				domain: awsEcrDomain,
+				is_public: false,
+				auth: {
+					public_credential: "test-access-key-id",
+					private_credential: {
+						store_id: providedStoreId,
+						secret_name: secretName,
+					},
+				},
+				kind: "ECR",
+			});
+
+			await runWrangler(
+				`containers registries configure ${awsEcrDomain} --aws-access-key-id=test-access-key-id --secret-store-id=${providedStoreId} --secret-name=${secretName}`
+			);
+
+			expect(cliStd.stdout).not.toContain("created in Secrets Store");
 		});
 
 		describe("non-interactive", () => {
@@ -426,7 +471,7 @@ describe("containers registries configure", () => {
 				);
 			});
 
-			it("should reuse existing secret with --skip-confirmation", async ({
+			it("should ignore a piped stdin value when reusing an existing secret with --skip-confirmation", async ({
 				expect,
 			}) => {
 				const storeId = "test-store-id-reuse";
@@ -474,6 +519,53 @@ describe("containers registries configure", () => {
 				// Should not contain "created" message since we reused existing secret
 				expect(cliStd.stdout).not.toContain("created in Secrets Store");
 			});
+
+			it("should reuse existing secret without requiring a value (no stdin)", async ({
+				expect,
+			}) => {
+				const storeId = "test-store-id-reuse";
+				const secretName = "existing_secret";
+
+				mockListSecretStores([
+					{
+						id: storeId,
+						account_id: "some-account-id",
+						name: "Default",
+						created: "2024-01-01T00:00:00Z",
+						modified: "2024-01-01T00:00:00Z",
+					},
+				]);
+				mockListSecrets(storeId, [
+					{
+						id: "existing-secret-id",
+						store_id: storeId,
+						name: secretName,
+						comment: "",
+						scopes: ["containers"],
+						created: "2024-01-01T00:00:00Z",
+						modified: "2024-01-01T00:00:00Z",
+						status: "active",
+					},
+				]);
+				mockPutRegistry(expect, {
+					domain: awsEcrDomain,
+					is_public: false,
+					auth: {
+						public_credential: "test-access-key-id",
+						private_credential: {
+							store_id: storeId,
+							secret_name: secretName,
+						},
+					},
+					kind: "ECR",
+				});
+
+				await runWrangler(
+					`containers registries configure ${awsEcrDomain} --public-credential=test-access-key-id --secret-name=${secretName} --skip-confirmation`
+				);
+
+				expect(cliStd.stdout).not.toContain("created in Secrets Store");
+			});
 		});
 	});
 
@@ -485,14 +577,14 @@ describe("containers registries configure", () => {
 			const dockerHubDomain = "docker.io";
 			const storeId = "test-store-id-123";
 			mockPrompt({
-				text: "Enter DockerHub PAT Token:",
-				options: { isSecret: true },
-				result: "test-pat-token",
-			});
-			mockPrompt({
 				text: "Secret name:",
 				options: { isSecret: false, defaultValue: "DockerHub_PAT_Token" },
 				result: "DockerHub_PAT_Token",
+			});
+			mockPrompt({
+				text: "Enter DockerHub PAT Token:",
+				options: { isSecret: true },
+				result: "test-pat-token",
 			});
 
 			mockListSecretStores([
@@ -564,6 +656,54 @@ describe("containers registries configure", () => {
 				await runWrangler(
 					`containers registries configure ${dockerHubDomain} --public-credential=cloudchambertest --secret-name=DockerHub_PAT_Token`
 				);
+			});
+
+			it("should reuse existing secret without requiring a value (no stdin)", async ({
+				expect,
+			}) => {
+				const storeId = "test-store-id-reuse";
+				const secretName = "existing_secret";
+
+				// No value is piped via stdin; the existing secret is reused by reference.
+				mockListSecretStores([
+					{
+						id: storeId,
+						account_id: "some-account-id",
+						name: "Default",
+						created: "2024-01-01T00:00:00Z",
+						modified: "2024-01-01T00:00:00Z",
+					},
+				]);
+				mockListSecrets(storeId, [
+					{
+						id: "existing-secret-id",
+						store_id: storeId,
+						name: secretName,
+						comment: "",
+						scopes: ["containers"],
+						created: "2024-01-01T00:00:00Z",
+						modified: "2024-01-01T00:00:00Z",
+						status: "active",
+					},
+				]);
+				mockPutRegistry(expect, {
+					domain: dockerHubDomain,
+					is_public: false,
+					auth: {
+						public_credential: "cloudchambertest",
+						private_credential: {
+							store_id: storeId,
+							secret_name: secretName,
+						},
+					},
+					kind: "DockerHub",
+				});
+
+				await runWrangler(
+					`containers registries configure ${dockerHubDomain} --public-credential=cloudchambertest --secret-name=${secretName} --skip-confirmation`
+				);
+
+				expect(cliStd.stdout).not.toContain("created in Secrets Store");
 			});
 		});
 	});

--- a/packages/wrangler/src/containers/registries.ts
+++ b/packages/wrangler/src/containers/registries.ts
@@ -159,15 +159,9 @@ async function registryConfigureCommand(
 	}
 
 	let secretStoreId = configureArgs.secretStoreId;
-	let secretName = configureArgs.secretName;
 	if (configureArgs.secretName) {
 		validateSecretName(configureArgs.secretName);
 	}
-
-	log(`Getting ${registryType.secretType}...\n`);
-	const privateCredential = await promptForRegistryPrivateCredential(
-		registryType.secretType
-	);
 
 	// Secret Store is not available in FedRAMP High
 	let private_credential: ImageRegistryAuth["private_credential"];
@@ -213,14 +207,32 @@ async function registryConfigureCommand(
 
 		log("\n");
 
-		secretName = await getOrCreateSecret({
+		const { secretName, secretExists } = await resolveSecretSelection({
 			configureArgs: configureArgs,
 			config: config,
 			accountId: accountId,
 			storeId: secretStoreId,
-			privateCredential,
 			secretType: registryType.secretType,
 		});
+
+		if (!secretExists) {
+			// New secret: read the private credential and store it.
+			log(`Getting ${registryType.secretType}...\n`);
+			const privateCredential = await promptForRegistryPrivateCredential(
+				registryType.secretType
+			);
+			await promiseSpinner(
+				createSecret(config, accountId, secretStoreId, {
+					name: secretName,
+					value: privateCredential,
+					scopes: ["containers"],
+					comment: `Created by Wrangler: credentials for image registry ${configureArgs.DOMAIN}`,
+				})
+			);
+			log(
+				`Container-scoped secret "${secretName}" created in Secrets Store.\n`
+			);
+		}
 
 		private_credential = {
 			store_id: secretStoreId,
@@ -228,7 +240,10 @@ async function registryConfigureCommand(
 		};
 	} else {
 		// If we are not using the secret store, we will be passing in the secret directly
-		private_credential = privateCredential;
+		log(`Getting ${registryType.secretType}...\n`);
+		private_credential = await promptForRegistryPrivateCredential(
+			registryType.secretType
+		);
 	}
 
 	try {
@@ -283,18 +298,22 @@ async function promptForSecretName(secretType?: string): Promise<string> {
 	}
 }
 
-interface GetOrCreateSecretOptions {
+interface ResolveSecretSelectionOptions {
 	configureArgs: HandlerArgs<typeof registryConfigureArgs>;
 	config: Config;
 	accountId: string;
 	storeId: string;
-	privateCredential: string;
 	secretType?: string;
 }
 
-async function getOrCreateSecret(
-	options: GetOrCreateSecretOptions
-): Promise<string> {
+/**
+ * If the Secrets Store secret already exists, it is reused by reference and no
+ * private credential is read; otherwise the caller reads the private credential
+ * and creates the secret.
+ */
+async function resolveSecretSelection(
+	options: ResolveSecretSelectionOptions
+): Promise<{ secretName: string; secretExists: boolean }> {
 	let secretName =
 		options.configureArgs.secretName ??
 		(await promptForSecretName(options.secretType));
@@ -307,22 +326,9 @@ async function getOrCreateSecret(
 			secretName
 		);
 
-		// secret doesn't exist - make a new one
+		// secret doesn't exist - caller will create it
 		if (!existingSecretId) {
-			await promiseSpinner(
-				createSecret(options.config, options.accountId, options.storeId, {
-					name: secretName,
-					value: options.privateCredential,
-					scopes: ["containers"],
-					comment: `Created by Wrangler: credentials for image registry ${options.configureArgs.DOMAIN}`,
-				})
-			);
-
-			log(
-				`Container-scoped secret "${secretName}" created in Secrets Store.\n`
-			);
-
-			return secretName;
+			return { secretName, secretExists: false };
 		}
 
 		// secret exists + skipConfirmation - default to reusing the secret
@@ -330,7 +336,7 @@ async function getOrCreateSecret(
 			log(
 				`Using existing secret "${secretName}" from secret store with id: ${options.storeId}.\n`
 			);
-			return secretName;
+			return { secretName, secretExists: true };
 		}
 
 		// secret exists but not skipping confirmation - ask user if they want to reuse the secret
@@ -346,7 +352,7 @@ async function getOrCreateSecret(
 			log(
 				`Using existing secret "${secretName}" from secret store with id: ${options.storeId}.\n`
 			);
-			return secretName;
+			return { secretName, secretExists: true };
 		}
 
 		secretName = await promptForSecretName(options.secretType);


### PR DESCRIPTION
Fixes #[CC-7994](https://jira.cfdata.org/browse/CC-7994), [Issue 14356](https://github.com/cloudflare/workers-sdk/issues/14356)

`containers registries configure` now checks whether the target Secrets Store secret already exists before resolving the private credential. If it exists, the secret is reused by reference, so the credential no longer needs to be supplied via stdin or an interactive prompt. The new-secret and FedRAMP inline paths are unchanged; the interactive secret prompt now appears only when creating a new secret.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: feature was already documented and this is a bug fix

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
