### PR TITLE
Add autoconfig support for React Router >= 8.0.0

### DIFF
--- a/.changeset/react-router-v8-skip-future-flags.md
+++ b/.changeset/react-router-v8-skip-future-flags.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/autoconfig": minor
+---
+
+Add support for React Router >= 8.0.0
+
+React Router v8 enables `viteEnvironmentApi` and `middleware` by default, so autoconfig no longer adds `future` flags to `react-router.config.ts` for v8+ projects and uses the middleware code pattern unconditionally.

--- a/packages/autoconfig/src/frameworks/all-frameworks.ts
+++ b/packages/autoconfig/src/frameworks/all-frameworks.ts
@@ -121,7 +121,7 @@ export const allKnownFrameworks = [
 			// react-router.config.ts which are required for Cloudflare Workers support
 			// See: https://remix.run/blog/react-router-v7
 			minimumVersion: "7.0.0",
-			maximumKnownMajorVersion: "7",
+			maximumKnownMajorVersion: "8",
 		},
 		supported: true,
 	},

--- a/packages/autoconfig/src/frameworks/react-router.ts
+++ b/packages/autoconfig/src/frameworks/react-router.ts
@@ -42,8 +42,15 @@ function getReactRouterConfigPath(projectPath: string): string | null {
 }
 
 /**
- * Checks whether the user's `react-router.config.ts` (or `.js`) has `v8_middleware: true`
- * set in its `future` block. This determines which code pattern to generate:
+ * Checks whether the middleware pattern should be used for the given React Router project.
+ *
+ * For React Router >= 8.0.0, middleware is enabled by default
+ * (ref: https://github.com/remix-run/react-router/pull/15078), so this always returns `true`.
+ *
+ * For earlier versions, it parses the user's `react-router.config.ts` (or `.js`) to check
+ * whether `future.v8_middleware` is explicitly set to `true`.
+ *
+ * This determines which code pattern to generate:
  * - With middleware: simplified fetch handler using `cloudflare:workers` env pattern
  * - Without middleware: traditional `AppLoadContext` pattern with `env`/`ctx` params
  *
@@ -51,10 +58,21 @@ function getReactRouterConfigPath(projectPath: string): string | null {
  * Handles both TS `satisfies`/`as` expressions and plain object exports.
  *
  * @param projectPath - Absolute path to the project root containing the React Router config file.
- * @returns `true` if `future.v8_middleware` is explicitly set to `true`, `false` otherwise
- *   (including when the config file is missing or has no `future` block).
+ * @param frameworkVersion - React Router semver version string. When provided and
+ *   >= 8.0.0, returns `true` without parsing the config file (middleware is the default in v8).
+ * @returns `true` if middleware is enabled (either by default in v8+ or via `future.v8_middleware`
+ *   in the config), `false` otherwise (including when the config file is missing or has no
+ *   `future` block).
  */
-export function hasV8MiddlewareFlag(projectPath: string): boolean {
+export function hasV8MiddlewareFlag(
+	projectPath: string,
+	frameworkVersion?: string
+): boolean {
+	// React Router >= 8.0.0 has middleware enabled by default
+	if (frameworkVersion && semiver(frameworkVersion, "8.0.0") >= 0) {
+		return true;
+	}
+
 	const filePath = getReactRouterConfigPath(projectPath);
 	if (!filePath) {
 		return false;
@@ -128,7 +146,7 @@ export function hasV8MiddlewareFlag(projectPath: string): boolean {
  */
 function transformReactRouterConfig(
 	projectPath: string,
-	viteEnvironmentKey: ReturnType<typeof configPropertyName>
+	viteEnvironmentKey: ReturnType<typeof viteEnvAPIconfigPropertyName>
 ) {
 	const filePath = getReactRouterConfigPath(projectPath);
 	if (!filePath) {
@@ -236,7 +254,7 @@ function transformReactRouterConfig(
  * @returns `"unstable_viteEnvironmentApi"` for versions before 7.10.0,
  *   or `"v8_viteEnvironmentApi"` for 7.10.0 and later.
  */
-function configPropertyName(reactRouterVersion: string) {
+function viteEnvAPIconfigPropertyName(reactRouterVersion: string) {
 	if (!reactRouterVersion) {
 		return "v8_viteEnvironmentApi";
 	}
@@ -247,6 +265,25 @@ function configPropertyName(reactRouterVersion: string) {
 	} else {
 		return "v8_viteEnvironmentApi";
 	}
+}
+
+/**
+ * Determines whether the installed React Router version still requires the explicit
+ * `future` flag in `react-router.config.ts` for enabling the vite environment API.
+ *
+ * React Router >= 8.0.0 enables these features by default
+ * (ref: https://github.com/remix-run/react-router/pull/15077), so no future flags
+ * are needed (they also can't be included as they would cause errors at build time).
+ *
+ * @param reactRouterVersion - The installed React Router semver version string (e.g. `"7.16.0"`).
+ * @returns `true` if the future flag needs to be set (versions < 8.0.0), `false` otherwise.
+ */
+function needsViteEnvAPIFutureFlag(reactRouterVersion: string): boolean {
+	if (!reactRouterVersion) {
+		return false;
+	}
+
+	return semiver(reactRouterVersion, "8.0.0") < 0;
 }
 
 /**
@@ -439,8 +476,10 @@ export class ReactRouter extends Framework {
 		isWorkspaceRoot,
 		context,
 	}: ConfigurationOptions): Promise<ConfigurationResults> {
-		const viteEnvironmentKey = configPropertyName(this.frameworkVersion);
-		const useMiddlewarePattern = hasV8MiddlewareFlag(projectPath);
+		const useMiddlewarePattern = hasV8MiddlewareFlag(
+			projectPath,
+			this.frameworkVersion
+		);
 		if (!dryRun) {
 			await installCloudflareVitePlugin({
 				packageManager: packageManager.type,
@@ -466,7 +505,12 @@ export class ReactRouter extends Framework {
 				incompatibleVitePlugins: ["netlifyReactRouter"],
 			});
 
-			transformReactRouterConfig(projectPath, viteEnvironmentKey);
+			if (needsViteEnvAPIFutureFlag(this.frameworkVersion)) {
+				const viteEnvironmentKey = viteEnvAPIconfigPropertyName(
+					this.frameworkVersion
+				);
+				transformReactRouterConfig(projectPath, viteEnvironmentKey);
+			}
 		}
 
 		return {

--- a/packages/autoconfig/src/frameworks/react-router.ts
+++ b/packages/autoconfig/src/frameworks/react-router.ts
@@ -146,7 +146,7 @@ export function hasV8MiddlewareFlag(
  */
 function transformReactRouterConfig(
 	projectPath: string,
-	viteEnvironmentKey: ReturnType<typeof viteEnvAPIconfigPropertyName>
+	viteEnvironmentKey: ReturnType<typeof viteEnvApiConfigPropertyName>
 ) {
 	const filePath = getReactRouterConfigPath(projectPath);
 	if (!filePath) {
@@ -506,7 +506,7 @@ export class ReactRouter extends Framework {
 			});
 
 			if (needsViteEnvAPIFutureFlag(this.frameworkVersion)) {
-				const viteEnvironmentKey = viteEnvAPIconfigPropertyName(
+				const viteEnvironmentKey = viteEnvApiConfigPropertyName(
 					this.frameworkVersion
 				);
 				transformReactRouterConfig(projectPath, viteEnvironmentKey);

--- a/packages/autoconfig/src/frameworks/react-router.ts
+++ b/packages/autoconfig/src/frameworks/react-router.ts
@@ -254,7 +254,7 @@ function transformReactRouterConfig(
  * @returns `"unstable_viteEnvironmentApi"` for versions before 7.10.0,
  *   or `"v8_viteEnvironmentApi"` for 7.10.0 and later.
  */
-function viteEnvAPIconfigPropertyName(reactRouterVersion: string) {
+function viteEnvApiConfigPropertyName(reactRouterVersion: string) {
 	if (!reactRouterVersion) {
 		return "v8_viteEnvironmentApi";
 	}

--- a/packages/autoconfig/tests/frameworks/react-router.test.ts
+++ b/packages/autoconfig/tests/frameworks/react-router.test.ts
@@ -56,7 +56,7 @@ function createFramework(version: string): ReactRouter {
 		{
 			name: "react-router",
 			minimumVersion: "7.0.0",
-			maximumKnownMajorVersion: "7",
+			maximumKnownMajorVersion: "8",
 		},
 		context
 	);
@@ -322,6 +322,95 @@ describe("React Router framework configure()", () => {
 			expect(content).toContain("v8_middleware: true");
 			// New flag added
 			expect(content).toContain("v8_viteEnvironmentApi: true");
+		});
+	});
+
+	describe("React Router >= 8.0.0", () => {
+		beforeEach(async () => {
+			await writeFile(
+				resolve("react-router.config.ts"),
+				fixture("config-no-future.ts")
+			);
+		});
+
+		it("does not add future flags to react-router.config.ts", async ({
+			expect,
+		}) => {
+			const original = readFileSync(resolve("react-router.config.ts"), "utf-8");
+
+			const framework = createFramework("8.0.0");
+			await framework.configure(getBaseOptions());
+
+			const content = readFileSync(resolve("react-router.config.ts"), "utf-8");
+			expect(content).not.toContain("v8_viteEnvironmentApi");
+			expect(content).not.toContain("unstable_viteEnvironmentApi");
+			expect(content).toBe(original);
+		});
+
+		it("does not add future flags for React Router 8.x", async ({ expect }) => {
+			const original = readFileSync(resolve("react-router.config.ts"), "utf-8");
+
+			const framework = createFramework("8.2.0");
+			await framework.configure(getBaseOptions());
+
+			const content = readFileSync(resolve("react-router.config.ts"), "utf-8");
+			expect(content).not.toContain("v8_viteEnvironmentApi");
+			expect(content).not.toContain("unstable_viteEnvironmentApi");
+			expect(content).toBe(original);
+		});
+
+		it("uses middleware pattern by default for workers/app.ts", async ({
+			expect,
+		}) => {
+			const framework = createFramework("8.0.0");
+			await framework.configure(getBaseOptions());
+
+			const content = readFileSync(resolve("workers/app.ts"), "utf-8");
+			expect(content).not.toContain("AppLoadContext");
+			expect(content).not.toContain("declare module");
+			expect(content).toContain("async fetch(request)");
+			expect(content).not.toContain("env, ctx");
+			expect(content).toContain("requestHandler(request)");
+		});
+
+		it("uses middleware pattern by default for entry.server.tsx", async ({
+			expect,
+		}) => {
+			const framework = createFramework("8.0.0");
+			await framework.configure(getBaseOptions());
+
+			const content = readFileSync(resolve("app/entry.server.tsx"), "utf-8");
+			expect(content).not.toContain("AppLoadContext");
+			expect(content).not.toContain("_loadContext");
+			expect(content).toContain(
+				'import type { EntryContext } from "react-router"'
+			);
+		});
+	});
+
+	describe("hasV8MiddlewareFlag with version >= 8.0.0", () => {
+		it("returns true without config file when version >= 8.0.0", ({
+			expect,
+		}) => {
+			expect(hasV8MiddlewareFlag(process.cwd(), "8.0.0")).toBe(true);
+		});
+
+		it("returns true regardless of config content when version >= 8.0.0", async ({
+			expect,
+		}) => {
+			await writeFile(
+				resolve("react-router.config.ts"),
+				fixture("config-no-future.ts")
+			);
+			expect(hasV8MiddlewareFlag(process.cwd(), "8.0.0")).toBe(true);
+		});
+
+		it("still parses config for versions < 8.0.0", async ({ expect }) => {
+			await writeFile(
+				resolve("react-router.config.ts"),
+				fixture("config-no-future.ts")
+			);
+			expect(hasV8MiddlewareFlag(process.cwd(), "7.16.0")).toBe(false);
 		});
 	});
 

--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -943,7 +943,6 @@ function getExperimentalFrameworkTestConfig(
 		},
 		{
 			name: "react-router",
-			quarantine: true,
 			unsupportedOSs: ["win32"],
 			testCommitMessage: true,
 			timeout: LONG_TIMEOUT,


### PR DESCRIPTION
React router 8.0.0 broke our autoconfig logic, this PR addresses such issue and allows autoconfig to support such new version of the framework.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/31569
  - [ ] Documentation not necessary because:

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
