### PR TITLE
Add missing changeset for autoconfig package and set package version to 0.0.0

### DIFF
--- a/.changeset/evil-drinks-sing.md
+++ b/.changeset/evil-drinks-sing.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/autoconfig": minor
+---
+
+Move Wrangler's autoconfig logic to this new experimental package

--- a/.changeset/evil-drinks-sing.md
+++ b/.changeset/evil-drinks-sing.md
@@ -2,4 +2,4 @@
 "@cloudflare/autoconfig": minor
 ---
 
-Move Wrangler's autoconfig logic to this new experimental package
+Add experimental package for framework autoconfig detection and configuration

--- a/.changeset/hungry-mails-cover.md
+++ b/.changeset/hungry-mails-cover.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/autoconfig": minor
+---
+
+Add support for React Router >= 8.0.0
+
+React Router v8 enables `viteEnvironmentApi` and `middleware` by default, so autoconfig no longer adds `future` flags to `react-router.config.ts` for v8+ projects and uses the middleware code pattern unconditionally.

--- a/.changeset/react-router-v8-skip-future-flags.md
+++ b/.changeset/react-router-v8-skip-future-flags.md
@@ -1,7 +1,0 @@
----
-"@cloudflare/autoconfig": minor
----
-
-Add support for React Router >= 8.0.0
-
-React Router v8 enables `viteEnvironmentApi` and `middleware` by default, so autoconfig no longer adds `future` flags to `react-router.config.ts` for v8+ projects and uses the middleware code pattern unconditionally.

--- a/packages/autoconfig/package.json
+++ b/packages/autoconfig/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cloudflare/autoconfig",
-	"version": "0.1.0",
+	"version": "0.0.0",
 	"description": "Framework autoconfig detection and configuration for Cloudflare Workers",
 	"license": "MIT OR Apache-2.0",
 	"files": [


### PR DESCRIPTION
In https://github.com/cloudflare/workers-sdk/pull/14295 I forgot to create a changeset for the autoconfig package, this PR adds such changeset.

Also this PR sets the (never released yet) package version to `0.0.0` since it was incorrectly set to `0.1.0`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: infra change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: infra change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->