### PR TITLE
Resolve relative cf-worker imports relative to the importing module

### DIFF
--- a/.changeset/cf-worker-relative-entrypoint-resolution.md
+++ b/.changeset/cf-worker-relative-entrypoint-resolution.md
@@ -1,0 +1,10 @@
+---
+"@cloudflare/vite-plugin": patch
+"wrangler": patch
+---
+
+Resolve relative `cf-worker` entrypoint imports relative to the importing module
+
+When loading the experimental `cloudflare.config.ts`, a relative entrypoint imported with `import ... with { type: "cf-worker" }` (e.g. `./src/index.ts`) is now anchored to the module where the import is written, rather than being passed through verbatim and later resolved against the top-level config file. This fixes incorrect resolution when the import lives in a file other than the entry config — for example a config that re-exports from a nested file.
+
+Bare specifiers (such as `@scope/pkg`) and virtual modules (such as `virtual:foo`) are still left unresolved so that consumers can apply their own resolution.

--- a/packages/config/src/__tests__/load.test.ts
+++ b/packages/config/src/__tests__/load.test.ts
@@ -65,7 +65,7 @@ describe("loadConfig", () => {
 		expect(result.config).toEqual({ name: "my-worker" });
 	});
 
-	it("passes cf-worker specifiers through verbatim without resolving or executing them", async ({
+	it("anchors relative cf-worker specifiers to an absolute path without executing them", async ({
 		expect,
 	}) => {
 		await seed({
@@ -81,14 +81,41 @@ describe("loadConfig", () => {
 			configPath: "./cloudflare.config.ts",
 		});
 
+		// The relative specifier is anchored to the importing module and
+		// emitted as an absolute path, but the entrypoint is never loaded or
+		// executed.
 		expect(
 			(result.config as { entrypoint: { default: string } }).entrypoint
-		).toEqual({ default: "./src/index.ts" });
+		).toEqual({ default: path.resolve("src/index.ts") });
 		// The entrypoint is referenced for its specifier only; changes to
 		// its source must not trigger a config reload, so it is not tracked.
 		expect(result.dependencies).not.toContain(path.resolve("src/index.ts"));
 		// The config file itself is still tracked.
 		expect(result.dependencies).toContain(path.resolve("cloudflare.config.ts"));
+	});
+
+	it("anchors relative cf-worker specifiers to the importing module, not the top-level config", async ({
+		expect,
+	}) => {
+		await seed({
+			"nested/src/index.ts": `throw new Error("entrypoint must not be executed at config load time");`,
+			"nested/sub.config.ts": `
+				import * as entrypoint from "./src/index.ts" with { type: "cf-worker" };
+				export default { name: "w", entrypoint };
+			`,
+			"cloudflare.config.ts": `export { default } from "./nested/sub.config.ts";`,
+		});
+
+		const result = runLoadConfigInSubprocess({
+			cwd: process.cwd(),
+			configPath: "./cloudflare.config.ts",
+		});
+
+		// `./src/index.ts` is written in `nested/sub.config.ts`, so it must
+		// resolve relative to that file — not the top-level config file.
+		expect(
+			(result.config as { entrypoint: { default: string } }).entrypoint
+		).toEqual({ default: path.resolve("nested/src/index.ts") });
 	});
 
 	it("passes bare and virtual cf-worker specifiers through verbatim", async ({
@@ -135,7 +162,7 @@ describe("loadConfig", () => {
 		});
 		const parsed = InputWorkerSchema.parse(result.config);
 
-		expect(parsed.entrypoint).toBe("./src/index.ts");
+		expect(parsed.entrypoint).toBe(path.resolve("src/index.ts"));
 	});
 
 	it("reloads the config when the file changes between calls in the same process", async ({

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -65,10 +65,12 @@ let deregister: (() => void) | undefined;
  * repeated calls return the same deregister function.
  *
  *  - Handles `with { type: "cf-worker" }` import attributes by synthesising an
- *    ES module whose default export is the raw specifier as written by the
- *    user — relative paths, bare specifiers, and virtual-module specifiers
- *    all pass through unchanged. The referenced module is NOT resolved, is
- *    NOT executed, and is NOT added to the dependencies set.
+ *    ES module whose default export is the entrypoint specifier. Relative
+ *    specifiers (`./`, `../`) are anchored to the importing module and emitted
+ *    as absolute paths; bare specifiers and virtual-module specifiers pass
+ *    through unchanged so consumers can apply their own resolution semantics.
+ *    The referenced module is NOT loaded, is NOT executed, and is NOT added to
+ *    the dependencies set.
  *  - Handles `with { cf: "no-cache" }` import attributes (set internally by
  *    `loadConfig`) by tagging the resolved URL with a unique UUID query
  *    string so Node treats each import as a fresh module. The UUID is
@@ -100,13 +102,25 @@ export function registerConfigHooks(): () => void {
 			const importAttributes = context.importAttributes ?? {};
 
 			if (importAttributes.type === CF_WORKER_TYPE) {
-				// Path-only reference. The entrypoint is never resolved or
-				// loaded, so we don't add it to dependencies (changes to the
-				// entrypoint's source should not trigger a config reload). The
-				// raw specifier is preserved verbatim so consumers can apply
-				// their own resolution semantics.
+				// Path-only reference. The entrypoint is never loaded or
+				// executed, so we don't add it to dependencies (changes to the
+				// entrypoint's source should not trigger a config reload).
+				//
+				// Relative specifiers (`./`, `../`) are anchored to the
+				// importing module via `parentURL`, producing an absolute path.
+				// This keeps resolution correct even when the import is written
+				// in a file other than the top-level config (e.g. a re-exported
+				// nested config), where resolving relative to the config file
+				// downstream would be wrong.
+				const isRelative =
+					specifier.startsWith("./") || specifier.startsWith("../");
+				const entrypoint =
+					isRelative && context.parentURL
+						? fileURLToPath(new URL(specifier, context.parentURL))
+						: specifier;
+
 				return {
-					url: `${CF_WORKER_SCHEME}${encodeURIComponent(specifier)}`,
+					url: `${CF_WORKER_SCHEME}${encodeURIComponent(entrypoint)}`,
 					format: "module",
 					shortCircuit: true,
 				};


### PR DESCRIPTION
Resolve relative `cf-worker` entrypoint imports relative to the importing module

When loading the experimental `cloudflare.config.ts`, a relative entrypoint imported with `import ... with { type: "cf-worker" }` (e.g. `./src/index.ts`) is now anchored to the module where the import is written, rather than being passed through verbatim and later resolved against the top-level config file. This fixes incorrect resolution when the import lives in a file other than the entry config — for example a config that re-exports from a nested file.

Bare specifiers (such as `@scope/pkg`) and virtual modules (such as `virtual:foo`) are still left unresolved so that consumers can apply their own resolution.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: experimental feature

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
