### PR TITLE
[wrangler] add ai-search jobs commands

### DIFF
--- a/.changeset/ai-search-jobs.md
+++ b/.changeset/ai-search-jobs.md
@@ -1,0 +1,17 @@
+---
+"wrangler": minor
+---
+
+Add `wrangler ai-search jobs` commands for managing AI Search indexing jobs
+
+You can now list, trigger, inspect, cancel, and read the logs of indexing jobs for an AI Search instance:
+
+```
+wrangler ai-search jobs list <instance>
+wrangler ai-search jobs create <instance> --description "manual reindex"
+wrangler ai-search jobs get <instance> <job-id>
+wrangler ai-search jobs cancel <instance> <job-id>
+wrangler ai-search jobs logs <instance> <job-id>
+```
+
+All commands accept `--namespace`/`-n` (defaults to `default`) and `--json` for clean machine-readable output.

--- a/.changeset/ai-search-jobs.md
+++ b/.changeset/ai-search-jobs.md
@@ -14,4 +14,4 @@ wrangler ai-search jobs cancel <instance> <job-id>
 wrangler ai-search jobs logs <instance> <job-id>
 ```
 
-All commands accept `--namespace`/`-n` (defaults to `default`) and `--json` for clean machine-readable output.
+All commands accept `--namespace`/`-n` (defaults to `default`). All commands except `cancel` also accept `--json` for clean machine-readable output.

--- a/packages/wrangler/src/__tests__/ai-search.test.ts
+++ b/packages/wrangler/src/__tests__/ai-search.test.ts
@@ -97,6 +97,29 @@ const MOCK_STATS = {
 	error: 2,
 };
 
+const MOCK_JOB = {
+	id: "job-001",
+	source: "user",
+	description: "Manual reindex",
+	started_at: "2025-03-01T00:00:00Z",
+	ended_at: "2025-03-01T00:05:00Z",
+	end_reason: "completed",
+	last_seen_at: "2025-03-01T00:05:00Z",
+};
+
+const MOCK_JOB_2 = {
+	id: "job-002",
+	source: "schedule",
+	started_at: "2025-03-02T00:00:00Z",
+};
+
+const MOCK_JOB_LOG = {
+	id: 1,
+	created_at: 1700000000,
+	message: "Indexing started",
+	message_type: 0,
+};
+
 // ── Help / Namespace ──────────────────────────────────────────────────────────
 
 describe("ai-search help", () => {
@@ -117,6 +140,7 @@ describe("ai-search help", () => {
 		expect(std.out).toContain("wrangler ai-search stats");
 		expect(std.out).toContain("wrangler ai-search search");
 		expect(std.out).toContain("wrangler ai-search namespace");
+		expect(std.out).toContain("wrangler ai-search jobs");
 	});
 
 	it("should show help when an invalid argument is passed", async ({
@@ -142,6 +166,19 @@ describe("ai-search help", () => {
 		expect(std.out).toContain("wrangler ai-search namespace get");
 		expect(std.out).toContain("wrangler ai-search namespace update");
 		expect(std.out).toContain("wrangler ai-search namespace delete");
+	});
+
+	it("should show jobs subcommand help", async ({ expect }) => {
+		await runWrangler("ai-search jobs");
+		await endEventLoop();
+
+		expect(std.out).toContain("wrangler ai-search jobs");
+		expect(std.out).toContain("AI Search indexing jobs");
+		expect(std.out).toContain("wrangler ai-search jobs list");
+		expect(std.out).toContain("wrangler ai-search jobs create");
+		expect(std.out).toContain("wrangler ai-search jobs get");
+		expect(std.out).toContain("wrangler ai-search jobs cancel");
+		expect(std.out).toContain("wrangler ai-search jobs logs");
 	});
 });
 
@@ -2139,6 +2176,242 @@ describe("ai-search commands", () => {
 			});
 		});
 	});
+
+	// ── jobs ────────────────────────────────────────────────────────────────────
+
+	describe("jobs", () => {
+		describe("list", () => {
+			it("should list jobs for an instance", async ({ expect }) => {
+				mockListJobs([MOCK_JOB, MOCK_JOB_2]);
+				await runWrangler("ai-search jobs list my-instance");
+				expect(std.out).toContain(MOCK_JOB.id);
+				expect(std.out).toContain(MOCK_JOB_2.id);
+				expect(std.out).toContain("user");
+				expect(std.out).toContain("schedule");
+			});
+
+			it("should list jobs as JSON", async ({ expect }) => {
+				mockListJobs([MOCK_JOB]);
+				await runWrangler("ai-search jobs list my-instance --json");
+				const parsed = JSON.parse(std.out);
+				expect(parsed).toEqual([MOCK_JOB]);
+			});
+
+			it("should route through the instance and namespace", async ({
+				expect,
+			}) => {
+				let capturedNamespace: string | undefined;
+				let capturedName: string | undefined;
+				msw.use(
+					http.get(
+						"*/accounts/:accountId/ai-search/namespaces/:namespace/instances/:name/jobs",
+						({ params }) => {
+							capturedNamespace = params.namespace as string;
+							capturedName = params.name as string;
+							return HttpResponse.json(createFetchResult([], true));
+						},
+						{ once: true }
+					)
+				);
+				await runWrangler("ai-search jobs list my-instance --namespace blog");
+				expect(capturedNamespace).toBe("blog");
+				expect(capturedName).toBe("my-instance");
+			});
+
+			it("should warn when no jobs exist", async ({ expect }) => {
+				mockListJobs([]);
+				await runWrangler("ai-search jobs list my-instance");
+				expect(std.warn).toContain(
+					'No indexing jobs found for AI Search instance "my-instance" in namespace "default".'
+				);
+			});
+
+			it("should pass pagination params", async ({ expect }) => {
+				let capturedUrl: URL | undefined;
+				msw.use(
+					http.get(
+						"*/accounts/:accountId/ai-search/namespaces/:namespace/instances/:name/jobs",
+						({ request }) => {
+							capturedUrl = new URL(request.url);
+							return HttpResponse.json(createFetchResult([], true));
+						},
+						{ once: true }
+					)
+				);
+				await runWrangler(
+					"ai-search jobs list my-instance --page 2 --per-page 5"
+				);
+				expect(capturedUrl?.searchParams.get("page")).toBe("2");
+				expect(capturedUrl?.searchParams.get("per_page")).toBe("5");
+			});
+		});
+
+		describe("create", () => {
+			it("should create a job with a description", async ({ expect }) => {
+				let capturedBody: Record<string, unknown> | undefined;
+				let capturedNamespace: string | undefined;
+				msw.use(
+					http.post(
+						"*/accounts/:accountId/ai-search/namespaces/:namespace/instances/:name/jobs",
+						async ({ request, params }) => {
+							capturedBody = (await request.json()) as Record<string, unknown>;
+							capturedNamespace = params.namespace as string;
+							return HttpResponse.json(createFetchResult(MOCK_JOB, true));
+						},
+						{ once: true }
+					)
+				);
+				await runWrangler(
+					'ai-search jobs create my-instance --description "Manual reindex"'
+				);
+				expect(capturedNamespace).toBe("default");
+				expect(capturedBody).toEqual({ description: "Manual reindex" });
+				expect(std.out).toContain(
+					'Successfully created indexing job "job-001"'
+				);
+			});
+
+			it("should create a job without a description", async ({ expect }) => {
+				let capturedBody: Record<string, unknown> | undefined;
+				msw.use(
+					http.post(
+						"*/accounts/:accountId/ai-search/namespaces/:namespace/instances/:name/jobs",
+						async ({ request }) => {
+							capturedBody = (await request.json()) as Record<string, unknown>;
+							return HttpResponse.json(createFetchResult(MOCK_JOB, true));
+						},
+						{ once: true }
+					)
+				);
+				await runWrangler("ai-search jobs create my-instance");
+				expect(capturedBody).toEqual({});
+			});
+
+			it("should create a job as JSON", async ({ expect }) => {
+				mockCreateJob(MOCK_JOB);
+				await runWrangler("ai-search jobs create my-instance --json");
+				const parsed = JSON.parse(std.out);
+				expect(parsed.id).toBe("job-001");
+			});
+		});
+
+		describe("get", () => {
+			it("should get job details", async ({ expect }) => {
+				mockGetJob(MOCK_JOB);
+				await runWrangler("ai-search jobs get my-instance job-001");
+				expect(std.out).toContain("job-001");
+				expect(std.out).toContain("user");
+				expect(std.out).toContain("completed");
+			});
+
+			it("should get a job as JSON", async ({ expect }) => {
+				mockGetJob(MOCK_JOB);
+				await runWrangler("ai-search jobs get my-instance job-001 --json");
+				const parsed = JSON.parse(std.out);
+				expect(parsed.id).toBe("job-001");
+			});
+
+			it("should route through the job id in the URL", async ({ expect }) => {
+				let capturedJobId: string | undefined;
+				msw.use(
+					http.get(
+						"*/accounts/:accountId/ai-search/namespaces/:namespace/instances/:name/jobs/:jobId",
+						({ params }) => {
+							capturedJobId = params.jobId as string;
+							return HttpResponse.json(createFetchResult(MOCK_JOB, true));
+						},
+						{ once: true }
+					)
+				);
+				await runWrangler("ai-search jobs get my-instance job-xyz");
+				expect(capturedJobId).toBe("job-xyz");
+			});
+
+			it("should error when job id is missing", async ({ expect }) => {
+				await expect(() =>
+					runWrangler("ai-search jobs get my-instance")
+				).rejects.toThrow("Not enough non-option arguments");
+			});
+		});
+
+		describe("cancel", () => {
+			it("should cancel with confirmation", async ({ expect }) => {
+				mockConfirm({
+					text: 'OK to cancel the indexing job "job-001" on AI Search instance "my-instance"?',
+					result: true,
+				});
+				const requests = mockCancelJob(MOCK_JOB);
+				await runWrangler("ai-search jobs cancel my-instance job-001");
+				expect(requests.count).toBe(1);
+				expect(std.out).toContain(
+					'Successfully cancelled indexing job "job-001"'
+				);
+			});
+
+			it("should send action=cancel in the PATCH body", async ({ expect }) => {
+				let capturedBody: Record<string, unknown> | undefined;
+				mockConfirm({
+					text: 'OK to cancel the indexing job "job-001" on AI Search instance "my-instance"?',
+					result: true,
+				});
+				msw.use(
+					http.patch(
+						"*/accounts/:accountId/ai-search/namespaces/:namespace/instances/:name/jobs/:jobId",
+						async ({ request }) => {
+							capturedBody = (await request.json()) as Record<string, unknown>;
+							return HttpResponse.json(createFetchResult(MOCK_JOB, true));
+						},
+						{ once: true }
+					)
+				);
+				await runWrangler("ai-search jobs cancel my-instance job-001");
+				expect(capturedBody).toEqual({ action: "cancel" });
+			});
+
+			it("should abort when not confirmed", async ({ expect }) => {
+				mockConfirm({
+					text: 'OK to cancel the indexing job "job-001" on AI Search instance "my-instance"?',
+					result: false,
+				});
+				const requests = mockCancelJob(MOCK_JOB);
+				await runWrangler("ai-search jobs cancel my-instance job-001");
+				expect(std.out).toContain("Cancellation aborted.");
+				expect(requests.count).toBe(0);
+			});
+
+			it("should cancel with --force flag", async ({ expect }) => {
+				const requests = mockCancelJob(MOCK_JOB);
+				await runWrangler("ai-search jobs cancel my-instance job-001 --force");
+				expect(requests.count).toBe(1);
+				expect(std.out).toContain(
+					'Successfully cancelled indexing job "job-001"'
+				);
+			});
+		});
+
+		describe("logs", () => {
+			it("should list job logs", async ({ expect }) => {
+				mockListJobLogs([MOCK_JOB_LOG]);
+				await runWrangler("ai-search jobs logs my-instance job-001");
+				expect(std.out).toContain("Indexing started");
+			});
+
+			it("should list job logs as JSON", async ({ expect }) => {
+				mockListJobLogs([MOCK_JOB_LOG]);
+				await runWrangler("ai-search jobs logs my-instance job-001 --json");
+				const parsed = JSON.parse(std.out);
+				expect(parsed).toEqual([MOCK_JOB_LOG]);
+			});
+
+			it("should warn when no logs exist", async ({ expect }) => {
+				mockListJobLogs([]);
+				await runWrangler("ai-search jobs logs my-instance job-001");
+				expect(std.warn).toContain(
+					'No log entries found for indexing job "job-001".'
+				);
+			});
+		});
+	});
 });
 
 // ── MSW Mock Handlers ─────────────────────────────────────────────────────────
@@ -2267,6 +2540,83 @@ function mockListNamespaces(namespaces: unknown[]) {
 						per_page: 20,
 						count: namespaces.length,
 						total_count: namespaces.length,
+					})
+				);
+			},
+			{ once: true }
+		)
+	);
+}
+
+function mockListJobs(jobs: unknown[]) {
+	msw.use(
+		http.get(
+			"*/accounts/:accountId/ai-search/namespaces/:namespace/instances/:name/jobs",
+			() => {
+				return HttpResponse.json(
+					createFetchResult(jobs, true, [], [], {
+						page: 1,
+						per_page: 20,
+						count: jobs.length,
+						total_count: jobs.length,
+					})
+				);
+			},
+			{ once: true }
+		)
+	);
+}
+
+function mockCreateJob(job: unknown) {
+	msw.use(
+		http.post(
+			"*/accounts/:accountId/ai-search/namespaces/:namespace/instances/:name/jobs",
+			() => {
+				return HttpResponse.json(createFetchResult(job, true));
+			},
+			{ once: true }
+		)
+	);
+}
+
+function mockGetJob(job: unknown) {
+	msw.use(
+		http.get(
+			"*/accounts/:accountId/ai-search/namespaces/:namespace/instances/:name/jobs/:jobId",
+			() => {
+				return HttpResponse.json(createFetchResult(job, true));
+			},
+			{ once: true }
+		)
+	);
+}
+
+function mockCancelJob(job: unknown) {
+	const requests = { count: 0 };
+	msw.use(
+		http.patch(
+			"*/accounts/:accountId/ai-search/namespaces/:namespace/instances/:name/jobs/:jobId",
+			() => {
+				requests.count++;
+				return HttpResponse.json(createFetchResult(job, true));
+			},
+			{ once: true }
+		)
+	);
+	return requests;
+}
+
+function mockListJobLogs(logs: unknown[]) {
+	msw.use(
+		http.get(
+			"*/accounts/:accountId/ai-search/namespaces/:namespace/instances/:name/jobs/:jobId/logs",
+			() => {
+				return HttpResponse.json(
+					createFetchResult(logs, true, [], [], {
+						page: 1,
+						per_page: 20,
+						count: logs.length,
+						total_count: logs.length,
 					})
 				);
 			},

--- a/packages/wrangler/src/ai-search/client.ts
+++ b/packages/wrangler/src/ai-search/client.ts
@@ -2,6 +2,8 @@ import { fetchListResult, fetchResult } from "../cfetch";
 import { requireAuth } from "../user";
 import type {
 	AiSearchInstance,
+	AiSearchJob,
+	AiSearchJobLog,
 	AiSearchMessage,
 	AiSearchNamespace,
 	AiSearchSearchResponse,
@@ -209,6 +211,97 @@ export async function deleteNamespace(
 	await fetchResult<unknown>(config, `${baseNamespaceUrl(accountId)}/${name}`, {
 		method: "DELETE",
 	});
+}
+
+// ── Jobs ─────────────────────────────────────────────────────────────────────
+
+function baseJobUrl(
+	accountId: string,
+	namespace: string,
+	instance: string
+): string {
+	return `${baseInstanceUrl(accountId, namespace)}/${instance}/jobs`;
+}
+
+export async function listJobs(
+	config: Config,
+	namespace: string,
+	instance: string,
+	queryParams?: URLSearchParams
+): Promise<AiSearchJob[]> {
+	const accountId = await requireAuth(config);
+	return await fetchResult<AiSearchJob[]>(
+		config,
+		baseJobUrl(accountId, namespace, instance),
+		{ method: "GET" },
+		queryParams
+	);
+}
+
+export async function createJob(
+	config: Config,
+	namespace: string,
+	instance: string,
+	body: { description?: string }
+): Promise<AiSearchJob> {
+	const accountId = await requireAuth(config);
+	return await fetchResult<AiSearchJob>(
+		config,
+		baseJobUrl(accountId, namespace, instance),
+		{
+			method: "POST",
+			headers: { "content-type": jsonContentType },
+			body: JSON.stringify(body),
+		}
+	);
+}
+
+export async function getJob(
+	config: Config,
+	namespace: string,
+	instance: string,
+	jobId: string
+): Promise<AiSearchJob> {
+	const accountId = await requireAuth(config);
+	return await fetchResult<AiSearchJob>(
+		config,
+		`${baseJobUrl(accountId, namespace, instance)}/${jobId}`,
+		{ method: "GET" }
+	);
+}
+
+export async function cancelJob(
+	config: Config,
+	namespace: string,
+	instance: string,
+	jobId: string
+): Promise<AiSearchJob> {
+	const accountId = await requireAuth(config);
+	return await fetchResult<AiSearchJob>(
+		config,
+		`${baseJobUrl(accountId, namespace, instance)}/${jobId}`,
+		{
+			method: "PATCH",
+			headers: { "content-type": jsonContentType },
+			body: JSON.stringify({ action: "cancel" }),
+		}
+	);
+}
+
+export async function listJobLogs(
+	config: Config,
+	namespace: string,
+	instance: string,
+	jobId: string,
+	queryParams?: URLSearchParams
+): Promise<AiSearchJobLog[]> {
+	const accountId = await requireAuth(config);
+	return await fetchResult<AiSearchJobLog[]>(
+		config,
+		`${baseJobUrl(accountId, namespace, instance)}/${jobId}/logs`,
+		{ method: "GET" },
+		queryParams
+	);
 }
 
 // ── Tokens ─────────────────────────────────────────────────────────────────────

--- a/packages/wrangler/src/ai-search/jobs/cancel.ts
+++ b/packages/wrangler/src/ai-search/jobs/cancel.ts
@@ -1,0 +1,52 @@
+import { createCommand } from "../../core/create-command";
+import { confirm } from "../../dialogs";
+import { logger } from "../../logger";
+import { cancelJob, DEFAULT_NAMESPACE } from "../client";
+
+export const aiSearchJobsCancelCommand = createCommand({
+	metadata: {
+		description: "Cancel an in-progress AI Search indexing job",
+		status: "open beta",
+		owner: "Product: AI Search",
+	},
+	args: {
+		name: {
+			type: "string",
+			demandOption: true,
+			description: "The name of the AI Search instance.",
+		},
+		"job-id": {
+			type: "string",
+			demandOption: true,
+			description: "The ID of the indexing job to cancel.",
+		},
+		namespace: {
+			type: "string",
+			alias: "n",
+			default: DEFAULT_NAMESPACE,
+			description: "The namespace the instance belongs to.",
+		},
+		force: {
+			type: "boolean",
+			alias: "y",
+			default: false,
+			description: "Skip confirmation",
+		},
+	},
+	positionalArgs: ["name", "job-id"],
+	async handler({ name, jobId, namespace, force }, { config }) {
+		if (!force) {
+			const confirmedCancellation = await confirm(
+				`OK to cancel the indexing job "${jobId}" on AI Search instance "${name}"?`
+			);
+			if (!confirmedCancellation) {
+				logger.log("Cancellation aborted.");
+				return;
+			}
+		}
+
+		logger.log(`Cancelling indexing job "${jobId}"...`);
+		await cancelJob(config, namespace, name, jobId);
+		logger.log(`Successfully cancelled indexing job "${jobId}"`);
+	},
+});

--- a/packages/wrangler/src/ai-search/jobs/create.ts
+++ b/packages/wrangler/src/ai-search/jobs/create.ts
@@ -1,0 +1,62 @@
+import { createCommand } from "../../core/create-command";
+import { logger } from "../../logger";
+import { createJob, DEFAULT_NAMESPACE } from "../client";
+
+export const aiSearchJobsCreateCommand = createCommand({
+	metadata: {
+		description: "Trigger a new indexing job for an AI Search instance",
+		status: "open beta",
+		owner: "Product: AI Search",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		name: {
+			type: "string",
+			demandOption: true,
+			description: "The name of the AI Search instance.",
+		},
+		namespace: {
+			type: "string",
+			alias: "n",
+			default: DEFAULT_NAMESPACE,
+			description: "The namespace the instance belongs to.",
+		},
+		description: {
+			type: "string",
+			description: "Optional description for the indexing job.",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as clean JSON",
+		},
+	},
+	positionalArgs: ["name"],
+	async handler(args, { config }) {
+		if (!args.json) {
+			logger.log(
+				`Triggering indexing job for AI Search instance "${args.name}"...`
+			);
+		}
+
+		const job = await createJob(config, args.namespace, args.name, {
+			...(args.description !== undefined
+				? { description: args.description }
+				: {}),
+		});
+
+		if (args.json) {
+			logger.log(JSON.stringify(job, null, 2));
+			return;
+		}
+
+		logger.log(
+			`Successfully created indexing job "${job.id}"\n` +
+				`  Source:      ${job.source}\n` +
+				`  Description: ${job.description ?? ""}\n` +
+				`  Started:     ${job.started_at ?? "-"}`
+		);
+	},
+});

--- a/packages/wrangler/src/ai-search/jobs/get.ts
+++ b/packages/wrangler/src/ai-search/jobs/get.ts
@@ -1,0 +1,58 @@
+import { createCommand } from "../../core/create-command";
+import { logger } from "../../logger";
+import { DEFAULT_NAMESPACE, getJob } from "../client";
+
+export const aiSearchJobsGetCommand = createCommand({
+	metadata: {
+		description: "Get details of an AI Search indexing job",
+		status: "open beta",
+		owner: "Product: AI Search",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		name: {
+			type: "string",
+			demandOption: true,
+			description: "The name of the AI Search instance.",
+		},
+		"job-id": {
+			type: "string",
+			demandOption: true,
+			description: "The ID of the indexing job.",
+		},
+		namespace: {
+			type: "string",
+			alias: "n",
+			default: DEFAULT_NAMESPACE,
+			description: "The namespace the instance belongs to.",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as clean JSON",
+		},
+	},
+	positionalArgs: ["name", "job-id"],
+	async handler({ name, jobId, namespace, json }, { config }) {
+		const job = await getJob(config, namespace, name, jobId);
+
+		if (json) {
+			logger.log(JSON.stringify(job, null, 2));
+			return;
+		}
+
+		logger.table([
+			{
+				id: job.id,
+				source: job.source,
+				description: job.description ?? "",
+				started: job.started_at ?? "-",
+				ended: job.ended_at ?? "-",
+				end_reason: job.end_reason ?? "-",
+				last_seen: job.last_seen_at ?? "-",
+			},
+		]);
+	},
+});

--- a/packages/wrangler/src/ai-search/jobs/index.ts
+++ b/packages/wrangler/src/ai-search/jobs/index.ts
@@ -1,0 +1,9 @@
+import { createNamespace } from "../../core/create-command";
+
+export const aiSearchJobsNamespace = createNamespace({
+	metadata: {
+		description: "AI Search indexing jobs",
+		status: "open beta",
+		owner: "Product: AI Search",
+	},
+});

--- a/packages/wrangler/src/ai-search/jobs/list.ts
+++ b/packages/wrangler/src/ai-search/jobs/list.ts
@@ -1,0 +1,86 @@
+import { createCommand } from "../../core/create-command";
+import { logger } from "../../logger";
+import { DEFAULT_NAMESPACE, listJobs } from "../client";
+
+export const aiSearchJobsListCommand = createCommand({
+	metadata: {
+		description: "List indexing jobs for an AI Search instance",
+		status: "open beta",
+		owner: "Product: AI Search",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		name: {
+			type: "string",
+			demandOption: true,
+			description: "The name of the AI Search instance.",
+		},
+		namespace: {
+			type: "string",
+			alias: "n",
+			default: DEFAULT_NAMESPACE,
+			description: "The namespace the instance belongs to.",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as clean JSON",
+		},
+		page: {
+			describe:
+				'Page number of the results, can configure page size using "per-page"',
+			type: "number",
+			default: 1,
+		},
+		"per-page": {
+			describe: "Number of jobs to show per page",
+			type: "number",
+		},
+	},
+	positionalArgs: ["name"],
+	async handler(args, { config }) {
+		const urlParams = new URLSearchParams();
+		urlParams.set("page", args.page.toString());
+		if (args.perPage !== undefined) {
+			urlParams.set("per_page", args.perPage.toString());
+		}
+
+		const jobs = await listJobs(config, args.namespace, args.name, urlParams);
+
+		if (args.json) {
+			logger.log(JSON.stringify(jobs, null, 2));
+			return;
+		}
+
+		if (jobs.length === 0 && args.page === 1) {
+			logger.warn(
+				`No indexing jobs found for AI Search instance "${args.name}" in namespace "${args.namespace}".`
+			);
+			return;
+		}
+
+		if (jobs.length === 0 && args.page > 1) {
+			logger.warn(
+				`No jobs found on page ${args.page}. Please try a smaller page number.`
+			);
+			return;
+		}
+
+		logger.info(
+			`Showing ${jobs.length} job${jobs.length !== 1 ? "s" : ""} for instance "${args.name}" from page ${args.page}:`
+		);
+
+		logger.table(
+			jobs.map((job) => ({
+				id: job.id,
+				source: job.source,
+				description: job.description ?? "",
+				started: job.started_at ?? "-",
+				ended: job.ended_at ?? "-",
+				end_reason: job.end_reason ?? "-",
+			}))
+		);
+	},
+});

--- a/packages/wrangler/src/ai-search/jobs/logs.ts
+++ b/packages/wrangler/src/ai-search/jobs/logs.ts
@@ -1,0 +1,92 @@
+import { createCommand } from "../../core/create-command";
+import { logger } from "../../logger";
+import { DEFAULT_NAMESPACE, listJobLogs } from "../client";
+
+export const aiSearchJobsLogsCommand = createCommand({
+	metadata: {
+		description: "List log entries for an AI Search indexing job",
+		status: "open beta",
+		owner: "Product: AI Search",
+	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+	args: {
+		name: {
+			type: "string",
+			demandOption: true,
+			description: "The name of the AI Search instance.",
+		},
+		"job-id": {
+			type: "string",
+			demandOption: true,
+			description: "The ID of the indexing job.",
+		},
+		namespace: {
+			type: "string",
+			alias: "n",
+			default: DEFAULT_NAMESPACE,
+			description: "The namespace the instance belongs to.",
+		},
+		json: {
+			type: "boolean",
+			default: false,
+			description: "Return output as clean JSON",
+		},
+		page: {
+			describe:
+				'Page number of the results, can configure page size using "per-page"',
+			type: "number",
+			default: 1,
+		},
+		"per-page": {
+			describe: "Number of log entries to show per page",
+			type: "number",
+		},
+	},
+	positionalArgs: ["name", "job-id"],
+	async handler(args, { config }) {
+		const urlParams = new URLSearchParams();
+		urlParams.set("page", args.page.toString());
+		if (args.perPage !== undefined) {
+			urlParams.set("per_page", args.perPage.toString());
+		}
+
+		const logs = await listJobLogs(
+			config,
+			args.namespace,
+			args.name,
+			args.jobId,
+			urlParams
+		);
+
+		if (args.json) {
+			logger.log(JSON.stringify(logs, null, 2));
+			return;
+		}
+
+		if (logs.length === 0 && args.page === 1) {
+			logger.warn(`No log entries found for indexing job "${args.jobId}".`);
+			return;
+		}
+
+		if (logs.length === 0 && args.page > 1) {
+			logger.warn(
+				`No log entries found on page ${args.page}. Please try a smaller page number.`
+			);
+			return;
+		}
+
+		logger.info(
+			`Showing ${logs.length} log ${logs.length !== 1 ? "entries" : "entry"} for job "${args.jobId}" from page ${args.page}:`
+		);
+
+		logger.table(
+			logs.map((entry) => ({
+				created_at: String(entry.created_at),
+				message_type: String(entry.message_type),
+				message: entry.message,
+			}))
+		);
+	},
+});

--- a/packages/wrangler/src/ai-search/types.ts
+++ b/packages/wrangler/src/ai-search/types.ts
@@ -163,3 +163,26 @@ export interface AiSearchNamespace {
 	created_at: string;
 	description?: string;
 }
+
+/**
+ * Represents an AI Search indexing job.
+ */
+export interface AiSearchJob {
+	id: string;
+	source: "user" | "schedule";
+	description?: string;
+	end_reason?: string;
+	ended_at?: string;
+	last_seen_at?: string;
+	started_at?: string;
+}
+
+/**
+ * A log entry for an AI Search indexing job.
+ */
+export interface AiSearchJobLog {
+	id: number;
+	created_at: number;
+	message: string;
+	message_type: number;
+}

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -22,6 +22,12 @@ import { aiSearchCreateCommand } from "./ai-search/create";
 import { aiSearchDeleteCommand } from "./ai-search/delete";
 import { aiSearchGetCommand } from "./ai-search/get";
 import { aiSearchNamespace } from "./ai-search/index";
+import { aiSearchJobsCancelCommand } from "./ai-search/jobs/cancel";
+import { aiSearchJobsCreateCommand } from "./ai-search/jobs/create";
+import { aiSearchJobsGetCommand } from "./ai-search/jobs/get";
+import { aiSearchJobsNamespace } from "./ai-search/jobs/index";
+import { aiSearchJobsListCommand } from "./ai-search/jobs/list";
+import { aiSearchJobsLogsCommand } from "./ai-search/jobs/logs";
 import { aiSearchListCommand } from "./ai-search/list";
 import { aiSearchNamespaceCreateCommand } from "./ai-search/namespace/create";
 import { aiSearchNamespaceDeleteCommand } from "./ai-search/namespace/delete";
@@ -1559,6 +1565,30 @@ export function createCLIParser(argv: string[]) {
 		{
 			command: "wrangler ai-search namespace delete",
 			definition: aiSearchNamespaceDeleteCommand,
+		},
+		{
+			command: "wrangler ai-search jobs",
+			definition: aiSearchJobsNamespace,
+		},
+		{
+			command: "wrangler ai-search jobs list",
+			definition: aiSearchJobsListCommand,
+		},
+		{
+			command: "wrangler ai-search jobs create",
+			definition: aiSearchJobsCreateCommand,
+		},
+		{
+			command: "wrangler ai-search jobs get",
+			definition: aiSearchJobsGetCommand,
+		},
+		{
+			command: "wrangler ai-search jobs cancel",
+			definition: aiSearchJobsCancelCommand,
+		},
+		{
+			command: "wrangler ai-search jobs logs",
+			definition: aiSearchJobsLogsCommand,
 		},
 	]);
 	registry.registerNamespace("ai-search");


### PR DESCRIPTION
Adds a new `jobs` sub-namespace under `wrangler ai-search` for managing AI Search indexing jobs. It wraps the AI Search instance Jobs API and mirrors the existing `wrangler ai-search namespace` command structure.

New commands:

- `wrangler ai-search jobs list <instance>` — list indexing jobs (`GET .../instances/{id}/jobs`)
- `wrangler ai-search jobs create <instance>` — trigger a new indexing job (`POST .../instances/{id}/jobs`)
- `wrangler ai-search jobs get <instance> <job-id>` — job details (`GET .../jobs/{job_id}`)
- `wrangler ai-search jobs cancel <instance> <job-id>` — cancel a running job (`PATCH .../jobs/{job_id}` with `{"action":"cancel"}`)
- `wrangler ai-search jobs logs <instance> <job-id>` — job log entries (`GET .../jobs/{job_id}/logs`)

All commands accept `--namespace`/`-n` (defaults to `default`) and `--json`; `list` and `logs` also support `--page`/`--per-page`. `cancel` prompts for confirmation unless `-y`/`--force` is passed.

Implementation notes:

- New `AiSearchJob`/`AiSearchJobLog` types and `listJobs`/`createJob`/`getJob`/`cancelJob`/`listJobLogs` client functions in `packages/wrangler/src/ai-search/`.
- Commands registered under the existing `ai-search` namespace in `src/index.ts`.
- Unit tests (MSW-mocked) covering each command, plus help-output assertions.
- Includes a `minor` changeset (new CLI commands).

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: these subcommands are in open beta and follow the existing `wrangler ai-search` command patterns; public docs will land alongside the AI Search jobs API.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->