### PR TITLE
Add containers[].observability support to wrangler deploy

### DIFF
--- a/.changeset/green-pumas-wave.md
+++ b/.changeset/green-pumas-wave.md
@@ -1,0 +1,9 @@
+---
+"wrangler": minor
+---
+
+Add `containers[].observability` support to `wrangler deploy`
+
+Wrangler now accepts container-specific observability settings via `containers[].observability`, including application-level targeting fields for Containers. Root `observability` continues to work as a fallback when a container does not define its own observability settings.
+
+`wrangler deploy` now preserves legacy `configuration.observability` for existing container apps that still use rollout-based observability, while using top-level application observability for new or already-migrated apps.

--- a/.changeset/green-pumas-wave.md
+++ b/.changeset/green-pumas-wave.md
@@ -1,0 +1,11 @@
+---
+"wrangler": minor
+---
+
+Add `containers[].observability` support to `wrangler deploy`
+
+Wrangler now accepts container-specific observability settings via `containers[].observability`, including application-level targeting fields for Containers. Root `observability` continues to work as a fallback when a container does not define its own observability settings.
+
+`wrangler deploy` now preserves legacy `configuration.observability` for existing container apps that still use rollout-based observability, while using top-level application observability for new or already-migrated apps.
+
+Existing application diffs are now normalized even when stored resource limits cannot be mapped to a named instance type. API-only metadata and equivalent managed-registry image names no longer appear as edits or affect whether deployment changes require a rollout.

--- a/packages/containers-shared/src/client/index.ts
+++ b/packages/containers-shared/src/client/index.ts
@@ -30,6 +30,7 @@ export type { ApplicationJobsConfig } from "./models/ApplicationJobsConfig";
 export { ApplicationMutationError } from "./models/ApplicationMutationError";
 export type { ApplicationName } from "./models/ApplicationName";
 export type { ApplicationNotFoundError } from "./models/ApplicationNotFoundError";
+export type { ApplicationObservability } from "./models/ApplicationObservability";
 export type { ApplicationPriorities } from "./models/ApplicationPriorities";
 export type { ApplicationPriority } from "./models/ApplicationPriority";
 export { ApplicationRollout } from "./models/ApplicationRollout";

--- a/packages/containers-shared/src/client/models/Application.ts
+++ b/packages/containers-shared/src/client/models/Application.ts
@@ -9,6 +9,7 @@ import type { ApplicationHealth } from "./ApplicationHealth";
 import type { ApplicationID } from "./ApplicationID";
 import type { ApplicationJobsConfig } from "./ApplicationJobsConfig";
 import type { ApplicationName } from "./ApplicationName";
+import type { ApplicationObservability } from "./ApplicationObservability";
 import type { ApplicationPriorities } from "./ApplicationPriorities";
 import type { ApplicationRolloutActiveGracePeriod } from "./ApplicationRolloutActiveGracePeriod";
 import type { ApplicationSchedulingHint } from "./ApplicationSchedulingHint";
@@ -37,6 +38,7 @@ export type Application = {
 	 */
 	max_instances?: number;
 	configuration: UserDeploymentConfiguration;
+	observability?: ApplicationObservability;
 	constraints?: ApplicationConstraints;
 	jobs?: ApplicationJobsConfig;
 	affinities?: ApplicationAffinities;

--- a/packages/containers-shared/src/client/models/ApplicationObservability.ts
+++ b/packages/containers-shared/src/client/models/ApplicationObservability.ts
@@ -1,0 +1,14 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ObservabilityLogs } from "./ObservabilityLogs";
+
+/**
+ * Application-level observability settings.
+ */
+export type ApplicationObservability = {
+	logs?: ObservabilityLogs;
+	target_instance_percentage?: number;
+	target_instance_count?: number;
+};

--- a/packages/containers-shared/src/client/models/CreateApplicationRequest.ts
+++ b/packages/containers-shared/src/client/models/CreateApplicationRequest.ts
@@ -5,6 +5,7 @@
 import type { ApplicationAffinities } from "./ApplicationAffinities";
 import type { ApplicationConstraints } from "./ApplicationConstraints";
 import type { ApplicationJobsConfig } from "./ApplicationJobsConfig";
+import type { ApplicationObservability } from "./ApplicationObservability";
 import type { ApplicationPriorities } from "./ApplicationPriorities";
 import type { ApplicationRolloutActiveGracePeriod } from "./ApplicationRolloutActiveGracePeriod";
 import type { DurableObjectsConfiguration } from "./DurableObjectsConfiguration";
@@ -34,6 +35,7 @@ export type CreateApplicationRequest = {
 	 *
 	 */
 	configuration: UserDeploymentConfiguration;
+	observability?: ApplicationObservability;
 	jobs?: ApplicationJobsConfig;
 	/**
 	 * If set, it will make the container application back a durable object namespace.

--- a/packages/containers-shared/src/client/models/ModifyApplicationRequestBody.ts
+++ b/packages/containers-shared/src/client/models/ModifyApplicationRequestBody.ts
@@ -4,6 +4,7 @@
 
 import type { ApplicationAffinities } from "./ApplicationAffinities";
 import type { ApplicationConstraints } from "./ApplicationConstraints";
+import type { ApplicationObservability } from "./ApplicationObservability";
 import type { ApplicationPriorities } from "./ApplicationPriorities";
 import type { ApplicationRolloutActiveGracePeriod } from "./ApplicationRolloutActiveGracePeriod";
 import type { ModifyUserDeploymentConfiguration } from "./ModifyUserDeploymentConfiguration";
@@ -32,6 +33,7 @@ export type ModifyApplicationRequestBody = {
 	scheduling_policy?: SchedulingPolicy;
 	constraints?: ApplicationConstraints;
 	rollout_active_grace_period?: ApplicationRolloutActiveGracePeriod;
+	observability?: ApplicationObservability;
 	/**
 	 * The deployment configuration of all deployments created by this application.
 	 * Right now, if you modify the application configuration, only new deployments

--- a/packages/containers-shared/src/types.ts
+++ b/packages/containers-shared/src/types.ts
@@ -91,7 +91,11 @@ export type SharedContainerConfig = {
 		colocation?: ApplicationAffinityColocation;
 		hardware_generation?: ApplicationAffinityHardwareGeneration;
 	};
-	observability: { logs_enabled: boolean };
+	observability: {
+		logs_enabled: boolean;
+		target_instance_percentage?: number;
+		target_instance_count?: number;
+	};
 } & InstanceTypeOrLimits;
 
 /** build/pull agnostic container options */

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -100,6 +100,24 @@ type UnsafeBinding = {
 /**
  * Configuration for a container application
  */
+export type ContainerObservability = {
+	/** If observability is enabled for this container application */
+	enabled?: boolean;
+	logs?: {
+		enabled?: boolean;
+	};
+	/**
+	 * Percentage of instances to target with application-level observability hot reloads.
+	 * Mutually exclusive with `target_instance_count`.
+	 */
+	target_instance_percentage?: number;
+	/**
+	 * Number of instances to target with application-level observability hot reloads.
+	 * Mutually exclusive with `target_instance_percentage`.
+	 */
+	target_instance_count?: number;
+};
+
 export type ContainerApp = {
 	// TODO: fill out the entire type
 
@@ -145,6 +163,13 @@ export type ContainerApp = {
 	 * The class name of the Durable Object the container is connected to.
 	 */
 	class_name: string;
+
+	/**
+	 * Specify the observability behavior of this container application.
+	 *
+	 * When set, this overrides the root `observability` config for this container.
+	 */
+	observability?: ContainerObservability;
 
 	/**
 	 * The scheduling policy of the application

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -100,6 +100,24 @@ type UnsafeBinding = {
 /**
  * Configuration for a container application
  */
+export type ContainerObservability = {
+	/** If observability is enabled for this container application */
+	enabled?: boolean;
+	logs?: {
+		enabled?: boolean;
+	};
+	/**
+	 * Percentage of instances to target with application-level observability hot reloads.
+	 * Mutually exclusive with `target_instance_count`.
+	 */
+	target_instance_percentage?: number;
+	/**
+	 * Number of instances to target with application-level observability hot reloads.
+	 * Mutually exclusive with `target_instance_percentage`.
+	 */
+	target_instance_count?: number;
+};
+
 export type ContainerApp = {
 	// TODO: fill out the entire type
 
@@ -155,6 +173,13 @@ export type ContainerApp = {
 	 * field. Exactly one of the two directions must be configured.
 	 */
 	class_name?: string;
+
+	/**
+	 * Specify the observability behavior of this container application.
+	 *
+	 * When set, this overrides the root `observability` config for this container.
+	 */
+	observability?: ContainerObservability;
 
 	/**
 	 * The scheduling policy of the application

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -43,6 +43,7 @@ import type {
 	CacheOptions,
 	ContainerApp,
 	CustomDomainRoute,
+	ContainerObservability,
 	DispatchNamespaceOutbound,
 	DurableObjectExport,
 	Environment,
@@ -3605,6 +3606,12 @@ function validateContainerApp(
 				containerAppOptional.image_vars,
 				"object"
 			);
+			validateContainerObservability(
+				diagnostics,
+				`${field}.observability`,
+				containerAppOptional.observability,
+				config
+			);
 			validateOptionalProperty(
 				diagnostics,
 				field,
@@ -3657,6 +3664,7 @@ function validateContainerApp(
 					"image",
 					"image_build_context",
 					"image_vars",
+					"observability",
 					"class_name",
 					"scheduling_policy",
 					"instance_type",
@@ -6344,6 +6352,176 @@ const validateExports: ValidatorFn = (diagnostics, field, value) => {
 	}
 
 	return valid;
+};
+
+const CONTAINER_OBSERVABILITY_TARGET_INSTANCE_PERCENTAGE_MIN = 1;
+const CONTAINER_OBSERVABILITY_TARGET_INSTANCE_PERCENTAGE_MAX = 99;
+const CONTAINER_OBSERVABILITY_TARGET_INSTANCE_COUNT_MIN = 1;
+
+function isContainerObservabilityEnabled(
+	observability: ContainerObservability | undefined
+): boolean {
+	return (
+		observability?.logs?.enabled === true || observability?.enabled === true
+	);
+}
+
+function hasConflictingContainerObservabilityEnabledValues(
+	observability: ContainerObservability
+): boolean {
+	return (
+		typeof observability.enabled === "boolean" &&
+		typeof observability.logs?.enabled === "boolean" &&
+		observability.enabled !== observability.logs.enabled
+	);
+}
+
+const validateContainerObservability: ValidatorFn = (
+	diagnostics,
+	field,
+	value
+) => {
+	if (value === undefined) {
+		return true;
+	}
+
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		diagnostics.errors.push(
+			`"${field}" should be an object but got ${JSON.stringify(value)}.`
+		);
+		return false;
+	}
+
+	const val = value as ContainerObservability;
+	let isValid = true;
+
+	isValid =
+		validateOptionalProperty(
+			diagnostics,
+			field,
+			"enabled",
+			val.enabled,
+			"boolean"
+		) && isValid;
+
+	if (val.logs !== undefined) {
+		if (
+			typeof val.logs !== "object" ||
+			val.logs === null ||
+			Array.isArray(val.logs)
+		) {
+			diagnostics.errors.push(
+				`Expected "${field}.logs" to be of type object but got ${JSON.stringify(
+					val.logs
+				)}.`
+			);
+			isValid = false;
+		} else {
+			isValid =
+				validateOptionalProperty(
+					diagnostics,
+					field,
+					"logs.enabled",
+					val.logs.enabled,
+					"boolean"
+				) && isValid;
+
+			isValid =
+				validateAdditionalProperties(
+					diagnostics,
+					`${field}.logs`,
+					Object.keys(val.logs),
+					["enabled"]
+				) && isValid;
+		}
+	}
+
+	isValid =
+		validateOptionalProperty(
+			diagnostics,
+			field,
+			"target_instance_percentage",
+			val.target_instance_percentage,
+			"number"
+		) && isValid;
+
+	isValid =
+		validateOptionalProperty(
+			diagnostics,
+			field,
+			"target_instance_count",
+			val.target_instance_count,
+			"number"
+		) && isValid;
+
+	isValid =
+		validateAdditionalProperties(diagnostics, field, Object.keys(val), [
+			"enabled",
+			"logs",
+			"target_instance_percentage",
+			"target_instance_count",
+		]) && isValid;
+
+	if (hasConflictingContainerObservabilityEnabledValues(val)) {
+		diagnostics.errors.push(
+			`"${field}.enabled" and "${field}.logs.enabled" cannot be set to different values.`
+		);
+		isValid = false;
+	}
+
+	if (
+		val.target_instance_percentage !== undefined &&
+		val.target_instance_count !== undefined
+	) {
+		diagnostics.errors.push(
+			`"${field}.target_instance_percentage" and "${field}.target_instance_count" cannot both be set.`
+		);
+		isValid = false;
+	}
+
+	if (
+		typeof val.target_instance_percentage === "number" &&
+		(!Number.isInteger(val.target_instance_percentage) ||
+			val.target_instance_percentage <
+				CONTAINER_OBSERVABILITY_TARGET_INSTANCE_PERCENTAGE_MIN ||
+			val.target_instance_percentage >
+				CONTAINER_OBSERVABILITY_TARGET_INSTANCE_PERCENTAGE_MAX)
+	) {
+		diagnostics.errors.push(
+			`"${field}.target_instance_percentage" must be an integer between ${CONTAINER_OBSERVABILITY_TARGET_INSTANCE_PERCENTAGE_MIN} and ${CONTAINER_OBSERVABILITY_TARGET_INSTANCE_PERCENTAGE_MAX} inclusive.`
+		);
+		isValid = false;
+	}
+
+	if (
+		typeof val.target_instance_count === "number" &&
+		(!Number.isInteger(val.target_instance_count) ||
+			val.target_instance_count <
+				CONTAINER_OBSERVABILITY_TARGET_INSTANCE_COUNT_MIN)
+	) {
+		diagnostics.errors.push(
+			`"${field}.target_instance_count" must be a positive integer.`
+		);
+		isValid = false;
+	}
+
+	const observabilityEnabled = isContainerObservabilityEnabled(val);
+
+	if (val.target_instance_percentage !== undefined && !observabilityEnabled) {
+		diagnostics.errors.push(
+			`"${field}.target_instance_percentage" cannot be set unless observability is enabled.`
+		);
+		isValid = false;
+	}
+
+	if (val.target_instance_count !== undefined && !observabilityEnabled) {
+		diagnostics.errors.push(
+			`"${field}.target_instance_count" cannot be set unless observability is enabled.`
+		);
+		isValid = false;
+	}
+
+	return isValid;
 };
 
 const validateObservability: ValidatorFn = (diagnostics, field, value) => {

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -46,6 +46,7 @@ import type {
 	CacheOptions,
 	ContainerApp,
 	CustomDomainRoute,
+	ContainerObservability,
 	DispatchNamespaceOutbound,
 	DurableObjectExport,
 	Environment,
@@ -3842,6 +3843,12 @@ function validateContainerApp(
 				containerAppOptional.image_vars,
 				"object"
 			);
+			validateContainerObservability(
+				diagnostics,
+				`${field}.observability`,
+				containerAppOptional.observability,
+				config
+			);
 			validateOptionalProperty(
 				diagnostics,
 				field,
@@ -3894,6 +3901,7 @@ function validateContainerApp(
 					"image",
 					"image_build_context",
 					"image_vars",
+					"observability",
 					"class_name",
 					"scheduling_policy",
 					"instance_type",
@@ -6752,6 +6760,201 @@ const validateExports: ValidatorFn = (diagnostics, field, value) => {
 	}
 
 	return valid;
+};
+
+const CONTAINER_OBSERVABILITY_TARGET_INSTANCE_PERCENTAGE_MIN = 1;
+const CONTAINER_OBSERVABILITY_TARGET_INSTANCE_PERCENTAGE_MAX = 99;
+const CONTAINER_OBSERVABILITY_TARGET_INSTANCE_COUNT_MIN = 1;
+
+function isContainerObservabilityEnabled(
+	observability: ContainerObservability | undefined
+): boolean {
+	return (
+		observability?.logs?.enabled === true || observability?.enabled === true
+	);
+}
+
+function hasConflictingContainerObservabilityEnabledValues(
+	observability: ContainerObservability
+): boolean {
+	return (
+		typeof observability.enabled === "boolean" &&
+		typeof observability.logs?.enabled === "boolean" &&
+		observability.enabled !== observability.logs.enabled
+	);
+}
+
+const validateContainerObservability: ValidatorFn = (
+	diagnostics,
+	field,
+	value
+) => {
+	if (value === undefined) {
+		return true;
+	}
+
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		diagnostics.errors.push(
+			`"${field}" should be an object but got ${JSON.stringify(value)}.`
+		);
+		return false;
+	}
+
+	const val = value as ContainerObservability;
+	let isValid = true;
+
+	isValid =
+		validateOptionalProperty(
+			diagnostics,
+			field,
+			"enabled",
+			val.enabled,
+			"boolean"
+		) && isValid;
+
+	if (val.logs !== undefined) {
+		if (
+			typeof val.logs !== "object" ||
+			val.logs === null ||
+			Array.isArray(val.logs)
+		) {
+			diagnostics.errors.push(
+				`Expected "${field}.logs" to be of type object but got ${JSON.stringify(
+					val.logs
+				)}.`
+			);
+			isValid = false;
+		} else {
+			isValid =
+				validateOptionalProperty(
+					diagnostics,
+					field,
+					"logs.enabled",
+					val.logs.enabled,
+					"boolean"
+				) && isValid;
+
+			isValid =
+				validateAdditionalProperties(
+					diagnostics,
+					`${field}.logs`,
+					Object.keys(val.logs),
+					["enabled"]
+				) && isValid;
+		}
+	}
+
+	if (
+		val.enabled === undefined &&
+		val.target_instance_percentage === undefined &&
+		val.target_instance_count === undefined &&
+		(val.logs === undefined ||
+			(typeof val.logs === "object" &&
+				val.logs !== null &&
+				!Array.isArray(val.logs) &&
+				val.logs.enabled === undefined))
+	) {
+		isValid =
+			validateAtLeastOnePropertyRequired(diagnostics, field, [
+				{
+					key: "enabled",
+					value: val.enabled,
+					type: "boolean",
+				},
+				{
+					key: "logs.enabled",
+					value: val.logs?.enabled,
+					type: "boolean",
+				},
+			]) && isValid;
+	}
+
+	isValid =
+		validateOptionalProperty(
+			diagnostics,
+			field,
+			"target_instance_percentage",
+			val.target_instance_percentage,
+			"number"
+		) && isValid;
+
+	isValid =
+		validateOptionalProperty(
+			diagnostics,
+			field,
+			"target_instance_count",
+			val.target_instance_count,
+			"number"
+		) && isValid;
+
+	isValid =
+		validateAdditionalProperties(diagnostics, field, Object.keys(val), [
+			"enabled",
+			"logs",
+			"target_instance_percentage",
+			"target_instance_count",
+		]) && isValid;
+
+	if (hasConflictingContainerObservabilityEnabledValues(val)) {
+		diagnostics.errors.push(
+			`"${field}.enabled" and "${field}.logs.enabled" cannot be set to different values.`
+		);
+		isValid = false;
+	}
+
+	if (
+		val.target_instance_percentage !== undefined &&
+		val.target_instance_count !== undefined
+	) {
+		diagnostics.errors.push(
+			`"${field}.target_instance_percentage" and "${field}.target_instance_count" cannot both be set.`
+		);
+		isValid = false;
+	}
+
+	if (
+		typeof val.target_instance_percentage === "number" &&
+		(!Number.isInteger(val.target_instance_percentage) ||
+			val.target_instance_percentage <
+				CONTAINER_OBSERVABILITY_TARGET_INSTANCE_PERCENTAGE_MIN ||
+			val.target_instance_percentage >
+				CONTAINER_OBSERVABILITY_TARGET_INSTANCE_PERCENTAGE_MAX)
+	) {
+		diagnostics.errors.push(
+			`"${field}.target_instance_percentage" must be an integer between ${CONTAINER_OBSERVABILITY_TARGET_INSTANCE_PERCENTAGE_MIN} and ${CONTAINER_OBSERVABILITY_TARGET_INSTANCE_PERCENTAGE_MAX} inclusive.`
+		);
+		isValid = false;
+	}
+
+	if (
+		typeof val.target_instance_count === "number" &&
+		(!Number.isInteger(val.target_instance_count) ||
+			val.target_instance_count <
+				CONTAINER_OBSERVABILITY_TARGET_INSTANCE_COUNT_MIN)
+	) {
+		diagnostics.errors.push(
+			`"${field}.target_instance_count" must be a positive integer.`
+		);
+		isValid = false;
+	}
+
+	const observabilityEnabled = isContainerObservabilityEnabled(val);
+
+	if (val.target_instance_percentage !== undefined && !observabilityEnabled) {
+		diagnostics.errors.push(
+			`"${field}.target_instance_percentage" requires "${field}.enabled" or "${field}.logs.enabled" to be true because container observability overrides root observability.`
+		);
+		isValid = false;
+	}
+
+	if (val.target_instance_count !== undefined && !observabilityEnabled) {
+		diagnostics.errors.push(
+			`"${field}.target_instance_count" requires "${field}.enabled" or "${field}.logs.enabled" to be true because container observability overrides root observability.`
+		);
+		isValid = false;
+	}
+
+	return isValid;
 };
 
 const validateObservability: ValidatorFn = (diagnostics, field, value) => {

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -3862,6 +3862,286 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
+			it("should allow shorthand container observability", ({ expect }) => {
+				const { diagnostics, config } = normalizeAndValidateConfig(
+					{
+						name: "test-worker",
+						containers: [
+							{
+								name: "test-container",
+								class_name: "TestClass",
+								image: "registry.cloudflare.com/test:latest",
+								observability: {
+									enabled: true,
+								},
+							},
+						],
+					} satisfies RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(config.containers?.[0]?.observability).toEqual({
+					enabled: true,
+				});
+			});
+
+			it("should allow nested container observability logs and targeting", ({
+				expect,
+			}) => {
+				const { diagnostics, config } = normalizeAndValidateConfig(
+					{
+						name: "test-worker",
+						containers: [
+							{
+								name: "test-container",
+								class_name: "TestClass",
+								image: "registry.cloudflare.com/test:latest",
+								observability: {
+									logs: {
+										enabled: true,
+									},
+									target_instance_count: 2,
+								},
+							},
+						],
+					} satisfies RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(config.containers?.[0]?.observability).toEqual({
+					logs: { enabled: true },
+					target_instance_count: 2,
+				});
+			});
+
+			it("should preserve container observability as a full override of root observability", ({
+				expect,
+			}) => {
+				const { diagnostics, config } = normalizeAndValidateConfig(
+					{
+						name: "test-worker",
+						observability: {
+							enabled: true,
+						},
+						containers: [
+							{
+								name: "test-container",
+								class_name: "TestClass",
+								image: "registry.cloudflare.com/test:latest",
+								observability: {
+									enabled: false,
+								},
+							},
+						],
+					} satisfies RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(config.observability).toEqual({ enabled: true });
+				expect(config.containers?.[0]?.observability).toEqual({
+					enabled: false,
+				});
+			});
+
+			it("should error when container observability is not an object", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						name: "test-worker",
+						containers: [
+							{
+								name: "test-container",
+								class_name: "TestClass",
+								image: "registry.cloudflare.com/test:latest",
+								observability: "enabled",
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "containers.observability" should be an object but got "enabled"."
+				`);
+			});
+
+			it("should error on invalid nested container observability values", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						name: "test-worker",
+						containers: [
+							{
+								name: "test-container",
+								class_name: "TestClass",
+								image: "registry.cloudflare.com/test:latest",
+								observability: {
+									enabled: "true",
+									logs: "enabled",
+									target_instance_percentage: "10",
+									target_instance_count: 0.5,
+								},
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - Expected "containers.observability.enabled" to be of type boolean but got "true".
+					  - Expected "containers.observability.logs" to be of type object but got "enabled".
+					  - Expected "containers.observability.target_instance_percentage" to be of type number but got "10".
+					  - "containers.observability.target_instance_percentage" and "containers.observability.target_instance_count" cannot both be set.
+					  - "containers.observability.target_instance_count" must be a positive integer.
+					  - "containers.observability.target_instance_percentage" cannot be set unless observability is enabled.
+					  - "containers.observability.target_instance_count" cannot be set unless observability is enabled."
+				`);
+			});
+
+			it("should error when container observability enabled values conflict", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						name: "test-worker",
+						containers: [
+							{
+								name: "test-container",
+								class_name: "TestClass",
+								image: "registry.cloudflare.com/test:latest",
+								observability: {
+									enabled: true,
+									logs: {
+										enabled: false,
+									},
+								},
+							},
+						],
+					} satisfies RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "containers.observability.enabled" and "containers.observability.logs.enabled" cannot be set to different values."
+				`);
+			});
+
+			it("should error when container observability logs is an array", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						name: "test-worker",
+						containers: [
+							{
+								name: "test-container",
+								class_name: "TestClass",
+								image: "registry.cloudflare.com/test:latest",
+								observability: {
+									logs: [],
+								},
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - Expected "containers.observability.logs" to be of type object but got []."
+				`);
+			});
+
+			it("should error when both container observability targeting fields are set", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						name: "test-worker",
+						containers: [
+							{
+								name: "test-container",
+								class_name: "TestClass",
+								image: "registry.cloudflare.com/test:latest",
+								observability: {
+									enabled: true,
+									target_instance_percentage: 10,
+									target_instance_count: 2,
+								},
+							},
+						],
+					} satisfies RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "containers.observability.target_instance_percentage" and "containers.observability.target_instance_count" cannot both be set."
+				`);
+			});
+
+			it("should warn on unsupported extra container observability keys", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						name: "test-worker",
+						containers: [
+							{
+								name: "test-container",
+								class_name: "TestClass",
+								image: "registry.cloudflare.com/test:latest",
+								observability: {
+									enabled: true,
+									invalid_key: "nope",
+								},
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - Unexpected fields found in containers.observability field: "invalid_key""
+				`);
+			});
+
 			it("should error if rollout_active_grace_period and rollout_step_percentage are out of range", ({
 				expect,
 			}) => {

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -4759,6 +4759,345 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 			});
 
+			it("should allow shorthand container observability", ({ expect }) => {
+				const { diagnostics, config } = normalizeAndValidateConfig(
+					{
+						name: "test-worker",
+						containers: [
+							{
+								name: "test-container",
+								class_name: "TestClass",
+								image: "registry.cloudflare.com/test:latest",
+								observability: {
+									enabled: true,
+								},
+							},
+						],
+					} satisfies RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(config.containers?.[0]?.observability).toEqual({
+					enabled: true,
+				});
+			});
+
+			it.for([
+				{ label: "an empty object", observability: {} },
+				{ label: "an empty logs object", observability: { logs: {} } },
+			])(
+				"should reject container observability with $label",
+				({ observability }, { expect }) => {
+					const { diagnostics } = normalizeAndValidateConfig(
+						{
+							name: "test-worker",
+							containers: [
+								{
+									name: "test-container",
+									class_name: "TestClass",
+									image: "registry.cloudflare.com/test:latest",
+									observability,
+								},
+							],
+						} satisfies RawConfig,
+						undefined,
+						undefined,
+						{ env: undefined }
+					);
+
+					expect(diagnostics.hasWarnings()).toBe(false);
+					expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+						"Processing wrangler configuration:
+						  - "containers.observability.enabled" or "containers.observability.logs.enabled" is required."
+					`);
+				}
+			);
+
+			it("should allow nested container observability logs and targeting", ({
+				expect,
+			}) => {
+				const { diagnostics, config } = normalizeAndValidateConfig(
+					{
+						name: "test-worker",
+						containers: [
+							{
+								name: "test-container",
+								class_name: "TestClass",
+								image: "registry.cloudflare.com/test:latest",
+								observability: {
+									logs: {
+										enabled: true,
+									},
+									target_instance_count: 2,
+								},
+							},
+						],
+					} satisfies RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(config.containers?.[0]?.observability).toEqual({
+					logs: { enabled: true },
+					target_instance_count: 2,
+				});
+			});
+
+			it("should preserve container observability as a full override of root observability", ({
+				expect,
+			}) => {
+				const { diagnostics, config } = normalizeAndValidateConfig(
+					{
+						name: "test-worker",
+						observability: {
+							enabled: true,
+						},
+						containers: [
+							{
+								name: "test-container",
+								class_name: "TestClass",
+								image: "registry.cloudflare.com/test:latest",
+								observability: {
+									enabled: false,
+								},
+							},
+						],
+					} satisfies RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(config.observability).toEqual({ enabled: true });
+				expect(config.containers?.[0]?.observability).toEqual({
+					enabled: false,
+				});
+			});
+
+			it("should explain that targeting requires container-level enablement", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						name: "test-worker",
+						observability: { enabled: true },
+						containers: [
+							{
+								name: "test-container",
+								class_name: "TestClass",
+								image: "registry.cloudflare.com/test:latest",
+								observability: { target_instance_count: 2 },
+							},
+						],
+					} satisfies RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "containers.observability.target_instance_count" requires "containers.observability.enabled" or "containers.observability.logs.enabled" to be true because container observability overrides root observability."
+				`);
+			});
+
+			it("should error when container observability is not an object", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						name: "test-worker",
+						containers: [
+							{
+								name: "test-container",
+								class_name: "TestClass",
+								image: "registry.cloudflare.com/test:latest",
+								observability: "enabled",
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "containers.observability" should be an object but got "enabled"."
+				`);
+			});
+
+			it("should error on invalid nested container observability values", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						name: "test-worker",
+						containers: [
+							{
+								name: "test-container",
+								class_name: "TestClass",
+								image: "registry.cloudflare.com/test:latest",
+								observability: {
+									enabled: "true",
+									logs: "enabled",
+									target_instance_percentage: "10",
+									target_instance_count: 0.5,
+								},
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - Expected "containers.observability.enabled" to be of type boolean but got "true".
+					  - Expected "containers.observability.logs" to be of type object but got "enabled".
+					  - Expected "containers.observability.target_instance_percentage" to be of type number but got "10".
+					  - "containers.observability.target_instance_percentage" and "containers.observability.target_instance_count" cannot both be set.
+					  - "containers.observability.target_instance_count" must be a positive integer.
+					  - "containers.observability.target_instance_percentage" requires "containers.observability.enabled" or "containers.observability.logs.enabled" to be true because container observability overrides root observability.
+					  - "containers.observability.target_instance_count" requires "containers.observability.enabled" or "containers.observability.logs.enabled" to be true because container observability overrides root observability."
+				`);
+			});
+
+			it("should error when container observability enabled values conflict", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						name: "test-worker",
+						containers: [
+							{
+								name: "test-container",
+								class_name: "TestClass",
+								image: "registry.cloudflare.com/test:latest",
+								observability: {
+									enabled: true,
+									logs: {
+										enabled: false,
+									},
+								},
+							},
+						],
+					} satisfies RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "containers.observability.enabled" and "containers.observability.logs.enabled" cannot be set to different values."
+				`);
+			});
+
+			it("should error when container observability logs is an array", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						name: "test-worker",
+						containers: [
+							{
+								name: "test-container",
+								class_name: "TestClass",
+								image: "registry.cloudflare.com/test:latest",
+								observability: {
+									logs: [],
+								},
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - Expected "containers.observability.logs" to be of type object but got []."
+				`);
+			});
+
+			it("should error when both container observability targeting fields are set", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						name: "test-worker",
+						containers: [
+							{
+								name: "test-container",
+								class_name: "TestClass",
+								image: "registry.cloudflare.com/test:latest",
+								observability: {
+									enabled: true,
+									target_instance_percentage: 10,
+									target_instance_count: 2,
+								},
+							},
+						],
+					} satisfies RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - "containers.observability.target_instance_percentage" and "containers.observability.target_instance_count" cannot both be set."
+				`);
+			});
+
+			it("should warn on unsupported extra container observability keys", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						name: "test-worker",
+						containers: [
+							{
+								name: "test-container",
+								class_name: "TestClass",
+								image: "registry.cloudflare.com/test:latest",
+								observability: {
+									enabled: true,
+									invalid_key: "nope",
+								},
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - Unexpected fields found in containers.observability field: "invalid_key""
+				`);
+			});
+
 			it("should error if rollout_active_grace_period and rollout_step_percentage are out of range", ({
 				expect,
 			}) => {

--- a/packages/wrangler/src/__tests__/containers/config.test.ts
+++ b/packages/wrangler/src/__tests__/containers/config.test.ts
@@ -505,6 +505,124 @@ describe("getNormalizedContainerOptions", () => {
 		});
 	});
 
+	it("should let container observability override root observability", async ({
+		expect,
+	}) => {
+		const config: Config = {
+			name: "test-worker",
+			configPath: "/test/wrangler.toml",
+			userConfigPath: "/test/wrangler.toml",
+			topLevelName: "test-worker",
+			observability: {
+				enabled: true,
+			},
+			containers: [
+				{
+					name: "custom-name",
+					class_name: "TestContainer",
+					image: "registry.cloudflare.com/test:latest",
+					observability: {
+						enabled: false,
+					},
+				},
+			],
+			durable_objects: {
+				bindings: [
+					{
+						name: "TEST_DO",
+						class_name: "TestContainer",
+					},
+				],
+			},
+			migrations: [{ tag: "v1", new_sqlite_classes: ["TestContainer"] }],
+		} as Partial<Config> as Config;
+
+		const result = await getNormalizedContainerOptions(config, {});
+
+		expect(result[0].observability).toEqual({
+			logs_enabled: false,
+		});
+	});
+
+	it("should normalize container observability targeting fields", async ({
+		expect,
+	}) => {
+		const config: Config = {
+			name: "test-worker",
+			configPath: "/test/wrangler.toml",
+			userConfigPath: "/test/wrangler.toml",
+			topLevelName: "test-worker",
+			containers: [
+				{
+					name: "custom-name",
+					class_name: "TestContainer",
+					image: "registry.cloudflare.com/test:latest",
+					observability: {
+						logs: {
+							enabled: true,
+						},
+						target_instance_percentage: 25,
+					},
+				},
+			],
+			durable_objects: {
+				bindings: [
+					{
+						name: "TEST_DO",
+						class_name: "TestContainer",
+					},
+				],
+			},
+			migrations: [{ tag: "v1", new_sqlite_classes: ["TestContainer"] }],
+		} as Partial<Config> as Config;
+
+		const result = await getNormalizedContainerOptions(config, {});
+
+		expect(result[0].observability).toEqual({
+			logs_enabled: true,
+			target_instance_percentage: 25,
+		});
+	});
+
+	it("should let root observability override enabled for logs fallback", async ({
+		expect,
+	}) => {
+		const config: Config = {
+			name: "test-worker",
+			configPath: "/test/wrangler.toml",
+			userConfigPath: "/test/wrangler.toml",
+			topLevelName: "test-worker",
+			observability: {
+				enabled: true,
+				logs: {
+					enabled: false,
+				},
+			},
+			containers: [
+				{
+					name: "custom-name",
+					class_name: "TestContainer",
+					image: "registry.cloudflare.com/test:latest",
+				},
+			],
+			durable_objects: {
+				bindings: [
+					{
+						name: "TEST_DO",
+						class_name: "TestContainer",
+					},
+				],
+			},
+			migrations: [{ tag: "v1", new_sqlite_classes: ["TestContainer"] }],
+		} as Partial<Config> as Config;
+
+		const result = await getNormalizedContainerOptions(config, {});
+
+		expect(result[0].observability).toEqual({
+			logs_enabled: false,
+		});
+	});
+
 	it("should handle dockerfile with default build context", async ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/__tests__/containers/config.test.ts
+++ b/packages/wrangler/src/__tests__/containers/config.test.ts
@@ -604,6 +604,124 @@ describe("getNormalizedContainerOptions", () => {
 		});
 	});
 
+	it("should let container observability override root observability", async ({
+		expect,
+	}) => {
+		const config: Config = {
+			name: "test-worker",
+			configPath: "/test/wrangler.toml",
+			userConfigPath: "/test/wrangler.toml",
+			topLevelName: "test-worker",
+			observability: {
+				enabled: true,
+			},
+			containers: [
+				{
+					name: "custom-name",
+					class_name: "TestContainer",
+					image: "registry.cloudflare.com/test:latest",
+					observability: {
+						enabled: false,
+					},
+				},
+			],
+			durable_objects: {
+				bindings: [
+					{
+						name: "TEST_DO",
+						class_name: "TestContainer",
+					},
+				],
+			},
+			migrations: [{ tag: "v1", new_sqlite_classes: ["TestContainer"] }],
+		} as Partial<Config> as Config;
+
+		const result = await getNormalizedContainerOptions(config, {});
+
+		expect(result[0].observability).toEqual({
+			logs_enabled: false,
+		});
+	});
+
+	it("should normalize container observability targeting fields", async ({
+		expect,
+	}) => {
+		const config: Config = {
+			name: "test-worker",
+			configPath: "/test/wrangler.toml",
+			userConfigPath: "/test/wrangler.toml",
+			topLevelName: "test-worker",
+			containers: [
+				{
+					name: "custom-name",
+					class_name: "TestContainer",
+					image: "registry.cloudflare.com/test:latest",
+					observability: {
+						logs: {
+							enabled: true,
+						},
+						target_instance_percentage: 25,
+					},
+				},
+			],
+			durable_objects: {
+				bindings: [
+					{
+						name: "TEST_DO",
+						class_name: "TestContainer",
+					},
+				],
+			},
+			migrations: [{ tag: "v1", new_sqlite_classes: ["TestContainer"] }],
+		} as Partial<Config> as Config;
+
+		const result = await getNormalizedContainerOptions(config, {});
+
+		expect(result[0].observability).toEqual({
+			logs_enabled: true,
+			target_instance_percentage: 25,
+		});
+	});
+
+	it("should let root observability override enabled for logs fallback", async ({
+		expect,
+	}) => {
+		const config: Config = {
+			name: "test-worker",
+			configPath: "/test/wrangler.toml",
+			userConfigPath: "/test/wrangler.toml",
+			topLevelName: "test-worker",
+			observability: {
+				enabled: true,
+				logs: {
+					enabled: false,
+				},
+			},
+			containers: [
+				{
+					name: "custom-name",
+					class_name: "TestContainer",
+					image: "registry.cloudflare.com/test:latest",
+				},
+			],
+			durable_objects: {
+				bindings: [
+					{
+						name: "TEST_DO",
+						class_name: "TestContainer",
+					},
+				],
+			},
+			migrations: [{ tag: "v1", new_sqlite_classes: ["TestContainer"] }],
+		} as Partial<Config> as Config;
+
+		const result = await getNormalizedContainerOptions(config, {});
+
+		expect(result[0].observability).toEqual({
+			logs_enabled: false,
+		});
+	});
+
 	it("should handle dockerfile with default build context", async ({
 		expect,
 	}) => {

--- a/packages/wrangler/src/__tests__/containers/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/containers/deploy.test.ts
@@ -1264,7 +1264,73 @@ describe("wrangler deploy with containers", () => {
 				namespace_id: "1",
 			},
 		};
-		it("should be able to enable observability logs (top level)", async ({
+
+		it("uses top-level observability for a new application from container config", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				containers: [
+					{
+						...DEFAULT_CONTAINER_FROM_REGISTRY,
+						observability: { enabled: true },
+					},
+				],
+			});
+
+			mockGetApplications([]);
+			const rolloutSpy = mockTrackApplicationRollout();
+
+			mockCreateApplication(expect, {
+				observability: {
+					logs: { enabled: true },
+				},
+				configuration: {
+					image: "registry.cloudflare.com/some-account-id/hello:world",
+				},
+			});
+
+			await runWrangler("deploy index.js");
+
+			expect(rolloutSpy).not.toHaveBeenCalled();
+			expect(cliStd.stdout).toMatchInlineSnapshot(`
+				"╭ Deploy a container application deploy changes to your application
+				│
+				│ Container application changes
+				│
+				├ NEW my-container
+				│
+				│   [[containers]]
+				│   name = "my-container"
+				│   scheduling_policy = "default"
+				│   instances = 0
+				│   max_instances = 10
+				│   rollout_active_grace_period = 0
+				│
+				│   [containers.observability.logs]
+				│   enabled = true
+				│
+				│   [containers.configuration]
+				│   image = "registry.cloudflare.com/some-account-id/hello:world"
+				│   instance_type = "lite"
+				│
+				│   [containers.constraints]
+				│   tiers = [ 1, 2 ]
+				│
+				│   [containers.durable_objects]
+				│   namespace_id = "1"
+				│
+				│
+				│  SUCCESS  Created application my-container (Application ID: undefined)
+				│
+				╰ Applied changes
+
+				"
+			`);
+		});
+
+		it("uses top-level observability for a new application from root fallback", async ({
 			expect,
 		}) => {
 			mockGetVersion("Galaxy-Class");
@@ -1274,15 +1340,13 @@ describe("wrangler deploy with containers", () => {
 				containers: [DEFAULT_CONTAINER_FROM_REGISTRY],
 			});
 
-			mockGetApplications([sharedGetApplicationResult]);
+			mockGetApplications([]);
 
-			mockModifyApplication(expect, {
-				configuration: {
-					image: "registry.cloudflare.com/some-account-id/hello:world",
-					observability: { logs: { enabled: true } },
+			mockCreateApplication(expect, {
+				observability: {
+					logs: { enabled: true },
 				},
 			});
-			mockCreateApplicationRollout(expect);
 
 			await runWrangler("deploy index.js");
 
@@ -1291,17 +1355,30 @@ describe("wrangler deploy with containers", () => {
 				│
 				│ Container application changes
 				│
-				├ EDIT my-container
+				├ NEW my-container
 				│
+				│   [[containers]]
+				│   name = "my-container"
+				│   scheduling_policy = "default"
+				│   instances = 0
+				│   max_instances = 10
+				│   rollout_active_grace_period = 0
+				│
+				│   [containers.observability.logs]
+				│   enabled = true
+				│
+				│   [containers.configuration]
 				│   image = "registry.cloudflare.com/some-account-id/hello:world"
 				│   instance_type = "lite"
-				│ + [containers.configuration.observability.logs]
-				│ + enabled = true
+				│
 				│   [containers.constraints]
 				│   tiers = [ 1, 2 ]
 				│
+				│   [containers.durable_objects]
+				│   namespace_id = "1"
 				│
-				│  SUCCESS  Modified application my-container (Application ID: abc)
+				│
+				│  SUCCESS  Created application my-container (Application ID: undefined)
 				│
 				╰ Applied changes
 
@@ -1309,221 +1386,9 @@ describe("wrangler deploy with containers", () => {
 			`);
 		});
 
-		it("should be able to enable observability logs (logs field)", async ({
+		it("keeps legacy configuration observability enabled for the root enabled shorthand", async ({
 			expect,
 		}) => {
-			mockGetVersion("Galaxy-Class");
-			writeWranglerConfig({
-				...DEFAULT_DURABLE_OBJECTS,
-				observability: { logs: { enabled: true } },
-				containers: [DEFAULT_CONTAINER_FROM_REGISTRY],
-			});
-
-			mockGetApplications([sharedGetApplicationResult]);
-
-			mockModifyApplication(expect, {
-				configuration: {
-					image: "registry.cloudflare.com/some-account-id/hello:world",
-					observability: { logs: { enabled: true } },
-				},
-			});
-
-			mockCreateApplicationRollout(expect);
-
-			await runWrangler("deploy index.js");
-			expect(cliStd.stdout).toMatchInlineSnapshot(`
-				"╭ Deploy a container application deploy changes to your application
-				│
-				│ Container application changes
-				│
-				├ EDIT my-container
-				│
-				│   image = "registry.cloudflare.com/some-account-id/hello:world"
-				│   instance_type = "lite"
-				│ + [containers.configuration.observability.logs]
-				│ + enabled = true
-				│   [containers.constraints]
-				│   tiers = [ 1, 2 ]
-				│
-				│
-				│  SUCCESS  Modified application my-container (Application ID: abc)
-				│
-				╰ Applied changes
-
-				"
-			`);
-		});
-
-		it("should be able to disable observability logs (top level)", async ({
-			expect,
-		}) => {
-			mockGetVersion("Galaxy-Class");
-			writeWranglerConfig({
-				...DEFAULT_DURABLE_OBJECTS,
-				observability: { enabled: false },
-				containers: [DEFAULT_CONTAINER_FROM_REGISTRY],
-			});
-
-			mockGetApplications([
-				{
-					...sharedGetApplicationResult,
-					configuration: {
-						...sharedGetApplicationResult.configuration,
-						observability: {
-							logs: {
-								enabled: true,
-							},
-						},
-					},
-				},
-			]);
-
-			mockModifyApplication(expect, {
-				configuration: {
-					image: "registry.cloudflare.com/some-account-id/hello:world",
-					observability: { logs: { enabled: false } },
-				},
-			});
-
-			mockCreateApplicationRollout(expect);
-
-			await runWrangler("deploy index.js");
-
-			expect(cliStd.stdout).toMatchInlineSnapshot(`
-				"╭ Deploy a container application deploy changes to your application
-				│
-				│ Container application changes
-				│
-				├ EDIT my-container
-				│
-				│   instance_type = "lite"
-				│   [containers.configuration.observability.logs]
-				│ - enabled = true
-				│ + enabled = false
-				│   [containers.constraints]
-				│   tiers = [ 1, 2 ]
-				│
-				│
-				│  SUCCESS  Modified application my-container (Application ID: abc)
-				│
-				╰ Applied changes
-
-				"
-			`);
-		});
-
-		it("should be able to disable observability logs (logs field)", async ({
-			expect,
-		}) => {
-			mockGetVersion("Galaxy-Class");
-			writeWranglerConfig({
-				...DEFAULT_DURABLE_OBJECTS,
-				observability: { logs: { enabled: false } },
-				containers: [DEFAULT_CONTAINER_FROM_REGISTRY],
-			});
-
-			mockGetApplications([
-				{
-					...sharedGetApplicationResult,
-					configuration: {
-						...sharedGetApplicationResult.configuration,
-						observability: {
-							logs: {
-								enabled: true,
-							},
-						},
-					},
-				},
-			]);
-
-			mockModifyApplication(expect, {
-				configuration: {
-					image: "registry.cloudflare.com/some-account-id/hello:world",
-					observability: { logs: { enabled: false } },
-				},
-			});
-
-			mockCreateApplicationRollout(expect);
-
-			await runWrangler("deploy index.js");
-
-			expect(cliStd.stdout).toMatchInlineSnapshot(`
-				"╭ Deploy a container application deploy changes to your application
-				│
-				│ Container application changes
-				│
-				├ EDIT my-container
-				│
-				│   instance_type = "lite"
-				│   [containers.configuration.observability.logs]
-				│ - enabled = true
-				│ + enabled = false
-				│   [containers.constraints]
-				│   tiers = [ 1, 2 ]
-				│
-				│
-				│  SUCCESS  Modified application my-container (Application ID: abc)
-				│
-				╰ Applied changes
-
-				"
-			`);
-		});
-		it("should be able to disable observability logs (absent field)", async ({
-			expect,
-		}) => {
-			mockGetVersion("Galaxy-Class");
-			writeWranglerConfig({
-				...DEFAULT_DURABLE_OBJECTS,
-				containers: [DEFAULT_CONTAINER_FROM_REGISTRY],
-			});
-
-			mockGetApplications([
-				{
-					...sharedGetApplicationResult,
-					configuration: {
-						...sharedGetApplicationResult.configuration,
-						observability: {
-							logs: {
-								enabled: true,
-							},
-						},
-					},
-				},
-			]);
-
-			mockModifyApplication(expect, {
-				configuration: {
-					image: "registry.cloudflare.com/some-account-id/hello:world",
-					observability: { logs: { enabled: false } },
-				},
-			});
-
-			mockCreateApplicationRollout(expect);
-			await runWrangler("deploy index.js");
-			expect(cliStd.stdout).toMatchInlineSnapshot(`
-				"╭ Deploy a container application deploy changes to your application
-				│
-				│ Container application changes
-				│
-				├ EDIT my-container
-				│
-				│   instance_type = "lite"
-				│   [containers.configuration.observability.logs]
-				│ - enabled = true
-				│ + enabled = false
-				│   [containers.constraints]
-				│   tiers = [ 1, 2 ]
-				│
-				│
-				│  SUCCESS  Modified application my-container (Application ID: abc)
-				│
-				╰ Applied changes
-
-				"
-			`);
-		});
-		it("should keep observability logs enabled", async ({ expect }) => {
 			mockGetVersion("Galaxy-Class");
 			writeWranglerConfig({
 				...DEFAULT_DURABLE_OBJECTS,
@@ -1544,17 +1409,13 @@ describe("wrangler deploy with containers", () => {
 					},
 				},
 			]);
-
-			mockModifyApplication(expect, {
-				configuration: {
-					image: "registry.cloudflare.com/some-account-id/hello:world",
-					observability: { logs: { enabled: true } },
-				},
-			});
-
-			mockCreateApplicationRollout(expect);
+			const modifySpy = mockTrackApplicationModification();
+			const rolloutSpy = mockTrackApplicationRollout();
 
 			await runWrangler("deploy index.js");
+
+			expect(modifySpy).not.toHaveBeenCalled();
+			expect(rolloutSpy).not.toHaveBeenCalled();
 			expect(cliStd.stdout).toMatchInlineSnapshot(`
 				"╭ Deploy a container application deploy changes to your application
 				│
@@ -1568,7 +1429,433 @@ describe("wrangler deploy with containers", () => {
 			`);
 		});
 
-		it("should keep obserability logs disabled if api returns false and undefined in config", async ({
+		it("keeps legacy configuration observability enabled for the root logs shorthand", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				observability: { logs: { enabled: true } },
+				containers: [DEFAULT_CONTAINER_FROM_REGISTRY],
+			});
+
+			mockGetApplications([
+				{
+					...sharedGetApplicationResult,
+					configuration: {
+						...sharedGetApplicationResult.configuration,
+						observability: {
+							logs: {
+								enabled: true,
+							},
+						},
+					},
+				},
+			]);
+			const modifySpy = mockTrackApplicationModification();
+			const rolloutSpy = mockTrackApplicationRollout();
+
+			await runWrangler("deploy index.js");
+
+			expect(modifySpy).not.toHaveBeenCalled();
+			expect(rolloutSpy).not.toHaveBeenCalled();
+			expect(cliStd.stdout).toMatchInlineSnapshot(`
+				"╭ Deploy a container application deploy changes to your application
+				│
+				│ Container application changes
+				│
+				├ no changes my-container
+				│
+				╰ No changes to be made
+
+				"
+			`);
+		});
+
+		it("preserves legacy configuration observability when a rollout updates other fields", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				observability: { enabled: true },
+				containers: [
+					{
+						...DEFAULT_CONTAINER_FROM_REGISTRY,
+						image: "registry.cloudflare.com/hello:moon",
+					},
+				],
+			});
+
+			const application = {
+				...sharedGetApplicationResult,
+				configuration: {
+					...sharedGetApplicationResult.configuration,
+					observability: {
+						logs: {
+							enabled: true,
+						},
+					},
+				},
+			};
+
+			mockGetApplications([application]);
+
+			let rolloutTargetConfiguration: Record<string, unknown> | undefined;
+
+			msw.use(
+				http.patch("*/applications/:id", async ({ request }) => {
+					const json = (await request.json()) as {
+						configuration?: Record<string, unknown>;
+					};
+
+					expect(json).toMatchObject({
+						configuration: {
+							image: "registry.cloudflare.com/some-account-id/hello:moon",
+						},
+					});
+					expect(json.configuration).not.toHaveProperty("observability");
+
+					return HttpResponse.json({
+						success: true,
+						result: {
+							...application,
+							configuration: {
+								...application.configuration,
+								...(json.configuration ?? {}),
+							},
+						},
+					});
+				}),
+				http.post("*/applications/:id/rollouts", async ({ request }) => {
+					const json = (await request.json()) as {
+						target_configuration: Record<string, unknown>;
+					};
+
+					expect(json.target_configuration).toMatchObject({
+						image: "registry.cloudflare.com/some-account-id/hello:moon",
+					});
+					expect(json.target_configuration).not.toHaveProperty("observability");
+
+					rolloutTargetConfiguration = {
+						...application.configuration,
+						...json.target_configuration,
+					};
+
+					expect(rolloutTargetConfiguration).toMatchObject({
+						image: "registry.cloudflare.com/some-account-id/hello:moon",
+						observability: {
+							logs: {
+								enabled: true,
+							},
+						},
+					});
+
+					return HttpResponse.json({
+						success: true,
+						result: {
+							id: "rollout-123",
+							status: "pending",
+							current_configuration: application.configuration,
+							target_configuration: rolloutTargetConfiguration,
+						},
+					});
+				})
+			);
+
+			await runWrangler("deploy index.js");
+
+			expect(rolloutTargetConfiguration).toMatchObject({
+				image: "registry.cloudflare.com/some-account-id/hello:moon",
+				observability: {
+					logs: {
+						enabled: true,
+					},
+				},
+			});
+		});
+
+		it("clears legacy configuration observability for mixed top-level apps during migration", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				containers: [
+					{
+						...DEFAULT_CONTAINER_FROM_REGISTRY,
+						observability: { enabled: false },
+					},
+				],
+			});
+
+			mockGetApplications([
+				{
+					...sharedGetApplicationResult,
+					observability: {
+						logs: {
+							enabled: true,
+						},
+					},
+					configuration: {
+						...sharedGetApplicationResult.configuration,
+						observability: {
+							logs: {
+								enabled: true,
+							},
+						},
+					},
+				},
+			]);
+
+			mockModifyApplication(expect, {
+				observability: {
+					logs: { enabled: false },
+				},
+				configuration: {
+					image: "registry.cloudflare.com/some-account-id/hello:world",
+					observability: { logs: { enabled: false } },
+				},
+			});
+
+			mockCreateApplicationRollout(expect, {
+				target_configuration: {
+					image: "registry.cloudflare.com/some-account-id/hello:world",
+					observability: { logs: { enabled: false } },
+				},
+			});
+
+			await runWrangler("deploy index.js");
+		});
+
+		it("can replace an active legacy rollout target while disabling observability for migration", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				containers: [
+					{
+						...DEFAULT_CONTAINER_FROM_REGISTRY,
+						observability: { enabled: false },
+					},
+				],
+			});
+
+			mockGetApplications([
+				{
+					...sharedGetApplicationResult,
+					configuration: {
+						...sharedGetApplicationResult.configuration,
+						observability: {
+							logs: {
+								enabled: false,
+							},
+						},
+					},
+					scheduling_hint: {
+						current: {
+							instances: 0,
+							configuration: {
+								image: "registry.cloudflare.com/hello:world",
+								observability: {
+									logs: {
+										enabled: false,
+									},
+								},
+							},
+							version: 1,
+						},
+						target: {
+							instances: 0,
+							configuration: {
+								image: "registry.cloudflare.com/hello:world",
+								observability: {
+									logs: {
+										enabled: true,
+									},
+								},
+							},
+							version: 2,
+						},
+					},
+				},
+			]);
+
+			mockModifyApplication(expect, {
+				configuration: {
+					image: "registry.cloudflare.com/some-account-id/hello:world",
+					observability: { logs: { enabled: false } },
+				},
+			});
+
+			mockCreateApplicationRollout(expect, {
+				target_configuration: {
+					image: "registry.cloudflare.com/some-account-id/hello:world",
+					observability: { logs: { enabled: false } },
+				},
+			});
+
+			await runWrangler("deploy index.js");
+		});
+
+		it("keeps using legacy configuration observability for legacy-enabled apps", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				containers: [DEFAULT_CONTAINER_FROM_REGISTRY],
+			});
+
+			mockGetApplications([
+				{
+					...sharedGetApplicationResult,
+					configuration: {
+						...sharedGetApplicationResult.configuration,
+						observability: {
+							logs: {
+								enabled: true,
+							},
+						},
+					},
+				},
+			]);
+
+			mockModifyApplication(expect, {
+				configuration: {
+					image: "registry.cloudflare.com/some-account-id/hello:world",
+					observability: { logs: { enabled: false } },
+				},
+			});
+
+			mockCreateApplicationRollout(expect);
+
+			await runWrangler("deploy index.js");
+
+			expect(cliStd.stdout).toMatchInlineSnapshot(`
+				"╭ Deploy a container application deploy changes to your application
+				│
+				│ Container application changes
+				│
+				├ EDIT my-container
+				│
+				│   instance_type = "lite"
+				│   [containers.configuration.observability.logs]
+				│ - enabled = true
+				│ + enabled = false
+				│   [containers.constraints]
+				│   tiers = [ 1, 2 ]
+				│
+				│
+				│  SUCCESS  Modified application my-container (Application ID: abc)
+				│
+				╰ Applied changes
+
+				"
+			`);
+		});
+
+		it("keeps using top-level observability and skips rollout for top-level-only changes", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				containers: [
+					{
+						...DEFAULT_CONTAINER_FROM_REGISTRY,
+						observability: { enabled: true },
+					},
+				],
+			});
+
+			mockGetApplications([
+				{
+					...sharedGetApplicationResult,
+					observability: {
+						logs: {
+							enabled: false,
+						},
+					},
+				},
+			]);
+			const rolloutSpy = mockTrackApplicationRollout();
+
+			mockModifyApplication(expect, {
+				observability: {
+					logs: { enabled: true },
+				},
+				configuration: {
+					image: "registry.cloudflare.com/some-account-id/hello:world",
+				},
+			});
+
+			await runWrangler("deploy index.js");
+
+			expect(rolloutSpy).not.toHaveBeenCalled();
+			expect(cliStd.stdout).toMatchInlineSnapshot(`
+				"╭ Deploy a container application deploy changes to your application
+				│
+				│ Container application changes
+				│
+				├ EDIT my-container
+				│
+				│   tiers = [ 1, 2 ]
+				│   [containers.observability.logs]
+				│ - enabled = false
+				│ + enabled = true
+				│
+				│
+				│  SUCCESS  Modified application my-container (Application ID: abc)
+				│
+				╰ Applied changes
+
+				"
+			`);
+		});
+
+		it("detects no changes when top-level observability already matches", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				observability: { enabled: true },
+				containers: [DEFAULT_CONTAINER_FROM_REGISTRY],
+			});
+
+			mockGetApplications([
+				{
+					...sharedGetApplicationResult,
+					observability: {
+						logs: {
+							enabled: true,
+						},
+					},
+				},
+			]);
+			const modifySpy = mockTrackApplicationModification();
+			const rolloutSpy = mockTrackApplicationRollout();
+
+			await runWrangler("deploy index.js");
+
+			expect(modifySpy).not.toHaveBeenCalled();
+			expect(rolloutSpy).not.toHaveBeenCalled();
+			expect(cliStd.stdout).toMatchInlineSnapshot(`
+				"╭ Deploy a container application deploy changes to your application
+				│
+				│ Container application changes
+				│
+				├ no changes my-container
+				│
+				╰ No changes to be made
+
+				"
+			`);
+		});
+
+		it("avoids no-op migration churn when legacy observability is already disabled", async ({
 			expect,
 		}) => {
 			mockGetVersion("Galaxy-Class");
@@ -1590,9 +1877,13 @@ describe("wrangler deploy with containers", () => {
 					},
 				},
 			]);
+			const modifySpy = mockTrackApplicationModification();
+			const rolloutSpy = mockTrackApplicationRollout();
 
 			await runWrangler("deploy index.js");
 
+			expect(modifySpy).not.toHaveBeenCalled();
+			expect(rolloutSpy).not.toHaveBeenCalled();
 			expect(cliStd.stdout).toMatchInlineSnapshot(`
 				"╭ Deploy a container application deploy changes to your application
 				│
@@ -1601,6 +1892,160 @@ describe("wrangler deploy with containers", () => {
 				├ no changes my-container
 				│
 				╰ No changes to be made
+
+				"
+			`);
+		});
+
+		it("throws a local error when application-level targeting is added before disabling legacy observability", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				containers: [
+					{
+						...DEFAULT_CONTAINER_FROM_REGISTRY,
+						observability: {
+							enabled: true,
+							target_instance_percentage: 10,
+						},
+					},
+				],
+			});
+
+			mockGetApplications([
+				{
+					...sharedGetApplicationResult,
+					configuration: {
+						...sharedGetApplicationResult.configuration,
+						observability: {
+							logs: {
+								enabled: true,
+							},
+						},
+					},
+				},
+			]);
+
+			await expect(runWrangler("deploy index.js")).rejects.toThrow(
+				"Application-level observability targeting cannot be enabled for container my-container while it still uses legacy rollout-based observability. Set containers[].observability.enabled = false in your Wrangler config and deploy once, then deploy again with target_instance_percentage or target_instance_count."
+			);
+		});
+
+		it("throws a local error when an active rollout still targets legacy observability", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				containers: [
+					{
+						...DEFAULT_CONTAINER_FROM_REGISTRY,
+						observability: {
+							enabled: true,
+							target_instance_count: 2,
+						},
+					},
+				],
+			});
+
+			mockGetApplications([
+				{
+					...sharedGetApplicationResult,
+					scheduling_hint: {
+						current: {
+							instances: 0,
+							configuration: {
+								image: "registry.cloudflare.com/hello:world",
+							},
+							version: 1,
+						},
+						target: {
+							instances: 0,
+							configuration: {
+								image: "registry.cloudflare.com/hello:world",
+								observability: {
+									logs: {
+										enabled: true,
+									},
+								},
+							},
+							version: 2,
+						},
+					},
+				},
+			]);
+
+			await expect(runWrangler("deploy index.js")).rejects.toThrow(
+				"Application-level observability targeting cannot be enabled for container my-container while it still uses legacy rollout-based observability. Set containers[].observability.enabled = false in your Wrangler config and deploy once, then deploy again with target_instance_percentage or target_instance_count."
+			);
+		});
+
+		it("still creates a rollout when top-level observability changes alongside deployment config", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				containers: [
+					{
+						...DEFAULT_CONTAINER_FROM_REGISTRY,
+						image: "registry.cloudflare.com/hello:moon",
+						observability: { enabled: true },
+					},
+				],
+			});
+
+			mockGetApplications([
+				{
+					...sharedGetApplicationResult,
+					observability: {
+						logs: {
+							enabled: false,
+						},
+					},
+				},
+			]);
+
+			mockModifyApplication(expect, {
+				observability: {
+					logs: { enabled: true },
+				},
+				configuration: {
+					image: "registry.cloudflare.com/some-account-id/hello:moon",
+				},
+			});
+			mockCreateApplicationRollout(expect, {
+				target_configuration: {
+					image: "registry.cloudflare.com/some-account-id/hello:moon",
+				},
+			});
+
+			await runWrangler("deploy index.js");
+
+			expect(cliStd.stdout).toMatchInlineSnapshot(`
+				"╭ Deploy a container application deploy changes to your application
+				│
+				│ Container application changes
+				│
+				├ EDIT my-container
+				│
+				│   scheduling_policy = "default"
+				│   [containers.configuration]
+				│ - image = "registry.cloudflare.com/some-account-id/hello:world"
+				│ + image = "registry.cloudflare.com/some-account-id/hello:moon"
+				│   instance_type = "lite"
+				│   [containers.constraints]
+				│   tiers = [ 1, 2 ]
+				│   [containers.observability.logs]
+				│ - enabled = false
+				│ + enabled = true
+				│
+				│
+				│  SUCCESS  Modified application my-container (Application ID: abc)
+				│
+				╰ Applied changes
 
 				"
 			`);
@@ -2209,21 +2654,18 @@ describe("wrangler deploy with containers", () => {
 			│
 			├ EDIT my-container
 			│
+			│   max_instances = 10
 			│   name = "my-container"
 			│   scheduling_policy = "default"
-			│   version = 1
 			│ + rollout_active_grace_period = 0
 			│   [containers.configuration]
-			│ - image = "registry.cloudflare.com/hello:world"
-			│ + image = "registry.cloudflare.com/some-account-id/hello:world"
+			│   image = "registry.cloudflare.com/some-account-id/hello:world"
 			│ + instance_type = "lite"
 			│ + [[containers.configuration.authorized_keys]]
 			│ + name = "jeff"
 			│ + public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC0chNcjRotdsxXTwPPNoqVCGn4EcEWdUkkBPNm/v4gm"
 			│ + [containers.configuration.ssh]
 			│ + enabled = true
-			│   [containers.durable_objects]
-			│   namespace_id = "1"
 			│ + [containers.constraints]
 			│ + tiers = [ 1, 2 ]
 			│
@@ -3175,6 +3617,23 @@ function mockModifyApplication(
 	);
 }
 
+function mockTrackApplicationModification() {
+	const modifySpy = vi.fn();
+	msw.use(
+		http.patch("*/applications/:id", async ({ request }) => {
+			modifySpy(await request.json());
+			return HttpResponse.json({
+				success: true,
+				result: {
+					id: "abc",
+					name: "my-container",
+				},
+			});
+		})
+	);
+	return modifySpy;
+}
+
 function mockCreateApplicationRollout(
 	expect: ExpectStatic,
 	expected?: Record<string, unknown>
@@ -3195,6 +3654,23 @@ function mockCreateApplicationRollout(
 			});
 		})
 	);
+}
+
+function mockTrackApplicationRollout() {
+	const rolloutSpy = vi.fn();
+	msw.use(
+		http.post("*/applications/:id/rollouts", async ({ request }) => {
+			rolloutSpy(await request.json());
+			return HttpResponse.json({
+				success: true,
+				result: {
+					id: "rollout-123",
+					status: "pending",
+				},
+			});
+		})
+	);
+	return rolloutSpy;
 }
 
 function mockGenerateImageRegistryCredentials(expect: ExpectStatic) {

--- a/packages/wrangler/src/__tests__/containers/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/containers/deploy.test.ts
@@ -1264,7 +1264,73 @@ describe("wrangler deploy with containers", () => {
 				namespace_id: "1",
 			},
 		};
-		it("should be able to enable observability logs (top level)", async ({
+
+		it("uses top-level observability for a new application from container config", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				containers: [
+					{
+						...DEFAULT_CONTAINER_FROM_REGISTRY,
+						observability: { enabled: true },
+					},
+				],
+			});
+
+			mockGetApplications([]);
+			const rolloutSpy = mockTrackApplicationRollout();
+
+			mockCreateApplication(expect, {
+				observability: {
+					logs: { enabled: true },
+				},
+				configuration: {
+					image: "registry.cloudflare.com/some-account-id/hello:world",
+				},
+			});
+
+			await runWrangler("deploy index.js");
+
+			expect(rolloutSpy).not.toHaveBeenCalled();
+			expect(cliStd.stdout).toMatchInlineSnapshot(`
+				"╭ Deploy a container application deploy changes to your application
+				│
+				│ Container application changes
+				│
+				├ NEW my-container
+				│
+				│   [[containers]]
+				│   name = "my-container"
+				│   scheduling_policy = "default"
+				│   instances = 0
+				│   max_instances = 10
+				│   rollout_active_grace_period = 0
+				│
+				│   [containers.observability.logs]
+				│   enabled = true
+				│
+				│   [containers.configuration]
+				│   image = "registry.cloudflare.com/some-account-id/hello:world"
+				│   instance_type = "lite"
+				│
+				│   [containers.constraints]
+				│   tiers = [ 1, 2 ]
+				│
+				│   [containers.durable_objects]
+				│   namespace_id = "1"
+				│
+				│
+				│  SUCCESS  Created application my-container (Application ID: undefined)
+				│
+				╰ Applied changes
+
+				"
+			`);
+		});
+
+		it("uses top-level observability for a new application from root fallback", async ({
 			expect,
 		}) => {
 			mockGetVersion("Galaxy-Class");
@@ -1274,15 +1340,13 @@ describe("wrangler deploy with containers", () => {
 				containers: [DEFAULT_CONTAINER_FROM_REGISTRY],
 			});
 
-			mockGetApplications([sharedGetApplicationResult]);
+			mockGetApplications([]);
 
-			mockModifyApplication(expect, {
-				configuration: {
-					image: "registry.cloudflare.com/some-account-id/hello:world",
-					observability: { logs: { enabled: true } },
+			mockCreateApplication(expect, {
+				observability: {
+					logs: { enabled: true },
 				},
 			});
-			mockCreateApplicationRollout(expect);
 
 			await runWrangler("deploy index.js");
 
@@ -1291,17 +1355,30 @@ describe("wrangler deploy with containers", () => {
 				│
 				│ Container application changes
 				│
-				├ EDIT my-container
+				├ NEW my-container
 				│
+				│   [[containers]]
+				│   name = "my-container"
+				│   scheduling_policy = "default"
+				│   instances = 0
+				│   max_instances = 10
+				│   rollout_active_grace_period = 0
+				│
+				│   [containers.observability.logs]
+				│   enabled = true
+				│
+				│   [containers.configuration]
 				│   image = "registry.cloudflare.com/some-account-id/hello:world"
 				│   instance_type = "lite"
-				│ + [containers.configuration.observability.logs]
-				│ + enabled = true
+				│
 				│   [containers.constraints]
 				│   tiers = [ 1, 2 ]
 				│
+				│   [containers.durable_objects]
+				│   namespace_id = "1"
 				│
-				│  SUCCESS  Modified application my-container (Application ID: abc)
+				│
+				│  SUCCESS  Created application my-container (Application ID: undefined)
 				│
 				╰ Applied changes
 
@@ -1309,221 +1386,9 @@ describe("wrangler deploy with containers", () => {
 			`);
 		});
 
-		it("should be able to enable observability logs (logs field)", async ({
+		it("keeps legacy configuration observability enabled for the root enabled shorthand", async ({
 			expect,
 		}) => {
-			mockGetVersion("Galaxy-Class");
-			writeWranglerConfig({
-				...DEFAULT_DURABLE_OBJECTS,
-				observability: { logs: { enabled: true } },
-				containers: [DEFAULT_CONTAINER_FROM_REGISTRY],
-			});
-
-			mockGetApplications([sharedGetApplicationResult]);
-
-			mockModifyApplication(expect, {
-				configuration: {
-					image: "registry.cloudflare.com/some-account-id/hello:world",
-					observability: { logs: { enabled: true } },
-				},
-			});
-
-			mockCreateApplicationRollout(expect);
-
-			await runWrangler("deploy index.js");
-			expect(cliStd.stdout).toMatchInlineSnapshot(`
-				"╭ Deploy a container application deploy changes to your application
-				│
-				│ Container application changes
-				│
-				├ EDIT my-container
-				│
-				│   image = "registry.cloudflare.com/some-account-id/hello:world"
-				│   instance_type = "lite"
-				│ + [containers.configuration.observability.logs]
-				│ + enabled = true
-				│   [containers.constraints]
-				│   tiers = [ 1, 2 ]
-				│
-				│
-				│  SUCCESS  Modified application my-container (Application ID: abc)
-				│
-				╰ Applied changes
-
-				"
-			`);
-		});
-
-		it("should be able to disable observability logs (top level)", async ({
-			expect,
-		}) => {
-			mockGetVersion("Galaxy-Class");
-			writeWranglerConfig({
-				...DEFAULT_DURABLE_OBJECTS,
-				observability: { enabled: false },
-				containers: [DEFAULT_CONTAINER_FROM_REGISTRY],
-			});
-
-			mockGetApplications([
-				{
-					...sharedGetApplicationResult,
-					configuration: {
-						...sharedGetApplicationResult.configuration,
-						observability: {
-							logs: {
-								enabled: true,
-							},
-						},
-					},
-				},
-			]);
-
-			mockModifyApplication(expect, {
-				configuration: {
-					image: "registry.cloudflare.com/some-account-id/hello:world",
-					observability: { logs: { enabled: false } },
-				},
-			});
-
-			mockCreateApplicationRollout(expect);
-
-			await runWrangler("deploy index.js");
-
-			expect(cliStd.stdout).toMatchInlineSnapshot(`
-				"╭ Deploy a container application deploy changes to your application
-				│
-				│ Container application changes
-				│
-				├ EDIT my-container
-				│
-				│   instance_type = "lite"
-				│   [containers.configuration.observability.logs]
-				│ - enabled = true
-				│ + enabled = false
-				│   [containers.constraints]
-				│   tiers = [ 1, 2 ]
-				│
-				│
-				│  SUCCESS  Modified application my-container (Application ID: abc)
-				│
-				╰ Applied changes
-
-				"
-			`);
-		});
-
-		it("should be able to disable observability logs (logs field)", async ({
-			expect,
-		}) => {
-			mockGetVersion("Galaxy-Class");
-			writeWranglerConfig({
-				...DEFAULT_DURABLE_OBJECTS,
-				observability: { logs: { enabled: false } },
-				containers: [DEFAULT_CONTAINER_FROM_REGISTRY],
-			});
-
-			mockGetApplications([
-				{
-					...sharedGetApplicationResult,
-					configuration: {
-						...sharedGetApplicationResult.configuration,
-						observability: {
-							logs: {
-								enabled: true,
-							},
-						},
-					},
-				},
-			]);
-
-			mockModifyApplication(expect, {
-				configuration: {
-					image: "registry.cloudflare.com/some-account-id/hello:world",
-					observability: { logs: { enabled: false } },
-				},
-			});
-
-			mockCreateApplicationRollout(expect);
-
-			await runWrangler("deploy index.js");
-
-			expect(cliStd.stdout).toMatchInlineSnapshot(`
-				"╭ Deploy a container application deploy changes to your application
-				│
-				│ Container application changes
-				│
-				├ EDIT my-container
-				│
-				│   instance_type = "lite"
-				│   [containers.configuration.observability.logs]
-				│ - enabled = true
-				│ + enabled = false
-				│   [containers.constraints]
-				│   tiers = [ 1, 2 ]
-				│
-				│
-				│  SUCCESS  Modified application my-container (Application ID: abc)
-				│
-				╰ Applied changes
-
-				"
-			`);
-		});
-		it("should be able to disable observability logs (absent field)", async ({
-			expect,
-		}) => {
-			mockGetVersion("Galaxy-Class");
-			writeWranglerConfig({
-				...DEFAULT_DURABLE_OBJECTS,
-				containers: [DEFAULT_CONTAINER_FROM_REGISTRY],
-			});
-
-			mockGetApplications([
-				{
-					...sharedGetApplicationResult,
-					configuration: {
-						...sharedGetApplicationResult.configuration,
-						observability: {
-							logs: {
-								enabled: true,
-							},
-						},
-					},
-				},
-			]);
-
-			mockModifyApplication(expect, {
-				configuration: {
-					image: "registry.cloudflare.com/some-account-id/hello:world",
-					observability: { logs: { enabled: false } },
-				},
-			});
-
-			mockCreateApplicationRollout(expect);
-			await runWrangler("deploy index.js");
-			expect(cliStd.stdout).toMatchInlineSnapshot(`
-				"╭ Deploy a container application deploy changes to your application
-				│
-				│ Container application changes
-				│
-				├ EDIT my-container
-				│
-				│   instance_type = "lite"
-				│   [containers.configuration.observability.logs]
-				│ - enabled = true
-				│ + enabled = false
-				│   [containers.constraints]
-				│   tiers = [ 1, 2 ]
-				│
-				│
-				│  SUCCESS  Modified application my-container (Application ID: abc)
-				│
-				╰ Applied changes
-
-				"
-			`);
-		});
-		it("should keep observability logs enabled", async ({ expect }) => {
 			mockGetVersion("Galaxy-Class");
 			writeWranglerConfig({
 				...DEFAULT_DURABLE_OBJECTS,
@@ -1544,17 +1409,13 @@ describe("wrangler deploy with containers", () => {
 					},
 				},
 			]);
-
-			mockModifyApplication(expect, {
-				configuration: {
-					image: "registry.cloudflare.com/some-account-id/hello:world",
-					observability: { logs: { enabled: true } },
-				},
-			});
-
-			mockCreateApplicationRollout(expect);
+			const modifySpy = mockTrackApplicationModification();
+			const rolloutSpy = mockTrackApplicationRollout();
 
 			await runWrangler("deploy index.js");
+
+			expect(modifySpy).not.toHaveBeenCalled();
+			expect(rolloutSpy).not.toHaveBeenCalled();
 			expect(cliStd.stdout).toMatchInlineSnapshot(`
 				"╭ Deploy a container application deploy changes to your application
 				│
@@ -1568,7 +1429,595 @@ describe("wrangler deploy with containers", () => {
 			`);
 		});
 
-		it("should keep obserability logs disabled if api returns false and undefined in config", async ({
+		it("keeps legacy configuration observability enabled for the root logs shorthand", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				observability: { logs: { enabled: true } },
+				containers: [DEFAULT_CONTAINER_FROM_REGISTRY],
+			});
+
+			mockGetApplications([
+				{
+					...sharedGetApplicationResult,
+					configuration: {
+						...sharedGetApplicationResult.configuration,
+						observability: {
+							logs: {
+								enabled: true,
+							},
+						},
+					},
+				},
+			]);
+			const modifySpy = mockTrackApplicationModification();
+			const rolloutSpy = mockTrackApplicationRollout();
+
+			await runWrangler("deploy index.js");
+
+			expect(modifySpy).not.toHaveBeenCalled();
+			expect(rolloutSpy).not.toHaveBeenCalled();
+			expect(cliStd.stdout).toMatchInlineSnapshot(`
+				"╭ Deploy a container application deploy changes to your application
+				│
+				│ Container application changes
+				│
+				├ no changes my-container
+				│
+				╰ No changes to be made
+
+				"
+			`);
+		});
+
+		it("preserves legacy configuration observability when a rollout updates other fields", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				observability: { enabled: true },
+				containers: [
+					{
+						...DEFAULT_CONTAINER_FROM_REGISTRY,
+						image: "registry.cloudflare.com/hello:moon",
+					},
+				],
+			});
+
+			const application = {
+				...sharedGetApplicationResult,
+				configuration: {
+					...sharedGetApplicationResult.configuration,
+					observability: {
+						logs: {
+							enabled: true,
+						},
+					},
+				},
+			};
+
+			mockGetApplications([application]);
+
+			let rolloutTargetConfiguration: Record<string, unknown> | undefined;
+
+			msw.use(
+				http.patch("*/applications/:id", async ({ request }) => {
+					const json = (await request.json()) as {
+						configuration?: Record<string, unknown>;
+					};
+
+					expect(json).toMatchObject({
+						configuration: {
+							image: "registry.cloudflare.com/some-account-id/hello:moon",
+						},
+					});
+					expect(json.configuration).not.toHaveProperty("observability");
+
+					return HttpResponse.json({
+						success: true,
+						result: {
+							...application,
+							configuration: {
+								...application.configuration,
+								...(json.configuration ?? {}),
+							},
+						},
+					});
+				}),
+				http.post("*/applications/:id/rollouts", async ({ request }) => {
+					const json = (await request.json()) as {
+						target_configuration: Record<string, unknown>;
+					};
+
+					expect(json.target_configuration).toMatchObject({
+						image: "registry.cloudflare.com/some-account-id/hello:moon",
+					});
+					expect(json.target_configuration).not.toHaveProperty("observability");
+
+					rolloutTargetConfiguration = {
+						...application.configuration,
+						...json.target_configuration,
+					};
+
+					expect(rolloutTargetConfiguration).toMatchObject({
+						image: "registry.cloudflare.com/some-account-id/hello:moon",
+						observability: {
+							logs: {
+								enabled: true,
+							},
+						},
+					});
+
+					return HttpResponse.json({
+						success: true,
+						result: {
+							id: "rollout-123",
+							status: "pending",
+							current_configuration: application.configuration,
+							target_configuration: rolloutTargetConfiguration,
+						},
+					});
+				})
+			);
+
+			await runWrangler("deploy index.js");
+
+			expect(rolloutTargetConfiguration).toMatchObject({
+				image: "registry.cloudflare.com/some-account-id/hello:moon",
+				observability: {
+					logs: {
+						enabled: true,
+					},
+				},
+			});
+		});
+
+		it.for([
+			{
+				label: "preserving enabled logs",
+				observability: { enabled: true },
+				previousObservability: { logs: { enabled: true } },
+				expectedPatch: undefined,
+			},
+			{
+				label: "disabling logs",
+				observability: { enabled: false },
+				previousObservability: { logs: { enabled: true } },
+				expectedPatch: { logs: { enabled: false } },
+			},
+			{
+				label: "adding application-level targeting",
+				observability: { enabled: true, target_instance_count: 2 },
+				previousObservability: {
+					logs: { enabled: true },
+					target_instance_percentage: 25,
+				},
+				expectedPatch: {
+					logs: { enabled: true },
+					target_instance_count: 2,
+				},
+			},
+		])(
+			"migrates mixed observability before $label",
+			async (
+				{ observability, previousObservability, expectedPatch },
+				{ expect }
+			) => {
+				mockGetVersion("Galaxy-Class");
+				writeWranglerConfig({
+					...DEFAULT_DURABLE_OBJECTS,
+					containers: [
+						{
+							...DEFAULT_CONTAINER_FROM_REGISTRY,
+							observability,
+						},
+					],
+				});
+
+				mockGetApplications([
+					{
+						...sharedGetApplicationResult,
+						observability: previousObservability,
+						configuration: {
+							...sharedGetApplicationResult.configuration,
+							observability: { logs: { enabled: true } },
+						},
+					},
+				]);
+				const modifySpy = mockTrackApplicationModification();
+				const rolloutSpy = mockTrackApplicationRollout();
+
+				await runWrangler("deploy index.js");
+
+				expect(modifySpy).toHaveBeenNthCalledWith(1, {
+					observability: { logs: { enabled: true } },
+				});
+				if (expectedPatch === undefined) {
+					expect(modifySpy).toHaveBeenCalledTimes(1);
+				} else {
+					expect(modifySpy).toHaveBeenCalledTimes(2);
+					expect(modifySpy).toHaveBeenNthCalledWith(
+						2,
+						expect.objectContaining({ observability: expectedPatch })
+					);
+					expect(modifySpy.mock.calls[1]?.[0]).not.toHaveProperty(
+						"configuration.observability"
+					);
+				}
+				expect(rolloutSpy).not.toHaveBeenCalled();
+				expect(cliStd.stdout).toContain(
+					"Migrated observability configuration for my-container"
+				);
+				expect(cliStd.stdout).toContain("Applied changes");
+				expect(cliStd.stdout).not.toContain("No changes to be made");
+			}
+		);
+
+		it("waits for an active rollout before migrating mixed observability", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				containers: [
+					{
+						...DEFAULT_CONTAINER_FROM_REGISTRY,
+						observability: { enabled: true, target_instance_count: 2 },
+					},
+				],
+			});
+
+			mockGetApplications([
+				{
+					...sharedGetApplicationResult,
+					active_rollout_id: "rollout-123",
+					observability: { logs: { enabled: true } },
+					configuration: {
+						...sharedGetApplicationResult.configuration,
+						observability: { logs: { enabled: true } },
+					},
+				},
+			]);
+
+			await expect(runWrangler("deploy index.js")).rejects.toThrow(
+				"Cannot migrate observability configuration for container my-container while an application rollout is active. Wait for the rollout to finish, then deploy again."
+			);
+		});
+
+		it("waits for an active rollout before enabling top-level observability over legacy observability", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				containers: [
+					{
+						...DEFAULT_CONTAINER_FROM_REGISTRY,
+						observability: { enabled: true },
+					},
+				],
+			});
+
+			mockGetApplications([
+				{
+					...sharedGetApplicationResult,
+					active_rollout_id: "rollout-123",
+					observability: { logs: { enabled: false } },
+					configuration: {
+						...sharedGetApplicationResult.configuration,
+						observability: { logs: { enabled: true } },
+					},
+				},
+			]);
+
+			await expect(runWrangler("deploy index.js")).rejects.toThrow(
+				"Cannot migrate observability configuration for container my-container while an application rollout is active. Wait for the rollout to finish, then deploy again."
+			);
+		});
+
+		it("can replace an active legacy rollout target while disabling observability for migration", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				containers: [
+					{
+						...DEFAULT_CONTAINER_FROM_REGISTRY,
+						observability: { enabled: false },
+					},
+				],
+			});
+
+			mockGetApplications([
+				{
+					...sharedGetApplicationResult,
+					configuration: {
+						...sharedGetApplicationResult.configuration,
+						observability: {
+							logs: {
+								enabled: false,
+							},
+						},
+					},
+					scheduling_hint: {
+						current: {
+							instances: 0,
+							configuration: {
+								image: "registry.cloudflare.com/hello:world",
+								observability: {
+									logs: {
+										enabled: false,
+									},
+								},
+							},
+							version: 1,
+						},
+						target: {
+							instances: 0,
+							configuration: {
+								image: "registry.cloudflare.com/hello:world",
+								observability: {
+									logs: {
+										enabled: true,
+									},
+								},
+							},
+							version: 2,
+						},
+					},
+				},
+			]);
+
+			mockModifyApplication(expect, {
+				configuration: {
+					image: "registry.cloudflare.com/some-account-id/hello:world",
+					observability: { logs: { enabled: false } },
+				},
+			});
+
+			mockCreateApplicationRollout(expect, {
+				target_configuration: {
+					image: "registry.cloudflare.com/some-account-id/hello:world",
+					observability: { logs: { enabled: false } },
+				},
+			});
+
+			await runWrangler("deploy index.js");
+		});
+
+		it("keeps using legacy configuration observability for legacy-enabled apps", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				containers: [DEFAULT_CONTAINER_FROM_REGISTRY],
+			});
+
+			mockGetApplications([
+				{
+					...sharedGetApplicationResult,
+					configuration: {
+						...sharedGetApplicationResult.configuration,
+						observability: {
+							logs: {
+								enabled: true,
+							},
+						},
+					},
+				},
+			]);
+
+			mockModifyApplication(expect, {
+				configuration: {
+					image: "registry.cloudflare.com/some-account-id/hello:world",
+					observability: { logs: { enabled: false } },
+				},
+			});
+
+			mockCreateApplicationRollout(expect);
+
+			await runWrangler("deploy index.js");
+
+			expect(cliStd.stdout).toMatchInlineSnapshot(`
+				"╭ Deploy a container application deploy changes to your application
+				│
+				│ Container application changes
+				│
+				├ EDIT my-container
+				│
+				│   instance_type = "lite"
+				│   [containers.configuration.observability.logs]
+				│ - enabled = true
+				│ + enabled = false
+				│   [containers.constraints]
+				│   tiers = [ 1, 2 ]
+				│
+				│
+				│  SUCCESS  Modified application my-container (Application ID: abc)
+				│
+				╰ Applied changes
+
+				"
+			`);
+		});
+
+		it("keeps using top-level observability and skips rollout for top-level-only changes", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				containers: [
+					{
+						...DEFAULT_CONTAINER_FROM_REGISTRY,
+						observability: { enabled: true },
+					},
+				],
+			});
+
+			mockGetApplications([
+				{
+					...sharedGetApplicationResult,
+					observability: {
+						logs: {
+							enabled: false,
+						},
+					},
+				},
+			]);
+			const rolloutSpy = mockTrackApplicationRollout();
+
+			mockModifyApplication(expect, {
+				observability: {
+					logs: { enabled: true },
+				},
+				configuration: {
+					image: "registry.cloudflare.com/some-account-id/hello:world",
+				},
+			});
+
+			await runWrangler("deploy index.js");
+
+			expect(rolloutSpy).not.toHaveBeenCalled();
+			expect(cliStd.stdout).toMatchInlineSnapshot(`
+				"╭ Deploy a container application deploy changes to your application
+				│
+				│ Container application changes
+				│
+				├ EDIT my-container
+				│
+				│   tiers = [ 1, 2 ]
+				│   [containers.observability.logs]
+				│ - enabled = false
+				│ + enabled = true
+				│
+				│
+				│  SUCCESS  Modified application my-container (Application ID: abc)
+				│
+				╰ Applied changes
+
+				"
+			`);
+		});
+
+		it.for([
+			{
+				label: "percentage targeting is removed",
+				previousTarget: { target_instance_percentage: 25 },
+				nextTarget: {},
+				removedSetting: "target_instance_percentage = 25",
+				addedSetting: undefined,
+			},
+			{
+				label: "count targeting is removed",
+				previousTarget: { target_instance_count: 2 },
+				nextTarget: {},
+				removedSetting: "target_instance_count = 2",
+				addedSetting: undefined,
+			},
+			{
+				label: "percentage targeting changes to count targeting",
+				previousTarget: { target_instance_percentage: 25 },
+				nextTarget: { target_instance_count: 2 },
+				removedSetting: "target_instance_percentage = 25",
+				addedSetting: "target_instance_count = 2",
+			},
+		])(
+			"updates top-level observability when $label",
+			async (
+				{ previousTarget, nextTarget, removedSetting, addedSetting },
+				{ expect }
+			) => {
+				mockGetVersion("Galaxy-Class");
+				writeWranglerConfig({
+					...DEFAULT_DURABLE_OBJECTS,
+					containers: [
+						{
+							...DEFAULT_CONTAINER_FROM_REGISTRY,
+							observability: {
+								enabled: true,
+								...nextTarget,
+							},
+						},
+					],
+				});
+
+				mockGetApplications([
+					{
+						...sharedGetApplicationResult,
+						observability: {
+							logs: { enabled: true },
+							...previousTarget,
+						},
+					},
+				]);
+				const modifySpy = mockTrackApplicationModification();
+				const rolloutSpy = mockTrackApplicationRollout();
+
+				await runWrangler("deploy index.js");
+
+				expect(modifySpy).toHaveBeenCalledWith(
+					expect.objectContaining({
+						observability: {
+							logs: { enabled: true },
+							...nextTarget,
+						},
+					})
+				);
+				expect(rolloutSpy).not.toHaveBeenCalled();
+				expect(cliStd.stdout).toContain(`- ${removedSetting}`);
+				if (addedSetting !== undefined) {
+					expect(cliStd.stdout).toContain(`+ ${addedSetting}`);
+				}
+			}
+		);
+
+		it("detects no changes when top-level observability already matches", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				observability: { enabled: true },
+				containers: [DEFAULT_CONTAINER_FROM_REGISTRY],
+			});
+
+			mockGetApplications([
+				{
+					...sharedGetApplicationResult,
+					observability: {
+						logs: {
+							enabled: true,
+						},
+					},
+				},
+			]);
+			const modifySpy = mockTrackApplicationModification();
+			const rolloutSpy = mockTrackApplicationRollout();
+
+			await runWrangler("deploy index.js");
+
+			expect(modifySpy).not.toHaveBeenCalled();
+			expect(rolloutSpy).not.toHaveBeenCalled();
+			expect(cliStd.stdout).toMatchInlineSnapshot(`
+				"╭ Deploy a container application deploy changes to your application
+				│
+				│ Container application changes
+				│
+				├ no changes my-container
+				│
+				╰ No changes to be made
+
+				"
+			`);
+		});
+
+		it("avoids no-op migration churn when legacy observability is already disabled", async ({
 			expect,
 		}) => {
 			mockGetVersion("Galaxy-Class");
@@ -1590,9 +2039,13 @@ describe("wrangler deploy with containers", () => {
 					},
 				},
 			]);
+			const modifySpy = mockTrackApplicationModification();
+			const rolloutSpy = mockTrackApplicationRollout();
 
 			await runWrangler("deploy index.js");
 
+			expect(modifySpy).not.toHaveBeenCalled();
+			expect(rolloutSpy).not.toHaveBeenCalled();
 			expect(cliStd.stdout).toMatchInlineSnapshot(`
 				"╭ Deploy a container application deploy changes to your application
 				│
@@ -1601,6 +2054,160 @@ describe("wrangler deploy with containers", () => {
 				├ no changes my-container
 				│
 				╰ No changes to be made
+
+				"
+			`);
+		});
+
+		it("throws a local error when application-level targeting is added before disabling legacy observability", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				containers: [
+					{
+						...DEFAULT_CONTAINER_FROM_REGISTRY,
+						observability: {
+							enabled: true,
+							target_instance_percentage: 10,
+						},
+					},
+				],
+			});
+
+			mockGetApplications([
+				{
+					...sharedGetApplicationResult,
+					configuration: {
+						...sharedGetApplicationResult.configuration,
+						observability: {
+							logs: {
+								enabled: true,
+							},
+						},
+					},
+				},
+			]);
+
+			await expect(runWrangler("deploy index.js")).rejects.toThrow(
+				"Application-level observability targeting cannot be enabled for container my-container while it still uses legacy rollout-based observability. Set containers[].observability.enabled = false in your Wrangler config and deploy once, then deploy again with target_instance_percentage or target_instance_count."
+			);
+		});
+
+		it("throws a local error when an active rollout still targets legacy observability", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				containers: [
+					{
+						...DEFAULT_CONTAINER_FROM_REGISTRY,
+						observability: {
+							enabled: true,
+							target_instance_count: 2,
+						},
+					},
+				],
+			});
+
+			mockGetApplications([
+				{
+					...sharedGetApplicationResult,
+					scheduling_hint: {
+						current: {
+							instances: 0,
+							configuration: {
+								image: "registry.cloudflare.com/hello:world",
+							},
+							version: 1,
+						},
+						target: {
+							instances: 0,
+							configuration: {
+								image: "registry.cloudflare.com/hello:world",
+								observability: {
+									logs: {
+										enabled: true,
+									},
+								},
+							},
+							version: 2,
+						},
+					},
+				},
+			]);
+
+			await expect(runWrangler("deploy index.js")).rejects.toThrow(
+				"Application-level observability targeting cannot be enabled for container my-container while it still uses legacy rollout-based observability. Set containers[].observability.enabled = false in your Wrangler config and deploy once, then deploy again with target_instance_percentage or target_instance_count."
+			);
+		});
+
+		it("still creates a rollout when top-level observability changes alongside deployment config", async ({
+			expect,
+		}) => {
+			mockGetVersion("Galaxy-Class");
+			writeWranglerConfig({
+				...DEFAULT_DURABLE_OBJECTS,
+				containers: [
+					{
+						...DEFAULT_CONTAINER_FROM_REGISTRY,
+						image: "registry.cloudflare.com/hello:moon",
+						observability: { enabled: true },
+					},
+				],
+			});
+
+			mockGetApplications([
+				{
+					...sharedGetApplicationResult,
+					observability: {
+						logs: {
+							enabled: false,
+						},
+					},
+				},
+			]);
+
+			mockModifyApplication(expect, {
+				observability: {
+					logs: { enabled: true },
+				},
+				configuration: {
+					image: "registry.cloudflare.com/some-account-id/hello:moon",
+				},
+			});
+			mockCreateApplicationRollout(expect, {
+				target_configuration: {
+					image: "registry.cloudflare.com/some-account-id/hello:moon",
+				},
+			});
+
+			await runWrangler("deploy index.js");
+
+			expect(cliStd.stdout).toMatchInlineSnapshot(`
+				"╭ Deploy a container application deploy changes to your application
+				│
+				│ Container application changes
+				│
+				├ EDIT my-container
+				│
+				│   scheduling_policy = "default"
+				│   [containers.configuration]
+				│ - image = "registry.cloudflare.com/some-account-id/hello:world"
+				│ + image = "registry.cloudflare.com/some-account-id/hello:moon"
+				│   instance_type = "lite"
+				│   [containers.constraints]
+				│   tiers = [ 1, 2 ]
+				│   [containers.observability.logs]
+				│ - enabled = false
+				│ + enabled = true
+				│
+				│
+				│  SUCCESS  Modified application my-container (Application ID: abc)
+				│
+				╰ Applied changes
 
 				"
 			`);
@@ -2133,7 +2740,7 @@ describe("wrangler deploy with containers", () => {
 		`);
 	});
 
-	it("should enable ssh when provided for an existing container", async ({
+	it("normalizes the diff when enabling ssh on an application without an inferable instance type", async ({
 		expect,
 	}) => {
 		mockGetVersion("Galaxy-Class");
@@ -2209,21 +2816,18 @@ describe("wrangler deploy with containers", () => {
 			│
 			├ EDIT my-container
 			│
+			│   max_instances = 10
 			│   name = "my-container"
 			│   scheduling_policy = "default"
-			│   version = 1
 			│ + rollout_active_grace_period = 0
 			│   [containers.configuration]
-			│ - image = "registry.cloudflare.com/hello:world"
-			│ + image = "registry.cloudflare.com/some-account-id/hello:world"
+			│   image = "registry.cloudflare.com/some-account-id/hello:world"
 			│ + instance_type = "lite"
 			│ + [[containers.configuration.authorized_keys]]
 			│ + name = "jeff"
 			│ + public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC0chNcjRotdsxXTwPPNoqVCGn4EcEWdUkkBPNm/v4gm"
 			│ + [containers.configuration.ssh]
 			│ + enabled = true
-			│   [containers.durable_objects]
-			│   namespace_id = "1"
 			│ + [containers.constraints]
 			│ + tiers = [ 1, 2 ]
 			│
@@ -3252,6 +3856,23 @@ function mockModifyApplication(
 	);
 }
 
+function mockTrackApplicationModification() {
+	const modifySpy = vi.fn();
+	msw.use(
+		http.patch("*/applications/:id", async ({ request }) => {
+			modifySpy(await request.json());
+			return HttpResponse.json({
+				success: true,
+				result: {
+					id: "abc",
+					name: "my-container",
+				},
+			});
+		})
+	);
+	return modifySpy;
+}
+
 function mockCreateApplicationRollout(
 	expect: ExpectStatic,
 	expected?: Record<string, unknown>
@@ -3272,6 +3893,23 @@ function mockCreateApplicationRollout(
 			});
 		})
 	);
+}
+
+function mockTrackApplicationRollout() {
+	const rolloutSpy = vi.fn();
+	msw.use(
+		http.post("*/applications/:id/rollouts", async ({ request }) => {
+			rolloutSpy(await request.json());
+			return HttpResponse.json({
+				success: true,
+				result: {
+					id: "rollout-123",
+					status: "pending",
+				},
+			});
+		})
+	);
+	return rolloutSpy;
 }
 
 function mockGenerateImageRegistryCredentials(expect: ExpectStatic) {

--- a/packages/wrangler/src/__tests__/preview.test.ts
+++ b/packages/wrangler/src/__tests__/preview.test.ts
@@ -2955,10 +2955,7 @@ describe("wrangler preview", () => {
 				);
 				await runWrangler("preview --name feature/my-branch");
 				expect(createdApplications).toHaveLength(1);
-				const configuration = createdApplications[0]?.configuration as
-					| { observability?: unknown }
-					| undefined;
-				expect(configuration?.observability).toEqual(expected);
+				expect(createdApplications[0]?.observability).toEqual(expected);
 			}
 		);
 

--- a/packages/wrangler/src/containers/config.ts
+++ b/packages/wrangler/src/containers/config.ts
@@ -16,7 +16,56 @@ import type {
 	SharedContainerConfig,
 } from "@cloudflare/containers-shared";
 import type { ApplicationAffinityHardwareGeneration } from "@cloudflare/containers-shared/src/client/models/ApplicationAffinityHardwareGeneration";
-import type { Config, ContainerApp } from "@cloudflare/workers-utils";
+import type {
+	Config,
+	ContainerApp,
+	ContainerObservability,
+	Observability,
+} from "@cloudflare/workers-utils";
+
+function hasConflictingObservabilityEnabledValues(
+	observability: ContainerObservability | undefined
+): boolean {
+	return (
+		typeof observability?.enabled === "boolean" &&
+		typeof observability.logs?.enabled === "boolean" &&
+		observability.enabled !== observability.logs.enabled
+	);
+}
+
+function isContainerObservabilityEnabled(
+	observability: ContainerObservability | undefined
+): boolean {
+	return (
+		observability?.logs?.enabled === true || observability?.enabled === true
+	);
+}
+
+function isRootObservabilityLogsEnabled(
+	observability: Observability | undefined
+): boolean {
+	return (
+		observability?.logs?.enabled === true ||
+		(observability?.enabled === true && observability?.logs?.enabled !== false)
+	);
+}
+
+function assertNoConflictingObservabilityEnabledValues(
+	containerName: string,
+	observability: ContainerObservability | undefined
+) {
+	if (!hasConflictingObservabilityEnabledValues(observability)) {
+		return;
+	}
+
+	throw new UserError(
+		`"containers.observability.enabled" and "containers.observability.logs.enabled" cannot be set to different values for container "${containerName}".`,
+		{
+			telemetryMessage:
+				"containers config observability enabled values conflict",
+		}
+	);
+}
 
 /**
  * Perform type conversion of affinities so that they can be fed to the API.
@@ -110,6 +159,20 @@ export const getNormalizedContainerOptions = async (
 			tiers = [1, 2];
 		}
 
+		let selectedObservabilityLogsEnabled = isRootObservabilityLogsEnabled(
+			config.observability
+		);
+
+		if (container.observability !== undefined) {
+			assertNoConflictingObservabilityEnabledValues(
+				container.name,
+				container.observability
+			);
+			selectedObservabilityLogsEnabled = isContainerObservabilityEnabled(
+				container.observability
+			);
+		}
+
 		const shared: Omit<SharedContainerConfig, "disk_size" | "instance_type"> = {
 			name: container.name,
 			class_name: container.class_name,
@@ -138,9 +201,19 @@ export const getNormalizedContainerOptions = async (
 					: (container.rollout_kind ?? "full_auto"),
 			rollout_active_grace_period: container.rollout_active_grace_period ?? 0,
 			observability: {
-				logs_enabled:
-					config.observability?.logs?.enabled ??
-					config.observability?.enabled === true,
+				logs_enabled: selectedObservabilityLogsEnabled,
+				...(container.observability?.target_instance_percentage !== undefined
+					? {
+							target_instance_percentage:
+								container.observability.target_instance_percentage,
+						}
+					: {}),
+				...(container.observability?.target_instance_count !== undefined
+					? {
+							target_instance_count:
+								container.observability.target_instance_count,
+						}
+					: {}),
 			},
 			// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, falls back to deprecated `wrangler_ssh` when `ssh` is not set
 			wrangler_ssh: container.ssh ?? container.wrangler_ssh,

--- a/packages/wrangler/src/containers/config.ts
+++ b/packages/wrangler/src/containers/config.ts
@@ -20,7 +20,29 @@ import type {
 	SharedContainerConfig,
 } from "@cloudflare/containers-shared";
 import type { ApplicationAffinityHardwareGeneration } from "@cloudflare/containers-shared/src/client/models/ApplicationAffinityHardwareGeneration";
-import type { Config, ContainerApp } from "@cloudflare/workers-utils";
+import type {
+	Config,
+	ContainerApp,
+	ContainerObservability,
+	Observability,
+} from "@cloudflare/workers-utils";
+
+function isContainerObservabilityEnabled(
+	observability: ContainerObservability | undefined
+): boolean {
+	return (
+		observability?.logs?.enabled === true || observability?.enabled === true
+	);
+}
+
+function isRootObservabilityLogsEnabled(
+	observability: Observability | undefined
+): boolean {
+	return (
+		observability?.logs?.enabled === true ||
+		(observability?.enabled === true && observability?.logs?.enabled !== false)
+	);
+}
 
 /**
  * Perform type conversion of affinities so that they can be fed to the API.
@@ -125,6 +147,16 @@ export const getNormalizedContainerOptions = async (
 			tiers = [1, 2];
 		}
 
+		let selectedObservabilityLogsEnabled = isRootObservabilityLogsEnabled(
+			config.observability
+		);
+
+		if (container.observability !== undefined) {
+			selectedObservabilityLogsEnabled = isContainerObservabilityEnabled(
+				container.observability
+			);
+		}
+
 		const shared: Omit<SharedContainerConfig, "disk_size" | "instance_type"> = {
 			name: container.name,
 			class_name: className,
@@ -153,9 +185,19 @@ export const getNormalizedContainerOptions = async (
 					: (container.rollout_kind ?? "full_auto"),
 			rollout_active_grace_period: container.rollout_active_grace_period ?? 0,
 			observability: {
-				logs_enabled:
-					config.observability?.logs?.enabled ??
-					config.observability?.enabled === true,
+				logs_enabled: selectedObservabilityLogsEnabled,
+				...(container.observability?.target_instance_percentage !== undefined
+					? {
+							target_instance_percentage:
+								container.observability.target_instance_percentage,
+						}
+					: {}),
+				...(container.observability?.target_instance_count !== undefined
+					? {
+							target_instance_count:
+								container.observability.target_instance_count,
+						}
+					: {}),
 			},
 			// eslint-disable-next-line @typescript-eslint/no-deprecated -- kept for backward compatibility, falls back to deprecated `wrangler_ssh` when `ssh` is not set
 			wrangler_ssh: container.ssh ?? container.wrangler_ssh,

--- a/packages/wrangler/src/containers/deploy.ts
+++ b/packages/wrangler/src/containers/deploy.ts
@@ -52,12 +52,13 @@ import type { ImageRef } from "../cloudchamber/build";
 import type { ApiVersion } from "../versions/types";
 import type {
 	Application,
+	ApplicationObservability as ApplicationObservabilityConfiguration,
 	ApplicationID,
 	ApplicationName,
 	ContainerNormalizedConfig,
 	CreateApplicationRequest,
 	ModifyApplicationRequestBody,
-	Observability as ObservabilityConfiguration,
+	Observability as DeploymentObservabilityConfiguration,
 	RolloutStepRequest,
 } from "@cloudflare/containers-shared";
 import type {
@@ -72,6 +73,8 @@ type DeployContainersArgs = {
 	accountId: string;
 	scriptName: string;
 };
+
+type ObservabilityWriteTarget = "top-level" | "configuration";
 
 export async function deployContainers(
 	config: Config,
@@ -245,6 +248,7 @@ function createApplicationToModifyApplication(
 ): ModifyApplicationRequestBody {
 	return {
 		configuration: req.configuration,
+		observability: req.observability,
 		max_instances: req.max_instances,
 		constraints: req.constraints,
 		affinities: req.affinities,
@@ -253,53 +257,212 @@ function createApplicationToModifyApplication(
 	};
 }
 
-/**
- * Resolves current configuration based on previous deployment.
- */
-function observabilityToConfiguration(
-	/** Taken from current wrangler config */
-	observabilityFromConfig: boolean,
-	/** From previous deployment */
-	existingObservabilityConfig: ObservabilityConfiguration | undefined
-): ObservabilityConfiguration | undefined {
-	// Let's use logs for the sake of simplicity of explanation.
-	//
-	// The first column specifies if logs are enabled in the current Wrangler config.
-	// The second column specifies if logs are currently enabled for the application.
-	// The third column specifies what the expected function result should be so that
-	// diff is minimal.
-	//
-	// | Wrangler  | Existing  | Result    |
-	// | --------- | --------- | --------- |
-	// | undefined | undefined | undefined |
-	// | undefined | false     | false     |
-	// | undefined | true      | false     |
-	// | false     | undefined | undefined |
-	// | false     | false     | false     |
-	// | false     | true      | false     |
-	// | true      | undefined | true      |
-	// | true      | false     | true      |
-	// | true      | true      | true      |
-	//
-	// Because the result is the same for Wrangler undefined and false, the table may be
-	// compressed as follows:
+function isLegacyObservabilityEnabled(
+	observability: DeploymentObservabilityConfiguration | undefined
+): boolean {
+	return observability?.logs?.enabled === true;
+}
 
-	//
-	// | Wrangler          | Existing                 | Result    |
-	// | ----------------- | ------------------------ | --------- |
-	// | false / undefined | undefined                | undefined |
-	// | false / undefined | false / true             | false     |
-	// | true              | undefined / false / true | true      |
+function hasLegacyRolloutObservabilityEnabled(
+	app: Application | undefined
+): boolean {
+	return (
+		isLegacyObservabilityEnabled(app?.configuration.observability) ||
+		isLegacyObservabilityEnabled(
+			app?.scheduling_hint?.target.configuration.observability
+		)
+	);
+}
 
-	const logsAlreadyEnabled = existingObservabilityConfig?.logs?.enabled;
+function getLatestLegacyObservabilityState(
+	app: Application | undefined
+): DeploymentObservabilityConfiguration | undefined {
+	return (
+		app?.scheduling_hint?.target.configuration.observability ??
+		app?.configuration.observability
+	);
+}
 
-	if (observabilityFromConfig) {
-		return { logs: { enabled: true } };
-	} else if (logsAlreadyEnabled === undefined) {
-		return undefined;
-	} else {
-		return { logs: { enabled: false } };
+function usesTopLevelObservability(app: Application | undefined): boolean {
+	return app?.observability !== undefined;
+}
+
+function hasTopLevelOnlyObservabilityFields(
+	observability: ContainerNormalizedConfig["observability"]
+): boolean {
+	return (
+		observability.target_instance_percentage !== undefined ||
+		observability.target_instance_count !== undefined
+	);
+}
+
+function selectObservabilityWriteTarget(
+	prevApp: Application | undefined
+): ObservabilityWriteTarget {
+	if (prevApp === undefined) {
+		return "top-level";
 	}
+
+	if (hasLegacyRolloutObservabilityEnabled(prevApp)) {
+		return "configuration";
+	}
+
+	return "top-level";
+}
+
+function buildTopLevelObservability(
+	observability: ContainerNormalizedConfig["observability"]
+): ApplicationObservabilityConfiguration {
+	return stripUndefined({
+		logs: { enabled: observability.logs_enabled },
+		target_instance_percentage: observability.target_instance_percentage,
+		target_instance_count: observability.target_instance_count,
+	});
+}
+
+function buildConfigurationObservability(
+	observability: ContainerNormalizedConfig["observability"]
+): DeploymentObservabilityConfiguration {
+	return {
+		logs: {
+			enabled: observability.logs_enabled,
+		},
+	};
+}
+
+function isSameApplicationObservability(
+	left: ApplicationObservabilityConfiguration | undefined,
+	right: ApplicationObservabilityConfiguration | undefined
+): boolean {
+	return (
+		left?.logs?.enabled === right?.logs?.enabled &&
+		left?.target_instance_percentage === right?.target_instance_percentage &&
+		left?.target_instance_count === right?.target_instance_count
+	);
+}
+
+function buildTopLevelObservabilityPatch(
+	observability: ContainerNormalizedConfig["observability"],
+	prevApp: Application | undefined,
+	writeTarget: ObservabilityWriteTarget
+): ApplicationObservabilityConfiguration | undefined {
+	if (writeTarget === "configuration" && !usesTopLevelObservability(prevApp)) {
+		return undefined;
+	}
+
+	const shouldWriteDisabledTopLevelObservability =
+		prevApp?.observability !== undefined &&
+		(prevApp.observability.logs?.enabled === true ||
+			prevApp.observability.target_instance_percentage !== undefined ||
+			prevApp.observability.target_instance_count !== undefined);
+
+	if (
+		!observability.logs_enabled &&
+		!hasTopLevelOnlyObservabilityFields(observability)
+	) {
+		return shouldWriteDisabledTopLevelObservability
+			? buildTopLevelObservability(observability)
+			: undefined;
+	}
+
+	const nextObservability = buildTopLevelObservability(observability);
+	return isSameApplicationObservability(
+		nextObservability,
+		prevApp?.observability
+	)
+		? undefined
+		: nextObservability;
+}
+
+function buildConfigurationObservabilityPatch(
+	observability: ContainerNormalizedConfig["observability"],
+	prevApp: Application | undefined
+): DeploymentObservabilityConfiguration | undefined {
+	const latestLegacyLogsEnabled =
+		getLatestLegacyObservabilityState(prevApp)?.logs?.enabled;
+
+	if (observability.logs_enabled === latestLegacyLogsEnabled) {
+		return undefined;
+	}
+
+	if (!observability.logs_enabled && latestLegacyLogsEnabled === undefined) {
+		return undefined;
+	}
+
+	return buildConfigurationObservability(observability);
+}
+
+function buildApplicationObservabilityPatch(
+	observability: ContainerNormalizedConfig["observability"],
+	writeTarget: ObservabilityWriteTarget,
+	prevApp: Application | undefined
+): {
+	observability?: ApplicationObservabilityConfiguration;
+	configurationObservability?: DeploymentObservabilityConfiguration;
+} {
+	const nextTopLevelObservability = buildTopLevelObservabilityPatch(
+		observability,
+		prevApp,
+		writeTarget
+	);
+
+	if (writeTarget === "configuration") {
+		const nextConfigurationObservability = buildConfigurationObservabilityPatch(
+			observability,
+			prevApp
+		);
+
+		return {
+			...(nextTopLevelObservability !== undefined
+				? { observability: nextTopLevelObservability }
+				: {}),
+			...(nextConfigurationObservability !== undefined
+				? {
+						configurationObservability: nextConfigurationObservability,
+					}
+				: {}),
+		};
+	}
+
+	return nextTopLevelObservability !== undefined
+		? { observability: nextTopLevelObservability }
+		: {};
+}
+
+function assertCanUseApplicationObservabilityTargeting(
+	prevApp: Application,
+	containerConfig: ContainerNormalizedConfig
+) {
+	if (!hasTopLevelOnlyObservabilityFields(containerConfig.observability)) {
+		return;
+	}
+
+	if (!hasLegacyRolloutObservabilityEnabled(prevApp)) {
+		return;
+	}
+
+	throw new UserError(
+		`Application-level observability targeting cannot be enabled for container ${containerConfig.name} while it still uses legacy rollout-based observability. Set containers[].observability.enabled = false in your Wrangler config and deploy once, then deploy again with target_instance_percentage or target_instance_count.`,
+		{
+			telemetryMessage: "containers deploy observability migration blocked",
+		}
+	);
+}
+
+function hasRolloutDiff(
+	prevApp: ModifyApplicationRequestBody,
+	nextApp: ModifyApplicationRequestBody
+): boolean {
+	const normalizedPrevApp = stripUndefined({ ...prevApp });
+	const normalizedNextApp = stripUndefined({ ...nextApp });
+
+	delete normalizedPrevApp.observability;
+	delete normalizedNextApp.observability;
+
+	return (
+		JSON.stringify(sortObjectRecursive(normalizedPrevApp)) !==
+		JSON.stringify(sortObjectRecursive(normalizedNextApp))
+	);
 }
 
 /**
@@ -314,11 +477,20 @@ function containerConfigToCreateRequest(
 	containerApp: ContainerNormalizedConfig,
 	imageRef: string,
 	durableObjectNamespaceId: string,
+	observabilityWriteTarget: ObservabilityWriteTarget,
 	prevApp?: Application
 ): CreateApplicationRequest {
+	const { observability, configurationObservability } =
+		buildApplicationObservabilityPatch(
+			containerApp.observability,
+			observabilityWriteTarget,
+			prevApp
+		);
+
 	return {
 		name: containerApp.name,
 		scheduling_policy: containerApp.scheduling_policy,
+		...(observability !== undefined ? { observability } : {}),
 		configuration: {
 			// De-sugar image name
 			image: resolveImageName(accountId, imageRef),
@@ -330,10 +502,9 @@ function containerConfigToCreateRequest(
 						memory_mib: containerApp.memory_mib,
 						vcpu: containerApp.vcpu,
 					}),
-			observability: observabilityToConfiguration(
-				containerApp.observability.logs_enabled,
-				prevApp?.configuration.observability
-			),
+			...(configurationObservability !== undefined
+				? { observability: configurationObservability }
+				: {}),
 			wrangler_ssh: containerApp.wrangler_ssh,
 			authorized_keys: containerApp.authorized_keys,
 			trusted_user_ca_keys: containerApp.trusted_user_ca_keys,
@@ -414,19 +585,27 @@ export async function apply(
 	log(dim("Container application changes\n"));
 
 	const accountId = await getOrSelectAccountId(config);
+	const observabilityWriteTarget = selectObservabilityWriteTarget(prevApp);
+
+	if (prevApp !== undefined) {
+		assertCanUseApplicationObservabilityTargeting(prevApp, containerConfig);
+	}
 
 	// let's always convert normalised container config -> CreateApplicationRequest
 	// since CreateApplicationRequest is a superset of ModifyApplicationRequestBody
-	const appConfig = mergeIfUnsafe(
-		config,
-		containerConfigToCreateRequest(
-			accountId,
-			containerConfig,
-			imageRef,
-			args.durable_object_namespace_id,
-			prevApp
-		),
-		containerConfig.name
+	const appConfig = stripUndefined(
+		mergeIfUnsafe(
+			config,
+			containerConfigToCreateRequest(
+				accountId,
+				containerConfig,
+				imageRef,
+				args.durable_object_namespace_id,
+				observabilityWriteTarget,
+				prevApp
+			),
+			containerConfig.name
+		)
 	);
 
 	if (prevApp !== undefined && prevApp !== null) {
@@ -453,21 +632,28 @@ export async function apply(
 		// we need to sort the objects (by key) because the diff algorithm works with lines
 		const normalisedPrevApp = sortObjectRecursive<ModifyApplicationRequestBody>(
 			stripUndefined(
-				cleanApplicationFromAPI(prevApp, containerConfig, accountId)
+				cleanApplicationFromAPI(
+					prevApp,
+					containerConfig,
+					accountId,
+					observabilityWriteTarget
+				)
 			)
 		);
 
 		// this will have removed the unsafe fields, so we need to add them back in after
-		const modifyReq = mergeIfUnsafe(
-			config,
-			createApplicationToModifyApplication(appConfig),
-			appConfig.name
+		const modifyReq = stripUndefined(
+			mergeIfUnsafe(
+				config,
+				createApplicationToModifyApplication(appConfig),
+				appConfig.name
+			)
 		);
+		const normalizedModifyReq =
+			sortObjectRecursive<ModifyApplicationRequestBody>(modifyReq);
 		/** only used for diffing */
-		const nowContainer = mergeDeep(
-			normalisedPrevApp,
-			sortObjectRecursive<ModifyApplicationRequestBody>(modifyReq)
-		);
+		const nowContainer = mergeDeep(normalisedPrevApp, normalizedModifyReq);
+		const shouldCreateRollout = hasRolloutDiff(normalisedPrevApp, nowContainer);
 
 		const prev = formatContainerSnippetForDisplay(
 			normalisedPrevApp,
@@ -499,11 +685,15 @@ export async function apply(
 				application: modifyReq,
 				id: prevApp.id,
 				name: prevApp.name,
-				rollout_step_percentage: containerConfig.rollout_step_percentage,
-				rollout_kind:
-					containerConfig.rollout_kind == "full_manual"
-						? CreateApplicationRolloutRequest.kind.FULL_MANUAL
-						: CreateApplicationRolloutRequest.kind.FULL_AUTO,
+				...(shouldCreateRollout
+					? {
+							rollout_step_percentage: containerConfig.rollout_step_percentage,
+							rollout_kind:
+								containerConfig.rollout_kind == "full_manual"
+									? CreateApplicationRolloutRequest.kind.FULL_MANUAL
+									: CreateApplicationRolloutRequest.kind.FULL_AUTO,
+						}
+					: {}),
 			});
 		} else {
 			log("Skipping application rollout");
@@ -590,8 +780,8 @@ const doAction = async (
 				application: ModifyApplicationRequestBody;
 				id: ApplicationID;
 				name: ApplicationName;
-				rollout_step_percentage: number | number[];
-				rollout_kind: CreateApplicationRolloutRequest.kind;
+				rollout_step_percentage?: number | number[];
+				rollout_kind?: CreateApplicationRolloutRequest.kind;
 		  }
 ) => {
 	if (action.action === "create") {
@@ -664,42 +854,47 @@ const doAction = async (
 			);
 		}
 
-		try {
-			await promiseSpinner(
-				RolloutsService.createApplicationRollout(action.id, {
-					description: "Progressive update",
-					strategy: CreateApplicationRolloutRequest.strategy.ROLLING,
-					target_configuration: action.application.configuration ?? {},
-					...configRolloutStepsToAPI(action.rollout_step_percentage),
-					kind: action.rollout_kind,
-				}),
-				{
-					message: `rolling out container version ${action.name}`,
+		if (
+			action.rollout_step_percentage !== undefined &&
+			action.rollout_kind !== undefined
+		) {
+			try {
+				await promiseSpinner(
+					RolloutsService.createApplicationRollout(action.id, {
+						description: "Progressive update",
+						strategy: CreateApplicationRolloutRequest.strategy.ROLLING,
+						target_configuration: action.application.configuration ?? {},
+						...configRolloutStepsToAPI(action.rollout_step_percentage),
+						kind: action.rollout_kind,
+					}),
+					{
+						message: `rolling out container version ${action.name}`,
+					}
+				);
+			} catch (err) {
+				if (!(err instanceof Error)) {
+					throw err;
 				}
-			);
-		} catch (err) {
-			if (!(err instanceof Error)) {
-				throw err;
-			}
 
-			if (!(err instanceof ApiError)) {
+				if (!(err instanceof ApiError)) {
+					throw new UserError(
+						`Unexpected error rolling out application "${action.name}":\n${err.message}`,
+						{ telemetryMessage: "containers deploy rollout unexpected error" }
+					);
+				}
+
+				if (err.status === 400) {
+					throw new UserError(
+						`Error rolling out application "${action.name}" due to a misconfiguration:\n\n\t${formatError(err)}`,
+						{ telemetryMessage: "containers deploy rollout misconfiguration" }
+					);
+				}
+
 				throw new UserError(
-					`Unexpected error rolling out application "${action.name}":\n${err.message}`,
-					{ telemetryMessage: "containers deploy rollout unexpected error" }
+					`Error rolling out application "${action.name}":\n${formatError(err)}`,
+					{ telemetryMessage: "containers deploy rollout request failed" }
 				);
 			}
-
-			if (err.status === 400) {
-				throw new UserError(
-					`Error rolling out application "${action.name}" due to a misconfiguration:\n\n\t${formatError(err)}`,
-					{ telemetryMessage: "containers deploy rollout misconfiguration" }
-				);
-			}
-
-			throw new UserError(
-				`Error rolling out application "${action.name}":\n${formatError(err)}`,
-				{ telemetryMessage: "containers deploy rollout request failed" }
-			);
 		}
 
 		success(
@@ -717,14 +912,21 @@ const doAction = async (
 export function cleanApplicationFromAPI(
 	prev: Application,
 	currentConfig: ContainerNormalizedConfig,
-	accountId: string
+	accountId: string,
+	observabilityWriteTarget: ObservabilityWriteTarget
 ): Partial<ModifyApplicationRequestBody> & Pick<Application, "configuration"> {
+	const configuration = {
+		...prev.configuration,
+		image: resolveImageName(accountId, prev.configuration.image),
+	};
+
+	if (observabilityWriteTarget === "top-level") {
+		delete configuration.observability;
+	}
+
 	const cleanedPreviousApp: Partial<ModifyApplicationRequestBody> &
 		Pick<Application, "configuration"> = {
-		configuration: {
-			...prev.configuration,
-			image: resolveImageName(accountId, prev.configuration.image),
-		},
+		configuration,
 		constraints: prev.constraints,
 		max_instances: prev.max_instances,
 		name: prev.name,
@@ -733,12 +935,24 @@ export function cleanApplicationFromAPI(
 		rollout_active_grace_period: prev.rollout_active_grace_period,
 	};
 
+	if (
+		observabilityWriteTarget === "configuration" &&
+		getLatestLegacyObservabilityState(prev) !== undefined
+	) {
+		cleanedPreviousApp.configuration.observability =
+			getLatestLegacyObservabilityState(prev);
+	}
+
+	if (prev.observability !== undefined) {
+		cleanedPreviousApp.observability = prev.observability;
+	}
+
 	if ("instance_type" in currentConfig) {
 		// returns undefined if we can't infer it.
 		const instance_type = inferInstanceType(cleanedPreviousApp.configuration);
 		if (!instance_type) {
-			// just leave as is if we can't infer the instance type
-			return prev;
+			// Keep the cleaned shape for diffing, but omit an inferred instance type.
+			return cleanedPreviousApp;
 		}
 		cleanedPreviousApp.configuration.instance_type = instance_type;
 

--- a/packages/wrangler/src/containers/deploy.ts
+++ b/packages/wrangler/src/containers/deploy.ts
@@ -52,12 +52,13 @@ import type { ImageRef } from "../cloudchamber/build";
 import type { ApiVersion } from "../versions/types";
 import type {
 	Application,
+	ApplicationObservability as ApplicationObservabilityConfiguration,
 	ApplicationID,
 	ApplicationName,
 	ContainerNormalizedConfig,
 	CreateApplicationRequest,
 	ModifyApplicationRequestBody,
-	Observability as ObservabilityConfiguration,
+	Observability as DeploymentObservabilityConfiguration,
 	RolloutStepRequest,
 } from "@cloudflare/containers-shared";
 import type {
@@ -72,6 +73,8 @@ type DeployContainersArgs = {
 	accountId: string;
 	scriptName: string;
 };
+
+type ObservabilityWriteTarget = "top-level" | "configuration";
 
 export async function deployContainers(
 	config: Config,
@@ -252,6 +255,7 @@ function createApplicationToModifyApplication(
 ): ModifyApplicationRequestBody {
 	return {
 		configuration: req.configuration,
+		observability: req.observability,
 		max_instances: req.max_instances,
 		constraints: req.constraints,
 		affinities: req.affinities,
@@ -260,53 +264,256 @@ function createApplicationToModifyApplication(
 	};
 }
 
-/**
- * Resolves current configuration based on previous deployment.
- */
-function observabilityToConfiguration(
-	/** Taken from current wrangler config */
-	observabilityFromConfig: boolean,
-	/** From previous deployment */
-	existingObservabilityConfig: ObservabilityConfiguration | undefined
-): ObservabilityConfiguration | undefined {
-	// Let's use logs for the sake of simplicity of explanation.
-	//
-	// The first column specifies if logs are enabled in the current Wrangler config.
-	// The second column specifies if logs are currently enabled for the application.
-	// The third column specifies what the expected function result should be so that
-	// diff is minimal.
-	//
-	// | Wrangler  | Existing  | Result    |
-	// | --------- | --------- | --------- |
-	// | undefined | undefined | undefined |
-	// | undefined | false     | false     |
-	// | undefined | true      | false     |
-	// | false     | undefined | undefined |
-	// | false     | false     | false     |
-	// | false     | true      | false     |
-	// | true      | undefined | true      |
-	// | true      | false     | true      |
-	// | true      | true      | true      |
-	//
-	// Because the result is the same for Wrangler undefined and false, the table may be
-	// compressed as follows:
+function isLegacyObservabilityEnabled(
+	observability: DeploymentObservabilityConfiguration | undefined
+): boolean {
+	return observability?.logs?.enabled === true;
+}
 
-	//
-	// | Wrangler          | Existing                 | Result    |
-	// | ----------------- | ------------------------ | --------- |
-	// | false / undefined | undefined                | undefined |
-	// | false / undefined | false / true             | false     |
-	// | true              | undefined / false / true | true      |
+function hasLegacyRolloutObservabilityEnabled(
+	app: Application | undefined
+): boolean {
+	return (
+		isLegacyObservabilityEnabled(app?.configuration.observability) ||
+		isLegacyObservabilityEnabled(
+			app?.scheduling_hint?.target.configuration.observability
+		)
+	);
+}
 
-	const logsAlreadyEnabled = existingObservabilityConfig?.logs?.enabled;
+function getLatestLegacyObservabilityState(
+	app: Application | undefined
+): DeploymentObservabilityConfiguration | undefined {
+	return (
+		app?.scheduling_hint?.target.configuration.observability ??
+		app?.configuration.observability
+	);
+}
 
-	if (observabilityFromConfig) {
-		return { logs: { enabled: true } };
-	} else if (logsAlreadyEnabled === undefined) {
-		return undefined;
-	} else {
-		return { logs: { enabled: false } };
+function usesTopLevelObservability(app: Application | undefined): boolean {
+	return app?.observability !== undefined;
+}
+
+function hasTopLevelOnlyObservabilityFields(
+	observability: ContainerNormalizedConfig["observability"]
+): boolean {
+	return (
+		observability.target_instance_percentage !== undefined ||
+		observability.target_instance_count !== undefined
+	);
+}
+
+function selectObservabilityWriteTarget(
+	prevApp: Application | undefined
+): ObservabilityWriteTarget {
+	if (prevApp === undefined) {
+		return "top-level";
 	}
+
+	if (hasLegacyRolloutObservabilityEnabled(prevApp)) {
+		return "configuration";
+	}
+
+	return "top-level";
+}
+
+function hasMixedEnabledObservability(app: Application): boolean {
+	return (
+		app.observability?.logs?.enabled === true &&
+		isLegacyObservabilityEnabled(app.configuration.observability)
+	);
+}
+
+function requiresObservabilityMigration(
+	app: Application,
+	observability: ContainerNormalizedConfig["observability"]
+): boolean {
+	return (
+		hasLegacyRolloutObservabilityEnabled(app) &&
+		(app.observability?.logs?.enabled === true ||
+			(usesTopLevelObservability(app) && observability.logs_enabled))
+	);
+}
+
+function buildLegacyObservabilityMigrationPatch(
+	app: Application
+): ApplicationObservabilityConfiguration {
+	const observability = app.configuration.observability;
+	assert(observability?.logs?.enabled === true);
+
+	// Coordinator clears legacy observability when a top-level PATCH matches it.
+	return { logs: observability.logs };
+}
+
+function migrateLegacyObservabilityState(
+	app: Application,
+	observability: ApplicationObservabilityConfiguration
+): Application {
+	const configuration = { ...app.configuration };
+	delete configuration.observability;
+
+	return {
+		...app,
+		configuration,
+		observability,
+	};
+}
+
+function buildTopLevelObservability(
+	observability: ContainerNormalizedConfig["observability"]
+): ApplicationObservabilityConfiguration {
+	return stripUndefined({
+		logs: { enabled: observability.logs_enabled },
+		target_instance_percentage: observability.target_instance_percentage,
+		target_instance_count: observability.target_instance_count,
+	});
+}
+
+function buildConfigurationObservability(
+	observability: ContainerNormalizedConfig["observability"]
+): DeploymentObservabilityConfiguration {
+	return {
+		logs: {
+			enabled: observability.logs_enabled,
+		},
+	};
+}
+
+function isSameApplicationObservability(
+	left: ApplicationObservabilityConfiguration | undefined,
+	right: ApplicationObservabilityConfiguration | undefined
+): boolean {
+	return (
+		left?.logs?.enabled === right?.logs?.enabled &&
+		left?.target_instance_percentage === right?.target_instance_percentage &&
+		left?.target_instance_count === right?.target_instance_count
+	);
+}
+
+function buildTopLevelObservabilityPatch(
+	observability: ContainerNormalizedConfig["observability"],
+	prevApp: Application | undefined,
+	writeTarget: ObservabilityWriteTarget
+): ApplicationObservabilityConfiguration | undefined {
+	if (writeTarget === "configuration" && !usesTopLevelObservability(prevApp)) {
+		return undefined;
+	}
+
+	const shouldWriteDisabledTopLevelObservability =
+		prevApp?.observability !== undefined &&
+		(prevApp.observability.logs?.enabled === true ||
+			prevApp.observability.target_instance_percentage !== undefined ||
+			prevApp.observability.target_instance_count !== undefined);
+
+	if (
+		!observability.logs_enabled &&
+		!hasTopLevelOnlyObservabilityFields(observability)
+	) {
+		return shouldWriteDisabledTopLevelObservability
+			? buildTopLevelObservability(observability)
+			: undefined;
+	}
+
+	const nextObservability = buildTopLevelObservability(observability);
+	return isSameApplicationObservability(
+		nextObservability,
+		prevApp?.observability
+	)
+		? undefined
+		: nextObservability;
+}
+
+function buildConfigurationObservabilityPatch(
+	observability: ContainerNormalizedConfig["observability"],
+	prevApp: Application | undefined
+): DeploymentObservabilityConfiguration | undefined {
+	const latestLegacyLogsEnabled =
+		getLatestLegacyObservabilityState(prevApp)?.logs?.enabled;
+
+	if (observability.logs_enabled === latestLegacyLogsEnabled) {
+		// Application PATCHes and rollout targets treat configuration as a partial
+		// update, so omitting unchanged legacy observability preserves it.
+		return undefined;
+	}
+
+	if (!observability.logs_enabled && latestLegacyLogsEnabled === undefined) {
+		return undefined;
+	}
+
+	return buildConfigurationObservability(observability);
+}
+
+function buildApplicationObservabilityPatch(
+	observability: ContainerNormalizedConfig["observability"],
+	writeTarget: ObservabilityWriteTarget,
+	prevApp: Application | undefined
+): {
+	observability?: ApplicationObservabilityConfiguration;
+	configurationObservability?: DeploymentObservabilityConfiguration;
+} {
+	const nextTopLevelObservability = buildTopLevelObservabilityPatch(
+		observability,
+		prevApp,
+		writeTarget
+	);
+
+	if (writeTarget === "configuration") {
+		const nextConfigurationObservability = buildConfigurationObservabilityPatch(
+			observability,
+			prevApp
+		);
+
+		return {
+			...(nextTopLevelObservability !== undefined
+				? { observability: nextTopLevelObservability }
+				: {}),
+			...(nextConfigurationObservability !== undefined
+				? {
+						configurationObservability: nextConfigurationObservability,
+					}
+				: {}),
+		};
+	}
+
+	return nextTopLevelObservability !== undefined
+		? { observability: nextTopLevelObservability }
+		: {};
+}
+
+function assertCanUseApplicationObservabilityTargeting(
+	prevApp: Application,
+	containerConfig: ContainerNormalizedConfig
+) {
+	if (!hasTopLevelOnlyObservabilityFields(containerConfig.observability)) {
+		return;
+	}
+
+	if (!hasLegacyRolloutObservabilityEnabled(prevApp)) {
+		return;
+	}
+
+	throw new UserError(
+		`Application-level observability targeting cannot be enabled for container ${containerConfig.name} while it still uses legacy rollout-based observability. Set containers[].observability.enabled = false in your Wrangler config and deploy once, then deploy again with target_instance_percentage or target_instance_count.`,
+		{
+			telemetryMessage: "containers deploy observability migration blocked",
+		}
+	);
+}
+
+function hasRolloutDiff(
+	prevApp: ModifyApplicationRequestBody,
+	nextApp: ModifyApplicationRequestBody
+): boolean {
+	const normalizedPrevApp = stripUndefined({ ...prevApp });
+	const normalizedNextApp = stripUndefined({ ...nextApp });
+
+	delete normalizedPrevApp.observability;
+	delete normalizedNextApp.observability;
+
+	return (
+		JSON.stringify(sortObjectRecursive(normalizedPrevApp)) !==
+		JSON.stringify(sortObjectRecursive(normalizedNextApp))
+	);
 }
 
 /**
@@ -322,11 +529,20 @@ function containerConfigToCreateRequest(
 	imageRef: string,
 	durableObjectNamespaceId: string,
 	complianceConfig: ComplianceConfig,
+	observabilityWriteTarget: ObservabilityWriteTarget,
 	prevApp?: Application
 ): CreateApplicationRequest {
+	const { observability, configurationObservability } =
+		buildApplicationObservabilityPatch(
+			containerApp.observability,
+			observabilityWriteTarget,
+			prevApp
+		);
+
 	return {
 		name: containerApp.name,
 		scheduling_policy: containerApp.scheduling_policy,
+		...(observability !== undefined ? { observability } : {}),
 		configuration: {
 			// De-sugar image name
 			image: resolveImageName(accountId, imageRef, complianceConfig),
@@ -338,10 +554,9 @@ function containerConfigToCreateRequest(
 						memory_mib: containerApp.memory_mib,
 						vcpu: containerApp.vcpu,
 					}),
-			observability: observabilityToConfiguration(
-				containerApp.observability.logs_enabled,
-				prevApp?.configuration.observability
-			),
+			...(configurationObservability !== undefined
+				? { observability: configurationObservability }
+				: {}),
 			wrangler_ssh: containerApp.wrangler_ssh,
 			authorized_keys: containerApp.authorized_keys,
 			trusted_user_ca_keys: containerApp.trusted_user_ca_keys,
@@ -411,7 +626,7 @@ export async function apply(
 	// TODO: this is not correct right now as there can be multiple applications
 	// with the same name.
 	/** Previous deployment of this app, if this exists  */
-	const prevApp = existingApplications.find(
+	let prevApp = existingApplications.find(
 		(app) => app.name === containerConfig.name
 	);
 
@@ -422,23 +637,9 @@ export async function apply(
 	log(dim("Container application changes\n"));
 
 	const accountId = await getOrSelectAccountId(config);
+	let migratedLegacyObservability = false;
 
-	// let's always convert normalised container config -> CreateApplicationRequest
-	// since CreateApplicationRequest is a superset of ModifyApplicationRequestBody
-	const appConfig = mergeIfUnsafe(
-		config,
-		containerConfigToCreateRequest(
-			accountId,
-			containerConfig,
-			imageRef,
-			args.durable_object_namespace_id,
-			config,
-			prevApp
-		),
-		containerConfig.name
-	);
-
-	if (prevApp !== undefined && prevApp !== null) {
+	if (prevApp !== undefined) {
 		if (!prevApp.durable_objects?.namespace_id) {
 			throw new FatalError(
 				"The previous deploy of this container application was not associated with a durable object",
@@ -459,24 +660,101 @@ export async function apply(
 			);
 		}
 
+		if (containerConfig.rollout_kind !== "none") {
+			if (
+				requiresObservabilityMigration(
+					prevApp,
+					containerConfig.observability
+				) &&
+				(prevApp.active_rollout_id !== undefined ||
+					isLegacyObservabilityEnabled(
+						prevApp.scheduling_hint?.target.configuration.observability
+					))
+			) {
+				throw new UserError(
+					`Cannot migrate observability configuration for container ${containerConfig.name} while an application rollout is active. Wait for the rollout to finish, then deploy again.`,
+					{
+						telemetryMessage:
+							"containers deploy observability migration rollout active",
+					}
+				);
+			}
+
+			if (hasMixedEnabledObservability(prevApp)) {
+				const migrationObservability =
+					buildLegacyObservabilityMigrationPatch(prevApp);
+				await doAction({
+					action: "modify",
+					application: { observability: migrationObservability },
+					id: prevApp.id,
+					name: prevApp.name,
+					successMessage: `Migrated observability configuration for ${brandColor(prevApp.name)} (Application ID: ${prevApp.id})`,
+				});
+				prevApp = migrateLegacyObservabilityState(
+					prevApp,
+					migrationObservability
+				);
+				migratedLegacyObservability = true;
+			}
+		}
+	}
+
+	const observabilityWriteTarget = selectObservabilityWriteTarget(prevApp);
+
+	if (prevApp !== undefined) {
+		assertCanUseApplicationObservabilityTargeting(prevApp, containerConfig);
+	}
+
+	// let's always convert normalised container config -> CreateApplicationRequest
+	// since CreateApplicationRequest is a superset of ModifyApplicationRequestBody
+	const appConfig = stripUndefined(
+		mergeIfUnsafe(
+			config,
+			containerConfigToCreateRequest(
+				accountId,
+				containerConfig,
+				imageRef,
+				args.durable_object_namespace_id,
+				config,
+				observabilityWriteTarget,
+				prevApp
+			),
+			containerConfig.name
+		)
+	);
+
+	if (prevApp !== undefined && prevApp !== null) {
 		// we need to sort the objects (by key) because the diff algorithm works with lines
 		const normalisedPrevApp = sortObjectRecursive<ModifyApplicationRequestBody>(
 			stripUndefined(
-				cleanApplicationFromAPI(prevApp, containerConfig, accountId, config)
+				cleanApplicationFromAPI(
+					prevApp,
+					containerConfig,
+					accountId,
+					observabilityWriteTarget,
+					config
+				)
 			)
 		);
 
 		// this will have removed the unsafe fields, so we need to add them back in after
-		const modifyReq = mergeIfUnsafe(
-			config,
-			createApplicationToModifyApplication(appConfig),
-			appConfig.name
+		const modifyReq = stripUndefined(
+			mergeIfUnsafe(
+				config,
+				createApplicationToModifyApplication(appConfig),
+				appConfig.name
+			)
 		);
+		const normalizedModifyReq =
+			sortObjectRecursive<ModifyApplicationRequestBody>(modifyReq);
 		/** only used for diffing */
-		const nowContainer = mergeDeep(
-			normalisedPrevApp,
-			sortObjectRecursive<ModifyApplicationRequestBody>(modifyReq)
-		);
+		const nowContainer = mergeDeep(normalisedPrevApp, normalizedModifyReq);
+		// Top-level observability is replaced as a unit. A deep merge would retain
+		// targeting fields that the user removed from their config.
+		if (normalizedModifyReq.observability !== undefined) {
+			nowContainer.observability = normalizedModifyReq.observability;
+		}
+		const shouldCreateRollout = hasRolloutDiff(normalisedPrevApp, nowContainer);
 
 		const prev = formatContainerSnippetForDisplay(
 			normalisedPrevApp,
@@ -491,6 +769,11 @@ export async function apply(
 		const diff = new Diff(prev, now);
 
 		if (diff.changes === 0) {
+			if (migratedLegacyObservability) {
+				newline();
+				endSection("Applied changes");
+				return;
+			}
 			updateStatus(`no changes ${brandColor(prevApp.name)}`);
 			endSection("No changes to be made");
 			return;
@@ -508,11 +791,15 @@ export async function apply(
 				application: modifyReq,
 				id: prevApp.id,
 				name: prevApp.name,
-				rollout_step_percentage: containerConfig.rollout_step_percentage,
-				rollout_kind:
-					containerConfig.rollout_kind == "full_manual"
-						? CreateApplicationRolloutRequest.kind.FULL_MANUAL
-						: CreateApplicationRolloutRequest.kind.FULL_AUTO,
+				...(shouldCreateRollout
+					? {
+							rollout_step_percentage: containerConfig.rollout_step_percentage,
+							rollout_kind:
+								containerConfig.rollout_kind == "full_manual"
+									? CreateApplicationRolloutRequest.kind.FULL_MANUAL
+									: CreateApplicationRolloutRequest.kind.FULL_AUTO,
+						}
+					: {}),
 			});
 		} else {
 			log("Skipping application rollout");
@@ -599,8 +886,9 @@ const doAction = async (
 				application: ModifyApplicationRequestBody;
 				id: ApplicationID;
 				name: ApplicationName;
-				rollout_step_percentage: number | number[];
-				rollout_kind: CreateApplicationRolloutRequest.kind;
+				rollout_step_percentage?: number | number[];
+				rollout_kind?: CreateApplicationRolloutRequest.kind;
+				successMessage?: string;
 		  }
 ) => {
 	if (action.action === "create") {
@@ -673,46 +961,52 @@ const doAction = async (
 			);
 		}
 
-		try {
-			await promiseSpinner(
-				RolloutsService.createApplicationRollout(action.id, {
-					description: "Progressive update",
-					strategy: CreateApplicationRolloutRequest.strategy.ROLLING,
-					target_configuration: action.application.configuration ?? {},
-					...configRolloutStepsToAPI(action.rollout_step_percentage),
-					kind: action.rollout_kind,
-				}),
-				{
-					message: `rolling out container version ${action.name}`,
+		if (
+			action.rollout_step_percentage !== undefined &&
+			action.rollout_kind !== undefined
+		) {
+			try {
+				await promiseSpinner(
+					RolloutsService.createApplicationRollout(action.id, {
+						description: "Progressive update",
+						strategy: CreateApplicationRolloutRequest.strategy.ROLLING,
+						target_configuration: action.application.configuration ?? {},
+						...configRolloutStepsToAPI(action.rollout_step_percentage),
+						kind: action.rollout_kind,
+					}),
+					{
+						message: `rolling out container version ${action.name}`,
+					}
+				);
+			} catch (err) {
+				if (!(err instanceof Error)) {
+					throw err;
 				}
-			);
-		} catch (err) {
-			if (!(err instanceof Error)) {
-				throw err;
-			}
 
-			if (!(err instanceof ApiError)) {
+				if (!(err instanceof ApiError)) {
+					throw new UserError(
+						`Unexpected error rolling out application "${action.name}":\n${err.message}`,
+						{ telemetryMessage: "containers deploy rollout unexpected error" }
+					);
+				}
+
+				if (err.status === 400) {
+					throw new UserError(
+						`Error rolling out application "${action.name}" due to a misconfiguration:\n\n\t${formatError(err)}`,
+						{ telemetryMessage: "containers deploy rollout misconfiguration" }
+					);
+				}
+
 				throw new UserError(
-					`Unexpected error rolling out application "${action.name}":\n${err.message}`,
-					{ telemetryMessage: "containers deploy rollout unexpected error" }
+					`Error rolling out application "${action.name}":\n${formatError(err)}`,
+					{ telemetryMessage: "containers deploy rollout request failed" }
 				);
 			}
-
-			if (err.status === 400) {
-				throw new UserError(
-					`Error rolling out application "${action.name}" due to a misconfiguration:\n\n\t${formatError(err)}`,
-					{ telemetryMessage: "containers deploy rollout misconfiguration" }
-				);
-			}
-
-			throw new UserError(
-				`Error rolling out application "${action.name}":\n${formatError(err)}`,
-				{ telemetryMessage: "containers deploy rollout request failed" }
-			);
 		}
 
 		success(
-			`Modified application ${brandColor(action.name)} (Application ID: ${action.id})`,
+			action.successMessage ??
+				`Modified application ${brandColor(action.name)} (Application ID: ${action.id})`,
 			{
 				shape: shapes.bar,
 			}
@@ -726,6 +1020,7 @@ const doAction = async (
  * @param prev - Previously deployed application returned by the API.
  * @param currentConfig - Current normalized container configuration.
  * @param accountId - Cloudflare account ID that owns managed-registry images.
+ * @param observabilityWriteTarget - API field used for observability updates.
  * @param complianceConfig - Compliance configuration used to normalize managed-registry image references.
  * @returns The cleaned application fields used to generate the deployment diff.
  */
@@ -733,18 +1028,25 @@ export function cleanApplicationFromAPI(
 	prev: Application,
 	currentConfig: ContainerNormalizedConfig,
 	accountId: string,
+	observabilityWriteTarget: ObservabilityWriteTarget,
 	complianceConfig?: ComplianceConfig
 ): Partial<ModifyApplicationRequestBody> & Pick<Application, "configuration"> {
+	const configuration = {
+		...prev.configuration,
+		image: resolveImageName(
+			accountId,
+			prev.configuration.image,
+			complianceConfig
+		),
+	};
+
+	if (observabilityWriteTarget === "top-level") {
+		delete configuration.observability;
+	}
+
 	const cleanedPreviousApp: Partial<ModifyApplicationRequestBody> &
 		Pick<Application, "configuration"> = {
-		configuration: {
-			...prev.configuration,
-			image: resolveImageName(
-				accountId,
-				prev.configuration.image,
-				complianceConfig
-			),
-		},
+		configuration,
 		constraints: prev.constraints,
 		max_instances: prev.max_instances,
 		name: prev.name,
@@ -753,12 +1055,25 @@ export function cleanApplicationFromAPI(
 		rollout_active_grace_period: prev.rollout_active_grace_period,
 	};
 
+	if (
+		observabilityWriteTarget === "configuration" &&
+		getLatestLegacyObservabilityState(prev) !== undefined
+	) {
+		cleanedPreviousApp.configuration.observability =
+			getLatestLegacyObservabilityState(prev);
+	}
+
+	if (prev.observability !== undefined) {
+		cleanedPreviousApp.observability = prev.observability;
+	}
+
 	if ("instance_type" in currentConfig) {
 		// returns undefined if we can't infer it.
 		const instance_type = inferInstanceType(cleanedPreviousApp.configuration);
 		if (!instance_type) {
-			// just leave as is if we can't infer the instance type
-			return prev;
+			// API-only fields must not affect either the rendered diff or the rollout
+			// decision when the stored limits do not map to a named instance type.
+			return cleanedPreviousApp;
 		}
 		cleanedPreviousApp.configuration.instance_type = instance_type;
 


### PR DESCRIPTION
Fixes CC-7704.

Add a first-class `containers[].observability` config for container apps. Use top-level application observability for new and already-migrated apps, while preserving legacy `configuration.observability` for apps that still rely on rollout-based updates.

Also validate container-specific targeting fields, block invalid migrations while legacy observability is still active, and avoid rollouts for top-level- only observability changes.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/31591
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->