### PR TITLE
Add support for /cdn-cgi/image transformations in miniflare

### DIFF
--- a/.changeset/cdn-cgi-image-local-transforms.md
+++ b/.changeset/cdn-cgi-image-local-transforms.md
@@ -1,0 +1,30 @@
+---
+"miniflare": minor
+"@cloudflare/workers-utils": minor
+"wrangler": minor
+---
+
+Add local-dev support for `/cdn-cgi/image/...` URL transformations
+
+`wrangler dev` can now serve the `/cdn-cgi/image/<options>/<source>` URL endpoint locally, mirroring production image transformation functionality. The transform itself runs through the existing sharp-backed loopback that already powers `cf.image` fetches and the `env.IMAGES` binding, so it's a low-fidelity mock — resize, rotate, format conversion and a small set of options only.
+
+Opt in per-worker via a new `url_transformations` block on the existing `images` config:
+
+```jsonc
+{
+	"images": {
+		"binding": "IMAGES",
+		"url_transformations": { "enabled": true },
+	},
+}
+```
+
+When the flag is on, miniflare intercepts `/cdn-cgi/image/...`, parses the options, fetches the source URL and performs the transform. The response carries `cf-resized: internal=ok/m`, matching the production header. When the flag is off (or absent), miniflare passes the request through to the user worker.
+
+A one-shot warning fires the first time `/cdn-cgi/image/...` is hit with the flag on, flagging that the local transform is a low-fidelity sharp-backed mock.
+
+Notes:
+
+- Production gating still needs to be plumbed through the Edgeworker Config Service for the same toggle to take effect outside `wrangler dev`. That work lives elsewhere.
+- `images.binding` is still required in the Wrangler config for now — users wanting only the URL endpoint can pass any binding name and ignore `env.IMAGES`. Relaxing this needs a small refactor of `convertConfigToBindings` and will follow.
+- Only the default `/cdn-cgi/image/...` URL flavour (and the transparent `flow` adapter) is supported locally; `fastly` and `akamai` adapter URLs are not parsed and fall through.

--- a/packages/config/src/bindings.ts
+++ b/packages/config/src/bindings.ts
@@ -235,6 +235,16 @@ export interface HyperdriveBinding extends HyperdriveBindingOptions {
 interface ImagesBindingOptions {
 	/** Whether the Images binding should be remote or not in local development. */
 	remote?: boolean;
+	/**
+	 * Configures URL-based image transformations (`/cdn-cgi/image/...`) for
+	 * this Worker.
+	 */
+	url_transformations?: {
+		/** When true, miniflare intercepts `/cdn-cgi/image/...` requests
+		 * and transforms them locally
+		 */
+		enabled: boolean;
+	};
 }
 
 /**

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -18,6 +18,7 @@ import { getTodaysCompatDate, removeDirSync } from "@cloudflare/workers-utils";
 import { MockAgent } from "undici";
 import SCRIPT_ENTRY from "worker:core/entry";
 import OUTBOUND_WORKER from "worker:core/outbound";
+import SCRIPT_CDN_CGI_IMAGE from "worker:images/cdn-cgi-image";
 import { z } from "zod";
 import { fetch } from "../../http";
 import { kVoid } from "../../runtime";
@@ -26,7 +27,7 @@ import { CoreBindings, CoreHeaders, viewToBuffer } from "../../workers";
 import { RPC_PROXY_SERVICE_NAME } from "../assets/constants";
 import { getCacheServiceName } from "../cache";
 import { DURABLE_OBJECTS_STORAGE_SERVICE_NAME } from "../do";
-import { IMAGES_PLUGIN_NAME } from "../images";
+import { CDN_CGI_IMAGE_SERVICE_NAME, IMAGES_PLUGIN_NAME } from "../images";
 import { getR2PublicService, R2_PUBLIC_SERVICE_NAME } from "../r2";
 import {
 	getUserBindingServiceName,
@@ -1111,9 +1112,12 @@ export function getGlobalServices({
 	const imagesBinding = allWorkerOpts
 		?.map((worker) => worker.images?.images)
 		.find(
-			(images) => images !== undefined && !images.remoteProxyConnectionString
+			(images) =>
+				images !== undefined &&
+				images.binding !== undefined &&
+				!images.remoteProxyConnectionString
 		);
-	if (imagesBinding) {
+	if (imagesBinding?.binding) {
 		serviceEntryBindings.push({
 			name: CoreBindings.SERVICE_IMAGES_DELIVERY,
 			service: {
@@ -1122,6 +1126,15 @@ export function getGlobalServices({
 					imagesBinding.binding
 				),
 			},
+		});
+	}
+	const urlTransformsEnabled = allWorkerOpts?.some(
+		(worker) => worker.images?.images?.urlTransformations?.enabled === true
+	);
+	if (urlTransformsEnabled) {
+		serviceEntryBindings.push({
+			name: CoreBindings.SERVICE_IMAGE_TRANSFORM,
+			service: { name: CDN_CGI_IMAGE_SERVICE_NAME },
 		});
 	}
 	if (sharedOptions.upstream !== undefined) {
@@ -1193,6 +1206,23 @@ export function getGlobalServices({
 
 	if (r2PublicService !== undefined) {
 		services.push(r2PublicService);
+	}
+
+	if (urlTransformsEnabled) {
+		services.push({
+			name: CDN_CGI_IMAGE_SERVICE_NAME,
+			worker: {
+				modules: [
+					{
+						name: "cdn-cgi-image.worker.js",
+						esModule: SCRIPT_CDN_CGI_IMAGE(),
+					},
+				],
+				compatibilityDate: "2025-01-01",
+				compatibilityFlags: ["nodejs_compat"],
+				bindings: [WORKER_BINDING_SERVICE_LOOPBACK],
+			},
+		});
 	}
 
 	if (sharedOptions.unsafeLocalExplorer) {

--- a/packages/miniflare/src/plugins/images/index.ts
+++ b/packages/miniflare/src/plugins/images/index.ts
@@ -19,9 +19,14 @@ import type { Service } from "../../runtime";
 import type { Plugin, RemoteProxyConnectionString } from "../shared";
 
 const ImagesSchema = z.object({
-	binding: z.string(),
+	binding: z.string().optional(),
 	remoteProxyConnectionString: z
 		.custom<RemoteProxyConnectionString>()
+		.optional(),
+	urlTransformations: z
+		.object({
+			enabled: z.boolean(),
+		})
 		.optional(),
 });
 
@@ -35,6 +40,9 @@ export const ImagesSharedOptionsSchema = z.object({
 
 export const IMAGES_PLUGIN_NAME = "images";
 
+/** Shared service that backs the `/cdn-cgi/image/` URL transformation handler. */
+export const CDN_CGI_IMAGE_SERVICE_NAME = `${IMAGES_PLUGIN_NAME}:cdn-cgi-image`;
+
 export const IMAGES_PLUGIN: Plugin<
 	typeof ImagesOptionsSchema,
 	typeof ImagesSharedOptionsSchema
@@ -43,7 +51,7 @@ export const IMAGES_PLUGIN: Plugin<
 	sharedOptions: ImagesSharedOptionsSchema,
 	bindingTypeDescription: "Images",
 	async getBindings(options) {
-		if (!options.images) {
+		if (!options.images?.binding) {
 			return [];
 		}
 
@@ -69,7 +77,7 @@ export const IMAGES_PLUGIN: Plugin<
 		];
 	},
 	getNodeBindings(options: z.infer<typeof ImagesOptionsSchema>) {
-		if (!options.images) {
+		if (!options.images?.binding) {
 			return {};
 		}
 		return {
@@ -83,7 +91,7 @@ export const IMAGES_PLUGIN: Plugin<
 		defaultPersistRoot,
 		unsafeStickyBlobs,
 	}) {
-		if (!options.images) {
+		if (!options.images?.binding) {
 			return [];
 		}
 

--- a/packages/miniflare/src/workers/core/constants.ts
+++ b/packages/miniflare/src/workers/core/constants.ts
@@ -21,6 +21,8 @@ export const CorePaths = {
 	STREAM_VIDEO: "/cdn-cgi/mf/stream",
 	/** Local image delivery endpoint for serving hosted images */
 	IMAGE_DELIVERY: "/cdn-cgi/mf/imagedelivery",
+	/** URL-based image transformations (`/cdn-cgi/image/<options>/<source>`) */
+	IMAGE_TRANSFORM: "/cdn-cgi/image",
 	/** Public R2 bucket object serving endpoint */
 	R2_PUBLIC: "/cdn-cgi/local/r2/public",
 } as const;
@@ -86,6 +88,7 @@ export const CoreBindings = {
 	DEV_REGISTRY_DEBUG_PORT: "DEV_REGISTRY_DEBUG_PORT",
 	SERVICE_STREAM: "MINIFLARE_STREAM",
 	SERVICE_IMAGES_DELIVERY: "MINIFLARE_IMAGES_DELIVERY",
+	SERVICE_IMAGE_TRANSFORM: "MINIFLARE_IMAGE_TRANSFORM",
 	SERVICE_R2_PUBLIC: "MINIFLARE_R2_PUBLIC",
 } as const;
 

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -15,6 +15,7 @@ type Env = {
 	[CoreBindings.SERVICE_LOCAL_EXPLORER]: Fetcher;
 	[CoreBindings.SERVICE_STREAM]?: Fetcher;
 	[CoreBindings.SERVICE_IMAGES_DELIVERY]?: Fetcher;
+	[CoreBindings.SERVICE_IMAGE_TRANSFORM]?: Fetcher;
 	[CoreBindings.SERVICE_R2_PUBLIC]?: Fetcher;
 	[CoreBindings.TEXT_CUSTOM_SERVICE]: string;
 	[CoreBindings.TEXT_UPSTREAM_URL]?: string;
@@ -556,6 +557,12 @@ export default <ExportedHandler<Env>>{
 				imagesDelivery
 			) {
 				return await imagesDelivery.fetch(request);
+			}
+			if (url.pathname.startsWith(`${CorePaths.IMAGE_TRANSFORM}/`)) {
+				const imageTransform = env[CoreBindings.SERVICE_IMAGE_TRANSFORM];
+				if (imageTransform) {
+					return await imageTransform.fetch(request);
+				}
 			}
 			if (env[CoreBindings.TRIGGER_HANDLERS]) {
 				if (

--- a/packages/miniflare/src/workers/images/cdn-cgi-image.worker.ts
+++ b/packages/miniflare/src/workers/images/cdn-cgi-image.worker.ts
@@ -1,0 +1,209 @@
+// Local handler for `/cdn-cgi/image/<options>/<source>` URL transformations.
+
+import { LogLevel, SharedHeaders } from "miniflare:shared";
+import { CoreBindings, CoreHeaders } from "../core/constants";
+import type { RequestInitCfPropertiesImage } from "@cloudflare/workers-types/experimental";
+
+interface Env {
+	[CoreBindings.SERVICE_LOOPBACK]: Fetcher;
+}
+
+// Match `/cdn-cgi/image/<options>/<source>` with an optional adapter prefix
+// (`fastly` / `akamai` / `flow`). Mirrors the IRW regex but operates on
+// pathname only since we already know the request hit our reserved path.
+const PATH_RE = /^\/cdn-cgi\/image\/(?:(fastly|akamai|flow)\/)?([^/]*)\/(.+)$/;
+
+const RESIZING_VIA_TOKEN = "image-resizing";
+
+let warnedLowFidelity = false;
+
+export default {
+	async fetch(request, env: Env): Promise<Response> {
+		const url = new URL(request.url);
+		const match = PATH_RE.exec(url.pathname);
+		if (!match) {
+			// Pathname starts with `/cdn-cgi/image/` but is malformed
+			return new Response(null, { status: 404 });
+		}
+
+		const [, adapter, optionsStr, rawSource] = match;
+		if (adapter && adapter !== "flow") {
+			// `fastly` / `akamai` URL flavours aren't supported locally
+			return new Response(null, { status: 404 });
+		}
+
+		const sourceUrl = resolveSourceUrl(rawSource, url);
+		if (!sourceUrl) {
+			return new Response(null, { status: 404 });
+		}
+
+		const options = parseImageOptions(optionsStr);
+		if (!options) {
+			return new Response(null, { status: 404 });
+		}
+
+		// Fetch the origin image. Stamp a `Via:` header to match production
+		const originHeaders = new Headers();
+		const accept = request.headers.get("accept");
+		if (accept) {
+			originHeaders.set("accept", accept);
+		}
+		originHeaders.set("via", RESIZING_VIA_TOKEN);
+
+		let originResponse: Response;
+		try {
+			originResponse = await fetch(sourceUrl, { headers: originHeaders });
+		} catch {
+			return new Response(null, { status: 502 });
+		}
+
+		if (!originResponse.ok) {
+			return new Response(await originResponse.arrayBuffer(), {
+				status: originResponse.status,
+				headers: originResponse.headers,
+			});
+		}
+
+		const source = await originResponse.arrayBuffer();
+
+		const form = new FormData();
+		form.append("image", new Blob([source]));
+		form.append("options", JSON.stringify(options));
+
+		const transformRequest = new Request("http://localhost/cdn-cgi-image", {
+			method: "POST",
+			body: form,
+		});
+		transformRequest.headers.set(
+			CoreHeaders.CUSTOM_FETCH_SERVICE,
+			CoreBindings.IMAGES_FETCH_SERVICE
+		);
+
+		const transformed =
+			await env[CoreBindings.SERVICE_LOOPBACK].fetch(transformRequest);
+
+		if (!transformed.ok) {
+			// Sharp couldn't decode/transform — fall back to source bytes
+			const headers = new Headers(originResponse.headers);
+			headers.delete("content-encoding");
+			headers.delete("content-length");
+			return new Response(source, {
+				status: originResponse.status,
+				headers,
+			});
+		}
+
+		await warnLowFidelityOnce(env);
+		return transformed;
+	},
+} satisfies ExportedHandler<Env>;
+
+function resolveSourceUrl(rawSource: string, requestUrl: URL): string | null {
+	let source = rawSource;
+
+  // Support URLs that have been through encodeURIComponent (`https%3A%..`)
+	if (/^https?%3[Aa]/.test(source)) {
+		try {
+			source = decodeURIComponent(source);
+		} catch {
+			return null;
+		}
+	}
+
+	// Collapse the `https:/example.com` shape (single slash) that nginx
+	// historically produces. IRW handles this; we match.
+	const absMatch = /^(https?):\/+(.*)/.exec(source);
+	if (absMatch) {
+		return `${absMatch[1]}://${absMatch[2]}`;
+	}
+
+	// Relative path → resolve against the request origin.
+	try {
+		return new URL(
+			source,
+			`${requestUrl.protocol}//${requestUrl.host}/`
+		).toString();
+	} catch {
+		return null;
+	}
+}
+
+// Parse the comma-separated `key=value` options string into an object shaped
+// like `cf.image` options, so we can reuse `cfImageLocalFetcher`. This is a
+// subset of what production supports:
+// (resize, fit, rotate, format, quality, gravity, background, dpr).
+const NUMERIC_KEYS = new Set(["width", "height", "rotate", "dpr", "quality"]);
+
+const PASSTHROUGH_KEYS = new Set([
+	"fit",
+	"format",
+	"gravity",
+	"background",
+	"quality",
+]);
+
+function parseImageOptions(raw: string): RequestInitCfPropertiesImage | null {
+	if (raw.length === 0) {
+		return null;
+	}
+
+	let decoded: string;
+	try {
+		decoded = decodeURIComponent(raw);
+	} catch {
+		return null;
+	}
+
+	const options: Record<string, unknown> = {};
+	for (const part of decoded.split(",")) {
+		if (part.length === 0) {
+			continue;
+		}
+		const eq = part.indexOf("=");
+		if (eq === -1) {
+			// Bare flags (e.g. `anim=false`) aren't supported in the MVP.
+			return null;
+		}
+		const key = part.slice(0, eq).trim();
+		const value = part.slice(eq + 1).trim();
+
+		if (key.length === 0) {
+			return null;
+		}
+
+		if (NUMERIC_KEYS.has(key)) {
+			const asNum = Number(value);
+			if (Number.isFinite(asNum)) {
+				options[key] = asNum;
+				continue;
+			}
+			// Quality also accepts named strings ("low", "high" etc.).
+			if (key === "quality" && PASSTHROUGH_KEYS.has(key)) {
+				options[key] = value;
+				continue;
+			}
+			return null;
+		}
+
+		if (PASSTHROUGH_KEYS.has(key)) {
+			options[key] = value;
+			continue;
+		}
+
+		// Silently drop unknown keys
+	}
+
+	return options as RequestInitCfPropertiesImage;
+}
+
+async function warnLowFidelityOnce(env: Env): Promise<void> {
+	if (warnedLowFidelity) {
+		return;
+	}
+	warnedLowFidelity = true;
+	await env[CoreBindings.SERVICE_LOOPBACK].fetch("http://localhost/core/log", {
+		method: "POST",
+		headers: { [SharedHeaders.LOG_LEVEL]: LogLevel.WARN.toString() },
+		body: "Local `/cdn-cgi/image/` transforms are a low-fidelity mock; only resize, rotate, format conversion and a small set of options are supported. Deploy to preview the full transformation.",
+	});
+}

--- a/packages/miniflare/test/plugins/core/cdn-cgi-image.spec.ts
+++ b/packages/miniflare/test/plugins/core/cdn-cgi-image.spec.ts
@@ -1,0 +1,260 @@
+import { Miniflare } from "miniflare";
+import sharp from "sharp";
+import { describe, test } from "vitest";
+import { useServer } from "../../test-shared/http";
+import type { MiniflareOptions } from "miniflare";
+
+// A simple user worker that just records that it was hit — we want to assert
+// that `/cdn-cgi/image/...` requests never reach the user worker code.
+const WORKER_SCRIPT = `
+export default {
+	async fetch(request) {
+		return new Response("user worker reached: " + new URL(request.url).pathname, {
+			status: 418,
+		});
+	},
+};
+`;
+
+async function makeMiniflare(opts: {
+	enabled?: boolean;
+	srcUrl: string;
+	sourcePng: Buffer;
+}): Promise<{ mf: Miniflare; cleanup: () => Promise<void> }> {
+	const optsBlock: Record<string, unknown> = {
+		binding: "IMAGES",
+	};
+	if (opts.enabled !== undefined) {
+		optsBlock.urlTransformations = { enabled: opts.enabled };
+	}
+	const mf = new Miniflare({
+		modules: true,
+		script: WORKER_SCRIPT,
+		images: optsBlock,
+	} satisfies MiniflareOptions);
+	return { mf, cleanup: () => mf.dispose() };
+}
+
+describe("/cdn-cgi/image/ local transforms", () => {
+	test("transforms when url_transformations.enabled is true", async ({
+		expect,
+	}) => {
+		const sourcePng = await sharp({
+			create: {
+				width: 200,
+				height: 100,
+				channels: 3,
+				background: { r: 255, g: 0, b: 0 },
+			},
+		})
+			.png()
+			.toBuffer();
+
+		const { http: originUrl } = await useServer((req, res) => {
+			res.writeHead(200, { "content-type": "image/png" });
+			res.end(sourcePng);
+		});
+
+		const { mf, cleanup } = await makeMiniflare({
+			enabled: true,
+			srcUrl: `${originUrl}img.png`,
+			sourcePng,
+		});
+
+		try {
+			const res = await mf.dispatchFetch(
+				`http://localhost/cdn-cgi/image/width=50/${originUrl}img.png`
+			);
+			expect(res.status).toBe(200);
+			expect(res.headers.get("cf-resized")).toBe("internal=ok/m");
+			const body = Buffer.from(await res.arrayBuffer());
+			const meta = await sharp(body).metadata();
+			expect(meta.width).toBe(50);
+			expect(meta.height).toBe(25);
+		} finally {
+			await cleanup();
+		}
+	});
+
+	test("falls through to the user worker when url_transformations is absent", async ({
+		expect,
+	}) => {
+		const sourcePng = await sharp({
+			create: {
+				width: 10,
+				height: 10,
+				channels: 3,
+				background: { r: 0, g: 255, b: 0 },
+			},
+		})
+			.png()
+			.toBuffer();
+
+		const { http: originUrl } = await useServer((_req, res) => {
+			res.writeHead(200, { "content-type": "image/png" });
+			res.end(sourcePng);
+		});
+
+		const { mf, cleanup } = await makeMiniflare({
+			srcUrl: `${originUrl}img.png`,
+			sourcePng,
+		});
+
+		try {
+			const res = await mf.dispatchFetch(
+				`http://localhost/cdn-cgi/image/width=10/${originUrl}img.png`
+			);
+			expect(res.status).toBe(418);
+			expect(res.headers.get("cf-resized")).toBe(null);
+			expect(await res.text()).toMatch(/user worker reached/);
+		} finally {
+			await cleanup();
+		}
+	});
+
+	test("falls through to the user worker when url_transformations.enabled is false", async ({
+		expect,
+	}) => {
+		const sourcePng = await sharp({
+			create: {
+				width: 10,
+				height: 10,
+				channels: 3,
+				background: { r: 0, g: 0, b: 255 },
+			},
+		})
+			.png()
+			.toBuffer();
+
+		const { http: originUrl } = await useServer((_req, res) => {
+			res.writeHead(200, { "content-type": "image/png" });
+			res.end(sourcePng);
+		});
+
+		const { mf, cleanup } = await makeMiniflare({
+			enabled: false,
+			srcUrl: `${originUrl}img.png`,
+			sourcePng,
+		});
+
+		try {
+			const res = await mf.dispatchFetch(
+				`http://localhost/cdn-cgi/image/width=10/${originUrl}img.png`
+			);
+			expect(res.status).toBe(418);
+			await res.arrayBuffer();
+		} finally {
+			await cleanup();
+		}
+	});
+
+	test("parses comma-separated options including format", async ({
+		expect,
+	}) => {
+		const sourcePng = await sharp({
+			create: {
+				width: 200,
+				height: 200,
+				channels: 3,
+				background: { r: 0, g: 0, b: 0 },
+			},
+		})
+			.png()
+			.toBuffer();
+		const { http: originUrl } = await useServer((_req, res) => {
+			res.writeHead(200, { "content-type": "image/png" });
+			res.end(sourcePng);
+		});
+		const { mf, cleanup } = await makeMiniflare({
+			enabled: true,
+			srcUrl: `${originUrl}img.png`,
+			sourcePng,
+		});
+		try {
+			const res = await mf.dispatchFetch(
+				`http://localhost/cdn-cgi/image/width=80,height=80,fit=cover,format=webp/${originUrl}img.png`
+			);
+			expect(res.status).toBe(200);
+			expect(res.headers.get("content-type")).toBe("image/webp");
+			const meta = await sharp(Buffer.from(await res.arrayBuffer())).metadata();
+			expect(meta.width).toBe(80);
+			expect(meta.height).toBe(80);
+			expect(meta.format).toBe("webp");
+		} finally {
+			await cleanup();
+		}
+	});
+
+	test("forwards origin status when source fetch fails", async ({ expect }) => {
+		const { http: originUrl } = await useServer((_req, res) => {
+			res.writeHead(404, { "content-type": "text/plain" });
+			res.end("nope");
+		});
+		const { mf, cleanup } = await makeMiniflare({
+			enabled: true,
+			srcUrl: `${originUrl}missing.png`,
+			sourcePng: Buffer.from([]),
+		});
+		try {
+			const res = await mf.dispatchFetch(
+				`http://localhost/cdn-cgi/image/width=50/${originUrl}missing.png`
+			);
+			expect(res.status).toBe(404);
+			await res.arrayBuffer();
+		} finally {
+			await cleanup();
+		}
+	});
+
+	test("malformed /cdn-cgi/image/ paths return 404 without invoking sharp", async ({
+		expect,
+	}) => {
+		const { mf, cleanup } = await makeMiniflare({
+			enabled: true,
+			srcUrl: "ignored",
+			sourcePng: Buffer.from([]),
+		});
+		try {
+			// Missing source segment entirely.
+			const res = await mf.dispatchFetch(
+				`http://localhost/cdn-cgi/image/width=80`
+			);
+			expect(res.status).toBe(404);
+			await res.arrayBuffer();
+		} finally {
+			await cleanup();
+		}
+	});
+
+	test("the flow adapter is treated like the default", async ({ expect }) => {
+		const sourcePng = await sharp({
+			create: {
+				width: 100,
+				height: 50,
+				channels: 3,
+				background: { r: 12, g: 34, b: 56 },
+			},
+		})
+			.png()
+			.toBuffer();
+		const { http: originUrl } = await useServer((_req, res) => {
+			res.writeHead(200, { "content-type": "image/png" });
+			res.end(sourcePng);
+		});
+		const { mf, cleanup } = await makeMiniflare({
+			enabled: true,
+			srcUrl: `${originUrl}img.png`,
+			sourcePng,
+		});
+		try {
+			const res = await mf.dispatchFetch(
+				`http://localhost/cdn-cgi/image/flow/width=25/${originUrl}img.png`
+			);
+			expect(res.status).toBe(200);
+			const meta = await sharp(Buffer.from(await res.arrayBuffer())).metadata();
+			expect(meta.width).toBe(25);
+		} finally {
+			await cleanup();
+		}
+	});
+});

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -1245,6 +1245,19 @@ export interface EnvironmentNonInheritable {
 				binding: string;
 				/** Whether the Images binding should be remote or not in local development */
 				remote?: boolean;
+				/**
+				 * Configures URL-based image transformations (`/cdn-cgi/image/...`)
+				 * for this Worker.
+				 *
+				 * TODO: nail down structure.
+				 */
+				url_transformations?: {
+					/**
+					 * When true, miniflare intercepts `/cdn-cgi/image/...` requests
+					 * and transforms them locally.
+					 */
+					enabled: boolean;
+				};
 		  }
 		| undefined;
 

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -1915,7 +1915,7 @@ function normalizeAndValidateEnvironment(
 			rawEnv,
 			envName,
 			"images",
-			validateNamedSimpleBinding(envName),
+			validateImagesBinding(envName),
 			undefined
 		),
 		stream: notInheritable(
@@ -3057,6 +3057,66 @@ const validateAIBinding =
 		if (!isRemoteValid(value, field, diagnostics)) {
 			isValid = false;
 		}
+
+		return isValid;
+	};
+
+const validateImagesBinding =
+	(envName: string): ValidatorFn =>
+	(diagnostics, field, value, config) => {
+		const fieldPath =
+			config === undefined ? `${field}` : `env.${envName}.${field}`;
+
+		if (typeof value !== "object" || value === null || Array.isArray(value)) {
+			diagnostics.errors.push(
+				`The field "${fieldPath}" should be an object but got ${JSON.stringify(
+					value
+				)}.`
+			);
+			return false;
+		}
+
+		let isValid = true;
+		if (!isRequiredProperty(value, "binding", "string")) {
+			diagnostics.errors.push(`binding should have a string "binding" field.`);
+			isValid = false;
+		}
+
+		if (!isRemoteValid(value, field, diagnostics)) {
+			isValid = false;
+		}
+
+		if (
+			"url_transformations" in value &&
+			value.url_transformations !== undefined
+		) {
+			const ut = value.url_transformations;
+			if (typeof ut !== "object" || ut === null || Array.isArray(ut)) {
+				diagnostics.errors.push(
+					`"${fieldPath}.url_transformations" should be an object.`
+				);
+				isValid = false;
+			} else {
+				if (!isRequiredProperty(ut, "enabled", "boolean")) {
+					diagnostics.errors.push(
+						`"${fieldPath}.url_transformations" should have a boolean "enabled" field.`
+					);
+					isValid = false;
+				}
+				validateAdditionalProperties(
+					diagnostics,
+					`${field}.url_transformations`,
+					Object.keys(ut as Record<string, unknown>),
+					["enabled"]
+				);
+			}
+		}
+
+		validateAdditionalProperties(diagnostics, field, Object.keys(value), [
+			"binding",
+			"remote",
+			"url_transformations",
+		]);
 
 		return isValid;
 	};

--- a/packages/workers-utils/src/worker.ts
+++ b/packages/workers-utils/src/worker.ts
@@ -138,6 +138,9 @@ export interface CfImagesBinding {
 	binding: string;
 	raw?: boolean;
 	remote?: boolean;
+	url_transformations?: {
+		enabled: boolean;
+	};
 }
 
 /**

--- a/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
+++ b/packages/workers-utils/tests/config/validation/normalize-and-validate-config.test.ts
@@ -2583,6 +2583,105 @@ describe("normalizeAndValidateConfig()", () => {
 					  - The field "images" should be an object but got null."
 				`);
 			});
+
+			it("accepts binding + url_transformations together", ({ expect }) => {
+				const { diagnostics, config } = normalizeAndValidateConfig(
+					{
+						images: {
+							binding: "IMAGES",
+							url_transformations: { enabled: true },
+						},
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(config.images).toEqual({
+					binding: "IMAGES",
+					url_transformations: { enabled: true },
+				});
+			});
+
+			it("accepts url_transformations.enabled set to false", ({ expect }) => {
+				const { diagnostics, config } = normalizeAndValidateConfig(
+					{
+						images: {
+							binding: "IMAGES",
+							url_transformations: { enabled: false },
+						},
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(config.images?.url_transformations).toEqual({ enabled: false });
+			});
+
+			it("errors when url_transformations is missing 'enabled'", ({
+				expect,
+			}) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						images: {
+							binding: "IMAGES",
+							url_transformations: {} as { enabled: boolean },
+						},
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toContain(
+					'"images.url_transformations" should have a boolean "enabled" field.'
+				);
+			});
+
+			it("warns on unknown fields inside url_transformations", ({ expect }) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						images: {
+							binding: "IMAGES",
+							url_transformations: {
+								enabled: true,
+								allowed_origins: ["example.com"],
+							} as unknown as { enabled: boolean },
+						},
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.renderWarnings()).toContain(
+					"Unexpected fields found in images.url_transformations field"
+				);
+			});
+
+			it("warns on unknown fields on the images block itself", ({ expect }) => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						images: {
+							binding: "IMAGES",
+							something_new: true,
+						} as unknown as { binding: string },
+					} as unknown as RawConfig,
+					undefined,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.renderWarnings()).toContain(
+					"Unexpected fields found in images field"
+				);
+			});
 		});
 
 		// Media

--- a/packages/wrangler/src/dev/miniflare/index.ts
+++ b/packages/wrangler/src/dev/miniflare/index.ts
@@ -939,6 +939,7 @@ export function buildMiniflareBindingOptions(
 							imagesBindings[0].remote && remoteProxyConnectionString
 								? remoteProxyConnectionString
 								: undefined,
+						urlTransformations: imagesBindings[0].url_transformations,
 					}
 				: undefined,
 		media:


### PR DESCRIPTION
Fixes IMAGES-2346

Note: This is a draft change that will not be shipped imminently. We need a workable solution that is compatible with workers.dev and production zones before release.

## Context

The ambition is to build on the previous `cf.image` worker fetch deliverable (https://github.com/cloudflare/workers-sdk/pull/14221) by supporting Image Transformations via the `/cdn-cgi/image/` URL. This feature allows Cloudflare customers to resize images with a URL that looks something like

```
https://images-probe.mglewis.uk/cdn-cgi/image/width=60/https://images.mglewis.uk/moon.jpg
```

Image resizing by URL currently doesn't work on both `workers.dev` zones and locally with `wrangler dev`. This change adds support in miniflare to solve the local issues, but we'll hold off releasing until we can ensure parity across all three different environments.

## Summary of changes

- New ingress handler in `cdn-cgi-image.worker.ts` that parses `/cdn-cgi-/image/<opts>/<src>` shared URLs and hands the bytes + options back to our existing `cfImageLocalFetcher`.
- Reserved `IMAGE_TRANSFORM` to our `CorePaths` list
- Wrangler prints a one-off dev warning about local transforms being a low fidelity mock (same as `cf.image` fetch change
- Modified `Environment.images and `CfImagesBinind` to carry new URL transformation config - this is WIP and will be nailed down once we have a more nailed down solution for other envs

## Considerations

- `images.binding` is currently still required, even if it is not being used. Food for thought when we circle back to this
- `Fastly` and `Akamai` adapters are not supported
-  Similar to `cf.image` fetches and the images binding mock - we only support a limited subset of URL transformation features (width, height, fit, rotate, format, quality, ..)

## Testing

Local testing with 

```
node ~/code/workers-sdk/packages/wrangler/wrangler-dist/cli.js dev --port 8787
```

Unit tests

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

<img width="225" height="225" alt="image" src="https://github.com/user-attachments/assets/e79b0889-cdb1-4f33-8c91-c5e045ced7d6" />
<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
