### PR TITLE
[wrangler] Don't error when find_additional_modules discovers a file matching a shadowed rule

### DIFF
--- a/.changeset/find-additional-modules-shadowed-rule.md
+++ b/.changeset/find-additional-modules-shadowed-rule.md
@@ -4,8 +4,7 @@
 
 Stop erroring when `find_additional_modules` discovers a file that only matches a inactive module rule
 
-Module rules assign module _types_ to imported files — they are not include/exclude filters. Also, setting `fallthrough: false` in a rule will cause subsequent rules to become inactive.
-Previously, when `find_additional_modules` walked the filesystem and discovered a file whose only matching rule is inactive, Wrangler would throw an error and fail the build.
+Module rules assign module _types_ to imported files — they are not include/exclude filters. Also, setting `fallthrough: false` in a rule will cause subsequent rules to become inactive. Previously, when `find_additional_modules` walked the filesystem and discovered a file whose only matching rule is inactive, Wrangler would throw an error and fail the build.
 
 This meant that adding a user rule like the one below would break the build for any `.txt`, `.html`, `.sql`, `.bin` or `.wasm` file that didn't match the user-supplied globs but lived somewhere under the module root:
 

--- a/.changeset/find-additional-modules-shadowed-rule.md
+++ b/.changeset/find-additional-modules-shadowed-rule.md
@@ -1,0 +1,26 @@
+---
+"wrangler": patch
+---
+
+Stop erroring when `find_additional_modules` discovers a file that only matches a shadowed module rule
+
+Module rules assign module _types_ to imported files — they are not include/exclude filters. Previously, when `find_additional_modules` walked the filesystem and discovered a file whose only matching rule had been shadowed by an earlier rule of the same type (via `fallthrough: false`, or by being a default rule overridden by a user-defined rule), Wrangler would throw an error and fail the build.
+
+This meant that adding a user rule like the one below would break the build for any `.txt`, `.html`, `.sql`, `.bin` or `.wasm` file that didn't match the user-supplied globs but lived somewhere under the module root:
+
+```jsonc
+// wrangler.json
+{
+	"rules": [
+		{
+			"type": "Text",
+			"globs": ["html/includeme.html"],
+			"fallthrough": false,
+		},
+	],
+}
+```
+
+Discovered files that only match a shadowed rule are now silently skipped (a `debug`-level log records each skip for troubleshooting), so users can use `fallthrough: false` to narrow the set of files attached to their Worker without having to delete or move untouched files on disk. The direct-import path is unchanged: importing a file in code that only matches a shadowed rule is still a hard error, because the imported file genuinely needs a defined module type.
+
+Fixes [#14257](https://github.com/cloudflare/workers-sdk/issues/14257).

--- a/.changeset/find-additional-modules-shadowed-rule.md
+++ b/.changeset/find-additional-modules-shadowed-rule.md
@@ -2,9 +2,10 @@
 "wrangler": patch
 ---
 
-Stop erroring when `find_additional_modules` discovers a file that only matches a shadowed module rule
+Stop erroring when `find_additional_modules` discovers a file that only matches a inactive module rule
 
-Module rules assign module _types_ to imported files — they are not include/exclude filters. Previously, when `find_additional_modules` walked the filesystem and discovered a file whose only matching rule had been shadowed by an earlier rule of the same type (via `fallthrough: false`, or by being a default rule overridden by a user-defined rule), Wrangler would throw an error and fail the build.
+Module rules assign module _types_ to imported files — they are not include/exclude filters. Also, setting `fallthrough: false` in a rule will cause subsequent rules to become inactive.
+Previously, when `find_additional_modules` walked the filesystem and discovered a file whose only matching rule is inactive, Wrangler would throw an error and fail the build.
 
 This meant that adding a user rule like the one below would break the build for any `.txt`, `.html`, `.sql`, `.bin` or `.wasm` file that didn't match the user-supplied globs but lived somewhere under the module root:
 
@@ -21,6 +22,8 @@ This meant that adding a user rule like the one below would break the build for 
 }
 ```
 
-Discovered files that only match a shadowed rule are now silently skipped (a `debug`-level log records each skip for troubleshooting), so users can use `fallthrough: false` to narrow the set of files attached to their Worker without having to delete or move untouched files on disk. The direct-import path is unchanged: importing a file in code that only matches a shadowed rule is still a hard error, because the imported file genuinely needs a defined module type.
+Discovered files that only match an inactive rule are now silently skipped (a `debug`-level log records each skip for troubleshooting), so users can use `fallthrough: false` to narrow the set of files attached to their Worker without having to delete or move untouched files on disk.
+
+The direct-import path is unchanged: importing a file in code that only matches an inactive rule is still a hard error, because the imported file genuinely needs a defined module type.
 
 Fixes [#14257](https://github.com/cloudflare/workers-sdk/issues/14257).

--- a/packages/wrangler/src/__tests__/find-additional-modules.test.ts
+++ b/packages/wrangler/src/__tests__/find-additional-modules.test.ts
@@ -284,7 +284,7 @@ describe("traverse module graph", () => {
 		expect(modules[0].name).toStrictEqual("other.txt");
 	});
 
-	it("should error if a rule is ignored because the previous was not marked 'fall-through'", async ({
+	it("should not error when a discovered file matches a rule that was shadowed by a previous rule of the same type", async ({
 		expect,
 	}) => {
 		await mkdir("./src", { recursive: true });
@@ -305,25 +305,72 @@ describe("traverse module graph", () => {
 			`
 		);
 
-		await expect(
-			findAdditionalModules(
-				{
-					file: path.join(process.cwd(), "./src/index.js"),
-					projectRoot: path.join(process.cwd(), "./src"),
-					configPath: undefined,
-					format: "modules",
-					// The default module root is dirname(file)
-					moduleRoot: path.join(process.cwd(), "./src"),
-					exports: [],
-				},
-				[
-					{ type: "Text", globs: ["**/*.txt"] },
-					{ type: "Text", globs: ["other.txt"] },
-				]
-			)
-		).rejects.toMatchInlineSnapshot(
-			`[Error: The file other.txt matched a module rule in your configuration ({"type":"Text","globs":["other.txt"]}), but was ignored because a previous rule with the same type was not marked as \`fallthrough = true\`.]`
+		// Two Text rules of the same type — the second is "shadowed" by the first
+		// (which has the default `fallthrough` behavior). The discovered file
+		// `other.txt` matches both rules' globs, but should be silently included
+		// under the first (live) rule rather than throwing.
+		const modules = await findAdditionalModules(
+			{
+				file: path.join(process.cwd(), "./src/index.js"),
+				projectRoot: path.join(process.cwd(), "./src"),
+				configPath: undefined,
+				format: "modules",
+				// The default module root is dirname(file)
+				moduleRoot: path.join(process.cwd(), "./src"),
+				exports: [],
+			},
+			[
+				{ type: "Text", globs: ["**/*.txt"] },
+				{ type: "Text", globs: ["other.txt"] },
+			]
 		);
+
+		expect(modules.map((m) => m.name)).toStrictEqual(["other.txt"]);
+	});
+
+	it("should silently skip a discovered file that only matches a shadowed rule (issue #14257)", async ({
+		expect,
+	}) => {
+		// Mirrors the reproduction from
+		// https://github.com/cloudflare/workers-sdk/issues/14257
+		// The user has a custom Text rule with `fallthrough: false`, which shadows
+		// the default Text rule (`**/*.txt`, `**/*.html`, `**/*.sql`). A file on
+		// disk that only matches the shadowed default rule should be silently
+		// excluded from the bundle, not error out the build.
+		await mkdir("./src/html", { recursive: true });
+		await writeFile(
+			"./src/index.js",
+			dedent /* javascript */ `
+			import text from './html/includeme.html'
+			export default {
+				async fetch(request) {
+					return new Response(text, {headers: {'Content-Type': 'text/html'}})
+				},
+			}
+			`
+		);
+		await writeFile("./src/html/includeme.html", "<p>include me</p>");
+		await writeFile("./src/html/dontincludeme.html", "<p>don't include me</p>");
+
+		const modules = await findAdditionalModules(
+			{
+				file: path.join(process.cwd(), "./src/index.js"),
+				projectRoot: path.join(process.cwd(), "./src"),
+				configPath: undefined,
+				format: "modules",
+				moduleRoot: path.join(process.cwd(), "./src"),
+				exports: [],
+			},
+			[
+				{
+					type: "Text",
+					globs: ["html/includeme.html"],
+					fallthrough: false,
+				},
+			]
+		);
+
+		expect(modules.map((m) => m.name)).toStrictEqual(["html/includeme.html"]);
 	});
 });
 

--- a/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
+++ b/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
@@ -301,17 +301,23 @@ async function matchFiles(
 			}
 		}
 
-		// This is just a sanity check verifying that no files match rules that were removed
-		for (const rule of removedRules) {
-			for (const glob of rule.globs) {
-				const regexp = globToRegExp(glob);
-				if (regexp.test(filePath)) {
-					throw new UserError(
-						`The file ${filePath} matched a module rule in your configuration (${JSON.stringify(
-							rule
-						)}), but was ignored because a previous rule with the same type was not marked as \`fallthrough = true\`.`,
-						{ telemetryMessage: "module rule ignored without fallthrough" }
-					);
+		// If a discovered file only matched a removed (shadowed) rule, skip it.
+		// Module rules assign types to imported files — they are not include/exclude filters.
+		// Since the file was not explicitly imported (it was discovered by walking the
+		// filesystem) we cannot give it an unambiguous type, so we leave it out of the
+		// bundle. The direct-import path in `module-collection.ts` still throws for
+		// imports that only match a shadowed rule, since those are real misconfigurations.
+		if (!moduleNames.has(filePath)) {
+			for (const rule of removedRules) {
+				for (const glob of rule.globs) {
+					const regexp = globToRegExp(glob);
+					if (regexp.test(filePath)) {
+						logger.debug(
+							`Skipping discovered file ${filePath} — it only matches a shadowed module rule (${JSON.stringify(
+								rule
+							)}). To include this file, add \`fallthrough = true\` to the earlier rule of the same type, or broaden your rule's globs.`
+						);
+					}
 				}
 			}
 		}

--- a/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
+++ b/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
@@ -310,7 +310,9 @@ async function matchFiles(
 		if (!moduleNames.has(filePath)) {
 			for (const rule of removedRules) {
 				for (const glob of rule.globs) {
-					const regexp = globToRegExp(glob);
+					const regexp = globToRegExp(glob, {
+						globstar: true,
+					});
 					if (regexp.test(filePath)) {
 						logger.debug(
 							`Skipping discovered file ${filePath} — it only matches a shadowed module rule (${JSON.stringify(


### PR DESCRIPTION
Fixes #14257.

Module rules assign module *types* to imported files — they are not include/exclude filters. Previously, when `find_additional_modules` walked the filesystem and discovered a file whose only matching rule had been shadowed by an earlier rule of the same type (via `fallthrough: false`, or by being a default rule overridden by a user-defined rule), wrangler would throw and fail the build.

For example, with this config and `no_bundle: true`, any `.txt` / `.html` / `.sql` file under the module root that did not match the user's glob would break the build, even when that file was never imported:

```jsonc
// wrangler.json
{
	"rules": [
		{
			"type": "Text",
			"globs": ["html/includeme.html"],
			"fallthrough": false
		}
	]
}
```

With this change, discovered files that only match a shadowed rule are silently skipped, and a `debug`-level log records each skip with a hint on how to include the file if desired (e.g. add `fallthrough: true` to the earlier rule or broaden the user rule's globs). The direct-import path in `module-collection.ts` is unchanged: importing a file in code that only matches a shadowed rule is still a hard error, since the imported file genuinely needs a defined module type.

Verified locally against [the reporter's reproduction](https://github.com/sgentle/wrangler-modules-fallback-repro):

```
$ wrangler deploy --dry-run --outdir=dist
Attaching additional modules:
┌─────────────────────┬──────┬──────────┐
│ Name                │ Type │ Size     │
├─────────────────────┼──────┼──────────┤
│ html/includeme.html │ text │ 0.02 KiB │
├─────────────────────┼──────┼──────────┤
│ Total (1 module)    │      │ 0.02 KiB │
└─────────────────────┴──────┴──────────┘
```

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: the prior behavior was a bug — the public docs do not describe `fallthrough: false` as a way to filter out files, and the only user-visible difference is that a misleading error is no longer raised for unimported files.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->