### PR TITLE
[wrangler] fix(d1): escape migrationsTableName and filenames in SQLite queries

### DIFF
--- a/.changeset/fix-d1-escape-migrations.md
+++ b/.changeset/fix-d1-escape-migrations.md
@@ -1,0 +1,13 @@
+---
+"wrangler": patch
+"@cloudflare/vitest-pool-workers": patch
+---
+
+fix(d1): escape `migrationsTableName` and filenames in SQLite queries
+
+D1 migration commands in both `wrangler` and `@cloudflare/vitest-pool-workers` interpolated the `migrationsTableName` config value and migration filenames directly into SQL strings without any escaping. This meant:
+
+- A table name such as `my"table` would produce invalid SQL in `CREATE TABLE`, `SELECT`, and `INSERT` statements, and
+- A migration filename containing an apostrophe (e.g. `what's-new.sql`) would break the `INSERT INTO ... VALUES ('...')` statement appended after each migration in `wrangler`.
+
+Both identifiers are now properly escaped before interpolation: `migrationsTableName` is wrapped in double-quotes with internal double-quotes doubled (SQL-standard identifier quoting), and migration filenames used as string literals have their single-quotes doubled before insertion.

--- a/packages/vitest-pool-workers/src/worker/d1.ts
+++ b/packages/vitest-pool-workers/src/worker/d1.ts
@@ -51,8 +51,11 @@ export async function applyD1Migrations(
 		);
 	}
 
+	const escapeId = (id: string) => `"${id.replace(/"/g, '""')}"`;
+	const escapedTableName = escapeId(migrationsTableName);
+
 	// Create migrations table if it doesn't exist
-	const schema = `CREATE TABLE IF NOT EXISTS ${migrationsTableName} (
+	const schema = `CREATE TABLE IF NOT EXISTS ${escapedTableName} (
 		id         INTEGER PRIMARY KEY AUTOINCREMENT,
 		name       TEXT UNIQUE,
 		applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
@@ -61,7 +64,7 @@ export async function applyD1Migrations(
 
 	// Find applied migrations
 	const appliedMigrationNamesResult = await db
-		.prepare(`SELECT name FROM ${migrationsTableName};`)
+		.prepare(`SELECT name FROM ${escapedTableName};`)
 		.all<{ name: string }>();
 	const appliedMigrationNames = appliedMigrationNamesResult.results.map(
 		({ name }) => name
@@ -69,7 +72,7 @@ export async function applyD1Migrations(
 
 	// Apply un-applied migrations
 	const insertMigrationStmt = db.prepare(
-		`INSERT INTO ${migrationsTableName} (name) VALUES (?);`
+		`INSERT INTO ${escapedTableName} (name) VALUES (?);`
 	);
 	for (const migration of migrations) {
 		if (appliedMigrationNames.includes(migration.name)) {

--- a/packages/wrangler/src/__tests__/d1/migrate.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrate.test.ts
@@ -490,7 +490,7 @@ Your database may not be available to serve requests during the migration, conti
 				.mockImplementation(async ({ command }) => {
 					if (typeof command === "string") {
 						const match = command.match(
-							/INSERT INTO d1_migrations \(name\)\s*values\s*\('([^']+)'\)/
+							/INSERT INTO "d1_migrations" \(name\)\s*values\s*\('([^']+)'\)/
 						);
 						if (match) {
 							insertedNames.push(match[1]);
@@ -823,6 +823,118 @@ Your database may not be available to serve requests during the migration, conti
 
 				When \`migrations_pattern\` is set, \`migrations_dir\` must also be set, and \`migrations_pattern\` must start with \`\${migrations_dir}/\`. Add a \`migrations_dir\` entry to your wrangler.jsonc file (for example, \`"migrations_dir": "migrations"\`).]
 			`);
+		});
+
+		it("should escape single quotes in migration filenames during apply", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			writeWranglerConfig({
+				d1_databases: [
+					{
+						binding: "DATABASE",
+						database_name: "db",
+						database_id: "xxxx",
+						migrations_dir: "migrations",
+					},
+				],
+			});
+			fs.mkdirSync("./migrations", { recursive: true });
+			fs.writeFileSync(
+				"./migrations/0001_add_user's_settings.sql",
+				"-- settings"
+			);
+
+			const executedQueries: string[] = [];
+			const spy = vi
+				.spyOn(d1Execute, "executeSql")
+				.mockImplementation(async ({ command }) => {
+					if (typeof command === "string") {
+						executedQueries.push(command);
+						if (command.includes("SELECT *")) {
+							return [{ results: [], success: true, meta: {} as never }];
+						}
+					}
+					return [{ results: [], success: true, meta: {} as never }];
+				});
+
+			mockConfirm({
+				text: `About to apply 1 migration(s)\nYour database may not be available to serve requests during the migration, continue?`,
+				result: true,
+			});
+
+			try {
+				await runWrangler("d1 migrations apply db --local");
+			} finally {
+				spy.mockRestore();
+			}
+
+			const insertQuery = executedQueries.find((q) =>
+				q.includes("INSERT INTO")
+			);
+			expect(insertQuery).toBeDefined();
+			expect(insertQuery).toContain("'0001_add_user''s_settings.sql'");
+		});
+
+		it("should escape migrationsTableName using double quotes in SQL queries", async ({
+			expect,
+		}) => {
+			setIsTTY(false);
+			writeWranglerConfig({
+				d1_databases: [
+					{
+						binding: "DATABASE",
+						database_name: "db",
+						database_id: "xxxx",
+						migrations_dir: "migrations",
+						migrations_table: "my-custom-table",
+					},
+				],
+			});
+			fs.mkdirSync("./migrations", { recursive: true });
+			fs.writeFileSync("./migrations/0001_init.sql", "-- init");
+
+			const executedQueries: string[] = [];
+			const spy = vi
+				.spyOn(d1Execute, "executeSql")
+				.mockImplementation(async ({ command }) => {
+					if (typeof command === "string") {
+						executedQueries.push(command);
+					}
+					return [{ results: [], success: true, meta: {} as never }];
+				});
+
+			mockConfirm({
+				text: `About to apply 1 migration(s)\nYour database may not be available to serve requests during the migration, continue?`,
+				result: true,
+			});
+
+			try {
+				await runWrangler("d1 migrations apply db --local");
+			} finally {
+				spy.mockRestore();
+			}
+
+			// Verify table creation uses quoted table name
+			const createQuery = executedQueries.find((q) =>
+				q.includes("CREATE TABLE IF NOT EXISTS")
+			);
+			expect(createQuery).toBeDefined();
+			expect(createQuery).toContain(
+				'CREATE TABLE IF NOT EXISTS "my-custom-table"'
+			);
+
+			// Verify query uses quoted table name
+			const selectQuery = executedQueries.find((q) => q.includes("SELECT *"));
+			expect(selectQuery).toBeDefined();
+			expect(selectQuery).toContain('FROM "my-custom-table"');
+
+			// Verify insert uses quoted table name
+			const insertQuery = executedQueries.find((q) =>
+				q.includes("INSERT INTO")
+			);
+			expect(insertQuery).toBeDefined();
+			expect(insertQuery).toContain('INSERT INTO "my-custom-table"');
 		});
 	});
 });

--- a/packages/wrangler/src/d1/migrations/apply.ts
+++ b/packages/wrangler/src/d1/migrations/apply.ts
@@ -8,6 +8,7 @@ import { logger } from "../../logger";
 import { executeSql } from "../execute";
 import { getDatabaseInfoFromConfig } from "../utils";
 import {
+	escapeIdentifier,
 	getMigrationsPath,
 	getUnappliedMigrations,
 	initMigrationsTable,
@@ -150,9 +151,12 @@ Your database may not be available to serve requests during the migration, conti
 				`${migrationsPath}/${migration.name}`,
 				"utf8"
 			);
+			const escapedTableName = escapeIdentifier(
+				migrationsConfig.migrationsTableName
+			);
 			query += `
-								INSERT INTO ${migrationsConfig.migrationsTableName} (name)
-								values ('${migration.name}');
+								INSERT INTO ${escapedTableName} (name)
+								values ('${migration.name.replace(/'/g, "''")}');
 						`;
 
 			let success = true;

--- a/packages/wrangler/src/d1/migrations/helpers.ts
+++ b/packages/wrangler/src/d1/migrations/helpers.ts
@@ -149,6 +149,10 @@ export function normalizeRelativePath(p: string): string {
 	return normalized;
 }
 
+export function escapeIdentifier(id: string): string {
+	return `"${id.replace(/"/g, '""')}"`;
+}
+
 export async function getMigrationsPath({
 	projectPath,
 	migrationsDir,
@@ -250,6 +254,7 @@ const listAppliedMigrations = async ({
 	persistTo,
 	preview,
 }: ListAppliedMigrationsProps): Promise<Migration[]> => {
+	const escapedTableName = escapeIdentifier(migrationsTableName);
 	const response: QueryResult[] | null = await executeSql({
 		local,
 		remote,
@@ -258,7 +263,7 @@ const listAppliedMigrations = async ({
 		shouldPrompt: !isNonInteractiveOrCI(),
 		persistTo,
 		command: `SELECT *
-		FROM ${migrationsTableName}
+		FROM ${escapedTableName}
 		ORDER BY id`,
 		file: undefined,
 		json: true,
@@ -481,6 +486,7 @@ export const initMigrationsTable = async ({
 	persistTo: string | undefined;
 	preview: boolean | undefined;
 }) => {
+	const escapedTableName = escapeIdentifier(migrationsTableName);
 	return executeSql({
 		local,
 		remote,
@@ -488,7 +494,7 @@ export const initMigrationsTable = async ({
 		name,
 		shouldPrompt: !isNonInteractiveOrCI(),
 		persistTo,
-		command: `CREATE TABLE IF NOT EXISTS ${migrationsTableName}(
+		command: `CREATE TABLE IF NOT EXISTS ${escapedTableName}(
 		id         INTEGER PRIMARY KEY AUTOINCREMENT,
 		name       TEXT UNIQUE,
 		applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL


### PR DESCRIPTION
Fixes two SQL escaping issues in D1 migrations.

## What changed

### Escape `migrationsTableName`

D1 migration queries previously interpolated `migrationsTableName` directly into SQLite statements.

This change escapes migration table identifiers using SQL-standard double quotes before constructing queries.

Affected queries include:

- `CREATE TABLE`
- `SELECT`
- `INSERT`

### Escape migration filenames

Migration filenames are inserted into SQL string literals when recording applied migrations.

Filenames containing apostrophes could generate invalid SQL. This change escapes single quotes before insertion.

Example:

```text
0001_user's_table.sql
```

becomes:

```text
0001_user''s_table.sql
```

when used inside SQL string literals.

## Why

These changes improve the robustness of D1 migrations by:

- supporting custom migration table names that contain special characters
- preventing SQL parsing failures caused by apostrophes in migration filenames

The changes are fully backward compatible and do not alter existing migration behavior.

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix

🦦
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->