### PR TITLE
[wrangler] Consolidate vi.mock calls for @cloudflare/autoconfig in entry-points.test.ts

### DIFF
--- a/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/entry-points.test.ts
@@ -58,11 +58,7 @@ vi.mock("../../package-manager", async (importOriginal) => ({
 	},
 }));
 
-vi.mock("@cloudflare/autoconfig", async (importOriginal) => ({
-	...(await importOriginal()),
-	runAutoConfig: vi.fn(),
-	getInstalledPackageVersion: vi.fn(),
-}));
+vi.mock(import("@cloudflare/autoconfig"), { spy: true });
 vi.mock("@cloudflare/cli-shared-helpers/command");
 
 describe("deploy", () => {
@@ -346,8 +342,6 @@ export default{
 		it("should not trigger autoconfig on `wrangler deploy <script>`", async ({
 			expect,
 		}) => {
-			vi.mock(import("@cloudflare/autoconfig"), { spy: true });
-
 			const {
 				getDetailsForAutoConfig: getDetailsForAutoConfigSpy,
 				runAutoConfig: runAutoConfigSpy,
@@ -888,8 +882,6 @@ addEventListener('fetch', event => {});`
 			it("should handle interactive `wrangler deploy <directory>` flows without triggering autoconfig", async ({
 				expect,
 			}) => {
-				vi.mock(import("@cloudflare/autoconfig"), { spy: true });
-
 				const {
 					getDetailsForAutoConfig: getDetailsForAutoConfigSpy,
 					runAutoConfig: runAutoConfigSpy,
@@ -966,8 +958,6 @@ addEventListener('fetch', event => {});`
 			it("should handle `wrangler deploy --assets` without name or compat date without triggering autoconfig", async ({
 				expect,
 			}) => {
-				vi.mock(import("@cloudflare/autoconfig"), { spy: true });
-
 				const {
 					getDetailsForAutoConfig: getDetailsForAutoConfigSpy,
 					runAutoConfig: runAutoConfigSpy,


### PR DESCRIPTION
The `entry-points.test.ts` test file previously had two patterns for mocking `@cloudflare/autoconfig`:

1. A top-level `vi.mock("@cloudflare/autoconfig", ...)` call that spread `importOriginal()` and replaced `runAutoConfig` / `getInstalledPackageVersion` with `vi.fn()`.
2. Repeated `vi.mock(import("@cloudflare/autoconfig"), { spy: true })` calls inside three individual `it()` blocks.

This consolidates both patterns into a single top-level `vi.mock(import("@cloudflare/autoconfig"), { spy: true })`, removing the duplicated per-test mocks. The `{ spy: true }` form preserves the original module's behaviour while making each export spy-able, which matches the intent of the inline mocks and is sufficient for the existing assertions.

All 30 tests in this file continue to pass.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This is a test-only refactor with no user-facing changes.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->