### PR TITLE
remove skipLastDeployedFromApiCheck from deploy helpers

### DIFF
--- a/.changeset/good-hoops-joke.md
+++ b/.changeset/good-hoops-joke.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/deploy-helpers": patch
+---
+
+remove skipLastDeployedFromApiCheck
+
+This was a temporary option to bypass an API issue, which has been fixed API side.

--- a/packages/deploy-helpers/src/deploy/helpers/validate-worker-props.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/validate-worker-props.ts
@@ -242,10 +242,7 @@ export async function preUploadApiChecks(
 						return { workerTag, tags, workerExists, aborted: true };
 					}
 				}
-			} else if (
-				script.last_deployed_from === "api" &&
-				!props.skipLastDeployedFromApiCheck
-			) {
+			} else if (script.last_deployed_from === "api") {
 				logger.warn(
 					`You are about to upload a Worker that was last updated via the script API.\nEdits that have been made via the script API will be overridden by your local code and config.`
 				);

--- a/packages/deploy-helpers/src/shared/types.ts
+++ b/packages/deploy-helpers/src/shared/types.ts
@@ -108,8 +108,6 @@ export type SharedDeployVersionsProps = {
 	resourcesProvision: boolean;
 	/** Controls whether provisioned resource IDs are written back to the config file. */
 	skipProvisioningConfigWriteback: boolean;
-	/** temporary hack - cf is not yet a recognised deploy source, so any deploys from cf comes back normalised to 'api'*/
-	skipLastDeployedFromApiCheck: boolean;
 	/** From --strict arg. In strict mode, conflicting pre-upload checks abort instead of auto-continuing. */
 	strict: boolean;
 };

--- a/packages/wrangler/src/deployment-bundle/merge-config-args.ts
+++ b/packages/wrangler/src/deployment-bundle/merge-config-args.ts
@@ -96,7 +96,6 @@ async function mergeSharedConfigArgs(
 		sendMetrics,
 		resourcesProvision: getFlag("RESOURCES_PROVISION") ?? false,
 		skipProvisioningConfigWriteback: false,
-		skipLastDeployedFromApiCheck: false,
 		strict: args.strict ?? false,
 	};
 


### PR DESCRIPTION
this was a temporary thing for cf, now have fixed this API side, should be in the next EWC release.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: removing something temporary
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: removing something temporary

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->