### PR TITLE
[wrangler] fix: Preserve capnp modules on version reupload

### DIFF
--- a/.changeset/preserve-capnp-schema-versions-secret.md
+++ b/.changeset/preserve-capnp-schema-versions-secret.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Preserve the capnp schema when updating secrets via `wrangler versions secret put/delete/bulk`
+
+These commands re-upload the latest version's content with the new secrets applied. Previously the compiled capnp schema attached to the version was dropped, producing a new version without it. The schema is now carried through from the existing version's content to the new version upload.

--- a/packages/deploy-helpers/src/deploy/helpers/create-worker-upload-form.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/create-worker-upload-form.ts
@@ -56,7 +56,17 @@ export function createWorkerUploadForm(
 	bindings: Record<string, Binding> | undefined,
 	options?: {
 		dryRun?: true;
-		unsafe?: { metadata?: Record<string, unknown>; capnp?: CfCapnp };
+		unsafe?: {
+			metadata?: Record<string, unknown>;
+			capnp?: CfCapnp;
+			/**
+			 * A pre-compiled capnp schema to attach as-is, used when re-uploading
+			 * the content of an existing version (e.g. `wrangler versions secret put`).
+			 * Unlike `capnp`, this is not compiled from source - the bytes are
+			 * attached directly and referenced via `metadata.capnp_schema`.
+			 */
+			capnpSchema?: { name: string; content: Uint8Array };
+		};
 	}
 ): FormData {
 	const formData = new FormData();
@@ -787,7 +797,18 @@ export function createWorkerUploadForm(
 	}
 
 	let capnpSchemaOutputFile: string | undefined;
-	if (options?.unsafe?.capnp) {
+	if (options?.unsafe?.capnpSchema) {
+		// Pre-compiled schema (e.g. re-uploading an existing version's content):
+		// attach the bytes directly under their existing part name.
+		const { name, content } = options.unsafe.capnpSchema;
+		capnpSchemaOutputFile = name;
+		formData.set(
+			name,
+			new File([content], name, {
+				type: "application/octet-stream",
+			})
+		);
+	} else if (options?.unsafe?.capnp) {
 		const capnpOutput = handleUnsafeCapnp(options.unsafe.capnp);
 		capnpSchemaOutputFile = `./capnp-${Date.now()}.compiled`;
 		formData.set(

--- a/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
@@ -132,6 +132,58 @@ describe("versions secret put", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
+	test("preserves the capnp schema from the existing version", async ({
+		expect,
+	}) => {
+		setIsTTY(true);
+
+		mockPrompt({
+			text: "Enter a secret value:",
+			options: { isSecret: true },
+			result: "the-secret",
+		});
+
+		mockSetupApiCalls(expect, {
+			capnpSchema: {
+				name: "./capnp-12345.compiled",
+				content: "my compiled capnp data",
+			},
+		});
+		mockPostVersion(expect, (metadata, formData) => {
+			// The schema is re-attached and referenced via metadata.capnp_schema
+			expect(metadata.capnp_schema).toEqual("./capnp-12345.compiled");
+			expect(formData.get("./capnp-12345.compiled")).not.toBeNull();
+			// The schema is not re-uploaded as a stray module binding
+			expect(metadata.bindings).toStrictEqual([
+				{ type: "inherit", name: "do-binding" },
+				{ type: "secret_text", name: "NEW_SECRET", text: "the-secret" },
+			]);
+		});
+		await runWrangler("versions secret put NEW_SECRET --name script-name");
+
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+
+	test("does not set capnp_schema when the version has none", async ({
+		expect,
+	}) => {
+		setIsTTY(true);
+
+		mockPrompt({
+			text: "Enter a secret value:",
+			options: { isSecret: true },
+			result: "the-secret",
+		});
+
+		mockSetupApiCalls(expect);
+		mockPostVersion(expect, (metadata) => {
+			expect(metadata.capnp_schema).toBeUndefined();
+		});
+		await runWrangler("versions secret put NEW_SECRET --name script-name");
+
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+
 	test("no wrangler configuration warnings shown", async ({ expect }) => {
 		await writeFile("wrangler.json", JSON.stringify({ invalid_field: true }));
 		setIsTTY(true);

--- a/packages/wrangler/src/__tests__/versions/secrets/utils.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/utils.ts
@@ -88,7 +88,10 @@ export function mockGetVersion(
 	);
 }
 
-function mockGetVersionContent(expect: ExpectStatic) {
+function mockGetVersionContent(
+	expect: ExpectStatic,
+	options?: { capnpSchema?: { name: string; content: string } }
+) {
 	msw.use(
 		http.get(
 			`*/accounts/:accountId/workers/scripts/:scriptName/content/v2`,
@@ -109,9 +112,20 @@ function mockGetVersionContent(expect: ExpectStatic) {
 					"index.js"
 				);
 
-				return HttpResponse.formData(formData, {
-					headers: { "cf-entrypoint": "index.js" },
-				});
+				const headers: Record<string, string> = { "cf-entrypoint": "index.js" };
+
+				if (options?.capnpSchema) {
+					formData.set(
+						options.capnpSchema.name,
+						new File([options.capnpSchema.content], options.capnpSchema.name, {
+							type: "application/octet-stream",
+						}),
+						options.capnpSchema.name
+					);
+					headers["cf-worker-capnp-schema-part"] = options.capnpSchema.name;
+				}
+
+				return HttpResponse.formData(formData, { headers });
 			},
 			{ once: true }
 		)
@@ -171,9 +185,12 @@ export function mockPostVersion(
 	);
 }
 
-export function mockSetupApiCalls(expect: ExpectStatic) {
+export function mockSetupApiCalls(
+	expect: ExpectStatic,
+	options?: { capnpSchema?: { name: string; content: string } }
+) {
 	mockGetVersions(expect);
 	mockGetVersion(expect);
-	mockGetVersionContent(expect);
+	mockGetVersionContent(expect, options);
 	mockGetWorkerSettings(expect);
 }

--- a/packages/wrangler/src/versions/secrets/index.ts
+++ b/packages/wrangler/src/versions/secrets/index.ts
@@ -116,7 +116,7 @@ export async function copyWorkerVersionWithNewSecrets({
 	);
 
 	// Naive implementation ahead, don't worry too much about it -- we will replace it
-	const { mainModule, modules, sourceMaps } = await parseModules(
+	const { mainModule, modules, sourceMaps, capnpSchema } = await parseModules(
 		config,
 		accountId,
 		scriptName,
@@ -199,7 +199,7 @@ export async function copyWorkerVersionWithNewSecrets({
 	};
 
 	const body = createWorkerUploadForm(worker, bindings, {
-		unsafe: { metadata: unsafeMetadata },
+		unsafe: { metadata: unsafeMetadata, capnpSchema },
 	});
 	const result = await fetchResult<{
 		available_on_subdomain: boolean;
@@ -234,6 +234,7 @@ async function parseModules(
 	mainModule: CfModule;
 	modules: CfModule[];
 	sourceMaps: CfWorkerSourceMap[];
+	capnpSchema?: { name: string; content: Buffer };
 }> {
 	// Pull the Worker content - https://developers.cloudflare.com/api/operations/worker-script-get-content
 	const contentRes = await performApiFetch(
@@ -275,12 +276,35 @@ async function parseModules(
 			type: fromMimeType(entrypointPart.type),
 		};
 
-		// Load all modules that are not the entrypoint or sourcemaps
+		// The compiled capnp schema is an internal upload-metadata concern referenced
+		// via `metadata.capnp_schema`, not a regular module. Pull it out so it can be
+		// re-attached as-is, and exclude it from `modules` so it isn't re-uploaded as a
+		// stray (orphaned) module that the new version's metadata wouldn't reference.
+		const capnpSchemaPart = contentRes.headers.get(
+			"cf-worker-capnp-schema-part"
+		);
+		let capnpSchema: { name: string; content: Buffer } | undefined;
+		if (capnpSchemaPart !== null) {
+			const capnpFile = formData.get(capnpSchemaPart) as File | null;
+			if (capnpFile === null) {
+				throw new FatalError("Could not find capnp schema part in form-data", {
+					telemetryMessage: "versions secrets modules missing capnp part",
+				});
+			}
+			capnpSchema = {
+				name: capnpSchemaPart,
+				content: Buffer.from(await capnpFile.arrayBuffer()),
+			};
+		}
+
+		// Load all modules that are not the entrypoint, sourcemaps, or capnp schema
 		const modules = await Promise.all(
 			Array.from(formData.entries() as SpecIterableIterator<[string, File]>)
 				.filter(
 					([name, file]) =>
-						name !== entrypoint && file.type !== "application/source-map"
+						name !== entrypoint &&
+						name !== capnpSchemaPart &&
+						file.type !== "application/source-map"
 				)
 				.map(
 					async ([name, file]) =>
@@ -306,7 +330,7 @@ async function parseModules(
 				)
 		);
 
-		return { mainModule, modules, sourceMaps };
+		return { mainModule, modules, sourceMaps, capnpSchema };
 	} else {
 		const contentType = contentRes.headers.get("content-type");
 		if (contentType === null) {


### PR DESCRIPTION
wrangler versions secret put/delete/bulk re-upload the latest version's content with the new secrets applied. The compiled capnp schema attached to the version was being dropped, producing a new version without it.

parseModules now extracts the capnp schema part from the content/v2 response (identified via the cf-worker-capnp-schema-part header) and excludes it from modules so it isn't re-uploaded as an orphaned module. createWorkerUploadForm gains an unsafe.capnpSchema option to re-attach the pre-compiled bytes and reference them via metadata.capnp_schema.

Fixes WC-3943

_Describe your change..._

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: small fix to an edge case of a preexisting feature, only used with unsafe fields.

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
