### PR TITLE
chore: consolidate dependabot changeset

### DIFF
--- a/.github/workflows/c3-dependabot-versioning-prs.yml
+++ b/.github/workflows/c3-dependabot-versioning-prs.yml
@@ -33,7 +33,9 @@ jobs:
           git config --global user.name 'Wrangler automated PR updater'
 
       - name: Generate C3 changesets
-        # Keep the final param (the changeset prefix: `c3-frameworks-update`) in sync with the filter in the `.github/workflows/c3-e2e-dependabot.yml` workflow.
-        run: node -r esbuild-register tools/dependabot/generate-dependabot-pr-changesets.ts "$PR_NUMBER" create-cloudflare packages/create-cloudflare/src/frameworks/package.json c3-frameworks-update
-        env:
-          PR_NUMBER: ${{ github.event.number }}
+        # Keep the final param (`c3-frameworks-update`) in sync with the filter in the `.github/workflows/c3-e2e-dependabot.yml` workflow.
+        run: >-
+          node -r esbuild-register tools/dependabot/generate-dependabot-pr-changesets.ts
+          create-cloudflare
+          packages/create-cloudflare/src/frameworks/package.json
+          c3-frameworks-update

--- a/.github/workflows/c3-dependabot-versioning-prs.yml
+++ b/.github/workflows/c3-dependabot-versioning-prs.yml
@@ -33,7 +33,6 @@ jobs:
           git config --global user.name 'Wrangler automated PR updater'
 
       - name: Generate C3 changesets
-        # Keep the final param (`c3-frameworks-update`) in sync with the filter in the `.github/workflows/c3-e2e-dependabot.yml` workflow.
         run: >-
           node -r esbuild-register tools/dependabot/generate-dependabot-pr-changesets.ts
           create-cloudflare

--- a/.github/workflows/miniflare-dependabot-versioning-prs.yml
+++ b/.github/workflows/miniflare-dependabot-versioning-prs.yml
@@ -34,16 +34,14 @@ jobs:
           git config --global user.name 'Wrangler automated PR updater'
 
       - name: Generate Miniflare changesets
-        # The paremeters to the script are:
-        # - PR: The number of the current Dependabot PR
+        # The parameters to the script are:
         # - Packages: Coma-separated names of the workers-sdk packages whose dependencies are being updated
         # - PackageJSON: The path to the package JSON being updated by Dependabot
-        # - Changeset prefix: The prefix to go on the front of the filename of the generated changeset
+        # - Changeset prefix: The prefix to go on the front of generated changeset filenames
+        # - Changeset label: Stable label for consolidating workerd updates before release
         run: >-
           node -r esbuild-register tools/dependabot/generate-dependabot-pr-changesets.ts
-          "$PR_NUMBER"
           miniflare,wrangler
           packages/miniflare/package.json
           dependabot-update
-        env:
-          PR_NUMBER: ${{ github.event.number }}
+          workerd

--- a/tools/dependabot/__tests__/generate-dependabot-pr-changesets.test.ts
+++ b/tools/dependabot/__tests__/generate-dependabot-pr-changesets.test.ts
@@ -1,13 +1,18 @@
 import { spawnSync } from "node:child_process";
-import { writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import dedent from "ts-dedent";
-import { describe, it, vitest } from "vitest";
+import { afterEach, describe, it, vitest } from "vitest";
 import {
 	commitAndPush,
 	generateChangesetHeader,
 	generateCommitMessage,
+	getChangesetFilename,
+	getFilenameSlug,
 	getPackageJsonDiff,
+	mergeChanges,
+	parseChangesetForChanges,
 	parseDiffForChanges,
+	readExistingChanges,
 	writeChangeSet,
 } from "../generate-dependabot-pr-changesets";
 import type { Mock } from "vitest";
@@ -20,8 +25,13 @@ vitest.mock("node:child_process", async () => {
 
 vitest.mock("node:fs", async () => {
 	return {
+		readFileSync: vitest.fn(),
 		writeFileSync: vitest.fn(),
 	};
+});
+
+afterEach(() => {
+	vitest.resetAllMocks();
 });
 
 describe("getPackageJsonDiff()", () => {
@@ -83,6 +93,141 @@ describe("parseDiffForChanges()", () => {
 	it("should ignore lines that do not match a change", ({ expect }) => {
 		const changes = parseDiffForChanges(["", undefined, "random text"]);
 		expect(changes.size).toBe(0);
+	});
+});
+
+describe("getFilenameSlug()", () => {
+	it("should return a sanitized slug for the first changed dependency", ({
+		expect,
+	}) => {
+		const slug = getFilenameSlug("@namespace/some-package");
+		expect(slug).toBe("namespace-some-package");
+	});
+});
+
+describe("getChangesetFilename()", () => {
+	it("should derive a changeset filename from the first changed dependency", ({
+		expect,
+	}) => {
+		const changesetFilename = getChangesetFilename(
+			"some-prefix",
+			new Map([["@namespace/some-package", { from: "1.0.0", to: "1.0.1" }]])
+		);
+		expect(changesetFilename).toBe("some-prefix-namespace-some-package.md");
+	});
+
+	it("should use a stable changeset label", ({ expect }) => {
+		const changesetFilename = getChangesetFilename(
+			"some-prefix",
+			new Map([["some-package", { from: "1.0.0", to: "1.0.1" }]]),
+			"stable-name"
+		);
+		expect(changesetFilename).toBe("some-prefix-stable-name.md");
+	});
+
+	it("should require a stable changeset label for multiple changed dependencies", ({
+		expect,
+	}) => {
+		expect(() =>
+			getChangesetFilename(
+				"some-prefix",
+				new Map([
+					["some-package", { from: "1.0.0", to: "1.0.1" }],
+					["other-package", { from: "2.0.0", to: "2.0.1" }],
+				])
+			)
+		).toThrowErrorMatchingInlineSnapshot(
+			`[Error: Cannot generate dependency-scoped changeset filename for multiple dependency changes. Pass a stable changeset label.]`
+		);
+	});
+
+	it("should throw for an empty changes map", ({ expect }) => {
+		expect(() =>
+			getChangesetFilename("some-prefix", new Map())
+		).toThrowErrorMatchingInlineSnapshot(
+			`[Error: Cannot generate changeset filename without dependency changes.]`
+		);
+	});
+});
+
+describe("parseChangesetForChanges()", () => {
+	it("should parse dependency rows from a generated changeset", ({
+		expect,
+	}) => {
+		const changes = parseChangesetForChanges(dedent`
+			---
+			"package-name": patch
+			---
+
+			Update dependencies of "package-name"
+
+			The following dependency versions have been updated:
+
+			| Dependency              | From   | To     |
+			| ----------------------- | ------ | ------ |
+			| some-package            | ^0.0.1 | ^0.0.2 |
+			| @namespace/some-package | 1.3.4  | 1.4.5  |
+		`);
+
+		expect(changes).toEqual(
+			new Map([
+				["some-package", { from: "^0.0.1", to: "^0.0.2" }],
+				["@namespace/some-package", { from: "1.3.4", to: "1.4.5" }],
+			])
+		);
+	});
+});
+
+describe("readExistingChanges()", () => {
+	it("should return an empty map when the changeset does not exist", ({
+		expect,
+	}) => {
+		const error = Object.assign(new Error("File not found"), {
+			code: "ENOENT",
+		});
+		(readFileSync as Mock).mockImplementation(() => {
+			throw error;
+		});
+
+		expect(readExistingChanges("missing.md")).toEqual(new Map());
+		expect(readFileSync).toHaveBeenCalledWith(".changeset/missing.md", "utf-8");
+	});
+
+	it("should parse an existing changeset", ({ expect }) => {
+		(readFileSync as Mock).mockReturnValue(dedent`
+			| Dependency   | From  | To    |
+			| ------------ | ----- | ----- |
+			| some-package | 1.0.0 | 1.0.1 |
+		`);
+
+		expect(readExistingChanges("existing.md")).toEqual(
+			new Map([["some-package", { from: "1.0.0", to: "1.0.1" }]])
+		);
+		expect(readFileSync).toHaveBeenCalledWith(
+			".changeset/existing.md",
+			"utf-8"
+		);
+	});
+});
+
+describe("mergeChanges()", () => {
+	it("should preserve the original from version and update to the latest version", ({
+		expect,
+	}) => {
+		const changes = mergeChanges(
+			new Map([
+				["some-package", { from: "1.0.0", to: "1.0.1" }],
+				["other-package", { from: "2.0.0", to: "2.0.1" }],
+			]),
+			new Map([["some-package", { from: "1.0.1", to: "1.0.2" }]])
+		);
+
+		expect(changes).toEqual(
+			new Map([
+				["some-package", { from: "1.0.0", to: "1.0.2" }],
+				["other-package", { from: "2.0.0", to: "2.0.1" }],
+			])
+		);
 	});
 });
 
@@ -182,10 +327,10 @@ describe("writeChangeSet()", () => {
 		| some-package            | ^0.0.1 | ^0.0.2 |
 		| @namespace/some-package | 1.3.4  | 1.4.5  |
 	`;
-		writeChangeSet("some-prefix", "1234", header, body);
+		writeChangeSet("some-prefix-some-package.md", header, body);
 		expect(writeFileSync).toHaveBeenCalledOnce();
 		expect((writeFileSync as Mock).mock.lastCall?.[0]).toMatchInlineSnapshot(
-			`".changeset/some-prefix-1234.md"`
+			`".changeset/some-prefix-some-package.md"`
 		);
 		expect((writeFileSync as Mock).mock.lastCall?.[1]).toMatchInlineSnapshot(`
 			"---

--- a/tools/dependabot/generate-dependabot-pr-changesets.ts
+++ b/tools/dependabot/generate-dependabot-pr-changesets.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { argv } from "node:process";
 import dedent from "ts-dedent";
@@ -23,14 +23,14 @@ if (require.main === module) {
 }
 
 type Args = {
-	// PR number
-	prNumber: string;
 	// Comma-separated package names
 	packageNames: string;
 	// Path to package.json
 	packageJSONPath: string;
 	// Changeset file prefix
 	changesetPrefix: string;
+	// Optional label for grouped dependency updates
+	changesetLabel?: string;
 };
 
 function processArgs(): Args {
@@ -41,28 +41,28 @@ function processArgs(): Args {
 	if (args[0] === __filename) {
 		args.shift();
 	}
-	if (args.length !== 4) {
+	if (args.length !== 3 && args.length !== 4) {
 		throw new Error(dedent`
 			Incorrect arguments, please provide:
-			- PR: The number of the current Dependabot PR
 			- Packages: Coma-separated names of the workers-sdk packages whose dependencies are being updated
 			- PackageJSON: The path to the package JSON being updated by Dependabot
-			- Changeset prefix: The prefix to go on the front of the filename of the generated changeset.
+			- Changeset prefix: The prefix to go on the front of generated changeset filenames.
+			- Optional changeset label: Stable label for grouped dependency updates.
 		`);
 	}
 	return {
-		prNumber: args[0],
-		packageNames: args[1],
-		packageJSONPath: args[2],
-		changesetPrefix: args[3],
+		packageNames: args[0],
+		packageJSONPath: args[1],
+		changesetPrefix: args[2],
+		changesetLabel: args[3],
 	};
 }
 
 function main({
-	prNumber,
 	packageNames,
 	packageJSONPath,
 	changesetPrefix,
+	changesetLabel,
 }: Args): void {
 	const diffLines = getPackageJsonDiff(resolve(packageJSONPath));
 	const changes = parseDiffForChanges(diffLines);
@@ -73,12 +73,21 @@ function main({
 		return;
 	}
 	const packages = packageNames.split(",").map((name: string) => name.trim());
+	const changesetFilename = getChangesetFilename(
+		changesetPrefix,
+		changes,
+		changesetLabel
+	);
+	const mergedChanges = mergeChanges(
+		readExistingChanges(changesetFilename),
+		changes
+	);
 	const changesetHeader = generateChangesetHeader(packages);
-	const commitMessage = generateCommitMessage(packages, changes);
+	const commitMessage = generateCommitMessage(packages, mergedChanges);
 	console.log(dedent`
 		INFO: Writing changeset with the following commit message
 		${commitMessage}`);
-	writeChangeSet(changesetPrefix, prNumber, changesetHeader, commitMessage);
+	writeChangeSet(changesetFilename, changesetHeader, commitMessage);
 	commitAndPush(commitMessage);
 }
 
@@ -107,6 +116,92 @@ export function parseDiffForChanges(
 		}
 	}
 	return changes;
+}
+
+export function getChangesetFilename(
+	changesetPrefix: string,
+	changes: Map<string, Change>,
+	changesetLabel?: string
+): string {
+	if (changesetLabel) {
+		return `${changesetPrefix}-${getFilenameSlug(changesetLabel)}.md`;
+	}
+	const [dependencyName, ...additionalDependencies] = [...changes.keys()];
+	if (dependencyName === undefined) {
+		throw new Error(
+			"Cannot generate changeset filename without dependency changes."
+		);
+	}
+	if (additionalDependencies.length > 0) {
+		throw new Error(
+			"Cannot generate dependency-scoped changeset filename for multiple dependency changes. Pass a stable changeset label."
+		);
+	}
+
+	return `${changesetPrefix}-${getFilenameSlug(dependencyName)}.md`;
+}
+
+export function getFilenameSlug(value: string): string {
+	return value
+		.replace(/^@/, "")
+		.replace(/[^a-zA-Z0-9]+/g, "-")
+		.replace(/^-|-$/g, "")
+		.toLowerCase();
+}
+
+export function readExistingChanges(
+	changesetFilename: string
+): Map<string, Change> {
+	const changesetPath = `.changeset/${changesetFilename}`;
+	try {
+		return parseChangesetForChanges(readFileSync(changesetPath, "utf-8"));
+	} catch (error) {
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+			return new Map();
+		}
+		throw error;
+	}
+}
+
+export function parseChangesetForChanges(
+	changeset: string
+): Map<string, Change> {
+	const changes = new Map<string, Change>();
+	for (const line of changeset.split("\n")) {
+		const match = line.match(
+			/^\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|$/
+		);
+		if (!match) {
+			continue;
+		}
+		const [, rawName, rawFrom, rawTo] = match;
+		if (rawName === undefined || rawFrom === undefined || rawTo === undefined) {
+			continue;
+		}
+		const name = rawName.trim();
+		const from = rawFrom.trim();
+		const to = rawTo.trim();
+		if (name === "Dependency" || /^-+$/.test(name)) {
+			continue;
+		}
+		changes.set(name, { from, to });
+	}
+	return changes;
+}
+
+export function mergeChanges(
+	existingChanges: Map<string, Change>,
+	newChanges: Map<string, Change>
+): Map<string, Change> {
+	const mergedChanges = new Map(existingChanges);
+	for (const [name, change] of newChanges.entries()) {
+		const existingChange = existingChanges.get(name);
+		mergedChanges.set(name, {
+			from: existingChange?.from || change.from,
+			to: change.to,
+		});
+	}
+	return mergedChanges;
 }
 
 export function generateChangesetHeader(packages: string[]): string {
@@ -164,13 +259,12 @@ export function generateCommitMessage(
 }
 
 export function writeChangeSet(
-	changesetPrefix: string,
-	prNumber: string,
+	changesetFilename: string,
 	changesetHeader: string,
 	commitMessage: string
 ): void {
 	writeFileSync(
-		`.changeset/${changesetPrefix}-${prNumber}.md`,
+		`.changeset/${changesetFilename}`,
 		changesetHeader + "\n\n" + commitMessage + "\n"
 	);
 }


### PR DESCRIPTION
Fixes n/a.

This updates the Dependabot changeset workflow so repeated dependency bumps before a release are consolidated into one changeset.

For example, if one workerd PR records:

```
| Dependency | From         | To           |
| ---------- | ------------ | ------------ |
| workerd    | 1.20260619.1 | 1.20260621.1 |
```

and a later PR bumps workerd again, **the same changeset** is updated to:

```
| Dependency | From         | To           |
| ---------- | ------------ | ------------ |
| workerd    | 1.20260619.1 | 1.20260623.1 |
```

This avoids adding multiple changesets updating the version of the same dependency.

C3 framework changesets remain scoped per dependency, so unrelated framework update PRs do not conflict with each other.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal tooling

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->