### PR TITLE
[wrangler] fix: add --experimental-new-config support to wrangler types

### DIFF
--- a/.changeset/wrangler-types-x-new-config.md
+++ b/.changeset/wrangler-types-x-new-config.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+`wrangler types` now accepts `--experimental-new-config` (`--x-new-config`), generating types from `cloudflare.config.ts` via the same path used by `wrangler dev` and `wrangler deploy`.

--- a/packages/wrangler/src/__tests__/type-generation-new-config.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation-new-config.test.ts
@@ -1,0 +1,75 @@
+import * as fs from "node:fs";
+import { runInTempDir } from "@cloudflare/workers-utils/test-helpers";
+import { beforeEach, describe, it, vi } from "vitest";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import { runWrangler } from "./helpers/run-wrangler";
+
+// Mock @cloudflare/config to avoid module.registerHooks incompatibility in vitest
+vi.mock("@cloudflare/config", async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+
+	async function loadConfig(configPath: string) {
+		const source = await fs.promises.readFile(configPath, "utf8");
+		const mod = (await import(
+			`data:text/javascript;base64,${Buffer.from(source).toString("base64")}`
+		)) as { default: unknown };
+		return {
+			config: mod.default,
+			dependencies: new Set<string>([configPath]),
+		};
+	}
+
+	return {
+		...actual,
+		loadConfig,
+		generateTypes: vi.fn().mockReturnValue("// Generated new-config types"),
+	};
+});
+
+describe("wrangler types --x-new-config", () => {
+	const std = mockConsoleMethods();
+	runInTempDir();
+
+	beforeEach(() => {
+		fs.writeFileSync(
+			"./tsconfig.json",
+			JSON.stringify({
+				compilerOptions: { types: ["worker-configuration.d.ts"] },
+			})
+		);
+	});
+
+	it("should error without cloudflare.config.ts", async ({ expect }) => {
+		await expect(
+			runWrangler("types --x-new-config")
+		).rejects.toMatchInlineSnapshot(
+			`[Error: cloudflare.config.ts is required when --experimental-new-config is enabled.]`
+		);
+	});
+
+	it("should generate types from cloudflare.config.ts", async ({ expect }) => {
+		fs.writeFileSync(
+			"./cloudflare.config.ts",
+			`export default { name: "my-worker", compatibilityDate: "2026-05-18" };`
+		);
+
+		await runWrangler("types --x-new-config");
+
+		const output = fs.readFileSync("./worker-configuration.d.ts", "utf-8");
+		expect(output).toContain("Generated new-config types");
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+
+	it("should accept --experimental-new-config alias", async ({ expect }) => {
+		fs.writeFileSync(
+			"./cloudflare.config.ts",
+			`export default { name: "my-worker", compatibilityDate: "2026-05-18" };`
+		);
+
+		await runWrangler("types --experimental-new-config");
+
+		const output = fs.readFileSync("./worker-configuration.d.ts", "utf-8");
+		expect(output).toContain("Generated new-config types");
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+});

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -13,11 +13,12 @@ import chalk from "chalk";
 import * as find from "empathic/find";
 import { getNodeCompat } from "miniflare";
 import yargs from "yargs";
-import { readConfig } from "../config";
+import { readConfig, readNewConfig } from "../config";
 import { createCommand } from "../core/create-command";
 import { getEntry } from "../deployment-bundle/entry";
 import { getDurableObjectClassNameToUseSQLiteMap } from "../dev/class-names-sqlite";
 import { getVarsForDev } from "../dev/dev-vars";
+import { experimentalNewConfigArg } from "../experimental-config/cli-flag";
 import { logger } from "../logger";
 import { isProcessEnvPopulated } from "../process-env";
 import {
@@ -29,6 +30,7 @@ import {
 	TOP_LEVEL_ENV_NAME,
 	validateEnvInterfaceNames,
 } from "./helpers";
+import { regenerateNewConfigTypes } from "./new-config";
 import { fetchPipelineTypes } from "./pipeline-schema";
 import { generateRuntimeTypes } from "./runtime";
 import { logRuntimeTypesMessage } from "./runtime/log-runtime-types-message";
@@ -159,6 +161,7 @@ export const typesCommand = createCommand({
 				"Check if the types at the provided path are up to date without regenerating them",
 			type: "boolean",
 		},
+		...experimentalNewConfigArg,
 	},
 	validateArgs(args) {
 		// args.xRuntime will be a string if the user passes "--x-include-runtime" or "--x-include-runtime=..."
@@ -204,6 +207,15 @@ export const typesCommand = createCommand({
 		}
 	},
 	async handler(args) {
+		if (args.experimentalNewConfig) {
+			const { config, types } = await readNewConfig(args);
+			await regenerateNewConfigTypes({
+				cloudflareConfigPath: config.configPath as string,
+				types,
+			});
+			return;
+		}
+
 		const resolvedOptions = await resolveGenerateTypesOptions(args, {
 			logSecondaryEntries: true,
 			validateOptions: false,


### PR DESCRIPTION
Fixes #14396.

`wrangler types --x-new-config` was failing with \"Unknown arguments: x-new-config, xNewConfig\" because the `types` command did not declare the `--experimental-new-config` flag in its yargs args. Meanwhile, `wrangler dev`, `wrangler deploy`, and `wrangler build` all support the flag via the shared `experimentalNewConfigArg`.

This PR:
- Adds `...experimentalNewConfigArg` to `typesCommand.args` so the flag is accepted
- Adds a handler branch for `--experimental-new-config` / `--x-new-config` that calls `readNewConfig` then `regenerateNewConfigTypes`, matching the behaviour of `wrangler dev` under the same flag
- Adds a focused test file verifying the flag is accepted, types are written from `cloudflare.config.ts`, and the correct error is shown when `cloudflare.config.ts` is absent

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: `--experimental-new-config` is a hidden experimental flag, not yet in public docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->