### PR TITLE
[wrangler] fix: validate --preview-alias client-side and suggest sanitized value

### DIFF
--- a/.changeset/preview-alias-validate-manual-input.md
+++ b/.changeset/preview-alias-validate-manual-input.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+`wrangler versions upload --preview-alias` now validates the alias client-side and returns a clear error with a sanitized suggestion when the value contains invalid characters (e.g. slashes from branch names like `feature/my-feature`) or exceeds 63 characters.

--- a/packages/deploy-helpers/src/deploy/helpers/preview-alias.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/preview-alias.ts
@@ -5,7 +5,8 @@ import { logger } from "../../shared/context";
 
 const MAX_DNS_LABEL_LENGTH = 63;
 const HASH_LENGTH = 4;
-const ALIAS_VALIDATION_REGEX = /^[a-z](?:[a-z0-9-]*[a-z0-9])?$/i;
+export const ALIAS_VALIDATION_REGEX = /^[a-z](?:[a-z0-9-]*[a-z0-9])?$/i;
+export const MAX_PREVIEW_ALIAS_LENGTH = MAX_DNS_LABEL_LENGTH;
 
 /**
  * Sanitizes a branch name to create a valid DNS label alias.

--- a/packages/wrangler/src/__tests__/deploy/config-args-merging.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/config-args-merging.test.ts
@@ -970,6 +970,41 @@ describe.each([
 			expect(metadata.annotations).toEqual({ "workers/alias": "my-alias" });
 		});
 
+		it("--preview-alias rejects aliases with slashes", async ({ expect }) => {
+			writeWranglerConfig({ main: "./index.js" });
+			writeWorkerSource();
+			await expect(
+				runWrangler("versions upload --preview-alias feature/my-feature")
+			).rejects.toThrow(
+				`Preview alias "feature/my-feature" is invalid. Aliases must start with a letter and contain only lowercase letters, numbers, and hyphens. Did you mean "feature-my-feature"?`
+			);
+		});
+
+		it("--preview-alias rejects aliases that are too long", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({ main: "./index.js" });
+			writeWorkerSource();
+			const longAlias = "a".repeat(64);
+			await expect(
+				runWrangler(`versions upload --preview-alias ${longAlias}`)
+			).rejects.toThrow(
+				`Preview alias "${longAlias}" is too long (64 characters). Aliases must be at most 63 characters.`
+			);
+		});
+
+		it("--preview-alias rejects aliases starting with a number", async ({
+			expect,
+		}) => {
+			writeWranglerConfig({ main: "./index.js" });
+			writeWorkerSource();
+			await expect(
+				runWrangler("versions upload --preview-alias 123abc")
+			).rejects.toThrow(
+				`Preview alias "123abc" is invalid. Aliases must start with a letter and contain only lowercase letters, numbers, and hyphens.`
+			);
+		});
+
 		it("annotations default to undefined when no flags provided", async ({
 			expect,
 		}) => {

--- a/packages/wrangler/src/deployment-bundle/merge-config-args.ts
+++ b/packages/wrangler/src/deployment-bundle/merge-config-args.ts
@@ -1,4 +1,9 @@
-import { generatePreviewAlias } from "@cloudflare/deploy-helpers";
+import {
+	ALIAS_VALIDATION_REGEX,
+	MAX_PREVIEW_ALIAS_LENGTH,
+	generatePreviewAlias,
+	sanitizeBranchName,
+} from "@cloudflare/deploy-helpers";
 import {
 	getCIGeneratePreviewAlias,
 	getCIOverrideName,
@@ -182,6 +187,23 @@ export async function mergeVersionsUploadConfigArgs(
 		(getCIGeneratePreviewAlias() === "true"
 			? generatePreviewAlias(shared.name ?? "")
 			: undefined);
+
+	if (args.previewAlias !== undefined) {
+		if (args.previewAlias.length > MAX_PREVIEW_ALIAS_LENGTH) {
+			throw new UserError(
+				`Preview alias "${args.previewAlias}" is too long (${args.previewAlias.length} characters). Aliases must be at most ${MAX_PREVIEW_ALIAS_LENGTH} characters.`,
+				{ telemetryMessage: true }
+			);
+		}
+		if (!ALIAS_VALIDATION_REGEX.test(args.previewAlias)) {
+			const suggestion = sanitizeBranchName(args.previewAlias);
+			throw new UserError(
+				`Preview alias "${args.previewAlias}" is invalid. Aliases must start with a letter and contain only lowercase letters, numbers, and hyphens.` +
+					(suggestion ? ` Did you mean "${suggestion}"?` : ""),
+				{ telemetryMessage: true }
+			);
+		}
+	}
 
 	return {
 		props: {

--- a/packages/wrangler/src/deployment-bundle/merge-config-args.ts
+++ b/packages/wrangler/src/deployment-bundle/merge-config-args.ts
@@ -200,7 +200,7 @@ export async function mergeVersionsUploadConfigArgs(
 			throw new UserError(
 				`Preview alias "${args.previewAlias}" is invalid. Aliases must start with a letter and contain only lowercase letters, numbers, and hyphens.` +
 					(suggestion ? ` Did you mean "${suggestion}"?` : ""),
-				{ telemetryMessage: true }
+				{ telemetryMessage: "versions upload preview alias invalid" }
 			);
 		}
 	}

--- a/packages/wrangler/src/deployment-bundle/merge-config-args.ts
+++ b/packages/wrangler/src/deployment-bundle/merge-config-args.ts
@@ -192,7 +192,7 @@ export async function mergeVersionsUploadConfigArgs(
 		if (args.previewAlias.length > MAX_PREVIEW_ALIAS_LENGTH) {
 			throw new UserError(
 				`Preview alias "${args.previewAlias}" is too long (${args.previewAlias.length} characters). Aliases must be at most ${MAX_PREVIEW_ALIAS_LENGTH} characters.`,
-				{ telemetryMessage: true }
+				{ telemetryMessage: "versions upload preview alias too long" }
 			);
 		}
 		if (!ALIAS_VALIDATION_REGEX.test(args.previewAlias)) {

--- a/packages/wrangler/src/deployment-bundle/merge-config-args.ts
+++ b/packages/wrangler/src/deployment-bundle/merge-config-args.ts
@@ -197,9 +197,14 @@ export async function mergeVersionsUploadConfigArgs(
 		}
 		if (!ALIAS_VALIDATION_REGEX.test(args.previewAlias)) {
 			const suggestion = sanitizeBranchName(args.previewAlias);
+			const validSuggestion =
+				suggestion !== args.previewAlias &&
+				ALIAS_VALIDATION_REGEX.test(suggestion)
+					? suggestion
+					: undefined;
 			throw new UserError(
 				`Preview alias "${args.previewAlias}" is invalid. Aliases must start with a letter and contain only lowercase letters, numbers, and hyphens.` +
-					(suggestion ? ` Did you mean "${suggestion}"?` : ""),
+					(validSuggestion ? ` Did you mean "${validSuggestion}"?` : ""),
 				{ telemetryMessage: "versions upload preview alias invalid" }
 			);
 		}


### PR DESCRIPTION
Fixes #14345.

Currently `wrangler versions upload --preview-alias <value>` passes the value through to the API without any client-side validation. When a user passes a branch name directly (e.g. `feature/my-feature`), they get an opaque API error rather than a clear message about why the value is invalid.

This PR adds client-side validation of manually-supplied preview aliases before the upload request is made:

- Rejects values that exceed 63 characters (DNS label limit) with a message showing the character count.
- Rejects values that don't match the `ALIAS_VALIDATION_REGEX` (`/^[a-z](?:[a-z0-9-]*[a-z0-9])?$/i`) with a clear message and a `Did you mean "..."?` suggestion built via `sanitizeBranchName`.
- Exports `ALIAS_VALIDATION_REGEX` and `MAX_PREVIEW_ALIAS_LENGTH` from `@cloudflare/deploy-helpers` so consumers share the same constants.

Auto-generated aliases (via `getCIGeneratePreviewAlias()`) are unaffected — those already go through `sanitizeBranchName` inside `generatePreviewAlias`.

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: error-message-only behaviour change, no new flags or APIs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->