### PR TITLE
make versions upload validation more on par with deploy

### DIFF
--- a/.changeset/consolidate-pre-upload-checks.md
+++ b/.changeset/consolidate-pre-upload-checks.md
@@ -1,0 +1,13 @@
+---
+"wrangler": minor
+---
+
+Add `--strict` flag to `wrangler versions upload` and improve pre-upload safety checks
+
+`wrangler versions upload` now runs the same pre-upload checks as `wrangler deploy`:
+
+- When the Worker was last edited via the Cloudflare Dashboard, the local and remote configurations are diffed and you are warned only if the diff is destructive (previously, an unconditional warning was shown).
+- When local configuration values conflict with remote secrets, a warning is shown before proceeding.
+- When deploying workflows that belong to a different Worker, a warning is shown before proceeding.
+
+The new `--strict` flag (already available on `wrangler deploy`) causes `wrangler versions upload` to abort in non-interactive/CI environments when any of these conflicts are detected, instead of auto-continuing.

--- a/.changeset/remote-secrets-override-name.md
+++ b/.changeset/remote-secrets-override-name.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix the remote secrets override check during deploy targeting the wrong Worker when `--name` is passed
+
+The check that warns when a config value would override an existing remote secret was using the Worker name from the config file rather than the resolved name. If you passed `--name <other-worker>`, the check ran against the config-file Worker name instead of the Worker actually being uploaded.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,19 +65,19 @@ This is the **Cloudflare Workers SDK** monorepo containing tools and libraries f
 
 ## WHERE TO LOOK
 
-| Task                                           | Location                                       | Notes                                                            |
-| ---------------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------- |
-| Add/modify a CLI command                       | `packages/wrangler/src/`                       | Commands registered in `src/index.ts` (2k+ line yargs tree)      |
-| Change local dev behavior                      | `packages/miniflare/src/`                      | `src/index.ts` is the main `Miniflare` class                     |
-| Modify Workers runtime simulation              | `packages/miniflare/src/workers/`              | ~30 embedded worker scripts, built via `worker:` virtual imports |
-| Add a test fixture                             | `fixtures/`                                    | Each fixture is a full workspace member with own `package.json`  |
-| Shared config types/validation                 | `packages/workers-utils/src/config/`           | `validation.ts` is the config normalizer (large file)            |
-| Test helpers (runInTempDir, seed, mockConsole) | `packages/workers-utils/src/test-helpers/`     | Shared across wrangler, miniflare, others                        |
-| Cloudflare API mocks for tests                 | `packages/wrangler/src/__tests__/helpers/msw/` | MSW handlers per API domain                                      |
-| CI workflows                                   | `.github/workflows/`                           | `test-and-check.yml` is the primary gate                         |
-| Build/deploy scripts                           | `tools/deployments/`                           | Validation + deployment helpers, run via `esbuild-register`      |
+| Task                                           | Location                                                              | Notes                                                                                                                                                                        |
+| ---------------------------------------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Add/modify a CLI command                       | `packages/wrangler/src/`                                              | Commands registered in `src/index.ts` (2k+ line yargs tree)                                                                                                                  |
+| Change local dev behavior                      | `packages/miniflare/src/`                                             | `src/index.ts` is the main `Miniflare` class                                                                                                                                 |
+| Modify Workers runtime simulation              | `packages/miniflare/src/workers/`                                     | ~30 embedded worker scripts, built via `worker:` virtual imports                                                                                                             |
+| Add a test fixture                             | `fixtures/`                                                           | Each fixture is a full workspace member with own `package.json`                                                                                                              |
+| Shared config types/validation                 | `packages/workers-utils/src/config/`                                  | `validation.ts` is the config normalizer (large file)                                                                                                                        |
+| Test helpers (runInTempDir, seed, mockConsole) | `packages/workers-utils/src/test-helpers/`                            | Shared across wrangler, miniflare, others                                                                                                                                    |
+| Cloudflare API mocks for tests                 | `packages/wrangler/src/__tests__/helpers/msw/`                        | MSW handlers per API domain                                                                                                                                                  |
+| CI workflows                                   | `.github/workflows/`                                                  | `test-and-check.yml` is the primary gate                                                                                                                                     |
+| Build/deploy scripts                           | `tools/deployments/`                                                  | Validation + deployment helpers, run via `esbuild-register`                                                                                                                  |
 | Deploy/versions-upload validation              | `packages/deploy-helpers/src/deploy/helpers/validate-worker-props.ts` | `validateWorkerProps()` for sync checks, `preUploadApiChecks()` for API checks (service metadata, config diff, secrets, workflows). All new pre-upload validation goes here. |
-| Changeset config and rules                     | `.changeset/README.md`                         | Must read before creating changesets                             |
+| Changeset config and rules                     | `.changeset/README.md`                                                | Must read before creating changesets                                                                                                                                         |
 
 ## Development Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ This is the **Cloudflare Workers SDK** monorepo containing tools and libraries f
 | Cloudflare API mocks for tests                 | `packages/wrangler/src/__tests__/helpers/msw/` | MSW handlers per API domain                                      |
 | CI workflows                                   | `.github/workflows/`                           | `test-and-check.yml` is the primary gate                         |
 | Build/deploy scripts                           | `tools/deployments/`                           | Validation + deployment helpers, run via `esbuild-register`      |
+| Deploy/versions-upload validation              | `packages/deploy-helpers/src/deploy/helpers/validate-worker-props.ts` | `validateWorkerProps()` for sync checks, `preUploadApiChecks()` for API checks (service metadata, config diff, secrets, workflows). All new pre-upload validation goes here. |
 | Changeset config and rules                     | `.changeset/README.md`                         | Must read before creating changesets                             |
 
 ## Development Guidelines

--- a/packages/deploy-helpers/src/deploy/deploy.ts
+++ b/packages/deploy-helpers/src/deploy/deploy.ts
@@ -135,20 +135,13 @@ export default async function deploy(
 	workerTag: string | null;
 	targets?: string[];
 }> {
-	const {
-		entry,
-		name,
-		compatibilityDate,
-		compatibilityFlags,
-		keepVars,
-		accountId,
-	} = props;
+	const { entry, compatibilityDate, compatibilityFlags, keepVars, accountId } =
+		props;
 
 	const assetsOptions = resolveAssetOptions(props, config);
 
 	// Any validation that does not require API calls should go in validateWorkerProps()
-	await validateWorkerProps({ ...props, assetsOptions }, config);
-	assert(name); // already validated inside validateWorkerProps, but TS can't see that
+	const { name } = validateWorkerProps({ ...props, assetsOptions }, config);
 
 	// any validation that DOES require API calls should go in preUploadApiChecks()
 	const { workerTag, tags, workerExists, aborted } = await preUploadApiChecks(

--- a/packages/deploy-helpers/src/deploy/deploy.ts
+++ b/packages/deploy-helpers/src/deploy/deploy.ts
@@ -6,7 +6,6 @@ import { cancel } from "@cloudflare/cli-shared-helpers";
 import { verifyDockerInstalled } from "@cloudflare/containers-shared";
 import {
 	APIError,
-	experimental_patchConfig,
 	formatTime,
 	getDockerPath,
 	parseNonHyphenedUuid,
@@ -14,7 +13,7 @@ import {
 	UserError,
 } from "@cloudflare/workers-utils";
 import { Response } from "undici";
-import { confirm, fetchResult, logger } from "../shared/context";
+import { fetchResult, logger } from "../shared/context";
 import { triggersDeploy } from "../triggers/deploy";
 import { ensureQueuesExistByConfig } from "../triggers/queue-consumers";
 import {
@@ -24,14 +23,9 @@ import {
 } from "./helpers/assets";
 import { getBindings } from "./helpers/binding-utils";
 import { printBundleSize } from "./helpers/bundle-reporter";
-import { checkRemoteSecretsOverride } from "./helpers/check-remote-secrets-override";
-import { checkWorkflowConflicts } from "./helpers/check-workflow-conflicts";
-import { getConfigPatch, getRemoteConfigDiff } from "./helpers/config-diffs";
 import { confirmLatestDeploymentOverwrite } from "./helpers/confirm-latest-deployment-overwrite";
 import { createWorkerUploadForm } from "./helpers/create-worker-upload-form";
-import { getDeployConfirmFunction } from "./helpers/deploy-confirm";
 import { deployWfpUserWorker } from "./helpers/deploy-wfp";
-import { downloadWorkerConfig } from "./helpers/download-worker-config";
 import { getMigrationsToUpload } from "./helpers/durable";
 import {
 	applyServiceAndEnvironmentTags,
@@ -52,12 +46,14 @@ import {
 	maybeRetrieveFileSourceMap,
 } from "./helpers/sourcemap";
 import { useServiceEnvironments as useServiceEnvironmentsConfig } from "./helpers/use-service-environments";
-import { validateWorkerProps } from "./helpers/validate-worker-props";
+import {
+	preUploadApiChecks,
+	validateWorkerProps,
+} from "./helpers/validate-worker-props";
 import {
 	createDeployment,
 	patchNonVersionedScriptSettings,
 } from "./helpers/versions-api";
-import { isWorkerNotFoundError } from "./helpers/worker-not-found-error";
 import { addWorkersSitesBindings } from "./helpers/workers-sites-bindings";
 import type { DeployProps, WorkerBuildResult } from "../shared/types";
 import type { RetrieveSourceMapFunction } from "./helpers/sourcemap";
@@ -76,7 +72,6 @@ import type {
 	ComplianceConfig,
 	Config,
 	LegacyAssetPaths,
-	RawConfig,
 } from "@cloudflare/workers-utils";
 import type { FormData } from "undici";
 
@@ -156,131 +151,15 @@ export default async function deploy(
 	await validateWorkerProps({ ...props, assetsOptions }, config);
 	assert(name); // already validated inside validateWorkerProps, but TS can't see that
 
-	const deployConfirm = getDeployConfirmFunction({
-		strictMode: props.strict,
-	});
-
 	// TODO: warn if git/hg has uncommitted changes
-	let workerTag: string | null = null;
 	let versionId: string | null = null;
-	let tags: string[] = []; // arbitrary metadata tags, not to be confused with script tag or annotations
 
-	let workerExists: boolean = true;
-
-	if (!props.dispatchNamespace && accountId) {
-		try {
-			const serviceMetaData = await fetchResult<{
-				default_environment: {
-					environment: string;
-					script: {
-						tag: string;
-						tags: string[] | null;
-						last_deployed_from: "dash" | "wrangler" | "api";
-					};
-				};
-			}>(config, `/accounts/${accountId}/workers/services/${name}`);
-			const {
-				default_environment: { script },
-			} = serviceMetaData;
-			workerTag = script.tag;
-			tags = script.tags ?? tags;
-
-			if (script.last_deployed_from === "dash") {
-				const remoteWorkerConfig = await downloadWorkerConfig(
-					name,
-					serviceMetaData.default_environment.environment,
-					entry.file,
-					accountId
-				);
-
-				const configDiff = getRemoteConfigDiff(remoteWorkerConfig, {
-					...config,
-					// We also want to include all the routes used for deployment
-					routes: props.routes,
-				});
-
-				// If there are only additive changes (or no changes at all) there should be no problem,
-				// just using the local config (and override the remote one) should be totally fine
-				if (!configDiff.nonDestructive) {
-					logger.warn(
-						"The local configuration being used (generated from your local configuration file) differs from the remote configuration of your Worker set via the Cloudflare Dashboard:" +
-							`\n${configDiff.diff}\n\n` +
-							"Deploying the Worker will override the remote configuration with your local one."
-					);
-					if (!(await deployConfirm("Would you like to continue?"))) {
-						if (
-							config.userConfigPath &&
-							/\.jsonc?$/.test(config.userConfigPath)
-						) {
-							if (
-								await confirm(
-									"Would you like to update the local config file with the remote values?",
-									{
-										defaultValue: true,
-										fallbackValue: true,
-									}
-								)
-							) {
-								const patchObj: RawConfig = getConfigPatch(
-									configDiff.diff,
-									props.env
-								);
-
-								experimental_patchConfig(
-									config.userConfigPath,
-									patchObj,
-									false
-								);
-							}
-						}
-
-						return { versionId, workerTag };
-					}
-				}
-			} else if (
-				script.last_deployed_from === "api" &&
-				!props.skipLastDeployedFromApiCheck
-			) {
-				logger.warn(
-					`You are about to publish a Workers Service that was last updated via the script API.\nEdits that have been made via the script API will be overridden by your local code and config.`
-				);
-				if (!(await deployConfirm("Would you like to continue?"))) {
-					return { versionId, workerTag };
-				}
-			}
-		} catch (e) {
-			if (isWorkerNotFoundError(e)) {
-				workerExists = false;
-			} else {
-				throw e;
-			}
-		}
-	}
-
-	if (accountId) {
-		const remoteSecretsCheck = await checkRemoteSecretsOverride(
-			config,
-			accountId,
-			props.env
-		);
-
-		if (remoteSecretsCheck?.override) {
-			logger.warn(remoteSecretsCheck.deployErrorMessage);
-			if (!(await deployConfirm("Would you like to continue?"))) {
-				return { versionId, workerTag };
-			}
-		}
-	}
-
-	if (accountId && config.workflows?.length) {
-		const workflowCheck = await checkWorkflowConflicts(config, accountId, name);
-
-		if (workflowCheck.hasConflicts) {
-			logger.warn(workflowCheck.message);
-			if (!(await deployConfirm("Do you want to continue?"))) {
-				return { versionId, workerTag };
-			}
-		}
+	const { workerTag, tags, workerExists, aborted } = await preUploadApiChecks(
+		props,
+		config
+	);
+	if (aborted) {
+		return { versionId, workerTag };
 	}
 
 	const scriptName = name;

--- a/packages/deploy-helpers/src/deploy/deploy.ts
+++ b/packages/deploy-helpers/src/deploy/deploy.ts
@@ -15,7 +15,6 @@ import {
 import { Response } from "undici";
 import { fetchResult, logger } from "../shared/context";
 import { triggersDeploy } from "../triggers/deploy";
-import { ensureQueuesExistByConfig } from "../triggers/queue-consumers";
 import {
 	buildAssetManifest,
 	resolveAssetOptions,
@@ -147,21 +146,21 @@ export default async function deploy(
 
 	const assetsOptions = resolveAssetOptions(props, config);
 
-	// All new validation should go in validateWorkerProps()
+	// Any validation that does not require API calls should go in validateWorkerProps()
 	await validateWorkerProps({ ...props, assetsOptions }, config);
 	assert(name); // already validated inside validateWorkerProps, but TS can't see that
 
-	// TODO: warn if git/hg has uncommitted changes
-	let versionId: string | null = null;
-
+	// any validation that DOES require API calls should go in preUploadApiChecks()
 	const { workerTag, tags, workerExists, aborted } = await preUploadApiChecks(
 		props,
 		config
 	);
+
 	if (aborted) {
-		return { versionId, workerTag };
+		return { versionId: null, workerTag };
 	}
 
+	let versionId: string | null = null;
 	const scriptName = name;
 
 	const envName = props.env ?? "production";
@@ -463,7 +462,6 @@ export default async function deploy(
 			}
 		);
 
-		await ensureQueuesExistByConfig(config, accountId);
 		let bindingsPrinted = false;
 
 		// Upload the script so it has time to propagate.

--- a/packages/deploy-helpers/src/deploy/helpers/check-remote-secrets-override.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/check-remote-secrets-override.ts
@@ -5,12 +5,11 @@ import type { Config } from "@cloudflare/workers-utils";
 
 export async function fetchSecrets(
 	config: Config,
+	scriptName: string,
 	accountId: string,
 	environment: string | undefined
 ): Promise<{ name: string; type: string }[]> {
 	const isServiceEnv = environment && useServiceEnvironments(config);
-
-	const scriptName = config.name;
 
 	const url = isServiceEnv
 		? `/accounts/${accountId}/workers/services/${scriptName}/environments/${environment}/secrets`
@@ -21,6 +20,7 @@ export async function fetchSecrets(
 
 export async function checkRemoteSecretsOverride(
 	config: Config,
+	scriptName: string,
 	accountId: string,
 	targetEnv: string | undefined
 ): Promise<
@@ -39,7 +39,12 @@ export async function checkRemoteSecretsOverride(
 		const secretNames = new Set<string>();
 
 		try {
-			const secrets = await fetchSecrets(config, accountId, targetEnv);
+			const secrets = await fetchSecrets(
+				config,
+				scriptName,
+				accountId,
+				targetEnv
+			);
 
 			for (const secret of secrets) {
 				secretNames.add(secret.name);

--- a/packages/deploy-helpers/src/deploy/helpers/deploy-confirm.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/deploy-confirm.ts
@@ -9,7 +9,7 @@ export function getDeployConfirmFunction(options: {
 	if (nonInteractive && strictMode) {
 		return async () => {
 			logger.error(
-				"Aborting the deployment operation because of conflicts. To override and deploy anyway remove the `--strict` flag"
+				"Aborting the upload operation because of conflicts. To override and upload anyway, remove the `--strict` flag"
 			);
 			process.exitCode = 1;
 			return false;

--- a/packages/deploy-helpers/src/deploy/helpers/validate-worker-props.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/validate-worker-props.ts
@@ -7,6 +7,7 @@ import {
 	UserError,
 } from "@cloudflare/workers-utils";
 import { confirm, fetchResult, logger } from "../../shared/context";
+import { ensureQueuesExistByConfig } from "../../triggers/queue-consumers";
 import { checkRemoteSecretsOverride } from "./check-remote-secrets-override";
 import { checkWorkflowConflicts } from "./check-workflow-conflicts";
 import { getConfigPatch, getRemoteConfigDiff } from "./config-diffs";
@@ -23,12 +24,15 @@ import type {
 } from "@cloudflare/workers-utils";
 
 /**
- * All validation of props (merged args and config) should go here,
- * and NOT inline in deploy() or versionsUpload()
+ *
+ * Any validation of props (merged args and config) that does not require API calls
+ * should go here, and NOT inline in deploy() or versionsUpload()
+ *
  * The order should be:
  * 1. generic validation checks
  * 2. deploy or versions upload specific checks
  * 3. checks that require making an API call
+ *
  */
 export async function validateWorkerProps(
 	props:
@@ -126,11 +130,17 @@ export type PreUploadApiChecksResult = {
 	aborted: boolean;
 };
 
+/**
+ *
+ * Any validation that requires API calls should go here.
+ * This is skipped on dry runs (for now)
+ */
 export async function preUploadApiChecks(
 	props: DeployProps | VersionsUploadProps,
 	config: Config
 ): Promise<PreUploadApiChecksResult> {
 	const { accountId, name } = props;
+
 	if (props.dryRun || !accountId || !name) {
 		return {
 			workerTag: null,
@@ -144,6 +154,7 @@ export async function preUploadApiChecks(
 		strictMode: props.strict,
 	});
 
+	// TODO: warn if git/hg has uncommitted changes
 	let workerTag: string | null = null;
 	let tags: string[] = []; // arbitrary metadata tags, not to be confused with script tag or annotations
 	let workerExists = true;
@@ -281,5 +292,6 @@ export async function preUploadApiChecks(
 		}
 	}
 
+	await ensureQueuesExistByConfig(config, accountId);
 	return { workerTag, tags, workerExists, aborted: false };
 }

--- a/packages/deploy-helpers/src/deploy/helpers/validate-worker-props.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/validate-worker-props.ts
@@ -252,7 +252,7 @@ export async function preUploadApiChecks(
 			if (isWorkerNotFoundError(e)) {
 				if (props.command === "versions upload") {
 					throw new UserError(
-						"You cannot upload a new version of a Worker that does not yet exist. Please use run the `deploy` command first.",
+						"You cannot upload a new version of a Worker that does not yet exist. Please run the `deploy` command first.",
 						{ telemetryMessage: "versions upload worker not found" }
 					);
 				}

--- a/packages/deploy-helpers/src/deploy/helpers/validate-worker-props.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/validate-worker-props.ts
@@ -31,8 +31,6 @@ import type {
  * The order should be:
  * 1. generic validation checks
  * 2. deploy or versions upload specific checks
- * 3. checks that require making an API call
- *
  */
 export async function validateWorkerProps(
 	props:
@@ -40,7 +38,7 @@ export async function validateWorkerProps(
 		| VersionsUploadProps,
 	config: Config
 ): Promise<void> {
-	const { name, dryRun, accountId, compatibilityDate } = props;
+	const { name, compatibilityDate } = props;
 	const { format } = props.entry;
 	if (!name) {
 		throw new UserError(
@@ -116,11 +114,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			);
 		}
 	}
-
-	if (!dryRun) {
-		assert(accountId, "Missing account ID");
-		await verifyWorkerMatchesCITag(config, accountId, name, config.configPath);
-	}
 }
 
 export type PreUploadApiChecksResult = {
@@ -149,6 +142,8 @@ export async function preUploadApiChecks(
 			aborted: false,
 		};
 	}
+
+	await verifyWorkerMatchesCITag(config, accountId, name, config.configPath);
 
 	const deployConfirm = getDeployConfirmFunction({
 		strictMode: props.strict,

--- a/packages/deploy-helpers/src/deploy/helpers/validate-worker-props.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/validate-worker-props.ts
@@ -1,15 +1,26 @@
 import assert from "node:assert";
 import {
 	configFileName,
+	experimental_patchConfig,
 	formatConfigSnippet,
 	getTodaysCompatDate,
 	UserError,
 } from "@cloudflare/workers-utils";
-import { logger } from "../../shared/context";
+import { confirm, fetchResult, logger } from "../../shared/context";
+import { checkRemoteSecretsOverride } from "./check-remote-secrets-override";
+import { checkWorkflowConflicts } from "./check-workflow-conflicts";
+import { getConfigPatch, getRemoteConfigDiff } from "./config-diffs";
+import { getDeployConfirmFunction } from "./deploy-confirm";
+import { downloadWorkerConfig } from "./download-worker-config";
 import { verifyWorkerMatchesCITag } from "./match-tag";
 import { validateRoutes } from "./validate-routes";
+import { isWorkerNotFoundError } from "./worker-not-found-error";
 import type { DeployProps, VersionsUploadProps } from "../../shared/types";
-import type { AssetsOptions, Config } from "@cloudflare/workers-utils";
+import type {
+	AssetsOptions,
+	Config,
+	RawConfig,
+} from "@cloudflare/workers-utils";
 
 /**
  * All validation of props (merged args and config) should go here,
@@ -97,7 +108,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 	} else {
 		if (config.containers && config.containers.length > 0) {
 			logger.warn(
-				`Your Worker has Containers configured. Container configuration changes (such as image, max_instances, etc.) will not be gradually rolled out with versions. These changes will only take effect after running \`wrangler deploy\`.`
+				`Your Worker has Containers configured. Container configuration changes (such as image, max_instances, etc.) will not be gradually rolled out with versions. These changes will only take effect after running \`deploy\`.`
 			);
 		}
 	}
@@ -106,4 +117,169 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		assert(accountId, "Missing account ID");
 		await verifyWorkerMatchesCITag(config, accountId, name, config.configPath);
 	}
+}
+
+export type PreUploadApiChecksResult = {
+	workerTag: string | null;
+	tags: string[];
+	workerExists: boolean;
+	aborted: boolean;
+};
+
+export async function preUploadApiChecks(
+	props: DeployProps | VersionsUploadProps,
+	config: Config
+): Promise<PreUploadApiChecksResult> {
+	const { accountId, name } = props;
+	if (props.dryRun || !accountId || !name) {
+		return {
+			workerTag: null,
+			tags: [],
+			workerExists: true,
+			aborted: false,
+		};
+	}
+
+	const deployConfirm = getDeployConfirmFunction({
+		strictMode: props.strict,
+	});
+
+	let workerTag: string | null = null;
+	let tags: string[] = []; // arbitrary metadata tags, not to be confused with script tag or annotations
+	let workerExists = true;
+
+	// Skip the service metadata fetch for dispatch namespace deploys (Workers for Platforms).
+	// Dispatch namespace scripts don't have standard service metadata.
+	const skipMetadataFetch =
+		props.command === "deploy" && !!props.dispatchNamespace;
+
+	if (!skipMetadataFetch) {
+		try {
+			const serviceMetaData = await fetchResult<{
+				default_environment: {
+					environment: string;
+					script: {
+						tag: string;
+						tags: string[] | null;
+						last_deployed_from: "dash" | "api";
+					};
+				};
+			}>(config, `/accounts/${accountId}/workers/services/${name}`);
+			const {
+				default_environment: { script },
+			} = serviceMetaData;
+			workerTag = script.tag;
+			tags = script.tags ?? tags;
+
+			if (script.last_deployed_from === "dash") {
+				const remoteWorkerConfig = await downloadWorkerConfig(
+					name,
+					serviceMetaData.default_environment.environment,
+					props.entry.file,
+					accountId
+				);
+
+				const configForDiff =
+					props.command === "deploy"
+						? {
+								...config,
+								// We also want to include all the routes used for deployment
+								routes: props.routes,
+							}
+						: config;
+
+				const configDiff = getRemoteConfigDiff(
+					remoteWorkerConfig,
+					configForDiff
+				);
+
+				// If there are only additive changes (or no changes at all) there should be no problem,
+				// just using the local config (and override the remote one) should be totally fine
+				if (!configDiff.nonDestructive) {
+					logger.warn(
+						"The local configuration being used (generated from your local configuration file) differs from the remote configuration of your Worker set via the Cloudflare Dashboard:" +
+							`\n${configDiff.diff}\n\n` +
+							"Uploading the Worker will override the remote configuration with your local one."
+					);
+					if (!(await deployConfirm("Would you like to continue?"))) {
+						if (
+							config.userConfigPath &&
+							/\.jsonc?$/.test(config.userConfigPath)
+						) {
+							if (
+								await confirm(
+									"Would you like to update the local config file with the remote values?",
+									{
+										defaultValue: true,
+										fallbackValue: true,
+									}
+								)
+							) {
+								const patchObj: RawConfig = getConfigPatch(
+									configDiff.diff,
+									props.env
+								);
+
+								experimental_patchConfig(
+									config.userConfigPath,
+									patchObj,
+									false
+								);
+							}
+						}
+
+						return { workerTag, tags, workerExists, aborted: true };
+					}
+				}
+			} else if (
+				script.last_deployed_from === "api" &&
+				!props.skipLastDeployedFromApiCheck
+			) {
+				logger.warn(
+					`You are about to upload a Worker that was last updated via the script API.\nEdits that have been made via the script API will be overridden by your local code and config.`
+				);
+				if (!(await deployConfirm("Would you like to continue?"))) {
+					return { workerTag, tags, workerExists, aborted: true };
+				}
+			}
+		} catch (e) {
+			if (isWorkerNotFoundError(e)) {
+				if (props.command === "versions upload") {
+					throw new UserError(
+						"You cannot upload a new version of a Worker that does not yet exist. Please use run the `deploy` command first.",
+						{ telemetryMessage: "versions upload worker not found" }
+					);
+				}
+				workerExists = false;
+			} else {
+				throw e;
+			}
+		}
+	}
+
+	const remoteSecretsCheck = await checkRemoteSecretsOverride(
+		config,
+		accountId,
+		props.env
+	);
+
+	if (remoteSecretsCheck?.override) {
+		logger.warn(remoteSecretsCheck.deployErrorMessage);
+		if (!(await deployConfirm("Would you like to continue?"))) {
+			return { workerTag, tags, workerExists, aborted: true };
+		}
+	}
+
+	if (config.workflows?.length) {
+		const workflowCheck = await checkWorkflowConflicts(config, accountId, name);
+
+		if (workflowCheck.hasConflicts) {
+			logger.warn(workflowCheck.message);
+			if (!(await deployConfirm("Do you want to continue?"))) {
+				return { workerTag, tags, workerExists, aborted: true };
+			}
+		}
+	}
+
+	return { workerTag, tags, workerExists, aborted: false };
 }

--- a/packages/deploy-helpers/src/deploy/helpers/validate-worker-props.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/validate-worker-props.ts
@@ -6,7 +6,12 @@ import {
 	getTodaysCompatDate,
 	UserError,
 } from "@cloudflare/workers-utils";
-import { confirm, fetchResult, logger } from "../../shared/context";
+import {
+	confirm,
+	fetchResult,
+	isNonInteractiveOrCI,
+	logger,
+} from "../../shared/context";
 import { ensureQueuesExistByConfig } from "../../triggers/queue-consumers";
 import { checkRemoteSecretsOverride } from "./check-remote-secrets-override";
 import { checkWorkflowConflicts } from "./check-workflow-conflicts";
@@ -209,29 +214,25 @@ export async function preUploadApiChecks(
 					);
 					if (!(await deployConfirm("Would you like to continue?"))) {
 						if (
+							// only patch if json/jsonc
 							config.userConfigPath &&
-							/\.jsonc?$/.test(config.userConfigPath)
+							/\.jsonc?$/.test(config.userConfigPath) &&
+							// skip the patch if we're in non-interactive mode and strict
+							!(props.strict && isNonInteractiveOrCI()) &&
+							(await confirm(
+								"Would you like to update the local config file with the remote values?",
+								{
+									defaultValue: true,
+									fallbackValue: true,
+								}
+							))
 						) {
-							if (
-								await confirm(
-									"Would you like to update the local config file with the remote values?",
-									{
-										defaultValue: true,
-										fallbackValue: true,
-									}
-								)
-							) {
-								const patchObj: RawConfig = getConfigPatch(
-									configDiff.diff,
-									props.env
-								);
+							const patchObj: RawConfig = getConfigPatch(
+								configDiff.diff,
+								props.env
+							);
 
-								experimental_patchConfig(
-									config.userConfigPath,
-									patchObj,
-									false
-								);
-							}
+							experimental_patchConfig(config.userConfigPath, patchObj, false);
 						}
 
 						return { workerTag, tags, workerExists, aborted: true };
@@ -265,6 +266,7 @@ export async function preUploadApiChecks(
 
 	const remoteSecretsCheck = await checkRemoteSecretsOverride(
 		config,
+		name,
 		accountId,
 		props.env
 	);

--- a/packages/deploy-helpers/src/deploy/helpers/validate-worker-props.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/validate-worker-props.ts
@@ -37,12 +37,14 @@ import type {
  * 1. generic validation checks
  * 2. deploy or versions upload specific checks
  */
-export async function validateWorkerProps(
-	props:
-		| (DeployProps & { assetsOptions?: AssetsOptions })
-		| VersionsUploadProps,
+type ValidateWorkerPropsInput =
+	| (DeployProps & { assetsOptions?: AssetsOptions })
+	| VersionsUploadProps;
+
+export function validateWorkerProps<T extends ValidateWorkerPropsInput>(
+	props: T,
 	config: Config
-): Promise<void> {
+): T & { name: string } {
 	const { name, compatibilityDate } = props;
 	const { format } = props.entry;
 	if (!name) {
@@ -119,6 +121,8 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			);
 		}
 	}
+
+	return { ...props, name };
 }
 
 export type PreUploadApiChecksResult = {

--- a/packages/deploy-helpers/src/deploy/versions-upload.ts
+++ b/packages/deploy-helpers/src/deploy/versions-upload.ts
@@ -9,7 +9,6 @@ import {
 } from "@cloudflare/workers-utils";
 import { Response } from "undici";
 import { fetchResult, logger } from "../shared/context";
-import { ensureQueuesExistByConfig } from "../triggers/queue-consumers";
 import { getWorkersDevSubdomain } from "../triggers/subdomain";
 import { resolveAssetOptions, syncAssets } from "./helpers/assets";
 import { getBindings } from "./helpers/binding-utils";
@@ -70,17 +69,17 @@ export default async function versionsUpload(
 
 	const assetsOptions = resolveAssetOptions(props, config);
 
-	// All new validation should go in validateWorkerProps()
+	// Any validation that does not require API calls should go in validateWorkerProps()
 	await validateWorkerProps(props, config);
 	assert(name); // already validated inside validateWorkerProps, but TS can't see that
 
-	let versionId: string | null = null;
-
+	// any validation that DOES require API calls should go in preUploadApiChecks()
 	const { workerTag, tags, aborted } = await preUploadApiChecks(props, config);
 	if (aborted) {
-		return { versionId, workerTag };
+		return { versionId: null, workerTag };
 	}
 
+	let versionId: string | null = null;
 	const scriptName = name;
 
 	const start = Date.now();
@@ -228,7 +227,6 @@ export default async function versionsUpload(
 			unsafe: config.unsafe,
 		});
 
-		await ensureQueuesExistByConfig(config, accountId);
 		let bindingsPrinted = false;
 
 		// Upload the version.

--- a/packages/deploy-helpers/src/deploy/versions-upload.ts
+++ b/packages/deploy-helpers/src/deploy/versions-upload.ts
@@ -8,7 +8,7 @@ import {
 	retryOnAPIFailure,
 } from "@cloudflare/workers-utils";
 import { Response } from "undici";
-import { confirm, fetchResult, logger } from "../shared/context";
+import { fetchResult, logger } from "../shared/context";
 import { ensureQueuesExistByConfig } from "../triggers/queue-consumers";
 import { getWorkersDevSubdomain } from "../triggers/subdomain";
 import { resolveAssetOptions, syncAssets } from "./helpers/assets";
@@ -35,9 +35,11 @@ import {
 	maybeRetrieveFileSourceMap,
 } from "./helpers/sourcemap";
 import { useServiceEnvironments as useServiceEnvironmentsConfig } from "./helpers/use-service-environments";
-import { validateWorkerProps } from "./helpers/validate-worker-props";
+import {
+	preUploadApiChecks,
+	validateWorkerProps,
+} from "./helpers/validate-worker-props";
 import { patchNonVersionedScriptSettings } from "./helpers/versions-api";
-import { isWorkerNotFoundError } from "./helpers/worker-not-found-error";
 import type { VersionsUploadProps, WorkerBuildResult } from "../shared/types";
 import type { DeployCallbacks } from "./deploy";
 import type { RetrieveSourceMapFunction } from "./helpers/sourcemap";
@@ -73,58 +75,10 @@ export default async function versionsUpload(
 	assert(name); // already validated inside validateWorkerProps, but TS can't see that
 
 	let versionId: string | null = null;
-	let workerTag: string | null = null;
-	let tags: string[] = []; // arbitrary metadata tags, not to be confused with script tag or annotations
 
-	if (accountId) {
-		try {
-			const {
-				default_environment: { script },
-			} = await fetchResult<{
-				default_environment: {
-					script: {
-						tag: string;
-						tags: string[] | null;
-						last_deployed_from: "dash" | "wrangler" | "api";
-					};
-				};
-			}>(
-				config,
-				`/accounts/${accountId}/workers/services/${name}` // TODO(consider): should this be a /versions endpoint?
-			);
-
-			workerTag = script.tag;
-			tags = script.tags ?? tags;
-
-			if (script.last_deployed_from === "dash") {
-				logger.warn(
-					`You are about to upload a Worker Version that was last published via the Cloudflare Dashboard.\nEdits that have been made via the dashboard will be overridden by your local code and config.`
-				);
-				if (!(await confirm("Would you like to continue?"))) {
-					return {
-						versionId,
-						workerTag,
-					};
-				}
-			} else if (
-				script.last_deployed_from === "api" &&
-				!props.skipLastDeployedFromApiCheck
-			) {
-				logger.warn(
-					`You are about to upload a Workers Version that was last updated via the API.\nEdits that have been made via the API will be overridden by your local code and config.`
-				);
-				if (!(await confirm("Would you like to continue?"))) {
-					return {
-						versionId,
-						workerTag,
-					};
-				}
-			}
-		} catch (e) {
-			if (!isWorkerNotFoundError(e)) {
-				throw e;
-			}
-		}
+	const { workerTag, tags, aborted } = await preUploadApiChecks(props, config);
+	if (aborted) {
+		return { versionId, workerTag };
 	}
 
 	const scriptName = name;

--- a/packages/deploy-helpers/src/deploy/versions-upload.ts
+++ b/packages/deploy-helpers/src/deploy/versions-upload.ts
@@ -58,20 +58,13 @@ export default async function versionsUpload(
 	versionPreviewUrl?: string | undefined;
 	versionPreviewAliasUrl?: string | undefined;
 }> {
-	const {
-		entry,
-		name,
-		compatibilityDate,
-		compatibilityFlags,
-		keepVars,
-		accountId,
-	} = props;
+	const { entry, compatibilityDate, compatibilityFlags, keepVars, accountId } =
+		props;
 
 	const assetsOptions = resolveAssetOptions(props, config);
 
 	// Any validation that does not require API calls should go in validateWorkerProps()
-	await validateWorkerProps(props, config);
-	assert(name); // already validated inside validateWorkerProps, but TS can't see that
+	const { name } = validateWorkerProps(props, config);
 
 	// any validation that DOES require API calls should go in preUploadApiChecks()
 	const { workerTag, tags, aborted } = await preUploadApiChecks(props, config);

--- a/packages/deploy-helpers/src/shared/types.ts
+++ b/packages/deploy-helpers/src/shared/types.ts
@@ -110,6 +110,8 @@ export type SharedDeployVersionsProps = {
 	skipProvisioningConfigWriteback: boolean;
 	/** temporary hack - cf is not yet a recognised deploy source, so any deploys from cf comes back normalised to 'api'*/
 	skipLastDeployedFromApiCheck: boolean;
+	/** From --strict arg. In strict mode, conflicting pre-upload checks abort instead of auto-continuing. */
+	strict: boolean;
 };
 
 export type DeployProps = SharedDeployVersionsProps & {
@@ -125,8 +127,6 @@ export type DeployProps = SharedDeployVersionsProps & {
 	logpush: boolean | undefined;
 	/** From --dispatch-namespace arg. Deploy-only (Workers for Platforms). */
 	dispatchNamespace: string | undefined;
-	/** From --strict arg. Deploy-only. */
-	strict: boolean;
 	/** From --old-asset-ttl arg. Deploy-only. */
 	oldAssetTtl: number | undefined;
 	/** From --containers-rollout arg. Deploy-only. */

--- a/packages/wrangler/src/__tests__/deploy/check-remote-secrets-override.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/check-remote-secrets-override.test.ts
@@ -22,10 +22,13 @@ async function runCheckRemoteSecretsOverride(
 	remoteSecrets: string[]
 ): ReturnType<typeof checkRemoteSecretsOverride> {
 	mockSecrets(remoteSecrets);
-	return checkRemoteSecretsOverride({
-		...config,
-		name: "test-script",
-	} as Config);
+	return checkRemoteSecretsOverride(
+		{
+			...config,
+			name: "test-script",
+		} as Config,
+		"test-script"
+	);
 }
 
 describe("checkRemoteSecretsOverride", () => {

--- a/packages/wrangler/src/__tests__/deploy/config-args-merging.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/config-args-merging.test.ts
@@ -176,6 +176,13 @@ describe.each([
 			setImmediate(fn);
 		});
 		setIsTTY(false);
+		// Mock the secrets endpoint that checkRemoteSecretsOverride calls
+		msw.use(
+			http.get(
+				"*/accounts/:accountId/workers/scripts/:scriptName/secrets",
+				() => HttpResponse.json(createFetchResult([]))
+			)
+		);
 	});
 
 	afterEach(() => {

--- a/packages/wrangler/src/__tests__/deploy/config-remote.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/config-remote.test.ts
@@ -483,11 +483,11 @@ describe("deploy", () => {
 				await runWrangler("deploy ./index --strict");
 
 				expect(std.warn).toMatchInlineSnapshot(`
-				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mYou are about to upload a Worker that was last updated via the script API.[0m
+					"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mYou are about to upload a Worker that was last updated via the script API.[0m
 
-				  Edits that have been made via the script API will be overridden by your local code and config.
+					  Edits that have been made via the script API will be overridden by your local code and config.
 
-				"
+					"
 				`);
 				expect(std.err).toMatchInlineSnapshot(`
 					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mAborting the upload operation because of conflicts. To override and upload anyway, remove the \`--strict\` flag[0m

--- a/packages/wrangler/src/__tests__/deploy/config-remote.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/config-remote.test.ts
@@ -194,7 +194,7 @@ describe("deploy", () => {
 				   }
 
 
-				  Deploying the Worker will override the remote configuration with your local one.
+				  Uploading the Worker will override the remote configuration with your local one.
 
 				"
 			`);
@@ -293,7 +293,7 @@ describe("deploy", () => {
 				   }
 
 
-				  Deploying the Worker will override the remote configuration with your local one.
+				  Uploading the Worker will override the remote configuration with your local one.
 
 				"
 			`);
@@ -374,7 +374,7 @@ describe("deploy", () => {
 				   }
 
 
-				  Deploying the Worker will override the remote configuration with your local one.
+				  Uploading the Worker will override the remote configuration with your local one.
 
 				"
 			`);
@@ -454,13 +454,13 @@ describe("deploy", () => {
 					   }
 
 
-					  Deploying the Worker will override the remote configuration with your local one.
+					  Uploading the Worker will override the remote configuration with your local one.
 
 					"
 				`);
 
 				expect(std.err).toMatchInlineSnapshot(`
-					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mAborting the deployment operation because of conflicts. To override and deploy anyway remove the \`--strict\` flag[0m
+					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mAborting the upload operation because of conflicts. To override and upload anyway, remove the \`--strict\` flag[0m
 
 					"
 				`);
@@ -483,14 +483,14 @@ describe("deploy", () => {
 				await runWrangler("deploy ./index --strict");
 
 				expect(std.warn).toMatchInlineSnapshot(`
-				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mYou are about to publish a Workers Service that was last updated via the script API.[0m
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mYou are about to upload a Worker that was last updated via the script API.[0m
 
 				  Edits that have been made via the script API will be overridden by your local code and config.
 
 				"
 				`);
 				expect(std.err).toMatchInlineSnapshot(`
-					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mAborting the deployment operation because of conflicts. To override and deploy anyway remove the \`--strict\` flag[0m
+					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mAborting the upload operation because of conflicts. To override and upload anyway, remove the \`--strict\` flag[0m
 
 					"
 				`);
@@ -705,7 +705,7 @@ describe("deploy", () => {
 			`);
 
 			expect(std.err).toMatchInlineSnapshot(`
-				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mAborting the deployment operation because of conflicts. To override and deploy anyway remove the \`--strict\` flag[0m
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mAborting the upload operation because of conflicts. To override and upload anyway, remove the \`--strict\` flag[0m
 
 				"
 			`);

--- a/packages/wrangler/src/__tests__/deploy/core.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/core.test.ts
@@ -1652,7 +1652,7 @@ describe("deploy", () => {
 			await runWrangler("deploy ./index");
 
 			expect(std.warn).toMatchInlineSnapshot(`
-			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mYou are about to publish a Workers Service that was last updated via the script API.[0m
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mYou are about to upload a Worker that was last updated via the script API.[0m
 
 			  Edits that have been made via the script API will be overridden by your local code and config.
 

--- a/packages/wrangler/src/__tests__/deploy/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/workflows.test.ts
@@ -1265,12 +1265,20 @@ describe("deploy", () => {
 
 				await runWrangler("deploy --strict");
 
-				expect(std.warn).toContain(
-					"already exist and belong to different workers"
-				);
-				expect(std.err).toContain(
-					"Aborting the deployment operation because of conflicts"
-				);
+				expect(std.warn).toMatchInlineSnapshot(`
+					"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe following workflow(s) already exist and belong to different workers:[0m
+
+					    - "my-workflow" (currently belongs to "other-worker")
+
+					  Deploying will reassign these workflows to "test-name".
+
+					"
+				`);
+				expect(std.err).toMatchInlineSnapshot(`
+					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mAborting the deployment operation because of conflicts. To override and deploy anyway remove the \`--strict\` flag[0m
+
+					"
+				`);
 				expect(std.out).not.toContain("Uploaded");
 				expect(process.exitCode).not.toBe(0);
 			});

--- a/packages/wrangler/src/__tests__/deploy/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/workflows.test.ts
@@ -1270,7 +1270,8 @@ describe("deploy", () => {
 
 					    - "my-workflow" (currently belongs to "other-worker")
 
-					  Deploying will reassign these workflows to "test-name".
+					  Deploying will reassign these workflows to "test-name". Workflow names must be unique per account.
+					  If this reassignment is unintended, rename the workflow(s) in the Wrangler config.
 
 					"
 				`);

--- a/packages/wrangler/src/__tests__/deploy/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/workflows.test.ts
@@ -1275,7 +1275,7 @@ describe("deploy", () => {
 					"
 				`);
 				expect(std.err).toMatchInlineSnapshot(`
-					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mAborting the deployment operation because of conflicts. To override and deploy anyway remove the \`--strict\` flag[0m
+					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mAborting the upload operation because of conflicts. To override and upload anyway, remove the \`--strict\` flag[0m
 
 					"
 				`);

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -136,6 +136,60 @@ describe("versions upload", () => {
 		) as WorkerMetadata;
 	}
 
+	beforeEach(() => {
+		// Mock the secrets endpoint that checkRemoteSecretsOverride calls
+		msw.use(
+			http.get(
+				"*/accounts/:accountId/workers/scripts/:scriptName/secrets",
+				() => HttpResponse.json(createFetchResult([]))
+			)
+		);
+	});
+
+	/**
+	 * Mocks the 6 endpoints that downloadWorkerConfig calls when
+	 * last_deployed_from === "dash". The remote config matches a minimal
+	 * local wrangler config so the diff is non-destructive by default.
+	 * Pass `remoteBindings` to create a destructive diff.
+	 */
+	function mockRemoteWorkerConfig(remoteBindings: unknown[] = []) {
+		msw.use(
+			http.get(
+				"*/accounts/:accountId/workers/services/:serviceName/environments/:env/bindings",
+				() => HttpResponse.json(createFetchResult(remoteBindings))
+			),
+			http.get(
+				"*/accounts/:accountId/workers/services/:serviceName/environments/:env/routes",
+				() => HttpResponse.json(createFetchResult([]))
+			),
+			http.get("*/accounts/:accountId/workers/domains/records", () =>
+				HttpResponse.json(createFetchResult([]))
+			),
+			http.get(
+				"*/accounts/:accountId/workers/services/:serviceName/environments/:env/subdomain",
+				() =>
+					HttpResponse.json(
+						createFetchResult({ enabled: false, previews_enabled: false })
+					)
+			),
+			http.get(
+				"*/accounts/:accountId/workers/services/:serviceName/environments/:env",
+				() =>
+					HttpResponse.json(
+						createFetchResult({
+							script: {
+								compatibility_date: "2024-01-01",
+							},
+						})
+					)
+			),
+			http.get(
+				"*/accounts/:accountId/workers/scripts/:workerName/schedules",
+				() => HttpResponse.json(createFetchResult({ schedules: [] }))
+			)
+		);
+	}
+
 	describe("with --temporary", () => {
 		mockAccountId({ accountId: null });
 		mockApiToken({ apiToken: null });
@@ -1318,11 +1372,12 @@ describe("versions upload", () => {
 			setIsTTY(true);
 		});
 
-		test("should warn when worker was last deployed from dashboard", async ({
+		test("should warn when worker was last deployed from dashboard with destructive config diff", async ({
 			expect,
 		}) => {
 			mockGetScript({
 				default_environment: {
+					environment: "production",
 					script: {
 						last_deployed_from: "dash",
 						tag: "test-tag",
@@ -1330,6 +1385,10 @@ describe("versions upload", () => {
 					},
 				},
 			});
+			// Remote config has a binding that local config does not — destructive diff
+			mockRemoteWorkerConfig([
+				{ name: "REMOTE_VAR", text: "remote-value", type: "plain_text" },
+			]);
 			mockUploadVersion(false);
 
 			writeWranglerConfig({
@@ -1346,7 +1405,7 @@ describe("versions upload", () => {
 			await runWrangler("versions upload");
 
 			expect(std.warn).toContain(
-				"You are about to upload a Worker Version that was last published via the Cloudflare Dashboard"
+				"Uploading the Worker will override the remote configuration with your local one."
 			);
 		});
 
@@ -1378,7 +1437,7 @@ describe("versions upload", () => {
 			await runWrangler("versions upload");
 
 			expect(std.warn).toContain(
-				"You are about to upload a Workers Version that was last updated via the API"
+				"You are about to upload a Worker that was last updated via the script API"
 			);
 		});
 
@@ -1387,6 +1446,7 @@ describe("versions upload", () => {
 		}) => {
 			mockGetScript({
 				default_environment: {
+					environment: "production",
 					script: {
 						last_deployed_from: "dash",
 						tag: "test-tag",
@@ -1394,6 +1454,10 @@ describe("versions upload", () => {
 					},
 				},
 			});
+			// Remote config has a binding that local config does not — destructive diff
+			mockRemoteWorkerConfig([
+				{ name: "REMOTE_VAR", text: "remote-value", type: "plain_text" },
+			]);
 
 			writeWranglerConfig({
 				name: "test-name",
@@ -1412,7 +1476,7 @@ describe("versions upload", () => {
 			expect(std.out).not.toContain("Uploaded");
 		});
 
-		test("should handle worker not found gracefully (new worker)", async ({
+		test("should error when worker not found (must deploy first)", async ({
 			expect,
 		}) => {
 			// Mock a 404 for the service lookup
@@ -1432,6 +1496,41 @@ describe("versions upload", () => {
 					{ once: true }
 				)
 			);
+
+			writeWranglerConfig({
+				name: "test-name",
+				main: "./index.js",
+			});
+			writeWorkerSource();
+
+			await expect(runWrangler("versions upload")).rejects.toThrow(
+				"You cannot upload a new version of a Worker that does not yet exist. Please use `wrangler deploy` to create your Worker before using `wrangler versions upload`."
+			);
+		});
+	});
+
+	describe("non-interactive/CI behavior", () => {
+		beforeEach(() => {
+			setIsTTY(false);
+		});
+
+		test("should continue without prompting in non-interactive mode when last deployed from dashboard", async ({
+			expect,
+		}) => {
+			mockGetScript({
+				default_environment: {
+					environment: "production",
+					script: {
+						last_deployed_from: "dash",
+						tag: "test-tag",
+						tags: null,
+					},
+				},
+			});
+			// Remote config has a destructive diff to exercise the warning path
+			mockRemoteWorkerConfig([
+				{ name: "REMOTE_VAR", text: "remote-value", type: "plain_text" },
+			]);
 			mockUploadVersion(false);
 
 			writeWranglerConfig({
@@ -1442,7 +1541,167 @@ describe("versions upload", () => {
 
 			await runWrangler("versions upload");
 
+			// Should upload successfully without prompting (auto-continues in CI)
 			expect(std.out).toContain("Uploaded test-name");
+		});
+
+		test("should continue without prompting in non-interactive mode when last deployed from API", async ({
+			expect,
+		}) => {
+			mockGetScript({
+				default_environment: {
+					script: {
+						last_deployed_from: "api",
+						tag: "test-tag",
+						tags: null,
+					},
+				},
+			});
+			mockUploadVersion(false);
+
+			writeWranglerConfig({
+				name: "test-name",
+				main: "./index.js",
+			});
+			writeWorkerSource();
+
+			await runWrangler("versions upload");
+
+			// Should upload successfully without prompting
+			expect(std.out).toContain("Uploaded test-name");
+		});
+
+		test("should error when worker not found in non-interactive mode", async ({
+			expect,
+		}) => {
+			// Mock a 404 for the service lookup
+			msw.use(
+				http.get(
+					`*/accounts/:accountId/workers/services/:scriptName`,
+					() => {
+						return HttpResponse.json(
+							createFetchResult(null, false, [
+								{
+									code: 10090,
+									message: "workers.api.error.service_not_found",
+								},
+							])
+						);
+					},
+					{ once: true }
+				)
+			);
+
+			writeWranglerConfig({
+				name: "test-name",
+				main: "./index.js",
+			});
+			writeWorkerSource();
+
+			await expect(runWrangler("versions upload")).rejects.toThrow(
+				"You cannot upload a new version of a Worker that does not yet exist. Please use `wrangler deploy` to create your Worker before using `wrangler versions upload`."
+			);
+		});
+
+		test("should abort in non-interactive strict mode when last deployed from API", async ({
+			expect,
+		}) => {
+			mockGetScript({
+				default_environment: {
+					script: {
+						last_deployed_from: "api",
+						tag: "test-tag",
+						tags: null,
+					},
+				},
+			});
+
+			writeWranglerConfig({
+				name: "test-name",
+				main: "./index.js",
+			});
+			writeWorkerSource();
+
+			await runWrangler("versions upload --strict");
+
+			expect(std.warn).toContain(
+				"You are about to upload a Worker that was last updated via the script API"
+			);
+			expect(std.err).toContain(
+				"Aborting the upload operation because of conflicts"
+			);
+			expect(std.out).not.toContain("Uploaded");
+			expect(process.exitCode).not.toBe(0);
+		});
+
+		test("should abort in non-interactive strict mode when dashboard config has destructive diff", async ({
+			expect,
+		}) => {
+			mockGetScript({
+				default_environment: {
+					environment: "production",
+					script: {
+						last_deployed_from: "dash",
+						tag: "test-tag",
+						tags: null,
+					},
+				},
+			});
+			// Remote config has a binding that local config does not — destructive diff
+			mockRemoteWorkerConfig([
+				{ name: "REMOTE_VAR", text: "remote-value", type: "plain_text" },
+			]);
+
+			writeWranglerConfig({
+				name: "test-name",
+				main: "./index.js",
+			});
+			writeWorkerSource();
+
+			await runWrangler("versions upload --strict");
+
+			expect(std.warn).toContain(
+				"Uploading the Worker will override the remote configuration with your local one."
+			);
+			expect(std.err).toContain(
+				"Aborting the upload operation because of conflicts"
+			);
+			expect(std.out).not.toContain("Uploaded");
+			expect(process.exitCode).not.toBe(0);
+		});
+
+		test("should abort in non-interactive strict mode when remote secrets would be overridden", async ({
+			expect,
+		}) => {
+			mockGetScript();
+
+			// Override default secrets mock to return a secret that conflicts with a local var
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/workers/scripts/:scriptName/secrets",
+					() =>
+						HttpResponse.json(
+							createFetchResult([{ name: "MY_VAR", type: "secret_text" }])
+						),
+					{ once: true }
+				)
+			);
+
+			writeWranglerConfig({
+				name: "test-name",
+				main: "./index.js",
+				vars: { MY_VAR: "not-a-secret" },
+			});
+			writeWorkerSource();
+
+			await runWrangler("versions upload --strict");
+
+			expect(std.warn).toContain("conflict");
+			expect(std.err).toContain(
+				"Aborting the upload operation because of conflicts"
+			);
+			expect(std.out).not.toContain("Uploaded");
+			expect(process.exitCode).not.toBe(0);
 		});
 	});
 

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -1504,7 +1504,7 @@ describe("versions upload", () => {
 			writeWorkerSource();
 
 			await expect(runWrangler("versions upload")).rejects.toThrow(
-				"You cannot upload a new version of a Worker that does not yet exist. Please use `wrangler deploy` to create your Worker before using `wrangler versions upload`."
+				"You cannot upload a new version of a Worker that does not yet exist. Please run the `deploy` command first."
 			);
 		});
 	});
@@ -1512,6 +1512,7 @@ describe("versions upload", () => {
 	describe("non-interactive/CI behavior", () => {
 		beforeEach(() => {
 			setIsTTY(false);
+			vi.stubEnv("CI", "true");
 		});
 
 		test("should continue without prompting in non-interactive mode when last deployed from dashboard", async ({
@@ -1599,7 +1600,7 @@ describe("versions upload", () => {
 			writeWorkerSource();
 
 			await expect(runWrangler("versions upload")).rejects.toThrow(
-				"You cannot upload a new version of a Worker that does not yet exist. Please use `wrangler deploy` to create your Worker before using `wrangler versions upload`."
+				"You cannot upload a new version of a Worker that does not yet exist. Please run the `deploy` command first."
 			);
 		});
 

--- a/packages/wrangler/src/deploy/check-remote-secrets-override.ts
+++ b/packages/wrangler/src/deploy/check-remote-secrets-override.ts
@@ -4,8 +4,14 @@ import type { Config } from "@cloudflare/workers-utils";
 
 export async function checkRemoteSecretsOverride(
 	config: Config,
+	scriptName: string,
 	targetEnv?: string
 ) {
 	const accountId = await requireAuth(config);
-	return checkRemoteSecretsOverrideBase(config, accountId, targetEnv);
+	return checkRemoteSecretsOverrideBase(
+		config,
+		scriptName,
+		accountId,
+		targetEnv
+	);
 }

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -84,12 +84,6 @@ export const deployCommand = createCommand({
 				"Rollout strategy for Containers changes. If set to immediate, it will override `rollout_percentage_steps` if configured and roll out to 100% of instances in one step. If set to none, the Worker will be deployed without building or updating any Containers.",
 			choices: ["immediate", "gradual", "none"] as const,
 		},
-		strict: {
-			describe:
-				"Enables strict mode for the deploy command, this prevents deployments to occur when there are even small potential risks.",
-			type: "boolean",
-			default: false,
-		},
 		autoconfig: {
 			describe:
 				"Enables framework detection and automatic configuration when deploying",

--- a/packages/wrangler/src/deployment-bundle/deploy-args.ts
+++ b/packages/wrangler/src/deployment-bundle/deploy-args.ts
@@ -185,6 +185,12 @@ export const sharedDeployVersionsArgs = {
 		hidden: true,
 		alias: ["x-deploy-helpers"],
 	},
+	strict: {
+		describe:
+			"Enables strict mode, which prevents uploads when there are conflicting remote changes.",
+		type: "boolean",
+		default: false,
+	},
 } as const satisfies NamedArgDefinitions;
 
 /**

--- a/packages/wrangler/src/deployment-bundle/merge-config-args.ts
+++ b/packages/wrangler/src/deployment-bundle/merge-config-args.ts
@@ -97,6 +97,7 @@ async function mergeSharedConfigArgs(
 		resourcesProvision: getFlag("RESOURCES_PROVISION") ?? false,
 		skipProvisioningConfigWriteback: false,
 		skipLastDeployedFromApiCheck: false,
+		strict: args.strict ?? false,
 	};
 
 	const buildProps: BuildProps = {
@@ -152,7 +153,6 @@ export async function mergeDeployConfigArgs(
 			routes: [...routes, ...domainRoutes],
 			logpush: args.logpush !== undefined ? args.logpush : config.logpush,
 			dispatchNamespace: args.dispatchNamespace,
-			strict: args.strict ?? false,
 			oldAssetTtl: args.oldAssetTtl,
 			containersRollout: args.containersRollout,
 		},

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -357,11 +357,7 @@ export const secretListCommand = createCommand({
 		let secrets: Awaited<ReturnType<typeof fetchSecrets>>;
 
 		try {
-			secrets = await fetchSecrets(
-				{ ...config, name: scriptName },
-				accountId,
-				args.env
-			);
+			secrets = await fetchSecrets(config, scriptName, accountId, args.env);
 		} catch (e) {
 			if (isWorkerNotFoundError(e)) {
 				throw new UserError(


### PR DESCRIPTION
Another PR to consolidate the versions upload and deploy paths.

I've also pulled validation into one place, shared by both commands with the hope that this makes it easier to keep parity between versions upload and deploy.

 New features to versions upload in this PR: 
- versions upload also gets a --strict flag.
- When the Worker was last edited via the dash, the local and remote configurations are diffed and you are warned only if the diff is destructive (previously, an unconditional warning was shown). 
- When local configuration values conflict with remote secrets, ask to proceed
- When deploying workflows that belong to a different Worker, ask to proceed

Also improves the error message when you run versions deploy without running deploy first.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: validation

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->