### PR TITLE
[wrangler] Add images source support to queues subscription create

### DIFF
--- a/.changeset/wrangler-queues-subscription-images-source.md
+++ b/.changeset/wrangler-queues-subscription-images-source.md
@@ -1,0 +1,17 @@
+---
+"wrangler": patch
+---
+
+Add `images` as a valid `--source` for `queues subscription create`
+
+The Cloudflare Images service can emit events (e.g. `image.uploaded`) to a
+Cloudflare Queue via the event subscriptions API, and this is supported by both
+the REST API and the Cloudflare Dashboard. However, the wrangler CLI was missing
+`images` from the hardcoded `--source` choices list, causing the command to
+reject it with an "Invalid values" error.
+
+You can now subscribe a queue to Cloudflare Images events via the CLI:
+
+```sh
+wrangler queues subscription create <queue> --source images --events image.uploaded
+```

--- a/.changeset/wrangler-queues-subscription-images-source.md
+++ b/.changeset/wrangler-queues-subscription-images-source.md
@@ -4,11 +4,7 @@
 
 Add `images` as a valid `--source` for `queues subscription create`
 
-The Cloudflare Images service can emit events (e.g. `image.uploaded`) to a
-Cloudflare Queue via the event subscriptions API, and this is supported by both
-the REST API and the Cloudflare Dashboard. However, the wrangler CLI was missing
-`images` from the hardcoded `--source` choices list, causing the command to
-reject it with an "Invalid values" error.
+The Cloudflare Images service can emit events (e.g. `image.uploaded`) to a Cloudflare Queue via the event subscriptions API, and this is supported by both the REST API and the Cloudflare Dashboard. However, the wrangler CLI was missing `images` from the hardcoded `--source` choices list, causing the command to reject it with an "Invalid values" error.
 
 You can now subscribe a queue to Cloudflare Images events via the CLI:
 

--- a/packages/wrangler/src/__tests__/queues/queues-subscription.test.ts
+++ b/packages/wrangler/src/__tests__/queues/queues-subscription.test.ts
@@ -83,7 +83,7 @@ describe("queues subscription", () => {
 				  -v, --version         Show version number  [boolean]
 
 				OPTIONS
-				      --source         The event source type  [string] [required] [choices: "kv", "r2", "superSlurper", "vectorize", "workersAi.model", "workersBuilds.worker", "workflows.workflow"]
+				      --source         The event source type  [string] [required] [choices: "images", "kv", "r2", "superSlurper", "vectorize", "workersAi.model", "workersBuilds.worker", "workflows.workflow"]
 				      --events         Comma-separated list of event types to subscribe to  [string] [required]
 				      --name           Name for the subscription (auto-generated if not provided)  [string]
 				      --enabled        Whether the subscription should be active  [boolean] [default: true]
@@ -138,6 +138,51 @@ describe("queues subscription", () => {
 				──────────────────
 				Creating event subscription for queue 'testQueue'...
 				✨ Successfully created event subscription 'testQueue workersBuilds.worker' with id 'sub-123'."
+			`);
+		});
+
+		it("should create a subscription for images source", async ({ expect }) => {
+			const queueNameResolveRequest = mockGetQueueByNameRequest(
+				expectedQueueName,
+				{
+					queue_id: expectedQueueId,
+					queue_name: expectedQueueName,
+					created_on: "",
+					producers: [],
+					consumers: [],
+					producers_total_count: 0,
+					consumers_total_count: 0,
+					modified_on: "",
+				}
+			);
+
+			const expectedRequest: Partial<CreateEventSubscriptionRequest> = {
+				name: "testQueue images",
+				enabled: true,
+				source: {
+					type: EventSourceType.IMAGES,
+				},
+				events: ["image.uploaded"],
+			};
+
+			const createRequest = mockCreateSubscriptionRequest(
+				expectedRequest,
+				expectedQueueId
+			);
+
+			await runWrangler(
+				"queues subscription create testQueue --source images --events image.uploaded"
+			);
+
+			expect(queueNameResolveRequest.count).toEqual(1);
+			expect(createRequest.count).toEqual(1);
+			expect(std.err).toMatchInlineSnapshot(`""`);
+			expect(std.out).toMatchInlineSnapshot(`
+				"
+				 ⛅️ wrangler x.x.x
+				──────────────────
+				Creating event subscription for queue 'testQueue'...
+				✨ Successfully created event subscription 'testQueue images' with id 'sub-123'."
 			`);
 		});
 
@@ -208,7 +253,7 @@ describe("queues subscription", () => {
 				)
 			).rejects.toThrowErrorMatchingInlineSnapshot(`
 				[Error: Invalid values:
-				  Argument: source, Given: "invalid", Choices: "kv", "r2", "superSlurper", "vectorize", "workersAi.model", "workersBuilds.worker", "workflows.workflow"]
+				  Argument: source, Given: "invalid", Choices: "images", "kv", "r2", "superSlurper", "vectorize", "workersAi.model", "workersBuilds.worker", "workflows.workflow"]
 			`);
 		});
 

--- a/packages/wrangler/src/queues/cli/commands/subscription/create.ts
+++ b/packages/wrangler/src/queues/cli/commands/subscription/create.ts
@@ -20,6 +20,9 @@ function parseSourceArgument(
 	}
 ): EventSource {
 	switch (source as EventSourceType) {
+		case EventSourceType.IMAGES:
+			return { type: EventSourceType.IMAGES };
+
 		case EventSourceType.KV:
 			return { type: EventSourceType.KV };
 

--- a/packages/wrangler/src/queues/subscription-types.ts
+++ b/packages/wrangler/src/queues/subscription-types.ts
@@ -15,6 +15,7 @@ export interface EventDestination {
 }
 
 export enum EventSourceType {
+	IMAGES = "images",
 	KV = "kv",
 	R2 = "r2",
 	SUPER_SLURPER = "superSlurper",
@@ -27,6 +28,7 @@ export enum EventSourceType {
 export const EVENT_SOURCE_TYPES = Object.values(EventSourceType);
 
 export type EventSource =
+	| ImagesEventSource
 	| KvEventSource
 	| R2EventSource
 	| SuperSlurperEventSource
@@ -34,6 +36,10 @@ export type EventSource =
 	| WorkersAiModelEventSource
 	| WorkersBuildsWorkerEventSource
 	| WorkflowsWorkflowEventSource;
+
+export interface ImagesEventSource {
+	type: EventSourceType.IMAGES;
+}
 
 export interface KvEventSource {
 	type: EventSourceType.KV;


### PR DESCRIPTION
Fixes #14413.

The `wrangler queues subscription create` command's `--source` argument was missing `images` from its hardcoded choices list, causing the CLI to reject it with an "Invalid values" error — even though the Cloudflare REST API and Dashboard both fully support it.

```sh
# Before: errors with "Invalid values: Argument: source, Given: "images", Choices: ..."
npx wrangler queues subscription create <queue> --source images --events image.uploaded

# After: works correctly
npx wrangler queues subscription create <queue> --source images --events image.uploaded
```

**Root cause:** `EventSourceType` enum in `subscription-types.ts` did not include `IMAGES = "images"`. Since `EVENT_SOURCE_TYPES = Object.values(EventSourceType)` is passed directly as the yargs `choices:` array, adding the enum member is sufficient to fix CLI validation, the switch case in `parseSourceArgument`, and the TypeScript type union.

---

- Tests
  - [x] Tests included/updated
- Public documentation
  - [x] Documentation not necessary because: this fixes a CLI gap to match existing REST API and Dashboard behavior — no new feature, no new docs needed

*A picture of a cute animal (not mandatory, but encouraged)*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->