### PR TITLE
[wrangler] Improve `tail` resilience and shutdown behaviour

### DIFF
--- a/.changeset/wrangler-tail-resilient-lifecycle.md
+++ b/.changeset/wrangler-tail-resilient-lifecycle.md
@@ -1,0 +1,16 @@
+---
+"wrangler": minor
+---
+
+Improve `wrangler tail` resilience and shutdown behaviour
+
+`wrangler tail` previously crashed with a raw stack trace when the keep-alive ping to the Worker timed out, and could exit with an ugly error on Ctrl-C because the disconnect path threw from inside the keep-alive `setInterval` after the command's promise had already resolved.
+
+The lifecycle has been refactored so that:
+
+- The command now blocks until a clean shutdown (Ctrl-C / SIGTERM, or a normal server close) or until it permanently loses the connection. Errors flow through wrangler's usual error pipeline instead of escaping as uncaught exceptions.
+- The keep-alive timeout message now clearly explains what happened and no longer prints a stack trace.
+- When the tail connection drops unexpectedly (keep-alive ping timeout or abnormal close), `wrangler tail` now automatically reconnects up to 5 times with a 1s / 2s / 4s / 8s / 16s exponential back-off (≈30s total). On success, streaming resumes. After 5 failed attempts it gives up with a clear message asking the user to re-run the command to start a new session.
+- Ctrl-C now prints a short "Stopping tail..." message (in pretty mode), awaits the server-side tail deletion, and exits cleanly with code 0.
+
+This also fixes a long-standing issue where `wrangler pages dev` registered its `SIGINT`/`SIGTERM` handlers at module scope, so they were active for _every_ wrangler command. On Ctrl-C those handlers ran first and called `process.exit()`, preventing other long-running commands (such as `wrangler tail`) from shutting down gracefully. The handlers are now scoped to the `pages dev` command itself.

--- a/.changeset/wrangler-tail-resilient-lifecycle.md
+++ b/.changeset/wrangler-tail-resilient-lifecycle.md
@@ -4,13 +4,9 @@
 
 Improve `wrangler tail` resilience and shutdown behaviour
 
-`wrangler tail` previously crashed with a raw stack trace when the keep-alive ping to the Worker timed out, and could exit with an ugly error on Ctrl-C because the disconnect path threw from inside the keep-alive `setInterval` after the command's promise had already resolved.
+`wrangler tail` previously crashed with a raw stack trace when the keep-alive ping to the Worker timed out, and could exit with an ugly error on Ctrl-C.
 
-The lifecycle has been refactored so that:
-
-- The command now blocks until a clean shutdown (Ctrl-C / SIGTERM, or a normal server close) or until it permanently loses the connection. Errors flow through wrangler's usual error pipeline instead of escaping as uncaught exceptions.
+- Errors now flow through wrangler's usual error pipeline instead of escaping as uncaught exceptions.
 - The keep-alive timeout message now clearly explains what happened and no longer prints a stack trace.
-- When the tail connection drops unexpectedly (keep-alive ping timeout or abnormal close), `wrangler tail` now automatically reconnects up to 5 times with a 1s / 2s / 4s / 8s / 16s exponential back-off (≈30s total). On success, streaming resumes. After 5 failed attempts it gives up with a clear message asking the user to re-run the command to start a new session.
+- When the tail connection drops unexpectedly, `wrangler tail` now automatically tries to reconnect with exponential back-off (up to 5 retries).
 - Ctrl-C now prints a short "Stopping tail..." message (in pretty mode), awaits the server-side tail deletion, and exits cleanly with code 0.
-
-This also fixes a long-standing issue where `wrangler pages dev` registered its `SIGINT`/`SIGTERM` handlers at module scope, so they were active for _every_ wrangler command. On Ctrl-C those handlers ran first and called `process.exit()`, preventing other long-running commands (such as `wrangler tail`) from shutting down gracefully. The handlers are now scoped to the `pages dev` command itself.

--- a/packages/wrangler/src/__tests__/helpers/mock-web-socket.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-web-socket.ts
@@ -2,21 +2,37 @@ import { WebSocket } from "mock-socket";
 
 /**
  * A version of the mock WebSocket that supports the methods that we use.
+ *
+ * The real `ws` package's `WebSocket` extends `EventEmitter` and supports
+ * multiple listeners per event. mock-socket's `WebSocket` only models the
+ * browser-style `on<event>` property setters (one-listener-per-event), so
+ * we delegate to its underlying `EventTarget.addEventListener` to give the
+ * production code multi-listener semantics that match real `ws`.
  */
 export class MockWebSocket extends WebSocket {
 	private pongListener: undefined | ((...args: unknown[]) => void);
+
 	on(event: string | symbol, listener: (...args: unknown[]) => void): this {
 		switch (event) {
 			case "message":
-				this.onmessage = ({ data }) => {
-					listener(data);
-				};
+				this.addEventListener("message", (e: unknown) => {
+					listener((e as MessageEvent).data);
+				});
 				break;
 			case "open":
-				this.onopen = listener;
+				this.addEventListener("open", listener);
 				break;
 			case "close":
-				this.onclose = listener;
+				// Match the real `ws` package's `close` event signature
+				// (`(code, reason) => void`) instead of forwarding the raw
+				// `CloseEvent`. This lets our production code branch on the
+				// close code in tests just like it does at runtime.
+				this.addEventListener("close", (e: unknown) => {
+					const closeEvent = e as
+						| { code?: number; reason?: string }
+						| undefined;
+					listener(closeEvent?.code, closeEvent?.reason);
+				});
 				break;
 			case "pong":
 				this.pongListener = listener;

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -8,6 +8,7 @@ import { http, HttpResponse } from "msw";
 import { Headers, Request } from "undici";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
 import MockWebSocketServer from "vitest-websocket-mock";
+import * as metricsModule from "../metrics";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs } from "./helpers/mock-dialogs";
@@ -1108,6 +1109,12 @@ describe("tail", () => {
 			const sigintBefore = process.listenerCount("SIGINT");
 			const sigtermBefore = process.listenerCount("SIGTERM");
 
+			// Spy on metrics so we can verify the give-up path sends the
+			// `"end log stream"` event symmetrically with `cleanStop` /
+			// `shutdownHandler` (it used to skip the metric, leaving a gap
+			// for sessions that ended via reconnect-exhaustion).
+			const sendMetricsEvent = vi.spyOn(metricsModule, "sendMetricsEvent");
+
 			// Fake `setTimeout` from the very start so every timer the tail
 			// command schedules — the initial WebSocket connection delay
 			// (mock-socket's 4ms `delay()`), the per-attempt reconnect
@@ -1159,6 +1166,13 @@ describe("tail", () => {
 			// way out.
 			expect(process.listenerCount("SIGINT")).toBe(sigintBefore);
 			expect(process.listenerCount("SIGTERM")).toBe(sigtermBefore);
+
+			// Give-up path must also emit the `"end log stream"` metric so
+			// the session is balanced with the `"begin log stream"` sent at
+			// handler start.
+			expect(sendMetricsEvent).toHaveBeenCalledWith("end log stream", {
+				sendMetrics: undefined,
+			});
 		});
 
 		it("retries then gives up after the connection drops (json format)", async ({
@@ -1603,11 +1617,19 @@ function mockWebsocketAPIs(
 		},
 		/**
 		 * Close the mock websocket and clean up the API.
+		 *
+		 * Passes `{ code: 1000 }` explicitly so the close event the
+		 * production code sees is unambiguously `NORMAL_CLOSURE` — that's
+		 * what routes through `cleanStop()` rather than `scheduleReconnect()`,
+		 * and is the path every "happy path" tail test relies on for clean
+		 * shutdown. The mock server defaults to 1000 anyway, but stating it
+		 * makes the test contract explicit and resilient to mock changes.
+		 *
 		 * The setTimeout forces a cycle to allow for closing and cleanup
 		 * @returns a Promise that resolves when the websocket is closed
 		 */
 		async closeHelper() {
-			api.ws.close();
+			api.ws.close({ code: 1000 });
 			await setTimeout(0);
 		},
 	};

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -1101,6 +1101,13 @@ describe("tail", () => {
 			// create/delete mocks need to fire more than once.
 			mockReusableWebsocketAPIs(expect);
 
+			// Snapshot signal listener counts so we can verify the give-up
+			// path removes the SIGINT/SIGTERM handlers it registered
+			// (regression guard: every other terminal path does this; the
+			// give-up branch used to leak listeners).
+			const sigintBefore = process.listenerCount("SIGINT");
+			const sigtermBefore = process.listenerCount("SIGTERM");
+
 			// Fake `setTimeout` from the very start so every timer the tail
 			// command schedules — the initial WebSocket connection delay
 			// (mock-socket's 4ms `delay()`), the per-attempt reconnect
@@ -1147,6 +1154,11 @@ describe("tail", () => {
 			expect(std.warn).toContain("Reconnecting (attempt 5 of 5)");
 
 			vi.useRealTimers();
+
+			// Give-up path must remove its SIGINT/SIGTERM listeners on the
+			// way out.
+			expect(process.listenerCount("SIGINT")).toBe(sigintBefore);
+			expect(process.listenerCount("SIGTERM")).toBe(sigtermBefore);
 		});
 
 		it("retries then gives up after the connection drops (json format)", async ({
@@ -1154,6 +1166,9 @@ describe("tail", () => {
 		}) => {
 			api = mockWebsocketAPIs(expect);
 			mockReusableWebsocketAPIs(expect);
+
+			const sigintBefore = process.listenerCount("SIGINT");
+			const sigtermBefore = process.listenerCount("SIGTERM");
 
 			vi.useFakeTimers({ toFake: ["setTimeout"] });
 
@@ -1177,6 +1192,9 @@ describe("tail", () => {
 			await assertion;
 
 			vi.useRealTimers();
+
+			expect(process.listenerCount("SIGINT")).toBe(sigintBefore);
+			expect(process.listenerCount("SIGTERM")).toBe(sigtermBefore);
 		});
 
 		it("auto-reconnects after a transient drop and continues streaming", async ({

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -60,8 +60,21 @@ describe("tail", () => {
 	mockAccountId();
 	mockApiToken();
 	let api: MockAPI;
+	// Tracks the currently running `wrangler tail` invocation so we can wait
+	// for it to fully unwind in afterEach (the handler now returns a blocking
+	// lifecycle promise that resolves on a clean stop or rejects on give-up).
+	let activeTailPromise: Promise<unknown> | undefined;
+
 	afterEach(async () => {
 		await api?.closeHelper?.();
+		if (activeTailPromise) {
+			try {
+				await activeTailPromise;
+			} catch {
+				// Tests that expected a rejection have already asserted on it.
+			}
+			activeTailPromise = undefined;
+		}
 		mockWebSockets.forEach((ws) => ws.close());
 		mockWebSockets = [];
 		clearDialogs();
@@ -71,6 +84,77 @@ describe("tail", () => {
 	runInTempDir();
 
 	const std = mockConsoleMethods();
+
+	/**
+	 * Start a `wrangler tail` invocation and wait for it to be connected to
+	 * the mock websocket server.
+	 *
+	 * The new tail handler blocks until a clean shutdown (server close with
+	 * code 1000) or rejects after reconnect-exhaustion, so tests must NOT
+	 * await `runWrangler("tail …")` directly. Instead, use this helper to
+	 * fire off the command and wait for the connection to be established;
+	 * the returned promise can be awaited at the end of the test after
+	 * triggering a clean shutdown via `api.closeHelper()` (or relied on the
+	 * `afterEach` to clean it up).
+	 */
+	async function startTail(
+		cmd: string
+	): Promise<{ tailPromise: Promise<unknown> }> {
+		if (!api) {
+			throw new Error("api must be initialized before startTail()");
+		}
+		const tailPromise = runWrangler(cmd);
+		activeTailPromise = tailPromise;
+		await api.ws.connected;
+		// Wrap in an object so the caller's `await startTail()` doesn't
+		// implicitly chain onto the still-pending `tailPromise` (which only
+		// resolves on clean shutdown).
+		return { tailPromise };
+	}
+
+	/**
+	 * Wait for the handler to finish its post-connect setup so that the
+	 * "Connected to <worker>" log is present in `std.out` before asserting
+	 * on pretty-format snapshots.
+	 */
+	async function waitForPrettyConnected(expect: ExpectStatic): Promise<void> {
+		await vi.waitFor(() => {
+			expect(std.out).toContain("waiting for logs");
+		});
+	}
+
+	/**
+	 * Drive vitest's fake timers forward in small steps until the supplied
+	 * promise settles, or a hard iteration cap is hit.
+	 *
+	 * The reconnect chain schedules a fresh `setTimeout` (the next attempt's
+	 * back-off) inside the callback of the previous one, and vitest's
+	 * `advanceTimersByTimeAsync` only fires timers that were already on the
+	 * queue at the start of the call. Stepping the clock in small chunks
+	 * lets newly scheduled timers be picked up on the next iteration and
+	 * keeps microtasks (HTTP responses, promise rejections from the
+	 * open-wait) interleaved between firings.
+	 */
+	async function advanceFakeTimersUntilSettled(
+		promise: Promise<unknown>,
+		maxIterations: number = 500
+	): Promise<void> {
+		let settled = false;
+		void promise.then(
+			() => {
+				settled = true;
+			},
+			() => {
+				settled = true;
+			}
+		);
+		for (let i = 0; i < maxIterations && !settled; i++) {
+			// `advanceTimersToNextTimerAsync` jumps to the next pending fake
+			// timer and fires it, which lets the reconnect chain unwind one
+			// step at a time without us having to guess the right delay.
+			await vi.advanceTimersToNextTimerAsync();
+		}
+	}
 
 	/**
 	 * Interaction with the tailing API, including tail creation,
@@ -89,13 +173,13 @@ describe("tail", () => {
 			api = mockWebsocketAPIs(expect);
 			expect(api.requests.creation.length).toStrictEqual(0);
 
-			await runWrangler("tail test-worker");
+			const { tailPromise } = await startTail("tail test-worker");
 
-			await expect(api.ws.connected).resolves.toBeTruthy();
 			expect(api.requests.creation.length).toStrictEqual(1);
 			expect(api.requests.deletion.count).toStrictEqual(0);
 
 			await api.closeHelper();
+			await tailPromise;
 			expect(api.requests.deletion.count).toStrictEqual(1);
 		});
 
@@ -147,13 +231,13 @@ describe("tail", () => {
 					{ once: true }
 				)
 			);
-			await runWrangler("tail example.com/*");
+			const { tailPromise } = await startTail("tail example.com/*");
 
-			await expect(api.ws.connected).resolves.toBeTruthy();
 			expect(api.requests.creation.length).toStrictEqual(1);
 			expect(api.requests.deletion.count).toStrictEqual(0);
 
 			await api.closeHelper();
+			await tailPromise;
 			expect(api.requests.deletion.count).toStrictEqual(1);
 		});
 
@@ -231,13 +315,15 @@ describe("tail", () => {
 			api = mockWebsocketAPIs(expect, "some-env", false);
 			expect(api.requests.creation.length).toStrictEqual(0);
 
-			await runWrangler("tail test-worker --env some-env --legacy-env true");
+			const { tailPromise } = await startTail(
+				"tail test-worker --env some-env --legacy-env true"
+			);
 
-			await expect(api.ws.connected).resolves.toBeTruthy();
 			expect(api.requests.creation.length).toStrictEqual(1);
 			expect(api.requests.deletion.count).toStrictEqual(0);
 
 			await api.closeHelper();
+			await tailPromise;
 			expect(api.requests.deletion.count).toStrictEqual(1);
 		});
 
@@ -245,13 +331,15 @@ describe("tail", () => {
 			api = mockWebsocketAPIs(expect, "some-env");
 			expect(api.requests.creation.length).toStrictEqual(0);
 
-			await runWrangler("tail test-worker --env some-env --legacy-env false");
+			const { tailPromise } = await startTail(
+				"tail test-worker --env some-env --legacy-env false"
+			);
 
-			await expect(api.ws.connected).resolves.toBeTruthy();
 			expect(api.requests.creation.length).toStrictEqual(1);
 			expect(api.requests.deletion.count).toStrictEqual(0);
 
 			await api.closeHelper();
+			await tailPromise;
 			expect(api.requests.deletion.count).toStrictEqual(1);
 		});
 
@@ -259,12 +347,13 @@ describe("tail", () => {
 			expect,
 		}) => {
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker --debug");
+			const { tailPromise } = await startTail("tail test-worker --debug");
 			await expect(api.nextMessageJson()).resolves.toHaveProperty(
 				"debug",
 				true
 			);
 			await api.closeHelper();
+			await tailPromise;
 		});
 	});
 
@@ -277,17 +366,22 @@ describe("tail", () => {
 			const tooLow = runWrangler("tail test-worker --sampling-rate -5");
 			await expect(tooLow).rejects.toThrow();
 
-			await runWrangler("tail test-worker --sampling-rate 0.25");
+			const { tailPromise } = await startTail(
+				"tail test-worker --sampling-rate 0.25"
+			);
 
 			expect(api.requests.creation[0]).toEqual({
 				filters: [{ sampling_rate: 0.25 }],
 			});
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("sends single status filters", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker --status error");
+			const { tailPromise } = await startTail(
+				"tail test-worker --status error"
+			);
 			expect(api.requests.creation[0]).toEqual({
 				filters: [
 					{
@@ -296,11 +390,14 @@ describe("tail", () => {
 				],
 			});
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("sends multiple status filters", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker --status error --status canceled");
+			const { tailPromise } = await startTail(
+				"tail test-worker --status error --status canceled"
+			);
 			expect(api.requests.creation[0]).toEqual({
 				filters: [
 					{
@@ -315,86 +412,109 @@ describe("tail", () => {
 				],
 			});
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("sends single HTTP method filters", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker --method POST");
+			const { tailPromise } = await startTail("tail test-worker --method POST");
 			expect(api.requests.creation[0]).toEqual({
 				filters: [{ method: ["POST"] }],
 			});
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("sends multiple HTTP method filters", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker --method POST --method GET");
+			const { tailPromise } = await startTail(
+				"tail test-worker --method POST --method GET"
+			);
 			expect(api.requests.creation[0]).toEqual({
 				filters: [{ method: ["POST", "GET"] }],
 			});
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("sends header filters without a query", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker --header X-CUSTOM-HEADER");
+			const { tailPromise } = await startTail(
+				"tail test-worker --header X-CUSTOM-HEADER"
+			);
 			expect(api.requests.creation[0]).toEqual({
 				filters: [{ header: { key: "X-CUSTOM-HEADER" } }],
 			});
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("sends header filters with a query", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker --header X-CUSTOM-HEADER:some-value");
+			const { tailPromise } = await startTail(
+				"tail test-worker --header X-CUSTOM-HEADER:some-value"
+			);
 			expect(api.requests.creation[0]).toEqual({
 				filters: [{ header: { key: "X-CUSTOM-HEADER", query: "some-value" } }],
 			});
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("sends single IP filters", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
 			const fakeIp = "192.0.2.1";
 
-			await runWrangler(`tail test-worker --ip ${fakeIp}`);
+			const { tailPromise } = await startTail(
+				`tail test-worker --ip ${fakeIp}`
+			);
 			expect(api.requests.creation[0]).toEqual({
 				filters: [{ client_ip: [fakeIp] }],
 			});
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("sends multiple IP filters", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
 			const fakeIp = "192.0.2.1";
 
-			await runWrangler(`tail test-worker --ip ${fakeIp} --ip self`);
+			const { tailPromise } = await startTail(
+				`tail test-worker --ip ${fakeIp} --ip self`
+			);
 			expect(api.requests.creation[0]).toEqual({
 				filters: [{ client_ip: [fakeIp, "self"] }],
 			});
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("sends search filters", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
 			const search = "filterMe";
 
-			await runWrangler(`tail test-worker --search ${search}`);
+			const { tailPromise } = await startTail(
+				`tail test-worker --search ${search}`
+			);
 			expect(api.requests.creation[0]).toEqual({
 				filters: [{ query: search }],
 			});
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("sends version id filters", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
 			const versionId = "87501bef-3ef2-4464-a3d6-35e548695742";
 
-			await runWrangler(`tail test-worker --version-id ${versionId}`);
+			const { tailPromise } = await startTail(
+				`tail test-worker --version-id ${versionId}`
+			);
 			expect(api.requests.creation[0]).toEqual({
 				filters: [{ scriptVersion: versionId }],
 			});
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("sends everything but the kitchen sink", async ({ expect }) => {
@@ -437,9 +557,10 @@ describe("tail", () => {
 				],
 			};
 
-			await runWrangler(`tail test-worker ${cliFilters}`);
+			const { tailPromise } = await startTail(`tail test-worker ${cliFilters}`);
 			expect(api.requests.creation[0]).toEqual(expectedWebsocketMessage);
 			await api.closeHelper();
+			await tailPromise;
 		});
 	});
 
@@ -448,7 +569,7 @@ describe("tail", () => {
 
 		it("logs request messages in JSON format", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker --format json");
+			const { tailPromise } = await startTail("tail test-worker --format json");
 
 			const event = generateMockRequestEvent();
 			const message = generateMockEventMessage({ event });
@@ -459,11 +580,12 @@ describe("tail", () => {
 				deserializeJsonMessage(serializedMessage)
 			);
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("logs scheduled messages in JSON format", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker --format json");
+			const { tailPromise } = await startTail("tail test-worker --format json");
 
 			const event = generateMockScheduledEvent();
 			const message = generateMockEventMessage({ event });
@@ -474,11 +596,12 @@ describe("tail", () => {
 				deserializeJsonMessage(serializedMessage)
 			);
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("logs alarm messages in json format", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker --format json");
+			const { tailPromise } = await startTail("tail test-worker --format json");
 
 			const event = generateMockAlarmEvent();
 			const message = generateMockEventMessage({ event });
@@ -489,11 +612,12 @@ describe("tail", () => {
 				deserializeJsonMessage(serializedMessage)
 			);
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("logs email messages in json format", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker --format json");
+			const { tailPromise } = await startTail("tail test-worker --format json");
 
 			const event = generateMockEmailEvent();
 			const message = generateMockEventMessage({ event });
@@ -504,11 +628,12 @@ describe("tail", () => {
 				deserializeJsonMessage(serializedMessage)
 			);
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("logs tail messages in json format", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker --format json");
+			const { tailPromise } = await startTail("tail test-worker --format json");
 
 			const event = generateMockTailEvent(["some-worker", "some-worker"]);
 			const message = generateMockEventMessage({ event });
@@ -519,11 +644,12 @@ describe("tail", () => {
 				deserializeJsonMessage(serializedMessage)
 			);
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("logs queue messages in json format", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker --format json");
+			const { tailPromise } = await startTail("tail test-worker --format json");
 
 			const event = generateMockQueueEvent();
 			const message = generateMockEventMessage({ event });
@@ -534,11 +660,15 @@ describe("tail", () => {
 				deserializeJsonMessage(serializedMessage)
 			);
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("logs request messages in pretty format", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker --format pretty");
+			const { tailPromise } = await startTail(
+				"tail test-worker --format pretty"
+			);
+			await waitForPrettyConnected(expect);
 
 			const event = generateMockRequestEvent();
 			const message = generateMockEventMessage({ event });
@@ -561,11 +691,15 @@ describe("tail", () => {
 				GET https://example.org/ - Ok @ [mock event timestamp]"
 			`);
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("logs rpc messages in pretty format", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker --format pretty");
+			const { tailPromise } = await startTail(
+				"tail test-worker --format pretty"
+			);
+			await waitForPrettyConnected(expect);
 
 			const event = generateMockRpcEvent();
 			const message = generateMockEventMessage({
@@ -591,11 +725,15 @@ describe("tail", () => {
 				MyDurableObject.foo - Ok @ [mock event timestamp]"
 			`);
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("logs scheduled messages in pretty format", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker --format pretty");
+			const { tailPromise } = await startTail(
+				"tail test-worker --format pretty"
+			);
+			await waitForPrettyConnected(expect);
 
 			const event = generateMockScheduledEvent();
 			const message = generateMockEventMessage({ event });
@@ -618,11 +756,15 @@ describe("tail", () => {
 				"* * * * *" @ [mock timestamp string] - Ok"
 			`);
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("logs alarm messages in pretty format", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker --format pretty");
+			const { tailPromise } = await startTail(
+				"tail test-worker --format pretty"
+			);
+			await waitForPrettyConnected(expect);
 
 			const event = generateMockAlarmEvent();
 			const message = generateMockEventMessage({ event });
@@ -645,11 +787,15 @@ describe("tail", () => {
 				Alarm @ [mock scheduled time] - Ok"
 			`);
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("logs email messages in pretty format", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker --format pretty");
+			const { tailPromise } = await startTail(
+				"tail test-worker --format pretty"
+			);
+			await waitForPrettyConnected(expect);
 
 			const event = generateMockEmailEvent();
 			const message = generateMockEventMessage({ event });
@@ -672,11 +818,15 @@ describe("tail", () => {
 				Email from:from@example.com to:to@example.com size:45416 @ [mock event timestamp] - Ok"
 			`);
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("logs tail messages in pretty format", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker --format pretty");
+			const { tailPromise } = await startTail(
+				"tail test-worker --format pretty"
+			);
+			await waitForPrettyConnected(expect);
 
 			const event = generateMockTailEvent(["some-worker", "other-worker", ""]);
 			const message = generateMockEventMessage({ event });
@@ -702,11 +852,15 @@ describe("tail", () => {
 				Tailing some-worker,other-worker - Ok @ [mock event timestamp]"
 			`);
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("logs tail overload message", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker --format pretty");
+			const { tailPromise } = await startTail(
+				"tail test-worker --format pretty"
+			);
+			await waitForPrettyConnected(expect);
 
 			let event = generateTailInfo(true);
 			let message = generateMockEventMessage({ event });
@@ -732,11 +886,15 @@ describe("tail", () => {
 				Tail has exited sampling mode and is no longer dropping messages."
 			`);
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("logs queue messages in pretty format", async ({ expect }) => {
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker --format pretty");
+			const { tailPromise } = await startTail(
+				"tail test-worker --format pretty"
+			);
+			await waitForPrettyConnected(expect);
 
 			const event = generateMockQueueEvent();
 			const message = generateMockEventMessage({ event });
@@ -759,13 +917,17 @@ describe("tail", () => {
 				Queue my-queue123 (7 messages) - Ok @ [mock timestamp string]"
 			`);
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("should not crash when the tail message has a void event", async ({
 			expect,
 		}) => {
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker --format pretty");
+			const { tailPromise } = await startTail(
+				"tail test-worker --format pretty"
+			);
+			await waitForPrettyConnected(expect);
 
 			const message = generateMockEventMessage({ event: null });
 			const serializedMessage = serialize(message);
@@ -787,6 +949,7 @@ describe("tail", () => {
 				Unknown Event - Ok @ [mock timestamp string]"
 			`);
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("defaults to logging in pretty format when the output is a TTY", async ({
@@ -794,7 +957,8 @@ describe("tail", () => {
 		}) => {
 			setIsTTY(true);
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker");
+			const { tailPromise } = await startTail("tail test-worker");
+			await waitForPrettyConnected(expect);
 
 			const event = generateMockRequestEvent();
 			const message = generateMockEventMessage({ event });
@@ -817,6 +981,7 @@ describe("tail", () => {
 				GET https://example.org/ - Ok @ [mock event timestamp]"
 			`);
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("defaults to logging in json format when the output is not a TTY", async ({
@@ -825,7 +990,7 @@ describe("tail", () => {
 			setIsTTY(false);
 
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker");
+			const { tailPromise } = await startTail("tail test-worker");
 
 			const event = generateMockRequestEvent();
 			const message = generateMockEventMessage({ event });
@@ -836,12 +1001,14 @@ describe("tail", () => {
 				deserializeJsonMessage(serializedMessage)
 			);
 			await api.closeHelper();
+			await tailPromise;
 		});
 
 		it("logs console messages and exceptions", async ({ expect }) => {
 			setIsTTY(true);
 			api = mockWebsocketAPIs(expect);
-			await runWrangler("tail test-worker");
+			const { tailPromise } = await startTail("tail test-worker");
+			await waitForPrettyConnected(expect);
 
 			const event = generateMockRequestEvent();
 			const message = generateMockEventMessage({
@@ -913,6 +1080,7 @@ describe("tail", () => {
 			`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 			await api.closeHelper();
+			await tailPromise;
 		});
 	});
 
@@ -925,46 +1093,175 @@ describe("tail", () => {
 			await api.closeHelper();
 		});
 
-		it("errors when the websocket stops reacting to pings (pretty format)", async ({
+		it("retries then gives up after the connection drops (pretty format)", async ({
 			expect,
 		}) => {
 			api = mockWebsocketAPIs(expect);
-			vi.useFakeTimers({
-				toFake: ["setInterval"],
-			});
-			// Block the websocket from replying to the ping
-			vi.spyOn(MockWebSocket.prototype, "ping").mockImplementation(() => {});
-			await runWrangler("tail test-worker --format=pretty");
-			await api.ws.connected;
-			// The ping is sent every 2 secs, so it should not fail until the second ping is due.
-			await vi.advanceTimersByTimeAsync(10000);
-			await expect(
-				vi.advanceTimersByTimeAsync(10000)
+			// The reconnect loop creates a fresh tail per attempt, so the
+			// create/delete mocks need to fire more than once.
+			mockReusableWebsocketAPIs(expect);
+
+			// Fake `setTimeout` from the very start so every timer the tail
+			// command schedules — the initial WebSocket connection delay
+			// (mock-socket's 4ms `delay()`), the per-attempt reconnect
+			// back-offs (1/2/4/8/16s), and every failed-connection delay on
+			// reconnect — lives in the fake queue. We can then drive the
+			// whole 30-ish seconds of back-off in microtask time without
+			// burning real wall-clock.
+			vi.useFakeTimers({ toFake: ["setTimeout"] });
+
+			const tailPromise = runWrangler(
+				"tail test-worker --format=pretty"
+			) as Promise<unknown>;
+			activeTailPromise = tailPromise;
+
+			// Set up the rejection assertion BEFORE driving any timers so the
+			// give-up FatalError doesn't become an unhandled rejection.
+			const assertion = expect(
+				tailPromise
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Tail disconnected, exiting.]`
+				`[Error: Unable to reconnect to the tail for test-worker after 5 attempts. Please re-run \`wrangler tail test-worker\` to start a new session.]`
 			);
-			await api.closeHelper();
+
+			// Let the initial connection establish (mock-socket schedules a
+			// 4ms fake setTimeout for the open event).
+			await vi.advanceTimersByTimeAsync(50);
+			await api.ws.connected;
+
+			// Simulate an abnormal disconnect by closing the server with a
+			// non-normal code. This dispatches close(code=1006) to the active
+			// WebSocket and removes the server from the network bridge so
+			// every reconnect `new WebSocket(url)` attempt fails with a
+			// close-before-open — which is exactly the "give up after N
+			// attempts" scenario we want to exercise.
+			api.ws.close({ code: 1006, reason: "abnormal", wasClean: false });
+
+			// Drive the reconnect chain forward in small steps so newly
+			// scheduled timers (each attempt's failed-connection 4ms + the
+			// next back-off sleep) are picked up by subsequent advances.
+			// Bail as soon as the give-up rejection lands.
+			await advanceFakeTimersUntilSettled(tailPromise);
+			await assertion;
+
+			expect(std.warn).toContain("Reconnecting (attempt 1 of 5)");
+			expect(std.warn).toContain("Reconnecting (attempt 5 of 5)");
+
+			vi.useRealTimers();
 		});
 
-		it("errors when the websocket stops reacting to pings (json format)", async ({
+		it("retries then gives up after the connection drops (json format)", async ({
 			expect,
 		}) => {
 			api = mockWebsocketAPIs(expect);
-			vi.useFakeTimers({
-				toFake: ["setInterval"],
-			});
-			// Block the websocket from replying to the ping
-			vi.spyOn(MockWebSocket.prototype, "ping").mockImplementation(() => {});
-			await runWrangler("tail test-worker --format=json");
-			await api.ws.connected;
-			// The ping is sent every 2 secs, so it should not fail until the second ping is due.
-			await vi.advanceTimersByTimeAsync(10000);
-			await expect(
-				vi.advanceTimersByTimeAsync(10000)
+			mockReusableWebsocketAPIs(expect);
+
+			vi.useFakeTimers({ toFake: ["setTimeout"] });
+
+			const tailPromise = runWrangler(
+				"tail test-worker --format=json"
+			) as Promise<unknown>;
+			activeTailPromise = tailPromise;
+
+			const assertion = expect(
+				tailPromise
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: "Tail disconnected, exiting."]`
+				`[Error: "Unable to reconnect to the tail for test-worker after 5 attempts. Please re-run \`wrangler tail test-worker\` to start a new session."]`
 			);
+
+			await vi.advanceTimersByTimeAsync(50);
+			await api.ws.connected;
+
+			api.ws.close({ code: 1006, reason: "abnormal", wasClean: false });
+
+			await advanceFakeTimersUntilSettled(tailPromise);
+			await assertion;
+
+			vi.useRealTimers();
+		});
+
+		it("auto-reconnects after a transient drop and continues streaming", async ({
+			expect,
+		}) => {
+			api = mockWebsocketAPIs(expect);
+			mockReusableWebsocketAPIs(expect);
+
+			const { tailPromise } = await startTail(
+				"tail test-worker --format=pretty"
+			);
+			await waitForPrettyConnected(expect);
+
+			// Simulate a transient network drop on the current WebSocket by
+			// dispatching a close event with an abnormal code directly on the
+			// client. The server-side mock is left intact so the subsequent
+			// reconnect attempt can succeed.
+			const clients = (
+				api.ws as unknown as {
+					server: { clients(): MockWebSocket[] };
+				}
+			).server.clients();
+			const firstClient = clients[clients.length - 1];
+			firstClient.dispatchEvent({
+				type: "close",
+				code: 1006,
+				reason: "transient drop",
+				wasClean: false,
+			} as unknown as Event);
+
+			// Wait for the reconnect to succeed (up to ~5s including the 1s
+			// backoff before the first reconnect attempt).
+			await vi.waitFor(
+				() => {
+					expect(std.out).toContain("Reconnected to test-worker");
+				},
+				{ timeout: 5000 }
+			);
+
+			expect(std.warn).toContain("Reconnecting (attempt 1 of 5)");
+
 			await api.closeHelper();
+			await tailPromise;
+		});
+	});
+
+	describe("shutdown", () => {
+		it("logs `Stopping tail...`, deletes the tail, and exits cleanly on Ctrl-C", async ({
+			expect,
+		}) => {
+			api = mockWebsocketAPIs(expect);
+
+			// Capture SIGINT listeners present before the command runs so we
+			// can identify (and invoke) the one the tail command registers.
+			const before = new Set(process.listeners("SIGINT"));
+
+			const { tailPromise } = await startTail(
+				"tail test-worker --format=pretty"
+			);
+			await waitForPrettyConnected(expect);
+
+			expect(api.requests.deletion.count).toStrictEqual(0);
+
+			// The tail command must register a SIGINT handler. Regression
+			// guard: a top-level `process.on("SIGINT")` elsewhere (previously
+			// in pages/index.ts) used to `process.exit()` first and prevent
+			// this handler from ever running.
+			const added = process
+				.listeners("SIGINT")
+				.filter((listener) => !before.has(listener));
+			expect(added.length).toBeGreaterThan(0);
+
+			// Emit a real SIGINT so we exercise the same dispatch path a user's
+			// Ctrl-C would. If a rogue module-level handler that calls
+			// `process.exit()` is ever re-introduced ahead of ours, this would
+			// hard-exit the worker and fail the run.
+			process.emit("SIGINT");
+
+			// The handler resolves the blocking lifecycle promise after a
+			// clean shutdown.
+			await tailPromise;
+
+			expect(std.out).toContain("Stopping tail...");
+			// The server-side tail was deleted as part of the clean shutdown.
+			expect(api.requests.deletion.count).toStrictEqual(1);
 		});
 	});
 
@@ -1248,6 +1545,24 @@ function mockWebsocketAPIs(
 	mockWebSockets.push(api.ws);
 
 	return api;
+}
+
+/**
+ * Register additional create-tail mocks beyond the initial one set up by
+ * {@link mockWebsocketAPIs}. The default MSW handler is `{ once: true }`, so
+ * the reconnect path (which calls `createTail` again for each attempt)
+ * would otherwise fail on the second tail creation.
+ *
+ * Call this in disconnect/reconnect tests so the handler can make
+ * subsequent create-tail HTTP calls successfully.
+ */
+function mockReusableWebsocketAPIs(
+	expect: ExpectStatic,
+	count: number = 5
+): void {
+	for (let i = 0; i < count; i++) {
+		mockCreateTailRequest(expect, "ws://localhost:1234");
+	}
 }
 
 /**

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -1090,8 +1090,17 @@ describe("tail", () => {
 			api = mockWebsocketAPIs(expect);
 			await api.closeHelper();
 
+			// Regression guard: initial-connect failure must still pair
+			// `"begin log stream"` with `"end log stream"` so failed sessions
+			// don't show up as unpaired in telemetry.
+			const sendMetricsEvent = vi.spyOn(metricsModule, "sendMetricsEvent");
+
 			await expect(runWrangler("tail test-worker")).rejects.toThrow();
 			await api.closeHelper();
+
+			expect(sendMetricsEvent).toHaveBeenCalledWith("end log stream", {
+				sendMetrics: undefined,
+			});
 		});
 
 		it("retries then gives up after the connection drops (pretty format)", async ({

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -1262,6 +1262,73 @@ describe("tail", () => {
 			await api.closeHelper();
 			await tailPromise;
 		});
+
+		it("treats a missed keep-alive pong as a disconnect and reconnects", async ({
+			expect,
+		}) => {
+			api = mockWebsocketAPIs(expect);
+			mockReusableWebsocketAPIs(expect);
+
+			// Suppress the pong for the very first ping only, so the first
+			// connection's keep-alive times out (exercising the
+			// `startWebSocketPing` -> `onDisconnect` path). Every later ping
+			// bounces a pong back as normal, so the reconnect stays healthy.
+			let pingsSuppressed = 0;
+			vi.spyOn(MockWebSocket.prototype, "ping").mockImplementation(function (
+				this: MockWebSocket,
+				data: Buffer
+			) {
+				if (pingsSuppressed === 0) {
+					pingsSuppressed++;
+					return;
+				}
+				// Default MockWebSocket.ping behaviour: echo the ping straight
+				// back to the registered "pong" listener.
+				(
+					this as unknown as { pongListener?: (d: Buffer) => void }
+				).pongListener?.(data);
+			});
+
+			// Fake both timers: `setInterval` drives the 10s keep-alive ping,
+			// `setTimeout` drives mock-socket's connection delay and the
+			// reconnect back-off.
+			vi.useFakeTimers({ toFake: ["setInterval", "setTimeout"] });
+
+			const tailPromise = runWrangler(
+				"tail test-worker --format=pretty"
+			) as Promise<unknown>;
+			activeTailPromise = tailPromise;
+
+			// Establish the initial connection.
+			await vi.advanceTimersByTimeAsync(50);
+			await api.ws.connected;
+
+			// Two ping cycles (PING_INTERVAL_MS = 10s each): the first sends a
+			// ping (no pong comes back), the second observes `waitingForPong`
+			// is still true and treats the connection as dropped ->
+			// `onDisconnect()` -> reconnect.
+			await vi.advanceTimersByTimeAsync(10_000);
+			await vi.advanceTimersByTimeAsync(10_000);
+
+			// Drive the back-off + reconnect handshake until streaming resumes.
+			for (let i = 0; i < 50; i++) {
+				if (std.out.includes("Reconnected to test-worker")) {
+					break;
+				}
+				await vi.advanceTimersByTimeAsync(1000);
+			}
+
+			expect(std.warn).toContain(
+				"did not respond to a keep-alive ping within 10000ms"
+			);
+			expect(std.warn).toContain("Reconnecting (attempt 1 of 5)");
+			expect(std.out).toContain("Reconnected to test-worker");
+
+			vi.useRealTimers();
+
+			await api.closeHelper();
+			await tailPromise;
+		});
 	});
 
 	describe("shutdown", () => {

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -1281,6 +1281,71 @@ describe("tail", () => {
 			// The server-side tail was deleted as part of the clean shutdown.
 			expect(api.requests.deletion.count).toStrictEqual(1);
 		});
+
+		it("shuts down cleanly when Ctrl-C is hit before the WebSocket finishes connecting", async ({
+			expect,
+		}) => {
+			api = mockWebsocketAPIs(expect);
+
+			// Fake `setTimeout` so we can hold the initial WebSocket
+			// connection in its CONNECTING state — mock-socket schedules the
+			// connection "open" dispatch via a 4 ms `delay()`, which we don't
+			// advance until we've emitted SIGINT. The handler will therefore
+			// be parked at `await new Promise(...)` for the open-wait when we
+			// signal.
+			vi.useFakeTimers({ toFake: ["setTimeout"] });
+
+			const tailPromise = runWrangler(
+				"tail test-worker --format=pretty"
+			) as Promise<unknown>;
+			activeTailPromise = tailPromise;
+
+			// Wait until the handler has actually entered the open-wait
+			// promise. Polling for `currentTail` from outside isn't possible,
+			// so instead we wait for the mock WebSocket to be constructed
+			// (visible to the server) AND for the close listener to be
+			// attached on it (one of the last sync steps before the await).
+			const server = (
+				api.ws as unknown as {
+					server: { clients(): { listeners: Record<string, unknown[]> }[] };
+				}
+			).server;
+			for (let i = 0; i < 200; i++) {
+				const clients = server.clients();
+				if (clients.length > 0) {
+					// MockWebSocket attaches listeners via `addEventListener`,
+					// which pushes into `listeners["close"]`. mock-socket
+					// itself does not add a default close listener, so once
+					// this array is non-empty the handler has finished its
+					// post-`createTail` sync setup and is parked at the
+					// open-wait.
+					if (clients[0].listeners?.close?.length) {
+						break;
+					}
+				}
+				await Promise.resolve();
+			}
+
+			// Emit SIGINT while the connection is still CONNECTING.
+			// `shutdownHandler` will call `teardownCurrentConnection` →
+			// `tail.terminate()`, which dispatches a `close` on the
+			// not-yet-opened WebSocket. The close handler must recognise this
+			// as an intentional close and resolve the open-wait (rather than
+			// reject it with "Connection ... closed unexpectedly.").
+			process.emit("SIGINT");
+
+			// Advance fake timers so terminate's close dispatch (and any
+			// other pending fake timers) fire.
+			await vi.advanceTimersByTimeAsync(100);
+
+			// Must resolve cleanly — *not* reject with "closed unexpectedly".
+			await tailPromise;
+
+			expect(std.out).toContain("Stopping tail...");
+			expect(std.err).not.toContain("closed unexpectedly");
+
+			vi.useRealTimers();
+		});
 	});
 
 	it("should error helpfully if pages_build_output_dir is set in wrangler.toml", async ({

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -1694,18 +1694,19 @@ function mockWebsocketAPIs(
 		/**
 		 * Close the mock websocket and clean up the API.
 		 *
-		 * Passes `{ code: 1000 }` explicitly so the close event the
-		 * production code sees is unambiguously `NORMAL_CLOSURE` — that's
-		 * what routes through `cleanStop()` rather than `scheduleReconnect()`,
-		 * and is the path every "happy path" tail test relies on for clean
-		 * shutdown. The mock server defaults to 1000 anyway, but stating it
-		 * makes the test contract explicit and resilient to mock changes.
+		 * Passes a normal-closure (`code: 1000`) close explicitly so the
+		 * close event the production code sees is unambiguously
+		 * `NORMAL_CLOSURE` — that's what routes through `cleanStop()` rather
+		 * than `scheduleReconnect()`, and is the path every "happy path" tail
+		 * test relies on for clean shutdown. The mock server defaults to 1000
+		 * anyway, but stating it makes the test contract explicit and
+		 * resilient to mock changes.
 		 *
 		 * The setTimeout forces a cycle to allow for closing and cleanup
 		 * @returns a Promise that resolves when the websocket is closed
 		 */
 		async closeHelper() {
-			api.ws.close({ code: 1000 });
+			api.ws.close({ code: 1000, reason: "", wasClean: true });
 			await setTimeout(0);
 		},
 	};

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -1042,9 +1042,18 @@ export const pagesDevCommand = createCommand({
 
 		metrics.sendMetricsEvent("run pages dev");
 
+		// Note: these signal handlers used to live at the top level of
+		// `pages/index.ts`, which meant they were registered for *every*
+		// wrangler command and would `process.exit()` on the first SIGINT —
+		// clobbering the graceful shutdown of other long-running commands
+		// (e.g. `wrangler tail`). They belong here, scoped to `pages dev`.
+		const cleanupAndExit = () => {
+			CLEANUP();
+			process.exit();
+		};
 		process.on("exit", CLEANUP);
-		process.on("SIGINT", CLEANUP);
-		process.on("SIGTERM", CLEANUP);
+		process.on("SIGINT", cleanupAndExit);
+		process.on("SIGTERM", cleanupAndExit);
 
 		await events.once(devServer.devEnv, "teardown");
 

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -39,7 +39,7 @@ import {
 	produceWorkerBundleForWorkerJSDirectory,
 } from "./functions/buildWorker";
 import { validateRoutes } from "./functions/routes-validation";
-import { CLEANUP, CLEANUP_CALLBACKS, getPagesTmpDir } from "./utils";
+import { getPagesTmpDir, RUNNING_BUILDERS } from "./utils";
 import type { AdditionalDevProps } from "../dev";
 import type { RoutesJSONSpec } from "./functions/routes-transformation";
 import type { PagesConfigCache } from "./types";
@@ -50,6 +50,16 @@ import type {
 	DurableObjectBindings,
 	EnvironmentNonInheritable,
 } from "@cloudflare/workers-utils";
+
+// Cleanup callbacks + a helper to run them, used to tear down `pages dev`
+// resources on shutdown. These are local to `pages dev` (the only command
+// that registers them); the signal handlers that invoke `CLEANUP` are set up
+// inside the command handler below.
+const CLEANUP_CALLBACKS: (() => void)[] = [];
+const CLEANUP = () => {
+	CLEANUP_CALLBACKS.forEach((callback) => callback());
+	RUNNING_BUILDERS.forEach((builder) => builder.stop?.());
+};
 
 /*
  * DURABLE_OBJECTS_BINDING_REGEXP matches strings like:

--- a/packages/wrangler/src/pages/index.ts
+++ b/packages/wrangler/src/pages/index.ts
@@ -1,5 +1,4 @@
 import { createNamespace } from "../core/create-command";
-import { CLEANUP } from "./utils";
 
 export const pagesNamespace = createNamespace({
 	metadata: {
@@ -45,13 +44,4 @@ export const pagesDownloadNamespace = createNamespace({
 		owner: "Workers: Authoring and Testing",
 		hideGlobalFlags: ["config", "env"],
 	},
-});
-
-process.on("SIGINT", () => {
-	CLEANUP();
-	process.exit();
-});
-process.on("SIGTERM", () => {
-	CLEANUP();
-	process.exit();
 });

--- a/packages/wrangler/src/pages/utils.ts
+++ b/packages/wrangler/src/pages/utils.ts
@@ -5,12 +5,6 @@ import type { BundleResult } from "../deployment-bundle/bundle";
 
 export const RUNNING_BUILDERS: BundleResult[] = [];
 
-export const CLEANUP_CALLBACKS: (() => void)[] = [];
-export const CLEANUP = () => {
-	CLEANUP_CALLBACKS.forEach((callback) => callback());
-	RUNNING_BUILDERS.forEach((builder) => builder.stop?.());
-};
-
 export function isUrl(maybeUrl?: string): maybeUrl is string {
 	if (!maybeUrl) {
 		return false;

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -350,6 +350,12 @@ export const tailCommand = createCommand({
 
 			attempt++;
 			if (attempt > MAX_RECONNECT_ATTEMPTS) {
+				// Match every other terminal path (`cleanStop`,
+				// `shutdownHandler`, the initial-connect catch) and remove
+				// the SIGINT/SIGTERM listeners before settling `done`.
+				// Otherwise this branch leaks listeners on `process`, which
+				// matters for in-process callers like `runWrangler` in tests.
+				removeSignalHandlers();
 				rejectDone(
 					createFatalError(
 						`Unable to reconnect to the tail for ${scriptDisplayName} after ${MAX_RECONNECT_ATTEMPTS} attempts. Please re-run \`wrangler tail${args.worker ? ` ${args.worker}` : ""}\` to start a new session.`,
@@ -465,10 +471,15 @@ function startWebSocketPing(
 			// died. Stop pinging and notify the caller — never throw from here,
 			// since this callback is detached from any awaited promise and an
 			// uncaught throw would crash the process with a raw stack trace.
+			//
+			// Use `warn` (not `error`): `onDisconnect()` will normally trigger
+			// a reconnect, and the reconnect path also surfaces a user-facing
+			// `Reconnecting (attempt N of M)` warning. Logging an error here
+			// would read as a hard failure even when recovery succeeds.
 			disconnected = true;
 			clearInterval(pingInterval);
-			logger.error(
-				`Tail disconnected: The Worker did not respond to a keep-alive ping within ${PING_INTERVAL_MS}ms, so the tail connection appears to have dropped.`
+			logger.warn(
+				`Tail connection lost: the Worker did not respond to a keep-alive ping within ${PING_INTERVAL_MS}ms.`
 			);
 			onDisconnect();
 			return;

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -256,13 +256,26 @@ export const tailCommand = createCommand({
 			let rejectOpenWait: ((err: Error) => void) | undefined;
 
 			tail.on("close", (code: number) => {
-				if (!hasOpened && rejectOpenWait) {
-					rejectOpenWait(
-						new Error(`Connection to ${scriptDisplayName} closed unexpectedly.`)
-					);
+				// Close fired before this connection ever opened.
+				if (!hasOpened) {
+					if (intentionalClose || isShuttingDown) {
+						// Tear-down beat us to the open event (e.g. Ctrl-C
+						// during the initial handshake). Don't reject — unblock
+						// the open-wait so `connect()` can return cleanly via
+						// its `isShuttingDown` check below. `cleanStop` /
+						// `shutdownHandler` have already settled `done`.
+						resolveOpenWait?.();
+					} else {
+						rejectOpenWait?.(
+							new Error(
+								`Connection to ${scriptDisplayName} closed unexpectedly.`
+							)
+						);
+					}
 					return;
 				}
-				if (intentionalClose || isShuttingDown || !hasOpened) {
+				// Steady-state path.
+				if (intentionalClose || isShuttingDown) {
 					return;
 				}
 				if (code === NORMAL_CLOSURE) {

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -1,10 +1,8 @@
-import { setTimeout } from "node:timers/promises";
 import {
 	configFileName,
 	createFatalError,
 	UserError,
 } from "@cloudflare/workers-utils";
-import onExit from "signal-exit";
 import { createCommand } from "../core/create-command";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
@@ -21,6 +19,32 @@ import {
 } from "./createTail";
 import type { TailCLIFilters } from "./createTail";
 import type WebSocket from "ws";
+
+/**
+ * The WebSocket close code that indicates the peer (the tail backend) ended
+ * the session cleanly. Anything else is treated as an unexpected disconnect.
+ */
+const NORMAL_CLOSURE = 1000;
+
+/** How long to wait between pings on the keepalive websocket (ms). */
+const PING_INTERVAL_MS = 10_000;
+
+/** Backoff delays between successive reconnect attempts (ms). */
+const RECONNECT_BACKOFF_MS = [1_000, 2_000, 4_000, 8_000, 16_000];
+
+/** How many reconnect attempts we'll make before giving up. */
+const MAX_RECONNECT_ATTEMPTS = RECONNECT_BACKOFF_MS.length;
+
+/**
+ * Promise-returning sleep using the global `setTimeout` (rather than the one
+ * from `node:timers/promises`) so it can be controlled by `vi.useFakeTimers`
+ * in tests.
+ */
+function sleep(ms: number): Promise<void> {
+	return new Promise<void>((resolve) => {
+		setTimeout(resolve, ms);
+	});
+}
 
 export const tailCommand = createCommand({
 	metadata: {
@@ -110,7 +134,7 @@ export const tailCommand = createCommand({
 			sendMetrics: config.send_metrics,
 		});
 
-		let scriptName;
+		let scriptName: string | undefined;
 
 		const accountId = await requireAuth(config);
 
@@ -152,117 +176,317 @@ export const tailCommand = createCommand({
 
 		const filters = translateCLICommandToFilterMessage(cliFilters);
 
-		const { tail, expiration, deleteTail } = await createTail(
-			config,
-			accountId,
-			scriptName,
-			filters,
-			args.debug,
-			useServiceEnvironments(config) ? args.env : undefined
-		);
-
 		const scriptDisplayName = `${scriptName}${
 			useServiceEnvironments(config) && args.env ? ` (${args.env})` : ""
 		}`;
 
-		if (args.format === "pretty") {
-			logger.log(
-				`Successfully created tail, expires at ${expiration.toLocaleString()}`
-			);
-		}
-
 		const printLog: (data: WebSocket.RawData) => void =
 			args.format === "pretty" ? prettyPrintLogs : jsonPrintLogs;
 
-		tail.on("message", printLog);
+		// Lifecycle state shared across reconnect attempts.
+		let isShuttingDown = false;
+		let attempt = 0;
 
-		while (tail.readyState !== tail.OPEN) {
-			switch (tail.readyState) {
-				case tail.CONNECTING:
-					await setTimeout(100);
-					break;
-				case tail.CLOSING:
-					await setTimeout(100);
-					break;
-				case tail.CLOSED:
-					metrics.sendMetricsEvent("end log stream", {
-						sendMetrics: config.send_metrics,
-					});
-					throw new Error(
-						`Connection to ${scriptDisplayName} closed unexpectedly.`
-					);
+		// Per-connection state, replaced on each (re)connect.
+		let currentTail: WebSocket | undefined;
+		let currentDeleteTail: (() => Promise<void>) | undefined;
+		let cancelPing: (() => void) | undefined;
+		// Set to `true` while we are intentionally tearing down the current
+		// connection — used to suppress the `close` handler so it doesn't
+		// race with reconnect/shutdown logic that already has things in hand.
+		let intentionalClose = false;
+
+		// The handler returns this promise. It resolves on a clean stop (Ctrl-C
+		// or a normal server close) and rejects when we have given up after
+		// exhausting all reconnect attempts. Rejection propagates through the
+		// normal yargs/main error pipeline → `cli.ts` translates it to a
+		// non-zero process exit (test-safe: no `process.exit()` here).
+		let resolveDone!: () => void;
+		let rejectDone!: (reason: unknown) => void;
+		const done = new Promise<void>((resolve, reject) => {
+			resolveDone = resolve;
+			rejectDone = reject;
+		});
+
+		// `scriptName` is guaranteed to be set after the check above; alias to
+		// a non-nullable local for use inside `connect()`.
+		const workerName = scriptName;
+
+		/**
+		 * Open a single tail connection.
+		 *
+		 * - Throws on the initial-connect path so first-attempt failures surface
+		 *   through the normal handler-throws pipeline (preserves existing
+		 *   `Connection … closed unexpectedly.` behaviour).
+		 * - On subsequent reconnects we catch the throw and schedule another
+		 *   reconnect attempt instead.
+		 */
+		async function connect(): Promise<void> {
+			const { tail, expiration, deleteTail } = await createTail(
+				config,
+				accountId,
+				workerName,
+				filters,
+				args.debug,
+				useServiceEnvironments(config) ? args.env : undefined
+			);
+
+			currentTail = tail;
+			currentDeleteTail = deleteTail;
+			intentionalClose = false;
+			// Tracks whether this connection ever transitioned to OPEN. Used to
+			// distinguish "close before we connected" (which should bubble up
+			// as an error / trigger reconnect via the throw path) from "close
+			// while streaming" (which routes through cleanStop / reconnect).
+			let hasOpened = false;
+
+			if (attempt === 0 && args.format === "pretty") {
+				logger.log(
+					`Successfully created tail, expires at ${expiration.toLocaleString()}`
+				);
 			}
-		}
 
-		if (args.format === "pretty") {
-			logger.log(`Connected to ${scriptDisplayName}, waiting for logs...`);
-		}
+			tail.on("message", printLog);
 
-		const cancelPing = startWebSocketPing();
-		const removeExitListener = onExit(exit);
-		tail.on("close", exit);
+			// Hooks used by the open-wait promise below. The close listener
+			// rejects the wait if close fires before open; the open listener
+			// resolves it. Both are reset to `undefined` after the wait so
+			// the steady-state close handler can take over.
+			let resolveOpenWait: (() => void) | undefined;
+			let rejectOpenWait: ((err: Error) => void) | undefined;
 
-		// Guard against re-entry: `exit` can be invoked by both the WebSocket
-		// `close` event and the signal-exit handler (e.g. on SIGINT during an
-		// in-flight close). Without this, `deleteTail()` fires twice, and —
-		// in tests — the second invocation runs at process exit after mocks
-		// have been torn down, producing spurious "Not logged in" unhandled
-		// rejections.
-		let hasExited = false;
-		async function exit() {
-			if (hasExited) {
+			tail.on("close", (code: number) => {
+				if (!hasOpened && rejectOpenWait) {
+					rejectOpenWait(
+						new Error(`Connection to ${scriptDisplayName} closed unexpectedly.`)
+					);
+					return;
+				}
+				if (intentionalClose || isShuttingDown || !hasOpened) {
+					return;
+				}
+				if (code === NORMAL_CLOSURE) {
+					void cleanStop();
+				} else {
+					void scheduleReconnect();
+				}
+			});
+
+			// Wait for the connection to actually open. The `open` and `close`
+			// events fire on this WebSocket — whichever happens first wins.
+			if (tail.readyState !== tail.OPEN) {
+				await new Promise<void>((resolve, reject) => {
+					resolveOpenWait = resolve;
+					rejectOpenWait = reject;
+					tail.on("open", () => {
+						resolveOpenWait?.();
+					});
+				});
+			}
+			// Clear the open-wait hooks so the close handler can switch to
+			// its steady-state behaviour.
+			resolveOpenWait = undefined;
+			rejectOpenWait = undefined;
+
+			if (isShuttingDown || tail !== currentTail) {
 				return;
 			}
-			hasExited = true;
-			removeExitListener();
-			cancelPing();
-			tail.terminate();
-			await deleteTail();
-			metrics.sendMetricsEvent("end log stream", {
-				sendMetrics: config.send_metrics,
-			});
+
+			hasOpened = true;
+
+			if (args.format === "pretty") {
+				if (attempt === 0) {
+					logger.log(`Connected to ${scriptDisplayName}, waiting for logs...`);
+				} else {
+					logger.log(`Reconnected to ${scriptDisplayName}.`);
+				}
+			}
+
+			// Successful connection — reset the reconnect counter.
+			attempt = 0;
+			cancelPing = startWebSocketPing(tail, scheduleReconnect);
 		}
 
 		/**
-		 * Start pinging the websocket to see if it is still connected.
-		 *
-		 * We need to know if the connection to the tail drops.
-		 * To do this we send a ping message to the backend every few seconds.
-		 * If we don't get a matching pong message back before the next ping is due
-		 * then we have probably lost the connect.
+		 * Tear down the current connection so we can either reconnect or shut
+		 * down cleanly. This is best-effort: failures deleting the server-side
+		 * tail are logged but don't prevent the next step.
 		 */
-		function startWebSocketPing() {
-			/** The corelation message to send to tail when pinging. */
-			const PING_MESSAGE = Buffer.from("wrangler tail ping");
-			/** How long to wait between pings. */
-			const PING_INTERVAL = 10000;
+		async function teardownCurrentConnection(): Promise<void> {
+			cancelPing?.();
+			cancelPing = undefined;
+			intentionalClose = true;
+			const tail = currentTail;
+			const deleteTail = currentDeleteTail;
+			currentTail = undefined;
+			currentDeleteTail = undefined;
+			try {
+				tail?.terminate();
+			} catch {
+				// Ignore: the socket may already be closed/closing.
+			}
+			if (deleteTail) {
+				try {
+					await deleteTail();
+				} catch (e) {
+					logger.debug("Tail: failed to delete tail on the server:", e);
+				}
+			}
+		}
 
-			let waitingForPong = false;
+		/**
+		 * Called when the active connection drops unexpectedly (ping timeout or
+		 * abnormal close). Tears the current connection down, then either
+		 * waits + reconnects or gives up after `MAX_RECONNECT_ATTEMPTS` tries.
+		 */
+		async function scheduleReconnect(): Promise<void> {
+			if (isShuttingDown) {
+				return;
+			}
+			await teardownCurrentConnection();
+			if (isShuttingDown) {
+				return;
+			}
 
-			const pingInterval = setInterval(() => {
-				if (waitingForPong) {
-					// We didn't get a pong back quickly enough so assume the connection died and exit.
-					// This approach relies on the fact that throwing an error inside a `setInterval()` callback
-					// causes the process to exit.
-					// This is a bit nasty but otherwise we have to make wholesale changes to how the `tail` command
-					// works, since currently all the tests assume that `runWrangler()` will return immediately.
-					throw createFatalError(
-						"Tail disconnected, exiting.",
+			attempt++;
+			if (attempt > MAX_RECONNECT_ATTEMPTS) {
+				rejectDone(
+					createFatalError(
+						`Unable to reconnect to the tail for ${scriptDisplayName} after ${MAX_RECONNECT_ATTEMPTS} attempts. Please re-run \`wrangler tail${args.worker ? ` ${args.worker}` : ""}\` to start a new session.`,
 						args.format === "json",
 						{ code: 1, telemetryMessage: "tail stream disconnected" }
-					);
-				}
-				waitingForPong = true;
-				tail.ping(PING_MESSAGE);
-			}, PING_INTERVAL);
+					)
+				);
+				return;
+			}
 
-			tail.on("pong", (data) => {
-				if (data.equals(PING_MESSAGE)) {
-					waitingForPong = false;
-				}
-			});
+			const delay =
+				RECONNECT_BACKOFF_MS[attempt - 1] ??
+				RECONNECT_BACKOFF_MS[RECONNECT_BACKOFF_MS.length - 1];
+			logger.warn(
+				`Tail connection lost. Reconnecting (attempt ${attempt} of ${MAX_RECONNECT_ATTEMPTS}) in ${delay / 1000}s...`
+			);
+			try {
+				await sleep(delay);
+			} catch {
+				// `sleep` rejects when its `AbortSignal` fires; we don't pass one,
+				// but guard anyway so a future change can't break the loop.
+				return;
+			}
+			if (isShuttingDown) {
+				return;
+			}
 
-			return () => clearInterval(pingInterval);
+			try {
+				await connect();
+			} catch (e) {
+				logger.debug("Tail: reconnect attempt failed:", e);
+				void scheduleReconnect();
+			}
 		}
+
+		/** Resolve `done` after a clean server-initiated shutdown (code 1000). */
+		async function cleanStop(): Promise<void> {
+			if (isShuttingDown) {
+				return;
+			}
+			isShuttingDown = true;
+			await teardownCurrentConnection();
+			metrics.sendMetricsEvent("end log stream", {
+				sendMetrics: config.send_metrics,
+			});
+			removeSignalHandlers();
+			resolveDone();
+		}
+
+		/** Idempotent Ctrl-C / SIGTERM handler. */
+		async function shutdownHandler(): Promise<void> {
+			if (isShuttingDown) {
+				return;
+			}
+			isShuttingDown = true;
+			if (args.format === "pretty") {
+				logger.log("\nStopping tail...");
+			}
+			await teardownCurrentConnection();
+			metrics.sendMetricsEvent("end log stream", {
+				sendMetrics: config.send_metrics,
+			});
+			removeSignalHandlers();
+			resolveDone();
+		}
+
+		function removeSignalHandlers() {
+			process.removeListener("SIGINT", shutdownHandler);
+			process.removeListener("SIGTERM", shutdownHandler);
+		}
+
+		process.on("SIGINT", shutdownHandler);
+		process.on("SIGTERM", shutdownHandler);
+
+		try {
+			await connect();
+		} catch (e) {
+			// Initial connect failed — clean up signal listeners and propagate
+			// through the normal error pipeline (preserves existing behaviour
+			// for things like "Connection … closed unexpectedly.").
+			removeSignalHandlers();
+			throw e;
+		}
+
+		await done;
 	},
 });
+
+/**
+ * Start pinging the websocket to see if it is still connected.
+ *
+ * We need to know if the connection to the tail drops.
+ * To do this we send a ping message to the backend every few seconds.
+ * If we don't get a matching pong message back before the next ping is due
+ * then we have probably lost the connection.
+ */
+function startWebSocketPing(
+	tail: WebSocket,
+	onDisconnect: () => void
+): () => void {
+	/** The correlation message to send to tail when pinging. */
+	const PING_MESSAGE = Buffer.from("wrangler tail ping");
+
+	let waitingForPong = false;
+	let disconnected = false;
+
+	const pingInterval = setInterval(() => {
+		if (disconnected) {
+			return;
+		}
+		if (waitingForPong) {
+			// We didn't get a pong back quickly enough so assume the connection
+			// died. Stop pinging and notify the caller — never throw from here,
+			// since this callback is detached from any awaited promise and an
+			// uncaught throw would crash the process with a raw stack trace.
+			disconnected = true;
+			clearInterval(pingInterval);
+			logger.error(
+				`Tail disconnected: The Worker did not respond to a keep-alive ping within ${PING_INTERVAL_MS}ms, so the tail connection appears to have dropped.`
+			);
+			onDisconnect();
+			return;
+		}
+		waitingForPong = true;
+		logger.debug("Tail: Sending ping to tail websocket");
+		tail.ping(PING_MESSAGE);
+	}, PING_INTERVAL_MS);
+
+	tail.on("pong", (data: Buffer) => {
+		if (data.equals(PING_MESSAGE)) {
+			logger.debug("Tail: Received pong from tail websocket");
+			waitingForPong = false;
+		}
+	});
+
+	return () => {
+		disconnected = true;
+		clearInterval(pingInterval);
+	};
+}

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -231,6 +231,26 @@ export const tailCommand = createCommand({
 				useServiceEnvironments(config) ? args.env : undefined
 			);
 
+			// We may have started shutting down (Ctrl-C / SIGTERM, or a clean
+			// stop) while `createTail()` was in flight. If so, `shutdownHandler`
+			// has already run with `currentTail === undefined` and settled
+			// `done`, so adopting this socket would orphan it — it would never
+			// be terminated and its server-side tail never deleted, keeping the
+			// event loop alive. Tear the just-created connection down and bail.
+			if (isShuttingDown) {
+				try {
+					tail.terminate();
+				} catch {
+					// Ignore: the socket may already be closed/closing.
+				}
+				try {
+					await deleteTail();
+				} catch (e) {
+					logger.debug("Tail: failed to delete tail on the server:", e);
+				}
+				return;
+			}
+
 			currentTail = tail;
 			currentDeleteTail = deleteTail;
 			intentionalClose = false;

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -457,6 +457,16 @@ export const tailCommand = createCommand({
 			// through the normal error pipeline (preserves existing behaviour
 			// for things like "Connection … closed unexpectedly.").
 			removeSignalHandlers();
+			// Pair the `"begin log stream"` metric sent at handler start with
+			// an `"end log stream"` here so sessions that never made it past
+			// the initial handshake are balanced in telemetry alongside the
+			// `cleanStop` / `shutdownHandler` / give-up exit paths. The old
+			// busy-wait-based implementation sent this metric on its
+			// `tail.CLOSED` branch; this preserves that behaviour after the
+			// switch to an event-based open-wait.
+			metrics.sendMetricsEvent("end log stream", {
+				sendMetrics: config.send_metrics,
+			});
 			throw e;
 		}
 

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -369,6 +369,13 @@ export const tailCommand = createCommand({
 				// Otherwise this branch leaks listeners on `process`, which
 				// matters for in-process callers like `runWrangler` in tests.
 				removeSignalHandlers();
+				// Pair the `"begin log stream"` metric sent at handler start
+				// with an `"end log stream"` here too, so the give-up path
+				// shows up symmetrically in telemetry alongside the
+				// `cleanStop` / `shutdownHandler` exit paths.
+				metrics.sendMetricsEvent("end log stream", {
+					sendMetrics: config.send_metrics,
+				});
 				rejectDone(
 					createFatalError(
 						`Unable to reconnect to the tail for ${scriptDisplayName} after ${MAX_RECONNECT_ATTEMPTS} attempts. Please re-run \`wrangler tail${args.worker ? ` ${args.worker}` : ""}\` to start a new session.`,

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -266,6 +266,11 @@ export const tailCommand = createCommand({
 				);
 			}
 
+			// NOTE: The tail backend does not actively close this WebSocket
+			// when the expiration time is reached — log delivery just stops.
+			// A proactive client-side refresh based on `expiration` is tracked
+			// as a follow-up.
+
 			tail.on("message", printLog);
 
 			// Hooks used by the open-wait promise below. The close listener

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -269,7 +269,8 @@ export const tailCommand = createCommand({
 			// NOTE: The tail backend does not actively close this WebSocket
 			// when the expiration time is reached — log delivery just stops.
 			// A proactive client-side refresh based on `expiration` is tracked
-			// as a follow-up.
+			// as a follow-up in
+			// https://github.com/cloudflare/workers-sdk/issues/14427.
 
 			tail.on("message", printLog);
 


### PR DESCRIPTION
Improve `wrangler tail` resilience and shutdown behaviour.

`wrangler tail` previously crashed with a raw stack trace when the keep-alive ping to the Worker timed out, and could exit with an ugly error on Ctrl-C because the disconnect path threw from inside the keep-alive `setInterval` after the command's promise had already resolved.

The lifecycle has been refactored so that:

- The command now blocks until a clean shutdown (Ctrl-C / SIGTERM, or a normal server close) or until it permanently loses the connection. Errors flow through wrangler's usual error pipeline instead of escaping as uncaught exceptions.
- The keep-alive timeout message now clearly explains what happened and no longer prints a stack trace.
- When the tail connection drops unexpectedly (keep-alive ping timeout or abnormal close), `wrangler tail` now automatically reconnects up to 5 times with a 1s / 2s / 4s / 8s / 16s exponential back-off (≈30s total). On success, streaming resumes. After 5 failed attempts it gives up with a clear message asking the user to re-run the command to start a new session.
- Ctrl-C now prints a short "Stopping tail..." message (in pretty mode), awaits the server-side tail deletion, and exits cleanly with code 0.

This PR also fixes a long-standing issue where `wrangler pages dev` registered its `SIGINT`/`SIGTERM` handlers at module scope, so they were active for _every_ wrangler command. On Ctrl-C those handlers ran first and called `process.exit()`, preventing other long-running commands (such as `wrangler tail`) from shutting down gracefully. The handlers are now scoped to the `pages dev` command itself, and a regression test has been added so we don't reintroduce this.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: the user-visible behaviour change is described in the changeset; the public `wrangler tail` reference docs at developers.cloudflare.com remain accurate (no flags, output format, or API surface have changed).
