### PR TITLE
[wrangler] Add preview auto-provisioning for KV and R2

### DIFF
--- a/.changeset/preview-auto-provision.md
+++ b/.changeset/preview-auto-provision.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add auto-provisioning for KV and R2 bindings in `wrangler preview`
+
+Preview deployments now create deterministic KV namespaces and R2 buckets for binding-only entries in the `previews` config block, then use those generated resources for the deployment without writing IDs back to the config file. `wrangler preview delete` also cleans up only those auto-provisioned preview resources, leaving explicitly configured KV namespaces and R2 buckets untouched.

--- a/packages/deploy-helpers/src/deploy/helpers/create-worker-upload-form.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/create-worker-upload-form.ts
@@ -468,6 +468,7 @@ export function createWorkerUploadForm(
 			binding,
 			service,
 			environment,
+			preview_id,
 			entrypoint,
 			props,
 			cross_account_grant,
@@ -478,6 +479,7 @@ export function createWorkerUploadForm(
 				service,
 				cross_account_grant,
 				...(environment && { environment }),
+				...(preview_id && { preview_id }),
 				...(entrypoint && { entrypoint }),
 				...(props && { props }),
 			});

--- a/packages/deploy-helpers/src/deploy/helpers/print-bindings.ts
+++ b/packages/deploy-helpers/src/deploy/helpers/print-bindings.ts
@@ -513,43 +513,49 @@ export function printBindings(
 
 	if (services.length > 0) {
 		output.push(
-			...services.map(({ binding, service, entrypoint, remote, dev }) => {
-				let value = service;
-				let mode = undefined;
+			...services.map(
+				({ binding, service, preview_id, entrypoint, remote, dev }) => {
+					let value = service;
+					let mode = undefined;
 
-				if (entrypoint) {
-					value += `#${entrypoint}`;
-				}
+					if (preview_id) {
+						value += `@${preview_id}`;
+					}
 
-				if (dev !== undefined && context.local) {
-					mode = getMode({ isSimulatedLocally: true });
-				} else if (remote) {
-					mode = getMode({ isSimulatedLocally: false });
-				} else if (context.local && context.registry !== null) {
-					const isSelfBinding = service === context.name;
+					if (entrypoint) {
+						value += `#${entrypoint}`;
+					}
 
-					if (isSelfBinding) {
-						hasConnectionStatus = true;
-						mode = getMode({ isSimulatedLocally: true, connected: true });
-					} else {
-						const registryDefinition = context.registry?.[service];
-						hasConnectionStatus = true;
+					if (dev !== undefined && context.local) {
+						mode = getMode({ isSimulatedLocally: true });
+					} else if (remote) {
+						mode = getMode({ isSimulatedLocally: false });
+					} else if (context.local && context.registry !== null) {
+						const isSelfBinding = service === context.name;
 
-						if (registryDefinition && registryDefinition.debugPortAddress) {
+						if (isSelfBinding) {
+							hasConnectionStatus = true;
 							mode = getMode({ isSimulatedLocally: true, connected: true });
 						} else {
-							mode = getMode({ isSimulatedLocally: true, connected: false });
+							const registryDefinition = context.registry?.[service];
+							hasConnectionStatus = true;
+
+							if (registryDefinition && registryDefinition.debugPortAddress) {
+								mode = getMode({ isSimulatedLocally: true, connected: true });
+							} else {
+								mode = getMode({ isSimulatedLocally: true, connected: false });
+							}
 						}
 					}
-				}
 
-				return {
-					name: binding,
-					type: getBindingTypeFriendlyName("service"),
-					value,
-					mode,
-				};
-			})
+					return {
+						name: binding,
+						type: getBindingTypeFriendlyName("service"),
+						value,
+						mode,
+					};
+				}
+			)
 		);
 	}
 

--- a/packages/workers-utils/src/config/environment.ts
+++ b/packages/workers-utils/src/config/environment.ts
@@ -1163,6 +1163,8 @@ export interface EnvironmentNonInheritable {
 				 * The environment of the service (e.g. production, staging, etc).
 				 */
 				environment?: string;
+				/** Optionally, the preview tag, slug, or display name of the service to bind to. */
+				preview_id?: string;
 				/** Optionally, the entrypoint (named export) of the service to bind to. */
 				entrypoint?: string;
 				/** Optional properties that will be made available to the service via ctx.props. */

--- a/packages/workers-utils/src/config/validation.ts
+++ b/packages/workers-utils/src/config/validation.ts
@@ -4581,6 +4581,14 @@ const validateServiceBinding: ValidatorFn = (diagnostics, field, value) => {
 		);
 		isValid = false;
 	}
+	if (!isOptionalProperty(value, "preview_id", "string")) {
+		diagnostics.errors.push(
+			`"${field}" bindings should have a string "preview_id" field but got ${JSON.stringify(
+				value
+			)}.`
+		);
+		isValid = false;
+	}
 	if (!isOptionalProperty(value, "entrypoint", "string")) {
 		diagnostics.errors.push(
 			`"${field}" bindings should have a string "entrypoint" field but got ${JSON.stringify(

--- a/packages/workers-utils/src/map-worker-metadata-bindings.ts
+++ b/packages/workers-utils/src/map-worker-metadata-bindings.ts
@@ -170,6 +170,7 @@ export function mapWorkerMetadataBindings(
 									binding: binding.name,
 									service: binding.service,
 									environment: binding.environment,
+									preview_id: binding.preview_id,
 									entrypoint: binding.entrypoint,
 								},
 							];

--- a/packages/workers-utils/src/types.ts
+++ b/packages/workers-utils/src/types.ts
@@ -145,6 +145,7 @@ export type WorkerMetadataBinding =
 			name: string;
 			service: string;
 			environment?: string;
+			preview_id?: string;
 			entrypoint?: string;
 			cross_account_grant?: string;
 	  }

--- a/packages/workers-utils/src/worker.ts
+++ b/packages/workers-utils/src/worker.ts
@@ -321,6 +321,7 @@ export interface CfService {
 	binding: string;
 	service: string;
 	environment?: string;
+	preview_id?: string;
 	entrypoint?: string;
 	props?: Record<string, unknown>;
 	remote?: boolean;

--- a/packages/wrangler/src/__tests__/create-worker-upload-form/bindings.test.ts
+++ b/packages/wrangler/src/__tests__/create-worker-upload-form/bindings.test.ts
@@ -234,6 +234,23 @@ describe("createWorkerUploadForm — bindings", () => {
 				entrypoint: "AuthHandler",
 			});
 		});
+
+		it("should include service bindings with preview IDs", ({ expect }) => {
+			const bindings: StartDevWorkerInput["bindings"] = {
+				AUTH: {
+					type: "service",
+					service: "auth-worker",
+					preview_id: "feature-preview",
+				},
+			};
+			const form = createWorkerUploadForm(createEsmWorker(), bindings);
+			expect(getBindings(form)).toContainEqual({
+				name: "AUTH",
+				type: "service",
+				service: "auth-worker",
+				preview_id: "feature-preview",
+			});
+		});
 	});
 
 	describe("queue bindings", () => {

--- a/packages/wrangler/src/__tests__/deploy/bindings.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/bindings.test.ts
@@ -1886,6 +1886,51 @@ describe("deploy", () => {
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 
+			it("should support service bindings to Worker Previews", async ({
+				expect,
+			}) => {
+				writeWranglerConfig({
+					services: [
+						{
+							binding: "FOO",
+							service: "foo-service",
+							preview_id: "feature-preview",
+						},
+					],
+				});
+				writeWorkerSource();
+				mockSubDomainRequest();
+				mockUploadWorkerRequest({
+					expectedBindings: [
+						{
+							type: "service",
+							name: "FOO",
+							service: "foo-service",
+							preview_id: "feature-preview",
+						},
+					],
+				});
+
+				await runWrangler("deploy index.js");
+				expect(std.out).toMatchInlineSnapshot(`
+					"
+					 ⛅️ wrangler x.x.x
+					──────────────────
+					Total Upload: xx KiB / gzip: xx KiB
+					Worker Startup Time: 100 ms
+					Your Worker has access to the following bindings:
+					Binding                                    Resource
+					env.FOO (foo-service@feature-preview)      Worker
+
+					Uploaded test-name (TIMINGS)
+					Deployed test-name triggers (TIMINGS)
+					  https://test-name.test-sub-domain.workers.dev
+					Current Version ID: Galaxy-Class"
+				`);
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(std.warn).toMatchInlineSnapshot(`""`);
+			});
+
 			it("should support service bindings with props", async ({ expect }) => {
 				writeWranglerConfig({
 					services: [

--- a/packages/wrangler/src/__tests__/preview.test.ts
+++ b/packages/wrangler/src/__tests__/preview.test.ts
@@ -260,6 +260,26 @@ describe("wrangler preview", () => {
 			});
 		});
 
+		test("should pass preview_id on service bindings", ({ expect }) => {
+			const config = configWithPreviews({
+				services: [
+					{
+						binding: "API",
+						service: "api-worker",
+						preview_id: "feature-preview",
+					},
+				],
+			});
+			const bindings = extractConfigBindings(config);
+			expect(bindings).toMatchObject({
+				API: {
+					type: "service",
+					service: "api-worker",
+					preview_id: "feature-preview",
+				},
+			});
+		});
+
 		test("should fold unsafe.bindings into the previews env", ({ expect }) => {
 			const config = configWithPreviews({
 				unsafe: {

--- a/packages/wrangler/src/__tests__/preview.test.ts
+++ b/packages/wrangler/src/__tests__/preview.test.ts
@@ -414,6 +414,310 @@ describe("wrangler preview", () => {
 			expect(std.out).toContain("◆ from wrangler.json");
 		});
 
+		test("should auto-provision missing preview KV and R2 bindings", async ({
+			expect,
+		}) => {
+			writeFileSync(
+				"wrangler.json",
+				JSON.stringify({
+					name: "test-worker",
+					main: "src/index.ts",
+					compatibility_date: "2025-01-01",
+					previews: {
+						kv_namespaces: [{ binding: "MY_KV" }],
+						r2_buckets: [{ binding: "MY_BUCKET" }],
+					},
+				})
+			);
+
+			let kvCreateBody: unknown;
+			let r2CreateBody: unknown;
+			let deploymentBody: { env?: Record<string, unknown> } | undefined;
+			msw.use(
+				http.get(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId`,
+					() =>
+						HttpResponse.json(
+							{
+								success: false,
+								result: null,
+								errors: [{ code: 10025, message: "Preview not found" }],
+							},
+							{ status: 404 }
+						)
+				),
+				http.post(
+					`*/accounts/:accountId/workers/workers/:workerId/previews`,
+					() =>
+						HttpResponse.json({
+							success: true,
+							result: {
+								id: "preview-id-123",
+								name: "test-preview",
+								slug: "test-preview",
+								urls: ["https://test-preview.test-worker.cloudflare.app"],
+								worker_name: "test-worker",
+								created_on: new Date().toISOString(),
+							},
+						})
+				),
+				http.get(`*/accounts/:accountId/storage/kv/namespaces`, () =>
+					HttpResponse.json({ success: true, result: [] })
+				),
+				http.post(
+					`*/accounts/:accountId/storage/kv/namespaces`,
+					async ({ request }) => {
+						kvCreateBody = await request.json();
+						return HttpResponse.json({
+							success: true,
+							result: { id: "auto-kv-id" },
+						});
+					}
+				),
+				http.get(`*/accounts/:accountId/r2/buckets/:bucketName`, () =>
+					HttpResponse.json(
+						{
+							success: false,
+							result: null,
+							errors: [{ code: 10006, message: "bucket not found" }],
+						},
+						{ status: 404 }
+					)
+				),
+				http.post(`*/accounts/:accountId/r2/buckets`, async ({ request }) => {
+					r2CreateBody = await request.json();
+					return HttpResponse.json({ success: true, result: null });
+				}),
+				http.post(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId/deployments`,
+					async ({ request }) => {
+						deploymentBody = (await request.json()) as typeof deploymentBody;
+						return HttpResponse.json({
+							success: true,
+							result: {
+								id: "deployment-id-123",
+								preview_id: "preview-id-123",
+								preview_name: "test-preview",
+								urls: ["https://abc12345.test-worker.cloudflare.app"],
+								compatibility_date: "2025-01-01",
+								env: deploymentBody?.env,
+								created_on: new Date().toISOString(),
+							},
+						});
+					}
+				)
+			);
+
+			await runWrangler("preview --name test-preview");
+
+			expect(kvCreateBody).toEqual({ title: "test-worker-test-preview-my-kv" });
+			expect(r2CreateBody).toEqual({
+				name: "test-worker-test-preview-my-bucket",
+			});
+			expect(deploymentBody?.env).toMatchObject({
+				MY_KV: { type: "kv_namespace", namespace_id: "auto-kv-id" },
+				MY_BUCKET: {
+					type: "r2_bucket",
+					bucket_name: "test-worker-test-preview-my-bucket",
+				},
+			});
+		});
+
+		test("should reuse deterministic preview resources and respect explicit bindings", async ({
+			expect,
+		}) => {
+			writeFileSync(
+				"wrangler.json",
+				JSON.stringify({
+					name: "test-worker",
+					main: "src/index.ts",
+					compatibility_date: "2025-01-01",
+					previews: {
+						kv_namespaces: [
+							{ binding: "OWNED_KV" },
+							{ binding: "USER_KV", id: "user-kv-id" },
+						],
+						r2_buckets: [
+							{ binding: "OWNED_BUCKET" },
+							{ binding: "USER_BUCKET", bucket_name: "user-bucket" },
+						],
+					},
+				})
+			);
+
+			let kvCreateCalled = false;
+			let r2CreateCalled = false;
+			let deploymentBody: { env?: Record<string, unknown> } | undefined;
+			msw.use(
+				http.get(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId`,
+					() =>
+						HttpResponse.json({
+							success: true,
+							result: {
+								id: "preview-id-123",
+								name: "test-preview",
+								slug: "test-preview",
+								urls: ["https://test-preview.test-worker.cloudflare.app"],
+								worker_name: "test-worker",
+								created_on: new Date().toISOString(),
+							},
+						})
+				),
+				http.get(`*/accounts/:accountId/storage/kv/namespaces`, () =>
+					HttpResponse.json({
+						success: true,
+						result: [
+							{
+								id: "existing-owned-kv-id",
+								title: "test-worker-test-preview-owned-kv",
+							},
+						],
+					})
+				),
+				http.post(`*/accounts/:accountId/storage/kv/namespaces`, () => {
+					kvCreateCalled = true;
+					return HttpResponse.json({ success: true, result: { id: "new-id" } });
+				}),
+				http.get(
+					`*/accounts/:accountId/r2/buckets/:bucketName`,
+					({ params }) => {
+						expect(params.bucketName).toBe(
+							"test-worker-test-preview-owned-bucket"
+						);
+						return HttpResponse.json({
+							success: true,
+							result: { name: params.bucketName, creation_date: "2025-01-01" },
+						});
+					}
+				),
+				http.post(`*/accounts/:accountId/r2/buckets`, () => {
+					r2CreateCalled = true;
+					return HttpResponse.json({ success: true, result: null });
+				}),
+				http.post(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId/deployments`,
+					async ({ request }) => {
+						deploymentBody = (await request.json()) as typeof deploymentBody;
+						return HttpResponse.json({
+							success: true,
+							result: {
+								id: "deployment-id-123",
+								preview_id: "preview-id-123",
+								preview_name: "test-preview",
+								urls: ["https://abc12345.test-worker.cloudflare.app"],
+								compatibility_date: "2025-01-01",
+								env: deploymentBody?.env,
+								created_on: new Date().toISOString(),
+							},
+						});
+					}
+				)
+			);
+
+			await runWrangler("preview --name test-preview");
+
+			expect(kvCreateCalled).toBe(false);
+			expect(r2CreateCalled).toBe(false);
+			expect(deploymentBody?.env).toMatchObject({
+				OWNED_KV: {
+					type: "kv_namespace",
+					namespace_id: "existing-owned-kv-id",
+				},
+				USER_KV: { type: "kv_namespace", namespace_id: "user-kv-id" },
+				OWNED_BUCKET: {
+					type: "r2_bucket",
+					bucket_name: "test-worker-test-preview-owned-bucket",
+				},
+				USER_BUCKET: { type: "r2_bucket", bucket_name: "user-bucket" },
+			});
+		});
+
+		test("should not use preview_id or preview_bucket_name as preview resource identifiers", async ({
+			expect,
+		}) => {
+			writeFileSync(
+				"wrangler.json",
+				JSON.stringify({
+					name: "test-worker",
+					main: "src/index.ts",
+					compatibility_date: "2025-01-01",
+					previews: {
+						kv_namespaces: [{ binding: "MY_KV", preview_id: "local-kv-id" }],
+						r2_buckets: [
+							{ binding: "MY_BUCKET", preview_bucket_name: "local-bucket" },
+						],
+					},
+				})
+			);
+
+			let deploymentBody: { env?: Record<string, unknown> } | undefined;
+			msw.use(
+				http.get(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId`,
+					() =>
+						HttpResponse.json({
+							success: true,
+							result: {
+								id: "preview-id-123",
+								name: "test-preview",
+								slug: "test-preview",
+								urls: ["https://test-preview.test-worker.cloudflare.app"],
+								worker_name: "test-worker",
+								created_on: new Date().toISOString(),
+							},
+						})
+				),
+				http.get(`*/accounts/:accountId/storage/kv/namespaces`, () =>
+					HttpResponse.json({ success: true, result: [] })
+				),
+				http.post(`*/accounts/:accountId/storage/kv/namespaces`, () =>
+					HttpResponse.json({ success: true, result: { id: "auto-kv-id" } })
+				),
+				http.get(`*/accounts/:accountId/r2/buckets/:bucketName`, () =>
+					HttpResponse.json(
+						{
+							success: false,
+							result: null,
+							errors: [{ code: 10006, message: "bucket not found" }],
+						},
+						{ status: 404 }
+					)
+				),
+				http.post(`*/accounts/:accountId/r2/buckets`, () =>
+					HttpResponse.json({ success: true, result: null })
+				),
+				http.post(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId/deployments`,
+					async ({ request }) => {
+						deploymentBody = (await request.json()) as typeof deploymentBody;
+						return HttpResponse.json({
+							success: true,
+							result: {
+								id: "deployment-id-123",
+								preview_id: "preview-id-123",
+								preview_name: "test-preview",
+								urls: ["https://abc12345.test-worker.cloudflare.app"],
+								compatibility_date: "2025-01-01",
+								env: deploymentBody?.env,
+								created_on: new Date().toISOString(),
+							},
+						});
+					}
+				)
+			);
+
+			await runWrangler("preview --name test-preview");
+
+			expect(deploymentBody?.env).toMatchObject({
+				MY_KV: { type: "kv_namespace", namespace_id: "auto-kv-id" },
+				MY_BUCKET: {
+					type: "r2_bucket",
+					bucket_name: "test-worker-test-preview-my-bucket",
+				},
+			});
+		});
+
 		test("should warn about top-level bindings missing from preview settings", async ({
 			expect,
 		}) => {
@@ -3080,6 +3384,111 @@ describe("wrangler preview", () => {
 			);
 			expect(deleteUrl).toContain("/previews/my-feature");
 			expect(std.out).toContain('Preview "my-feature" deleted successfully');
+		});
+
+		test("should delete only auto-provisioned preview KV and R2 resources", async ({
+			expect,
+		}) => {
+			writeFileSync(
+				"wrangler.json",
+				JSON.stringify({
+					name: "test-worker",
+					main: "src/index.ts",
+					compatibility_date: "2025-01-01",
+					previews: {
+						kv_namespaces: [
+							{ binding: "OWNED_KV" },
+							{ binding: "USER_KV", id: "user-kv-id" },
+						],
+						r2_buckets: [
+							{ binding: "OWNED_BUCKET" },
+							{ binding: "USER_BUCKET", bucket_name: "user-bucket" },
+						],
+					},
+				})
+			);
+
+			const deletedKVNamespaces: string[] = [];
+			const deletedR2Objects: string[] = [];
+			const deletedR2Buckets: string[] = [];
+			msw.use(
+				http.get(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId`,
+					() =>
+						HttpResponse.json({
+							success: true,
+							result: {
+								id: "preview-id-123",
+								name: "Feature Branch/One",
+								slug: "feature-branch-one",
+								urls: ["https://feature-branch-one.test-worker.cloudflare.app"],
+								worker_name: "test-worker",
+								created_on: new Date().toISOString(),
+							},
+						})
+				),
+				http.delete(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId`,
+					() => HttpResponse.json({ success: true, result: null })
+				),
+				http.get(`*/accounts/:accountId/storage/kv/namespaces`, () =>
+					HttpResponse.json({
+						success: true,
+						result: [
+							{
+								id: "owned-kv-id",
+								title: "test-worker-feature-branch-one-owned-kv",
+							},
+							{ id: "user-kv-id", title: "user-kv" },
+						],
+					})
+				),
+				http.delete(
+					`*/accounts/:accountId/storage/kv/namespaces/:namespaceId`,
+					({ params }) => {
+						deletedKVNamespaces.push(String(params.namespaceId));
+						return HttpResponse.json({
+							success: true,
+							result: { id: params.namespaceId },
+						});
+					}
+				),
+				http.get(`*/accounts/:accountId/r2/buckets/:bucketName`, ({ params }) =>
+					HttpResponse.json({
+						success: true,
+						result: { name: params.bucketName, creation_date: "2025-01-01" },
+					})
+				),
+				http.get(`*/accounts/:accountId/r2/buckets/:bucketName/objects`, () =>
+					HttpResponse.json({
+						result: { objects: [{ key: "a.txt" }, { key: "b.txt" }] },
+					})
+				),
+				http.delete(
+					`*/accounts/:accountId/r2/buckets/:bucketName/objects/:objectName`,
+					({ params }) => {
+						deletedR2Objects.push(String(params.objectName));
+						return HttpResponse.json({ success: true, result: null });
+					}
+				),
+				http.delete(
+					`*/accounts/:accountId/r2/buckets/:bucketName`,
+					({ params }) => {
+						deletedR2Buckets.push(String(params.bucketName));
+						return HttpResponse.json({ success: true, result: null });
+					}
+				)
+			);
+
+			await runWrangler(
+				'preview delete --name "Feature Branch/One" --skip-confirmation --worker-name test-worker'
+			);
+
+			expect(deletedKVNamespaces).toEqual(["owned-kv-id"]);
+			expect(deletedR2Objects).toEqual(["a.txt", "b.txt"]);
+			expect(deletedR2Buckets).toEqual([
+				"test-worker-feature-branch-one-owned-bucket",
+			]);
 		});
 
 		test("should proceed with deletion in non-interactive mode (CI fallback)", async ({

--- a/packages/wrangler/src/__tests__/preview.test.ts
+++ b/packages/wrangler/src/__tests__/preview.test.ts
@@ -3481,7 +3481,9 @@ describe("wrangler preview", () => {
 				),
 				http.get(`*/accounts/:accountId/r2/buckets/:bucketName/objects`, () =>
 					HttpResponse.json({
-						result: { objects: [{ key: "a.txt" }, { key: "b.txt" }] },
+						success: true,
+						result: [{ key: "a.txt" }, { key: "b.txt" }],
+						result_info: { is_truncated: false },
 					})
 				),
 				http.delete(
@@ -3508,6 +3510,116 @@ describe("wrangler preview", () => {
 			expect(deletedR2Objects).toEqual(["a.txt", "b.txt"]);
 			expect(deletedR2Buckets).toEqual([
 				"test-worker-feature-branch-one-owned-bucket",
+			]);
+		});
+
+		test("should page through R2 objects and retry bucket deletion if the bucket is not empty", async ({
+			expect,
+		}) => {
+			writeFileSync(
+				"wrangler.json",
+				JSON.stringify({
+					name: "test-worker",
+					main: "src/index.ts",
+					compatibility_date: "2025-01-01",
+					previews: {
+						r2_buckets: [{ binding: "OWNED_BUCKET" }],
+					},
+				})
+			);
+
+			const deletedR2Objects: string[] = [];
+			const deletedR2Buckets: string[] = [];
+			let objectListCalls = 0;
+			let bucketDeleteCalls = 0;
+			msw.use(
+				http.get(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId`,
+					() =>
+						HttpResponse.json({
+							success: true,
+							result: {
+								id: "preview-id-123",
+								name: "test-preview",
+								slug: "test-preview",
+								urls: ["https://test-preview.test-worker.cloudflare.app"],
+								worker_name: "test-worker",
+								created_on: new Date().toISOString(),
+							},
+						})
+				),
+				http.delete(
+					`*/accounts/:accountId/workers/workers/:workerId/previews/:previewId`,
+					() => HttpResponse.json({ success: true, result: null })
+				),
+				http.get(`*/accounts/:accountId/r2/buckets/:bucketName`, ({ params }) =>
+					HttpResponse.json({
+						success: true,
+						result: { name: params.bucketName, creation_date: "2025-01-01" },
+					})
+				),
+				http.get(
+					`*/accounts/:accountId/r2/buckets/:bucketName/objects`,
+					({ request }) => {
+						objectListCalls++;
+						const cursor = new URL(request.url).searchParams.get("cursor");
+						if (objectListCalls === 1) {
+							expect(cursor).toBeNull();
+							return HttpResponse.json({
+								success: true,
+								result: [{ key: "a.txt" }],
+								result_info: { is_truncated: true, cursor: "next-page" },
+							});
+						}
+						if (objectListCalls === 2) {
+							expect(cursor).toBe("next-page");
+							return HttpResponse.json({
+								success: true,
+								result: [{ key: "b.txt" }],
+								result_info: { is_truncated: false },
+							});
+						}
+						return HttpResponse.json({
+							success: true,
+							result: [{ key: "late.txt" }],
+							result_info: { is_truncated: false },
+						});
+					}
+				),
+				http.delete(
+					`*/accounts/:accountId/r2/buckets/:bucketName/objects/:objectName`,
+					({ params }) => {
+						deletedR2Objects.push(String(params.objectName));
+						return HttpResponse.json({ success: true, result: null });
+					}
+				),
+				http.delete(
+					`*/accounts/:accountId/r2/buckets/:bucketName`,
+					({ params }) => {
+						bucketDeleteCalls++;
+						if (bucketDeleteCalls === 1) {
+							return HttpResponse.json(
+								{
+									success: false,
+									result: null,
+									errors: [{ code: 10008, message: "bucket is not empty" }],
+								},
+								{ status: 400 }
+							);
+						}
+						deletedR2Buckets.push(String(params.bucketName));
+						return HttpResponse.json({ success: true, result: null });
+					}
+				)
+			);
+
+			await runWrangler(
+				"preview delete --name test-preview --skip-confirmation --worker-name test-worker"
+			);
+
+			expect(deletedR2Objects).toEqual(["a.txt", "b.txt", "late.txt"]);
+			expect(deletedR2Buckets).toEqual([
+				"test-worker-test-preview-owned-bucket",
 			]);
 		});
 

--- a/packages/wrangler/src/api/startDevWorker/utils.ts
+++ b/packages/wrangler/src/api/startDevWorker/utils.ts
@@ -214,6 +214,7 @@ export function convertWorkerMetadataBindingsToFlatBindings(
 					type: "service",
 					service: b.service,
 					environment: b.environment,
+					preview_id: b.preview_id,
 					entrypoint: b.entrypoint,
 					cross_account_grant: b.cross_account_grant,
 				};

--- a/packages/wrangler/src/pages/download-config.ts
+++ b/packages/wrangler/src/pages/download-config.ts
@@ -29,6 +29,7 @@ interface PagesDeploymentConfig extends DeploymentConfig {
 		{
 			service: string;
 			environment?: string;
+			preview_id?: string;
 		}
 	>;
 	queue_producers: Record<
@@ -161,7 +162,7 @@ async function toEnvironment(
 		});
 	}
 
-	for (const [name, { service, environment }] of Object.entries(
+	for (const [name, { service, environment, preview_id }] of Object.entries(
 		deploymentConfig.services ?? {}
 	)) {
 		configObj.services ??= [];
@@ -169,6 +170,7 @@ async function toEnvironment(
 			binding: name,
 			service,
 			environment,
+			preview_id,
 		});
 	}
 

--- a/packages/wrangler/src/preview/api.ts
+++ b/packages/wrangler/src/preview/api.ts
@@ -47,6 +47,7 @@ export interface Binding {
 	staging?: boolean;
 	enable_timer?: boolean;
 	app_id?: string;
+	preview_id?: string;
 	entrypoint?: string;
 	class_name?: string;
 	script_name?: string;

--- a/packages/wrangler/src/preview/preview.ts
+++ b/packages/wrangler/src/preview/preview.ts
@@ -43,6 +43,12 @@ import {
 	getWorkerPreviewDefaults,
 } from "./api";
 import {
+	cleanupPreviewBindings,
+	getFallbackPreviewSlug,
+	hasPreviewBindingsToProvision,
+	provisionPreviewBindings,
+} from "./provision";
+import {
 	assemblePreviewScriptSettings,
 	extractConfigBindings,
 	getBindingValue,
@@ -853,8 +859,15 @@ export async function handlePreviewCommand(
 		}
 	}
 
-	const deploymentRequest = await assemblePreviewDeploymentSettings(
+	const previewConfig = await provisionPreviewBindings(
 		config,
+		accountId,
+		workerName,
+		preview.slug
+	);
+
+	const deploymentRequest = await assemblePreviewDeploymentSettings(
+		previewConfig,
 		args.script,
 		accountId,
 		workerName,
@@ -887,8 +900,8 @@ export async function handlePreviewCommand(
 		return;
 	}
 
-	const scriptLevel = buildMergedScriptLevel(config, preview);
-	const versionLevel = buildMergedVersionLevel(config, deployment);
+	const scriptLevel = buildMergedScriptLevel(previewConfig, preview);
+	const versionLevel = buildMergedVersionLevel(previewConfig, deployment);
 	const configName = configFileName(config.configPath);
 	logger.log(
 		formatPreviewResource(preview, scriptLevel, isNewPreview, configName)
@@ -905,7 +918,7 @@ export async function handlePreviewCommand(
 		logMissingPreviewsBindingsWarning(
 			topLevelBindings,
 			previewDefaults.env,
-			extractConfigBindings(config)
+			extractConfigBindings(previewConfig)
 		);
 	}
 }
@@ -945,6 +958,38 @@ export async function handlePreviewDeleteCommand(
 	}
 
 	const accountId = await requireAuth(config);
-	await deletePreview(config, accountId, workerName, previewName);
+	if (hasPreviewBindingsToProvision(config)) {
+		let previewSlug = getFallbackPreviewSlug(previewName);
+		try {
+			const preview = await getPreview(
+				config,
+				accountId,
+				workerName,
+				previewName
+			);
+			previewSlug = preview.slug;
+		} catch (error) {
+			if (
+				!(error instanceof Error && "code" in error && error.code === 10025)
+			) {
+				throw error;
+			}
+		}
+
+		let deleteError: unknown;
+		try {
+			await deletePreview(config, accountId, workerName, previewName);
+		} catch (error) {
+			deleteError = error;
+		}
+
+		await cleanupPreviewBindings(config, accountId, workerName, previewSlug);
+
+		if (deleteError !== undefined) {
+			throw deleteError;
+		}
+	} else {
+		await deletePreview(config, accountId, workerName, previewName);
+	}
 	logger.log(`\n✨ Preview "${previewName}" deleted successfully.`);
 }

--- a/packages/wrangler/src/preview/provision.ts
+++ b/packages/wrangler/src/preview/provision.ts
@@ -32,6 +32,10 @@ function isNotFoundError(error: unknown): boolean {
 	);
 }
 
+function isR2BucketNotEmptyError(error: unknown): boolean {
+	return error instanceof APIError && error.code === 10008;
+}
+
 export function getFallbackPreviewSlug(previewName: string): string {
 	return previewName
 		.toLowerCase()
@@ -182,26 +186,34 @@ export async function cleanupPreviewBindings(
 			throw error;
 		}
 
-		for (const key of await listR2ObjectKeys(
-			config,
-			accountId,
-			bucketName,
-			r2.jurisdiction
-		)) {
-			await deleteR2Object(
+		for (let attempt = 0; attempt < 3; attempt++) {
+			const keys = await listR2ObjectKeys(
 				config,
 				accountId,
 				bucketName,
-				key,
-				true,
 				r2.jurisdiction
 			);
-		}
+			for (const key of keys) {
+				await deleteR2Object(
+					config,
+					accountId,
+					bucketName,
+					key,
+					true,
+					r2.jurisdiction
+				);
+			}
 
-		try {
-			await deleteR2Bucket(config, accountId, bucketName, r2.jurisdiction);
-		} catch (error) {
-			if (!isNotFoundError(error)) {
+			try {
+				await deleteR2Bucket(config, accountId, bucketName, r2.jurisdiction);
+				break;
+			} catch (error) {
+				if (isNotFoundError(error)) {
+					break;
+				}
+				if (isR2BucketNotEmptyError(error) && attempt < 2) {
+					continue;
+				}
 				throw error;
 			}
 		}

--- a/packages/wrangler/src/preview/provision.ts
+++ b/packages/wrangler/src/preview/provision.ts
@@ -71,7 +71,7 @@ export async function provisionPreviewBindings(
 
 			const title = getPreviewResourceName(workerName, previewSlug, kv.binding);
 			const existing = (await listKVNamespaces(config, accountId)).find(
-				(namespace) => namespace.title === title
+				(kvNamespace) => kvNamespace.title === title
 			);
 			const id =
 				existing?.id ?? (await createKVNamespace(config, accountId, title));
@@ -146,15 +146,15 @@ export async function cleanupPreviewBindings(
 		}
 
 		const title = getPreviewResourceName(workerName, previewSlug, kv.binding);
-		const namespace = (await listKVNamespaces(config, accountId)).find(
+		const kvNamespace = (await listKVNamespaces(config, accountId)).find(
 			(namespace) => namespace.title === title
 		);
-		if (!namespace) {
+		if (!kvNamespace) {
 			continue;
 		}
 
 		try {
-			await deleteKVNamespace(config, accountId, namespace.id);
+			await deleteKVNamespace(config, accountId, kvNamespace.id);
 		} catch (error) {
 			if (!isNotFoundError(error)) {
 				throw error;

--- a/packages/wrangler/src/preview/provision.ts
+++ b/packages/wrangler/src/preview/provision.ts
@@ -1,0 +1,209 @@
+import { APIError } from "@cloudflare/workers-utils";
+import { autoProvisionedResourceName } from "../deployment-bundle/auto-provisioned-name";
+import { getFlag } from "../experimental-flags";
+import {
+	createKVNamespace,
+	deleteKVNamespace,
+	listKVNamespaces,
+} from "../kv/helpers";
+import {
+	createR2Bucket,
+	deleteR2Bucket,
+	getR2Bucket,
+} from "../r2/helpers/bucket";
+import { deleteR2Object, listR2ObjectKeys } from "../r2/helpers/object";
+import type { Config, PreviewsConfig } from "@cloudflare/workers-utils";
+
+function getPreviewResourceName(
+	workerName: string,
+	previewSlug: string,
+	bindingName: string
+): string {
+	return autoProvisionedResourceName(
+		`${workerName}-${previewSlug}`,
+		bindingName
+	);
+}
+
+function isNotFoundError(error: unknown): boolean {
+	return (
+		error instanceof APIError &&
+		(error.status === 404 || error.code === 10006 || error.code === 10025)
+	);
+}
+
+export function getFallbackPreviewSlug(previewName: string): string {
+	return previewName
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+}
+
+export function hasPreviewBindingsToProvision(config: Config): boolean {
+	const previews = config.previews as PreviewsConfig | undefined;
+	return !!(
+		previews?.kv_namespaces?.some((kv) => !kv.id) ||
+		previews?.r2_buckets?.some((r2) => !r2.bucket_name)
+	);
+}
+
+export async function provisionPreviewBindings(
+	config: Config,
+	accountId: string,
+	workerName: string,
+	previewSlug: string
+): Promise<Config> {
+	if (!getFlag("RESOURCES_PROVISION")) {
+		return config;
+	}
+
+	const previews = config.previews as PreviewsConfig | undefined;
+	if (!previews || !hasPreviewBindingsToProvision(config)) {
+		return config;
+	}
+
+	let changed = false;
+	const kvNamespaces = await Promise.all(
+		(previews.kv_namespaces ?? []).map(async (kv) => {
+			if (kv.id) {
+				return kv;
+			}
+
+			const title = getPreviewResourceName(workerName, previewSlug, kv.binding);
+			const existing = (await listKVNamespaces(config, accountId)).find(
+				(namespace) => namespace.title === title
+			);
+			const id =
+				existing?.id ?? (await createKVNamespace(config, accountId, title));
+			changed = true;
+			return { ...kv, id };
+		})
+	);
+
+	const r2Buckets = await Promise.all(
+		(previews.r2_buckets ?? []).map(async (r2) => {
+			if (r2.bucket_name) {
+				return r2;
+			}
+
+			const bucketName = getPreviewResourceName(
+				workerName,
+				previewSlug,
+				r2.binding
+			);
+			try {
+				await getR2Bucket(config, accountId, bucketName, r2.jurisdiction);
+			} catch (error) {
+				if (!isNotFoundError(error)) {
+					throw error;
+				}
+				await createR2Bucket(
+					config,
+					accountId,
+					bucketName,
+					undefined,
+					r2.jurisdiction
+				);
+			}
+
+			changed = true;
+			return { ...r2, bucket_name: bucketName };
+		})
+	);
+
+	if (!changed) {
+		return config;
+	}
+
+	return {
+		...config,
+		previews: {
+			...previews,
+			kv_namespaces: kvNamespaces,
+			r2_buckets: r2Buckets,
+		},
+	};
+}
+
+export async function cleanupPreviewBindings(
+	config: Config,
+	accountId: string,
+	workerName: string,
+	previewSlug: string
+): Promise<void> {
+	if (!getFlag("RESOURCES_PROVISION")) {
+		return;
+	}
+
+	const previews = config.previews as PreviewsConfig | undefined;
+	if (!previews || !hasPreviewBindingsToProvision(config)) {
+		return;
+	}
+
+	for (const kv of previews.kv_namespaces ?? []) {
+		if (kv.id) {
+			continue;
+		}
+
+		const title = getPreviewResourceName(workerName, previewSlug, kv.binding);
+		const namespace = (await listKVNamespaces(config, accountId)).find(
+			(namespace) => namespace.title === title
+		);
+		if (!namespace) {
+			continue;
+		}
+
+		try {
+			await deleteKVNamespace(config, accountId, namespace.id);
+		} catch (error) {
+			if (!isNotFoundError(error)) {
+				throw error;
+			}
+		}
+	}
+
+	for (const r2 of previews.r2_buckets ?? []) {
+		if (r2.bucket_name) {
+			continue;
+		}
+
+		const bucketName = getPreviewResourceName(
+			workerName,
+			previewSlug,
+			r2.binding
+		);
+
+		try {
+			await getR2Bucket(config, accountId, bucketName, r2.jurisdiction);
+		} catch (error) {
+			if (isNotFoundError(error)) {
+				continue;
+			}
+			throw error;
+		}
+
+		for (const key of await listR2ObjectKeys(
+			config,
+			accountId,
+			bucketName,
+			r2.jurisdiction
+		)) {
+			await deleteR2Object(
+				config,
+				accountId,
+				bucketName,
+				key,
+				true,
+				r2.jurisdiction
+			);
+		}
+
+		try {
+			await deleteR2Bucket(config, accountId, bucketName, r2.jurisdiction);
+		} catch (error) {
+			if (!isNotFoundError(error)) {
+				throw error;
+			}
+		}
+	}
+}

--- a/packages/wrangler/src/preview/shared.ts
+++ b/packages/wrangler/src/preview/shared.ts
@@ -91,9 +91,9 @@ export function getBindingValue(binding: Binding): string {
 		case "r2_bucket":
 			return String(binding.bucket_name ?? "");
 		case "service":
-			return binding.entrypoint
-				? `${binding.service}#${binding.entrypoint}`
-				: String(binding.service ?? "");
+			return `${binding.service ?? ""}${
+				binding.preview_id ? `@${binding.preview_id}` : ""
+			}${binding.entrypoint ? `#${binding.entrypoint}` : ""}`;
 		case "durable_object_namespace":
 			return binding.script_name
 				? `${binding.class_name} (${binding.script_name})`
@@ -177,6 +177,7 @@ export function extractConfigBindings(config: Config): EnvBindings {
 		env[service.binding] = {
 			type: "service",
 			service: service.service,
+			preview_id: service.preview_id,
 			entrypoint: service.entrypoint,
 			...(crossAccountGrant !== undefined && {
 				cross_account_grant: crossAccountGrant,

--- a/packages/wrangler/src/r2/helpers/object.ts
+++ b/packages/wrangler/src/r2/helpers/object.ts
@@ -18,11 +18,12 @@ import type { ReadableStream } from "node:stream/web";
 import type { HeadersInit } from "undici";
 
 type R2ObjectsListResponse = {
-	result?: {
-		objects?: Array<{ key?: string; name?: string }>;
-		truncated?: boolean;
+	result?: Array<{ key?: string; name?: string }>;
+	result_info?: {
+		is_truncated?: boolean;
 		cursor?: string;
 	};
+	// Keep this permissive for older tests/mocks and any API envelope changes.
 	objects?: Array<{ key?: string; name?: string }>;
 	truncated?: boolean;
 	cursor?: string;
@@ -44,6 +45,7 @@ export async function listR2ObjectKeys(
 		}
 
 		const query = new URLSearchParams();
+		query.set("per_page", "1000");
 		if (cursor !== undefined) {
 			query.set("cursor", cursor);
 		}
@@ -61,15 +63,20 @@ export async function listR2ObjectKeys(
 		}
 
 		const body = (await response.json()) as R2ObjectsListResponse;
-		const result = body.result ?? body;
-		for (const object of result.objects ?? []) {
+		const objects = Array.isArray(body.result)
+			? body.result
+			: (body.objects ?? []);
+		for (const object of objects) {
 			const key = object.key ?? object.name;
 			if (key !== undefined) {
 				keys.push(key);
 			}
 		}
 
-		cursor = result.truncated ? result.cursor : undefined;
+		const isTruncated = body.result_info?.is_truncated ?? body.truncated;
+		cursor = isTruncated
+			? (body.result_info?.cursor ?? body.cursor)
+			: undefined;
 	} while (cursor !== undefined);
 
 	return keys;

--- a/packages/wrangler/src/r2/helpers/object.ts
+++ b/packages/wrangler/src/r2/helpers/object.ts
@@ -17,6 +17,64 @@ import type { Readable } from "node:stream";
 import type { ReadableStream } from "node:stream/web";
 import type { HeadersInit } from "undici";
 
+type R2ObjectsListResponse = {
+	result?: {
+		objects?: Array<{ key?: string; name?: string }>;
+		truncated?: boolean;
+		cursor?: string;
+	};
+	objects?: Array<{ key?: string; name?: string }>;
+	truncated?: boolean;
+	cursor?: string;
+};
+
+export async function listR2ObjectKeys(
+	complianceConfig: ComplianceConfig,
+	accountId: string,
+	bucketName: string,
+	jurisdiction?: string
+): Promise<string[]> {
+	const keys: string[] = [];
+	let cursor: string | undefined;
+
+	do {
+		const headers: HeadersInit = {};
+		if (jurisdiction !== undefined) {
+			headers["cf-r2-jurisdiction"] = jurisdiction;
+		}
+
+		const query = new URLSearchParams();
+		if (cursor !== undefined) {
+			query.set("cursor", cursor);
+		}
+
+		const response = await fetchR2Objects(
+			complianceConfig,
+			`/accounts/${accountId}/r2/buckets/${bucketName}/objects${
+				query.size > 0 ? `?${query.toString()}` : ""
+			}`,
+			{ headers }
+		);
+
+		if (response === null) {
+			return keys;
+		}
+
+		const body = (await response.json()) as R2ObjectsListResponse;
+		const result = body.result ?? body;
+		for (const object of result.objects ?? []) {
+			const key = object.key ?? object.name;
+			if (key !== undefined) {
+				keys.push(key);
+			}
+		}
+
+		cursor = result.truncated ? result.cursor : undefined;
+	} while (cursor !== undefined);
+
+	return keys;
+}
+
 /**
  * Downloads an object
  */


### PR DESCRIPTION
`wrangler preview` can now provision new, per-preview resources for binding-only entries in the `previews` config block. `wrangler preview delete` cleans up only those auto-provisioned preview resources and leaves explicitly configured resources untouched. Preview auto-provisioning does not update the `previews` config block, since resource names and IDs are unique for each preview.

This implementation is incomplete and not intended to be reviewed or merged yet. Auto-provisioning for `wrangler preview` should support the same set of resources as `wrangler deploy`. `wrangler preview` is currently missing a number of resources, including D1 and others.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: `wrangler preview` is still in private beta

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->