### PR TITLE
Remove loopback for Asset worker

### DIFF
--- a/.changeset/calm-assets-flow.md
+++ b/.changeset/calm-assets-flow.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/workers-shared": patch
+"miniflare": patch
+---
+
+Bypass the Asset Worker loopback on normal request and RPC paths
+
+The inner asset entrypoint is now the default, avoiding the latency added by forwarding every call through `ctx.exports`. The outer loopback entrypoint and its cohort-routing infrastructure remain available as named exports in the Asset Worker and Miniflare bundles so the boundary can be re-enabled later.

--- a/.changeset/calm-assets-flow.md
+++ b/.changeset/calm-assets-flow.md
@@ -3,6 +3,6 @@
 "miniflare": patch
 ---
 
-Bypass the Asset Worker loopback on normal request and RPC paths
+Improve asset serving performance by removing an unnecessary internal dispatch hop
 
-The inner asset entrypoint is now the default, avoiding the latency added by forwarding every call through `ctx.exports`. The outer loopback entrypoint and its cohort-routing infrastructure remain available as named exports in the Asset Worker and Miniflare bundles so the boundary can be re-enabled later.
+Asset requests and RPC calls now avoid an extra internal forwarding layer, reducing latency. The forwarding infrastructure is preserved for future use by cohort-based deployments.

--- a/fixtures/workers-shared-asset-config/loopback.test.ts
+++ b/fixtures/workers-shared-asset-config/loopback.test.ts
@@ -1,5 +1,6 @@
 import Worker, {
 	AssetWorkerInner,
+	AssetWorkerOuter,
 } from "@cloudflare/workers-shared/asset-worker";
 import { normalizeConfiguration } from "@cloudflare/workers-shared/asset-worker/src/configuration";
 import { getAssetWithMetadataFromKV } from "@cloudflare/workers-shared/asset-worker/src/utils/kv";
@@ -41,6 +42,10 @@ describe("[Asset Worker] loopback", () => {
 
 	afterEach(() => {
 		vi.restoreAllMocks();
+	});
+
+	it("uses the outer entrypoint as the default export", ({ expect }) => {
+		expect(Worker).toBe(AssetWorkerOuter);
 	});
 
 	it("uses AssetWorkerInner for fetch path resolution", async ({ expect }) => {

--- a/fixtures/workers-shared-asset-config/loopback.test.ts
+++ b/fixtures/workers-shared-asset-config/loopback.test.ts
@@ -4,8 +4,9 @@ import Worker, {
 } from "@cloudflare/workers-shared/asset-worker";
 import { normalizeConfiguration } from "@cloudflare/workers-shared/asset-worker/src/configuration";
 import { getAssetWithMetadataFromKV } from "@cloudflare/workers-shared/asset-worker/src/utils/kv";
-import { SELF } from "cloudflare:test";
+import { SELF, createExecutionContext } from "cloudflare:test";
 import { afterEach, beforeEach, describe, it, vi } from "vitest";
+import type { Env } from "@cloudflare/workers-shared/asset-worker";
 import type { AssetMetadata } from "@cloudflare/workers-shared/asset-worker/src/utils/kv";
 
 const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
@@ -13,7 +14,7 @@ const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
 vi.mock("@cloudflare/workers-shared/asset-worker/src/utils/kv.ts");
 vi.mock("@cloudflare/workers-shared/asset-worker/src/configuration");
 
-describe("[Asset Worker] loopback", () => {
+describe("[Asset Worker] entrypoints", () => {
 	beforeEach(async () => {
 		vi.mocked(getAssetWithMetadataFromKV).mockImplementation(
 			() =>
@@ -44,14 +45,12 @@ describe("[Asset Worker] loopback", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("uses the outer entrypoint as the default export", ({ expect }) => {
-		expect(Worker).toBe(AssetWorkerOuter);
+	it("uses the inner entrypoint as the default export", ({ expect }) => {
+		expect(Worker).toBe(AssetWorkerInner);
 	});
 
-	it("uses AssetWorkerInner for fetch path resolution", async ({ expect }) => {
-		const outerExists = vi
-			.spyOn(Worker.prototype, "unstable_exists")
-			.mockResolvedValue(null);
+	it("routes directly through the inner entrypoint", async ({ expect }) => {
+		const outerExists = vi.spyOn(AssetWorkerOuter.prototype, "unstable_exists");
 		const innerExists = vi
 			.spyOn(AssetWorkerInner.prototype, "unstable_exists")
 			.mockResolvedValue("/file.bin");
@@ -67,5 +66,36 @@ describe("[Asset Worker] loopback", () => {
 			undefined,
 			"/file.bin"
 		);
+	});
+
+	it("keeps the outer-to-inner loopback available", async ({ expect }) => {
+		const request = new Request("https://example.com");
+		const ctx = createExecutionContext();
+		const innerFetch = vi.fn(async (_request: Request) => {
+			return new Response("inner response");
+		});
+		const createInnerEntrypoint = vi.fn(() => ({ fetch: innerFetch }));
+		Object.defineProperty(ctx, "exports", {
+			value: {
+				AssetWorkerInner: createInnerEntrypoint,
+			},
+		});
+
+		const response = await new AssetWorkerOuter(ctx, {} as Env).fetch(request);
+
+		expect(createInnerEntrypoint).toHaveBeenCalledOnce();
+		expect(createInnerEntrypoint).toHaveBeenCalledWith({
+			props: {
+				traceContext: {
+					traceId: "test-trace",
+					spanId: "test-span",
+					parentSpanId: "test-parent-span",
+					traceFlags: 0,
+				},
+			},
+		});
+		expect(innerFetch).toHaveBeenCalledOnce();
+		expect(innerFetch).toHaveBeenCalledWith(request);
+		expect(await response.text()).toBe("inner response");
 	});
 });

--- a/packages/miniflare/src/workers/assets/assets.worker.ts
+++ b/packages/miniflare/src/workers/assets/assets.worker.ts
@@ -1,8 +1,7 @@
-// Re-export the asset-worker so that its contents gets compiled into the Miniflare code base as a Worker template.
-// AssetWorkerInner must be explicitly re-exported so that the bundled module exposes it
-// via ctx.exports (enabled by the enable_ctx_exports compat flag). Without this,
-// esbuild tree-shakes AssetWorkerInner and the outer→inner loopback dispatch fails.
+// Re-export the asset-worker entrypoints so ctx.exports loopback bindings are
+// preserved in the bundled worker template.
 export {
 	default,
 	AssetWorkerInner,
+	AssetWorkerOuter,
 } from "@cloudflare/workers-shared/asset-worker";

--- a/packages/workers-shared/asset-worker/src/worker.ts
+++ b/packages/workers-shared/asset-worker/src/worker.ts
@@ -527,19 +527,19 @@ export class AssetWorkerInner<TEnv extends Env = Env>
 		const loopbackCtx = this.ctx as AssetWorkerContext;
 		const traceContext = loopbackCtx.props?.traceContext ?? null;
 		const cohort = this.ctx.version?.cohort;
+		const runRequest = () =>
+			runFetchRequest(
+				request,
+				this.env,
+				this.ctx,
+				this.unstable_exists.bind(this),
+				this.unstable_getByETag.bind(this),
+				cohort
+			);
 
-		const response = await this.env.JAEGER.runWithSpanContext(
-			traceContext,
-			() =>
-				runFetchRequest(
-					request,
-					this.env,
-					this.ctx,
-					this.unstable_exists.bind(this),
-					this.unstable_getByETag.bind(this),
-					cohort
-				)
-		);
+		const response = traceContext
+			? await this.env.JAEGER.runWithSpanContext(traceContext, runRequest)
+			: await runRequest();
 
 		if (response instanceof Response) {
 			return response;

--- a/packages/workers-shared/asset-worker/src/worker.ts
+++ b/packages/workers-shared/asset-worker/src/worker.ts
@@ -359,6 +359,12 @@ async function runFetchRequest(
  *
  * AssetWorkerOuter serves as the dispatch layer. It forwards all method
  * calls to AssetWorkerInner via ctx.exports.
+ *
+ * This now-unused entrypoint can be used for loopback invocations if made the
+ * default export, which is how cohorted deployments will be implemented.
+ * For now, the latency added by loopback invocations is too high for normal
+ * traffic. When that has been addressed, re-enable loopback by making this
+ * the default export.
  */
 export class AssetWorkerOuter<TEnv extends Env = Env>
 	extends WorkerEntrypoint<TEnv>
@@ -500,18 +506,16 @@ export class AssetWorkerOuter<TEnv extends Env = Env>
 	}
 }
 
-export default AssetWorkerOuter;
-
 // ============================================================
 // SECTION 4: INNER ENTRYPOINT (AssetWorkerInner)
 // ============================================================
 
 /*
  * AssetWorkerInner contains the actual implementation logic for all asset
- * worker methods. In production, it is instantiated by AssetWorkerOuter via
- * ctx.exports. For local development, tools such as the Vite plugin can
- * subclass AssetWorkerInner directly to override methods like unstable_exists
- * and unstable_getByETag with dev-server-backed implementations.
+ * worker methods. AssetWorkerOuter can instantiate it via ctx.exports to
+ * enable cohort-based loopback. For local development, tools such as the Vite
+ * plugin can subclass AssetWorkerInner directly to override methods like
+ * unstable_exists and unstable_getByETag with dev-server-backed implementations.
  */
 export class AssetWorkerInner<TEnv extends Env = Env>
 	extends WorkerEntrypoint<TEnv>
@@ -583,3 +587,5 @@ export class AssetWorkerInner<TEnv extends Env = Env>
 		return unstableExistsImpl(this.env, pathname, request);
 	}
 }
+
+export default AssetWorkerInner;

--- a/packages/workers-shared/asset-worker/src/worker.ts
+++ b/packages/workers-shared/asset-worker/src/worker.ts
@@ -360,7 +360,7 @@ async function runFetchRequest(
  * AssetWorkerOuter serves as the dispatch layer. It forwards all method
  * calls to AssetWorkerInner via ctx.exports.
  */
-export default class AssetWorkerOuter<TEnv extends Env = Env>
+export class AssetWorkerOuter<TEnv extends Env = Env>
 	extends WorkerEntrypoint<TEnv>
 	implements AssetWorkerMethods
 {
@@ -499,6 +499,8 @@ export default class AssetWorkerOuter<TEnv extends Env = Env>
 		return this.getInnerEntrypoint(cohort).unstable_exists(pathname, request);
 	}
 }
+
+export default AssetWorkerOuter;
 
 // ============================================================
 // SECTION 4: INNER ENTRYPOINT (AssetWorkerInner)


### PR DESCRIPTION
Fixes WC-5345.

Bypass the Asset Worker loopback on normal request and RPC paths

The inner asset entrypoint is now the default, avoiding the latency added by forwarding every call through `ctx.exports`. The outer loopback entrypoint and its cohort-routing infrastructure remain available as named exports in the Asset Worker and Miniflare bundles so the boundary can be re-enabled later.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal only change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->