### PR TITLE
Remove loopback for Router worker

### DIFF
--- a/.changeset/quiet-routers-loop.md
+++ b/.changeset/quiet-routers-loop.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/workers-shared": patch
+"miniflare": patch
+"@cloudflare/vite-plugin": patch
+---
+
+Bypass the router Worker loopback on the normal request path
+
+The inner routing entrypoint is now the default, avoiding the latency added by forwarding every request through `ctx.exports`. The outer loopback entrypoint and its supporting infrastructure remain available as named exports in the router Worker, Miniflare, and Vite plugin bundles so the boundary can be re-enabled later.

--- a/.changeset/quiet-routers-loop.md
+++ b/.changeset/quiet-routers-loop.md
@@ -4,6 +4,6 @@
 "@cloudflare/vite-plugin": patch
 ---
 
-Bypass the router Worker loopback on the normal request path
+Improve routing performance for Workers with assets
 
-The inner routing entrypoint is now the default, avoiding the latency added by forwarding every request through `ctx.exports`. The outer loopback entrypoint and its supporting infrastructure remain available as named exports in the router Worker, Miniflare, and Vite plugin bundles so the boundary can be re-enabled later.
+Reduce request handling latency by streamlining the router Worker's request path. The loopback infrastructure remains available for future use.

--- a/packages/miniflare/src/workers/assets/router.worker.ts
+++ b/packages/miniflare/src/workers/assets/router.worker.ts
@@ -3,4 +3,5 @@
 export {
 	default,
 	RouterInnerEntrypoint,
+	RouterOuterEntrypoint,
 } from "@cloudflare/workers-shared/router-worker";

--- a/packages/vite-plugin-cloudflare/src/workers/router-worker/index.ts
+++ b/packages/vite-plugin-cloudflare/src/workers/router-worker/index.ts
@@ -1,4 +1,5 @@
 export {
 	default,
 	RouterInnerEntrypoint,
+	RouterOuterEntrypoint,
 } from "@cloudflare/workers-shared/router-worker";

--- a/packages/workers-shared/router-worker/src/worker.ts
+++ b/packages/workers-shared/router-worker/src/worker.ts
@@ -45,6 +45,11 @@ type LoopbackExecutionContext = ExecutionContext & {
 	};
 };
 
+// This now-unused Entrypoint can be used for loopback invocations if made the
+// default export, which is how cohorted deployments will be implemented.
+// For now, the latency added by loopback invocations is too much for such a
+// load-bearing Worker. When that has been addressed in the future, re-enable
+// loopback by making this the default export.
 export class RouterOuterEntrypoint extends WorkerEntrypoint<Env> {
 	override async fetch(request: Request): Promise<Response> {
 		// Router worker is typechecked both in this package and as a transitive
@@ -101,8 +106,6 @@ export class RouterOuterEntrypoint extends WorkerEntrypoint<Env> {
 		return inner.fetch(request);
 	}
 }
-
-export default RouterOuterEntrypoint;
 
 export class RouterInnerEntrypoint extends WorkerEntrypoint<Env> {
 	override async fetch(request: Request): Promise<Response> {
@@ -360,6 +363,8 @@ export class RouterInnerEntrypoint extends WorkerEntrypoint<Env> {
 		}
 	}
 }
+
+export default RouterInnerEntrypoint;
 
 /**
  * Check if the Content Type is allowed for the the `_next/image` endpoint.

--- a/packages/workers-shared/router-worker/src/worker.ts
+++ b/packages/workers-shared/router-worker/src/worker.ts
@@ -45,44 +45,48 @@ type LoopbackExecutionContext = ExecutionContext & {
 	};
 };
 
-export default {
-	async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+export class RouterOuterEntrypoint extends WorkerEntrypoint<Env> {
+	override async fetch(request: Request): Promise<Response> {
 		// Router worker is typechecked both in this package and as a transitive
 		// dependency during miniflare builds. In the miniflare type context,
 		// Cloudflare.Exports may not include this worker's mainModule mapping from
 		// worker-configuration.d.ts, so `ctx.exports.RouterInnerEntrypoint` does not
 		// resolve structurally. Keep this narrow cast so loopback typechecks in both
 		// compilation contexts without changing runtime behavior.
-		const loopbackCtx = ctx as LoopbackExecutionContext;
+		const loopbackCtx = this.ctx as LoopbackExecutionContext;
 
-		const analytics = new Analytics(env.ANALYTICS);
+		const analytics = new Analytics(this.env.ANALYTICS);
 		let inner;
 		try {
-			if (env.COLO_METADATA && env.VERSION_METADATA && env.CONFIG) {
+			if (
+				this.env.COLO_METADATA &&
+				this.env.VERSION_METADATA &&
+				this.env.CONFIG
+			) {
 				const url = new URL(request.url);
 				analytics.setData({
-					accountId: env.CONFIG.account_id,
-					scriptId: env.CONFIG.script_id,
-					coloId: env.COLO_METADATA.coloId,
-					metalId: env.COLO_METADATA.metalId,
-					coloTier: env.COLO_METADATA.coloTier,
-					coloRegion: env.COLO_METADATA.coloRegion,
+					accountId: this.env.CONFIG.account_id,
+					scriptId: this.env.CONFIG.script_id,
+					coloId: this.env.COLO_METADATA.coloId,
+					metalId: this.env.COLO_METADATA.metalId,
+					coloTier: this.env.COLO_METADATA.coloTier,
+					coloRegion: this.env.COLO_METADATA.coloRegion,
 					hostname: url.hostname,
-					version: env.VERSION_METADATA.tag,
+					version: this.env.VERSION_METADATA.tag,
 				});
 			}
 			inner = loopbackCtx.exports.RouterInnerEntrypoint({ props: {} });
 		} catch (err) {
 			const sentry = setupSentry(
 				request,
-				ctx,
-				env.SENTRY_DSN,
-				env.SENTRY_ACCESS_CLIENT_ID,
-				env.SENTRY_ACCESS_CLIENT_SECRET,
-				env.COLO_METADATA,
-				env.VERSION_METADATA,
-				env.CONFIG?.account_id,
-				env.CONFIG?.script_id
+				this.ctx,
+				this.env.SENTRY_DSN,
+				this.env.SENTRY_ACCESS_CLIENT_ID,
+				this.env.SENTRY_ACCESS_CLIENT_SECRET,
+				this.env.COLO_METADATA,
+				this.env.VERSION_METADATA,
+				this.env.CONFIG?.account_id,
+				this.env.CONFIG?.script_id
 			);
 			sentry?.captureException(err);
 
@@ -95,8 +99,10 @@ export default {
 		}
 
 		return inner.fetch(request);
-	},
-};
+	}
+}
+
+export default RouterOuterEntrypoint;
 
 export class RouterInnerEntrypoint extends WorkerEntrypoint<Env> {
 	override async fetch(request: Request): Promise<Response> {

--- a/packages/workers-shared/router-worker/tests/index.test.ts
+++ b/packages/workers-shared/router-worker/tests/index.test.ts
@@ -1,7 +1,10 @@
 import { createExecutionContext } from "cloudflare:test";
 import { exports, env as runtimeEnv } from "cloudflare:workers";
 import { describe, it } from "vitest";
-import { RouterInnerEntrypoint } from "../src/worker";
+import DefaultRouterEntrypoint, {
+	RouterInnerEntrypoint,
+	RouterOuterEntrypoint,
+} from "../src/worker";
 import type { Env } from "../src/worker";
 
 async function fetchFromInnerEntrypoint(
@@ -13,6 +16,10 @@ async function fetchFromInnerEntrypoint(
 }
 
 describe("runtime loopback", () => {
+	it("uses the outer entrypoint as the default export", ({ expect }) => {
+		expect(DefaultRouterEntrypoint).toBe(RouterOuterEntrypoint);
+	});
+
 	it("routes through outer->inner loopback at runtime boundary", async ({
 		expect,
 	}) => {

--- a/packages/workers-shared/router-worker/tests/index.test.ts
+++ b/packages/workers-shared/router-worker/tests/index.test.ts
@@ -1,6 +1,6 @@
 import { createExecutionContext } from "cloudflare:test";
 import { exports, env as runtimeEnv } from "cloudflare:workers";
-import { describe, it } from "vitest";
+import { describe, it, vi } from "vitest";
 import DefaultRouterEntrypoint, {
 	RouterInnerEntrypoint,
 	RouterOuterEntrypoint,
@@ -15,12 +15,12 @@ async function fetchFromInnerEntrypoint(
 	return new RouterInnerEntrypoint(ctx, env).fetch(request);
 }
 
-describe("runtime loopback", () => {
-	it("uses the outer entrypoint as the default export", ({ expect }) => {
-		expect(DefaultRouterEntrypoint).toBe(RouterOuterEntrypoint);
+describe("entrypoints", () => {
+	it("uses the inner entrypoint as the default export", ({ expect }) => {
+		expect(DefaultRouterEntrypoint).toBe(RouterInnerEntrypoint);
 	});
 
-	it("routes through outer->inner loopback at runtime boundary", async ({
+	it("routes directly through the inner entrypoint at the runtime boundary", async ({
 		expect,
 	}) => {
 		(runtimeEnv as Env).CONFIG = {
@@ -28,7 +28,7 @@ describe("runtime loopback", () => {
 		};
 		(runtimeEnv as Env).ASSET_WORKER = {
 			async fetch(_request: Request): Promise<Response> {
-				return new Response("loopback asset worker");
+				return new Response("asset worker");
 			},
 			async unstable_canFetch(_request: Request): Promise<boolean> {
 				return true;
@@ -40,7 +40,31 @@ describe("runtime loopback", () => {
 		);
 
 		expect(response.status).toBe(200);
-		expect(await response.text()).toBe("loopback asset worker");
+		expect(await response.text()).toBe("asset worker");
+	});
+
+	it("keeps the outer-to-inner loopback available", async ({ expect }) => {
+		const request = new Request("https://example.com");
+		const ctx = createExecutionContext();
+		const innerFetch = vi.fn(async (_request: Request) => {
+			return new Response("inner response");
+		});
+		const createInnerEntrypoint = vi.fn(() => ({ fetch: innerFetch }));
+		Object.defineProperty(ctx, "exports", {
+			value: {
+				RouterInnerEntrypoint: createInnerEntrypoint,
+			},
+		});
+
+		const response = await new RouterOuterEntrypoint(ctx, {} as Env).fetch(
+			request
+		);
+
+		expect(createInnerEntrypoint).toHaveBeenCalledOnce();
+		expect(createInnerEntrypoint).toHaveBeenCalledWith({ props: {} });
+		expect(innerFetch).toHaveBeenCalledOnce();
+		expect(innerFetch).toHaveBeenCalledWith(request);
+		expect(await response.text()).toBe("inner response");
 	});
 });
 


### PR DESCRIPTION
Fixes WC-5346.

Bypass the router Worker loopback on the normal request path

The inner routing entrypoint is now the default, avoiding the latency added by forwarding every request through `ctx.exports`. The outer loopback entrypoint and its supporting infrastructure remain available as named exports in the router Worker, Miniflare, and Vite plugin bundles so the boundary can be re-enabled later.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal only change

*A picture of a cute animal (not mandatory, but encouraged)*

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->