### PR TITLE
wrangler types: add --x-new-config flag support

### DIFF
--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -13,8 +13,9 @@ import chalk from "chalk";
 import * as find from "empathic/find";
 import { getNodeCompat } from "miniflare";
 import yargs from "yargs";
-import { readConfig } from "../config";
+import { readConfig, readNewConfig } from "../config";
 import { createCommand } from "../core/create-command";
+import { experimentalNewConfigArg } from "../experimental-config/cli-flag";
 import { getEntry } from "../deployment-bundle/entry";
 import { getDurableObjectClassNameToUseSQLiteMap } from "../dev/class-names-sqlite";
 import { getVarsForDev } from "../dev/dev-vars";
@@ -30,6 +31,7 @@ import {
 	validateEnvInterfaceNames,
 } from "./helpers";
 import { fetchPipelineTypes } from "./pipeline-schema";
+import { regenerateNewConfigTypes } from "./new-config";
 import { generateRuntimeTypes } from "./runtime";
 import { logRuntimeTypesMessage } from "./runtime/log-runtime-types-message";
 import type {
@@ -118,6 +120,7 @@ export const typesCommand = createCommand({
 	},
 	positionalArgs: ["path"],
 	args: {
+		...experimentalNewConfigArg,
 		path: {
 			describe: "The path to the declaration file for the generated types",
 			type: "string",
@@ -204,6 +207,15 @@ export const typesCommand = createCommand({
 		}
 	},
 	async handler(args) {
+		if (args.experimentalNewConfig) {
+			const newConfig = await readNewConfig(args);
+			await regenerateNewConfigTypes({
+				cloudflareConfigPath: newConfig.config.configPath as string,
+				types: newConfig.types,
+			});
+			return;
+		}
+
 		const resolvedOptions = await resolveGenerateTypesOptions(args, {
 			logSecondaryEntries: true,
 			validateOptions: false,


### PR DESCRIPTION
Fixes #14396

`wrangler deploy --x-new-config` and `wrangler build --x-new-config` both load `cloudflare.config.ts` successfully, but `wrangler types --x-new-config` rejected the flag with "Unknown arguments: x-new-config, xNewConfig"

The fix wires the existing `experimentalNewConfigArg` definition into `typesCommand.args` — the same spread used by `buildCommand`, `deployCommand`, and others. When the flag is present, the handler calls `readNewConfig(args)` to load `cloudflare.config.ts`, then passes the result to `regenerateNewConfigTypes`, which is the same function the `ConfigController` calls during `wrangler dev --experimental-new-config`. The legacy code path is left completely untouched.

The `regenerateNewConfigTypes` implementation (in `type-generation/new-config.ts`) already handles the full flow: generating types via `@cloudflare/config`, diffing against the on-disk file to avoid mtime churn, and writing only when the content changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->