### PR TITLE
[wrangler] interpolate current date to fix brittle test

### DIFF
--- a/packages/wrangler/src/__tests__/deploy/config-args-merging.test.ts
+++ b/packages/wrangler/src/__tests__/deploy/config-args-merging.test.ts
@@ -11,6 +11,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { getTodaysCompatDate } from "@cloudflare/workers-utils";
 import {
 	runInTempDir,
 	writeWranglerConfig,
@@ -344,16 +345,15 @@ describe.each([
 			}) => {
 				writeWranglerConfig({ compatibility_date: undefined });
 				writeWorkerSource();
+				const today = getTodaysCompatDate();
 				await expect(runWrangler("deploy ./index.js")).rejects
-					.toThrowErrorMatchingInlineSnapshot(`
-					[Error: A compatibility_date is required when uploading a Worker. Add the following to your wrangler.toml file:
-					    \`\`\`
-					    compatibility_date = "2026-06-24"
+					.toThrowError(`A compatibility_date is required when uploading a Worker. Add the following to your wrangler.toml file:
+    \`\`\`
+    compatibility_date = "${today}"
 
-					    \`\`\`
-					    Or you could pass it in your terminal as \`--compatibility-date 2026-06-24\`
-					See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.]
-				`);
+    \`\`\`
+    Or you could pass it in your terminal as \`--compatibility-date ${today}\`
+See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`);
 			});
 		});
 


### PR DESCRIPTION
The test is relying on a hard-coded date, which will only ever be correct on that specific date. Interpolating the current date so it consistently passes.

No docs updates as it's just a test fix.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is a test fix
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/14421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->